### PR TITLE
Remove `?nested` import flag; flatten SCC merged-module paths

### DIFF
--- a/fixtures/stdlib_import_nested/build/lib/index.d.ts
+++ b/fixtures/stdlib_import_nested/build/lib/index.d.ts
@@ -1,1 +1,0 @@
-export declare const pi: number;

--- a/fixtures/stdlib_import_nested/build/lib/index.js
+++ b/fixtures/stdlib_import_nested/build/lib/index.js
@@ -1,2 +1,0 @@
-export const pi = Math.PI;
-//# sourceMappingURL=./index.js.map

--- a/fixtures/stdlib_import_nested/build/lib/index.js.map
+++ b/fixtures/stdlib_import_nested/build/lib/index.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"./index.js","sources":["../../lib/index.esc"],"sourcesContent":["import \"std:math?nested\"\n\nexport val pi: number = std.math.PI\n"],"names":[],"mappings":"aAEW,AAAA,KAAa,AAAA,KAAA"}

--- a/fixtures/stdlib_import_nested/lib/index.esc
+++ b/fixtures/stdlib_import_nested/lib/index.esc
@@ -1,3 +1,0 @@
-import "std:math?nested"
-
-export val pi: number = std.math.PI

--- a/fixtures/stdlib_import_nested/package.json
+++ b/fixtures/stdlib_import_nested/package.json
@@ -1,6 +1,0 @@
-{
-    "name": "stdlib-import-nested",
-    "version": "0.0.1",
-    "type": "module",
-    "main": "build/lib/index.js"
-}

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -26,13 +26,11 @@ var stdlibSchemesSet = set.FromSlice(stdlibSchemes)
 // stdlibKnownFlags is the recognized set of binding-shape flags.
 // Per §2.3 the slot is extensible (future `?type-only`, `?lazy`, …); the
 // table-driven check means new entries slot in without restructuring.
-var stdlibKnownFlags = set.FromSlice([]string{"local", "nested"})
-
-// stdlibBindingShape captures the resolved binding-shape for a single
-// import statement. Exactly one of the two booleans is true.
-type stdlibBindingShape struct {
-	local, nested bool
-}
+// `?local` is currently the only shape flag — historical `?nested` was
+// removed because the dep_graph cycle detection only matched canonical
+// `<scheme>.<pkg>.<name>` keys, defeating the point of an alternate
+// binding path for sources that mostly need flat `<pkg>.<name>` access.
+var stdlibKnownFlags = set.FromSlice([]string{"local"})
 
 // isSchemePrefixedImport reports whether spec begins with one of the
 // recognized scheme prefixes (`std:`, `web:`, `node:`) or any other
@@ -101,8 +99,7 @@ func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []E
 		})
 	}
 
-	shape, flagErrs := resolveStdlibFlags(importStmt.Flags, span)
-	errs = append(errs, flagErrs...)
+	errs = append(errs, resolveStdlibFlags(importStmt.Flags, span)...)
 
 	// node:* is reserved; the resolver rejects every package until Node
 	// support lands. Gated on schemeKnown so an unknown-scheme URI
@@ -148,21 +145,10 @@ func (c *Checker) inferStdlibImport(ctx Context, importStmt *ast.ImportStmt) []E
 		return errs
 	}
 
-	// --- Bind phase. Single-class shortcut applies only to ?local
-	// (per §2.4 last bullet).
-
-	var bindErrs []Error
-
-	// resolveStdlibFlags guarantees exactly one shape is set.
-	switch {
-	case shape.local:
-		bindErrs = c.bindStdlibLocal(ctx, pkg, pkgNs, span)
-	case shape.nested:
-		bindErrs = c.bindStdlibNested(ctx, scheme, pkg, pkgNs, span)
-	}
-
-	errs = append(errs, bindErrs...)
-
+	// --- Bind phase. `?local` is the only binding shape; the
+	// single-class shortcut may bind a class directly when the pkg name
+	// matches the class name case-insensitively (FR5).
+	errs = append(errs, c.bindStdlibLocal(ctx, pkg, pkgNs, span)...)
 	return errs
 }
 
@@ -181,18 +167,18 @@ func isRecognizedScheme(scheme string) bool {
 	return stdlibSchemesSet.Contains(scheme)
 }
 
