### PR TITLE
Standard Library 3 (PR A): @js codegen lowering + loader rules 1-3

### DIFF
--- a/fixtures/stdlib_import_flat/build/lib/index.js
+++ b/fixtures/stdlib_import_flat/build/lib/index.js
@@ -1,2 +1,2 @@
-export const pi = js.PI;
+export const pi = Math.PI;
 //# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_flat/build/lib/index.js.map
+++ b/fixtures/stdlib_import_flat/build/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math?flat\"\n\nexport val pi: number = js.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,GAAG"}
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math?flat\"\n\nexport val pi: number = js.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAA"}

--- a/fixtures/stdlib_import_local/build/lib/index.js
+++ b/fixtures/stdlib_import_local/build/lib/index.js
@@ -1,2 +1,2 @@
-export const pi = math.PI;
+export const pi = Math.PI;
 //# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_local/build/lib/index.js.map
+++ b/fixtures/stdlib_import_local/build/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math\"\n\nexport val pi: number = math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAK"}
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math\"\n\nexport val pi: number = math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAA"}

--- a/fixtures/stdlib_import_nested/build/lib/index.js
+++ b/fixtures/stdlib_import_nested/build/lib/index.js
@@ -1,2 +1,2 @@
-export const pi = js.math.PI;
+export const pi = Math.PI;
 //# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_nested/build/lib/index.js.map
+++ b/fixtures/stdlib_import_nested/build/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math?nested\"\n\nexport val pi: number = js.math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,AAAA,GAAG,KAAK"}
+{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"js:math?nested\"\n\nexport val pi: number = js.math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAA"}

--- a/internal/ast/binding_owner.go
+++ b/internal/ast/binding_owner.go
@@ -1,0 +1,11 @@
+package ast
+
+// VarDecl, FuncDecl, and ClassDecl are the AST kinds that introduce a
+// value binding and can carry decorators per §3.3 of the builtins plan.
+// They opt in to `type_system.BindingOwner` here so a `Binding.Owner`
+// is guaranteed to be a value-introducing decl — codegen can safely
+// type-switch on the concrete kinds below to read decorators.
+
+func (*VarDecl) IsBindingOwner()   {}
+func (*FuncDecl) IsBindingOwner()  {}
+func (*ClassDecl) IsBindingOwner() {}

--- a/internal/ast/decorators.go
+++ b/internal/ast/decorators.go
@@ -1,0 +1,48 @@
+package ast
+
+// JSDecoratorName is the decorator that carries the JS-runtime expression
+// each pseudo-package member lowers to at codegen. See
+// planning/builtins/implementation_plan.md §3.
+const JSDecoratorName = "js"
+
+// DeclDecorators returns the decorator list attached to decl, or nil if
+// decl is a kind that cannot carry decorators (the parser rejects
+// decorators on those kinds at parse time; the nil return lets callers
+// treat "no decorators" and "cannot carry" uniformly).
+func DeclDecorators(decl Decl) []*Decorator {
+	switch d := decl.(type) {
+	case *VarDecl:
+		return d.Decorators
+	case *FuncDecl:
+		return d.Decorators
+	case *ClassDecl:
+		return d.Decorators
+	default:
+		return nil
+	}
+}
+
+// FindJsDecorator returns the first `@js("...")` decorator on decl and
+// its argument string. Returns (nil, "", false) if no `@js` decorator is
+// present, and (dec, "", false) if `@js` is present but the argument
+// isn't a single string literal (reported as a loader error).
+func FindJsDecorator(decl Decl) (*Decorator, string, bool) {
+	for _, dec := range DeclDecorators(decl) {
+		if dec.Name == nil || dec.Name.Name != JSDecoratorName {
+			continue
+		}
+		if len(dec.Args) != 1 {
+			return dec, "", false
+		}
+		lit, ok := dec.Args[0].(*LiteralExpr)
+		if !ok {
+			return dec, "", false
+		}
+		s, ok := lit.Lit.(*StrLit)
+		if !ok {
+			return dec, "", false
+		}
+		return dec, s.Value, true
+	}
+	return nil, "", false
+}

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
 // NamespaceID represents a unique identifier for a namespace
@@ -283,10 +284,19 @@ func NewLitExpr(lit Lit) *LiteralExpr {
 }
 
 type IdentExpr struct {
-	Name         string
-	Namespace    NamespaceID
-	VarID        int // set by the rename pass (liveness.VarID); 0 = unset
-	Source       provenance.Provenance
+	Name      string
+	Namespace NamespaceID
+	VarID     int // set by the rename pass (liveness.VarID); 0 = unset
+	Source    provenance.Provenance
+	// Owner is the resolved binding's owning top-level declaration —
+	// the `FuncDecl` / `VarDecl` / `ClassDecl` that introduced the
+	// name. Stamped by inference when this identifier resolves to a
+	// top-level value binding; nil for unbound references, params,
+	// locals, or references that resolve to a namespace rather than a
+	// value. Carried so codegen can walk back to the declaration's
+	// decorators (e.g. `@js("Math.sin")`) without a re-lookup. See
+	// planning/builtins/implementation_plan.md §3.
+	Owner        type_system.BindingOwner
 	span         Span
 	inferredType Type
 }
