### PR TITLE
Rework plans so that we don't need to do per-file inteface merging

### DIFF
--- a/internal/checker/tests/spike_aug_test.go
+++ b/internal/checker/tests/spike_aug_test.go
@@ -122,8 +122,9 @@ export val el = createElement("canvas")
 `
 	_, errs := inferSpike(t, src)
 	require.NotEmpty(t, errs)
-	require.Contains(t, errs[0].Message(),
-		`?flat name collision: "HTMLElementTagNameMap"`)
+	require.Equal(t,
+		`?flat name collision: "HTMLElementTagNameMap" is contributed by both "web:dom" and "web:canvas"; rename upstream or drop one import's ?flat flag`,
+		errs[0].Message())
 }
 
 // TestSpikeAugmentation_NestedNoMerge confirms that two ?nested
@@ -278,9 +279,15 @@ export val el = web.dom.createElement("canvas")
 	// If the leak occurred, errs is empty and el: HTMLCanvasElement.
 	// If FR9 is respected (current behavior), errs contains the
 	// "canvas" cannot be assigned to never rejection.
+	require.NotEmpty(t, errs)
+	var foundNever bool
 	for _, e := range errs {
-		t.Logf("err: %s", e.Message())
+		if e.Message() == `"canvas" cannot be assigned to never` {
+			foundNever = true
+		}
 	}
+	require.True(t, foundNever,
+		"expected sibling-leak rejection; got: %v", errs)
 }
 
 // TestSpikeAugmentation_SiblingMatchesImporter shows the corollary:

--- a/internal/checker/tests/spike_aug_test.go
+++ b/internal/checker/tests/spike_aug_test.go
@@ -1,0 +1,304 @@
+// Spike for planning/builtins/implementation_plan.md §4.1.
+//
+// Throwaway prototype that answers two architectural questions before
+// committing to a §4 implementation shape:
+//
+//  Q1. Can the existing checker machinery be parameterized by a
+//      per-importing-file "active augmentation set" derived from the
+//      file's resolved imports?
+//
+//  Q2. Does indexed access `HTMLElementTagNameMap[K]` re-resolve
+//      against the per-file augmentation set, or does it snapshot at
+//      registry-declaration time?
+//
+// We model a tiny slice of the web stdlib: `web:dom` declares an empty
+// `HTMLElementTagNameMap` registry and a generic
+// `createElement<K extends keyof HTMLElementTagNameMap>(tag: K) ->
+// HTMLElementTagNameMap[K]`. `web:canvas` augments the registry with
+// `canvas: HTMLCanvasElement` and re-exports `HTMLCanvasElement` as a
+// nominal class.
+//
+// Two scenarios:
+//   - importerHasCanvas: file imports both `web:dom` and `web:canvas`,
+//     calls `createElement("canvas")`.
+//   - importerNoCanvas: file imports only `web:dom`, calls
+//     `createElement("canvas")`.
+//
+// Per FR9, augmentation visibility is per-importing-file: the importer
+// scenario should see `HTMLCanvasElement`; the sibling scenario should
+// see `never` (or some "no such key" diagnostic).
+//
+// This file is committed as the §4.1 spike scaffolding. If the §4
+// implementation lands and obviates it, delete it.
+
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	. "github.com/escalier-lang/escalier/internal/checker"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
+)
+
+// stagedStdlib lays out a tiny stdlib data tree under a temp dir:
+//
+//	<tmp>/std/.keep        (placeholder; looksLikeStdlibDir requires std/)
+//	<tmp>/web/dom.esc      (base registry + createElement)
+//	<tmp>/web/canvas.esc   (augmentation + HTMLCanvasElement)
+//
+// The full path is returned and pre-loaded into ESCALIER_STDLIB_DIR.
+func stagedStdlib(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "std"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "web"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "std", ".keep"), nil, 0o644))
+
+	dom := `
+@js("document.createElement")
+export declare fn createElement<K: keyof HTMLElementTagNameMap>(tag: K) -> HTMLElementTagNameMap[K]
+
+export declare interface HTMLElementTagNameMap {}
+`
+	canvas := `
+import "web:dom?flat"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    width: number,
+    height: number,
+}
+
+export declare interface HTMLElementTagNameMap {
+    canvas: HTMLCanvasElement,
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(root, "web", "dom.esc"), []byte(dom), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "web", "canvas.esc"), []byte(canvas), 0o644))
+	t.Setenv("ESCALIER_STDLIB_DIR", root)
+	return root
+}
+
+func inferSpike(t *testing.T, src string) (map[string]string, []Error) {
+	t.Helper()
+	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	require.Empty(t, parseErrs)
+
+	c := NewChecker(ctx)
+	inferCtx := Context{Scope: Prelude(c)}
+	_, inferErrs := c.InferModule(inferCtx, module)
+
+	types := map[string]string{}
+	for name, b := range inferCtx.Scope.Namespace.Values {
+		types[name] = b.Type.String()
+	}
+	for name, ta := range inferCtx.Scope.Namespace.Types {
+		types["type:"+name] = ta.Type.String()
+	}
+	return types, inferErrs
+}
+
+// TestSpikeAugmentation_FlatCollision pins down the FR4 ?flat
+// collision behavior: two packages contributing the same interface
+// name into the same file scope error out. There is no implicit
+// cross-package merge under ?flat today.
+func TestSpikeAugmentation_FlatCollision(t *testing.T) {
+	stagedStdlib(t)
+	src := `
+import "web:dom?flat"
+import "web:canvas?flat"
+
+export val el = createElement("canvas")
+`
+	_, errs := inferSpike(t, src)
+	require.NotEmpty(t, errs)
+	require.Contains(t, errs[0].Message(),
+		`?flat name collision: "HTMLElementTagNameMap"`)
+}
+
+// TestSpikeAugmentation_NestedNoMerge confirms that two ?nested
+// imports keep their HTMLElementTagNameMap declarations as separate,
+// independent types — `web.dom.HTMLElementTagNameMap` and
+// `web.canvas.HTMLElementTagNameMap` are distinct, no augmentation
+// flows from canvas into dom.
+//
+// Q1 ("can the existing merge primitive support per-importing-file
+// activation?") answers NO at the language level: today the loader
+// produces two unrelated interface types, so any §4 implementation
+// must introduce *new* machinery to compose a merged view per file.
+func TestSpikeAugmentation_NestedNoMerge(t *testing.T) {
+	stagedStdlib(t)
+	src := `
+import "web:dom?nested"
+import "web:canvas?nested"
+
+export type CanvasViaDom = web.dom.HTMLElementTagNameMap["canvas"]
+export type CanvasViaCanvas = web.canvas.HTMLElementTagNameMap["canvas"]
+`
+	types, errs := inferSpike(t, src)
+	require.Empty(t, errs)
+	// Both indexed accesses print symbolically because the printer
+	// keeps IndexType as-is. The relevant signal is that they refer
+	// to TWO DIFFERENT registry interfaces, not a merged one.
+	require.Equal(t,
+		`web.dom.HTMLElementTagNameMap["canvas"]`,
+		types["type:CanvasViaDom"])
+	require.Equal(t,
+		`web.canvas.HTMLElementTagNameMap["canvas"]`,
+		types["type:CanvasViaCanvas"])
+}
+
+// TestSpikeAugmentation_CallSiteSnapshot pins down Q2: even when the
+// importing file has both packages in scope, `createElement("canvas")`
+// is rejected because `K: keyof HTMLElementTagNameMap` was resolved at
+// `createElement`'s declaration site (inside dom.esc) against the
+// empty registry — yielding `K: never`. The call-site does NOT
+// re-resolve `keyof T` / `T[K]` against the caller's active import
+// set. The constraint is snapshotted at declaration time.
+//
+// Q2 answers SNAPSHOT: indexed-access machinery would need explicit
+// re-resolution support added in §4 for any augmentation to be
+// observable, even if Q1's per-file merge existed.
+func TestSpikeAugmentation_CallSiteSnapshot(t *testing.T) {
+	stagedStdlib(t)
+	src := `
+import "web:dom?nested"
+import "web:canvas?nested"
+
+export val el = web.dom.createElement("canvas")
+`
+	_, errs := inferSpike(t, src)
+	require.NotEmpty(t, errs)
+	// The empty registry collapses K's bound to `never`, so the
+	// string literal "canvas" can't be passed in.
+	var foundNever bool
+	for _, e := range errs {
+		if e.Message() == `"canvas" cannot be assigned to never` {
+			foundNever = true
+		}
+	}
+	require.True(t, foundNever,
+		"expected snapshot-against-empty-registry rejection; got: %v", errs)
+}
+
+// TestSpikeAugmentation_FlatThenDeclareMergesIntoDom probes the
+// suggestion: have canvas.esc do `import "web:dom?flat"` first, then
+// declare its own `interface HTMLElementTagNameMap`. The hope was
+// that the in-namespace merge at infer_module.go:872 would mutate
+// dom's shared ObjectType, turning cross-package augmentation into
+// existing-mechanism merge.
+//
+// Result: the merge does NOT fire. `?flat` lands the import into
+// the per-scheme sub-namespace (`pkgNs.Namespaces["web"].Types["..."]`,
+// see bindStdlibFlat in infer_stdlib_import.go), while canvas's own
+// `interface HTMLElementTagNameMap` declaration lands at
+// `pkgNs.Types["HTMLElementTagNameMap"]`. The existing-alias check
+// in infer_module.go reads only the current namespace, finds
+// nothing, and creates a fresh ObjectType. The two interfaces stay
+// at distinct pointers.
+//
+// Even if we *did* hoist ?flat-imports into pkgNs.Types directly
+// (so the merge fired), the result would be GLOBAL augmentation —
+// the shared ObjectType.Elems mutation persists in the
+// PackageRegistry-cached namespace, so every later file that
+// imports `web:dom` (without importing canvas) would also see the
+// canvas member. That's the TS DOM-lib model, not FR9. So this
+// path is a dead end for per-file activation regardless of whether
+// the namespace plumbing were rewired.
+func TestSpikeAugmentation_FlatThenDeclareMergesIntoDom(t *testing.T) {
+	stagedStdlib(t)
+	src := `
+import "web:dom?nested"
+import "web:canvas?nested"
+`
+	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	require.Empty(t, parseErrs)
+	c := NewChecker(ctx)
+	inferCtx := Context{Scope: Prelude(c)}
+	_, inferErrs := c.InferModule(inferCtx, module)
+	require.Empty(t, inferErrs)
+
+	// Walk: web -> dom -> HTMLElementTagNameMap, then prune to
+	// underlying ObjectType and count elements. Same for canvas side.
+	// Look at the cached package namespaces directly via the
+	// PackageRegistry — they're what carry the underlying types.
+	domPkg, ok := c.PackageRegistry.Lookup("web:dom")
+	require.Truef(t, ok, "web:dom not in registry")
+	canvasPkg, ok := c.PackageRegistry.Lookup("web:canvas")
+	require.Truef(t, ok, "web:canvas not in registry")
+	asObject := func(label string, ns *type_system.Namespace) *type_system.ObjectType {
+		alias, ok := ns.Types["HTMLElementTagNameMap"]
+		require.Truef(t, ok, "no HTMLElementTagNameMap in %s", label)
+		obj, ok := type_system.Prune(alias.Type).(*type_system.ObjectType)
+		require.Truef(t, ok, "%s: not an ObjectType", label)
+		return obj
+	}
+	domObj := asObject("web:dom", domPkg)
+	canvasObj := asObject("web:canvas", canvasPkg)
+	require.Empty(t, domObj.Elems,
+		"expected dom's HTMLElementTagNameMap to stay empty (no cross-package leak)")
+	require.Len(t, canvasObj.Elems, 1,
+		"expected canvas's HTMLElementTagNameMap to have only its own member")
+	require.NotSame(t, domObj, canvasObj,
+		"expected dom and canvas to hold distinct ObjectType instances")
+}
+
+// TestSpikeAugmentation_FlatThenDeclareSiblingLeak is the
+// per-file-activation probe: a sibling file imports ONLY web:dom
+// (NOT web:canvas), but the same Checker also loaded web:canvas via
+// another file's import. If canvas.esc's interface decl mutated
+// dom's shared ObjectType during canvas's own load, this sibling
+// will see `createElement("canvas")` succeed — which violates FR9.
+func TestSpikeAugmentation_FlatThenDeclareSiblingLeak(t *testing.T) {
+	stagedStdlib(t)
+	// Single source unit can't have two "files" in the current test
+	// helper. Instead, simulate the leak by loading canvas (which is
+	// what binds it into the per-Checker PackageRegistry), then
+	// having the importing file import only dom.
+	src := `
+import "web:canvas?nested"
+import "web:dom?nested"
+
+export val el = web.dom.createElement("canvas")
+`
+	_, errs := inferSpike(t, src)
+	// If the leak occurred, errs is empty and el: HTMLCanvasElement.
+	// If FR9 is respected (current behavior), errs contains the
+	// "canvas" cannot be assigned to never rejection.
+	for _, e := range errs {
+		t.Logf("err: %s", e.Message())
+	}
+}
+
+// TestSpikeAugmentation_SiblingMatchesImporter shows the corollary:
+// a sibling file without the canvas import sees the *same* `never`
+// rejection. The visibility difference §4 needs (importer succeeds,
+// sibling fails) is invisible to the current pipeline because neither
+// scenario succeeds — both are blocked by the snapshot at declaration
+// time, regardless of which packages the file imports.
+func TestSpikeAugmentation_SiblingMatchesImporter(t *testing.T) {
+	stagedStdlib(t)
+	src := `
+import "web:dom?nested"
+
+export val el = web.dom.createElement("canvas")
+`
+	_, errs := inferSpike(t, src)
+	require.NotEmpty(t, errs)
+	require.Equal(t,
+		`"canvas" cannot be assigned to never`,
+		errs[0].Message())
+}

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -16,11 +16,11 @@ Status legend: ✅ done, 🚧 partial, ⬜ not started.
 | 1   | Declaration-printer audit                            | FR14        | ✅      | —          | Audit test lives in [internal/printer/print_decl_audit_test.go](../../internal/printer/print_decl_audit_test.go); every in-scope form round-trips. Notes on converter-side syntax decisions below.                                                  |
 | 2   | URI-scheme imports + binding-shape flags             | FR2–FR5     | ✅      | §1         | Parser, resolver, all three binding shapes, single-class shortcut, `?flat` collisions, and the `--stdlib-dir` flag (+ env var, sibling-to-exe, repo-relative discovery) all landed. Gate satisfied via `std:math` and `std:array` stubs; unit + fixture coverage in place. Two follow-ups deferred to later sections — see §8 for the two-package `?flat` `web` fixture, §7 for the FR5 "non-class package exports as namespace members on the same binding" surface. |
 | 3   | Codegen lowering and `@js` decorators                | FR3         | ✅      | §1         | Decorator parser, `@js` codegen lowering, and loader rules §3.4(1-4) all landed. The §3.5 fixtures that need `std:number` / `std:iterator` stubs (`parseInt`, Symbol re-export, package-private invisibility) moved to §7 where the stubs live.                            |
-| 4   | Cross-package augmentation + inter-package imports   | FR6–FR9     | ⬜      | §2         | Confirm §6 interface-merge can be reused for cross-package augmentation (registry interfaces only) with per-importing-file activation. Pseudo-package import cycles are permitted. Well-known symbols stay on `Symbol`; domain packages re-export aliases (FR8). |
+| 4   | Single `web:dom` package + inter-package imports     | FR6, FR7 (deferred), FR8, FR9 (deferred) | ⬜ | §2 | MVP collapses the entire DOM tree (HTML/SVG/MathML/CSSOM/observers/events/...) into one `web:dom` package with closed registries; standalone web APIs (Fetch, Streams, Crypto, Workers, WebGL, …) get sibling `web:*` packages that thread `web:dom` types through via qualified references (§4.2). `createElementNS` stays one overloaded method on `Document`, matching WebIDL. Pseudo-package import cycles permitted (§4.3). Well-known symbols stay on `Symbol`; domain packages re-export aliases (FR8). FR7 (per-file cross-package augmentation) and FR9 (its activation semantics) are deferred to a future custom-elements workstream; the §4.1 spike scaffolding under [internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go) is kept as a regression harness. |
 | 5   | Converter MVP (`tools/dts_to_esc/`)                  | FR10        | ⬜      | §1, §3     | Two tiny slices: a trio-idiom class (`Boolean`) and a small `declare namespace` block (e.g. `JSON`). AST-to-AST translation; emit to stdout; no partition logic. Exercises trio recognition + namespace flattening; emits `@js` decorators per §3. |
 | 6   | Converter productionization                          | FR10        | ⬜      | §5         | Partition table; full output paths under `internal/interop/data/{std,web}/`; `--check` mode; full `lib.*.d.ts` input set; registry/well-known-symbol routing.                                                                                        |
 | 7   | Stdlib bootstrap (committed `.esc` files)            | FR1–FR2     | ⬜      | §6         | Run the converter once; review; hand-edit high-value `throws`, lifetimes, mutability; commit.                                                                                                                                                        |
-| 8   | Internal fixture migration                           | (precedes §9) | ⬜ | §4, §7    | Migrate Escalier's own fixtures to `import "std:*"`. Must land **before §9** so the prelude switchover doesn't break the test suite. Requires §7 because the imports resolve against the committed `.esc` files; requires §4 for any fixture that touches DOM-style augmentation. The legacy prelude still resolves previously-ambient names side-by-side until §9 deletes it. |
+| 8   | Internal fixture migration                           | (precedes §9) | ⬜ | §4, §7    | Migrate Escalier's own fixtures to `import "std:*"`. Must land **before §9** so the prelude switchover doesn't break the test suite. Requires §7 because the imports resolve against the committed `.esc` files; requires §4 for any fixture that touches inter-package imports / the single-`web:dom` package + cross-package type references. The legacy prelude still resolves previously-ambient names side-by-side until §9 deletes it. |
 | 9   | Prelude switchover + override deletion               | FR11, FR12  | ⬜      | §2, §4, §7, §8 | Replace `lib.*.d.ts` walking in [prelude.go](../../internal/checker/prelude.go) with the per-file shape loader. Delete the legacy `BuildBuiltinStore` / `loadGlobalDefinitions` / `populateSelfParams` / `UpdateMethodMutability` / `mergeReadonlyVariant` / `mutabilityOverrides` paths in the same PR — pre-1.0, no deprecation cycle. Also migrate loader rule §3.4(4) (`@js` arg validation): move it out of the loader (currently reads `GlobalScope.Namespace.Values` in [js_globals.go](../../internal/checker/js_globals.go)) into a CI-only test under [internal/checker/tests/](../../internal/checker/tests/) that freshly parses the pinned `lib.*.d.ts` and validates every `@js("...")` arg across the committed stdlib. Delete `js_globals.go` and the rule-4 branch in [js_decorator.go](../../internal/checker/js_decorator.go) in the same PR. Same CI-only test should add **rule §3.4(5): `@js` decl shape matches lib target** — locate the lib member named by each `@js("...")` and assert: `readonly` / getter-only lib member ⇒ Escalier decl is `val` (or `get`), never `var`; setter-only ⇒ `set`; method ⇒ `fn`. Catches stdlib stubs that silently make readonly things look writable (today `@js("Math.PI") export declare var PI: number` compiles and lowers to a `Math.PI = ...` that TypeErrors at runtime). Rule 5 shares the lib parser with rule 4, so doing them separately would duplicate the parse. |
 | 10  | Intrinsics, adaptive rendering, LSP support          | FR13, FR15, FR16 | ⬜ | §9      | Implement adaptive diagnostic rendering (FR15) and the auto-import quick-fix (FR16); verify `Awaited<T>` source-level definition with documented-fallback policy; confirm intrinsic handlers stay checker-resident (FR13).                                                                                                          |
 
@@ -34,12 +34,15 @@ edges shown — transitive deps omitted for clarity):
 ```
 
 Two lanes diverge from §1 and reconverge at §8: the upper lane
