### PR TITLE
Key solver extrude cache by (var ID, polarity), not ID alone

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -16,6 +16,14 @@ import (
 // "Forward requirements for the named-ref node design".
 type constraintKey struct{ lhs, rhs soltype.Type }
 
+// extrudeKey keys extrude's per-extrusion cache by both the origin variable's
+// ID and the polarity it was reached in, so the same variable copied in
+// covariant and contravariant position produces two distinct fresh vars.
+type extrudeKey struct {
+	id  int
+	pol soltype.Polarity
+}
+
 // Constrain asserts lhs <: rhs, mutating bound lists. An empty result means
 // success.
 func (c *Context) Constrain(lhs, rhs soltype.Type) []SolverError {
@@ -102,7 +110,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		}
 		// rhs lives at a higher level: extrude it down so it isn't wrongly
 		// generalized at lv's level.
-		return c.constrain(lhs, c.extrude(rhs, soltype.Negative, lv.Level, map[int]*soltype.TypeVarType{}), seen)
+		return c.constrain(lhs, c.extrude(rhs, soltype.Negative, lv.Level, map[extrudeKey]*soltype.TypeVarType{}), seen)
 	}
 	// rhs is a variable: symmetric — record lhs as a lower bound, propagate uppers.
 	if rv, ok := rhs.(*soltype.TypeVarType); ok {
@@ -114,7 +122,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			}
 			return errs
 		}
-		return c.constrain(c.extrude(lhs, soltype.Positive, rv.Level, map[int]*soltype.TypeVarType{}), rhs, seen)
+		return c.constrain(c.extrude(lhs, soltype.Positive, rv.Level, map[extrudeKey]*soltype.TypeVarType{}), rhs, seen)
 	}
 
 	return []SolverError{&CannotConstrainError{LHS: lhs, RHS: rhs}}
@@ -122,18 +130,23 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 
 // extrude copies t so that variables above lvl are replaced by fresh variables
 // at lvl, wired to the originals through the polarity-appropriate bound
-// direction. (Same algorithm as the spike; the cache is keyed by var ID.)
-func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache map[int]*soltype.TypeVarType) soltype.Type {
+// direction. The cache is keyed by (var ID, polarity): a variable reached in
+// both polarities during a single extrusion must yield two distinct fresh vars
+// with opposite bound wiring (matching canonical Simple-sub's PolarVariable
+// cache). Keying by ID alone would reuse a Negative-polarity copy in Positive
+// position — skipping its covariant bounds — and vice versa.
+func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache map[extrudeKey]*soltype.TypeVarType) soltype.Type {
 	if soltype.LevelOf(t) <= lvl {
 		return t
 	}
 	switch t := t.(type) {
 	case *soltype.TypeVarType:
-		if nv, ok := cache[t.ID]; ok {
+		key := extrudeKey{id: t.ID, pol: pol}
+		if nv, ok := cache[key]; ok {
 			return nv
 		}
 		nv := c.freshVar(lvl)
-		cache[t.ID] = nv
+		cache[key] = nv
 		if pol == soltype.Positive {
 			t.UpperBounds = append(t.UpperBounds, nv)
 			for _, lb := range t.LowerBounds {

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -278,3 +278,36 @@ func TestConstrainExtrusion(t *testing.T) {
 	require.Len(t, high.LowerBounds, 1)
 	require.Same(t, soltype.Type(bound), high.LowerBounds[0])
 }
+
+func TestConstrainExtrusionBothPolarities(t *testing.T) {
+	// Extruding a function that mentions the same higher-level variable in both
+	// a contravariant (param) and a covariant (return) position must produce
+	// TWO distinct fresh vars — one per polarity, with opposite bound wiring.
+	// A cache keyed by var ID alone would reuse the first-seen polarity's copy
+	// in the other position; the (id, polarity) key keeps them distinct.
+	c := &Context{}
+	low := c.freshVar(0) // level 0
+	a := c.freshVar(1)   // level 1, used in both positions of fn
+	fn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{identParam("x", a)},
+		Ret:    a,
+	}
+
+	// low <: fn. fn lives above low's level, so it is extruded down; `a` is
+	// reached at Positive (return) and Negative (param) polarity.
+	require.Empty(t, c.Constrain(low, fn))
+
+	require.Len(t, low.UpperBounds, 1)
+	extruded, ok := low.UpperBounds[0].(*soltype.FuncType)
+	require.True(t, ok)
+
+	paramVar, ok := extruded.Params[0].Type.(*soltype.TypeVarType)
+	require.True(t, ok)
+	retVar, ok := extruded.Ret.(*soltype.TypeVarType)
+	require.True(t, ok)
+
+	// Distinct fresh vars, both copied down to low's level.
+	require.NotSame(t, paramVar, retVar)
+	require.Equal(t, 0, paramVar.Level)
+	require.Equal(t, 0, retVar.Level)
+}


### PR DESCRIPTION
## Problem

`solver.extrude` caches the fresh variables it creates by origin variable ID only (`cache map[int]*soltype.TypeVarType`, `cache[t.ID]`). When a single extrusion reaches the same higher-level variable in **both** a contravariant and a covariant position — the common `(a) -> a` shape — the second polarity hits the cache and reuses the first polarity's copy, skipping the opposite-direction bound wiring.

Concretely, extruding `(a) -> a`:
- param `a` is reached at Positive polarity → fresh var `nv` created, wired with `a.UpperBounds += nv` / `nv.LowerBounds = …`
- return `a` is reached at Negative polarity → cache hit on `a.ID` → returns the *same* `nv`, never installing the `a.LowerBounds += nv` / `nv.UpperBounds = …` wiring

So the two positions collapse to one variable carrying only half its bounds.

Canonical Simple-sub keys this cache by `(variable, polarity)` (its `PolarVariable`); the id-only keying was a latent bug carried into the port from the spike.

## Fix

Add `extrudeKey{ id int; pol soltype.Polarity }` and key the per-extrusion cache on it, so a variable copied in covariant and contravariant position yields two distinct fresh vars with the correct opposite wiring.

## Test

`TestConstrainExtrusionBothPolarities` constrains a level-0 variable against `(a) -> a` (with `a` at level 1) and asserts the extruded param and return are **distinct** vars at the lower level. It fails under the old id-only keying (param and return collapse to one var) and passes with the `(id, pol)` key.

`go build ./...`, `go vet ./internal/solver/...`, and `go test ./internal/solver/...` are green.

## Context

This is a follow-up to #690 (the solver `constrain`/`extrude` engine), which merged before this fix was ready. No behavior outside `solver.extrude` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxnmaBaLZBVKGvg28tU2t8)_