@@ -398,7 +408,7 @@ func NewCall(callee Expr, args []Expr, optChain bool, span Span) *CallExpr {
 //
 //   - nil           → no dispatch was resolved (error paths)
 //   - NeverType     → resolved to a non-throwing arm (sentinel: the
-//                     callee declared no throws clause)
+//     callee declared no throws clause)
 //   - any other Type → the resolved throws type
 //
 // Callers that just want "what does this call throw" should treat

--- a/internal/checker/infer_class_decl.go
+++ b/internal/checker/infer_class_decl.go
@@ -328,6 +328,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 
 	classBinding := &type_system.Binding{
 		Source:     provenance,
+		Owner:      decl,
 		Type:       classObjType,
 		Assignable: false,
 		Mutable:    false,

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -310,6 +310,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				exprType.SetProvenance(&ast.NodeProvenance{Node: expr})
 			}
 			expr.Source = binding.Source
+			expr.Owner = binding.Owner
 			errors = nil
 		} else if namespace := ctx.Scope.getNamespace(expr.Name); namespace != nil {
 			t := type_system.NewNamespaceType(provenance, namespace)

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -288,6 +288,7 @@ func (c *Checker) InferComponent(
 				if binding == nil {
 					nsCtx.Scope.setValue(decl.Name.Name, &type_system.Binding{
 						Source:     &ast.NodeProvenance{Node: decl},
+						Owner:      decl,
 						Type:       funcType,
 						Assignable: false,
 						Mutable:    false,
@@ -335,6 +336,7 @@ func (c *Checker) InferComponent(
 				for name, binding := range bindings {
 					binding.Exported = decl.Export()
 					binding.Assignable = assignable
+					binding.Owner = decl
 					nsCtx.Scope.setValue(name, binding)
 					names = append(names, name)
 				}
@@ -792,6 +794,7 @@ func (c *Checker) InferComponent(
 
 				ctor := &type_system.Binding{
 					Source:     &ast.NodeProvenance{Node: decl},
+					Owner:      decl,
 					Type:       classObjType,
 					Assignable: false,
 					Mutable:    false,
@@ -1162,6 +1165,9 @@ func (c *Checker) InferComponent(
 						classObjType := type_system.NewObjectType(provenance, classObjTypeElems)
 						classObjType.SymbolKeyMap = symbolKeyMap
 
+						// Enum variants get no Owner — EnumDecl can't carry
+						// `@js` decorators (parser rejects them on enum decls),
+						// so there's nothing useful for codegen to find here.
 						ctor := &type_system.Binding{
 							Source:     provenance,
 							Type:       classObjType,
@@ -2143,6 +2149,7 @@ func (c *Checker) processExportAssignment(stmt *ast.ExportAssignmentStmt, ctx Co
 	// Create default export
 	ctx.Scope.setValue("default", &type_system.Binding{
 		Source:     &ast.NodeProvenance{Node: stmt},
+		Owner:      binding.Owner,
 		Type:       binding.Type,
 		Assignable: binding.Assignable,
 		Mutable:    binding.Mutable,

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -342,6 +342,14 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 		return nil, errs
 	}
 
+	// Loader rules §3.4 (1-3): every exported value-level decl must
+	// carry `@js`; unexported value-level decls are rejected. Rule 4
+	// (`@js` target validation against TS lib globals) lands separately.
+	if decErrs := validateStdlibDecorators(filePath, mod, span); len(decErrs) > 0 {
+		delete(c.PackageRegistry.packages, uri)
+		return nil, decErrs
+	}
+
 	pkgNs := type_system.NewNamespace()
 	pkgScope := &Scope{Parent: c.GlobalScope, Namespace: pkgNs}
 	pkgCtx := Context{Scope: pkgScope, IsAsync: false, IsPatMatch: false}

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -345,7 +345,7 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 	// Loader rules §3.4 (1-3): every exported value-level decl must
 	// carry `@js`; unexported value-level decls are rejected. Rule 4
 	// (`@js` target validation against TS lib globals) lands separately.
-	if decErrs := validateStdlibDecorators(filePath, mod, span); len(decErrs) > 0 {
+	if decErrs := validateJsDecorators(filePath, mod, span); len(decErrs) > 0 {
 		delete(c.PackageRegistry.packages, uri)
 		return nil, decErrs
 	}

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -124,6 +124,7 @@ func (c *Checker) inferVarDecl(
 	assignable := decl.Kind == ast.VarKind
 	for _, binding := range bindings {
 		binding.Assignable = assignable
+		binding.Owner = decl
 	}
 
 	if decl.TypeAnn == nil && decl.Init == nil {
@@ -261,6 +262,7 @@ func (c *Checker) inferFuncDecl(ctx Context, decl *ast.FuncDecl) []Error {
 
 	binding := type_system.Binding{
 		Source:     &ast.NodeProvenance{Node: decl},
+		Owner:      decl,
 		Type:       funcType,
 		Assignable: false,
 		Mutable:    false,

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -121,10 +121,12 @@ func (c *Checker) inferVarDecl(
 
 	// `var x` rebinds; `val x` does not. `Mutable` (value-mutation through
 	// the name) was already populated by inferPattern from the pattern flag.
+	// Owner is intentionally not set here: this path runs for locals inside
+	// function bodies, and `Binding.Owner` is reserved for top-level decls
+	// (the file-scope path in InferComponent stamps it).
 	assignable := decl.Kind == ast.VarKind
 	for _, binding := range bindings {
 		binding.Assignable = assignable
-		binding.Owner = decl
 	}
 
 	if decl.TypeAnn == nil && decl.Init == nil {

--- a/internal/checker/js_decorator.go
+++ b/internal/checker/js_decorator.go
@@ -6,28 +6,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
-// jsDecoratorName is the decorator that carries the JS-runtime expression
-// each pseudo-package member lowers to at codegen. See
-// planning/builtins/implementation_plan.md §3.
-const jsDecoratorName = "js"
-
-// declDecorators returns the decorator list attached to decl, or nil if
-// decl is a kind that cannot carry decorators (the parser rejects
-// decorators on those kinds at parse time; the nil return lets callers
-// treat "no decorators" and "cannot carry" uniformly).
-func declDecorators(decl ast.Decl) []*ast.Decorator {
-	switch d := decl.(type) {
-	case *ast.VarDecl:
-		return d.Decorators
-	case *ast.FuncDecl:
-		return d.Decorators
-	case *ast.ClassDecl:
-		return d.Decorators
-	default:
-		return nil
-	}
-}
-
 // declName returns a printable name for decl used in loader diagnostics.
 // Returns "" if decl has no obvious single-identifier name (e.g. a
 // VarDecl with a destructuring pattern); diagnostics fall back to the
@@ -68,32 +46,7 @@ func declKindLabel(decl ast.Decl) string {
 	}
 }
 
-// findJSDecorator returns the first `@js("...")` decorator on decl and
-// its argument string. Returns (nil, "", false) if no `@js` decorator is
-// present, and (dec, "", false) if `@js` is present but the argument
-// isn't a single string literal (reported as a loader error).
-func findJSDecorator(decl ast.Decl) (*ast.Decorator, string, bool) {
-	for _, dec := range declDecorators(decl) {
-		if dec.Name == nil || dec.Name.Name != jsDecoratorName {
-			continue
-		}
-		if len(dec.Args) != 1 {
-			return dec, "", false
-		}
-		lit, ok := dec.Args[0].(*ast.LiteralExpr)
-		if !ok {
-			return dec, "", false
-		}
-		s, ok := lit.Lit.(*ast.StrLit)
-		if !ok {
-			return dec, "", false
-		}
-		return dec, s.Value, true
-	}
-	return nil, "", false
-}
-
-// validateStdlibDecorators enforces the §3.4 loader rules on the
+// validateJsDecorators enforces the §3.4 loader rules on the
 // declarations of a parsed pseudo-package module (rules 1-3; rule 4
 // lives in a separate PR):
 //
@@ -107,18 +60,18 @@ func findJSDecorator(decl ast.Decl) (*ast.Decorator, string, bool) {
 // Each diagnostic names the file (via the importing-file `span`), the
 // declaration, and the rule that fired so the user can act on it
 // without leaving their project.
-func validateStdlibDecorators(filePath string, mod *ast.Module, importSpan ast.Span) []Error {
+func validateJsDecorators(filePath string, mod *ast.Module, importSpan ast.Span) []Error {
 	var errs []Error
 	mod.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
 		for _, decl := range ns.Decls {
-			errs = append(errs, validateStdlibDecl(filePath, decl, importSpan)...)
+			errs = append(errs, validateJsDecorator(filePath, decl, importSpan)...)
 		}
 		return true
 	})
 	return errs
 }
 
-func validateStdlibDecl(filePath string, decl ast.Decl, importSpan ast.Span) []Error {
+func validateJsDecorator(filePath string, decl ast.Decl, importSpan ast.Span) []Error {
 	switch decl.(type) {
 	case *ast.VarDecl, *ast.FuncDecl, *ast.ClassDecl:
 		// fall through — value-level decl handled below
@@ -126,7 +79,7 @@ func validateStdlibDecl(filePath string, decl ast.Decl, importSpan ast.Span) []E
 		return nil
 	}
 
-	jsDec, jsArg, jsOK := findJSDecorator(decl)
+	jsDec, jsArg, jsOK := ast.FindJsDecorator(decl)
 	name := declName(decl)
 	if name == "" {
 		name = "<unnamed>"

--- a/internal/checker/stdlib_decorator.go
+++ b/internal/checker/stdlib_decorator.go
@@ -1,0 +1,169 @@
+package checker
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// jsDecoratorName is the decorator that carries the JS-runtime expression
+// each pseudo-package member lowers to at codegen. See
+// planning/builtins/implementation_plan.md §3.
+const jsDecoratorName = "js"
+
+// declDecorators returns the decorator list attached to decl, or nil if
+// decl is a kind that cannot carry decorators (the parser rejects
+// decorators on those kinds at parse time; the nil return lets callers
+// treat "no decorators" and "cannot carry" uniformly).
+func declDecorators(decl ast.Decl) []*ast.Decorator {
+	switch d := decl.(type) {
+	case *ast.VarDecl:
+		return d.Decorators
+	case *ast.FuncDecl:
+		return d.Decorators
+	case *ast.ClassDecl:
+		return d.Decorators
+	default:
+		return nil
+	}
+}
+
+// declName returns a printable name for decl used in loader diagnostics.
+// Returns "" if decl has no obvious single-identifier name (e.g. a
+// VarDecl with a destructuring pattern); diagnostics fall back to the
+// span in that case.
+func declName(decl ast.Decl) string {
+	switch d := decl.(type) {
+	case *ast.VarDecl:
+		if id, ok := d.Pattern.(*ast.IdentPat); ok {
+			return id.Name
+		}
+		return ""
+	case *ast.FuncDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+		return ""
+	case *ast.ClassDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+		return ""
+	}
+	return ""
+}
+
+// declKindLabel returns a short label for decl used in diagnostics
+// ("function", "class", "value"). Matches the §3.3 grammar terms.
+func declKindLabel(decl ast.Decl) string {
+	switch decl.(type) {
+	case *ast.FuncDecl:
+		return "function"
+	case *ast.ClassDecl:
+		return "class"
+	case *ast.VarDecl:
+		return "value"
+	default:
+		return "declaration"
+	}
+}
+
+// findJSDecorator returns the first `@js("...")` decorator on decl and
+// its argument string. Returns (nil, "", false) if no `@js` decorator is
+// present, and (dec, "", false) if `@js` is present but the argument
+// isn't a single string literal (reported as a loader error).
+func findJSDecorator(decl ast.Decl) (*ast.Decorator, string, bool) {
+	for _, dec := range declDecorators(decl) {
+		if dec.Name == nil || dec.Name.Name != jsDecoratorName {
+			continue
+		}
+		if len(dec.Args) != 1 {
+			return dec, "", false
+		}
+		lit, ok := dec.Args[0].(*ast.LiteralExpr)
+		if !ok {
+			return dec, "", false
+		}
+		s, ok := lit.Lit.(*ast.StrLit)
+		if !ok {
+			return dec, "", false
+		}
+		return dec, s.Value, true
+	}
+	return nil, "", false
+}
+
+// validateStdlibDecorators enforces the §3.4 loader rules on the
+// declarations of a parsed pseudo-package module (rules 1-3; rule 4
+// lives in a separate PR):
+//
+//  1. Every exported value-level top-level decl must carry `@js`.
+//  2. An unexported value-level top-level decl is rejected (no runtime
+//     mapping; invisible to importers — almost certainly a missing
+//     `export`).
+//  3. An unexported type-level decl is allowed and must not carry `@js`
+//     (already enforced at parse time, so nothing to check here).
+//
+// Each diagnostic names the file (via the importing-file `span`), the
+// declaration, and the rule that fired so the user can act on it
+// without leaving their project.
+func validateStdlibDecorators(filePath string, mod *ast.Module, importSpan ast.Span) []Error {
+	var errs []Error
+	mod.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, decl := range ns.Decls {
+			errs = append(errs, validateStdlibDecl(filePath, decl, importSpan)...)
+		}
+		return true
+	})
+	return errs
+}
+
+func validateStdlibDecl(filePath string, decl ast.Decl, importSpan ast.Span) []Error {
+	switch decl.(type) {
+	case *ast.VarDecl, *ast.FuncDecl, *ast.ClassDecl:
+		// fall through — value-level decl handled below
+	default:
+		return nil
+	}
+
+	jsDec, jsArg, jsOK := findJSDecorator(decl)
+	name := declName(decl)
+	if name == "" {
+		name = "<unnamed>"
+	}
+	kindLabel := declKindLabel(decl)
+
+	if !decl.Export() {
+		// Rule 2: unexported value-level decl is rejected.
+		return []Error{&GenericError{
+			message: fmt.Sprintf(
+				"unexported %s %q in pseudo-package file %s has no runtime mapping; "+
+					"add `export` (and an `@js(...)` decorator) or remove the declaration",
+				kindLabel, name, filePath),
+			span: importSpan,
+		}}
+	}
+
+	// Rule 1: exported value-level decl must carry `@js`.
+	if jsDec == nil {
+		return []Error{&GenericError{
+			message: fmt.Sprintf(
+				"exported %s %q in pseudo-package file %s is missing an `@js(\"...\")` decorator",
+				kindLabel, name, filePath),
+			span: importSpan,
+		}}
+	}
+	if !jsOK {
+		// `@js` is present but malformed — argument isn't a single string
+		// literal. Loader rule, not a parser error: the parser accepts any
+		// positional expression list to leave room for future decorators.
+		return []Error{&GenericError{
+			message: fmt.Sprintf(
+				"`@js` decorator on %s %q in pseudo-package file %s must take a single string-literal argument",
+				kindLabel, name, filePath),
+			span: importSpan,
+		}}
+	}
+	_ = jsArg // arg validation against TS lib globals lands in a separate PR
+	return nil
+}

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -313,3 +313,31 @@ func TestStdlibImport_LoaderRule_AcceptsValidPackage(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import "js:example"`)
 	require.Empty(t, errorMessages(errs))
 }
+
+// TestStdlibImport_LoaderRule_MalformedJSDecorator pins the loader's
+// shape check on `@js(...)`: the argument must be a single string
+// literal. Non-string args and zero/multi-arg forms are rejected
+// uniformly. The parser accepts any positional expression list to leave
+// room for future decorators, so this rule lives in the loader.
+func TestStdlibImport_LoaderRule_MalformedJSDecorator(t *testing.T) {
+	cases := map[string]string{
+		"NonStringArg":  "@js(123)\nexport declare val PI: number",
+		"MultipleArgs":  "@js(\"a\", \"b\")\nexport declare val PI: number",
+		"NoArgs":        "@js()\nexport declare val PI: number",
+	}
+	for name, source := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := makeCustomStdlibDir(t, map[string]string{
+				"js/example.esc": source,
+			})
+			t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+			_, errs := inferStdlibImportSource(t, `import "js:example"`)
+			require.Len(t, errs, 1)
+			require.Equal(t,
+				fmt.Sprintf("`@js` decorator on value %q in pseudo-package file %s must take a single string-literal argument",
+					"PI", filepath.Join(dir, "js/example.esc")),
+				errs[0].Message())
+		})
+	}
+}

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -273,10 +273,10 @@ func TestStdlibImport_LoaderRule_MissingJSDecorator(t *testing.T) {
 
 	_, errs := inferStdlibImportSource(t, `import "js:example"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(),
-		`exported value "PI"`)
-	require.Contains(t, errs[0].Message(),
-		"is missing an `@js(\"...\")` decorator")
+	require.Equal(t,
+		fmt.Sprintf("exported value %q in pseudo-package file %s is missing an `@js(\"...\")` decorator",
+			"PI", filepath.Join(dir, "js/example.esc")),
+		errs[0].Message())
 }
 
 // TestStdlibImport_LoaderRule_UnexportedValueLevelRejected pins loader
@@ -292,10 +292,11 @@ func TestStdlibImport_LoaderRule_UnexportedValueLevelRejected(t *testing.T) {
 
 	_, errs := inferStdlibImportSource(t, `import "js:example"`)
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(),
-		`unexported value "helper"`)
-	require.Contains(t, errs[0].Message(),
-		"has no runtime mapping")
+	require.Equal(t,
+		fmt.Sprintf("unexported value %q in pseudo-package file %s has no runtime mapping; "+
+			"add `export` (and an `@js(...)` decorator) or remove the declaration",
+			"helper", filepath.Join(dir, "js/example.esc")),
+		errs[0].Message())
 }
 
 // TestStdlibImport_LoaderRule_AcceptsValidPackage confirms the loader

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -199,8 +199,8 @@ func TestStdlibImport_FlatNameCollision(t *testing.T) {
 	// Both packages export the same identifier; the second ?flat
 	// import must fail with the taxonomy-aligned collision message.
 	dir := makeCustomStdlibDir(t, map[string]string{
-		"js/alpha.esc": `export val Common: number = 1`,
-		"js/beta.esc":  `export val Common: number = 2`,
+		"js/alpha.esc": "@js(\"Common\")\nexport val Common: number = 1",
+		"js/beta.esc":  "@js(\"Common\")\nexport val Common: number = 2",
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
@@ -259,4 +259,56 @@ func TestStdlibImport_InvalidPackageName(t *testing.T) {
 		`invalid package name "Math" in js:Math; expected lowercase letters, digits, and underscores`,
 		errs[0].Message(),
 	)
+}
+
+// TestStdlibImport_LoaderRule_MissingJSDecorator pins loader rule §3.4(1):
+// every exported value-level decl in a pseudo-package file must carry
+// an `@js("...")` decorator. The error is anchored to the importing
+// `import` statement, not a location inside the stdlib file.
+func TestStdlibImport_LoaderRule_MissingJSDecorator(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"js/example.esc": "export val PI: number = 3.14",
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `import "js:example"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(),
+		`exported value "PI"`)
+	require.Contains(t, errs[0].Message(),
+		"is missing an `@js(\"...\")` decorator")
+}
+
+// TestStdlibImport_LoaderRule_UnexportedValueLevelRejected pins loader
+// rule §3.4(2): unexported value-level decls in pseudo-package files
+// are rejected (no runtime mapping, invisible to importers — almost
+// certainly a missing `export`). The diagnostic tells the user how to
+// fix it.
+func TestStdlibImport_LoaderRule_UnexportedValueLevelRejected(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"js/example.esc": "@js(\"helper\")\ndeclare val helper: number",
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `import "js:example"`)
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(),
+		`unexported value "helper"`)
+	require.Contains(t, errs[0].Message(),
+		"has no runtime mapping")
+}
+
+// TestStdlibImport_LoaderRule_AcceptsValidPackage confirms the loader
+// rules don't false-positive on a correctly-authored pseudo-package
+// (every exported value-level decl has `@js("...")`; type-level decls
+// have no decorator).
+func TestStdlibImport_LoaderRule_AcceptsValidPackage(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"js/example.esc": "@js(\"Foo\")\nexport declare fn foo() -> number\n" +
+			"declare type Helper = number",
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `import "js:example"`)
+	require.Empty(t, errorMessages(errs))
 }

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1408,8 +1408,8 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 		argExpr, argStmts := b.buildExpr(expr.Arg, expr)
 		return NewUnaryExpr(UnaryOp(expr.Op), argExpr, expr), argStmts
 	case *ast.IdentExpr:
-		if lowered, ok := b.jsLoweringFor(expr); ok {
-			return lowered, []Stmt{}
+		if jsExpr, ok := jsExprFromOwner(expr.Owner); ok {
+			return buildDottedJSExpr(jsExpr, expr), []Stmt{}
 		}
 		var namespaceStr string
 		if b.depGraph != nil {
@@ -1448,12 +1448,12 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 		stmts := slices.Concat(objStmts, indexStmts)
 		return NewIndexExpr(objExpr, indexExpr, expr.OptChain, expr), stmts
 	case *ast.MemberExpr:
-		if lowered, ok := b.jsLoweringFor(expr); ok {
+		if jsExpr, ok := memberJSExpr(expr); ok {
 			// `math.sin` collapses to the @js-decorated declaration's
 			// argument (e.g. `Math.sin`). The original receiver doesn't
 			// participate in the lowered output, so we drop the
 			// receiver-binding / temp-var logic below.
-			return lowered, []Stmt{}
+			return buildDottedJSExpr(jsExpr, expr), []Stmt{}
 		}
 		objExpr, objStmts := b.buildExpr(expr.Object, expr)
 		propExpr := buildIdent(expr.Prop)

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1408,6 +1408,9 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 		argExpr, argStmts := b.buildExpr(expr.Arg, expr)
 		return NewUnaryExpr(UnaryOp(expr.Op), argExpr, expr), argStmts
 	case *ast.IdentExpr:
+		if lowered, ok := b.jsLoweringFor(expr); ok {
+			return lowered, []Stmt{}
+		}
 		var namespaceStr string
 		if b.depGraph != nil {
 			namespaceStr = b.depGraph.GetNamespaceString(expr.Namespace)
@@ -1445,6 +1448,13 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 		stmts := slices.Concat(objStmts, indexStmts)
 		return NewIndexExpr(objExpr, indexExpr, expr.OptChain, expr), stmts
 	case *ast.MemberExpr:
+		if lowered, ok := b.jsLoweringFor(expr); ok {
+			// `math.sin` collapses to the @js-decorated declaration's
+			// argument (e.g. `Math.sin`). The original receiver doesn't
+			// participate in the lowered output, so we drop the
+			// receiver-binding / temp-var logic below.
+			return lowered, []Stmt{}
+		}
 		objExpr, objStmts := b.buildExpr(expr.Object, expr)
 		propExpr := buildIdent(expr.Prop)
 

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -64,36 +64,20 @@ func memberJSExpr(m *ast.MemberExpr) (string, bool) {
 
 // jsExprFromOwner reads the `@js("...")` decorator argument off a
 // binding's owning declaration. Returns ("", false) when the owner is
-// nil or carries no `@js` decorator. The owner is guaranteed (by the
-// `BindingOwner` sumtype) to be one of the three decl kinds switched
-// on below.
+// nil, isn't a decorator-carrying decl, or carries no well-formed `@js`
+// decorator. Loader rules §3.4 already reject malformed `@js` on
+// pseudo-package decls, so reaching this from production code means
+// well-formed or absent — both handled by ast.FindJSDecorator.
 func jsExprFromOwner(owner type_system.BindingOwner) (string, bool) {
-	var decorators []*ast.Decorator
-	switch d := owner.(type) {
-	case *ast.VarDecl:
-		decorators = d.Decorators
-	case *ast.FuncDecl:
-		decorators = d.Decorators
-	case *ast.ClassDecl:
-		decorators = d.Decorators
-	default:
+	decl, ok := owner.(ast.Decl)
+	if !ok {
 		return "", false
 	}
-	for _, dec := range decorators {
-		if dec.Name == nil || dec.Name.Name != "js" || len(dec.Args) != 1 {
-			continue
-		}
-		lit, ok := dec.Args[0].(*ast.LiteralExpr)
-		if !ok {
-			continue
-		}
-		s, ok := lit.Lit.(*ast.StrLit)
-		if !ok {
-			continue
-		}
-		return s.Value, true
+	_, arg, ok := ast.FindJsDecorator(decl)
+	if !ok {
+		return "", false
 	}
-	return "", false
+	return arg, true
 }
 
 // buildDottedJSExpr parses a dotted JS expression like "Math.sin" or

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -101,6 +101,10 @@ func jsExprFromOwner(owner type_system.BindingOwner) (string, bool) {
 // Single identifiers (no dot) become a bare IdentExpr. The whole chain
 // shares the same source AST node so source maps still point back at
 // the original Escalier expression.
+//
+// jsArg comes from a string literal in an `@js(...)` decorator authored
+// in a stdlib `.esc` file, so empty segments (".foo", "Math..PI") would
+// be a stdlib authoring bug — not validated here.
 func buildDottedJSExpr(jsArg string, source ast.Node) Expr {
 	parts := strings.Split(jsArg, ".")
 	var out Expr = NewIdentExpr(parts[0], "", source)

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -1,0 +1,111 @@
+package codegen
+
+import (
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// jsLoweringFor returns the lowered JS expression for an AST identifier
+// or member-access node that resolves to a pseudo-package declaration
+// carrying an `@js("...")` decorator. Returns (nil, false) when no
+// lowering applies — callers fall through to ordinary codegen.
+//
+// See planning/builtins/implementation_plan.md §3.1-§3.2:
+//   - IdentExpr `parseInt` / `Array` whose owning decl has
+//     `@js("parseInt")` / `@js("Array")` lowers to the parsed JS
+//     expression.
+//   - MemberExpr `math.sin` / `iterator.iteratorKey` whose property's
+//     binding owns a decl with `@js("Math.sin")` /
+//     `@js("Symbol.iterator")` lowers to the parsed JS expression (the
+//     receiver vanishes because @js carries the complete JS-runtime
+//     expression).
+func (b *Builder) jsLoweringFor(expr ast.Expr) (Expr, bool) {
+	switch e := expr.(type) {
+	case *ast.IdentExpr:
+		jsExpr, ok := jsExprFromOwner(e.Owner)
+		if !ok {
+			return nil, false
+		}
+		return buildDottedJSExpr(jsExpr, e), true
+	case *ast.MemberExpr:
+		jsExpr, ok := memberJSExpr(e)
+		if !ok {
+			return nil, false
+		}
+		return buildDottedJSExpr(jsExpr, e), true
+	}
+	return nil, false
+}
+
+// memberJSExpr returns the JS lowering for a MemberExpr whose receiver
+// resolves to a NamespaceType (the package binding under ?local /
+// ?nested / ?flat). The property's Binding in that namespace owns a
+// decl whose `@js("...")` decorator carries the lowering.
+func memberJSExpr(m *ast.MemberExpr) (string, bool) {
+	if m.Prop == nil {
+		return "", false
+	}
+	objType := m.Object.InferredType()
+	if objType == nil {
+		return "", false
+	}
+	nsType, ok := type_system.Prune(objType).(*type_system.NamespaceType)
+	if !ok || nsType.Namespace == nil {
+		return "", false
+	}
+	binding := nsType.Namespace.Values[m.Prop.Name]
+	if binding == nil {
+		return "", false
+	}
+	return jsExprFromOwner(binding.Owner)
+}
+
+// jsExprFromOwner reads the `@js("...")` decorator argument off a
+// binding's owning declaration. Returns ("", false) when the owner is
+// nil or carries no `@js` decorator. The owner is guaranteed (by the
+// `BindingOwner` sumtype) to be one of the three decl kinds switched
+// on below.
+func jsExprFromOwner(owner type_system.BindingOwner) (string, bool) {
+	var decorators []*ast.Decorator
+	switch d := owner.(type) {
+	case *ast.VarDecl:
+		decorators = d.Decorators
+	case *ast.FuncDecl:
+		decorators = d.Decorators
+	case *ast.ClassDecl:
+		decorators = d.Decorators
+	default:
+		return "", false
+	}
+	for _, dec := range decorators {
+		if dec.Name == nil || dec.Name.Name != "js" || len(dec.Args) != 1 {
+			continue
+		}
+		lit, ok := dec.Args[0].(*ast.LiteralExpr)
+		if !ok {
+			continue
+		}
+		s, ok := lit.Lit.(*ast.StrLit)
+		if !ok {
+			continue
+		}
+		return s.Value, true
+	}
+	return "", false
+}
+
+// buildDottedJSExpr parses a dotted JS expression like "Math.sin" or
+// "Symbol.iterator" into a codegen IdentExpr + chain of MemberExprs.
+// Single identifiers (no dot) become a bare IdentExpr. The whole chain
+// shares the same source AST node so source maps still point back at
+// the original Escalier expression.
+func buildDottedJSExpr(jsArg string, source ast.Node) Expr {
+	parts := strings.Split(jsArg, ".")
+	var out Expr = NewIdentExpr(parts[0], "", source)
+	for _, part := range parts[1:] {
+		out = NewMemberExpr(out, NewIdentifier(part, source), false, source)
+	}
+	return out
+}

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -7,37 +7,17 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// jsLoweringFor returns the lowered JS expression for an AST identifier
-// or member-access node that resolves to a pseudo-package declaration
-// carrying an `@js("...")` decorator. Returns (nil, false) when no
-// lowering applies — callers fall through to ordinary codegen.
+// This file implements the `@js("...")` codegen lowering described in
+// planning/builtins/implementation_plan.md §3.1-§3.2:
 //
-// See planning/builtins/implementation_plan.md §3.1-§3.2:
 //   - IdentExpr `parseInt` / `Array` whose owning decl has
 //     `@js("parseInt")` / `@js("Array")` lowers to the parsed JS
-//     expression.
+//     expression. The caller in builder.go reads `expr.Owner` directly.
 //   - MemberExpr `math.sin` / `iterator.iteratorKey` whose property's
 //     binding owns a decl with `@js("Math.sin")` /
 //     `@js("Symbol.iterator")` lowers to the parsed JS expression (the
 //     receiver vanishes because @js carries the complete JS-runtime
 //     expression).
-func (b *Builder) jsLoweringFor(expr ast.Expr) (Expr, bool) {
-	switch e := expr.(type) {
-	case *ast.IdentExpr:
-		jsExpr, ok := jsExprFromOwner(e.Owner)
-		if !ok {
-			return nil, false
-		}
-		return buildDottedJSExpr(jsExpr, e), true
-	case *ast.MemberExpr:
-		jsExpr, ok := memberJSExpr(e)
-		if !ok {
-			return nil, false
-		}
-		return buildDottedJSExpr(jsExpr, e), true
-	}
-	return nil, false
-}
 
 // memberJSExpr returns the JS lowering for a MemberExpr whose receiver
 // resolves to a NamespaceType (the package binding under ?local /
@@ -67,7 +47,7 @@ func memberJSExpr(m *ast.MemberExpr) (string, bool) {
 // nil, isn't a decorator-carrying decl, or carries no well-formed `@js`
 // decorator. Loader rules §3.4 already reject malformed `@js` on
 // pseudo-package decls, so reaching this from production code means
-// well-formed or absent — both handled by ast.FindJSDecorator.
+// well-formed or absent — both handled by ast.FindJsDecorator.
 func jsExprFromOwner(owner type_system.BindingOwner) (string, bool) {
 	decl, ok := owner.(ast.Decl)
 	if !ok {

--- a/internal/interop/__snapshots__/helper_test.snap
+++ b/internal/interop/__snapshots__/helper_test.snap
@@ -973,6 +973,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:2},
                             End:      ast.Location{Line:1, Column:3},
@@ -1007,6 +1008,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
                             End:      ast.Location{Line:1, Column:17},
@@ -1706,6 +1708,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:6},
@@ -1743,6 +1746,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:6},
@@ -1767,6 +1771,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:16},
                     End:      ast.Location{Line:1, Column:19},
@@ -1804,6 +1809,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:6},
@@ -1841,6 +1847,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:11},
                     End:      ast.Location{Line:1, Column:13},
@@ -2762,6 +2769,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:8},
                         End:      ast.Location{Line:1, Column:9},
@@ -2786,6 +2794,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:19},
                         End:      ast.Location{Line:1, Column:20},
@@ -4112,6 +4121,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:22},
             End:      ast.Location{Line:1, Column:25},
@@ -4202,6 +4212,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:29},
             End:      ast.Location{Line:1, Column:35},
@@ -4260,6 +4271,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:30},
             End:      ast.Location{Line:1, Column:36},
@@ -4326,6 +4338,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:28},
             End:      ast.Location{Line:1, Column:37},
@@ -4412,6 +4425,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:22},
             End:      ast.Location{Line:1, Column:25},
@@ -4552,6 +4566,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:22},
             End:      ast.Location{Line:1, Column:27},
@@ -4587,6 +4602,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:31},
             End:      ast.Location{Line:1, Column:33},
@@ -4622,6 +4638,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:29},
             End:      ast.Location{Line:1, Column:36},
@@ -4657,6 +4674,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:30},
             End:      ast.Location{Line:1, Column:36},
@@ -4692,6 +4710,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:22},
             End:      ast.Location{Line:1, Column:33},
@@ -4727,6 +4746,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:38},
             End:      ast.Location{Line:1, Column:46},
@@ -4762,6 +4782,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:26},
             End:      ast.Location{Line:1, Column:31},
@@ -4827,6 +4848,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:33},
             End:      ast.Location{Line:1, Column:41},
@@ -4896,6 +4918,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:34},
             End:      ast.Location{Line:1, Column:47},
@@ -4961,6 +4984,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:26},
             End:      ast.Location{Line:1, Column:31},
@@ -5057,6 +5081,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:33},
             End:      ast.Location{Line:1, Column:39},
@@ -5147,6 +5172,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:34},
             End:      ast.Location{Line:1, Column:38},

--- a/internal/interop/data/js/array.esc
+++ b/internal/interop/data/js/array.esc
@@ -1,6 +1,7 @@
 // Stub for §2's single-class shortcut gate. The real Array surface is
 // authored by the converter (§7); this minimal declaration exists so
 // the resolver's FR5 path has something to bind.
+@js("Array")
 export declare class Array<T> {
     constructor(mut self, length: number),
     static isArray(value: unknown) -> boolean,

--- a/internal/interop/data/js/math.esc
+++ b/internal/interop/data/js/math.esc
@@ -1,1 +1,2 @@
+@js("Math.PI")
 export val PI: number = 3.14

--- a/internal/parser/__snapshots__/expr_test.snap
+++ b/internal/parser/__snapshots__/expr_test.snap
@@ -10,6 +10,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
                         End:      ast.Location{Line:1, Column:7},
@@ -39,6 +40,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
@@ -90,6 +92,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:8},
@@ -123,6 +126,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -136,6 +140,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -170,6 +175,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -300,6 +306,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -314,6 +321,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:7},
@@ -327,6 +335,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
@@ -370,6 +379,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -383,6 +393,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -420,6 +431,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -433,6 +445,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -603,6 +616,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -615,6 +629,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:8},
@@ -639,6 +654,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -653,6 +669,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -833,6 +850,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:12},
                             End:      ast.Location{Line:1, Column:13},
@@ -846,6 +864,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:16},
                             End:      ast.Location{Line:1, Column:17},