-(§2 → §4) builds the resolver and augmentation machinery; the
-lower lane (§3 → §5 → §6 → §7) builds the decorator parser,
-the converter, and the committed `.esc` files. §8 needs both
-lanes — fixtures import the `.esc` files via the resolver, and
-any DOM-touching fixture relies on augmentation. §9 cuts over
-the prelude; §10 adds LSP/diagnostic tooling on top.
+(§2 → §4) builds the resolver and inter-package import
+machinery (including the cycle handling needed for sibling
+`web:*` packages that mutually reference `web:dom`); the lower
+lane (§3 → §5 → §6 → §7) builds the decorator parser, the
+converter, and the committed `.esc` files. §8 needs both lanes
+— fixtures import the `.esc` files via the resolver, and any
+cross-package-typed fixture relies on §4.2b qualified type
+references. §9 cuts over the prelude; §10 adds LSP/diagnostic
+tooling on top.
 
 **Step ordering rationale.** §1 is first because a failed audit
 forces parser work that gates everything else. §2 (resolver),
@@ -49,8 +52,9 @@ no internal dependency beyond the audit, so the implementer is
 free to land them in any order (or interleave). §3 must land
 before §5 lands its decorator
 emission step; §3 must also land before any fixture exercises
-codegen end-to-end. §4 lands after §2 because augmentation tests
-need real `import` statements. §7 produces the source-of-truth
+codegen end-to-end. §4 lands after §2 because the inter-package
+import / cycle tests need real `import` statements. §7 produces
+the source-of-truth
 `.esc` files. §8 migrates internal fixtures to `import "std:*"`
 while the legacy prelude is still live; §9 then swaps the prelude
 and deletes the legacy paths in a single cut (pre-1.0, no
@@ -60,8 +64,9 @@ deprecation cycle); §10 adds the LSP / diagnostic tooling on top.
 change that swaps the prelude, so existing fixtures must already
 be migrated to `import "std:*"`. §8 is feasible once §7 has
 committed the `.esc` files (so imports actually resolve) and §4
-has landed (so any DOM-touching fixture can use augmentation);
-the resolver from §2 is in place transitively via §7. The legacy
+has landed (so any DOM-touching fixture can use the
+single-`web:dom` package + cross-package type references); the
+resolver from §2 is in place transitively via §7. The legacy
 prelude still resolves previously-ambient names side-by-side
 during the fixture-rewriting commit, then §9 removes it. §10
 (LSP, adaptive rendering, intrinsic verification) has no
@@ -304,9 +309,9 @@ it lazily on first scheme-prefixed import.
   for the colliding name; compilation does not proceed past
   the resolver. See "Error taxonomy" cross-cutting section.
 - Internal bookkeeping (whether a file has loaded a package's
-  augmentations / declarations) keys on the package's full URI
-  (`web:canvas`), independent of binding-shape flag. This
-  applies uniformly across `?local`, `?nested`, and `?flat`.
+  declarations) keys on the package's full URI (`web:fetch`),
+  independent of binding-shape flag. This applies uniformly
+  across `?local`, `?nested`, and `?flat`.
 - **Mutually exclusive:** combining any two of `?local`,
   `?nested`, `?flat` on one URI is a compile error; the
   resolver reports which flag pair is invalid.
@@ -578,168 +583,387 @@ data directory (§2.2a). User code is free of these constraints.
 
 ---
 
-## §4. Cross-package augmentation + inter-package imports (FR6–FR9)
+## §4. Single `web:dom` package + inter-package imports (FR6, FR7 deferred, FR8, FR9 deferred)
 
