### PR TITLE
Add journaled probe mechanism for speculative type unification

### DIFF
--- a/cmd/lsp-server/completion.go
+++ b/cmd/lsp-server/completion.go
@@ -417,7 +417,7 @@ func completionsFromType(t type_system.Type, scope *checker.Scope) []protocol.Co
 // MutType so the receiver's outer mutability isn't lost when we strip
 // the wrapper to look up the inner type's members.
 func completionsFromTypeImpl(t type_system.Type, scope *checker.Scope, receiverMut bool) []protocol.CompletionItem {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	switch t := t.(type) {
 	case *type_system.MutType:
@@ -608,7 +608,7 @@ func completionsFromUnionType(u *type_system.UnionType, scope *checker.Scope, re
 	// detail type is shown with "| undefined".
 	var allSets []map[string]protocol.CompletionItem
 	for _, variant := range u.Types {
-		variant = type_system.Prune(variant)
+		variant = type_system.Prune(variant, nil)
 		// Skip null/undefined in unions
 		if isNullOrUndefined(variant) {
 			continue
@@ -1327,7 +1327,7 @@ func safeTypeString(t type_system.Type) string {
 }
 
 func completionKindForValueType(t type_system.Type) protocol.CompletionItemKind {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	if _, ok := t.(*type_system.FuncType); ok {
 		return protocol.CompletionItemKindFunction
 	}

--- a/cmd/lsp-server/completion.go
+++ b/cmd/lsp-server/completion.go
@@ -409,7 +409,7 @@ func (s *Server) moduleCompletion(
 
 // completionsFromType returns completion items for member access on a type.
 func completionsFromType(t type_system.Type, scope *checker.Scope) []protocol.CompletionItem {
-	return completionsFromTypeImpl(t, scope, checker.ReceiverIsDefinitelyMutable(t))
+	return completionsFromTypeImpl(t, scope, checker.ReceiverIsDefinitelyMutable(t, nil))
 }
 
 // completionsFromTypeImpl is the same as completionsFromType but lets internal

--- a/internal/checker/check_implements.go
+++ b/internal/checker/check_implements.go
@@ -44,7 +44,7 @@ func (c *Checker) checkImplementsOne(
 	if len(expandErrors) > 0 {
 		return expandErrors
 	}
-	ifaceObj, ok := type_system.Prune(expanded).(*type_system.ObjectType)
+	ifaceObj, ok := type_system.Prune(expanded, ctx.BindJournal).(*type_system.ObjectType)
 	if !ok {
 		return nil
 	}
@@ -275,7 +275,7 @@ func findElemByKey(ctx Context, c *Checker, objType *type_system.ObjectType, key
 	}
 	for _, ext := range objType.Extends {
 		expanded, _ := c.expandTypeRef(ctx, ext)
-		if parent, ok := type_system.Prune(expanded).(*type_system.ObjectType); ok {
+		if parent, ok := type_system.Prune(expanded, ctx.BindJournal).(*type_system.ObjectType); ok {
 			if found := findElemByKey(ctx, c, parent, key); found != nil {
 				return found
 			}

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -191,7 +191,7 @@ func (c *Checker) checkMutabilityTransition(
 // them to another variable creates an independent copy, so alias tracking
 // is unnecessary.
 func isValueType(t type_system.Type) bool {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 	switch p := pruned.(type) {
 	case *type_system.PrimType, *type_system.LitType:
 		return true
@@ -210,7 +210,7 @@ func isValueType(t type_system.Type) bool {
 // determines how a variable accesses the shared value for alias tracking
 // purposes.
 func isMutableType(t type_system.Type) bool {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 	_, ok := pruned.(*type_system.MutType)
 	return ok
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -169,9 +169,12 @@ type Context struct {
 	QueryUnify bool
 	// BindJournal, when non-nil, records every TypeVar mutation made by
 	// bind / handleArrayConstraintBinding / openClosedObjectForParam / the
-	// widening fallback / Prune's path compression. Probe sets it for the
-	// duration of a single probed unification; Discard replays the records
-	// in reverse to restore the pre-probe state. See probe.go.
+	// widening fallback / Prune's path compression, every LifetimeVar
+	// binding made by UnifyLifetimes, and any ad-hoc rollback closure
+	// registered via AddCleanup (e.g. expr.SetResolvedThrows on the
+	// overload-dispatch path). Probe sets it for the duration of a
+	// single probed unification; Discard replays the records in reverse
+	// to restore the pre-probe state. See probe.go.
 	//
 	// Same propagation discipline as QueryUnify: value-copied ctx carries
 	// the pointer through recursive unifyInner calls, so a Probe at the

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -131,7 +131,7 @@ func (c *Checker) FreshLifetimeVar(name string) *type_system.LifetimeVar {
 //     Symbol.customMatcher method
 //   - (nil, nil) when the extractor is not an ObjectType
 func (c *Checker) findCustomMatcherMethod(ext *type_system.ExtractorType) (*type_system.MethodElem, *type_system.ObjectType) {
-	extractor := type_system.Prune(ext.Extractor)
+	extractor := type_system.Prune(ext.Extractor, nil)
 	extObj, ok := extractor.(*type_system.ObjectType)
 	if !ok {
 		return nil, nil

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -167,6 +167,16 @@ type Context struct {
 	// any save/restore dance, and so that the field is structurally
 	// scoped to the query that turned it on.
 	QueryUnify bool
+	// BindJournal, when non-nil, records every TypeVar mutation made by
+	// bind / handleArrayConstraintBinding / openClosedObjectForParam / the
+	// widening fallback / Prune's path compression. Probe sets it for the
+	// duration of a single probed unification; Discard replays the records
+	// in reverse to restore the pre-probe state. See probe.go.
+	//
+	// Same propagation discipline as QueryUnify: value-copied ctx carries
+	// the pointer through recursive unifyInner calls, so a Probe at the
+	// top auto-journals every nested mutation.
+	BindJournal *BindJournal
 	TypeRefsToUpdate       *Ref[[]*type_system.TypeRefType]
 	// FileScopes maps SourceID to file-specific scope.
 	// Used for file-scoped imports in modules.

--- a/internal/checker/elision.go
+++ b/internal/checker/elision.go
@@ -45,7 +45,7 @@ func IsReferenceType(t type_system.Type) bool {
 	if t == nil {
 		return false
 	}
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.MutType:
 		return IsReferenceType(ty.Type)
 	case *type_system.ObjectType, *type_system.TupleType, *type_system.FuncType:

--- a/internal/checker/exhaustiveness.go
+++ b/internal/checker/exhaustiveness.go
@@ -113,7 +113,7 @@ func (c *Checker) checkExhaustiveness(
 // covered for exhaustiveness. Returns the coverage set and whether the type is
 // finite (i.e., can be fully enumerated without a catch-all).
 func expandCoverageSet(targetType type_system.Type) ([]type_system.Type, bool) {
-	targetType = type_system.Prune(targetType)
+	targetType = type_system.Prune(targetType, nil)
 
 	if union, ok := targetType.(*type_system.UnionType); ok {
 		// Each union member is a separate item in the coverage set.
@@ -224,7 +224,7 @@ func isCatchAllPat(pat ast.Pat) bool {
 // both top-level and inner exhaustiveness checking: Prune, resolve type aliases,
 // and expand booleans into {true, false}.
 func normalizeTargetType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	t = resolveTypeRef(t)
 	if expanded, ok := expandBooleanType(t); ok {
 		t = expanded
@@ -270,11 +270,11 @@ func (c *Checker) computePatternCoverage(
 
 	case *ast.IdentPat:
 		if pat.TypeAnn != nil && pat.TypeAnn.InferredType() != nil {
-			inferredType := type_system.Prune(pat.TypeAnn.InferredType())
+			inferredType := type_system.Prune(pat.TypeAnn.InferredType(), nil)
 			// If the annotated type matches the entire target type (e.g.,
 			// n: number against number), treat it as a catch-all for this
 			// position rather than computing partial coverage.
-			if typesMatchForCoverage(inferredType, type_system.Prune(targetType)) {
+			if typesMatchForCoverage(inferredType, type_system.Prune(targetType, nil)) {
 				coverage.IsCatchAll = true
 			} else {
 				coverage.CoveredTypes = findMatchingMembers(inferredType, targetType)
@@ -286,13 +286,13 @@ func (c *Checker) computePatternCoverage(
 	case *ast.LitPat:
 		// The pattern's inferred type is a literal type (e.g., true, "foo", 42).
 		// It covers that specific literal type within the target union.
-		inferredType := type_system.Prune(pat.InferredType())
+		inferredType := type_system.Prune(pat.InferredType(), nil)
 		coverage.CoveredTypes = findMatchingMembers(inferredType, targetType)
 
 	case *ast.ObjectPat:
 		// Read MatchedUnionMembers from the pattern's inferred ObjectType,
 		// which was populated by unifyPatternWithUnion during type checking.
-		inferredType := type_system.Prune(pat.InferredType())
+		inferredType := type_system.Prune(pat.InferredType(), nil)
 		if objType, ok := inferredType.(*type_system.ObjectType); ok {
 			if len(objType.MatchedUnionMembers) > 0 {
 				coverage.CoveredTypes = objType.MatchedUnionMembers
@@ -302,7 +302,7 @@ func (c *Checker) computePatternCoverage(
 				// tuple pattern coverage.
 				if covered := c.computeObjectPatCoverage(pat, targetObj); covered != nil {
 					coverage.CoveredTypes = covered
-				} else if typesMatchForCoverage(inferredType, type_system.Prune(targetType)) {
+				} else if typesMatchForCoverage(inferredType, type_system.Prune(targetType, nil)) {
 					// The pattern's inferred type structurally matches the
 					// entire target (e.g., {value::number} vs {value: number}).
 					// Treat as catch-all since the coverage set is non-finite.
@@ -324,7 +324,7 @@ func (c *Checker) computePatternCoverage(
 		// The customMatcher method's param type identifies which variant
 		// this extractor matches. Walk the extractor's resolved type to
 		// find [Symbol.customMatcher] and read its param type.
-		inferredType := type_system.Prune(pat.InferredType())
+		inferredType := type_system.Prune(pat.InferredType(), nil)
 		if ext, ok := inferredType.(*type_system.ExtractorType); ok {
 			paramType := c.getCustomMatcherParamType(ext)
 			if paramType != nil {
@@ -335,7 +335,7 @@ func (c *Checker) computePatternCoverage(
 	case *ast.InstancePat:
 		// The pattern's inferred type is a nominal ObjectType with an ID
 		// matching a specific union member. Find which member shares that ID.
-		inferredType := type_system.Prune(pat.InferredType())
+		inferredType := type_system.Prune(pat.InferredType(), nil)
 		coverage.CoveredTypes = findMatchingMembers(inferredType, targetType)
 
 	case *ast.TuplePat:
@@ -368,13 +368,13 @@ func (c *Checker) computePatternCoverage(
 			// We must NOT set IsCatchAll here because the union may contain
 			// non-tuple members (e.g., number) that a TuplePat cannot match.
 			for _, member := range union.Types {
-				memberTuple, ok := type_system.Prune(member).(*type_system.TupleType)
+				memberTuple, ok := type_system.Prune(member, nil).(*type_system.TupleType)
 				if !ok || len(memberTuple.Elems) != len(pat.Elems) {
 					continue
 				}
 				matches := true
 				for i, elemPat := range pat.Elems {
-					elemType := type_system.Prune(memberTuple.Elems[i])
+					elemType := type_system.Prune(memberTuple.Elems[i], nil)
 					switch ep := elemPat.(type) {
 					case *ast.WildcardPat:
 						// Matches anything at this position.
@@ -382,13 +382,13 @@ func (c *Checker) computePatternCoverage(
 						// An IdentPat without a type annotation is a catch-all.
 						// With a type annotation, check if it covers the element type.
 						if ep.TypeAnn != nil && ep.TypeAnn.InferredType() != nil {
-							inferredType := type_system.Prune(ep.TypeAnn.InferredType())
+							inferredType := type_system.Prune(ep.TypeAnn.InferredType(), nil)
 							if !typesMatchForCoverage(inferredType, elemType) {
 								matches = false
 							}
 						}
 					case *ast.LitPat:
-						inferredType := type_system.Prune(ep.InferredType())
+						inferredType := type_system.Prune(ep.InferredType(), nil)
 						if !typesMatchForCoverage(inferredType, elemType) {
 							// Check if the literal is a valid value of the
 							// element type (e.g., true is a value of boolean).
@@ -454,7 +454,7 @@ func (c *Checker) getCustomMatcherParamType(ext *type_system.ExtractorType) type
 	if methodElem != nil {
 		fn := methodElem.SingleSig()
 		if fn != nil && len(fn.Params) == 1 {
-			return type_system.Prune(fn.Params[0].Type)
+			return type_system.Prune(fn.Params[0].Type, nil)
 		}
 	}
 	return nil
@@ -468,7 +468,7 @@ func (c *Checker) getCustomMatcherReturnType(ext *type_system.ExtractorType) typ
 	methodElem, _ := c.findCustomMatcherMethod(ext)
 	if methodElem != nil {
 		if fn := methodElem.SingleSig(); fn != nil {
-			return type_system.Prune(fn.Return)
+			return type_system.Prune(fn.Return, nil)
 		}
 	}
 	return nil
@@ -478,7 +478,7 @@ func (c *Checker) getCustomMatcherReturnType(ext *type_system.ExtractorType) typ
 // the given pattern type. If the target is a union, it checks each member.
 // Otherwise, it checks if the pattern type matches the target directly.
 func findMatchingMembers(patternType type_system.Type, targetType type_system.Type) []type_system.Type {
-	targetType = type_system.Prune(targetType)
+	targetType = type_system.Prune(targetType, nil)
 
 	if union, ok := targetType.(*type_system.UnionType); ok {
 		var matched []type_system.Type
@@ -503,7 +503,7 @@ func findMatchingMembers(patternType type_system.Type, targetType type_system.Ty
 // are expanded before coverage set computation.
 func resolveTypeRef(t type_system.Type) type_system.Type {
 	if ref, ok := t.(*type_system.TypeRefType); ok && ref.TypeAlias != nil {
-		return type_system.Prune(ref.TypeAlias.Type)
+		return type_system.Prune(ref.TypeAlias.Type, nil)
 	}
 	return t
 }
@@ -518,8 +518,8 @@ func resolveTypeRef(t type_system.Type) type_system.Type {
 // unifyPatternWithUnion. Those pointers are the same objects as the ones in
 // the coverage set (from UnionType.Types), so identity comparison suffices.
 func typesMatchForCoverage(patternType, memberType type_system.Type) bool {
-	patternType = type_system.Prune(patternType)
-	memberType = type_system.Prune(memberType)
+	patternType = type_system.Prune(patternType, nil)
+	memberType = type_system.Prune(memberType, nil)
 
 	// Pointer identity: if both types are the exact same object (e.g.,
 	// MatchedUnionMembers stores direct references to union members),
@@ -705,7 +705,7 @@ func collectStrProps(obj *type_system.ObjectType) map[string]type_system.Type {
 	for _, elem := range obj.Elems {
 		if prop, ok := elem.(*type_system.PropertyElem); ok {
 			if prop.Name.Kind == type_system.StrObjTypeKeyKind {
-				props[prop.Name.Str] = type_system.Prune(prop.Value)
+				props[prop.Name.Str] = type_system.Prune(prop.Value, nil)
 			}
 		}
 	}
@@ -752,7 +752,7 @@ func (c *Checker) computePositionCoverage(elemPat ast.Pat, elemType type_system.
 		return members, true
 	case *ast.IdentPat:
 		if p.TypeAnn != nil && p.TypeAnn.InferredType() != nil {
-			inferredType := type_system.Prune(p.TypeAnn.InferredType())
+			inferredType := type_system.Prune(p.TypeAnn.InferredType(), nil)
 			matched := findMatchingMembers(inferredType, elemType)
 			if len(matched) == 0 {
 				return nil, false
@@ -765,14 +765,14 @@ func (c *Checker) computePositionCoverage(elemPat ast.Pat, elemType type_system.
 		}
 		return members, true
 	case *ast.LitPat:
-		inferredType := type_system.Prune(p.InferredType())
+		inferredType := type_system.Prune(p.InferredType(), nil)
 		matched := findMatchingMembers(inferredType, elemType)
 		if len(matched) == 0 {
 			return nil, false
 		}
 		return matched, true
 	case *ast.ExtractorPat:
-		inferredType := type_system.Prune(p.InferredType())
+		inferredType := type_system.Prune(p.InferredType(), nil)
 		ext, ok := inferredType.(*type_system.ExtractorType)
 		if !ok {
 			return nil, false
@@ -787,14 +787,14 @@ func (c *Checker) computePositionCoverage(elemPat ast.Pat, elemType type_system.
 		}
 		return matched, true
 	case *ast.InstancePat:
-		inferredType := type_system.Prune(p.InferredType())
+		inferredType := type_system.Prune(p.InferredType(), nil)
 		matched := findMatchingMembers(inferredType, elemType)
 		if len(matched) == 0 {
 			return nil, false
 		}
 		return matched, true
 	case *ast.ObjectPat:
-		inferredType := type_system.Prune(p.InferredType())
+		inferredType := type_system.Prune(p.InferredType(), nil)
 		matched := findMatchingMembers(inferredType, elemType)
 		if len(matched) == 0 {
 			return nil, false
@@ -949,7 +949,7 @@ func literalBelongsToType(litType type_system.Type, targetType type_system.Type)
 		return false
 	}
 
-	targetType = type_system.Prune(targetType)
+	targetType = type_system.Prune(targetType, nil)
 	targetType = resolveTypeRef(targetType)
 
 	// Boolean expansion: true/false belong to boolean.
@@ -1094,8 +1094,8 @@ func typeAnnsMatchForEquality(a, b ast.TypeAnn) bool {
 	if aType == nil || bType == nil {
 		return aType == nil && bType == nil
 	}
-	aPruned := type_system.Prune(aType)
-	bPruned := type_system.Prune(bType)
+	aPruned := type_system.Prune(aType, nil)
+	bPruned := type_system.Prune(bType, nil)
 	return typesMatchForCoverage(aPruned, bPruned) && typesMatchForCoverage(bPruned, aPruned)
 }
 
@@ -1144,23 +1144,23 @@ func branchPartiallyCovers(cov CaseCoverage[ast.Pat], member type_system.Type) b
 	// For TuplePat matching a literal-element tuple member: check if every
 	// LitPat element exactly matches the member's corresponding LitType.
 	if tuplePat, ok := cov.Pattern.(*ast.TuplePat); ok {
-		memberTuple, ok := type_system.Prune(resolveTypeRef(member)).(*type_system.TupleType)
+		memberTuple, ok := type_system.Prune(resolveTypeRef(member), nil).(*type_system.TupleType)
 		if ok && len(tuplePat.Elems) == len(memberTuple.Elems) {
 			allExactMatch := true
 			for i, elemPat := range tuplePat.Elems {
-				elemType := type_system.Prune(memberTuple.Elems[i])
+				elemType := type_system.Prune(memberTuple.Elems[i], nil)
 				switch p := elemPat.(type) {
 				case *ast.WildcardPat:
 					// catch-all — always matches
 				case *ast.IdentPat:
 					if p.TypeAnn != nil && p.TypeAnn.InferredType() != nil {
-						inferredType := type_system.Prune(p.TypeAnn.InferredType())
+						inferredType := type_system.Prune(p.TypeAnn.InferredType(), nil)
 						if !typesMatchForCoverage(inferredType, elemType) {
 							allExactMatch = false
 						}
 					}
 				case *ast.LitPat:
-					inferredType := type_system.Prune(p.InferredType())
+					inferredType := type_system.Prune(p.InferredType(), nil)
 					if !typesMatchForCoverage(inferredType, elemType) {
 						allExactMatch = false
 					}
@@ -1221,7 +1221,7 @@ func (c *Checker) checkExtractorInnerExhaustiveness(
 ) *ExhaustivenessResult {
 	firstPat := branchCoverages[0].Pattern
 
-	inferredType := type_system.Prune(firstPat.InferredType())
+	inferredType := type_system.Prune(firstPat.InferredType(), nil)
 	ext, ok := inferredType.(*type_system.ExtractorType)
 	if !ok {
 		return nil
@@ -1232,7 +1232,7 @@ func (c *Checker) checkExtractorInnerExhaustiveness(
 		return nil
 	}
 
-	returnTuple, ok := type_system.Prune(returnType).(*type_system.TupleType)
+	returnTuple, ok := type_system.Prune(returnType, nil).(*type_system.TupleType)
 	if !ok {
 		return nil
 	}
@@ -1275,7 +1275,7 @@ func (c *Checker) checkObjectInnerExhaustiveness(
 	branchCoverages []CaseCoverage[*ast.ObjectPat],
 	member type_system.Type,
 ) *ExhaustivenessResult {
-	memberObj, ok := type_system.Prune(resolveTypeRef(member)).(*type_system.ObjectType)
+	memberObj, ok := type_system.Prune(resolveTypeRef(member), nil).(*type_system.ObjectType)
 	if !ok {
 		return nil
 	}
@@ -1296,7 +1296,7 @@ func (c *Checker) checkObjectInnerExhaustiveness(
 		}
 		props = append(props, objPropInfo{
 			name:     prop.Name.Str,
-			propType: type_system.Prune(prop.Value),
+			propType: type_system.Prune(prop.Value, nil),
 		})
 	}
 
@@ -1412,7 +1412,7 @@ func (c *Checker) checkTupleInnerExhaustiveness(
 	branchCoverages []CaseCoverage[*ast.TuplePat],
 	member type_system.Type,
 ) *ExhaustivenessResult {
-	memberTuple, ok := type_system.Prune(resolveTypeRef(member)).(*type_system.TupleType)
+	memberTuple, ok := type_system.Prune(resolveTypeRef(member), nil).(*type_system.TupleType)
 	if !ok {
 		return nil
 	}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -964,10 +964,12 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 				// Optional chaining: obj?.bar infers obj: {bar: T} | null | undefined.
 				// You can't mutate through optional chaining — the object might be
 				// null/undefined.
+				ctx.BindJournal.Snapshot(t)
 				t.Instance = type_system.NewUnionType(nil, openObj, type_system.NewNullType(nil), type_system.NewUndefinedType(nil))
 				// The expression obj?.bar itself may produce undefined
 				return type_system.NewUnionType(nil, propTV, type_system.NewUndefinedType(nil)), errors
 			}
+			ctx.BindJournal.Snapshot(t)
 			t.Instance = openObj
 			return propTV, errors
 		case IndexKey:
@@ -976,6 +978,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 			if indexLit, ok := keyType.(*type_system.LitType); ok {
 				if strLit, ok := indexLit.Lit.(*type_system.StrLit); ok {
 					propTV, openObj := c.newOpenObjectWithProperty(strLit.Value, k)
+					ctx.BindJournal.Snapshot(t)
 					t.Instance = openObj
 					return propTV, errors
 				}

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -77,7 +77,7 @@ func isSymbolIndexKey(key MemberAccessKey) bool {
 	if !ok {
 		return false
 	}
-	keyType := type_system.Prune(indexKey.Type)
+	keyType := type_system.Prune(indexKey.Type, nil)
 	if mut, ok := keyType.(*type_system.MutType); ok {
 		keyType = mut.Type
 	}
@@ -115,7 +115,7 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 		return false
 	}
 
-	expandedType := type_system.Prune(typeAlias.Type)
+	expandedType := type_system.Prune(typeAlias.Type, ctx.BindJournal)
 
 	// Don't expand nominal object types — nominal semantics are enforced
 	// in the ObjectType vs ObjectType case in unifyMatched. Expanding here
@@ -152,7 +152,7 @@ func (c *Checker) canExpandTypeRef(ctx Context, t *type_system.TypeRefType) bool
 		if alias == nil {
 			break
 		}
-		cur = type_system.Prune(alias.Type)
+		cur = type_system.Prune(alias.Type, ctx.BindJournal)
 	}
 
 	return true
@@ -165,7 +165,7 @@ func (c *Checker) ExpandType(ctx Context, t type_system.Type, expandTypeRefsCoun
 }
 
 func (c *Checker) expandTypeWithConfig(ctx Context, t type_system.Type, expandTypeRefsCount int, seen expandSeen) (type_system.Type, []Error) {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, ctx.BindJournal)
 	visitor := NewTypeExpansionVisitor(c, ctx, expandTypeRefsCount)
 	visitor.seen = seen
 
@@ -369,11 +369,11 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		return distributed
 	case *type_system.KeyOfType:
 		// Expand keyof T by extracting the keys from the type T
-		targetType := type_system.Prune(t.Type)
+		targetType := type_system.Prune(t.Type, nil)
 
 		// First, try to expand the target type
 		expandedTarget, _ := v.checker.expandTypeWithConfig(v.ctx, targetType, 1, v.seen)
-		expandedTarget = type_system.Prune(expandedTarget)
+		expandedTarget = type_system.Prune(expandedTarget, nil)
 
 		// Unwrap MutType so keyof sees the actual object type
 		if mut, ok := expandedTarget.(*type_system.MutType); ok {
@@ -559,7 +559,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
 			// Do not perform distributions if the conditional type is the child
 			// of any other type.
-			switch prunedType := type_system.Prune(expandedType).(type) {
+			switch prunedType := type_system.Prune(expandedType, nil).(type) {
 			case *type_system.CondType:
 				// generateSubstitutionSets expands each arg internally to check
 				// whether it's a union for distribution purposes, so we don't
@@ -599,7 +599,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			// Expand MappedElems in ObjectTypes even if there are no type params/args
 			// `{[P]: string for P in "foo" | "bar"}` should be expanded to
 			// `{foo: string, bar: string}`
-			if objType, ok := type_system.Prune(expandedType).(*type_system.ObjectType); ok {
+			if objType, ok := type_system.Prune(expandedType, nil).(*type_system.ObjectType); ok {
 				expandedType = v.expandMappedElems(objType)
 			}
 		}
@@ -663,7 +663,7 @@ func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key Membe
 func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key MemberAccessKey, mode AccessMode, receiverMut bool) (type_system.Type, []Error) {
 	errors := []Error{}
 
-	objType = type_system.Prune(objType)
+	objType = type_system.Prune(objType, ctx.BindJournal)
 
 	// Fast path for TypeRefTypes: try O(1) per-member lazy lookup before
 	// the expansion loop which would substitute the entire ObjectType (#461).
@@ -933,7 +933,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 			case IndexKey:
 				// If the index is a string literal, route to property access
 				// instead of numeric index access.
-				keyType := type_system.Prune(k.Type)
+				keyType := type_system.Prune(k.Type, ctx.BindJournal)
 				if mut, ok := keyType.(*type_system.MutType); ok {
 					keyType = mut.Type
 				}
@@ -1014,9 +1014,9 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 // resolveToObjectType attempts to resolve a type to an *ObjectType. It handles
 // direct ObjectTypes, MutType wrappers, and TypeRefTypes with aliases.
 func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
-	resolved := type_system.Prune(t)
+	resolved := type_system.Prune(t, nil)
 	if mut, ok := resolved.(*type_system.MutType); ok {
-		resolved = type_system.Prune(mut.Type)
+		resolved = type_system.Prune(mut.Type, nil)
 	}
 	if obj, ok := resolved.(*type_system.ObjectType); ok {
 		return obj
@@ -1040,7 +1040,7 @@ func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
 // constraint's wrapper is consulted; an unconstrained type variable is
 // treated as immutable so generic code can't sneak past the gate.
 func ReceiverIsDefinitelyMutable(t type_system.Type) bool {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 	if _, ok := pruned.(*type_system.MutType); ok {
 		return true
 	}
@@ -1115,7 +1115,7 @@ func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name
 		return nil, false
 	}
 
-	aliasType := type_system.Prune(typeAlias.Type)
+	aliasType := type_system.Prune(typeAlias.Type, ctx.BindJournal)
 	objType, ok := aliasType.(*type_system.ObjectType)
 	if !ok {
 		return nil, false
@@ -1275,14 +1275,14 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		for _, extendsTypeRef := range objType.Extends {
 			extendsType := type_system.Type(extendsTypeRef)
 
-			if typeRef, ok := type_system.Prune(extendsType).(*type_system.TypeRefType); ok {
+			if typeRef, ok := type_system.Prune(extendsType, nil).(*type_system.TypeRefType); ok {
 				if typeRef.TypeAlias != nil {
 					resolved := typeRef.TypeAlias.Type
 					if len(typeRef.TypeAlias.TypeParams) > 0 && len(typeRef.TypeArgs) > 0 {
 						subs := createTypeParamSubstitutions(typeRef.TypeArgs, typeRef.TypeAlias.TypeParams)
 						resolved = SubstituteTypeParams(resolved, subs)
 					}
-					extendsType = type_system.Prune(resolved)
+					extendsType = type_system.Prune(resolved, nil)
 				}
 			}
 
@@ -1505,14 +1505,14 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// is guaranteed non-nil for valid code).
 		for _, extendsTypeRef := range objType.Extends {
 			extendsType := type_system.Type(extendsTypeRef)
-			if typeRef, ok := type_system.Prune(extendsType).(*type_system.TypeRefType); ok {
+			if typeRef, ok := type_system.Prune(extendsType, nil).(*type_system.TypeRefType); ok {
 				if typeRef.TypeAlias != nil {
 					resolved := typeRef.TypeAlias.Type
 					if len(typeRef.TypeAlias.TypeParams) > 0 && len(typeRef.TypeArgs) > 0 {
 						subs := createTypeParamSubstitutions(typeRef.TypeArgs, typeRef.TypeAlias.TypeParams)
 						resolved = SubstituteTypeParams(resolved, subs)
 					}
-					extendsType = type_system.Prune(resolved)
+					extendsType = type_system.Prune(resolved, nil)
 				}
 			}
 			if extendsObjType, ok := extendsType.(*type_system.ObjectType); ok {
@@ -1619,7 +1619,7 @@ func markPropertyWritten(prunedType type_system.Type, propName string) bool {
 // This includes the number primitive and numeric literal types that are not
 // valid non-negative integer tuple indices (e.g. floats, negatives).
 func isNumericType(t type_system.Type) bool {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	if numPrim, ok := t.(*type_system.PrimType); ok && numPrim.Prim == type_system.NumPrim {
 		return true
 	}
@@ -1644,7 +1644,7 @@ func isNumericType(t type_system.Type) bool {
 const maxTupleIndex = 20
 
 func asNonNegativeIntLiteral(t type_system.Type) (int, bool) {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	if litType, ok := t.(*type_system.LitType); ok {
 		if numLit, ok := litType.Lit.(*type_system.NumLit); ok {
 			val := numLit.Value
@@ -1744,7 +1744,7 @@ func (c *Checker) isArrayOnlyMethod(propName string) bool {
 	if arrayAlias == nil {
 		return false
 	}
-	arrayType := type_system.Prune(arrayAlias.Type)
+	arrayType := type_system.Prune(arrayAlias.Type, nil)
 	objType, ok := arrayType.(*type_system.ObjectType)
 	if !ok {
 		return false
@@ -1765,7 +1765,7 @@ func (c *Checker) isArrayMutatingMethod(methodName string) bool {
 	if arrayAlias == nil {
 		return false
 	}
-	arrayType := type_system.Prune(arrayAlias.Type)
+	arrayType := type_system.Prune(arrayAlias.Type, nil)
 	objType, ok := arrayType.(*type_system.ObjectType)
 	if !ok {
 		return false
@@ -1857,7 +1857,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 	funcTypes := []*type_system.FuncType{}
 
 	for _, part := range intersectionType.Types {
-		part = type_system.Prune(part)
+		part = type_system.Prune(part, ctx.BindJournal)
 		// Unwrap MutType so explicit `mut Foo` parts are classified as
 		// object parts of the intersection.
 		if mut, ok := part.(*type_system.MutType); ok {
@@ -1932,7 +1932,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 
 	// If not found in object types, try other parts (primitives, functions, etc.)
 	for _, part := range intersectionType.Types {
-		part = type_system.Prune(part)
+		part = type_system.Prune(part, ctx.BindJournal)
 		// Skip object types (including MutType-wrapped) since we already checked them
 		unwrapped := part
 		if mut, ok := unwrapped.(*type_system.MutType); ok {
@@ -1991,7 +1991,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 			// Extract keys from the constraint
 			var keys []type_system.Type
-			switch constraint := type_system.Prune(expandedConstraint).(type) {
+			switch constraint := type_system.Prune(expandedConstraint, nil).(type) {
 			case *type_system.UnionType:
 				keys = constraint.Types
 			default:
@@ -2000,7 +2000,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 			// For each key in the constraint, create a property or index signature
 			for _, keyType := range keys {
-				keyType = type_system.Prune(keyType)
+				keyType = type_system.Prune(keyType, nil)
 
 				// If the key type is a primitive (string, number, symbol), emit an
 				// IndexSignatureElem — we cannot enumerate an infinite key space.
@@ -2057,7 +2057,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 					// Expand the property key to resolve template literals
 					propKeyType, _ = v.checker.ExpandType(v.ctx, propKeyType, -1)
-					propKeyType = type_system.Prune(propKeyType)
+					propKeyType = type_system.Prune(propKeyType, nil)
 
 					// Convert the expanded key type to an ObjTypeKey
 					switch kt := propKeyType.(type) {
@@ -2182,7 +2182,7 @@ func (v *TypeExpansionVisitor) expandTemplateLitType(t *type_system.TemplateLitT
 	typeOptions := make([][]type_system.Type, len(t.Types))
 
 	for i, t := range t.Types {
-		t = type_system.Prune(t)
+		t = type_system.Prune(t, nil)
 		t, _ = v.checker.ExpandType(v.ctx, t, -1) // fully expand nested type refs
 
 		if unionType, ok := t.(*type_system.UnionType); ok {
@@ -2265,7 +2265,7 @@ func (c *Checker) NormalizeIntersectionType(ctx Context, t *type_system.Intersec
 	expanded := make([]type_system.Type, len(t.Types))
 	for i, typ := range t.Types {
 		// Prune to resolve type variables
-		typ = type_system.Prune(typ)
+		typ = type_system.Prune(typ, ctx.BindJournal)
 
 		// Expand type aliases to their underlying types
 		// Use depth 1 to expand one level of type aliases
@@ -2402,7 +2402,7 @@ func (v *InferTypeFinder) EnterType(t type_system.Type) type_system.EnterResult 
 }
 
 func (v *InferTypeFinder) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	if inferType, ok := t.(*type_system.InferType); ok {
 		if existingVar, exists := v.inferVars[inferType.Name]; exists {
@@ -2439,7 +2439,7 @@ func (v *InferTypeReplacer) EnterType(t type_system.Type) type_system.EnterResul
 }
 
 func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	// Check if this is an InferType that should be replaced
 	if inferType, ok := t.(*type_system.InferType); ok {
@@ -2459,7 +2459,7 @@ func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
 // it returns T (the index doesn't matter since all elements have the same
 // type). For unresolved types it returns the type as-is.
 func restElemType(rest *type_system.RestSpreadType, index int) type_system.Type {
-	resolved := type_system.Prune(rest.Type)
+	resolved := type_system.Prune(rest.Type, nil)
 	switch r := resolved.(type) {
 	case *type_system.TupleType:
 		// Count fixed (non-rest) elements and find any nested rest spread.
@@ -2508,7 +2508,7 @@ func tupleElemUnion(t *type_system.TupleType) type_system.Type {
 	var types []type_system.Type
 	for _, elem := range t.Elems {
 		if rest, ok := elem.(*type_system.RestSpreadType); ok {
-			resolved := type_system.Prune(rest.Type)
+			resolved := type_system.Prune(rest.Type, nil)
 			switch r := resolved.(type) {
 			case *type_system.TupleType:
 				types = append(types, r.Elems...)

--- a/internal/checker/expand_type.go
+++ b/internal/checker/expand_type.go
@@ -72,12 +72,12 @@ func containsTypeVar(t type_system.Type) bool {
 
 // isSymbolIndexKey returns true if the given MemberAccessKey is an IndexKey
 // whose underlying type is a UniqueSymbolType (e.g. Symbol.iterator).
-func isSymbolIndexKey(key MemberAccessKey) bool {
+func isSymbolIndexKey(key MemberAccessKey, j type_system.Journal) bool {
 	indexKey, ok := key.(IndexKey)
 	if !ok {
 		return false
 	}
-	keyType := type_system.Prune(indexKey.Type, nil)
+	keyType := type_system.Prune(indexKey.Type, j)
 	if mut, ok := keyType.(*type_system.MutType); ok {
 		keyType = mut.Type
 	}
@@ -279,10 +279,10 @@ func (v *TypeExpansionVisitor) EnterType(t type_system.Type) type_system.EnterRe
 		// TODO: Add a test case to ensure that infer type shadowing works and
 		// fix the bug if it doesn't.
 
-		inferSubs := v.checker.findInferTypes(t.Extends)
+		inferSubs := v.checker.findInferTypes(t.Extends, v.ctx.BindJournal)
 		groupSubs := v.checker.FindNamedGroups(t.Extends)
 		extendsType := v.checker.replaceRegexGroupTypes(t.Extends, groupSubs)
-		extendsType = v.checker.replaceInferTypes(extendsType, inferSubs)
+		extendsType = v.checker.replaceInferTypes(extendsType, inferSubs, v.ctx.BindJournal)
 
 		maps.Copy(inferSubs, groupSubs)
 
@@ -327,7 +327,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 	case *type_system.IntersectionType:
 		// First distribute intersection over any unions it contains
 		// e.g., A & (B | C) becomes (A & B) | (A & C)
-		distributed, changed := distributeIntersectionOverUnion(t)
+		distributed, changed := distributeIntersectionOverUnion(t, v.ctx.BindJournal)
 
 		if !changed {
 			// If no distribution occurred, re-normalize intersection after type expansion
@@ -369,11 +369,11 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		return distributed
 	case *type_system.KeyOfType:
 		// Expand keyof T by extracting the keys from the type T
-		targetType := type_system.Prune(t.Type, nil)
+		targetType := type_system.Prune(t.Type, v.ctx.BindJournal)
 
 		// First, try to expand the target type
 		expandedTarget, _ := v.checker.expandTypeWithConfig(v.ctx, targetType, 1, v.seen)
-		expandedTarget = type_system.Prune(expandedTarget, nil)
+		expandedTarget = type_system.Prune(expandedTarget, v.ctx.BindJournal)
 
 		// Unwrap MutType so keyof sees the actual object type
 		if mut, ok := expandedTarget.(*type_system.MutType); ok {
@@ -559,7 +559,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 		if len(typeAlias.TypeParams) > 0 && len(t.TypeArgs) > 0 {
 			// Do not perform distributions if the conditional type is the child
 			// of any other type.
-			switch prunedType := type_system.Prune(expandedType, nil).(type) {
+			switch prunedType := type_system.Prune(expandedType, v.ctx.BindJournal).(type) {
 			case *type_system.CondType:
 				// generateSubstitutionSets expands each arg internally to check
 				// whether it's a union for distribution purposes, so we don't
@@ -599,7 +599,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 			// Expand MappedElems in ObjectTypes even if there are no type params/args
 			// `{[P]: string for P in "foo" | "bar"}` should be expanded to
 			// `{foo: string, bar: string}`
-			if objType, ok := type_system.Prune(expandedType, nil).(*type_system.ObjectType); ok {
+			if objType, ok := type_system.Prune(expandedType, v.ctx.BindJournal).(*type_system.ObjectType); ok {
 				expandedType = v.expandMappedElems(objType)
 			}
 		}
@@ -653,7 +653,7 @@ func (v *TypeExpansionVisitor) ExitType(t type_system.Type) type_system.Type {
 // mode indicates whether the access is a read (rvalue) or write (lvalue), which affects
 // getter/setter resolution: reads use getters, writes use setters.
 func (c *Checker) getMemberType(ctx Context, objType type_system.Type, key MemberAccessKey, mode AccessMode) (type_system.Type, []Error) {
-	return c.getMemberTypeImpl(ctx, objType, key, mode, ReceiverIsDefinitelyMutable(objType))
+	return c.getMemberTypeImpl(ctx, objType, key, mode, ReceiverIsDefinitelyMutable(objType, ctx.BindJournal))
 }
 
 // getMemberTypeImpl is the same as getMemberType but lets internal recursive
@@ -671,7 +671,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 	// and non-nominal generic aliases (avoiding full expansion entirely).
 	if tref, ok := objType.(*type_system.TypeRefType); ok {
 		// Handle Array numeric index access (skip symbol keys like Symbol.iterator)
-		if indexKey, ok := key.(IndexKey); ok && type_system.QualIdentToString(tref.Name) == "Array" && !isSymbolIndexKey(key) {
+		if indexKey, ok := key.(IndexKey); ok && type_system.QualIdentToString(tref.Name) == "Array" && !isSymbolIndexKey(key, ctx.BindJournal) {
 			unifyErrors := c.Unify(ctx, indexKey.Type, type_system.NewNumPrimType(nil))
 			errors = slices.Concat(errors, unifyErrors)
 			return tref.TypeArgs[0], errors
@@ -800,7 +800,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 						if rest, isRest := elem.(*type_system.RestSpreadType); isRest {
 							// Index beyond fixed prefix — return the rest's element type
 							restIndex := index - fixedCount
-							return restElemType(rest, restIndex), errors
+							return restElemType(rest, restIndex, ctx.BindJournal), errors
 						}
 					}
 					errors = append(errors, &OutOfBoundsError{
@@ -819,7 +819,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 		}
 		// If a property (method) is accessed on a tuple, delegate to Array<T>
 		if _, ok := key.(PropertyKey); ok {
-			elemUnion := tupleElemUnion(t)
+			elemUnion := tupleElemUnion(t, ctx.BindJournal)
 			arrayRef := &type_system.TypeRefType{
 				Name:     type_system.NewIdent("Array"),
 				TypeArgs: []type_system.Type{elemUnion},
@@ -847,7 +847,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 				Name:     type_system.NewIdent(builtinName),
 				TypeArgs: []type_system.Type{},
 			}
-			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key) {
+			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key, ctx.BindJournal) {
 				return c.getMemberTypeImpl(ctx, builtinRef, key, mode, receiverMut)
 			}
 		}
@@ -873,7 +873,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 				Name:     type_system.NewIdent(builtinName),
 				TypeArgs: []type_system.Type{},
 			}
-			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key) {
+			if _, ok := key.(PropertyKey); ok || isSymbolIndexKey(key, ctx.BindJournal) {
 				return c.getMemberTypeImpl(ctx, builtinRef, key, mode, receiverMut)
 			}
 		}
@@ -895,7 +895,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 		return type_system.NewNeverType(nil), errors
 
 	case *type_system.ObjectType:
-		return c.getObjectAccess(t, key, mode, receiverMut, errors)
+		return c.getObjectAccess(ctx, t, key, mode, receiverMut, errors)
 	case *type_system.UnionType:
 		return c.getUnionAccess(ctx, t, key, mode, receiverMut, errors)
 	case *type_system.NamespaceType:
@@ -984,7 +984,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 			// immediately binding to Array<T>. This defers the tuple-vs-array
 			// decision until closing time.
 			constraint := c.getOrCreateArrayConstraint(t)
-			if litIndex, ok := asNonNegativeIntLiteral(keyType); ok {
+			if litIndex, ok := asNonNegativeIntLiteral(keyType, ctx.BindJournal); ok {
 				// Record literal index with a fresh widenable type variable
 				if _, exists := constraint.LiteralIndexes[litIndex]; !exists {
 					elemTV := c.FreshVar(nil)
@@ -993,7 +993,7 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 				}
 				return constraint.LiteralIndexes[litIndex], errors
 			}
-			if isNumericType(keyType) {
+			if isNumericType(keyType, ctx.BindJournal) {
 				// Non-literal numeric type (e.g. number) — must be Array, not tuple
 				constraint.HasNonLiteralIndex = true
 				return constraint.ElemTypeVar, errors
@@ -1013,10 +1013,10 @@ func (c *Checker) getMemberTypeImpl(ctx Context, objType type_system.Type, key M
 
 // resolveToObjectType attempts to resolve a type to an *ObjectType. It handles
 // direct ObjectTypes, MutType wrappers, and TypeRefTypes with aliases.
-func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
-	resolved := type_system.Prune(t, nil)
+func resolveToObjectType(t type_system.Type, j type_system.Journal) *type_system.ObjectType {
+	resolved := type_system.Prune(t, j)
 	if mut, ok := resolved.(*type_system.MutType); ok {
-		resolved = type_system.Prune(mut.Type, nil)
+		resolved = type_system.Prune(mut.Type, j)
 	}
 	if obj, ok := resolved.(*type_system.ObjectType); ok {
 		return obj
@@ -1028,7 +1028,7 @@ func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
 				subs := createTypeParamSubstitutions(ref.TypeArgs, ref.TypeAlias.TypeParams)
 				aliasType = SubstituteTypeParams(aliasType, subs)
 			}
-			return resolveToObjectType(aliasType)
+			return resolveToObjectType(aliasType, j)
 		}
 	}
 	return nil
@@ -1039,13 +1039,13 @@ func resolveToObjectType(t type_system.Type) *type_system.ObjectType {
 // for receiver-mutability gating. For type-variable receivers, the
 // constraint's wrapper is consulted; an unconstrained type variable is
 // treated as immutable so generic code can't sneak past the gate.
-func ReceiverIsDefinitelyMutable(t type_system.Type) bool {
-	pruned := type_system.Prune(t, nil)
+func ReceiverIsDefinitelyMutable(t type_system.Type, j type_system.Journal) bool {
+	pruned := type_system.Prune(t, j)
 	if _, ok := pruned.(*type_system.MutType); ok {
 		return true
 	}
 	if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Constraint != nil {
-		return ReceiverIsDefinitelyMutable(tv.Constraint)
+		return ReceiverIsDefinitelyMutable(tv.Constraint, j)
 	}
 	return false
 }
@@ -1199,7 +1199,7 @@ func (c *Checker) lazyMemberLookup(ctx Context, t *type_system.TypeRefType, name
 // receiverMut indicates whether the receiver was wrapped in a definite `mut`;
 // when false, `mut self` methods and (in AccessWrite mode) setters are hidden,
 // causing the lookup to fall through to the property-not-found path.
-func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAccessKey, mode AccessMode, receiverMut bool, errors []Error) (type_system.Type, []Error) {
+func (c *Checker) getObjectAccess(ctx Context, objType *type_system.ObjectType, key MemberAccessKey, mode AccessMode, receiverMut bool, errors []Error) (type_system.Type, []Error) {
 	// Open objects are still being built up by inference; they only ever hold
 	// PropertyElems (no `mut self` methods), so the visibility filter has
 	// nothing to do here. Treat as mutable to skip the filter and avoid any
@@ -1238,8 +1238,8 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 					return elem.Fn.Params[0].Type, errors
 				}
 			case *type_system.RestSpreadElem:
-				if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-					spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, receiverMut, nil)
+				if resolvedObj := resolveToObjectType(elem.Value, ctx.BindJournal); resolvedObj != nil {
+					spreadType, spreadErrors := c.getObjectAccess(ctx, resolvedObj, key, mode, receiverMut, nil)
 					if len(spreadErrors) == 0 {
 						return spreadType, errors
 					}
@@ -1275,20 +1275,20 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		for _, extendsTypeRef := range objType.Extends {
 			extendsType := type_system.Type(extendsTypeRef)
 
-			if typeRef, ok := type_system.Prune(extendsType, nil).(*type_system.TypeRefType); ok {
+			if typeRef, ok := type_system.Prune(extendsType, ctx.BindJournal).(*type_system.TypeRefType); ok {
 				if typeRef.TypeAlias != nil {
 					resolved := typeRef.TypeAlias.Type
 					if len(typeRef.TypeAlias.TypeParams) > 0 && len(typeRef.TypeArgs) > 0 {
 						subs := createTypeParamSubstitutions(typeRef.TypeArgs, typeRef.TypeAlias.TypeParams)
 						resolved = SubstituteTypeParams(resolved, subs)
 					}
-					extendsType = type_system.Prune(resolved, nil)
+					extendsType = type_system.Prune(resolved, ctx.BindJournal)
 				}
 			}
 
 			if extendsObjType, ok := extendsType.(*type_system.ObjectType); ok {
 				// Recursively check the extended type
-				return c.getObjectAccess(extendsObjType, key, mode, receiverMut, errors)
+				return c.getObjectAccess(ctx, extendsObjType, key, mode, receiverMut, errors)
 			}
 
 			// If the extended type cannot be resolved to an ObjectType,
@@ -1344,8 +1344,8 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							indexSigFallback = elem.Value
 						}
 					case *type_system.RestSpreadElem:
-						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-							spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, receiverMut, nil)
+						if resolvedObj := resolveToObjectType(elem.Value, ctx.BindJournal); resolvedObj != nil {
+							spreadType, spreadErrors := c.getObjectAccess(ctx, resolvedObj, key, mode, receiverMut, nil)
 							if len(spreadErrors) == 0 {
 								return spreadType, errors
 							}
@@ -1391,8 +1391,8 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 							}
 						}
 					case *type_system.RestSpreadElem:
-						if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-							spreadType, spreadErrors := c.getObjectAccess(resolvedObj, key, mode, receiverMut, nil)
+						if resolvedObj := resolveToObjectType(elem.Value, ctx.BindJournal); resolvedObj != nil {
+							spreadType, spreadErrors := c.getObjectAccess(ctx, resolvedObj, key, mode, receiverMut, nil)
 							if len(spreadErrors) == 0 {
 								return spreadType, errors
 							}
@@ -1481,8 +1481,8 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 						indexSigFallback = elem.Value
 					}
 				case *type_system.RestSpreadElem:
-					if resolvedObj := resolveToObjectType(elem.Value); resolvedObj != nil {
-						symPropType, symPropErrors := c.getObjectAccess(resolvedObj, key, mode, receiverMut, nil)
+					if resolvedObj := resolveToObjectType(elem.Value, ctx.BindJournal); resolvedObj != nil {
+						symPropType, symPropErrors := c.getObjectAccess(ctx, resolvedObj, key, mode, receiverMut, nil)
 						if len(symPropErrors) == 0 {
 							return symPropType, errors
 						}
@@ -1505,19 +1505,19 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 		// is guaranteed non-nil for valid code).
 		for _, extendsTypeRef := range objType.Extends {
 			extendsType := type_system.Type(extendsTypeRef)
-			if typeRef, ok := type_system.Prune(extendsType, nil).(*type_system.TypeRefType); ok {
+			if typeRef, ok := type_system.Prune(extendsType, ctx.BindJournal).(*type_system.TypeRefType); ok {
 				if typeRef.TypeAlias != nil {
 					resolved := typeRef.TypeAlias.Type
 					if len(typeRef.TypeAlias.TypeParams) > 0 && len(typeRef.TypeArgs) > 0 {
 						subs := createTypeParamSubstitutions(typeRef.TypeArgs, typeRef.TypeAlias.TypeParams)
 						resolved = SubstituteTypeParams(resolved, subs)
 					}
-					extendsType = type_system.Prune(resolved, nil)
+					extendsType = type_system.Prune(resolved, ctx.BindJournal)
 				}
 			}
 			if extendsObjType, ok := extendsType.(*type_system.ObjectType); ok {
 				// Recursively check the extended type
-				return c.getObjectAccess(extendsObjType, key, mode, receiverMut, errors)
+				return c.getObjectAccess(ctx, extendsObjType, key, mode, receiverMut, errors)
 			}
 		}
 
@@ -1530,7 +1530,7 @@ func (c *Checker) getObjectAccess(objType *type_system.ObjectType, key MemberAcc
 			}
 			// Numeric literal index — add a numeric-keyed property to the open object.
 			// Objects can have both string and numeric keys.
-			if litIndex, isNonNegInt := asNonNegativeIntLiteral(keyType); isNonNegInt {
+			if litIndex, isNonNegInt := asNonNegativeIntLiteral(keyType, ctx.BindJournal); isNonNegInt {
 				return c.addNumericPropertyToOpenObject(objType, float64(litIndex), k), errors
 			}
 		}
@@ -1618,8 +1618,8 @@ func markPropertyWritten(prunedType type_system.Type, propName string) bool {
 // isNumericType returns true if the type represents a numeric type.
 // This includes the number primitive and numeric literal types that are not
 // valid non-negative integer tuple indices (e.g. floats, negatives).
-func isNumericType(t type_system.Type) bool {
-	t = type_system.Prune(t, nil)
+func isNumericType(t type_system.Type, j type_system.Journal) bool {
+	t = type_system.Prune(t, j)
 	if numPrim, ok := t.(*type_system.PrimType); ok && numPrim.Prim == type_system.NumPrim {
 		return true
 	}
@@ -1628,7 +1628,7 @@ func isNumericType(t type_system.Type) bool {
 			// If it's a valid non-negative int literal, it's handled by
 			// asNonNegativeIntLiteral, not here. Only treat non-integer
 			// or negative numeric literals as generic numeric types.
-			if _, isIndex := asNonNegativeIntLiteral(t); !isIndex {
+			if _, isIndex := asNonNegativeIntLiteral(t, j); !isIndex {
 				return true
 			}
 		}
@@ -1643,8 +1643,8 @@ func isNumericType(t type_system.Type) bool {
 // TODO(#402): Make maxTupleIndex configurable via checker options.
 const maxTupleIndex = 20
 
-func asNonNegativeIntLiteral(t type_system.Type) (int, bool) {
-	t = type_system.Prune(t, nil)
+func asNonNegativeIntLiteral(t type_system.Type, j type_system.Journal) (int, bool) {
+	t = type_system.Prune(t, j)
 	if litType, ok := t.(*type_system.LitType); ok {
 		if numLit, ok := litType.Lit.(*type_system.NumLit); ok {
 			val := numLit.Value
@@ -1715,11 +1715,11 @@ func (c *Checker) getArrayConstraintPropertyAccess(ctx Context, t *type_system.T
 
 // getArrayConstraintIndexAccess handles numeric index access on a TypeVarType
 // that already has an ArrayConstraint.
-func (c *Checker) getArrayConstraintIndexAccess(_ Context, t *type_system.TypeVarType, k IndexKey, errors []Error) (type_system.Type, []Error) {
+func (c *Checker) getArrayConstraintIndexAccess(ctx Context, t *type_system.TypeVarType, k IndexKey, errors []Error) (type_system.Type, []Error) {
 	constraint := t.ArrayConstraint
 	var keyType type_system.Type = k.Type
 
-	if litIndex, ok := asNonNegativeIntLiteral(keyType); ok {
+	if litIndex, ok := asNonNegativeIntLiteral(keyType, ctx.BindJournal); ok {
 		if _, exists := constraint.LiteralIndexes[litIndex]; !exists {
 			elemTV := c.FreshVar(nil)
 			elemTV.Widenable = true
@@ -1727,7 +1727,7 @@ func (c *Checker) getArrayConstraintIndexAccess(_ Context, t *type_system.TypeVa
 		}
 		return constraint.LiteralIndexes[litIndex], errors
 	}
-	if isNumericType(keyType) {
+	if isNumericType(keyType, ctx.BindJournal) {
 		constraint.HasNonLiteralIndex = true
 		return constraint.ElemTypeVar, errors
 	}
@@ -1744,6 +1744,10 @@ func (c *Checker) isArrayOnlyMethod(propName string) bool {
 	if arrayAlias == nil {
 		return false
 	}
+	// arrayAlias is the immutable global TypeAlias installed by the
+	// prelude; its Type is the declaration-time Array<T> ObjectType and
+	// has no alias chain that path-compression would mutate. Safe to
+	// pass nil here even on probe paths.
 	arrayType := type_system.Prune(arrayAlias.Type, nil)
 	objType, ok := arrayType.(*type_system.ObjectType)
 	if !ok {
@@ -1765,6 +1769,10 @@ func (c *Checker) isArrayMutatingMethod(methodName string) bool {
 	if arrayAlias == nil {
 		return false
 	}
+	// arrayAlias is the immutable global TypeAlias installed by the
+	// prelude; its Type is the declaration-time Array<T> ObjectType and
+	// has no alias chain that path-compression would mutate. Safe to
+	// pass nil here even on probe paths.
 	arrayType := type_system.Prune(arrayAlias.Type, nil)
 	objType, ok := arrayType.(*type_system.ObjectType)
 	if !ok {
@@ -1876,7 +1884,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 		foundAny := false
 
 		for _, objType := range objectTypes {
-			memberType, memberErrors := c.getObjectAccess(objType, key, mode, receiverMut, nil)
+			memberType, memberErrors := c.getObjectAccess(ctx, objType, key, mode, receiverMut, nil)
 			// Only include results from object types that have this property
 			if len(memberErrors) == 0 {
 				memberTypes = append(memberTypes, memberType)
@@ -1914,7 +1922,7 @@ func (c *Checker) getIntersectionAccess(ctx Context, intersectionType *type_syst
 	// First, collect all properties from object type parts
 	memberTypesFromObjects := []type_system.Type{}
 	for _, objType := range objectTypes {
-		memberType, memberErrors := c.getObjectAccess(objType, key, mode, receiverMut, nil)
+		memberType, memberErrors := c.getObjectAccess(ctx, objType, key, mode, receiverMut, nil)
 		if len(memberErrors) == 0 {
 			memberTypesFromObjects = append(memberTypesFromObjects, memberType)
 		}
@@ -1991,7 +1999,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 			// Extract keys from the constraint
 			var keys []type_system.Type
-			switch constraint := type_system.Prune(expandedConstraint, nil).(type) {
+			switch constraint := type_system.Prune(expandedConstraint, v.ctx.BindJournal).(type) {
 			case *type_system.UnionType:
 				keys = constraint.Types
 			default:
@@ -2000,7 +2008,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 			// For each key in the constraint, create a property or index signature
 			for _, keyType := range keys {
-				keyType = type_system.Prune(keyType, nil)
+				keyType = type_system.Prune(keyType, v.ctx.BindJournal)
 
 				// If the key type is a primitive (string, number, symbol), emit an
 				// IndexSignatureElem — we cannot enumerate an infinite key space.
@@ -2057,7 +2065,7 @@ func (v *TypeExpansionVisitor) expandMappedElems(objType *type_system.ObjectType
 
 					// Expand the property key to resolve template literals
 					propKeyType, _ = v.checker.ExpandType(v.ctx, propKeyType, -1)
-					propKeyType = type_system.Prune(propKeyType, nil)
+					propKeyType = type_system.Prune(propKeyType, v.ctx.BindJournal)
 
 					// Convert the expanded key type to an ObjTypeKey
 					switch kt := propKeyType.(type) {
@@ -2182,7 +2190,7 @@ func (v *TypeExpansionVisitor) expandTemplateLitType(t *type_system.TemplateLitT
 	typeOptions := make([][]type_system.Type, len(t.Types))
 
 	for i, t := range t.Types {
-		t = type_system.Prune(t, nil)
+		t = type_system.Prune(t, v.ctx.BindJournal)
 		t, _ = v.checker.ExpandType(v.ctx, t, -1) // fully expand nested type refs
 
 		if unionType, ok := t.(*type_system.UnionType); ok {
@@ -2381,10 +2389,11 @@ func (v *TypeExpansionVisitor) cartesianProduct(sets [][]type_system.Type) [][]t
 
 // findInferTypes finds all InferType nodes in a type and replaces them with fresh type variables.
 // Returns a mapping from infer names to the type variables that replaced them.
-func (c *Checker) findInferTypes(t type_system.Type) map[string]type_system.Type {
+func (c *Checker) findInferTypes(t type_system.Type, j type_system.Journal) map[string]type_system.Type {
 	visitor := &InferTypeFinder{
 		checker:   c,
 		inferVars: make(map[string]type_system.Type),
+		j:         j,
 	}
 	t.Accept(visitor)
 	return visitor.inferVars
@@ -2394,6 +2403,7 @@ func (c *Checker) findInferTypes(t type_system.Type) map[string]type_system.Type
 type InferTypeFinder struct {
 	checker   *Checker
 	inferVars map[string]type_system.Type
+	j         type_system.Journal
 }
 
 func (v *InferTypeFinder) EnterType(t type_system.Type) type_system.EnterResult {
@@ -2402,7 +2412,7 @@ func (v *InferTypeFinder) EnterType(t type_system.Type) type_system.EnterResult 
 }
 
 func (v *InferTypeFinder) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t, nil)
+	t = type_system.Prune(t, v.j)
 
 	if inferType, ok := t.(*type_system.InferType); ok {
 		if existingVar, exists := v.inferVars[inferType.Name]; exists {
@@ -2420,9 +2430,10 @@ func (v *InferTypeFinder) ExitType(t type_system.Type) type_system.Type {
 }
 
 // replaceInferTypes substitutes infer variables in a type with their inferred values from the mapping.
-func (c *Checker) replaceInferTypes(t type_system.Type, inferMapping map[string]type_system.Type) type_system.Type {
+func (c *Checker) replaceInferTypes(t type_system.Type, inferMapping map[string]type_system.Type, j type_system.Journal) type_system.Type {
 	visitor := &InferTypeReplacer{
 		inferMapping: inferMapping,
+		j:            j,
 	}
 	return t.Accept(visitor)
 }
@@ -2431,6 +2442,7 @@ func (c *Checker) replaceInferTypes(t type_system.Type, inferMapping map[string]
 // with their actual inferred values
 type InferTypeReplacer struct {
 	inferMapping map[string]type_system.Type
+	j            type_system.Journal
 }
 
 func (v *InferTypeReplacer) EnterType(t type_system.Type) type_system.EnterResult {
@@ -2439,7 +2451,7 @@ func (v *InferTypeReplacer) EnterType(t type_system.Type) type_system.EnterResul
 }
 
 func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t, nil)
+	t = type_system.Prune(t, v.j)
 
 	// Check if this is an InferType that should be replaced
 	if inferType, ok := t.(*type_system.InferType); ok {
@@ -2458,8 +2470,8 @@ func (v *InferTypeReplacer) ExitType(t type_system.Type) type_system.Type {
 // it returns the exact element type; otherwise it returns never. For Array<T>
 // it returns T (the index doesn't matter since all elements have the same
 // type). For unresolved types it returns the type as-is.
-func restElemType(rest *type_system.RestSpreadType, index int) type_system.Type {
-	resolved := type_system.Prune(rest.Type, nil)
+func restElemType(rest *type_system.RestSpreadType, index int, j type_system.Journal) type_system.Type {
+	resolved := type_system.Prune(rest.Type, j)
 	switch r := resolved.(type) {
 	case *type_system.TupleType:
 		// Count fixed (non-rest) elements and find any nested rest spread.
@@ -2486,7 +2498,7 @@ func restElemType(rest *type_system.RestSpreadType, index int) type_system.Type 
 			}
 		}
 		if nestedRest != nil {
-			return restElemType(nestedRest, index-fixedCount)
+			return restElemType(nestedRest, index-fixedCount, j)
 		}
 		return type_system.NewNeverType(nil)
 	case *type_system.TypeRefType:
@@ -2504,11 +2516,11 @@ func restElemType(rest *type_system.RestSpreadType, index int) type_system.Type 
 // RestSpreadType whose inner type is an Array<T>, T is included; for a
 // TupleType, its elements are included; otherwise the rest type itself
 // is included.
-func tupleElemUnion(t *type_system.TupleType) type_system.Type {
+func tupleElemUnion(t *type_system.TupleType, j type_system.Journal) type_system.Type {
 	var types []type_system.Type
 	for _, elem := range t.Elems {
 		if rest, ok := elem.(*type_system.RestSpreadType); ok {
-			resolved := type_system.Prune(rest.Type, nil)
+			resolved := type_system.Prune(rest.Type, j)
 			switch r := resolved.(type) {
 			case *type_system.TupleType:
 				types = append(types, r.Elems...)

--- a/internal/checker/generalize.go
+++ b/internal/checker/generalize.go
@@ -34,7 +34,7 @@ func collectUnresolvedTypeVarsImpl(
 		return
 	}
 
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	if visited.Contains(t) {
 		return
@@ -147,7 +147,7 @@ func collectUnresolvedTypeVarsImpl(
 // Container types (FuncType, TupleType, etc.) are rebuilt; leaf types (LitType,
 // PrimType, NeverType, etc.) are shared since Unify never mutates them.
 func (c *Checker) deepCloneType(t type_system.Type, varMapping map[int]*type_system.TypeVarType) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	switch t := t.(type) {
 	case *type_system.TypeVarType:
 		if fresh, ok := varMapping[t.ID]; ok {
@@ -383,7 +383,7 @@ func (c *Checker) tryMergeCallSitesWithOptionalParams(ctx Context, sites []*type
 			return nil // shouldn't happen after sort, but defensive
 		}
 		for j := 0; j < prefixLen; j++ {
-			if !type_system.Equals(type_system.Prune(site.Params[j].Type), type_system.Prune(shortest.Params[j].Type)) {
+			if !type_system.Equals(type_system.Prune(site.Params[j].Type, ctx.BindJournal), type_system.Prune(shortest.Params[j].Type, ctx.BindJournal)) {
 				return nil // prefix doesn't match
 			}
 		}
@@ -392,7 +392,7 @@ func (c *Checker) tryMergeCallSitesWithOptionalParams(ctx Context, sites []*type
 		// corresponding prefix of the longest.
 		for j := prefixLen; j < len(site.Params); j++ {
 			if j < len(longest.Params) {
-				if !type_system.Equals(type_system.Prune(site.Params[j].Type), type_system.Prune(longest.Params[j].Type)) {
+				if !type_system.Equals(type_system.Prune(site.Params[j].Type, ctx.BindJournal), type_system.Prune(longest.Params[j].Type, ctx.BindJournal)) {
 					return nil
 				}
 			}
@@ -445,7 +445,7 @@ func (c *Checker) resolveCallSites(ctx Context) {
 		// existing binding, and (2) the call sites' arg types were already unified
 		// against the synthetic FuncType params during handleFuncCall, so type
 		// constraints from the calls have already been captured.
-		if type_system.Prune(tv) != tv {
+		if type_system.Prune(tv, ctx.BindJournal) != tv {
 			continue
 		}
 
@@ -518,7 +518,7 @@ func finalizeOpenObject(openObj *type_system.ObjectType) bool {
 		// widenable TypeVar created by newOpenObjectWithProperty; if any
 		// chained access bound it to another open object, that object is
 		// the recursive target.
-		valPruned := type_system.Prune(prop.Value)
+		valPruned := type_system.Prune(prop.Value, nil)
 		if nestedObj, ok := valPruned.(*type_system.ObjectType); ok && nestedObj.Open {
 			if finalizeOpenObject(nestedObj) {
 				// Per the invariant documented above, prop.Value is always a
@@ -671,7 +671,7 @@ func leadsToCycle(t type_system.Type, target type_system.Type, visited set.Set[t
 	if t == nil {
 		return false
 	}
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	if t == target {
 		return true
 	}
@@ -778,7 +778,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 			if !ok {
 				continue
 			}
-			pruned := type_system.Prune(tv)
+			pruned := type_system.Prune(tv, nil)
 			openObj, ok := pruned.(*type_system.ObjectType)
 			if !ok || !openObj.Open {
 				continue
@@ -890,7 +890,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 			if _, inReturn := fv.returnVars[id]; !inReturn {
 				continue
 			}
-			pruned := type_system.Prune(funcType.Return)
+			pruned := type_system.Prune(funcType.Return, nil)
 			tv, ok := pruned.(*type_system.TypeVarType)
 			if !ok || tv.ID != id {
 				allTopLevel = false
@@ -908,7 +908,7 @@ func generalizeFuncTypes(funcTypes []*type_system.FuncType, excluded set.Set[int
 	// never — these can't both be expressed via TV.Instance, so the
 	// throws field is rewritten directly.)
 	for _, funcType := range funcTypes {
-		throwsTV, ok := type_system.Prune(funcType.Throws).(*type_system.TypeVarType)
+		throwsTV, ok := type_system.Prune(funcType.Throws, nil).(*type_system.TypeVarType)
 		if !ok {
 			continue
 		}

--- a/internal/checker/generalize_test.go
+++ b/internal/checker/generalize_test.go
@@ -40,7 +40,7 @@ func TestGeneralizeFuncType_TypeVarConstraintWithNestedTypeVar(t *testing.T) {
 	assert.Equal(t, "Array", ts.QualIdentToString(constraint.Name))
 	assert.Len(t, constraint.TypeArgs, 1)
 	// The type arg resolves (via Prune) to a TypeRefType referencing T1
-	typeArg, ok := ts.Prune(constraint.TypeArgs[0]).(*ts.TypeRefType)
+	typeArg, ok := ts.Prune(constraint.TypeArgs[0], nil).(*ts.TypeRefType)
 	assert.True(t, ok, "type arg should resolve to a TypeRefType")
 	assert.Equal(t, "T1", ts.QualIdentToString(typeArg.Name))
 }
@@ -322,7 +322,7 @@ func TestGeneralizeFuncType_ThrowsOnlyTypeVarBecomesNever(t *testing.T) {
 
 	assert.Len(t, funcType.TypeParams, 0)
 	// tvThrows should have been resolved to never
-	pruned := ts.Prune(tvThrows)
+	pruned := ts.Prune(tvThrows, nil)
 	_, isNever := pruned.(*ts.NeverType)
 	assert.True(t, isNever)
 }

--- a/internal/checker/infer_class_decl.go
+++ b/internal/checker/infer_class_decl.go
@@ -281,7 +281,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 		extendsType, extendsErrors := c.inferTypeAnn(declCtx, decl.Extends)
 		errors = slices.Concat(errors, extendsErrors)
 		if extendsType != nil {
-			if typeRef, ok := type_system.Prune(extendsType).(*type_system.TypeRefType); ok {
+			if typeRef, ok := type_system.Prune(extendsType, ctx.BindJournal).(*type_system.TypeRefType); ok {
 				objType.Extends = []*type_system.TypeRefType{typeRef}
 			}
 		}
@@ -291,7 +291,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 	for _, implTypeAnn := range decl.Implements {
 		implType, implErrors := c.inferTypeAnn(declCtx, implTypeAnn)
 		errors = slices.Concat(errors, implErrors)
-		typeRef, ok := type_system.Prune(implType).(*type_system.TypeRefType)
+		typeRef, ok := type_system.Prune(implType, ctx.BindJournal).(*type_system.TypeRefType)
 		if !ok {
 			continue
 		}
@@ -404,7 +404,7 @@ func (c *Checker) inferClassDecl(ctx Context, decl *ast.ClassDecl) []Error {
 			if isStatic && bodyElem.Value == nil {
 				resolved, expandErrors := c.ExpandType(ctx, prop.Value, 1)
 				errors = slices.Concat(errors, expandErrors)
-				if !typeContainsUndefined(type_system.Prune(resolved)) {
+				if !typeContainsUndefined(type_system.Prune(resolved, ctx.BindJournal)) {
 					errors = append(errors, StaticFieldMissingInitializerError{
 						FieldName: classFieldName(bodyElem.Name),
 						span:      bodyElem.Span(),

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -953,10 +953,12 @@ func (c *Checker) isPropertyReadonly(ctx Context, objType type_system.Type, prop
 // Array<T1 | T2 | ...> (e.g. [...Array<T>] → Array<T>). Otherwise it
 // returns a TupleType with the elements as-is.
 //
-// Note: this function does not Prune elements before checking because it is
-// called during inference before call-site specialization. TypeVarType-based
-// rests (e.g. [...T0]) are still unbound at this point and correctly fall
-// through to the TupleType path.
+// Only rest-spread elements are Pruned (with a nil journal — no probe is
+// active at tuple-expression inference time, see analysis in PR #672).
+// Non-rest elements are intentionally left unpruned because inference and
+// call-site specialization order requires it: TypeVarType-based elements
+// are still unbound at this point and must fall through to the TupleType
+// path so the downstream Unify can drive their binding.
 func collapseArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.Type {
 	var unionMembers []type_system.Type
 	for _, elem := range elems {

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1069,6 +1069,12 @@ func (c *Checker) inferCallExpr(
 				// param-arg unifications and binds the return TypeVar,
 				// so a single (t1, t2) Probe doesn't fit.
 				scope := c.beginProbeScope(&ctx)
+				// Snapshot expr.ResolvedThrows so a failed arm's
+				// handleFuncCall write is rolled back by Discard. Probe-
+				// nil-receiver safe; if there's no journal (no probe is
+				// active above this dispatch), AddCleanup is a no-op.
+				prevThrows := expr.ResolvedThrows()
+				ctx.BindJournal.AddCleanup(func() { expr.SetResolvedThrows(prevThrows) })
 				retType, callErrors := c.handleFuncCall(ctx, funcType, expr, argTypes, provneance, []Error{})
 
 				if len(callErrors) == 0 {
@@ -1076,20 +1082,16 @@ func (c *Checker) inferCallExpr(
 					return retType, errors
 				}
 
-				// Roll back the arm's TypeVar mutations so the next arm
-				// sees a clean slate. SetResolvedThrows on `expr` is not
-				// journaled — the cleanup below clears it after the
-				// loop, matching the prior behavior.
+				// Roll back the arm's TypeVar mutations and the
+				// SetResolvedThrows cleanup so the next arm sees a clean
+				// slate.
 				scope.Discard()
 				attemptedErrors = append(attemptedErrors, callErrors)
 			}
 		}
 
-		// No overload matched - create a comprehensive error.
-		// Clear ResolvedThrows since handleFuncCall set it on the last
-		// attempted (failing) arm; downstream code should treat this
-		// call as having no resolved signature.
-		expr.SetResolvedThrows(nil)
+		// No overload matched; all arms have Discard'd their state,
+		// including ResolvedThrows. Build the error.
 		overloadErr := &NoMatchingOverloadError{
 			CallExpr:         expr,
 			IntersectionType: t,

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -78,7 +78,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 						span:     expr.Left.Span(),
 					})
 				} else {
-					pruned := type_system.Prune(objType)
+					pruned := type_system.Prune(objType, ctx.BindJournal)
 					// Open object types start without a MutType wrapper —
 					// mark the property as written since we now know mutation occurs.
 					if !markPropertyWritten(pruned, memberExpr.Prop.Name) {
@@ -125,7 +125,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 						span:     expr.Left.Span(),
 					})
 				} else {
-					pruned := type_system.Prune(objType)
+					pruned := type_system.Prune(objType, ctx.BindJournal)
 					// Check if the base has an ArrayConstraint — mark index assignment
 					if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
 						tv.ArrayConstraint.HasIndexAssignment = true
@@ -295,7 +295,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 			// We create a new type and set its provenance to be the identifier
 			// instead of the binding source.  This ensures that errors are reported
 			// on the identifier itself instead of the binding source.
-			t := type_system.Prune(binding.Type)
+			t := type_system.Prune(binding.Type, ctx.BindJournal)
 			if _, isTypeVar := t.(*type_system.TypeVarType); isTypeVar {
 				// Don't copy TypeVarType — preserving pointer identity is essential
 				// so that unification constraints flow back to the function signature.
@@ -330,10 +330,10 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 				spreadType, spreadErrors := c.inferExpr(ctx, spread.Value)
 				errors = slices.Concat(errors, spreadErrors)
 
-				prunedType := type_system.Prune(spreadType)
+				prunedType := type_system.Prune(spreadType, ctx.BindJournal)
 				// Unwrap MutType if present
 				if mut, ok := prunedType.(*type_system.MutType); ok {
-					prunedType = type_system.Prune(mut.Type)
+					prunedType = type_system.Prune(mut.Type, ctx.BindJournal)
 				}
 				handled := false
 				switch st := prunedType.(type) {
@@ -690,7 +690,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 					expr := expr.Exprs[i]
 					t, _ := c.inferExpr(ctx, expr)
 
-					switch t := type_system.Prune(t).(type) {
+					switch t := type_system.Prune(t, ctx.BindJournal).(type) {
 					case *type_system.LitType:
 						str += t.Lit.String()
 					default:
@@ -752,7 +752,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 		// For if-let expressions, we need to narrow the target type by removing null/undefined
 		// The pattern should match the non-nullable part of the target type
 		narrowedTargetType := targetType
-		if unionType, ok := type_system.Prune(targetType).(*type_system.UnionType); ok {
+		if unionType, ok := type_system.Prune(targetType, ctx.BindJournal).(*type_system.UnionType); ok {
 			definedElems := c.getDefinedElems(unionType)
 			if len(definedElems) > 0 {
 				narrowedTargetType = type_system.NewUnionType(nil, definedElems...)
@@ -907,7 +907,7 @@ func (c *Checker) inferExpr(ctx Context, expr ast.Expr) (type_system.Type, []Err
 
 // isPropertyReadonly checks if a specific property in an object type is readonly
 func (c *Checker) isPropertyReadonly(ctx Context, objType type_system.Type, propertyName string) bool {
-	objType = type_system.Prune(objType)
+	objType = type_system.Prune(objType, ctx.BindJournal)
 
 	// Repeatedly expand objType until it's either an ObjectType or can't be expanded further
 	for {
@@ -964,7 +964,7 @@ func collapseArrayRestSpreads(c *Checker, elems []type_system.Type) type_system.
 		if !ok {
 			return type_system.NewTupleType(nil, elems...)
 		}
-		inner := type_system.Prune(rest.Type)
+		inner := type_system.Prune(rest.Type, nil)
 		ref, ok := inner.(*type_system.TypeRefType)
 		if !ok || !c.isArrayType(ref) || len(ref.TypeArgs) == 0 {
 			return type_system.NewTupleType(nil, elems...)
@@ -1010,7 +1010,7 @@ func (c *Checker) inferCallExpr(
 				&CalleeIsNotCallableError{Type: calleeType, span: expr.Callee.Span()}}
 		}
 
-		if objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType); ok {
+		if objType, ok := type_system.Prune(typeAlias.Type, ctx.BindJournal).(*type_system.ObjectType); ok {
 			// Check if ObjectType has a constructor or callable element
 			var fnType *type_system.FuncType = nil
 
@@ -1276,7 +1276,7 @@ func (c *Checker) handleFuncCall(
 		returnType := fnType.Return
 		// Don't copy TypeVarType — preserving pointer identity is essential
 		// so that unification constraints flow back to the caller.
-		if _, isTypeVar := type_system.Prune(returnType).(*type_system.TypeVarType); !isTypeVar {
+		if _, isTypeVar := type_system.Prune(returnType, ctx.BindJournal).(*type_system.TypeVarType); !isTypeVar {
 			returnType = returnType.Copy()
 			returnType.SetProvenance(provneance)
 		}
@@ -1327,7 +1327,7 @@ func (c *Checker) handleFuncCall(
 		returnType := fnType.Return
 		// Don't copy TypeVarType — preserving pointer identity is essential
 		// so that unification constraints flow back to the caller.
-		if _, isTypeVar := type_system.Prune(returnType).(*type_system.TypeVarType); !isTypeVar {
+		if _, isTypeVar := type_system.Prune(returnType, ctx.BindJournal).(*type_system.TypeVarType); !isTypeVar {
 			returnType = returnType.Copy()
 			returnType.SetProvenance(provneance)
 		}
@@ -1402,7 +1402,7 @@ func (c *Checker) inferMatchExpr(ctx Context, expr *ast.MatchExpr) (type_system.
 	matchErrors = slices.Concat(matchErrors, targetErrors)
 
 	// Check if target type is a constructor when patterns expect instances
-	targetObjType, isObj := type_system.Prune(targetType).(*type_system.ObjectType)
+	targetObjType, isObj := type_system.Prune(targetType, ctx.BindJournal).(*type_system.ObjectType)
 	if isObj {
 		hasCallableOrConstructor := false
 		for _, elem := range targetObjType.Elems {
@@ -1441,7 +1441,7 @@ func (c *Checker) inferMatchExpr(ctx Context, expr *ast.MatchExpr) (type_system.
 	// Phase 2: If the target is an unresolved TypeVar (e.g. an unannotated
 	// function parameter), infer its type from the match patterns before
 	// processing individual cases.
-	if _, isTypeVar := type_system.Prune(targetType).(*type_system.TypeVarType); isTypeVar {
+	if _, isTypeVar := type_system.Prune(targetType, ctx.BindJournal).(*type_system.TypeVarType); isTypeVar {
 		if inferredType := c.inferTargetTypeFromPatterns(ctx, expr.Cases, patternInfos); inferredType != nil {
 			unifyErrors := c.Unify(ctx, targetType, inferredType)
 			matchErrors = slices.Concat(matchErrors, unifyErrors)
@@ -1636,7 +1636,7 @@ func (c *Checker) getEnumTypeFromExtractor(ctx Context, p *ast.ExtractorPat) typ
 	if binding == nil {
 		return nil
 	}
-	objType, ok := type_system.Prune(binding.Type).(*type_system.ObjectType)
+	objType, ok := type_system.Prune(binding.Type, ctx.BindJournal).(*type_system.ObjectType)
 	if !ok {
 		return nil
 	}

--- a/internal/checker/infer_expr.go
+++ b/internal/checker/infer_expr.go
@@ -1056,20 +1056,31 @@ func (c *Checker) inferCallExpr(
 		return c.handleFuncCall(ctx, fnType, expr, argTypes, provneance, errors)
 
 	case *type_system.IntersectionType:
-		// Try each function type in the intersection as a potential overload
+		// Try each function type in the intersection as a potential overload.
+		// Each arm runs under a probe scope so its partial TypeVar bindings
+		// are rolled back before the next arm is tried — without this,
+		// generic arms like (x: T) leak their binding for T into subsequent
+		// arms (see #660).
 		attemptedErrors := [][]Error{}
 
 		for _, funcType := range t.Types {
 			if funcType, ok := funcType.(*type_system.FuncType); ok {
-				// Try this overload
+				// Probe-scope spans the full arm: handleFuncCall does
+				// param-arg unifications and binds the return TypeVar,
+				// so a single (t1, t2) Probe doesn't fit.
+				scope := c.beginProbeScope(&ctx)
 				retType, callErrors := c.handleFuncCall(ctx, funcType, expr, argTypes, provneance, []Error{})
 
-				// If this overload succeeds (no errors), use it
 				if len(callErrors) == 0 {
+					scope.Commit()
 					return retType, errors
 				}
 
-				// Otherwise, record the errors for this overload attempt
+				// Roll back the arm's TypeVar mutations so the next arm
+				// sees a clean slate. SetResolvedThrows on `expr` is not
+				// journaled — the cleanup below clears it after the
+				// loop, matching the prior behavior.
+				scope.Discard()
 				attemptedErrors = append(attemptedErrors, callErrors)
 			}
 		}

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -351,7 +351,7 @@ func (c *Checker) inferFuncBodyWithFuncSigType(
 	// async/generator wrappers wrap the return in a Promise/Generator
 	// where `never` semantics differ.
 	if divergent && !containsYield && !isAsync {
-		annotated := type_system.Prune(funcSigType.Return)
+		annotated := type_system.Prune(funcSigType.Return, ctx.BindJournal)
 		if _, isTypeVar := annotated.(*type_system.TypeVarType); !isTypeVar {
 			if _, isNever := annotated.(*type_system.NeverType); !isNever {
 				errors = append(errors, DivergingBodyNonNeverReturnError{
@@ -575,7 +575,7 @@ func exprAlwaysExits(expr ast.Expr) bool {
 		// no-value sentinel rather than as a divergence marker
 		// (notably assignment expressions).
 		if t := e.InferredType(); t != nil {
-			if _, isNever := type_system.Prune(t).(*type_system.NeverType); isNever {
+			if _, isNever := type_system.Prune(t, nil).(*type_system.NeverType); isNever {
 				return true
 			}
 		}
@@ -740,7 +740,7 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 // clause, or its throws type is `never`).
 func calleeThrowsType(callExpr *ast.CallExpr) type_system.Type {
 	if rt := callExpr.ResolvedThrows(); rt != nil {
-		if _, isNever := type_system.Prune(rt).(*type_system.NeverType); isNever {
+		if _, isNever := type_system.Prune(rt, nil).(*type_system.NeverType); isNever {
 			return nil
 		}
 		return rt
@@ -752,13 +752,13 @@ func calleeThrowsType(callExpr *ast.CallExpr) type_system.Type {
 	if calleeType == nil {
 		return nil
 	}
-	fns := collectCalleeFuncTypes(type_system.Prune(calleeType))
+	fns := collectCalleeFuncTypes(type_system.Prune(calleeType, nil))
 	throws := []type_system.Type{}
 	for _, fn := range fns {
 		if fn.Throws == nil {
 			continue
 		}
-		if _, isNever := type_system.Prune(fn.Throws).(*type_system.NeverType); isNever {
+		if _, isNever := type_system.Prune(fn.Throws, nil).(*type_system.NeverType); isNever {
 			continue
 		}
 		throws = append(throws, fn.Throws)
@@ -801,11 +801,11 @@ func collectCalleeFuncTypes(t type_system.Type) []*type_system.FuncType {
 		if tt.TypeAlias == nil {
 			return nil
 		}
-		return collectCalleeFuncTypes(type_system.Prune(tt.TypeAlias.Type))
+		return collectCalleeFuncTypes(type_system.Prune(tt.TypeAlias.Type, nil))
 	case *type_system.IntersectionType:
 		var out []*type_system.FuncType
 		for _, arm := range tt.Types {
-			out = append(out, collectCalleeFuncTypes(type_system.Prune(arm))...)
+			out = append(out, collectCalleeFuncTypes(type_system.Prune(arm, nil))...)
 		}
 		return out
 	default:
@@ -868,7 +868,7 @@ func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 		// equivalence class. If Instance is set (param was unified with the
 		// return TypeVar), the representative is the other end of the chain;
 		// otherwise the param TypeVar is its own representative.
-		rep := type_system.Prune(tv)
+		rep := type_system.Prune(tv, nil)
 		if repTV, ok := rep.(*type_system.TypeVarType); ok {
 			repTV.Instance = resolved
 		} else {
@@ -880,7 +880,7 @@ func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 		return
 	}
 
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	// Recurse into type constructors that can appear in inferred parameter types.
 	// We only need to cover shapes produced by inference on unannotated params:
@@ -1005,7 +1005,7 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 // constructors (TypeRefType args, TupleType elements, UnionType options, etc.)
 // to find and close nested open objects.
 func closeOpenObjectsInType(t type_system.Type, returnVars map[int]*type_system.TypeVarType) {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 
 	// If t is a TypeVar resolving to an open object, finalize and close it.
 	// Setting tv.Instance is the standard union-find mechanism: Prune()
@@ -1087,7 +1087,7 @@ func closeObjectType(objType *type_system.ObjectType, returnVars map[int]*type_s
 	filtered := make([]type_system.ObjTypeElem, 0, len(objType.Elems))
 	for _, elem := range objType.Elems {
 		if rest, ok := elem.(*type_system.RestSpreadElem); ok {
-			if rowVar, ok := type_system.Prune(rest.Value).(*type_system.TypeVarType); ok {
+			if rowVar, ok := type_system.Prune(rest.Value, nil).(*type_system.TypeVarType); ok {
 				if _, found := returnVars[rowVar.ID]; !found {
 					continue // remove this RestSpreadElem
 				}
@@ -1109,7 +1109,7 @@ func closeTupleType(tupleType *type_system.TupleType, returnVars map[int]*type_s
 	}
 	last := tupleType.Elems[len(tupleType.Elems)-1]
 	if rest, ok := last.(*type_system.RestSpreadType); ok {
-		if tv, ok := type_system.Prune(rest.Type).(*type_system.TypeVarType); ok {
+		if tv, ok := type_system.Prune(rest.Type, nil).(*type_system.TypeVarType); ok {
 			// Preserve rest variables from explicit destructuring patterns.
 			// For example, in `fn foo([first, ...rest]) { return first }`,
 			// the rest type variable should be kept even though it doesn't

--- a/internal/checker/infer_func.go
+++ b/internal/checker/infer_func.go
@@ -574,6 +574,15 @@ func exprAlwaysExits(expr ast.Expr) bool {
 		// expression forms in this codebase use `never` as a
 		// no-value sentinel rather than as a divergence marker
 		// (notably assignment expressions).
+		//
+		// Prune journal is nil because exprAlwaysExits runs during
+		// post-body control-flow analysis (called from
+		// inferFuncBodyWithFuncSigType), never inside a Probe scope —
+		// no probe is open during top-level body inference. If a future
+		// feature triggers exit analysis inside the unifier or expand
+		// path (currently unreachable), this site and every other
+		// Prune(..., nil) below in this file would need to take the
+		// active ctx.BindJournal.
 		if t := e.InferredType(); t != nil {
 			if _, isNever := type_system.Prune(t, nil).(*type_system.NeverType); isNever {
 				return true
@@ -738,6 +747,14 @@ func (c *Checker) findThrowTypes(ctx Context, block *ast.Block) ([]type_system.T
 //
 // Returns nil when no throws can be attributed (callee has no throws
 // clause, or its throws type is `never`).
+//
+// Prune journal is nil throughout: this is post-body throws collection,
+// reachable only from findThrowTypes → inferFuncBodyWithFuncSigType.
+// To require journal threading, an inferExpr-driven path would have to
+// call calleeThrowsType from inside a Probe scope (e.g. if the unifier
+// gained a lazy expression-inference hook). In that case calleeThrowsType
+// and collectCalleeFuncTypes would both need to take a Journal parameter
+// and forward it into every Prune call below.
 func calleeThrowsType(callExpr *ast.CallExpr) type_system.Type {
 	if rt := callExpr.ResolvedThrows(); rt != nil {
 		if _, isNever := type_system.Prune(rt, nil).(*type_system.NeverType); isNever {
@@ -855,6 +872,14 @@ func (c *Checker) closeOpenParams(funcSigType *type_system.FuncType) {
 // the pre-prune check catches it), or the incoming TypeVar's representative
 // is a different param TypeVar that will be processed in its own iteration
 // of closeOpenParams's loop over all params.
+//
+// Prune journal is nil here: this is closing-time, after body inference
+// completes and before generalization, called from closeOpenParams which
+// is itself called outside any Probe. Threading would be required if a
+// future code path performs closing inside a Probe (e.g. speculative
+// generalization of a candidate signature). At that point this function
+// and its recursive walk over params/returns would need to take a
+// Journal parameter and forward it into every Prune call.
 func (c *Checker) resolveArrayConstraintsInType(t type_system.Type) {
 	// Check for ArrayConstraint before pruning: a param TypeVar with an
 	// ArrayConstraint may have had its Instance set during return-type
@@ -1004,6 +1029,14 @@ func (c *Checker) resolveArrayConstraint(constraint *type_system.ArrayConstraint
 // mutability and closes the object. Otherwise, it recurses into type
 // constructors (TypeRefType args, TupleType elements, UnionType options, etc.)
 // to find and close nested open objects.
+//
+// Prune journal is nil here and in closeObjectType / closeTupleType: the
+// whole close-family runs at closing time, after body inference and
+// outside any Probe. To require threading, a future feature would need to
+// run object/tuple closing speculatively inside a probe (e.g. trial
+// closure to test if a signature would be inferred correctly). All three
+// close-family functions would then need to take a Journal parameter and
+// forward it to every Prune call below.
 func closeOpenObjectsInType(t type_system.Type, returnVars map[int]*type_system.TypeVarType) {
 	pruned := type_system.Prune(t, nil)
 

--- a/internal/checker/infer_jsx.go
+++ b/internal/checker/infer_jsx.go
@@ -552,6 +552,15 @@ func (c *Checker) resolveJSXComponentType(ctx Context, tagName ast.QualIdent) (t
 // extractPropsFromComponentType extracts the props type from a component type.
 // For function components (fn(props: Props) -> JSX.Element), it returns the first parameter's type.
 // For other component patterns (class components, etc.), it returns nil to allow any props.
+//
+// Prune journal is nil because JSX inference (inferJSXElement → getComponentProps
+// → extractPropsFromComponentType) runs at expression-inference time and is
+// not reachable from any Probe scope: nothing in unify.go or expand_type.go
+// invokes inferJSX*. To require threading, the unifier would need to
+// expand component-typed values speculatively inside a Probe — at that
+// point this function would need to take ctx (or a Journal) and forward
+// it into the Prune call here, plus its caller getComponentProps would
+// need to plumb the journal in.
 func (c *Checker) extractPropsFromComponentType(componentType type_system.Type) type_system.Type {
 	// Prune to get the underlying type (resolve type variables, etc.)
 	prunedType := type_system.Prune(componentType, nil)

--- a/internal/checker/infer_jsx.go
+++ b/internal/checker/infer_jsx.go
@@ -112,7 +112,7 @@ func (c *Checker) unifyJSXPropsWithAttrs(ctx Context, propsType type_system.Type
 	c.collectPropsFromType(ctx, propsType, &expectedProps, &requiredProps)
 
 	// Get the provided attributes as an object type
-	attrObj, ok := type_system.Prune(attrType).(*type_system.ObjectType)
+	attrObj, ok := type_system.Prune(attrType, ctx.BindJournal).(*type_system.ObjectType)
 	if !ok {
 		return errors
 	}
@@ -242,7 +242,7 @@ func (c *Checker) inferJSXAttributes(ctx Context, attrs []ast.JSXAttrElem) (JSXA
 			// Note: key and ref in spread objects are passed through to regular props
 			// (this matches React's behavior - only explicit key/ref are special)
 			if spreadType != nil {
-				if objType, ok := type_system.Prune(spreadType).(*type_system.ObjectType); ok {
+				if objType, ok := type_system.Prune(spreadType, ctx.BindJournal).(*type_system.ObjectType); ok {
 					elems = append(elems, objType.Elems...)
 				}
 				// For non-object spread types, we could add an error, but for now
@@ -323,7 +323,7 @@ func (c *Checker) validateChildrenType(
 	var childrenPropOptional bool
 	var childrenPropExists bool
 
-	if objType, ok := type_system.Prune(propsType).(*type_system.ObjectType); ok {
+	if objType, ok := type_system.Prune(propsType, ctx.BindJournal).(*type_system.ObjectType); ok {
 		for _, elem := range objType.Elems {
 			if prop, ok := elem.(*type_system.PropertyElem); ok {
 				if prop.Name.Kind == type_system.StrObjTypeKeyKind && prop.Name.Str == "children" {
@@ -464,7 +464,7 @@ func (c *Checker) getIntrinsicElementProps(ctx Context, tagName ast.QualIdent, e
 	}
 
 	// Get the underlying type (resolve type aliases, type variables, etc.)
-	intrinsicType := type_system.Prune(intrinsicElements.Type)
+	intrinsicType := type_system.Prune(intrinsicElements.Type, ctx.BindJournal)
 
 	// IntrinsicElements should be an object type mapping tag names to prop types
 	switch t := intrinsicType.(type) {
@@ -554,7 +554,7 @@ func (c *Checker) resolveJSXComponentType(ctx Context, tagName ast.QualIdent) (t
 // For other component patterns (class components, etc.), it returns nil to allow any props.
 func (c *Checker) extractPropsFromComponentType(componentType type_system.Type) type_system.Type {
 	// Prune to get the underlying type (resolve type variables, etc.)
-	prunedType := type_system.Prune(componentType)
+	prunedType := type_system.Prune(componentType, nil)
 
 	switch t := prunedType.(type) {
 	case *type_system.FuncType:
@@ -630,7 +630,7 @@ func (c *Checker) collectPropsFromType(
 	expectedProps *btree.Map[string, type_system.Type],
 	requiredProps *btree.Set[string],
 ) {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, ctx.BindJournal)
 
 	switch typ := t.(type) {
 	case *type_system.ObjectType:

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -485,9 +485,9 @@ func descendIntoSlot(t type_system.Type, path []liveness.ProjectionStep) type_sy
 // here so we can match against TupleType / ObjectType / Array<T> /
 // Promise<T> regardless of mutability wrappers.
 func stepIntoSlot(t type_system.Type, step liveness.ProjectionStep) type_system.Type {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 	if mut, ok := pruned.(*type_system.MutType); ok {
-		pruned = type_system.Prune(mut.Type)
+		pruned = type_system.Prune(mut.Type, nil)
 	}
 	switch s := step.(type) {
 	case liveness.IndexOf:
@@ -616,7 +616,7 @@ func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
 	if pat == nil || t == nil {
 		return
 	}
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	switch p := pat.(type) {
 	case *ast.IdentPat:
 		if p.VarID > 0 {
@@ -712,7 +712,7 @@ func walkPatternForLeaves(pat ast.Pat, t type_system.Type, into *[]paramLeaf) {
 // not wrapped.
 func stripMutabilityWrapper(t type_system.Type) type_system.Type {
 	if mt, ok := t.(*type_system.MutType); ok {
-		return type_system.Prune(mt.Type)
+		return type_system.Prune(mt.Type, nil)
 	}
 	return t
 }
@@ -720,7 +720,7 @@ func stripMutabilityWrapper(t type_system.Type) type_system.Type {
 // arrayElemType returns the element type T of an Array<T> reference,
 // walking past mutability wrappers. Returns nil if t is not an Array.
 func arrayElemType(t type_system.Type) type_system.Type {
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	tref, ok := pt.(*type_system.TypeRefType)
 	if !ok {
 		return nil
@@ -843,7 +843,7 @@ func (v *escapingRefsVisitor) isEscapingLValue(expr ast.Expr) bool {
 // Has no effect on types that don't carry a lifetime field (primitives,
 // void, never, etc.).
 func setLifetimeOnType(t type_system.Type, lt type_system.Lifetime) {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.TypeRefType:
 		ty.Lifetime = lt
 	case *type_system.ObjectType:
@@ -964,7 +964,7 @@ func walkPatternForStaticLeaves(pat type_system.Pat, t type_system.Type, into *[
 	if pat == nil || t == nil {
 		return
 	}
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	switch p := pat.(type) {
 	case *type_system.IdentPat:
 		lt := type_system.PruneLifetime(type_system.GetLifetime(t))
@@ -1297,7 +1297,7 @@ func attachFieldSlotLifetimes(
 	// The instance type is the class's TypeAlias.Type, which after Prune
 	// is the ObjectType holding the field properties. Anything else (e.g.
 	// a generic instantiation that hasn't resolved yet) is skipped.
-	instanceObj, ok := type_system.Prune(instanceType).(*type_system.ObjectType)
+	instanceObj, ok := type_system.Prune(instanceType, nil).(*type_system.ObjectType)
 	if !ok {
 		return
 	}
@@ -1505,7 +1505,7 @@ func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
 // constraint is itself lifetime-bearing — every legal instantiation of
 // the parameter will then have a place to attach the lifetime.
 func typeCarriesLifetime(t type_system.Type) bool {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.TypeRefType:
 		if ty.TypeAlias != nil && ty.TypeAlias.IsTypeParam {
 			// Phase 10.2: walk into the bound. For type-parameter
@@ -1539,7 +1539,7 @@ func typeCarriesLifetime(t type_system.Type) bool {
 // real reference shapes (classes, parameterized aliases over objects)
 // flow through it.
 func boundCarriesLifetime(t type_system.Type) bool {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.TypeRefType:
 		if ty.TypeAlias != nil && ty.TypeAlias.IsTypeParam {
 			if ty.TypeAlias.Type == nil {
@@ -1572,7 +1572,7 @@ func cloneLifetimeBearing(t type_system.Type) type_system.Type {
 	if !boundCarriesLifetime(t) {
 		return nil
 	}
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.MutType:
 		inner := cloneLifetimeBearing(ty.Type)
 		if inner == nil {
@@ -1591,7 +1591,7 @@ func cloneLifetimeBearing(t type_system.Type) type_system.Type {
 // shape, leaving any pre-existing annotation in place for the caller
 // to unify.
 func lifetimeBearingHasNoLifetime(t type_system.Type) bool {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.TypeRefType:
 		return ty.Lifetime == nil
 	case *type_system.ObjectType:
@@ -1607,7 +1607,7 @@ func lifetimeBearingHasNoLifetime(t type_system.Type) bool {
 // setLifetimeArgsOnType attaches a list of lifetime arguments to a
 // TypeRefType (e.g. Container<'a, 'b>), walking past mutability wrappers.
 func setLifetimeArgsOnType(t type_system.Type, args []type_system.Lifetime) {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.TypeRefType:
 		ty.LifetimeArgs = args
 	case *type_system.MutType:
@@ -1845,9 +1845,9 @@ func collectReturnLifetimeSlots(t type_system.Type) []returnLifetimeSlot {
 }
 
 func walkReturnLifetimeSlots(t type_system.Type, path []liveness.ProjectionStep, into *[]returnLifetimeSlot) {
-	pruned := type_system.Prune(t)
+	pruned := type_system.Prune(t, nil)
 	if mut, ok := pruned.(*type_system.MutType); ok {
-		pruned = type_system.Prune(mut.Type)
+		pruned = type_system.Prune(mut.Type, nil)
 	}
 	var lifetime type_system.Lifetime
 	switch ty := pruned.(type) {
@@ -1898,12 +1898,12 @@ func walkReturnLifetimeSlots(t type_system.Type, path []liveness.ProjectionStep,
 // extractFuncType reaches into the (possibly wrapped) callee type to find
 // the underlying FuncType. Mirrors the dispatch in inferCallExpr.
 func extractFuncType(t type_system.Type) *type_system.FuncType {
-	switch ty := type_system.Prune(t).(type) {
+	switch ty := type_system.Prune(t, nil).(type) {
 	case *type_system.FuncType:
 		return ty
 	case *type_system.TypeRefType:
 		if ty.TypeAlias != nil {
-			if obj, ok := type_system.Prune(ty.TypeAlias.Type).(*type_system.ObjectType); ok {
+			if obj, ok := type_system.Prune(ty.TypeAlias.Type, nil).(*type_system.ObjectType); ok {
 				return funcFromObjectType(obj)
 			}
 		}
@@ -1978,7 +1978,7 @@ func (v *returnExprVisitor) EnterDecl(decl ast.Decl) bool {
 // mutability wrappers. Returns nil if t is not a generator reference or
 // has no type args.
 func generatorYieldType(t type_system.Type) type_system.Type {
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	tref, ok := pt.(*type_system.TypeRefType)
 	if !ok {
 		return nil
@@ -1998,7 +1998,7 @@ func generatorYieldType(t type_system.Type) type_system.Type {
 // reference, walking past mutability wrappers. Returns nil if t is not
 // a generator reference or doesn't have a second type arg.
 func generatorReturnType(t type_system.Type) type_system.Type {
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	tref, ok := pt.(*type_system.TypeRefType)
 	if !ok {
 		return nil
@@ -2017,7 +2017,7 @@ func generatorReturnType(t type_system.Type) type_system.Type {
 // Promise<T, E> reference, walking past mutability wrappers. Returns
 // nil if t is not a Promise reference or has no type args.
 func promiseValueType(t type_system.Type) type_system.Type {
-	pt := stripMutabilityWrapper(type_system.Prune(t))
+	pt := stripMutabilityWrapper(type_system.Prune(t, nil))
 	tref, ok := pt.(*type_system.TypeRefType)
 	if !ok {
 		return nil

--- a/internal/checker/infer_module.go
+++ b/internal/checker/infer_module.go
@@ -203,7 +203,7 @@ func sortKeysForDefinitions(depGraph *dep_graph.DepGraph, keys []dep_graph.Bindi
 // encountered (skipped), so callers can emit a diagnostic for name collisions
 // between a function overload and a non-function binding.
 func collectFuncArms(t type_system.Type, arms *[]*type_system.FuncType) int {
-	switch t := type_system.Prune(t).(type) {
+	switch t := type_system.Prune(t, nil).(type) {
 	case *type_system.IntersectionType:
 		nonFunc := 0
 		for _, arm := range t.Types {
@@ -749,7 +749,7 @@ func (c *Checker) InferComponent(
 					errors = slices.Concat(errors, extendsErrors)
 
 					if extendsType != nil {
-						if typeRef, ok := type_system.Prune(extendsType).(*type_system.TypeRefType); ok {
+						if typeRef, ok := type_system.Prune(extendsType, ctx.BindJournal).(*type_system.TypeRefType); ok {
 							objType.Extends = []*type_system.TypeRefType{typeRef}
 						}
 					}
@@ -760,7 +760,7 @@ func (c *Checker) InferComponent(
 				for _, implTypeAnn := range decl.Implements {
 					implType, implErrors := c.inferTypeAnn(declCtx, implTypeAnn)
 					errors = slices.Concat(errors, implErrors)
-					typeRef, ok := type_system.Prune(implType).(*type_system.TypeRefType)
+					typeRef, ok := type_system.Prune(implType, ctx.BindJournal).(*type_system.TypeRefType)
 					if !ok {
 						continue
 					}
@@ -1048,7 +1048,7 @@ func (c *Checker) InferComponent(
 					// Generalize VarDecl bindings that resolve to FuncType.
 					// This handles cases like `val I = S(K)(K)` where the
 					// initializer is a call returning a FuncType with unresolved vars.
-					prunedType := type_system.Prune(decl.InferredType)
+					prunedType := type_system.Prune(decl.InferredType, ctx.BindJournal)
 					if funcType, ok := prunedType.(*type_system.FuncType); ok {
 						c.resolveCallSites(nsCtx)
 						pendingFuncTypes = append(pendingFuncTypes, funcType)
@@ -1073,7 +1073,7 @@ func (c *Checker) InferComponent(
 				// Get the existing type alias from the CURRENT namespace only.
 				// The placeholder phase should have created this in the current namespace.
 				existingTypeAlias := nsCtx.Scope.Namespace.Types[decl.Name.Name]
-				prunedType := type_system.Prune(existingTypeAlias.Type)
+				prunedType := type_system.Prune(existingTypeAlias.Type, ctx.BindJournal)
 
 				// Check if the pruned type is already an ObjectType (from a previous interface)
 				if existingObjType, ok := prunedType.(*type_system.ObjectType); ok && existingObjType.Interface {
@@ -1161,7 +1161,7 @@ func (c *Checker) InferComponent(
 						// Create the SymbolKeyMap for the object type
 						symbolKeyMap := make(map[int]any)
 
-						switch customMatcher := type_system.Prune(customMatcher).(type) {
+						switch customMatcher := type_system.Prune(customMatcher, ctx.BindJournal).(type) {
 						case *type_system.UniqueSymbolType:
 							subjectPat := &type_system.IdentPat{Name: "subject"}
 							// The subject type should include type arguments if the enum is generic
@@ -1259,7 +1259,7 @@ func (c *Checker) InferComponent(
 				}
 
 				typeAlias := nsCtx.Scope.GetTypeAlias(decl.Name.Name)
-				instanceType := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
+				instanceType := type_system.Prune(typeAlias.Type, ctx.BindJournal).(*type_system.ObjectType)
 
 				// Get the class binding to access static methods
 				classBinding := nsCtx.Scope.GetValue(decl.Name.Name)
@@ -1348,7 +1348,7 @@ func (c *Checker) InferComponent(
 								// is detected.
 								resolved, expandErrors := c.ExpandType(ctx, prop.Value, 1)
 								errors = slices.Concat(errors, expandErrors)
-								if !typeContainsUndefined(type_system.Prune(resolved)) {
+								if !typeContainsUndefined(type_system.Prune(resolved, ctx.BindJournal)) {
 									errors = append(errors, StaticFieldMissingInitializerError{
 										FieldName: classFieldName(bodyElem.Name),
 										span:      bodyElem.Span(),

--- a/internal/checker/infer_pat.go
+++ b/internal/checker/infer_pat.go
@@ -170,10 +170,10 @@ func (c *Checker) inferPattern(
 				bindings[name] = binding
 			}
 
-			typeAliasType := type_system.Prune(typeAlias.Type)
+			typeAliasType := type_system.Prune(typeAlias.Type, ctx.BindJournal)
 
 			if clsType, ok := typeAliasType.(*type_system.ObjectType); ok {
-				if patType, ok := type_system.Prune(patType).(*type_system.ObjectType); ok {
+				if patType, ok := type_system.Prune(patType, ctx.BindJournal).(*type_system.ObjectType); ok {
 					// We know that the object type inferred from this pattern
 					// must be an instance of the class type, so we set the ID
 					// of the pattern type to be the same as the class type.
@@ -222,7 +222,7 @@ func (c *Checker) inferPattern(
 // move from true → false, so this is a one-way OR.
 func updateBindingMutableFromType(bindings map[string]*type_system.Binding) {
 	for _, binding := range bindings {
-		if _, isMut := type_system.Prune(binding.Type).(*type_system.MutType); isMut {
+		if _, isMut := type_system.Prune(binding.Type, nil).(*type_system.MutType); isMut {
 			binding.Mutable = true
 		}
 	}

--- a/internal/checker/infer_stmt.go
+++ b/internal/checker/infer_stmt.go
@@ -453,7 +453,7 @@ func (c *Checker) inferInterface(
 			} else {
 				// If it's not a TypeRefType, we still set it but wrap it if needed
 				// This handles cases where the type might be pruned or indirect
-				prunedType := type_system.Prune(extendsType)
+				prunedType := type_system.Prune(extendsType, ctx.BindJournal)
 				if typeRef, ok := prunedType.(*type_system.TypeRefType); ok {
 					extendsTypes = append(extendsTypes, typeRef)
 				}
@@ -498,7 +498,7 @@ func (c *Checker) inferInterface(
 		errors = slices.Concat(errors, validateLifetimeErrors)
 
 		// If it exists, merge the elements
-		if existingObjType, ok := type_system.Prune(existingAlias.Type).(*type_system.ObjectType); ok &&
+		if existingObjType, ok := type_system.Prune(existingAlias.Type, ctx.BindJournal).(*type_system.ObjectType); ok &&
 			existingObjType.Interface {
 			// Validate that duplicate properties have compatible types
 			mergeErrors := c.validateInterfaceMerge(ctx, existingObjType, objType, decl)
@@ -674,7 +674,7 @@ func (c *Checker) inferEnumDecl(ctx Context, decl *ast.EnumDecl) []Error {
 
 			symbolKeyMap := make(map[int]any)
 
-			switch customMatcher := type_system.Prune(customMatcher).(type) {
+			switch customMatcher := type_system.Prune(customMatcher, ctx.BindJournal).(type) {
 			case *type_system.UniqueSymbolType:
 				subjectPat := &type_system.IdentPat{Name: "subject"}
 				subjectType := type_system.NewTypeRefType(

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -241,7 +241,7 @@ func (c *Checker) inferTypeAnn(
 			// However, if it's a TypeRefType (type parameter), we skip the check
 			// because it will be validated when the type is actually used/expanded.
 			// TODO: Also check if the value has a .toString() method.
-			if _, isTypeRef := type_system.Prune(typeAnnType).(*type_system.TypeRefType); !isTypeRef {
+			if _, isTypeRef := type_system.Prune(typeAnnType, ctx.BindJournal).(*type_system.TypeRefType); !isTypeRef {
 				unifyErrors := c.Unify(ctx, typeAnnType, strOrNumType)
 				errors = slices.Concat(errors, unifyErrors)
 			}

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -179,7 +179,7 @@ func (c *Checker) inferTypeAnn(
 		errors = slices.Concat(errors, extendsErrors)
 
 		// Find all InferType nodes in the extends type and create type aliases for them
-		inferTypesMap := c.findInferTypes(extendsType)
+		inferTypesMap := c.findInferTypes(extendsType, ctx.BindJournal)
 
 		// TODO: find all named capture groups in the extends type
 		// and add them to the context scope as type aliases

--- a/internal/checker/iterable.go
+++ b/internal/checker/iterable.go
@@ -14,7 +14,7 @@ func lookupSymbolID(ns *type_system.Namespace, name string) (int, bool) {
 	if !ok {
 		return 0, false
 	}
-	objType, ok := type_system.Prune(symbolConstructor.Type).(*type_system.ObjectType)
+	objType, ok := type_system.Prune(symbolConstructor.Type, nil).(*type_system.ObjectType)
 	if !ok {
 		return 0, false
 	}
@@ -23,7 +23,7 @@ func lookupSymbolID(ns *type_system.Namespace, name string) (int, bool) {
 		if !ok || prop.Name.Kind != type_system.StrObjTypeKeyKind || prop.Name.Str != name {
 			continue
 		}
-		if sym, ok := type_system.Prune(prop.Value).(*type_system.UniqueSymbolType); ok {
+		if sym, ok := type_system.Prune(prop.Value, nil).(*type_system.UniqueSymbolType); ok {
 			return sym.Value, true
 		}
 	}
@@ -45,11 +45,11 @@ func (c *Checker) getSymbolID(name string) (int, bool) {
 // the first type argument from the returned Iterator type.
 // Returns nil if the type is not iterable.
 func (c *Checker) GetIterableElementType(ctx Context, t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, ctx.BindJournal)
 
 	// Unwrap MutType
 	if mut, ok := t.(*type_system.MutType); ok {
-		t = type_system.Prune(mut.Type)
+		t = type_system.Prune(mut.Type, ctx.BindJournal)
 	}
 
 	// Handle UnionType by extracting the element type from each branch and unioning
@@ -113,7 +113,7 @@ func (c *Checker) GetIterableElementType(ctx Context, t type_system.Type) type_s
 		return nil
 	}
 
-	iteratorMethod = type_system.Prune(iteratorMethod)
+	iteratorMethod = type_system.Prune(iteratorMethod, ctx.BindJournal)
 
 	// [Symbol.iterator] should be a function that returns an Iterator
 	funcType, ok := iteratorMethod.(*type_system.FuncType)
@@ -121,7 +121,7 @@ func (c *Checker) GetIterableElementType(ctx Context, t type_system.Type) type_s
 		return nil
 	}
 
-	returnType := type_system.Prune(funcType.Return)
+	returnType := type_system.Prune(funcType.Return, ctx.BindJournal)
 
 	// Extract the element type from the return type.
 	// The return type should be Iterator<T, ...>, IterableIterator<T, ...>,
@@ -152,7 +152,7 @@ func (c *Checker) unifyIteratorNextReturn(ctx Context, t type_system.Type) (type
 		return nil, nil
 	}
 
-	nextMethod = type_system.Prune(nextMethod)
+	nextMethod = type_system.Prune(nextMethod, ctx.BindJournal)
 	funcType, ok := nextMethod.(*type_system.FuncType)
 	if !ok {
 		return nil, nil
@@ -172,7 +172,7 @@ func (c *Checker) unifyIteratorNextReturn(ctx Context, t type_system.Type) (type
 		return nil, nil
 	}
 
-	return type_system.Prune(freshT), type_system.Prune(freshTReturn)
+	return type_system.Prune(freshT, ctx.BindJournal), type_system.Prune(freshTReturn, ctx.BindJournal)
 }
 
 // extractIteratorElementType extracts the element type T from an Iterator-like type
@@ -188,10 +188,10 @@ func (c *Checker) extractIteratorElementType(ctx Context, t type_system.Type) ty
 // TReturn from the IteratorResult<T, TReturn> returned by next().
 // Used for determining the type of `yield from` (yield*) expressions.
 func (c *Checker) GetIteratorReturnType(ctx Context, t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, ctx.BindJournal)
 
 	if mut, ok := t.(*type_system.MutType); ok {
-		t = type_system.Prune(mut.Type)
+		t = type_system.Prune(mut.Type, ctx.BindJournal)
 	}
 
 	// Handle UnionType by extracting TReturn from each branch and unioning the results.
@@ -231,13 +231,13 @@ func (c *Checker) GetIteratorReturnType(ctx Context, t type_system.Type) type_sy
 		return nil
 	}
 
-	iteratorMethod = type_system.Prune(iteratorMethod)
+	iteratorMethod = type_system.Prune(iteratorMethod, ctx.BindJournal)
 	funcType, ok := iteratorMethod.(*type_system.FuncType)
 	if !ok {
 		return nil
 	}
 
-	returnType := type_system.Prune(funcType.Return)
+	returnType := type_system.Prune(funcType.Return, ctx.BindJournal)
 	_, tReturn := c.unifyIteratorNextReturn(ctx, returnType)
 	return tReturn
 }
@@ -247,10 +247,10 @@ func (c *Checker) GetIteratorReturnType(ctx Context, t type_system.Type) type_sy
 // AsyncIterator type. Returns nil if the type is not async iterable.
 // Note: Requires ES2018+ lib files to be loaded for AsyncIterable/AsyncIterator types.
 func (c *Checker) GetAsyncIterableElementType(ctx Context, t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, ctx.BindJournal)
 
 	if mut, ok := t.(*type_system.MutType); ok {
-		t = type_system.Prune(mut.Type)
+		t = type_system.Prune(mut.Type, ctx.BindJournal)
 	}
 
 	asyncIterSymID, ok := c.getSymbolID("asyncIterator")
@@ -269,12 +269,12 @@ func (c *Checker) GetAsyncIterableElementType(ctx Context, t type_system.Type) t
 		return nil
 	}
 
-	iteratorMethod = type_system.Prune(iteratorMethod)
+	iteratorMethod = type_system.Prune(iteratorMethod, ctx.BindJournal)
 	funcType, ok := iteratorMethod.(*type_system.FuncType)
 	if !ok {
 		return nil
 	}
 
-	returnType := type_system.Prune(funcType.Return)
+	returnType := type_system.Prune(funcType.Return, ctx.BindJournal)
 	return c.extractIteratorElementType(ctx, returnType)
 }

--- a/internal/checker/js_globals.go
+++ b/internal/checker/js_globals.go
@@ -91,7 +91,7 @@ func (c *Checker) knownJSGlobals() set.Set[string] {
 // SymbolConstructor, …) surface their members. Returns nil for any
 // non-object shape.
 func objectMemberNames(t type_system.Type) []string {
-	obj := resolveToObjectType(t)
+	obj := resolveToObjectType(t, nil)
 	if obj == nil {
 		return nil
 	}

--- a/internal/checker/method_helpers.go
+++ b/internal/checker/method_helpers.go
@@ -145,7 +145,7 @@ func walkPopulateSelfParams(
 		walkPopulateSelfParams(child, iterID, hasIter, asyncIterID, hasAsync)
 	}
 	for name, typeAlias := range ns.Types {
-		objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
+		objType, ok := type_system.Prune(typeAlias.Type, nil).(*type_system.ObjectType)
 		if !ok {
 			continue
 		}
@@ -201,7 +201,7 @@ func wrapReturnMut(fn *type_system.FuncType) {
 	if fn == nil || fn.Return == nil {
 		return
 	}
-	if _, isMut := type_system.Prune(fn.Return).(*type_system.MutType); isMut {
+	if _, isMut := type_system.Prune(fn.Return, nil).(*type_system.MutType); isMut {
 		return
 	}
 	fn.Return = type_system.NewMutType(nil, fn.Return)

--- a/internal/checker/method_helpers_test.go
+++ b/internal/checker/method_helpers_test.go
@@ -45,7 +45,7 @@ func TestPopulateSelfParamsRecursesIntoNestedNamespaces(t *testing.T) {
 	populateSelfParams(root)
 
 	check := func(alias *type_system.TypeAlias, methodName string) {
-		obj := type_system.Prune(alias.Type).(*type_system.ObjectType)
+		obj := type_system.Prune(alias.Type, nil).(*type_system.ObjectType)
 		var fn *type_system.FuncType
 		for _, elem := range obj.Elems {
 			if me, ok := elem.(*type_system.MethodElem); ok && me.Name.Str == methodName {

--- a/internal/checker/overload_specificity.go
+++ b/internal/checker/overload_specificity.go
@@ -149,8 +149,8 @@ func (c *Checker) compareBySubtype(a, b *type_system.FuncType) specificity {
 	allBIsSubtypeOfA := true
 	sawComparable := false
 	for i := range a.Params {
-		ap := type_system.Prune(a.Params[i].Type)
-		bp := type_system.Prune(b.Params[i].Type)
+		ap := type_system.Prune(a.Params[i].Type, nil)
+		bp := type_system.Prune(b.Params[i].Type, nil)
 		aTop, aEff := effectiveParamType(ap, aTP)
 		bTop, bEff := effectiveParamType(bp, bTP)
 		if aTop && bTop {
@@ -214,8 +214,8 @@ func typeParamBounds(fn *type_system.FuncType) map[string]type_system.Type {
 	for _, tp := range fn.TypeParams {
 		var bound type_system.Type
 		if tp.Constraint != nil {
-			if _, isNever := type_system.Prune(tp.Constraint).(*type_system.NeverType); !isNever {
-				bound = type_system.Prune(tp.Constraint)
+			if _, isNever := type_system.Prune(tp.Constraint, nil).(*type_system.NeverType); !isNever {
+				bound = type_system.Prune(tp.Constraint, nil)
 			}
 		}
 		out[tp.Name] = bound
@@ -280,7 +280,7 @@ func countTypeParamRefParams(fn *type_system.FuncType) int {
 	}
 	n := 0
 	for _, p := range fn.Params {
-		if isOwnedTypeParamRef(type_system.Prune(p.Type), names) {
+		if isOwnedTypeParamRef(type_system.Prune(p.Type, nil), names) {
 			n++
 		}
 	}
@@ -293,7 +293,7 @@ func countRequiredParams(fn *type_system.FuncType) int {
 		if p.Optional {
 			continue
 		}
-		if _, isRest := type_system.Prune(p.Type).(*type_system.RestSpreadType); isRest {
+		if _, isRest := type_system.Prune(p.Type, nil).(*type_system.RestSpreadType); isRest {
 			continue
 		}
 		n++

--- a/internal/checker/prelude.go
+++ b/internal/checker/prelude.go
@@ -383,10 +383,10 @@ func UpdateMethodMutability(ctx Context, namespace *type_system.Namespace) {
 			classTypeAlias := namespace.Types[name]
 
 			var instIdent type_system.QualIdent
-			if ct, ok := type_system.Prune(classTypeAlias.Type).(*type_system.ObjectType); ok {
+			if ct, ok := type_system.Prune(classTypeAlias.Type, ctx.BindJournal).(*type_system.ObjectType); ok {
 				for _, elem := range ct.Elems {
 					if ce, ok := elem.(*type_system.ConstructorElem); ok {
-						if rt, ok := type_system.Prune(ce.Fn.Return).(*type_system.TypeRefType); ok {
+						if rt, ok := type_system.Prune(ce.Fn.Return, ctx.BindJournal).(*type_system.TypeRefType); ok {
 							instIdent = rt.Name
 						}
 					}
@@ -409,7 +409,7 @@ func UpdateMethodMutability(ctx Context, namespace *type_system.Namespace) {
 				// TODO(#254): Support qualified identifiers in mutability overrides
 				overrides := mutabilityOverrides[instName]
 
-				if it, ok := type_system.Prune(instTypeAlias.Type).(*type_system.ObjectType); ok {
+				if it, ok := type_system.Prune(instTypeAlias.Type, ctx.BindJournal).(*type_system.ObjectType); ok {
 					// TypeScript .d.ts has no mut-self annotation, so
 					// methods default to `mut self` (set by
 					// populateSelfParams). Apply per-interface overrides
@@ -447,7 +447,7 @@ func UpdateMethodMutability(ctx Context, namespace *type_system.Namespace) {
 	slices.Sort(typeNames)
 	for _, name := range typeNames {
 		typeAlias := namespace.Types[name]
-		objType, ok := type_system.Prune(typeAlias.Type).(*type_system.ObjectType)
+		objType, ok := type_system.Prune(typeAlias.Type, ctx.BindJournal).(*type_system.ObjectType)
 		if !ok {
 			continue
 		}
@@ -485,11 +485,11 @@ func mergeReadonlyVariant(namespace *type_system.Namespace, mutableName, readonl
 	if !ok {
 		return
 	}
-	mutableType, ok := type_system.Prune(mutableTypeAlias.Type).(*type_system.ObjectType)
+	mutableType, ok := type_system.Prune(mutableTypeAlias.Type, nil).(*type_system.ObjectType)
 	if !ok {
 		return
 	}
-	readonlyType, ok := type_system.Prune(readonlyTypeAlias.Type).(*type_system.ObjectType)
+	readonlyType, ok := type_system.Prune(readonlyTypeAlias.Type, nil).(*type_system.ObjectType)
 	if !ok {
 		return
 	}
@@ -556,11 +556,11 @@ func (c *Checker) initializeGlobalScope() {
 
 	// Post-process the namespace
 	for _, typeAlias := range globalNs.Types {
-		typeAlias.Type = type_system.Prune(typeAlias.Type)
+		typeAlias.Type = type_system.Prune(typeAlias.Type, nil)
 	}
 
 	for _, binding := range globalNs.Values {
-		binding.Type = type_system.Prune(binding.Type)
+		binding.Type = type_system.Prune(binding.Type, nil)
 	}
 
 	inferCtx := Context{
@@ -822,7 +822,7 @@ func (c *Checker) addCustomMatcherToSymbol(ns *type_system.Namespace) {
 	}
 
 	// Get the ObjectType from the type alias
-	objType, ok := type_system.Prune(symbolConstructor.Type).(*type_system.ObjectType)
+	objType, ok := type_system.Prune(symbolConstructor.Type, nil).(*type_system.ObjectType)
 	if !ok {
 		return
 	}

--- a/internal/checker/probe.go
+++ b/internal/checker/probe.go
@@ -21,6 +21,19 @@ import (
 type BindJournal struct {
 	records         []bindRecord
 	lifetimeRecords []lifetimeRecord
+	// cleanups holds deferred rollback closures for side effects that
+	// don't fit the TypeVar / LifetimeVar record shape — e.g.
+	// expr.SetResolvedThrows on the overload-dispatch path. Closures
+	// run in reverse order during rollback, mirroring the record
+	// slices.
+	cleanups []func()
+	// depth counts open ProbeScopes sharing this journal. When the
+	// last open scope Commits, records become permanent — no outer
+	// scope can roll them back — so we can free the backing slices to
+	// keep journal memory bounded across many committed probes
+	// (otherwise the slice would grow append-only for the lifetime of
+	// the journal).
+	depth int
 }
 
 // bindRecord snapshots the subset of TypeVarType fields that the unifier
@@ -89,11 +102,22 @@ func (j *BindJournal) SnapshotLifetime(lt *type_system.LifetimeVar) {
 	})
 }
 
+// AddCleanup registers a closure that runs during rollback in reverse
+// order. Use for ad-hoc side effects (e.g. AST mutations like
+// SetResolvedThrows) that don't fit the TypeVar / LifetimeVar record
+// shape. Tolerates a nil receiver.
+func (j *BindJournal) AddCleanup(f func()) {
+	if j == nil {
+		return
+	}
+	j.cleanups = append(j.cleanups, f)
+}
+
 // rollback restores every record added at or after the given marks, in
 // reverse order. Used by Discard and by callers that need probe-scope
 // semantics over operations that aren't a single (t1, t2) unification
 // (e.g. an overload arm's full handleFuncCall — see infer_expr.go).
-func (j *BindJournal) rollback(mark, ltMark int) {
+func (j *BindJournal) rollback(mark, ltMark, cleanupMark int) {
 	records := j.records
 	for i := len(records) - 1; i >= mark; i-- {
 		r := &records[i]
@@ -112,6 +136,12 @@ func (j *BindJournal) rollback(mark, ltMark int) {
 		r.lifetimeVar.Instance = r.instance
 	}
 	j.lifetimeRecords = ltRecords[:ltMark]
+
+	cleanups := j.cleanups
+	for i := len(cleanups) - 1; i >= cleanupMark; i-- {
+		cleanups[i]()
+	}
+	j.cleanups = cleanups[:cleanupMark]
 }
 
 // ProbeScope is the journaled-bind context that beginProbeScope opens.
@@ -121,10 +151,18 @@ func (j *BindJournal) rollback(mark, ltMark int) {
 //
 // Carries both record-slice marks so Discard rolls back exactly the
 // TypeVar and LifetimeVar mutations made between begin and discard.
+//
+// `done` is a heap pointer so the first Commit or Discard call on the
+// scope flips it for every value-receiver copy of the scope, making
+// subsequent Commit/Discard calls no-ops. Without this, a caller that
+// committed mutations could later (e.g. in deferred cleanup) Discard
+// the same scope and silently roll them back.
 type ProbeScope struct {
-	journal *BindJournal
-	mark    int
-	ltMark  int
+	journal      *BindJournal
+	mark         int
+	ltMark       int
+	cleanupMark  int
+	done         *bool
 }
 
 // beginProbeScope installs a journal on ctx (allocating one if ctx had
@@ -141,24 +179,50 @@ func (c *Checker) beginProbeScope(ctx *Context) ProbeScope {
 		ctx.BindJournal = &BindJournal{}
 	}
 	j := ctx.BindJournal
+	done := false
+	j.depth++
 	return ProbeScope{
-		journal: j,
-		mark:    len(j.records),
-		ltMark:  len(j.lifetimeRecords),
+		journal:     j,
+		mark:        len(j.records),
+		ltMark:      len(j.lifetimeRecords),
+		cleanupMark: len(j.cleanups),
+		done:        &done,
 	}
 }
 
 // Commit keeps every mutation made during the scope. The records stay
 // in the journal: if the scope is nested inside an outer probe the
-// outer can still roll them back as part of its own Discard; if not,
-// the records are effectively permanent and get GC'd with the journal.
-func (s ProbeScope) Commit() {}
+// outer can still roll them back as part of its own Discard. When
+// this is the last open scope on the journal (depth reaches 0), the
+// records become permanent and the journal trims its backing slices
+// to free the memory accumulated by every committed probe so far.
+//
+// Idempotent: a second Commit or a Discard after Commit is a no-op.
+func (s ProbeScope) Commit() {
+	if *s.done {
+		return
+	}
+	*s.done = true
+	s.journal.depth--
+	if s.journal.depth == 0 {
+		s.journal.records = s.journal.records[:0]
+		s.journal.lifetimeRecords = s.journal.lifetimeRecords[:0]
+		s.journal.cleanups = s.journal.cleanups[:0]
+	}
+}
 
 // Discard restores every TypeVar and LifetimeVar field touched during
 // the scope to its pre-scope value. Replays records in reverse so
 // stacked mutations to the same variable peel off in the right order.
+//
+// Idempotent: a second Discard or a Commit after Discard is a no-op.
 func (s ProbeScope) Discard() {
-	s.journal.rollback(s.mark, s.ltMark)
+	if *s.done {
+		return
+	}
+	*s.done = true
+	s.journal.depth--
+	s.journal.rollback(s.mark, s.ltMark, s.cleanupMark)
 }
 
 // ProbeResult holds the outcome of a Probe call. The caller inspects
@@ -171,6 +235,13 @@ type ProbeResult struct {
 // Errors returns the errors produced by the probed unification, or an
 // empty slice if probing succeeded.
 func (p ProbeResult) Errors() []Error { return p.errors }
+
+// Journal returns the BindJournal this probe wrote to. Use it to nest
+// a follow-on probe under the same journal — set ctx.BindJournal to
+// the returned pointer and call Probe with that ctx. (Probe takes ctx
+// by value, so it can't propagate the journal back to the caller's
+// scope automatically.)
+func (p ProbeResult) Journal() *BindJournal { return p.scope.journal }
 
 // Success is true iff the probed unification produced no errors.
 func (p ProbeResult) Success() bool { return len(p.errors) == 0 }

--- a/internal/checker/probe.go
+++ b/internal/checker/probe.go
@@ -1,0 +1,162 @@
+package checker
+
+import (
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/type_system"
+)
+
+// BindJournal records the TypeVar field values that bind() and its helpers
+// (handleArrayConstraintBinding, openClosedObjectForParam, the widening
+// fallback in unifyInner, and Prune's path compression) are about to
+// overwrite. Discard walks the records in reverse and restores the saved
+// values; Commit is a no-op since mutations were applied tentatively
+// in-place.
+//
+// Lives on Context so a value-copied ctx propagates the journal pointer
+// through every recursive unifyInner call without a save/restore dance —
+// the same propagation discipline used by QueryUnify (see unify_mode.go).
+type BindJournal struct {
+	records []bindRecord
+}
+
+// bindRecord snapshots the subset of TypeVarType fields that the unifier
+// mutates. Discard restores all of them so the post-rollback TypeVar is
+// indistinguishable from its pre-probe state.
+type bindRecord struct {
+	typeVar         *type_system.TypeVarType
+	instance        type_system.Type
+	constraint      type_system.Type
+	isObjectRest    bool
+	arrayConstraint *type_system.ArrayConstraint
+	instanceChain   []*type_system.TypeVarType
+	prov            provenance.Provenance
+}
+
+// snapshot appends a record of tv's current mutable fields. Callers MUST
+// invoke this before any mutation when ctx.BindJournal is non-nil.
+//
+// Idempotency is not required: multiple snapshots of the same TypeVar
+// just stack. Discard restores in reverse order so each snapshot peels
+// one mutation off the stack, leaving the TypeVar in its pre-probe shape.
+func (j *BindJournal) snapshot(tv *type_system.TypeVarType) {
+	j.records = append(j.records, bindRecord{
+		typeVar:         tv,
+		instance:        tv.Instance,
+		constraint:      tv.Constraint,
+		isObjectRest:    tv.IsObjectRest,
+		arrayConstraint: tv.ArrayConstraint,
+		instanceChain:   tv.InstanceChain,
+		prov:            tv.Provenance(),
+	})
+}
+
+// rollback restores every record added at or after mark, in reverse
+// order. Used by Discard and by callers that need probe-scope semantics
+// over operations that aren't a single (t1, t2) unification (e.g. an
+// overload arm's full handleFuncCall — see infer_expr.go).
+func (j *BindJournal) rollback(mark int) {
+	records := j.records
+	for i := len(records) - 1; i >= mark; i-- {
+		r := &records[i]
+		r.typeVar.Instance = r.instance
+		r.typeVar.Constraint = r.constraint
+		r.typeVar.IsObjectRest = r.isObjectRest
+		r.typeVar.ArrayConstraint = r.arrayConstraint
+		r.typeVar.InstanceChain = r.instanceChain
+		r.typeVar.SetProvenance(r.prov)
+	}
+	j.records = records[:mark]
+}
+
+// ProbeScope is the journaled-bind context that beginProbeScope opens.
+// Callers run their probed operation between BeginProbeScope and
+// scope.Commit() / scope.Discard(). Use Probe instead for the common
+// case of probing a single (t1, t2) unification.
+type ProbeScope struct {
+	journal  *BindJournal
+	mark     int
+	prevHook func(*type_system.TypeVarType)
+}
+
+// beginProbeScope installs a journal (allocating one if ctx had none)
+// and a Prune mutation hook so subsequent mutations are snapshotted. The
+// caller is responsible for calling Commit or Discard on the returned
+// scope.
+//
+// Takes *Context so the journal pointer becomes visible to subsequent
+// recursive calls that pass ctx by value (each copy keeps the same
+// pointer). Callers that don't want their outer ctx mutated should pass
+// a local copy.
+func (c *Checker) beginProbeScope(ctx *Context) ProbeScope {
+	if ctx.BindJournal == nil {
+		ctx.BindJournal = &BindJournal{}
+	}
+	j := ctx.BindJournal
+	s := ProbeScope{
+		journal:  j,
+		mark:     len(j.records),
+		prevHook: type_system.PruneMutationHook,
+	}
+	type_system.PruneMutationHook = j.snapshot
+	return s
+}
+
+// Commit keeps every mutation made during the scope. The records stay
+// in the journal: if the scope is nested inside an outer probe the
+// outer can still roll them back as part of its own Discard; if not,
+// the records are effectively permanent and get GC'd with the journal.
+func (s ProbeScope) Commit() {
+	type_system.PruneMutationHook = s.prevHook
+}
+
+// Discard restores every TypeVar field touched during the scope to its
+// pre-scope value. Replays records in reverse so stacked mutations to
+// the same TypeVar peel off in the right order.
+func (s ProbeScope) Discard() {
+	type_system.PruneMutationHook = s.prevHook
+	s.journal.rollback(s.mark)
+}
+
+// ProbeResult holds the outcome of a Probe call. The caller inspects
+// Errors() / Success() and then decides Commit or Discard.
+type ProbeResult struct {
+	scope  ProbeScope
+	errors []Error
+}
+
+// Errors returns the errors produced by the probed unification, or an
+// empty slice if probing succeeded.
+func (p ProbeResult) Errors() []Error { return p.errors }
+
+// Success is true iff the probed unification produced no errors.
+func (p ProbeResult) Success() bool { return len(p.errors) == 0 }
+
+// Commit keeps every mutation made during the probe.
+func (p ProbeResult) Commit() { p.scope.Commit() }
+
+// Discard restores every TypeVar field touched during the probe.
+func (p ProbeResult) Discard() { p.scope.Discard() }
+
+// Probe runs unifyInner under a BindJournal so the caller can commit or
+// discard the resulting TypeVar bindings as a unit. It is the sibling of
+// Check (refuses all mutations, returns a pure subtype answer) and Unify
+// (commits unconditionally): Probe commits tentatively, lets the unifier
+// observe its own bindings during recursion, and lets the caller decide
+// after the fact whether to keep them.
+//
+// Replaces the deepCloneType-then-unify pattern at intersection/union
+// sites in unify.go: instead of cloning the inputs and trial-unifying on
+// the clones, Probe unifies on the originals while journaling every
+// mutation, then either commits (cheap — records are dropped) or
+// discards (records are replayed in reverse to restore the pre-probe
+// state).
+//
+// Nested probes share the outer journal; the inner scope's mark records
+// the offset so Discard rolls back only the inner probe's records. An
+// inner Commit leaves records in the outer journal, so the outer scope
+// can still roll them back as part of its own Discard.
+func (c *Checker) Probe(ctx Context, t1, t2 type_system.Type) ProbeResult {
+	scope := c.beginProbeScope(&ctx)
+	errors := c.unifyInner(ctx, t1, t2, make(unifySeen))
+	return ProbeResult{scope: scope, errors: errors}
+}

--- a/internal/checker/probe.go
+++ b/internal/checker/probe.go
@@ -5,12 +5,13 @@ import (
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
-// BindJournal records the TypeVar field values that bind() and its helpers
-// (handleArrayConstraintBinding, openClosedObjectForParam, the widening
-// fallback in unifyInner, and Prune's path compression) are about to
-// overwrite. Discard walks the records in reverse and restores the saved
-// values; Commit is a no-op since mutations were applied tentatively
-// in-place.
+// BindJournal records the TypeVar and LifetimeVar field values that
+// bind() and its helpers (handleArrayConstraintBinding,
+// openClosedObjectForParam, the widening fallback in unifyInner, the
+// open-object expansion in expand_type, Prune's path compression, and
+// UnifyLifetimes) are about to overwrite. Discard walks the records in
+// reverse and restores the saved values; Commit is a no-op since
+// mutations were applied tentatively in-place.
 //
 // Lives on Context so a value-copied ctx propagates the journal pointer
 // through every recursive unifyInner call without a save/restore dance —
@@ -18,7 +19,8 @@ import (
 //
 // Implements type_system.Journal so it can be passed directly to Prune.
 type BindJournal struct {
-	records []bindRecord
+	records         []bindRecord
+	lifetimeRecords []lifetimeRecord
 }
 
 // bindRecord snapshots the subset of TypeVarType fields that the unifier
@@ -32,6 +34,16 @@ type bindRecord struct {
 	arrayConstraint *type_system.ArrayConstraint
 	instanceChain   []*type_system.TypeVarType
 	prov            provenance.Provenance
+}
+
+// lifetimeRecord snapshots the Instance of a LifetimeVar mutated by
+// UnifyLifetimes. LifetimeVar has fewer mutable fields than TypeVar, so
+// the record is much smaller. Lives in a separate slice from bindRecord
+// because the two share no state: their rollbacks are independent and
+// the order between them doesn't matter.
+type lifetimeRecord struct {
+	lifetimeVar *type_system.LifetimeVar
+	instance    type_system.Lifetime
 }
 
 // Snapshot appends a record of tv's current mutable fields. Callers MUST
@@ -63,11 +75,25 @@ func (j *BindJournal) Snapshot(tv *type_system.TypeVarType) {
 	})
 }
 
-// rollback restores every record added at or after mark, in reverse
-// order. Used by Discard and by callers that need probe-scope semantics
-// over operations that aren't a single (t1, t2) unification (e.g. an
-// overload arm's full handleFuncCall — see infer_expr.go).
-func (j *BindJournal) rollback(mark int) {
+// SnapshotLifetime records lt's current Instance for rollback. Callers
+// MUST invoke this before any mutation to lt.Instance when
+// ctx.BindJournal is non-nil. Tolerates a nil receiver for the same
+// reason Snapshot does — see Snapshot's doc.
+func (j *BindJournal) SnapshotLifetime(lt *type_system.LifetimeVar) {
+	if j == nil {
+		return
+	}
+	j.lifetimeRecords = append(j.lifetimeRecords, lifetimeRecord{
+		lifetimeVar: lt,
+		instance:    lt.Instance,
+	})
+}
+
+// rollback restores every record added at or after the given marks, in
+// reverse order. Used by Discard and by callers that need probe-scope
+// semantics over operations that aren't a single (t1, t2) unification
+// (e.g. an overload arm's full handleFuncCall — see infer_expr.go).
+func (j *BindJournal) rollback(mark, ltMark int) {
 	records := j.records
 	for i := len(records) - 1; i >= mark; i-- {
 		r := &records[i]
@@ -79,15 +105,26 @@ func (j *BindJournal) rollback(mark int) {
 		r.typeVar.SetProvenance(r.prov)
 	}
 	j.records = records[:mark]
+
+	ltRecords := j.lifetimeRecords
+	for i := len(ltRecords) - 1; i >= ltMark; i-- {
+		r := &ltRecords[i]
+		r.lifetimeVar.Instance = r.instance
+	}
+	j.lifetimeRecords = ltRecords[:ltMark]
 }
 
 // ProbeScope is the journaled-bind context that beginProbeScope opens.
 // Callers run their probed operation between BeginProbeScope and
 // scope.Commit() / scope.Discard(). Use Probe instead for the common
 // case of probing a single (t1, t2) unification.
+//
+// Carries both record-slice marks so Discard rolls back exactly the
+// TypeVar and LifetimeVar mutations made between begin and discard.
 type ProbeScope struct {
 	journal *BindJournal
 	mark    int
+	ltMark  int
 }
 
 // beginProbeScope installs a journal on ctx (allocating one if ctx had
@@ -107,6 +144,7 @@ func (c *Checker) beginProbeScope(ctx *Context) ProbeScope {
 	return ProbeScope{
 		journal: j,
 		mark:    len(j.records),
+		ltMark:  len(j.lifetimeRecords),
 	}
 }
 
@@ -116,11 +154,11 @@ func (c *Checker) beginProbeScope(ctx *Context) ProbeScope {
 // the records are effectively permanent and get GC'd with the journal.
 func (s ProbeScope) Commit() {}
 
-// Discard restores every TypeVar field touched during the scope to its
-// pre-scope value. Replays records in reverse so stacked mutations to
-// the same TypeVar peel off in the right order.
+// Discard restores every TypeVar and LifetimeVar field touched during
+// the scope to its pre-scope value. Replays records in reverse so
+// stacked mutations to the same variable peel off in the right order.
 func (s ProbeScope) Discard() {
-	s.journal.rollback(s.mark)
+	s.journal.rollback(s.mark, s.ltMark)
 }
 
 // ProbeResult holds the outcome of a Probe call. The caller inspects
@@ -161,8 +199,22 @@ func (p ProbeResult) Discard() { p.scope.Discard() }
 // the offset so Discard rolls back only the inner probe's records. An
 // inner Commit leaves records in the outer journal, so the outer scope
 // can still roll them back as part of its own Discard.
+//
+// Allocates a fresh unifySeen, so callers driving Probe from within an
+// already-running unifyInner (the three intersection/union dispatch
+// sites in unify.go) should use probeWithSeen instead to inherit the
+// outer call's co-inductive cycle-detection history.
 func (c *Checker) Probe(ctx Context, t1, t2 type_system.Type) ProbeResult {
+	return c.probeWithSeen(ctx, t1, t2, make(unifySeen))
+}
+
+// probeWithSeen is the internal Probe variant that inherits an outer
+// unifyInner's seen map. Used by the intersection/union dispatch sites
+// in unifyMatched so a recursive type alias the outer call already
+// marked seen isn't re-expanded inside the probe (which would lose the
+// co-inductive cycle-termination guarantee).
+func (c *Checker) probeWithSeen(ctx Context, t1, t2 type_system.Type, seen unifySeen) ProbeResult {
 	scope := c.beginProbeScope(&ctx)
-	errors := c.unifyInner(ctx, t1, t2, make(unifySeen))
+	errors := c.unifyInner(ctx, t1, t2, seen)
 	return ProbeResult{scope: scope, errors: errors}
 }

--- a/internal/checker/probe.go
+++ b/internal/checker/probe.go
@@ -15,6 +15,8 @@ import (
 // Lives on Context so a value-copied ctx propagates the journal pointer
 // through every recursive unifyInner call without a save/restore dance —
 // the same propagation discipline used by QueryUnify (see unify_mode.go).
+//
+// Implements type_system.Journal so it can be passed directly to Prune.
 type BindJournal struct {
 	records []bindRecord
 }
@@ -32,13 +34,24 @@ type bindRecord struct {
 	prov            provenance.Provenance
 }
 
-// snapshot appends a record of tv's current mutable fields. Callers MUST
-// invoke this before any mutation when ctx.BindJournal is non-nil.
+// Snapshot appends a record of tv's current mutable fields. Callers MUST
+// invoke this before any mutation when ctx.BindJournal is non-nil. This
+// is also the method that satisfies type_system.Journal so Prune can
+// record path-compression and recordInstanceChain mutations.
+//
+// Tolerates a nil receiver so callers can pass ctx.BindJournal
+// unconditionally — a typed-nil *BindJournal wrapped in the Journal
+// interface looks non-nil to Prune's `j != nil` guard, and this nil
+// check is the simpler fix than having every caller compute the
+// interface conversion themselves.
 //
 // Idempotency is not required: multiple snapshots of the same TypeVar
 // just stack. Discard restores in reverse order so each snapshot peels
 // one mutation off the stack, leaving the TypeVar in its pre-probe shape.
-func (j *BindJournal) snapshot(tv *type_system.TypeVarType) {
+func (j *BindJournal) Snapshot(tv *type_system.TypeVarType) {
+	if j == nil {
+		return
+	}
 	j.records = append(j.records, bindRecord{
 		typeVar:         tv,
 		instance:        tv.Instance,
@@ -73,15 +86,14 @@ func (j *BindJournal) rollback(mark int) {
 // scope.Commit() / scope.Discard(). Use Probe instead for the common
 // case of probing a single (t1, t2) unification.
 type ProbeScope struct {
-	journal  *BindJournal
-	mark     int
-	prevHook func(*type_system.TypeVarType)
+	journal *BindJournal
+	mark    int
 }
 
-// beginProbeScope installs a journal (allocating one if ctx had none)
-// and a Prune mutation hook so subsequent mutations are snapshotted. The
-// caller is responsible for calling Commit or Discard on the returned
-// scope.
+// beginProbeScope installs a journal on ctx (allocating one if ctx had
+// none) so subsequent Prune calls and bind sites that receive
+// ctx.BindJournal will snapshot pre-mutation state. The caller is
+// responsible for calling Commit or Discard on the returned scope.
 //
 // Takes *Context so the journal pointer becomes visible to subsequent
 // recursive calls that pass ctx by value (each copy keeps the same
@@ -92,28 +104,22 @@ func (c *Checker) beginProbeScope(ctx *Context) ProbeScope {
 		ctx.BindJournal = &BindJournal{}
 	}
 	j := ctx.BindJournal
-	s := ProbeScope{
-		journal:  j,
-		mark:     len(j.records),
-		prevHook: type_system.PruneMutationHook,
+	return ProbeScope{
+		journal: j,
+		mark:    len(j.records),
 	}
-	type_system.PruneMutationHook = j.snapshot
-	return s
 }
 
 // Commit keeps every mutation made during the scope. The records stay
 // in the journal: if the scope is nested inside an outer probe the
 // outer can still roll them back as part of its own Discard; if not,
 // the records are effectively permanent and get GC'd with the journal.
-func (s ProbeScope) Commit() {
-	type_system.PruneMutationHook = s.prevHook
-}
+func (s ProbeScope) Commit() {}
 
 // Discard restores every TypeVar field touched during the scope to its
 // pre-scope value. Replays records in reverse so stacked mutations to
 // the same TypeVar peel off in the right order.
 func (s ProbeScope) Discard() {
-	type_system.PruneMutationHook = s.prevHook
 	s.journal.rollback(s.mark)
 }
 

--- a/internal/checker/probe_test.go
+++ b/internal/checker/probe_test.go
@@ -24,7 +24,7 @@ func TestProbeCommitKeepsBindings(t *testing.T) {
 	require.True(t, probe.Success(), "probing TV =:= number should succeed")
 	probe.Commit()
 
-	require.Same(t, numType, ts.Prune(tv),
+	require.Same(t, numType, ts.Prune(tv, nil),
 		"after Commit, tv must resolve to the bound type")
 }
 

--- a/internal/checker/probe_test.go
+++ b/internal/checker/probe_test.go
@@ -1,0 +1,131 @@
+package checker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ts "github.com/escalier-lang/escalier/internal/type_system"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProbeCommitKeepsBindings: a probe that succeeds and is committed
+// leaves TypeVar.Instance set, so subsequent Prune sees the bound type.
+func TestProbeCommitKeepsBindings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	tv := c.FreshVar(nil)
+	numType := ts.NewNumPrimType(nil)
+
+	probe := c.Probe(inferCtx, tv, numType)
+	require.True(t, probe.Success(), "probing TV =:= number should succeed")
+	probe.Commit()
+
+	require.Same(t, numType, ts.Prune(tv),
+		"after Commit, tv must resolve to the bound type")
+}
+
+// TestProbeDiscardRollsBackBindings: a successful probe that is discarded
+// leaves the TypeVar unbound, as if the probe never happened.
+func TestProbeDiscardRollsBackBindings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	tv := c.FreshVar(nil)
+	numType := ts.NewNumPrimType(nil)
+
+	probe := c.Probe(inferCtx, tv, numType)
+	require.True(t, probe.Success())
+	require.Same(t, numType, tv.Instance,
+		"during probe, tv.Instance is tentatively set")
+	probe.Discard()
+
+	require.Nil(t, tv.Instance,
+		"after Discard, tv.Instance must be restored to nil")
+}
+
+// TestProbeFailureLeavesNoPollution: a probe that fails (because the
+// inputs are incompatible) and is then discarded must leave every
+// TypeVar it touched in its pre-probe state.
+//
+// Scenario: a fresh TypeVar appears inside both sides of a unification
+// where the rest is incompatible. Without journaling, the unifier would
+// bind the TypeVar before discovering the mismatch and leave the binding
+// behind.
+func TestProbeFailureLeavesNoPollution(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	tv := c.FreshVar(nil)
+	numType := ts.NewNumPrimType(nil)
+	strType := ts.NewStrPrimType(nil)
+
+	// Tuple unification: [tv, "x"] vs [number, "y"]. Element 0 unifies
+	// (binds tv = number); element 1 fails ("x" vs "y" literal strings).
+	// Build the literal types so the second pair is genuinely
+	// incompatible.
+	strX := ts.NewStrLitType(nil, "x")
+	strY := ts.NewStrLitType(nil, "y")
+	tup1 := ts.NewTupleType(nil, tv, strX)
+	tup2 := ts.NewTupleType(nil, numType, strY)
+
+	probe := c.Probe(inferCtx, tup1, tup2)
+	require.False(t, probe.Success(), "probe must report failure")
+	probe.Discard()
+
+	require.Nil(t, tv.Instance,
+		"after Discard, the speculatively-bound tv must be unbound")
+	// Sanity check: tv didn't accidentally adopt strType either.
+	_ = strType
+}
+
+// TestProbeNestedDiscardRestoresOuterView: nested probes share a single
+// journal. An inner Discard rolls back only the inner records; an outer
+// Discard rolls back the inner+outer records together.
+func TestProbeNestedDiscardRestoresOuterView(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	tvOuter := c.FreshVar(nil)
+	tvInner := c.FreshVar(nil)
+	numType := ts.NewNumPrimType(nil)
+	strType := ts.NewStrPrimType(nil)
+
+	// Outer probe binds tvOuter = number, then nests an inner probe
+	// that binds tvInner = string. After inner Discard, tvOuter is
+	// still bound (inner Discard only rolls back tvInner). After outer
+	// Discard, both are unbound.
+	outer := c.Probe(inferCtx, tvOuter, numType)
+	require.True(t, outer.Success())
+
+	// Inner probe sees the outer-set journal via ctx-propagation: pass
+	// the same ctx, and Probe reuses the existing BindJournal. The
+	// inner ctx is constructed by Probe(*ctx), so we set BindJournal
+	// here for the inner call.
+	innerCtx := inferCtx
+	innerCtx.BindJournal = outer.scope.journal
+	inner := c.Probe(innerCtx, tvInner, strType)
+	require.True(t, inner.Success())
+
+	require.Same(t, numType, tvOuter.Instance)
+	require.Same(t, strType, tvInner.Instance)
+
+	inner.Discard()
+	require.Same(t, numType, tvOuter.Instance,
+		"inner Discard must not roll back outer bindings")
+	require.Nil(t, tvInner.Instance,
+		"inner Discard must roll back tvInner")
+
+	outer.Discard()
+	require.Nil(t, tvOuter.Instance,
+		"outer Discard must roll back tvOuter")
+}

--- a/internal/checker/probe_test.go
+++ b/internal/checker/probe_test.go
@@ -113,6 +113,28 @@ func TestProbeDiscardRollsBackLifetimeBindings(t *testing.T) {
 		"after Discard, LifetimeVar.Instance must be restored to nil")
 }
 
+// TestProbeCommitThenDiscardIsNoOp: once a probe is committed, a
+// subsequent Discard must not roll back the just-committed mutations.
+// Guards against the documented gap that calling Discard after Commit
+// would silently undo the commit.
+func TestProbeCommitThenDiscardIsNoOp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	tv := c.FreshVar(nil)
+	numType := ts.NewNumPrimType(nil)
+
+	probe := c.Probe(inferCtx, tv, numType)
+	require.True(t, probe.Success())
+	probe.Commit()
+	probe.Discard() // must not undo the commit
+
+	require.Same(t, numType, tv.Instance,
+		"Discard after Commit must be a no-op")
+}
+
 // TestProbeNestedDiscardRestoresOuterView: nested probes share a single
 // journal. An inner Discard rolls back only the inner records; an outer
 // Discard rolls back the inner+outer records together.
@@ -134,12 +156,12 @@ func TestProbeNestedDiscardRestoresOuterView(t *testing.T) {
 	outer := c.Probe(inferCtx, tvOuter, numType)
 	require.True(t, outer.Success())
 
-	// Inner probe sees the outer-set journal via ctx-propagation: pass
-	// the same ctx, and Probe reuses the existing BindJournal. The
-	// inner ctx is constructed by Probe(*ctx), so we set BindJournal
-	// here for the inner call.
+	// Nest the inner probe under the outer journal by passing it
+	// through ctx. Probe takes ctx by value, so the outer probe's
+	// journal pointer isn't visible in the caller's ctx after Probe
+	// returns; ProbeResult.Journal() exposes it for this purpose.
 	innerCtx := inferCtx
-	innerCtx.BindJournal = outer.scope.journal
+	innerCtx.BindJournal = outer.Journal()
 	inner := c.Probe(innerCtx, tvInner, strType)
 	require.True(t, inner.Success())
 

--- a/internal/checker/probe_test.go
+++ b/internal/checker/probe_test.go
@@ -86,6 +86,33 @@ func TestProbeFailureLeavesNoPollution(t *testing.T) {
 	_ = strType
 }
 
+// TestProbeDiscardRollsBackLifetimeBindings: a probe that binds a
+// LifetimeVar through UnifyLifetimes and is then discarded leaves the
+// LifetimeVar's Instance unset, as if the probe never happened.
+//
+// Without LifetimeVar journaling, a failed overload arm with a generic
+// lifetime parameter would leak the binding into the next arm.
+func TestProbeDiscardRollsBackLifetimeBindings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := NewChecker(ctx)
+	inferCtx := Context{}
+
+	lv := c.FreshLifetimeVar("a")
+	val := &ts.LifetimeValue{ID: 42, Name: "v"}
+
+	// Open a probe scope manually so we can invoke UnifyLifetimes
+	// directly (it isn't a (t1, t2) unification).
+	scope := c.beginProbeScope(&inferCtx)
+	errs := c.UnifyLifetimes(inferCtx, lv, val)
+	require.Empty(t, errs, "lifetime unification should succeed")
+	require.NotNil(t, lv.Instance, "during probe, lv.Instance is tentatively set")
+	scope.Discard()
+
+	require.Nil(t, lv.Instance,
+		"after Discard, LifetimeVar.Instance must be restored to nil")
+}
+
 // TestProbeNestedDiscardRestoresOuterView: nested probes share a single
 // journal. An inner Discard rolls back only the inner records; an outer
 // Discard rolls back the inner+outer records together.

--- a/internal/checker/regex.go
+++ b/internal/checker/regex.go
@@ -26,7 +26,7 @@ func (v *NamedCaptureGroupExtractor) EnterType(t type_system.Type) type_system.E
 }
 
 func (v *NamedCaptureGroupExtractor) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	if regexType, ok := t.(*type_system.RegexType); ok {
 		// Create a new RegexType with fresh type variables for named capture groups
@@ -68,7 +68,7 @@ func (v *RegexTypeReplacer) EnterType(t type_system.Type) type_system.EnterResul
 }
 
 func (v *RegexTypeReplacer) ExitType(t type_system.Type) type_system.Type {
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 
 	if regexType, ok := t.(*type_system.RegexType); ok {
 		// Check if any named groups in this regex type have substitutions

--- a/internal/checker/substitute.go
+++ b/internal/checker/substitute.go
@@ -25,7 +25,7 @@ func (v *TypeParamSubstitutionVisitor) SubstituteType(t type_system.Type) type_s
 		return nil
 	}
 
-	t = type_system.Prune(t)
+	t = type_system.Prune(t, nil)
 	return t.Accept(v)
 }
 
@@ -105,7 +105,7 @@ func SubstituteTypeParams[T type_system.Type](t T, substitutions map[string]type
 		return t
 	}
 
-	t = type_system.Prune(t).(T)
+	t = type_system.Prune(t, nil).(T)
 	visitor := NewTypeParamSubstitutionVisitor(substitutions)
 	result := t.Accept(visitor)
 	return result.(T)

--- a/internal/checker/tests/benchmark_test.go
+++ b/internal/checker/tests/benchmark_test.go
@@ -699,9 +699,9 @@ func TestArrayTypeStructure(t *testing.T) {
 	if alias == nil {
 		t.Fatal("Array type alias not found")
 	}
-	objType, ok := type_system.Prune(alias.Type).(*type_system.ObjectType)
+	objType, ok := type_system.Prune(alias.Type, nil).(*type_system.ObjectType)
 	if !ok {
-		t.Fatalf("Array type is %T, not ObjectType", type_system.Prune(alias.Type))
+		t.Fatalf("Array type is %T, not ObjectType", type_system.Prune(alias.Type, nil))
 	}
 
 	// Array should be a nominal interface with many elements and no Extends.

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -720,14 +720,14 @@ func TestClassMethodSelfParamPopulated(t *testing.T) {
 			classAlias := ns.Types[test.className]
 			require.NotNilf(t, classAlias, "class type alias %q not found", test.className)
 
-			searchObj := type_system.Prune(classAlias.Type).(*type_system.ObjectType)
+			searchObj := type_system.Prune(classAlias.Type, nil).(*type_system.ObjectType)
 			if test.expectStatic {
 				// Static methods live on the class object's value
 				// binding, not on the instance type. Look up the
 				// constructor type alias for the class to inspect them.
 				ctorBinding := ns.Values[test.className]
 				require.NotNil(t, ctorBinding, "constructor binding not found")
-				if obj, ok := type_system.Prune(ctorBinding.Type).(*type_system.ObjectType); ok {
+				if obj, ok := type_system.Prune(ctorBinding.Type, nil).(*type_system.ObjectType); ok {
 					searchObj = obj
 				}
 			}
@@ -790,7 +790,7 @@ func TestClassMethodSelfLifetime(t *testing.T) {
 	ns := mustInferAsModule(t, src)
 	classAlias := ns.Types["Container"]
 	require.NotNil(t, classAlias)
-	objType := type_system.Prune(classAlias.Type).(*type_system.ObjectType)
+	objType := type_system.Prune(classAlias.Type, nil).(*type_system.ObjectType)
 
 	findMethod := func(name string) *type_system.FuncType {
 		for _, e := range objType.Elems {

--- a/internal/checker/tests/integration_test.go
+++ b/internal/checker/tests/integration_test.go
@@ -334,8 +334,8 @@ func TestE2E_MultiplePackagesWithSameSymbols(t *testing.T) {
 
 	// Both should be function types
 	if lodashMapExists && ramdaMapExists {
-		_, isLodashFunc := type_system.Prune(lodashMapBinding.Type).(*type_system.FuncType)
-		_, isRamdaFunc := type_system.Prune(ramdaMapBinding.Type).(*type_system.FuncType)
+		_, isLodashFunc := type_system.Prune(lodashMapBinding.Type, nil).(*type_system.FuncType)
+		_, isRamdaFunc := type_system.Prune(ramdaMapBinding.Type, nil).(*type_system.FuncType)
 		assert.True(t, isLodashFunc, "lodashMap should be a function")
 		assert.True(t, isRamdaFunc, "ramdaMap should be a function")
 	}
@@ -411,7 +411,7 @@ func TestE2E_GlobalThisBypassesShadowing(t *testing.T) {
 	globalSymbolBinding, globalSymbolExists := scope.Values["globalSymbol"]
 	assert.True(t, globalSymbolExists, "globalSymbol should exist")
 	if globalSymbolExists {
-		symType := type_system.Prune(globalSymbolBinding.Type)
+		symType := type_system.Prune(globalSymbolBinding.Type, nil)
 		_, isUniqueSymbol := symType.(*type_system.UniqueSymbolType)
 		assert.True(t, isUniqueSymbol, "globalSymbol should be a unique symbol type, got %T", symType)
 	}
@@ -679,8 +679,8 @@ func TestE2E_SubpathImportsIsolation(t *testing.T) {
 
 	// Both should be functions
 	if mainMapExists && fpMapExists {
-		mainMapType := type_system.Prune(mainMapBinding.Type)
-		fpMapType := type_system.Prune(fpMapBinding.Type)
+		mainMapType := type_system.Prune(mainMapBinding.Type, nil)
+		fpMapType := type_system.Prune(fpMapBinding.Type, nil)
 
 		mainFuncType, isMainFunc := mainMapType.(*type_system.FuncType)
 		fpFuncType, isFpFunc := fpMapType.(*type_system.FuncType)

--- a/internal/checker/tests/intersection_test.go
+++ b/internal/checker/tests/intersection_test.go
@@ -117,7 +117,7 @@ func TestNormalizeIntersectionType(t *testing.T) {
 
 			// Prune to resolve type variables, then repeatedly call NormalizeIntersectionType
 			// until the result stops changing
-			resultType := type_system.Prune(binding.Type)
+			resultType := type_system.Prune(binding.Type, nil)
 
 			// Keep normalizing until the result stabilizes
 			maxIterations := 10
@@ -132,7 +132,7 @@ func TestNormalizeIntersectionType(t *testing.T) {
 					}
 
 					// Prune again in case we got a type variable
-					resultType = type_system.Prune(resultType)
+					resultType = type_system.Prune(resultType, nil)
 				} else {
 					// Not an intersection type anymore, we're done
 					break
@@ -298,8 +298,8 @@ func TestDistributiveLawsUsingExpandType(t *testing.T) {
 			t2Binding, ok := scope.Types["T2"]
 			assert.True(t, ok, "Expected T2 type alias to be defined")
 
-			t1Type := type_system.Prune(t1Binding.Type)
-			t2Type := type_system.Prune(t2Binding.Type)
+			t1Type := type_system.Prune(t1Binding.Type, nil)
+			t2Type := type_system.Prune(t2Binding.Type, nil)
 
 			// Expand T1 to see what it becomes after distribution
 			expandedT1, expandErrors := c.ExpandType(inferCtx, t1Type, -1)
@@ -566,8 +566,8 @@ func TestUnifyWithIntersections(t *testing.T) {
 			t2Binding, ok := scope.Types["T2"]
 			assert.True(t, ok, "Expected T2 type alias to be defined")
 
-			t1Type := type_system.Prune(t1Binding.Type)
-			t2Type := type_system.Prune(t2Binding.Type)
+			t1Type := type_system.Prune(t1Binding.Type, nil)
+			t2Type := type_system.Prune(t2Binding.Type, nil)
 
 			unifyErrors := c.Unify(inferCtx, t1Type, t2Type)
 

--- a/internal/checker/tests/iterator_test.go
+++ b/internal/checker/tests/iterator_test.go
@@ -76,7 +76,7 @@ func TestStdLibIteratorTypesLoaded(t *testing.T) {
 		symbolConstructor := scope.GetTypeAlias("SymbolConstructor")
 		require.NotNil(t, symbolConstructor, "SymbolConstructor should be loaded")
 
-		objType, ok := type_system.Prune(symbolConstructor.Type).(*type_system.ObjectType)
+		objType, ok := type_system.Prune(symbolConstructor.Type, nil).(*type_system.ObjectType)
 		require.True(t, ok, "SymbolConstructor should be an ObjectType")
 
 		// Check that the 'iterator' property exists
@@ -85,7 +85,7 @@ func TestStdLibIteratorTypesLoaded(t *testing.T) {
 			if prop, ok := elem.(*type_system.PropertyElem); ok {
 				if prop.Name.Kind == type_system.StrObjTypeKeyKind && prop.Name.Str == "iterator" {
 					found = true
-					_, isUniqueSymbol := type_system.Prune(prop.Value).(*type_system.UniqueSymbolType)
+					_, isUniqueSymbol := type_system.Prune(prop.Value, nil).(*type_system.UniqueSymbolType)
 					assert.True(t, isUniqueSymbol, "Symbol.iterator should be a unique symbol type")
 					break
 				}

--- a/internal/checker/tests/jsx_test.go
+++ b/internal/checker/tests/jsx_test.go
@@ -2973,7 +2973,7 @@ func TestJSXElementTypeResolution(t *testing.T) {
 		assert.NotNil(t, binding, "Expected elem binding to exist")
 
 		// Prune the type to resolve any type variables
-		prunedType := type_system.Prune(binding.Type)
+		prunedType := type_system.Prune(binding.Type, nil)
 
 		// The type should be the JSX.Element type we defined
 		objType, ok := prunedType.(*type_system.ObjectType)
@@ -3105,7 +3105,7 @@ func TestJSXFragmentTypeResolution(t *testing.T) {
 		assert.NotNil(t, binding, "Expected elem binding to exist")
 
 		// Prune the type to resolve any type variables
-		prunedType := type_system.Prune(binding.Type)
+		prunedType := type_system.Prune(binding.Type, nil)
 
 		// The type should be the JSX.Element type we defined
 		objType, ok := prunedType.(*type_system.ObjectType)

--- a/internal/checker/tests/pattern_mut_test.go
+++ b/internal/checker/tests/pattern_mut_test.go
@@ -316,14 +316,14 @@ func TestPatternLevelMut_GenericParam(t *testing.T) {
 	ns := mustInferAsModule(t, input)
 	binding, ok := ns.Values["f"]
 	require.True(t, ok, "f binding not found")
-	fn, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
+	fn, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
 	require.True(t, ok, "expected FuncType for f, got %T", binding.Type)
 	require.Len(t, fn.Params, 1, "expected one parameter")
-	pruned := type_system.Prune(fn.Params[0].Type)
+	pruned := type_system.Prune(fn.Params[0].Type, nil)
 	mut, isMut := pruned.(*type_system.MutType)
 	require.Truef(t, isMut, "expected param type wrapped in MutType, got %T", pruned)
 	// The wrapped inner type should be a TypeRef to T (the type parameter).
-	inner := type_system.Prune(mut.Type)
+	inner := type_system.Prune(mut.Type, nil)
 	_, isRef := inner.(*type_system.TypeRefType)
 	assert.Truef(t, isRef, "expected MutType wrapping a TypeRefType, got %T", inner)
 }
@@ -389,23 +389,23 @@ func TestPatternLevelMut_NoLeakIntoParentContainer(t *testing.T) {
 
 			switch p := pat.(type) {
 			case *ast.ObjectPat:
-				ot, ok := type_system.Prune(p.InferredType()).(*type_system.ObjectType)
+				ot, ok := type_system.Prune(p.InferredType(), nil).(*type_system.ObjectType)
 				require.Truef(t, ok, "expected ObjectType, got %T", p.InferredType())
 				for _, elem := range ot.Elems {
 					prop, ok := elem.(*type_system.PropertyElem)
 					if !ok {
 						continue
 					}
-					_, isMut := type_system.Prune(prop.Value).(*type_system.MutType)
+					_, isMut := type_system.Prune(prop.Value, nil).(*type_system.MutType)
 					assert.Falsef(t, isMut,
 						"property %v should not be wrapped in MutType (leak from leaf binding); got %v",
 						prop.Name, prop.Value)
 				}
 			case *ast.TuplePat:
-				tt, ok := type_system.Prune(p.InferredType()).(*type_system.TupleType)
+				tt, ok := type_system.Prune(p.InferredType(), nil).(*type_system.TupleType)
 				require.Truef(t, ok, "expected TupleType, got %T", p.InferredType())
 				for i, elem := range tt.Elems {
-					_, isMut := type_system.Prune(elem).(*type_system.MutType)
+					_, isMut := type_system.Prune(elem, nil).(*type_system.MutType)
 					assert.Falsef(t, isMut,
 						"element %d should not be wrapped in MutType (leak from leaf binding); got %v",
 						i, elem)

--- a/internal/checker/tests/shadowing_test.go
+++ b/internal/checker/tests/shadowing_test.go
@@ -76,7 +76,7 @@ func TestLocalShadowingOfGlobals(t *testing.T) {
 	require.NotNil(t, numBinding, "num binding should exist")
 
 	// The type annotation creates a TypeRefType pointing to our local Number type alias
-	numType := type_system.Prune(numBinding.Type)
+	numType := type_system.Prune(numBinding.Type, nil)
 	typeRef, ok := numType.(*type_system.TypeRefType)
 	require.True(t, ok, "num should have TypeRefType, got %T", numType)
 
@@ -85,7 +85,7 @@ func TestLocalShadowingOfGlobals(t *testing.T) {
 
 	// Verify the type alias points to our custom object type
 	require.NotNil(t, typeRef.TypeAlias, "TypeRefType should have TypeAlias set")
-	aliasType := type_system.Prune(typeRef.TypeAlias.Type)
+	aliasType := type_system.Prune(typeRef.TypeAlias.Type, nil)
 	objType, ok := aliasType.(*type_system.ObjectType)
 	require.True(t, ok, "Number alias should be object type, got %T", aliasType)
 
@@ -142,7 +142,7 @@ func TestGlobalThisAccessToGlobals(t *testing.T) {
 	require.NotNil(t, globalArrayBinding, "globalArray binding should exist")
 
 	// globalArray should use the global Array type (via globalThis)
-	globalArrayType := type_system.Prune(globalArrayBinding.Type)
+	globalArrayType := type_system.Prune(globalArrayBinding.Type, nil)
 	globalTypeRef, ok := globalArrayType.(*type_system.TypeRefType)
 	require.True(t, ok, "globalArray should have TypeRefType, got %T", globalArrayType)
 
@@ -200,7 +200,7 @@ func TestGlobalThisAccessWhenShadowed(t *testing.T) {
 	require.NotNil(t, globalArrBinding, "globalArr binding should exist")
 
 	// localArr should use the local Array type (TypeRefType pointing to our custom type)
-	localArrType := type_system.Prune(localArrBinding.Type)
+	localArrType := type_system.Prune(localArrBinding.Type, nil)
 	typeRef, ok := localArrType.(*type_system.TypeRefType)
 	require.True(t, ok, "localArr should have TypeRefType, got %T", localArrType)
 
@@ -209,7 +209,7 @@ func TestGlobalThisAccessWhenShadowed(t *testing.T) {
 
 	// Verify the type alias points to our custom object type with isLocal property
 	require.NotNil(t, typeRef.TypeAlias, "TypeRefType should have TypeAlias set")
-	aliasType := type_system.Prune(typeRef.TypeAlias.Type)
+	aliasType := type_system.Prune(typeRef.TypeAlias.Type, nil)
 	objType, ok := aliasType.(*type_system.ObjectType)
 	require.True(t, ok, "Array alias should be object type, got %T", aliasType)
 
@@ -225,7 +225,7 @@ func TestGlobalThisAccessWhenShadowed(t *testing.T) {
 	assert.True(t, hasIsLocalProp, "Local Array type should have isLocal property")
 
 	// globalArr should use the global Array type (via globalThis)
-	globalArrType := type_system.Prune(globalArrBinding.Type)
+	globalArrType := type_system.Prune(globalArrBinding.Type, nil)
 	globalTypeRef, ok := globalArrType.(*type_system.TypeRefType)
 	require.True(t, ok, "globalArr should have TypeRefType, got %T", globalArrType)
 
@@ -298,7 +298,7 @@ func TestGlobalThisValueAccess(t *testing.T) {
 	symBinding := scope.Namespace.Values["sym"]
 	require.NotNil(t, symBinding, "sym binding should exist")
 
-	symType := type_system.Prune(symBinding.Type)
+	symType := type_system.Prune(symBinding.Type, nil)
 	_, ok := symType.(*type_system.UniqueSymbolType)
 	assert.True(t, ok, "sym should be a unique symbol type, got %T", symType)
 }

--- a/internal/checker/tests/substitute_test.go
+++ b/internal/checker/tests/substitute_test.go
@@ -452,9 +452,9 @@ func TestSubstituteTypeParams_DoesNotMutateSharedSubstitute(t *testing.T) {
 	require.True(t, ok, "expected tuple result, got %T", result)
 	require.Len(t, resTuple.Elems, 2)
 
-	first, ok := type_system.Prune(resTuple.Elems[0]).(*type_system.ObjectType)
+	first, ok := type_system.Prune(resTuple.Elems[0], nil).(*type_system.ObjectType)
 	require.True(t, ok)
-	second, ok := type_system.Prune(resTuple.Elems[1]).(*type_system.ObjectType)
+	second, ok := type_system.Prune(resTuple.Elems[1], nil).(*type_system.ObjectType)
 	require.True(t, ok)
 
 	assert.Equal(t, ltA, first.Lifetime, "first slot should carry 'a")

--- a/internal/checker/tests/throw_inference_test.go
+++ b/internal/checker/tests/throw_inference_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestThrowExpressionInference(t *testing.T) {
@@ -159,7 +160,7 @@ func TestThrowExpressionInference(t *testing.T) {
 
 			// Prune the type to resolve any type variables
 			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
-			assert.True(t, ok, "Expected testFunc to be a function type, got %T", type_system.Prune(binding.Type, nil))
+			require.Truef(t, ok, "Expected testFunc to be a function type, got %T", type_system.Prune(binding.Type, nil))
 			assert.NotNil(t, funcType, "Expected function type to be non-nil")
 
 			// Check that the throws type matches expected
@@ -243,7 +244,7 @@ func TestNeverReturnInference(t *testing.T) {
 			assert.NotNil(t, binding, "Expected testFunc to be defined")
 
 			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
-			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
+			require.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
 
 			returnStr := type_system.Prune(funcType.Return, nil).String()
 			assert.Equal(t, test.expectedReturn, returnStr, "Expected return type to match")
@@ -408,7 +409,7 @@ func TestCallSiteThrowsInference(t *testing.T) {
 			assert.Truef(t, ok, "Expected testFunc to be defined")
 
 			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
-			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
+			require.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
 
 			assert.Equal(t, test.expectedTestFunc, funcType.String())
 		})

--- a/internal/checker/tests/throw_inference_test.go
+++ b/internal/checker/tests/throw_inference_test.go
@@ -158,8 +158,8 @@ func TestThrowExpressionInference(t *testing.T) {
 			assert.NotNil(t, binding, "Expected testFunc to be defined")
 
 			// Prune the type to resolve any type variables
-			funcType, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
-			assert.True(t, ok, "Expected testFunc to be a function type, got %T", type_system.Prune(binding.Type))
+			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
+			assert.True(t, ok, "Expected testFunc to be a function type, got %T", type_system.Prune(binding.Type, nil))
 			assert.NotNil(t, funcType, "Expected function type to be non-nil")
 
 			// Check that the throws type matches expected
@@ -242,10 +242,10 @@ func TestNeverReturnInference(t *testing.T) {
 			binding := scope.GetValue("testFunc")
 			assert.NotNil(t, binding, "Expected testFunc to be defined")
 
-			funcType, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
-			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type))
+			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
+			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
 
-			returnStr := type_system.Prune(funcType.Return).String()
+			returnStr := type_system.Prune(funcType.Return, nil).String()
 			assert.Equal(t, test.expectedReturn, returnStr, "Expected return type to match")
 		})
 	}
@@ -407,8 +407,8 @@ func TestCallSiteThrowsInference(t *testing.T) {
 			binding, ok := inferCtx.Scope.Namespace.Values["testFunc"]
 			assert.Truef(t, ok, "Expected testFunc to be defined")
 
-			funcType, ok := type_system.Prune(binding.Type).(*type_system.FuncType)
-			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type))
+			funcType, ok := type_system.Prune(binding.Type, nil).(*type_system.FuncType)
+			assert.Truef(t, ok, "Expected FuncType, got %T", type_system.Prune(binding.Type, nil))
 
 			assert.Equal(t, test.expectedTestFunc, funcType.String())
 		})

--- a/internal/checker/tests/unify_test.go
+++ b/internal/checker/tests/unify_test.go
@@ -600,7 +600,7 @@ func TestUnifyTypeVarNotCorruptedByFailedUnionTrial(t *testing.T) {
 		assert.Empty(t, errors, "TypeVar should unify with second union member {x: string}")
 
 		// After successful unification, TypeVar should be bound to string
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to a PrimType")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.StrPrim, prim.Prim, "TypeVar should be bound to string, not number")
@@ -625,7 +625,7 @@ func TestUnifyTypeVarNotCorruptedByFailedUnionTrial(t *testing.T) {
 		errors := checker.Unify(inferCtx, t1, t2)
 		assert.Empty(t, errors, "TypeVar in tuple should unify with second union member")
 
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to a PrimType")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.StrPrim, prim.Prim, "TypeVar should be bound to string, not number")
@@ -686,7 +686,7 @@ func TestUnifyTypeVarNotCorruptedByFailedIntersectionTrial(t *testing.T) {
 		errors := checker.Unify(inferCtx, t1, t2)
 		assert.Empty(t, errors, "second intersection part {x: string, a: string} should unify with {x: TypeVar, a: string}")
 
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to string")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.StrPrim, prim.Prim, "TypeVar should be bound to string, not number")
@@ -751,7 +751,7 @@ func TestUnifyTypeVarNotCorruptedByFailedIntersectionTrial(t *testing.T) {
 		errors := checker.Unify(inferCtx, t1, t2)
 		assert.Empty(t, errors, "intersection types should unify successfully")
 
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to string")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.StrPrim, prim.Prim, "TypeVar should be bound to string, not number")
@@ -789,7 +789,7 @@ func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
 		assert.Empty(t, errors, "unifying matching index signatures should not produce errors")
 
 		// The type variable should be bound to number
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to number")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.NumPrim, prim.Prim)
@@ -867,7 +867,7 @@ func TestUnifyOpenClosedIndexSignatureDedup(t *testing.T) {
 		assert.Empty(t, errors, "unifying matching index signatures should not produce errors")
 
 		// The type variable should be bound to number
-		resolved := type_system.Prune(tv)
+		resolved := type_system.Prune(tv, nil)
 		assert.IsType(t, &type_system.PrimType{}, resolved, "TypeVar should resolve to number")
 		prim := resolved.(*type_system.PrimType)
 		assert.Equal(t, type_system.NumPrim, prim.Prim)
@@ -914,7 +914,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(inferCtx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		assert.Equal(t, "number", type_system.Prune(tv).String(),
+		assert.Equal(t, "number", type_system.Prune(tv, nil).String(),
 			"numeric key should resolve to number via numeric index signature")
 	})
 
@@ -935,7 +935,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(inferCtx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		assert.Equal(t, "number", type_system.Prune(tv).String(),
+		assert.Equal(t, "number", type_system.Prune(tv, nil).String(),
 			"numeric key should resolve to number regardless of signature declaration order")
 	})
 
@@ -955,7 +955,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(inferCtx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		assert.Equal(t, "number", type_system.Prune(tv).String(),
+		assert.Equal(t, "number", type_system.Prune(tv, nil).String(),
 			"string key should match string index signature")
 	})
 
@@ -974,7 +974,7 @@ func TestFindIndexSignatureForKeyOrderIndependence(t *testing.T) {
 		errors := checker.Unify(inferCtx, obj1, obj2)
 		assert.Empty(t, errors)
 
-		assert.Equal(t, "string", type_system.Prune(tv).String(),
+		assert.Equal(t, "string", type_system.Prune(tv, nil).String(),
 			"numeric key should fall back to string index signature when no numeric sig exists")
 	})
 

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -206,8 +206,8 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 	// concrete type. Prune records the alias chain in tv2.InstanceChain, which
 	// the widening fallback reads to update all aliased TypeVars.
 	tv2, _ := t2.(*type_system.TypeVarType)
-	t1 = type_system.Prune(t1)
-	t2 = type_system.Prune(t2)
+	t1 = type_system.Prune(t1, ctx.BindJournal)
+	t2 = type_system.Prune(t2, ctx.BindJournal)
 
 	errors := c.unifyPruned(ctx, t1, t2, seen)
 	if len(errors) == 0 {
@@ -268,7 +268,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 		}
 		for _, tv := range widenableChain {
 			if ctx.BindJournal != nil {
-				ctx.BindJournal.snapshot(tv)
+				ctx.BindJournal.Snapshot(tv)
 			}
 			tv.Instance = widened
 		}
@@ -344,8 +344,8 @@ func (c *Checker) unifyPruned(ctx Context, t1, t2 type_system.Type, seen unifySe
 			// Prune after expansion to resolve any TypeVarTypes returned by
 			// expansion (e.g. TypeOfType resolves to a scope binding's
 			// TypeVarType, which must be pruned before re-entering unifyMatched).
-			t1 = type_system.Prune(nonRefExpT1)
-			t2 = type_system.Prune(nonRefExpT2)
+			t1 = type_system.Prune(nonRefExpT1, ctx.BindJournal)
+			t2 = type_system.Prune(nonRefExpT2, ctx.BindJournal)
 			continue
 		}
 
@@ -1782,9 +1782,9 @@ func (c *Checker) unifyClosedWithRests(
 			// Setters on the outer object are kept (direct access).
 			addEffective(elem.Name, elem.Fn.Params[0].Type)
 		case *type_system.RestSpreadElem:
-			pruned := type_system.Prune(elem.Value)
+			pruned := type_system.Prune(elem.Value, ctx.BindJournal)
 			if mut, ok := pruned.(*type_system.MutType); ok {
-				pruned = type_system.Prune(mut.Type)
+				pruned = type_system.Prune(mut.Type, ctx.BindJournal)
 			}
 			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 				unboundRests = append(unboundRests, tv)
@@ -1805,7 +1805,7 @@ func (c *Checker) unifyClosedWithRests(
 						// Nested rest from chained destructuring (e.g. the T3 in
 						// {y: T2, ...T3}). Collect so remaining target properties
 						// can flow into it.
-						innerPruned := type_system.Prune(re.Value)
+						innerPruned := type_system.Prune(re.Value, ctx.BindJournal)
 						if tv, ok := innerPruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 							unboundRests = append(unboundRests, tv)
 						}
@@ -2169,15 +2169,15 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 						// Propagate the constraint to typeVar2 since it becomes the
 						// representative of this equivalence class after binding.
 						if ctx.BindJournal != nil {
-							ctx.BindJournal.snapshot(typeVar2)
+							ctx.BindJournal.Snapshot(typeVar2)
 						}
 						typeVar2.Constraint = typeVar1.Constraint
 					}
 					// Propagate IsObjectRest so that Prune() returns a TypeVar
 					// that preserves the marker for the tuple spread check.
 					if ctx.BindJournal != nil {
-						ctx.BindJournal.snapshot(typeVar1)
-						ctx.BindJournal.snapshot(typeVar2)
+						ctx.BindJournal.Snapshot(typeVar1)
+						ctx.BindJournal.Snapshot(typeVar2)
 					}
 					typeVar2.IsObjectRest = typeVar2.IsObjectRest || typeVar1.IsObjectRest
 					typeVar1.Instance = t2
@@ -2238,7 +2238,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 					targetType = rebuildContainers(targetType)
 				}
 				if ctx.BindJournal != nil {
-					ctx.BindJournal.snapshot(typeVar1)
+					ctx.BindJournal.Snapshot(typeVar1)
 				}
 				typeVar1.Instance = targetType
 				typeVar1.SetProvenance(&type_system.TypeProvenance{
@@ -2287,7 +2287,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 					targetType = rebuildContainers(targetType)
 				}
 				if ctx.BindJournal != nil {
-					ctx.BindJournal.snapshot(typeVar2)
+					ctx.BindJournal.Snapshot(typeVar2)
 				}
 				typeVar2.Instance = targetType
 				typeVar2.SetProvenance(&type_system.TypeProvenance{
@@ -2312,7 +2312,7 @@ func (v *OccursInVisitor) EnterType(t type_system.Type) type_system.EnterResult 
 }
 
 func (v *OccursInVisitor) ExitType(t type_system.Type) type_system.Type {
-	if type_system.Equals(type_system.Prune(t), v.t1) {
+	if type_system.Equals(type_system.Prune(t, nil), v.t1) {
 		v.result = true
 	}
 	return nil
@@ -2331,7 +2331,7 @@ func occursInType(t1, t2 type_system.Type) bool {
 	// the occursInType calls below will themselves hit this same block if
 	// ElemTypeVar or a LiteralIndexes entry is a TypeVar with its own
 	// ArrayConstraint, so nested constraints are covered without additional work.
-	if tv, ok := type_system.Prune(t2).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
+	if tv, ok := type_system.Prune(t2, nil).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
 		if occursInType(t1, tv.ArrayConstraint.ElemTypeVar) {
 			return true
 		}
@@ -2379,7 +2379,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 			// Bind the TypeVar to the array type and clear the constraint so
 			// that resolveArrayConstraintsInType won't re-resolve it.
 			if ctx.BindJournal != nil {
-				ctx.BindJournal.snapshot(typeVar)
+				ctx.BindJournal.Snapshot(typeVar)
 			}
 			typeVar.Instance = boundType
 			typeVar.ArrayConstraint = nil
@@ -2401,7 +2401,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 				// literal indexes). Indexes beyond the prefix fall into rest.
 				targetType = rest.Type
 				// Extract element type from Array<T> if the rest is an array
-				if ref, ok := type_system.Prune(targetType).(*type_system.TypeRefType); ok && c.isArrayType(ref) && len(ref.TypeArgs) > 0 {
+				if ref, ok := type_system.Prune(targetType, ctx.BindJournal).(*type_system.TypeRefType); ok && c.isArrayType(ref) && len(ref.TypeArgs) > 0 {
 					targetType = ref.TypeArgs[0]
 				}
 			} else if idx < len(prefix)+len(suffix) {
@@ -2417,7 +2417,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 		// Bind the TypeVar to the tuple and clear the constraint so that
 		// resolveArrayConstraintsInType won't recreate a different tuple.
 		if ctx.BindJournal != nil {
-			ctx.BindJournal.snapshot(typeVar)
+			ctx.BindJournal.Snapshot(typeVar)
 		}
 		typeVar.Instance = boundType
 		typeVar.ArrayConstraint = nil
@@ -2460,7 +2460,7 @@ func (c *Checker) openClosedObjectForParam(ctx Context, typeVar *type_system.Typ
 	}
 	// Re-wrap in MutType if the original was wrapped.
 	if ctx.BindJournal != nil {
-		ctx.BindJournal.snapshot(typeVar)
+		ctx.BindJournal.Snapshot(typeVar)
 	}
 	if mutWrapper != nil {
 		typeVar.Instance = &type_system.MutType{
@@ -2555,7 +2555,7 @@ func distributeIntersectionOverUnion(intersection *type_system.IntersectionType)
 	// Check if any of the types in the intersection is a union
 	var unionIndex = -1
 	for i, t := range intersection.Types {
-		t = type_system.Prune(t)
+		t = type_system.Prune(t, nil)
 		if _, ok := t.(*type_system.UnionType); ok {
 			unionIndex = i
 			break
@@ -2567,7 +2567,7 @@ func distributeIntersectionOverUnion(intersection *type_system.IntersectionType)
 		return intersection, false
 	}
 
-	union := type_system.Prune(intersection.Types[unionIndex]).(*type_system.UnionType)
+	union := type_system.Prune(intersection.Types[unionIndex], nil).(*type_system.UnionType)
 
 	otherTypes := make([]type_system.Type, 0, len(intersection.Types)-1)
 	otherTypes = append(otherTypes, intersection.Types[:unionIndex]...)
@@ -2606,7 +2606,7 @@ func widenLiteral(t type_system.Type) type_system.Type {
 	}
 	// Follow TypeVar instances so we can widen the underlying concrete type
 	// (e.g. MutType wrapping a TypeVar whose Instance is an ObjectType).
-	inner = type_system.Prune(inner)
+	inner = type_system.Prune(inner, nil)
 
 	var widened type_system.Type
 	switch v := inner.(type) {
@@ -2661,7 +2661,7 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 		switch e := elem.(type) {
 		case *type_system.PropertyElem:
 			// Prune through TypeVars, then widen.
-			val := type_system.Prune(e.Value)
+			val := type_system.Prune(e.Value, nil)
 			widened := widenLiteral(val)
 			if widened != e.Value {
 				changed = true
@@ -2730,7 +2730,7 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 func widenFuncType(fn *type_system.FuncType) *type_system.FuncType {
 	changed := false
 
-	ret := type_system.Prune(fn.Return)
+	ret := type_system.Prune(fn.Return, nil)
 	widenedReturn := widenLiteral(ret)
 	if widenedReturn != fn.Return {
 		changed = true
@@ -2738,7 +2738,7 @@ func widenFuncType(fn *type_system.FuncType) *type_system.FuncType {
 
 	newParams := make([]*type_system.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
-		pt := type_system.Prune(p.Type)
+		pt := type_system.Prune(p.Type, nil)
 		widened := widenLiteral(pt)
 		if widened != p.Type {
 			changed = true
@@ -2764,7 +2764,7 @@ func widenTupleLiterals(tuple *type_system.TupleType) *type_system.TupleType {
 	newElems := make([]type_system.Type, len(tuple.Elems))
 	changed := false
 	for i, elem := range tuple.Elems {
-		val := type_system.Prune(elem)
+		val := type_system.Prune(elem, nil)
 		widened := widenLiteral(val)
 		if widened != elem {
 			changed = true

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -256,7 +256,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 		if _, isTV := oldType.(*type_system.TypeVarType); isTV {
 			return errors
 		}
-		newType := widenLiteral(t1)
+		newType := widenLiteral(t1, ctx.BindJournal)
 		widened := oldType
 		// Check answers "is newType a subtype of oldType" directly: if
 		// so, widening to add it would be redundant (a literal already
@@ -1277,7 +1277,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 	// First, try to distribute intersections over unions (Phase 2: Distributive laws)
 	// A & (B | C) should be equivalent to (A & B) | (A & C)
 	if intersection1, ok := t1.(*type_system.IntersectionType); ok {
-		distributed1, _ := distributeIntersectionOverUnion(intersection1)
+		distributed1, _ := distributeIntersectionOverUnion(intersection1, ctx.BindJournal)
 		// Check if distribution occurred by seeing if the type changed
 		if _, stillIntersection := distributed1.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
@@ -1285,7 +1285,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 		}
 
 		if intersection2, ok := t2.(*type_system.IntersectionType); ok {
-			distributed2, _ := distributeIntersectionOverUnion(intersection2)
+			distributed2, _ := distributeIntersectionOverUnion(intersection2, ctx.BindJournal)
 			// Check if distribution occurred on t2
 			if _, stillIntersection := distributed2.(*type_system.IntersectionType); !stillIntersection {
 				// Distribution occurred on t2, retry unification
@@ -1326,7 +1326,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 	// We try each part and if any succeeds, the intersection is valid.
 	if intersection, ok := t1.(*type_system.IntersectionType); ok {
 		// First, try distribution (Phase 2: Distributive laws)
-		distributed, _ := distributeIntersectionOverUnion(intersection)
+		distributed, _ := distributeIntersectionOverUnion(intersection, ctx.BindJournal)
 		// Check if distribution occurred
 		if _, stillIntersection := distributed.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
@@ -1354,7 +1354,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 	// This is because B & C requires all the properties of both B and C.
 	if intersection, ok := t2.(*type_system.IntersectionType); ok {
 		// First, try distribution (Phase 2: Distributive laws)
-		distributed, _ := distributeIntersectionOverUnion(intersection)
+		distributed, _ := distributeIntersectionOverUnion(intersection, ctx.BindJournal)
 		// Check if distribution occurred
 		if _, stillIntersection := distributed.(*type_system.IntersectionType); !stillIntersection {
 			// Distribution created a different type (likely a union), retry unification
@@ -1788,7 +1788,7 @@ func (c *Checker) unifyClosedWithRests(
 			}
 			if tv, ok := pruned.(*type_system.TypeVarType); ok && tv.Instance == nil {
 				unboundRests = append(unboundRests, tv)
-			} else if obj := resolveToObjectType(pruned); obj != nil {
+			} else if obj := resolveToObjectType(pruned, ctx.BindJournal); obj != nil {
 				// Apply spread semantics: methods → fn type, getters → return
 				// type, setter-only → skipped.
 				for _, re := range obj.Elems {
@@ -2149,7 +2149,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 	errors := []Error{}
 
 	if !type_system.Equals(t1, t2) {
-		if occursInType(t1, t2) {
+		if occursInType(t1, t2, ctx.BindJournal) {
 			fmt.Fprintf(os.Stderr, "Recursive unification: cannot bind %s to %s\n", t1.String(), t2.String())
 			return []Error{&RecursiveUnificationError{
 				Left:  t1,
@@ -2229,7 +2229,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				// (e.g. "hello" -> string, {x: 1} -> {x: number}).
 				targetType := t2
 				if typeVar1.Widenable {
-					targetType = widenLiteral(targetType)
+					targetType = widenLiteral(targetType, ctx.BindJournal)
 				}
 				// FromBinding TypeVars need re-normalization: a union/intersection
 				// built before its inner TypeVars were resolved may now collapse
@@ -2278,7 +2278,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				// (e.g. "hello" -> string, {x: 1} -> {x: number}).
 				targetType := t1
 				if typeVar2.Widenable {
-					targetType = widenLiteral(targetType)
+					targetType = widenLiteral(targetType, ctx.BindJournal)
 				}
 				// FromBinding TypeVars need re-normalization: a union/intersection
 				// built before its inner TypeVars were resolved may now collapse
@@ -2304,6 +2304,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 type OccursInVisitor struct {
 	result bool
 	t1     type_system.Type
+	j      type_system.Journal
 }
 
 func (v *OccursInVisitor) EnterType(t type_system.Type) type_system.EnterResult {
@@ -2312,14 +2313,14 @@ func (v *OccursInVisitor) EnterType(t type_system.Type) type_system.EnterResult 
 }
 
 func (v *OccursInVisitor) ExitType(t type_system.Type) type_system.Type {
-	if type_system.Equals(type_system.Prune(t, nil), v.t1) {
+	if type_system.Equals(type_system.Prune(t, v.j), v.t1) {
 		v.result = true
 	}
 	return nil
 }
 
-func occursInType(t1, t2 type_system.Type) bool {
-	visitor := &OccursInVisitor{result: false, t1: t1}
+func occursInType(t1, t2 type_system.Type, j type_system.Journal) bool {
+	visitor := &OccursInVisitor{result: false, t1: t1, j: j}
 	t2.Accept(visitor)
 	if visitor.result {
 		return true
@@ -2331,12 +2332,12 @@ func occursInType(t1, t2 type_system.Type) bool {
 	// the occursInType calls below will themselves hit this same block if
 	// ElemTypeVar or a LiteralIndexes entry is a TypeVar with its own
 	// ArrayConstraint, so nested constraints are covered without additional work.
-	if tv, ok := type_system.Prune(t2, nil).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
-		if occursInType(t1, tv.ArrayConstraint.ElemTypeVar) {
+	if tv, ok := type_system.Prune(t2, j).(*type_system.TypeVarType); ok && tv.ArrayConstraint != nil {
+		if occursInType(t1, tv.ArrayConstraint.ElemTypeVar, j) {
 			return true
 		}
 		for _, elemTV := range tv.ArrayConstraint.LiteralIndexes {
-			if occursInType(t1, elemTV) {
+			if occursInType(t1, elemTV, j) {
 				return true
 			}
 		}
@@ -2551,11 +2552,11 @@ func rebuildContainers(t type_system.Type) type_system.Type {
 // distributeIntersectionOverUnion distributes an intersection type over any unions it contains.
 // For example: A & (B | C) becomes (A & B) | (A & C)
 // Returns the original type if no distribution is needed or if distribution involves problematic nominal types.
-func distributeIntersectionOverUnion(intersection *type_system.IntersectionType) (type_system.Type, bool) {
+func distributeIntersectionOverUnion(intersection *type_system.IntersectionType, j type_system.Journal) (type_system.Type, bool) {
 	// Check if any of the types in the intersection is a union
 	var unionIndex = -1
 	for i, t := range intersection.Types {
-		t = type_system.Prune(t, nil)
+		t = type_system.Prune(t, j)
 		if _, ok := t.(*type_system.UnionType); ok {
 			unionIndex = i
 			break
@@ -2567,7 +2568,7 @@ func distributeIntersectionOverUnion(intersection *type_system.IntersectionType)
 		return intersection, false
 	}
 
-	union := type_system.Prune(intersection.Types[unionIndex], nil).(*type_system.UnionType)
+	union := type_system.Prune(intersection.Types[unionIndex], j).(*type_system.UnionType)
 
 	otherTypes := make([]type_system.Type, 0, len(intersection.Types)-1)
 	otherTypes = append(otherTypes, intersection.Types[:unionIndex]...)
@@ -2597,7 +2598,7 @@ func distributeIntersectionOverUnion(intersection *type_system.IntersectionType)
 //
 // If the type is wrapped in a MutType, the wrapper is preserved on the
 // widened inner type. Types that don't match any case are returned unchanged.
-func widenLiteral(t type_system.Type) type_system.Type {
+func widenLiteral(t type_system.Type, j type_system.Journal) type_system.Type {
 	inner := t
 	var mutWrapper *type_system.MutType
 	if mut, ok := inner.(*type_system.MutType); ok {
@@ -2606,7 +2607,7 @@ func widenLiteral(t type_system.Type) type_system.Type {
 	}
 	// Follow TypeVar instances so we can widen the underlying concrete type
 	// (e.g. MutType wrapping a TypeVar whose Instance is an ObjectType).
-	inner = type_system.Prune(inner, nil)
+	inner = type_system.Prune(inner, j)
 
 	var widened type_system.Type
 	switch v := inner.(type) {
@@ -2616,9 +2617,9 @@ func widenLiteral(t type_system.Type) type_system.Type {
 			return t
 		}
 	case *type_system.ObjectType:
-		widened = widenObjectLiterals(v)
+		widened = widenObjectLiterals(v, j)
 	case *type_system.TupleType:
-		widened = widenTupleLiterals(v)
+		widened = widenTupleLiterals(v, j)
 	default:
 		return t
 	}
@@ -2654,15 +2655,15 @@ func widenLitToPrim(lit *type_system.LitType) type_system.Type {
 // widenObjectLiterals returns a copy of the ObjectType with all element types
 // recursively widened (literals → primitives). Handles property values, method
 // param/return types, and getter/setter types.
-func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
+func widenObjectLiterals(obj *type_system.ObjectType, j type_system.Journal) *type_system.ObjectType {
 	newElems := make([]type_system.ObjTypeElem, len(obj.Elems))
 	changed := false
 	for i, elem := range obj.Elems {
 		switch e := elem.(type) {
 		case *type_system.PropertyElem:
 			// Prune through TypeVars, then widen.
-			val := type_system.Prune(e.Value, nil)
-			widened := widenLiteral(val)
+			val := type_system.Prune(e.Value, j)
+			widened := widenLiteral(val, j)
 			if widened != e.Value {
 				changed = true
 				newElems[i] = &type_system.PropertyElem{
@@ -2682,15 +2683,15 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 			// compatible with PR-C overloads.
 			newSigs := e.Signatures
 			armChanged := false
-			for j, fn := range e.Signatures {
-				widened := widenFuncType(fn)
+			for k, fn := range e.Signatures {
+				widened := widenFuncType(fn, j)
 				if widened != fn {
 					if !armChanged {
 						newSigs = make([]*type_system.FuncType, len(e.Signatures))
 						copy(newSigs, e.Signatures)
 						armChanged = true
 					}
-					newSigs[j] = widened
+					newSigs[k] = widened
 				}
 			}
 			if armChanged {
@@ -2700,14 +2701,14 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 				newElems[i] = elem
 			}
 		case *type_system.GetterElem:
-			if fn := widenFuncType(e.Fn); fn != e.Fn {
+			if fn := widenFuncType(e.Fn, j); fn != e.Fn {
 				changed = true
 				newElems[i] = &type_system.GetterElem{Name: e.Name, Fn: fn}
 			} else {
 				newElems[i] = elem
 			}
 		case *type_system.SetterElem:
-			if fn := widenFuncType(e.Fn); fn != e.Fn {
+			if fn := widenFuncType(e.Fn, j); fn != e.Fn {
 				changed = true
 				newElems[i] = &type_system.SetterElem{Name: e.Name, Fn: fn}
 			} else {
@@ -2727,19 +2728,19 @@ func widenObjectLiterals(obj *type_system.ObjectType) *type_system.ObjectType {
 
 // widenFuncType returns a copy of the FuncType with parameter and return types
 // recursively widened. Returns the original if nothing changed.
-func widenFuncType(fn *type_system.FuncType) *type_system.FuncType {
+func widenFuncType(fn *type_system.FuncType, j type_system.Journal) *type_system.FuncType {
 	changed := false
 
-	ret := type_system.Prune(fn.Return, nil)
-	widenedReturn := widenLiteral(ret)
+	ret := type_system.Prune(fn.Return, j)
+	widenedReturn := widenLiteral(ret, j)
 	if widenedReturn != fn.Return {
 		changed = true
 	}
 
 	newParams := make([]*type_system.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
-		pt := type_system.Prune(p.Type, nil)
-		widened := widenLiteral(pt)
+		pt := type_system.Prune(p.Type, j)
+		widened := widenLiteral(pt, j)
 		if widened != p.Type {
 			changed = true
 			newParams[i] = &type_system.FuncParam{
@@ -2760,12 +2761,12 @@ func widenFuncType(fn *type_system.FuncType) *type_system.FuncType {
 
 // widenTupleLiterals returns a copy of the TupleType with all element types
 // recursively widened (literals → primitives).
-func widenTupleLiterals(tuple *type_system.TupleType) *type_system.TupleType {
+func widenTupleLiterals(tuple *type_system.TupleType, j type_system.Journal) *type_system.TupleType {
 	newElems := make([]type_system.Type, len(tuple.Elems))
 	changed := false
 	for i, elem := range tuple.Elems {
-		val := type_system.Prune(elem, nil)
-		widened := widenLiteral(val)
+		val := type_system.Prune(elem, j)
+		widened := widenLiteral(val, j)
 		if widened != elem {
 			changed = true
 		}

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -267,9 +267,7 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 			widened = flatUnion(oldType, newType)
 		}
 		for _, tv := range widenableChain {
-			if ctx.BindJournal != nil {
-				ctx.BindJournal.Snapshot(tv)
-			}
+			ctx.BindJournal.Snapshot(tv)
 			tv.Instance = widened
 		}
 		return nil
@@ -2163,22 +2161,22 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 
 			if typeVar1, ok := t1.(*type_system.TypeVarType); ok {
 				if typeVar2, ok := t2.(*type_system.TypeVarType); ok {
+					// Snapshot both upfront — covers the Constraint
+					// propagation, IsObjectRest propagation, and Instance
+					// write that follow. One record per TypeVar instead
+					// of stacking three for typeVar2 in the constraint-
+					// propagation branch.
+					ctx.BindJournal.Snapshot(typeVar1)
+					ctx.BindJournal.Snapshot(typeVar2)
 					if typeVar1.Constraint != nil && typeVar2.Constraint != nil {
 						errors = c.unifyInner(ctx, typeVar1.Constraint, typeVar2.Constraint, seen)
 					} else if typeVar1.Constraint != nil && typeVar2.Constraint == nil {
 						// Propagate the constraint to typeVar2 since it becomes the
 						// representative of this equivalence class after binding.
-						if ctx.BindJournal != nil {
-							ctx.BindJournal.Snapshot(typeVar2)
-						}
 						typeVar2.Constraint = typeVar1.Constraint
 					}
 					// Propagate IsObjectRest so that Prune() returns a TypeVar
 					// that preserves the marker for the tuple spread check.
-					if ctx.BindJournal != nil {
-						ctx.BindJournal.Snapshot(typeVar1)
-						ctx.BindJournal.Snapshot(typeVar2)
-					}
 					typeVar2.IsObjectRest = typeVar2.IsObjectRest || typeVar1.IsObjectRest
 					typeVar1.Instance = t2
 					typeVar1.SetProvenance(&type_system.TypeProvenance{
@@ -2237,9 +2235,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				if typeVar1.FromBinding {
 					targetType = rebuildContainers(targetType)
 				}
-				if ctx.BindJournal != nil {
-					ctx.BindJournal.Snapshot(typeVar1)
-				}
+				ctx.BindJournal.Snapshot(typeVar1)
 				typeVar1.Instance = targetType
 				typeVar1.SetProvenance(&type_system.TypeProvenance{
 					Type: targetType,
@@ -2286,9 +2282,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				if typeVar2.FromBinding {
 					targetType = rebuildContainers(targetType)
 				}
-				if ctx.BindJournal != nil {
-					ctx.BindJournal.Snapshot(typeVar2)
-				}
+				ctx.BindJournal.Snapshot(typeVar2)
 				typeVar2.Instance = targetType
 				typeVar2.SetProvenance(&type_system.TypeProvenance{
 					Type: targetType,
@@ -2379,9 +2373,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 			}
 			// Bind the TypeVar to the array type and clear the constraint so
 			// that resolveArrayConstraintsInType won't re-resolve it.
-			if ctx.BindJournal != nil {
-				ctx.BindJournal.Snapshot(typeVar)
-			}
+			ctx.BindJournal.Snapshot(typeVar)
 			typeVar.Instance = boundType
 			typeVar.ArrayConstraint = nil
 			return true, errs
@@ -2417,9 +2409,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 		}
 		// Bind the TypeVar to the tuple and clear the constraint so that
 		// resolveArrayConstraintsInType won't recreate a different tuple.
-		if ctx.BindJournal != nil {
-			ctx.BindJournal.Snapshot(typeVar)
-		}
+		ctx.BindJournal.Snapshot(typeVar)
 		typeVar.Instance = boundType
 		typeVar.ArrayConstraint = nil
 		return true, errs
@@ -2460,9 +2450,7 @@ func (c *Checker) openClosedObjectForParam(ctx Context, typeVar *type_system.Typ
 		Mutable:   closedObj.Mutable,
 	}
 	// Re-wrap in MutType if the original was wrapped.
-	if ctx.BindJournal != nil {
-		ctx.BindJournal.Snapshot(typeVar)
-	}
+	ctx.BindJournal.Snapshot(typeVar)
 	if mutWrapper != nil {
 		typeVar.Instance = &type_system.MutType{
 			Type: openCopy,

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -1301,7 +1301,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 			for _, t2Part := range intersection2.Types {
 				found := false
 				for _, t1Part := range intersection1.Types {
-					probe := c.Probe(ctx, t1Part, t2Part)
+					probe := c.probeWithSeen(ctx, t1Part, t2Part, seen)
 					if probe.Success() {
 						probe.Commit()
 						found = true
@@ -1338,7 +1338,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 		// (see #381, #660).
 		var allErrors []Error
 		for _, part := range intersection.Types {
-			probe := c.Probe(ctx, part, t2)
+			probe := c.probeWithSeen(ctx, part, t2, seen)
 			if probe.Success() {
 				probe.Commit()
 				return nil
@@ -1507,7 +1507,7 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 		// failed attempts can roll back their partial TypeVar mutations
 		// (see #381, #660).
 		for _, unionType := range union.Types {
-			probe := c.Probe(ctx, t1, unionType)
+			probe := c.probeWithSeen(ctx, t1, unionType, seen)
 			if probe.Success() {
 				probe.Commit()
 				return nil

--- a/internal/checker/unify.go
+++ b/internal/checker/unify.go
@@ -267,6 +267,9 @@ func (c *Checker) unifyInner(ctx Context, t1, t2 type_system.Type, seen unifySee
 			widened = flatUnion(oldType, newType)
 		}
 		for _, tv := range widenableChain {
+			if ctx.BindJournal != nil {
+				ctx.BindJournal.snapshot(tv)
+			}
 			tv.Instance = widened
 		}
 		return nil
@@ -1289,35 +1292,22 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 				return c.unifyInner(ctx, distributed1, distributed2, seen)
 			}
 
-			// Probe-then-commit: trial-unify clones to avoid partially mutating
-			// TypeVars on failure (see #381). Fast path first: if Check
-			// succeeds on the originals, no binding is required and we can
-			// commit without the clone-probe allocation.
+			// Probe-then-commit: trial-unify on the originals with a journal
+			// so failed attempts can roll back their partial TypeVar mutations
+			// (see #381, #660). Probe runs unifyInner exactly once per arm —
+			// on success we Commit (keep mutations); on failure we Discard
+			// (rollback) and try the next arm.
 			errors := []Error{}
 			for _, t2Part := range intersection2.Types {
 				found := false
 				for _, t1Part := range intersection1.Types {
-					// Check is side-effect-free and skips lifetime
-					// reconciliation, so a true result doesn't guarantee
-					// the real unify will succeed. Commit only if the
-					// follow-up unifyInner also has no errors; otherwise
-					// fall through to the clone-probe.
-					if c.Check(ctx, t1Part, t2Part) {
-						if errs := c.unifyInner(ctx, t1Part, t2Part, seen); len(errs) == 0 {
-							found = true
-							break
-						}
-					}
-					varMapping := make(map[int]*type_system.TypeVarType)
-					t1Clone := c.deepCloneType(t1Part, varMapping)
-					t2Clone := c.deepCloneType(t2Part, varMapping)
-					probeErrors := c.unifyInner(ctx, t1Clone, t2Clone, seen)
-					if len(probeErrors) == 0 {
-						// Probe succeeded — safe to unify originals.
-						c.unifyInner(ctx, t1Part, t2Part, seen)
+					probe := c.Probe(ctx, t1Part, t2Part)
+					if probe.Success() {
+						probe.Commit()
 						found = true
 						break
 					}
+					probe.Discard()
 				}
 				if !found {
 					// Could not find a matching type in intersection1 for this t2Part
@@ -1343,31 +1333,18 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 			return c.unifyInner(ctx, distributed, t2, seen)
 		}
 
-		// Probe-then-commit: trial-unify clones to avoid partially mutating
-		// TypeVars on failure (see #381). Fast path first: if Check
-		// succeeds on the originals, no binding is required and we can
-		// commit without the clone-probe allocation.
+		// Probe-then-commit: trial-unify on the originals with a journal so
+		// failed attempts can roll back their partial TypeVar mutations
+		// (see #381, #660).
 		var allErrors []Error
 		for _, part := range intersection.Types {
-			// Check is side-effect-free and skips lifetime reconciliation,
-			// so a true result doesn't guarantee the real unify will
-			// succeed. Commit only if the follow-up unifyInner also has
-			// no errors; otherwise fall through to the clone-probe.
-			if c.Check(ctx, part, t2) {
-				if errs := c.unifyInner(ctx, part, t2, seen); len(errs) == 0 {
-					return nil
-				}
-			}
-			varMapping := make(map[int]*type_system.TypeVarType)
-			partClone := c.deepCloneType(part, varMapping)
-			t2Clone := c.deepCloneType(t2, varMapping)
-			probeErrors := c.unifyInner(ctx, partClone, t2Clone, seen)
-			if len(probeErrors) == 0 {
-				// Probe succeeded — safe to unify originals.
-				c.unifyInner(ctx, part, t2, seen)
+			probe := c.Probe(ctx, part, t2)
+			if probe.Success() {
+				probe.Commit()
 				return nil
 			}
-			allErrors = slices.Concat(allErrors, probeErrors)
+			allErrors = slices.Concat(allErrors, probe.Errors())
+			probe.Discard()
 		}
 		// None of the parts successfully unified with t2
 		return allErrors
@@ -1526,29 +1503,16 @@ func (c *Checker) unifyMatched(ctx Context, t1, t2 type_system.Type, seen unifyS
 	}
 	// | _, UnionType -> ...
 	if union, ok := t2.(*type_system.UnionType); ok {
-		// Probe-then-commit: trial-unify clones to avoid partially mutating
-		// TypeVars on failure (see #381). Fast path first: if Check
-		// succeeds on the originals, no binding is required and we can
-		// commit without the clone-probe allocation.
+		// Probe-then-commit: trial-unify on the originals with a journal so
+		// failed attempts can roll back their partial TypeVar mutations
+		// (see #381, #660).
 		for _, unionType := range union.Types {
-			// Check is side-effect-free and skips lifetime reconciliation,
-			// so a true result doesn't guarantee the real unify will
-			// succeed. Commit only if the follow-up unifyInner also has
-			// no errors; otherwise fall through to the clone-probe.
-			if c.Check(ctx, t1, unionType) {
-				if errs := c.unifyInner(ctx, t1, unionType, seen); len(errs) == 0 {
-					return nil
-				}
-			}
-			varMapping := make(map[int]*type_system.TypeVarType)
-			t1Clone := c.deepCloneType(t1, varMapping)
-			unionTypeClone := c.deepCloneType(unionType, varMapping)
-			probeErrors := c.unifyInner(ctx, t1Clone, unionTypeClone, seen)
-			if len(probeErrors) == 0 {
-				// Probe succeeded — safe to unify originals.
-				c.unifyInner(ctx, t1, unionType, seen)
+			probe := c.Probe(ctx, t1, unionType)
+			if probe.Success() {
+				probe.Commit()
 				return nil
 			}
+			probe.Discard()
 		}
 		// If we couldn't unify with any union member, return a unification error
 		return []Error{&CannotUnifyTypesError{
@@ -2204,10 +2168,17 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 					} else if typeVar1.Constraint != nil && typeVar2.Constraint == nil {
 						// Propagate the constraint to typeVar2 since it becomes the
 						// representative of this equivalence class after binding.
+						if ctx.BindJournal != nil {
+							ctx.BindJournal.snapshot(typeVar2)
+						}
 						typeVar2.Constraint = typeVar1.Constraint
 					}
 					// Propagate IsObjectRest so that Prune() returns a TypeVar
 					// that preserves the marker for the tuple spread check.
+					if ctx.BindJournal != nil {
+						ctx.BindJournal.snapshot(typeVar1)
+						ctx.BindJournal.snapshot(typeVar2)
+					}
 					typeVar2.IsObjectRest = typeVar2.IsObjectRest || typeVar1.IsObjectRest
 					typeVar1.Instance = t2
 					typeVar1.SetProvenance(&type_system.TypeProvenance{
@@ -2241,7 +2212,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				// the type variable as a side effect, and openClosedObjectForParam
 				// checks Instance != nil to avoid double-binding.
 				if typeVar1.IsParam {
-					if opened := c.openClosedObjectForParam(typeVar1, t2); opened {
+					if opened := c.openClosedObjectForParam(ctx, typeVar1, t2); opened {
 						return errors
 					}
 				}
@@ -2265,6 +2236,9 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				// (e.g. `number | 10` → `number`).
 				if typeVar1.FromBinding {
 					targetType = rebuildContainers(targetType)
+				}
+				if ctx.BindJournal != nil {
+					ctx.BindJournal.snapshot(typeVar1)
 				}
 				typeVar1.Instance = targetType
 				typeVar1.SetProvenance(&type_system.TypeProvenance{
@@ -2295,7 +2269,7 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				}
 				// See comment in typeVar1 branch above re: IsParam and Constraint.
 				if typeVar2.IsParam {
-					if opened := c.openClosedObjectForParam(typeVar2, t1); opened {
+					if opened := c.openClosedObjectForParam(ctx, typeVar2, t1); opened {
 						return errors
 					}
 				}
@@ -2311,6 +2285,9 @@ func (c *Checker) bind(ctx Context, t1 type_system.Type, t2 type_system.Type, se
 				// (e.g. `number | 10` → `number`).
 				if typeVar2.FromBinding {
 					targetType = rebuildContainers(targetType)
+				}
+				if ctx.BindJournal != nil {
+					ctx.BindJournal.snapshot(typeVar2)
 				}
 				typeVar2.Instance = targetType
 				typeVar2.SetProvenance(&type_system.TypeProvenance{
@@ -2401,6 +2378,9 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 			}
 			// Bind the TypeVar to the array type and clear the constraint so
 			// that resolveArrayConstraintsInType won't re-resolve it.
+			if ctx.BindJournal != nil {
+				ctx.BindJournal.snapshot(typeVar)
+			}
 			typeVar.Instance = boundType
 			typeVar.ArrayConstraint = nil
 			return true, errs
@@ -2436,6 +2416,9 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 		}
 		// Bind the TypeVar to the tuple and clear the constraint so that
 		// resolveArrayConstraintsInType won't recreate a different tuple.
+		if ctx.BindJournal != nil {
+			ctx.BindJournal.snapshot(typeVar)
+		}
 		typeVar.Instance = boundType
 		typeVar.ArrayConstraint = nil
 		return true, errs
@@ -2450,7 +2433,7 @@ func (c *Checker) handleArrayConstraintBinding(ctx Context, typeVar *type_system
 // properties inferred from other usage in the function body (e.g. `obj.b = "hi"`).
 // By converting to an open copy with a RestSpreadElem row variable, the parameter
 // picks up bar's constraints while remaining extensible.
-func (c *Checker) openClosedObjectForParam(typeVar *type_system.TypeVarType, boundType type_system.Type) bool {
+func (c *Checker) openClosedObjectForParam(ctx Context, typeVar *type_system.TypeVarType, boundType type_system.Type) bool {
 	if typeVar.Instance != nil {
 		return false // already bound (e.g. during constraint unification)
 	}
@@ -2476,6 +2459,9 @@ func (c *Checker) openClosedObjectForParam(typeVar *type_system.TypeVarType, bou
 		Mutable:   closedObj.Mutable,
 	}
 	// Re-wrap in MutType if the original was wrapped.
+	if ctx.BindJournal != nil {
+		ctx.BindJournal.snapshot(typeVar)
+	}
 	if mutWrapper != nil {
 		typeVar.Instance = &type_system.MutType{
 			Type: openCopy,

--- a/internal/checker/unify_lifetimes.go
+++ b/internal/checker/unify_lifetimes.go
@@ -89,10 +89,12 @@ func (c *Checker) UnifyLifetimes(ctx Context, l1, l2 type_system.Lifetime) []Err
 	// the only way to construct a cycle would be a same-var-twice
 	// binding, which the `l1 == l2` early return above already covers.
 	if v1, ok := l1.(*type_system.LifetimeVar); ok {
+		ctx.BindJournal.SnapshotLifetime(v1)
 		v1.Instance = l2
 		return nil
 	}
 	if v2, ok := l2.(*type_system.LifetimeVar); ok {
+		ctx.BindJournal.SnapshotLifetime(v2)
 		v2.Instance = l1
 		return nil
 	}

--- a/internal/checker/unify_mut.go
+++ b/internal/checker/unify_mut.go
@@ -15,8 +15,8 @@ func (c *Checker) unifyMut(ctx Context, mut1, mut2 *type_system.MutType) []Error
 	t1 := mut1.Type
 	t2 := mut2.Type
 
-	t1 = type_system.Prune(t1)
-	t2 = type_system.Prune(t2)
+	t1 = type_system.Prune(t1, ctx.BindJournal)
+	t2 = type_system.Prune(t2, ctx.BindJournal)
 
 	// For invariant unification, the types must be exactly equal —
 	// except when one side is an unbound TypeVar (e.g. a fresh

--- a/internal/checker/utils.go
+++ b/internal/checker/utils.go
@@ -83,7 +83,7 @@ func (c *Checker) astKeyToTypeKey(ctx Context, key ast.ObjKey) (*type_system.Obj
 
 		// TODO(#413): handle custom symbols from Symbol() — currently only
 		// well-known symbols (UniqueSymbolType) are supported as computed keys.
-		switch t := type_system.Prune(keyType).(type) {
+		switch t := type_system.Prune(keyType, ctx.BindJournal).(type) {
 		case *type_system.LitType:
 			switch lit := t.Lit.(type) {
 			case *type_system.StrLit:
@@ -108,10 +108,10 @@ func (c *Checker) astKeyToTypeKey(ctx Context, key ast.ObjKey) (*type_system.Obj
 
 // Helper function to remove undefined from a union type
 func removeUndefinedFromType(t type_system.Type) type_system.Type {
-	if unionType, ok := type_system.Prune(t).(*type_system.UnionType); ok {
+	if unionType, ok := type_system.Prune(t, nil).(*type_system.UnionType); ok {
 		nonUndefinedTypes := []type_system.Type{}
 		for _, typ := range unionType.Types {
-			if litType, ok := type_system.Prune(typ).(*type_system.LitType); ok {
+			if litType, ok := type_system.Prune(typ, nil).(*type_system.LitType); ok {
 				if _, isUndefined := litType.Lit.(*type_system.UndefinedLit); isUndefined {
 					continue // Skip undefined
 				}
@@ -129,7 +129,7 @@ func removeUndefinedFromType(t type_system.Type) type_system.Type {
 func (c *Checker) getDefinedElems(unionType *type_system.UnionType) []type_system.Type {
 	definedElems := []type_system.Type{}
 	for _, elem := range unionType.Types {
-		elem = type_system.Prune(elem)
+		elem = type_system.Prune(elem, nil)
 		switch elem := elem.(type) {
 		case *type_system.LitType:
 			switch elem.Lit.(type) {

--- a/internal/checker/widening_test.go
+++ b/internal/checker/widening_test.go
@@ -78,7 +78,7 @@ func TestWideningWithAliasedTypeVars(t *testing.T) {
 	// Sanity: tvB should resolve to number. Do NOT Prune tvA here — that
 	// would path-compress tvA.Instance from tvB to numType, destroying the
 	// alias chain before the widening test.
-	assert.Equal(t, "number", ts.Prune(tvB).String())
+	assert.Equal(t, "number", ts.Prune(tvB, nil).String())
 
 	// Conflicting write through tvA: Unify("hello", tvA).
 	// This should trigger widening to number | string.
@@ -87,9 +87,9 @@ func TestWideningWithAliasedTypeVars(t *testing.T) {
 	assert.Empty(t, errors, "widening should suppress the error")
 
 	// Both tvA and tvB should resolve to number | string.
-	assert.Equal(t, "number | string", ts.Prune(tvA).String(),
+	assert.Equal(t, "number | string", ts.Prune(tvA, nil).String(),
 		"tvA should see the widened type")
-	assert.Equal(t, "number | string", ts.Prune(tvB).String(),
+	assert.Equal(t, "number | string", ts.Prune(tvB, nil).String(),
 		"tvB should also see the widened type (alias consistency)")
 }
 

--- a/internal/checker/widening_test.go
+++ b/internal/checker/widening_test.go
@@ -7,6 +7,7 @@ import (
 
 	ts "github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlatUnionFlattensNestedUnions(t *testing.T) {
@@ -78,18 +79,18 @@ func TestWideningWithAliasedTypeVars(t *testing.T) {
 	// Sanity: tvB should resolve to number. Do NOT Prune tvA here — that
 	// would path-compress tvA.Instance from tvB to numType, destroying the
 	// alias chain before the widening test.
-	assert.Equal(t, "number", ts.Prune(tvB, nil).String())
+	require.Equal(t, "number", ts.Prune(tvB, nil).String())
 
 	// Conflicting write through tvA: Unify("hello", tvA).
 	// This should trigger widening to number | string.
 	strLit := ts.NewStrLitType(nil, "hello")
 	errors := c.Unify(inferCtx, strLit, tvA)
-	assert.Empty(t, errors, "widening should suppress the error")
+	require.Empty(t, errors, "widening should suppress the error")
 
 	// Both tvA and tvB should resolve to number | string.
-	assert.Equal(t, "number | string", ts.Prune(tvA, nil).String(),
+	require.Equal(t, "number | string", ts.Prune(tvA, nil).String(),
 		"tvA should see the widened type")
-	assert.Equal(t, "number | string", ts.Prune(tvB, nil).String(),
+	require.Equal(t, "number | string", ts.Prune(tvB, nil).String(),
 		"tvB should also see the widened type (alias consistency)")
 }
 

--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -1336,13 +1336,13 @@ func (b *Builder) buildTypeGuard(valueExpr Expr, typeAnn ast.TypeAnn) Expr {
 		inferredType := t.InferredType()
 		if inferredType != nil {
 			// Prune type variables to get the actual type
-			prunedType := type_system.Prune(inferredType)
+			prunedType := type_system.Prune(inferredType, nil)
 
 			// Check if it's a TypeRefType with a TypeAlias
 			if typeRef, ok := prunedType.(*type_system.TypeRefType); ok {
 				if typeRef.TypeAlias != nil {
 					// Get the aliased type
-					aliasedType := type_system.Prune(typeRef.TypeAlias.Type)
+					aliasedType := type_system.Prune(typeRef.TypeAlias.Type, nil)
 
 					// Check if the aliased type is a nominal object type
 					if objType, ok := aliasedType.(*type_system.ObjectType); ok && objType.Nominal {
@@ -1721,13 +1721,13 @@ func (b *Builder) buildExpr(expr ast.Expr, parent ast.Expr) (Expr, []Stmt) {
 
 		// For if-let expressions, check if the target type is nullable and add null/undefined check
 		if expr.Target.InferredType() != nil {
-			targetType := type_system.Prune(expr.Target.InferredType())
+			targetType := type_system.Prune(expr.Target.InferredType(), nil)
 			if unionType, ok := targetType.(*type_system.UnionType); ok {
 				// Check if the union contains null or undefined
 				hasNull := false
 				hasUndefined := false
 				for _, t := range unionType.Types {
-					if litType, ok := type_system.Prune(t).(*type_system.LitType); ok {
+					if litType, ok := type_system.Prune(t, nil).(*type_system.LitType); ok {
 						if _, isNull := litType.Lit.(*type_system.NullLit); isNull {
 							hasNull = true
 						}

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -130,7 +130,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 			}
 
 			localName := extractLocalName(name)
-			bindingType := type_sys.Prune(binding.Type)
+			bindingType := type_sys.Prune(binding.Type, nil)
 
 			var ifaceStmt *DeclStmt = nil
 			typeAnn := b.buildTypeAnn(bindingType)
@@ -380,7 +380,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 			return nil
 		}
 
-		t := type_sys.Prune(typeAlias.Type)
+		t := type_sys.Prune(typeAlias.Type, nil)
 
 		// Classes are represented as nominal ObjectTypes
 		objType, ok := t.(*type_sys.ObjectType)
@@ -435,7 +435,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 			return nil
 		}
 
-		staticType, ok := type_sys.Prune(staticTypeBinding.Type).(*type_sys.ObjectType)
+		staticType, ok := type_sys.Prune(staticTypeBinding.Type, nil).(*type_sys.ObjectType)
 		if !ok {
 			return nil
 		}
@@ -488,7 +488,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 				// Create type declaration for the variant instance type
 				variantTypeAlias := enumNS.Types[variantLocalName]
 				if variantTypeAlias != nil {
-					variantType := type_sys.Prune(variantTypeAlias.Type)
+					variantType := type_sys.Prune(variantTypeAlias.Type, nil)
 					variantTypeAnn := b.buildTypeAnn(variantType)
 
 					// Build type parameters from the variant's type alias
@@ -531,7 +531,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 				// Create value declaration for the variant constructor
 				variantBinding := enumNS.Values[variantLocalName]
 				if variantBinding != nil {
-					constructorType := type_sys.Prune(variantBinding.Type)
+					constructorType := type_sys.Prune(variantBinding.Type, nil)
 					constructorTypeAnn := b.buildTypeAnn(constructorType)
 
 					variantValueDecl := &VarDecl{
@@ -583,7 +583,7 @@ func (b *Builder) buildDeclStmt(decl ast.Decl, namespace *type_sys.Namespace, is
 		// Create the type alias for the enum (union of all variants)
 		enumTypeAlias := namespace.Types[decl.Name.Name]
 		if enumTypeAlias != nil {
-			enumType := type_sys.Prune(enumTypeAlias.Type)
+			enumType := type_sys.Prune(enumTypeAlias.Type, nil)
 			enumTypeAnn := b.buildTypeAnn(enumType)
 
 			// Build type parameters from the declaration
@@ -696,7 +696,7 @@ func convertQualIdent(tsIdent type_sys.QualIdent) QualIdent {
 }
 
 func (b *Builder) buildTypeAnn(t type_sys.Type) TypeAnn {
-	switch t := type_sys.Prune(t).(type) {
+	switch t := type_sys.Prune(t, nil).(type) {
 	case *type_sys.TypeVarType:
 		// After generalization, unresolved type vars should not reach here.
 		// Fall back to unknown as a safety net.

--- a/internal/codegen/js_lowering.go
+++ b/internal/codegen/js_lowering.go
@@ -31,7 +31,7 @@ func memberJSExpr(m *ast.MemberExpr) (string, bool) {
 	if objType == nil {
 		return "", false
 	}
-	nsType, ok := type_system.Prune(objType).(*type_system.NamespaceType)
+	nsType, ok := type_system.Prune(objType, nil).(*type_system.NamespaceType)
 	if !ok || nsType.Namespace == nil {
 		return "", false
 	}

--- a/internal/codegen/self_type_utils.go
+++ b/internal/codegen/self_type_utils.go
@@ -21,7 +21,7 @@ type selfTypeRefVisitor struct {
 }
 
 func (v *selfTypeRefVisitor) EnterType(t type_system.Type) type_system.EnterResult {
-	if tref, ok := type_system.Prune(t).(*type_system.TypeRefType); ok {
+	if tref, ok := type_system.Prune(t, nil).(*type_system.TypeRefType); ok {
 		if type_system.QualIdentToString(tref.Name) == "Self" {
 			v.found = true
 			return type_system.EnterResult{SkipChildren: true}
@@ -43,7 +43,7 @@ func (v *selfReplaceVisitor) EnterType(t type_system.Type) type_system.EnterResu
 }
 
 func (v *selfReplaceVisitor) ExitType(t type_system.Type) type_system.Type {
-	if tref, ok := type_system.Prune(t).(*type_system.TypeRefType); ok {
+	if tref, ok := type_system.Prune(t, nil).(*type_system.TypeRefType); ok {
 		if type_system.QualIdentToString(tref.Name) == "Self" {
 			return &type_system.TypeRefType{Name: type_system.NewIdent("this"), TypeAlias: nil, TypeArgs: nil}
 			// return &type_system.GlobalThisType{}

--- a/internal/type_system/prune_test.go
+++ b/internal/type_system/prune_test.go
@@ -16,13 +16,13 @@ func newWidenableTV(id int) *TypeVarType {
 
 func TestPruneConcreteType(t *testing.T) {
 	strType := NewStrPrimType(nil)
-	result := Prune(strType)
+	result := Prune(strType, nil)
 	assert.Equal(t, strType, result, "pruning a concrete type returns it unchanged")
 }
 
 func TestPruneUnboundTypeVar(t *testing.T) {
 	tv := NewTypeVarType(nil, 1)
-	result := Prune(tv)
+	result := Prune(tv, nil)
 	assert.Equal(t, tv, result, "pruning an unbound TypeVar returns it unchanged")
 }
 
@@ -31,7 +31,7 @@ func TestPruneSingleTypeVarWithConcreteInstance(t *testing.T) {
 	tv := NewTypeVarType(nil, 1)
 	tv.Instance = numType
 
-	result := Prune(tv)
+	result := Prune(tv, nil)
 	assert.Equal(t, numType, result, "pruning a TypeVar with concrete Instance returns the Instance")
 	assert.Equal(t, numType, tv.Instance, "Instance should still point to concrete type")
 }
@@ -43,7 +43,7 @@ func TestPruneTwoTypeVarChain(t *testing.T) {
 	tvA.Instance = tvB
 	tvB.Instance = numType
 
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, numType, result, "should resolve to the terminal concrete type")
 	// Path compression: both should point directly at the concrete type.
 	assert.Equal(t, numType, tvA.Instance, "tvA.Instance should be path-compressed to concrete type")
@@ -59,7 +59,7 @@ func TestPruneThreeTypeVarChain(t *testing.T) {
 	tvB.Instance = tvC
 	tvC.Instance = strType
 
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, strType, result, "should resolve through 3-node chain")
 	assert.Equal(t, strType, tvA.Instance, "tvA should be path-compressed")
 	assert.Equal(t, strType, tvB.Instance, "tvB should be path-compressed")
@@ -73,7 +73,7 @@ func TestPruneInstanceChainTwoNodes(t *testing.T) {
 	tvA.Instance = tvB
 	tvB.Instance = numType
 
-	Prune(tvA)
+	Prune(tvA, nil)
 
 	// tvA should have InstanceChain [tvA, tvB]
 	assert.Len(t, tvA.InstanceChain, 2, "tvA.InstanceChain should contain both TypeVars")
@@ -94,7 +94,7 @@ func TestPruneInstanceChainThreeNodes(t *testing.T) {
 	tvB.Instance = tvC
 	tvC.Instance = strType
 
-	Prune(tvA)
+	Prune(tvA, nil)
 
 	assert.Len(t, tvA.InstanceChain, 3)
 	assert.Equal(t, []*TypeVarType{tvA, tvB, tvC}, tvA.InstanceChain)
@@ -113,7 +113,7 @@ func TestPruneNoInstanceChainForNonWidenableTypeVars(t *testing.T) {
 	tvA.Instance = tvB
 	tvB.Instance = numType
 
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, numType, result, "path compression should still work")
 	assert.Nil(t, tvA.InstanceChain, "non-Widenable TypeVars should not get InstanceChain")
 	assert.Nil(t, tvB.InstanceChain, "non-Widenable TypeVars should not get InstanceChain")
@@ -124,7 +124,7 @@ func TestPruneNoInstanceChainForDirectConcreteInstance(t *testing.T) {
 	tv := NewTypeVarType(nil, 1)
 	tv.Instance = numType
 
-	Prune(tv)
+	Prune(tv, nil)
 
 	// No chain when Instance is directly a concrete type (not another TypeVar).
 	assert.Nil(t, tv.InstanceChain, "no InstanceChain when Instance is concrete")
@@ -137,12 +137,12 @@ func TestPruneInstanceChainNotOverwrittenOnSecondCall(t *testing.T) {
 	tvA.Instance = tvB
 	tvB.Instance = numType
 
-	Prune(tvA)
+	Prune(tvA, nil)
 	originalChain := tvA.InstanceChain
 
 	// After path compression, tvA.Instance is numType (concrete).
 	// A second Prune should NOT overwrite the chain.
-	Prune(tvA)
+	Prune(tvA, nil)
 	assert.Equal(t, originalChain, tvA.InstanceChain, "InstanceChain should not be overwritten by second Prune")
 }
 
@@ -153,7 +153,7 @@ func TestPruneChainWithUnboundTerminal(t *testing.T) {
 	tvA.Instance = tvB
 	// tvB.Instance is nil (unbound)
 
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, tvB, result, "should resolve to the terminal unbound TypeVar")
 
 	// InstanceChain should still be recorded.
@@ -169,11 +169,11 @@ func TestPruneUnboundTerminalNotSelfReferencing(t *testing.T) {
 	tvB := NewTypeVarType(nil, 2)
 	tvA.Instance = tvB
 
-	Prune(tvA)
+	Prune(tvA, nil)
 	assert.Nil(t, tvB.Instance, "terminal unbound TypeVar must not get a self-referencing Instance")
 
 	// A subsequent Prune on tvB must not loop.
-	result := Prune(tvB)
+	result := Prune(tvB, nil)
 	assert.Equal(t, tvB, result, "pruning unbound tvB should return tvB itself")
 }
 
@@ -186,7 +186,7 @@ func TestPruneUnboundTerminalThreeNodeChain(t *testing.T) {
 	tvA.Instance = tvB
 	tvB.Instance = tvC
 
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, tvC, result)
 	assert.Equal(t, tvC, tvA.Instance, "tvA should be compressed to tvC")
 	assert.Equal(t, tvC, tvB.Instance, "tvB should be compressed to tvC")
@@ -206,12 +206,12 @@ func TestPruneMiddleThenHead_PreservesFullChain(t *testing.T) {
 	tvC.Instance = numType
 
 	// Prune middle first — tvB gets [tvB, tvC], tvC gets [tvC].
-	Prune(tvB)
+	Prune(tvB, nil)
 	assert.Equal(t, []*TypeVarType{tvB, tvC}, tvB.InstanceChain)
 	assert.Equal(t, []*TypeVarType{tvC}, tvC.InstanceChain)
 
 	// Now prune from the head.
-	Prune(tvA)
+	Prune(tvA, nil)
 
 	// tvA's chain must include all three, not just [tvA, tvB].
 	assert.Equal(t, []*TypeVarType{tvA, tvB, tvC}, tvA.InstanceChain,
@@ -224,7 +224,7 @@ func TestPruneMiddleThenHead_PreservesFullChain(t *testing.T) {
 
 func TestPruneRealiasExtendsCachedChain(t *testing.T) {
 	// Prune tvA (tvA->tvB unbound), then re-alias tvB->tvC.
-	// A second Prune(tvA) must detect the new link and extend the chain.
+	// A second Prune(tvA, nil) must detect the new link and extend the chain.
 	numType := NewNumPrimType(nil)
 	tvA := newWidenableTV(1)
 	tvB := newWidenableTV(2)
@@ -234,7 +234,7 @@ func TestPruneRealiasExtendsCachedChain(t *testing.T) {
 	// tvB is unbound
 
 	// First prune captures chain [tvA, tvB].
-	Prune(tvA)
+	Prune(tvA, nil)
 	assert.Equal(t, []*TypeVarType{tvA, tvB}, tvA.InstanceChain)
 
 	// Simulate bind re-aliasing tvB to tvC.
@@ -242,7 +242,7 @@ func TestPruneRealiasExtendsCachedChain(t *testing.T) {
 	tvC.Instance = numType
 
 	// Second prune should detect the new link and extend the chain.
-	result := Prune(tvA)
+	result := Prune(tvA, nil)
 	assert.Equal(t, numType, result)
 	assert.Contains(t, tvA.InstanceChain, tvC,
 		"tvA.InstanceChain should include tvC after re-aliasing")
@@ -258,7 +258,7 @@ func TestPruneCalledOnMiddleOfChain(t *testing.T) {
 	tvC.Instance = numType
 
 	// Prune starting from tvB (middle of chain).
-	result := Prune(tvB)
+	result := Prune(tvB, nil)
 	assert.Equal(t, numType, result)
 	assert.Equal(t, numType, tvB.Instance, "tvB should be path-compressed")
 

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -88,10 +88,39 @@ func (*NamespaceType) isType()    {}
 func (*RegexType) isType()        {}
 func (*ErrorType) isType()        {}
 
+// PruneMutationHook, when non-nil, is called by Prune for every TypeVar
+// in the alias chain BEFORE Prune mutates that TypeVar's Instance or
+// InstanceChain field. The checker installs a hook during Probe so the
+// journal can snapshot the intermediate TypeVars for rollback — without
+// it, Discard would leave compressed pointers pointing at probe-time
+// concrete types after their terminal TypeVars were restored to unbound.
+//
+// Package-level (not threaded through Prune) because Prune has hundreds
+// of callers — changing its signature would touch every type-resolution
+// site in the checker. The hook is single-threaded by construction (the
+// checker is single-threaded) and is set/restored around the probe.
+var PruneMutationHook func(*TypeVarType)
+
 func Prune(t Type) Type {
 	tv, ok := t.(*TypeVarType)
 	if !ok || tv.Instance == nil {
 		return t
+	}
+
+	// Snapshot every TypeVar in the alias chain before recordInstanceChain
+	// and path compression mutate their Instance / InstanceChain fields.
+	// Doing this once up-front (rather than at each mutation site) keeps
+	// the rollback semantics simple: each chain member has exactly one
+	// pre-Prune snapshot, regardless of how many times Prune touches it.
+	if PruneMutationHook != nil {
+		for cur := tv; cur != nil; {
+			PruneMutationHook(cur)
+			next, ok := cur.Instance.(*TypeVarType)
+			if !ok {
+				break
+			}
+			cur = next
+		}
 	}
 
 	// Record the alias chain for Widenable TypeVars before path compression

--- a/internal/type_system/types.go
+++ b/internal/type_system/types.go
@@ -88,20 +88,50 @@ func (*NamespaceType) isType()    {}
 func (*RegexType) isType()        {}
 func (*ErrorType) isType()        {}
 
-// PruneMutationHook, when non-nil, is called by Prune for every TypeVar
-// in the alias chain BEFORE Prune mutates that TypeVar's Instance or
-// InstanceChain field. The checker installs a hook during Probe so the
-// journal can snapshot the intermediate TypeVars for rollback — without
-// it, Discard would leave compressed pointers pointing at probe-time
-// concrete types after their terminal TypeVars were restored to unbound.
+// Journal is the type_system-side interface that lets Prune record
+// pre-mutation snapshots of TypeVars it's about to modify (path
+// compression + recordInstanceChain). The checker's BindJournal in
+// internal/checker/probe.go implements this so Probe can roll back
+// Prune's mutations as part of a failed probe.
 //
-// Package-level (not threaded through Prune) because Prune has hundreds
-// of callers — changing its signature would touch every type-resolution
-// site in the checker. The hook is single-threaded by construction (the
-// checker is single-threaded) and is set/restored around the probe.
-var PruneMutationHook func(*TypeVarType)
+// Defined here so type_system stays free of a checker import; the
+// concrete journal type lives in checker.
+type Journal interface {
+	Snapshot(*TypeVarType)
+}
 
-func Prune(t Type) Type {
+// resolve walks t's alias chain to the terminal type without mutating
+// any intermediate TypeVar. Private to type_system: used internally by
+// Type.Accept and the union/intersection constructors so visitor-driven
+// traversal doesn't need a Journal in scope. Callers in the checker
+// that want path compression call the public Prune (which takes a
+// Journal).
+func resolve(t Type) Type {
+	tv, ok := t.(*TypeVarType)
+	if !ok || tv.Instance == nil {
+		return t
+	}
+	cur := tv.Instance
+	for {
+		next, ok := cur.(*TypeVarType)
+		if !ok || next.Instance == nil {
+			return cur
+		}
+		cur = next.Instance
+	}
+}
+
+// Prune resolves t's alias chain, path-compresses intermediate
+// TypeVars, and records InstanceChain for Widenable TypeVars. When j
+// is non-nil, every TypeVar that will be mutated is snapshotted via
+// j.Snapshot first so the change can be rolled back by a Probe's
+// Discard.
+//
+// j is threaded through Context (carried by the checker's BindJournal),
+// not as package-level state — so concurrent goroutines with separate
+// Contexts don't race on a shared hook. Callers outside the unifier
+// hot path (codegen, LSP, declaration-level checker code) pass nil.
+func Prune(t Type, j Journal) Type {
 	tv, ok := t.(*TypeVarType)
 	if !ok || tv.Instance == nil {
 		return t
@@ -112,9 +142,9 @@ func Prune(t Type) Type {
 	// Doing this once up-front (rather than at each mutation site) keeps
 	// the rollback semantics simple: each chain member has exactly one
 	// pre-Prune snapshot, regardless of how many times Prune touches it.
-	if PruneMutationHook != nil {
+	if j != nil {
 		for cur := tv; cur != nil; {
-			PruneMutationHook(cur)
+			j.Snapshot(cur)
 			next, ok := cur.Instance.(*TypeVarType)
 			if !ok {
 				break
@@ -251,9 +281,14 @@ func (t *TypeVarType) Accept(v TypeVisitor) Type {
 		return t
 	}
 
-	prunedType := Prune(t)
+	// resolve (not Prune) here so visitor-driven traversals don't trigger
+	// path compression. Compressing intermediate Instance fields during a
+	// Probe would need journaling, but Accept has no Journal in scope.
+	// Direct Prune calls from the unifier still compress with rollback
+	// support.
+	prunedType := resolve(t)
 	if prunedType != t {
-		return prunedType.Accept(v) // Accept on the pruned type
+		return prunedType.Accept(v) // Accept on the resolved type
 	}
 
 	if result := v.ExitType(t); result != nil {
@@ -1917,7 +1952,7 @@ func NewIntersectionType(provenance Provenance, types ...Type) Type {
 	// Flatten nested intersections
 	flattened := []Type{}
 	for _, t := range types {
-		t = Prune(t)
+		t = resolve(t)
 		if inter, ok := t.(*IntersectionType); ok {
 			flattened = append(flattened, inter.Types...)
 		} else {
@@ -1932,7 +1967,7 @@ func NewIntersectionType(provenance Provenance, types ...Type) Type {
 	primitiveTypes := make(map[Prim]*PrimType)
 
 	for _, t := range flattened {
-		t = Prune(t)
+		t = resolve(t)
 
 		// Check for any
 		if _, ok := t.(*AnyType); ok {
@@ -2000,7 +2035,7 @@ func NewIntersectionType(provenance Provenance, types ...Type) Type {
 			// Prune mut.Type so a TypeVar bound to a concrete type compares
 			// equal to that concrete type — the first pass already pruned
 			// `normalized` entries the same way.
-			mutInner := Prune(mut.Type)
+			mutInner := resolve(mut.Type)
 			hasImmutable := false
 			for _, other := range normalized {
 				if other.Equals(mutInner) {

--- a/internal/type_system/visitor_test.go
+++ b/internal/type_system/visitor_test.go
@@ -940,7 +940,7 @@ func TestTypeVarVisitor(t *testing.T) {
 		visitor := &IdentityVisitor{}
 		result := original.Accept(visitor)
 
-		// This is a bit of a special case because the visitor calls Prune(t)
+		// This is a bit of a special case because the visitor calls Prune(t, nil)
 		// which results in the instance being returned directly instead of the
 		// original TypeVarType.
 		assert.Same(t, instanceType, result)


### PR DESCRIPTION
## Summary

Implements a journaled probe mechanism that allows the type checker to speculatively unify types and roll back partial mutations if the unification fails. This fixes issues where failed unification attempts would leave TypeVars and LifetimeVars in partially-bound states, polluting subsequent type inference.

## Key Changes

- **New `BindJournal` type** (`internal/checker/probe.go`): Records mutations to TypeVar and LifetimeVar fields before they occur, enabling rollback on probe failure. Supports nested probes via a depth counter that frees memory when the last scope commits.

- **New `ProbeScope` and `ProbeResult` types**: Provide a clean API for probe-then-commit semantics. `ProbeScope` tracks record marks and ensures idempotency (Commit/Discard can be called multiple times safely). `ProbeResult` wraps the outcome and provides `Success()` / `Errors()` / `Commit()` / `Discard()` methods.

- **New `Probe()` and `probeWithSeen()` methods**: Convenience functions that open a scope, run a unification, and return a `ProbeResult` for the caller to inspect and commit/discard.

- **Updated `type_system.Prune()`**: Now accepts an optional `Journal` parameter. When non-nil, snapshots every TypeVar in the alias chain before path compression and InstanceChain mutations, allowing rollback. Added a private `resolve()` function for visitor-driven traversal that doesn't need journaling.

- **Updated unification hot paths**: All `Prune()` calls in `unify.go` now pass `ctx.BindJournal`. The widening fallback and intersection distribution logic now use probes instead of deep cloning, eliminating the allocation overhead while maintaining correctness.

- **Updated `distributeIntersectionOverUnion()`**: Now accepts a `Journal` parameter and snapshots TypeVars before mutations.

- **Comprehensive test coverage** (`internal/checker/probe_test.go`): Tests cover commit/discard semantics, nested probes, lifetime bindings, and idempotency.

## Implementation Details

- The journal is stored on `Context` (passed by value) so every recursive call shares the same pointer without explicit threading.
- Rollback replays records in reverse order, so stacked mutations to the same variable peel off correctly.
- Cleanup closures support ad-hoc side effects (e.g., AST mutations) that don't fit the TypeVar/LifetimeVar record shape.
- The `Journal` interface is defined in `type_system` to avoid a checker import; the concrete `BindJournal` lives in `checker`.
- All existing `Prune()` calls outside the unifier hot path pass `nil` for the journal (no journaling overhead).

Fixes #381 and #660 by eliminating the need for deep cloning during speculative unification while maintaining the ability to roll back failed attempts.

https://claude.ai/code/session_011yCXg5QdYjNwpaFyuFuzeX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable and accurate type inference across the editor and tooling, reducing spurious errors and improving overload selection.
  * More stable and predictable autocomplete and JSX/type-resolution behavior.
  * Better handling of speculative type checks so failed inference attempts no longer leak partial bindings, improving IDE correctness and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->