@@ -889,6 +908,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -903,6 +923,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -972,6 +993,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:6},
                         End:      ast.Location{Line:1, Column:7},
@@ -1030,6 +1052,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -1043,6 +1066,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -1055,6 +1079,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:8},
                 End:      ast.Location{Line:1, Column:9},
@@ -1067,6 +1092,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:12},
@@ -1112,6 +1138,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -1125,6 +1152,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
                 End:      ast.Location{Line:1, Column:7},
@@ -1138,6 +1166,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:16},
@@ -1171,6 +1200,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:2},
                 End:      ast.Location{Line:1, Column:3},
@@ -1193,6 +1223,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
                 End:      ast.Location{Line:1, Column:8},
@@ -1246,6 +1277,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -1356,6 +1388,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -1404,6 +1437,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -1418,6 +1452,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:7},
@@ -1431,6 +1466,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
@@ -1480,6 +1516,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -1494,6 +1531,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -1506,6 +1544,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
                 End:      ast.Location{Line:1, Column:8},
@@ -1537,6 +1576,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:8},
@@ -1552,6 +1592,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:11},
                         End:      ast.Location{Line:1, Column:12},
@@ -1581,6 +1622,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:22},
                             End:      ast.Location{Line:1, Column:23},
@@ -1686,6 +1728,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:9},
                         End:      ast.Location{Line:1, Column:10},
