### PR TITLE
Parse and attach JSDoc comments to class and interface members

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -17,6 +17,18 @@ type Inferrable interface {
 	SetInferredType(Type)
 }
 
+// Documented is implemented by any node that can carry a leading JSDoc
+// (`/** ... */`) comment. The string is the raw comment text including
+// delimiters; consumers strip tags as needed. Both ClassElem and
+// ObjTypeAnnElem embed this contract so any implementation must
+// participate — variants that conceptually don't carry a doc (e.g.
+// CallableTypeAnn, ConstructorTypeAnn, MappedTypeAnn) implement Doc as
+// a constant "" and SetDoc as a no-op.
+type Documented interface {
+	Doc() string
+	SetDoc(string)
+}
+
 // If `Name` is an empty string it means that the identifier is missing in
 // the expression.
 type Ident struct {

--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -22,10 +22,10 @@ type ClassElem interface {
 	Accept(v Visitor)
 	Span() Span
 	// Doc returns the leading JSDoc (`/** ... */`) retained on the elem,
-	// verbatim with delimiters, or "" if absent. Set today only by the
-	// dts_to_esc converter — handwritten Escalier sources don't yet
-	// parse leading member docs (see #663).
+	// verbatim with delimiters, or "" if absent. Populated by both the
+	// dts_to_esc converter and the regular parser (#663).
 	Doc() string
+	SetDoc(string)
 }
 
 // MethodReceiver describes a `self` receiver on a method, getter, setter, or

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -189,12 +189,12 @@ func (t *VoidTypeAnn) Accept(v Visitor) {
 type ObjTypeAnnElem interface {
 	isObjTypeAnnElem()
 	// Doc returns the leading JSDoc retained on the elem, verbatim
-	// with `/** ... */` delimiters, or "" if absent. Set today only by
-	// the dts_to_esc converter via convertInterfaceMember. Variants
-	// that don't conceptually carry a doc (CallableTypeAnn,
-	// ConstructorTypeAnn, MappedTypeAnn, RestSpreadTypeAnn) return ""
-	// from a no-op implementation.
+	// with `/** ... */` delimiters, or "" if absent. Variants that
+	// don't conceptually carry a doc (CallableTypeAnn,
+	// ConstructorTypeAnn, MappedTypeAnn) return "" from a no-op
+	// implementation; SetDoc on those is a no-op.
 	Doc() string
+	SetDoc(string)
 }
 
 func (*CallableTypeAnn) isObjTypeAnnElem()    {}
@@ -206,11 +206,13 @@ func (*PropertyTypeAnn) isObjTypeAnnElem()    {}
 func (*MappedTypeAnn) isObjTypeAnnElem()      {}
 func (*RestSpreadTypeAnn) isObjTypeAnnElem()  {}
 
-// No-op Doc() impls for the variants that don't carry a JSDoc.
-func (*CallableTypeAnn) Doc() string    { return "" }
-func (*ConstructorTypeAnn) Doc() string { return "" }
-func (*MappedTypeAnn) Doc() string      { return "" }
-func (*RestSpreadTypeAnn) Doc() string  { return "" }
+// No-op Doc/SetDoc impls for the variants that don't carry a JSDoc.
+func (*CallableTypeAnn) Doc() string       { return "" }
+func (*CallableTypeAnn) SetDoc(string)     {}
+func (*ConstructorTypeAnn) Doc() string    { return "" }
+func (*ConstructorTypeAnn) SetDoc(string)  {}
+func (*MappedTypeAnn) Doc() string         { return "" }
+func (*MappedTypeAnn) SetDoc(string)       {}
 
 type CallableTypeAnn struct{ Fn *FuncTypeAnn }
 type ConstructorTypeAnn struct{ Fn *FuncTypeAnn }
@@ -288,6 +290,7 @@ type IndexParamTypeAnn struct {
 
 type RestSpreadTypeAnn struct {
 	Value        TypeAnn
+	doc          string
 	span         Span
 	inferredType Type
 }
@@ -302,6 +305,11 @@ func (t *RestSpreadTypeAnn) Accept(v Visitor) {
 	}
 	v.ExitTypeAnn(t)
 }
+
+// RestSpreadTypeAnn carries a real doc field: a hand-authored
+// `interface F { /** doc */ ...Bar }` should round-trip the JSDoc.
+func (t *RestSpreadTypeAnn) Doc() string       { return t.doc }
+func (t *RestSpreadTypeAnn) SetDoc(doc string) { t.doc = doc }
 
 type ObjectTypeAnn struct {
 	Elems        []ObjTypeAnnElem

--- a/internal/dts_parser/base.go
+++ b/internal/dts_parser/base.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/lexer_util"
 )
 
 // DtsParser parses TypeScript .d.ts declaration files
@@ -128,7 +129,7 @@ func (p *DtsParser) consumeLeadingDoc() string {
 	for {
 		t := p.peek()
 		if t.Type == BlockComment {
-			if isJSDoc(t.Value) {
+			if lexer_util.IsJSDoc(t.Value) {
 				doc = t.Value
 			} else {
 				doc = ""
@@ -143,13 +144,6 @@ func (p *DtsParser) consumeLeadingDoc() string {
 		}
 		return doc
 	}
-}
-
-// isJSDoc reports whether a block-comment token value is a JSDoc
-// comment: must start with `/**` and have content beyond the leading
-// stars (excludes `/**/`).
-func isJSDoc(value string) bool {
-	return len(value) > 4 && strings.HasPrefix(value, "/**")
 }
 
 // attachDoc sets doc on n if n implements Documented and doc is

--- a/internal/interop/dts_to_esc_test.go
+++ b/internal/interop/dts_to_esc_test.go
@@ -91,22 +91,33 @@ func TestStandalone_BooleanTrio(t *testing.T) {
 	require.Empty(t, parseErrs, "printed output parses")
 	require.NotEmpty(t, parsedDecls)
 
-	// Gate: full round trip — every elem on the parser-roundtripped class
-	// body carries the same Doc that the converter emitted. Pins #663:
-	// the parser must populate Doc, not silently drop the JSDoc that the
-	// printer emits.
-	var parsedClass *ast.ClassDecl
+	// Gate: full round trip — every elem on the parser-roundtripped
+	// class body carries the same Doc that the converter emitted, in
+	// the same order. Per-elem parity, not a blanket NotEmpty: if the
+	// converter ever emits a synthesized member without a JSDoc, this
+	// test should pin doc-parity, not require every member to have a
+	// doc.
+	var converterClass, parsedClass *ast.ClassDecl
+	for _, d := range rootNS.Decls {
+		if c, ok := d.(*ast.ClassDecl); ok {
+			converterClass = c
+			break
+		}
+	}
 	for _, d := range parsedDecls {
 		if c, ok := d.(*ast.ClassDecl); ok {
 			parsedClass = c
 			break
 		}
 	}
+	require.NotNil(t, converterClass, "converter emitted a fused class")
 	require.NotNil(t, parsedClass, "parser-roundtripped output contains the fused class")
-	require.NotEmpty(t, parsedClass.Body, "class body has members to inspect")
-	for i, elem := range parsedClass.Body {
-		require.NotEmpty(t, elem.Doc(),
-			"elem[%d] (%T) lost its JSDoc on parse — #663 regression", i, elem)
+	require.Equal(t, len(converterClass.Body), len(parsedClass.Body),
+		"converter and parser-roundtripped classes have the same number of elems")
+	for i, before := range converterClass.Body {
+		after := parsedClass.Body[i]
+		require.Equal(t, before.Doc(), after.Doc(),
+			"elem[%d] (%T) Doc parity broken on parse — #663 regression", i, after)
 	}
 
 	// Gate: idempotent — converting and re-printing the parser-roundtripped

--- a/internal/interop/dts_to_esc_test.go
+++ b/internal/interop/dts_to_esc_test.go
@@ -358,6 +358,28 @@ func TestStandalone_SharedInterfaceNotFlattened(t *testing.T) {
 	require.Equal(t, 2, varCount, "both vars survive")
 	require.Contains(t, printed, "/** does a thing */",
 		"interface member JSDoc preserved on the surviving interface")
+
+	// Full round-trip: the printed output parses, and the surviving
+	// interface's member carries its Doc on the parsed AST. Pins the
+	// objTypeAnnElem half of #663 — without the parser-side fix, leading
+	// JSDoc inside an interface body silently lost its Doc field (and
+	// in fact failed to parse at all).
+	parsedDecls, parseErrs := parser.ParseDecls(context.Background(),
+		&ast.Source{Path: "out.esc", Contents: printed, ID: 1})
+	require.Empty(t, parseErrs, "printed output parses")
+	var parsedIface *ast.InterfaceDecl
+	for _, d := range parsedDecls {
+		if i, ok := d.(*ast.InterfaceDecl); ok {
+			parsedIface = i
+			break
+		}
+	}
+	require.NotNil(t, parsedIface, "parsed output contains the interface")
+	require.NotEmpty(t, parsedIface.TypeAnn.Elems, "interface has members")
+	for i, elem := range parsedIface.TypeAnn.Elems {
+		require.NotEmpty(t, elem.Doc(),
+			"elem[%d] (%T) lost its JSDoc on parse — #663 regression", i, elem)
+	}
 }
 
 // multilineDocSlice mirrors the real lib.es5.d.ts JSON shape: an

--- a/internal/interop/dts_to_esc_test.go
+++ b/internal/interop/dts_to_esc_test.go
@@ -91,6 +91,24 @@ func TestStandalone_BooleanTrio(t *testing.T) {
 	require.Empty(t, parseErrs, "printed output parses")
 	require.NotEmpty(t, parsedDecls)
 
+	// Gate: full round trip — every elem on the parser-roundtripped class
+	// body carries the same Doc that the converter emitted. Pins #663:
+	// the parser must populate Doc, not silently drop the JSDoc that the
+	// printer emits.
+	var parsedClass *ast.ClassDecl
+	for _, d := range parsedDecls {
+		if c, ok := d.(*ast.ClassDecl); ok {
+			parsedClass = c
+			break
+		}
+	}
+	require.NotNil(t, parsedClass, "parser-roundtripped output contains the fused class")
+	require.NotEmpty(t, parsedClass.Body, "class body has members to inspect")
+	for i, elem := range parsedClass.Body {
+		require.NotEmpty(t, elem.Doc(),
+			"elem[%d] (%T) lost its JSDoc on parse — #663 regression", i, elem)
+	}
+
 	// Gate: idempotent — converting and re-printing the parser-roundtripped
 	// dts module yields the same string.
 	_, printed2 := convertSlice(t, booleanSlice)

--- a/internal/lexer_util/lexer_util.go
+++ b/internal/lexer_util/lexer_util.go
@@ -1,11 +1,29 @@
 package lexer_util
 
 import (
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 )
+
+// IsJSDoc reports whether a block-comment token value is a JSDoc
+// comment. A value qualifies when it starts with `/**`, ends with
+// `*/`, and has at least one non-asterisk character between the
+// opening `/**` and closing `*/`. Pure asterisk runs like `/**/`,
+// `/***/`, and `/****/` are not JSDoc and are rejected — they carry
+// no documentation content.
+//
+// Shared between the regular parser and dts_parser so both agree on
+// what counts as an attachable JSDoc block.
+func IsJSDoc(value string) bool {
+	if len(value) < 5 || !strings.HasPrefix(value, "/**") || !strings.HasSuffix(value, "*/") {
+		return false
+	}
+	inner := value[3 : len(value)-2]
+	return strings.TrimLeft(inner, "*") != ""
+}
 
 // Based on https://www.unicode.org/reports/tr31/#D1
 func IsIdentStart(r rune) bool {

--- a/internal/lexer_util/lexer_util_test.go
+++ b/internal/lexer_util/lexer_util_test.go
@@ -2,6 +2,8 @@ package lexer_util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanIdent(t *testing.T) {
@@ -588,9 +590,8 @@ func TestIsJSDoc(t *testing.T) {
 		{"/**", false},
 	}
 	for _, tc := range tests {
-		if got := IsJSDoc(tc.value); got != tc.want {
-			t.Errorf("IsJSDoc(%q) = %v, want %v", tc.value, got, tc.want)
-		}
+		got := IsJSDoc(tc.value)
+		require.Equal(t, tc.want, got, "IsJSDoc(%q)", tc.value)
 	}
 }
 

--- a/internal/lexer_util/lexer_util_test.go
+++ b/internal/lexer_util/lexer_util_test.go
@@ -564,6 +564,36 @@ func TestIsIdentContinue(t *testing.T) {
 	}
 }
 
+func TestIsJSDoc(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		// Real JSDoc.
+		{"/** doc */", true},
+		{"/** */", true},
+		{"/**\n * multi\n */", true},
+		{"/**foo*/", true},
+		// All-asterisk runs carry no content.
+		{"/**/", false},
+		{"/***/", false},
+		{"/****/", false},
+		{"/*****/", false},
+		// Not a JSDoc opener.
+		{"/* doc */", false},
+		{"// doc", false},
+		{"", false},
+		// Unterminated.
+		{"/** doc", false},
+		{"/**", false},
+	}
+	for _, tc := range tests {
+		if got := IsJSDoc(tc.value); got != tc.want {
+			t.Errorf("IsJSDoc(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
 func BenchmarkScanIdent(b *testing.B) {
 	benchmarks := []struct {
 		name     string

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -1,8 +1,68 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 )
+
+// consumeLeadingDoc consumes any comment tokens preceding the next
+// non-comment token and returns the most recent contiguous JSDoc block
+// (a `/** ... */` block comment) immediately before that token, or ""
+// if there is none. Non-JSDoc comments interleaved between a JSDoc
+// block and the next token reset the captured doc — JSDoc must be the
+// immediately preceding comment to attach. Mirrors
+// dts_parser.consumeLeadingDoc so the two parsers agree on what counts
+// as a leading doc.
+func (p *Parser) consumeLeadingDoc() string {
+	var doc string
+	for {
+		t := p.lexer.peek()
+		if t.Type == BlockComment {
+			if isJSDoc(t.Value) {
+				doc = t.Value
+			} else {
+				doc = ""
+			}
+			p.lexer.consume()
+			continue
+		}
+		if t.Type == LineComment {
+			doc = ""
+			p.lexer.consume()
+			continue
+		}
+		return doc
+	}
+}
+
+// isJSDoc reports whether a block-comment token value is a JSDoc
+// comment: must start with `/**` and have content beyond the leading
+// stars (excludes `/**/`).
+func isJSDoc(value string) bool {
+	return len(value) > 4 && strings.HasPrefix(value, "/**")
+}
+
+// setClassElemDoc attaches doc to elem when doc is non-empty. Mirrors
+// the type switch in printer.printClassElem so every elem kind that
+// the printer emits a doc for also accepts one from the parser.
+func setClassElemDoc(elem ast.ClassElem, doc string) {
+	if doc == "" || elem == nil {
+		return
+	}
+	switch e := elem.(type) {
+	case *ast.FieldElem:
+		e.SetDoc(doc)
+	case *ast.MethodElem:
+		e.SetDoc(doc)
+	case *ast.GetterElem:
+		e.SetDoc(doc)
+	case *ast.SetterElem:
+		e.SetDoc(doc)
+	case *ast.ConstructorElem:
+		e.SetDoc(doc)
+	}
+}
 
 // maybeTypeParams parses optional type parameters if present.
 // Returns the parsed type parameters and updates the current token position.
@@ -611,17 +671,18 @@ func (p *Parser) parseConstructorElem(
 }
 
 // parseClassElem parses a single class element (field, method, static, etc.)
+// and attaches any leading JSDoc block comment to the resulting elem's
+// Doc field. Non-JSDoc comments (line comments, plain block comments)
+// are still consumed but do not populate Doc.
 func (p *Parser) parseClassElem() ast.ClassElem {
-	// TODO(#663): attach JSDoc to the parsed elem's Doc field instead
-	// of dropping it. The five class-elem AST types carry a Doc string,
-	// the printer emits it, but the parser currently throws it away —
-	// so JSDoc on hand-authored class members silently fails to round
-	// trip. Port dts_parser.consumeLeadingDoc and wire it through here.
+	doc := p.consumeLeadingDoc()
+	elem := p.parseClassElemInner()
+	setClassElemDoc(elem, doc)
+	return elem
+}
+
+func (p *Parser) parseClassElemInner() ast.ClassElem {
 	token := p.lexer.peek()
-	for token.Type == LineComment || token.Type == BlockComment {
-		p.lexer.consume()
-		token = p.lexer.peek()
-	}
 
 	isStatic := false
 	isAsync := false

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
-	"strings"
+	"reflect"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/lexer_util"
 )
 
 // consumeLeadingDoc consumes any comment tokens preceding the next
@@ -13,13 +14,18 @@ import (
 // block and the next token reset the captured doc — JSDoc must be the
 // immediately preceding comment to attach. Mirrors
 // dts_parser.consumeLeadingDoc so the two parsers agree on what counts
-// as a leading doc.
+// as a leading doc; both rely on lexer_util.IsJSDoc for the predicate.
 func (p *Parser) consumeLeadingDoc() string {
 	var doc string
 	for {
+		select {
+		case <-p.ctx.Done():
+			return doc
+		default:
+		}
 		t := p.lexer.peek()
 		if t.Type == BlockComment {
-			if isJSDoc(t.Value) {
+			if lexer_util.IsJSDoc(t.Value) {
 				doc = t.Value
 			} else {
 				doc = ""
@@ -36,54 +42,20 @@ func (p *Parser) consumeLeadingDoc() string {
 	}
 }
 
-// isJSDoc reports whether a block-comment token value is a JSDoc
-// comment: must start with `/**` and have content beyond the leading
-// stars (excludes `/**/`).
-func isJSDoc(value string) bool {
-	return len(value) > 4 && strings.HasPrefix(value, "/**")
-}
-
-// setClassElemDoc attaches doc to elem when doc is non-empty. Mirrors
-// the type switch in printer.printClassElem so every elem kind that
-// the printer emits a doc for also accepts one from the parser.
-func setClassElemDoc(elem ast.ClassElem, doc string) {
-	if doc == "" || elem == nil {
+// attachDoc sets doc on node when doc is non-empty and node is
+// non-nil. Both the interface-nil case (untyped nil from an inner
+// returning `return nil`) and the typed-nil case (a future caller
+// returning `var fe *FieldElem; ... return fe`) are guarded — without
+// the reflect check the typed-nil path would nil-deref inside SetDoc.
+func attachDoc(node ast.Documented, doc string) {
+	if doc == "" || node == nil {
 		return
 	}
-	switch e := elem.(type) {
-	case *ast.FieldElem:
-		e.SetDoc(doc)
-	case *ast.MethodElem:
-		e.SetDoc(doc)
-	case *ast.GetterElem:
-		e.SetDoc(doc)
-	case *ast.SetterElem:
-		e.SetDoc(doc)
-	case *ast.ConstructorElem:
-		e.SetDoc(doc)
-	}
-}
-
-// setObjTypeAnnElemDoc attaches doc to elem when doc is non-empty.
-// Mirrors the type switch in printer.printObjTypeAnnElem — only the
-// elem kinds with a real doc field (MethodTypeAnn, GetterTypeAnn,
-// SetterTypeAnn, PropertyTypeAnn) accept one; CallableTypeAnn,
-// ConstructorTypeAnn, MappedTypeAnn, and RestSpreadTypeAnn fall
-// through with Doc() == "".
-func setObjTypeAnnElemDoc(elem ast.ObjTypeAnnElem, doc string) {
-	if doc == "" || elem == nil {
+	v := reflect.ValueOf(node)
+	if v.Kind() == reflect.Ptr && v.IsNil() {
 		return
 	}
-	switch e := elem.(type) {
-	case *ast.MethodTypeAnn:
-		e.SetDoc(doc)
-	case *ast.GetterTypeAnn:
-		e.SetDoc(doc)
-	case *ast.SetterTypeAnn:
-		e.SetDoc(doc)
-	case *ast.PropertyTypeAnn:
-		e.SetDoc(doc)
-	}
+	node.SetDoc(doc)
 }
 
 // maybeTypeParams parses optional type parameters if present.
@@ -698,8 +670,19 @@ func (p *Parser) parseConstructorElem(
 // are still consumed but do not populate Doc.
 func (p *Parser) parseClassElem() ast.ClassElem {
 	doc := p.consumeLeadingDoc()
+	// After consuming a leading JSDoc, if we're sitting on the class
+	// body's closing brace, there's no elem to attach the doc to.
+	// Surface that to the user as a parse error AND return nil so
+	// parseDelimSeq exits cleanly (avoiding a spurious 'Expected a
+	// property name' from objExprKey).
+	if next := p.lexer.peek(); next.Type == CloseBrace {
+		if doc != "" {
+			p.reportError(next.Span, "JSDoc comment is not attached to a declaration")
+		}
+		return nil
+	}
 	elem := p.parseClassElemInner()
-	setClassElemDoc(elem, doc)
+	attachDoc(elem, doc)
 	return elem
 }
 

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -64,6 +64,28 @@ func setClassElemDoc(elem ast.ClassElem, doc string) {
 	}
 }
 
+// setObjTypeAnnElemDoc attaches doc to elem when doc is non-empty.
+// Mirrors the type switch in printer.printObjTypeAnnElem — only the
+// elem kinds with a real doc field (MethodTypeAnn, GetterTypeAnn,
+// SetterTypeAnn, PropertyTypeAnn) accept one; CallableTypeAnn,
+// ConstructorTypeAnn, MappedTypeAnn, and RestSpreadTypeAnn fall
+// through with Doc() == "".
+func setObjTypeAnnElemDoc(elem ast.ObjTypeAnnElem, doc string) {
+	if doc == "" || elem == nil {
+		return
+	}
+	switch e := elem.(type) {
+	case *ast.MethodTypeAnn:
+		e.SetDoc(doc)
+	case *ast.GetterTypeAnn:
+		e.SetDoc(doc)
+	case *ast.SetterTypeAnn:
+		e.SetDoc(doc)
+	case *ast.PropertyTypeAnn:
+		e.SetDoc(doc)
+	}
+}
+
 // maybeTypeParams parses optional type parameters if present.
 // Returns the parsed type parameters and updates the current token position.
 //

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1020,6 +1020,107 @@ func TestClassElemDocs(t *testing.T) {
 	})
 }
 
+func TestObjTypeAnnElemDocs(t *testing.T) {
+	parseIface := func(t *testing.T, src string) *ast.InterfaceDecl {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc", Contents: src})
+		require.Empty(t, errors)
+		require.Len(t, decls, 1)
+		iface, ok := decls[0].(*ast.InterfaceDecl)
+		require.True(t, ok, "first decl is an interface")
+		require.NotNil(t, iface.TypeAnn)
+		return iface
+	}
+
+	t.Run("PropertyTypeAnn", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface Point {
+				/** the x coordinate */
+				x: number
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		p, ok := iface.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
+		require.True(t, ok, "elem is a PropertyTypeAnn")
+		require.Equal(t, "/** the x coordinate */", p.Doc())
+	})
+
+	t.Run("MethodTypeAnn", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface Dog {
+				/** says hi */
+				bark(self) -> string
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		m, ok := iface.TypeAnn.Elems[0].(*ast.MethodTypeAnn)
+		require.True(t, ok, "elem is a MethodTypeAnn")
+		require.Equal(t, "/** says hi */", m.Doc())
+	})
+
+	t.Run("GetterTypeAnn", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface Sized {
+				/** the size */
+				get size(self) -> number
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		g, ok := iface.TypeAnn.Elems[0].(*ast.GetterTypeAnn)
+		require.True(t, ok, "elem is a GetterTypeAnn")
+		require.Equal(t, "/** the size */", g.Doc())
+	})
+
+	t.Run("SetterTypeAnn", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface HasValue {
+				/** replace the value */
+				set value(mut self, x: number) -> undefined
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		s, ok := iface.TypeAnn.Elems[0].(*ast.SetterTypeAnn)
+		require.True(t, ok, "elem is a SetterTypeAnn")
+		require.Equal(t, "/** replace the value */", s.Doc())
+	})
+
+	t.Run("LineCommentBetweenJSDocAndElemResetsDoc", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface Point {
+				/** the x coordinate */
+				// reset
+				x: number
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		p, ok := iface.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
+		require.True(t, ok)
+		require.Empty(t, p.Doc(), "intervening line comment resets the captured doc")
+	})
+
+	t.Run("PlainBlockCommentBetweenJSDocAndElemResetsDoc", func(t *testing.T) {
+		t.Parallel()
+		iface := parseIface(t, `
+			interface Point {
+				/** the x coordinate */
+				/* plain block */
+				x: number
+			}
+		`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		p, ok := iface.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
+		require.True(t, ok)
+		require.Empty(t, p.Doc(), "intervening non-JSDoc block comment resets the captured doc")
+	})
+}
+
 func TestClassConstructorErrors(t *testing.T) {
 	tests := map[string]struct {
 		input string

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -885,6 +885,141 @@ func TestClassDeclarations(t *testing.T) {
 	}
 }
 
+func TestClassElemDocs(t *testing.T) {
+	parseClass := func(t *testing.T, src string) *ast.ClassDecl {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc", Contents: src})
+		require.Empty(t, errors)
+		require.Len(t, decls, 1)
+		cls, ok := decls[0].(*ast.ClassDecl)
+		require.True(t, ok, "first decl is a class")
+		return cls
+	}
+
+	t.Run("FieldElem", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Point {
+				/** the x coordinate */
+				x: number,
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		f, ok := cls.Body[0].(*ast.FieldElem)
+		require.True(t, ok, "elem is a FieldElem")
+		require.Equal(t, "/** the x coordinate */", f.Doc())
+	})
+
+	t.Run("MethodElem", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Dog {
+				/** says hi */
+				bark(self) {
+					return "Woof!"
+				}
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		m, ok := cls.Body[0].(*ast.MethodElem)
+		require.True(t, ok, "elem is a MethodElem")
+		require.Equal(t, "/** says hi */", m.Doc())
+	})
+
+	t.Run("GetterElem", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Box {
+				/** the wrapped value */
+				get value(self) -> number {
+					return 0
+				}
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		g, ok := cls.Body[0].(*ast.GetterElem)
+		require.True(t, ok, "elem is a GetterElem")
+		require.Equal(t, "/** the wrapped value */", g.Doc())
+	})
+
+	t.Run("SetterElem", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Box {
+				/** replace the wrapped value */
+				set value(mut self, v: number) {}
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		s, ok := cls.Body[0].(*ast.SetterElem)
+		require.True(t, ok, "elem is a SetterElem")
+		require.Equal(t, "/** replace the wrapped value */", s.Doc())
+	})
+
+	t.Run("ConstructorElem", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Email {
+				addr: string,
+				/** make a new Email */
+				constructor(mut self, addr: string) {
+					self.addr = addr
+				},
+			}
+		`)
+		require.Len(t, cls.Body, 2)
+		c, ok := cls.Body[1].(*ast.ConstructorElem)
+		require.True(t, ok, "second elem is a ConstructorElem")
+		require.Equal(t, "/** make a new Email */", c.Doc())
+	})
+
+	t.Run("LineCommentBetweenJSDocAndElemResetsDoc", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Point {
+				/** the x coordinate */
+				// reset
+				x: number,
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		f, ok := cls.Body[0].(*ast.FieldElem)
+		require.True(t, ok)
+		require.Empty(t, f.Doc(), "intervening line comment resets the captured doc")
+	})
+
+	t.Run("PlainBlockCommentBetweenJSDocAndElemResetsDoc", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Point {
+				/** the x coordinate */
+				/* plain block */
+				x: number,
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		f, ok := cls.Body[0].(*ast.FieldElem)
+		require.True(t, ok)
+		require.Empty(t, f.Doc(), "intervening non-JSDoc block comment resets the captured doc")
+	})
+
+	t.Run("EmptyDocComment", func(t *testing.T) {
+		t.Parallel()
+		cls := parseClass(t, `
+			class Point {
+				/**/
+				x: number,
+			}
+		`)
+		require.Len(t, cls.Body, 1)
+		f, ok := cls.Body[0].(*ast.FieldElem)
+		require.True(t, ok)
+		require.Empty(t, f.Doc(), "/**/ is not a JSDoc block")
+	})
+}
+
 func TestClassConstructorErrors(t *testing.T) {
 	tests := map[string]struct {
 		input string

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1033,7 +1033,7 @@ func TestClassElemDocs(t *testing.T) {
 		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
 			Contents: `class Foo { /** trail */ }`})
 		require.Len(t, errors, 1)
-		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Equal(t, "JSDoc comment is not attached to a declaration", errors[0].Message)
 		require.Len(t, decls, 1)
 		cls, ok := decls[0].(*ast.ClassDecl)
 		require.True(t, ok)
@@ -1049,7 +1049,7 @@ func TestClassElemDocs(t *testing.T) {
 		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
 			Contents: `class Foo { x: number, /** trail */ }`})
 		require.Len(t, errors, 1)
-		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Equal(t, "JSDoc comment is not attached to a declaration", errors[0].Message)
 		require.Len(t, decls, 1)
 		cls, ok := decls[0].(*ast.ClassDecl)
 		require.True(t, ok)
@@ -1175,7 +1175,7 @@ func TestObjTypeAnnElemDocs(t *testing.T) {
 		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
 			Contents: `interface Foo { /** trail */ }`})
 		require.Len(t, errors, 1)
-		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Equal(t, "JSDoc comment is not attached to a declaration", errors[0].Message)
 		require.Len(t, decls, 1)
 		iface, ok := decls[0].(*ast.InterfaceDecl)
 		require.True(t, ok)
@@ -1192,7 +1192,7 @@ func TestObjTypeAnnElemDocs(t *testing.T) {
 		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
 			Contents: `interface I { /** d */ x }`})
 		require.Len(t, errors, 1)
-		require.Contains(t, errors[0].Message, "expected type annotation")
+		require.Equal(t, "expected type annotation", errors[0].Message)
 		require.Len(t, decls, 1)
 		iface := decls[0].(*ast.InterfaceDecl)
 		require.Len(t, iface.TypeAnn.Elems, 1)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1007,16 +1007,53 @@ func TestClassElemDocs(t *testing.T) {
 
 	t.Run("EmptyDocComment", func(t *testing.T) {
 		t.Parallel()
-		cls := parseClass(t, `
-			class Point {
-				/**/
-				x: number,
-			}
-		`)
-		require.Len(t, cls.Body, 1)
-		f, ok := cls.Body[0].(*ast.FieldElem)
+		// /**/, /***/, /****/ — all pure-asterisk runs carry no
+		// documentation content and must not attach as JSDoc.
+		for _, src := range []string{
+			"class Point { /**/ x: number, }",
+			"class Point { /***/ x: number, }",
+			"class Point { /****/ x: number, }",
+		} {
+			cls := parseClass(t, src)
+			require.Len(t, cls.Body, 1, "src=%q", src)
+			f, ok := cls.Body[0].(*ast.FieldElem)
+			require.True(t, ok, "src=%q", src)
+			require.Empty(t, f.Doc(), "all-asterisk comment is not JSDoc (src=%q)", src)
+		}
+	})
+
+	t.Run("TrailingDocReportsOrphanError", func(t *testing.T) {
+		t.Parallel()
+		// #1 + #4: a JSDoc immediately before `}` has no elem to
+		// attach to. The parser should report a clear diagnostic
+		// instead of falling through to the cascading 'Expected a
+		// property name' error from the inner.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
+			Contents: `class Foo { /** trail */ }`})
+		require.Len(t, errors, 1)
+		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Len(t, decls, 1)
+		cls, ok := decls[0].(*ast.ClassDecl)
 		require.True(t, ok)
-		require.Empty(t, f.Doc(), "/**/ is not a JSDoc block")
+		require.Empty(t, cls.Body, "no spurious elem from the orphan path")
+	})
+
+	t.Run("TrailingDocAfterCommaReportsOrphanError", func(t *testing.T) {
+		t.Parallel()
+		// Same shape as TrailingDocReportsOrphanError, but the doc
+		// comes after a trailing comma.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
+			Contents: `class Foo { x: number, /** trail */ }`})
+		require.Len(t, errors, 1)
+		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Len(t, decls, 1)
+		cls, ok := decls[0].(*ast.ClassDecl)
+		require.True(t, ok)
+		require.Len(t, cls.Body, 1, "the elem before the comma still parses")
 	})
 }
 
@@ -1118,6 +1155,53 @@ func TestObjTypeAnnElemDocs(t *testing.T) {
 		p, ok := iface.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
 		require.True(t, ok)
 		require.Empty(t, p.Doc(), "intervening non-JSDoc block comment resets the captured doc")
+	})
+
+	t.Run("RestSpreadTypeAnn", func(t *testing.T) {
+		t.Parallel()
+		// #3: RestSpreadTypeAnn now carries a real doc field.
+		iface := parseIface(t, `interface F { /** spread */ ...Bar }`)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		rs, ok := iface.TypeAnn.Elems[0].(*ast.RestSpreadTypeAnn)
+		require.True(t, ok, "elem is a RestSpreadTypeAnn")
+		require.Equal(t, "/** spread */", rs.Doc())
+	})
+
+	t.Run("TrailingDocReportsOrphanError", func(t *testing.T) {
+		t.Parallel()
+		// #1 + #4 for interface bodies.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
+			Contents: `interface Foo { /** trail */ }`})
+		require.Len(t, errors, 1)
+		require.Contains(t, errors[0].Message, "JSDoc comment is not attached to a declaration")
+		require.Len(t, decls, 1)
+		iface, ok := decls[0].(*ast.InterfaceDecl)
+		require.True(t, ok)
+		require.Empty(t, iface.TypeAnn.Elems)
+	})
+
+	t.Run("MissingTypeAnnotationGetsNeverRecovery", func(t *testing.T) {
+		t.Parallel()
+		// #5: PropertyTypeAnn{Value: nil} from error recovery is
+		// replaced with a NeverTypeAnn so the printer/checker see a
+		// well-formed type instead of a nil dereference target.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc",
+			Contents: `interface I { /** d */ x }`})
+		require.Len(t, errors, 1)
+		require.Contains(t, errors[0].Message, "expected type annotation")
+		require.Len(t, decls, 1)
+		iface := decls[0].(*ast.InterfaceDecl)
+		require.Len(t, iface.TypeAnn.Elems, 1)
+		prop, ok := iface.TypeAnn.Elems[0].(*ast.PropertyTypeAnn)
+		require.True(t, ok)
+		require.IsType(t, &ast.NeverTypeAnn{}, prop.Value,
+			"recovery substitutes NeverTypeAnn for the missing type")
+		require.Equal(t, "/** d */", prop.Doc(),
+			"the captured doc still attaches to the recovered property")
 	})
 }
 

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -718,7 +718,19 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 	return nil
 }
 
+// objTypeAnnElem parses a single member of an object type annotation
+// (interface body, inline object type, etc.) and attaches any leading
+// JSDoc block comment to the resulting elem's Doc field. Non-JSDoc
+// comments are still consumed but do not populate Doc. Mirrors the
+// shape of parseClassElem — see #663.
 func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
+	doc := p.consumeLeadingDoc()
+	elem := p.objTypeAnnElemInner()
+	setObjTypeAnnElemDoc(elem, doc)
+	return elem
+}
+
+func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 	token := p.lexer.peek()
 
 	// Handle rest spread syntax: ...T

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -725,8 +725,19 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 // shape of parseClassElem — see #663.
 func (p *Parser) objTypeAnnElem() ast.ObjTypeAnnElem {
 	doc := p.consumeLeadingDoc()
+	// After consuming a leading JSDoc, if we're sitting on the object
+	// type's closing brace, there's no elem to attach the doc to.
+	// Surface that to the user as a parse error AND return nil so
+	// parseDelimSeq exits cleanly (avoiding cascading 'Expected a
+	// property name' / 'Expected }' errors from the inner).
+	if next := p.lexer.peek(); next.Type == CloseBrace {
+		if doc != "" {
+			p.reportError(next.Span, "JSDoc comment is not attached to a declaration")
+		}
+		return nil
+	}
 	elem := p.objTypeAnnElemInner()
-	setObjTypeAnnElemDoc(elem, doc)
+	attachDoc(elem, doc)
 	return elem
 }
 
@@ -801,6 +812,16 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		}
 	}
 
+	// Error-recovery placeholder: when the user wrote a property name
+	// without (or with a malformed) type annotation we substitute
+	// `never` so downstream consumers (printer, checker) see a
+	// well-formed type instead of a nil dereference target. The
+	// `expected type annotation` diagnostic already tells the user
+	// what went wrong; `never` is just a typed stand-in.
+	recoveryNever := func(span ast.Span) ast.TypeAnn {
+		return ast.NewNeverTypeAnn(span)
+	}
+
 	// nolint: exhaustive
 	switch token.Type {
 	case CloseBrace:
@@ -810,7 +831,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 			Name:     objKey,
 			Optional: false,
 			Readonly: readonly,
-			Value:    nil,
+			Value:    recoveryNever(token.Span),
 		}
 		return property
 	case Comma:
@@ -820,7 +841,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 			Name:     objKey,
 			Optional: false,
 			Readonly: readonly,
-			Value:    nil,
+			Value:    recoveryNever(token.Span),
 		}
 		return property
 	case Colon:
@@ -836,6 +857,7 @@ func (p *Parser) objTypeAnnElemInner() ast.ObjTypeAnnElem {
 		token = p.lexer.peek()
 		if token.Type == Comma {
 			p.reportError(token.Span, "expected type annotation")
+			property.Value = recoveryNever(token.Span)
 			return property
 		}
 


### PR DESCRIPTION
Fixes #663: JSDoc comments on class fields, methods, getters, setters, constructors, and interface members now round-trip through the parser instead of being silently dropped.

## Summary

The parser was consuming JSDoc block comments but discarding them instead of attaching them to the AST nodes' `Doc` fields. This caused hand-authored JSDoc to be lost when code was parsed and re-printed. The printer already emitted these docs, so the round-trip was broken.

## Changes

- **internal/parser/decl.go**: Added `consumeLeadingDoc()` to extract JSDoc blocks preceding tokens, mirroring the logic in `dts_parser.consumeLeadingDoc`. Non-JSDoc comments (line comments, plain block comments) reset the captured doc, ensuring JSDoc must be immediately adjacent to attach.
  - Added `isJSDoc()` helper to identify valid JSDoc blocks (`/** ... */` with content, excluding `/**/`).
  - Added `setClassElemDoc()` and `setObjTypeAnnElemDoc()` to attach docs to the appropriate AST node types.
  - Refactored `parseClassElem()` to call `consumeLeadingDoc()` and attach the result via `setClassElemDoc()`.

- **internal/parser/type_ann.go**: Refactored `objTypeAnnElem()` to call `consumeLeadingDoc()` and attach the result via `setObjTypeAnnElemDoc()`, mirroring the class-elem pattern.

- **internal/parser/parser_test.go**: Added comprehensive test coverage:
  - `TestClassElemDocs`: Tests JSDoc attachment on `FieldElem`, `MethodElem`, `GetterElem`, `SetterElem`, and `ConstructorElem`, plus edge cases (intervening line comments, plain block comments, empty doc comments).
  - `TestObjTypeAnnElemDocs`: Tests JSDoc attachment on `PropertyTypeAnn`, `MethodTypeAnn`, `GetterTypeAnn`, and `SetterTypeAnn`, plus edge cases.

- **internal/interop/dts_to_esc_test.go**: Added round-trip assertions to `TestStandalone_BooleanTrio` and `TestStandalone_SharedInterfaceNotFlattened` to verify that parsed class and interface members retain their JSDoc after conversion and re-parsing.

## Implementation Details

- The `consumeLeadingDoc()` function consumes all leading comments and returns the most recent JSDoc block, or "" if no JSDoc is found or if non-JSDoc comments intervene. This ensures JSDoc must be the immediately preceding comment to attach.
- Both `parseClassElem()` and `objTypeAnnElem()` now follow the same pattern: consume leading doc, parse the element, then attach the doc if non-empty.
- The type switches in `setClassElemDoc()` and `setObjTypeAnnElemDoc()` mirror the corresponding switches in the printer, ensuring parser and printer agree on which elem kinds carry docs.

https://claude.ai/code/session_01R9yH7zNcR1tjrrvG6u2jaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where JSDoc comments were lost during parsing and conversions; class members and interface properties now retain their documentation.

* **New Features**
  * Added explicit detection and handling so JSDoc-style block comments are recognized and preserved.

* **Tests**
  * Added comprehensive tests ensuring JSDoc is captured, attached, reset correctly, and survives round-trip parse/print operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->