### PR TITLE
Add soltype.Print for rendering coalesced M1 types

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -1,0 +1,157 @@
+package soltype
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Precedence levels for type operators, matching the Escalier parser (and
+// type_system/print_type.go). Higher values bind more tightly. M1 carries only
+// the subset reachable from coalesced output — functions, unions, intersections,
+// and atoms; type_system's precPrefix (keyof/mut/...) has no M1 analogue yet.
+const (
+	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
+	precUnion        = 3 // A | B
+	precIntersection = 4 // A & B
+	precAtom         = 6 // primary types, never need parens
+)
+
+// typePrec returns the printing precedence of a coalesced M1 type.
+func typePrec(t Type) int {
+	switch t.(type) {
+	case *FuncType:
+		return precFunc
+	case *UnionType:
+		return precUnion
+	case *IntersectionType:
+		return precIntersection
+	default:
+		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms.
+		// TypeVarType never appears in coalesced output (coalesce inlines every
+		// variable, m1-implementation-plan Delta #1), so it has no printer arm.
+		return precAtom
+	}
+}
+
+// Print renders a coalesced Type as an Escalier type-annotation string.
+//
+// This is Delta #2 of m1-implementation-plan §2.2: a native soltype printer that
+// shares NO code with type_system.PrintType but deliberately mirrors its surface
+// forms so the two checkers' rendered types stay string-comparable in M7's
+// differential harness. It renders the M1 coalesced type set only
+// (PrimType/LitType/FuncType/TupleType/Void/NeverType/UnknownType/UnionType/
+// IntersectionType). There is no <T0, ...> quantifier prefix in M1 — no named
+// refs exist to collect, since coalescing always inlines variables; that
+// machinery lands in M3 with the rest of the polymorphism-rendering bundle
+// (§3.3).
+//
+// Print is distinct from solver's describe(): describe renders a RAW,
+// uncoalesced type (t0, function, number) mid-constrain for error messages,
+// whereas Print renders a COALESCED type as user-facing syntax. They look
+// similar but operate at different stages and must not be merged (§2.2).
+func Print(t Type) string {
+	return printType(t)
+}
+
+// printTypeMinPrec prints a child type, wrapping it in parentheses when its
+// precedence is below the required minimum — mirrors type_system's helper of the
+// same shape, so e.g. a function inside a union renders as
+// `(fn () -> number) | string`.
+func printTypeMinPrec(t Type, minPrec int) string {
+	result := printType(t)
+	if typePrec(t) < minPrec {
+		return "(" + result + ")"
+	}
+	return result
+}
+
+func printType(t Type) string {
+	switch t := t.(type) {
+	case *PrimType:
+		return printPrim(t.Prim)
+	case *LitType:
+		return printLit(t.Lit)
+	case *NeverType:
+		return "never"
+	case *UnknownType:
+		return "unknown"
+	case *Void:
+		return "void"
+	case *TupleType:
+		elems := make([]string, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = printType(e)
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case *FuncType:
+		return "fn " + printFuncTail(t)
+	case *UnionType:
+		parts := make([]string, len(t.Types))
+		for i, m := range t.Types {
+			parts[i] = printTypeMinPrec(m, precUnion)
+		}
+		return strings.Join(parts, " | ")
+	case *IntersectionType:
+		parts := make([]string, len(t.Types))
+		for i, m := range t.Types {
+			parts[i] = printTypeMinPrec(m, precIntersection)
+		}
+		return strings.Join(parts, " & ")
+	}
+	panic(fmt.Sprintf("printType: unhandled %T", t))
+}
+
+// printFuncTail renders the "(params) -> ret" portion of a function, without the
+// leading "fn" keyword. Kept as a separate helper so M3 can compose it with a
+// <...> quantifier prefix without byte-slicing the "fn " back off.
+func printFuncTail(t *FuncType) string {
+	ps := make([]string, len(t.Params))
+	for i, p := range t.Params {
+		ps[i] = paramName(p, i) + ": " + printType(p.Type)
+	}
+	return "(" + strings.Join(ps, ", ") + ") -> " + printType(t.Ret)
+}
+
+// paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or
+// otherwise-unknown pattern falls back to a positional name ("x0", "x1", ...).
+// M2's destructuring Pat concretes add their own arms here.
+func paramName(p *FuncParam, i int) string {
+	if pat, ok := p.Pattern.(*IdentPat); ok {
+		return pat.Name
+	}
+	return "x" + strconv.Itoa(i)
+}
+
+// printPrim maps a Prim to its Escalier surface name — mirrors
+// type_system/print_type.go's printPrimType.
+func printPrim(p Prim) string {
+	switch p {
+	case NumPrim:
+		return "number"
+	case StrPrim:
+		return "string"
+	case BoolPrim:
+		return "boolean"
+	}
+	panic(fmt.Sprintf("printPrim: unhandled Prim %d", p))
+}
+
+// printLit renders a literal value in Escalier surface syntax.
+func printLit(lit Lit) string {
+	switch lit := lit.(type) {
+	case *StrLit:
+		return strconv.Quote(lit.Value)
+	case *NumLit:
+		// 64-bit precision, matching solver's describe() (see its comment):
+		// NumLit.Value is a float64, so bitSize 32 would round-trip through
+		// float32 and misrender values beyond float32's range/mantissa.
+		// type_system's printer still uses bitSize 32 here — a latent bug noted
+		// in describe — so this is the one surface form where Print is
+		// deliberately more correct than the renderer it otherwise mirrors.
+		return strconv.FormatFloat(lit.Value, 'f', -1, 64)
+	case *BoolLit:
+		return strconv.FormatBool(lit.Value)
+	}
+	panic(fmt.Sprintf("printLit: unhandled Lit %T", lit))
+}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -114,13 +114,13 @@ func printFuncTail(t *FuncType) string {
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or
-// otherwise-unknown pattern falls back to a positional name ("x0", "x1", ...).
-// M2's destructuring Pat concretes add their own arms here.
+// otherwise-unknown pattern falls back to a positional name ("arg0", "arg1",
+// ...). M2's destructuring Pat concretes add their own arms here.
 func paramName(p *FuncParam, i int) string {
 	if pat, ok := p.Pattern.(*IdentPat); ok {
 		return pat.Name
 	}
-	return "x" + strconv.Itoa(i)
+	return "arg" + strconv.Itoa(i)
 }
 
 // printPrim maps a Prim to its Escalier surface name — mirrors

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -92,3 +92,18 @@ func TestPrintNestedPrecedence(t *testing.T) {
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
 	})
 }
+
+// TestPrintUnnamedParamFallback verifies that a parameter with no IdentPat
+// pattern falls back to a positional name (arg0, arg1, ...), numbered by param
+// index. This path isn't reachable in M1 (params are always IdentPat), but the
+// fallback exists for nil/unknown patterns, so it's covered directly here.
+func TestPrintUnnamedParamFallback(t *testing.T) {
+	fn := &FuncType{
+		Params: []*FuncParam{
+			{Pattern: nil, Type: numP()},
+			{Pattern: nil, Type: strP()},
+		},
+		Ret: boolP(),
+	}
+	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
+}

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -1,0 +1,94 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/require"
+)
+
+func numP() *PrimType  { return &PrimType{Prim: NumPrim} }
+func strP() *PrimType  { return &PrimType{Prim: StrPrim} }
+func boolP() *PrimType { return &PrimType{Prim: BoolPrim} }
+
+func identP(name string, t Type) *FuncParam {
+	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t}
+}
+
+// TestPrintRoundTrips covers the short, stable round-trips for the M1 coalesced
+// type set: primitives, literals, the lattice bounds, tuples, multi-arg
+// functions, and multi-element unions/intersections. Per CLAUDE.md these are the
+// short stable strings, so they use require.Equal; the richer nested shapes
+// (which exercise precedence parenthesization) use MatchInlineSnapshot below.
+func TestPrintRoundTrips(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		// Primitives.
+		{"number", numP(), "number"},
+		{"string", strP(), "string"},
+		{"boolean", boolP(), "boolean"},
+
+		// Literals.
+		{"num literal", &LitType{Lit: &NumLit{Value: 5}}, "5"},
+		{"str literal", &LitType{Lit: &StrLit{Value: "hello"}}, `"hello"`},
+		{"bool literal", &LitType{Lit: &BoolLit{Value: true}}, "true"},
+
+		// Lattice bounds and void.
+		{"never", &NeverType{}, "never"},
+		{"unknown", &UnknownType{}, "unknown"},
+		{"void", &Void{}, "void"},
+
+		// Tuples.
+		{"empty tuple", &TupleType{}, "[]"},
+		{"pair tuple", &TupleType{Elems: []Type{numP(), strP()}}, "[number, string]"},
+
+		// Functions.
+		{"nullary fn", &FuncType{Ret: numP()}, "fn () -> number"},
+		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}, "fn (x: number) -> string"},
+		{
+			"multi-arg fn",
+			&FuncType{Params: []*FuncParam{identP("a", numP()), identP("b", strP())}, Ret: boolP()},
+			"fn (a: number, b: string) -> boolean",
+		},
+
+		// Unions and intersections.
+		{"union pair", &UnionType{Types: []Type{numP(), strP()}}, "number | string"},
+		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
+		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// TestPrintNestedPrecedence covers the shapes where operator precedence forces
+// parenthesization, mirroring type_system/print_type.go's behavior. These use
+// inline snapshots per CLAUDE.md since they're the richer rendered forms.
+func TestPrintNestedPrecedence(t *testing.T) {
+	// A function inside a union: precFunc < precUnion, so the function is parenthesized.
+	t.Run("function in union", func(t *testing.T) {
+		ty := &UnionType{Types: []Type{&FuncType{Ret: numP()}, strP()}}
+		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`(fn () -> number) | string`))
+	})
+
+	// A union inside an intersection: precUnion < precIntersection, so the union
+	// is parenthesized.
+	t.Run("union in intersection", func(t *testing.T) {
+		ty := &IntersectionType{Types: []Type{&UnionType{Types: []Type{numP(), strP()}}, boolP()}}
+		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`(number | string) & boolean`))
+	})
+
+	// A function inside a tuple is delimited by brackets, so it needs no parens.
+	t.Run("function in tuple", func(t *testing.T) {
+		ty := &TupleType{Elems: []Type{
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
+			boolP(),
+		}}
+		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
+	})
+}