@@ -1718,6 +1761,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:4},
             End:      ast.Location{Line:1, Column:9},
@@ -1733,6 +1777,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:12},
                         End:      ast.Location{Line:1, Column:13},
@@ -1761,6 +1806,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:24},
                     End:      ast.Location{Line:1, Column:29},
@@ -1776,6 +1822,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:32},
                                 End:      ast.Location{Line:1, Column:33},
@@ -1805,6 +1852,7 @@
                                 Namespace: 0,
                                 VarID:     0,
                                 Source:    nil,
+                                Owner:     nil,
                                 span:      ast.Span{
                                     Start:    ast.Location{Line:1, Column:43},
                                     End:      ast.Location{Line:1, Column:44},
@@ -1871,6 +1919,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -1884,6 +1933,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -1904,6 +1954,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
             End:      ast.Location{Line:1, Column:10},
@@ -1948,6 +1999,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
                     End:      ast.Location{Line:1, Column:4},
@@ -1961,6 +2013,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:5},
                         End:      ast.Location{Line:1, Column:6},
@@ -1984,6 +2037,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
@@ -2007,6 +2061,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:12},
@@ -2033,6 +2088,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -2046,6 +2102,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:4},
                 End:      ast.Location{Line:1, Column:8},
@@ -2059,6 +2116,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:11},
                 End:      ast.Location{Line:1, Column:17},