-**Goal.** A file that imports `web:canvas` sees
-`createElement("canvas") → HTMLCanvasElement`; a sibling file
-without the import does not. Inter-package imports between
-pseudo-packages work, including cycles. (Well-known symbols are
-**not** augmented — all of them live on `Symbol`'s static side
-in `std:symbol`; domain packages re-export them as plain
-aliases per FR8, no augmentation machinery involved.)
+**Goal.** Inter-package imports between pseudo-packages work,
+including cycles. The entire DOM tree (Document, Element, every
+HTML/SVG/MathML element class, CSSOM, observers, animations,
+events, custom elements, etc.) lives in a **single `web:dom`
+package** with all its registries (`HTMLElementTagNameMap`,
+`SVGElementTagNameMap`, `MathMLElementTagNameMap`,
+`HTMLElementEventMap`, …) declared closed alongside the methods
+that key on them. Standalone web APIs that ship in
+`lib.dom.d.ts` without DOM coupling (Fetch, Streams, Crypto,
+Workers, WebGL, Web Audio, WebRTC, WebCodecs, IndexedDB, Service
+Workers, WebSocket, Storage, URL, Encoding, File, Performance,
+WebAuthn, Payments) occupy sibling `web:*` packages and reference
+`web:dom` types via qualified names. Cross-package augmentation
+is sidestepped entirely. (Well-known symbols live on `Symbol`'s
+static side in `std:symbol`; domain packages re-export them as
+plain aliases per FR8, no augmentation machinery involved.)
 
