### PR TITLE
Add M1 coalescer for type variable bound inlining

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1,0 +1,159 @@
+package solver
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// coalesce walks a bound-carrying soltype.Type and returns a *coalesced*
+// soltype.Type in which every TypeVarType has been inlined to its bounds
+// (Delta #1 in m1-implementation-plan §2.2): positive position ⇒ the union of
+// the variable's lower bounds, negative position ⇒ the intersection of its
+// upper bounds, with empty bounds collapsing to never (⊥, positive) or unknown
+// (⊤, negative).
+//
+// It is a package-private free function in M1 — it needs no Context (no shared
+// counters or occurrence state until M3 reintroduces them). Unlike the spike,
+// M1's coalescer is uniformly inlining: no bipolar-variable retention, no
+// occurrence-analysis input, no named-ref output node. That whole
+// polymorphism-rendering bundle lands in M3 (§3.3).
+//
+// M1 needs no `seen` recursion guard: the M1 type set has no recursive formers
+// (no aliases, no recursive types), so a uniform-inline walk terminates on the
+// bound graph as-is. M3 adds the guard when bipolar retention and aliases make
+// recursive structures in coalesced output possible.
+func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.PrimType, *soltype.LitType, *soltype.Void,
+		*soltype.NeverType, *soltype.UnknownType:
+		return t // atoms pass through
+	case *soltype.FuncType:
+		params := make([]*soltype.FuncParam, len(t.Params))
+		for i, p := range t.Params {
+			// Params are contravariant, so flip polarity.
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesce(p.Type, pol.Flip())}
+		}
+		return &soltype.FuncType{Params: params, Ret: coalesce(t.Ret, pol)} // covariant return
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = coalesce(e, pol) // covariant elements
+		}
+		return &soltype.TupleType{Elems: elems}
+	case *soltype.TypeVarType:
+		// Uniform inline: drop the variable, keep only its (recursively
+		// coalesced) bounds in the current polarity.
+		bounds := make([]soltype.Type, 0, len(t.BoundsAt(pol)))
+		for _, b := range t.BoundsAt(pol) {
+			bounds = append(bounds, coalesce(b, pol))
+		}
+		if len(bounds) == 0 {
+			if pol == soltype.Positive {
+				return &soltype.NeverType{} // ⊥ — empty positive (the identity of |)
+			}
+			return &soltype.UnknownType{} // ⊤ — empty negative (the identity of &)
+		}
+		return combine(pol, dedup(bounds))
+	}
+	panic(fmt.Sprintf("coalesce: unhandled %T", t))
+}
+
+// combine builds a soltype.UnionType (Positive) or soltype.IntersectionType
+// (Negative) of parts, returning the sole element directly when only one
+// remains. The UnionType/IntersectionType nodes ship in M1 (soltype/type.go) so
+// combine can always return a native soltype.Type.
+func combine(pol soltype.Polarity, parts []soltype.Type) soltype.Type {
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	if pol == soltype.Positive {
+		return &soltype.UnionType{Types: parts}
+	}
+	return &soltype.IntersectionType{Types: parts}
+}
+
+// dedup removes structurally-equal parts, preserving first-occurrence order.
+// The spike deduplicated by rendered string (via type_system.PrintType); M1
+// has no printer in `solver` yet (it ships in PR4, in `soltype`), so M1
+// deduplicates by structural equality instead.
+func dedup(parts []soltype.Type) []soltype.Type {
+	out := make([]soltype.Type, 0, len(parts))
+	for _, p := range parts {
+		dup := false
+		for _, kept := range out {
+			if equalType(p, kept) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// equalType is structural equality over the M1 coalesced type set. Coalesced
+// output contains no TypeVarTypes (every variable has been inlined), so the
+// variable case is unreachable here and intentionally omitted.
+func equalType(a, b soltype.Type) bool {
+	switch a := a.(type) {
+	case *soltype.PrimType:
+		b, ok := b.(*soltype.PrimType)
+		return ok && a.Prim == b.Prim
+	case *soltype.LitType:
+		b, ok := b.(*soltype.LitType)
+		return ok && a.Equal(b)
+	case *soltype.Void:
+		_, ok := b.(*soltype.Void)
+		return ok
+	case *soltype.NeverType:
+		_, ok := b.(*soltype.NeverType)
+		return ok
+	case *soltype.UnknownType:
+		_, ok := b.(*soltype.UnknownType)
+		return ok
+	case *soltype.FuncType:
+		b, ok := b.(*soltype.FuncType)
+		if !ok || len(a.Params) != len(b.Params) {
+			return false
+		}
+		for i := range a.Params {
+			if !equalType(a.Params[i].Type, b.Params[i].Type) {
+				return false
+			}
+		}
+		return equalType(a.Ret, b.Ret)
+	case *soltype.TupleType:
+		b, ok := b.(*soltype.TupleType)
+		if !ok || len(a.Elems) != len(b.Elems) {
+			return false
+		}
+		for i := range a.Elems {
+			if !equalType(a.Elems[i], b.Elems[i]) {
+				return false
+			}
+		}
+		return true
+	case *soltype.UnionType:
+		b, ok := b.(*soltype.UnionType)
+		return ok && equalTypeSlice(a.Types, b.Types)
+	case *soltype.IntersectionType:
+		b, ok := b.(*soltype.IntersectionType)
+		return ok && equalTypeSlice(a.Types, b.Types)
+	}
+	return false
+}
+
+func equalTypeSlice(a, b []soltype.Type) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalType(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -1,0 +1,116 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoalesceAtomsPassThrough(t *testing.T) {
+	tests := []struct {
+		name string
+		in   soltype.Type
+	}{
+		{"number", num()},
+		{"literal 5", numLit(5)},
+		{"void", &soltype.Void{}},
+		{"never", &soltype.NeverType{}},
+		{"unknown", &soltype.UnknownType{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Same(t, tt.in, coalesce(tt.in, soltype.Positive))
+			require.Same(t, tt.in, coalesce(tt.in, soltype.Negative))
+		})
+	}
+}
+
+func TestCoalesceSingleBoundInline(t *testing.T) {
+	// A positive variable with a single lower bound (5) coalesces to that bound.
+	t.Run("positive lower", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.LowerBounds = []soltype.Type{numLit(5)}
+		got := coalesce(a, soltype.Positive)
+		require.True(t, equalType(numLit(5), got))
+	})
+
+	// A negative variable with a single upper bound (number) coalesces to it.
+	t.Run("negative upper", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.UpperBounds = []soltype.Type{num()}
+		got := coalesce(a, soltype.Negative)
+		require.True(t, equalType(num(), got))
+	})
+}
+
+func TestCoalesceEmptyBoundCollapse(t *testing.T) {
+	// An empty positive variable is the identity of `|` ⇒ never (⊥).
+	t.Run("empty positive ⇒ never", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		require.IsType(t, &soltype.NeverType{}, coalesce(a, soltype.Positive))
+	})
+
+	// An empty negative variable is the identity of `&` ⇒ unknown (⊤).
+	t.Run("empty negative ⇒ unknown", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		require.IsType(t, &soltype.UnknownType{}, coalesce(a, soltype.Negative))
+	})
+}
+
+func TestCoalesceMultiBound(t *testing.T) {
+	// A positive variable with two distinct lower bounds ⇒ union of the lowers.
+	t.Run("positive ⇒ union", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.LowerBounds = []soltype.Type{num(), str()}
+		got := coalesce(a, soltype.Positive)
+		want := &soltype.UnionType{Types: []soltype.Type{num(), str()}}
+		require.True(t, equalType(want, got))
+	})
+
+	// A negative variable with two distinct upper bounds ⇒ intersection.
+	t.Run("negative ⇒ intersection", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.UpperBounds = []soltype.Type{num(), str()}
+		got := coalesce(a, soltype.Negative)
+		want := &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}
+		require.True(t, equalType(want, got))
+	})
+
+	// Duplicate bounds are deduplicated by structural equality, collapsing back
+	// to the sole element (combine returns it directly).
+	t.Run("duplicate lowers dedup", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.LowerBounds = []soltype.Type{num(), num()}
+		got := coalesce(a, soltype.Positive)
+		require.True(t, equalType(num(), got))
+	})
+}
+
+func TestCoalesceStructuralRecursion(t *testing.T) {
+	// The identity function `fn (x) -> x` is built with one variable used both as
+	// the parameter type (negative) and the return type (positive). With empty
+	// bounds, the uniform-inline coalescer renders the degenerate
+	// `fn (x: unknown) -> never`: the param var is negative-empty ⇒ unknown, the
+	// return var is positive-empty ⇒ never. (The named-`<T0>` rendering is M3.)
+	c := &Context{}
+	a := c.freshVar(0)
+	fn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: a}},
+		Ret:    a,
+	}
+	got := coalesce(fn, soltype.Positive)
+
+	want := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.UnknownType{}}},
+		Ret:    &soltype.NeverType{},
+	}
+	require.True(t, equalType(want, got))
+}


