### PR TITLE
Fix #655: subtype-based overload specificity

### DIFF
--- a/internal/checker/merge_overloads_test.go
+++ b/internal/checker/merge_overloads_test.go
@@ -26,7 +26,7 @@ func methodElemArm(name string, mut bool, litTag string) *type_system.MethodElem
 }
 
 func TestMergeMethodOverloads_NoDuplicates_RoundTrip(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	elems := []type_system.ObjTypeElem{
 		methodElemArm("foo", false, "a"),
 		methodElemArm("bar", false, "b"),
@@ -41,7 +41,7 @@ func TestMergeMethodOverloads_NoDuplicates_RoundTrip(t *testing.T) {
 }
 
 func TestMergeMethodOverloads_CollapsesSameName(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	a := methodElemArm("foo", false, "a")
 	b := methodElemArm("foo", false, "b")
 	other := methodElemArm("bar", false, "x")
@@ -63,7 +63,7 @@ func TestMergeMethodOverloads_CollapsesSameName(t *testing.T) {
 }
 
 func TestMergeMethodOverloads_ReceiverMutMismatch(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	a := methodElemArm("swap", false, "a")
 	b := methodElemArm("swap", true, "b")
 	elems := []type_system.ObjTypeElem{a, b}
@@ -84,7 +84,7 @@ func TestMergeMethodOverloads_ReceiverMutMismatch(t *testing.T) {
 }
 
 func TestMergeMethodOverloads_ReceiverMutMismatch_ReverseDirection(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	a := methodElemArm("swap", true, "a")
 	b := methodElemArm("swap", false, "b")
 	elems := []type_system.ObjTypeElem{a, b}
@@ -110,7 +110,7 @@ func TestMergeMethodOverloads_ReceiverMutMismatch_ReverseDirection(t *testing.T)
 // has a mismatch. Go map iteration is randomized per-run, so iterating
 // indicesByName directly would expose this test to flakes.
 func TestMergeMethodOverloads_StableErrorOrder(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	elems := []type_system.ObjTypeElem{
 		methodElemArm("alpha", false, "a"),
 		methodElemArm("alpha", true, "b"),
@@ -129,7 +129,7 @@ func TestMergeMethodOverloads_StableErrorOrder(t *testing.T) {
 }
 
 func TestMergeMethodOverloads_Idempotent(t *testing.T) {
-	c := &Checker{}
+	c := NewChecker(nil)
 	elems := []type_system.ObjTypeElem{
 		methodElemArm("foo", false, "a"),
 		methodElemArm("foo", false, "b"),

--- a/internal/checker/overload_specificity.go
+++ b/internal/checker/overload_specificity.go
@@ -26,40 +26,41 @@ const (
 // Rules in descending priority — checked in order, the first
 // discriminating rule wins:
 //
-//  1. **Literal-typed params before non-literal.** Count the number
-//     of *LitType params (after Prune) in each arm; the arm with
-//     more literal params is more specific. Handles e.g.
-//     `createElement(tag: "canvas")` vs.
-//     `createElement(tag: string)`.
+//  1. **Pointwise param subtype.** When arities match, arm a is more
+//     specific than b iff `a.Params[i]` is a structural subtype of
+//     `b.Params[i]` for every i and at least one position is a strict
+//     subtype (i.e. the reverse direction fails). The check is a
+//     pure, side-effect-free traversal of the pruned type shapes —
+//     it never invokes the unifier and never resolves a TypeRefType
+//     to its underlying alias definition (though it does recurse
+//     into the type arguments of same-alias references), so it's
+//     safe to call during placeholder phases where unifying
+//     against unrelated overload arms would be unsound. Subsumes the
+//     old literal-count heuristic and naturally handles unions,
+//     object fields, and nested literals.
 //
-//  2. **Bounded generics before unbounded.** Count the number of
-//     type params whose Constraint is non-nil and not NeverType.
-//     A bounded `<K: keyof T>` ranks ahead of an unbounded `<T>`
-//     or a fallback like `(x: string)`.
-//
-//  3. **Fewer required params is more specific.** Optional params
+//  2. **Fewer required params is more specific.** Optional params
 //     (FuncParam.Optional) and rest params (*RestSpreadType) do
 //     not count as required. Matches TS's "more required args
 //     before fewer" rule.
 //
-//  4. **Fewer type-param-typed params is more specific.** Count
+//  3. **Fewer type-param-typed params is more specific.** Count
 //     params whose top-level type is a `TypeRefType` to one of
 //     the fn's own type params. A concrete `(value: string)` ranks
 //     ahead of a generic `<T>(value: T)` because `T` provides no
 //     constraint on what the caller may pass.
 //
-//  5. Source order tiebreaker. Returns 0 here; the caller's stable
-//     sort preserves declared order.
+//  4. Source order tiebreaker. Returns 0 here; the caller's stable
+//     sort preserves declared order. Subtype is a partial order, so
+//     many real arms — different literal tags, disjoint object
+//     shapes, etc. — will be incomparable under rule 1 and rely on
+//     this fallback.
 //
 // This comparator is used both for free-fn overload arms (sorted
 // when the intersection is constructed in infer_module.go /
-// generalize.go) and for the PR-C method-elem merge pass. Keeping
+// generalize.go) and for the method-elem merge pass. Keeping
 // a single comparator means free-fn and method overload dispatch
 // have identical semantics.
-//
-// TODO(#655): rules 1–2 are a top-level literal-count heuristic and
-// miss unions, object fields, and other nested narrowing. Replace
-// with a subtype-based comparison once §4.6 lands.
 func compareOverloadArms(a, b *type_system.FuncType) specificity {
 	if a == nil || b == nil {
 		// Nil sorts last — should never happen with well-formed
@@ -73,20 +74,8 @@ func compareOverloadArms(a, b *type_system.FuncType) specificity {
 		return aMoreSpecific
 	}
 
-	aLits, bLits := countLiteralParams(a), countLiteralParams(b)
-	if aLits != bLits {
-		if aLits > bLits {
-			return aMoreSpecific
-		}
-		return bMoreSpecific
-	}
-
-	aBounded, bBounded := countBoundedTypeParams(a), countBoundedTypeParams(b)
-	if aBounded != bBounded {
-		if aBounded > bBounded {
-			return aMoreSpecific
-		}
-		return bMoreSpecific
+	if cmp := compareBySubtype(a, b); cmp != tie {
+		return cmp
 	}
 
 	aReq, bReq := countRequiredParams(a), countRequiredParams(b)
@@ -111,9 +100,9 @@ func compareOverloadArms(a, b *type_system.FuncType) specificity {
 // sortOverloadArms returns the arms ordered most-specific-first
 // using compareOverloadArms. Sort is stable, so arms that compare
 // equal preserve their input order — the declared-source-order
-// tiebreaker for rule 4. Returns the input slice (sorted in place);
-// callers that need to preserve the original slice should clone
-// before calling.
+// tiebreaker. Returns the input slice (sorted in place); callers
+// that need to preserve the original slice should clone before
+// calling.
 func sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
 	sort.SliceStable(arms, func(i, j int) bool {
 		return compareOverloadArms(arms[i], arms[j]) < 0
@@ -121,28 +110,250 @@ func sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
 	return arms
 }
 
-func countLiteralParams(fn *type_system.FuncType) int {
-	n := 0
-	for _, p := range fn.Params {
-		if _, ok := type_system.Prune(p.Type).(*type_system.LitType); ok {
-			n++
+// compareBySubtype implements rule 1 of compareOverloadArms.
+//
+// For arms of equal positive arity, checks whether one arm's params
+// are pointwise subtypes of the other's. Returns aMoreSpecific when
+// every a.Params[i] <: b.Params[i] AND at least one position is
+// strict (the reverse b.Params[i] <: a.Params[i] fails). bMoreSpecific
+// symmetrically. tie otherwise — including when arities differ or
+// the relation is incomparable.
+//
+// Param positions where either side is a TypeRefType naming one of
+// the arm's own type params are skipped: the universal quantifier
+// makes them effectively top-typed for specificity, and rule 3
+// orders concrete-vs-generic separately. Without the skip, both
+// directions of subtype would tie at such positions and rule 1
+// could not fire even when other positions discriminate.
+func compareBySubtype(a, b *type_system.FuncType) specificity {
+	if len(a.Params) != len(b.Params) || len(a.Params) == 0 {
+		return tie
+	}
+	aTP := typeParamNames(a)
+	bTP := typeParamNames(b)
+
+	allAToB := true
+	allBToA := true
+	sawComparable := false
+	for i := range a.Params {
+		ap := type_system.Prune(a.Params[i].Type)
+		bp := type_system.Prune(b.Params[i].Type)
+		if isOwnedTypeParamRef(ap, aTP) || isOwnedTypeParamRef(bp, bTP) {
+			continue
+		}
+		aToB := structuralSubtype(ap, bp, make(structuralSeen))
+		bToA := structuralSubtype(bp, ap, make(structuralSeen))
+		// If neither direction succeeds, the shape is one
+		// structuralSubtype doesn't recognize (FuncType, intersection,
+		// nominal object, …) or the two types are simply disjoint
+		// (e.g. different literal tags). Skip the position rather
+		// than AND-poisoning both directions to false — otherwise an
+		// unrelated unrecognized position would mask a real subtype
+		// discrimination at another position.
+		if !aToB && !bToA {
+			continue
+		}
+		sawComparable = true
+		if !aToB {
+			allAToB = false
+		}
+		if !bToA {
+			allBToA = false
 		}
 	}
-	return n
+	if !sawComparable {
+		return tie
+	}
+	if allAToB && !allBToA {
+		return aMoreSpecific
+	}
+	if allBToA && !allAToB {
+		return bMoreSpecific
+	}
+	return tie
 }
 
-func countBoundedTypeParams(fn *type_system.FuncType) int {
-	n := 0
-	for _, tp := range fn.TypeParams {
-		if tp.Constraint == nil {
-			continue
-		}
-		if _, isNever := type_system.Prune(tp.Constraint).(*type_system.NeverType); isNever {
-			continue
-		}
-		n++
+func typeParamNames(fn *type_system.FuncType) map[string]struct{} {
+	if len(fn.TypeParams) == 0 {
+		return nil
 	}
-	return n
+	out := make(map[string]struct{}, len(fn.TypeParams))
+	for _, tp := range fn.TypeParams {
+		out[tp.Name] = struct{}{}
+	}
+	return out
+}
+
+func isOwnedTypeParamRef(t type_system.Type, ownTP map[string]struct{}) bool {
+	if len(ownTP) == 0 {
+		return false
+	}
+	ref, ok := t.(*type_system.TypeRefType)
+	if !ok {
+		return false
+	}
+	ident, ok := ref.Name.(*type_system.Ident)
+	if !ok {
+		return false
+	}
+	_, ok = ownTP[ident.Name]
+	return ok
+}
+
+// structuralSeen guards against unbounded recursion on cyclic types
+// (e.g. recursive object types). Keyed by the (sub, sup) pointer
+// pair; revisiting a pair returns true co-inductively, matching
+// `unifyInner`'s seen-set discipline.
+type structuralSeen map[[2]type_system.Type]bool
+
+// structuralSubtype reports whether sub is a structural subtype of
+// sup. The check is intentionally narrow: it covers the kinds the
+// issue calls out (literals vs prims, narrowing unions, object
+// fields, tuples) plus enough identity/equality cases to handle the
+// "same shape on both sides" path that other rules rely on. Anything
+// unrecognized returns false so the caller falls through to the
+// syntactic tiebreakers.
+//
+// Both arguments must already be pruned.
+func structuralSubtype(sub, sup type_system.Type, seen structuralSeen) bool {
+	if sub == sup {
+		return true
+	}
+	key := [2]type_system.Type{sub, sup}
+	if seen[key] {
+		return true
+	}
+	seen[key] = true
+
+	// Union on sub: every member must be subtype of sup.
+	if subU, ok := sub.(*type_system.UnionType); ok {
+		for _, m := range subU.Types {
+			if !structuralSubtype(type_system.Prune(m), sup, seen) {
+				return false
+			}
+		}
+		return true
+	}
+	// Union on sup: sub must be subtype of some member.
+	if supU, ok := sup.(*type_system.UnionType); ok {
+		for _, m := range supU.Types {
+			if structuralSubtype(sub, type_system.Prune(m), seen) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Same identical primitive.
+	if subP, ok := sub.(*type_system.PrimType); ok {
+		if supP, ok := sup.(*type_system.PrimType); ok {
+			return subP.Prim == supP.Prim
+		}
+		return false
+	}
+
+	// Literal on sub.
+	if subL, ok := sub.(*type_system.LitType); ok {
+		if supL, ok := sup.(*type_system.LitType); ok {
+			return subL.Lit.Equal(supL.Lit)
+		}
+		if supP, ok := sup.(*type_system.PrimType); ok {
+			return litMatchesPrim(subL, supP)
+		}
+		return false
+	}
+
+	// Tuple: pointwise equal-arity subtype.
+	if subT, ok := sub.(*type_system.TupleType); ok {
+		supT, ok := sup.(*type_system.TupleType)
+		if !ok || len(subT.Elems) != len(supT.Elems) {
+			return false
+		}
+		for i := range subT.Elems {
+			if !structuralSubtype(type_system.Prune(subT.Elems[i]),
+				type_system.Prune(supT.Elems[i]), seen) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Object: every property in sup must appear in sub with a subtype
+	// value. Extra fields in sub are fine (width subtyping). Anything
+	// other than plain PropertyElem makes us bail out — the issue's
+	// motivating case is `{kind: "click"}` vs `{kind: string}`, not
+	// methods / index signatures, so this is sufficient.
+	if subO, ok := sub.(*type_system.ObjectType); ok {
+		supO, ok := sup.(*type_system.ObjectType)
+		if !ok {
+			return false
+		}
+		subProps := plainProps(subO)
+		supProps := plainProps(supO)
+		if subProps == nil || supProps == nil {
+			return false
+		}
+		for name, supV := range supProps {
+			subV, ok := subProps[name]
+			if !ok {
+				return false
+			}
+			if !structuralSubtype(type_system.Prune(subV),
+				type_system.Prune(supV), seen) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// TypeRefType on both sides referring to the same alias.
+	if subR, ok := sub.(*type_system.TypeRefType); ok {
+		if supR, ok := sup.(*type_system.TypeRefType); ok {
+			if subR.TypeAlias != nil && subR.TypeAlias == supR.TypeAlias &&
+				len(subR.TypeArgs) == len(supR.TypeArgs) {
+				for i := range subR.TypeArgs {
+					if !structuralSubtype(type_system.Prune(subR.TypeArgs[i]),
+						type_system.Prune(supR.TypeArgs[i]), seen) {
+						return false
+					}
+				}
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func litMatchesPrim(lit *type_system.LitType, prim *type_system.PrimType) bool {
+	switch lit.Lit.(type) {
+	case *type_system.StrLit:
+		return prim.Prim == type_system.StrPrim
+	case *type_system.NumLit:
+		return prim.Prim == type_system.NumPrim
+	case *type_system.BoolLit:
+		return prim.Prim == type_system.BoolPrim
+	case *type_system.BigIntLit:
+		return prim.Prim == type_system.BigIntPrim
+	}
+	return false
+}
+
+// plainProps collects PropertyElems into a name→value map. Returns
+// nil if the object carries any non-PropertyElem (method, index sig,
+// mapped, etc.) so the caller bails on the subtype check rather than
+// silently ignoring those elems and producing a misleading answer.
+func plainProps(o *type_system.ObjectType) map[string]type_system.Type {
+	out := make(map[string]type_system.Type, len(o.Elems))
+	for _, e := range o.Elems {
+		switch e := e.(type) {
+		case *type_system.PropertyElem:
+			out[e.Name.String()] = e.Value
+		default:
+			return nil
+		}
+	}
+	return out
 }
 
 // countTypeParamRefParams counts params whose top-level type (after Prune)
@@ -152,21 +363,10 @@ func countTypeParamRefParams(fn *type_system.FuncType) int {
 	if len(fn.TypeParams) == 0 {
 		return 0
 	}
-	tpNames := make(map[string]struct{}, len(fn.TypeParams))
-	for _, tp := range fn.TypeParams {
-		tpNames[tp.Name] = struct{}{}
-	}
+	tpNames := typeParamNames(fn)
 	n := 0
 	for _, p := range fn.Params {
-		ref, ok := type_system.Prune(p.Type).(*type_system.TypeRefType)
-		if !ok {
-			continue
-		}
-		ident, ok := ref.Name.(*type_system.Ident)
-		if !ok {
-			continue
-		}
-		if _, ok := tpNames[ident.Name]; ok {
+		if isOwnedTypeParamRef(type_system.Prune(p.Type), tpNames) {
 			n++
 		}
 	}

--- a/internal/checker/overload_specificity.go
+++ b/internal/checker/overload_specificity.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"sort"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -119,73 +120,101 @@ func sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
 // symmetrically. tie otherwise — including when arities differ or
 // the relation is incomparable.
 //
-// Param positions where either side is a TypeRefType naming one of
-// the arm's own type params are skipped: the universal quantifier
-// makes them effectively top-typed for specificity, and rule 3
-// orders concrete-vs-generic separately. Without the skip, both
-// directions of subtype would tie at such positions and rule 1
-// could not fire even when other positions discriminate.
+// Owned type-param references are resolved to their upper bound:
+// `<K: C>` substitutes C, `<T>` (unbounded or constrained to never)
+// is treated as top. This makes bounded generics rank ahead of
+// unbounded ones at the same position — `<K: string>(x: K)` beats
+// `<T>(x: T)` because `string <: top` — while two unbounded TP refs
+// at the same position simply skip (no information). Rule 3 still
+// runs separately to order concrete-vs-generic at positions where
+// rule 1 ties.
 func compareBySubtype(a, b *type_system.FuncType) specificity {
 	if len(a.Params) != len(b.Params) || len(a.Params) == 0 {
 		return tie
 	}
-	aTP := typeParamNames(a)
-	bTP := typeParamNames(b)
+	aTP := typeParamBounds(a)
+	bTP := typeParamBounds(b)
 
-	allAToB := true
-	allBToA := true
+	allAIsSubtypeOfB := true
+	allBIsSubtypeOfA := true
 	sawComparable := false
 	for i := range a.Params {
 		ap := type_system.Prune(a.Params[i].Type)
 		bp := type_system.Prune(b.Params[i].Type)
-		if isOwnedTypeParamRef(ap, aTP) || isOwnedTypeParamRef(bp, bTP) {
+		aTop, aEff := effectiveParamType(ap, aTP)
+		bTop, bEff := effectiveParamType(bp, bTP)
+		if aTop && bTop {
+			// Both unbounded TP refs at this position — universal on
+			// both sides, no specificity signal. Skip without changing
+			// the running AND state.
 			continue
 		}
-		aToB := structuralSubtype(ap, bp, make(structuralSeen))
-		bToA := structuralSubtype(bp, ap, make(structuralSeen))
-		// If neither direction succeeds, the shape is one
-		// structuralSubtype doesn't recognize (FuncType, intersection,
-		// nominal object, …) or the two types are simply disjoint
-		// (e.g. different literal tags). Skip the position rather
-		// than AND-poisoning both directions to false — otherwise an
-		// unrelated unrecognized position would mask a real subtype
-		// discrimination at another position.
-		if !aToB && !bToA {
-			continue
+		// Both true → equivalent shapes; exactly one true → that side
+		// is strictly narrower; both false → incomparable (disjoint or
+		// unrecognized shape).
+		var aIsSubtypeOfB, bIsSubtypeOfA bool
+		switch {
+		case aTop:
+			// a ranges over all types, b is something narrower:
+			// b <: a holds, a <: b does not.
+			aIsSubtypeOfB, bIsSubtypeOfA = false, true
+		case bTop:
+			aIsSubtypeOfB, bIsSubtypeOfA = true, false
+		default:
+			aIsSubtypeOfB = structuralSubtype(aEff, bEff, make(structuralSeen))
+			bIsSubtypeOfA = structuralSubtype(bEff, aEff, make(structuralSeen))
+		}
+		// Any position where neither direction holds — an unrecognized
+		// shape (FuncType, intersection, nominal object, …) or genuinely
+		// disjoint shapes (e.g. different literal tags) — makes the arms
+		// pointwise-incomparable as a whole. Bail out to the source-order
+		// tiebreaker rather than letting later positions falsely decide.
+		if !aIsSubtypeOfB && !bIsSubtypeOfA {
+			return tie
 		}
 		sawComparable = true
-		if !aToB {
-			allAToB = false
+		if !aIsSubtypeOfB {
+			allAIsSubtypeOfB = false
 		}
-		if !bToA {
-			allBToA = false
+		if !bIsSubtypeOfA {
+			allBIsSubtypeOfA = false
 		}
 	}
 	if !sawComparable {
 		return tie
 	}
-	if allAToB && !allBToA {
+	if allAIsSubtypeOfB && !allBIsSubtypeOfA {
 		return aMoreSpecific
 	}
-	if allBToA && !allAToB {
+	if allBIsSubtypeOfA && !allAIsSubtypeOfB {
 		return bMoreSpecific
 	}
 	return tie
 }
 
-func typeParamNames(fn *type_system.FuncType) map[string]struct{} {
+// typeParamBounds returns a name→constraint map for fn's own type
+// params. A nil value means the param is unbounded — either no
+// constraint or a NeverType constraint (which the old comparator
+// treated as equivalent to unbounded). Non-nil values are pruned.
+func typeParamBounds(fn *type_system.FuncType) map[string]type_system.Type {
 	if len(fn.TypeParams) == 0 {
 		return nil
 	}
-	out := make(map[string]struct{}, len(fn.TypeParams))
+	out := make(map[string]type_system.Type, len(fn.TypeParams))
 	for _, tp := range fn.TypeParams {
-		out[tp.Name] = struct{}{}
+		var bound type_system.Type
+		if tp.Constraint != nil {
+			if _, isNever := type_system.Prune(tp.Constraint).(*type_system.NeverType); !isNever {
+				bound = type_system.Prune(tp.Constraint)
+			}
+		}
+		out[tp.Name] = bound
 	}
 	return out
 }
 
-func isOwnedTypeParamRef(t type_system.Type, ownTP map[string]struct{}) bool {
-	if len(ownTP) == 0 {
+func isOwnedTypeParamRef(t type_system.Type, ownTP set.Set[string]) bool {
+	if ownTP.Len() == 0 {
 		return false
 	}
 	ref, ok := t.(*type_system.TypeRefType)
@@ -196,8 +225,36 @@ func isOwnedTypeParamRef(t type_system.Type, ownTP map[string]struct{}) bool {
 	if !ok {
 		return false
 	}
-	_, ok = ownTP[ident.Name]
-	return ok
+	return ownTP.Contains(ident.Name)
+}
+
+// effectiveParamType resolves an owned type-param reference to its
+// upper bound for specificity comparison. Returns isTop=true when
+// the referenced param is unbounded (so the position ranges over all
+// types). For a bounded `<K: C>`, returns (false, C) — substituting
+// the constraint lets `<K: string>(x: K)` rank ahead of `<T>(x: T)`
+// just as `(x: string)` would. For any non-owned-TP type, returns
+// the input unchanged.
+func effectiveParamType(
+	t type_system.Type,
+	ownTP map[string]type_system.Type,
+) (isTop bool, eff type_system.Type) {
+	ref, ok := t.(*type_system.TypeRefType)
+	if !ok {
+		return false, t
+	}
+	ident, ok := ref.Name.(*type_system.Ident)
+	if !ok {
+		return false, t
+	}
+	bound, owned := ownTP[ident.Name]
+	if !owned {
+		return false, t
+	}
+	if bound == nil {
+		return true, nil
+	}
+	return false, bound
 }
 
 // structuralSeen guards against unbounded recursion on cyclic types
@@ -215,6 +272,11 @@ type structuralSeen map[[2]type_system.Type]bool
 // syntactic tiebreakers.
 //
 // Both arguments must already be pruned.
+//
+// TODO(#658): replace with the pure `Check` predicate once that
+// lands — it would subsume this hand-rolled traversal and handle
+// FuncType, intersections, nominal objects, and mapped types
+// without us having to grow the cases here.
 func structuralSubtype(sub, sup type_system.Type, seen structuralSeen) bool {
 	if sub == sup {
 		return true
@@ -363,10 +425,13 @@ func countTypeParamRefParams(fn *type_system.FuncType) int {
 	if len(fn.TypeParams) == 0 {
 		return 0
 	}
-	tpNames := typeParamNames(fn)
+	names := set.NewSet[string]()
+	for _, tp := range fn.TypeParams {
+		names.Add(tp.Name)
+	}
 	n := 0
 	for _, p := range fn.Params {
-		if isOwnedTypeParamRef(type_system.Prune(p.Type), tpNames) {
+		if isOwnedTypeParamRef(type_system.Prune(p.Type), names) {
 			n++
 		}
 	}

--- a/internal/checker/overload_specificity_test.go
+++ b/internal/checker/overload_specificity_test.go
@@ -72,54 +72,50 @@ func TestCompareOverloadArms(t *testing.T) {
 			b:    mkFn(nil, []*type_system.FuncParam{mkParam(canvasLit), mkParam(str)}),
 			want: aMoreSpecific,
 		},
+		// Subtype check handles unions and nested literals
+		// the old literal-count heuristic missed.
 		{
-			name: "two literal arms compare equal under rule 1 (same count)",
+			name: "union of literals beats string prim",
+			a: mkFn(nil, []*type_system.FuncParam{mkParam(
+				type_system.NewUnionType(nil, canvasLit, divLit),
+			)}),
+			b:    mkFn(nil, []*type_system.FuncParam{mkParam(str)}),
+			want: aMoreSpecific,
+		},
+		{
+			name: "object with literal field beats object with prim field",
+			a: mkFn(nil, []*type_system.FuncParam{mkParam(
+				type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+					&type_system.PropertyElem{Name: type_system.NewStrKey("kind"), Value: canvasLit},
+				}),
+			)}),
+			b: mkFn(nil, []*type_system.FuncParam{mkParam(
+				type_system.NewObjectType(nil, []type_system.ObjTypeElem{
+					&type_system.PropertyElem{Name: type_system.NewStrKey("kind"), Value: str},
+				}),
+			)}),
+			want: aMoreSpecific,
+		},
+		{
+			name: "tuple of literals beats tuple of prims",
+			a: mkFn(nil, []*type_system.FuncParam{mkParam(
+				type_system.NewTupleType(nil, canvasLit, divLit),
+			)}),
+			b: mkFn(nil, []*type_system.FuncParam{mkParam(
+				type_system.NewTupleType(nil, str, str),
+			)}),
+			want: aMoreSpecific,
+		},
+		{
+			// Disjoint literal tags are incomparable under subtype
+			// (neither <: the other) and source order breaks the tie.
+			name: "disjoint literal arms tie under subtype",
 			a:    mkFn(nil, []*type_system.FuncParam{mkParam(canvasLit)}),
 			b:    mkFn(nil, []*type_system.FuncParam{mkParam(divLit)}),
 			want: tie,
 		},
 
-		// Rule 2: bounded generics before unbounded.
-		{
-			name: "bounded <K: string> beats unbounded <T>",
-			a: mkFn(
-				[]*type_system.TypeParam{{Name: "K", Constraint: str}},
-				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
-			),
-			b: mkFn(
-				[]*type_system.TypeParam{{Name: "T"}},
-				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))},
-			),
-			want: aMoreSpecific,
-		},
-		{
-			name: "bounded type param with NeverType constraint counts as unbounded",
-			a: mkFn(
-				[]*type_system.TypeParam{{Name: "K", Constraint: str}},
-				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
-			),
-			b: mkFn(
-				[]*type_system.TypeParam{{Name: "K", Constraint: type_system.NewNeverType(nil)}},
-				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
-			),
-			want: aMoreSpecific,
-		},
-		{
-			name: "rule 2 only applies when rule 1 ties",
-			// a has unbounded generic but a literal param; b has bounded generic
-			// but a non-literal param. Rule 1 (more literals) picks a first.
-			a: mkFn(
-				[]*type_system.TypeParam{{Name: "T"}},
-				[]*type_system.FuncParam{mkParam(canvasLit)},
-			),
-			b: mkFn(
-				[]*type_system.TypeParam{{Name: "K", Constraint: str}},
-				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
-			),
-			want: aMoreSpecific,
-		},
-
-		// Rule 3: fewer required params is more specific.
+		// Rule 2: fewer required params is more specific.
 		{
 			name: "one required param beats two required params",
 			a:    mkFn(nil, []*type_system.FuncParam{mkParam(str)}),
@@ -139,7 +135,7 @@ func TestCompareOverloadArms(t *testing.T) {
 			want: tie,
 		},
 
-		// Rule 4: concrete-typed params beat type-param-typed params.
+		// Rule 3: concrete-typed params beat type-param-typed params.
 		{
 			name: "concrete (value: string) beats generic <T>(value: T)",
 			a:    mkFn(nil, []*type_system.FuncParam{mkParam(str)}),
@@ -150,7 +146,7 @@ func TestCompareOverloadArms(t *testing.T) {
 			want: aMoreSpecific,
 		},
 		{
-			name: "rule 4 ignores type params that aren't referenced by any param",
+			name: "rule 3 ignores type params that aren't referenced by any param",
 			a: mkFn(
 				[]*type_system.TypeParam{{Name: "T"}},
 				[]*type_system.FuncParam{mkParam(str)},
@@ -159,7 +155,7 @@ func TestCompareOverloadArms(t *testing.T) {
 			want: tie,
 		},
 
-		// Rule 5: source order tiebreaker — comparator returns 0,
+		// Rule 4: source order tiebreaker — comparator returns 0,
 		// stable sort handles the rest.
 		{
 			// Duplicate-decl detection (#654) will reject identical signatures
@@ -227,29 +223,26 @@ func TestSortOverloadArms_AcrossAllRules(t *testing.T) {
 	num := type_system.NewNumPrimType(nil)
 	canvasLit := type_system.NewStrLitType(nil, "canvas")
 
-	// Five arms covering each rule, declared in least-specific to
-	// most-specific order so the sort actually has to do work.
-	twoRequired := mkFn(nil, []*type_system.FuncParam{mkParam(str), mkParam(num)})                                               // 0 lit, 0 bounded, 2 req
-	oneRequiredStr := mkFn(nil, []*type_system.FuncParam{mkParam(str)})                                                          // 0 lit, 0 bounded, 1 req
-	unboundedGeneric := mkFn([]*type_system.TypeParam{{Name: "T"}}, []*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))}) // 0 lit, 0 bounded, 1 req (tied with above on rules 1-3)
-	boundedGeneric := mkFn(
-		[]*type_system.TypeParam{{Name: "K", Constraint: str}},
-		[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
-	) // 0 lit, 1 bounded, 1 req
-	literalArm := mkFn(nil, []*type_system.FuncParam{mkParam(canvasLit)}) // 1 lit, ...
+	// Four arms covering each rule, declared in least-specific-first
+	// order so the sort actually has to do work.
+	twoRequired := mkFn(nil, []*type_system.FuncParam{mkParam(str), mkParam(num)})        // 2 required
+	unboundedGeneric := mkFn(                                                             // 1 required, 1 TP-ref
+		[]*type_system.TypeParam{{Name: "T"}},
+		[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))},
+	)
+	oneRequiredStr := mkFn(nil, []*type_system.FuncParam{mkParam(str)})   // 1 required, 0 TP-ref
+	literalArm := mkFn(nil, []*type_system.FuncParam{mkParam(canvasLit)}) // subtype-narrower than oneRequiredStr
 
-	arms := []*type_system.FuncType{twoRequired, oneRequiredStr, unboundedGeneric, boundedGeneric, literalArm}
+	arms := []*type_system.FuncType{twoRequired, unboundedGeneric, oneRequiredStr, literalArm}
 	sorted := sortOverloadArms(arms)
 
 	// Expected most-specific-first order:
-	//   1. literalArm        (rule 1 wins)
-	//   2. boundedGeneric    (rule 2 wins among the rest)
-	//   3. oneRequiredStr    (rule 3: 1 required beats twoRequired; rule 4: 0 TP refs beats unboundedGeneric)
-	//   4. unboundedGeneric  (rule 3: 1 required beats twoRequired; rule 4 loses to oneRequiredStr)
-	//   5. twoRequired       (rule 3: 2 required, least specific)
+	//   1. literalArm        (rule 1 subtype: "canvas" <: string)
+	//   2. oneRequiredStr    (rule 3: 0 TP refs beats unboundedGeneric)
+	//   3. unboundedGeneric  (rule 2 ties with oneRequiredStr; rule 3 loses)
+	//   4. twoRequired       (rule 2: 2 required, least specific)
 	require.Same(t, literalArm, sorted[0])
-	require.Same(t, boundedGeneric, sorted[1])
-	require.Same(t, oneRequiredStr, sorted[2])
-	require.Same(t, unboundedGeneric, sorted[3])
-	require.Same(t, twoRequired, sorted[4])
+	require.Same(t, oneRequiredStr, sorted[1])
+	require.Same(t, unboundedGeneric, sorted[2])
+	require.Same(t, twoRequired, sorted[3])
 }

--- a/internal/checker/overload_specificity_test.go
+++ b/internal/checker/overload_specificity_test.go
@@ -114,6 +114,48 @@ func TestCompareOverloadArms(t *testing.T) {
 			b:    mkFn(nil, []*type_system.FuncParam{mkParam(divLit)}),
 			want: tie,
 		},
+		{
+			// Bounded TP substitutes its constraint; unbounded TP is top.
+			// `string <: top` and not vice versa, so bounded wins.
+			name: "bounded <K: string> beats unbounded <T>",
+			a: mkFn(
+				[]*type_system.TypeParam{{Name: "K", Constraint: str}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
+			),
+			b: mkFn(
+				[]*type_system.TypeParam{{Name: "T"}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))},
+			),
+			want: aMoreSpecific,
+		},
+		{
+			// Never constraint is treated as unbounded, matching the
+			// pre-§4.6 comparator's behavior.
+			name: "<K: never> ties with <T> (both treated as top)",
+			a: mkFn(
+				[]*type_system.TypeParam{{Name: "K", Constraint: type_system.NewNeverType(nil)}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
+			),
+			b: mkFn(
+				[]*type_system.TypeParam{{Name: "T"}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))},
+			),
+			want: tie,
+		},
+		{
+			// Two bounded TPs compare by their constraints.
+			// `"canvas" <: string` so the canvas-bounded arm wins.
+			name: "<K: \"canvas\"> beats <L: string>",
+			a: mkFn(
+				[]*type_system.TypeParam{{Name: "K", Constraint: canvasLit}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "K", nil))},
+			),
+			b: mkFn(
+				[]*type_system.TypeParam{{Name: "L", Constraint: str}},
+				[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "L", nil))},
+			),
+			want: aMoreSpecific,
+		},
 
 		// Rule 2: fewer required params is more specific.
 		{

--- a/internal/checker/tests/intersection_test.go
+++ b/internal/checker/tests/intersection_test.go
@@ -923,14 +923,17 @@ func TestFunctionOverloads(t *testing.T) {
 			expectedVars: map[string]string{},
 			wantErr:      true,
 		},
-		"overload returns first matching signature": {
+		"overload returns most specific matching signature": {
+			// Arm 2's `number` is a structural subtype of arm 1's
+			// `string | number`, so the comparator ranks arm 2 first
+			// and `process(42)` dispatches to it.
 			input: `
 				declare fn process(value: string | number) -> string
 				declare fn process(value: number) -> number
 				val result = process(42)
 			`,
 			expectedVars: map[string]string{
-				"result": "string",
+				"result": "number",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overload resolution to select more specific matching signatures based on structural subtype comparison instead of parameter counting heuristics.

* **Tests**
  * Updated overload specificity and resolution test suites to reflect refined subtype-driven matching behavior for literals, unions, and tuples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->