-### 4.1 Confirm the augmentation mechanism
+**FR7 / FR9 are deferred for MVP.** True per-file cross-package
+augmentation — the original §4.2 design where `web:canvas`
+augmented `web:dom`'s `HTMLElementTagNameMap`, as specified in
+[requirements.md FR7](requirements.md#fr7-dom-packaging-cross-package-type-references-open-augmentation-deferred)
+and [requirements.md FR9 (deferred spec in appendix)](requirements.md#appendix-deferred-fr9-spec) —
+is **not** implemented. The §4.1 spike found that achieving FR9
+(per-file activation) would require two distinct new pieces of
+checker machinery (per-file composition layer + call-site
+re-resolution of `keyof T` / `T[K]`), neither of which is a small
+wrapper around existing code. Rather than build those subsystems,
+the partition is restructured so cross-package augmentation is
+not needed at all: the DOM is one cohesive package, and the only
+cross-package coupling is the standalone-web-API edge cases that
+qualified type references handle cleanly. The spike scaffolding
+remains under
+[internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go)
+as documentation for the deferred custom-elements work.
 
-The [§5 (interop_mutability)](../interop_mutability/implementation_plan.md#5-override-file-format-loader--merge)
-override-merge code already does interface merging at a fixed
-merge point. Cross-package
-augmentation needs the same primitive applied **per importing
-file**: the same `interface HTMLElementTagNameMap` is merged
-with different augmentation sets depending on which packages the
-checking file has imported.
+### 4.1 Spike findings (informing the MVP punt)
 
-Decision required up-front (before writing more code): does the
-existing merge code support per-file scoping, or does
-augmentation need its own loader path? Output of this
-investigation lives in a short note appended to this section.
+The §4.1 spike was originally a gate on the §4.2 augmentation
+implementation. Its output reshaped §4 instead: the work is
+deferred and §4.2 is rewritten around closed registries. The
+findings below remain the authoritative reference for what true
+cross-package augmentation would require if a future workstream
+(custom elements; third-party DOM extensions) needs it.
 
-**Pre-§4 spike (gates the rest of §4).** Before committing to
-the §4 implementation shape, run a time-boxed spike (≤3 days)
-that answers two questions concretely:
+Prototype landed in
+[internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go).
+Stages a two-file stdlib (`web/dom.esc` + `web/canvas.esc`) under a
+temp `ESCALIER_STDLIB_DIR` and runs scenarios encoded as
+assertions so future drift breaks the build.
 
-1. Can the existing `internal/interop/` merge primitive be
-   parameterized by an "active augmentation set" derived from
-   the importing file's resolved imports? Build a throwaway
-   two-file fixture (`web/web.esc` with empty
-   `HTMLElementTagNameMap`; `web/canvas.esc` augmenting it) and
-   wire just enough to make `createElement("canvas")` narrow
-   in the importing file and not in a sibling.
-2. Does indexed access (`HTMLElementTagNameMap[K]`) re-resolve
-   against the per-file augmentation set, or does it snapshot
-   at registry-declaration time?
+**Q1: Can the existing `internal/interop/` merge primitive be
+parameterized by a per-importing-file active augmentation set?**
+**No.** Two findings:
 
-If question 1's answer is "no", the spike output documents the
-shape of the new loader path needed (rough Go interface +
-estimated PR count) so §4's scope is sized realistically before
-work starts. If question 2's answer is "snapshot", the indexed-
-access machinery is added to §4's work items.
+1. The interop `Merge`/`Collapse` pipeline
+   ([merge.go](../../internal/interop/merge.go)) operates at a single
+   global collapse point producing one static `OverrideStore`; it
+   has no notion of a per-importer view.
+2. The Escalier-internal interface merge in
+   [infer_module.go:1026-1052](../../internal/checker/infer_module.go)
+   merges only *within the same namespace* (mutates a shared
+   `ObjectType.Elems`). Two `interface HTMLElementTagNameMap { … }`
+   declarations in two different `.esc` packages produce two
+   **distinct, unrelated** type aliases today —
+   `TestSpikeAugmentation_NestedNoMerge` pins this:
+   `web.dom.HTMLElementTagNameMap["canvas"]` and
+   `web.canvas.HTMLElementTagNameMap["canvas"]` are separate types.
 
-The spike's deliverable is a short note appended to this
-section (committed before §4 implementation begins) — yes/no on
-each question, with the prototype code linked if it's worth
-keeping.
+   Under `?flat`, the same-name re-export hits the existing FR4
+   collision (`TestSpikeAugmentation_FlatCollision`) — the ?flat path
+   doesn't silently merge either, it errors. So no existing channel
+   composes the two declarations.
 
-Touch points:
-- [internal/interop/](../../internal/interop/) — existing merge.
-- [internal/checker/infer_import.go](../../internal/checker/infer_import.go) —
-  per-file scope assembly.
+3. Variant tried: have `web/canvas.esc` do `import "web:dom?flat"`
+   *first*, then declare `interface HTMLElementTagNameMap { … }`,
+   hoping the in-namespace merge would mutate dom's shared
+   `ObjectType.Elems`
+   (`TestSpikeAugmentation_FlatThenDeclareMergesIntoDom`). The merge
+   does **not** fire: `?flat` lands the import into the per-scheme
+   sub-namespace
+   (`pkgNs.Namespaces["web"].Types["HTMLElementTagNameMap"]`, see
+   `bindStdlibFlat` in
+   [infer_stdlib_import.go](../../internal/checker/infer_stdlib_import.go)),
+   while canvas's own `interface` lands at
+   `pkgNs.Types["HTMLElementTagNameMap"]`. The existing-alias check
+   only reads the current namespace, finds nothing, and creates a
+   fresh `ObjectType` at a different pointer. Even if we rewired
+   ?flat to deposit into `pkgNs.Types` directly so the merge *would*
+   fire, the result would be **global** augmentation — the mutation
+   sits in the PackageRegistry-cached namespace and every later
+   importer of `web:dom` would see the canvas member regardless of
+   whether they imported canvas. That's the TS DOM-lib model, not
+   FR9. Dead end for per-file activation either way.
 
-### 4.2 Open-registry augmentation (FR7)
+If we wanted the per-element-family split, §4.2 would need
+**new** machinery (not a reuse of interop's merge): a
+per-importing-file pass that, given F's resolved scheme-imports,
+builds a composed view of each registry interface by collecting
+all contributing declarations across the active set. The MVP
+sidesteps the requirement by collapsing the DOM tree into a
+single `web:dom` package — see §4.2.
 
-- `web:dom` declares the registries
-  (`HTMLElementTagNameMap`, `HTMLElementEventMap`,
-  `SVGElementTagNameMap`, `MathMLElementTagNameMap`, …) with
-  empty bodies and writes the registry-keyed APIs
-  (`createElement`, `querySelector`, `getElementsByTagName`,
-  `createElementNS`) against them. The element families
-  themselves (`HTMLCanvasElement`, `SVGCircleElement`,
-  `MathMLElement`, …) live in their feature packages — the
-  registry interface is a contract slot; `web:dom` never
-  references the element classes directly.
-- Feature packages augment **only** the registry, not the API:
-  `web:canvas` adds `{ canvas: HTMLCanvasElement }` to
-  `HTMLElementTagNameMap`; `web:svg` adds
-  `{ circle: SVGCircleElement, path: SVGPathElement, … }` to
-  `SVGElementTagNameMap`.
-- Activation is per-importing-file (FR9): the augmentation is
-  visible iff the importing file imports the augmenting package
-  (under any binding-shape flag).
-- Augmentations propagate via **explicit re-export** only:
-  `export * from "web:canvas"` in file A makes A's importers see
-  canvas's augmentations; a bare `import "web:canvas"` in A does
-  not leak.
-- Sibling file without the import sees `never` (or the
-  pre-augmentation shape) from the indexed access, surfacing the
-  missing import.
+**Q2: Does indexed access (`HTMLElementTagNameMap[K]`) re-resolve
+against the per-file augmentation set, or snapshot at
+registry-declaration time?**
+**Snapshot.** `TestSpikeAugmentation_CallSiteSnapshot` and
+`TestSpikeAugmentation_SiblingMatchesImporter` together show that
+`createElement<K: keyof HTMLElementTagNameMap>(tag: K) -> …` resolves
+its bound `keyof HTMLElementTagNameMap` at *declaration time inside
+`web:dom`*, against the empty registry — yielding `K: never`. The
+caller's import set has no effect: both the importer-with-canvas
+scenario and the sibling-without-canvas scenario reject
+`createElement("canvas")` with the identical
+`"canvas" cannot be assigned to never`.
 
-**Language requirements verified at this phase.** Output of
-§4.1's investigation must confirm both:
+Even if Q1's per-file merge machinery existed, `createElement`'s
+constraint would still be the snapshot. The deferred augmentation
+workstream would additionally need to teach the indexed-access /
+`keyof` machinery to re-resolve against the caller-file's active
+augmentation view — or rewrite registry-keyed APIs to thread the
+merged registry in differently (e.g. by defining them in a way
+that the merged view substitutes through). MVP avoids both by
+declaring the registries closed inside `web:dom`, where the
+snapshot is against the populated map and Just Works (§4.2).
 
-1. **Open interfaces / cross-package interface merging** — the
-   [§5 (interop_mutability)](../interop_mutability/implementation_plan.md#5-override-file-format-loader--merge)
-   merge code can be applied per importing file, or a new
-   loader path is built.
-2. **Indexed access over open registries** refreshes correctly
-   when the registry is augmented:
-   `HTMLElementTagNameMap[K]` where
-   `K extends keyof HTMLElementTagNameMap` must pick up the
-   augmented entries in the importing file's view, not a
-   snapshot taken at registry-declaration time.
+**Implications for §4 sizing.** Both gates failed; rather than
+take on the new checker machinery, §4 is reshaped around a
+**single `web:dom` package** with closed registries (see §4.2).
+The augmentation work is recorded here for the deferred
+custom-elements workstream:
 
-If either fails, the gap becomes a follow-up issue blocking §4
-completion.
+- **(Deferred) per-file composition layer:** would need new
+  loader/composition code. Likely its own PR.
+- **(Deferred) call-site re-resolution of `keyof T` / `T[K]`
+  when T is an augmentable interface:** would need new checker
+  plumbing. Likely its own PR.
 
-### 4.2a No `override declare` for builtins (FR7)
+### 4.2 Single `web:dom` package + standalone web siblings (replaces the original FR7 / FR9 design)
+
+**Single `web:dom` package.** The entire DOM tree — Document,
+Element, Node, Window, Navigator, every HTML / SVG / MathML
+element class, every registry interface
+(`HTMLElementTagNameMap`, `SVGElementTagNameMap`,
+`MathMLElementTagNameMap`, `HTMLElementEventMap`,
+`SVGElementEventMap`, `MathMLElementEventMap`, …), CSSOM,
+XML/XPath/parsing, selection, range, history, navigation,
+input/pointer/keyboard/touch events, drag-and-drop, observers
+(Intersection/Resize/Mutation), Web Animations, custom
+elements, fullscreen, picture-in-picture, view transitions —
+lives in **one** `web:dom` package. The registries are declared
+**closed** alongside the methods that key on them:
+
+```escalier
+// In web:dom
+interface Document {
+    fn createElement<K: keyof HTMLElementTagNameMap>(
+        self, tag: K
+    ) -> HTMLElementTagNameMap[K]
+
+    fn createElementNS<K: keyof SVGElementTagNameMap>(
+        self,
+        ns: "http://www.w3.org/2000/svg",
+        qualifiedName: K
+    ) -> SVGElementTagNameMap[K]
+
+    fn createElementNS<K: keyof MathMLElementTagNameMap>(
+        self,
+        ns: "http://www.w3.org/1998/Math/MathML",
+        qualifiedName: K
+    ) -> MathMLElementTagNameMap[K]
+
+    // ... XHTML overload, generic fallback overload
+}
+
+interface HTMLElementTagNameMap {
+    canvas: HTMLCanvasElement,
+    div: HTMLDivElement,
+    // ... every HTML tag
+}
+
+interface SVGElementTagNameMap {
+    circle: SVGCircleElement,
+    path: SVGPathElement,
+    // ... every SVG tag
+}
+```
+
+`createElementNS` stays one method on `Document` with its
+NS-keyed overload set declared once — matching WebIDL exactly,
+no API rename, no cross-package method merge.
+
+**Standalone web siblings.** Families that ship in
+`lib.dom.d.ts` but have no DOM coupling (no dependency on
+`Document` / `Element` / `Event`) split into their own
+pseudo-packages. Initial set, drawn from a survey of
+`lib.dom.d.ts` (final list in §6.1's partition table):
+
+| Package | Surface |
+|---|---|
+| `web:fetch` | Request, Response, Headers, Body, FormData, XHR |
+| `web:streams` | Readable/Writable/Transform streams + queuing strategies |
+| `web:crypto` | Crypto, SubtleCrypto, algorithm dicts, JsonWebKey |
+| `web:workers` | Worker, SharedWorker, MessagePort/Channel, BroadcastChannel |
+| `web:webgl` | WebGL 1/2 contexts + extensions |
+| `web:web_audio` | Web Audio API + WebCodecs Audio* |
+| `web:web_rtc` | RTC*, MediaStream, MediaDevices |
+| `web:web_codecs` | Video/AudioEncoder/Decoder, EncodedChunk, VideoFrame |
+| `web:indexeddb` | IDB* |
+| `web:service_worker` | ServiceWorker, Cache, Push, Notifications |
+| `web:websocket` | WebSocket, EventSource |
+| `web:storage` | localStorage, sessionStorage, StorageManager |
+| `web:url` | URL, URLSearchParams |
+| `web:encoding` | TextEncoder, TextDecoder |
+| `web:file` | Blob, File, FileReader, FileSystemHandle / FS Access |
+| `web:performance` | Performance*, PerformanceObserver |
+| `web:webauthn` | Credentials, PublicKey |
+| `web:payments` | Payment Request API |
+
+(Small one-offs — geolocation, gamepad, clipboard, permissions,
+speech, midi, locks, idle, screen/wake-lock, sensors — live in
+`web:dom` for MVP unless a user needs to import a narrow slice
+without the full DOM surface. Promote to standalone packages
+later if that need is real. See §6.1.)
+
+**Why one big `web:dom` works.** The §4.1 spike showed that
+splitting along element-family lines would require two new
+checker subsystems. Collapsing the DOM tree into one package
+gets the same user-visible narrowing for `createElement(tag) →
+ConcreteElement` and `createElementNS(svgNS, tag) →
+SVGConcreteElement` using only the existing type system — every
+registry is a normal closed `ObjectType`, every `keyof T` / `T[K]`
+resolves at declaration time against the populated map. The
+DOM is genuinely a cohesive surface (`Element.parentNode` walks
+across HTML / SVG / MathML; events bubble across the same tree);
+splitting it into per-family packages was a partition that
+didn't reflect the API.
+
+**What's lost.** Two cases that the original split-DOM design
+contemplated are not expressible in the single-`web:dom` model:
+
+1. **User-side custom-element registration** — code like
+   `declare module "web:dom" { interface HTMLElementTagNameMap
+   { "my-widget": MyWidget } }`. Punted to a later workstream
+   (custom elements). Users can type custom-element results
+   manually until then.
+2. **Third-party packages adding overloads to `web:dom` methods**
+   or extending its event maps. Out of scope for the builtins
+   workstream regardless; would be a third-party concern.
+
+### 4.2a No `override declare` for builtins
 
 The `override declare` syntax — designed for the third-party
-workstream's override mechanism — is **not** used for builtin
-augmentation. Pseudo-package augmentation uses plain
-`declare interface Foo { … }` blocks added to the augmenting
-package's `.esc` file. The converter (§6) must emit
-augmentation blocks in plain `declare interface` form, not
-`override declare`. Reviewers of §7 verify this on the
-committed files.
+workstream's override mechanism — is **not** used for any
+builtin `.esc` file. All builtin declarations are plain
+`declare class` / `declare interface` / `declare fn`. The
+converter (§6) emits in plain form; reviewers of §7 verify on
+the committed files.
 
-### 4.2b Per-API augmentation fallback (FR7)
+### 4.2b Cross-package type references (primary pattern, supersedes old fallback)
 
-For the rare cross-package API that does not fit a registry
-pattern, the requirements specify two fallback patterns. Track
-each occurrence in the partition table (§6.1) so it is
-deliberately classified, not silently mis-routed:
+Any API in one pseudo-package that needs to mention a type from
+another pseudo-package does so via a **qualified type reference**.
+The owning package exports the type; the consuming package
+references it through its imported namespace. No augmentation
+machinery involved.
 
-1. **Parameter-typed APIs** — the feature package exports the
-   type; `web:dom` references it via the type's qualified name;
-   no augmentation needed.
-2. **String-overload APIs without a registry** — the feature
-   package augments the API's overload set directly. Rare;
-   treated case-by-case when it arises.
+Example shapes (drawn from the actual partition):
 
-The converter records candidate per-API augmentations in a
-log so reviewers can confirm the classification during §7
-bootstrap review.
+1. **Standalone web API referencing a `web:dom` type** —
+   `web:webgl`'s context constructor takes an
+   `HTMLCanvasElement`:
+   ```escalier
+   // In web:webgl
+   import "web:dom"
+
+   declare fn getContext(
+       canvas: web.dom.HTMLCanvasElement,
+       contextId: "webgl"
+   ) -> WebGLRenderingContext
+   ```
+2. **Standalone web API referencing another standalone API** —
+   `web:fetch`'s `Response.body` returns a stream from
+   `web:streams`:
+   ```escalier
+   // In web:fetch
+   import "web:streams"
+
+   interface Response {
+       body: web.streams.ReadableStream | null,
+       // ...
+   }
+   ```
+3. **`web:dom` referencing a standalone API** — `web:dom`'s
+   `HTMLCanvasElement.getContext` returns a WebGL context from
+   `web:webgl` (creating a mutual import; cycles between
+   pseudo-packages are permitted per FR6 / §4.3). In practice
+   the converter often inverts the direction here — keeping
+   `getContext` typed in `web:dom` with a forward reference and
+   the implementation type living in `web:webgl` — to keep
+   cycle-count minimal.
+
+Tracking: the partition table (§6.1) records every
+cross-package type reference so reviewers can confirm the
+direction (which package owns the type) during §7 bootstrap.
+
+The original "string-overload APIs without a registry" fallback
+is dropped — the single-`web:dom` rule eliminates this case by
+construction (every string-overload API and its registry
+co-locate in `web:dom`).
 
 ### 4.3 Inter-package imports + cycles (FR6)
 
 - Pseudo-packages `import` other pseudo-packages explicitly
-  (e.g. `web/canvas.esc` does `import "web:dom"` to extend
-  `HTMLElement`).
+  (e.g. `web/webgl.esc` does `import "web:dom"` to reference
+  `web.dom.HTMLCanvasElement` in a parameter type per §4.2b;
+  `web/fetch.esc` does `import "web:streams"` to reference
+  `web.streams.ReadableStream` in `Response.body`).
 - **Cycles between pseudo-packages are permitted.** The
   resolver / `internal/dep_graph/` must special-case `std:`,
   `web:`, `node:` schemes to skip cycle reporting when both
-  endpoints of an edge live under these schemes.
+  endpoints of an edge live under these schemes. Cycles are
+  expected (e.g. `web:dom` ↔ `web:webgl` for the
+  `HTMLCanvasElement.getContext` round-trip).
 - Cycles among user packages, and user-package-to-pseudo-package
   cycles, remain disallowed.
 
 ### 4.4 Tests and gate
 
-- Two-file fixture: `web/web.esc` declares an empty
-  `HTMLElementTagNameMap`; `web/canvas.esc` augments it with
-  `canvas: HTMLCanvasElement`. Importing file gets the narrow
-  return; sibling file gets `never` / base shape.
-- Run the fixture under each of `?local`, `?nested`, `?flat` —
-  binding shape must not affect augmentation visibility.
-- Cycle fixture: two `std:*` packages with a mutual import; the
-  resolver accepts the cycle; the same shape between two user
+- **Closed-registry fixture:** `web/dom.esc` declares
+  `HTMLElementTagNameMap` populated with at least two entries
+  (`canvas: HTMLCanvasElement`, `div: HTMLDivElement`) plus
+  `createElement(tag)`. Importing file calls
+  `createElement("canvas")` and gets `HTMLCanvasElement`;
+  `createElement("does-not-exist")` errors with a typed-key
+  diagnostic.
+- **`createElementNS` NS-keyed overloads fixture:** the same
+  `web/dom.esc` also declares `SVGElementTagNameMap` with
+  `circle: SVGCircleElement` plus the
+  `createElementNS<K: keyof SVGElementTagNameMap>(ns:
+  "http://www.w3.org/2000/svg", qualifiedName: K)` overload.
+  `document.createElementNS(svgNS, "circle")` narrows to
+  `SVGCircleElement`. Verifies that NS-keyed overloads of a
+  single method co-located in `web:dom` resolve correctly.
+- **Cross-package type reference fixture:** a `web/fetch.esc`
+  declares `Response.body: web.streams.ReadableStream | null`
+  (qualified reference into `web:streams`). Importing file uses
+  the stream; type-checks.
+- **Cycle fixture:** two `std:*` packages with a mutual import;
+  the resolver accepts the cycle; the same shape between two user
   packages errors.
 
 (Symbol re-export aliasing — `iterator.iteratorKey` as an alias of
 `Symbol.iterator` via the `@js` decorator — is covered by §3.5's
-codegen fixtures and the §7 bootstrap review; no separate
-augmentation test is needed because Symbol no longer uses the
-augmentation mechanism, see FR8.)
+codegen fixtures and the §7 bootstrap review.)
 
-**Gate.** All three fixtures pass; the dependency-investigation
-note in §4.1 is committed.
+**Gate.** All four fixtures pass; the §4.1 spike note is
+committed and the §4.2 single-`web:dom` decision is reflected
+in the partition table (§6.1).
+
+### 4.5 Deferred: true cross-package augmentation
+
+The original split-DOM design — feature packages augmenting
+`web:dom`'s registry interfaces with per-file activation per
+FR9 — is **not** implemented for MVP. The two use cases that
+would need it:
+
+1. **User-side custom-element registration.** Users define
+   `class MyWidget extends HTMLElement` and want
+   `createElement("my-widget") → MyWidget`. Today: users type
+   the result manually; no compiler help.
+2. **Third-party packages extending DOM/event maps.** Out of
+   scope for the builtins workstream regardless; would be a
+   third-party concern.
+
+If/when this workstream resumes, the §4.1 spike findings size
+the work: per-file composition layer + call-site re-resolution
+of `keyof T` / `T[K]` over the merged view. The spike
+scaffolding stays committed as a regression harness for any
+future implementation.
 
 ---
 
@@ -908,16 +1132,38 @@ output and the LSP name-index (§10.3). Driven by the
 | `std:temporal`    | bundled             | unchanged                                                                                                                        |
 | `std:wasm`        | bundled             | unchanged                                                                                                                        |
 
-**`web/` partition.** DOM splits more finely than `std/` because
-the surface is larger; a typical browser program touches 2–3
-`web:*` packages. Initial set:
+**`web/` partition.** Per §4.2, the DOM partition is **one big
+package + standalone web siblings**:
 
-`web:dom` (registries + core APIs), `web:html`, `web:svg`,
-`web:mathml`, `web:http`, `web:canvas`, `web:webgl`,
-`web:webrtc`, `web:storage`, `web:workers`, `web:media`,
-`web:forms`. Additional `web:*` packages may be added in §7
+- **`web:dom`** — the entire DOM tree. Document, Element, Node,
+  Window, Navigator; every HTML / SVG / MathML element class;
+  every tag-name-map and event-map registry (closed); CSSOM;
+  XML/XPath/parsing; selection; range; history; navigation;
+  input/pointer/keyboard/touch events; drag-and-drop;
+  observers (Intersection/Resize/Mutation); Web Animations;
+  custom elements; fullscreen; picture-in-picture; view
+  transitions. One large `.esc` file; one `import "web:dom"`
+  gets the whole DOM surface.
+
+- **Standalone web siblings** — families that ship in
+  `lib.dom.d.ts` but have no DOM coupling. Initial set:
+  `web:fetch`, `web:streams`, `web:crypto`, `web:workers`,
+  `web:webgl`, `web:web_audio`, `web:web_rtc`,
+  `web:web_codecs`, `web:indexeddb`, `web:service_worker`,
+  `web:websocket`, `web:storage`, `web:url`, `web:encoding`,
+  `web:file`, `web:performance`, `web:webauthn`, `web:payments`.
+
+Small one-offs (geolocation, gamepad, clipboard, permissions,
+speech, midi, locks, idle, screen/wake-lock, sensors) land in
+`web:dom` for MVP; promote to standalone packages later if a
+real user needs to import them without the full DOM surface.
+Additional standalone `web:*` packages may be added in §7
 review as the partition is exercised against the full lib
 input.
+
+A typical browser program imports `web:dom` plus 1–2 sibling
+packages (`web:fetch` for HTTP, `web:storage` for
+localStorage, etc.).
 
 **Single-class shortcut eligibility (FR5).** Per FR5, the
 single-class shortcut applies to:
@@ -956,11 +1202,25 @@ actually made.
 
 ### 6.2 Registry routing
 
-- Detect TS-lib entries on registry interfaces
-  (`HTMLElementTagNameMap`, `HTMLElementEventMap`,
-  `SVGElementTagNameMap`, `MathMLElementTagNameMap`, …) and
-  route each entry into the corresponding feature package's
-  augmentation block.
+- Per §4.2 (single `web:dom` package), every registry interface
+  and every element class lands in `web:dom`:
+  `HTMLElementTagNameMap`, `SVGElementTagNameMap`,
+  `MathMLElementTagNameMap`, `HTMLElementEventMap`,
+  `SVGElementEventMap`, `MathMLElementEventMap`, and every
+  element class they index (`HTMLCanvasElement`,
+  `SVGCircleElement`, `MathMLElement`, …) all route to `web:dom`
+  alongside the methods that key on them (`createElement`,
+  `createElementNS`, `addEventListener`). No cross-package
+  augmentation block is emitted; no per-NS package split.
+- Standalone web families that ship in `lib.dom.d.ts` without
+  DOM coupling route to their sibling `web:*` packages per the
+  §6.1 partition table — Fetch / Streams / Crypto / Workers /
+  WebGL / Web Audio / WebRTC / WebCodecs / IndexedDB / Service
+  Worker / WebSocket / Storage / URL / Encoding / File /
+  Performance / WebAuthn / Payments. Standalone-package
+  declarations that reference DOM types (e.g. WebGL's
+  `getContext` taking an `HTMLCanvasElement`) emit qualified
+  type references per §4.2b.
 - Well-known symbol declarations on `SymbolConstructor` stay
   in `std/symbol.esc` — they are **not** rerouted (FR8). The
   domain-package re-export aliases (`iterator.iteratorKey`, `async.asyncIteratorKey`,
@@ -1160,9 +1420,9 @@ behavior; it just lands the source-of-truth `.esc` files.
 prelude without breaking the suite.
 
 **Prerequisites.** §7 (the `.esc` files must be committed for
-imports to resolve) and §4 (cross-package augmentation must be
-in place if any fixture touches DOM). §2's resolver is in place
-transitively via §7.
+imports to resolve) and §4 (the single-`web:dom` package +
+cross-package type references must be in place if any fixture
+touches DOM). §2's resolver is in place transitively via §7.
 
 Update every fixture and test under
 [fixtures/](../../fixtures/) and
@@ -1263,7 +1523,8 @@ prelude removes the resolution path that previously made `Math`,
 … visible without imports. Every fixture and test that names
 those symbols must already be rewritten to use
 `import "std:*"` — that is §8's job. §8 is feasible after §3 and
-§4 land (resolver + augmentation in place) and runs while the
+§4 land (resolver + closed registries + cross-package type
+references in place) and runs while the
 legacy prelude is still live, so migrated and not-yet-migrated
 files type-check side-by-side throughout the §8 work. §9 is the
 cut-over: the PR that opens §9 must have a green test suite on
@@ -1567,9 +1828,9 @@ full message-text assertions per CLAUDE.md test conventions.
 Per requirements §"Testing strategy":
 
 - Parser, resolver, binding-shape (§2).
-- Registry augmentation, activation scoping (§4); Symbol
-  re-export aliases via `@js` (§3.5 codegen fixtures + §7
-  bootstrap review).
+- Closed registries, cross-package type references, inter-package
+  cycles (§4); Symbol re-export aliases via `@js` (§3.5 codegen
+  fixtures + §7 bootstrap review).
 - Prelude switchover (§9) — internal fixtures, migrated to
   `import "std:*"` ahead of the switchover commit (§8), keep
   type-checking under the new resolver. No parity check against
@@ -1591,9 +1852,10 @@ Per requirements §"Testing strategy":
   recompiling the compiler is the priority.
 - **Zero runtime cost.** Pseudo-package imports erase at
   codegen.
-- **Soundness of activation.** A file's view of cross-package
-  augmentations is fully determined by that file's own
-  imports.
+- **Soundness of activation.** With closed registries (§4.2),
+  this reduces to "a file sees a name iff it imported the
+  package that owns it." The original FR9 per-file augmentation
+  semantics are deferred along with FR7.
 - **Ergonomics.** `?local` default; single-class shortcut keeps
   per-class access terse.
 
@@ -1611,9 +1873,10 @@ phasing above:
   (FR5/§2.4).
 - **Initial bootstrap quality** — mitigated by human review
   pass at §7 and by `--check` mode at §6.4.
-- **Cross-package augmentation mechanism** — investigation
-  output is the first deliverable of §4.1; if reuse fails, the
-  loader-path work adds to §4.
+- **Cross-package augmentation mechanism** — investigated by
+  §4.1 spike; the conclusion was to deferred FR7 and ship
+  closed registries (§4.2) for MVP. Risk re-emerges only when
+  custom-element support is added (§4.5).
 - **Polyfill story is separate.** This workstream assumes
   polyfill insertion at lowering is tractable (per FR12). No
   polyfill work happens here.
@@ -1653,9 +1916,9 @@ or more phases above.
 | FR4   | Binding-shape flags                        | §2.3 (all three shapes, mutual exclusion, extensibility, hard-error on `?flat` collision, URI-keyed bookkeeping) |
 | FR5   | Single-class shortcut                      | §2.4; eligibility list in §6.1                                                                                   |
 | FR6   | Inter-package imports                      | §4.3 (cycles permitted within pseudo-package layer)                                                              |
-| FR7   | Cross-package augmentation (registries)    | §4.1 (mechanism investigation), §4.2 (registry pattern), §4.2a (no `override declare`), §4.2b (per-API fallback) |
+| FR7   | DOM packaging; cross-package type references; open augmentation deferred | §4.2 (single `web:dom` package + standalone web siblings; closed registries; `createElementNS` stays one overloaded method on `Document`), §4.2b (qualified cross-package type references), §4.5 (deferred augmentation work scoped for the future custom-elements workstream). Spike (§4.1) showed achieving the old per-file-activation design needs two new checker subsystems; MVP sidesteps by collapsing the DOM tree into one package. |
 | FR8   | Well-known symbol re-exports               | §7 step 2 (hand-authored re-export aliases with `@js("Symbol.<name>")`), §3 (decorator semantics carry the alias) |
-| FR9   | Augmentation activation semantics          | §4.2 (per-file scoping, explicit-re-export propagation, flag independence — registries only)                     |
+| FR9   | Augmentation activation semantics          | N/A for MVP — single-`web:dom` partition (§4.2) requires no activation semantics. Original spec preserved in [requirements.md appendix](requirements.md#appendix-deferred-fr9-spec) for the deferred custom-elements work. |
 | FR10  | Bootstrap converter                        | §5 (MVP, trio idiom, namespace flattening), §5.0 (JSDoc precursor), §6.1 (partition), §6.2 (routing), §6.4 (`--check`), §6.5 (`throws`), §6.6 (TS-bump workflow) |
 | FR11  | Prelude changes; lazy shape loading        | §9.1 (trigger map), §9.2 (shared parsed copies), §9.2a (cross-package verification), §9.3 (legacy-path deletion in same PR) |
 | FR12  | Always-current API; polyfills at lowering  | Acknowledged as out-of-scope dependency in cross-cutting; type checker sees modern surface unconditionally       |

--- a/planning/builtins/requirements.md
+++ b/planning/builtins/requirements.md
@@ -25,7 +25,7 @@ scope here and will be tracked separately.
   primitive method dispatch, iteration, and `await` from
   language-level shape knowledge.
 - Provide a uniform import model (`import "std:math"`,
-  `import "web:canvas"`) for accessing standard-library and Web
+  `import "web:dom"`) for accessing standard-library and Web
   platform APIs, with per-import flags for choosing the binding
   shape.
 - Make `throws`, lifetimes, mutability, and any other Escalier-specific
@@ -78,11 +78,30 @@ In scope:
   package's lowercased name matches a class declared in it, the
   `?local` binding *is* the class for member access, construction,
   and type position.
-- Cross-package augmentation via open registry interfaces
-  (`HTMLElementTagNameMap`, `HTMLElementEventMap`,
-  `SVGElementTagNameMap`, …), with activation scoped to the
-  importing file.
-- Inter-package imports between pseudo-packages.
+- **The entire DOM tree lives in one package, `web:dom`** —
+  core DOM, SVG, MathML, CSSOM, XML/XPath/parsing, selection,
+  history, input events, observers, animations, custom elements,
+  etc. All `lib.dom.d.ts` interfaces that meaningfully depend on
+  `Document` / `Element` / `Event` are co-located. String-overload
+  APIs (`createElement`, `createElementNS`) and their registries
+  (`HTMLElementTagNameMap`, `SVGElementTagNameMap`,
+  `MathMLElementTagNameMap`) live entirely inside `web:dom`,
+  closed and not augmentable across packages.
+- **Standalone web APIs split into sibling `web:*` packages** —
+  the families that happen to ship in `lib.dom.d.ts` but have no
+  DOM coupling: `web:fetch`, `web:streams`, `web:crypto`,
+  `web:workers`, `web:webgl`, `web:webaudio`, `web:webrtc`,
+  `web:webcodecs`, `web:indexeddb`, `web:service_worker`,
+  `web:websocket`, `web:storage`, `web:url`, `web:encoding`,
+  `web:file`, `web:performance`, `web:webauthn`, `web:payments`.
+- (True per-file cross-package augmentation — FR7/FR9 in earlier
+  drafts — is **deferred** to a future workstream; the closed
+  `web:dom` partition makes it unnecessary for MVP.)
+- Inter-package imports between pseudo-packages, with
+  cross-package type references via qualified names for APIs
+  in sibling `web:*` packages that need to mention `web:dom`
+  types (e.g. `web:fetch`'s `Response.body` returning a
+  `web.streams.ReadableStream`).
 - A one-time bootstrap converter `tools/dts_to_esc/` that
   AST-to-AST translates the pinned TypeScript `.d.ts` set into the
   initial `.esc` files. Output is hand-edited and committed; ongoing
@@ -249,14 +268,27 @@ internal/interop/data/
         intl.esc, temporal.esc, wasm.esc
 
     web/
-        web.esc, html.esc, svg.esc, mathml.esc,
-        http.esc, canvas.esc, webgl.esc, webrtc.esc,
-        storage.esc, workers.esc, media.esc, forms.esc,
-        # additional web:* packages as needed
+        # the entire DOM tree, including SVG/MathML/CSSOM/XML/
+        # selection/history/input events/observers/animations/
+        # custom elements/etc. Anything coupled to Document,
+        # Element, or Event lives here.
+        dom.esc,
+
+        # standalone web APIs (no DOM coupling) that ship in
+        # lib.dom.d.ts only by historical accident
+        fetch.esc, streams.esc, crypto.esc, workers.esc,
+        webgl.esc, web_audio.esc, web_rtc.esc, web_codecs.esc,
+        indexeddb.esc, service_worker.esc, websocket.esc,
+        storage.esc, url.esc, encoding.esc, file.esc,
+        performance.esc, webauthn.esc, payments.esc
+        # additional standalone web:* packages as needed
 ```
 
-DOM packages split more finely than `std/` because the surface is
-larger; a typical browser program touches 2–3 `web:*` packages.
+DOM-coupled APIs are deliberately bundled into a single
+`web:dom` package: splitting along HTML/SVG/MathML lines turned
+out to require cross-package augmentation primitives that are
+not in scope for MVP (see FR7). A typical browser program imports
+`web:dom` plus 1–2 standalone web packages (`web:fetch` etc.).
 
 **File-naming convention.** Multi-word package names use underscores
 in both the file name and the user-visible binding so the two
@@ -274,8 +306,8 @@ The module-specifier grammar accepts a new shape:
 ```escalier
 import "std:math"
 import "std:json"
-import "web:canvas"
-import "web:http"
+import "web:dom"
+import "web:fetch"
 ```
 
 We need to **add** support for resolving modules with the `std:`,
@@ -290,7 +322,7 @@ specifiers to the resolved stdlib data directory (see
 "Filesystem-resident stdlib data" in non-functional requirements
 for the discovery scheme). Mapping is mechanical:
 `std:math` → `<stdlib>/std/math.esc`,
-`web:http` → `<stdlib>/web/http.esc`. The `?flag`
+`web:fetch` → `<stdlib>/web/fetch.esc`. The `?flag`
 portion of the URI (see FR4) is stripped before path resolution.
 
 **Grammar updates.** The parser must be extended to accept two
@@ -353,7 +385,7 @@ they are mutually exclusive and exactly one is in effect per import
   identifier equal to the lowercased last URI segment. Each import
   is its own binding; no cross-import merging.
   - `import "std:math"` → `math.sin(x)`, `math.PI`
-  - `import "web:canvas"` → `canvas.HTMLCanvasElement`
+  - `import "web:webgl"` → `webgl.WebGLRenderingContext`
   - **Exception:** when the package qualifies for the single-class
     shortcut (FR5), the `?local` binding is the class name with its
     original capitalization (e.g. `Array`, `Date`), not the
@@ -367,8 +399,8 @@ they are mutually exclusive and exactly one is in effect per import
 - **`?flat`.** Merge the package's contents directly into a shared
   scheme-named namespace. Multiple `?flat` imports from the same
   scheme merge; package names are dropped from the access path.
-  - `import "web:canvas?flat"` + `import "web:webgl?flat"` →
-    `web.HTMLCanvasElement`, `web.WebGLRenderingContext`.
+  - `import "web:webgl?flat"` + `import "web:fetch?flat"` →
+    `web.WebGLRenderingContext`, `web.Response`.
   - Collision risk is real (two packages exporting the same name
     under one scheme conflict). Opt-in for that reason. **When
     `?flat` produces a name collision, the compiler reports a
@@ -394,9 +426,9 @@ need a `-` → `_` substitution when computing the binding name; that
 substitution rule is part of the third-party workstream and is out
 of scope here.) `?flat` drops the package name from the user-visible
 binding, but internal bookkeeping (tracking whether a given file's
-imports have already pulled in a package's declarations / registry
-augmentations) uses the pseudo-package's full URI as the key —
-e.g. `web:canvas` — regardless of which binding-shape flag the
+imports have already pulled in a package's declarations) uses the
+pseudo-package's full URI as the key — e.g. `web:fetch` —
+regardless of which binding-shape flag the
 import carried. This applies uniformly across `?local`, `?nested`,
 and `?flat`.
 
@@ -506,20 +538,65 @@ depend on pseudo-packages but pseudo-packages do not depend on
 user code), and cycles among user packages remain disallowed as
 before.
 
-### FR7. Cross-package augmentation via open registries
+### FR7. DOM packaging; cross-package type references (open augmentation deferred)
 
-Splitting the DOM into feature packages requires that `web:dom`
-APIs return or reference types that live in feature packages, e.g.
-`document.createElement("canvas")` should return
-`HTMLCanvasElement`.
+The pseudo-package partition needs to handle two distinct
+shapes of cross-package coupling: **DOM-internal coupling** (the
+tight web of `Document`, `Element`, `Event`, HTML/SVG/MathML
+element classes, CSSOM, observers, …) and **standalone web APIs
+coupled to DOM only at the edges** (`web:fetch` returns a
+`Response.body` of type `ReadableStream`; `web:webgl`'s context
+is obtained from an `HTMLCanvasElement`; etc.).
 
-**Primary mechanism: open registry interfaces, augmented per
-package.** `web:dom` declares the registry (`HTMLElementTagNameMap`,
-`HTMLElementEventMap`, `SVGElementTagNameMap`,
-`MathMLElementTagNameMap`, etc.) with a minimal baseline or empty
-body. Core APIs are written once against the registry:
+**MVP design — single `web:dom` package + standalone web siblings.**
+
+- The **entire DOM tree** — Document, Element, Node, Window,
+  Navigator, every HTML element class, SVG, MathML, CSSOM,
+  XML/XPath/parsing, selection, range, history, navigation,
+  input/pointer/keyboard/touch events, drag-and-drop,
+  observers (Intersection/Resize/Mutation), Web Animations,
+  custom elements, fullscreen, picture-in-picture, view
+  transitions — lives in a **single `web:dom` package**. All
+  the registry interfaces (`HTMLElementTagNameMap`,
+  `SVGElementTagNameMap`, `MathMLElementTagNameMap`,
+  `HTMLElementEventMap`, `SVGElementEventMap`,
+  `MathMLElementEventMap`, …) are closed and declared in
+  `web:dom` alongside the methods that key on them
+  (`createElement`, `createElementNS`, `addEventListener`).
+- **Standalone web APIs** — families that ship in
+  `lib.dom.d.ts` but have no DOM coupling — split into sibling
+  `web:*` packages: `web:fetch`, `web:streams`, `web:crypto`,
+  `web:workers`, `web:webgl`, `web:webaudio`, `web:webrtc`,
+  `web:webcodecs`, `web:indexeddb`, `web:service_worker`,
+  `web:websocket`, `web:storage`, `web:url`, `web:encoding`,
+  `web:file`, `web:performance`, `web:webauthn`,
+  `web:payments`. (Final list in [implementation_plan.md §6.1](implementation_plan.md#61-partition-table).)
+
+**Why a single `web:dom` package.** Earlier drafts split DOM
+into per-element-family packages (`web:svg`, `web:mathml`,
+`web:canvas`, etc.) with cross-package augmentation activated
+per-importing-file (the original FR7 + FR9). The
+implementation-plan §4.1 spike
+([internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go))
+showed that achieving per-file activation would require two new
+checker subsystems: per-file composition of contributing
+interface fragments + call-site re-resolution of `keyof T` /
+`T[K]` over the merged view. Neither is a small extension of
+existing code.
+
+Collapsing the DOM tree into one package sidesteps the problem
+entirely. `createElementNS` stays a single overloaded method on
+`Document` with its NS-keyed signatures declared once, exactly
+matching WebIDL. `SVGElement` etc. are reachable from
+`HTMLElement` via `Element.parentNode` and event-target shared
+behavior, so the cohesion is real — the DOM is not a clean
+partition along element-family lines. Per-element-class
+discoverability is preserved by the FR16 auto-import quick-fix
+and adaptive diagnostic rendering (FR15), which surface the
+owning package on demand.
 
 ```escalier
+// In web:dom — registries declared closed, alongside the methods
 fn createElement<K: keyof HTMLElementTagNameMap>(
     self, tag: K
 ) -> HTMLElementTagNameMap[K]
@@ -527,81 +604,75 @@ fn createElement<K: keyof HTMLElementTagNameMap>(
 fn createElementNS<K: keyof SVGElementTagNameMap>(
     self, ns: "http://www.w3.org/2000/svg", qualifiedName: K
 ) -> SVGElementTagNameMap[K]
-```
+// ... plus MathML, XHTML, and the generic fallback overload
 
-Each feature package augments only the registry by declaring its
-own contribution to the open interface in its `.esc` source, e.g.
-`web:canvas`:
-
-```escalier
-declare interface HTMLElementTagNameMap {
+interface HTMLElementTagNameMap {
     canvas: HTMLCanvasElement,
+    div: HTMLDivElement,
+    // ... every HTML tag
+}
+
+interface SVGElementTagNameMap {
+    circle: SVGCircleElement,
+    path: SVGPathElement,
+    // ... every SVG tag
 }
 ```
 
-Every registry-keyed API (`createElement`, `querySelector`,
-`getElementsByTagName`, `createElementNS`, …) picks up the new
-entry automatically.
+**Cross-package type references via qualified names.** Sibling
+`web:*` packages that need to mention `web:dom` types do so by
+qualified name through their imported namespace. No augmentation
+machinery involved:
 
-**Registries live in `web:dom`; the element families they index
-live in their feature packages.** `SVGElement` and its subclasses
-live in `web:svg`; `MathMLElement` and its subclasses live in
-`web:mathml`; specialized HTML element classes
-(`HTMLCanvasElement`, `HTMLVideoElement`, …) live in their
-respective feature packages. `web:dom` declares each registry
-interface with an empty body — no reference to the element classes
-themselves — and writes the keyed APIs purely against the registry.
-Feature packages augment the registry with their entries (e.g.
-`web:svg` adds `{ circle: SVGCircleElement, path: SVGPathElement,
-… }` to `SVGElementTagNameMap`). The registry interface is more a
-contract slot than a real type; the value types it indexes need
-not be visible to `web:dom` at all.
+```escalier
+// In web:webgl
+import "web:dom"
 
-A file that imports `web:svg` gets `createElementNS(svgNS, "circle")
-→ SVGCircleElement`; a file without the import gets `never` from
-the indexed access, which loudly surfaces the missing import. This
-keeps the augmentation pattern uniform across all element families
-and avoids needing the per-API augmentation fallback for the SVG
-and MathML cases.
+declare fn getContext(
+    canvas: web.dom.HTMLCanvasElement,
+    contextId: "webgl"
+) -> WebGLRenderingContext
+```
 
-**No `override declare`.** Builtins are declared directly in their
-own `.esc` files. The `override declare` syntax is **not** used for
-pseudo-package augmentation — that syntax is reserved for the
-third-party workstream's override mechanism and does not apply to
-builtins or pseudo-packages.
+The same shape works between any two pseudo-packages: `web:fetch`
+references `web.streams.ReadableStream` for `Response.body`;
+`web:service_worker` references `web.fetch.Request` /
+`web.fetch.Response`. Inter-package import cycles between
+pseudo-packages are permitted (FR6) when needed for these
+references.
 
-**Fallback: per-API augmentation** for the rare cross-package APIs
-that do not fit a registry pattern. Two cases:
+**No `override declare`.** Builtins are declared directly in
+their own `.esc` files. The `override declare` syntax is **not**
+used for any builtin `.esc` file — that syntax is reserved for
+the third-party workstream's override mechanism and does not
+apply to builtins or pseudo-packages.
 
-1. The API takes the type as a *parameter* (not a return type): the
-   feature package exports the type; `web:dom` references it via
-   the type's qualified name; no augmentation needed.
-2. The API is overload-keyed on a string but lacks a registry: the
-   feature package augments the API's overload set directly. Rare;
-   treat as one-off when it arises.
+**What's deferred until a follow-up workstream un-punts FR7.**
+With the single-`web:dom` partition no augmentation primitive
+is needed for MVP. The augmentation work resurfaces only for:
 
-**Language requirements this depends on:**
+1. **User-side custom-element registration** — TS-style
+   `declare module "web:dom" { interface
+   HTMLElementTagNameMap { "my-widget": MyWidget } }`. Users
+   must type custom-element results manually until this work
+   resumes.
+2. **Third-party packages extending DOM/event maps.** Out of
+   scope for the builtins workstream regardless; would be a
+   third-party concern.
 
-- Open interfaces / cross-package interface merging. The §5
-  override-merge code already does interface merging for type
-  refinement; whether the same mechanism can be repurposed for
-  cross-package augmentation, or whether augmentation needs its own
-  loader path, must be confirmed during the resolver-extension step.
-- Indexed access over open registries: `HTMLElementTagNameMap[K]`
-  where `K extends keyof HTMLElementTagNameMap` must refresh
-  correctly when the registry is augmented.
-
-Activation semantics for these augmentations — per-importing-file
-scoping, transitive propagation rules, independence from the
-binding-shape flag — are specified in FR9.
+When the un-punt happens, the §4.1 spike findings size the
+work: per-file composition layer + call-site re-resolution of
+`keyof T` / `T[K]` over the merged view. The spike scaffolding
+stays committed as a regression harness so future drift
+breaks the build.
 
 ### FR8. Well-known symbol re-exports
 
 All well-known symbols (`Symbol.iterator`, `Symbol.asyncIterator`,
 `Symbol.match`, `Symbol.toPrimitive`, …) are declared directly on
 `Symbol`'s static side in `std:symbol`. There is **no Symbol
-augmentation mechanism**; the registry-based augmentation in FR7
-does not extend to Symbol.
+augmentation mechanism**; domain-package aliases (below) are
+plain re-exports, not augmentations.
 
 **Shape-loaded language-level use vs. explicit references.**
 Language-level use of well-known symbols (the `for-of` desugaring
@@ -656,55 +727,24 @@ alias is a re-export with a different binding name, not a separate
 symbol.
 
 The re-export aliases are visible only when the importing file
-imports the domain package; this is plain Escalier import scoping,
-not the FR9 augmentation-activation rule (which no longer applies
-to Symbol).
+imports the domain package; this is plain Escalier import scoping.
 
-### FR9. Augmentation activation semantics
+### FR9. Augmentation activation semantics (deferred with FR7)
 
-The scoping rules below apply to DOM-style registry augmentation
-(FR7). Any future augmentation mechanism added under this
-workstream inherits the same rules. (FR8's domain-package
-re-exports of well-known symbols are **not** augmentations —
-they are plain Escalier exports governed by ordinary import
-scoping, not by these rules.)
+**MVP: N/A.** FR9 specified per-importing-file activation rules
+for cross-package augmentation. With FR7 deferred (single
+`web:dom` package + standalone web siblings adopted instead),
+there is no augmentation mechanism to scope — a file sees a name
+iff it imported the package that owns it, which is plain
+Escalier import scoping covered by FR3 / FR4.
 
-**Per-importing-file scoping.** Augmentation activation is
-**scoped to the importing module**, not the whole compilation
-unit. A file that imports `web:canvas` sees the augmented
-`HTMLElementTagNameMap` entry for `canvas`; a sibling file in the
-same program that does not import `web:canvas` does not. This
-deliberately departs from TypeScript's `declare module` behavior,
-where any module-augmenting import becomes global. The type a
-file sees is fully determined by that file's own imports.
-
-**Note for library authors.** Per-importing-file scoping means a
-library function that calls `document.createElement("canvas")`
-must itself include `import "web:canvas"` — relying on the
-application to import the package is not enough. Each file that
-*uses* the augmented shape needs the import; importing only in
-the application's entry point gives the entry-point file the
-narrow type but leaves the library file with the pre-augmentation
-shape. The same applies to every other augmentation entry point
-(SVG element families, etc.). When in doubt, import the augmenting
-package in every file that consumes the augmented type. This is
-the inverse of the TypeScript habit of relying on a global
-side-effect import.
-
-**Transitive propagation via explicit re-export.** Augmentations
-propagate only through **explicit re-exports** of the pseudo-package.
-If file A writes `export * from "web:canvas"` (or an equivalent
-named re-export of canvas's bindings), then a file importing A
-sees canvas's augmentations as part of importing A. A plain
-`import "web:canvas"` in A that does not re-export anything from
-canvas does *not* leak the augmentation to A's importers. Simply
-importing a package never magically re-exports it.
-
-**Independent of the binding-shape flag.** Importing `web:canvas`
-under any of `?local`, `?nested`, or `?flat` adds canvas's
-contributions to that file's view of `HTMLElementTagNameMap`. The
-flag only affects how canvas's *direct exports* land in the
-importing scope, not which augmentations are activated.
+The original FR9 rules — per-importing-file scoping, transitive
+propagation via explicit re-export, independence from the
+binding-shape flag — are preserved verbatim in the [appendix](#appendix-deferred-fr9-spec)
+at the end of this document as the spec for the deferred work.
+When/if FR7 is un-punted (custom-element support; third-party
+DOM extension), those rules are what the augmentation mechanism
+must satisfy.
 
 ### FR10. Bootstrap converter (`tools/dts_to_esc/`)
 
@@ -759,10 +799,22 @@ A one-time seeding tool. A Go binary that:
    error is exercised by the routing code that emits per-package
    `.esc` output: the partition-table lookup is the choke point,
    and a missing entry surfaces there, not somewhere downstream.
-5. Detects which TS-lib symbols belong to registries
-   (`HTMLElementTagNameMap`, `HTMLElementEventMap`, …) and routes
-   their per-feature entries into the appropriate feature
-   package's augmentation block. Well-known symbols
+5. Routes every DOM-coupled declaration — Document, Element,
+   Node, Window, every HTML/SVG/MathML element class, every
+   registry interface (`HTMLElementTagNameMap`,
+   `SVGElementTagNameMap`, `MathMLElementTagNameMap`,
+   `HTMLElementEventMap`, `SVGElementEventMap`,
+   `MathMLElementEventMap`, …), CSSOM, observers, animations,
+   custom elements, input events, etc. — into the single
+   `web:dom` package per FR7. Standalone web APIs that ship in
+   `lib.dom.d.ts` but have no DOM coupling (Fetch, Streams,
+   Crypto, Workers, WebGL, Web Audio, WebRTC, WebCodecs,
+   IndexedDB, Service Workers, WebSocket, Storage, URL,
+   Encoding, File, Performance, WebAuthn, Payments, …) route
+   to their own sibling `web:*` packages — the partition table
+   in [implementation_plan.md §6.1](implementation_plan.md#61-partition-table)
+   has the full mapping. No cross-package augmentation block
+   is emitted. Well-known symbols
    (`Symbol.iterator`, `Symbol.asyncIterator`, …) are **not**
    routed — they stay on `Symbol`'s static side in
    `std/symbol.esc` (FR8). Domain-package re-export aliases
@@ -1065,9 +1117,12 @@ The implementation depends on:
 - **Ergonomics.** Default `?local` binding gives terse access
   (`math.sin(x)`, `console.log(...)`). The binding choice per
   import is the file author's; no global configuration.
-- **Soundness of activation.** A file's view of cross-package
-  augmentations is fully determined by that file's own imports — no
-  spooky action from a sibling module.
+- **Soundness of activation.** Under the single-`web:dom`
+  partition (FR7), this reduces to "a file sees a name iff it
+  imported the package that owns it" — plain Escalier import
+  scoping, no spooky action from a sibling module. (If FR7 is
+  later un-punted for custom-element support, the per-file
+  augmentation rules in the deferred-FR9 appendix govern.)
 - **Zero runtime cost.** Pseudo-package imports erase entirely at
   codegen.
 - **Filesystem-resident stdlib data.** `.esc` files under
@@ -1082,11 +1137,17 @@ The implementation depends on:
   → repo-relative when running from a build tree. The toolchain
   has no `node_modules` or network dependency for pseudo-package
   declarations; the stdlib tree is a fixed install artifact.
-- **`--explain-type` diagnostic.** When a tag-keyed return is wider
-  than expected (e.g. `createElement` returning the union element
-  type instead of `HTMLCanvasElement`), the diagnostic suggests
-  likely `web:*` imports to widen the file's view. Complements the
-  FR16 auto-import quick-fix for the type-narrowing case.
+- **`--explain-type` diagnostic.** When a tag-keyed return is
+  unexpected (e.g. `createElement("does-not-exist")` rejects
+  because the tag isn't a key of `HTMLElementTagNameMap`), the
+  diagnostic surfaces the closed registry contents and suggests
+  the closest valid tag — and, when an HTML tag is misused with
+  `createElement` instead of an SVG-specific `createElementNS`
+  call, points at the corresponding `createElementNS(svgNS, …)`
+  signature (also in `web:dom`). For names that resolve in a
+  sibling `web:*` package the user has not imported, suggests
+  the missing `import "web:<pkg>"`. Complements the FR16
+  auto-import quick-fix.
 
 ## Migration phases
 
@@ -1116,21 +1177,34 @@ omitted; they belong to the third-party workstream.
      `std.PI`); a two-package fixture
      (`web:a?flat` + `web:b?flat`) merges into one `web` binding;
      mutually-exclusive flag combos error.
-3. **Cross-package augmentation support.** Confirm that the
-   existing §5 interface-merging mechanism (or a small extension of
-   it) lets a package augment an open interface declared in another
-   package, with augmentation scoped to files that import the
-   augmenting package. Test with a hand-authored two-file pair:
-   `web/web.esc` declares an empty `HTMLElementTagNameMap`;
-   `web/canvas.esc` augments it with `canvas: HTMLCanvasElement`;
-   importing `web:canvas` under any binding-shape flag (`?local`,
-   `?nested`, `?flat`) makes `createElement("canvas")` narrow
-   correctly in the importing file, and a sibling file *without*
-   the import sees only the pre-augmentation shape.
-   - **Gate:** that test passes; indexed-access over the augmented
-     registry resolves to the right element type;
-     registry-augmentation activation is shown to be orthogonal to
-     the binding-shape flag.
+3. **Single `web:dom` partition + inter-package imports.** Build
+   the FR7 MVP: the entire DOM tree lives in `web:dom` with all
+   its registries (`HTMLElementTagNameMap`,
+   `SVGElementTagNameMap`, …) declared closed inside the same
+   package; standalone web APIs occupy sibling `web:*` packages
+   that reference `web:dom` types via qualified names. Two
+   pre-step deliverables inform this step:
+   - The §4.1 augmentation spike (already landed under
+     [internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go))
+     answered "can existing checker machinery support per-file
+     activation?" with **no/snapshot**, which is what motivated
+     the single-`web:dom` partition. The scaffolding is kept as
+     a regression harness — if a future change quietly enables
+     cross-package augmentation, those assertions fail loudly
+     and the FR7-defer decision can be revisited.
+   - **Gate:** a hand-authored fixture declares
+     `HTMLElementTagNameMap` populated with at least two
+     entries in `web/dom.esc`; `createElement("canvas")`
+     narrows to `HTMLCanvasElement`,
+     `createElement("does-not-exist")` errors. A second
+     fixture exercises an SVG overload of `createElementNS`
+     on the same Document (verifying that NS-keyed overloads
+     of one method co-located in `web:dom` resolve correctly).
+     A third fixture exercises a cross-package type reference
+     (`web:fetch` API parameter typed as
+     `web.streams.ReadableStream`). Inter-package import
+     cycles between two `std:*` packages are accepted by the
+     resolver.
 4. **Converter MVP.** Build `tools/dts_to_esc/` against a tiny
    slice (`Boolean` alone, ~10 lines of `.d.ts`). Emit to stdout.
    No file layout, no partition logic.
@@ -1140,10 +1214,15 @@ omitted; they belong to the third-party workstream.
    table (which TS-lib declaration goes into which `std:*` / `web:*`
    package per FR1/FR2), full output paths under
    `internal/interop/data/`, `--check` mode, and the full
-   `lib.*.d.ts` set as input. The converter must also detect which
-   TS-lib symbols belong to registries (and to `Symbol`'s well-known
-   symbol set) and route their per-feature entries into the
-   appropriate package's augmentation block.
+   `lib.*.d.ts` set as input. The converter must route every
+   DOM-coupled declaration (Document/Element/Node and the
+   HTML/SVG/MathML/CSSOM/event/observer/animation/custom-element
+   surfaces hanging off them) into `web:dom`, and route the
+   standalone web families (Fetch, Streams, Crypto, Workers,
+   WebGL, Web Audio, WebRTC, WebCodecs, IndexedDB, Service
+   Workers, WebSocket, Storage, URL, Encoding, File,
+   Performance, WebAuthn, Payments) into their sibling
+   `web:*` packages (per FR7 MVP).
    - **Gate:** every output file parses; running the converter
      twice produces byte-identical output.
 6. **Stdlib bootstrap.** Run the converter, review the output,
@@ -1211,20 +1290,26 @@ per step.
   the partition table needs an entry — manual decision per
   addition. Not large in practice (TS lib additions are rare in
   minor versions) but not zero.
-- **Cross-package augmentation mechanism.** The registry pattern
-  depends on a package being able to augment an open interface
-  declared in another package. Escalier's §5 interface-merge code
-  is *probably* reusable, but it was designed for type-refinement at
-  a fixed merge point, not for arbitrary cross-package activation.
-  If the existing mechanism does not fit, augmentation needs its own
-  loader path — adds work to migration step 3.
-- **Non-local reasoning from augmentation activation.** A function
-  using `document.createElement("canvas")` gets `HTMLCanvasElement`
-  only if that file imported `web:canvas`. Type-only (runtime
-  behavior unchanged) but users encountering an unexpectedly-coarse
-  type will need to learn to look for missing imports. Mitigation:
-  an `--explain-type` diagnostic that suggests likely `web:*`
-  imports.
+- **Cross-package augmentation mechanism.** *Resolved by MVP
+  punt.* The §4.1 spike confirmed that per-file augmentation
+  with FR9 semantics would need two new checker subsystems
+  (per-file composition + call-site `keyof T` / `T[K]`
+  re-resolution); MVP adopts closed registries (FR7) instead.
+  Risk re-emerges only when custom-element support is added.
+- **`web:dom` is one large package.** Under the MVP partition,
+  every DOM-coupled declaration (Document, every HTML / SVG /
+  MathML element class, CSSOM, observers, events, etc.) lives
+  in `web:dom`. The committed `.esc` file is large — tens of
+  thousands of lines. Mitigations: (a) one `import "web:dom"`
+  gets the whole DOM surface, so users do not face per-feature
+  import churn; (b) FR15 adaptive diagnostic rendering surfaces
+  the owning package name on demand; (c) FR16 auto-import
+  quick-fix points at `web:dom` for any unresolved DOM-coupled
+  reference. Editor performance against a single large `.esc`
+  file is the realistic risk; if it becomes a problem the file
+  can be split into multiple `.esc` files under
+  `internal/interop/data/web/dom/` that the loader concatenates
+  into one package namespace (no language-level change).
 - **Hand-edits drift from upstream TS.** If TS adds a method to
   `Array.prototype` in a minor version bump, someone has to notice
   (via `--check`) and port it by hand. Mostly a feature — gives us
@@ -1317,11 +1402,37 @@ Requirements:
 - **Binding-shape tests** (per FR4). Fixture per shape (`?local`,
   `?nested`, `?flat`), per single- and multi-package case,
   including `?flat` collision error.
-- **Registry augmentation tests** (per FR7). Two-file fixture
-  where one file imports the augmenting package and the other does
-  not; assert the augmented-vs-base type at each site (e.g.
-  `createElement("canvas")` narrows in the importing file,
-  returns the base element type in the sibling).
+- **Closed-registry tests** (per FR7 MVP). Fixture where
+  `web/dom.esc` declares `HTMLElementTagNameMap` with at least
+  two entries (`canvas: HTMLCanvasElement`,
+  `div: HTMLDivElement`) plus `createElement(tag)`.
+  `createElement("canvas")` narrows to `HTMLCanvasElement`;
+  `createElement("does-not-exist")` errors with a typed-key
+  diagnostic.
+- **`createElementNS` NS-keyed overload tests** (per FR7 MVP).
+  Same `web/dom.esc` fixture also declares
+  `SVGElementTagNameMap` with `circle: SVGCircleElement` and
+  the `createElementNS<K: keyof SVGElementTagNameMap>(ns:
+  "http://www.w3.org/2000/svg", qualifiedName: K)` overload.
+  `document.createElementNS(svgNS, "circle")` narrows to
+  `SVGCircleElement`; verifies that NS-keyed overloads of a
+  single method co-located in `web:dom` resolve correctly
+  against the literal NS string.
+- **Cross-package type reference tests** (per FR7 MVP). A
+  package `web:fetch` declares `Response.body` returning
+  `web.streams.ReadableStream` via qualified type reference.
+  Importing file uses the returned stream; type-checks.
+- **Inter-package cycle tests** (per FR6). Two `std:*` packages
+  with a mutual import are accepted by the resolver; the same
+  shape between two user packages errors.
+- **Spike regression harness** (per FR7's deferred portion).
+  [internal/checker/tests/spike_aug_test.go](../../internal/checker/tests/spike_aug_test.go)
+  pins the observed current behavior (interfaces in two
+  separate packages do not merge; `?flat` collisions error;
+  call-site `keyof T` snapshots at declaration time). If a
+  future change quietly enables cross-package augmentation,
+  these assertions fail loudly so the FR7-defer decision can
+  be revisited.
 - **Symbol re-export tests** (per FR8). Verify that
   domain-package aliases (`iterator.iteratorKey`, `regexp.matchKey`, …)
   refer to the same runtime value as `Symbol.<name>` via the
@@ -1329,12 +1440,6 @@ Requirements:
   implementing `[iterator.iteratorKey]()` is recognized as iterable by
   `for-of` (importing `std:iterator` alone, without
   `std:symbol`).
-- **Augmentation activation tests** (per FR9). Per-file scoping:
-  sibling file without the import does not see augmentations.
-  Transitive propagation: `export * from "web:canvas"` propagates
-  augmentations; bare `import "web:canvas"` (no re-export) does
-  not. Flag independence: augmentation visibility is identical
-  under `?local`, `?nested`, and `?flat`.
 - **Prelude switchover.** Internal fixtures are migrated to
   `import "std:*"` (migration step 7) before the legacy path is
   deleted (step 8); the test suite passes on the new path alone
@@ -1387,3 +1492,56 @@ them for day-to-day use:
   qualified form.
 
 No automatic codemod for user code ships with this workstream.
+
+## Appendix: deferred FR9 spec
+
+Preserved verbatim from the pre-MVP-punt version. Not in force
+under the current single-`web:dom` partition (no augmentation
+mechanism exists to scope). Reactivates if/when FR7 is un-punted
+for custom-element support or third-party DOM extension —
+whatever augmentation mechanism lands at that point must satisfy
+these rules.
+
+The scoping rules below applied to DOM-style registry
+augmentation (FR7). Any future augmentation mechanism added under
+this workstream inherits the same rules. (FR8's domain-package
+re-exports of well-known symbols are **not** augmentations —
+they are plain Escalier exports governed by ordinary import
+scoping, not by these rules.)
+
+**Per-importing-file scoping.** Augmentation activation is
+**scoped to the importing module**, not the whole compilation
+unit. A file that imports `web:canvas` sees the augmented
+`HTMLElementTagNameMap` entry for `canvas`; a sibling file in the
+same program that does not import `web:canvas` does not. This
+deliberately departs from TypeScript's `declare module` behavior,
+where any module-augmenting import becomes global. The type a
+file sees is fully determined by that file's own imports.
+
+**Note for library authors.** Per-importing-file scoping means a
+library function that calls `document.createElement("canvas")`
+must itself include `import "web:canvas"` — relying on the
+application to import the package is not enough. Each file that
+*uses* the augmented shape needs the import; importing only in
+the application's entry point gives the entry-point file the
+narrow type but leaves the library file with the pre-augmentation
+shape. The same applies to every other augmentation entry point
+(SVG element families, etc.). When in doubt, import the augmenting
+package in every file that consumes the augmented type. This is
+the inverse of the TypeScript habit of relying on a global
+side-effect import.
+
+**Transitive propagation via explicit re-export.** Augmentations
+propagate only through **explicit re-exports** of the pseudo-package.
+If file A writes `export * from "web:canvas"` (or an equivalent
+named re-export of canvas's bindings), then a file importing A
+sees canvas's augmentations as part of importing A. A plain
+`import "web:canvas"` in A that does not re-export anything from
+canvas does *not* leak the augmentation to A's importers. Simply
+importing a package never magically re-exports it.
+
+**Independent of the binding-shape flag.** Importing `web:canvas`
+under any of `?local`, `?nested`, or `?flat` adds canvas's
+contributions to that file's view of `HTMLElementTagNameMap`. The
+flag only affects how canvas's *direct exports* land in the
+importing scope, not which augmentations are activated.

--- a/planning/builtins/requirements.md
+++ b/planning/builtins/requirements.md
@@ -90,8 +90,8 @@ In scope:
 - **Standalone web APIs split into sibling `web:*` packages** —
   the families that happen to ship in `lib.dom.d.ts` but have no
   DOM coupling: `web:fetch`, `web:streams`, `web:crypto`,
-  `web:workers`, `web:webgl`, `web:webaudio`, `web:webrtc`,
-  `web:webcodecs`, `web:indexeddb`, `web:service_worker`,
+  `web:workers`, `web:webgl`, `web:web_audio`, `web:web_rtc`,
+  `web:web_codecs`, `web:indexeddb`, `web:service_worker`,
   `web:websocket`, `web:storage`, `web:url`, `web:encoding`,
   `web:file`, `web:performance`, `web:webauthn`, `web:payments`.
 - (True per-file cross-package augmentation — FR7/FR9 in earlier
@@ -566,8 +566,8 @@ is obtained from an `HTMLCanvasElement`; etc.).
 - **Standalone web APIs** — families that ship in
   `lib.dom.d.ts` but have no DOM coupling — split into sibling
   `web:*` packages: `web:fetch`, `web:streams`, `web:crypto`,
-  `web:workers`, `web:webgl`, `web:webaudio`, `web:webrtc`,
-  `web:webcodecs`, `web:indexeddb`, `web:service_worker`,
+  `web:workers`, `web:webgl`, `web:web_audio`, `web:web_rtc`,
+  `web:web_codecs`, `web:indexeddb`, `web:service_worker`,
   `web:websocket`, `web:storage`, `web:url`, `web:encoding`,
   `web:file`, `web:performance`, `web:webauthn`,
   `web:payments`. (Final list in [implementation_plan.md §6.1](implementation_plan.md#61-partition-table).)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added type inference test suite validating package isolation and registry semantics.

* **Chores**
  * Updated DOM package architecture to consolidate into a single unified package model.
  * Deferred cross-package type augmentation features to a future release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->