### PR DESCRIPTION
Implements the M1 coalescer (Delta #1 from m1-implementation-plan §2.2), which walks a bound-carrying `soltype.Type` and returns a coalesced type where every `TypeVarType` has been inlined to its bounds.

## Key changes

- **`coalesce.go`**: Core coalescer implementation with three helper functions:
  - `coalesce(t, pol)` — uniformly inlines type variables to their bounds, respecting polarity (positive → union of lower bounds, negative → intersection of upper bounds), with empty bounds collapsing to `never` (⊥) or `unknown` (⊤)
  - `combine(pol, parts)` — builds `UnionType` (positive) or `IntersectionType` (negative), returning the sole element directly when only one remains
  - `dedup(parts)` — removes structurally-equal parts by equality check, preserving first-occurrence order
  - `equalType(a, b)` and `equalTypeSlice(a, b)` — structural equality over the M1 coalesced type set (no `TypeVarType` case, as all variables are inlined)

- **`coalesce_test.go`**: Comprehensive test suite covering:
  - Atoms pass through unchanged
  - Single-bound inlining (positive lower, negative upper)
  - Empty-bound collapse to `never`/`unknown`
  - Multi-bound union/intersection formation
  - Duplicate bound deduplication
  - Structural recursion through function types with polarity flipping

## Implementation notes

- M1's coalescer is uniformly inlining with no recursion guard (the M1 type set has no recursive formers), unlike the spike or M3
- No `Context` dependency needed — this is a package-private free function
- Polarity flipping for contravariant function parameters is handled correctly
- Deduplication uses structural equality rather than string rendering (printer ships in PR4)

https://claude.ai/code/session_0139oTLrXGAsviywev4YHRWu