@@ -2091,6 +2149,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -2104,6 +2163,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -2124,6 +2184,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:9},
             End:      ast.Location{Line:1, Column:10},
@@ -2148,6 +2209,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -2161,6 +2223,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -2182,6 +2245,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:9},
                 End:      ast.Location{Line:1, Column:10},
@@ -2195,6 +2259,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:13},
                 End:      ast.Location{Line:1, Column:14},
@@ -2244,6 +2309,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:14},
@@ -2268,6 +2334,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -2282,6 +2349,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -2321,6 +2389,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -2335,6 +2404,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:8},
@@ -2348,6 +2418,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:9},
                     End:      ast.Location{Line:1, Column:10},
@@ -2408,6 +2479,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -2420,6 +2492,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:10},
                 End:      ast.Location{Line:1, Column:11},
@@ -2444,6 +2517,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -2457,6 +2531,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
@@ -2480,6 +2555,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -2493,6 +2569,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:6},
                 End:      ast.Location{Line:1, Column:9},
@@ -2539,6 +2616,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:2},
@@ -2551,6 +2629,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:3},
                 End:      ast.Location{Line:1, Column:4},
@@ -2571,6 +2650,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -2642,6 +2722,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:13},
                             End:      ast.Location{Line:1, Column:14},
@@ -2655,6 +2736,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
@@ -2733,6 +2815,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:15},
                     End:      ast.Location{Line:1, Column:18},
@@ -2803,6 +2886,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:37},
                     End:      ast.Location{Line:1, Column:40},
@@ -2826,6 +2910,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:43},
                         End:      ast.Location{Line:1, Column:46},
@@ -2878,6 +2963,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:3},
                         End:      ast.Location{Line:1, Column:6},
@@ -2964,6 +3050,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:3},
                     End:      ast.Location{Line:1, Column:6},
@@ -3001,6 +3088,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:10},
                     End:      ast.Location{Line:1, Column:13},
@@ -3062,6 +3150,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3075,6 +3164,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -3098,6 +3188,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3111,6 +3202,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
@@ -3134,6 +3226,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3147,6 +3240,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -3170,6 +3264,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3183,6 +3278,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:5},
             End:      ast.Location{Line:1, Column:6},
@@ -3206,6 +3302,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3219,6 +3316,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -3242,6 +3340,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3255,6 +3354,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -3278,6 +3378,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -3307,6 +3408,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
@@ -3329,6 +3431,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
@@ -3352,6 +3455,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:15},
                                 End:      ast.Location{Line:1, Column:16},
@@ -3374,6 +3478,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:18},
                                 End:      ast.Location{Line:1, Column:19},
@@ -3424,6 +3529,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:1},
                     End:      ast.Location{Line:1, Column:4},
@@ -3464,6 +3570,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:11},
             End:      ast.Location{Line:1, Column:14},
@@ -3506,6 +3613,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -3519,6 +3627,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:6},
             End:      ast.Location{Line:1, Column:7},
@@ -3542,6 +3651,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -3645,6 +3755,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:13},
@@ -3691,6 +3802,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:31},
                         End:      ast.Location{Line:1, Column:36},
@@ -3729,6 +3841,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:44},
                         End:      ast.Location{Line:1, Column:49},
@@ -3862,6 +3975,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:12},
@@ -3908,6 +4022,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:25},
                         End:      ast.Location{Line:1, Column:29},
@@ -3975,6 +4090,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:51},
                         End:      ast.Location{Line:1, Column:56},
@@ -4040,6 +4156,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4091,6 +4208,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:21},
                         End:      ast.Location{Line:1, Column:22},
@@ -4104,6 +4222,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:25},
                         End:      ast.Location{Line:1, Column:26},
@@ -4160,6 +4279,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4189,6 +4309,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:2, Column:3},
                                             End:      ast.Location{Line:2, Column:10},
@@ -4218,6 +4339,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:2, Column:15},
                                             End:      ast.Location{Line:2, Column:16},
@@ -4296,6 +4418,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4321,6 +4444,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4435,6 +4559,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4541,6 +4666,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4597,6 +4723,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4653,6 +4780,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:8},
@@ -4799,6 +4927,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:21},
@@ -4857,6 +4986,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:45},
                                             End:      ast.Location{Line:1, Column:52},
@@ -4886,6 +5016,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:57},
                                             End:      ast.Location{Line:1, Column:62},
@@ -4949,6 +5080,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:13},
                                             End:      ast.Location{Line:1, Column:27},
@@ -5059,6 +5191,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:71},
                         End:      ast.Location{Line:1, Column:76},
@@ -5094,6 +5227,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:21},
@@ -5146,6 +5280,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:15},
@@ -5199,6 +5334,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:37},
                             End:      ast.Location{Line:1, Column:42},
@@ -5294,6 +5430,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:80},
                             End:      ast.Location{Line:1, Column:85},
@@ -5345,6 +5482,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -5435,6 +5573,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:65},
                             End:      ast.Location{Line:1, Column:68},
@@ -5552,6 +5691,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:23},
@@ -5609,6 +5749,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:2, Column:3},
                                         End:      ast.Location{Line:2, Column:11},
@@ -5622,6 +5763,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:2, Column:12},
                                             End:      ast.Location{Line:2, Column:17},
@@ -5725,6 +5867,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -5811,6 +5954,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -5933,6 +6077,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -6046,6 +6191,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -6098,6 +6244,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -6152,6 +6299,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:38},
                         End:      ast.Location{Line:1, Column:43},
@@ -6266,6 +6414,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:7},
                             End:      ast.Location{Line:1, Column:16},
@@ -6435,6 +6584,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:23},
                             End:      ast.Location{Line:1, Column:24},
@@ -6448,6 +6598,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:27},
                             End:      ast.Location{Line:1, Column:28},
@@ -6564,6 +6715,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:36},
                             End:      ast.Location{Line:1, Column:37},
@@ -6577,6 +6729,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:40},
                             End:      ast.Location{Line:1, Column:41},
@@ -6621,6 +6774,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:7},
                 End:      ast.Location{Line:1, Column:19},
@@ -6655,6 +6809,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:7},
             End:      ast.Location{Line:1, Column:12},
@@ -6775,6 +6930,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:32},
                                 End:      ast.Location{Line:1, Column:37},
@@ -6814,6 +6970,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:46},
                                         End:      ast.Location{Line:1, Column:51},
@@ -6949,6 +7106,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:22},
                     End:      ast.Location{Line:1, Column:25},
@@ -7051,6 +7209,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:59},
                     End:      ast.Location{Line:1, Column:62},
@@ -7074,6 +7233,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:65},
                         End:      ast.Location{Line:1, Column:68},
@@ -7140,6 +7300,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:1},
                 End:      ast.Location{Line:1, Column:6},
@@ -7186,6 +7347,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:6},
@@ -7217,6 +7379,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -7231,6 +7394,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -7342,6 +7506,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:25},
                         End:      ast.Location{Line:1, Column:30},
@@ -7524,6 +7689,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:36},
                                 End:      ast.Location{Line:1, Column:37},
@@ -7536,6 +7702,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:39},
                                 End:      ast.Location{Line:1, Column:40},
