### PR TITLE
Add Info side table for recording inferred types

### DIFF
--- a/internal/solver/info.go
+++ b/internal/solver/info.go
@@ -1,0 +1,29 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Info is the AST->type side table (à la go/types.Info). The new checker records
+// inferred types here rather than mutating ast nodes via InferredType() /
+// SetInferredType(). No probe/cleanup discipline in M1 — that arrives with
+// Prov/Probe in a later milestone.
+type Info struct {
+	types map[ast.Node]soltype.Type
+}
+
+// NewInfo returns an empty Info side table ready to record inferred types.
+func NewInfo() *Info {
+	return &Info{types: map[ast.Node]soltype.Type{}}
+}
+
+// TypeOf returns the type recorded for n, or nil if none has been set.
+func (i *Info) TypeOf(n ast.Node) soltype.Type {
+	return i.types[n]
+}
+
+// setType records t as the inferred type of n, overwriting any prior entry.
+func (i *Info) setType(n ast.Node, t soltype.Type) {
+	i.types[n] = t
+}

--- a/internal/solver/info_test.go
+++ b/internal/solver/info_test.go
@@ -1,0 +1,39 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoSetTypeAndTypeOf(t *testing.T) {
+	info := NewInfo()
+
+	a := ast.NewIdentifier("a", ast.Span{})
+	b := ast.NewIdentifier("b", ast.Span{})
+
+	numT := &soltype.PrimType{Prim: soltype.NumPrim}
+	strT := &soltype.PrimType{Prim: soltype.StrPrim}
+
+	info.setType(a, numT)
+	info.setType(b, strT)
+
+	// Each node round-trips to the type it was recorded with.
+	require.Same(t, numT, info.TypeOf(a))
+	require.Same(t, strT, info.TypeOf(b))
+
+	// Overwriting an entry replaces the prior type.
+	info.setType(a, strT)
+	require.Same(t, strT, info.TypeOf(a))
+}
+
+func TestInfoTypeOfAbsentNodeIsNil(t *testing.T) {
+	info := NewInfo()
+
+	n := ast.NewIdentifier("missing", ast.Span{})
+
+	// A node that was never recorded returns the zero value (nil).
+	require.Nil(t, info.TypeOf(n))
+}


### PR DESCRIPTION
Introduce `Info`, an AST→type side table (modeled after `go/types.Info`) to record inferred types during type checking without mutating AST nodes.

## Summary

This change adds a new `Info` struct in the `solver` package that maintains a map from AST nodes to their inferred types. Rather than storing type information directly on AST nodes via `InferredType()`/`SetInferredType()` methods, the type checker will now record inferred types in this separate side table.

## Changes

- **internal/solver/info.go**: New file implementing the `Info` type with:
  - `NewInfo()` constructor that initializes an empty side table
  - `TypeOf(n ast.Node)` method to retrieve the recorded type for a node (returns nil if not set)
  - `setType(n ast.Node, t soltype.Type)` private method to record inferred types
  
- **internal/solver/info_test.go**: Comprehensive test coverage including:
  - `TestInfoSetTypeAndTypeOf`: Verifies that types round-trip correctly and can be overwritten
  - `TestInfoTypeOfAbsentNodeIsNil`: Confirms that querying an unrecorded node returns nil

This establishes the foundation for the new type checker to separate type inference logic from AST mutation, improving separation of concerns and enabling future features like provenance tracking.

https://claude.ai/code/session_01QaVSNhe7HEVLpa61FVz8VH