### PR TITLE
Plan §4.6 method-elem overloads + PR-A: MethodElem.Signatures slice

### DIFF
--- a/cmd/lsp-server/completion.go
+++ b/cmd/lsp-server/completion.go
@@ -513,11 +513,14 @@ func completionsFromObjectType(obj *type_system.ObjectType, receiverMut bool) []
 				continue
 			}
 			// Hide `mut self` methods on non-mut receivers.
-			if !receiverMutForElems && type_system.ReceiverIsMut(elem.Fn) {
+			// All arms share receiver mutability (enforced at merge time
+			// in PR-C); inspecting any arm is sufficient.
+			sig := elem.SingleSig()
+			if !receiverMutForElems && type_system.ReceiverIsMut(sig) {
 				continue
 			}
 			kind := protocol.CompletionItemKindMethod
-			detail := elem.Fn.String()
+			detail := elem.AsType().String()
 			items = append(items, protocol.CompletionItem{
 				Label:      elem.Name.Str,
 				Kind:       &kind,

--- a/internal/checker/check_implements.go
+++ b/internal/checker/check_implements.go
@@ -111,14 +111,18 @@ func (c *Checker) checkInterfaceElem(
 		if ce == nil {
 			return missingMember(span, className, ifaceName, ie.Name.String())
 		}
-		ifaceFn := SubstituteTypeParams(ie.Fn, sub)
+		// PR-A: methods are single-signature here; overload arm-vs-arm
+		// assignability is deferred to #651.
+		ieSig := ie.SingleSig()
+		ifaceFn := SubstituteTypeParams(ieSig, sub)
 		switch m := ce.(type) {
 		case *type_system.MethodElem:
-			if !selfReceiverCompatible(ie.Fn, m.Fn) {
+			mSig := m.SingleSig()
+			if !selfReceiverCompatible(ieSig, mSig) {
 				return mismatchedMember(span, className, ifaceName, ie.Name.String(),
 					"self receiver does not match")
 			}
-			if errs := c.unifyFuncTypes(ctx, m.Fn, ifaceFn, make(unifySeen)); len(errs) > 0 {
+			if errs := c.unifyFuncTypes(ctx, mSig, ifaceFn, make(unifySeen)); len(errs) > 0 {
 				return mismatchedMember(span, className, ifaceName, ie.Name.String(),
 					"signature does not match")
 			}
@@ -136,7 +140,7 @@ func (c *Checker) checkInterfaceElem(
 			// circuits to nil. When the structures differ enough that
 			// only one side has lifetimes, `unifyFuncTypes` above will
 			// already have failed and we won't reach this line.
-			return c.VerifyLifetimeCompatibility(ifaceFn, m.Fn, span)
+			return c.VerifyLifetimeCompatibility(ifaceFn, mSig, span)
 		case *type_system.PropertyElem:
 			if errs := c.Unify(ctx, m.Value, ifaceFn); len(errs) > 0 {
 				return mismatchedMember(span, className, ifaceName, ie.Name.String(),

--- a/internal/checker/exhaustiveness.go
+++ b/internal/checker/exhaustiveness.go
@@ -451,8 +451,11 @@ func (c *Checker) computePatternCoverage(
 // variant the extractor matches.
 func (c *Checker) getCustomMatcherParamType(ext *type_system.ExtractorType) type_system.Type {
 	methodElem, _ := c.findCustomMatcherMethod(ext)
-	if methodElem != nil && len(methodElem.Fn.Params) == 1 {
-		return type_system.Prune(methodElem.Fn.Params[0].Type)
+	if methodElem != nil {
+		fn := methodElem.SingleSig()
+		if fn != nil && len(fn.Params) == 1 {
+			return type_system.Prune(fn.Params[0].Type)
+		}
 	}
 	return nil
 }
@@ -464,7 +467,9 @@ func (c *Checker) getCustomMatcherParamType(ext *type_system.ExtractorType) type
 func (c *Checker) getCustomMatcherReturnType(ext *type_system.ExtractorType) type_system.Type {
 	methodElem, _ := c.findCustomMatcherMethod(ext)
 	if methodElem != nil {
-		return type_system.Prune(methodElem.Fn.Return)
+		if fn := methodElem.SingleSig(); fn != nil {
+			return type_system.Prune(fn.Return)
+		}
 	}
 	return nil
 }

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -1053,7 +1053,7 @@ func isMemberVisible(elem type_system.ObjTypeElem, mode AccessMode, receiverMut 
 			if receiverMut {
 				return true
 			}
-			return !type_system.ReceiverIsMut(e.Fn)
+			return !type_system.ReceiverIsMut(e.SingleSig())
 		case *type_system.GetterElem:
 			if receiverMut {
 				return true
@@ -1130,7 +1130,7 @@ func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name
 			}
 		case *type_system.MethodElem:
 			if elem.Name == targetKey {
-				memberType = elem.Fn
+				memberType = elem.AsType()
 			}
 		case *type_system.GetterElem:
 			if elem.Name == targetKey && mode == AccessRead {
@@ -1207,7 +1207,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 				}
 			case *type_system.MethodElem:
 				if elem.Name == targetKey {
-					return elem.Fn, errors
+					return elem.AsType(), errors
 				}
 			case *type_system.GetterElem:
 				if elem.Name == targetKey && mode == AccessRead {
@@ -1309,7 +1309,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						}
 					case *type_system.MethodElem:
 						if elem.Name == targetKey {
-							return elem.Fn, errors
+							return elem.AsType(), errors
 						}
 					case *type_system.GetterElem:
 						if elem.Name == targetKey && mode == AccessRead {
@@ -1446,7 +1446,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					}
 				case *type_system.MethodElem:
 					if elem.Name == symKey {
-						return elem.Fn, errors
+						return elem.AsType(), errors
 					}
 				case *type_system.GetterElem:
 					if elem.Name == symKey && mode == AccessRead {
@@ -1753,7 +1753,7 @@ func (c *Checker) isArrayMutatingMethod(methodName string) bool {
 	for _, elem := range objType.Elems {
 		if method, ok := elem.(*type_system.MethodElem); ok {
 			if method.Name == type_system.NewStrKey(methodName) {
-				return type_system.ReceiverIsMut(method.Fn)
+				return type_system.ReceiverIsMut(method.SingleSig())
 			}
 		}
 	}

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -82,7 +82,9 @@ func collectUnresolvedTypeVarsImpl(
 			case *type_system.PropertyElem:
 				collectUnresolvedTypeVarsImpl(e.Value, vars, order, visited)
 			case *type_system.MethodElem:
-				collectUnresolvedTypeVarsImpl(e.Fn, vars, order, visited)
+				for _, fn := range e.Signatures {
+					collectUnresolvedTypeVarsImpl(fn, vars, order, visited)
+				}
 			case *type_system.GetterElem:
 				collectUnresolvedTypeVarsImpl(e.Fn, vars, order, visited)
 			case *type_system.SetterElem:
@@ -246,9 +248,13 @@ func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_sys
 					Value:    c.deepCloneType(e.Value, varMapping),
 				}
 			case *type_system.MethodElem:
+				clonedSigs := make([]*type_system.FuncType, len(e.Signatures))
+				for j, fn := range e.Signatures {
+					clonedSigs[j] = c.deepCloneType(fn, varMapping).(*type_system.FuncType)
+				}
 				elems[i] = &type_system.MethodElem{
-					Name: e.Name,
-					Fn:   c.deepCloneType(e.Fn, varMapping).(*type_system.FuncType),
+					Name:       e.Name,
+					Signatures: clonedSigs,
 				}
 			case *type_system.GetterElem:
 				elems[i] = &type_system.GetterElem{

--- a/internal/checker/infer_class_decl.go
+++ b/internal/checker/infer_class_decl.go
@@ -427,9 +427,10 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 				continue
 			}
 
+			methodSig := methodType.SingleSig()
 			paramBindings := make(map[string]*type_system.Binding)
 			if !isStatic {
-				isMutableSelf := type_system.ReceiverIsMut(methodType.Fn)
+				isMutableSelf := type_system.ReceiverIsMut(methodSig)
 				var t type_system.Type = classSelfRef
 				if isMutableSelf {
 					t = type_system.NewMutType(nil, t)
@@ -442,7 +443,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 				}
 			}
 
-			for paramIdx, param := range methodType.Fn.Params {
+			for paramIdx, param := range methodSig.Params {
 				if param.Pattern == nil {
 					continue
 				}
@@ -463,7 +464,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 
 			methodCtx := methodCtxForElem[i]
 			bodyErrors := c.inferFuncBodyWithFuncSigType(
-				methodCtx, methodType.Fn, paramBindings,
+				methodCtx, methodSig, paramBindings,
 				bodyElem.Fn.Params, bodyElem.Fn.Body,
 				asyncModeFrom(bodyElem.Fn.Async), nonConstructorBody,
 			)

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -1136,7 +1136,7 @@ func (c *Checker) InferComponent(
 									Kind: type_system.SymObjTypeKeyKind,
 									Sym:  customMatcher.Value,
 								},
-								Fn: type_system.NewFuncType(
+								Signatures: []*type_system.FuncType{type_system.NewFuncType(
 									nil,
 									typeParams,
 									[]*type_system.FuncParam{{
@@ -1145,7 +1145,7 @@ func (c *Checker) InferComponent(
 									}},
 									returnType,
 									type_system.NewNeverType(nil),
-								),
+								)},
 							}
 							classObjTypeElems = append(classObjTypeElems, methodElem)
 
@@ -1348,6 +1348,7 @@ func (c *Checker) InferComponent(
 						}
 
 						if methodType != nil {
+							methodSig := methodType.SingleSig()
 							paramBindings := make(map[string]*type_system.Binding)
 
 							// For instance methods, add 'self' parameter and the
@@ -1374,7 +1375,7 @@ func (c *Checker) InferComponent(
 								// args. Reusing methodType.Fn.SelfParam.Type would
 								// be more correct but requires fixing that
 								// classifier first.
-								isMutableSelf := type_system.ReceiverIsMut(methodType.Fn)
+								isMutableSelf := type_system.ReceiverIsMut(methodSig)
 								var t type_system.Type = type_system.NewTypeRefType(nil, decl.Name.Name, typeAlias)
 								if isMutableSelf {
 									t = type_system.NewMutType(nil, t)
@@ -1396,7 +1397,7 @@ func (c *Checker) InferComponent(
 							// sees a mut value; checking both is defense-in-depth
 							// in case one source is ever set without the other.
 							// Mirrors the same OR'd computation in inferPattern.
-							for paramIdx, param := range methodType.Fn.Params {
+							for paramIdx, param := range methodSig.Params {
 								if param.Pattern == nil {
 									continue
 								}
@@ -1417,7 +1418,7 @@ func (c *Checker) InferComponent(
 
 							methodCtx := methodCtxForElem[classMethodCtxKey{decl: decl, elemIndex: i}]
 							bodyErrors := c.inferFuncBodyWithFuncSigType(
-								methodCtx, methodType.Fn, paramBindings,
+								methodCtx, methodSig, paramBindings,
 								bodyElem.Fn.Params, bodyElem.Fn.Body,
 								asyncModeFrom(bodyElem.Fn.Async), nonConstructorBody,
 							)
@@ -2178,7 +2179,7 @@ func (c *Checker) validateInterfaceMerge(
 		case *type_system.PropertyElem:
 			existingProps[elem.Name] = elem.Value
 		case *type_system.MethodElem:
-			existingProps[elem.Name] = elem.Fn
+			existingProps[elem.Name] = elem.AsType()
 			existingMethods[elem.Name] = true
 		case *type_system.GetterElem:
 			existingProps[elem.Name] = elem.Fn.Return
@@ -2199,7 +2200,7 @@ func (c *Checker) validateInterfaceMerge(
 			newType = elem.Value
 		case *type_system.MethodElem:
 			name = elem.Name
-			newType = elem.Fn
+			newType = elem.AsType()
 			isMethod = true
 		case *type_system.GetterElem:
 			name = elem.Name

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -695,7 +695,7 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 						Kind: type_system.SymObjTypeKeyKind,
 						Sym:  customMatcher.Value,
 					},
-					Fn: type_system.NewFuncType(
+					Signatures: []*type_system.FuncType{type_system.NewFuncType(
 						nil,
 						typeParams,
 						[]*type_system.FuncParam{{
@@ -704,7 +704,7 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 						}},
 						returnType,
 						type_system.NewNeverType(nil),
-					),
+					)},
 				}
 				classObjTypeElems = append(classObjTypeElems, methodElem)
 

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -166,6 +166,9 @@ func walkPopulateSelfParams(
 				// mutability uniformity is enforced at merge time so each
 				// arm sees the same fixup.
 				for _, fn := range e.Signatures {
+					if fn == nil {
+						continue
+					}
 					if fn.SelfParam == nil {
 						fn.SelfParam = type_system.NewSelfParam(selfRef, true)
 					}

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -160,20 +160,24 @@ func walkPopulateSelfParams(
 		for _, elem := range objType.Elems {
 			switch e := elem.(type) {
 			case *type_system.MethodElem:
-				if e.Fn == nil {
-					continue
-				}
-				if e.Fn.SelfParam == nil {
-					e.Fn.SelfParam = type_system.NewSelfParam(selfRef, true)
-				}
-				// Iterator-protocol fixup: `[Symbol.iterator]()` /
-				// `[Symbol.asyncIterator]()` are non-mutating on the
-				// source and return a freshly-owned (mut) iterator.
-				if e.Name.Kind == type_system.SymObjTypeKeyKind &&
-					((hasIter && e.Name.Sym == iterID) ||
-						(hasAsync && e.Name.Sym == asyncIterID)) {
-					setReceiverMut(e.Fn, false)
-					wrapReturnMut(e.Fn)
+				// Apply fixups to every arm. At PR-A there is at most one
+				// arm per method (no merge pass yet); the loop is forward-
+				// compatible with overloaded methods, where receiver-
+				// mutability uniformity is enforced at merge time so each
+				// arm sees the same fixup.
+				for _, fn := range e.Signatures {
+					if fn.SelfParam == nil {
+						fn.SelfParam = type_system.NewSelfParam(selfRef, true)
+					}
+					// Iterator-protocol fixup: `[Symbol.iterator]()` /
+					// `[Symbol.asyncIterator]()` are non-mutating on the
+					// source and return a freshly-owned (mut) iterator.
+					if e.Name.Kind == type_system.SymObjTypeKeyKind &&
+						((hasIter && e.Name.Sym == iterID) ||
+							(hasAsync && e.Name.Sym == asyncIterID)) {
+						setReceiverMut(fn, false)
+						wrapReturnMut(fn)
+					}
 				}
 			case *type_system.GetterElem:
 				if e.Fn != nil && e.Fn.SelfParam == nil {

--- a/internal/checker/method_helpers_test.go
+++ b/internal/checker/method_helpers_test.go
@@ -49,7 +49,7 @@ func TestPopulateSelfParamsRecursesIntoNestedNamespaces(t *testing.T) {
 		var fn *type_system.FuncType
 		for _, elem := range obj.Elems {
 			if me, ok := elem.(*type_system.MethodElem); ok && me.Name.Str == methodName {
-				fn = me.Fn
+				fn = me.SingleSig()
 				break
 			}
 		}

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -353,11 +353,11 @@ func applyMethodMutability(objType *type_system.ObjectType, names MethodNames) {
 		}
 		name := me.Name.Str
 		if names.Contains(name) {
-			setReceiverMut(me.Fn, false)
+			setReceiverMut(me.SingleSig(), false)
 			continue
 		}
 		if mut, classified := interop.ClassifyMethodByName(name); classified && !mut {
-			setReceiverMut(me.Fn, false)
+			setReceiverMut(me.SingleSig(), false)
 		}
 	}
 }
@@ -499,7 +499,7 @@ func mergeReadonlyVariant(namespace *type_system.Namespace, mutableName, readonl
 			readonlyElems.Add(me.Name)
 
 			// Methods on the Readonly* variant are non-mutating.
-			setReceiverMut(me.Fn, false)
+			setReceiverMut(me.SingleSig(), false)
 		}
 	}
 
@@ -510,7 +510,7 @@ func mergeReadonlyVariant(namespace *type_system.Namespace, mutableName, readonl
 			continue
 		}
 		mut := !readonlyElems.Contains(me.Name)
-		setReceiverMut(me.Fn, mut)
+		setReceiverMut(me.SingleSig(), mut)
 	}
 }
 

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -740,7 +740,7 @@ func TestClassMethodSelfParamPopulated(t *testing.T) {
 				switch e := elem.(type) {
 				case *type_system.MethodElem:
 					if matchKey(e.Name) {
-						methodFn = e.Fn
+						methodFn = e.SingleSig()
 					}
 				case *type_system.GetterElem:
 					if matchKey(e.Name) {
@@ -796,7 +796,7 @@ func TestClassMethodSelfLifetime(t *testing.T) {
 		for _, e := range objType.Elems {
 			if m, ok := e.(*type_system.MethodElem); ok &&
 				m.Name.Kind == type_system.StrObjTypeKeyKind && m.Name.Str == name {
-				return m.Fn
+				return m.SingleSig()
 			}
 		}
 		return nil

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -366,8 +366,8 @@ func TestSubstituteTypeParamsInObjElem(t *testing.T) {
 	methodFunc := test_util.ParseTypeAnn("fn (x: T) -> U").(*type_system.FuncType)
 	methodFunc.SelfParam = type_system.NewSelfParam(selfRef, false)
 	method := &type_system.MethodElem{
-		Name: type_system.NewStrKey("method"),
-		Fn:   methodFunc,
+		Name:       type_system.NewStrKey("method"),
+		Signatures: []*type_system.FuncType{methodFunc},
 	}
 
 	getterFunc := test_util.ParseTypeAnn("fn () -> T").(*type_system.FuncType)

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1530,10 +1530,11 @@ func (c *Checker) unifyExtractor(
 			ObjectType: extObj,
 		}}
 	}
-	if len(methodElem.Fn.Params) != 1 {
+	customMatcherSig := methodElem.SingleSig()
+	if len(customMatcherSig.Params) != 1 {
 		return []Error{&IncorrectParamCountForCustomMatcherError{
-			Method:    methodElem.Fn,
-			NumParams: len(methodElem.Fn.Params),
+			Method:    customMatcherSig,
+			NumParams: len(customMatcherSig.Params),
 		}}
 	}
 
@@ -1545,7 +1546,7 @@ func (c *Checker) unifyExtractor(
 	//
 	// Note: instantiateGenericFunc preserves the param count, so the
 	// single-param validation on line 1243 is still satisfied after this.
-	fn := methodElem.Fn
+	fn := customMatcherSig
 	if len(fn.TypeParams) > 0 || len(fn.LifetimeParams) > 0 {
 		fn = c.instantiateGenericFunc(fn)
 	}
@@ -1734,7 +1735,7 @@ func (c *Checker) unifyClosedWithRests(
 		case *type_system.PropertyElem:
 			addEffective(elem.Name, elem.Value)
 		case *type_system.MethodElem:
-			addEffective(elem.Name, elem.Fn)
+			addEffective(elem.Name, elem.AsType())
 		case *type_system.GetterElem:
 			addEffective(elem.Name, elem.Fn.Return)
 		case *type_system.SetterElem:
@@ -1755,7 +1756,7 @@ func (c *Checker) unifyClosedWithRests(
 					case *type_system.PropertyElem:
 						addEffective(re.Name, re.Value)
 					case *type_system.MethodElem:
-						addEffective(re.Name, re.Fn)
+						addEffective(re.Name, re.AsType())
 					case *type_system.GetterElem:
 						addEffective(re.Name, re.Fn.Return)
 					case *type_system.SetterElem:
@@ -2605,9 +2606,26 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 				newElems[i] = elem
 			}
 		case *type_system.MethodElem:
-			if fn := widenFuncType(e.Fn); fn != e.Fn {
+			// Widen each arm. Reuses the existing slice when no arm
+			// changed to avoid unnecessary allocation; PR-A still has
+			// at most one arm per method, but the loop is forward-
+			// compatible with PR-C overloads.
+			newSigs := e.Signatures
+			armChanged := false
+			for j, fn := range e.Signatures {
+				widened := widenFuncType(fn)
+				if widened != fn {
+					if !armChanged {
+						newSigs = make([]*type_system.FuncType, len(e.Signatures))
+						copy(newSigs, e.Signatures)
+						armChanged = true
+					}
+					newSigs[j] = widened
+				}
+			}
+			if armChanged {
 				changed = true
-				newElems[i] = &type_system.MethodElem{Name: e.Name, Fn: fn}
+				newElems[i] = &type_system.MethodElem{Name: e.Name, Signatures: newSigs}
 			} else {
 				newElems[i] = elem
 			}
@@ -3077,7 +3095,7 @@ func collectObjElemTypes(obj *type_system.ObjectType, collectOrigElems bool) col
 				result.OrigWrite[elem.Name] = elem
 			}
 		case *type_system.MethodElem:
-			result.Read[elem.Name] = elem.Fn
+			result.Read[elem.Name] = elem.AsType()
 			if !seen[elem.Name] {
 				result.Keys = append(result.Keys, elem.Name)
 				seen[elem.Name] = true

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -897,9 +897,11 @@ func (b *Builder) buildObjTypeAnnElem(elem type_sys.ObjTypeElem, symbolExprMap m
 			Fn: b.buildFuncTypeAnn(elem.Fn),
 		}
 	case *type_sys.MethodElem:
+		// PR-A: methods are single-signature here. PR-C will fan out
+		// one MethodTypeAnn per overload arm in specificity order.
 		return &MethodTypeAnn{
 			Name: b.buildTypeAnnObjKey(elem.Name, symbolExprMap),
-			Fn:   b.buildFuncTypeAnn(elem.Fn),
+			Fn:   b.buildFuncTypeAnn(elem.SingleSig()),
 		}
 	case *type_sys.GetterElem:
 		return &GetterTypeAnn{

--- a/internal/interop/class_shapes.go
+++ b/internal/interop/class_shapes.go
@@ -280,7 +280,7 @@ func fillMemberSet(set *MemberSet, obj *type_system.ObjectType) {
 	for _, elem := range obj.Elems {
 		switch e := elem.(type) {
 		case *type_system.MethodElem:
-			set.Methods[e.Name.String()] = leafEffective(e.Fn)
+			set.Methods[e.Name.String()] = leafEffective(e.AsType())
 		case *type_system.GetterElem:
 			set.Getters[e.Name.String()] = leafEffective(e.Fn)
 		case *type_system.SetterElem:

--- a/internal/interop/extract.go
+++ b/internal/interop/extract.go
@@ -470,7 +470,7 @@ func lookupStaticObject(ns *type_system.Namespace, name string) *type_system.Obj
 func objElemMatch(elem type_system.ObjTypeElem) (type_system.Type, string, bool) {
 	switch e := elem.(type) {
 	case *type_system.MethodElem:
-		return e.Fn, e.Name.String(), true
+		return e.AsType(), e.Name.String(), true
 	case *type_system.GetterElem:
 		return e.Fn, e.Name.String(), true
 	case *type_system.SetterElem:

--- a/internal/test_util/test_util.go
+++ b/internal/test_util/test_util.go
@@ -295,8 +295,8 @@ func convertObjTypeAnnElem(elem ast.ObjTypeAnnElem) ObjTypeElem {
 		funcType := typeAnnToType(e.Fn).(*FuncType)
 		applyMethodReceiver(funcType, e.Receiver)
 		return &MethodElem{
-			Name: key,
-			Fn:   funcType,
+			Name:       key,
+			Signatures: []*FuncType{funcType},
 		}
 	case *ast.GetterTypeAnn:
 		key := convertObjKey(e.Name)

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -384,19 +384,31 @@ func printPatternWithInlineTypesContext(pattern Pat, paramType Type, pt func(Typ
 	return pattern.String()
 }
 
-func printFuncType(t *FuncType, pt func(Type) string) string {
-	result := "fn "
-	if len(t.LifetimeParams) > 0 || len(t.TypeParams) > 0 {
+// printFuncSig prints a function signature body — generic params,
+// parameter list (optionally with a leading `self` / `mut self`),
+// return type, and throws clause — after the caller-supplied
+// `header` (e.g. `"fn "` for bare function types, or a method name
+// for method-elem arms).
+//
+// includeSelf controls whether fn.SelfParam is rendered. Bare
+// function values pass false: even when the FuncType originated
+// from a method, the receiver is already bound at the use site
+// (`val f = obj.method`) and shouldn't resurface. Method-elem
+// arms pass true so that `self` / `mut self` appears in the
+// printed signature.
+func printFuncSig(header string, fn *FuncType, includeSelf bool, pt func(Type) string) string {
+	result := header
+	if len(fn.LifetimeParams) > 0 || len(fn.TypeParams) > 0 {
 		result += "<"
 		first := true
-		for _, lp := range t.LifetimeParams {
+		for _, lp := range fn.LifetimeParams {
 			if !first {
 				result += ", "
 			}
 			first = false
 			result += "'" + lp.Name
 		}
-		for _, param := range t.TypeParams {
+		for _, param := range fn.TypeParams {
 			if !first {
 				result += ", "
 			}
@@ -412,30 +424,35 @@ func printFuncType(t *FuncType, pt func(Type) string) string {
 		result += ">"
 	}
 	result += "("
-	// Note: SelfParam is intentionally NOT printed here. printFuncType
-	// is shared between (a) bare function values and (b) the inner
-	// signature of method elements. Method elements emit `self` /
-	// `mut self` themselves at the printObjectType level; printing
-	// SelfParam here would duplicate it for methods AND, more
-	// problematically, attach a phantom `self` to function values
-	// extracted from a method (`val f = obj.method`), where the
-	// receiver is already bound and shouldn't surface.
-	if len(t.Params) > 0 {
-		for i, param := range t.Params {
-			if i > 0 {
-				result += ", "
-			}
-			result += printFuncParam(param, pt)
+	hasSelf := includeSelf && fn.SelfParam != nil
+	if hasSelf {
+		if ReceiverIsMut(fn) {
+			result += "mut "
 		}
+		result += "self"
+	}
+	for i, param := range fn.Params {
+		if i > 0 || hasSelf {
+			result += ", "
+		}
+		result += printFuncParam(param, pt)
 	}
 	result += ")"
-	if t.Return != nil {
-		result += " -> " + pt(t.Return)
+	if fn.Return != nil {
+		result += " -> " + pt(fn.Return)
 	}
-	if !IsNeverType(t.Throws) {
-		result += " throws " + pt(t.Throws)
+	if !IsNeverType(fn.Throws) {
+		result += " throws " + pt(fn.Throws)
 	}
 	return result
+}
+
+func printFuncType(t *FuncType, pt func(Type) string) string {
+	return printFuncSig("fn ", t, false, pt)
+}
+
+func printMethodSig(name ObjTypeKey, fn *FuncType, pt func(Type) string) string {
+	return printFuncSig(name.String(), fn, true, pt)
 }
 
 func printObjectType(t *ObjectType, pt func(Type) string) string {
@@ -471,55 +488,7 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 					if armIdx > 0 {
 						result += ", "
 					}
-					result += elem.Name.String()
-					if len(fn.LifetimeParams) > 0 || len(fn.TypeParams) > 0 {
-						result += "<"
-						first := true
-						for _, lp := range fn.LifetimeParams {
-							if !first {
-								result += ", "
-							}
-							first = false
-							result += "'" + lp.Name
-						}
-						for _, param := range fn.TypeParams {
-							if !first {
-								result += ", "
-							}
-							first = false
-							result += param.Name
-							if param.Constraint != nil {
-								result += ": " + pt(param.Constraint)
-							}
-							if param.Default != nil {
-								result += " = " + pt(param.Default)
-							}
-						}
-						result += ">"
-					}
-					result += "("
-					hasSelf := fn.SelfParam != nil
-					if hasSelf {
-						if ReceiverIsMut(fn) {
-							result += "mut "
-						}
-						result += "self"
-					}
-					if len(fn.Params) > 0 {
-						for i, param := range fn.Params {
-							if i > 0 || hasSelf {
-								result += ", "
-							}
-							result += printFuncParam(param, pt)
-						}
-					}
-					result += ")"
-					if fn.Return != nil {
-						result += " -> " + pt(fn.Return)
-					}
-					if !IsNeverType(fn.Throws) {
-						result += " throws " + pt(fn.Throws)
-					}
+					result += printMethodSig(elem.Name, fn, pt)
 				}
 			case *GetterElem:
 				result += "get " + elem.Name.String() + "(" + printSelfReceiver(elem.Fn) + ") -> " + pt(elem.Fn.Return)

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -452,54 +452,64 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 			case *ConstructorElem:
 				result += "new " + printFuncType(elem.Fn, pt)
 			case *MethodElem:
-				result += elem.Name.String()
-				if len(elem.Fn.LifetimeParams) > 0 || len(elem.Fn.TypeParams) > 0 {
-					result += "<"
-					first := true
-					for _, lp := range elem.Fn.LifetimeParams {
-						if !first {
-							result += ", "
-						}
-						first = false
-						result += "'" + lp.Name
+				// Print one entry per overload arm. For a single-arm
+				// (non-overloaded) method this matches the historical
+				// output exactly; overloads — once §4.6 PR-C lands —
+				// render as comma-separated arms sharing nothing but
+				// the method name on each line.
+				for armIdx, fn := range elem.Signatures {
+					if armIdx > 0 {
+						result += ", "
 					}
-					for _, param := range elem.Fn.TypeParams {
-						if !first {
-							result += ", "
+					result += elem.Name.String()
+					if len(fn.LifetimeParams) > 0 || len(fn.TypeParams) > 0 {
+						result += "<"
+						first := true
+						for _, lp := range fn.LifetimeParams {
+							if !first {
+								result += ", "
+							}
+							first = false
+							result += "'" + lp.Name
 						}
-						first = false
-						result += param.Name
-						if param.Constraint != nil {
-							result += ": " + pt(param.Constraint)
+						for _, param := range fn.TypeParams {
+							if !first {
+								result += ", "
+							}
+							first = false
+							result += param.Name
+							if param.Constraint != nil {
+								result += ": " + pt(param.Constraint)
+							}
+							if param.Default != nil {
+								result += " = " + pt(param.Default)
+							}
 						}
-						if param.Default != nil {
-							result += " = " + pt(param.Default)
+						result += ">"
+					}
+					result += "("
+					hasSelf := fn.SelfParam != nil
+					if hasSelf {
+						if ReceiverIsMut(fn) {
+							result += "mut "
+						}
+						result += "self"
+					}
+					if len(fn.Params) > 0 {
+						for i, param := range fn.Params {
+							if i > 0 || hasSelf {
+								result += ", "
+							}
+							result += printFuncParam(param, pt)
 						}
 					}
-					result += ">"
-				}
-				result += "("
-				hasSelf := elem.Fn != nil && elem.Fn.SelfParam != nil
-				if hasSelf {
-					if ReceiverIsMut(elem.Fn) {
-						result += "mut "
+					result += ")"
+					if fn.Return != nil {
+						result += " -> " + pt(fn.Return)
 					}
-					result += "self"
-				}
-				if len(elem.Fn.Params) > 0 {
-					for i, param := range elem.Fn.Params {
-						if i > 0 || hasSelf {
-							result += ", "
-						}
-						result += printFuncParam(param, pt)
+					if !IsNeverType(fn.Throws) {
+						result += " throws " + pt(fn.Throws)
 					}
-				}
-				result += ")"
-				if elem.Fn.Return != nil {
-					result += " -> " + pt(elem.Fn.Return)
-				}
-				if !IsNeverType(elem.Fn.Throws) {
-					result += " throws " + pt(elem.Fn.Throws)
 				}
 			case *GetterElem:
 				result += "get " + elem.Name.String() + "(" + printSelfReceiver(elem.Fn) + ") -> " + pt(elem.Fn.Return)

--- a/internal/type_system/print_type.go
+++ b/internal/type_system/print_type.go
@@ -457,6 +457,16 @@ func printObjectType(t *ObjectType, pt func(Type) string) string {
 				// output exactly; overloads — once §4.6 PR-C lands —
 				// render as comma-separated arms sharing nothing but
 				// the method name on each line.
+				//
+				// PR-C TODO: the arm separator below (", ") collides
+				// with the outer element separator on line 447, making
+				// overloaded arms visually indistinguishable from
+				// sibling elements (e.g. `{ foo(x: A), foo(x: B), bar:
+				// number }` — is `bar` a third arm or a property?).
+				// Pick a distinct separator for arms (e.g. "; ") when
+				// len(Signatures) > 1, or restructure to emit one
+				// arm-line per arm. Harmless today since every method
+				// is single-arm.
 				for armIdx, fn := range elem.Signatures {
 					if armIdx > 0 {
 						result += ", "

--- a/internal/type_system/print_type_audit_test.go
+++ b/internal/type_system/print_type_audit_test.go
@@ -172,11 +172,11 @@ func TestPrintTypeAudit_RoundTrip(t *testing.T) {
 		{"object method", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			&type_system.MethodElem{
 				Name: type_system.NewStrKey("foo"),
-				Fn: type_system.NewFuncType(nil, nil,
+				Signatures: []*type_system.FuncType{type_system.NewFuncType(nil, nil,
 					[]*type_system.FuncParam{
 						{Pattern: type_system.NewIdentPat("x"), Type: type_system.NewNumPrimType(nil)},
 					},
-					type_system.NewBoolPrimType(nil), nil),
+					type_system.NewBoolPrimType(nil), nil)},
 			},
 		})},
 		{"object getter", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
@@ -332,14 +332,14 @@ func TestPrintTypeAudit_RoundTrip(t *testing.T) {
 		// --- method with self receiver ---
 		{"method with self", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			&type_system.MethodElem{
-				Name: type_system.NewStrKey("foo"),
-				Fn:   funcWithSelf(false),
+				Name:       type_system.NewStrKey("foo"),
+				Signatures: []*type_system.FuncType{funcWithSelf(false)},
 			},
 		})},
 		{"method with mut self", type_system.NewObjectType(nil, []type_system.ObjTypeElem{
 			&type_system.MethodElem{
-				Name: type_system.NewStrKey("foo"),
-				Fn:   funcWithSelf(true),
+				Name:       type_system.NewStrKey("foo"),
+				Signatures: []*type_system.FuncType{funcWithSelf(true)},
 			},
 		})},
 	}

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1050,9 +1050,56 @@ type ObjTypeElem interface {
 
 type CallableElem struct{ Fn *FuncType }
 type ConstructorElem struct{ Fn *FuncType }
+// MethodElem is a method member of an object type.
+//
+// Signatures carries the method's callable arms. A non-
+// overloaded method has exactly one arm; an overloaded method
+// (multiple same-named arms in one class/interface body) has
+// the arms ordered most-specific-first. Until §4.6 PR-C lands,
+// every MethodElem produced by elaboration still has exactly
+// one arm. The merge pass that produces multi-arm methods runs
+// at the elaboration boundary, so all downstream readers must
+// be overload-aware via the Signatures slice; SingleSig() exists
+// for the small number of call sites that genuinely cannot
+// handle overloads (Symbol.iterator, custom matchers, etc.).
 type MethodElem struct {
-	Name ObjTypeKey
-	Fn   *FuncType
+	Name       ObjTypeKey
+	Signatures []*FuncType
+}
+
+// SingleSig returns the sole signature for a method that is
+// known to be single-signature. Panics if the method has been
+// overloaded — callers that genuinely cannot handle overloads
+// should use this so the misuse surfaces immediately. Returns
+// nil if Signatures is empty.
+func (m *MethodElem) SingleSig() *FuncType {
+	if len(m.Signatures) == 0 {
+		return nil
+	}
+	if len(m.Signatures) > 1 {
+		panic(fmt.Sprintf("MethodElem.SingleSig called on overloaded method %v (%d arms)", m.Name, len(m.Signatures)))
+	}
+	return m.Signatures[0]
+}
+
+// AsType returns a Type view of the method's callable shape:
+// the lone FuncType for single-sig methods, an IntersectionType
+// of FuncType arms for overloaded methods. Used by member-access
+// resolution and any other site that needs to plug the method
+// into a Type-valued slot. Returns nil if Signatures is empty.
+func (m *MethodElem) AsType() Type {
+	switch len(m.Signatures) {
+	case 0:
+		return nil
+	case 1:
+		return m.Signatures[0]
+	default:
+		arms := make([]Type, len(m.Signatures))
+		for i, fn := range m.Signatures {
+			arms[i] = fn
+		}
+		return NewIntersectionType(nil, arms...)
+	}
 }
 type GetterElem struct {
 	Name ObjTypeKey
@@ -1105,7 +1152,7 @@ type PropertyElem struct {
 }
 
 func NewMethodElem(name ObjTypeKey, fn *FuncType) *MethodElem {
-	return &MethodElem{Name: name, Fn: fn}
+	return &MethodElem{Name: name, Signatures: []*FuncType{fn}}
 }
 func NewGetterElem(name ObjTypeKey, fn *FuncType) *GetterElem {
 	return &GetterElem{Name: name, Fn: fn}
@@ -1201,11 +1248,19 @@ func (c *ConstructorElem) Accept(v TypeVisitor) ObjTypeElem {
 	return c
 }
 func (m *MethodElem) Accept(v TypeVisitor) ObjTypeElem {
-	newFn := m.Fn.Accept(v).(*FuncType)
-	if newFn != m.Fn {
-		return &MethodElem{Name: m.Name, Fn: newFn}
+	changed := false
+	newSigs := make([]*FuncType, len(m.Signatures))
+	for i, fn := range m.Signatures {
+		newFn := fn.Accept(v).(*FuncType)
+		newSigs[i] = newFn
+		if newFn != fn {
+			changed = true
+		}
 	}
-	return m
+	if !changed {
+		return m
+	}
+	return &MethodElem{Name: m.Name, Signatures: newSigs}
 }
 func (g *GetterElem) Accept(v TypeVisitor) ObjTypeElem {
 	newFn := g.Fn.Accept(v).(*FuncType)
@@ -2679,7 +2734,15 @@ func objTypeElemEquals(e1, e2 ObjTypeElem) bool {
 		}
 	case *MethodElem:
 		if e2, ok := e2.(*MethodElem); ok {
-			return e1.Name == e2.Name && equals(e1.Fn, e2.Fn)
+			if e1.Name != e2.Name || len(e1.Signatures) != len(e2.Signatures) {
+				return false
+			}
+			for i := range e1.Signatures {
+				if !equals(e1.Signatures[i], e2.Signatures[i]) {
+					return false
+				}
+			}
+			return true
 		}
 	case *GetterElem:
 		if e2, ok := e2.(*GetterElem); ok {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -1248,13 +1248,16 @@ func (c *ConstructorElem) Accept(v TypeVisitor) ObjTypeElem {
 	return c
 }
 func (m *MethodElem) Accept(v TypeVisitor) ObjTypeElem {
+	newSigs := m.Signatures
 	changed := false
-	newSigs := make([]*FuncType, len(m.Signatures))
 	for i, fn := range m.Signatures {
 		newFn := fn.Accept(v).(*FuncType)
-		newSigs[i] = newFn
 		if newFn != fn {
-			changed = true
+			if !changed {
+				newSigs = append([]*FuncType(nil), m.Signatures...)
+				changed = true
+			}
+			newSigs[i] = newFn
 		}
 	}
 	if !changed {

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -2737,6 +2737,11 @@ func objTypeElemEquals(e1, e2 ObjTypeElem) bool {
 		}
 	case *MethodElem:
 		if e2, ok := e2.(*MethodElem); ok {
+			// Arm order is significant: Signatures is ordered
+			// most-specific-first, and dispatch picks the first
+			// matching arm. Two methods with the same arms in a
+			// different order dispatch differently and are not
+			// structurally equal.
 			if e1.Name != e2.Name || len(e1.Signatures) != len(e2.Signatures) {
 				return false
 			}

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -1315,6 +1315,15 @@ review surface manageable. (The original PR-D — inheritance and
    IntersectionType path automatically (because `getObjectAccess`
    now returns the intersection). Gate fixtures (below) flip
    to method-shape in this PR.
+   - **Printer separator fix.** [print_type.go:454](../../internal/type_system/print_type.go#L454)
+     emits overload arms with `", "`, the same separator
+     `printObjectType` uses between top-level elements. Once
+     methods can have multiple arms, the output
+     `{ foo(x: A), foo(x: B), bar: number }` is ambiguous —
+     `bar` reads as a third arm. Switch the arm separator to
+     `"; "` (or restructure to emit one arm-line per arm) when
+     `len(Signatures) > 1`. Add a print snapshot for an
+     overloaded method as part of this PR.
 PR-A and PR-B are independent and can land in either order.
 PR-C depends on both. The deferred inheritance work
 ([#651](https://github.com/escalier-lang/escalier/issues/651))

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -1017,15 +1017,16 @@ machinery used anywhere else.
    overwrites; replace with an overload-aware insertion that
    merges the new signature into an intersection-typed `Fn` on
    the existing elem.
-2. Widen `MethodElem.Fn` from `*FuncType` to `Type` (carrying
-   either a single `FuncType` for the common case or an
-   `IntersectionType` of `FuncType` arms for overloads). Add a
-   helper `(*MethodElem).Signatures() []*FuncType` that returns
-   `[fn]` for the single-arm case and the arms for intersections,
-   so every site that currently pattern-matches `method.Fn` as
-   `*FuncType` can switch to a uniform iteration without each
-   caller re-doing the intersection unwrap. Audit and update:
-   `ReceiverIsMut`, the array-mutating-method scan
+2. Replace `MethodElem.Fn *FuncType` with `MethodElem.Signatures
+   []*FuncType` (length 1 for non-overloaded, length > 1 for
+   overloads, ordered most-specific-first). The slice-of-FuncType
+   shape makes the "arms are FuncTypes" invariant a compile-time
+   guarantee — there's no `Type`-typed field that could hold an
+   arbitrary intersection or anything else. Add `SingleSig()` for
+   call sites that genuinely cannot handle overloads (panics on
+   misuse) and `AsType()` for sites that need a Type view (returns
+   the lone arm or `NewIntersectionType(arms...)`). Audit and
+   update: `ReceiverIsMut`, the array-mutating-method scan
    ([expand_type.go:1734,1756](../../internal/checker/expand_type.go#L1734)),
    mutability checks, `findCustomMatcherMethod`
    ([checker.go:133](../../internal/checker/checker.go#L133)),
@@ -1083,6 +1084,242 @@ questions — these are the chosen behaviours):**
   intersection can be constructed directly from the AST without
   going through call-site collection.
 
+**Where "last wins" actually happens.** Insertion is *not* the
+overwrite point — every site that builds class/interface object
+types just `append`s `MethodElem`s
+([infer_module.go:591,599](../../internal/checker/infer_module.go#L591),
+[infer_class_decl.go:182,185](../../internal/checker/infer_class_decl.go#L182),
+[infer_type_ann.go:408](../../internal/checker/infer_type_ann.go#L408),
+[infer_stmt.go:693](../../internal/checker/infer_stmt.go#L693)).
+The "last wins" surfacing is the reverse-iteration lookup in
+[expand_type.go:1195](../../internal/checker/expand_type.go#L1195):
+`getObjectAccess` scans `objType.Elems` in reverse, returns at
+the first name match, and stops. With two same-named MethodElems
+both present, the later one shadows the earlier one at every
+read site — but both arms are still in the type, so a merge pass
+that runs at the class-elaboration boundary (between elem build
+and the `NewObjectType` call that wraps them) is enough to fix
+this; we don't need to rewrite the insertion path.
+
+**The merge helper.** Add `MergeMethodOverloads(elems
+[]ObjTypeElem, reportErr func(...)) []ObjTypeElem` in
+`internal/type_system/` (alongside object-type construction
+helpers). Algorithm:
+
+1. Walk `elems` once, building `byName map[ObjTypeKey][]int` of
+   MethodElem indices. PropertyElem / GetterElem / SetterElem /
+   ConstructorElem / CallableElem / IndexSignatureElem /
+   RestSpreadElem / MappedElem pass through unchanged. A
+   PropertyElem and a MethodElem sharing a name is a separate
+   pre-existing error, not §4.6's concern; leave it alone here.
+2. For each name with `len(indices) > 1`:
+   - Verify all arms agree on receiver mutability via
+     `ReceiverIsMut`. On mismatch, emit
+     `OverloadReceiverMutMismatchError{Name, FirstArm, MismatchedArm}`
+     and drop the mismatched arm (keep the first arm's shape so
+     downstream code still type-checks).
+   - Sort arms by the specificity comparator (below); preserve
+     source order as the tiebreaker.
+   - Collect the arm `*FuncType`s into a slice, build
+     `NewIntersectionType(nil, arms...)`. The intersection
+     constructor at
+     [expand_type.go:2235](../../internal/checker/expand_type.go#L2235)
+     currently dedupes / flattens — add a `preserveOrder bool`
+     param (or a sibling `NewOrderedIntersectionType`) so the
+     specificity-sorted order survives, since dispatch at
+     [infer_expr.go:1059](../../internal/checker/infer_expr.go#L1059)
+     relies on iteration order being most-specific-first.
+   - Replace the first occurrence's `MethodElem` with one whose
+     `Fn` is the intersection. Remove the other occurrences.
+3. Return the rewritten slice. Idempotent: a slice with no
+   duplicates round-trips unchanged.
+
+Call this from every MethodElem-collection site listed above,
+immediately before the `NewObjectType` call that consumes the
+elems. Also from `unify.go:2610` (which reconstructs a MethodElem
+during unification — verify whether the surrounding context
+already guarantees uniqueness; if so, a debug `require` instead
+of a merge call is enough).
+
+**Specificity comparator.** Implement
+`compareOverloadArms(a, b *FuncType) int` in the checker
+(alongside [infer_expr.go:1059](../../internal/checker/infer_expr.go#L1059)).
+Returns -1 when `a` is more specific than `b`. Rules in
+descending priority:
+
+1. **Literal-typed params before non-literal.** Count the
+   number of `*LitType` params (after `Prune`) in each arm; the
+   arm with more literal params is more specific. This handles
+   `createElement(tag: "canvas")` vs.
+   `createElement(tag: "div")` (tied) vs.
+   `createElement(tag: string)` (less specific).
+2. **Bounded generics before unbounded / `string` / `number`
+   fallbacks.** For type-param-bearing arms, the arm whose
+   bound is a `keyof T` / `T[K]` / union of literals is more
+   specific than an unbounded `<T>` or a `string` param. Probe
+   each type param's `Constraint`: a non-nil bound that isn't
+   `NeverType` ranks ahead of a missing or `NeverType` bound.
+3. **Param count.** Fewer required params is more specific
+   (matches TS's "more required args before fewer / optional");
+   optional params (`Optional: true` or those with default) and
+   `...rest` params don't count as required.
+4. **Source order tiebreaker.** When the above don't
+   discriminate, keep declared order. Stable sort.
+
+Pin these rules with a table-driven test in
+`internal/checker/tests/overload_specificity_test.go` before
+wiring the comparator into `MergeMethodOverloads` — the test
+should cover each rule and a tie that falls through to source
+order. The free-fn overload path at infer_expr.go:1059 should
+*also* sort its intersection arms with this comparator (today
+the order is just whatever the generalize-time intersection
+construction yielded); doing both in the same PR avoids
+divergent semantics between free-fn and method overloads.
+
+**MethodElem widening: a `Signatures []*FuncType` field.**
+Replace the `Fn *FuncType` field with a slice of FuncType arms.
+A non-overloaded method has exactly one arm; an overloaded
+method has the arms ordered most-specific-first. The invariant
+"arms are FuncTypes" is a compile-time guarantee, not a
+documented one — there is no way to store a non-FuncType in
+this slot.
+
+```go
+type MethodElem struct {
+    Name       ObjTypeKey
+    Signatures []*FuncType
+}
+
+// SingleSig returns the sole signature; panics on overload. Used
+// at call sites that genuinely cannot handle overloads (e.g.
+// Symbol.iterator, custom matchers). Returns nil if Signatures
+// is empty.
+func (m *MethodElem) SingleSig() *FuncType { /* asserts len==1 */ }
+
+// AsType returns the lone FuncType for single-sig methods,
+// or NewIntersectionType(arms...) for overloaded methods.
+// Used by member-access resolution (e.g. getObjectAccess) and
+// anywhere a Type-valued view of the method shape is needed.
+func (m *MethodElem) AsType() Type { /* returns FuncType or IntersectionType */ }
+```
+
+Sites that just want to walk the arms call `m.Signatures`
+directly (no method call). Sites that need a Type for downstream
+plumbing call `m.AsType()`. The deprecated `Fn` field is gone.
+
+Sites to audit and update (all in `internal/checker/`):
+
+| File:line | Today | After |
+|---|---|---|
+| `getObjectAccess` MethodElem branch in `expand_type.go` | `return elem.Fn, errors` | `return elem.AsType(), errors` — call-site dispatch at infer_expr.go:1058 picks up the IntersectionType case automatically |
+| array-mutating-method scan in `expand_type.go` | `ReceiverIsMut(method.Fn)` | `ReceiverIsMut(method.SingleSig())` — mutability must be uniform across arms (enforced at merge time in PR-C) |
+| `findCustomMatcherMethod` in `checker.go` | reads `methodElem.Fn` | use `SingleSig()` — custom matcher is single-signature by convention |
+| `Symbol.iterator` shape check in `unify.go` | `methodElem.Fn.Params` | use `SingleSig()` — iterator/asyncIterator are single-sig by spec |
+| MethodElem reconstruction during ObjectType unification in `unify.go` | builds new MethodElem with widened `Fn` | walk `Signatures` and widen each arm; only allocate a new slice if any arm changed |
+| pattern-match custom-matcher lookup in `exhaustiveness.go` | `methodElem.Fn.Params[0]` | `SingleSig()` — custom-matcher is single-sig |
+| self-param + iterator-protocol fixup in `method_helpers.go` | mutates `e.Fn.SelfParam` directly | iterate `e.Signatures` and mutate each arm in place (PR-A: one arm; PR-C: all arms share receiver mutability so the per-arm fixup is uniform) |
+| method-body inference in `infer_module.go` / `infer_class_decl.go` | reads `methodType.Fn.Params` etc. | hoist `methodSig := methodType.SingleSig()` once per method — body inference runs per AST elem **before** the merge pass collapses arms, so single-sig is the right shape |
+| deep-clone MethodElem in `generalize.go` | clones `.Fn` as `*FuncType` | walk `Signatures` and deep-clone each arm |
+| `collectUnresolvedTypeVarsImpl` MethodElem branch in `generalize.go` | walks `.Fn` | walk each arm in `Signatures` |
+| spread / read-set collection in `unify.go` | adds `elem.Fn` to the effective-values map | use `elem.AsType()` so overloaded methods spread as their IntersectionType |
+| interface-merging in `infer_module.go` (`existingProps`, `newType`) | stores `elem.Fn` as the property's type | use `elem.AsType()` |
+| printing MethodElem in `print_type.go` | prints one signature | iterate `Signatures` and print each arm; single-arm output identical to before |
+| `objElemMatch` and `fillMemberSet` in `internal/interop` | reads `e.Fn` as a Type | `e.AsType()` |
+| completion item detail in `cmd/lsp-server/completion.go` | `elem.Fn.String()` | `elem.AsType().String()` |
+| `.d.ts` emitter in `codegen/dts.go` | `b.buildFuncTypeAnn(elem.Fn)` | `b.buildFuncTypeAnn(elem.SingleSig())` at PR-A; PR-C fans out one `MethodTypeAnn` per arm |
+
+Construction sites (currently `&MethodElem{Name: k, Fn: fn}`)
+must be updated to `&MethodElem{Name: k, Signatures: []*FuncType{fn}}`;
+`NewMethodElem(name, fn)` continues to wrap a single arm, so any
+caller that goes through the helper is unaffected.
+
+The `codegen/builder.go:2279-2382` `e.Fn` references are
+unrelated — those read AST `FuncExpr.Fn`, not type-system
+`MethodElem`. JS codegen for class bodies doesn't see
+overload arms (TS doesn't either — overload arms are
+declaration-only and collapse to one runtime method).
+
+**Inheritance + `implements` — deferred to
+[#651](https://github.com/escalier-lang/escalier/issues/651).**
+The §4.6 scope below covers same-class method overloads only.
+Cross-hierarchy overload merging (subclass adding arms to a
+parent's overloaded method, `interface extends`, and `implements`
+arm-vs-arm assignability) lands in a follow-up. Sketch retained
+here for reference:
+
+For `class B extends A` where
+`A` declares `foo(x: A1) -> R1` and `B` adds `foo(x: A2) -> R2`:
+
+- During B's elaboration, after the local merge, walk B's
+  parent chain to find any inherited MethodElem with the same
+  name. If found, build an intersection
+  `[B's arms..., A's arms...]` (subclass arms first so they
+  win the specificity sort when equally specific, matching TS).
+- Sort the combined intersection with the specificity
+  comparator and re-emit B's MethodElem with the merged `Fn`.
+- For `interface` `extends`: identical, but operate on the
+  declared `Extends` chain instead of class hierarchy.
+- For `implements`: `check_implements.go`
+  ([:109](../../internal/checker/check_implements.go#L109),
+  [:285](../../internal/checker/check_implements.go#L285))
+  walks elem-by-elem. Switch the MethodElem branch to call
+  `Signatures()` on both sides and require that **every arm
+  on the interface side has at least one assignable arm on
+  the class side** (TS rule: the implementer must provide a
+  signature for each declared overload, but may add more).
+  Reuse the existing pairwise `Unify` call for the
+  arm-vs-arm check.
+
+A subtle case: `extends` brings in arms whose `SelfParam` is
+typed to the *parent* class. After merging into B, those arms
+must have `SelfParam` retyped to B (or the comparator and
+dispatch will see incompatible receiver types across arms,
+which contradicts the receiver-mutability-uniform invariant
+even if mutability matches). Add a `retargetSelfParam(arm,
+newSelf)` helper and apply it during the inheritance merge.
+
+**Error types.** New diagnostics (add to `internal/checker/errors.go`):
+
+- `OverloadReceiverMutMismatchError{Name, FirstArm, MismatchedArm, span}` — for the receiver-mutability uniformity check.
+- `OverloadArmShapeMismatchError{Name, Side, OtherSide}` — for `unify.go:2610` when two `MethodElem`s being unified disagree on arm count or specificity ordering in a way the unifier can't reconcile. (Soft error path: pick the first side and continue, but report.)
+
+`NoMatchingOverloadError` is reused as-is for call-site
+dispatch failure — the existing intersection-arm path at
+infer_expr.go:1082 already constructs it.
+
+**PR phasing.** Suggest splitting §4.6 into three PRs to keep
+review surface manageable. (The original PR-D — inheritance and
+`implements` — is deferred to
+[#651](https://github.com/escalier-lang/escalier/issues/651).)
+
+1. **PR-A — Replace `MethodElem.Fn *FuncType` with
+   `Signatures []*FuncType`, add `SingleSig()` and `AsType()`,
+   audit all consumer sites.** Zero behavior change: the merge
+   pass is not yet introduced, so every `MethodElem` has exactly
+   one arm at runtime. This PR exists purely to make the type-
+   system shape ready and to prove the audit table above is
+   complete (CI green with no panics is the gate). Includes the
+   print_type / codegen printer updates with snapshot churn
+   limited to printing one-arm methods identically.
+2. **PR-B — Specificity comparator + free-fn intersection
+   sort.** Adds `compareOverloadArms`, the
+   `overload_specificity_test.go` table tests, and applies
+   the comparator to free-fn overload intersections at
+   generalize.go:478 / infer_expr.go:1058 iteration. Catches
+   any drift in existing free-fn overload behavior before
+   methods enter the picture.
+3. **PR-C — `MergeMethodOverloads` + class/interface
+   elaboration call.** Wires the merge into every MethodElem
+   collection site listed above. Receiver-mut mismatch
+   diagnostic. Method-call dispatch starts going through the
+   IntersectionType path automatically (because `getObjectAccess`
+   now returns the intersection). Gate fixtures (below) flip
+   to method-shape in this PR.
+PR-A and PR-B are independent and can land in either order.
+PR-C depends on both. The deferred inheritance work
+([#651](https://github.com/escalier-lang/escalier/issues/651))
+depends on PR-C.
+
 **Gate fixtures (live in `internal/checker/tests/`).**
 
 - Rewrite `TestStdlibImport_NSKeyedOverloads` so the two
@@ -1107,10 +1344,6 @@ questions — these are the chosen behaviours):**
   per-event-name overloads of `addEventListener` on a single
   class, verifying the handler param narrows to the
   event-specific type for each literal name.
-- Add an inheritance fixture: a subclass adding a new overload
-  to a method already overloaded on its parent; both old and
-  new overloads must remain callable, with dispatch picking the
-  most-specific arm regardless of which body declared it.
 - Add a receiver-mutability mismatch fixture: a class declaring
   the same method with both `self` and `mut self` receivers
   should produce an elaboration-time error naming both arms.


### PR DESCRIPTION
## Summary

Two coupled changes laying the groundwork for method-elem overload resolution (planning/builtins §4.6):

1. **Planning** — flesh out §4.6 with concrete file:line anchors, the `MergeMethodOverloads` helper sketch, the specificity comparator design (four ranked rules), an audit table of every `MethodElem` consumer, and a three-PR phasing. Inheritance + `implements` arm-vs-arm assignability is deferred to #651.

2. **PR-A — zero-behavior-change shape change.** Replace `MethodElem.Fn *FuncType` with `Signatures []*FuncType` (length 1 today, length > 1 once PR-C lands). The slice-of-FuncType shape makes the "arms are FuncTypes" invariant a compile-time guarantee — no Type-typed field that could hold an arbitrary intersection. Add `SingleSig()` and `AsType()` helpers and migrate every consumer site listed in the audit table.

## Notable details

- **Tightest possible static guarantee.** Initial draft used `Fn Type` with a runtime invariant; switched to `Signatures []*FuncType` so the type checker enforces the shape. `Signatures` is a field, not a method — walking arms is a plain `for _, fn := range m.Signatures` loop.
- `SingleSig()` panics if called on an overloaded method — call sites that genuinely cannot handle overloads (Symbol.iterator, custom matchers, getter/setter callable shapes) use this so the misuse surfaces immediately.
- `AsType()` returns the lone arm for single-sig methods, or `NewIntersectionType(arms...)` for overloads. Used by `getObjectAccess` and the few other sites that need a Type-valued view of the method.
- The type-system `MethodElem` printer was restructured to iterate `Signatures`; single-arm output is byte-identical to before, so snapshot tests pass without churn.
- `method_helpers.go` self-param + iterator-protocol fixup now iterates `Signatures` for forward-compatibility with PR-C, even though there's only one arm to fix up today.
- The MethodElem widening at `unify.go:2610` walks each arm and only allocates a new slice if any arm changed.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean — no snapshot churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)