@@ -7580,6 +7747,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:2, Column:11},
             End:      ast.Location{Line:2, Column:16},
@@ -7662,6 +7830,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:22},
                             End:      ast.Location{Line:3, Column:23},
@@ -7675,6 +7844,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:26},
                             End:      ast.Location{Line:3, Column:27},
@@ -7751,6 +7921,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:4, Column:25},
                             End:      ast.Location{Line:4, Column:31},
@@ -7954,6 +8125,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -8016,6 +8188,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:2},
@@ -8030,6 +8203,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:16},
                 End:      ast.Location{Line:1, Column:21},
@@ -8061,6 +8235,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:12},
             End:      ast.Location{Line:1, Column:17},
@@ -8085,6 +8260,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},
@@ -8098,6 +8274,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:5},
                 End:      ast.Location{Line:1, Column:6},
@@ -8110,6 +8287,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:8},
                 End:      ast.Location{Line:1, Column:9},
@@ -8149,6 +8327,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:1},
             End:      ast.Location{Line:1, Column:4},

--- a/internal/parser/__snapshots__/jsx_test.snap
+++ b/internal/parser/__snapshots__/jsx_test.snap
@@ -404,6 +404,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:14},
                     End:      ast.Location{Line:1, Column:17},
@@ -505,6 +506,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:14},
                                 End:      ast.Location{Line:1, Column:17},
@@ -942,6 +944,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:10},
                         End:      ast.Location{Line:1, Column:16},
@@ -961,6 +964,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:22},
                         End:      ast.Location{Line:1, Column:28},
@@ -1053,6 +1057,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:10},
                         End:      ast.Location{Line:1, Column:15},
@@ -1104,6 +1109,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:10},
                         End:      ast.Location{Line:1, Column:15},
@@ -1217,6 +1223,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:18},
                         End:      ast.Location{Line:1, Column:23},

--- a/internal/parser/__snapshots__/lifetime_test.snap
+++ b/internal/parser/__snapshots__/lifetime_test.snap
@@ -309,6 +309,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:42},
                 End:      ast.Location{Line:1, Column:45},
@@ -465,6 +466,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:54},
                             End:      ast.Location{Line:1, Column:55},
@@ -611,6 +613,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:46},
                             End:      ast.Location{Line:1, Column:47},
@@ -832,6 +835,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:77},
                             End:      ast.Location{Line:1, Column:78},
@@ -994,6 +998,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:59},
                             End:      ast.Location{Line:1, Column:60},
@@ -1232,6 +1237,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:86},
                             End:      ast.Location{Line:1, Column:87},
@@ -1293,6 +1299,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:22},
                             End:      ast.Location{Line:1, Column:28},
@@ -1450,6 +1457,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:13},
                         End:      ast.Location{Line:1, Column:19},
@@ -1553,6 +1561,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:64},
                                         End:      ast.Location{Line:1, Column:65},
@@ -1648,6 +1657,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:23},
                         End:      ast.Location{Line:1, Column:24},
@@ -1744,6 +1754,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:24},
                             End:      ast.Location{Line:1, Column:25},
@@ -1857,6 +1868,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:29},
                 End:      ast.Location{Line:1, Column:32},
@@ -1944,6 +1956,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:43},
                         End:      ast.Location{Line:1, Column:48},
@@ -2059,6 +2072,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:19},
                 End:      ast.Location{Line:1, Column:22},
@@ -2157,6 +2171,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:22},
                 End:      ast.Location{Line:1, Column:25},
@@ -2293,6 +2308,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:54},
                                 End:      ast.Location{Line:1, Column:55},
@@ -2436,6 +2452,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:29},
                 End:      ast.Location{Line:1, Column:32},
@@ -2530,6 +2547,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:1, Column:26},
                 End:      ast.Location{Line:1, Column:29},
@@ -2579,6 +2597,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:14},
                         End:      ast.Location{Line:1, Column:18},
@@ -2640,6 +2659,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:1, Column:53},
                                             End:      ast.Location{Line:1, Column:57},
@@ -2749,6 +2769,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:20},
                             End:      ast.Location{Line:1, Column:24},
@@ -2870,6 +2891,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:21},
                             End:      ast.Location{Line:1, Column:28},
@@ -3023,6 +3045,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:19},
                         End:      ast.Location{Line:1, Column:26},

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -7,6 +7,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
                 End:      ast.Location{Line:2, Column:8},
@@ -151,6 +152,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:13},
                                 End:      ast.Location{Line:3, Column:14},
@@ -164,6 +166,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:17},
                                 End:      ast.Location{Line:3, Column:18},
@@ -233,6 +236,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:13},
                 End:      ast.Location{Line:2, Column:14},
@@ -284,6 +288,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:14},
                     End:      ast.Location{Line:2, Column:15},
@@ -297,6 +302,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:7},
@@ -339,6 +345,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:2, Column:5},
                 End:      ast.Location{Line:2, Column:6},
@@ -352,6 +359,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:7},
                     End:      ast.Location{Line:2, Column:11},
@@ -365,6 +373,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:6},
                     End:      ast.Location{Line:3, Column:12},
@@ -449,6 +458,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:15},
                                             End:      ast.Location{Line:4, Column:16},
@@ -482,6 +492,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:8},
                                             End:      ast.Location{Line:5, Column:9},
@@ -552,6 +563,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:5},
                 End:      ast.Location{Line:3, Column:8},
@@ -656,6 +668,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:15},
                     End:      ast.Location{Line:4, Column:16},
@@ -669,6 +682,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:4, Column:19},
                     End:      ast.Location{Line:4, Column:20},
@@ -767,6 +781,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:13},
                                 End:      ast.Location{Line:6, Column:14},
@@ -780,6 +795,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:6, Column:17},
                                 End:      ast.Location{Line:6, Column:18},
@@ -850,6 +866,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:16},
                     End:      ast.Location{Line:2, Column:20},
@@ -1080,6 +1097,7 @@
             Namespace: 0,
             VarID:     0,
             Source:    nil,
+            Owner:     nil,
             span:      ast.Span{
                 Start:    ast.Location{Line:3, Column:6},
                 End:      ast.Location{Line:3, Column:7},
@@ -1111,6 +1129,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:2, Column:5},
                     End:      ast.Location{Line:2, Column:6},
@@ -1175,6 +1194,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:3, Column:5},
                     End:      ast.Location{Line:3, Column:6},
@@ -1320,6 +1340,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:13},
                                 End:      ast.Location{Line:3, Column:14},
@@ -1333,6 +1354,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:3, Column:17},
                                 End:      ast.Location{Line:3, Column:18},
@@ -1477,6 +1499,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:3, Column:27},
                                         End:      ast.Location{Line:3, Column:32},
@@ -1490,6 +1513,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:33},
                                             End:      ast.Location{Line:3, Column:36},
@@ -1541,6 +1565,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:4, Column:19},
                                         End:      ast.Location{Line:4, Column:27},
@@ -1813,6 +1838,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:3, Column:19},
                                         End:      ast.Location{Line:3, Column:22},
@@ -1842,6 +1868,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:3, Column:31},
                                         End:      ast.Location{Line:3, Column:33},
@@ -1953,6 +1980,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:3, Column:19},
                                         End:      ast.Location{Line:3, Column:31},
@@ -1966,6 +1994,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:32},
                                             End:      ast.Location{Line:3, Column:37},
@@ -2055,6 +2084,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:5, Column:24},
                         End:      ast.Location{Line:5, Column:27},
@@ -2070,6 +2100,7 @@
                                 Namespace: 0,
                                 VarID:     0,
                                 Source:    nil,
+                                Owner:     nil,
                                 span:      ast.Span{
                                     Start:    ast.Location{Line:5, Column:34},
                                     End:      ast.Location{Line:5, Column:37},
@@ -2197,6 +2228,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:37},
                                         End:      ast.Location{Line:1, Column:40},
@@ -2226,6 +2258,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:49},
                                         End:      ast.Location{Line:1, Column:51},
@@ -2372,6 +2405,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:13},
                             End:      ast.Location{Line:3, Column:18},
@@ -3355,6 +3389,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:13},
             End:      ast.Location{Line:1, Column:17},
@@ -3377,6 +3412,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:24},
             End:      ast.Location{Line:1, Column:28},
@@ -3425,6 +3461,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:19},
             End:      ast.Location{Line:1, Column:22},
@@ -3447,6 +3484,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:27},
             End:      ast.Location{Line:1, Column:33},
@@ -3664,6 +3702,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:22},
             End:      ast.Location{Line:1, Column:27},
@@ -3686,6 +3725,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:17},
             End:      ast.Location{Line:1, Column:21},
@@ -4061,6 +4101,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:56},
                             End:      ast.Location{Line:1, Column:57},
@@ -4384,6 +4425,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:49},
                             End:      ast.Location{Line:1, Column:56},
@@ -4889,6 +4931,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -5023,6 +5066,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:11},
@@ -5126,6 +5170,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:12},
@@ -5266,6 +5311,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:14},
@@ -5311,6 +5357,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:14},
                                             End:      ast.Location{Line:4, Column:18},
@@ -5413,6 +5460,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:7},
@@ -5445,6 +5493,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:4, Column:6},
                         End:      ast.Location{Line:4, Column:7},
@@ -5542,6 +5591,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:18},
@@ -5678,6 +5728,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -5785,6 +5836,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -5882,6 +5934,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -5995,6 +6048,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:11},
@@ -6102,6 +6156,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -6227,6 +6282,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -6405,6 +6461,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:7},
@@ -6441,6 +6498,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:4, Column:6},
                             End:      ast.Location{Line:4, Column:7},
@@ -6519,6 +6577,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:3, Column:6},
                             End:      ast.Location{Line:3, Column:10},
@@ -6543,6 +6602,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:4, Column:6},
                             End:      ast.Location{Line:4, Column:9},
@@ -7572,6 +7632,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:21},
                         End:      ast.Location{Line:1, Column:24},
@@ -7908,6 +7969,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -8026,6 +8088,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:19},
                                             End:      ast.Location{Line:5, Column:23},
@@ -8118,6 +8181,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:7},
@@ -8217,6 +8281,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:16},
                                             End:      ast.Location{Line:5, Column:17},
