### PR TITLE
Fix #658: Add a pure Check predicate alongside Unify

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -63,12 +63,6 @@ type Checker struct {
 	// namespace tree — which already exposes each member at its derived
 	// path — isn't shadowed by an empty filtered copy.
 	activeSCC set.Set[string]
-
-	// queryUnify, when true, makes unifyInner / bind behave as a pure
-	// structural-subtype predicate: TypeVar binding, Widenable widening,
-	// and lifetime reconciliation are all refused. Check swaps this on
-	// for the duration of a single query; see unify_mode.go.
-	queryUnify bool
 }
 
 func NewChecker(ctx context.Context) *Checker {
@@ -163,6 +157,16 @@ type Context struct {
 	IsAsync                bool
 	IsPatMatch             bool
 	AllowUndefinedTypeRefs bool
+	// QueryUnify, when true, makes unifyInner / bind behave as a pure
+	// structural-subtype predicate: TypeVar binding, Widenable widening,
+	// and lifetime reconciliation are all refused. Check sets this for
+	// the duration of a single query; see unify_mode.go.
+	//
+	// Lives on Context (not Checker) so the auto-propagation through
+	// value-copy keeps nested unifyInner calls in the same mode without
+	// any save/restore dance, and so that the field is structurally
+	// scoped to the query that turned it on.
+	QueryUnify bool
 	TypeRefsToUpdate       *Ref[[]*type_system.TypeRefType]
 	// FileScopes maps SourceID to file-specific scope.
 	// Used for file-scoped imports in modules.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14,11 +14,11 @@ import (
 )
 
 type Checker struct {
-	ctx                   context.Context            // Context for timeout/cancellation support (#457)
+	ctx                   context.Context // Context for timeout/cancellation support (#457)
 	TypeVarID             int
 	LifetimeVarID         int
 	SymbolID              int
-	CustomMatcherSymbolID int                        // Symbol ID for Symbol.customMatcher (used for enum destructuring)
+	CustomMatcherSymbolID int // Symbol ID for Symbol.customMatcher (used for enum destructuring)
 	Schema                *gqlast.Schema
 	OverloadDecls         map[string][]*ast.FuncDecl // Tracks overloaded function declarations for codegen
 	PackageRegistry       *PackageRegistry           // Registry for package namespaces (separate from scope chain)
@@ -63,6 +63,12 @@ type Checker struct {
 	// namespace tree — which already exposes each member at its derived
 	// path — isn't shadowed by an empty filtered copy.
 	activeSCC set.Set[string]
+
+	// queryUnify, when true, makes unifyInner / bind behave as a pure
+	// structural-subtype predicate: TypeVar binding, Widenable widening,
+	// and lifetime reconciliation are all refused. Check swaps this on
+	// for the duration of a single query; see unify_mode.go.
+	queryUnify bool
 }
 
 func NewChecker(ctx context.Context) *Checker {

--- a/internal/checker/error.go
+++ b/internal/checker/error.go
@@ -772,7 +772,6 @@ func (e InnerNonExhaustiveMatchError) Message() string {
 	return "Non-exhaustive match: " + memberStr + " is missing inner cases for " + strings.Join(names, ", ")
 }
 
-
 // MissingMutSelfParameterError is reported when a constructor's `mut self`
 // parameter is missing, not declared `mut`, or has a type annotation.
 //
@@ -897,7 +896,6 @@ func (e FieldInitializerNotAllowedError) Message() string {
 	return "Field '" + e.FieldName + "' cannot have a `= expr` initializer; only static fields may use this form. Initialize instance fields in the constructor body."
 }
 
-
 // StaticFieldMissingInitializerError is reported when a static field
 // has no `= expr` initializer and no literal-typed annotation that
 // codegen can materialize. Without one of those, the emitted JS
@@ -913,7 +911,6 @@ func (e StaticFieldMissingInitializerError) Span() ast.Span {
 func (e StaticFieldMissingInitializerError) Message() string {
 	return "Static field '" + e.FieldName + "' must have an initializer (e.g. `static " + e.FieldName + ": number = 0`)."
 }
-
 
 // SubclassConstructorRequiredError is reported when a class with an
 // `extends` clause has no explicit `constructor` block. Synthesizing a

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -92,6 +92,14 @@ func isSymbolIndexKey(key MemberAccessKey) bool {
 func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool {
 	typeAlias := t.TypeAlias
 	if typeAlias == nil {
+		// Scope is required to resolve an unbound qualified name.
+		// Callers without a scope (e.g. the structural Check predicate
+		// invoked from overload specificity) pass a zero Context — in
+		// that case the ref simply isn't expandable, and the caller
+		// falls through to its tiebreaker.
+		if ctx.Scope == nil {
+			return false
+		}
 		typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
 	}
 	if typeAlias == nil {
@@ -499,6 +507,13 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		// First, check if TypeAlias is already set on the TypeRefType
 		typeAlias := t.TypeAlias
 		if typeAlias == nil {
+			// Scope-less callers (e.g. the structural Check predicate
+			// invoked from overload specificity) pass a zero Context.
+			// Treat unresolvable refs as non-expandable rather than
+			// dereferencing a nil scope.
+			if v.ctx.Scope == nil {
+				return nil
+			}
 			typeAlias = resolveQualifiedTypeAlias(v.ctx, t.Name)
 		}
 		// TODO: Check if the qualifier is a type.  If it is, we can treat this

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -92,12 +92,14 @@ func isSymbolIndexKey(key MemberAccessKey) bool {
 func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool {
 	typeAlias := t.TypeAlias
 	if typeAlias == nil {
-		// Scope is required to resolve an unbound qualified name.
-		// Callers without a scope (e.g. the structural Check predicate
-		// invoked from overload specificity) pass a zero Context — in
-		// that case the ref simply isn't expandable, and the caller
-		// falls through to its tiebreaker.
-		if ctx.Scope == nil {
+		// The structural Check predicate (e.g. invoked from overload
+		// specificity) can be called with a zero Context, so we have no
+		// scope to resolve an unbound qualified name. Fail closed — the
+		// ref isn't expandable in query mode, and the caller falls
+		// through to its tiebreaker. Outside query mode a nil scope
+		// here would be a bug, so let resolveQualifiedTypeAlias panic
+		// loudly rather than silently degrading.
+		if ctx.QueryUnify {
 			return false
 		}
 		typeAlias = resolveQualifiedTypeAlias(ctx, t.Name)
@@ -507,11 +509,12 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		// First, check if TypeAlias is already set on the TypeRefType
 		typeAlias := t.TypeAlias
 		if typeAlias == nil {
-			// Scope-less callers (e.g. the structural Check predicate
-			// invoked from overload specificity) pass a zero Context.
-			// Treat unresolvable refs as non-expandable rather than
-			// dereferencing a nil scope.
-			if v.ctx.Scope == nil {
+			// In query mode (Check) the caller may have passed a zero
+			// Context with no scope; treat the ref as non-expandable
+			// rather than dereferencing nil. Outside query mode this
+			// would be a bug, so fall through and let
+			// resolveQualifiedTypeAlias panic loudly.
+			if v.ctx.QueryUnify {
 				return nil
 			}
 			typeAlias = resolveQualifiedTypeAlias(v.ctx, t.Name)

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -482,7 +482,7 @@ func (c *Checker) resolveCallSites(ctx Context) {
 				// the first hit — same semantics as free-fn declared overloads.
 				sortedSites := make([]*type_system.FuncType, len(sites))
 				copy(sortedSites, sites)
-				sortOverloadArms(sortedSites)
+				c.sortOverloadArms(sortedSites)
 				types := make([]type_system.Type, len(sortedSites))
 				for i, s := range sortedSites {
 					types[i] = s

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -336,7 +336,7 @@ func (c *Checker) InferComponent(
 							decl.Span()))
 					}
 					arms = append(arms, funcType)
-					sortOverloadArms(arms)
+					c.sortOverloadArms(arms)
 					armTypes := make([]type_system.Type, len(arms))
 					for i, fn := range arms {
 						armTypes[i] = fn

--- a/internal/checker/merge_overloads.go
+++ b/internal/checker/merge_overloads.go
@@ -133,7 +133,7 @@ func (c *Checker) MergeMethodOverloads(elems []type_system.ObjTypeElem, span ast
 			arms = append(arms, sig)
 		}
 
-		sortOverloadArms(arms)
+		c.sortOverloadArms(arms)
 		mergedAt[idxs[0]] = &type_system.MethodElem{
 			Name:       firstMe.Name,
 			Signatures: arms,

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -100,33 +100,33 @@ func setReceiverMut(fn *type_system.FuncType, mut bool) {
 // populateSelfParams does two structural per-method adjustments in a
 // single recursive walk over ns.
 //
-// 1. Backfills FuncType.SelfParam on every instance method / getter /
-//    setter whose owning type is an ObjectType. Source-inferred types
-//    already get SelfParam at inference time (see infer_module.go,
-//    infer_stmt.go, infer_expr.go); this pass covers the .d.ts-loaded
-//    TypeScript lib types — Array, Map, Set, Promise, etc. — which
-//    arrive without a receiver representation.
+//  1. Backfills FuncType.SelfParam on every instance method / getter /
+//     setter whose owning type is an ObjectType. Source-inferred types
+//     already get SelfParam at inference time (see infer_module.go,
+//     infer_stmt.go, infer_expr.go); this pass covers the .d.ts-loaded
+//     TypeScript lib types — Array, Map, Set, Promise, etc. — which
+//     arrive without a receiver representation.
 //
-//    Defaults:
-//      - MethodElem → `mut self`. TS .d.ts carries no receiver-mut
-//        annotation, so for any method we haven't positively classified
-//        we don't know whether it mutates. Defaulting to mut is the
-//        conservative choice (UpdateMethodMutability and
-//        mergeReadonlyVariant strip `mut` afterwards where the method
-//        is positively classified as non-mutating).
-//      - GetterElem → non-mut self.
-//      - SetterElem → `mut self`.
-//    Accessor shape is the tier-3 strong signal — reading state doesn't
-//    mutate; assignment does — so getters and setters get opposite
-//    defaults rather than both defaulting to mut.
+//     Defaults:
+//     - MethodElem → `mut self`. TS .d.ts carries no receiver-mut
+//     annotation, so for any method we haven't positively classified
+//     we don't know whether it mutates. Defaulting to mut is the
+//     conservative choice (UpdateMethodMutability and
+//     mergeReadonlyVariant strip `mut` afterwards where the method
+//     is positively classified as non-mutating).
+//     - GetterElem → non-mut self.
+//     - SetterElem → `mut self`.
+//     Accessor shape is the tier-3 strong signal — reading state doesn't
+//     mutate; assignment does — so getters and setters get opposite
+//     defaults rather than both defaulting to mut.
 //
-// 2. For symbol-keyed MethodElems whose name is `Symbol.iterator` or
-//    `Symbol.asyncIterator`, strips `mut` from the receiver and wraps
-//    the return type in `MutType`. This bakes the structural rule
-//    "iterator producers don't mutate the source; the iterator they
-//    produce is owned by the caller and is mut" into the receiver and
-//    return-type representations. See iterable.go for why both
-//    adjustments are needed (and which is subsumed by #614).
+//  2. For symbol-keyed MethodElems whose name is `Symbol.iterator` or
+//     `Symbol.asyncIterator`, strips `mut` from the receiver and wraps
+//     the return type in `MutType`. This bakes the structural rule
+//     "iterator producers don't mutate the source; the iterator they
+//     produce is owned by the caller and is mut" into the receiver and
+//     return-type representations. See iterable.go for why both
+//     adjustments are needed (and which is subsumed by #614).
 //
 // Recurses into nested namespaces so namespaced lib types (e.g.
 // `Intl.Collator`) are covered too.

--- a/internal/checker/overload_specificity.go
+++ b/internal/checker/overload_specificity.go
@@ -30,15 +30,16 @@ const (
 //  1. **Pointwise param subtype.** When arities match, arm a is more
 //     specific than b iff `a.Params[i]` is a structural subtype of
 //     `b.Params[i]` for every i and at least one position is a strict
-//     subtype (i.e. the reverse direction fails). The check is a
-//     pure, side-effect-free traversal of the pruned type shapes —
-//     it never invokes the unifier and never resolves a TypeRefType
-//     to its underlying alias definition (though it does recurse
-//     into the type arguments of same-alias references), so it's
-//     safe to call during placeholder phases where unifying
-//     against unrelated overload arms would be unsound. Subsumes the
-//     old literal-count heuristic and naturally handles unions,
-//     object fields, and nested literals.
+//     subtype (i.e. the reverse direction fails). The check delegates
+//     to `c.Check(...)` (the query-mode unifier), so it runs the full
+//     structural recursion — including expansion of `TypeRefType` when
+//     a scope is available. `compareBySubtype` passes a zero `Context`
+//     so unresolvable refs fail closed and no scope-based expansion
+//     fires, but the call still drives `unifyInner`; query mode refuses
+//     TypeVar binding, Widenable widening, and lifetime reconciliation
+//     so no inference state is committed. Subsumes the old literal-count
+//     heuristic and naturally handles unions, object fields, and nested
+//     literals.
 //
 //  2. **Fewer required params is more specific.** Optional params
 //     (FuncParam.Optional) and rest params (*RestSpreadType) do

--- a/internal/checker/overload_specificity.go
+++ b/internal/checker/overload_specificity.go
@@ -62,7 +62,7 @@ const (
 // generalize.go) and for the method-elem merge pass. Keeping
 // a single comparator means free-fn and method overload dispatch
 // have identical semantics.
-func compareOverloadArms(a, b *type_system.FuncType) specificity {
+func (c *Checker) compareOverloadArms(a, b *type_system.FuncType) specificity {
 	if a == nil || b == nil {
 		// Nil sorts last — should never happen with well-formed
 		// intersections, but defensive against malformed input.
@@ -75,7 +75,7 @@ func compareOverloadArms(a, b *type_system.FuncType) specificity {
 		return aMoreSpecific
 	}
 
-	if cmp := compareBySubtype(a, b); cmp != tie {
+	if cmp := c.compareBySubtype(a, b); cmp != tie {
 		return cmp
 	}
 
@@ -104,9 +104,9 @@ func compareOverloadArms(a, b *type_system.FuncType) specificity {
 // tiebreaker. Returns the input slice (sorted in place); callers
 // that need to preserve the original slice should clone before
 // calling.
-func sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
+func (c *Checker) sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
 	sort.SliceStable(arms, func(i, j int) bool {
-		return compareOverloadArms(arms[i], arms[j]) < 0
+		return c.compareOverloadArms(arms[i], arms[j]) < 0
 	})
 	return arms
 }
@@ -128,12 +128,21 @@ func sortOverloadArms(arms []*type_system.FuncType) []*type_system.FuncType {
 // at the same position simply skip (no information). Rule 3 still
 // runs separately to order concrete-vs-generic at positions where
 // rule 1 ties.
-func compareBySubtype(a, b *type_system.FuncType) specificity {
+func (c *Checker) compareBySubtype(a, b *type_system.FuncType) specificity {
 	if len(a.Params) != len(b.Params) || len(a.Params) == 0 {
 		return tie
 	}
 	aTP := typeParamBounds(a)
 	bTP := typeParamBounds(b)
+
+	// Check is a structural subtype query and doesn't depend on the
+	// caller's lexical scope for the kinds of types overload arms
+	// carry here (pruned concrete shapes plus owned-TP refs already
+	// resolved to bounds above). A zero Context is sufficient — if
+	// some recursion needs scope-based TypeRef expansion it will fail
+	// closed, matching the old structuralSubtype's "unrecognized →
+	// false" behavior.
+	var ctx Context
 
 	allAIsSubtypeOfB := true
 	allBIsSubtypeOfA := true
@@ -161,8 +170,8 @@ func compareBySubtype(a, b *type_system.FuncType) specificity {
 		case bTop:
 			aIsSubtypeOfB, bIsSubtypeOfA = true, false
 		default:
-			aIsSubtypeOfB = structuralSubtype(aEff, bEff, make(structuralSeen))
-			bIsSubtypeOfA = structuralSubtype(bEff, aEff, make(structuralSeen))
+			aIsSubtypeOfB = c.Check(ctx, aEff, bEff)
+			bIsSubtypeOfA = c.Check(ctx, bEff, aEff)
 		}
 		// Any position where neither direction holds — an unrecognized
 		// shape (FuncType, intersection, nominal object, …) or genuinely
@@ -255,167 +264,6 @@ func effectiveParamType(
 		return true, nil
 	}
 	return false, bound
-}
-
-// structuralSeen guards against unbounded recursion on cyclic types
-// (e.g. recursive object types). Keyed by the (sub, sup) pointer
-// pair; revisiting a pair returns true co-inductively, matching
-// `unifyInner`'s seen-set discipline.
-type structuralSeen map[[2]type_system.Type]bool
-
-// structuralSubtype reports whether sub is a structural subtype of
-// sup. The check is intentionally narrow: it covers the kinds the
-// issue calls out (literals vs prims, narrowing unions, object
-// fields, tuples) plus enough identity/equality cases to handle the
-// "same shape on both sides" path that other rules rely on. Anything
-// unrecognized returns false so the caller falls through to the
-// syntactic tiebreakers.
-//
-// Both arguments must already be pruned.
-//
-// TODO(#658): replace with the pure `Check` predicate once that
-// lands — it would subsume this hand-rolled traversal and handle
-// FuncType, intersections, nominal objects, and mapped types
-// without us having to grow the cases here.
-func structuralSubtype(sub, sup type_system.Type, seen structuralSeen) bool {
-	if sub == sup {
-		return true
-	}
-	key := [2]type_system.Type{sub, sup}
-	if seen[key] {
-		return true
-	}
-	seen[key] = true
-
-	// Union on sub: every member must be subtype of sup.
-	if subU, ok := sub.(*type_system.UnionType); ok {
-		for _, m := range subU.Types {
-			if !structuralSubtype(type_system.Prune(m), sup, seen) {
-				return false
-			}
-		}
-		return true
-	}
-	// Union on sup: sub must be subtype of some member.
-	if supU, ok := sup.(*type_system.UnionType); ok {
-		for _, m := range supU.Types {
-			if structuralSubtype(sub, type_system.Prune(m), seen) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Same identical primitive.
-	if subP, ok := sub.(*type_system.PrimType); ok {
-		if supP, ok := sup.(*type_system.PrimType); ok {
-			return subP.Prim == supP.Prim
-		}
-		return false
-	}
-
-	// Literal on sub.
-	if subL, ok := sub.(*type_system.LitType); ok {
-		if supL, ok := sup.(*type_system.LitType); ok {
-			return subL.Lit.Equal(supL.Lit)
-		}
-		if supP, ok := sup.(*type_system.PrimType); ok {
-			return litMatchesPrim(subL, supP)
-		}
-		return false
-	}
-
-	// Tuple: pointwise equal-arity subtype.
-	if subT, ok := sub.(*type_system.TupleType); ok {
-		supT, ok := sup.(*type_system.TupleType)
-		if !ok || len(subT.Elems) != len(supT.Elems) {
-			return false
-		}
-		for i := range subT.Elems {
-			if !structuralSubtype(type_system.Prune(subT.Elems[i]),
-				type_system.Prune(supT.Elems[i]), seen) {
-				return false
-			}
-		}
-		return true
-	}
-
-	// Object: every property in sup must appear in sub with a subtype
-	// value. Extra fields in sub are fine (width subtyping). Anything
-	// other than plain PropertyElem makes us bail out — the issue's
-	// motivating case is `{kind: "click"}` vs `{kind: string}`, not
-	// methods / index signatures, so this is sufficient.
-	if subO, ok := sub.(*type_system.ObjectType); ok {
-		supO, ok := sup.(*type_system.ObjectType)
-		if !ok {
-			return false
-		}
-		subProps := plainProps(subO)
-		supProps := plainProps(supO)
-		if subProps == nil || supProps == nil {
-			return false
-		}
-		for name, supV := range supProps {
-			subV, ok := subProps[name]
-			if !ok {
-				return false
-			}
-			if !structuralSubtype(type_system.Prune(subV),
-				type_system.Prune(supV), seen) {
-				return false
-			}
-		}
-		return true
-	}
-
-	// TypeRefType on both sides referring to the same alias.
-	if subR, ok := sub.(*type_system.TypeRefType); ok {
-		if supR, ok := sup.(*type_system.TypeRefType); ok {
-			if subR.TypeAlias != nil && subR.TypeAlias == supR.TypeAlias &&
-				len(subR.TypeArgs) == len(supR.TypeArgs) {
-				for i := range subR.TypeArgs {
-					if !structuralSubtype(type_system.Prune(subR.TypeArgs[i]),
-						type_system.Prune(supR.TypeArgs[i]), seen) {
-						return false
-					}
-				}
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func litMatchesPrim(lit *type_system.LitType, prim *type_system.PrimType) bool {
-	switch lit.Lit.(type) {
-	case *type_system.StrLit:
-		return prim.Prim == type_system.StrPrim
-	case *type_system.NumLit:
-		return prim.Prim == type_system.NumPrim
-	case *type_system.BoolLit:
-		return prim.Prim == type_system.BoolPrim
-	case *type_system.BigIntLit:
-		return prim.Prim == type_system.BigIntPrim
-	}
-	return false
-}
-
-// plainProps collects PropertyElems into a name→value map. Returns
-// nil if the object carries any non-PropertyElem (method, index sig,
-// mapped, etc.) so the caller bails on the subtype check rather than
-// silently ignoring those elems and producing a misleading answer.
-func plainProps(o *type_system.ObjectType) map[string]type_system.Type {
-	out := make(map[string]type_system.Type, len(o.Elems))
-	for _, e := range o.Elems {
-		switch e := e.(type) {
-		case *type_system.PropertyElem:
-			out[e.Name.String()] = e.Value
-		default:
-			return nil
-		}
-	}
-	return out
 }
 
 // countTypeParamRefParams counts params whose top-level type (after Prune)

--- a/internal/checker/overload_specificity_test.go
+++ b/internal/checker/overload_specificity_test.go
@@ -233,7 +233,7 @@ func TestCompareOverloadArms(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := compareOverloadArms(tt.a, tt.b)
+			got := NewChecker(nil).compareOverloadArms(tt.a, tt.b)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -252,7 +252,7 @@ func TestSortOverloadArms_StableSourceOrderOnTies(t *testing.T) {
 	strArm := mkFn(nil, []*type_system.FuncParam{mkParam(str)})
 
 	arms := []*type_system.FuncType{strArm, canvasArm, divArm}
-	sorted := sortOverloadArms(arms)
+	sorted := NewChecker(nil).sortOverloadArms(arms)
 
 	require.Len(t, sorted, 3)
 	require.Same(t, canvasArm, sorted[0], "canvas literal arm declared before div, must come first")
@@ -267,8 +267,8 @@ func TestSortOverloadArms_AcrossAllRules(t *testing.T) {
 
 	// Four arms covering each rule, declared in least-specific-first
 	// order so the sort actually has to do work.
-	twoRequired := mkFn(nil, []*type_system.FuncParam{mkParam(str), mkParam(num)})        // 2 required
-	unboundedGeneric := mkFn(                                                             // 1 required, 1 TP-ref
+	twoRequired := mkFn(nil, []*type_system.FuncParam{mkParam(str), mkParam(num)}) // 2 required
+	unboundedGeneric := mkFn(                                                      // 1 required, 1 TP-ref
 		[]*type_system.TypeParam{{Name: "T"}},
 		[]*type_system.FuncParam{mkParam(type_system.NewTypeRefType(nil, "T", nil))},
 	)
@@ -276,7 +276,7 @@ func TestSortOverloadArms_AcrossAllRules(t *testing.T) {
 	literalArm := mkFn(nil, []*type_system.FuncParam{mkParam(canvasLit)}) // subtype-narrower than oneRequiredStr
 
 	arms := []*type_system.FuncType{twoRequired, unboundedGeneric, oneRequiredStr, literalArm}
-	sorted := sortOverloadArms(arms)
+	sorted := NewChecker(nil).sortOverloadArms(arms)
 
 	// Expected most-specific-first order:
 	//   1. literalArm        (rule 1 subtype: "canvas" <: string)

--- a/internal/checker/tests/elision_test.go
+++ b/internal/checker/tests/elision_test.go
@@ -253,4 +253,3 @@ func TestVerifyLifetimeCompatibility(t *testing.T) {
 		assert.NotEmpty(t, errs)
 	})
 }
-

--- a/internal/checker/tests/import_test.go
+++ b/internal/checker/tests/import_test.go
@@ -47,7 +47,7 @@ func TestImportInferenceScript(t *testing.T) {
 			expectedValues: map[string]string{
 				// Order reflects the §4.6 PR-B specificity sort: the no-arg
 				// arm has 0 required params and so ranks ahead of the
-				// 1-required-param arm under rule 3 ("fewer required params
+				// 1-required-param arm under rule 2 ("fewer required params
 				// is more specific"). Dispatch is unaffected — for a call
 				// like `useState("x")` the no-arg arm fails fast and the
 				// 1-arg arm matches; for `useState()` the no-arg arm matches

--- a/internal/checker/tests/import_test.go
+++ b/internal/checker/tests/import_test.go
@@ -46,14 +46,14 @@ func TestImportInferenceScript(t *testing.T) {
 			`,
 			expectedValues: map[string]string{
 				// Order reflects the §4.6 PR-B specificity sort: the no-arg
-			// arm has 0 required params and so ranks ahead of the
-			// 1-required-param arm under rule 3 ("fewer required params
-			// is more specific"). Dispatch is unaffected — for a call
-			// like `useState("x")` the no-arg arm fails fast and the
-			// 1-arg arm matches; for `useState()` the no-arg arm matches
-			// first. React declares them in the opposite order in the
-			// source .d.ts.
-			"useState": "(fn <S = undefined>() -> [S | undefined, Dispatch<SetStateAction<S | undefined>>]) & (fn <S>(initialState: S | (fn () -> S)) -> [S, Dispatch<SetStateAction<S>>])",
+				// arm has 0 required params and so ranks ahead of the
+				// 1-required-param arm under rule 3 ("fewer required params
+				// is more specific"). Dispatch is unaffected — for a call
+				// like `useState("x")` the no-arg arm fails fast and the
+				// 1-arg arm matches; for `useState()` the no-arg arm matches
+				// first. React declares them in the opposite order in the
+				// source .d.ts.
+				"useState": "(fn <S = undefined>() -> [S | undefined, Dispatch<SetStateAction<S | undefined>>]) & (fn <S>(initialState: S | (fn () -> S)) -> [S, Dispatch<SetStateAction<S>>])",
 			},
 		},
 	}

--- a/internal/checker/tests/mut_prefix_test.go
+++ b/internal/checker/tests/mut_prefix_test.go
@@ -364,4 +364,3 @@ func TestMutPrefixWithBuiltinCollections(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -671,9 +671,14 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 			// so this check applies on both branches below.
 			ltErrors := []Error{}
 			if len(ref1.LifetimeArgs) == len(ref2.LifetimeArgs) {
-				for i := 0; i < len(ref1.LifetimeArgs); i++ {
-					ltErrors = slices.Concat(ltErrors,
-						c.UnifyLifetimes(ctx, ref1.LifetimeArgs[i], ref2.LifetimeArgs[i]))
+				// UnifyLifetimes binds LifetimeVars — skip in query mode
+				// so Check stays side-effect-free. Structural subtype
+				// queries don't depend on lifetime equality.
+				if !c.queryUnify {
+					for i := 0; i < len(ref1.LifetimeArgs); i++ {
+						ltErrors = slices.Concat(ltErrors,
+							c.UnifyLifetimes(ctx, ref1.LifetimeArgs[i], ref2.LifetimeArgs[i]))
+					}
 				}
 			} else if len(ref1.LifetimeArgs) > 0 && len(ref2.LifetimeArgs) > 0 {
 				// Mismatched lifetime-arg arity is a structural error.
@@ -958,32 +963,39 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 				// "x" already present in obj1 and skip the merge, losing obj2's
 				// setter. By checking read and write separately, the setter is
 				// correctly appended so obj1 ends up with both get x and set x.
-				for _, key := range keys2 {
-					re := collected2.OrigRead[key]
-					we := collected2.OrigWrite[key]
-					if re != nil {
-						if _, has := namedElems1[key]; !has {
-							obj1.Elems = append(obj1.Elems, re)
+				//
+				// Skip the cross-side elem merge in query mode: it mutates
+				// obj1/obj2.Elems, which Check must not do. Shared-property
+				// unification above is read-only (it recurses through
+				// unifyInner, which honors queryUnify).
+				if !c.queryUnify {
+					for _, key := range keys2 {
+						re := collected2.OrigRead[key]
+						we := collected2.OrigWrite[key]
+						if re != nil {
+							if _, has := namedElems1[key]; !has {
+								obj1.Elems = append(obj1.Elems, re)
+							}
+						}
+						if we != nil && we != re {
+							if _, has := collected1.Write[key]; !has {
+								obj1.Elems = append(obj1.Elems, we)
+							}
 						}
 					}
-					if we != nil && we != re {
-						if _, has := collected1.Write[key]; !has {
-							obj1.Elems = append(obj1.Elems, we)
+					// Add elems from obj1 not in obj2 to obj2.
+					for _, key := range keys1 {
+						re := collected1.OrigRead[key]
+						we := collected1.OrigWrite[key]
+						if re != nil {
+							if _, has := namedElems2[key]; !has {
+								obj2.Elems = append(obj2.Elems, re)
+							}
 						}
-					}
-				}
-				// Add elems from obj1 not in obj2 to obj2.
-				for _, key := range keys1 {
-					re := collected1.OrigRead[key]
-					we := collected1.OrigWrite[key]
-					if re != nil {
-						if _, has := namedElems2[key]; !has {
-							obj2.Elems = append(obj2.Elems, re)
-						}
-					}
-					if we != nil && we != re {
-						if _, has := collected2.Write[key]; !has {
-							obj2.Elems = append(obj2.Elems, we)
+						if we != nil && we != re {
+							if _, has := collected2.Write[key]; !has {
+								obj2.Elems = append(obj2.Elems, we)
+							}
 						}
 					}
 				}
@@ -998,6 +1010,10 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 			// Open(t1)-vs-closed(t2): unify shared properties preserving
 			// t1/t2 directionality, add closed-only properties to the open type.
 			// Open-only properties are allowed (structural subtyping).
+			// Closed-to-open elem copies in the asymmetric branches below
+			// also mutate, so they're gated on !c.queryUnify too. Shared-
+			// property unification still runs in both modes — that's
+			// recursive structural checking via unifyInner.
 			if obj1.Open && !obj2.Open {
 				for _, key := range keys2 {
 					value1, has1 := namedElems1[key]
@@ -1005,6 +1021,9 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 					if has1 && has2 {
 						unifyErrors := c.unifyInner(ctx, value1, value2, seen)
 						errors = slices.Concat(errors, unifyErrors)
+					}
+					if c.queryUnify {
+						continue
 					}
 					re := collected2.OrigRead[key]
 					we := collected2.OrigWrite[key]
@@ -1025,7 +1044,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 						// Both sides have the same key-kind — unify their value types.
 						unifyErrors := c.unifyInner(ctx, existing.Value, sig.Value, seen)
 						errors = slices.Concat(errors, unifyErrors)
-					} else {
+					} else if !c.queryUnify {
 						obj1.Elems = append(obj1.Elems, copyObjTypeElem(sig))
 					}
 				}
@@ -1040,6 +1059,9 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 					if has1 && has2 {
 						unifyErrors := c.unifyInner(ctx, value1, value2, seen)
 						errors = slices.Concat(errors, unifyErrors)
+					}
+					if c.queryUnify {
+						continue
 					}
 					re := collected1.OrigRead[key]
 					we := collected1.OrigWrite[key]
@@ -1059,7 +1081,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 					if existing := findMatchingIndexSignature(sig, collected2.IndexSignatures); existing != nil {
 						unifyErrors := c.unifyInner(ctx, existing.Value, sig.Value, seen)
 						errors = slices.Concat(errors, unifyErrors)
-					} else {
+					} else if !c.queryUnify {
 						obj2.Elems = append(obj2.Elems, copyObjTypeElem(sig))
 					}
 				}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -222,7 +222,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 		// Lifetime reconciliation binds LifetimeVars — a side effect, so
 		// queryMode skips it. Structural subtype queries don't depend on
 		// lifetime equality.
-		if !c.queryUnify {
+		if !ctx.QueryUnify {
 			lt1 := type_system.GetLifetime(t1)
 			lt2 := type_system.GetLifetime(t2)
 			if lt1 != nil || lt2 != nil {
@@ -248,7 +248,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 	// path-compresses the chain but records it in tvA.InstanceChain. We use
 	// that chain to update ALL aliased TypeVars so reads through any alias
 	// observe the widened type.
-	if widenableChain := widenableInstanceChain(tv2); !c.queryUnify && len(widenableChain) > 0 {
+	if widenableChain := widenableInstanceChain(tv2); !ctx.QueryUnify && len(widenableChain) > 0 {
 		oldType := t2
 		// If oldType is still a TypeVarType (e.g. the chain ended at an unbound
 		// TypeVar and bind failed due to an occurs check), we must not build a
@@ -674,7 +674,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 				// UnifyLifetimes binds LifetimeVars — skip in query mode
 				// so Check stays side-effect-free. Structural subtype
 				// queries don't depend on lifetime equality.
-				if !c.queryUnify {
+				if !ctx.QueryUnify {
 					for i := 0; i < len(ref1.LifetimeArgs); i++ {
 						ltErrors = slices.Concat(ltErrors,
 							c.UnifyLifetimes(ctx, ref1.LifetimeArgs[i], ref2.LifetimeArgs[i]))
@@ -968,7 +968,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 				// obj1/obj2.Elems, which Check must not do. Shared-property
 				// unification above is read-only (it recurses through
 				// unifyInner, which honors queryUnify).
-				if !c.queryUnify {
+				if !ctx.QueryUnify {
 					for _, key := range keys2 {
 						re := collected2.OrigRead[key]
 						we := collected2.OrigWrite[key]
@@ -1011,7 +1011,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 			// t1/t2 directionality, add closed-only properties to the open type.
 			// Open-only properties are allowed (structural subtyping).
 			// Closed-to-open elem copies in the asymmetric branches below
-			// also mutate, so they're gated on !c.queryUnify too. Shared-
+			// also mutate, so they're gated on !ctx.QueryUnify too. Shared-
 			// property unification still runs in both modes — that's
 			// recursive structural checking via unifyInner.
 			if obj1.Open && !obj2.Open {
@@ -1022,7 +1022,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 						unifyErrors := c.unifyInner(ctx, value1, value2, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
-					if c.queryUnify {
+					if ctx.QueryUnify {
 						continue
 					}
 					re := collected2.OrigRead[key]
@@ -1044,7 +1044,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 						// Both sides have the same key-kind — unify their value types.
 						unifyErrors := c.unifyInner(ctx, existing.Value, sig.Value, seen)
 						errors = slices.Concat(errors, unifyErrors)
-					} else if !c.queryUnify {
+					} else if !ctx.QueryUnify {
 						obj1.Elems = append(obj1.Elems, copyObjTypeElem(sig))
 					}
 				}
@@ -1060,7 +1060,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 						unifyErrors := c.unifyInner(ctx, value1, value2, seen)
 						errors = slices.Concat(errors, unifyErrors)
 					}
-					if c.queryUnify {
+					if ctx.QueryUnify {
 						continue
 					}
 					re := collected1.OrigRead[key]
@@ -1081,7 +1081,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 					if existing := findMatchingIndexSignature(sig, collected2.IndexSignatures); existing != nil {
 						unifyErrors := c.unifyInner(ctx, existing.Value, sig.Value, seen)
 						errors = slices.Concat(errors, unifyErrors)
-					} else if !c.queryUnify {
+					} else if !ctx.QueryUnify {
 						obj2.Elems = append(obj2.Elems, copyObjTypeElem(sig))
 					}
 				}
@@ -2139,7 +2139,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 	// succeed via the Equals fast-path below; only the cases that would
 	// commit a TypeVar.Instance write report failure. The caller treats
 	// the resulting CannotUnifyTypesError like any other mismatch.
-	if c.queryUnify && !type_system.Equals(t1, t2) {
+	if ctx.QueryUnify && !type_system.Equals(t1, t2) {
 		return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 	}
 

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -219,11 +219,16 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 		// unifyMatched, which call back into unifyInner per element —
 		// each of those nested calls will also hit this hook for the
 		// per-element lifetime.
-		lt1 := type_system.GetLifetime(t1)
-		lt2 := type_system.GetLifetime(t2)
-		if lt1 != nil || lt2 != nil {
-			if ltErrors := c.UnifyLifetimes(ctx, lt1, lt2); len(ltErrors) > 0 {
-				return ltErrors
+		// Lifetime reconciliation binds LifetimeVars — a side effect, so
+		// queryMode skips it. Structural subtype queries don't depend on
+		// lifetime equality.
+		if !c.queryUnify {
+			lt1 := type_system.GetLifetime(t1)
+			lt2 := type_system.GetLifetime(t2)
+			if lt1 != nil || lt2 != nil {
+				if ltErrors := c.UnifyLifetimes(ctx, lt1, lt2); len(ltErrors) > 0 {
+					return ltErrors
+				}
 			}
 		}
 		return nil
@@ -243,7 +248,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 	// path-compresses the chain but records it in tvA.InstanceChain. We use
 	// that chain to update ALL aliased TypeVars so reads through any alias
 	// observe the widened type.
-	if widenableChain := widenableInstanceChain(tv2); len(widenableChain) > 0 {
+	if widenableChain := widenableInstanceChain(tv2); !c.queryUnify && len(widenableChain) > 0 {
 		oldType := t2
 		// If oldType is still a TypeVarType (e.g. the chain ended at an unbound
 		// TypeVar and bind failed due to an occurs check), we must not build a
@@ -291,6 +296,16 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, seen unifySe
 		// `type Point = {x: number, y: number}; val p: Point = {x: 1, y: 2}`
 		// would corrupt Point's alias if unification mutated the shared pointer),
 		// and unifyInner provides Prune + widening on the expanded result.
+		// All three expansion paths below need a real Scope to resolve
+		// qualified type names and run mapped-type elaboration. Scope-less
+		// callers (the structural Check predicate invoked from overload
+		// specificity) pass a zero Context — skip expansion in that case
+		// so the unifier falls through to CannotUnifyTypesError and the
+		// caller treats the pair as incomparable.
+		if ctx.Scope == nil {
+			return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
+		}
+
 		refCanExpand := false
 		if isRef1 && c.canExpandTypeRef(ctx, ref1) {
 			refCanExpand = true
@@ -2096,6 +2111,14 @@ func (c *Checker) unifyFuncTypes(ctx Context, func1, func2 *type_system.FuncType
 func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, seen unifySeen) []Error {
 	if t1 == nil || t2 == nil {
 		panic("Cannot bind nil types") // this should never happen
+	}
+
+	// In queryMode (Check), refuse to bind. Equal types still trivially
+	// succeed via the Equals fast-path below; only the cases that would
+	// commit a TypeVar.Instance write report failure. The caller treats
+	// the resulting CannotUnifyTypesError like any other mismatch.
+	if c.queryUnify && !type_system.Equals(t1, t2) {
+		return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 	}
 
 	errors := []Error{}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -297,12 +297,13 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, seen unifySe
 		// would corrupt Point's alias if unification mutated the shared pointer),
 		// and unifyInner provides Prune + widening on the expanded result.
 		// All three expansion paths below need a real Scope to resolve
-		// qualified type names and run mapped-type elaboration. Scope-less
-		// callers (the structural Check predicate invoked from overload
-		// specificity) pass a zero Context — skip expansion in that case
-		// so the unifier falls through to CannotUnifyTypesError and the
-		// caller treats the pair as incomparable.
-		if ctx.Scope == nil {
+		// qualified type names and run mapped-type elaboration. In query
+		// mode (Check), callers may have passed a zero Context with no
+		// scope — skip expansion so the unifier falls through to
+		// CannotUnifyTypesError and the caller treats the pair as
+		// incomparable. Outside query mode a nil scope here would be a
+		// bug; the expansion paths panic loudly so we catch it.
+		if ctx.QueryUnify {
 			return []Error{&CannotUnifyTypesError{T1: t1, T2: t2}}
 		}
 

--- a/internal/checker/unify_mode.go
+++ b/internal/checker/unify_mode.go
@@ -1,0 +1,54 @@
+package checker
+
+import "github.com/escalier-lang/escalier/internal/type_system"
+
+// queryUnify reports whether the checker is currently in query mode —
+// i.e. unifyInner is running as a pure structural-subtype predicate
+// and must refuse every side effect. `Unify` runs with this false
+// (the default — TypeVars bind, Widenable TypeVars widen, lifetimes
+// reconcile). `Check` swaps it to true for the duration of a single
+// query.
+//
+// The mutation surface inside unifyInner / unifyMatched / bind that
+// query mode disables:
+//
+//  1. TypeVar binding (`tv.Instance = ...` in bind, plus the helpers
+//     reached from bind: openClosedObjectForParam,
+//     handleArrayConstraintBinding). bind returns a regular
+//     CannotUnifyTypesError so the caller reports a structural
+//     mismatch like any other.
+//  2. Widenable TypeVar widening at unify.go's concrete-vs-concrete
+//     failure fallback. Speculative callers want the current shape,
+//     not "would succeed if we mutated".
+//  3. Lifetime reconciliation via UnifyLifetimes (which itself binds
+//     LifetimeVars). Structural subtyping doesn't depend on lifetime
+//     equality.
+//
+// The flag lives on *Checker rather than threading through every
+// recursive call because the recursion has ~80+ internal call sites
+// and the mode is invariant across the whole traversal. The Checker
+// is single-threaded so a per-call field swap is safe.
+//
+// Prune's path compression is intentionally permitted in query mode:
+// it rewrites Instance chains that are already aliased, so it can't
+// change what any TypeVar resolves to — only how many hops the next
+// resolution takes.
+
+// Check reports whether t1 is a structural subtype of t2 without
+// committing any inference side effects. It is the pure counterpart
+// of Unify: same recursion, same case analysis, but TypeVar binding,
+// Widenable widening, and lifetime reconciliation are all refused.
+//
+// An unbound TypeVar on either side (after Prune) makes Check return
+// false rather than bind — if the caller wanted to commit a binding
+// they would have called Unify.
+//
+// Safe to call during placeholder phases, speculative overload
+// ranking, simplification, and any other context that needs a
+// side-effect-free subtype query.
+func (c *Checker) Check(ctx Context, t1, t2 type_system.Type) bool {
+	prev := c.queryUnify
+	c.queryUnify = true
+	defer func() { c.queryUnify = prev }()
+	return len(c.unifyInner(ctx, t1, t2, make(unifySeen))) == 0
+}

--- a/internal/checker/unify_mode.go
+++ b/internal/checker/unify_mode.go
@@ -49,11 +49,3 @@ func (c *Checker) Check(ctx Context, t1, t2 type_system.Type) bool {
 	ctx.QueryUnify = true
 	return len(c.unifyInner(ctx, t1, t2, make(unifySeen))) == 0
 }
-
-// MutuallyAssignable reports whether t1 and t2 are structural subtypes
-// of each other (i.e. equivalent modulo aliasing). Equivalent to
-// Check(t1, t2) && Check(t2, t1); exposed as a sibling so callers
-// don't forget the second direction.
-func (c *Checker) MutuallyAssignable(ctx Context, t1, t2 type_system.Type) bool {
-	return c.Check(ctx, t1, t2) && c.Check(ctx, t2, t1)
-}

--- a/internal/checker/unify_mode.go
+++ b/internal/checker/unify_mode.go
@@ -2,12 +2,11 @@ package checker
 
 import "github.com/escalier-lang/escalier/internal/type_system"
 
-// queryUnify reports whether the checker is currently in query mode —
-// i.e. unifyInner is running as a pure structural-subtype predicate
-// and must refuse every side effect. `Unify` runs with this false
-// (the default — TypeVars bind, Widenable TypeVars widen, lifetimes
-// reconcile). `Check` swaps it to true for the duration of a single
-// query.
+// Context.QueryUnify reports whether the checker is currently in query
+// mode — i.e. unifyInner is running as a pure structural-subtype
+// predicate and must refuse every side effect. `Unify` runs with this
+// false (the default — TypeVars bind, Widenable TypeVars widen, lifetimes
+// reconcile). `Check` sets it to true for the duration of a single query.
 //
 // The mutation surface inside unifyInner / unifyMatched / bind that
 // query mode disables:
@@ -24,10 +23,10 @@ import "github.com/escalier-lang/escalier/internal/type_system"
 //     LifetimeVars). Structural subtyping doesn't depend on lifetime
 //     equality.
 //
-// The flag lives on *Checker rather than threading through every
-// recursive call because the recursion has ~80+ internal call sites
-// and the mode is invariant across the whole traversal. The Checker
-// is single-threaded so a per-call field swap is safe.
+// The flag lives on Context (not Checker) so a value-copied ctx with
+// QueryUnify=true auto-propagates through every recursive unifyInner
+// call without a save/restore dance, and so the flag's scope is
+// structurally tied to the query that set it.
 //
 // Prune's path compression is intentionally permitted in query mode:
 // it rewrites Instance chains that are already aliased, so it can't
@@ -47,8 +46,14 @@ import "github.com/escalier-lang/escalier/internal/type_system"
 // ranking, simplification, and any other context that needs a
 // side-effect-free subtype query.
 func (c *Checker) Check(ctx Context, t1, t2 type_system.Type) bool {
-	prev := c.queryUnify
-	c.queryUnify = true
-	defer func() { c.queryUnify = prev }()
+	ctx.QueryUnify = true
 	return len(c.unifyInner(ctx, t1, t2, make(unifySeen))) == 0
+}
+
+// MutuallyAssignable reports whether t1 and t2 are structural subtypes
+// of each other (i.e. equivalent modulo aliasing). Equivalent to
+// Check(t1, t2) && Check(t2, t1); exposed as a sibling so callers
+// don't forget the second direction.
+func (c *Checker) MutuallyAssignable(ctx Context, t1, t2 type_system.Type) bool {
+	return c.Check(ctx, t1, t2) && c.Check(ctx, t2, t1)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Overload arm comparison and sorting now use structured type checking methods.
  * Unification behavior enhanced with a query-safe mode to prevent unintended type variable modifications during type queries.

* **Bug Fixes**
  * Type expansion now properly handles contexts without scope resolution to prevent errors.

* **Tests**
  * Updated tests to align with new method dispatch patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->