-// resolveStdlibFlags inspects the parsed flag list and returns the
-// binding shape, defaulting to ?local. Reports unknown-flag,
-// mutually-exclusive, and duplicate-flag diagnostics per the taxonomy.
-func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Error) {
-	shape := stdlibBindingShape{}
+// resolveStdlibFlags validates the parsed flag list. `?local` is
+// currently the only shape flag; reports unknown-flag and
+// duplicate-flag diagnostics per the taxonomy. There is no
+// "mutually exclusive" case to surface (only one shape exists), but
+// the table-driven check leaves room for future flags
+// (`?type-only`, `?lazy`, …) to slot in without restructuring.
+func resolveStdlibFlags(flags []string, span ast.Span) []Error {
 	if len(flags) == 0 {
-		shape.local = true
-		return shape, nil
+		return nil
 	}
 
 	seen := set.NewSet[string]()
-	shapeFlags := []string{}
 	var errs []Error
 	for _, f := range flags {
 		if f == "" {
@@ -218,29 +204,8 @@ func resolveStdlibFlags(flags []string, span ast.Span) (stdlibBindingShape, []Er
 			continue
 		}
 		seen.Add(f)
-		if f == "local" || f == "nested" {
-			shapeFlags = append(shapeFlags, f)
-		}
 	}
-	if len(errs) > 0 {
-		return shape, errs
-	}
-
-	if len(shapeFlags) > 1 {
-		sort.Strings(shapeFlags)
-		return shape, []Error{&GenericError{
-			message: fmt.Sprintf("binding-shape flags %q and %q are mutually exclusive; pick one",
-				shapeFlags[0], shapeFlags[1]),
-			span: span,
-		}}
-	}
-	switch shapeFlags[0] {
-	case "local":
-		shape.local = true
-	case "nested":
-		shape.nested = true
-	}
-	return shape, nil
+	return errs
 }
 
 // resolveStdlibPath maps a `scheme:pkg` URI to an on-disk `.esc` file
@@ -442,44 +407,6 @@ func findSingleClassShortcut(ns *type_system.Namespace, pkg string) (string, boo
 		}
 	}
 	return "", false
-}
-
-// bindStdlibNested binds the package under <scheme>.<pkg> in the file
-// scope, lazily creating the per-scheme namespace. Duplicate ?nested
-// imports of the same package within a single file are silently
-// idempotent — bookkeeping keys on the URI (per §2.3) so the first
-// import "won" and any subsequent ones add nothing. Like bindStdlibLocal,
-// the binding shares the canonical pkgNs pointer.
-func (c *Checker) bindStdlibNested(ctx Context, scheme, pkg string, pkgNs *type_system.Namespace, span ast.Span) []Error {
-	schemeNs, err := getOrCreateSchemeNamespace(ctx.Scope.Namespace, scheme)
-	if err != nil {
-		return []Error{&GenericError{message: err.Error(), span: span}}
-	}
-	if _, exists := schemeNs.GetNamespace(pkg); exists {
-		// Already bound from an earlier ?nested import of the same URI.
-		return nil
-	}
-	if err := schemeNs.SetNamespace(pkg, pkgNs); err != nil {
-		return []Error{&GenericError{
-			message: fmt.Sprintf("cannot bind %s.%s: %s", scheme, pkg, err.Error()),
-			span:    span,
-		}}
-	}
-	return nil
-}
-
-// getOrCreateSchemeNamespace returns the `<scheme>` sub-namespace on
-// ns, creating it on first access. Returns an error if a non-namespace
-// binding (value/type) already occupies that name in ns.
-func getOrCreateSchemeNamespace(ns *type_system.Namespace, scheme string) (*type_system.Namespace, error) {
-	if existing, ok := ns.GetNamespace(scheme); ok {
-		return existing, nil
-	}
-	schemeNs := type_system.NewNamespace()
-	if err := ns.SetNamespace(scheme, schemeNs); err != nil {
-		return nil, fmt.Errorf("cannot create per-scheme namespace %q: %w", scheme, err)
-	}
-	return schemeNs, nil
 }
 
 // lastSegmentLower returns the last `_`-separated segment of pkg,