@@ -8315,6 +8380,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:11},
@@ -8444,6 +8510,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:20},
                                             End:      ast.Location{Line:5, Column:25},
@@ -8536,6 +8603,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:7},
@@ -8635,6 +8703,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:16},
                                             End:      ast.Location{Line:5, Column:17},
@@ -9506,6 +9575,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:16},
                                             End:      ast.Location{Line:4, Column:17},
@@ -9837,6 +9907,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:16},
                                             End:      ast.Location{Line:4, Column:17},
@@ -10013,6 +10084,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:11},
@@ -10136,6 +10208,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:20},
                                             End:      ast.Location{Line:5, Column:25},
@@ -10247,6 +10320,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -10346,6 +10420,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:19},
                                             End:      ast.Location{Line:5, Column:23},
@@ -10402,6 +10477,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:7, Column:6},
                         End:      ast.Location{Line:7, Column:10},
@@ -10538,6 +10614,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -10694,6 +10771,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -10869,6 +10947,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:10},
@@ -10984,6 +11063,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:9},
@@ -11216,6 +11296,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:6},
                         End:      ast.Location{Line:3, Column:9},
@@ -11388,6 +11469,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:31},
                         End:      ast.Location{Line:1, Column:39},
@@ -11505,6 +11587,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:7},
                                 End:      ast.Location{Line:4, Column:15},
@@ -11675,6 +11758,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:34},
                             End:      ast.Location{Line:1, Column:35},
@@ -12084,6 +12168,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:19, Column:9},
                                 End:      ast.Location{Line:19, Column:17},
@@ -12216,6 +12301,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:27, Column:9},
                                 End:      ast.Location{Line:27, Column:14},
@@ -12391,6 +12477,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:35, Column:9},
                                 End:      ast.Location{Line:35, Column:12},
@@ -12470,6 +12557,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:36, Column:9},
                                 End:      ast.Location{Line:36, Column:12},

--- a/internal/parser/__snapshots__/stmt_test.snap
+++ b/internal/parser/__snapshots__/stmt_test.snap
@@ -446,6 +446,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
                                 End:      ast.Location{Line:4, Column:13},
@@ -586,6 +587,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
                                 End:      ast.Location{Line:1, Column:17},
@@ -599,6 +601,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
                                 End:      ast.Location{Line:1, Column:21},
@@ -1324,6 +1327,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
@@ -1337,6 +1341,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
                                 End:      ast.Location{Line:1, Column:28},
@@ -1447,6 +1452,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
@@ -1460,6 +1466,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:27},
                                 End:      ast.Location{Line:1, Column:28},
@@ -1570,6 +1577,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:16},
                                 End:      ast.Location{Line:1, Column:17},
@@ -1583,6 +1591,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:20},
                                 End:      ast.Location{Line:1, Column:21},
@@ -1688,6 +1697,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:17},
                             End:      ast.Location{Line:1, Column:18},
@@ -1712,6 +1722,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:28},
                             End:      ast.Location{Line:1, Column:29},
@@ -1913,6 +1924,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:19},
                                 End:      ast.Location{Line:1, Column:20},
@@ -1926,6 +1938,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:23},
                                 End:      ast.Location{Line:1, Column:24},
@@ -2104,6 +2117,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:12},
                                 End:      ast.Location{Line:4, Column:13},
@@ -2117,6 +2131,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:4, Column:16},
                                 End:      ast.Location{Line:4, Column:17},
@@ -2201,6 +2216,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:31},
                             End:      ast.Location{Line:1, Column:36},
@@ -2237,6 +2253,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:41},
                             End:      ast.Location{Line:1, Column:47},
@@ -2564,6 +2581,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:5},
                         End:      ast.Location{Line:2, Column:6},
@@ -2596,6 +2614,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:5},
                         End:      ast.Location{Line:3, Column:6},
@@ -2734,6 +2753,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:15},
                                             End:      ast.Location{Line:5, Column:16},
@@ -2773,6 +2793,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:15},
                                             End:      ast.Location{Line:6, Column:16},
@@ -2829,6 +2850,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:8, Column:5},
                         End:      ast.Location{Line:8, Column:8},
@@ -2995,6 +3017,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:21},
                         End:      ast.Location{Line:1, Column:29},
@@ -3081,6 +3104,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:53},
                                         End:      ast.Location{Line:1, Column:54},
@@ -3165,6 +3189,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:5},
                         End:      ast.Location{Line:2, Column:10},
@@ -3209,6 +3234,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:9},
                         End:      ast.Location{Line:3, Column:12},
@@ -3254,6 +3280,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:13},
                                             End:      ast.Location{Line:4, Column:17},
@@ -3320,6 +3347,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:6, Column:9},
                         End:      ast.Location{Line:6, Column:12},
@@ -3394,6 +3422,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:7, Column:19},
                                             End:      ast.Location{Line:7, Column:24},
@@ -3493,6 +3522,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:5},
                         End:      ast.Location{Line:2, Column:10},
@@ -3537,6 +3567,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:5},
                         End:      ast.Location{Line:3, Column:8},
@@ -3693,6 +3724,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:13},
                                             End:      ast.Location{Line:4, Column:19},
@@ -3811,6 +3843,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:35},
                         End:      ast.Location{Line:1, Column:39},
@@ -3916,6 +3949,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:5},
                         End:      ast.Location{Line:2, Column:10},
@@ -3960,6 +3994,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:5},
                         End:      ast.Location{Line:3, Column:11},
@@ -4040,6 +4075,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:21},
                         End:      ast.Location{Line:1, Column:29},
@@ -4126,6 +4162,7 @@
                                     Namespace: 0,
                                     VarID:     0,
                                     Source:    nil,
+                                    Owner:     nil,
                                     span:      ast.Span{
                                         Start:    ast.Location{Line:1, Column:53},
                                         End:      ast.Location{Line:1, Column:54},
@@ -4204,6 +4241,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:21},
                         End:      ast.Location{Line:1, Column:24},
@@ -4343,6 +4381,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:12},
                         End:      ast.Location{Line:2, Column:15},
@@ -4424,6 +4463,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:13},
                                             End:      ast.Location{Line:3, Column:14},
@@ -4437,6 +4477,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:17},
                                             End:      ast.Location{Line:3, Column:18},
@@ -4486,6 +4527,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:5, Column:5},
                         End:      ast.Location{Line:5, Column:8},
@@ -4567,6 +4609,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:13},
                                             End:      ast.Location{Line:6, Column:14},
@@ -4580,6 +4623,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:17},
                                             End:      ast.Location{Line:6, Column:18},
@@ -4673,6 +4717,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:11},
                         End:      ast.Location{Line:2, Column:20},
@@ -4816,6 +4861,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:18},
                         End:      ast.Location{Line:2, Column:30},
@@ -4927,6 +4973,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:5},
                         End:      ast.Location{Line:2, Column:8},
@@ -5006,6 +5053,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:11},
                         End:      ast.Location{Line:3, Column:14},
@@ -5112,6 +5160,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:4, Column:18},
                         End:      ast.Location{Line:4, Column:21},
@@ -5223,6 +5272,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:13},
                         End:      ast.Location{Line:2, Column:19},
@@ -5302,6 +5352,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:5},
                         End:      ast.Location{Line:3, Column:9},
@@ -5424,6 +5475,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:13},
                         End:      ast.Location{Line:2, Column:16},
@@ -5456,6 +5508,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:5},
                         End:      ast.Location{Line:3, Column:8},
@@ -5609,6 +5662,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:17},
                                             End:      ast.Location{Line:5, Column:20},
@@ -5648,6 +5702,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:17},
                                             End:      ast.Location{Line:6, Column:20},
@@ -5704,6 +5759,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:8, Column:13},
                         End:      ast.Location{Line:8, Column:16},
@@ -5730,6 +5786,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:8, Column:32},
                                             End:      ast.Location{Line:8, Column:36},
@@ -5796,6 +5853,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:9, Column:5},
                         End:      ast.Location{Line:9, Column:8},
@@ -5822,6 +5880,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:9, Column:24},
                                             End:      ast.Location{Line:9, Column:28},
@@ -5924,6 +5983,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:13},
                         End:      ast.Location{Line:2, Column:19},
@@ -6038,6 +6098,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:20},
                                             End:      ast.Location{Line:4, Column:26},
@@ -6094,6 +6155,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:6, Column:5},
                         End:      ast.Location{Line:6, Column:11},
@@ -6120,6 +6182,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:27},
                                             End:      ast.Location{Line:6, Column:31},
@@ -6222,6 +6285,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:13},
                         End:      ast.Location{Line:2, Column:19},
@@ -6336,6 +6400,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:20},
                                             End:      ast.Location{Line:4, Column:26},
@@ -6392,6 +6457,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:6, Column:13},
                         End:      ast.Location{Line:6, Column:19},
@@ -6418,6 +6484,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:35},
                                             End:      ast.Location{Line:6, Column:39},
@@ -6484,6 +6551,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:7, Column:5},
                         End:      ast.Location{Line:7, Column:9},
@@ -6606,6 +6674,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:9},
                         End:      ast.Location{Line:2, Column:14},
@@ -6720,6 +6789,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:16},
                         End:      ast.Location{Line:2, Column:22},
@@ -6834,6 +6904,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:16},
                         End:      ast.Location{Line:2, Column:22},
@@ -6866,6 +6937,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:9},
                         End:      ast.Location{Line:3, Column:14},
@@ -6928,6 +7000,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:48},
                                             End:      ast.Location{Line:3, Column:49},
@@ -7021,6 +7094,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:16},
                         End:      ast.Location{Line:2, Column:22},
@@ -7053,6 +7127,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:9},
                         End:      ast.Location{Line:3, Column:14},
@@ -7086,6 +7161,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:3, Column:40},
                                             End:      ast.Location{Line:3, Column:44},
@@ -7152,6 +7228,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:4, Column:9},
                         End:      ast.Location{Line:4, Column:14},
@@ -7214,6 +7291,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:48},
                                             End:      ast.Location{Line:4, Column:49},
@@ -7307,6 +7385,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:16},
                         End:      ast.Location{Line:2, Column:23},
