### PR TITLE
M2 implementation plan: parser/resolver bridge

### DIFF
--- a/planning/simple_sub/00-overview.md
+++ b/planning/simple_sub/00-overview.md
@@ -50,7 +50,7 @@ This plan turns that spike into a production checker.
 - Bug-for-bug parity with the old checker.
 
 (Type-level operators — `keyof`, conditional, indexed access — **are** in the
-MVP, as the final milestone M8; the spike already proved them.)
+MVP, as the final milestone M9; the spike already proved them.)
 
 ## Strategic decisions (settled)
 
@@ -61,7 +61,7 @@ MVP, as the final milestone M8; the spike already proved them.)
 | AST coupling | **Untouched** — side table (`Info`), option (a) | No AST generics; old checker undisturbed; AST becomes type-system-agnostic at cleanup. |
 | Compatibility | Improve, don't match | Corpus encodes language semantics; improvements are blessed. |
 | Lifetimes | In the core from the start | Introduced with the first lifetime-carrying type (records); lifetimes ride on values. |
-| Exactness | Flag + subtyping rule from the start (M3–M6); machinery deferred (M8+) | Exact-by-default (`planning/exact-types/requirements.md`); a flag on each former, same born-with-the-type shape as lifetimes. The *default* must be settled before M7's corpus. |
+| Exactness | Flag + subtyping rule from the start (M3–M6); machinery deferred (M9+) | Exact-by-default (`planning/exact-types/requirements.md`); a flag on each former, same born-with-the-type shape as lifetimes. The *default* must be settled before M8's corpus. |
 | Codegen / LSP | Deferred | The MVP is pure checking; biggest integration cost (codegen's `type_system` use) is paid later. |
 
 ## Boundary analysis (why this is tractable)

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -3,8 +3,9 @@
 Ordered milestones for the new checker. Each is independently testable and
 leaves the old checker fully working. "Structural core first"; lifetimes are
 introduced **with the first lifetime-carrying type** (records, M4). The MVP is
-M1–M8 (structural core + nominal classes + unions/intersections + fixture
-differential + type-level operators); codegen/LSP and the cutover come after.
+M1–M9 (structural core + nominal classes + unions/intersections + library type
+resolution + fixture differential + type-level operators); codegen/LSP and the
+cutover come after.
 
 Spike provenance is cited where a milestone promotes proven spike work
 (`internal/simplesub/`).
@@ -19,7 +20,7 @@ lifetimes — so the **representation** (an `exact` flag) and the **one-way
 not retrofitted. The richer machinery (`Exact<T>`/`Inexact<T>` type operators,
 exactness propagation through `keyof`/mapped/conditional types, the value-level
 `exact<T>(v)` lowering, and the `std:*`/`dom:*` annotation effort) is deferred to
-M8 and later. See [02-design-notes.md](02-design-notes.md) §"Exactness" for the representation and
+M9 and later. See [02-design-notes.md](02-design-notes.md) §"Exactness" for the representation and
 rules. The **default is settled**: Escalier code is exact-by-default, TypeScript
 imports are inexact-by-default, and each former implements its default *as it
 lands* (M3 functions, M4 records/tuples, M5 class instances via `final`,
@@ -34,11 +35,12 @@ a section recording both before M3 lands.)
 - [M1 — Package skeleton + `soltype`](#m1--package-skeleton--soltype)
 - [M2 — Parser/resolver bridge](#m2--parserresolver-bridge)
 - [M3 — Functions, application, let-polymorphism](#m3--functions-application-let-polymorphism)
-- [M4 — Core value types: records + usage-based inference + `mut` + **lifetimes**](#m4--core-value-types-records--usage-based-inference--mut--lifetimes)
+- [M4 — Core value types: records + usage-based inference + `mut` + **lifetimes** + destructuring/`match`](#m4--core-value-types-records--usage-based-inference--mut--lifetimes--destructuringmatch)
 - [M5 — Nominal types (classes)](#m5--nominal-types-classes)
 - [M6 — Unions / intersections](#m6--unions--intersections)
-- [M7 — Second fixture harness + differential triage](#m7--second-fixture-harness--differential-triage)
-- [M8 — Type-level operators](#m8--type-level-operators)
+- [M7 — Library type resolution (`std:*` / `web:*` / `node:*`)](#m7--library-type-resolution-std--web--node)
+- [M8 — Second fixture harness + differential triage](#m8--second-fixture-harness--differential-triage)
+- [M9 — Type-level operators](#m9--type-level-operators)
 - [Later (post-MVP)](#later-post-mvp)
 - [Dependency / risk ordering rationale](#dependency--risk-ordering-rationale)
 
@@ -134,19 +136,22 @@ Replace the spike's hand-built IR with a real constraint-generating walk over
   `Generator<Y, R, TNext>` / `AsyncGenerator<…>`; iteration-related
   built-ins need a `{value, done}` `IteratorResult<T>`. None of these
   type-checking *rules* land in M2 (they sit in the milestones that own the
-  language features below), but the stdlib type *definitions* they reference
-  must exist by the time those milestones can wire up their rules. M2's
-  responsibility is just to make sure these names resolve through the
-  existing stdlib decls (whether sourced from `lib.esc.d.ts`-equivalents,
-  Escalier's own stdlib, or both) — i.e., the parser-bridge produces
-  `soltype` types for them — so downstream milestones aren't blocked on
-  "but where does `Promise` come from?"
+  language features below), and the **real** stdlib type definitions are ingested
+  in **M7** (library type resolution), once the representational machinery they
+  need (generics, objects, classes, unions) exists. M2's narrower job is just to
+  **seed placeholder bindings** for these names — hand-built opaque `soltype`
+  stubs in the new checker's prelude — so a *reference* resolves without an
+  unbound-name error and downstream rules can be authored against a stand-in. M2
+  does **not** read the real stdlib decls (that path is old-checker- and
+  `type_system`-coupled, and `soltype` has no generic-type node until M3/M4);
+  M7 swaps the placeholders for real structures. See the M2 implementation
+  plan §3.8.
 
 **Accept:** top-level `val`/`fn` declarations from real source infer correct
 rendered types end-to-end; multi-file module via the dep graph resolves;
-references to the stdlib types listed above resolve through the existing
-declaration channels and surface as `soltype.Type` values (the rules that
-*use* them land later).
+references to the stdlib type names listed above resolve to placeholder
+`soltype.Type` stubs without an unbound-name error (real structures and the
+rules that *use* them land in M7 and the feature milestones).
 
 **Gate:** if driving from the real AST/dep-graph requires reaching back into the
 old checker's internals, the parallel-package boundary is wrong — stop and
@@ -171,9 +176,10 @@ reassess.
   variable. Awaiting outside an `async` function is rejected by the AST
   walk, not by the type rule. Nested `Promise<Promise<T>>` does *not*
   auto-flatten in this milestone — `Awaited<T>` (the recursive-conditional
-  flattening) is a type-level operator that lands in M8; user code that
+  flattening) is a type-level operator that lands in M9; user code that
   cares about flattening writes `Awaited<T>` explicitly until then.
-  Depends on `Promise<T>` being available from the stdlib (M2 prerequisite).
+  Depends on `Promise<T>` being available from the stdlib (M2 placeholder;
+  real resolution lands in M7).
 - **Function exactness flag.** `Function` carries an `exact` flag; a bare
   `fn(...)` is exact, `fn(..., ...)` is inexact. **Direct calls reject extra
   args regardless of exactness** (an inexact function ignores them, but passing
@@ -198,7 +204,7 @@ are accepted while exact `fn(x)` and any 3+-param function are rejected. Plus,
 on async: `async fn () -> number` renders as `fn () -> Promise<number>`;
 `await p` where `p: Promise<string>` yields `string`; `await p` where
 `p: Promise<Promise<number>>` yields `Promise<number>` (no auto-flatten —
-that's M8's `Awaited<T>`).
+that's M9's `Awaited<T>`).
 
 **Function overloading.** Escalier supports overloaded `fn` declarations and
 this milestone is where they land for free functions. Overloading is a poor fit
@@ -247,7 +253,7 @@ checker:
 
 ---
 
-## M4 — Core value types: records + usage-based inference + `mut` + **lifetimes**
+## M4 — Core value types: records + usage-based inference + `mut` + **lifetimes** + destructuring/`match`
 
 The big one. These are inseparable: lifetimes ride on borrows, records are the
 first value type that can be borrowed, and `mut` borrows (via the `Ref`
@@ -294,6 +300,36 @@ wrapper) are what first populate a lifetime. Land them together.
   originate at parameters typed as `Ref` (mut or immut); returning shares by
   value identity; multi-source returns union lifetimes; escape constrains `<:
   'static`. (Spike M4.)
+- **Destructuring patterns + the `match` expression form.** `IdentPat` (M1, the
+  only `Pat` concrete through M2–M3) is joined here by the structural concretes —
+  `TuplePat`, `RecordPat`, and literal patterns — now that tuple/record types
+  exist to type them. The *same* `Pat` machinery powers both **binding
+  destructuring** (`val {x, y} = p`, `val [a, b] = t`, and the identical forms in
+  function params) and **`match` arms**: a pattern dispatches through the usage /
+  member-lookup path (`obj.bar` ⇒ `constrain(obj <: {bar: β})`), **not**
+  subtyping — the rule M5 restates for class/enum patterns. M4 owns introducing
+  the `match` *expression* over these structural patterns; exhaustiveness for a
+  closed scrutinee follows the exactness flag (an exact record/tuple pattern set
+  is complete; an inexact one requires a catch-all arm). **Constructor/enum
+  patterns and enum-exhaustive `match` are M5; union `match` exhaustiveness is
+  M6** — M4 lays the form and the structural-pattern machinery they both extend.
+- **Namespace member lookup (`Foo.bar`, `Foo["x"]`).** Lands here, co-located
+  with object member access, because it's the same operation against a different
+  container. M2 introduced the `Namespace` *structure* and made a free-floating
+  namespace ident an error; M4 adds the *access*. A single `resolvePath` resolves
+  an ident/member/index chain to `Value | Namespace` (a name is never both — a
+  scope invariant); the **object/index position tolerates a namespace, every
+  other (value) position rejects one** — so the `NamespaceUsedAsValueError` moves
+  off `inferIdent` to the value-position consumer and fires once, covering both
+  `f(Foo)` and partial chains `f(A.B)`. Namespace lookup is a **direct,
+  non-lexical** read of the namespace's own `Values`/`Nested` maps
+  (`LookupValue`/`LookupNamespace`) — unlike `Scope.Get*`, no parent walk, just
+  like object member access. Index keys into a namespace must be **statically
+  constant** (string/symbol — for members whose names aren't valid identifiers),
+  since membership is resolved by name, not dynamically. New errors:
+  `UnknownNamespaceMemberError`, `DynamicNamespaceIndexError`. (Producing the
+  namespace in the first place — cross-package import resolution — is a separate
+  concern from this lookup logic.)
 
 **Accept:** the canonical lifetime cases against real source — `IdentityRefReturn`
 ⇒ `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`; `FreshObjectReturn`
@@ -305,6 +341,14 @@ the reverse; an extra property on an exact target is rejected; `Ref` neither
 tightens nor loosens the inner's exactness (the inner carrier's `exact` flag
 passes through, per [exact-types/requirements.md](../exact-types/requirements.md)
 §7.11 — orthogonal to `Ref`'s mut/lifetime axes).
+Plus patterns: `val {x, y} = p` and `val [a, b] = t` bind each name at the
+member's type (and reject a missing field / wrong arity); a destructured param
+`fn (({x, y})) { … }` types the same way; a `match` over structural patterns
+binds and type-checks each arm, and an exact-record/tuple scrutinee with a
+complete pattern set needs no catch-all while an inexact one does.
+Plus namespaces: `Foo.bar` resolves to the member's type and `Foo["weird-name"]`
+to a constant-keyed member, while `f(Foo)` and `f(A.B)` are rejected as
+`NamespaceUsedAsValueError` and a dynamic `Foo[k]` as `DynamicNamespaceIndexError`.
 
 **Mutability-transition checking reuses existing infrastructure.** Escalier's
 flow-sensitive analysis that permits mutable↔immutable alias creation in
@@ -377,12 +421,16 @@ M4 substrate without retrofitting.
   built from each class's `Extends`/`Implements`. Mixed
   `Class <: structural record` (and the reverse) rejects: a `Point` is not a
   `{x: number}`.
-- **Pattern matching and destructuring are separate from assignability.** A
-  record pattern like `let {x, y} = point` (and the equivalent `match` arm)
-  succeeds against a `Point` because patterns dispatch through member lookup,
-  not subtyping — the same path that resolves `p.x`. The assignment forms
+- **`match` extends to nominal patterns; destructuring stays separate from
+  assignability.** M5 adds **enum/class constructor patterns** to the `match`
+  expression introduced in M4 (structural patterns there), plus
+  **enum-exhaustive `match`** — enum variants are implicitly `final` (above), so
+  a `match` covering every variant needs no default arm. A record pattern like
+  `let {x, y} = point` (and the equivalent `match` arm) still succeeds against a
+  `Point` because patterns dispatch through member lookup, **not** subtyping —
+  the same path that resolves `p.x`. The assignment forms
   `var foo: {x: number, y: number} = Point(5, 10)` and
-  `var bar: Point = {x: 5, y: 10}` both remain rejected by the rule above.
+  `var bar: Point = {x: 5, y: 10}` both remain rejected by the nominal rule above.
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,
   exactly as SimpleSub already does for inference variables. A parameter that
@@ -402,7 +450,7 @@ M4 substrate without retrofitting.
 - **Generic type aliases do *not* carry variance separately.** A non-recursive
   alias like `type Box<T> = {value: T}` is transparent: `Box<A> <: Box<B>`
   reduces to the structural subtyping of its expansion, so variance falls out
-  for free and storing it would be redundant. Recursive aliases (handled in M8
+  for free and storing it would be redundant. Recursive aliases (handled in M9
   via the cycle cache) are the wrinkle — at the cycle-cache hit point the rule
   must dispatch without expanding, so variance is inferred internally for use
   there, but is never user-annotated. `in`/`out` modifiers are therefore
@@ -421,7 +469,7 @@ M4 substrate without retrofitting.
   No new constraint machinery needed; this is purely "wire the loop syntax to
   the existing dispatch path." Depends on `Iterable<T>` / `Iterator<T>` /
   `AsyncIterable<T>` / `IteratorResult<T>` being available from the stdlib
-  (M2 prerequisite).
+  (M2 placeholder; real resolution lands in M7).
 - **`mut` and lifetimes ride on it free.** `Class` is borrowed the same way
   records and tuples are — wrapped in `Ref{mut, lt, inner: Class{...}}`. The
   M4 lifetime machinery applies unchanged (`mut 'a Point` is `Ref{mut: true,
@@ -527,10 +575,12 @@ recursive references (cf. `infer_module.go:431-872` and the discussion in
     mirrors SAT/SMT unit-propagation-before-branching: do all the forced work
     first, and when forced to branch, keep the decision symbolic in a
     variable's bounds.
-- **Union exactness flag.** A bare `A | B` is an **exact** (closed) union — its
+- **Union exactness flag — completes `match` exhaustiveness.** A bare `A | B` is
+  an **exact** (closed) union — its
   inhabitants are exactly `A ∪ B`; `A | B | ...` is inexact (at least these, with
-  an `unknown`-typed tail). Exact `<:` inexact, not the reverse. Exactness drives
-  the closed-set consequences: a `match` over an exact union is exhaustive with
+  an `unknown`-typed tail). Exact `<:` inexact, not the reverse. This is the
+  third and last leg of the `match` story (structural M4, enum M5, union here):
+  a `match` over an exact union is exhaustive with
   no default arm; over an inexact union a default is required. (The exhaustiveness
   payoff is the main motivation, per
   [exact-types/requirements.md](../exact-types/requirements.md) §5.) `keyof` of an exact object and the
@@ -546,7 +596,72 @@ inexact-union `match` does.
 
 ---
 
-## M7 — Second fixture harness + differential triage
+## M7 — Library type resolution (`std:*` / `web:*` / `node:*`)
+
+Port the standard-library type ingestion onto `soltype`. Today this is a
+self-contained subsystem living entirely in `internal/checker/`
+(`infer_import.go`, `infer_stdlib_import.go`, `infer_stdlib_scc.go`) plus
+`internal/interop/`, and it produces `type_system.Type`. This milestone
+retargets it to produce `soltype.Type` in the new checker's `Scope`/`Namespace`,
+covering both ingestion channels:
+
+- **Ambient global lib** — `Array`, `Promise`, `Map`, `Set`, `console`, `Math`,
+  `JSON`, the iteration protocols, etc., loaded from `lib.*.d.ts` without an
+  import (the `globalThis` surface).
+- **Scheme imports** — `std:*` / `web:*` / `node:*` (the DOM lives under
+  `web:dom`), routed through the `interop` partition table to the stdlib `.esc`
+  modules.
+
+This **replaces M2's placeholder "prerequisite tracking"**: the names M2 stubbed
+(`Promise`/`Iterable`/`Generator`/`IteratorResult`) and the broader lib surface
+now resolve to real `soltype` structures rather than opaque placeholders.
+
+- **Interop reuse, gate intact.** The front half of the existing pipeline
+  (`dts_parser` parse → `interop.ConvertModule` → `*ast.Module`) is reusable as
+  AST. The back half (the old checker's `InferModule` → `type_system`) is what
+  this milestone replaces with the new checker's `soltype` walk over that AST.
+  `interop` itself imports `type_system`, so this milestone must consume only its
+  AST-producing surface and keep the `soltype` output path free of `type_system`
+  — confirm the M2 parallel-package gate still holds.
+- **Scope = the operator-free lib subset.** Everything expressible with the
+  M3–M6 representational features (generics, object/record types, nominal
+  classes + `final`, unions): `Array`, `Promise`, `Map`/`Set`, the
+  `Iterable`/`Iterator`/`IteratorResult` protocols, `console`, `Math`, `JSON`,
+  the `string`/`number`/`boolean`/`symbol`/`regexp` method surfaces, and the
+  common `web:dom` types.
+- **Deferred to a phase-2 backfill (after M9).** Lib types whose definitions
+  need conditional/mapped/utility **type operators** (`Awaited<T>`, `Partial`,
+  `Pick`, `Record`, and the operator-heavy parts of `web:dom`) cannot be
+  represented until M9 (type-level operators) lands. Until then they resolve as
+  placeholders/inexact stubs — the same posture M2 takes — and are backfilled
+  once the operator machinery exists. Record which lib names are stubbed so the
+  gap stays visible rather than reading as full coverage.
+- **Exactness.** TS-imported lib types are **inexact by default**
+  ([exact-types/requirements.md](../exact-types/requirements.md) §8); this
+  milestone stamps the inexact flag on ingested lib formers as they land.
+- **Not in scope: operators.** The built-in operator schemes (`+`, `==`, `&&`,
+  `++`, …) are **not** library types and are **not** owned here. They are
+  hand-coded, monomorphic-over-primitive value bindings the expression walk needs
+  from day one, so they live in the M2 prelude (a port of the old checker's
+  `addOperatorBindings`). M7 ports *type* ingestion (`.d.ts`/interop → `soltype`),
+  not the value-level operator env.
+
+**Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
+`Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
+to real `soltype` structures and type-checks (not placeholders); `import { … }
+from "std:array"` / `"web:dom"` resolves member types; the M3 `await` and M5
+`for (x in xs)` rules now exercise against the **real** `Promise`/`Iterable`
+(replacing the M2 placeholders); operator-dependent utility types remain stubbed
+pending M9, and which names are stubbed is reported, not silently dropped.
+
+**Depends on:** M3 (generics), M4 (objects/records), M5 (classes / methods /
+`final`), M6 (unions). **Feeds:** M8 — the real-package differential cannot run
+the existing `fixtures/` tree (which uses `console`/`Array`/`Promise`/…) without
+real lib types.
+
+---
+
+## M8 — Second fixture harness + differential triage
 
 Two complementary mechanisms, picked to match the granularity of what each one
 tests:
@@ -564,7 +679,7 @@ tests:
   `cmd/escalier/fixture_test.go`). Phase 1 (this milestone) runs the checker
   only — no codegen; acceptance is "the new checker accepts/rejects every
   fixture the way the old checker does, modulo triaged intended
-  improvements." Phase 2 (post-M9) extends to end-to-end compilation and
+  improvements." Phase 2 (post-M10) extends to end-to-end compilation and
   `build/` golden diffs once the codegen path is settled. This is the
   regression net that catches "did we break anything real."
 - **Differential triage** runs both checkers on the same parsed tree (parse
@@ -585,7 +700,7 @@ tests:
   still need to express the distinction. Strategy (cheapest first):
   - **Parser-level tolerance, semantics no-op in old checker.** Teach the
     shared parser to accept the `...` trailing-marker syntax (and the
-    `Exact<T>`/`Inexact<T>` type operators once M8 lands); the old checker
+    `Exact<T>`/`Inexact<T>` type operators once M9 lands); the old checker
     reads the AST node and ignores the flag, behaving as today. The old
     checker is already an effectively-inexact world, so most fixtures "just
     work" without semantic changes — the cost is one parser change and zero
@@ -619,7 +734,7 @@ gaps; burn down before proceeding.
 
 ---
 
-## M8 — Type-level operators
+## M9 — Type-level operators
 
 The last MVP milestone. The full type-level operator surface, reduced via
 Baseline-D (reduce when operands ground) + Design-A residual nodes reduced
@@ -665,7 +780,8 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
   The constraint engine extends just like `throws` did: parallel arms in
   `constrain`/`extrude`/`LevelOf`/printer, no new lattice machinery.
   Depends on `Generator<Y, R, TNext>` / `AsyncGenerator<…>` being
-  available from the stdlib (M2 prerequisite).
+  available from the stdlib (M2 placeholder; real resolution in M7 — M9 follows,
+  so generators can rely on the real types).
 - **`throws T` clause on functions.** `FuncType` gains a `Throws Type` field
   (parallel to `Ret`), covariant in subtyping, defaulting to `never` (⊥) when
   the source has no `throws` clause. The constraint engine extends naturally:
@@ -720,13 +836,13 @@ externally as `Generator<1 | "a", void, unknown>`; `yield from g` where
 includes `number`; `gen fn` outside a `gen` context (top-level `yield`)
 is rejected by the AST walk; `Awaited<ReturnType<F>>` over an
 `async gen fn () -> R` returns `R` once `Awaited<T>` and `ReturnType<F>`
-reduce through the M8 operator machinery.
+reduce through the M9 operator machinery.
 
 ---
 
 ## Later (post-MVP)
 
-- **M9 — Codegen.** Either a `soltype → type_system` bridge to reuse codegen
+- **M10 — Codegen.** Either a `soltype → type_system` bridge to reuse codegen
   unchanged, or port codegen (`dts.go` et al., ~4 files / ~30 refs) onto
   `soltype`. Decide when the checker is proven. **The value-level `exact<T>(v)`
   conversion** ([exact-types/requirements.md](../exact-types/requirements.md)
@@ -736,8 +852,8 @@ reduce through the M8 operator machinery.
   JSDoc round-tripping for exactness
   ([exact-types/requirements.md](../exact-types/requirements.md) §9) is also
   codegen work.
-- **M10 — LSP.** Switch the LSP to the new checker's `Scope`/`Info`.
-- **M11 — Flip & cleanup.** Make the new checker the default; retire the old
+- **M11 — LSP.** Switch the LSP to the new checker's `Scope`/`Info`.
+- **M12 — Flip & cleanup.** Make the new checker the default; retire the old
   checker + its tests; **delete** the AST `inferredType` field, the
   `type Type = type_system.Type` alias, and `tools/gen_ast`'s generation of the
   field — leaving the AST fully type-system-agnostic.
@@ -762,7 +878,7 @@ reduce through the M8 operator machinery.
 - Codegen is deferred to the latest safe point because it is the single largest
   integration cost (its `type_system` dependency) and is not needed to prove the
   checker.
-- M7's test posture is "improve, don't match" — table tests assert intended
+- M8's test posture is "improve, don't match" — table tests assert intended
   semantics (not old-checker output), and the second fixture harness's
   differential is a triage tool, not a parity gate. This is what lets
   intended improvements through instead of forcing old-checker parity.

--- a/planning/simple_sub/02-design-notes.md
+++ b/planning/simple_sub/02-design-notes.md
@@ -394,7 +394,7 @@ either every signature in the unifier picks up generic parameters or it
 coerces to `UnionType[Type]` at the door and the precision evaporates.
 Coalescing has the same problem in reverse — it would have to pick a
 parameterization based on whether all bounds happen to be `RefInner`, a
-runtime check on every coalesce. And M8 type-level operators (`keyof`,
+runtime check on every coalesce. And M9 type-level operators (`keyof`,
 conditional, indexed access) don't preserve `RefInner`-ness anyway
 (`keyof UnionType[RefInner]` is `UnionType[LiteralType]`, and `LiteralType` isn't
 `RefInner`), so the chain breaks at the first operator. Non-generic
@@ -640,7 +640,7 @@ same architectural shape as lifetimes — a property *carried on the former*, ch
 to add when the former is born, painful to retrofit across `constrain` /
 `coalesce` / `analyze` / `freshenAbove` / `extrude` / `print`. So the **flag and
 the subtyping rule are introduced with each former (M3–M6)**; the propagation and
-utility machinery is deferred (M8) and the value-level conversion is codegen (M9).
+utility machinery is deferred (M9) and the value-level conversion is codegen (M10).
 
 **Representation** — an `exact` flag on each structural former, plus `final` on
 classes (a class instance is exact iff `final`):
@@ -713,9 +713,9 @@ and the tests another. (The spike itself is uniformly inexact-by-default — the
 production direction.)
 
 **Deferred (not core):** `Exact<T>`/`Inexact<T>` type operators and exactness
-propagation through `keyof`/mapped/conditional types (M8, type operators);
+propagation through `keyof`/mapped/conditional types (M9, type operators);
 value-level `exact<T>(v)` lowering and `@escalier-type` JSDoc round-tripping
-(M9, codegen); the `std:*`/`dom:*` finality/inexactness annotation effort
+(M10, codegen); the `std:*`/`dom:*` finality/inexactness annotation effort
 ([exact-types/requirements.md](../exact-types/requirements.md) §11 +
 [exact-types/builtin-classes.md](../exact-types/builtin-classes.md), independent
 stdlib track).
@@ -735,7 +735,7 @@ func (i *Info) setType(n ast.Node, t soltype.Type) { i.types[n] = t }
 ```
 
 The new checker **never** calls `ast` node `InferredType()`/`SetInferredType()`.
-The embedded `inferredType` field stays for the old checker until M11 cleanup.
+The embedded `inferredType` field stays for the old checker until M12 cleanup.
 
 ## Provenance side table (the inverse of `Info`)
 
@@ -834,7 +834,7 @@ a single pointer.
 `Prov: Type → Origin` is its inverse. Same package, same walk populates both,
 same downstream consumers (error messages, LSP hovers, the differential harness
 when diagnosing divergence) query both. If it turns out we don't need it,
-dropping a map at M11 is one file edit; dropping a field would be a refactor of
+dropping a map at M12 is one file edit; dropping a field would be a refactor of
 every `Type` constructor.
 
 **Population discipline.** Helpers in `infer.go` keep both tables in sync:
@@ -963,7 +963,7 @@ JS objects (`buildNamespaceStatements` in
 restriction is purely a *type-system* discipline: you address namespace
 members only through qualified names known statically.
 
-## Test coverage for M7
+## Test coverage for M8
 
 Two mechanisms, picked to match the granularity of what each one tests.
 **Granular semantics** lives in table-driven `*_test.go` files in the new
@@ -1031,18 +1031,18 @@ omit the other map entirely.
 ### Real-package regression: second fixture harness
 
 `fixtures/` already encodes whole-package behavior — `package.json` +
-`lib/*.esc` + golden `build/` and optional `error.txt`. M7 adds a **second
+`lib/*.esc` + golden `build/` and optional `error.txt`. M8 adds a **second
 harness** that runs the new checker over the same fixtures. Two phases match
-the codegen-port decision (M9):
+the codegen-port decision (M10):
 
-- **Phase 1 (M7, before codegen is ported):** new-checker harness runs the
+- **Phase 1 (M8, before codegen is ported):** new-checker harness runs the
   checker only — no codegen. Acceptance is "checker accepts (or rejects)
   every fixture the way the old checker does, modulo triaged intended
   improvements." Each divergence is bucketed as match / intended-improvement
   / bug; CI fails only on `bug`. Implemented as a sibling to
   `cmd/escalier/fixture_test.go` that loads the same fixtures and runs only
   the check phase.
-- **Phase 2 (post-M9, once codegen is decided):** the harness compiles
+- **Phase 2 (post-M10, once codegen is decided):** the harness compiles
   end-to-end and diffs `build/` against fixture goldens using the same
   `UPDATE_FIXTURES=true` flow. At that point both checkers can drive the
   full pipeline.
@@ -1077,7 +1077,7 @@ intended-improvement / bug. The bug bucket is the only CI gate; intended
 improvements are recorded (a short note per case is enough — no separate
 ledger needed) so future contributors don't mistake them for regressions.
 
-## Compiler wiring (M7)
+## Compiler wiring (M8)
 
 The flag lives at the **3** `checker.NewChecker(ctx)` sites in
 `internal/compiler/compiler.go` (`CheckLib`, `Compile`, `CompilePackage`).
@@ -1085,7 +1085,7 @@ the MVP selects the new checker for *checking only* — codegen continues from t
 checker's output (codegen deferred). Simplest form: an env var or build tag
 read once and branched at those three sites.
 
-## What gets deleted at M11 (cleanup)
+## What gets deleted at M12 (cleanup)
 
 - `internal/checker/` (old package) + its ~38k LoC of tests.
 - `internal/ast/ast.go`: `type Type = type_system.Type`.
@@ -1103,8 +1103,8 @@ read once and branched at those three sites.
 2. **`BindingOwner`** — move the marker interface into `internal/ast` itself
    (rather than living in `type_system`). Both the old and new checkers refer
    to `ast.BindingOwner`; neither package owns it. This also clears one of the
-   AST→`type_system` imports that M11 cleanup is targeting.
-3. **Codegen path (M9)** — **port codegen onto `soltype`**, not a bridge.
+   AST→`type_system` imports that M12 cleanup is targeting.
+3. **Codegen path (M10)** — **port codegen onto `soltype`**, not a bridge.
    Driver: the `@escalier-type` JSDoc round-tripping for exactness needs the new
    checker's exactness information end-to-end; a `soltype → type_system`
    bridge would either lose the flag or have to re-encode it on the way back
@@ -1119,7 +1119,7 @@ read once and branched at those three sites.
    `NewModuleScope *solver.Scope` (plus the matching `FileScopes` maps), with
    a flag picking which one is active at each downstream call site. The
    branching is confined to LSP entry points and the codegen driver — a
-   small, stable set of sites. At M11 cleanup, drop the old field; no
+   small, stable set of sites. At M12 cleanup, drop the old field; no
    interface ever needed.
 6. **Exact-by-default is day-one behavior.** Escalier code is
    exact-by-default and TypeScript-imported types are inexact-by-default
@@ -1127,7 +1127,7 @@ read once and branched at those three sites.
    records/tuples in M4, exact class-instances-via-`final` in M5, exact
    unions in M6. Tests at each milestone assert what the implementation
    produces, so there's no window in which the code is one default and the
-   tests another. No M7 deadline.
+   tests another. No M8 deadline.
 7. **Exact-only fixture skip-tag location** — **magic comment header** in
    `lib/index.esc` (e.g. `// @applicable_to new`). More visible than a
    `package.json` field; people rarely open the package.json in a fixture.

--- a/planning/simple_sub/m1-implementation-plan.md
+++ b/planning/simple_sub/m1-implementation-plan.md
@@ -13,7 +13,7 @@ call with a native `soltype` node so coalescing returns `soltype.Type`, and
 ships its own `soltype/print.go`. The result is a `soltype`/`solver` package
 pair with **zero** `type_system` imports — though several surfaces are
 deliberately **inspired by** `type_system` (node names mirror the `…Type`
-convention, the printer mirrors `type_system.PrintType`'s surface syntax so M7's
+convention, the printer mirrors `type_system.PrintType`'s surface syntax so M8's
 differential harness can string-compare outputs, and M1 error wording matches
 the spike's, which echoes the old checker's). None of that is shared code; the
 only sharing actually planned (per [02-design-notes.md](02-design-notes.md)
@@ -75,14 +75,14 @@ Per the milestone, M1 delivers the **structural core**:
 | **Co-occurrence variable merging** (`collectCoOcc`/`mergeCoOccurring`/union-find) | M3 | Hangs off occurrence analysis; lands as part of the M3 polymorphism-rendering bundle above. |
 | Records, `RefType`/`mut`, **lifetimes** | M4 | First lifetime-carrying types. |
 | `exact` flag on formers + the inexact `constrain` arms | M3 (functions), M4 (records, tuples), M6 (unions) | M1 stands up bare `FuncType`/`TupleType` without the flag. Because Escalier is **exact-by-default**, M1 implements each former's *exact* rule uniformly — so each M1 constraint rule is the **exact "one side"** of the eventual exact/inexact split: M1's `FuncType` "same-arity required" is the *exact-function* case (the inexact fewer-params-is-subtype arm lands in M3 with the flag); M1's `TupleType` "same length, element-wise covariant" is the *exact-tuple* case (the inexact arm `longer <: shorter` lands in M4 alongside `RecordType`). Functions and tuples thus follow the **same trajectory** — ship exact now, add the inexact arm with the flag later. See [01-milestones.md](01-milestones.md) §M4 "Exactness flag on records and tuples." |
-| Classes, union/intersection **subtyping rules** in `constrain`, type-level operators | M5/M6/M8 | M1 ships `UnionType`/`IntersectionType` *nodes* for coalesced output, but their lattice rules in `constrain` land in M6. |
+| Classes, union/intersection **subtyping rules** in `constrain`, type-level operators | M5/M6/M9 | M1 ships `UnionType`/`IntersectionType` *nodes* for coalesced output, but their lattice rules in `constrain` land in M6. |
 | `Prov` provenance side table, `Probe` speculation API | M3+/as-needed | M1 has no speculation and no error-message provenance yet. |
 
 ### Reversibility
 
 M1 is **purely additive**: it creates new files in a new package and edits
 **zero** existing files. The old checker is untouched; there is no flag to flip
-yet (that's M7). `go build ./...` and `go test ./...` stay green throughout.
+yet (that's M8). `go build ./...` and `go test ./...` stay green throughout.
 
 ---
 
@@ -111,7 +111,7 @@ Most of M1 is a faithful copy-with-rename. The files that map directly:
 | Spike file | M1 destination | Notes |
 |---|---|---|
 | `polarity.go` | `soltype/polarity.go` | Copy verbatim. Lives in `soltype` (not `solver`) so `soltype.TypeVarType.BoundsAt` can take a `Polarity` argument without `soltype` importing `solver`. |
-| `types.go` (M1 subset) | `soltype/type.go` | Keep `Variable`→`TypeVarType`, `Primitive`→`PrimType`, `Literal`→`LitType`, `Function`→`FuncType`, `Tuple`→`TupleType`, `Void`; add `NeverType`/`UnknownType` (lattice ⊥/⊤, which the spike emits via `type_system`); add `UnionType`/`IntersectionType` (needed by Delta #1's `combine` — the spike emits these via `type_system.NewUnionType`/`NewIntersectionType`). **Reshape `PrimType` and `LitType` to mirror `type_system`** (closed `Prim` enum instead of `Name string`; sealed `Lit` interface with `NumLit`/`StrLit`/`BoolLit` concretes instead of a flat `{Kind, Str, Num, Bool}` struct) — see §2.3 row 3. **Drop** `Record`/`Mut`/`Alias` (M4) and the spike's `TypeRefType` role (M3 — see §3.3). Trim `levelOf`/`containsVariable` to the M1 cases — this also drops their `*ResidualOp` arms (the `ResidualOp` type itself is defined in the spike's `residual.go`, not `types.go`, and is M8). |
+| `types.go` (M1 subset) | `soltype/type.go` | Keep `Variable`→`TypeVarType`, `Primitive`→`PrimType`, `Literal`→`LitType`, `Function`→`FuncType`, `Tuple`→`TupleType`, `Void`; add `NeverType`/`UnknownType` (lattice ⊥/⊤, which the spike emits via `type_system`); add `UnionType`/`IntersectionType` (needed by Delta #1's `combine` — the spike emits these via `type_system.NewUnionType`/`NewIntersectionType`). **Reshape `PrimType` and `LitType` to mirror `type_system`** (closed `Prim` enum instead of `Name string`; sealed `Lit` interface with `NumLit`/`StrLit`/`BoolLit` concretes instead of a flat `{Kind, Str, Num, Bool}` struct) — see §2.3 row 3. **Drop** `Record`/`Mut`/`Alias` (M4) and the spike's `TypeRefType` role (M3 — see §3.3). Trim `levelOf`/`containsVariable` to the M1 cases — this also drops their `*ResidualOp` arms (the `ResidualOp` type itself is defined in the spike's `residual.go`, not `types.go`, and is M9). |
 | `constrain.go` | `solver/constrain.go` | Keep the prim/literal/function/tuple/variable cases + `extrude`. Drop the union/intersection lattice rules **that fire on `UnionType`/`IntersectionType` inputs to `constrain`** (distributivity laws like `A \| B <: C` ⟹ `A <: C ∧ B <: C`), and drop the record/mut/alias cases (re-added in their milestones). The implicit lattice — bounds on `TypeVarType` (lowers semantically join, uppers meet) — is fully present in M1; only the explicit-node rules go. M1 ships `UnionType`/`IntersectionType` nodes in `soltype` for coalesced output, but no path in M1 feeds them back as `constrain` inputs (no user annotations until M2, scheme bounds carry raw `TypeVarType`s, coalesced output isn't re-constrained). |
 | `simplify.go` | — | Not M1. Both `analyze` (occurrence analysis) and co-occurrence merging land in M3 as part of the polymorphism-rendering bundle (§3.3). |
 | `coalesce.go` | `solver/coalesce.go` | **Delta #1 below.** Significantly trimmed vs. the spike — no occurrence/`bipolar` branching, no `nameFor`/`inProc`, just inline-to-bounds. |
@@ -162,7 +162,7 @@ quantifier-prefix machinery lands in M3 with the rest of the
 polymorphism-rendering bundle.
 
 Mirror `type_system.PrintType`'s surface syntax so the two checkers' rendered
-types are comparable in M7's differential harness, but share **no code** with
+types are comparable in M8's differential harness, but share **no code** with
 it.
 
 > **Two renderers, distinct jobs.** Keep this printer separate from the spike's
@@ -177,7 +177,7 @@ it.
 |---|---|---|---|
 | 1 | One flat `package simplesub` | Two packages: `solver` (engine) + `soltype` (representation + printer) | Matches [02-design-notes.md](02-design-notes.md) layout; lets the printer live with the types without importing the engine. |
 | 2 | Terse names: `Variable`, `Primitive`, `Literal`, `Function`, `Tuple` | `TypeVarType`, `PrimType`, `LitType`, `FuncType`, `TupleType` | The design-notes names; consistent `…Type` suffix. |
-| 3 | `Primitive { name string }`; `Literal { kind string; str string; num float64; bool bool }` — flat structs with string discriminators; `Function { params []SimpleType; paramNames []string; ret SimpleType }` — two parallel arrays for params | `PrimType { Prim Prim }` with closed `Prim` enum; `LitType { Lit Lit }` where `Lit` is a sealed interface with `NumLit { Value float64 }` / `StrLit { Value string }` / `BoolLit { Value bool }` concretes; `FuncType { Params []*FuncParam; Ret Type }` where `FuncParam { Pattern Pat; Type Type }` and `Pat` is a sealed interface (`IdentPat { Name string }` in M1; M2 adds destructuring concretes) | Mirrors `type_system`'s shapes: closed enum catches mismatches at compile time (vs. silent typos like `"numbr"`); per-kind literal structs carry exactly the value field they need (vs. flat struct with two dead value fields per instance); single struct per param (vs. parallel-array bug-trap); `FuncParam.Pattern` is a sealed interface from day one so M2's destructuring lands as new `Pat` concretes without restructuring `FuncParam`. `soltype.Pat` is defined inside `soltype` (not imported from `ast`) to keep `soltype` ast-free. M1 omits `type_system.FuncParam.Optional` — no optional params in M1. |
+| 3 | `Primitive { name string }`; `Literal { kind string; str string; num float64; bool bool }` — flat structs with string discriminators; `Function { params []SimpleType; paramNames []string; ret SimpleType }` — two parallel arrays for params | `PrimType { Prim Prim }` with closed `Prim` enum; `LitType { Lit Lit }` where `Lit` is a sealed interface with `NumLit { Value float64 }` / `StrLit { Value string }` / `BoolLit { Value bool }` concretes; `FuncType { Params []*FuncParam; Ret Type }` where `FuncParam { Pattern Pat; Type Type }` and `Pat` is a sealed interface (`IdentPat { Name string }` in M1; M4 adds destructuring concretes, M2 stays IdentPat-only) | Mirrors `type_system`'s shapes: closed enum catches mismatches at compile time (vs. silent typos like `"numbr"`); per-kind literal structs carry exactly the value field they need (vs. flat struct with two dead value fields per instance); single struct per param (vs. parallel-array bug-trap); `FuncParam.Pattern` is a sealed interface from day one so M4's destructuring lands as new `Pat` concretes without restructuring `FuncParam`. `soltype.Pat` is defined inside `soltype` (not imported from `ast`) to keep `soltype` ast-free. M1 omits `type_system.FuncParam.Optional` — no optional params in M1. |
 | 4 | `SimpleType` interface (`isSimpleType()`) | `soltype.Type` interface (`isType()`) | One representation in production — no separate "SimpleType vs output type" split, since coalescing now stays within `soltype` (Delta #1). |
 | 5 | `Inferer` struct carrying `varCounter`, `lifetimeCounter`, `paramLifetimes`, `written` | `solver.Context` carrying **only** `varCounter` (+ `freshVar`) | `lifetimeCounter`/`paramLifetimes` are M4 (lifetimes); `written` (field-write tracking) is M4 (records/`mut`). M1's `Context` is correspondingly lean. |
 | 6 | Public entry points `Infer(term)` / `Render(...)` over a hand-built `Term` IR | **No public inference entry point in M1.** Tests drive `constrain` / `coalesce` / `Print` directly | The `Term` IR and `typeTerm` walk are the spike's stand-in for the parser bridge — replaced wholesale by the real AST walk in **M2**, not promoted. |
@@ -232,7 +232,7 @@ Per [CLAUDE.md](../../CLAUDE.md):
   This is about **shared code**, not shared *design*. Several M1 surfaces are
   intentionally modeled on `type_system` and must stay comparable to it:
   `soltype`'s node names follow the `…Type` convention, `print.go` mirrors
-  `type_system.PrintType`'s surface forms (so M7 can string-diff the two
+  `type_system.PrintType`'s surface forms (so M8 can string-diff the two
   checkers' output), and error wording is preserved verbatim from the spike.
   None of these share an import — they're reimplementations that look alike on
   purpose. The one place real sharing is on the roadmap is **diagnostic types**
@@ -662,9 +662,10 @@ func (l *LitType) Equal(o *LitType) bool { /* dispatch on Lit concrete, compare 
 
 // Pat is the sealed interface for parameter patterns. Mirrors the role of
 // type_system.Pat (and ast.Pat) but lives in soltype to keep soltype ast-free.
-// M1 ships a single concrete (IdentPat); M2 adds destructuring concretes
-// (TuplePat, RecordPat, …) as the parser bridge surfaces them, with no
-// FuncParam restructuring.
+// M1 ships a single concrete (IdentPat); M4 adds destructuring concretes
+// (TuplePat, RecordPat, …) once record/tuple types exist — M2 stays
+// IdentPat-only. The sealed interface means they land as new Pat concretes
+// with no FuncParam restructuring.
 type Pat interface{ isPat() }
 
 type IdentPat struct{ Name string }
@@ -673,7 +674,7 @@ func (*IdentPat) isPat() {}
 
 // FuncParam mirrors type_system.FuncParam. M1 omits Optional (no optional
 // params until M3+); Pattern is reachable only through Pat concretes M1
-// defines (IdentPat).
+// defines (IdentPat). Destructured params (TuplePat/RecordPat) arrive in M4.
 type FuncParam struct {
 	Pattern Pat
 	Type    Type
@@ -1070,7 +1071,7 @@ func printFuncTail(t *FuncType) string {
 
 // paramName renders p.Pattern; for M1 the only Pat concrete is IdentPat,
 // so this dispatches on that and falls back to "x"+strconv.Itoa(i) for a
-// nil/unknown pattern. M2's destructuring Pat concretes add their own arms.
+// nil/unknown pattern. M4's destructuring Pat concretes add their own arms.
 func paramName(p *FuncParam, i int) string {
 	switch pat := p.Pattern.(type) {
 	case *IdentPat:

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -47,14 +47,35 @@ wrong — **stop and reassess**.
 
 ### Scope boundary against neighbouring milestones
 
-- **M1 (prerequisite — Package skeleton + `soltype`)** must land first. It
-  creates the new package — `internal/solver/` (settled decision #1 in
-  design-notes; sibling to `internal/checker/`) — the `soltype` representation
-  (bound-list `TypeVar` with `lowerBounds`/`upperBounds` + `level`, `Primitive`,
-  `Literal`, `Function`, `Tuple`), `constrain`, levels/extrusion, polarity-driven
-  coalescing, the **own** `soltype` printer, and the `Info` side table
-  (`map[ast.Node]soltype.Type` + `TypeOf`/`setType`). M2 consumes all of these;
-  it does not modify the core algorithm.
+- **M1 (prerequisite — Package skeleton + `soltype`) has landed** (PRs #686–#693
+  on `main`). It created **two** packages: `internal/soltype/` (the type
+  representation — its own top-level package, imported as `soltype`) and
+  `internal/solver/` (the engine + side tables, sibling to `internal/checker/`).
+  M2 code lives in `internal/solver/`. What M1 actually delivered, and what it
+  **deferred**, materially shapes M2 — see the "M1 landed: deltas from this
+  plan's original assumptions" box in §2.
+  - **Available now:** `soltype.Type` and its kinds (`TypeVarType` with
+    `ID`/`Level`/`LowerBounds`/`UpperBounds`; `PrimType`/`LitType`/`FuncType`
+    (params are `*FuncParam` carrying a sealed `Pat`, M1 = `IdentPat` only)/
+    `TupleType`/`Void`/`NeverType`/`UnknownType`/`UnionType`/`IntersectionType`);
+    `soltype.Polarity` + `TypeVarType.BoundsAt(pol)`; `solver.Context` with
+    `freshVar(level)` and `Constrain(lhs, rhs) []SolverError`; levels/extrusion;
+    bound-inlining `coalesce(t, pol)`; the `soltype.Print(t)` printer;
+    `solver.Info` (`TypeOf` / unexported `setType`); and a `SolverError`
+    interface with concrete span-free error kinds.
+  - **Deferred to M3 (NOT available to M2):** type **schemes**
+    (`TypeScheme`/`MonoScheme`/`PolyScheme`), `instantiate`/`freshenAbove`,
+    occurrence analysis / co-occurrence merging, and the `<T0, …>` quantifier
+    prefix in the printer. **Consequence:** M2 inference is **monomorphic** — it
+    cannot generalize a top-level binding, so an un-annotated polymorphic
+    function (`val id = fn (x) { x }`) cannot render as `fn <T0>(x: T0) -> T0`
+    in M2. That rendering, and the `TopLevelLetPolymorphism` /
+    `IdentityPolymorphism` / `InnerCapturesOuterParam` acceptance cases, are
+    **M3** (the M1 milestone already moves them there). M2's "infer correct
+    rendered types end-to-end" bar therefore means the **monomorphic** forms
+    (`val x = 5` ⇒ `5`; `val f = fn (x: number) { x }` ⇒ `fn(x: number) -> number`).
+  - **Deferred to later (NOT available to M2):** the `Prov` provenance side
+    table (M2/later) and error `Span()` (M2 *adds* this — see §3.5).
 - **M2 expression coverage is deliberately shallow.** The milestone's bar is
   "top-level `val`/`fn` infer correct rendered types end-to-end" plus multi-file
   resolution. The *deep* function/application/let-polymorphism work — and its
@@ -62,21 +83,47 @@ wrong — **stop and reassess**.
   `InnerCapturesOuterParam`) plus the simplification pass and function
   exactness — is **M3**. M2 wires up enough of the walk to satisfy its own
   acceptance (literals, identifiers, simple `val` initializers, `fn` decls with
-  bodies the spike already handles) and leaves richer expression coverage and
-  polish to M3.
+  bodies the spike already handles), all **monomorphic** (M1 deferred schemes /
+  generalization to M3), and leaves richer expression coverage and polish to M3.
+- **Stdlib-type prerequisite tracking (new in M2's milestone).** The M1-era
+  edit to `01-milestones.md` added an M2 responsibility: names that downstream
+  type rules reference — `Promise<T>`, `Iterable<T>`/`AsyncIterable<T>`,
+  `Generator`/`AsyncGenerator`, `IteratorResult<T>` — must **resolve** through
+  the existing stdlib declaration channels and surface as `soltype.Type` values.
+  M2 does **not** implement the rules that *use* them (`await`/`for-in`/`yield`
+  land in later milestones); it only ensures the parser-bridge produces
+  `soltype` types for these names so later milestones aren't blocked on "where
+  does `Promise` come from?". See §3.8.
 - **Records/`mut`/lifetimes (M4), classes (M5), unions (M6), operators (M8)**
   are out of scope. Unsupported expression/decl nodes produce a structured
   "unsupported in M2" error, never a panic.
 
 ## 2. Current state this builds on
 
-- **Spike core** (`internal/simplesub/`): `typeTerm` (the recursive
-  switch we are re-targeting), `constrain`, `coalesce`, `simplify`, levels via
-  `scheme.go` (`MonoScheme`/`PolyScheme`, `instantiate`/`freshenAbove`),
-  `LetRecGroup` (fresh var per binding + `constrain` + generalize — the
-  recursion story that avoids placeholder patching). The spike's `Infer` returns
-  `(type_system.Type, []error)` and renders via `type_system.PrintType`; M1
-  re-homes this onto `soltype` with its own printer.
+> **M1 landed: deltas from this plan's original assumptions.** This plan was
+> drafted before M1 merged. M1 (PRs #686–#693) came in with a different package
+> split and a narrower scope than assumed; the sketches in §3.7 were updated to
+> match, but read these deltas first:
+>
+> | Plan originally assumed | M1 actually shipped |
+> |---|---|
+> | `soltype` is a sub-package `internal/solver/soltype/` | **Two top-level packages**: `internal/soltype/` (types) + `internal/solver/` (engine). M2 code is in `internal/solver/`, importing `soltype`. |
+> | An `Inferer` carrier with `c.core.Level()` | `solver.Context{ varCounter }` with `freshVar(level)`; **no ambient level** — level is an explicit argument everywhere. |
+> | Schemes + `instantiate`/`freshenAbove` exist (re-homed from spike) | **Deferred to M3.** No `TypeScheme`/`MonoScheme`/`PolyScheme`, no `instantiate`. M2 inference is **monomorphic**. |
+> | `Info.setType` callable; a `Prov` table exists | `solver.Info` with **unexported** `setType` (so the walk lives in `package solver`); **no `Prov`** (deferred). |
+> | M2 defines the error types | M1 already ships `SolverError` + `CannotConstrainError`/`FuncArityMismatchError`/`TupleLengthMismatchError`, **span-free**; M2's job is to **add `Span()`** and the new error kinds it needs. |
+> | `coalesce` does occurrence analysis / quantifier prefix | M1 `coalesce` is **bound-inlining only** (positive ⇒ ∪ lowers, negative ⇒ ∩ uppers; empty ⇒ `never`/`unknown`). Occurrence analysis + `<T0,…>` prefix are M3. |
+>
+> The single biggest impact: **M2 cannot generalize**, so polymorphic rendering
+> (`fn <T0>(x: T0) -> T0`) and the recursive-group `LetRecGroup` lift both move
+> their *generalization* aspect to M3. M2's SCC handling (PR-5) still orders and
+> infers groups, but binds them monomorphically (see §3.7 note).
+
+- **Spike core** (`internal/simplesub/`, the throwaway PoC): `typeTerm` (the
+  recursive switch M2 re-targets), `constrain`, `coalesce`, `simplify`, levels
+  via `scheme.go`, `LetRecGroup`. **Note:** the spike is the *reference shape*,
+  but M1 re-homed only a subset onto `soltype`/`solver` (see the deltas box);
+  the scheme/generalization parts the spike has are M3, not available to M2.
 - **AST** (`internal/ast/`): expression nodes the walk must handle for the M2
   bar — `LiteralExpr`, `IdentExpr`, `FuncExpr` (`FuncSig` at `expr.go:326`,
   `FuncExpr` at `expr.go:335`), `CallExpr`, `ObjectExpr`, `MemberExpr`,
@@ -96,15 +143,17 @@ wrong — **stop and reassess**.
 
 ### 3.1 Package layout
 
-Inside the M1 package (`internal/solver/`):
+M2 code goes in `internal/solver/` (the engine package M1 created); the type
+representation it consumes lives in the **separate** `internal/soltype/` package
+(M1). M2 adds no files to `soltype` — it only imports it.
 
 ```
-internal/solver/
-  infer.go        # constraint-generating walk over *ast.Module (production typeTerm)
-  infer_expr.go   # per-expression-kind constraint generation
-  infer_decl.go   # VarDecl / FuncDecl → bindings, SCC group inference
-  module.go       # InferModule(s): dep_graph SCC ordering + drive the walk
-  scope.go        # Scope / Binding / Namespace (own, not type_system)
+internal/solver/        # M1: context.go, constrain.go, coalesce.go, info.go, errors.go
+  infer.go        # M2: constraint-generating walk over *ast.Module (production typeTerm)
+  infer_expr.go   # M2: per-expression-kind constraint generation
+  infer_decl.go   # M2: VarDecl / FuncDecl → bindings, SCC group inference
+  module.go       # M2: InferModule(s): dep_graph SCC ordering + drive the walk
+  scope.go        # M2: Scope / Binding / Namespace (own, not type_system)
   errors.go       # bridge errors (unbound name, unsupported node) with provenance/spans
   // (soltype core, Info side table, printer: from M1)
   testdata/ or fixtures wiring   # see §3.6
@@ -142,10 +191,11 @@ AST instead of `Term`:
 | `IfElseExpr` | join branches; `constrain(cond, boolean)` | yes |
 | `Block` | type each stmt; result = last expr (or `void`) | yes |
 
-Every node that produces a type calls the M1 `Info.setType(node, t)` so the side
-table is the single source of truth for node→type (the AST stays untouched — no
-`InferredType()` writes; that is the AST-decoupling decision). Nodes outside the
-M2 subset emit an "unsupported in M2" error.
+Every node that produces a type records it in M1's `Info` side table via the
+(unexported, same-package) `setType(node, t)` — which is why the M2 walk lives
+in `package solver`. `Info` is the single source of truth for node→type (the AST
+stays untouched — no `InferredType()` writes; that is the AST-decoupling
+decision). Nodes outside the M2 subset emit an "unsupported in M2" error.
 
 ### 3.3 Module driver (`module.go`) — dep_graph-ordered inference
 
@@ -222,9 +272,11 @@ func (s *Scope) GetNamespace(name string) (*Namespace, bool)
 sketches these as pointer returns; the comma-ok form is the M2 refinement so the
 not-found case is explicit at every call site.)
 
-- `ValueBinding` — a name's `soltype` scheme (`MonoScheme`/`PolyScheme`, from the
-  spike's `scheme.go`) plus its source provenance. The production analogue of the
-  spike's `ctx map[string]TypeScheme`.
+- `ValueBinding` — in M2, a name's **monomorphic** `soltype.Type` plus its
+  source provenance (the production analogue of the spike's
+  `ctx map[string]TypeScheme`, minus the scheme). M1 has no schemes, so binding
+  carries a plain type; M3 swaps the field for a `TypeScheme` when generalization
+  lands.
 - The **value-position `IdentExpr`** path queries `GetValue`, then `GetNamespace`
   only to raise `NamespaceUsedAsValueError` (namespaces are a separate sort and
   never flow as values — design-notes §"The constraint-generating AST walk").
@@ -271,41 +323,52 @@ field-by-field drilling.
 
 Concrete shapes to anchor the PRs below. These are *sketches* — names and
 fields will shift in review — but they pin down the surface area each PR owns.
-All live in `internal/solver`. Types prefixed `soltype.` come from M1; the rest
-are introduced by M2 (the PR that owns each is noted).
+All M2 code lives in `internal/solver`. Types prefixed `soltype.` come from the
+`internal/soltype/` package (M1); `solver.`-level names without comment are M1's
+engine; the rest are introduced by M2 (the PR that owns each is noted).
 
-**The checker carrier (PR-1).** A per-inference-run struct threading the M1
-core's mutable state (the fresh-var counter, the `Info`/provenance tables) — the
-production analogue of the spike's `Inferer`. Method receiver for the whole walk.
+> **These sketches reflect M1 as shipped** (see §2 deltas box). Specifically:
+> the carrier embeds M1's `*solver.Context` (there is no `Inferer`); there are
+> **no schemes** (`ValueBinding` holds a plain `soltype.Type`, not a
+> `TypeScheme`), **no `Instantiate`**, and **no `Prov`** — all M3-or-later. M2
+> is monomorphic.
+
+**The checker carrier (PR-1).** A per-inference-run struct wrapping M1's
+`solver.Context` (the fresh-var counter + `Constrain`) and threading the `Info`
+side table and accumulated errors. Method receiver for the whole walk.
 
 ```go
 // infer.go
 type checker struct {
-    core *soltype.Inferer  // M1: freshVar, constrain, instantiate, freshenAbove, level
-    info *soltype.Info     // M1: node → type side table
-    prov soltype.Prov      // M1: type → origin side table
-    errs []Error           // accumulated; mirrors the spike's []error threading
+    ctx  *Context  // M1 solver.Context: freshVar(level), Constrain(lhs, rhs) []SolverError
+    info *Info     // M1 solver.Info: node → soltype.Type side table (unexported setType)
+    errs []Error   // accumulated; mirrors the spike's []error threading
 }
 
 func newChecker() *checker
 
-// freshAt allocates a fresh inference variable at the given level (wrapping the
-// spike's Inferer.freshVar(level)) and records its AST origin in prov (the
-// freshVarAt helper from design-notes §Provenance).
-func (c *checker) freshAt(lvl int, n ast.Node, kind soltype.ASTOriginKind) *soltype.TypeVarType
+// freshAt allocates a fresh inference variable at the given level (delegates to
+// ctx.freshVar(level)). No provenance recording in M2 — Prov is deferred.
+func (c *checker) freshAt(lvl int) *soltype.TypeVarType
 
-// report appends a structured error; returns soltype's error type so callers
-// can `return c.report(...)` in a value position (yielding an error placeholder).
+// constrain delegates to ctx.Constrain and appends any SolverErrors (wrapped
+// with the offending node's span) to c.errs.
+func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type)
+
+// report appends a structured error; returns a placeholder type (e.g.
+// &soltype.NeverType{}) so callers can `return c.report(...)` in value position.
 func (c *checker) report(e Error) soltype.Type
 ```
 
 **Scope / Binding / Namespace (PR-1).** Design-notes §"Scope / Binding" gives
-the three-slot shape; the constructors and `define*` mutators are M2's:
+the three-slot shape; the constructors and `define*` mutators are M2's. Because
+M1 has **no schemes**, an M2 `ValueBinding` holds a plain monomorphic
+`soltype.Type` — the `Scheme` field arrives in M3 with generalization:
 
 ```go
 // scope.go
 type ValueBinding struct {
-    Scheme soltype.TypeScheme    // MonoScheme | PolyScheme (spike scheme.go)
+    Type   soltype.Type          // M2: monomorphic. M3 replaces with a TypeScheme.
     Source provenance.Provenance // the introducing VarDecl/FuncDecl/param
 }
 type TypeBinding struct {        // shape only in M2; populated M3+
@@ -353,13 +416,16 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 ```
 
 `inferIdent` is the load-bearing one — it's the production form of the spike's
-`*Var` case crossed with design-notes §"The constraint-generating AST walk":
+`*Var` case crossed with design-notes §"The constraint-generating AST walk". In
+M2 (monomorphic, no schemes) it returns the binding's type directly; the M3
+note marks where `instantiate` slots in once schemes exist:
 
 ```go
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
     if b, ok := scope.GetValue(e.Name); ok {
-        t := c.core.Instantiate(b.Scheme, lvl) // MonoScheme: as-is; PolyScheme: freshenAbove
-        c.info.SetType(e, t)
+        t := b.Type // M2: monomorphic — return as-is.
+                    // M3: t = c.instantiate(b.Scheme, lvl) (fresh copy per use).
+        c.recordType(e, t) // wraps info.setType (unexported; same package)
         return t
     }
     if _, ok := scope.GetNamespace(e.Name); ok {
@@ -374,8 +440,8 @@ checker's `InferDepGraph`/`InferComponent`, over `soltype`:
 
 ```go
 // module.go
-func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)   // PR-2 (source-order), PR-5 (SCC)
-func InferModules(modules []*ast.Module) (*Scope, *soltype.Info, []Error) // PR-6 (multi-file)
+func InferModule(module *ast.Module) (*Scope, *Info, []Error)   // PR-2 (source-order), PR-5 (SCC)
+func InferModules(modules []*ast.Module) (*Scope, *Info, []Error) // PR-6 (multi-file)
 
 func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) // PR-5
 func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph, // PR-5
@@ -386,52 +452,72 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBindi
 func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding // PR-3
 ```
 
-`inferComponent` is the LetRecGroup lift (PR-5); the singleton non-recursive
-case is the same code with a one-element slice. The level discipline mirrors the
-spike's `LetRecGroup` exactly: bind the group's vars and infer its bodies at
-`lvl+1`, then generalize at the outer `lvl` — `freshenAbove` only quantifies
-vars whose level is `> lim`, so the `+1`/generalize-at-`lvl` split is what makes
-the recursive bindings polymorphic. (Generalizing at `lvl+1` instead would leave
-them monomorphic — the bug to avoid.)
+`inferComponent` orders an SCC and binds it (PR-5); the singleton non-recursive
+case is the same code with a one-element slice. **M2 binds the group
+monomorphically** — it still uses the spike's level discipline (fresh var per
+binding, infer bodies at `lvl+1`, all group members visible before any body so
+recursive references resolve) but **does not generalize**: M1 has no schemes, so
+the group's vars stay as their (coalesced) monomorphic types. The
+generalization step — wrapping each in a `PolyScheme` at the outer `lvl` so
+`freshenAbove` quantifies the `lvl+1` vars — is **M3**, and is what turns these
+into reusable polymorphic bindings. M2's value is correct *ordering* and
+*recursive resolution*; M3 adds the polymorphism on top.
 
 ```go
 func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph,
     component []dep_graph.BindingKey) {
     inner := lvl + 1
     // 1. fresh var per binding at the inner level, all visible before any body
+    //    (so mutually-recursive references resolve through the var).
     vars := map[dep_graph.BindingKey]*soltype.TypeVarType{}
     for _, key := range component {
-        v := c.freshAt(inner, /* decl node */ nil, soltype.OriginRecBinding)
+        v := c.freshAt(inner)
         vars[key] = v
-        scope.defineValue(key.Name(), ValueBinding{Scheme: &soltype.MonoScheme{Ty: v}})
+        scope.defineValue(key.Name(), ValueBinding{Type: v})
     }
     // 2. infer each body at the inner level, constrain body <: its var
     for _, key := range component {
         for _, d := range g.GetDecls(key) {
             body := c.inferDeclBody(scope, inner, d)
-            c.core.Constrain(body, vars[key])
+            c.constrain(d, body, vars[key])
         }
     }
-    // 3. generalize the whole group at the OUTER level lvl (not inner): vars
-    //    created at lvl+1 are > lvl, so freshenAbove quantifies them.
+    // 3. M2: rebind each name to its (monomorphic) coalesced type.
+    //    M3 replaces this with generalization at the outer level:
+    //      scope.defineValue(key.Name(),
+    //          ValueBinding{Scheme: &soltype.PolyScheme{Level: lvl, Body: vars[key]}})
     for _, key := range component {
-        scope.defineValue(key.Name(), ValueBinding{
-            Scheme: &soltype.PolyScheme{Level: lvl, Body: vars[key]},
-        })
+        t := coalesce(vars[key], soltype.Positive)
+        scope.defineValue(key.Name(), ValueBinding{Type: t})
     }
 }
 ```
 
-**Errors (PR-1).** A small set of structured errors with spans; assert full
-messages in tests:
+**Errors (PR-1).** M1 already ships a `SolverError` interface
+(`isSolverError()` + `Message()`) with span-free concrete kinds
+(`CannotConstrainError`, `FuncArityMismatchError`, `TupleLengthMismatchError`).
+The M1 milestone notes M2 is where `Span()` arrives. So M2's error work is:
+**(a)** add `Span() ast.Span` to the `SolverError` interface and backfill it on
+M1's existing kinds (carrying the offending node's span), and **(b)** add the
+M2-specific bridge kinds below. Assert full messages in tests.
 
 ```go
-// errors.go
-type Error interface{ error; Span() ast.Span }
-type UnknownIdentifierError struct{ Name string; Span ast.Span }
-type NamespaceUsedAsValueError struct{ Name string; Span ast.Span }
-type UnsupportedNodeError struct{ Kind string; Span ast.Span } // M2-subset guard
+// errors.go — M2 extends M1's SolverError
+type SolverError interface {  // M1 interface, + Span() added in M2
+    isSolverError()
+    Message() string
+    Span() ast.Span           // NEW in M2
+}
+// new M2 kinds (each implements SolverError):
+type UnknownIdentifierError struct{ Name string; span ast.Span }
+type NamespaceUsedAsValueError struct{ Name string; span ast.Span }
+type UnsupportedNodeError struct{ Kind string; span ast.Span } // M2-subset guard
 ```
+
+(The plan earlier used a separate `Error` interface; M1 having already
+established `SolverError` means M2 should extend *that*, not introduce a
+parallel hierarchy. The `Error`/`c.report` naming in the carrier sketch reads
+against this `SolverError` type.)
 
 **Test harness (PR-2 table; PR-6 fixtures).**
 
@@ -443,6 +529,36 @@ func inferSource(t *testing.T, src string) (values, types map[string]string)
 // fixture_test.go — multi-file harness (sibling to cmd/escalier/fixture_test.go)
 func checkSolverFixture(t *testing.T, fixtureDir string) // asserts rendered top-level types
 ```
+
+### 3.8 Stdlib-type prerequisite tracking
+
+The M1-era edit to `01-milestones.md` added a new M2 acceptance clause: names
+that *downstream* type rules will reference must already **resolve** through the
+stdlib declaration channels and surface as `soltype.Type` values by the end of
+M2 — even though the rules that consume them land later. The names called out:
+
+| Name | Consumed by (later milestone) |
+|------|-------------------------------|
+| `Promise<T>` | `await e` |
+| `Iterable<T>` / `AsyncIterable<T>` | `for (x in xs)` / `for await (x in xs)` |
+| `Generator` / `AsyncGenerator` | `yield e` |
+| `IteratorResult<T>` (`{value, done}`) | iteration built-ins |
+
+**M2's responsibility is resolution only, not rules.** The parser-bridge must
+make these names resolve (whether sourced from Escalier's own stdlib decls,
+`lib.esc.d.ts`-equivalents, or both) and produce `soltype` types for them, so
+later milestones aren't blocked on "where does `Promise` come from?". M2 does
+**not** implement `await`/`for-in`/`yield` type-checking.
+
+Practically this is the same `TypeBinding`/`Namespace` machinery (§3.4) the
+val/fn path already needs, pointed at the stdlib decl source — but note two M2
+caveats: these are *generic* type references (`Promise<T>`), and M1's `soltype`
+has no generic-type-reference / alias node yet (that's M3/M4). For M2 the
+acceptance is just that the **names resolve** to *some* `soltype.Type` (likely a
+placeholder type-binding) without an unbound-name error — full generic
+instantiation of them is later. This is folded into **PR-6** (the milestone that
+owns multi-file/stdlib resolution); if it proves heavier than a name-resolution
+stub, split it into its own PR-7.
 
 ## 4. Sequencing
 
@@ -472,12 +588,13 @@ feature additions. Concretely:
 ### PR dependency graph
 
 ```text
-                M1 (soltype + Info + printer)
+        M1 shipped: soltype/ + solver/ (Context, Constrain,
+        coalesce, Info, SolverError, Print) — monomorphic; no schemes
                         │
                         ▼
                 ┌─────────────────┐
-                │ PR-1  carrier +  │   checker{}, Scope/Binding/Namespace,
-                │ scope + leaves   │   errors, inferExpr(lits, idents)
+                │ PR-1  carrier +  │   checker{ctx,info,errs}, Scope/Binding/Namespace,
+                │ scope + leaves   │   SolverError+Span, inferExpr(lits, idents)
                 └───────┬─────────┘
                         │
             ┌───────────┴───────────┐
@@ -492,7 +609,7 @@ feature additions. Concretely:
            ▼   ▼                     ▼
    ┌──────────────────┐   ┌──────────────────────┐
    │ PR-5 dep_graph   │   │ PR-4 objects /        │   (PR-4 ∥ PR-5:
-   │ SCC + LetRecGroup│   │ member access         │    both need PR-2+PR-3)
+   │ SCC (monomorphic)│   │ member access         │    both need PR-2+PR-3)
    └───────┬──────────┘   └──────────┬───────────┘
            │                         │
            └───────────┬─────────────┘
@@ -515,31 +632,34 @@ which exercises decls, functions, and SCC ordering together).
 > its **tests**, and an **exit** line. "LoC" estimates are non-test code.
 
 ### PR-1 — Checker carrier + Scope + leaf expressions  (~250 LoC)
-- `infer.go`: the `checker` struct, `newChecker`, `fresh`, `report`;
-  `inferExpr` dispatch with only the leaf cases wired.
-- `scope.go`: `Scope`/`ValueBinding`/`TypeBinding`/`Namespace` + `NewScope`,
-  `Child`, `defineValue`, `GetValue`/`GetType`/`GetNamespace`.
-- `errors.go`: `Error` interface, `UnknownIdentifierError`,
-  `NamespaceUsedAsValueError`, `UnsupportedNodeError`.
+- `infer.go`: the `checker` struct (wrapping M1's `*Context` + `*Info`),
+  `newChecker`, `freshAt`, `constrain`, `report`, `recordType`; `inferExpr`
+  dispatch with only the leaf cases wired.
+- `scope.go`: `Scope`/`ValueBinding`(monomorphic `Type`)/`TypeBinding`/
+  `Namespace` + `NewScope`, `Child`, `defineValue`, `GetValue`/`GetType`/
+  `GetNamespace`.
+- `errors.go`: add `Span() ast.Span` to M1's `SolverError` and backfill it on
+  M1's existing kinds; add `UnknownIdentifierError`, `NamespaceUsedAsValueError`,
+  `UnsupportedNodeError`.
 - `infer_expr.go`: `inferLiteral`, `inferIdent`; all other `ast.Expr` kinds fall
   through to `UnsupportedNodeError` (no panic).
 - Tests: literal → rendered type; identifier resolves to a pre-seeded binding's
-  scheme; unbound identifier and namespace-as-value → full-message errors with
+  type; unbound identifier and namespace-as-value → full-message errors with
   spans.
 - **Exit:** the walk types the literal/identifier subset against `soltype`/`Info`;
   every other node fails cleanly.
 
 ### PR-2 — Single-module decl driver + table harness  (~250 LoC)
 *(depends on PR-1; parallel with PR-3)*
-- `infer_decl.go`: `inferVarDecl` (initializer typed via `inferExpr`, generalized
-  into a `ValueBinding`).
+- `infer_decl.go`: `inferVarDecl` (initializer typed via `inferExpr`, coalesced
+  into a **monomorphic** `ValueBinding` — no generalization in M2).
 - `module.go`: first `InferModule` for one module, decls in **source order**
   (no SCC yet), seeding the module `Scope` and `Info`.
 - `infer_test.go`: the `inferSource` table harness.
 - Tests: `val x = 5` ⇒ `5`/`number` (per M1 widening); `val y = x` referencing an
   earlier decl; forward reference → (documented) error until PR-5 adds ordering.
 - **Exit:** top-level `val` decls with literal/identifier initializers infer
-  end-to-end and render correctly via the harness.
+  end-to-end (monomorphic) and render correctly via the harness.
 
 ### PR-3 — Function / application / block walk  (~300 LoC)
 *(depends on PR-1; parallel with PR-2)*
@@ -547,10 +667,12 @@ which exercises decls, functions, and SCC ordering together).
   `inferCall` (`constrain(callee <: Function{args, fresh})`), `inferBlock` /
   `inferStmt` (sequence; result = last expr or `void`).
 - `infer_decl.go`: `inferFuncDecl` (reuses `inferFuncExpr` on the decl's sig+body).
-- Tests: identity `fn`, application of it, a block with a `return`, arity
-  mismatch on a direct call → full-message error.
-- **Exit:** `fn` decls and calls infer end-to-end (the second half of the
-  per-expression bar; deep let-polymorphism polish is still M3).
+- Tests: an **annotated** `fn` (e.g. `fn (x: number) { x }` ⇒ `fn(x: number) ->
+  number`), application of it, a block with a `return`, arity mismatch on a
+  direct call → full-message error. (Un-annotated polymorphic `fn` renders with
+  fresh vars, **not** `<T0>` — generalization is M3.)
+- **Exit:** `fn` decls and calls infer end-to-end, monomorphically (let-
+  polymorphism and `<T0>` rendering are M3, which M1 deferred schemes to).
 
 ### PR-4 — Objects & member access  (~200 LoC)
 *(depends on PR-2 + PR-3; parallel with PR-5)*
@@ -565,14 +687,16 @@ which exercises decls, functions, and SCC ordering together).
 ### PR-5 — dep_graph SCC ordering + recursive groups  (~250 LoC)
 *(depends on PR-2 + PR-3)*
 - `module.go`: `inferDepGraph` (iterate `g.Components`), `inferComponent` (the
-  LetRecGroup lift sketched in §3.7).
+  monomorphic SCC bind sketched in §3.7: fresh var per binding, infer bodies at
+  `lvl+1`, group members visible before any body).
 - Replace PR-2's source-order loop with SCC ordering. **No placeholder/patching
-  phase.**
-- Tests: self-recursive `fn`; mutually-recursive `fn` pair; a decl that
-  forward-references a later decl now resolves via SCC ordering (the PR-2
-  documented-error case flips to success).
+  phase.** **No generalization** — bindings are bound monomorphically; the
+  `PolyScheme` generalization step is M3 (M1 deferred schemes).
+- Tests: self-recursive `fn` (resolves, monomorphic); mutually-recursive `fn`
+  pair; a decl that forward-references a later decl now resolves via SCC
+  ordering (the PR-2 documented-error case flips to success).
 - **Exit:** recursive and out-of-order top-level decls infer correctly in one
-  module.
+  module (monomorphically).
 
 ### PR-6 — Multi-file (cross-module) resolution + fixtures harness  (~250 LoC)
 *(depends on PR-4 + PR-5)*
@@ -580,13 +704,19 @@ which exercises decls, functions, and SCC ordering together).
   across them; cross-module references resolve through the qualified-`BindingKey`
   `Namespace` (`dep_graph.GetNamespace`). Engage `internal/resolver` only if a
   fixture imports a `.d.ts`-typed third-party module.
+- Stdlib-type prerequisite resolution (§3.8): `Promise`/`Iterable`/`Generator`/
+  `IteratorResult` names resolve to `soltype` types through the stdlib decl
+  channel without unbound-name errors (resolution only; the rules that use them
+  are later). If heavier than a name-resolution stub, split into PR-7.
 - `fixture_test.go`: the `checkSolverFixture` harness (sibling to
   `cmd/escalier/fixture_test.go`).
 - Tests: a two-file fixture where file B imports a `val`/`fn` from file A and the
-  inferred types render correctly end-to-end.
+  inferred types render correctly end-to-end; a fixture referencing a stdlib
+  type name resolves without error.
 - Update `01-milestones.md` M2 status.
 - **Exit (M2 exit criteria):** multi-file module resolves via the dep graph;
-  top-level `val`/`fn` infer correct rendered types end-to-end.
+  top-level `val`/`fn` infer correct rendered types end-to-end (monomorphic);
+  stdlib type names resolve.
 
 ## 6. Risks & mitigations
 
@@ -614,8 +744,17 @@ which exercises decls, functions, and SCC ordering together).
 
 ## 7. Open questions to resolve during M2
 
-- **Package name** is settled (`internal/solver/`, design-notes decision #1);
-  M2 inherits it from M1. No open decision here.
+- **Package name** is settled and shipped: `internal/solver/` (engine, where M2
+  code lives) + `internal/soltype/` (types). No open decision here.
+- **Monomorphic-`ValueBinding` forward-compat.** M2's `ValueBinding` holds a
+  plain `soltype.Type`; M3 swaps it for a `TypeScheme`. Decide in PR-1 whether to
+  (a) ship the plain-`Type` field now and take the M3 churn, or (b) introduce a
+  thin `ValueBinding` accessor M3 can re-point. Leaning (a) — the churn is
+  mechanical and (b) risks over-abstracting before schemes exist.
+- **Does anything in M2 need `coalesce` at binding time?** The §3.7 SCC sketch
+  coalesces each group var before binding so the stored monomorphic type is
+  inspectable; confirm in PR-5 whether binding the raw var (and coalescing only
+  at render) is simpler. M1's `coalesce` is available either way.
 - **How much namespace resolution to drive in M2 vs. defer.** If full
   cross-module/namespace resolution is heavier than the val/fn bar needs, PR-6
   can scope to the minimum that satisfies the multi-file acceptance (a binding
@@ -632,11 +771,17 @@ which exercises decls, functions, and SCC ordering together).
 
 - [ ] Constraint-generating walk over `*ast.Module` produces `soltype` and
       populates `Info` (no AST `InferredType()` writes).
-- [ ] Package-owned `Scope`/`Binding`/`Namespace` (no `type_system` reuse).
-- [ ] Top-level `val`/`fn` from real source infer correct rendered types
-      end-to-end (table harness).
+- [ ] Package-owned `Scope`/`Binding`/`Namespace` in `internal/solver/` (no
+      `type_system` reuse).
+- [ ] Top-level `val`/`fn` from real source infer correct **monomorphic**
+      rendered types end-to-end (table harness). *(Polymorphic `<T0>` rendering
+      is M3 — M1 deferred schemes/generalization.)*
 - [ ] Multi-file module resolves via the dep graph (fixtures harness).
-- [ ] Recursive SCC groups infer with no placeholder/patching phase.
+- [ ] Recursive SCC groups infer (monomorphically) with no placeholder/patching
+      phase.
+- [ ] Stdlib type names (`Promise`/`Iterable`/`Generator`/`IteratorResult`)
+      resolve to `soltype` types without unbound-name errors (resolution only).
+- [ ] `SolverError` gained `Span()`; M2 error kinds carry spans.
 - [ ] No imports of `internal/checker/` or `internal/type_system/` from the new
       package (gate honored).
 - [ ] `01-milestones.md` M2 status updated.

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -23,7 +23,7 @@ in the `Info` side table.
 > `GetTypesEntryPoint`) — it is *not* the general name resolver. The milestone's
 > phrase "dep_graph/resolver" therefore means: drive declaration order and
 > cross-declaration references through `dep_graph`; `resolver` is relevant only
-> when a fixture imports a `.d.ts`-typed third-party module (likely beyond the
+> when a test source imports a `.d.ts`-typed third-party module (likely beyond the
 > M2 `val`/`fn` bar). The plan below is built around `dep_graph`.
 
 Per the milestone, M2 delivers:
@@ -33,8 +33,10 @@ Per the milestone, M2 delivers:
    `soltype` types and populates `Info`.
 2. **Own `Scope`/`Binding`/`Namespace`.** Analogues owned by the new package,
    *not* reused from `internal/type_system/`.
-3. **A fixture-style harness.** Given `.esc` source, infer and assert the
-   rendered binding types — its own assertions, independent of the old checker.
+3. **A table-driven test harness.** Given `.esc` source (single- and multi-file,
+   in-memory), infer and assert the rendered binding types — its own assertions,
+   independent of the old checker. No on-disk `fixtures/` directories in M2; the
+   real fixture harness is M8's job (see §3.6).
 
 **Exit criteria (from the milestone):**
 - Top-level `val`/`fn` declarations from real source infer correct rendered
@@ -85,18 +87,27 @@ wrong — **stop and reassess**.
   acceptance (literals, identifiers, simple `val` initializers, `fn` decls with
   bodies the spike already handles), all **monomorphic** (M1 deferred schemes /
   generalization to M3), and leaves richer expression coverage and polish to M3.
-- **Stdlib-type prerequisite tracking (new in M2's milestone).** The M1-era
+- **Stdlib-type placeholder seeding (new in M2's milestone).** The M1-era
   edit to `01-milestones.md` added an M2 responsibility: names that downstream
   type rules reference — `Promise<T>`, `Iterable<T>`/`AsyncIterable<T>`,
-  `Generator`/`AsyncGenerator`, `IteratorResult<T>` — must **resolve** through
-  the existing stdlib declaration channels and surface as `soltype.Type` values.
-  M2 does **not** implement the rules that *use* them (`await`/`for-in`/`yield`
-  land in later milestones); it only ensures the parser-bridge produces
-  `soltype` types for these names so later milestones aren't blocked on "where
-  does `Promise` come from?". See §3.8.
-- **Records/`mut`/lifetimes (M4), classes (M5), unions (M6), operators (M8)**
+  `Generator`/`AsyncGenerator`, `IteratorResult<T>` — must **resolve** to *some*
+  `soltype.Type` so a reference doesn't error. M2 does this with **hand-seeded
+  placeholder bindings**, not by reading the real stdlib decls: the real
+  ingestion is checker/`type_system`-coupled and needs generics M1's `soltype`
+  doesn't have yet. Real library type resolution is its own milestone, **M7**;
+  M2 only unblocks the names. M2 also does **not** implement the rules that
+  *use* them (`await`/`for-in`/`yield` land in later milestones). See §3.8.
+- **Records/`mut`/lifetimes (M4), classes (M5), unions (M6), operators (M9)**
   are out of scope. Unsupported expression/decl nodes produce a structured
   "unsupported in M2" error, never a panic.
+- **Body-level declarations are `VarDecl`-only — a language rule, not a subset
+  gate.** Inside a function/method body the only declaration a statement may
+  introduce is a `val`/`var`; any other decl kind (`FuncDecl`, `TypeDecl`,
+  `ClassDecl`, …) is a permanent `BodyDeclNotAllowedError`, distinct from the
+  temporary "unsupported in M2" gate above. Bodies may also **redeclare** a
+  name — a later `val x` rebinds it with a fresh, unrelated type. Both are
+  deliberate language simplifications that keep the body walk to a single
+  decl shape; see §3.2. (Methods get the same rule when classes land in M5.)
 
 ## 2. Current state this builds on
 
@@ -137,7 +148,7 @@ wrong — **stop and reassess**.
 - **Compiler entry points: 3** (`CheckLib`, `Compile`, `CompilePackage` in
   `internal/compiler/compiler.go`). M2 does **not** wire into these — the new
   checker is exercised only through M2's own harness. Compiler wiring behind a
-  flag is M7.
+  flag is M8.
 
 ## 3. Design
 
@@ -154,9 +165,10 @@ internal/solver/        # M1: context.go, constrain.go, coalesce.go, info.go, er
   infer_decl.go   # M2: VarDecl / FuncDecl → bindings, SCC group inference
   module.go       # M2: InferModule(s): dep_graph SCC ordering + drive the walk
   scope.go        # M2: Scope / Binding / Namespace (own, not type_system)
+  prelude.go      # M2: global scope — operator/builtin schemes + placeholder stdlib type bindings (§3.8)
   errors.go       # bridge errors (unbound name, unsupported node) with provenance/spans
   // (soltype core, Info side table, printer: from M1)
-  testdata/ or fixtures wiring   # see §3.6
+  *_test.go       # M2: table-driven tests (single- + multi-file, in-memory); see §3.6
 ```
 
 ### 3.2 The constraint-generating walk (`infer.go`)
@@ -189,13 +201,62 @@ AST instead of `Term`:
 | `ObjectExpr` | `Record{fields}` (basic; usage-inference is M4) | yes |
 | `MemberExpr` | `constrain(recv, Record{name: fresh})` (basic; M4 deepens) | yes |
 | `IfElseExpr` | join branches; `constrain(cond, boolean)` | yes |
-| `Block` | type each stmt; result = last expr (or `void`) | yes |
+| `Block` | type each stmt in source order; result = last expr (or `void`). Body decls are `VarDecl`-only; redeclaration rebinds (below) | yes |
 
 Every node that produces a type records it in M1's `Info` side table via the
 (unexported, same-package) `setType(node, t)` — which is why the M2 walk lives
 in `package solver`. `Info` is the single source of truth for node→type (the AST
 stays untouched — no `InferredType()` writes; that is the AST-decoupling
 decision). Nodes outside the M2 subset emit an "unsupported in M2" error.
+
+**Statement-level declarations in bodies — `VarDecl` only.** Inside a
+function/method body the only declaration a statement may introduce is a
+`VarDecl` (`val`/`var`). A body-level `DeclStmt` wrapping any other decl kind —
+`FuncDecl`, `TypeDecl`, `ClassDecl`, `EnumDecl`, `InterfaceDecl`, … — is a
+**language-level error** (`BodyDeclNotAllowedError`, §3.7), *not* the
+"unsupported in M2" subset gate: it is a deliberate, permanent simplification of
+the language, so the body walk only ever folds a `VarDecl` into scope. No
+expressiveness is lost — a function value inside a body is written as a `val`
+bound to a `FuncExpr` (`val f = fn () { … }`), which is a `VarDecl`. Top-level
+decls are unaffected: the module driver (§3.3) still infers
+`FuncDecl`/`TypeDecl`/… through the dep graph.
+
+**Redeclaration within a body is allowed.** A body may bind the same name more
+than once, each occurrence with its own type:
+
+```
+fn foo() {
+    val x: string = "hello"   // x : string here
+    val x: number = 5         // x : number from here on
+}
+```
+
+Each `val`/`var` introduces a **fresh, independent** binding: `inferVarDecl`
+infers the initializer on its own and the body walk *overwrites* the name's slot
+in the current `Scope` (plain map assignment via `defineValue`, §3.4). No
+constraint links the old and new bindings — the second `x` is **not** constrained
+`<:` the first — so the two types need not be compatible. Statements between the
+decls see the earlier type; statements after the second see the later one (the
+walk is strictly source-order within a block). This matches what the current
+checker already does for `val`/`var` (it merges body bindings with `maps.Copy`,
+an overwrite); M2 makes the behavior uniform and intentional rather than an
+accident of which insertion path a decl kind happens to take.
+
+```go
+// infer_stmt.go — body-level DeclStmt: VarDecl only, redeclaration overwrites.
+case *ast.DeclStmt:
+    vd, ok := s.Decl.(*ast.VarDecl)
+    if !ok {
+        c.report(BodyDeclNotAllowedError{Kind: declKind(s.Decl), span: s.Span()})
+        break
+    }
+    b := c.inferVarDecl(scope, lvl, vd)
+    scope.defineValue(varName(vd), b) // overwrite ⇒ same-name redeclaration rebinds
+```
+
+(`varName(vd)` reads the `IdentPat` name — M2 binds `IdentPat`-only patterns,
+mirroring M1's `IdentPat`-only `FuncParam`; destructuring `val`/param patterns
+(`TuplePat`/`RecordPat`) arrive in **M4**, once record/tuple types exist.)
 
 ### 3.3 Module driver (`module.go`) — dep_graph-ordered inference
 
@@ -233,11 +294,10 @@ func (c *Checker) InferComponent(ctx Context, depGraph *dep_graph.DepGraph,
   `Namespace` (below): cross-module references resolve through the qualified
   `BindingKey` namespace recorded on each binding (`DeclNamespace` /
   `GetNamespace(key)`).
-- **`resolver` is *not* on this path.** `internal/resolver/` only locates
-  `@types` `.d.ts` packages; it is engaged only if an M2 fixture imports a
-  TypeScript-typed third-party module, which the `val`/`fn` bar does not
-  require. M2 leaves `.d.ts` import typing to later milestones unless a fixture
-  forces it.
+- **`resolver` is *not* on this path (decided — §7).** `internal/resolver/` only
+  locates `@types/*` third-party TypeScript packages; the `val`/`fn` bar has no
+  such imports, so **M2 skips `resolver` entirely**. `.d.ts` / stdlib / library
+  type ingestion is M7.
 
 Entry point (working signature, paralleling the old driver):
 
@@ -270,7 +330,9 @@ func (s *Scope) GetNamespace(name string) (*Namespace, bool)
 
 (Comma-ok return shape, matching the `inferIdent` sketch in §3.7. Design-notes
 sketches these as pointer returns; the comma-ok form is the M2 refinement so the
-not-found case is explicit at every call site.)
+not-found case is explicit at every call site. All three `Get*` are lexical
+lookups: check this scope's own map, then walk the `parent` chain — they differ
+only in which of the three sorts (`values`/`types`/`namespaces`) they consult.)
 
 - `ValueBinding` — in M2, a name's **monomorphic** `soltype.Type` plus its
   source provenance (the production analogue of the spike's
@@ -279,14 +341,32 @@ not-found case is explicit at every call site.)
   lands.
 - The **value-position `IdentExpr`** path queries `GetValue`, then `GetNamespace`
   only to raise `NamespaceUsedAsValueError` (namespaces are a separate sort and
-  never flow as values — design-notes §"The constraint-generating AST walk").
+  never flow as values — design-notes §"The constraint-generating AST walk"). M2
+  has **no** namespace *member* access (`Foo.bar`) — that's M4 (see the
+  `inferIdent` note in §3.7). M2's `Namespace` is structure + the free-floating
+  error only.
 - `Namespace` is keyed by the qualified `BindingKey` namespace `dep_graph`
   records (`GetNamespace(key)`), which is how multi-file resolution lands.
+  Cross-file references in M2's acceptance use **root-namespace short names**
+  (`foo`, resolved through the module scope), not qualified `Foo.bar` access —
+  the latter needs the M4 namespace-member lookup.
 
 **M2 scope:** `values` + `namespaces` are what the `val`/`fn` + multi-file bar
 needs. The `types` slot's shape lands now (cheap, and it's load-bearing for the
 two-map test harness below), but populating it with real type aliases/classes is
 M3+ work. Keep the rest deliberately small; it grows with later milestones.
+
+**`defineValue` overwrites — redeclaration and rec-groups both rely on it.**
+`defineValue(name, b)` is a plain insert into the current scope's `values` map:
+if `name` is already bound *in this scope* it replaces the binding — it does
+**not** panic or error the way the old checker's `setValue` does on a duplicate.
+Two M2 paths depend on the overwrite: (a) body-level variable redeclaration
+(§3.2), and (b) `inferComponent`, which binds each rec-group name twice — first
+to its fresh var, then to its coalesced type (§3.7). The old checker's split
+behavior — `val`/`var` overwrite via `maps.Copy` but a duplicate `fn` panics via
+`setValue` — is **not** carried into M2: `defineValue` is uniformly overwrite,
+and `fn`-as-a-body-statement is disallowed outright (§3.2), so that inconsistency
+cannot arise.
 
 ### 3.5 Errors & provenance
 
@@ -294,26 +374,45 @@ M3+ work. Keep the rest deliberately small; it grows with later milestones.
   spans (`ast.Span`) taken from the offending AST node via `node.Span()`. (Note:
   the `internal/provenance/` package exports only the `Provenance` marker
   interface — `IsProvenance()` — *not* a span type; spans live in `internal/ast`.)
-- Inference errors from the core (`constrain` failures) attach the offending
-  node's provenance via the `Info`/provenance side table (M1 provides the
-  mechanism; M2 supplies the AST node). Assert **full** messages in tests
-  (CLAUDE.md).
+- Inference errors from the core (`constrain` failures) carry the offending
+  node's span **directly on the error kind** (the `Span() ast.Span` field added
+  to `SolverError`, §3.7) — M2 stamps it at the `constrain` call site from the
+  AST node being walked. M2 does **not** look provenance up from a side table:
+  the `Prov` provenance table (`Type → Origin`, the inverse of `Info`) is
+  **deferred to M3+** ([02-design-notes.md](02-design-notes.md) §"Provenance side
+  table"), so the richer "why this type" derivation chains it powers are a later
+  milestone. (`ValueBinding.Source` is a separate, per-binding back-pointer to
+  the *introducing* AST node — present in M2, unrelated to `Prov`.) Assert
+  **full** messages in tests (CLAUDE.md).
 
-### 3.6 Fixture-style harness
+### 3.6 Test harness (table-driven)
 
-Two complementary test surfaces, matching the milestone's "fixture-style harness
-… its own assertions, independent of the old checker":
+M2 has **one** test surface — table-driven `*_test.go` in the new package — and
+**no** on-disk `fixtures/` directories. This satisfies the milestone's "given
+`.esc` source, infer and assert the rendered binding types … its own assertions,
+independent of the old checker" directly, and keeps M2 from standing up fixture
+infrastructure that M8 owns deliberately.
 
-- **Table-driven `*_test.go`** in the new package: `.esc` snippet → expected
-  rendered binding type string (using the M1 `soltype` printer). This is the
-  primary M2 surface — fast, no per-case package overhead, mirrors the spike's
-  existing `simplesub_test.go` pattern and the checker-tests pattern in
-  `internal/checker/tests/`.
-- **A real `fixtures/`-style harness** (sibling to
-  `cmd/escalier/fixture_test.go`) for the multi-file/dep-graph acceptance:
-  `fixtures/<name>/lib/index.esc` (+ `package.json`) → resolve via dep graph →
-  assert rendered top-level binding types. This proves the dep-graph/multi-file
-  path end-to-end, which a single-snippet table test can't.
+- **Single-file cases:** `.esc` snippet → expected rendered binding type string
+  (using the M1 `soltype` printer). The primary M2 surface — fast, no per-case
+  package overhead, mirrors the spike's `simplesub_test.go` pattern and the
+  checker-tests pattern in `internal/checker/tests/`.
+- **Multi-file / dep-graph cases:** still table-driven, but the case supplies
+  **several in-memory sources** instead of one. `ast.Module` already holds
+  `Files []*File` (and `Sources`), and `InferModule`/`InferModules` take parsed
+  modules — so a case parses each source string, assembles a multi-file `Module`
+  (or several modules), drives `BuildDepGraph` across them, and asserts the
+  rendered top-level types. This exercises the exact dep-graph-spanning-files
+  path on-disk fixtures would, without `package.json` / file-discovery ceremony.
+
+**Why no on-disk fixtures in M2.** Real `fixtures/<name>/lib/index.esc` (+
+`package.json`) directories would pull in the `resolver` / file-discovery layer
+and a second harness — both of which M2 otherwise defers (M2 doesn't engage
+`resolver` unless a `.d.ts` import forces it, and doesn't wire into the compiler
+entry points; that's M8). An M2 on-disk fixture wouldn't run the real pipeline
+anyway — it'd run M2's own harness — so the directory layout is pure ceremony
+here. M8 stands up the real fixture harness (sibling to
+`cmd/escalier/fixture_test.go`) with differential triage; M2 leaves it there.
 
 Assert inferred types as Escalier type-annotation strings; use `testify/require`
 (CLAUDE.md). For tree-shaped assertions prefer `snaps.MatchInlineSnapshot` over
@@ -392,8 +491,8 @@ type Scope struct {
 func NewScope() *Scope
 func (s *Scope) Child() *Scope
 func (s *Scope) defineValue(name string, b ValueBinding)
-func (s *Scope) GetValue(name string) (ValueBinding, bool)      // walks parents
-func (s *Scope) GetType(name string) (TypeBinding, bool)
+func (s *Scope) GetValue(name string) (ValueBinding, bool)      // all three walk parents
+func (s *Scope) GetType(name string) (TypeBinding, bool)        // (lexical lookup: this scope, then parent chain)
 func (s *Scope) GetNamespace(name string) (*Namespace, bool)
 ```
 
@@ -434,6 +533,20 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
     return c.report(UnknownIdentifierError{Name: e.Name, Span: e.Span()})
 }
 ```
+
+> **Namespace member access (`Foo.bar`) is M4, not M2.** In M2 the *only* thing a
+> namespace ident can do is fail: there is no legal namespace-member position yet
+> (M2's `MemberExpr` is value-only — `constrain(recv, Record{…})` — and there is
+> no `IndexExpr`). So `inferIdent` raising `NamespaceUsedAsValueError` on *any*
+> namespace name is correct for M2. M4 — where member access deepens and
+> `IndexExpr` lands — adds qualified namespace access: a `resolvePath` that
+> returns `Value | Namespace`, namespace branches in member/index access
+> (`LookupValue`/`LookupNamespace` — a **direct**, non-lexical lookup in the
+> namespace's own maps, unlike `Scope.Get*`), and at that point the
+> `NamespaceUsedAsValueError` moves from `inferIdent` to the value-position
+> consumer (so `Foo.bar` is allowed while `f(Foo)` / `f(A.B)` still error). M2
+> keeps the namespace **structure** (for qualified `BindingKey` resolution) and
+> the free-floating error; the *lookup* is M4.
 
 **Declaration & module driver (PR-2 single-decl; PR-5 SCC).** Mirrors the old
 checker's `InferDepGraph`/`InferComponent`, over `soltype`:
@@ -512,6 +625,7 @@ type SolverError interface {  // M1 interface, + Span() added in M2
 type UnknownIdentifierError struct{ Name string; span ast.Span }
 type NamespaceUsedAsValueError struct{ Name string; span ast.Span }
 type UnsupportedNodeError struct{ Kind string; span ast.Span } // M2-subset guard
+type BodyDeclNotAllowedError struct{ Kind string; span ast.Span } // body decls are VarDecl-only (§3.2); permanent language rule, not a subset gate
 ```
 
 (The plan earlier used a separate `Error` interface; M1 having already
@@ -519,23 +633,26 @@ established `SolverError` means M2 should extend *that*, not introduce a
 parallel hierarchy. The `Error`/`c.report` naming in the carrier sketch reads
 against this `SolverError` type.)
 
-**Test harness (PR-2 table; PR-6 fixtures).**
+**Test harness (PR-2 single-file table; PR-6 multi-file table).**
 
 ```go
-// infer_test.go — table harness
+// infer_test.go — table harness, single-file
 func inferSource(t *testing.T, src string) (values, types map[string]string)
 // returns name → rendered soltype string, via parser + InferModule + soltype printer
 
-// fixture_test.go — multi-file harness (sibling to cmd/escalier/fixture_test.go)
-func checkSolverFixture(t *testing.T, fixtureDir string) // asserts rendered top-level types
+// infer_test.go — table harness, multi-file (in-memory; no on-disk fixtures)
+func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string)
+// parses each named source, assembles a multi-file Module / modules, drives
+// BuildDepGraph + InferModule(s), returns rendered top-level types
 ```
 
-### 3.8 Stdlib-type prerequisite tracking
+### 3.8 Stdlib-type placeholder seeding
 
 The M1-era edit to `01-milestones.md` added a new M2 acceptance clause: names
-that *downstream* type rules will reference must already **resolve** through the
-stdlib declaration channels and surface as `soltype.Type` values by the end of
-M2 — even though the rules that consume them land later. The names called out:
+that *downstream* type rules will reference must already **resolve** to a
+`soltype.Type` by the end of M2 — even though the rules that consume them, and
+the real type definitions, land later (real ingestion is its own milestone, M7).
+The names called out:
 
 | Name | Consumed by (later milestone) |
 |------|-------------------------------|
@@ -544,21 +661,29 @@ M2 — even though the rules that consume them land later. The names called out:
 | `Generator` / `AsyncGenerator` | `yield e` |
 | `IteratorResult<T>` (`{value, done}`) | iteration built-ins |
 
-**M2's responsibility is resolution only, not rules.** The parser-bridge must
-make these names resolve (whether sourced from Escalier's own stdlib decls,
-`lib.esc.d.ts`-equivalents, or both) and produce `soltype` types for them, so
-later milestones aren't blocked on "where does `Promise` come from?". M2 does
-**not** implement `await`/`for-in`/`yield` type-checking.
+**M2 seeds placeholders only; real ingestion is M7.** M2 does **not** read the
+real stdlib decls and does **not** implement `await`/`for-in`/`yield`. Two hard
+reasons it can't: (a) the existing stdlib ingestion lives inside
+`internal/checker/` and produces `type_system.Type` — off-limits behind the M2
+gate; and (b) these are *generic* type references (`Promise<T>`), and M1's
+`soltype` has **no** generic-type-reference / alias node yet (that's M3/M4). So
+M2's whole job here is to **hand-seed placeholder `TypeBinding`s** — opaque
+stubs (e.g. `soltype.Unknown`) for exactly `Promise`, `Iterable`,
+`AsyncIterable`, `Generator`, `AsyncGenerator`, `IteratorResult` — into the
+prelude `Scope.types` (§3.4), so a *reference* to the name resolves without an
+unbound-name error. Nothing structural; no arity.
 
-Practically this is the same `TypeBinding`/`Namespace` machinery (§3.4) the
-val/fn path already needs, pointed at the stdlib decl source — but note two M2
-caveats: these are *generic* type references (`Promise<T>`), and M1's `soltype`
-has no generic-type-reference / alias node yet (that's M3/M4). For M2 the
-acceptance is just that the **names resolve** to *some* `soltype.Type` (likely a
-placeholder type-binding) without an unbound-name error — full generic
-instantiation of them is later. This is folded into **PR-6** (the milestone that
-owns multi-file/stdlib resolution); if it proves heavier than a name-resolution
-stub, split it into its own PR-7.
+The **real** ingestion — retargeting `internal/checker/`'s
+`infer_stdlib_import` / `infer_import` + `interop` onto `soltype` — is its own
+milestone, **M7 (library type resolution)**, sequenced after M6 once generics
+(M3), objects (M4), classes (M5), and unions (M6) exist to represent the lib
+types. M7 swaps these placeholders for real structures. (See
+[01-milestones.md](01-milestones.md) M7.)
+
+Because it's just a hand-seeded table, this belongs with the **prelude
+construction in PR-1** (alongside the operator/builtin bindings the
+`BinaryExpr` walk needs), not the multi-file PR — it has no dependency on
+dep-graph or multi-file resolution.
 
 ## 4. Sequencing
 
@@ -580,7 +705,7 @@ feature additions. Concretely:
   fn/call/block walk is a self-contained set of `inferExpr` cases. Either can
   merge first; the second rebases trivially.
 - **PR-4** (objects/members) is a small, optional-for-the-bar add that several
-  fixtures will want; isolated so it can slip without blocking the SCC/multi-file
+  test cases will want; isolated so it can slip without blocking the SCC/multi-file
   work.
 - The old PR-3 (SCC) becomes **PR-5**, the old PR-4 (multi-file) becomes
   **PR-6** — unchanged in content, renumbered.
@@ -592,39 +717,39 @@ feature additions. Concretely:
         coalesce, Info, SolverError, Print) — monomorphic; no schemes
                         │
                         ▼
-                ┌─────────────────┐
+                ┌──────────────────┐
                 │ PR-1  carrier +  │   checker{ctx,info,errs}, Scope/Binding/Namespace,
                 │ scope + leaves   │   SolverError+Span, inferExpr(lits, idents)
-                └───────┬─────────┘
+                └───────┬──────────┘
                         │
             ┌───────────┴───────────┐
             ▼                       ▼
-   ┌──────────────────┐   ┌──────────────────────┐
+   ┌──────────────────┐   ┌───────────────────────┐
    │ PR-2 decl driver │   │ PR-3 fn / call /      │   (PR-2 ∥ PR-3:
    │ + table harness  │   │ block walk            │    independent given PR-1)
    │ (val end-to-end) │   │ (fn end-to-end)       │
-   └───────┬──────────┘   └──────────┬───────────┘
+   └───────┬──────────┘   └──────────┬────────────┘
            │                         │
            │   ┌─────────────────────┤
            ▼   ▼                     ▼
-   ┌──────────────────┐   ┌──────────────────────┐
+   ┌──────────────────┐   ┌───────────────────────┐
    │ PR-5 dep_graph   │   │ PR-4 objects /        │   (PR-4 ∥ PR-5:
    │ SCC (monomorphic)│   │ member access         │    both need PR-2+PR-3)
-   └───────┬──────────┘   └──────────┬───────────┘
+   └───────┬──────────┘   └──────────┬────────────┘
            │                         │
            └───────────┬─────────────┘
                        ▼
-           ┌────────────────────────┐
+           ┌─────────────────────────┐
            │ PR-6 multi-file (x-mod) │   closes M2 exit criteria
-           │ resolution + fixtures   │
-           └────────────────────────┘
+           │ resolution + table tests│
+           └─────────────────────────┘
 ```
 
 Edges are hard dependencies (the target imports/uses symbols the source
 introduces). The two `∥` pairs (PR-2 ∥ PR-3, and PR-4 ∥ PR-5) have no edge
 between them and can be developed/reviewed in parallel. PR-6 is the only PR that
-needs *both* upstream branches merged (it asserts end-to-end over real fixtures,
-which exercises decls, functions, and SCC ordering together).
+needs *both* upstream branches merged (it asserts end-to-end over in-memory
+multi-file sources, which exercises decls, functions, and SCC ordering together).
 
 ## 5. PR breakdown
 
@@ -640,14 +765,30 @@ which exercises decls, functions, and SCC ordering together).
   `GetNamespace`.
 - `errors.go`: add `Span() ast.Span` to M1's `SolverError` and backfill it on
   M1's existing kinds; add `UnknownIdentifierError`, `NamespaceUsedAsValueError`,
-  `UnsupportedNodeError`.
+  `UnsupportedNodeError`, `BodyDeclNotAllowedError`.
 - `infer_expr.go`: `inferLiteral`, `inferIdent`; all other `ast.Expr` kinds fall
   through to `UnsupportedNodeError` (no panic).
+- `prelude.go`: build the global/prelude `Scope` — operator/builtin value
+  schemes the `BinaryExpr` walk needs, plus the **placeholder stdlib type
+  bindings** (§3.8): opaque `soltype` stubs for `Promise`/`Iterable`/
+  `AsyncIterable`/`Generator`/`AsyncGenerator`/`IteratorResult` so references
+  resolve. Hand-built, no checker/`type_system` import; real ingestion is M7.
+  The operator schemes are a near-mechanical port of the old checker's
+  `addOperatorBindings` (`internal/checker/prelude.go`) from `type_system`
+  constructors to `soltype` ones — **every operator is monomorphic over
+  primitives** (`+`/`-`/`*`/`/`: `fn(number, number) -> number`; `<`/`>`/`<=`/
+  `>=`: `fn(number, number) -> boolean`; `==`/`!=`: `fn(unknown, unknown) ->
+  boolean`; `&&`/`||`: `fn(boolean, boolean) -> boolean`; `!`:
+  `fn(boolean) -> boolean`; `++`: `fn(string, string) -> string`), so they need
+  no generics/unions/lib types and belong here, not in a later milestone.
+  Richer forms (bigint arithmetic, string `<`, generic equality) are refinements
+  that land with their enabling milestone (overloads M3, unions M6), not M2.
 - Tests: literal → rendered type; identifier resolves to a pre-seeded binding's
-  type; unbound identifier and namespace-as-value → full-message errors with
-  spans.
+  type; a stdlib placeholder name resolves without an unbound-name error;
+  unbound identifier and namespace-as-value → full-message errors with spans.
 - **Exit:** the walk types the literal/identifier subset against `soltype`/`Info`;
-  every other node fails cleanly.
+  the prelude resolves operators and the placeholder stdlib names; every other
+  node fails cleanly.
 
 ### PR-2 — Single-module decl driver + table harness  (~250 LoC)
 *(depends on PR-1; parallel with PR-3)*
@@ -692,31 +833,37 @@ which exercises decls, functions, and SCC ordering together).
 - Replace PR-2's source-order loop with SCC ordering. **No placeholder/patching
   phase.** **No generalization** — bindings are bound monomorphically; the
   `PolyScheme` generalization step is M3 (M1 deferred schemes).
+- **Verify `coalesce` terminates on recursive groups.** A mutually-recursive SCC
+  can build a cyclic var↔var bound graph, and M1's `coalesce` has no `seen`-guard
+  (deferred to M3). Confirm guard-free `coalesce` terminates on the recursive
+  tests below; if an ungrounded group loops, pull the M3 `seen`-guard forward (§7).
 - Tests: self-recursive `fn` (resolves, monomorphic); mutually-recursive `fn`
   pair; a decl that forward-references a later decl now resolves via SCC
   ordering (the PR-2 documented-error case flips to success).
 - **Exit:** recursive and out-of-order top-level decls infer correctly in one
   module (monomorphically).
 
-### PR-6 — Multi-file (cross-module) resolution + fixtures harness  (~250 LoC)
+### PR-6 — Multi-file (cross-module) resolution + multi-file table tests  (~250 LoC)
 *(depends on PR-4 + PR-5)*
 - `module.go`: `InferModules` over multiple parsed modules; build the dep graph
   across them; cross-module references resolve through the qualified-`BindingKey`
-  `Namespace` (`dep_graph.GetNamespace`). Engage `internal/resolver` only if a
-  fixture imports a `.d.ts`-typed third-party module.
-- Stdlib-type prerequisite resolution (§3.8): `Promise`/`Iterable`/`Generator`/
-  `IteratorResult` names resolve to `soltype` types through the stdlib decl
-  channel without unbound-name errors (resolution only; the rules that use them
-  are later). If heavier than a name-resolution stub, split into PR-7.
-- `fixture_test.go`: the `checkSolverFixture` harness (sibling to
-  `cmd/escalier/fixture_test.go`).
-- Tests: a two-file fixture where file B imports a `val`/`fn` from file A and the
-  inferred types render correctly end-to-end; a fixture referencing a stdlib
-  type name resolves without error.
+  `Namespace` (`dep_graph.GetNamespace`). **M2 does not engage `internal/resolver`**
+  (it resolves `@types/*` third-party packages; M2 has no such imports — that's
+  M7; see §7).
+- `infer_test.go`: the `inferSources` multi-file table helper (§3.7) — in-memory
+  sources, **no** on-disk `fixtures/` directories (those are M8; see §3.6).
+- Tests: a two-file table case where file B references a `val`/`fn` from file A
+  by **root-namespace short name** (not qualified `Foo.bar`) and the inferred
+  types render correctly end-to-end. (Qualified namespace-member access is M4;
+  stdlib placeholder names are seeded in PR-1, §3.8 — not this PR; real ingestion
+  is M7.)
+- **Out of scope (→ M4):** qualified namespace-member access (`Foo.bar`,
+  `Foo["x"]`) and the `resolvePath` `Value | Namespace` machinery. M2 resolves
+  cross-file references through the dep-graph namespace structure under
+  short/qualified `BindingKey`s, but the *expression-level* `Foo.bar` walk is M4.
 - Update `01-milestones.md` M2 status.
 - **Exit (M2 exit criteria):** multi-file module resolves via the dep graph;
-  top-level `val`/`fn` infer correct rendered types end-to-end (monomorphic);
-  stdlib type names resolve.
+  top-level `val`/`fn` infer correct rendered types end-to-end (monomorphic).
 
 ## 6. Risks & mitigations
 
@@ -746,26 +893,43 @@ which exercises decls, functions, and SCC ordering together).
 
 - **Package name** is settled and shipped: `internal/solver/` (engine, where M2
   code lives) + `internal/soltype/` (types). No open decision here.
-- **Monomorphic-`ValueBinding` forward-compat.** M2's `ValueBinding` holds a
-  plain `soltype.Type`; M3 swaps it for a `TypeScheme`. Decide in PR-1 whether to
-  (a) ship the plain-`Type` field now and take the M3 churn, or (b) introduce a
-  thin `ValueBinding` accessor M3 can re-point. Leaning (a) — the churn is
-  mechanical and (b) risks over-abstracting before schemes exist.
-- **Does anything in M2 need `coalesce` at binding time?** The §3.7 SCC sketch
-  coalesces each group var before binding so the stored monomorphic type is
-  inspectable; confirm in PR-5 whether binding the raw var (and coalescing only
-  at render) is simpler. M1's `coalesce` is available either way.
-- **How much namespace resolution to drive in M2 vs. defer.** If full
-  cross-module/namespace resolution is heavier than the val/fn bar needs, PR-6
-  can scope to the minimum that satisfies the multi-file acceptance (a binding
-  in file B referencing a top-level `val`/`fn` in file A via its qualified
-  `BindingKey`) and leave richer namespace semantics (`ns.foo` member access,
-  nested namespaces) to later milestones — decide when PR-6 starts, based on what
-  `dep_graph` already records in `DeclNamespace`.
-- **Whether M2 needs `internal/resolver` at all.** It's only for `@types`
-  `.d.ts` resolution; if no M2 fixture imports a TS-typed module, M2 can skip it
-  entirely and the milestone's "dep_graph/resolver" phrasing is satisfied by
-  `dep_graph` alone.
+- **Monomorphic-`ValueBinding` forward-compat — DECIDED: (a).** M2's
+  `ValueBinding` holds a plain `soltype.Type`; M3 swaps it for a `TypeScheme`.
+  Ship the plain-`Type` field now and take the M3 churn — it's mechanical, and
+  the alternative (a thin accessor M3 re-points) over-abstracts before schemes
+  exist.
+- **`coalesce` at binding time — DECIDED: keep it (coalesce at SCC completion).**
+  The binding-vs-render *timing* is correctness-neutral: a binding is stored at
+  **Positive** polarity, `coalesce(var, Positive)` reads only *lower* bounds, and
+  every downstream *use* adds *upper* bounds (`f(x)`, `x.foo`, `x+1`, `val y=x`
+  all upper-bound `x`), so the Positive view is stable after the defining SCC —
+  binding-time and render-time coalesce yield the identical type. Keep
+  coalesce-at-binding anyway because it (i) **isolates SCCs** (a later SCC gets a
+  frozen, var-free type and can't mutate an earlier binding's vars), (ii) makes
+  `ValueBinding.Type` stable/inspectable, and (iii) is the natural monomorphic
+  stand-in for M3's `PolyScheme` — both freeze the binding at its definition
+  boundary, so the (a) field-swap above is the only M3 change. Binding the raw
+  var renders identically but leaves live shared vars in scope (not simpler).
+  **Caveat for PR-5:** `coalesce` has **no recursion guard** (M1 deferred the
+  `seen`-set to M3), but a mutually-recursive SCC can build a cyclic var↔var
+  bound graph (`constrain` appends var-to-var bounds; it terminates on cycles via
+  its own coinductive `seen`-set, `coalesce` does not). Well-typed recursion
+  usually grounds the return to a concrete type so the cycle collapses, but an
+  ungrounded recursive group could loop — PR-5 must verify guard-free `coalesce`
+  terminates on its recursive-SCC tests, or pull the M3 `seen`-guard forward.
+- **How much namespace resolution to drive in M2 — DECIDED: the minimum.** M2
+  populates the `Namespace` slot from `dep_graph` and resolves cross-file
+  references by **short name through the scope chain** (the multi-file acceptance:
+  file B references a top-level `val`/`fn` in file A by short name). M2 does
+  **not** implement `Foo.bar`/`ns.foo` member access, nested-namespace access, or
+  qualified cross-namespace resolution — all **M4** (the `resolvePath`
+  `Value | Namespace` machinery; see §3.7 and PR-6). M2's namespace surface is
+  the slot + qualified `BindingKey` structure + the free-floating-namespace error.
+- **Whether M2 needs `internal/resolver` — DECIDED: no, M2 skips it.** `resolver`
+  resolves `@types/*` third-party TypeScript packages
+  (`ResolveTypesPackage`/`GetTypesEntryPoint`); M2 has no such imports, so it is
+  entirely off the M2 path and `dep_graph` alone satisfies the milestone's
+  "dep_graph/resolver" phrasing. `.d.ts` / third-party typing lands in M7.
 
 ## 8. M2 exit checklist
 
@@ -776,11 +940,13 @@ which exercises decls, functions, and SCC ordering together).
 - [ ] Top-level `val`/`fn` from real source infer correct **monomorphic**
       rendered types end-to-end (table harness). *(Polymorphic `<T0>` rendering
       is M3 — M1 deferred schemes/generalization.)*
-- [ ] Multi-file module resolves via the dep graph (fixtures harness).
+- [ ] Multi-file module resolves via the dep graph (in-memory multi-file table
+      test; no on-disk fixtures — those are M8).
 - [ ] Recursive SCC groups infer (monomorphically) with no placeholder/patching
       phase.
 - [ ] Stdlib type names (`Promise`/`Iterable`/`Generator`/`IteratorResult`)
-      resolve to `soltype` types without unbound-name errors (resolution only).
+      resolve to **placeholder** `soltype` stubs without unbound-name errors
+      (seeded in the prelude; real ingestion is M7).
 - [ ] `SolverError` gained `Span()`; M2 error kinds carry spans.
 - [ ] No imports of `internal/checker/` or `internal/type_system/` from the new
       package (gate honored).

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -194,8 +194,10 @@ Entry point (working signature, paralleling the old driver):
 ```go
 // InferModule builds the dep graph for the parsed module, infers every
 // top-level declaration in SCC order, populates Info, and returns the module
-// Scope plus errors. Multi-file callers pass the merged module / module set.
-func (c *checker) InferModule(module *ast.Module) (*Scope, *Info, []error)
+// Scope plus errors. The package-level entry constructs a fresh checker
+// internally; multi-file callers use InferModules (§3.7). Full signatures in
+// §3.7.
+func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)
 ```
 
 ### 3.4 Scope / Binding / Namespace (own, not `type_system`)
@@ -211,10 +213,14 @@ type Scope struct {
     namespaces map[string]*Namespace     // a separate sort — NOT a soltype.Type
     parent     *Scope
 }
-func (s *Scope) GetValue(name string) *ValueBinding
-func (s *Scope) GetType(name string) *TypeBinding
-func (s *Scope) GetNamespace(name string) *Namespace
+func (s *Scope) GetValue(name string) (ValueBinding, bool)
+func (s *Scope) GetType(name string) (TypeBinding, bool)
+func (s *Scope) GetNamespace(name string) (*Namespace, bool)
 ```
+
+(Comma-ok return shape, matching the `inferIdent` sketch in §3.7. Design-notes
+sketches these as pointer returns; the comma-ok form is the M2 refinement so the
+not-found case is explicit at every call site.)
 
 - `ValueBinding` — a name's `soltype` scheme (`MonoScheme`/`PolyScheme`, from the
   spike's `scheme.go`) plus its source provenance. The production analogue of the
@@ -232,8 +238,10 @@ M3+ work. Keep the rest deliberately small; it grows with later milestones.
 
 ### 3.5 Errors & provenance
 
-- Bridge errors (`errors.go`): unbound name, unsupported node — carry
-  `provenance`/source spans from the AST node (reuse `internal/provenance/`).
+- Bridge errors (`errors.go`): unbound name, unsupported node — carry source
+  spans (`ast.Span`) taken from the offending AST node via `node.Span()`. (Note:
+  the `internal/provenance/` package exports only the `Provenance` marker
+  interface — `IsProvenance()` — *not* a span type; spans live in `internal/ast`.)
 - Inference errors from the core (`constrain` failures) attach the offending
   node's provenance via the `Info`/provenance side table (M1 provides the
   mechanism; M2 supplies the AST node). Assert **full** messages in tests
@@ -281,9 +289,10 @@ type checker struct {
 
 func newChecker() *checker
 
-// fresh allocates a fresh inference variable at the current level and records
-// its AST origin in prov (the freshVarAt helper from design-notes §Provenance).
-func (c *checker) fresh(n ast.Node, kind soltype.ASTOriginKind) *soltype.TypeVarType
+// freshAt allocates a fresh inference variable at the given level (wrapping the
+// spike's Inferer.freshVar(level)) and records its AST origin in prov (the
+// freshVarAt helper from design-notes §Provenance).
+func (c *checker) freshAt(lvl int, n ast.Node, kind soltype.ASTOriginKind) *soltype.TypeVarType
 
 // report appends a structured error; returns soltype's error type so callers
 // can `return c.report(...)` in a value position (yielding an error placeholder).
@@ -368,8 +377,8 @@ checker's `InferDepGraph`/`InferComponent`, over `soltype`:
 func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)   // PR-2 (source-order), PR-5 (SCC)
 func InferModules(modules []*ast.Module) (*Scope, *soltype.Info, []Error) // PR-6 (multi-file)
 
-func (c *checker) inferDepGraph(scope *Scope, g *dep_graph.DepGraph) // PR-5
-func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph, // PR-5
+func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) // PR-5
+func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph, // PR-5
     component []dep_graph.BindingKey)
 
 // infer_decl.go
@@ -378,29 +387,36 @@ func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBin
 ```
 
 `inferComponent` is the LetRecGroup lift (PR-5); the singleton non-recursive
-case is the same code with a one-element slice:
+case is the same code with a one-element slice. The level discipline mirrors the
+spike's `LetRecGroup` exactly: bind the group's vars and infer its bodies at
+`lvl+1`, then generalize at the outer `lvl` — `freshenAbove` only quantifies
+vars whose level is `> lim`, so the `+1`/generalize-at-`lvl` split is what makes
+the recursive bindings polymorphic. (Generalizing at `lvl+1` instead would leave
+them monomorphic — the bug to avoid.)
 
 ```go
-func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph,
+func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph,
     component []dep_graph.BindingKey) {
-    // 1. fresh var per binding at lvl+1, all visible in scope before any body
+    inner := lvl + 1
+    // 1. fresh var per binding at the inner level, all visible before any body
     vars := map[dep_graph.BindingKey]*soltype.TypeVarType{}
     for _, key := range component {
-        v := c.fresh(/* decl node */ nil, soltype.OriginRecBinding)
+        v := c.freshAt(inner, /* decl node */ nil, soltype.OriginRecBinding)
         vars[key] = v
         scope.defineValue(key.Name(), ValueBinding{Scheme: &soltype.MonoScheme{Ty: v}})
     }
-    // 2. infer each body, constrain body <: its var
+    // 2. infer each body at the inner level, constrain body <: its var
     for _, key := range component {
         for _, d := range g.GetDecls(key) {
-            body := c.inferDeclBody(scope, c.core.Level()+1, d)
+            body := c.inferDeclBody(scope, inner, d)
             c.core.Constrain(body, vars[key])
         }
     }
-    // 3. generalize the whole group at the shared (outer) level
+    // 3. generalize the whole group at the OUTER level lvl (not inner): vars
+    //    created at lvl+1 are > lvl, so freshenAbove quantifies them.
     for _, key := range component {
         scope.defineValue(key.Name(), ValueBinding{
-            Scheme: &soltype.PolyScheme{Level: c.core.Level(), Body: vars[key]},
+            Scheme: &soltype.PolyScheme{Level: lvl, Body: vars[key]},
         })
     }
 }
@@ -411,10 +427,10 @@ messages in tests:
 
 ```go
 // errors.go
-type Error interface{ error; Span() provenance.Span }
-type UnknownIdentifierError struct{ Name string; Span provenance.Span }
-type NamespaceUsedAsValueError struct{ Name string; Span provenance.Span }
-type UnsupportedNodeError struct{ Kind string; Span provenance.Span } // M2-subset guard
+type Error interface{ error; Span() ast.Span }
+type UnknownIdentifierError struct{ Name string; Span ast.Span }
+type NamespaceUsedAsValueError struct{ Name string; Span ast.Span }
+type UnsupportedNodeError struct{ Kind string; Span ast.Span } // M2-subset guard
 ```
 
 **Test harness (PR-2 table; PR-6 fixtures).**

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -947,9 +947,10 @@ multi-file sources, which exercises decls, functions, and SCC ordering together)
       test; no on-disk fixtures — those are M8).
 - [ ] Recursive SCC groups infer (monomorphically) with no placeholder/patching
       phase.
-- [ ] Stdlib type names (`Promise`/`Iterable`/`Generator`/`IteratorResult`)
-      resolve to **placeholder** `soltype` stubs without unbound-name errors
-      (seeded in the prelude; real ingestion is M7).
+- [ ] Stdlib type names (`Promise`/`Iterable`/`AsyncIterable`/`Generator`/
+      `AsyncGenerator`/`IteratorResult`) resolve to **placeholder** `soltype`
+      stubs without unbound-name errors (seeded in the prelude; real ingestion
+      is M7).
 - [ ] `SolverError` gained `Span()`; M2 error kinds carry spans.
 - [ ] No imports of `internal/checker/` or `internal/type_system/` from the new
       package (gate honored).

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -325,7 +325,7 @@ func (s *Scope) GetType(name string) (TypeBinding, bool)
 func (s *Scope) GetNamespace(name string) (*Namespace, bool)
 ```
 
-**The expression walk (PR-1 lits/idents; PR-2 fn/call/block; PR-2b objects).**
+**The expression walk (PR-1 lits/idents; PR-3 fn/call/block; PR-4 objects).**
 The production `typeTerm`, split by node category. Each returns a `soltype.Type`
 and threads `*Scope` + `level`:
 
@@ -338,9 +338,9 @@ func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type
 // inferExpr dispatches; the per-kind helpers mirror the spike's typeTerm cases:
 func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type           // PR-1
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type   // PR-1
-func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type // PR-2
-func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type     // PR-2
-func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type // PR-2b
+func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type // PR-3
+func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type     // PR-3
+func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type // PR-4
 ```
 
 `inferIdent` is the load-bearing one — it's the production form of the spike's
@@ -360,24 +360,24 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 }
 ```
 
-**Declaration & module driver (PR-2 single-decl; PR-3 SCC).** Mirrors the old
+**Declaration & module driver (PR-2 single-decl; PR-5 SCC).** Mirrors the old
 checker's `InferDepGraph`/`InferComponent`, over `soltype`:
 
 ```go
 // module.go
-func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)   // PR-2 (1 file), PR-3 (SCC)
-func InferModules(modules []*ast.Module) (*Scope, *soltype.Info, []Error) // PR-4 (multi-file)
+func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)   // PR-2 (source-order), PR-5 (SCC)
+func InferModules(modules []*ast.Module) (*Scope, *soltype.Info, []Error) // PR-6 (multi-file)
 
-func (c *checker) inferDepGraph(scope *Scope, g *dep_graph.DepGraph) // PR-3
-func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph, // PR-3
+func (c *checker) inferDepGraph(scope *Scope, g *dep_graph.DepGraph) // PR-5
+func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph, // PR-5
     component []dep_graph.BindingKey)
 
 // infer_decl.go
-func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding // PR-2
-func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding // PR-2
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding   // PR-2
+func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding // PR-3
 ```
 
-`inferComponent` is the LetRecGroup lift (PR-3); the singleton non-recursive
+`inferComponent` is the LetRecGroup lift (PR-5); the singleton non-recursive
 case is the same code with a one-element slice:
 
 ```go
@@ -417,7 +417,7 @@ type NamespaceUsedAsValueError struct{ Name string; Span provenance.Span }
 type UnsupportedNodeError struct{ Kind string; Span provenance.Span } // M2-subset guard
 ```
 
-**Test harness (PR-2 table; PR-4 fixtures).**
+**Test harness (PR-2 table; PR-6 fixtures).**
 
 ```go
 // infer_test.go — table harness
@@ -581,7 +581,7 @@ which exercises decls, functions, and SCC ordering together).
   stop-and-reassess signal — raise it rather than working around it.
 - **dep_graph coupling to `type_system`.** `dep_graph` operates on `*ast.Module`
   and `ast.Decl` (its `Decls`/`Components`/`BindingKey` API is type-system-free),
-  so this risk is low — but confirm it in PR-3. *Mitigation:* consume only its
+  so this risk is low — but confirm it in PR-5. *Mitigation:* consume only its
   structural outputs (`BindingKey`s, `Components`, `GetDecls`/`GetNamespace`);
   keep all *type* data in `soltype`/`Info`.
 - **Walk vs. AST `Visitor` deviation.** Using a direct switch instead of the
@@ -601,11 +601,11 @@ which exercises decls, functions, and SCC ordering together).
 - **Package name** is settled (`internal/solver/`, design-notes decision #1);
   M2 inherits it from M1. No open decision here.
 - **How much namespace resolution to drive in M2 vs. defer.** If full
-  cross-module/namespace resolution is heavier than the val/fn bar needs, PR-4
+  cross-module/namespace resolution is heavier than the val/fn bar needs, PR-6
   can scope to the minimum that satisfies the multi-file acceptance (a binding
   in file B referencing a top-level `val`/`fn` in file A via its qualified
   `BindingKey`) and leave richer namespace semantics (`ns.foo` member access,
-  nested namespaces) to later milestones — decide when PR-4 starts, based on what
+  nested namespaces) to later milestones — decide when PR-6 starts, based on what
   `dep_graph` already records in `DeclNamespace`.
 - **Whether M2 needs `internal/resolver` at all.** It's only for `@types`
   `.d.ts` resolution; if no M2 fixture imports a TS-typed module, M2 can skip it

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -266,10 +266,12 @@ checker's `InferDepGraph` / `InferComponent` shape exactly, swapping
 `type_system` for `soltype`:
 
 ```go
-// Old checker (internal/checker/infer_module.go), for reference:
-func (c *Checker) InferDepGraph(ctx Context, depGraph *dep_graph.DepGraph) (errors []Error)
+// Old checker (internal/checker/infer_module.go), for reference. NB: these
+// []Error are the old checker.Error type — distinct from the solver's
+// SolverError (§3.7); the names are qualified here to keep the boundary clear.
+func (c *Checker) InferDepGraph(ctx Context, depGraph *dep_graph.DepGraph) (errors []checker.Error)
 func (c *Checker) InferComponent(ctx Context, depGraph *dep_graph.DepGraph,
-    component []dep_graph.BindingKey) []Error
+    component []dep_graph.BindingKey) []checker.Error
 ```
 
 - **Declaration ordering comes from `dep_graph`.** `BuildDepGraph(module)`
@@ -307,7 +309,7 @@ Entry point (working signature, paralleling the old driver):
 // Scope plus errors. The package-level entry constructs a fresh checker
 // internally; multi-file callers use InferModules (§3.7). Full signatures in
 // §3.7.
-func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)
+func InferModule(module *ast.Module) (*Scope, *Info, []SolverError)
 ```
 
 ### 3.4 Scope / Binding / Namespace (own, not `type_system`)
@@ -441,7 +443,7 @@ side table and accumulated errors. Method receiver for the whole walk.
 type checker struct {
     ctx  *Context  // M1 solver.Context: freshVar(level), Constrain(lhs, rhs) []SolverError
     info *Info     // M1 solver.Info: node → soltype.Type side table (unexported setType)
-    errs []Error   // accumulated; mirrors the spike's []error threading
+    errs []SolverError // accumulated; mirrors the spike's []error threading
 }
 
 func newChecker() *checker
@@ -456,7 +458,7 @@ func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type)
 
 // report appends a structured error; returns a placeholder type (e.g.
 // &soltype.NeverType{}) so callers can `return c.report(...)` in value position.
-func (c *checker) report(e Error) soltype.Type
+func (c *checker) report(e SolverError) soltype.Type
 ```
 
 **Scope / Binding / Namespace (PR-1).** Design-notes §"Scope / Binding" gives
@@ -553,8 +555,8 @@ checker's `InferDepGraph`/`InferComponent`, over `soltype`:
 
 ```go
 // module.go
-func InferModule(module *ast.Module) (*Scope, *Info, []Error)   // PR-2 (source-order), PR-5 (SCC)
-func InferModules(modules []*ast.Module) (*Scope, *Info, []Error) // PR-6 (multi-file)
+func InferModule(module *ast.Module) (*Scope, *Info, []SolverError)   // PR-2 (source-order), PR-5 (SCC)
+func InferModules(modules []*ast.Module) (*Scope, *Info, []SolverError) // PR-6 (multi-file)
 
 func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) // PR-5
 func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph, // PR-5
@@ -628,10 +630,11 @@ type UnsupportedNodeError struct{ Kind string; span ast.Span } // M2-subset guar
 type BodyDeclNotAllowedError struct{ Kind string; span ast.Span } // body decls are VarDecl-only (§3.2); permanent language rule, not a subset gate
 ```
 
-(The plan earlier used a separate `Error` interface; M1 having already
-established `SolverError` means M2 should extend *that*, not introduce a
-parallel hierarchy. The `Error`/`c.report` naming in the carrier sketch reads
-against this `SolverError` type.)
+(An earlier draft of this plan used a separate `Error` interface; M1 having
+already established `SolverError` means M2 extends *that*, not a parallel
+hierarchy. The carrier's `errs []SolverError` and `report(e SolverError)` use
+this type directly. Note the old checker's reference signatures in §3.3 use the
+distinct `checker.Error` type — same spelling, different package.)
 
 **Test harness (PR-2 single-file table; PR-6 multi-file table).**
 

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -1,0 +1,334 @@
+# M2 Implementation Plan — AST → Simple-sub lowering
+
+> Companion to [`01-milestones.md`](01-milestones.md) (M2 entry) and
+> [`02-design-notes.md`](02-design-notes.md) ("AST lowering" section).
+> Status legend: `[ ]` not started · `[~]` in progress · `[x]` complete
+
+## 1. Goal & scope
+
+M2 connects the standalone Simple-sub core to real Escalier source. We lower a
+useful subset of the `ast` package into Simple-sub `Term`s, add a driver that
+runs `lexer → parser → lower → Infer`, and assert inferred (and simplified)
+types over `.esc` snippets.
+
+**In scope (per the milestone):**
+- A lowering layer mapping `ast.Expr` / `ast.Decl` → Simple-sub `Term`.
+- Coverage for: literals, identifiers, lambdas/functions, application, `let` /
+  `letrec` bindings, records, field access, conditionals.
+- A driver returning the inferred type for a source string.
+- Golden tests over `.esc` snippets, including the Simple-sub paper examples
+  translated to Escalier syntax.
+- Error reporting (unbound variables, failed constraints) carrying source spans.
+
+**Out of scope (later milestones):**
+- Type annotations / ascription (M3).
+- Variants and pattern matching beyond plain records (M4).
+- Recursive types surfaced as named types, full `let` generalization polish (M5).
+- Effects / throws / async (M6).
+- Mapping `simplesub.Type` → `type_system.Type`, checker/codegen wiring (M7).
+- Diagnostics polish and provenance threading (M8).
+
+The lowering must sit **behind a small interface** so M7 can widen AST coverage
+without rewriting the core (design-notes "AST lowering").
+
+## 2. Current state (what M2 builds on)
+
+- **Spike core** lives in `internal/simplesub/` (commit #676): `term.go`,
+  `types.go`, `infer.go`, `simplify.go`, `builtins.go`, `errors.go`.
+- **Public API today:** `func Infer(term Term) (Type, error)` — fresh context per
+  call, returns a coalesced surface `Type`. (`infer.go`)
+- **`Term` ADT (curried):** `Lit{Value int}`, `Var{Name}`, `Lam{Name, Body}`,
+  `App{Func, Arg}`, `Rcd{Fields}`, `Sel{Term, Name}`,
+  `Let{IsRec, Name, Body, Rest}`. (`term.go`)
+- **Default environment** (`builtins.go`): `bool`, `+`, `if`, etc.
+- **Escalier AST expression nodes** (`internal/ast/expr.go`): `LiteralExpr`,
+  `IdentExpr`, `FuncExpr` (`Fn *FuncLit`, with `FuncSig` + body, **n-ary** params),
+  `CallExpr` (`Callee`, `Args []Expr`), `ObjectExpr` (`Elems []ObjectExprElem`),
+  `MemberExpr`, `IfElseExpr`, `BinaryExpr`, `TupleExpr`, `ArrayExpr`, …
+- **Decls:** `VarDecl`, `FuncDecl`, `TypeDecl`, `ClassDecl`.
+  **Stmts:** `DeclStmt`, `ExprStmt`, `ReturnStmt`.
+
+### Dependency on M1
+
+M2's deliverables ("a clean API the lowering can depend on") assume M1 has
+stabilized the core API. M1 is not yet started and M0 is in progress. Two viable
+sequencings:
+
+- **Preferred:** land M1's API freeze first (at minimum the items in §6 PR-0),
+  then build M2 against it.
+- **Pragmatic (parallel):** start M2 against the current M0 `Infer`/`Term`
+  surface, but treat any churn in that surface as M1 work and keep the lowering's
+  dependency on the core narrow (only `Term` constructors + `Infer`). This plan
+  assumes the pragmatic path with an explicit "API touch-ups" PR (PR-0) that can
+  be folded into M1 if M1 lands first.
+
+## 3. Design
+
+### 3.1 Package layout
+
+```
+internal/simplesub/
+  lower/
+    lower.go        # Lowerer + Expr/Decl/Stmt → Term entry points
+    lower_expr.go   # per-expression-kind lowering
+    lower_decl.go   # VarDecl/FuncDecl → Let/letrec
+    builtins.go     # surface-name → builtin Var mapping shared with the env
+    errors.go       # LowerError (unsupported node, unbound name) with spans
+    driver.go       # InferSource(src) — lexer→parser→lower→Infer
+    lower_test.go
+    driver_test.go
+  testdata/
+    *.esc           # paper examples + Escalier-specific snippets
+```
+
+Rationale for a sub-package (`internal/simplesub/lower`) rather than living in
+`internal/simplesub`: it keeps the core free of any `ast`/`parser` dependency
+(the core stays a pure algorithm package), and it gives M7 a clear seam — the
+checker integration can provide an alternative lowering target without importing
+this package. The "small interface" is the `Lowerer` type below.
+
+### 3.2 The lowering interface
+
+```go
+// Lowerer translates a subset of the Escalier AST into Simple-sub Terms.
+type Lowerer struct {
+    // builtins maps surface operator/keyword names to the Var names bound in
+    // simplesub's default environment (e.g. "+" -> "+", "if" -> "if").
+    // span side-table: Term has no span field, so we record spans here keyed
+    // by Term pointer for error reporting.
+    spans map[simplesub.Term]ast.Span
+    errs  []LowerError
+}
+
+func (l *Lowerer) LowerExpr(e ast.Expr) simplesub.Term
+func (l *Lowerer) LowerDecls(decls []ast.Decl, body simplesub.Term) simplesub.Term
+func (l *Lowerer) Errors() []LowerError
+```
+
+`Term` has no provenance/span field today (deliberately — spans are "added in
+integration" per design-notes `errors.go`). M2 keeps `Term` clean and records
+spans in a **side table** keyed by `Term` pointer. This is enough to attach
+spans to lowering errors and, once the core surfaces constraint failures with a
+`Term` reference, to inference errors too.
+
+### 3.3 AST → Term mapping (M2 subset)
+
+Following design-notes "AST lowering":
+
+| Escalier AST | Simple-sub `Term` | Notes |
+|--------------|-------------------|-------|
+| `LiteralExpr` (number) | `Lit` | see §3.4 — `Lit.Value` is `int` today |
+| `LiteralExpr` (string/bool) | `Lit` / builtin `Var` | needs core support (§3.4) |
+| `IdentExpr` | `Var` | unbound → `LowerError` with span |
+| `FuncExpr` (1 param) | `Lam` | direct |
+| `FuncExpr` (n params) | curried `Lam` | `\a b. e` ⇒ `Lam a (Lam b e)` |
+| `CallExpr` (1 arg) | `App` | direct |
+| `CallExpr` (n args) | curried `App` | `f x y` ⇒ `App (App f x) y` |
+| `ObjectExpr` | `Rcd` | shorthand/spread/computed → unsupported error in M2 |
+| `MemberExpr` (`.field`) | `Sel` | computed/optional access → unsupported in M2 |
+| `BinaryExpr` | `App (App (Var op) l) r` | op resolved via builtins env |
+| `IfElseExpr` | `App` of `if` builtin (or dedicated `If`) | see §3.5 |
+| `VarDecl` (value) | `Let{IsRec:false}` | §3.6 |
+| `FuncDecl` | `Let{IsRec:true}` | recursion allowed |
+
+Block bodies (`FuncLit` body, `IfElseExpr` arms) are sequences of statements
+ending in an expression. M2 lowers a block by folding its leading `DeclStmt`s
+into nested `Let`s wrapping the final `ExprStmt`/`ReturnStmt` value (§3.6).
+
+Nodes **explicitly unsupported in M2** (emit a clear `LowerError`, not a panic):
+`ArrayExpr`/`TupleExpr`, `MatchExpr`, `AwaitExpr`, `AssignExpr`, JSX,
+`TemplateLitExpr`, `TypeCastExpr` (M3), `IndexExpr`, `ClassDecl`, `TypeDecl`.
+
+### 3.4 Literals (core touch-up — feeds PR-0 / M1)
+
+`Lit.Value` is `int`. Escalier literals are number/string/bool. Minimum viable
+options, in preference order:
+
+1. **Extend the env, not the term:** keep `Lit` for numbers; lower `true`/`false`
+   to builtin `Var`s (`true`/`false : bool`) and strings to a `str`-typed
+   builtin or a new `Lit` payload. Smallest blast radius if strings are deferred.
+2. **Generalize `Lit`:** change `Lit.Value` to a tagged payload
+   (`Kind: Int|Str|Bool`) and add `int`/`str`/`bool` primitives to the core.
+
+Recommendation: do (2) as a small, well-scoped change because string/bool
+literals appear in nearly every realistic snippet and option (1) leaks encoding
+into the lowering. This is a **core change**, so it belongs in PR-0 (or M1) and
+is a prerequisite for the records/conditionals PRs.
+
+### 3.5 Conditionals
+
+Two encodings (design-notes leaves this open):
+- **Builtin `if`:** `if : bool -> 'a -> 'a -> 'a`, lowered as
+  `App(App(App(Var "if", cond), then), else)`. Reuses the existing `builtins.go`
+  `if`. Zero core change.
+- **Dedicated `If` term:** add `If{Cond, Then, Else}` to the `Term` ADT and type
+  it directly in `infer.go`.
+
+Recommendation: **start with the builtin `if`** (zero core change, matches the
+reference's approach and the existing `builtins.go`). Revisit a dedicated `If`
+only if branch-type precision or error messages demand it.
+
+### 3.6 Decls, blocks, and `letrec`
+
+- A module / block is a list of statements. Lower it right-to-left: the trailing
+  expression is the result `Term`; each preceding `DeclStmt` becomes a `Let`
+  whose `Rest` is the already-lowered remainder.
+- `FuncDecl` ⇒ `Let{IsRec: true}` so self-recursion type-checks.
+- `VarDecl` binding a `FuncExpr` ⇒ also `IsRec: true` (matches the milestone's
+  "`isrec` for functions"); other `VarDecl`s ⇒ `IsRec: false`.
+- Destructuring patterns in `VarDecl` are **out of scope** for M2 (single-name
+  bindings only); emit `LowerError` otherwise.
+
+### 3.7 Driver
+
+```go
+// InferSource lowers a single Escalier expression/module source and returns the
+// inferred, simplified type, or the first lowering/inference error.
+func InferSource(src string) (simplesub.Type, error)
+```
+
+Pipeline: `lexer_util` → `parser` → collect parse diagnostics (fail fast on
+parse errors) → `Lowerer.LowerExpr` / `LowerDecls` → check `Lowerer.Errors()` →
+`simplesub.Infer`. Errors are wrapped so the caller sees span + message. Reuse
+the existing fixture/parse harness conventions where practical, but the driver
+itself is a thin, testable function.
+
+### 3.8 Errors & spans
+
+- `LowerError{Span ast.Span, Msg string}` for unbound names and unsupported
+  nodes. Assert the **full** message in tests (CLAUDE.md convention).
+- Inference errors from the core (`errors.go`) currently lack spans. M2 attaches
+  a span by mapping the failing `Term` back through the side table when the core
+  exposes the offending `Term`; if it doesn't yet, that hook is a small core
+  addition tracked in PR-0/M1. Until then, inference errors surface message-only
+  and span-from-root.
+
+## 4. Testing strategy
+
+- **Lowering unit tests** (`lower_test.go`): parse a snippet, lower it, assert
+  the resulting `Term` tree via `snaps.MatchInlineSnapshot` (per CLAUDE.md, snapshot
+  tree-shaped output rather than drilling field-by-field).
+- **Driver / golden tests** (`driver_test.go`): table-driven, `.esc` snippet →
+  expected simplified type string. Include:
+  - All Simple-sub paper examples, translated to Escalier syntax (milestone exit
+    criterion). Track each against its reference-expected type.
+  - Escalier-flavored snippets: records, field access, curried calls,
+    `if`/ternary, recursive `FuncDecl`.
+  - Error cases: unbound variable, unsupported node, failed constraint — assert
+    full message + span.
+- Use `testify/require`. Keep snippet inputs as Escalier source and expected
+  types as Escalier type-annotation strings (CLAUDE.md).
+- Run with `UPDATE_SNAPS=true` on first authoring.
+
+## 5. Sequencing
+
+```
+PR-0  core API touch-ups (literals, error/term hook)   ── prereq, foldable into M1
+        │
+        ▼
+PR-1  lowering skeleton + driver (lits, idents, lambda, app)
+        │
+        ▼
+PR-2  records + field access            ┐ (PR-2 and PR-3 are
+PR-3  conditionals + binary operators   ┘  independent; either order / parallel)
+        │
+        ▼
+PR-4  decls, blocks, letrec
+        │
+        ▼
+PR-5  paper-example golden suite + error/span polish  ── closes M2 exit criteria
+```
+
+PR-1 must land first (it establishes the `Lowerer`, driver, and test harness).
+PR-2 and PR-3 are independent and can be developed in parallel once PR-1 is in.
+PR-4 depends on the expression coverage from PR-1–PR-3. PR-5 is the
+exit-criteria gate.
+
+## 6. PR breakdown
+
+### PR-0 — Core API touch-ups (prerequisite; fold into M1 if M1 lands first)
+- Generalize `Lit` to carry `int | string | bool` and add the matching
+  primitives + builtins (`true`, `false`, string prim). (§3.4)
+- Add a hook so inference errors can reference the offending `Term` (enables
+  span attachment in M2). If infeasible cheaply, document the gap and ship
+  message-only inference errors.
+- Tests: extend the core's existing example tests for the new literal kinds.
+- **Exit:** core builds, `Infer` handles bool/string literals, existing tests green.
+
+### PR-1 — Lowering skeleton + driver
+- New `internal/simplesub/lower` package: `Lowerer`, span side-table,
+  `LowerError`, `LowerExpr` for `LiteralExpr`/`IdentExpr`/`FuncExpr`/`CallExpr`
+  (with currying), and `InferSource` driver.
+- Unsupported nodes return structured `LowerError` (no panics).
+- Tests: lowering snapshots for the four node kinds; driver round-trips
+  `(fun x -> x)` / identity, application, and an unbound-variable error.
+- **Exit:** `InferSource` infers types for the lambda-calculus subset; errors
+  carry spans.
+
+### PR-2 — Records & field access
+- Lower `ObjectExpr` → `Rcd`, `MemberExpr` → `Sel`.
+- Reject shorthand/spread/computed members with `LowerError`.
+- Tests: record literal type, field selection, row-polymorphic function
+  (`fun r -> r.x`), missing-field constraint failure.
+- **Exit:** record snippets infer expected structural types.
+
+### PR-3 — Conditionals & binary operators
+- Lower `IfElseExpr` via the `if` builtin (§3.5); lower `BinaryExpr` via builtin
+  operator `Var`s.
+- Ensure both `if`/`else` and ternary forms route through the same path.
+- Tests: `if`-expression type (join of branches), arithmetic/comparison
+  operators, branch-type-mismatch behavior.
+- **Exit:** conditional and operator snippets infer expected types.
+
+### PR-4 — Decls, blocks, and `letrec`
+- Lower `VarDecl`/`FuncDecl` and statement blocks → nested `Let` (§3.6), with
+  `IsRec` for functions.
+- Single-name bindings only; destructuring → `LowerError`.
+- Tests: `let` polymorphism (`let id = fun x -> x in (id 1, id true)`-style),
+  recursive function, sequenced bindings in a block.
+- **Exit:** multi-binding modules infer end-to-end; `let` generalization works.
+
+### PR-5 — Paper examples + error/span polish
+- Add `testdata/*.esc` for every Simple-sub paper example with its expected
+  simplified type; wire into the golden table.
+- Tighten error messages and ensure unbound-variable and failed-constraint
+  errors report correct spans.
+- Update milestone status in `01-milestones.md` (`M2` → `[x]`).
+- **Exit (M2 exit criteria):** paper examples infer expected types; errors are
+  reported with source spans.
+
+## 7. Risks & mitigations
+
+- **M1 not done:** M2's API dependency may churn. *Mitigation:* keep the
+  lowering's dependency on the core to `Term` constructors + `Infer`; isolate any
+  core change in PR-0 so it can merge into M1.
+- **`Term` has no span:** can't attach spans natively. *Mitigation:* span
+  side-table keyed by `Term` pointer; add a core error→Term hook in PR-0.
+- **Literal encoding leak:** deferring string/bool support would push encoding
+  hacks into the lowering. *Mitigation:* generalize `Lit` up front (PR-0, §3.4).
+- **Currying vs n-ary divergence from eventual checker types:** curried lowering
+  produces curried function types that won't match Escalier's n-ary `FuncType`.
+  *Mitigation:* acceptable for M2 (types asserted in simplesub's own surface);
+  flag n-ary `Lam`/`App` as an M7 decision point (design-notes already notes
+  this).
+- **Scope creep from richer AST nodes:** *Mitigation:* explicit "unsupported in
+  M2" list (§3.3) that fails with a clear error rather than partial handling.
+
+## 8. Resolved decisions (milestone "open questions")
+
+- **Reuse `ast` vs. dedicated surface syntax?** → Reuse the existing `ast`
+  package; no new surface syntax (design-notes "AST lowering" already commits to
+  this).
+- **Where does lowering live so it's shareable with checker integration?** →
+  `internal/simplesub/lower`, behind the `Lowerer` interface, so the core stays
+  AST-free and M7 can supply richer coverage against the same seam.
+
+## 9. M2 exit checklist
+
+- [ ] Lowering covers literals, identifiers, lambdas/functions, application,
+      `let`/`letrec`, records, field access, conditionals.
+- [ ] `InferSource` driver runs lexer → parser → lower → `Infer`.
+- [ ] Golden tests assert inferred + simplified types over `.esc` snippets.
+- [ ] Simple-sub paper examples have Escalier equivalents inferring expected types.
+- [ ] Unbound variables and failed constraints report errors with source spans.
+- [ ] `01-milestones.md` M2 status set to `[x]`.

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -1,334 +1,333 @@
-# M2 Implementation Plan — AST → Simple-sub lowering
+# M2 Implementation Plan — Parser/resolver bridge
 
-> Companion to [`01-milestones.md`](01-milestones.md) (M2 entry) and
-> [`02-design-notes.md`](02-design-notes.md) ("AST lowering" section).
-> Status legend: `[ ]` not started · `[~]` in progress · `[x]` complete
+> Companion to [`01-milestones.md`](01-milestones.md) (the **M2 — Parser/resolver
+> bridge** entry) and [`02-design-notes.md`](02-design-notes.md)
+> (§"The constraint-generating AST walk", §"Scope / Binding", §"`Info` side
+> table"). Status legend: `[ ]` not started · `[~]` in progress · `[x]` complete.
 
-## 1. Goal & scope
+## 1. What M2 is (and is not)
 
-M2 connects the standalone Simple-sub core to real Escalier source. We lower a
-useful subset of the `ast` package into Simple-sub `Term`s, add a driver that
-runs `lexer → parser → lower → Infer`, and assert inferred (and simplified)
-types over `.esc` snippets.
+**M2 replaces the spike's hand-built expression IR with a real
+constraint-generating walk over `*ast.Module`.** The spike
+(`internal/simplesub/`) proved the algorithm against a toy `Term` ADT
+(`Lit`/`Var`/`Lam`/`App`/`Let`/…) driven by `typeTerm`. M2 throws that IR away
+and drives the *same algorithm* — now living in the M1 package — directly from
+real parsed source, resolved through the existing `dep_graph`/`resolver`, with
+results recorded in the `Info` side table.
 
-**In scope (per the milestone):**
-- A lowering layer mapping `ast.Expr` / `ast.Decl` → Simple-sub `Term`.
-- Coverage for: literals, identifiers, lambdas/functions, application, `let` /
-  `letrec` bindings, records, field access, conditionals.
-- A driver returning the inferred type for a source string.
-- Golden tests over `.esc` snippets, including the Simple-sub paper examples
-  translated to Escalier syntax.
-- Error reporting (unbound variables, failed constraints) carrying source spans.
+Per the milestone, M2 delivers:
 
-**Out of scope (later milestones):**
-- Type annotations / ascription (M3).
-- Variants and pattern matching beyond plain records (M4).
-- Recursive types surfaced as named types, full `let` generalization polish (M5).
-- Effects / throws / async (M6).
-- Mapping `simplesub.Type` → `type_system.Type`, checker/codegen wiring (M7).
-- Diagnostics polish and provenance threading (M8).
+1. **Drive from real source.** `parser.Parse*` → `*ast.Module` →
+   `dep_graph`/`resolver` → a constraint-generating AST visitor that produces
+   `soltype` types and populates `Info`.
+2. **Own `Scope`/`Binding`/`Namespace`.** Analogues owned by the new package,
+   *not* reused from `internal/type_system/`.
+3. **A fixture-style harness.** Given `.esc` source, infer and assert the
+   rendered binding types — its own assertions, independent of the old checker.
 
-The lowering must sit **behind a small interface** so M7 can widen AST coverage
-without rewriting the core (design-notes "AST lowering").
+**Exit criteria (from the milestone):**
+- Top-level `val`/`fn` declarations from real source infer correct rendered
+  types end-to-end.
+- A multi-file module resolves via the dep graph.
 
-## 2. Current state (what M2 builds on)
+**Gate (from the milestone):** if driving from the real AST/dep-graph requires
+reaching back into the old checker's internals, the parallel-package boundary is
+wrong — **stop and reassess**.
 
-- **Spike core** lives in `internal/simplesub/` (commit #676): `term.go`,
-  `types.go`, `infer.go`, `simplify.go`, `builtins.go`, `errors.go`.
-- **Public API today:** `func Infer(term Term) (Type, error)` — fresh context per
-  call, returns a coalesced surface `Type`. (`infer.go`)
-- **`Term` ADT (curried):** `Lit{Value int}`, `Var{Name}`, `Lam{Name, Body}`,
-  `App{Func, Arg}`, `Rcd{Fields}`, `Sel{Term, Name}`,
-  `Let{IsRec, Name, Body, Rest}`. (`term.go`)
-- **Default environment** (`builtins.go`): `bool`, `+`, `if`, etc.
-- **Escalier AST expression nodes** (`internal/ast/expr.go`): `LiteralExpr`,
-  `IdentExpr`, `FuncExpr` (`Fn *FuncLit`, with `FuncSig` + body, **n-ary** params),
-  `CallExpr` (`Callee`, `Args []Expr`), `ObjectExpr` (`Elems []ObjectExprElem`),
-  `MemberExpr`, `IfElseExpr`, `BinaryExpr`, `TupleExpr`, `ArrayExpr`, …
-- **Decls:** `VarDecl`, `FuncDecl`, `TypeDecl`, `ClassDecl`.
-  **Stmts:** `DeclStmt`, `ExprStmt`, `ReturnStmt`.
+### Scope boundary against neighbouring milestones
 
-### Dependency on M1
+- **M1 (prerequisite — Package skeleton + `soltype`)** must land first. It
+  creates the new package (sibling to `internal/checker/`, leaf name TBD —
+  `internal/solver/` is the working name), the `soltype` representation
+  (bound-list `TypeVar` with `lowerBounds`/`upperBounds` + `level`, `Primitive`,
+  `Literal`, `Function`, `Tuple`), `constrain`, levels/extrusion, polarity-driven
+  coalescing, the **own** `soltype` printer, and the `Info` side table
+  (`map[ast.Node]soltype.Type` + `TypeOf`/`setType`). M2 consumes all of these;
+  it does not modify the core algorithm.
+- **M2 expression coverage is deliberately shallow.** The milestone's bar is
+  "top-level `val`/`fn` infer correct rendered types end-to-end" plus multi-file
+  resolution. The *deep* function/application/let-polymorphism work — and its
+  acceptance cases (`TopLevelLetPolymorphism`, `IdentityPolymorphism`,
+  `InnerCapturesOuterParam`) plus the simplification pass and function
+  exactness — is **M3**. M2 wires up enough of the walk to satisfy its own
+  acceptance (literals, identifiers, simple `val` initializers, `fn` decls with
+  bodies the spike already handles) and leaves richer expression coverage and
+  polish to M3.
+- **Records/`mut`/lifetimes (M4), classes (M5), unions (M6), operators (M8)**
+  are out of scope. Unsupported expression/decl nodes produce a structured
+  "unsupported in M2" error, never a panic.
 
-M2's deliverables ("a clean API the lowering can depend on") assume M1 has
-stabilized the core API. M1 is not yet started and M0 is in progress. Two viable
-sequencings:
+## 2. Current state this builds on
 
-- **Preferred:** land M1's API freeze first (at minimum the items in §6 PR-0),
-  then build M2 against it.
-- **Pragmatic (parallel):** start M2 against the current M0 `Infer`/`Term`
-  surface, but treat any churn in that surface as M1 work and keep the lowering's
-  dependency on the core narrow (only `Term` constructors + `Infer`). This plan
-  assumes the pragmatic path with an explicit "API touch-ups" PR (PR-0) that can
-  be folded into M1 if M1 lands first.
+- **Spike core** (`internal/simplesub/`): `typeTerm` (the recursive
+  switch we are re-targeting), `constrain`, `coalesce`, `simplify`, levels via
+  `scheme.go` (`MonoScheme`/`PolyScheme`, `instantiate`/`freshenAbove`),
+  `LetRecGroup` (fresh var per binding + `constrain` + generalize — the
+  recursion story that avoids placeholder patching). The spike's `Infer` returns
+  `(type_system.Type, []error)` and renders via `type_system.PrintType`; M1
+  re-homes this onto `soltype` with its own printer.
+- **AST** (`internal/ast/`): expression nodes the walk must handle for the M2
+  bar — `LiteralExpr`, `IdentExpr`, `FuncExpr` (`FuncSig` at `expr.go:326`,
+  `FuncExpr` at `expr.go:335`), `CallExpr`, `ObjectExpr`, `MemberExpr`,
+  `TupleExpr`, `IfElseExpr`, `BinaryExpr`, plus `Block` (`expr.go:905`). Decls:
+  `VarDecl` (`decl.go:40`), `FuncDecl`, with `Param` at `decl.go:101`. Stmts:
+  `DeclStmt`, `ExprStmt`, `ReturnStmt`.
+- **Reusable as-is** (overview boundary analysis): `parser`, `ast`, `resolver`,
+  `dep_graph`, `set`, `provenance`, `liveness`, `interop`. M2 must consume these
+  **without** touching `internal/checker/` or `internal/type_system/` (that is
+  the gate).
+- **Compiler entry points: 3** (`CheckLib`, `Compile`, `CompilePackage` in
+  `internal/compiler/compiler.go`). M2 does **not** wire into these — the new
+  checker is exercised only through M2's own harness. Compiler wiring behind a
+  flag is M7.
 
 ## 3. Design
 
 ### 3.1 Package layout
 
+Inside the M1 package (working name `internal/solver/`):
+
 ```
-internal/simplesub/
-  lower/
-    lower.go        # Lowerer + Expr/Decl/Stmt → Term entry points
-    lower_expr.go   # per-expression-kind lowering
-    lower_decl.go   # VarDecl/FuncDecl → Let/letrec
-    builtins.go     # surface-name → builtin Var mapping shared with the env
-    errors.go       # LowerError (unsupported node, unbound name) with spans
-    driver.go       # InferSource(src) — lexer→parser→lower→Infer
-    lower_test.go
-    driver_test.go
-  testdata/
-    *.esc           # paper examples + Escalier-specific snippets
+internal/solver/
+  infer.go        # constraint-generating walk over *ast.Module (production typeTerm)
+  infer_expr.go   # per-expression-kind constraint generation
+  infer_decl.go   # VarDecl / FuncDecl → bindings, SCC group inference
+  module.go       # InferModule: dep_graph SCC ordering + resolver + drive the walk
+  scope.go        # Scope / Binding / Namespace (own, not type_system)
+  errors.go       # bridge errors (unbound name, unsupported node) with provenance/spans
+  // (soltype core, Info side table, printer: from M1)
+  testdata/ or fixtures wiring   # see §3.6
 ```
 
-Rationale for a sub-package (`internal/simplesub/lower`) rather than living in
-`internal/simplesub`: it keeps the core free of any `ast`/`parser` dependency
-(the core stays a pure algorithm package), and it gives M7 a clear seam — the
-checker integration can provide an alternative lowering target without importing
-this package. The "small interface" is the `Lowerer` type below.
+### 3.2 The constraint-generating walk (`infer.go`)
 
-### 3.2 The lowering interface
+The production analogue of the spike's `typeTerm`. Two realistic shapes:
+
+- **Direct recursive switch** over `ast.Expr`/`ast.Stmt`/`ast.Decl`, mirroring
+  the spike's `typeTerm` (returns `(soltype.Type, []error)` and threads a
+  `*Scope` + `level`). This is the natural fit: constraint generation is
+  bottom-up and value-producing, which the AST's enter/exit `Visitor`
+  (`internal/ast/visitor.go`, designed for transformation) does not model
+  cleanly.
+- **AST `Visitor`** — rejected for the expression walk: CLAUDE.md says prefer
+  the existing visitor for traversals, but that visitor returns no synthesized
+  value per node and is shaped for rewriting, not type synthesis. A direct
+  switch matching the spike (and the old checker's `inferExpr`) is the right
+  call; note this deviation explicitly in the PR.
+
+Each node maps to the constraint the spike already established, now over real
+AST instead of `Term`:
+
+| AST node | Constraint (per spike `typeTerm`) | Records into `Info`? |
+|----------|-----------------------------------|----------------------|
+| `LiteralExpr` | `Literal` soltype | yes |
+| `IdentExpr` | resolve via `Scope` → `instantiate` scheme | yes |
+| `FuncExpr` | `Function{params, ret}`; params get fresh vars | yes |
+| `CallExpr` | fresh `res`; `constrain(fn, Function{args, res})` | yes |
+| `BinaryExpr` | operator scheme from builtins env | yes |
+| `TupleExpr` | `Tuple{elems}` | yes |
+| `ObjectExpr` | `Record{fields}` (basic; usage-inference is M4) | yes |
+| `MemberExpr` | `constrain(recv, Record{name: fresh})` (basic; M4 deepens) | yes |
+| `IfElseExpr` | join branches; `constrain(cond, boolean)` | yes |
+| `Block` | type each stmt; result = last expr (or `void`) | yes |
+
+Every node that produces a type calls the M1 `Info.setType(node, t)` so the side
+table is the single source of truth for node→type (the AST stays untouched — no
+`InferredType()` writes; that is the AST-decoupling decision). Nodes outside the
+M2 subset emit an "unsupported in M2" error.
+
+### 3.3 Module driver (`module.go`) — dep_graph + resolver
+
+The milestone's spine: `parser.Parse*` → `*ast.Module` → `dep_graph`/`resolver`
+→ walk.
+
+- **Name resolution** runs through the existing `resolver` so identifiers bind
+  to their declarations/namespaces before inference. M2 *consumes* resolver
+  output; it does not reimplement resolution.
+- **Declaration ordering** comes from `dep_graph`: top-level declarations are
+  grouped into strongly-connected components (SCCs) and processed in dependency
+  order. This is exactly how the old `infer_module.go` consumes the dep graph —
+  M2 reuses the same `dep_graph` package, but feeds its SCCs into the new walk.
+- **Recursive groups need no placeholder phase.** Where the old checker uses a
+  placeholder/`typeRefsToUpdate` patching pass for cross-declaration recursion
+  (`infer_module.go`), the simple-sub approach handles an SCC the way the spike's
+  `LetRecGroup` does: give each binding in the SCC a fresh var at `level+1`, make
+  all of them visible in every body, `constrain` each body `<:` its var, then
+  generalize the whole group at the shared level. M2 lifts this pattern from the
+  spike to operate over a `dep_graph` SCC of `VarDecl`/`FuncDecl`. This is the
+  single biggest simplification the bridge buys and should be called out.
+- **Multi-file** falls out of the dep graph spanning modules: the driver builds
+  the graph across the parsed modules and resolves cross-module references
+  through the resolver + the new `Namespace` (below).
+
+Entry point (working signature):
 
 ```go
-// Lowerer translates a subset of the Escalier AST into Simple-sub Terms.
-type Lowerer struct {
-    // builtins maps surface operator/keyword names to the Var names bound in
-    // simplesub's default environment (e.g. "+" -> "+", "if" -> "if").
-    // span side-table: Term has no span field, so we record spans here keyed
-    // by Term pointer for error reporting.
-    spans map[simplesub.Term]ast.Span
-    errs  []LowerError
-}
-
-func (l *Lowerer) LowerExpr(e ast.Expr) simplesub.Term
-func (l *Lowerer) LowerDecls(decls []ast.Decl, body simplesub.Term) simplesub.Term
-func (l *Lowerer) Errors() []LowerError
+// InferModule resolves and infers every top-level declaration in the parsed
+// module(s), populating Info and returning the module Scope plus errors.
+func InferModule(modules []*ast.Module) (*Scope, *Info, []error)
 ```
 
-`Term` has no provenance/span field today (deliberately — spans are "added in
-integration" per design-notes `errors.go`). M2 keeps `Term` clean and records
-spans in a **side table** keyed by `Term` pointer. This is enough to attach
-spans to lowering errors and, once the core surfaces constraint failures with a
-`Term` reference, to inference errors too.
+### 3.4 Scope / Binding / Namespace (own, not `type_system`)
 
-### 3.3 AST → Term mapping (M2 subset)
+A minimal, package-owned analogue (the milestone forbids reusing
+`type_system`'s):
 
-Following design-notes "AST lowering":
+- `Binding` — a name's `soltype` scheme (`MonoScheme`/`PolyScheme`) plus its
+  source provenance.
+- `Scope` — parent-linked name→`Binding` lookup, the production analogue of the
+  spike's `ctx map[string]TypeScheme`.
+- `Namespace` — the module/namespace grouping that cross-module resolution
+  resolves through.
 
-| Escalier AST | Simple-sub `Term` | Notes |
-|--------------|-------------------|-------|
-| `LiteralExpr` (number) | `Lit` | see §3.4 — `Lit.Value` is `int` today |
-| `LiteralExpr` (string/bool) | `Lit` / builtin `Var` | needs core support (§3.4) |
-| `IdentExpr` | `Var` | unbound → `LowerError` with span |
-| `FuncExpr` (1 param) | `Lam` | direct |
-| `FuncExpr` (n params) | curried `Lam` | `\a b. e` ⇒ `Lam a (Lam b e)` |
-| `CallExpr` (1 arg) | `App` | direct |
-| `CallExpr` (n args) | curried `App` | `f x y` ⇒ `App (App f x) y` |
-| `ObjectExpr` | `Rcd` | shorthand/spread/computed → unsupported error in M2 |
-| `MemberExpr` (`.field`) | `Sel` | computed/optional access → unsupported in M2 |
-| `BinaryExpr` | `App (App (Var op) l) r` | op resolved via builtins env |
-| `IfElseExpr` | `App` of `if` builtin (or dedicated `If`) | see §3.5 |
-| `VarDecl` (value) | `Let{IsRec:false}` | §3.6 |
-| `FuncDecl` | `Let{IsRec:true}` | recursion allowed |
+Keep this deliberately small in M2 — only what top-level `val`/`fn` +
+multi-file resolution require. It grows with later milestones (types,
+lifetimes, classes).
 
-Block bodies (`FuncLit` body, `IfElseExpr` arms) are sequences of statements
-ending in an expression. M2 lowers a block by folding its leading `DeclStmt`s
-into nested `Let`s wrapping the final `ExprStmt`/`ReturnStmt` value (§3.6).
+### 3.5 Errors & provenance
 
-Nodes **explicitly unsupported in M2** (emit a clear `LowerError`, not a panic):
-`ArrayExpr`/`TupleExpr`, `MatchExpr`, `AwaitExpr`, `AssignExpr`, JSX,
-`TemplateLitExpr`, `TypeCastExpr` (M3), `IndexExpr`, `ClassDecl`, `TypeDecl`.
+- Bridge errors (`errors.go`): unbound name, unsupported node — carry
+  `provenance`/source spans from the AST node (reuse `internal/provenance/`).
+- Inference errors from the core (`constrain` failures) attach the offending
+  node's provenance via the `Info`/provenance side table (M1 provides the
+  mechanism; M2 supplies the AST node). Assert **full** messages in tests
+  (CLAUDE.md).
 
-### 3.4 Literals (core touch-up — feeds PR-0 / M1)
+### 3.6 Fixture-style harness
 
-`Lit.Value` is `int`. Escalier literals are number/string/bool. Minimum viable
-options, in preference order:
+Two complementary test surfaces, matching the milestone's "fixture-style harness
+… its own assertions, independent of the old checker":
 
-1. **Extend the env, not the term:** keep `Lit` for numbers; lower `true`/`false`
-   to builtin `Var`s (`true`/`false : bool`) and strings to a `str`-typed
-   builtin or a new `Lit` payload. Smallest blast radius if strings are deferred.
-2. **Generalize `Lit`:** change `Lit.Value` to a tagged payload
-   (`Kind: Int|Str|Bool`) and add `int`/`str`/`bool` primitives to the core.
+- **Table-driven `*_test.go`** in the new package: `.esc` snippet → expected
+  rendered binding type string (using the M1 `soltype` printer). This is the
+  primary M2 surface — fast, no per-case package overhead, mirrors the spike's
+  existing `simplesub_test.go` pattern and the checker-tests pattern in
+  `internal/checker/tests/`.
+- **A real `fixtures/`-style harness** (sibling to
+  `cmd/escalier/fixture_test.go`) for the multi-file/dep-graph acceptance:
+  `fixtures/<name>/lib/index.esc` (+ `package.json`) → resolve via dep graph →
+  assert rendered top-level binding types. This proves the dep-graph/multi-file
+  path end-to-end, which a single-snippet table test can't.
 
-Recommendation: do (2) as a small, well-scoped change because string/bool
-literals appear in nearly every realistic snippet and option (1) leaks encoding
-into the lowering. This is a **core change**, so it belongs in PR-0 (or M1) and
-is a prerequisite for the records/conditionals PRs.
+Assert inferred types as Escalier type-annotation strings; use `testify/require`
+(CLAUDE.md). For tree-shaped assertions prefer `snaps.MatchInlineSnapshot` over
+field-by-field drilling.
 
-### 3.5 Conditionals
-
-Two encodings (design-notes leaves this open):
-- **Builtin `if`:** `if : bool -> 'a -> 'a -> 'a`, lowered as
-  `App(App(App(Var "if", cond), then), else)`. Reuses the existing `builtins.go`
-  `if`. Zero core change.
-- **Dedicated `If` term:** add `If{Cond, Then, Else}` to the `Term` ADT and type
-  it directly in `infer.go`.
-
-Recommendation: **start with the builtin `if`** (zero core change, matches the
-reference's approach and the existing `builtins.go`). Revisit a dedicated `If`
-only if branch-type precision or error messages demand it.
-
-### 3.6 Decls, blocks, and `letrec`
-
-- A module / block is a list of statements. Lower it right-to-left: the trailing
-  expression is the result `Term`; each preceding `DeclStmt` becomes a `Let`
-  whose `Rest` is the already-lowered remainder.
-- `FuncDecl` ⇒ `Let{IsRec: true}` so self-recursion type-checks.
-- `VarDecl` binding a `FuncExpr` ⇒ also `IsRec: true` (matches the milestone's
-  "`isrec` for functions"); other `VarDecl`s ⇒ `IsRec: false`.
-- Destructuring patterns in `VarDecl` are **out of scope** for M2 (single-name
-  bindings only); emit `LowerError` otherwise.
-
-### 3.7 Driver
-
-```go
-// InferSource lowers a single Escalier expression/module source and returns the
-// inferred, simplified type, or the first lowering/inference error.
-func InferSource(src string) (simplesub.Type, error)
-```
-
-Pipeline: `lexer_util` → `parser` → collect parse diagnostics (fail fast on
-parse errors) → `Lowerer.LowerExpr` / `LowerDecls` → check `Lowerer.Errors()` →
-`simplesub.Infer`. Errors are wrapped so the caller sees span + message. Reuse
-the existing fixture/parse harness conventions where practical, but the driver
-itself is a thin, testable function.
-
-### 3.8 Errors & spans
-
-- `LowerError{Span ast.Span, Msg string}` for unbound names and unsupported
-  nodes. Assert the **full** message in tests (CLAUDE.md convention).
-- Inference errors from the core (`errors.go`) currently lack spans. M2 attaches
-  a span by mapping the failing `Term` back through the side table when the core
-  exposes the offending `Term`; if it doesn't yet, that hook is a small core
-  addition tracked in PR-0/M1. Until then, inference errors surface message-only
-  and span-from-root.
-
-## 4. Testing strategy
-
-- **Lowering unit tests** (`lower_test.go`): parse a snippet, lower it, assert
-  the resulting `Term` tree via `snaps.MatchInlineSnapshot` (per CLAUDE.md, snapshot
-  tree-shaped output rather than drilling field-by-field).
-- **Driver / golden tests** (`driver_test.go`): table-driven, `.esc` snippet →
-  expected simplified type string. Include:
-  - All Simple-sub paper examples, translated to Escalier syntax (milestone exit
-    criterion). Track each against its reference-expected type.
-  - Escalier-flavored snippets: records, field access, curried calls,
-    `if`/ternary, recursive `FuncDecl`.
-  - Error cases: unbound variable, unsupported node, failed constraint — assert
-    full message + span.
-- Use `testify/require`. Keep snippet inputs as Escalier source and expected
-  types as Escalier type-annotation strings (CLAUDE.md).
-- Run with `UPDATE_SNAPS=true` on first authoring.
-
-## 5. Sequencing
+## 4. Sequencing
 
 ```
-PR-0  core API touch-ups (literals, error/term hook)   ── prereq, foldable into M1
+M1 (package skeleton + soltype + Info + printer)   ── prerequisite
         │
         ▼
-PR-1  lowering skeleton + driver (lits, idents, lambda, app)
+PR-1  Scope/Binding/Namespace + expression walk skeleton (lits, idents)
         │
         ▼
-PR-2  records + field access            ┐ (PR-2 and PR-3 are
-PR-3  conditionals + binary operators   ┘  independent; either order / parallel)
+PR-2  single-decl driver: VarDecl/FuncDecl, table harness, val/fn end-to-end
         │
         ▼
-PR-4  decls, blocks, letrec
+PR-3  dep_graph SCC ordering + recursive-group (LetRecGroup) inference
         │
         ▼
-PR-5  paper-example golden suite + error/span polish  ── closes M2 exit criteria
+PR-4  resolver wiring + multi-file fixtures harness  ── closes M2 exit criteria
 ```
 
-PR-1 must land first (it establishes the `Lowerer`, driver, and test harness).
-PR-2 and PR-3 are independent and can be developed in parallel once PR-1 is in.
-PR-4 depends on the expression coverage from PR-1–PR-3. PR-5 is the
-exit-criteria gate.
+PR-1 establishes the package-owned `Scope` and the value-returning walk against
+M1's `soltype`/`Info`. PR-2 makes a *single* module's top-level `val`/`fn`
+infer end-to-end with the table harness — the first half of the exit bar. PR-3
+brings in dep-graph SCC ordering and recursive groups (still single-file). PR-4
+adds resolver-driven cross-module resolution and the `fixtures/` harness,
+closing the multi-file half of the exit bar. PRs are mostly linear because each
+depends on the prior layer's plumbing; PR-2's table harness and PR-1's walk
+skeleton are the only pieces that could overlap.
 
-## 6. PR breakdown
+## 5. PR breakdown
 
-### PR-0 — Core API touch-ups (prerequisite; fold into M1 if M1 lands first)
-- Generalize `Lit` to carry `int | string | bool` and add the matching
-  primitives + builtins (`true`, `false`, string prim). (§3.4)
-- Add a hook so inference errors can reference the offending `Term` (enables
-  span attachment in M2). If infeasible cheaply, document the gap and ship
-  message-only inference errors.
-- Tests: extend the core's existing example tests for the new literal kinds.
-- **Exit:** core builds, `Infer` handles bool/string literals, existing tests green.
+### PR-1 — Scope + expression-walk skeleton
+- `scope.go`: `Scope`/`Binding`/`Namespace` (minimal).
+- `infer.go`/`infer_expr.go`: value-returning recursive walk over `ast.Expr`
+  for `LiteralExpr`, `IdentExpr` (via `Scope`), writing into `Info`.
+- Unsupported nodes return a structured error (no panic).
+- Tests: literal type; identifier resolves to its binding's scheme; unbound
+  identifier → full-message error with span.
+- **Exit:** the walk types the trivial expression subset against `soltype`/`Info`.
 
-### PR-1 — Lowering skeleton + driver
-- New `internal/simplesub/lower` package: `Lowerer`, span side-table,
-  `LowerError`, `LowerExpr` for `LiteralExpr`/`IdentExpr`/`FuncExpr`/`CallExpr`
-  (with currying), and `InferSource` driver.
-- Unsupported nodes return structured `LowerError` (no panics).
-- Tests: lowering snapshots for the four node kinds; driver round-trips
-  `(fun x -> x)` / identity, application, and an unbound-variable error.
-- **Exit:** `InferSource` infers types for the lambda-calculus subset; errors
-  carry spans.
+### PR-2 — Single-module decl driver + table harness
+- `infer_decl.go`: `VarDecl` → `Binding`; `FuncDecl` → `Function` binding,
+  walking the body with the spike's function/let machinery (as re-homed in M1).
+- `module.go`: a first `InferModule` that handles one module, declarations in
+  source order (no SCC yet), populating `Scope` + `Info`.
+- Table-driven harness: `.esc` snippet → rendered top-level binding type.
+- Tests: `val x = 5` ⇒ `5`/`number` per M1 widening; a simple `fn` infers its
+  rendered type; an expression-stmt module.
+- **Exit:** top-level `val`/`fn` in a *single* module infer correct rendered
+  types end-to-end (first half of the milestone bar).
 
-### PR-2 — Records & field access
-- Lower `ObjectExpr` → `Rcd`, `MemberExpr` → `Sel`.
-- Reject shorthand/spread/computed members with `LowerError`.
-- Tests: record literal type, field selection, row-polymorphic function
-  (`fun r -> r.x`), missing-field constraint failure.
-- **Exit:** record snippets infer expected structural types.
+### PR-3 — dep_graph SCC ordering + recursive groups
+- `module.go`: build the dependency graph from the module, process top-level
+  decls in SCC order.
+- Lift the spike's `LetRecGroup` pattern to a `dep_graph` SCC: fresh var per
+  binding at `level+1`, all visible in every body, `constrain` body `<:` var,
+  generalize the group at the shared level. **No placeholder/patching phase.**
+- Tests: self-recursive `fn`; mutually-recursive `fn` pair; a decl that
+  forward-references a later decl resolves via SCC ordering.
+- **Exit:** recursive and out-of-order top-level decls infer correctly in one
+  module.
 
-### PR-3 — Conditionals & binary operators
-- Lower `IfElseExpr` via the `if` builtin (§3.5); lower `BinaryExpr` via builtin
-  operator `Var`s.
-- Ensure both `if`/`else` and ternary forms route through the same path.
-- Tests: `if`-expression type (join of branches), arithmetic/comparison
-  operators, branch-type-mismatch behavior.
-- **Exit:** conditional and operator snippets infer expected types.
+### PR-4 — resolver wiring + multi-file fixtures harness
+- Wire the existing `resolver` so identifiers (incl. cross-module) bind before
+  inference; resolve through the new `Namespace`.
+- `module.go`: accept multiple parsed modules; build the dep graph across them.
+- Add a `fixtures/`-style harness (sibling to `cmd/escalier/fixture_test.go`)
+  asserting rendered top-level binding types for a multi-file fixture.
+- Tests: a two-file fixture where file B imports a `val`/`fn` from file A and the
+  inferred types render correctly end-to-end.
+- Update `01-milestones.md` M2 status.
+- **Exit (M2 exit criteria):** multi-file module resolves via the dep graph;
+  top-level `val`/`fn` infer correct rendered types end-to-end.
 
-### PR-4 — Decls, blocks, and `letrec`
-- Lower `VarDecl`/`FuncDecl` and statement blocks → nested `Let` (§3.6), with
-  `IsRec` for functions.
-- Single-name bindings only; destructuring → `LowerError`.
-- Tests: `let` polymorphism (`let id = fun x -> x in (id 1, id true)`-style),
-  recursive function, sequenced bindings in a block.
-- **Exit:** multi-binding modules infer end-to-end; `let` generalization works.
+## 6. Risks & mitigations
 
-### PR-5 — Paper examples + error/span polish
-- Add `testdata/*.esc` for every Simple-sub paper example with its expected
-  simplified type; wire into the golden table.
-- Tighten error messages and ensure unbound-variable and failed-constraint
-  errors report correct spans.
-- Update milestone status in `01-milestones.md` (`M2` → `[x]`).
-- **Exit (M2 exit criteria):** paper examples infer expected types; errors are
-  reported with source spans.
+- **Gate — reaching into old checker internals.** Driving from
+  AST/dep-graph/resolver must not pull in `internal/checker/` or
+  `internal/type_system/`. *Mitigation:* a package-boundary test/lint that the
+  new package imports neither; if dep_graph/resolver turn out to expose
+  checker-coupled types, that is the milestone's stop-and-reassess signal — raise
+  it rather than working around it.
+- **dep_graph/resolver coupling to `type_system`.** If those packages return
+  `type_system`-flavoured data, the bridge leaks. *Mitigation:* consume only
+  their structural outputs (names, SCCs, resolution edges); keep all *type* data
+  in `soltype`/`Info`.
+- **Walk vs. AST `Visitor` deviation.** Using a direct switch instead of the
+  shared visitor is a deliberate departure from the CLAUDE.md convention.
+  *Mitigation:* document the rationale (value-synthesis vs. transformation) in
+  the PR; it matches both the spike and the old checker's `inferExpr`.
+- **Scope creep into M3/M4.** Records/usage-inference, full let-polymorphism
+  polish, simplification, exactness are *not* M2. *Mitigation:* the explicit
+  "unsupported in M2" error path and the shallow-coverage table in §3.2.
+- **Curried-Term assumptions in the spike.** The spike curries `Lam`/`App`;
+  Escalier `FuncExpr`/`CallExpr` are n-ary. *Mitigation:* the production walk
+  builds n-ary `Function` constraints directly (the spike's `typeTerm` `*Lam`
+  case already supports multi-param), so no currying shim is needed.
 
-## 7. Risks & mitigations
+## 7. Open questions to resolve during M2
 
-- **M1 not done:** M2's API dependency may churn. *Mitigation:* keep the
-  lowering's dependency on the core to `Term` constructors + `Infer`; isolate any
-  core change in PR-0 so it can merge into M1.
-- **`Term` has no span:** can't attach spans natively. *Mitigation:* span
-  side-table keyed by `Term` pointer; add a core error→Term hook in PR-0.
-- **Literal encoding leak:** deferring string/bool support would push encoding
-  hacks into the lowering. *Mitigation:* generalize `Lit` up front (PR-0, §3.4).
-- **Currying vs n-ary divergence from eventual checker types:** curried lowering
-  produces curried function types that won't match Escalier's n-ary `FuncType`.
-  *Mitigation:* acceptable for M2 (types asserted in simplesub's own surface);
-  flag n-ary `Lam`/`App` as an M7 decision point (design-notes already notes
-  this).
-- **Scope creep from richer AST nodes:** *Mitigation:* explicit "unsupported in
-  M2" list (§3.3) that fails with a clear error rather than partial handling.
+- **Final package name.** M1 picks the leaf (working name `internal/solver/`);
+  M2 inherits it. No new decision unless M1 defers it.
+- **How much resolver to drive in M2 vs. defer.** If full namespace resolution
+  is heavier than the val/fn bar needs, PR-4 can scope to the minimum
+  cross-module resolution that satisfies the multi-file acceptance and leave
+  richer namespace semantics to later milestones — decide when PR-4 starts,
+  based on what `resolver` already provides.
 
-## 8. Resolved decisions (milestone "open questions")
+## 8. M2 exit checklist
 
-- **Reuse `ast` vs. dedicated surface syntax?** → Reuse the existing `ast`
-  package; no new surface syntax (design-notes "AST lowering" already commits to
-  this).
-- **Where does lowering live so it's shareable with checker integration?** →
-  `internal/simplesub/lower`, behind the `Lowerer` interface, so the core stays
-  AST-free and M7 can supply richer coverage against the same seam.
-
-## 9. M2 exit checklist
-
-- [ ] Lowering covers literals, identifiers, lambdas/functions, application,
-      `let`/`letrec`, records, field access, conditionals.
-- [ ] `InferSource` driver runs lexer → parser → lower → `Infer`.
-- [ ] Golden tests assert inferred + simplified types over `.esc` snippets.
-- [ ] Simple-sub paper examples have Escalier equivalents inferring expected types.
-- [ ] Unbound variables and failed constraints report errors with source spans.
-- [ ] `01-milestones.md` M2 status set to `[x]`.
+- [ ] Constraint-generating walk over `*ast.Module` produces `soltype` and
+      populates `Info` (no AST `InferredType()` writes).
+- [ ] Package-owned `Scope`/`Binding`/`Namespace` (no `type_system` reuse).
+- [ ] Top-level `val`/`fn` from real source infer correct rendered types
+      end-to-end (table harness).
+- [ ] Multi-file module resolves via the dep graph (fixtures harness).
+- [ ] Recursive SCC groups infer with no placeholder/patching phase.
+- [ ] No imports of `internal/checker/` or `internal/type_system/` from the new
+      package (gate honored).
+- [ ] `01-milestones.md` M2 status updated.

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -12,13 +12,24 @@ constraint-generating walk over `*ast.Module`.** The spike
 (`internal/simplesub/`) proved the algorithm against a toy `Term` ADT
 (`Lit`/`Var`/`Lam`/`App`/`Let`/…) driven by `typeTerm`. M2 throws that IR away
 and drives the *same algorithm* — now living in the M1 package — directly from
-real parsed source, resolved through the existing `dep_graph`/`resolver`, with
-results recorded in the `Info` side table.
+real parsed source, ordered by the existing `dep_graph`, with results recorded
+in the `Info` side table.
+
+> **Terminology note (corrected after surveying the packages).** In Escalier,
+> top-level *name/dependency resolution* is done by **`internal/dep_graph/`**
+> (`BuildDepGraph(*ast.Module)` → `DepGraph.Components`, the SCCs the checker
+> infers in order). `internal/resolver/` is a **narrow** helper that only
+> resolves TypeScript `@types` packages (`ResolveTypesPackage`,
+> `GetTypesEntryPoint`) — it is *not* the general name resolver. The milestone's
+> phrase "dep_graph/resolver" therefore means: drive declaration order and
+> cross-declaration references through `dep_graph`; `resolver` is relevant only
+> when a fixture imports a `.d.ts`-typed third-party module (likely beyond the
+> M2 `val`/`fn` bar). The plan below is built around `dep_graph`.
 
 Per the milestone, M2 delivers:
 
 1. **Drive from real source.** `parser.Parse*` → `*ast.Module` →
-   `dep_graph`/`resolver` → a constraint-generating AST visitor that produces
+   `dep_graph.BuildDepGraph` → a constraint-generating AST walk that produces
    `soltype` types and populates `Info`.
 2. **Own `Scope`/`Binding`/`Namespace`.** Analogues owned by the new package,
    *not* reused from `internal/type_system/`.
@@ -37,8 +48,8 @@ wrong — **stop and reassess**.
 ### Scope boundary against neighbouring milestones
 
 - **M1 (prerequisite — Package skeleton + `soltype`)** must land first. It
-  creates the new package (sibling to `internal/checker/`, leaf name TBD —
-  `internal/solver/` is the working name), the `soltype` representation
+  creates the new package — `internal/solver/` (settled decision #1 in
+  design-notes; sibling to `internal/checker/`) — the `soltype` representation
   (bound-list `TypeVar` with `lowerBounds`/`upperBounds` + `level`, `Primitive`,
   `Literal`, `Function`, `Tuple`), `constrain`, levels/extrusion, polarity-driven
   coalescing, the **own** `soltype` printer, and the `Info` side table
@@ -85,7 +96,7 @@ wrong — **stop and reassess**.
 
 ### 3.1 Package layout
 
-Inside the M1 package (working name `internal/solver/`):
+Inside the M1 package (`internal/solver/`):
 
 ```
 internal/solver/
@@ -136,53 +147,88 @@ table is the single source of truth for node→type (the AST stays untouched —
 `InferredType()` writes; that is the AST-decoupling decision). Nodes outside the
 M2 subset emit an "unsupported in M2" error.
 
-### 3.3 Module driver (`module.go`) — dep_graph + resolver
+### 3.3 Module driver (`module.go`) — dep_graph-ordered inference
 
-The milestone's spine: `parser.Parse*` → `*ast.Module` → `dep_graph`/`resolver`
-→ walk.
-
-- **Name resolution** runs through the existing `resolver` so identifiers bind
-  to their declarations/namespaces before inference. M2 *consumes* resolver
-  output; it does not reimplement resolution.
-- **Declaration ordering** comes from `dep_graph`: top-level declarations are
-  grouped into strongly-connected components (SCCs) and processed in dependency
-  order. This is exactly how the old `infer_module.go` consumes the dep graph —
-  M2 reuses the same `dep_graph` package, but feeds its SCCs into the new walk.
-- **Recursive groups need no placeholder phase.** Where the old checker uses a
-  placeholder/`typeRefsToUpdate` patching pass for cross-declaration recursion
-  (`infer_module.go`), the simple-sub approach handles an SCC the way the spike's
-  `LetRecGroup` does: give each binding in the SCC a fresh var at `level+1`, make
-  all of them visible in every body, `constrain` each body `<:` its var, then
-  generalize the whole group at the shared level. M2 lifts this pattern from the
-  spike to operate over a `dep_graph` SCC of `VarDecl`/`FuncDecl`. This is the
-  single biggest simplification the bridge buys and should be called out.
-- **Multi-file** falls out of the dep graph spanning modules: the driver builds
-  the graph across the parsed modules and resolves cross-module references
-  through the resolver + the new `Namespace` (below).
-
-Entry point (working signature):
+The milestone's spine: `parser.Parse*` → `*ast.Module` →
+`dep_graph.BuildDepGraph` → SCC-ordered walk. The new driver mirrors the old
+checker's `InferDepGraph` / `InferComponent` shape exactly, swapping
+`type_system` for `soltype`:
 
 ```go
-// InferModule resolves and infers every top-level declaration in the parsed
-// module(s), populating Info and returning the module Scope plus errors.
-func InferModule(modules []*ast.Module) (*Scope, *Info, []error)
+// Old checker (internal/checker/infer_module.go), for reference:
+func (c *Checker) InferDepGraph(ctx Context, depGraph *dep_graph.DepGraph) (errors []Error)
+func (c *Checker) InferComponent(ctx Context, depGraph *dep_graph.DepGraph,
+    component []dep_graph.BindingKey) []Error
+```
+
+- **Declaration ordering comes from `dep_graph`.** `BuildDepGraph(module)`
+  returns a `*dep_graph.DepGraph` whose `Components` field is the list of SCCs
+  (`[][]dep_graph.BindingKey`) in **topological order** (if A depends on B, B's
+  component precedes A's). A `BindingKey` is `"value:"` / `"type:"` + the
+  qualified name; `GetDecls(key)` returns the `[]ast.Decl` for that binding
+  (a slice because overloads / interface-merging contribute several). M2's
+  driver iterates `Components` and infers each, exactly as the old
+  `InferDepGraph` loops over `depGraph.Components` calling `InferComponent`.
+- **Recursive groups need no placeholder phase.** The old `InferComponent`
+  runs a two-phase placeholder/definition pass (`sortKeysForPlaceholders` +
+  signature-then-body) to break cross-declaration recursion. The simple-sub
+  approach replaces that with the spike's `LetRecGroup` pattern: for an SCC,
+  give each binding a fresh var at `level+1`, make all of them visible in every
+  body, `constrain` each body `<:` its var, then generalize the whole group at
+  the shared level. **No placeholder phase, no `typeRefsToUpdate` patching** —
+  this is the single biggest simplification the bridge buys and should be
+  called out in the PR. (A singleton non-recursive SCC is just the degenerate
+  case — one binding, generalize after its body.)
+- **Multi-file** falls out of the dep graph spanning modules and the new
+  `Namespace` (below): cross-module references resolve through the qualified
+  `BindingKey` namespace recorded on each binding (`DeclNamespace` /
+  `GetNamespace(key)`).
+- **`resolver` is *not* on this path.** `internal/resolver/` only locates
+  `@types` `.d.ts` packages; it is engaged only if an M2 fixture imports a
+  TypeScript-typed third-party module, which the `val`/`fn` bar does not
+  require. M2 leaves `.d.ts` import typing to later milestones unless a fixture
+  forces it.
+
+Entry point (working signature, paralleling the old driver):
+
+```go
+// InferModule builds the dep graph for the parsed module, infers every
+// top-level declaration in SCC order, populates Info, and returns the module
+// Scope plus errors. Multi-file callers pass the merged module / module set.
+func (c *checker) InferModule(module *ast.Module) (*Scope, *Info, []error)
 ```
 
 ### 3.4 Scope / Binding / Namespace (own, not `type_system`)
 
-A minimal, package-owned analogue (the milestone forbids reusing
-`type_system`'s):
+A package-owned, **multi-sorted** analogue (the milestone forbids reusing
+`type_system`'s). Design-notes §"Scope / Binding" already specifies the shape —
+three slots, one per binding sort:
 
-- `Binding` — a name's `soltype` scheme (`MonoScheme`/`PolyScheme`) plus its
-  source provenance.
-- `Scope` — parent-linked name→`Binding` lookup, the production analogue of the
+```go
+type Scope struct {
+    values     map[string]ValueBinding   // soltype schemes (Mono | Poly)
+    types      map[string]TypeBinding    // type aliases, class types
+    namespaces map[string]*Namespace     // a separate sort — NOT a soltype.Type
+    parent     *Scope
+}
+func (s *Scope) GetValue(name string) *ValueBinding
+func (s *Scope) GetType(name string) *TypeBinding
+func (s *Scope) GetNamespace(name string) *Namespace
+```
+
+- `ValueBinding` — a name's `soltype` scheme (`MonoScheme`/`PolyScheme`, from the
+  spike's `scheme.go`) plus its source provenance. The production analogue of the
   spike's `ctx map[string]TypeScheme`.
-- `Namespace` — the module/namespace grouping that cross-module resolution
-  resolves through.
+- The **value-position `IdentExpr`** path queries `GetValue`, then `GetNamespace`
+  only to raise `NamespaceUsedAsValueError` (namespaces are a separate sort and
+  never flow as values — design-notes §"The constraint-generating AST walk").
+- `Namespace` is keyed by the qualified `BindingKey` namespace `dep_graph`
+  records (`GetNamespace(key)`), which is how multi-file resolution lands.
 
-Keep this deliberately small in M2 — only what top-level `val`/`fn` +
-multi-file resolution require. It grows with later milestones (types,
-lifetimes, classes).
+**M2 scope:** `values` + `namespaces` are what the `val`/`fn` + multi-file bar
+needs. The `types` slot's shape lands now (cheap, and it's load-bearing for the
+two-map test harness below), but populating it with real type aliases/classes is
+M3+ work. Keep the rest deliberately small; it grows with later milestones.
 
 ### 3.5 Errors & provenance
 
@@ -228,15 +274,16 @@ PR-2  single-decl driver: VarDecl/FuncDecl, table harness, val/fn end-to-end
 PR-3  dep_graph SCC ordering + recursive-group (LetRecGroup) inference
         │
         ▼
-PR-4  resolver wiring + multi-file fixtures harness  ── closes M2 exit criteria
+PR-4  multi-file (cross-module) resolution + fixtures harness  ── closes M2 exit
 ```
 
 PR-1 establishes the package-owned `Scope` and the value-returning walk against
 M1's `soltype`/`Info`. PR-2 makes a *single* module's top-level `val`/`fn`
 infer end-to-end with the table harness — the first half of the exit bar. PR-3
 brings in dep-graph SCC ordering and recursive groups (still single-file). PR-4
-adds resolver-driven cross-module resolution and the `fixtures/` harness,
-closing the multi-file half of the exit bar. PRs are mostly linear because each
+adds cross-module resolution (via the qualified-`BindingKey` `Namespace`) and
+the `fixtures/` harness, closing the multi-file half of the exit bar. PRs are
+mostly linear because each
 depends on the prior layer's plumbing; PR-2's table harness and PR-1's walk
 skeleton are the only pieces that could overlap.
 
@@ -273,9 +320,10 @@ skeleton are the only pieces that could overlap.
 - **Exit:** recursive and out-of-order top-level decls infer correctly in one
   module.
 
-### PR-4 — resolver wiring + multi-file fixtures harness
-- Wire the existing `resolver` so identifiers (incl. cross-module) bind before
-  inference; resolve through the new `Namespace`.
+### PR-4 — multi-file (cross-module) resolution + fixtures harness
+- Cross-module references resolve through the qualified-`BindingKey` `Namespace`
+  recorded on each binding (`dep_graph.GetNamespace`); engage `internal/resolver`
+  only if a fixture imports a `.d.ts`-typed third-party module.
 - `module.go`: accept multiple parsed modules; build the dep graph across them.
 - Add a `fixtures/`-style harness (sibling to `cmd/escalier/fixture_test.go`)
   asserting rendered top-level binding types for a multi-file fixture.
@@ -287,16 +335,16 @@ skeleton are the only pieces that could overlap.
 
 ## 6. Risks & mitigations
 
-- **Gate — reaching into old checker internals.** Driving from
-  AST/dep-graph/resolver must not pull in `internal/checker/` or
-  `internal/type_system/`. *Mitigation:* a package-boundary test/lint that the
-  new package imports neither; if dep_graph/resolver turn out to expose
-  checker-coupled types, that is the milestone's stop-and-reassess signal — raise
-  it rather than working around it.
-- **dep_graph/resolver coupling to `type_system`.** If those packages return
-  `type_system`-flavoured data, the bridge leaks. *Mitigation:* consume only
-  their structural outputs (names, SCCs, resolution edges); keep all *type* data
-  in `soltype`/`Info`.
+- **Gate — reaching into old checker internals.** Driving from AST/dep-graph
+  must not pull in `internal/checker/` or `internal/type_system/`. *Mitigation:*
+  a package-boundary test/lint that the new package imports neither; if
+  `dep_graph` turns out to expose checker-coupled types, that is the milestone's
+  stop-and-reassess signal — raise it rather than working around it.
+- **dep_graph coupling to `type_system`.** `dep_graph` operates on `*ast.Module`
+  and `ast.Decl` (its `Decls`/`Components`/`BindingKey` API is type-system-free),
+  so this risk is low — but confirm it in PR-3. *Mitigation:* consume only its
+  structural outputs (`BindingKey`s, `Components`, `GetDecls`/`GetNamespace`);
+  keep all *type* data in `soltype`/`Info`.
 - **Walk vs. AST `Visitor` deviation.** Using a direct switch instead of the
   shared visitor is a deliberate departure from the CLAUDE.md convention.
   *Mitigation:* document the rationale (value-synthesis vs. transformation) in
@@ -311,13 +359,19 @@ skeleton are the only pieces that could overlap.
 
 ## 7. Open questions to resolve during M2
 
-- **Final package name.** M1 picks the leaf (working name `internal/solver/`);
-  M2 inherits it. No new decision unless M1 defers it.
-- **How much resolver to drive in M2 vs. defer.** If full namespace resolution
-  is heavier than the val/fn bar needs, PR-4 can scope to the minimum
-  cross-module resolution that satisfies the multi-file acceptance and leave
-  richer namespace semantics to later milestones — decide when PR-4 starts,
-  based on what `resolver` already provides.
+- **Package name** is settled (`internal/solver/`, design-notes decision #1);
+  M2 inherits it from M1. No open decision here.
+- **How much namespace resolution to drive in M2 vs. defer.** If full
+  cross-module/namespace resolution is heavier than the val/fn bar needs, PR-4
+  can scope to the minimum that satisfies the multi-file acceptance (a binding
+  in file B referencing a top-level `val`/`fn` in file A via its qualified
+  `BindingKey`) and leave richer namespace semantics (`ns.foo` member access,
+  nested namespaces) to later milestones — decide when PR-4 starts, based on what
+  `dep_graph` already records in `DeclNamespace`.
+- **Whether M2 needs `internal/resolver` at all.** It's only for `@types`
+  `.d.ts` resolution; if no M2 fixture imports a TS-typed module, M2 can skip it
+  entirely and the milestone's "dep_graph/resolver" phrasing is satisfied by
+  `dep_graph` alone.
 
 ## 8. M2 exit checklist
 

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -103,7 +103,7 @@ internal/solver/
   infer.go        # constraint-generating walk over *ast.Module (production typeTerm)
   infer_expr.go   # per-expression-kind constraint generation
   infer_decl.go   # VarDecl / FuncDecl → bindings, SCC group inference
-  module.go       # InferModule: dep_graph SCC ordering + resolver + drive the walk
+  module.go       # InferModule(s): dep_graph SCC ordering + drive the walk
   scope.go        # Scope / Binding / Namespace (own, not type_system)
   errors.go       # bridge errors (unbound name, unsupported node) with provenance/spans
   // (soltype core, Info side table, printer: from M1)
@@ -259,74 +259,313 @@ Assert inferred types as Escalier type-annotation strings; use `testify/require`
 (CLAUDE.md). For tree-shaped assertions prefer `snaps.MatchInlineSnapshot` over
 field-by-field drilling.
 
+### 3.7 Sketched types & function signatures
+
+Concrete shapes to anchor the PRs below. These are *sketches* — names and
+fields will shift in review — but they pin down the surface area each PR owns.
+All live in `internal/solver`. Types prefixed `soltype.` come from M1; the rest
+are introduced by M2 (the PR that owns each is noted).
+
+**The checker carrier (PR-1).** A per-inference-run struct threading the M1
+core's mutable state (the fresh-var counter, the `Info`/provenance tables) — the
+production analogue of the spike's `Inferer`. Method receiver for the whole walk.
+
+```go
+// infer.go
+type checker struct {
+    core *soltype.Inferer  // M1: freshVar, constrain, instantiate, freshenAbove, level
+    info *soltype.Info     // M1: node → type side table
+    prov soltype.Prov      // M1: type → origin side table
+    errs []Error           // accumulated; mirrors the spike's []error threading
+}
+
+func newChecker() *checker
+
+// fresh allocates a fresh inference variable at the current level and records
+// its AST origin in prov (the freshVarAt helper from design-notes §Provenance).
+func (c *checker) fresh(n ast.Node, kind soltype.ASTOriginKind) *soltype.TypeVarType
+
+// report appends a structured error; returns soltype's error type so callers
+// can `return c.report(...)` in a value position (yielding an error placeholder).
+func (c *checker) report(e Error) soltype.Type
+```
+
+**Scope / Binding / Namespace (PR-1).** Design-notes §"Scope / Binding" gives
+the three-slot shape; the constructors and `define*` mutators are M2's:
+
+```go
+// scope.go
+type ValueBinding struct {
+    Scheme soltype.TypeScheme    // MonoScheme | PolyScheme (spike scheme.go)
+    Source provenance.Provenance // the introducing VarDecl/FuncDecl/param
+}
+type TypeBinding struct {        // shape only in M2; populated M3+
+    Type   soltype.Type
+    Source provenance.Provenance
+}
+type Namespace struct {
+    Name   string                // qualified, from dep_graph.GetNamespace
+    Values map[string]ValueBinding
+    Types  map[string]TypeBinding
+    Nested map[string]*Namespace
+}
+
+type Scope struct {
+    values     map[string]ValueBinding
+    types      map[string]TypeBinding
+    namespaces map[string]*Namespace
+    parent     *Scope
+}
+
+func NewScope() *Scope
+func (s *Scope) Child() *Scope
+func (s *Scope) defineValue(name string, b ValueBinding)
+func (s *Scope) GetValue(name string) (ValueBinding, bool)      // walks parents
+func (s *Scope) GetType(name string) (TypeBinding, bool)
+func (s *Scope) GetNamespace(name string) (*Namespace, bool)
+```
+
+**The expression walk (PR-1 lits/idents; PR-2 fn/call/block; PR-2b objects).**
+The production `typeTerm`, split by node category. Each returns a `soltype.Type`
+and threads `*Scope` + `level`:
+
+```go
+// infer.go / infer_expr.go
+func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type
+func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type
+func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type
+
+// inferExpr dispatches; the per-kind helpers mirror the spike's typeTerm cases:
+func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type           // PR-1
+func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type   // PR-1
+func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type // PR-2
+func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type     // PR-2
+func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type // PR-2b
+```
+
+`inferIdent` is the load-bearing one — it's the production form of the spike's
+`*Var` case crossed with design-notes §"The constraint-generating AST walk":
+
+```go
+func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
+    if b, ok := scope.GetValue(e.Name); ok {
+        t := c.core.Instantiate(b.Scheme, lvl) // MonoScheme: as-is; PolyScheme: freshenAbove
+        c.info.SetType(e, t)
+        return t
+    }
+    if _, ok := scope.GetNamespace(e.Name); ok {
+        return c.report(NamespaceUsedAsValueError{Name: e.Name, Span: e.Span()})
+    }
+    return c.report(UnknownIdentifierError{Name: e.Name, Span: e.Span()})
+}
+```
+
+**Declaration & module driver (PR-2 single-decl; PR-3 SCC).** Mirrors the old
+checker's `InferDepGraph`/`InferComponent`, over `soltype`:
+
+```go
+// module.go
+func InferModule(module *ast.Module) (*Scope, *soltype.Info, []Error)   // PR-2 (1 file), PR-3 (SCC)
+func InferModules(modules []*ast.Module) (*Scope, *soltype.Info, []Error) // PR-4 (multi-file)
+
+func (c *checker) inferDepGraph(scope *Scope, g *dep_graph.DepGraph) // PR-3
+func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph, // PR-3
+    component []dep_graph.BindingKey)
+
+// infer_decl.go
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding // PR-2
+func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding // PR-2
+```
+
+`inferComponent` is the LetRecGroup lift (PR-3); the singleton non-recursive
+case is the same code with a one-element slice:
+
+```go
+func (c *checker) inferComponent(scope *Scope, g *dep_graph.DepGraph,
+    component []dep_graph.BindingKey) {
+    // 1. fresh var per binding at lvl+1, all visible in scope before any body
+    vars := map[dep_graph.BindingKey]*soltype.TypeVarType{}
+    for _, key := range component {
+        v := c.fresh(/* decl node */ nil, soltype.OriginRecBinding)
+        vars[key] = v
+        scope.defineValue(key.Name(), ValueBinding{Scheme: &soltype.MonoScheme{Ty: v}})
+    }
+    // 2. infer each body, constrain body <: its var
+    for _, key := range component {
+        for _, d := range g.GetDecls(key) {
+            body := c.inferDeclBody(scope, c.core.Level()+1, d)
+            c.core.Constrain(body, vars[key])
+        }
+    }
+    // 3. generalize the whole group at the shared (outer) level
+    for _, key := range component {
+        scope.defineValue(key.Name(), ValueBinding{
+            Scheme: &soltype.PolyScheme{Level: c.core.Level(), Body: vars[key]},
+        })
+    }
+}
+```
+
+**Errors (PR-1).** A small set of structured errors with spans; assert full
+messages in tests:
+
+```go
+// errors.go
+type Error interface{ error; Span() provenance.Span }
+type UnknownIdentifierError struct{ Name string; Span provenance.Span }
+type NamespaceUsedAsValueError struct{ Name string; Span provenance.Span }
+type UnsupportedNodeError struct{ Kind string; Span provenance.Span } // M2-subset guard
+```
+
+**Test harness (PR-2 table; PR-4 fixtures).**
+
+```go
+// infer_test.go — table harness
+func inferSource(t *testing.T, src string) (values, types map[string]string)
+// returns name → rendered soltype string, via parser + InferModule + soltype printer
+
+// fixture_test.go — multi-file harness (sibling to cmd/escalier/fixture_test.go)
+func checkSolverFixture(t *testing.T, fixtureDir string) // asserts rendered top-level types
+```
+
 ## 4. Sequencing
 
-```
-M1 (package skeleton + soltype + Info + printer)   ── prerequisite
-        │
-        ▼
-PR-1  Scope/Binding/Namespace + expression walk skeleton (lits, idents)
-        │
-        ▼
-PR-2  single-decl driver: VarDecl/FuncDecl, table harness, val/fn end-to-end
-        │
-        ▼
-PR-3  dep_graph SCC ordering + recursive-group (LetRecGroup) inference
-        │
-        ▼
-PR-4  multi-file (cross-module) resolution + fixtures harness  ── closes M2 exit
+### Sizing rationale (why six PRs, not four)
+
+The earlier four-PR cut bundled too much into "PR-2" (decl driver + the
+fn/call/block walk + the table harness all at once) and left "PR-1" thin. The
+revised split keeps each PR to **one reviewable concern** — roughly
+150–400 LoC of non-test code plus its tests — and front-loads the
+infrastructure (`checker` carrier, `Scope`, harness) so later PRs are pure
+feature additions. Concretely:
+
+- **PR-1** is foundation only (carrier + scope + errors + the two leaf
+  expression cases). Small, no driver.
+- The old PR-2 split into **PR-2 (decl driver, source-order, the table
+  harness — `val` end-to-end)** and **PR-3 (the function/application/block
+  walk — `fn` end-to-end)**. These are independent given PR-1: the decl driver
+  can land typing only `val x = <literal/ident>` initializers, and the
+  fn/call/block walk is a self-contained set of `inferExpr` cases. Either can
+  merge first; the second rebases trivially.
+- **PR-4** (objects/members) is a small, optional-for-the-bar add that several
+  fixtures will want; isolated so it can slip without blocking the SCC/multi-file
+  work.
+- The old PR-3 (SCC) becomes **PR-5**, the old PR-4 (multi-file) becomes
+  **PR-6** — unchanged in content, renumbered.
+
+### PR dependency graph
+
+```text
+                M1 (soltype + Info + printer)
+                        │
+                        ▼
+                ┌─────────────────┐
+                │ PR-1  carrier +  │   checker{}, Scope/Binding/Namespace,
+                │ scope + leaves   │   errors, inferExpr(lits, idents)
+                └───────┬─────────┘
+                        │
+            ┌───────────┴───────────┐
+            ▼                       ▼
+   ┌──────────────────┐   ┌──────────────────────┐
+   │ PR-2 decl driver │   │ PR-3 fn / call /      │   (PR-2 ∥ PR-3:
+   │ + table harness  │   │ block walk            │    independent given PR-1)
+   │ (val end-to-end) │   │ (fn end-to-end)       │
+   └───────┬──────────┘   └──────────┬───────────┘
+           │                         │
+           │   ┌─────────────────────┤
+           ▼   ▼                     ▼
+   ┌──────────────────┐   ┌──────────────────────┐
+   │ PR-5 dep_graph   │   │ PR-4 objects /        │   (PR-4 ∥ PR-5:
+   │ SCC + LetRecGroup│   │ member access         │    both need PR-2+PR-3)
+   └───────┬──────────┘   └──────────┬───────────┘
+           │                         │
+           └───────────┬─────────────┘
+                       ▼
+           ┌────────────────────────┐
+           │ PR-6 multi-file (x-mod) │   closes M2 exit criteria
+           │ resolution + fixtures   │
+           └────────────────────────┘
 ```
 
-PR-1 establishes the package-owned `Scope` and the value-returning walk against
-M1's `soltype`/`Info`. PR-2 makes a *single* module's top-level `val`/`fn`
-infer end-to-end with the table harness — the first half of the exit bar. PR-3
-brings in dep-graph SCC ordering and recursive groups (still single-file). PR-4
-adds cross-module resolution (via the qualified-`BindingKey` `Namespace`) and
-the `fixtures/` harness, closing the multi-file half of the exit bar. PRs are
-mostly linear because each
-depends on the prior layer's plumbing; PR-2's table harness and PR-1's walk
-skeleton are the only pieces that could overlap.
+Edges are hard dependencies (the target imports/uses symbols the source
+introduces). The two `∥` pairs (PR-2 ∥ PR-3, and PR-4 ∥ PR-5) have no edge
+between them and can be developed/reviewed in parallel. PR-6 is the only PR that
+needs *both* upstream branches merged (it asserts end-to-end over real fixtures,
+which exercises decls, functions, and SCC ordering together).
 
 ## 5. PR breakdown
 
-### PR-1 — Scope + expression-walk skeleton
-- `scope.go`: `Scope`/`Binding`/`Namespace` (minimal).
-- `infer.go`/`infer_expr.go`: value-returning recursive walk over `ast.Expr`
-  for `LiteralExpr`, `IdentExpr` (via `Scope`), writing into `Info`.
-- Unsupported nodes return a structured error (no panic).
-- Tests: literal type; identifier resolves to its binding's scheme; unbound
-  identifier → full-message error with span.
-- **Exit:** the walk types the trivial expression subset against `soltype`/`Info`.
+> Each PR lists its **owned files**, the **sketches from §3.7** it implements,
+> its **tests**, and an **exit** line. "LoC" estimates are non-test code.
 
-### PR-2 — Single-module decl driver + table harness
-- `infer_decl.go`: `VarDecl` → `Binding`; `FuncDecl` → `Function` binding,
-  walking the body with the spike's function/let machinery (as re-homed in M1).
-- `module.go`: a first `InferModule` that handles one module, declarations in
-  source order (no SCC yet), populating `Scope` + `Info`.
-- Table-driven harness: `.esc` snippet → rendered top-level binding type.
-- Tests: `val x = 5` ⇒ `5`/`number` per M1 widening; a simple `fn` infers its
-  rendered type; an expression-stmt module.
-- **Exit:** top-level `val`/`fn` in a *single* module infer correct rendered
-  types end-to-end (first half of the milestone bar).
+### PR-1 — Checker carrier + Scope + leaf expressions  (~250 LoC)
+- `infer.go`: the `checker` struct, `newChecker`, `fresh`, `report`;
+  `inferExpr` dispatch with only the leaf cases wired.
+- `scope.go`: `Scope`/`ValueBinding`/`TypeBinding`/`Namespace` + `NewScope`,
+  `Child`, `defineValue`, `GetValue`/`GetType`/`GetNamespace`.
+- `errors.go`: `Error` interface, `UnknownIdentifierError`,
+  `NamespaceUsedAsValueError`, `UnsupportedNodeError`.
+- `infer_expr.go`: `inferLiteral`, `inferIdent`; all other `ast.Expr` kinds fall
+  through to `UnsupportedNodeError` (no panic).
+- Tests: literal → rendered type; identifier resolves to a pre-seeded binding's
+  scheme; unbound identifier and namespace-as-value → full-message errors with
+  spans.
+- **Exit:** the walk types the literal/identifier subset against `soltype`/`Info`;
+  every other node fails cleanly.
 
-### PR-3 — dep_graph SCC ordering + recursive groups
-- `module.go`: build the dependency graph from the module, process top-level
-  decls in SCC order.
-- Lift the spike's `LetRecGroup` pattern to a `dep_graph` SCC: fresh var per
-  binding at `level+1`, all visible in every body, `constrain` body `<:` var,
-  generalize the group at the shared level. **No placeholder/patching phase.**
+### PR-2 — Single-module decl driver + table harness  (~250 LoC)
+*(depends on PR-1; parallel with PR-3)*
+- `infer_decl.go`: `inferVarDecl` (initializer typed via `inferExpr`, generalized
+  into a `ValueBinding`).
+- `module.go`: first `InferModule` for one module, decls in **source order**
+  (no SCC yet), seeding the module `Scope` and `Info`.
+- `infer_test.go`: the `inferSource` table harness.
+- Tests: `val x = 5` ⇒ `5`/`number` (per M1 widening); `val y = x` referencing an
+  earlier decl; forward reference → (documented) error until PR-5 adds ordering.
+- **Exit:** top-level `val` decls with literal/identifier initializers infer
+  end-to-end and render correctly via the harness.
+
+### PR-3 — Function / application / block walk  (~300 LoC)
+*(depends on PR-1; parallel with PR-2)*
+- `infer_expr.go`: `inferFuncExpr` (n-ary `Function`, fresh var per param),
+  `inferCall` (`constrain(callee <: Function{args, fresh})`), `inferBlock` /
+  `inferStmt` (sequence; result = last expr or `void`).
+- `infer_decl.go`: `inferFuncDecl` (reuses `inferFuncExpr` on the decl's sig+body).
+- Tests: identity `fn`, application of it, a block with a `return`, arity
+  mismatch on a direct call → full-message error.
+- **Exit:** `fn` decls and calls infer end-to-end (the second half of the
+  per-expression bar; deep let-polymorphism polish is still M3).
+
+### PR-4 — Objects & member access  (~200 LoC)
+*(depends on PR-2 + PR-3; parallel with PR-5)*
+- `infer_expr.go`: `inferObject` (`Record{fields}`), `inferMember` (basic
+  `constrain(recv <: Record{name: fresh})`), `inferTuple`.
+- Reject shorthand/spread/computed members with `UnsupportedNodeError`.
+- Tests: record literal type; field read; field-on-missing → constraint failure;
+  tuple literal.
+- **Exit:** record/tuple literals and simple field reads infer; usage-inference
+  depth is explicitly deferred to M4.
+
+### PR-5 — dep_graph SCC ordering + recursive groups  (~250 LoC)
+*(depends on PR-2 + PR-3)*
+- `module.go`: `inferDepGraph` (iterate `g.Components`), `inferComponent` (the
+  LetRecGroup lift sketched in §3.7).
+- Replace PR-2's source-order loop with SCC ordering. **No placeholder/patching
+  phase.**
 - Tests: self-recursive `fn`; mutually-recursive `fn` pair; a decl that
-  forward-references a later decl resolves via SCC ordering.
+  forward-references a later decl now resolves via SCC ordering (the PR-2
+  documented-error case flips to success).
 - **Exit:** recursive and out-of-order top-level decls infer correctly in one
   module.
 
-### PR-4 — multi-file (cross-module) resolution + fixtures harness
-- Cross-module references resolve through the qualified-`BindingKey` `Namespace`
-  recorded on each binding (`dep_graph.GetNamespace`); engage `internal/resolver`
-  only if a fixture imports a `.d.ts`-typed third-party module.
-- `module.go`: accept multiple parsed modules; build the dep graph across them.
-- Add a `fixtures/`-style harness (sibling to `cmd/escalier/fixture_test.go`)
-  asserting rendered top-level binding types for a multi-file fixture.
+### PR-6 — Multi-file (cross-module) resolution + fixtures harness  (~250 LoC)
+*(depends on PR-4 + PR-5)*
+- `module.go`: `InferModules` over multiple parsed modules; build the dep graph
+  across them; cross-module references resolve through the qualified-`BindingKey`
+  `Namespace` (`dep_graph.GetNamespace`). Engage `internal/resolver` only if a
+  fixture imports a `.d.ts`-typed third-party module.
+- `fixture_test.go`: the `checkSolverFixture` harness (sibling to
+  `cmd/escalier/fixture_test.go`).
 - Tests: a two-file fixture where file B imports a `val`/`fn` from file A and the
   inferred types render correctly end-to-end.
 - Update `01-milestones.md` M2 status.


### PR DESCRIPTION
Add the detailed M2 implementation plan document, which specifies how to replace the spike's hand-built expression IR with a real constraint-generating walk over the parsed AST and dep graph.

## Summary

This adds `planning/simple_sub/m2-implementation-plan.md`, a comprehensive 956-line design document that details the M2 milestone (Parser/resolver bridge). M2 is the next step after M1 (which landed the `soltype` type representation and `solver` engine package) and bridges the gap between the spike's proof-of-concept and production inference over real parsed source.

## Key changes

- **New M2 implementation plan document** (`m2-implementation-plan.md`):
  - Defines what M2 is and is not (monomorphic inference, no generalization yet)
  - Specifies the package layout (`internal/solver/` for M2 code)
  - Details the constraint-generating walk over `*ast.Module` and `*ast.Expr`
  - Describes the module driver using `dep_graph` for declaration ordering and SCC handling
  - Defines `Scope`/`Binding`/`Namespace` structures (owned by M2, not reused from `type_system`)
  - Outlines the table-driven test harness (in-memory, no on-disk fixtures)
  - Specifies error handling with span provenance
  - Includes concrete function signatures and type sketches for all major components
  - Documents stdlib placeholder seeding (M2 seeds stubs; real ingestion is M7)

- **Updated milestone documents** to reflect M1 landing and M2's scope:
  - `01-milestones.md`: Renumbered M7–M9 (library resolution, fixture harness, type-level operators) to account for the new M7 milestone; clarified M2's stdlib placeholder responsibility vs. M7's real ingestion
  - `02-design-notes.md`: Updated references from M8 to M9 for type-level operators
  - `m1-implementation-plan.md`: Updated reference from M7 to M8 for differential harness
  - `00-overview.md`: Minor reference update

## Notable details

- M2 inference is **monomorphic** (no schemes, no generalization) — M1 deferred those to M3
- The walk is a **direct recursive switch** over AST nodes (not the visitor pattern), mirroring the spike's `typeTerm` shape
- **No placeholder phase** for recursive groups — uses the spike's `LetRecGroup` pattern with fresh vars at `level+1`
- Body-level declarations are **`VarDecl`-only** (a permanent language rule, not a subset gate); redeclaration rebinds with a fresh type
- Stdlib type names (`Promise`, `Iterable`, etc.) are **hand-seeded as placeholder stubs** in M2; real definitions come in M7
- Test harness is **table-driven in-memory only** — no on-disk `fixtures/` directories (M8 owns the real fixture harness)
- Detailed sketches of all major types and function signatures to anchor the implementation PRs

https://claude.ai/code/session_01UMVE6KdUSYSp2eNUcw4xxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal milestone planning documentation to reflect revised scheduling and scope adjustments for type-system development phases.
  * Added comprehensive implementation plan documentation for upcoming development phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->