### PR TITLE
Optimize lexer rune decoding for ASCII characters

### DIFF
--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -194,7 +194,15 @@ func (lexer *Lexer) next() *Token {
 		}
 	}
 
-	codePoint, width := utf8.DecodeRuneInString(lexer.source.Contents[startOffset:])
+	var codePoint rune
+	var width int
+	if startOffset < len(lexer.source.Contents) {
+		if b := lexer.source.Contents[startOffset]; b < utf8.RuneSelf {
+			codePoint, width = rune(b), 1
+		} else {
+			codePoint, width = utf8.DecodeRuneInString(lexer.source.Contents[startOffset:])
+		}
+	}
 
 	endOffset := startOffset + width
 	end := ast.Location{Line: start.Line, Column: start.Column + 1}


### PR DESCRIPTION
## Summary
Optimize the lexer's rune decoding path by fast-tracking ASCII characters (bytes < 128) to avoid the overhead of `utf8.DecodeRuneInString` for the common case.

## Changes
- Added a bounds check before decoding to prevent potential panics on out-of-bounds access
- Implemented a fast path for ASCII characters (single-byte UTF-8) that directly converts the byte to a rune with width 1
- Falls back to `utf8.DecodeRuneInString` only for multi-byte UTF-8 sequences

## Implementation details
The optimization recognizes that ASCII characters (0–127) are single-byte UTF-8 sequences and can be decoded with a simple cast and constant width, avoiding the function call overhead of `utf8.DecodeRuneInString`. This is particularly beneficial since most source code consists of ASCII characters. The bounds check ensures safety when `startOffset` reaches the end of the source.

https://claude.ai/code/session_01XYaxVVVEFM6gR4WWKRKcKm