@@ -7339,6 +7418,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:17},
                         End:      ast.Location{Line:3, Column:23},
@@ -7425,6 +7505,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:4, Column:17},
                         End:      ast.Location{Line:4, Column:23},
@@ -7487,6 +7568,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:4, Column:58},
                                             End:      ast.Location{Line:4, Column:59},
@@ -7580,6 +7662,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:2, Column:25},
                         End:      ast.Location{Line:2, Column:27},
@@ -7612,6 +7695,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:3, Column:14},
                         End:      ast.Location{Line:3, Column:21},
@@ -7765,6 +7849,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:5, Column:16},
                                             End:      ast.Location{Line:5, Column:18},
@@ -7804,6 +7889,7 @@
                                         Namespace: 0,
                                         VarID:     0,
                                         Source:    nil,
+                                        Owner:     nil,
                                         span:      ast.Span{
                                             Start:    ast.Location{Line:6, Column:21},
                                             End:      ast.Location{Line:6, Column:28},
@@ -7896,6 +7982,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:28},
                             End:      ast.Location{Line:1, Column:35},
@@ -7973,6 +8060,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:24},
                             End:      ast.Location{Line:1, Column:29},
@@ -8009,6 +8097,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:34},
                             End:      ast.Location{Line:1, Column:40},
@@ -8087,6 +8176,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:27},
                             End:      ast.Location{Line:1, Column:31},
@@ -8111,6 +8201,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:41},
                             End:      ast.Location{Line:1, Column:44},
@@ -8183,6 +8274,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:20},
                             End:      ast.Location{Line:1, Column:25},
@@ -8261,6 +8353,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:19},
                             End:      ast.Location{Line:1, Column:20},
@@ -8285,6 +8378,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:30},
                             End:      ast.Location{Line:1, Column:31},
@@ -8353,6 +8447,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:9},
                     End:      ast.Location{Line:1, Column:13},
@@ -8700,6 +8795,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:19},
             End:      ast.Location{Line:1, Column:29},
@@ -8745,6 +8841,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:13},
             End:      ast.Location{Line:1, Column:18},
@@ -8762,6 +8859,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:21},
                                 End:      ast.Location{Line:1, Column:28},
@@ -8791,6 +8889,7 @@
                             Namespace: 0,
                             VarID:     0,
                             Source:    nil,
+                            Owner:     nil,
                             span:      ast.Span{
                                 Start:    ast.Location{Line:1, Column:33},
                                 End:      ast.Location{Line:1, Column:37},
@@ -8861,6 +8960,7 @@
                                 Namespace: 0,
                                 VarID:     0,
                                 Source:    nil,
+                                Owner:     nil,
                                 span:      ast.Span{
                                     Start:    ast.Location{Line:1, Column:32},
                                     End:      ast.Location{Line:1, Column:33},
@@ -8958,6 +9058,7 @@
         Namespace: 0,
         VarID:     0,
         Source:    nil,
+        Owner:     nil,
         span:      ast.Span{
             Start:    ast.Location{Line:1, Column:21},
             End:      ast.Location{Line:1, Column:24},
@@ -9150,6 +9251,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:13},
                         End:      ast.Location{Line:1, Column:14},
@@ -9182,6 +9284,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:24},
                         End:      ast.Location{Line:1, Column:25},
@@ -9250,6 +9353,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:19},
                             End:      ast.Location{Line:1, Column:22},
@@ -9384,6 +9488,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:21},
                             End:      ast.Location{Line:1, Column:30},
@@ -9470,6 +9575,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:21},
                             End:      ast.Location{Line:1, Column:26},
@@ -9556,6 +9662,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:18},
                             End:      ast.Location{Line:1, Column:22},
@@ -9634,6 +9741,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:26},
                             End:      ast.Location{Line:1, Column:31},
@@ -9751,6 +9859,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:23},
                             End:      ast.Location{Line:1, Column:27},
@@ -9837,6 +9946,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:24},
                             End:      ast.Location{Line:1, Column:29},
@@ -9923,6 +10033,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:17},
                         End:      ast.Location{Line:1, Column:22},
@@ -10031,6 +10142,7 @@
                         Namespace: 0,
                         VarID:     0,
                         Source:    nil,
+                        Owner:     nil,
                         span:      ast.Span{
                             Start:    ast.Location{Line:1, Column:15},
                             End:      ast.Location{Line:1, Column:19},

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -750,6 +750,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
@@ -786,6 +787,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:8},
                     End:      ast.Location{Line:1, Column:9},
@@ -823,6 +825,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:16},
                         End:      ast.Location{Line:1, Column:17},
@@ -861,6 +864,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:24},
                         End:      ast.Location{Line:1, Column:25},
@@ -1523,6 +1527,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
@@ -1629,6 +1634,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},
@@ -1681,6 +1687,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:19},
                     End:      ast.Location{Line:1, Column:20},
@@ -1981,6 +1988,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:8},
                         End:      ast.Location{Line:1, Column:9},
@@ -2005,6 +2013,7 @@
                     Namespace: 0,
                     VarID:     0,
                     Source:    nil,
+                    Owner:     nil,
                     span:      ast.Span{
                         Start:    ast.Location{Line:1, Column:19},
                         End:      ast.Location{Line:1, Column:20},
@@ -2743,6 +2752,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:4},
@@ -2767,6 +2777,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:23},
                     End:      ast.Location{Line:1, Column:27},
@@ -3213,6 +3224,7 @@
                 Namespace: 0,
                 VarID:     0,
                 Source:    nil,
+                Owner:     nil,
                 span:      ast.Span{
                     Start:    ast.Location{Line:1, Column:2},
                     End:      ast.Location{Line:1, Column:3},

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1094,6 +1094,7 @@ func NewSelfParam(receiverType Type, mut bool) *FuncParam {
 		Type:    t,
 	}
 }
+
 type PropertyElem struct {
 	Name       ObjTypeKey
 	Optional   bool
@@ -2454,9 +2455,32 @@ func (t *IntrinsicType) String() string {
 	return PrintType(t, PrintConfig{})
 }
 
+// BindingOwner is the AST-declaration sumtype that introduces a value
+// binding (VarDecl, FuncDecl, ClassDecl — every kind that can carry
+// decorators per §3.3). Defined here rather than in `ast` because
+// `Binding` needs to name it, and the cycle `type_system → ast` would
+// otherwise close (ast already imports type_system for Type). AST
+// nodes opt in via an `IsBindingOwner()` marker method on their side
+// — exported because Go requires marker methods on cross-package
+// implementers to be exported.
+type BindingOwner interface {
+	IsBindingOwner()
+}
+
 // We want to model both `let x = 5` as well as `fn (x: number) => x`
 type Binding struct {
-	Source     provenance.Provenance // optional
+	// Source points at the AST node that *introduced* this name — for a
+	// destructuring `val {a, b} = …` that's the IdentPat for `a` or
+	// `b`, not the enclosing VarDecl. Used for diagnostics so error
+	// arrows point at the offending name, not the whole decl.
+	Source provenance.Provenance // optional
+	// Owner is the enclosing top-level declaration that produced this
+	// binding (the VarDecl, FuncDecl, or ClassDecl). Only set on
+	// top-level value-introducing bindings — param/local/match-arm
+	// bindings leave it nil. Carried so codegen can walk back to the
+	// declaration's decorators (e.g. `@js("Math.sin")`) without a
+	// re-lookup. See planning/builtins/implementation_plan.md §3.
+	Owner      BindingOwner
 	Type       Type
 	Assignable bool // can the binding name be rebound? (var = true, val = false)
 	Mutable    bool // can the underlying value be mutated through this name? (mut = true)

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -2573,6 +2573,7 @@ func (t *NamespaceType) Accept(v TypeVisitor) Type {
 			changed = true
 			newValues[name] = &Binding{
 				Source:     binding.Source,
+				Owner:      binding.Owner,
 				Type:       newType,
 				Assignable: binding.Assignable,
 				Mutable:    binding.Mutable,


### PR DESCRIPTION
## Summary

Implements the bulk of [planning/builtins/implementation_plan.md §3](planning/builtins/implementation_plan.md):

- **Loader rules §3.4(1-3)**: every exported value-level decl in a pseudo-package file must carry `@js("...")`; unexported value-level decls are rejected; unexported type-level decls are allowed (parser already forbids decorators on `declare type` / `interface`).
- **Codegen `@js` lowering**: pseudo-package references collapse to the declaration's `@js` argument. Bindings carry the lowering through a new `type_system.Binding.JSExpr` field; `IdentExpr` nodes carry it through a new `JSExpr` field stamped during inference. `MemberExpr` lowering looks up the property in the receiver's `NamespaceType` and replaces the whole member access with the parsed JS expression.
- **`new` insertion** for class callees (e.g. `Date()` → `new Date()`) works via the existing constructor-detection path; the class binding's `@js("Date")` lowers the callee identifier and `NewExpr` wraps it.

Existing `js:math` / `js:array` stubs gain `@js` decorators. The three binding-shape fixtures (`?local`, `?nested`, `?flat`) now all emit identical `Math.PI`, exercising the binding-shape-independence gate.

## Punted to PR B

- Rule 4 (`@js` target validation against `lib.*.d.ts` globals + allow-list).
- §3.5 fixtures for `parseInt`, Symbol re-export, and package-private invisibility — these need hand-authored stubs for `js:number` / `js:iterator` that belong to §7's stdlib bootstrap.

## Test plan

- [x] `go test ./...` green
- [x] Three new loader-rule tests in `internal/checker/tests/stdlib_import_test.go` (positive valid package, missing-`@js` negative, unexported-value-level negative)
- [x] Existing stdlib_import_{local,nested,flat,single_class} fixtures regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard library declarations can be annotated to map directly to JavaScript runtime expressions, enabling direct JS references in generated output.
  * Code generation now recognizes those mappings and emits dotted JS expressions (e.g., Math.sin) where applicable.

* **Bug Fixes**
  * JavaScript constants now reference their actual JS equivalents (e.g., PI → Math.PI).

* **Tests**
  * Added loader-rule tests to validate decorator usage and rejection cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->