--- a/internal/checker/infer_stdlib_import.go
+++ b/internal/checker/infer_stdlib_import.go
@@ -167,12 +167,8 @@ func isRecognizedScheme(scheme string) bool {
 	return stdlibSchemesSet.Contains(scheme)
 }
 
-// resolveStdlibFlags validates the parsed flag list. `?local` is
-// currently the only shape flag; reports unknown-flag and
-// duplicate-flag diagnostics per the taxonomy. There is no
-// "mutually exclusive" case to surface (only one shape exists), but
-// the table-driven check leaves room for future flags
-// (`?type-only`, `?lazy`, …) to slot in without restructuring.
+// resolveStdlibFlags validates the parsed flag list against
+// stdlibKnownFlags, reporting unknown- and duplicate-flag diagnostics.
 func resolveStdlibFlags(flags []string, span ast.Span) []Error {
 	if len(flags) == 0 {
 		return nil

--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -277,18 +277,12 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 		pkgNs := type_system.NewNamespace()
 		members = append(members, sccMember{uri: uri, scheme: scheme, pkg: pkg, path: path, ns: pkgNs})
 
-		// Pre-create scheme/pkg sub-namespaces on mergedNs so that when
-		// InferModule walks `<scheme>.<pkg>` paths it lands declarations
-		// into the same Namespace pointer we publish below.
-		schemeNs, ok := mergedNs.GetNamespace(scheme)
-		if !ok {
-			schemeNs = type_system.NewNamespace()
-			if err := mergedNs.SetNamespace(scheme, schemeNs); err != nil {
-				rollback()
-				return []Error{&GenericError{message: err.Error(), span: span}}
-			}
-		}
-		if err := schemeNs.SetNamespace(pkg, pkgNs); err != nil {
+		// Pre-create the <pkg> sub-namespace on mergedNs so InferModule
+		// lands `<pkg>.<name>` declarations into the same Namespace
+		// pointer we publish below — and so the dep_graph sees the
+		// member's binding keys at the same flat `<pkg>.<name>` path
+		// source files reference them under.
+		if err := mergedNs.SetNamespace(pkg, pkgNs); err != nil {
 			rollback()
 			return []Error{&GenericError{message: err.Error(), span: span}}
 		}
@@ -316,14 +310,17 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 		}
 		sourceID := c.stdlibNextSourceID
 		c.stdlibNextSourceID++
-		// Path is `<scheme>/<pkg>/index.esc` so deriveNamespaceFromPath
-		// yields `<scheme>.<pkg>` — the dotted namespace key declarations
-		// from this file land under in mod.Namespaces. The actual on-disk
-		// `.esc` file is flat (`<scheme>/<pkg>.esc`); this synthetic
-		// path just steers ParseLibFiles' namespace inference.
+		// Path is `<pkg>/index.esc` so deriveNamespaceFromPath yields
+		// `<pkg>` — that's the namespace key declarations from this file
+		// land under in mod.Namespaces, and also the binding-key prefix
+		// the dep_graph uses for cycle detection. Source files reference
+		// SCC siblings as `<pkg>.<name>`, so the dep_graph's qualified
+		// lookup hits the canonical key directly. The actual on-disk
+		// `.esc` file is flat (`<scheme>/<pkg>.esc`); this synthetic path
+		// only steers ParseLibFiles' namespace inference.
 		sources = append(sources, &ast.Source{
 			ID:       sourceID,
-			Path:     m.scheme + "/" + m.pkg + "/index.esc",
+			Path:     m.pkg + "/index.esc",
 			Contents: string(contents),
 		})
 	}
@@ -346,7 +343,7 @@ func (c *Checker) loadStdlibSCC(sccURIs []string, span ast.Span) []Error {
 	globals := c.knownJSGlobals()
 	var decErrs []Error
 	for _, m := range members {
-		ns, ok := mod.Namespaces.Get(m.scheme + "." + m.pkg)
+		ns, ok := mod.Namespaces.Get(m.pkg)
 		if !ok {
 			continue
 		}

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -134,57 +134,14 @@ func TestStdlibImport_UnknownFlag(t *testing.T) {
 	_, errs := inferStdlibImportSource(t, `import "std:math?wat"`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		`unknown import flag "wat"; recognized flags: local, nested`,
+		`unknown import flag "wat"; recognized flags: local`,
 		errs[0].Message(),
 	)
-}
-
-func TestStdlibImport_MutuallyExclusiveFlags(t *testing.T) {
-	_, errs := inferStdlibImportSource(t, `import "std:math?local&nested"`)
-	require.Len(t, errs, 1)
-	require.Equal(t,
-		`binding-shape flags "local" and "nested" are mutually exclusive; pick one`,
-		errs[0].Message(),
-	)
-}
-
-func TestStdlibImport_NestedBindsUnderSchemeNamespace(t *testing.T) {
-	fileScopes, errs := inferStdlibImportSource(t, `
-		import "std:math?nested"
-		val x: number = std.math.PI
-	`)
-	require.Empty(t, errorMessages(errs))
-
-	fileScope, ok := fileScopes[0]
-	require.True(t, ok)
-	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
-	require.True(t, ok, "expected `std` namespace bound in file scope")
-	_, ok = schemeNs.GetNamespace("math")
-	require.True(t, ok, "expected `std.math` sub-namespace")
-}
-
-func TestStdlibImport_MultipleNestedSharesSchemeNamespace(t *testing.T) {
-	fileScopes, errs := inferStdlibImportSource(t, `
-		import "std:math?nested"
-		import "std:array?nested"
-		val x: number = std.math.PI
-		val isArr: boolean = std.array.Array.isArray(0)
-	`)
-	require.Empty(t, errorMessages(errs))
-
-	fileScope := fileScopes[0]
-	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
-	require.True(t, ok)
-	_, ok = schemeNs.GetNamespace("math")
-	require.True(t, ok)
-	_, ok = schemeNs.GetNamespace("array")
-	require.True(t, ok)
 }
 
 func TestStdlibImport_SingleClassShortcut(t *testing.T) {
 	// std:array stub exposes `class Array<T>` — FR5 binds the class
-	// with its original capitalization (not lowercased "array") when
-	// imported as ?local.
+	// with its original capitalization (not lowercased "array").
 	fileScopes, errs := inferStdlibImportSource(t, `
 		import "std:array"
 		val isArr: boolean = Array.isArray(0)
@@ -202,19 +159,6 @@ func TestStdlibImport_SingleClassShortcut(t *testing.T) {
 	// shortcut fires.
 	_, hasNs := fileScope.Namespace.GetNamespace("array")
 	require.False(t, hasNs, "single-class shortcut should suppress lowercased namespace")
-}
-
-func TestStdlibImport_SingleClassShortcutDoesNotApplyToNested(t *testing.T) {
-	fileScopes, errs := inferStdlibImportSource(t, `import "std:array?nested"`)
-	require.Empty(t, errorMessages(errs))
-
-	fileScope := fileScopes[0]
-	schemeNs, ok := fileScope.Namespace.GetNamespace("std")
-	require.True(t, ok)
-	pkgNs, ok := schemeNs.GetNamespace("array")
-	require.True(t, ok, "?nested must bind the package as a sub-namespace, not the class")
-	_, hasArray := pkgNs.Values["Array"]
-	require.True(t, hasArray, "Array class should be reachable via std.array.Array")
 }
 
 func TestStdlibImport_InvalidPackageName(t *testing.T) {
@@ -282,15 +226,9 @@ func TestStdlibImport_LoaderRule_AcceptsValidPackage(t *testing.T) {
 // TestStdlibImport_LocalBindingSharesPkgNsPointer pins the
 // share-by-pointer model: a `?local` file-scope binding for a stdlib
 // pkg holds the *same* `*type_system.Namespace` instance that the
-// PackageRegistry caches. This (combined with the §3.4 rule
-// extension that forbids unexported types in stdlib pkgs) lets
-// importers see the canonical declarations without an intervening
-// filtered copy — necessary for late-population scenarios (e.g.
-// intra-SCC bindings under PR C) to work.
-//
-// `?nested` likewise binds the same pointer under `<scheme>.<pkg>`,
-// so a file that imports the same package both ways sees one shared
-// namespace under two file-scope paths.
+// PackageRegistry caches. Combined with the §3.4 rule that forbids
+// unexported decls in stdlib pkgs, this lets importers see the
+// canonical declarations without an intervening filtered copy.
 func TestStdlibImport_LocalBindingSharesPkgNsPointer(t *testing.T) {
 	// std:math has no class whose name matches the pkg name, so the
 	// single-class shortcut doesn't fire and `?local` binds the pkg as
@@ -299,7 +237,6 @@ func TestStdlibImport_LocalBindingSharesPkgNsPointer(t *testing.T) {
 	// the class directly.
 	source := &ast.Source{ID: 0, Path: "lib/main.esc", Contents: `
 		import "std:math"
-		import "std:math?nested"
 	`}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -316,17 +253,10 @@ func TestStdlibImport_LocalBindingSharesPkgNsPointer(t *testing.T) {
 	require.NotNil(t, canonical)
 
 	fileScope := c.FileScopes[0]
-	localBind, ok := fileScope.Namespace.GetNamespace("math")
-	require.True(t, ok, "expected `math` namespace from ?local import")
-	require.Same(t, canonical, localBind,
+	bound, ok := fileScope.Namespace.GetNamespace("math")
+	require.True(t, ok, "expected `math` namespace from import")
+	require.Same(t, canonical, bound,
 		"?local binding should share the canonical pkgNs pointer, not a filtered copy")
-
-	stdNs, ok := fileScope.Namespace.GetNamespace("std")
-	require.True(t, ok)
-	nestedBind, ok := stdNs.GetNamespace("math")
-	require.True(t, ok, "expected `std.math` namespace from ?nested import")
-	require.Same(t, canonical, nestedBind,
-		"?nested binding should share the canonical pkgNs pointer")
 }
 
 // TestStdlibImport_LoaderRule_UnexportedTypeLevelRejected pins the
@@ -513,27 +443,26 @@ func TestStdlibImport_LoaderRule_KnownGlobals(t *testing.T) {
 // .canvas: HTMLCanvasElement` pair — load as a single merged module
 // so each side's qualified type references into the other resolve.
 //
-// The user-side import uses the default binding shape (no flag →
-// ?local), exercising the singleton-namespace binding path on top of
-// a cyclic load. Intra-SCC imports still use ?nested because the
-// cross-package type references inside the merged module are written
-// with `web.<pkg>` qualified paths.
+// All imports use the default binding shape (?local) and the
+// cross-package type references inside the merged module use the
+// flat `<pkg>.<name>` shape that matches both the file-scope binding
+// and the dep_graph's canonical binding keys.
 func TestStdlibImport_PseudoPackageCycle(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/dom.esc": `
-import "web:webgl?nested"
+import "web:webgl"
 
 @js("HTMLCanvasElement")
 export declare class HTMLCanvasElement {
-    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+    getContext(self, id: "webgl") -> webgl.WebGLRenderingContext,
 }
 `,
 		"web/webgl.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("WebGLRenderingContext")
 export declare class WebGLRenderingContext {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 `,
 	})
@@ -561,33 +490,33 @@ export declare fn make() -> dom.HTMLCanvasElement
 func TestStdlibImport_PseudoPackageCycleThreeWay(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/a.esc": `
-import "web:b?nested"
+import "web:b"
 
 @js("Map")
 export declare class ClassA {
-    refB: web.b.ClassB,
+    refB: b.ClassB,
 }
 `,
 		"web/b.esc": `
-import "web:c?nested"
+import "web:c"
 
 @js("Set")
 export declare class ClassB {
-    refC: web.c.ClassC,
+    refC: c.ClassC,
 }
 `,
 		"web/c.esc": `
-import "web:a?nested"
+import "web:a"
 
 @js("WeakMap")
 export declare class ClassC {
-    refA: web.a.ClassA,
+    refA: a.ClassA,
 }
 `,
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
-	_, errs := inferStdlibImportSource(t, `import "web:a?nested"`)
+	_, errs := inferStdlibImportSource(t, `import "web:a"`)
 	require.Empty(t, errorMessages(errs))
 }
 
@@ -599,45 +528,50 @@ export declare class ClassC {
 func TestStdlibImport_PseudoPackageCycle_NonCyclicImporter(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/dom.esc": `
-import "web:webgl?nested"
+import "web:webgl"
 
 @js("HTMLCanvasElement")
 export declare class HTMLCanvasElement {
-    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+    getContext(self, id: "webgl") -> webgl.WebGLRenderingContext,
 }
 `,
 		"web/webgl.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("WebGLRenderingContext")
 export declare class WebGLRenderingContext {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 `,
 		"web/app.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("Map")
 export declare class App {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 `,
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
 	fileScopes, errs := inferStdlibImportSource(t, `
-import "web:app?nested"
-import "web:dom?nested"
-import "web:webgl?nested"
+import "web:app"
+import "web:dom"
+import "web:webgl"
 `)
 	require.Empty(t, errorMessages(errs))
 
-	webNs, ok := fileScopes[0].Namespace.GetNamespace("web")
-	require.True(t, ok)
-	for _, pkg := range []string{"app", "dom", "webgl"} {
-		_, ok := webNs.GetNamespace(pkg)
-		require.True(t, ok, "expected web.%s sub-namespace", pkg)
+	fileNs := fileScopes[0].Namespace
+	// dom and webgl don't trigger the single-class shortcut (class
+	// names don't match pkg names), so they bind under lowercased pkg
+	// namespaces. app does trigger the shortcut (class App ↔ pkg app),
+	// so the App class binds directly at file scope.
+	for _, pkg := range []string{"dom", "webgl"} {
+		_, ok := fileNs.GetNamespace(pkg)
+		require.True(t, ok, "expected %s namespace bound at file scope", pkg)
 	}
+	_, hasAppType := fileNs.Types["App"]
+	require.True(t, hasAppType, "expected App class type bound at file scope (single-class shortcut)")
 }
 
 // TestStdlibImport_PseudoPackageCycleMixedSchemes verifies the SCC
@@ -655,19 +589,19 @@ import "web:webgl?nested"
 func TestStdlibImport_PseudoPackageCycleMixedSchemes(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"std/host.esc": `
-import "web:client?nested"
+import "web:client"
 
 @js("Map")
 export declare class Host {
-    client: web.client.Client,
+    client: client.Client,
 }
 `,
 		"web/client.esc": `
-import "std:host?nested"
+import "std:host"
 
 @js("Set")
 export declare class Client {
-    host: std.host.Host,
+    host: host.Host,
 }
 `,
 	})
@@ -696,25 +630,25 @@ export declare fn makeClient() -> Client
 func TestStdlibImport_PseudoPackageCycle_DecoratorErrorNamesURI(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/dom.esc": `
-import "web:webgl?nested"
+import "web:webgl"
 
 @js("HTMLCanvasElement")
 export declare class HTMLCanvasElement {
-    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+    getContext(self, id: "webgl") -> webgl.WebGLRenderingContext,
 }
 `,
 		"web/webgl.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("ThisGlobalDoesNotExist")
 export declare class WebGLRenderingContext {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 `,
 	})
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
-	_, errs := inferStdlibImportSource(t, `import "web:dom?nested"`)
+	_, errs := inferStdlibImportSource(t, `import "web:dom"`)
 	expected := []string{
 		"`@js(\"ThisGlobalDoesNotExist\")` on class \"WebGLRenderingContext\" in pseudo-package file web:webgl does not name a known JS runtime global",
 	}
@@ -730,19 +664,19 @@ export declare class WebGLRenderingContext {
 func TestStdlibImport_PseudoPackageCycle_RollbackOnFailure(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		"web/dom.esc": `
-import "web:webgl?nested"
+import "web:webgl"
 
 @js("HTMLCanvasElement")
 export declare class HTMLCanvasElement {
-    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+    getContext(self, id: "webgl") -> webgl.WebGLRenderingContext,
 }
 `,
 		"web/webgl.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("ThisGlobalDoesNotExist")
 export declare class WebGLRenderingContext {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 `,
 	})
@@ -754,8 +688,8 @@ export declare class WebGLRenderingContext {
 	// Without rollback, the second silently binds an empty namespace and
 	// produces no diagnostic.
 	_, errs := inferStdlibImportSource(t, `
-import "web:dom?nested"
-import "web:webgl?nested"
+import "web:dom"
+import "web:webgl"
 `)
 	msg := "`@js(\"ThisGlobalDoesNotExist\")` on class \"WebGLRenderingContext\" in pseudo-package file web:webgl does not name a known JS runtime global"
 	require.Equal(t, []string{msg, msg}, errorMessages(errs))
@@ -771,22 +705,22 @@ func TestStdlibImport_PseudoPackageCycle_RollbackOnParseError(t *testing.T) {
 	dir := makeCustomStdlibDir(t, map[string]string{
 		// dom.esc imports webgl cleanly so the SCC scanner sees the cycle.
 		"web/dom.esc": `
-import "web:webgl?nested"
+import "web:webgl"
 
 @js("HTMLCanvasElement")
 export declare class HTMLCanvasElement {
-    getContext(self, id: "webgl") -> web.webgl.WebGLRenderingContext,
+    getContext(self, id: "webgl") -> webgl.WebGLRenderingContext,
 }
 `,
 		// webgl.esc parses its import line, then fails on the trailing
 		// garbage — that error surfaces during the SCC's real-load parse,
 		// not during the graph scan.
 		"web/webgl.esc": `
-import "web:dom?nested"
+import "web:dom"
 
 @js("WebGLRenderingContext")
 export declare class WebGLRenderingContext {
-    canvas: web.dom.HTMLCanvasElement,
+    canvas: dom.HTMLCanvasElement,
 }
 
 @@@ this is not valid escalier
@@ -795,8 +729,8 @@ export declare class WebGLRenderingContext {
 	t.Setenv("ESCALIER_STDLIB_DIR", dir)
 
 	_, errs := inferStdlibImportSource(t, `
-import "web:dom?nested"
-import "web:webgl?nested"
+import "web:dom"
+import "web:webgl"
 `)
 	msgs := errorMessages(errs)
 	require.NotEmpty(t, msgs, "expected parse-error diagnostics from both imports")

--- a/internal/checker/tests/stdlib_import_test.go
+++ b/internal/checker/tests/stdlib_import_test.go
@@ -139,6 +139,15 @@ func TestStdlibImport_UnknownFlag(t *testing.T) {
 	)
 }
 
+func TestStdlibImport_DuplicateFlag(t *testing.T) {
+	_, errs := inferStdlibImportSource(t, `import "std:math?local&local"`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		`duplicate import flag "local"`,
+		errs[0].Message(),
+	)
+}
+
 func TestStdlibImport_SingleClassShortcut(t *testing.T) {
 	// std:array stub exposes `class Array<T>` — FR5 binds the class
 	// with its original capitalization (not lowercased "array").

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -20,9 +20,9 @@ import (
 //     expression).
 
 // memberJSExpr returns the JS lowering for a MemberExpr whose receiver
-// resolves to a NamespaceType (the package binding under ?local /
-// ?nested). The property's Binding in that namespace owns a
-// decl whose `@js("...")` decorator carries the lowering.
+// resolves to a NamespaceType (the package binding under ?local).
+// The property's Binding in that namespace owns a decl whose
+// `@js("...")` decorator carries the lowering.
 func memberJSExpr(m *ast.MemberExpr) (string, bool) {
 	if m.Prop == nil {
 		return "", false

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -288,27 +288,21 @@ it lazily on first scheme-prefixed import.
 ### 2.3 Binding-shape application
 
 - Implement the flag rules from FR4. Each pseudo-package import
-  contributes a binding entry whose shape depends on the flag:
-  - `?local` (default): binding name = lowercased last URI
-    segment (or capitalized class name when the single-class
-    shortcut FR5 fires).
-  - `?nested`: contributes to a per-scheme namespace
-    (`std`, `web`); the package sits under it as
-    `std.<package>`. Multiple `?nested` imports from the same
-    scheme merge under disjoint sub-namespaces — no collision
-    risk.
+  contributes a binding entry under `?local` (the only shape today):
+  binding name = lowercased last URI segment (or capitalized class
+  name when the single-class shortcut FR5 fires).
 - Internal bookkeeping (whether a file has loaded a package's
   declarations) keys on the package's full URI (`web:fetch`),
-  independent of binding-shape flag. This applies uniformly
-  across `?local` and `?nested`.
-- **Mutually exclusive:** combining `?local` and `?nested` on
-  one URI is a compile error; the resolver reports which flag
-  pair is invalid.
+  independent of binding-shape flag.
 - **Extensible flag slot.** The grammar reserves the `?flag` /
   `?flag1&flag2` shape for future flags (`?type-only`, `?lazy`,
   …). Unknown flags currently error per the taxonomy; the
   resolver factors flag recognition into a per-flag table so
-  future flags slot in without restructuring.
+  future flags slot in without restructuring. **Note:** the
+  earlier `?nested` shape (bound under `<scheme>.<package>`) was
+  removed once it became clear the dep_graph's cycle detection
+  only matched canonical `<pkg>.<name>` binding keys; cross-stdlib
+  collisions can be addressed later via file-local renaming.
 
 ### 2.4 Single-class shortcut (FR5)
 
@@ -322,7 +316,6 @@ it lazily on first scheme-prefixed import.
   `Array(5)` (construct, no `new`).
 - Static methods on the class take precedence over namespace
   members on name collision.
-- Not applicable to `?nested`.
 
 ### 2.5 Tests and gates
 

--- a/planning/builtins/requirements.md
+++ b/planning/builtins/requirements.md
@@ -71,9 +71,10 @@ In scope:
   per-file based on language-feature usage (primitive method
   dispatch, `await`, iteration, …), and **named** when the file
   explicitly imports the package.
-- Per-import binding-shape flags (`?local`, `?nested`)
-  governing how a pseudo-package's namespace lands in the importing
-  file.
+- Per-import binding-shape flag (`?local`) governing how a
+  pseudo-package's namespace lands in the importing file. The
+  earlier `?nested` shape was removed; see [implementation_plan.md](implementation_plan.md)
+  §2.3 for context.
 - The **single-class shortcut** for per-class packages: when the
   package's lowercased name matches a class declared in it, the
   `?local` binding *is* the class for member access, construction,


### PR DESCRIPTION
## Summary

- Removes `?nested` end-to-end. `?local` is now the only binding-shape flag; default behavior is unchanged.
- Restructures SCC merged-module synthetic source paths from `<scheme>/<pkg>/index.esc` to `<pkg>/index.esc` so `deriveNamespaceFromPath` yields just `<pkg>`. **This is correctness-load-bearing, not cosmetic:** the merged-module namespace tree and dep_graph binding keys now match the `<pkg>.<name>` shape that `?local`-bound source references use, so the dep_graph's qualified lookup hits the canonical key directly and cycle detection works.
- Rewrites cycle tests' `.esc` bodies to use the flat `<pkg>.X` form everywhere.

### Why drop `?nested`?

Two reasons surfaced while sketching PR C's original "intra-SCC short-circuit performs the bind" approach:

1. The dep_graph's `addTypeDependency` only matches canonical `<ns>.<typeName>` binding keys. `?local`-style `<pkg>.X` references inside SCC `.esc` files never produced dep edges, so members had to use `<scheme>.<pkg>.X` regardless of the user's flag — meaning the flag didn't actually control much at source-write time.
2. Cross-stdlib name collisions (`std:foo` vs `web:foo`) — the only thing `?nested` was protecting against — never come up, and can be addressed later with file-local import renaming when/if they do.

Dropping the flag and flattening the merged-module path turns these into one coherent story: source files use `<pkg>.X`, that matches the canonical binding key, the dep_graph creates the edge, cycle detection works.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `TestStdlibImport_UnknownFlag` recognized-flags message now reads `recognized flags: local`
- [x] `TestStdlibImport_DuplicateFlag` covers `?local&local`
- [x] All `TestStdlibImport_PseudoPackageCycle*` tests rewritten to use flat `<pkg>.X` references
- [x] `?nested`-only tests removed (`TestStdlibImport_NestedBindsUnderSchemeNamespace`, `TestStdlibImport_MultipleNestedSharesSchemeNamespace`, `TestStdlibImport_SingleClassShortcutDoesNotApplyToNested`, `TestStdlibImport_MutuallyExclusiveFlags`)
- [x] `fixtures/stdlib_import_nested/` deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)