### PR TITLE
Clarify decorator design: exclude TypeDecl and InterfaceDecl by design

### DIFF
--- a/internal/interop/dts_to_esc.go
+++ b/internal/interop/dts_to_esc.go
@@ -810,11 +810,12 @@ func jsName(nsPath, name string) string {
 	return nsPath + "." + name
 }
 
-// attachJSDecorator stamps `@js("<arg>")` onto a decoratable decl. Only
-// the decl kinds with a Decorators field are handled; other kinds are
-// no-ops (matching the §3.3 rule that decorators apply to declarations
-// that lower to a JS reference — type aliases and similar are silently
-// dropped if they have no field).
+// attachJSDecorator stamps `@js("<arg>")` onto a decoratable decl. Per
+// the §3.3 rule, decorators apply only to declarations that lower to a
+// JS reference — `VarDecl`, `FuncDecl`, and `ClassDecl`. `TypeDecl` and
+// `InterfaceDecl` erase at codegen and are excluded by design: they have
+// no Decorators field and these branches are intentional no-ops (see the
+// per-case comments below).
 func attachJSDecorator(decl ast.Decl, arg string) {
 	dec := &ast.Decorator{
 		Name: ast.NewIdentifier("js", ast.Span{}),
@@ -828,12 +829,17 @@ func attachJSDecorator(decl ast.Decl, arg string) {
 	case *ast.ClassDecl:
 		d.Decorators = append(d.Decorators, dec)
 	case *ast.TypeDecl:
-		// TODO(#664): TypeDecl has no Decorators field; this is a silent
-		// no-op. Decide whether type aliases (and InterfaceDecls below)
-		// should carry @js("...") or stay unmarked by design, and
-		// either widen the AST or codify the exclusion in §3.3.
+		// By design (§3.3): @js("...") only applies to decls that lower
+		// to a JS reference. A type alias erases at codegen and has no
+		// runtime form, so there is nothing for @js to point at — the
+		// parser even rejects decorators on `declare type`. Attaching one
+		// here would be meaningless, so this is an intentional no-op (and
+		// AST.TypeDecl deliberately carries no Decorators field).
 	case *ast.InterfaceDecl:
-		// TODO(#664): see TypeDecl above.
+		// Likewise (§3.3): a bare interface that survives trio detection
+		// is purely a type and erases at codegen, so @js has no runtime
+		// reference to lower. Intentional no-op; InterfaceDecl carries no
+		// Decorators field.
 	}
 }
 

--- a/internal/interop/dts_to_esc_test.go
+++ b/internal/interop/dts_to_esc_test.go
@@ -257,12 +257,12 @@ func TestStandalone_QualifiedBindingSkipsTrio(t *testing.T) {
 }
 
 // typeAliasSlice exercises convertStandaloneStmt's TypeDecl path. The
-// converter exports the alias but attachJSDecorator is a no-op for
-// TypeDecl (the AST has no Decorators field on type aliases). This test
-// asserts that asymmetry. See #664 for the decision on whether to widen
-// the AST so type aliases carry @js("...") too. If that lands, update
-// this test to assert that the converter emits an @js("Id") decorator
-// on the type alias.
+// converter exports the alias but attachJSDecorator is intentionally a
+// no-op for TypeDecl: per §3.3, @js("...") applies only to decls that
+// lower to a JS reference, and a type alias erases at codegen with no
+// runtime form to point at (the parser likewise rejects decorators on
+// `declare type`). This test is the regression guard for that design
+// decision — see #664.
 const typeAliasSlice = `
 type Id = string;
 `

--- a/planning/builtins/implementation_plan.md
+++ b/planning/builtins/implementation_plan.md
@@ -479,6 +479,19 @@ syntax. This phase adds it:
   concrete need surfaces.
 - Printer round-trips decorators (FR14 audit must cover them,
   in combination with the `export` modifier).
+- **Converter symmetry (#664).** The same "decorators only on
+  decls that lower to a JS reference" rule governs the `.d.ts`
+  converter. `attachJSDecorator` in
+  [internal/interop/dts_to_esc.go](../../internal/interop/dts_to_esc.go)
+  stamps `@js("...")` only on `VarDecl`, `FuncDecl`, and
+  `ClassDecl`; `TypeDecl` and `InterfaceDecl` are excluded by
+  design and carry no `Decorators` field, so those branches are
+  intentional no-ops. A bare exported type alias or interface is
+  therefore emitted *unmarked*, which is correct: it erases at
+  codegen and has no runtime reference to point at (and a printed
+  `@js("...")` on it would not even re-parse, given the
+  parse-time rejection above). `TestStandalone_TypeAliasExportedNoDecorator`
+  pins this.
 
 Touch points:
 [internal/lexer_util/](../../internal/lexer_util/),


### PR DESCRIPTION
## Summary

Resolves #664 by clarifying and documenting the intentional design decision that `@js("...")` decorators apply only to declarations that lower to a JS reference (`VarDecl`, `FuncDecl`, `ClassDecl`), excluding `TypeDecl` and `InterfaceDecl` which erase at codegen.

## Changes

- **internal/interop/dts_to_esc.go**: Rewrote the `attachJSDecorator` function's documentation and per-case comments to explain that the exclusion of `TypeDecl` and `InterfaceDecl` is intentional by design (§3.3), not a TODO. Type aliases and interfaces have no runtime form to point at, so decorators would be meaningless. The AST deliberately omits a `Decorators` field on these types, making the branches intentional no-ops.

- **planning/builtins/implementation_plan.md**: Added a "Converter symmetry (#664)" section documenting that the same rule governs the `.d.ts` converter, with a reference to the regression test that pins this behavior.

- **internal/interop/dts_to_esc_test.go**: Updated the `typeAliasSlice` test comment to reflect the design decision rather than framing it as an open question. The test now serves as a regression guard for the intentional exclusion.

## Implementation details

The changes are purely documentation and comment updates that clarify existing behavior. No functional changes to the code — the decorator attachment logic remains unchanged. The clarification makes it explicit that:

1. Per §3.3, decorators only apply to declarations that lower to a JS reference
2. Type aliases and interfaces erase at codegen with no runtime form
3. The parser itself rejects decorators on `declare type`, so the exclusion is consistent across the pipeline
4. The AST design (no `Decorators` field on `TypeDecl`/`InterfaceDecl`) codifies this rule

https://claude.ai/code/session_01XDALE2Dey1ME3w4YEije8v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation regarding decorator behavior for different declaration types in type conversion.

* **Chores**
  * Updated internal implementation planning notes with details on type declaration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->