### PR TITLE
Handle cycles between 'web:*' pseudo-packages

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -65,16 +65,6 @@ type Checker struct {
 	// contributing URI (e.g. `web:canvas`).
 	flatContributors map[*Scope]map[string]map[string]string
 
-	// stdlibSCCByURI maps each pseudo-package URI to the slice of URIs
-	// in its SCC (size 1 for non-cyclic packages, including self).
-	// Computed lazily on first stdlib import via stdlibSCCOnce.
-	// Pseudo-package cycles within `std:`/`web:` are loaded as a single
-	// merged module so cross-package type references resolve through
-	// the dep_graph's own SCC handling.
-	stdlibSCCByURI  map[string][]string
-	stdlibSCCErr    error
-	stdlibSCCOnce   sync.Once
-
 	// activeSCC names the URIs currently being loaded as a single
 	// merged module (set during loadStdlibSCC, cleared after).
 	// Intra-SCC imports skip file-scope binding so the merged module's

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -63,6 +63,23 @@ type Checker struct {
 	// (`std`/`web`), inner key is the identifier; value is the
 	// contributing URI (e.g. `web:canvas`).
 	flatContributors map[*Scope]map[string]map[string]string
+
+	// stdlibSCCByURI maps each pseudo-package URI to the slice of URIs
+	// in its SCC (size 1 for non-cyclic packages, including self).
+	// Computed lazily on first stdlib import via stdlibSCCOnce.
+	// Pseudo-package cycles within `std:`/`web:` are loaded as a single
+	// merged module so cross-package type references resolve through
+	// the dep_graph's own SCC handling.
+	stdlibSCCByURI  map[string][]string
+	stdlibSCCErr    error
+	stdlibSCCOnce   sync.Once
+
+	// activeSCC names the URIs currently being loaded as a single
+	// merged module (set during loadStdlibSCC, cleared after).
+	// Intra-SCC imports skip file-scope binding so the merged module's
+	// namespace tree — which already exposes each member at its derived
+	// path — isn't shadowed by an empty filtered copy.
+	activeSCC map[string]bool
 }
 
 func NewChecker(ctx context.Context) *Checker {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/interop"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 	gqlast "github.com/vektah/gqlparser/v2/ast"
 )
@@ -79,7 +80,7 @@ type Checker struct {
 	// Intra-SCC imports skip file-scope binding so the merged module's
 	// namespace tree — which already exposes each member at its derived
 	// path — isn't shadowed by an empty filtered copy.
-	activeSCC map[string]bool
+	activeSCC set.Set[string]
 }
 
 func NewChecker(ctx context.Context) *Checker {

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -128,7 +128,7 @@ func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []E
 	// A file-scope bind here would just shadow that live, populating
 	// namespace with an empty filtered copy because the target package
 	// hasn't gone through its placeholder phase yet.
-	if c.activeSCC[importStmt.PackageName] {
+	if c.activeSCC.Contains(importStmt.PackageName) {
 		return errs
 	}
 

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -121,6 +121,17 @@ func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []E
 		return errs
 	}
 
+	// Intra-SCC short-circuit. When we're inside a merged-SCC load and
+	// the import targets another member of the same SCC, the merged
+	// module's namespace tree already exposes that member at its
+	// derived `<scheme>.<pkg>` path through the module-scope namespace.
+	// A file-scope bind here would just shadow that live, populating
+	// namespace with an empty filtered copy because the target package
+	// hasn't gone through its placeholder phase yet.
+	if c.activeSCC[importStmt.PackageName] {
+		return errs
+	}
+
 	// --- Resolution + load phase. ---
 
 	filePath, resolveErrs := c.resolveStdlibPath(scheme, pkg, span)
@@ -301,6 +312,22 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 		// are permitted" note.
 		return pkgNs, nil
 	}
+
+	// Cycle-aware path: if this URI is part of an SCC of size > 1,
+	// load every member as a single merged module so cross-package type
+	// references resolve through the dep_graph's own SCC handling.
+	scc, sccErr := c.stdlibSCCFor(uri)
+	if sccErr != nil {
+		return nil, []Error{&GenericError{message: sccErr.Error(), span: span}}
+	}
+	if len(scc) > 1 {
+		if errs := c.loadStdlibSCC(scc, span); len(errs) > 0 {
+			return nil, errs
+		}
+		pkgNs, _ := c.PackageRegistry.Lookup(uri)
+		return pkgNs, nil
+	}
+
 	c.PackageRegistry.MarkInProgress(uri)
 
 	contents, err := os.ReadFile(filePath)

--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -124,23 +125,20 @@ func tarjanSCCs(edges map[string][]string) [][]string {
 	index := 0
 	indices := map[string]int{}
 	lowlink := map[string]int{}
-	onStack := map[string]bool{}
+	onStack := set.NewSet[string]()
 	stack := []string{}
 	var sccs [][]string
 
 	// Gather all nodes (sources + targets) so isolated importees are
 	// represented even if they have no outgoing edges.
-	nodeSet := map[string]bool{}
+	nodeSet := set.NewSet[string]()
 	for n, succs := range edges {
-		nodeSet[n] = true
+		nodeSet.Add(n)
 		for _, s := range succs {
-			nodeSet[s] = true
+			nodeSet.Add(s)
 		}
 	}
-	nodes := make([]string, 0, len(nodeSet))
-	for n := range nodeSet {
-		nodes = append(nodes, n)
-	}
+	nodes := nodeSet.ToSlice()
 	sort.Strings(nodes) // deterministic traversal
 
 	var strongconnect func(v string)
@@ -149,7 +147,7 @@ func tarjanSCCs(edges map[string][]string) [][]string {
 		lowlink[v] = index
 		index++
 		stack = append(stack, v)
-		onStack[v] = true
+		onStack.Add(v)
 
 		for _, w := range edges[v] {
 			if _, seen := indices[w]; !seen {
@@ -157,7 +155,7 @@ func tarjanSCCs(edges map[string][]string) [][]string {
 				if lowlink[w] < lowlink[v] {
 					lowlink[v] = lowlink[w]
 				}
-			} else if onStack[w] {
+			} else if onStack.Contains(w) {
 				if indices[w] < lowlink[v] {
 					lowlink[v] = indices[w]
 				}
@@ -169,7 +167,7 @@ func tarjanSCCs(edges map[string][]string) [][]string {
 			for {
 				w := stack[len(stack)-1]
 				stack = stack[:len(stack)-1]
-				onStack[w] = false
+				onStack.Remove(w)
 				scc = append(scc, w)
 				if w == v {
 					break
@@ -259,10 +257,7 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 	// (Tarjan output), so a nested loadStdlibSCC cannot share URIs with
 	// an outer one; replacing the map is safe under save/restore.
 	prev := c.activeSCC
-	c.activeSCC = map[string]bool{}
-	for _, uri := range sccURIs {
-		c.activeSCC[uri] = true
-	}
+	c.activeSCC = set.FromSlice(sccURIs)
 	defer func() { c.activeSCC = prev }()
 
 	var sources []*ast.Source

--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -1,0 +1,346 @@
+package checker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// schemesWithSCCSupport lists the URI schemes whose pseudo-packages
+// participate in cycle-aware loading. node:* is reserved and skipped
+// until the node loader lands; mixing schemes is allowed by the graph
+// (e.g. a web:* package importing std:*), but cycles always stay
+// confined to these schemes — user packages don't appear in this graph.
+var schemesWithSCCSupport = []string{"std", "web"}
+
+// stdlibSCCFor returns the SCC containing uri. The returned slice
+// always contains uri itself; length > 1 means the package is part
+// of a real cycle and must be loaded via loadStdlibSCC.
+func (c *Checker) stdlibSCCFor(uri string) ([]string, error) {
+	c.stdlibSCCOnce.Do(func() {
+		c.stdlibSCCByURI, c.stdlibSCCErr = c.buildStdlibPkgGraph()
+	})
+	if c.stdlibSCCErr != nil {
+		return nil, c.stdlibSCCErr
+	}
+	if scc, ok := c.stdlibSCCByURI[uri]; ok {
+		return scc, nil
+	}
+	// URI isn't in the discovered graph (e.g. a not-yet-existing pkg);
+	// treat as a singleton so the normal load path runs and reports the
+	// not-found diagnostic.
+	return []string{uri}, nil
+}
+
+// buildStdlibPkgGraph scans every `.esc` file under the stdlib data
+// directory's recognized scheme subdirectories, parses just its
+// imports, and computes the SCC each URI belongs to.
+func (c *Checker) buildStdlibPkgGraph() (map[string][]string, error) {
+	dir, err := c.getStdlibDir()
+	if err != nil {
+		return nil, err
+	}
+
+	edges := map[string][]string{}
+	for _, scheme := range schemesWithSCCSupport {
+		schemeDir := filepath.Join(dir, scheme)
+		entries, err := os.ReadDir(schemeDir)
+		if err != nil {
+			// Missing scheme subdir is fine — just no packages there.
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("cannot scan %s/: %w", schemeDir, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".esc") {
+				continue
+			}
+			pkg := strings.TrimSuffix(e.Name(), ".esc")
+			uri := scheme + ":" + pkg
+			path := filepath.Join(schemeDir, e.Name())
+			imports, ierr := c.extractPseudoPackageImports(path)
+			if ierr != nil {
+				return nil, ierr
+			}
+			edges[uri] = imports
+		}
+	}
+
+	sccs := tarjanSCCs(edges)
+	out := map[string][]string{}
+	for _, scc := range sccs {
+		// Deterministic order so tests and diagnostics are stable.
+		sort.Strings(scc)
+		for _, uri := range scc {
+			out[uri] = scc
+		}
+	}
+	return out, nil
+}
+
+// extractPseudoPackageImports parses path and returns the package
+// names of every `import "<scheme>:..."` statement whose scheme is in
+// schemesWithSCCSupport.
+func (c *Checker) extractPseudoPackageImports(path string) ([]string, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+	src := &ast.Source{ID: 0, Path: filepath.Base(path), Contents: string(contents)}
+	mod, _ := parser.ParseLibFiles(c.ctx, []*ast.Source{src})
+	// Parse errors are intentionally ignored here: the SCC scan only
+	// cares about import statements. The same file is parsed again at
+	// real-load time, and any parse errors surface there with the
+	// proper diagnostic plumbing.
+
+	var out []string
+	for _, file := range mod.Files {
+		for _, imp := range file.Imports {
+			scheme, _, ok := splitScheme(imp.PackageName)
+			if !ok {
+				continue
+			}
+			if slices.Contains(schemesWithSCCSupport, scheme) {
+				out = append(out, imp.PackageName)
+			}
+		}
+	}
+	return out, nil
+}
+
+// tarjanSCCs runs Tarjan's strongly-connected-components algorithm
+// over the adjacency list `edges`. Nodes referenced only as targets
+// (not present as keys) are included as singletons. Returns one slice
+// per SCC.
+func tarjanSCCs(edges map[string][]string) [][]string {
+	index := 0
+	indices := map[string]int{}
+	lowlink := map[string]int{}
+	onStack := map[string]bool{}
+	stack := []string{}
+	var sccs [][]string
+
+	// Gather all nodes (sources + targets) so isolated importees are
+	// represented even if they have no outgoing edges.
+	nodeSet := map[string]bool{}
+	for n, succs := range edges {
+		nodeSet[n] = true
+		for _, s := range succs {
+			nodeSet[s] = true
+		}
+	}
+	nodes := make([]string, 0, len(nodeSet))
+	for n := range nodeSet {
+		nodes = append(nodes, n)
+	}
+	sort.Strings(nodes) // deterministic traversal
+
+	var strongconnect func(v string)
+	strongconnect = func(v string) {
+		indices[v] = index
+		lowlink[v] = index
+		index++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		for _, w := range edges[v] {
+			if _, seen := indices[w]; !seen {
+				strongconnect(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onStack[w] {
+				if indices[w] < lowlink[v] {
+					lowlink[v] = indices[w]
+				}
+			}
+		}
+
+		if lowlink[v] == indices[v] {
+			var scc []string
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			sccs = append(sccs, scc)
+		}
+	}
+
+	for _, n := range nodes {
+		if _, seen := indices[n]; !seen {
+			strongconnect(n)
+		}
+	}
+	return sccs
+}
+
+// loadStdlibSCC parses and infers every URI in sccURIs as a single
+// merged module so cross-package type references resolve through the
+// dep_graph's own SCC handling. After this returns successfully, every
+// URI in sccURIs has a populated namespace in PackageRegistry. If any
+// step fails, all members are removed from PackageRegistry so a
+// subsequent import re-attempts the load (matching the single-package
+// path's rollback behavior in loadStdlibPackage).
+//
+// `span` is the original importing-file span; surfaces as the anchor
+// on any diagnostics that arise during the merged load.
+func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
+	// Invariant: SCC members are always loaded together (either all
+	// registered or all absent), so checking the first is equivalent to
+	// checking every member. The lazy stdlibSCCOnce ensures the SCC
+	// graph is computed before any singleton load runs, so a member can
+	// never have been loaded via the singleton path.
+	if c.PackageRegistry.Has(sccURIs[0]) {
+		return nil
+	}
+
+	// Stage every member as in-progress so that any non-SCC Lookup that
+	// fires during the merged load sees the sentinel (and treats the
+	// URI as cyclic) rather than an empty namespace. Intra-SCC imports
+	// are short-circuited earlier via activeSCC and never reach Lookup.
+	mergedNs := type_system.NewNamespace()
+	pkgNsByURI := map[string]*type_system.Namespace{}
+	pathByURI := map[string]string{}
+
+	// Rollback helper: drop every registry entry for this SCC. Called
+	// on any error return after staging so a subsequent import re-tries
+	// the load instead of finding a half-baked entry.
+	rollback := func() {
+		for _, uri := range sccURIs {
+			delete(c.PackageRegistry.packages, uri)
+		}
+	}
+
+	for _, uri := range sccURIs {
+		scheme, pkg, _ := splitScheme(uri)
+		path, resolveErrs := c.resolveStdlibPath(scheme, pkg, span)
+		if len(resolveErrs) > 0 {
+			rollback()
+			return resolveErrs
+		}
+		pkgNs := type_system.NewNamespace()
+		pkgNsByURI[uri] = pkgNs
+		pathByURI[uri] = path
+
+		// Pre-create scheme/pkg sub-namespaces on mergedNs so that when
+		// InferModule walks `<scheme>.<pkg>` paths it lands declarations
+		// into the same Namespace pointer we publish below.
+		schemeNs, ok := mergedNs.GetNamespace(scheme)
+		if !ok {
+			schemeNs = type_system.NewNamespace()
+			if err := mergedNs.SetNamespace(scheme, schemeNs); err != nil {
+				rollback()
+				return []Error{&GenericError{message: err.Error(), span: span}}
+			}
+		}
+		if err := schemeNs.SetNamespace(pkg, pkgNs); err != nil {
+			rollback()
+			return []Error{&GenericError{message: err.Error(), span: span}}
+		}
+
+		c.PackageRegistry.MarkInProgress(uri)
+	}
+
+	// Activate the intra-SCC skip so file-scope imports don't shadow
+	// the live module-scope bindings. SCCs are disjoint by construction
+	// (Tarjan output), so a nested loadStdlibSCC cannot share URIs with
+	// an outer one; replacing the map is safe under save/restore.
+	prev := c.activeSCC
+	c.activeSCC = map[string]bool{}
+	for _, uri := range sccURIs {
+		c.activeSCC[uri] = true
+	}
+	defer func() { c.activeSCC = prev }()
+
+	var sources []*ast.Source
+	for _, uri := range sccURIs {
+		scheme, pkg, _ := splitScheme(uri)
+		contents, readErr := os.ReadFile(pathByURI[uri])
+		if readErr != nil {
+			rollback()
+			return []Error{&GenericError{
+				message: fmt.Sprintf("failed to read stdlib file %s: %s", pathByURI[uri], readErr.Error()),
+				span:    span,
+			}}
+		}
+		sourceID := c.stdlibNextSourceID
+		c.stdlibNextSourceID++
+		// Path is `<scheme>/<pkg>/index.esc` so deriveNamespaceFromPath
+		// yields `<scheme>.<pkg>` — the dotted namespace key declarations
+		// from this file land under in mod.Namespaces. The actual on-disk
+		// `.esc` file is flat (`<scheme>/<pkg>.esc`); this synthetic
+		// path just steers ParseLibFiles' namespace inference.
+		sources = append(sources, &ast.Source{
+			ID:       sourceID,
+			Path:     scheme + "/" + pkg + "/index.esc",
+			Contents: string(contents),
+		})
+	}
+
+	mod, parseErrs := parser.ParseLibFiles(c.ctx, sources)
+	if len(parseErrs) > 0 {
+		rollback()
+		errs := make([]Error, 0, len(parseErrs))
+		for _, pe := range parseErrs {
+			errs = append(errs, &GenericError{
+				message: fmt.Sprintf("parse error in stdlib SCC: %s", pe.String()),
+				span:    span,
+			})
+		}
+		return errs
+	}
+
+	// §3.4 loader rules per member, so diagnostic messages name the
+	// originating URI (e.g. `web:dom`) instead of an opaque SCC label.
+	globals := c.knownJSGlobals()
+	var decErrs []Error
+	for _, uri := range sccURIs {
+		scheme, pkg, _ := splitScheme(uri)
+		nsKey := scheme + "." + pkg
+		ns, ok := mod.Namespaces.Get(nsKey)
+		if !ok {
+			continue
+		}
+		for _, decl := range ns.Decls {
+			decErrs = append(decErrs, validateJsDecorator(uri, decl, span, globals)...)
+		}
+	}
+	if len(decErrs) > 0 {
+		rollback()
+		return decErrs
+	}
+
+	pkgScope := &Scope{Parent: c.GlobalScope, Namespace: mergedNs}
+	pkgCtx := Context{Scope: pkgScope, IsAsync: false, IsPatMatch: false}
+	_, inferErrs := c.InferModule(pkgCtx, mod)
+	if len(inferErrs) > 0 {
+		rollback()
+		return inferErrs
+	}
+
+	// Publish the populated namespaces, swapping each sentinel for its
+	// real pointer.
+	for _, uri := range sccURIs {
+		if updateErr := c.PackageRegistry.Update(uri, pkgNsByURI[uri]); updateErr != nil {
+			rollback()
+			return []Error{&GenericError{
+				message: fmt.Sprintf("cannot publish stdlib SCC member %s: %s", uri, updateErr.Error()),
+				span:    span,
+			}}
+		}
+	}
+	return nil
+}

--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -1,12 +1,14 @@
 package checker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/parser"
@@ -21,17 +23,38 @@ import (
 // confined to these schemes — user packages don't appear in this graph.
 var schemesWithSCCSupport = []string{"std", "web"}
 
+// stdlibSCCCache memoizes the per-stdlib-dir SCC graph for the process
+// lifetime. The scan is the same for every Checker that resolves to
+// the same on-disk directory, so we only pay the parse cost once per
+// dir per process (instead of once per Checker). Tests that point at a
+// fresh tempdir via ESCALIER_STDLIB_DIR get their own cache entry.
+var (
+	stdlibSCCCacheMu sync.Mutex
+	stdlibSCCCache   = map[string]*stdlibSCCEntry{}
+)
+
+type stdlibSCCEntry struct {
+	once  sync.Once
+	byURI map[string][]string
+	err   error
+}
+
 // stdlibSCCFor returns the SCC containing uri. The returned slice
 // always contains uri itself; length > 1 means the package is part
 // of a real cycle and must be loaded via loadStdlibSCC.
 func (c *Checker) stdlibSCCFor(uri string) ([]string, error) {
-	c.stdlibSCCOnce.Do(func() {
-		c.stdlibSCCByURI, c.stdlibSCCErr = c.buildStdlibPkgGraph()
-	})
-	if c.stdlibSCCErr != nil {
-		return nil, c.stdlibSCCErr
+	dir, err := c.getStdlibDir()
+	if err != nil {
+		return nil, err
 	}
-	if scc, ok := c.stdlibSCCByURI[uri]; ok {
+	entry := getStdlibSCCEntry(dir)
+	entry.once.Do(func() {
+		entry.byURI, entry.err = buildStdlibPkgGraph(c.ctx, dir)
+	})
+	if entry.err != nil {
+		return nil, entry.err
+	}
+	if scc, ok := entry.byURI[uri]; ok {
 		return scc, nil
 	}
 	// URI isn't in the discovered graph (e.g. a not-yet-existing pkg);
@@ -40,14 +63,21 @@ func (c *Checker) stdlibSCCFor(uri string) ([]string, error) {
 	return []string{uri}, nil
 }
 
+func getStdlibSCCEntry(dir string) *stdlibSCCEntry {
+	stdlibSCCCacheMu.Lock()
+	defer stdlibSCCCacheMu.Unlock()
+	if e, ok := stdlibSCCCache[dir]; ok {
+		return e
+	}
+	e := &stdlibSCCEntry{}
+	stdlibSCCCache[dir] = e
+	return e
+}
+
 // buildStdlibPkgGraph scans every `.esc` file under the stdlib data
 // directory's recognized scheme subdirectories, parses just its
 // imports, and computes the SCC each URI belongs to.
-func (c *Checker) buildStdlibPkgGraph() (map[string][]string, error) {
-	dir, err := c.getStdlibDir()
-	if err != nil {
-		return nil, err
-	}
+func buildStdlibPkgGraph(ctx context.Context, dir string) (map[string][]string, error) {
 
 	edges := map[string][]string{}
 	for _, scheme := range schemesWithSCCSupport {
@@ -67,7 +97,7 @@ func (c *Checker) buildStdlibPkgGraph() (map[string][]string, error) {
 			pkg := strings.TrimSuffix(e.Name(), ".esc")
 			uri := scheme + ":" + pkg
 			path := filepath.Join(schemeDir, e.Name())
-			imports, ierr := c.extractPseudoPackageImports(path)
+			imports, ierr := extractPseudoPackageImports(ctx, path)
 			if ierr != nil {
 				return nil, ierr
 			}
@@ -90,17 +120,25 @@ func (c *Checker) buildStdlibPkgGraph() (map[string][]string, error) {
 // extractPseudoPackageImports parses path and returns the package
 // names of every `import "<scheme>:..."` statement whose scheme is in
 // schemesWithSCCSupport.
-func (c *Checker) extractPseudoPackageImports(path string) ([]string, error) {
+func extractPseudoPackageImports(ctx context.Context, path string) ([]string, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read %s: %w", path, err)
 	}
 	src := &ast.Source{ID: 0, Path: filepath.Base(path), Contents: string(contents)}
-	mod, _ := parser.ParseLibFiles(c.ctx, []*ast.Source{src})
+	mod, _ := parser.ParseLibFiles(ctx, []*ast.Source{src})
 	// Parse errors are intentionally ignored here: the SCC scan only
 	// cares about import statements. The same file is parsed again at
 	// real-load time, and any parse errors surface there with the
 	// proper diagnostic plumbing.
+	//
+	// Edge case: imports live at the top of `.esc` files, so any parse
+	// error before the last import statement may truncate parsed.Imports
+	// — the file could be misclassified into a smaller SCC than it
+	// actually belongs to. The real-load parse re-reports the same error
+	// with the proper anchor, so the user is never silently mis-served:
+	// the worst outcome is a slightly different shape of failure
+	// diagnostic. The file isn't compiling either way.
 
 	var out []string
 	for _, file := range mod.Files {
@@ -121,6 +159,10 @@ func (c *Checker) extractPseudoPackageImports(path string) ([]string, error) {
 // over the adjacency list `edges`. Nodes referenced only as targets
 // (not present as keys) are included as singletons. Returns one slice
 // per SCC.
+//
+// The DFS is implemented recursively; Go grows goroutine stacks
+// dynamically (8KB → many MB), so depth is bounded only by available
+// memory and is far beyond any realistic stdlib graph size.
 func tarjanSCCs(edges map[string][]string) [][]string {
 	index := 0
 	indices := map[string]int{}
@@ -210,8 +252,11 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 	// URI as cyclic) rather than an empty namespace. Intra-SCC imports
 	// are short-circuited earlier via activeSCC and never reach Lookup.
 	mergedNs := type_system.NewNamespace()
-	pkgNsByURI := map[string]*type_system.Namespace{}
-	pathByURI := map[string]string{}
+	type sccMember struct {
+		uri, scheme, pkg, path string
+		ns                     *type_system.Namespace
+	}
+	members := make([]sccMember, 0, len(sccURIs))
 
 	// Rollback helper: drop every registry entry for this SCC. Called
 	// on any error return after staging so a subsequent import re-tries
@@ -230,8 +275,7 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 			return resolveErrs
 		}
 		pkgNs := type_system.NewNamespace()
-		pkgNsByURI[uri] = pkgNs
-		pathByURI[uri] = path
+		members = append(members, sccMember{uri: uri, scheme: scheme, pkg: pkg, path: path, ns: pkgNs})
 
 		// Pre-create scheme/pkg sub-namespaces on mergedNs so that when
 		// InferModule walks `<scheme>.<pkg>` paths it lands declarations
@@ -260,14 +304,13 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 	c.activeSCC = set.FromSlice(sccURIs)
 	defer func() { c.activeSCC = prev }()
 
-	var sources []*ast.Source
-	for _, uri := range sccURIs {
-		scheme, pkg, _ := splitScheme(uri)
-		contents, readErr := os.ReadFile(pathByURI[uri])
+	sources := make([]*ast.Source, 0, len(members))
+	for _, m := range members {
+		contents, readErr := os.ReadFile(m.path)
 		if readErr != nil {
 			rollback()
 			return []Error{&GenericError{
-				message: fmt.Sprintf("failed to read stdlib file %s: %s", pathByURI[uri], readErr.Error()),
+				message: fmt.Sprintf("failed to read stdlib file %s: %s", m.path, readErr.Error()),
 				span:    span,
 			}}
 		}
@@ -280,7 +323,7 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 		// path just steers ParseLibFiles' namespace inference.
 		sources = append(sources, &ast.Source{
 			ID:       sourceID,
-			Path:     scheme + "/" + pkg + "/index.esc",
+			Path:     m.scheme + "/" + m.pkg + "/index.esc",
 			Contents: string(contents),
 		})
 	}
@@ -302,15 +345,13 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 	// originating URI (e.g. `web:dom`) instead of an opaque SCC label.
 	globals := c.knownJSGlobals()
 	var decErrs []Error
-	for _, uri := range sccURIs {
-		scheme, pkg, _ := splitScheme(uri)
-		nsKey := scheme + "." + pkg
-		ns, ok := mod.Namespaces.Get(nsKey)
+	for _, m := range members {
+		ns, ok := mod.Namespaces.Get(m.scheme + "." + m.pkg)
 		if !ok {
 			continue
 		}
 		for _, decl := range ns.Decls {
-			decErrs = append(decErrs, validateJsDecorator(uri, decl, span, globals)...)
+			decErrs = append(decErrs, validateJsDecorator(m.uri, decl, span, globals)...)
 		}
 	}
 	if len(decErrs) > 0 {
@@ -328,11 +369,11 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 
 	// Publish the populated namespaces, swapping each sentinel for its
 	// real pointer.
-	for _, uri := range sccURIs {
-		if updateErr := c.PackageRegistry.Update(uri, pkgNsByURI[uri]); updateErr != nil {
+	for _, m := range members {
+		if updateErr := c.PackageRegistry.Update(m.uri, m.ns); updateErr != nil {
 			rollback()
 			return []Error{&GenericError{
-				message: fmt.Sprintf("cannot publish stdlib SCC member %s: %s", uri, updateErr.Error()),
+				message: fmt.Sprintf("cannot publish stdlib SCC member %s: %s", m.uri, updateErr.Error()),
 				span:    span,
 			}}
 		}

--- a/internal/checker/infer_stdlib_scc_test.go
+++ b/internal/checker/infer_stdlib_scc_test.go
@@ -1,0 +1,144 @@
+package checker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTarjanSCCs_NonCyclicImporterStaysSingleton pins the Tarjan
+// invariant that a node which imports into an SCC but isn't reachable
+// back from the SCC is its own singleton component, not absorbed into
+// the cycle. Without this, the loader would merge a non-cyclic
+// importer into the cyclic load — duplicating its declarations into
+// the merged module and breaking the singleton load path it should
+// have taken.
+func TestTarjanSCCs_NonCyclicImporterStaysSingleton(t *testing.T) {
+	// app → dom ↔ webgl (app is a one-way importer of the cycle).
+	edges := map[string][]string{
+		"web:app":   {"web:dom"},
+		"web:dom":   {"web:webgl"},
+		"web:webgl": {"web:dom"},
+	}
+	sccs := tarjanSCCs(edges)
+	got := normalizeSCCs(sccs)
+	want := [][]string{
+		{"web:app"},
+		{"web:dom", "web:webgl"},
+	}
+	require.Equal(t, want, got)
+}
+
+// TestTarjanSCCs_TwoCyclesWithBridge verifies SCC isolation when one
+// cycle imports into another: bridge → {dom ↔ webgl} and bridge is
+// itself part of a different cycle {bridge ↔ host}. The two cycles
+// must remain distinct SCCs (no transitive merging).
+func TestTarjanSCCs_TwoCyclesWithBridge(t *testing.T) {
+	edges := map[string][]string{
+		"web:dom":    {"web:webgl"},
+		"web:webgl":  {"web:dom"},
+		"web:bridge": {"web:dom", "web:host"},
+		"web:host":   {"web:bridge"},
+	}
+	got := normalizeSCCs(tarjanSCCs(edges))
+	want := [][]string{
+		{"web:bridge", "web:host"},
+		{"web:dom", "web:webgl"},
+	}
+	require.Equal(t, want, got)
+}
+
+// TestBuildStdlibPkgGraph_FullPipeline exercises the full scan +
+// extract + Tarjan pipeline against an on-disk tempdir that covers
+// the cases the higher-level tests don't isolate:
+//
+//   - A 2-cycle inside `web/` (dom ↔ webgl).
+//   - A `web/` package that imports into the cycle but isn't part of it
+//     (app → dom) — must remain a singleton SCC.
+//   - An isolated `std/` package with no imports — singleton.
+//   - A `std/` package with non-pseudo imports (a user-package import
+//     and a `node:` import) — both must be filtered out of the graph.
+//   - A `node/` subdir entirely — must be skipped, since `node:` isn't
+//     in schemesWithSCCSupport.
+func TestBuildStdlibPkgGraph_FullPipeline(t *testing.T) {
+	dir := makeTempStdlibDir(t, map[string]string{
+		"web/dom.esc": `
+import "web:webgl?nested"
+export declare class HTMLCanvasElement {}
+`,
+		"web/webgl.esc": `
+import "web:dom?nested"
+export declare class WebGLRenderingContext {}
+`,
+		"web/app.esc": `
+import "web:dom?nested"
+export declare class App {}
+`,
+		"std/math.esc": `
+export declare fn add(a: number, b: number) -> number
+`,
+		"std/util.esc": `
+import "node:fs"
+import "some-user-package"
+export declare fn util() -> number
+`,
+		// node/* is in stdlibSchemes but not schemesWithSCCSupport, so the
+		// scan must skip this directory entirely.
+		"node/fs.esc": `
+import "web:dom?nested"
+export declare fn readFile(path: string) -> string
+`,
+	})
+
+	got, err := buildStdlibPkgGraph(context.Background(), dir)
+	require.NoError(t, err)
+
+	// Convert the returned URI → SCC map into the canonical form
+	// `URI → sorted member list` so test assertions are stable.
+	gotByURI := map[string][]string{}
+	for uri, scc := range got {
+		s := append([]string(nil), scc...)
+		sort.Strings(s)
+		gotByURI[uri] = s
+	}
+	want := map[string][]string{
+		"web:dom":   {"web:dom", "web:webgl"},
+		"web:webgl": {"web:dom", "web:webgl"},
+		"web:app":   {"web:app"},
+		"std:math":  {"std:math"},
+		"std:util":  {"std:util"},
+	}
+	require.Equal(t, want, gotByURI)
+}
+
+// makeTempStdlibDir writes the {relative-path → contents} map under a
+// fresh t.TempDir() and returns the directory.
+func makeTempStdlibDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, contents := range files {
+		full := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+	}
+	return dir
+}
+
+// normalizeSCCs sorts each component and the outer list so test
+// assertions don't depend on Tarjan's visit order.
+func normalizeSCCs(sccs [][]string) [][]string {
+	out := make([][]string, len(sccs))
+	for i, scc := range sccs {
+		s := append([]string(nil), scc...)
+		sort.Strings(s)
+		out[i] = s
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][0] < out[j][0]
+	})
+	return out
+}

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -322,9 +322,9 @@ func TestStdlibImport_LoaderRule_AcceptsValidPackage(t *testing.T) {
 // room for future decorators, so this rule lives in the loader.
 func TestStdlibImport_LoaderRule_MalformedJSDecorator(t *testing.T) {
 	cases := map[string]string{
-		"NonStringArg":  "@js(123)\nexport declare val PI: number",
-		"MultipleArgs":  "@js(\"a\", \"b\")\nexport declare val PI: number",
-		"NoArgs":        "@js()\nexport declare val PI: number",
+		"NonStringArg": "@js(123)\nexport declare val PI: number",
+		"MultipleArgs": "@js(\"a\", \"b\")\nexport declare val PI: number",
+		"NoArgs":       "@js()\nexport declare val PI: number",
 	}
 	for name, source := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -450,6 +450,12 @@ func TestStdlibImport_LoaderRule_KnownGlobals(t *testing.T) {
 // .getContext("webgl") -> WebGLRenderingContext` ↔ `WebGLRenderingContext
 // .canvas: HTMLCanvasElement` pair — load as a single merged module
 // so each side's qualified type references into the other resolve.
+//
+// The user-side import uses the default binding shape (no flag →
+// ?local), exercising the singleton-namespace binding path on top of
+// a cyclic load. Intra-SCC imports still use ?nested because the
+// cross-package type references inside the merged module are written
+// with `web.<pkg>` qualified paths.
 func TestStdlibImport_PseudoPackageCycle(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/dom.esc": `
@@ -472,19 +478,17 @@ export declare class WebGLRenderingContext {
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
 	fileScopes, errs := inferStdlibImportSource(t, `
-import "web:dom?nested"
+import "web:dom"
 
-export declare fn make() -> web.dom.HTMLCanvasElement
+export declare fn make() -> dom.HTMLCanvasElement
 `)
 	require.Empty(t, errorMessages(errs))
 
 	fileScope := fileScopes[0]
-	webNs, ok := fileScope.Namespace.GetNamespace("web")
-	require.True(t, ok, "expected web namespace bound in importing file")
-	domNs, ok := webNs.GetNamespace("dom")
-	require.True(t, ok, "expected web.dom sub-namespace")
+	domNs, ok := fileScope.Namespace.GetNamespace("dom")
+	require.True(t, ok, "expected dom namespace bound at file scope (default ?local)")
 	_, hasCanvas := domNs.Types["HTMLCanvasElement"]
-	require.True(t, hasCanvas, "HTMLCanvasElement should be exposed via web.dom")
+	require.True(t, hasCanvas, "HTMLCanvasElement should be exposed via dom")
 }
 
 // TestStdlibImport_PseudoPackageCycleThreeWay verifies SCC handling
@@ -525,10 +529,67 @@ export declare class ClassC {
 	require.Empty(t, errorMessages(errs))
 }
 
+// TestStdlibImport_PseudoPackageCycle_NonCyclicImporter pins that a
+// pseudo-package which imports into a cycle but isn't itself part of
+// the cycle is loaded via the normal singleton path, not absorbed
+// into the merged SCC load. `web:app → web:dom ↔ web:webgl`: app is a
+// one-way importer of the cycle and must remain its own SCC.
+func TestStdlibImport_PseudoPackageCycle_NonCyclicImporter(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"web/dom.esc": `
+import "web:webgl?nested"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+}
+`,
+		"web/webgl.esc": `
+import "web:dom?nested"
+
+@js("WebGLRenderingContext")
+export declare class WebGLRenderingContext {
+    canvas: web.dom.HTMLCanvasElement,
+}
+`,
+		"web/app.esc": `
+import "web:dom?nested"
+
+@js("Map")
+export declare class App {
+    canvas: web.dom.HTMLCanvasElement,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	fileScopes, errs := inferStdlibImportSource(t, `
+import "web:app?nested"
+import "web:dom?nested"
+import "web:webgl?nested"
+`)
+	require.Empty(t, errorMessages(errs))
+
+	webNs, ok := fileScopes[0].Namespace.GetNamespace("web")
+	require.True(t, ok)
+	for _, pkg := range []string{"app", "dom", "webgl"} {
+		_, ok := webNs.GetNamespace(pkg)
+		require.True(t, ok, "expected web.%s sub-namespace", pkg)
+	}
+}
+
 // TestStdlibImport_PseudoPackageCycleMixedSchemes verifies the SCC
 // loader handles cross-scheme cycles (a `std:*` package importing a
 // `web:*` package and vice versa) as a single merged load, not just
 // cycles confined to a single scheme.
+//
+// The user-side imports use the default binding shape (no flag →
+// ?local). Both packages expose a single class whose name matches the
+// pkg name case-insensitively (`Host`/`host`, `Client`/`client`), so
+// the §FR5 single-class shortcut fires: the class names bind directly
+// at file scope rather than under a `host`/`client` namespace. This
+// proves the shortcut path stacks correctly on top of the cyclic
+// merged load.
 func TestStdlibImport_PseudoPackageCycleMixedSchemes(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"std/host.esc": `
@@ -550,11 +611,20 @@ export declare class Client {
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
-	_, errs := inferStdlibImportSource(t, `
-import "std:host?nested"
-import "web:client?nested"
+	fileScopes, errs := inferStdlibImportSource(t, `
+import "std:host"
+import "web:client"
+
+export declare fn makeHost() -> Host
+export declare fn makeClient() -> Client
 `)
 	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	_, hasHostType := fileScope.Namespace.Types["Host"]
+	require.True(t, hasHostType, "single-class shortcut should bind Host directly at file scope")
+	_, hasClientType := fileScope.Namespace.Types["Client"]
+	require.True(t, hasClientType, "single-class shortcut should bind Client directly at file scope")
 }
 
 // TestStdlibImport_PseudoPackageCycle_DecoratorErrorNamesURI pins the

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -581,14 +580,10 @@ export declare class WebGLRenderingContext {
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
 	_, errs := inferStdlibImportSource(t, `import "web:dom?nested"`)
-	msgs := errorMessages(errs)
-	require.NotEmpty(t, msgs, "expected an @js validation error")
-
-	joined := strings.Join(msgs, "\n")
-	require.Contains(t, joined, "web:webgl",
-		"diagnostic should name the offending member URI, got: %s", joined)
-	require.NotContains(t, joined, "SCC{",
-		"diagnostic should not leak the synthetic SCC label, got: %s", joined)
+	expected := []string{
+		"`@js(\"ThisGlobalDoesNotExist\")` on class \"WebGLRenderingContext\" in pseudo-package file web:webgl does not name a known JS runtime global",
+	}
+	require.Equal(t, expected, errorMessages(errs))
 }
 
 // TestStdlibImport_PseudoPackageCycle_RollbackOnFailure verifies that
@@ -627,13 +622,6 @@ export declare class WebGLRenderingContext {
 import "web:dom?nested"
 import "web:webgl?nested"
 `)
-	msgs := errorMessages(errs)
-	hits := 0
-	for _, m := range msgs {
-		if strings.Contains(m, "ThisGlobalDoesNotExist") {
-			hits++
-		}
-	}
-	require.GreaterOrEqual(t, hits, 2,
-		"expected the decorator error to surface for both imports (rollback should re-attempt the load); got msgs: %v", msgs)
+	msg := "`@js(\"ThisGlobalDoesNotExist\")` on class \"WebGLRenderingContext\" in pseudo-package file web:webgl does not name a known JS runtime global"
+	require.Equal(t, []string{msg, msg}, errorMessages(errs))
 }

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -441,4 +442,198 @@ func TestStdlibImport_LoaderRule_KnownGlobals(t *testing.T) {
 			require.Empty(t, errorMessages(errs))
 		})
 	}
+}
+
+// TestStdlibImport_PseudoPackageCycle pins §4.3's "cycles between
+// pseudo-packages are permitted" rule. Two `web:*` packages with a
+// mutual import — modeled on the canonical `HTMLCanvasElement
+// .getContext("webgl") -> WebGLRenderingContext` ↔ `WebGLRenderingContext
+// .canvas: HTMLCanvasElement` pair — load as a single merged module
+// so each side's qualified type references into the other resolve.
+func TestStdlibImport_PseudoPackageCycle(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"web/dom.esc": `
+import "web:webgl?nested"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+}
+`,
+		"web/webgl.esc": `
+import "web:dom?nested"
+
+@js("WebGLRenderingContext")
+export declare class WebGLRenderingContext {
+    canvas: web.dom.HTMLCanvasElement,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	fileScopes, errs := inferStdlibImportSource(t, `
+import "web:dom?nested"
+
+export declare fn make() -> web.dom.HTMLCanvasElement
+`)
+	require.Empty(t, errorMessages(errs))
+
+	fileScope := fileScopes[0]
+	webNs, ok := fileScope.Namespace.GetNamespace("web")
+	require.True(t, ok, "expected web namespace bound in importing file")
+	domNs, ok := webNs.GetNamespace("dom")
+	require.True(t, ok, "expected web.dom sub-namespace")
+	_, hasCanvas := domNs.Types["HTMLCanvasElement"]
+	require.True(t, hasCanvas, "HTMLCanvasElement should be exposed via web.dom")
+}
+
+// TestStdlibImport_PseudoPackageCycleThreeWay verifies SCC handling
+// generalizes beyond pairs: three packages in a 3-cycle still resolve
+// each other's qualified references.
+func TestStdlibImport_PseudoPackageCycleThreeWay(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"web/a.esc": `
+import "web:b?nested"
+
+@js("Map")
+export declare class ClassA {
+    refB: web.b.ClassB,
+}
+`,
+		"web/b.esc": `
+import "web:c?nested"
+
+@js("Set")
+export declare class ClassB {
+    refC: web.c.ClassC,
+}
+`,
+		"web/c.esc": `
+import "web:a?nested"
+
+@js("WeakMap")
+export declare class ClassC {
+    refA: web.a.ClassA,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `import "web:a?nested"`)
+	require.Empty(t, errorMessages(errs))
+}
+
+// TestStdlibImport_PseudoPackageCycleMixedSchemes verifies the SCC
+// loader handles cross-scheme cycles (a `std:*` package importing a
+// `web:*` package and vice versa) as a single merged load, not just
+// cycles confined to a single scheme.
+func TestStdlibImport_PseudoPackageCycleMixedSchemes(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"std/host.esc": `
+import "web:client?nested"
+
+@js("Map")
+export declare class Host {
+    client: web.client.Client,
+}
+`,
+		"web/client.esc": `
+import "std:host?nested"
+
+@js("Set")
+export declare class Client {
+    host: std.host.Host,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `
+import "std:host?nested"
+import "web:client?nested"
+`)
+	require.Empty(t, errorMessages(errs))
+}
+
+// TestStdlibImport_PseudoPackageCycle_DecoratorErrorNamesURI pins the
+// diagnostic-label fix: when an SCC member fails the §3.4 `@js` rules,
+// the error message must identify the offending member by URI
+// (e.g. `web:webgl`) rather than by an opaque synthetic SCC label.
+func TestStdlibImport_PseudoPackageCycle_DecoratorErrorNamesURI(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"web/dom.esc": `
+import "web:webgl?nested"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+}
+`,
+		"web/webgl.esc": `
+import "web:dom?nested"
+
+@js("ThisGlobalDoesNotExist")
+export declare class WebGLRenderingContext {
+    canvas: web.dom.HTMLCanvasElement,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `import "web:dom?nested"`)
+	msgs := errorMessages(errs)
+	require.NotEmpty(t, msgs, "expected an @js validation error")
+
+	joined := strings.Join(msgs, "\n")
+	require.Contains(t, joined, "web:webgl",
+		"diagnostic should name the offending member URI, got: %s", joined)
+	require.NotContains(t, joined, "SCC{",
+		"diagnostic should not leak the synthetic SCC label, got: %s", joined)
+}
+
+// TestStdlibImport_PseudoPackageCycle_RollbackOnFailure verifies that
+// when an SCC load fails (decorator-rule violation in one member), the
+// PackageRegistry is rolled back so a subsequent import of any member
+// re-attempts the load and surfaces the same diagnostic. Without
+// rollback, the second import would silently succeed against an empty
+// staged namespace.
+func TestStdlibImport_PseudoPackageCycle_RollbackOnFailure(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		"web/dom.esc": `
+import "web:webgl?nested"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+}
+`,
+		"web/webgl.esc": `
+import "web:dom?nested"
+
+@js("ThisGlobalDoesNotExist")
+export declare class WebGLRenderingContext {
+    canvas: web.dom.HTMLCanvasElement,
+}
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	// Two imports in the same file share one Checker. The first triggers
+	// the SCC load (and fails); the second targets the *other* member.
+	// With rollback, both report the same underlying decorator error.
+	// Without rollback, the second silently binds an empty namespace and
+	// produces no diagnostic.
+	_, errs := inferStdlibImportSource(t, `
+import "web:dom?nested"
+import "web:webgl?nested"
+`)
+	msgs := errorMessages(errs)
+	hits := 0
+	for _, m := range msgs {
+		if strings.Contains(m, "ThisGlobalDoesNotExist") {
+			hits++
+		}
+	}
+	require.GreaterOrEqual(t, hits, 2,
+		"expected the decorator error to surface for both imports (rollback should re-attempt the load); got msgs: %v", msgs)
 }

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -488,7 +489,9 @@ export declare fn make() -> web.dom.HTMLCanvasElement
 
 // TestStdlibImport_PseudoPackageCycleThreeWay verifies SCC handling
 // generalizes beyond pairs: three packages in a 3-cycle still resolve
-// each other's qualified references.
+// each other's qualified references. The `@js("Map"/"Set"/"WeakMap")`
+// targets are arbitrary placeholders chosen because they're on the
+// known-globals allow-list; they bear no relationship to ClassA/B/C.
 func TestStdlibImport_PseudoPackageCycleThreeWay(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/a.esc": `
@@ -624,4 +627,58 @@ import "web:webgl?nested"
 `)
 	msg := "`@js(\"ThisGlobalDoesNotExist\")` on class \"WebGLRenderingContext\" in pseudo-package file web:webgl does not name a known JS runtime global"
 	require.Equal(t, []string{msg, msg}, errorMessages(errs))
+}
+
+// TestStdlibImport_PseudoPackageCycle_RollbackOnParseError exercises
+// the same rollback contract as RollbackOnFailure but via a different
+// error branch in loadStdlibSCC: when one SCC member has a parse
+// error, the merged-module ParseLibFiles fails. A second import of any
+// member must re-attempt the load (and produce the same diagnostic),
+// not silently bind an empty namespace.
+func TestStdlibImport_PseudoPackageCycle_RollbackOnParseError(t *testing.T) {
+	dir := makeCustomStdlibDir(t, map[string]string{
+		// dom.esc imports webgl cleanly so the SCC scanner sees the cycle.
+		"web/dom.esc": `
+import "web:webgl?nested"
+
+@js("HTMLCanvasElement")
+export declare class HTMLCanvasElement {
+    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+}
+`,
+		// webgl.esc parses its import line, then fails on the trailing
+		// garbage — that error surfaces during the SCC's real-load parse,
+		// not during the graph scan.
+		"web/webgl.esc": `
+import "web:dom?nested"
+
+@js("WebGLRenderingContext")
+export declare class WebGLRenderingContext {
+    canvas: web.dom.HTMLCanvasElement,
+}
+
+@@@ this is not valid escalier
+`,
+	})
+	t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+	_, errs := inferStdlibImportSource(t, `
+import "web:dom?nested"
+import "web:webgl?nested"
+`)
+	msgs := errorMessages(errs)
+	require.NotEmpty(t, msgs, "expected parse-error diagnostics from both imports")
+	// Each error is anchored to the importing statement's span. With
+	// rollback, both imports re-attempt the load, so the parse-error
+	// diagnostics surface at *both* import spans. Without rollback, the
+	// second import finds a sentinel in the registry and silently skips
+	// reloading, so all parse errors come from a single span.
+	parseSpans := map[ast.Span]int{}
+	for _, e := range errs {
+		if strings.HasPrefix(e.Message(), "parse error in stdlib SCC:") {
+			parseSpans[e.Span()]++
+		}
+	}
+	require.Len(t, parseSpans, 2,
+		"expected parse-error diagnostics anchored to both import spans (rollback should re-attempt the load); got spans=%v, msgs=%v", parseSpans, msgs)
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1038,3 +1038,30 @@ func TestStatementRecovery(t *testing.T) {
 		})
 	}
 }
+
+// TestDeriveNamespaceFromPath locks the path → dotted-namespace
+// contract that several callers depend on. The stdlib SCC loader
+// constructs synthetic source paths of the form `<scheme>/<pkg>/index.esc`
+// expecting them to derive to `<scheme>.<pkg>`; if that mapping ever
+// drifts, the SCC merged-module load silently lands declarations in
+// the wrong namespace.
+func TestDeriveNamespaceFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"main.esc", ""},
+		{"lib/main.esc", ""},
+		{"foo/math.esc", "foo"},
+		{"bar/string.esc", "bar"},
+		{"core/utils/helpers.esc", "core.utils"},
+		// stdlib SCC loader's synthetic paths.
+		{"web/dom/index.esc", "web.dom"},
+		{"std/host/index.esc", "std.host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			require.Equal(t, tc.want, deriveNamespaceFromPath(tc.path))
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of circular import dependencies in the standard library, ensuring consistent type resolution and module loading when packages reference each other.

* **Tests**
  * Added comprehensive test coverage for circular import scenarios, including multi-package cycles and cross-scheme imports, with validation for error reporting and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->