--- a/internal/solver/print_test.go
+++ b/internal/solver/print_test.go
@@ -1,0 +1,24 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiBoundRenders is the M1 end-to-end demo that the engine→coalesce→print
+// pipeline is wired up correctly: a variable with two distinct lower bounds,
+// coalesced in positive position, renders as a union of those bounds.
+//
+// It lives in package solver (not soltype) because it drives the engine's
+// unexported Context/freshVar and coalesce, then reaches soltype.Print across
+// the package boundary — soltype must not import solver (m1-implementation-plan
+// §3.1), so the pipeline can only be exercised from this side.
+func TestMultiBoundRenders(t *testing.T) {
+	c := &Context{}
+	a := c.freshVar(1)
+	a.LowerBounds = []soltype.Type{num(), str()}
+	got := soltype.Print(coalesce(a, soltype.Positive))
+	require.Equal(t, "number | string", got)
+}


### PR DESCRIPTION
Implements Delta #2 of m1-implementation-plan §2.2: a native soltype printer that renders coalesced M1 types as Escalier type-annotation strings, mirroring type_system.PrintType's surface forms for string-comparability in M7's differential harness.

## Key changes

- **internal/soltype/print.go**: New printer for the M1 coalesced type set (PrimType, LitType, FuncType, TupleType, Void, NeverType, UnknownType, UnionType, IntersectionType)
  - `Print(t Type) string` — main entry point
  - Operator precedence handling (precFunc=2, precUnion=3, precIntersection=4, precAtom=6) to parenthesize lower-precedence types in higher-precedence contexts (e.g., `(fn () -> number) | string`)
  - Separate `printFuncTail` helper to support M3's quantifier prefix composition without byte-slicing
  - Literal rendering with 64-bit float precision (more correct than type_system's bitSize-32 approach, noted as latent bug)

- **internal/soltype/print_test.go**: Comprehensive test coverage
  - `TestPrintRoundTrips`: 16 table-driven cases for primitives, literals, lattice bounds, tuples, functions, unions, and intersections
  - `TestPrintNestedPrecedence`: 3 inline-snapshot cases exercising parenthesization (function in union, union in intersection, function in tuple)

- **internal/solver/print_test.go**: End-to-end integration test
  - `TestMultiBoundRenders`: Demonstrates the engine→coalesce→print pipeline wiring by rendering a variable with two lower bounds as a union

## Implementation notes

- Print is distinct from solver's `describe()`: describe renders raw, uncoalesced types mid-constrain for error messages; Print renders coalesced types as user-facing syntax
- No TypeVarType printer arm — variables are inlined during coalescing (m1-implementation-plan Delta #1), so they never appear in coalesced output
- No `<T0, ...>` quantifier prefix in M1 — named refs don't exist yet; that machinery lands in M3 (§3.3)
- soltype does not import solver (m1-implementation-plan §3.1), so the pipeline is exercised from solver's test side

https://claude.ai/code/session_01SdqvkDFWqczfgZ8w52jZnc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for formatting and displaying type information in human-readable string format, including primitives, literals, tuples, functions, unions, and intersections.

* **Tests**
  * Added comprehensive unit tests for type formatting functionality.
  * Added integration tests verifying type output consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->