### PR TITLE
Stdlib pkgNs bindings share canonical pointer

### DIFF
--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -397,6 +397,10 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 // already "filtered" by construction, and sharing it means qualified
 // refs through the binding see the same types as refs through the
 // registry-cached namespace tree.
+//
+// Invariant: callers must not mutate pkgNs (or the namespace tree it
+// stores) after binding — every importer of this package, plus the
+// PackageRegistry entry, observes the same `*Namespace`.
 func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
 	// Single-class shortcut: look for a class whose name matches the
 	// package name case-insensitively. Activation requires the package

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -391,18 +391,22 @@ func (c *Checker) loadStdlibPackage(uri, filePath string, span ast.Span) (*type_
 // top-level class whose name matches the package name
 // case-insensitively (FR5 single-class shortcut), bind that class
 // directly with its original capitalization instead.
+//
+// The binding shares the canonical pkgNs pointer (no filtered copy):
+// stdlib pkgs by §3.4 contain only exported decls, so the pointer is
+// already "filtered" by construction, and sharing it means qualified
+// refs through the binding see the same types as refs through the
+// registry-cached namespace tree.
 func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
-	filtered := filterExportedNamespace(pkgNs)
-
 	// Single-class shortcut: look for a class whose name matches the
 	// package name case-insensitively. Activation requires the package
 	// to expose both a value (the constructor) and a type alias under
 	// the same identifier — which is exactly the shape a class
 	// declaration produces.
-	if className, ok := findSingleClassShortcut(filtered, pkg); ok {
+	if className, ok := findSingleClassShortcut(pkgNs, pkg); ok {
 		ns := ctx.Scope.Namespace
-		ns.Values[className] = filtered.Values[className]
-		ns.Types[className] = filtered.Types[className]
+		ns.Values[className] = pkgNs.Values[className]
+		ns.Types[className] = pkgNs.Types[className]
 		// TODO (§2.4): also expose other package exports as namespace
 		// members on the same binding, with static methods winning on
 		// collision. Deferred until a stdlib package actually has both
@@ -412,7 +416,7 @@ func (c *Checker) bindStdlibLocal(ctx Context, pkg string, pkgNs *type_system.Na
 	}
 
 	bindingName := lastSegmentLower(pkg)
-	if err := ctx.Scope.Namespace.SetNamespace(bindingName, filtered); err != nil {
+	if err := ctx.Scope.Namespace.SetNamespace(bindingName, pkgNs); err != nil {
 		return []Error{&GenericError{
 			message: fmt.Sprintf("cannot bind stdlib namespace %q: %s", bindingName, err.Error()),
 			span:    span,
@@ -440,7 +444,8 @@ func findSingleClassShortcut(ns *type_system.Namespace, pkg string) (string, boo
 // scope, lazily creating the per-scheme namespace. Duplicate ?nested
 // imports of the same package within a single file are silently
 // idempotent — bookkeeping keys on the URI (per §2.3) so the first
-// import "won" and any subsequent ones add nothing.
+// import "won" and any subsequent ones add nothing. Like bindStdlibLocal,
+// the binding shares the canonical pkgNs pointer.
 func (c *Checker) bindStdlibNested(ctx Context, scheme, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
 	schemeNs, err := getOrCreateSchemeNamespace(ctx.Scope.Namespace, scheme)
 	if err != nil {
@@ -450,8 +455,7 @@ func (c *Checker) bindStdlibNested(ctx Context, scheme, pkg string, pkgNs *type_
 		// Already bound from an earlier ?nested import of the same URI.
 		return nil
 	}
-	filtered := filterExportedNamespace(pkgNs)
-	if err := schemeNs.SetNamespace(pkg, filtered); err != nil {
+	if err := schemeNs.SetNamespace(pkg, pkgNs); err != nil {
 		return []Error{&GenericError{
 			message: fmt.Sprintf("cannot bind %s.%s: %s", scheme, pkg, err.Error()),
 			span:    span,

--- a/internal/checker/js_decorator.go
+++ b/internal/checker/js_decorator.go
@@ -29,12 +29,36 @@ func declName(decl ast.Decl) string {
 			return d.Name.Name
 		}
 		return ""
+	case *ast.TypeDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+		return ""
+	case *ast.InterfaceDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+		return ""
+	case *ast.EnumDecl:
+		if d.Name != nil {
+			return d.Name.Name
+		}
+		return ""
 	}
 	return ""
 }
 
+// declNameOrPlaceholder is declName with a "<unnamed>" fallback for
+// diagnostics that need a non-empty string.
+func declNameOrPlaceholder(decl ast.Decl) string {
+	if n := declName(decl); n != "" {
+		return n
+	}
+	return "<unnamed>"
+}
+
 // declKindLabel returns a short label for decl used in diagnostics
-// ("function", "class", "value"). Matches the §3.3 grammar terms.
+// ("function", "class", "value", …). Matches the §3.3 grammar terms.
 func declKindLabel(decl ast.Decl) string {
 	switch decl.(type) {
 	case *ast.FuncDecl:
@@ -43,6 +67,12 @@ func declKindLabel(decl ast.Decl) string {
 		return "class"
 	case *ast.VarDecl:
 		return "value"
+	case *ast.TypeDecl:
+		return "type"
+	case *ast.InterfaceDecl:
+		return "interface"
+	case *ast.EnumDecl:
+		return "enum"
 	default:
 		return "declaration"
 	}
@@ -55,8 +85,14 @@ func declKindLabel(decl ast.Decl) string {
 //  2. An unexported value-level top-level decl is rejected (no runtime
 //     mapping; invisible to importers — almost certainly a missing
 //     `export`).
-//  3. An unexported type-level decl is allowed and must not carry `@js`
-//     (already enforced at parse time, so nothing to check here).
+//  3. An unexported type-level decl is rejected too. Importers'
+//     file-scope bindings share the canonical pkgNs pointer (see
+//     bindStdlibLocal / bindStdlibNested), so any member in pkgNs is
+//     potentially reachable through qualified refs — unexported types
+//     would leak. Forbidding them at the loader keeps the
+//     share-by-pointer model safe; the `@js` decorator is forbidden
+//     on type-level decls at parse time, so we don't need to check it
+//     here.
 //  4. The `@js` argument names a known JS runtime path — a top-level
 //     global from the pinned TS lib (e.g. `Math.sin`, `parseInt`) or
 //     an entry in the hand-authored allow-list
@@ -82,15 +118,25 @@ func validateJsDecorator(filePath string, decl ast.Decl, importSpan ast.Span, gl
 	switch decl.(type) {
 	case *ast.VarDecl, *ast.FuncDecl, *ast.ClassDecl:
 		// fall through — value-level decl handled below
+	case *ast.TypeDecl, *ast.InterfaceDecl, *ast.EnumDecl:
+		// Rule 3: type-level decls must be exported. No `@js` checks
+		// apply (parser forbids `@js` on type-level decls).
+		if !decl.Export() {
+			return []Error{&GenericError{
+				message: fmt.Sprintf(
+					"unexported %s %q in pseudo-package file %s has no runtime mapping; "+
+						"add `export` or remove the declaration",
+					declKindLabel(decl), declNameOrPlaceholder(decl), filePath),
+				span: importSpan,
+			}}
+		}
+		return nil
 	default:
 		return nil
 	}
 
 	jsDec, jsArg, jsOK := ast.FindJsDecorator(decl)
-	name := declName(decl)
-	if name == "" {
-		name = "<unnamed>"
-	}
+	name := declNameOrPlaceholder(decl)
 	kindLabel := declKindLabel(decl)
 
 	if !decl.Export() {

--- a/internal/checker/js_decorator.go
+++ b/internal/checker/js_decorator.go
@@ -124,7 +124,8 @@ func validateJsDecorator(filePath string, decl ast.Decl, importSpan ast.Span, gl
 		if !decl.Export() {
 			return []Error{&GenericError{
 				message: fmt.Sprintf(
-					"unexported %s %q in pseudo-package file %s has no runtime mapping; "+
+					"unexported %s %q in pseudo-package file %s would leak to importers "+
+						"through the shared package namespace; "+
 						"add `export` or remove the declaration",
 					declKindLabel(decl), declNameOrPlaceholder(decl), filePath),
 				span: importSpan,

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -352,6 +352,11 @@ func TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected(t *testing.T) {
 			src:  "declare interface Helper {}",
 			decl: `interface "Helper"`,
 		},
+		{
+			name: "Enum",
+			src:  "declare enum Helper {}",
+			decl: `enum "Helper"`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -363,7 +368,8 @@ func TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected(t *testing.T) {
 			_, errs := inferStdlibImportSource(t, `import "std:example"`)
 			require.Len(t, errs, 1)
 			require.Equal(t,
-				fmt.Sprintf("unexported %s in pseudo-package file %s has no runtime mapping; "+
+				fmt.Sprintf("unexported %s in pseudo-package file %s would leak to importers "+
+					"through the shared package namespace; "+
 					"add `export` or remove the declaration",
 					tc.decl, filepath.Join(dir, "std/example.esc")),
 				errs[0].Message())

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -266,17 +266,109 @@ func TestStdlibImport_LoaderRule_UnexportedValueLevelRejected(t *testing.T) {
 
 // TestStdlibImport_LoaderRule_AcceptsValidPackage confirms the loader
 // rules don't false-positive on a correctly-authored pseudo-package
-// (every exported value-level decl has `@js("...")`; type-level decls
-// have no decorator).
+// (every exported value-level decl has `@js("...")`; every type-level
+// decl is exported).
 func TestStdlibImport_LoaderRule_AcceptsValidPackage(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"std/example.esc": "@js(\"parseInt\")\nexport declare fn foo() -> number\n" +
-			"declare type Helper = number",
+			"export declare type Helper = number",
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
 	_, errs := inferStdlibImportSource(t, `import "std:example"`)
 	require.Empty(t, errorMessages(errs))
+}
+
+// TestStdlibImport_LocalBindingSharesPkgNsPointer pins the
+// share-by-pointer model: a `?local` file-scope binding for a stdlib
+// pkg holds the *same* `*type_system.Namespace` instance that the
+// PackageRegistry caches. This (combined with the §3.4 rule
+// extension that forbids unexported types in stdlib pkgs) lets
+// importers see the canonical declarations without an intervening
+// filtered copy — necessary for late-population scenarios (e.g.
+// intra-SCC bindings under PR C) to work.
+//
+// `?nested` likewise binds the same pointer under `<scheme>.<pkg>`,
+// so a file that imports the same package both ways sees one shared
+// namespace under two file-scope paths.
+func TestStdlibImport_LocalBindingSharesPkgNsPointer(t *testing.T) {
+	// std:math has no class whose name matches the pkg name, so the
+	// single-class shortcut doesn't fire and `?local` binds the pkg as
+	// a namespace under `math` — the right shape for the pointer
+	// comparison. std:array would route through the shortcut and bind
+	// the class directly.
+	source := &ast.Source{ID: 0, Path: "lib/main.esc", Contents: `
+		import "std:math"
+		import "std:math?nested"
+	`}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	module, parseErrs := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	require.Empty(t, parseErrs)
+
+	c := NewChecker(ctx)
+	inferCtx := Context{Scope: Prelude(c)}
+	_, errs := c.InferModule(inferCtx, module)
+	require.Empty(t, errorMessages(errs))
+
+	canonical, ok := c.PackageRegistry.Lookup("std:math")
+	require.True(t, ok, "expected std:math in PackageRegistry")
+	require.NotNil(t, canonical)
+
+	fileScope := c.FileScopes[0]
+	localBind, ok := fileScope.Namespace.GetNamespace("math")
+	require.True(t, ok, "expected `math` namespace from ?local import")
+	require.Same(t, canonical, localBind,
+		"?local binding should share the canonical pkgNs pointer, not a filtered copy")
+
+	stdNs, ok := fileScope.Namespace.GetNamespace("std")
+	require.True(t, ok)
+	nestedBind, ok := stdNs.GetNamespace("math")
+	require.True(t, ok, "expected `std.math` namespace from ?nested import")
+	require.Same(t, canonical, nestedBind,
+		"?nested binding should share the canonical pkgNs pointer")
+}
+
+// TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected pins the
+// extended §3.4 rule: unexported type-level decls in pseudo-package
+// files are rejected. The canonical pkgNs is shared by reference into
+// importers' file scopes (so they can resolve qualified refs through
+// the registry-cached namespace tree), which means leaving unexported
+// members in pkgNs would leak them to importers. Forbidding them at
+// the loader makes the share-by-pointer model safe.
+func TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		decl string // human-readable kind+name for the expected diagnostic
+	}{
+		{
+			name: "TypeAlias",
+			src:  "declare type Helper = number",
+			decl: `type "Helper"`,
+		},
+		{
+			name: "Interface",
+			src:  "declare interface Helper {}",
+			decl: `interface "Helper"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := makeCustomStdlibDir(t, map[string]string{
+				"std/example.esc": tc.src,
+			})
+			t.Setenv("ESCALIER_STDLIB_DIR", dir)
+
+			_, errs := inferStdlibImportSource(t, `import "std:example"`)
+			require.Len(t, errs, 1)
+			require.Equal(t,
+				fmt.Sprintf("unexported %s in pseudo-package file %s has no runtime mapping; "+
+					"add `export` or remove the declaration",
+					tc.decl, filepath.Join(dir, "std/example.esc")),
+				errs[0].Message())
+		})
+	}
 }
 
 // TestStdlibImport_LoaderRule_MalformedJSDecorator pins the loader's


### PR DESCRIPTION
## Summary

- `bindStdlibLocal` and `bindStdlibNested` now bind the canonical `pkgNs` pointer directly, instead of producing a filtered copy via `filterExportedNamespace`. File-scope bindings under `?local` / `?nested` are pointer-equal to the namespace cached in `PackageRegistry`.
- Extends loader rule §3.4: unexported type-level decls (`TypeDecl`, `InterfaceDecl`, `EnumDecl`) in pseudo-package files are now rejected — same treatment as unexported value-level decls. Necessary because sharing the canonical `pkgNs` by pointer would otherwise leak unexported members to importers.
- Stdlib data dir audit: `internal/interop/data/std/*.esc` already contains only exported decls, so the tightened rule is a no-op for shipped data.

This unblocks the planned PR C, where the intra-SCC short-circuit will perform the file-scope bind using the in-flight `pkgNs` pointer. Today's filtered copy would be empty at bind time, so pointer sharing is the prerequisite.

## Test plan

- [x] `go test ./...` — full suite green
- [x] New `TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected` (TypeAlias + Interface subcases) — confirmed failing without the §3.4 extension
- [x] New `TestStdlibImport_LocalBindingSharesPkgNsPointer` — proves both `?local` and `?nested` bindings are pointer-equal to the PackageRegistry entry; confirmed failing without the share-by-pointer change

🤖 Generated with [Claude Code](https://claude.com/claude-code)