### PR TITLE
M2: Add scope, prelude, and expression inference scaffolding

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -14,18 +15,32 @@ import (
 // error refers to — e.g. navigate to a type's declaration — without reparsing
 // the message. Modeled on internal/checker/error.go's shape.
 //
-// Errors are span-free in M1 (there is no parser bridge until M2). M2 adds a
-// Span() ast.Span method and likely rebases these onto the checker's diagnostic
-// types per 02-design-notes.md Settled Decision #4.
+// M2 adds Span() ast.Span. The constraint kinds (CannotConstrainError, …) are
+// still constructed span-free inside the engine (constrain.go has no AST node
+// in hand); the M2 walk stamps the offending node's span onto each returned
+// error via the unexported setSpan at the constrain call site (see
+// (*checker).constrain). The M2 bridge kinds below carry their span from
+// construction.
 type SolverError interface {
 	isSolverError()
 	Message() string
+	Span() ast.Span
+	setSpan(ast.Span)
 }
+
+// errSpan is the embeddable span carrier shared by every SolverError kind. It
+// supplies Span()/setSpan so a span-free engine error can be stamped after the
+// fact and a bridge error can be built with its span in place.
+type errSpan struct{ span ast.Span }
+
+func (e *errSpan) Span() ast.Span     { return e.span }
+func (e *errSpan) setSpan(s ast.Span) { e.span = s }
 
 // CannotConstrainError fires when a non-variable LHS/RHS pair fails to match:
 // prim/prim mismatch, lit/lit mismatch, lit/prim mismatch, and the generic
 // "no rule applies" fall-through at the end of constrain.
 type CannotConstrainError struct {
+	errSpan
 	LHS, RHS soltype.Type
 }
 
@@ -35,6 +50,7 @@ type CannotConstrainError struct {
 // report param/return types too. M3 narrows the firing conditions when the
 // exactness flag adds the inexact fewer-params-is-subtype arm.
 type FuncArityMismatchError struct {
+	errSpan
 	LHS, RHS *soltype.FuncType
 }
 
@@ -42,12 +58,68 @@ type FuncArityMismatchError struct {
 // lengths (M1's exact-tuple case; M4 may narrow the firing conditions when the
 // inexact flag is added).
 type TupleLengthMismatchError struct {
+	errSpan
 	LHS, RHS *soltype.TupleType
 }
 
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
+
+// --- M2 bridge errors (carry their span from construction) ---
+
+// UnknownIdentifierError fires when a value-position identifier resolves to no
+// binding in the scope chain.
+type UnknownIdentifierError struct {
+	errSpan
+	Name string
+}
+
+// NamespaceUsedAsValueError fires when an identifier resolves to a namespace
+// rather than a value. Namespaces are a separate binding sort and never flow as
+// values; in M2 a namespace name in value position can only fail (qualified
+// member access — Foo.bar — is M4).
+type NamespaceUsedAsValueError struct {
+	errSpan
+	Name string
+}
+
+// UnsupportedNodeError is the M2-subset guard: an AST node outside the M2 walk's
+// coverage. Unlike BodyDeclNotAllowedError this is a temporary scope gate, not a
+// permanent language rule — later milestones widen coverage and remove arms.
+type UnsupportedNodeError struct {
+	errSpan
+	Kind string
+}
+
+// BodyDeclNotAllowedError fires when a statement-level declaration in a function
+// body is anything other than a VarDecl. This is a permanent language rule
+// (§3.2), not the temporary subset gate above: body decls are VarDecl-only.
+type BodyDeclNotAllowedError struct {
+	errSpan
+	Kind string
+}
+
+func (*UnknownIdentifierError) isSolverError()    {}
+func (*NamespaceUsedAsValueError) isSolverError() {}
+func (*UnsupportedNodeError) isSolverError()      {}
+func (*BodyDeclNotAllowedError) isSolverError()   {}
+
+func (e *UnknownIdentifierError) Message() string {
+	return "Unknown identifier: " + e.Name
+}
+
+func (e *NamespaceUsedAsValueError) Message() string {
+	return "Namespace used as a value: " + e.Name
+}
+
+func (e *UnsupportedNodeError) Message() string {
+	return "Unsupported in M2: " + e.Kind
+}
+
+func (e *BodyDeclNotAllowedError) Message() string {
+	return "Declaration not allowed in function body: " + e.Kind
+}
 
 func (e *CannotConstrainError) Message() string {
 	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.LHS), describe(e.RHS))

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -1,0 +1,79 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// checker is the per-inference-run carrier for the M2 constraint-generating
+// walk. It wraps M1's *Context (the fresh-var counter + Constrain), threads the
+// Info side table that records node→type, and accumulates SolverErrors. It is
+// the method receiver for the whole walk.
+//
+// The walk is a direct recursive switch over ast.Expr/Stmt/Decl, NOT the shared
+// ast.Visitor. This is a deliberate deviation from the CLAUDE.md "use the
+// existing visitor" convention: constraint generation is bottom-up and
+// value-producing (every node synthesizes a soltype.Type), which the visitor —
+// shaped for enter/exit transformation with no per-node synthesized value — does
+// not model cleanly. The shape matches both the simplesub spike's typeTerm and
+// the old checker's inferExpr. See m2-implementation-plan §3.2.
+type checker struct {
+	ctx  *Context      // M1: freshVar(level), Constrain(lhs, rhs) []SolverError
+	info *Info         // M1: node → soltype.Type side table (unexported setType)
+	errs []SolverError // accumulated; mirrors the spike's []error threading
+}
+
+// newChecker returns a checker with a fresh Context and an empty Info table.
+func newChecker() *checker {
+	return &checker{ctx: &Context{}, info: NewInfo()}
+}
+
+// freshAt allocates a fresh inference variable at the given level. No provenance
+// recording in M2 — the Prov side table is deferred to M3+.
+func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
+	return c.ctx.freshVar(lvl)
+}
+
+// constrain asserts lhs <: rhs and stamps the offending node's span onto any
+// resulting SolverErrors before accumulating them. M2 does not look provenance
+// up from a side table — the span is taken directly from the AST node being
+// walked (§3.5).
+func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
+	for _, e := range c.ctx.Constrain(lhs, rhs) {
+		e.setSpan(n.Span())
+		c.errs = append(c.errs, e)
+	}
+}
+
+// report accumulates a structured error and returns a placeholder type so a
+// caller can `return c.report(...)` in value position.
+func (c *checker) report(e SolverError) soltype.Type {
+	c.errs = append(c.errs, e)
+	return &soltype.NeverType{}
+}
+
+// recordType records t as the inferred type of n in the Info side table. Wraps
+// the unexported setType — which is why the whole M2 walk lives in package
+// solver. The AST stays untouched (no InferredType() writes); Info is the single
+// source of truth for node→type.
+func (c *checker) recordType(n ast.Node, t soltype.Type) {
+	c.info.setType(n, t)
+}
+
+// inferExpr dispatches on the concrete expression kind. PR-1 wires only the two
+// leaf cases (literals, identifiers); every other kind falls through to a clean
+// UnsupportedNodeError (never a panic). Later PRs replace fall-through arms with
+// real cases: fn/call/block (PR-3), objects/members/tuples (PR-4).
+func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
+	switch e := e.(type) {
+	case *ast.LiteralExpr:
+		return c.inferLiteral(e)
+	case *ast.IdentExpr:
+		return c.inferIdent(scope, lvl, e)
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: e.Span()},
+			Kind:    exprKind(e),
+		})
+	}
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1,0 +1,74 @@
+package solver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferLiteral types a literal expression as its singleton soltype.LitType and
+// records it in Info. M1's soltype.Lit set is num/str/bool only; the remaining
+// ast literal kinds (regex, bigint, null, undefined) fall through to the M2
+// subset guard until later milestones extend soltype.Lit (§ soltype/type.go
+// Prim/Lit note).
+func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
+	var lit soltype.Lit
+	switch l := e.Lit.(type) {
+	case *ast.NumLit:
+		lit = &soltype.NumLit{Value: l.Value}
+	case *ast.StrLit:
+		lit = &soltype.StrLit{Value: l.Value}
+	case *ast.BoolLit:
+		lit = &soltype.BoolLit{Value: l.Value}
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: e.Span()},
+			Kind:    litKind(e.Lit),
+		})
+	}
+	t := &soltype.LitType{Lit: lit}
+	c.recordType(e, t)
+	return t
+}
+
+// inferIdent resolves a value-position identifier through the scope chain — the
+// production form of the spike's *Var case crossed with design-notes §"The
+// constraint-generating AST walk". In M2 (monomorphic, no schemes) it returns
+// the binding's type directly; M3 slots instantiate() in once schemes exist.
+//
+// A namespace name in value position can only fail in M2: there is no legal
+// namespace-member position yet (MemberExpr is value-only and there is no
+// IndexExpr), so raising NamespaceUsedAsValueError on any namespace name is
+// correct here. M4 moves that error to the value-position consumer once
+// qualified Foo.bar access lands.
+func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
+	if b, ok := scope.GetValue(e.Name); ok {
+		c.recordType(e, b.Type)
+		return b.Type
+	}
+	if _, ok := scope.GetNamespace(e.Name); ok {
+		return c.report(&NamespaceUsedAsValueError{
+			errSpan: errSpan{span: e.Span()},
+			Name:    e.Name,
+		})
+	}
+	return c.report(&UnknownIdentifierError{
+		errSpan: errSpan{span: e.Span()},
+		Name:    e.Name,
+	})
+}
+
+// exprKind returns a short surface name for an expression node, used in the M2
+// subset-guard error message. It strips the leading "*ast." from the Go type
+// name so e.g. *ast.BinaryExpr renders as "BinaryExpr".
+func exprKind(e ast.Expr) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", e), "*ast.")
+}
+
+// litKind returns a short surface name for a literal node, used when a literal
+// kind is outside M1's soltype.Lit set.
+func litKind(l ast.Lit) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", l), "*ast.")
+}

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -1,0 +1,110 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// testSpan is a fixed, non-zero span used to build the AST nodes these unit
+// tests feed directly into the walk (the source-driven harness arrives in PR-2).
+func testSpan() ast.Span {
+	return ast.NewSpan(ast.Location{Line: 1, Column: 1}, ast.Location{Line: 1, Column: 2}, 0)
+}
+
+func TestInferLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		lit  ast.Lit
+		want string
+	}{
+		{"number", ast.NewNumber(5, testSpan()), "5"},
+		{"string", ast.NewString("hello", testSpan()), `"hello"`},
+		{"boolean", ast.NewBoolean(true, testSpan()), "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			e := ast.NewLitExpr(tt.lit)
+			got := c.inferExpr(NewScope(), 0, e)
+			require.Empty(t, c.errs)
+			require.Equal(t, tt.want, soltype.Print(got))
+			// The same type is recorded in the Info side table.
+			require.Equal(t, got, c.info.TypeOf(e))
+		})
+	}
+}
+
+// A literal kind outside M1's soltype.Lit set (regex, bigint, null, undefined)
+// is an M2 subset miss, not a crash.
+func TestInferLiteralUnsupported(t *testing.T) {
+	c := newChecker()
+	e := ast.NewLitExpr(ast.NewNull(testSpan()))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: NullLit", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferIdentResolvesBinding(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("x", ValueBinding{Type: &soltype.PrimType{Prim: soltype.NumPrim}})
+
+	e := ast.NewIdent("x", testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", soltype.Print(got))
+	require.Equal(t, got, c.info.TypeOf(e))
+}
+
+func TestInferIdentResolvesThroughParent(t *testing.T) {
+	c := newChecker()
+	parent := NewScope()
+	parent.defineValue("y", ValueBinding{Type: &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}})
+	child := parent.Child()
+
+	e := ast.NewIdent("y", testSpan())
+	got := c.inferExpr(child, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, `"hi"`, soltype.Print(got))
+}
+
+func TestInferIdentUnknown(t *testing.T) {
+	c := newChecker()
+	e := ast.NewIdent("nope", testSpan())
+	got := c.inferExpr(NewScope(), 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unknown identifier: nope", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferIdentNamespaceUsedAsValue(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
+
+	e := ast.NewIdent("Foo", testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferExprUnsupportedNode(t *testing.T) {
+	c := newChecker()
+	left := ast.NewLitExpr(ast.NewNumber(1, testSpan()))
+	right := ast.NewLitExpr(ast.NewNumber(2, testSpan()))
+	e := ast.NewBinary(left, right, ast.Plus, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: BinaryExpr", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -43,6 +43,17 @@ func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
 // primitives (so they need no generics/unions/lib types). Richer forms (bigint
 // arithmetic, string <, generic equality) are refinements that land with their
 // enabling milestone (overloads M3, unions M6), not M2.
+//
+// LATENT TRAP for PR-3 (==/!= over unknown): the equality operators are seeded
+// with `unknown` (⊤) parameters, but M1's constrain has NO `T <: UnknownType`
+// rule — its switch handles prim/lit/func/tuple/void plus the two TypeVar arms,
+// and an UnknownType RHS falls through to CannotConstrainError. Nothing applies
+// the operators in PR-1 (BinaryExpr is still UnsupportedNodeError), so this is
+// inert today; but the moment the operator/call walk lands, `1 == 2` will
+// constrain `1 <: unknown` and fail with a spurious "cannot constrain 1 <:
+// unknown". When wiring PR-3, either give the engine an `_ <: UnknownType => ok`
+// arm (UnknownType as ⊤) or seed ==/!= with fresh per-call vars instead, and add
+// a `1 == 2 ⇒ boolean` regression test.
 func addOperatorBindings(s *Scope) {
 	num := func() soltype.Type { return prim(soltype.NumPrim) }
 	str := func() soltype.Type { return prim(soltype.StrPrim) }

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -1,0 +1,86 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/soltype"
+
+// NewPrelude builds the global scope every inference run starts from. It holds
+// two hand-seeded sorts:
+//
+//   - operator/builtin value bindings — the monomorphic-over-primitives schemes
+//     the BinaryExpr/UnaryExpr walk resolves (the BinaryExpr walk itself is a
+//     later PR; the bindings live here from PR-1). A near-mechanical port of the
+//     old checker's addOperatorBindings from type_system constructors to soltype
+//     ones.
+//   - placeholder stdlib *type* bindings (§3.8) — opaque stubs so a reference to
+//     Promise/Iterable/… resolves without an unbound-name error. M2 seeds
+//     placeholders only; real ingestion (real structures, arity) is M7.
+//
+// Nothing here imports internal/checker or internal/type_system — that is the
+// M2 gate.
+func NewPrelude() *Scope {
+	s := NewScope()
+	addOperatorBindings(s)
+	addStdlibTypePlaceholders(s)
+	return s
+}
+
+// prim builds a fresh primitive atom; opFunc builds a monomorphic operator
+// FuncType with IdentPat-named params "a", "b", …. Fresh values per call keep
+// each binding's type independent.
+func prim(p soltype.Prim) soltype.Type { return &soltype.PrimType{Prim: p} }
+
+func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
+	ps := make([]*soltype.FuncParam, len(params))
+	for i, p := range params {
+		ps[i] = &soltype.FuncParam{
+			Pattern: &soltype.IdentPat{Name: string(rune('a' + i))},
+			Type:    p,
+		}
+	}
+	return &soltype.FuncType{Params: ps, Ret: ret}
+}
+
+// addOperatorBindings seeds the built-in operators, every one monomorphic over
+// primitives (so they need no generics/unions/lib types). Richer forms (bigint
+// arithmetic, string <, generic equality) are refinements that land with their
+// enabling milestone (overloads M3, unions M6), not M2.
+func addOperatorBindings(s *Scope) {
+	num := func() soltype.Type { return prim(soltype.NumPrim) }
+	str := func() soltype.Type { return prim(soltype.StrPrim) }
+	boolean := func() soltype.Type { return prim(soltype.BoolPrim) }
+	unknown := func() soltype.Type { return &soltype.UnknownType{} }
+
+	define := func(t soltype.Type, names ...string) {
+		for _, name := range names {
+			s.defineValue(name, ValueBinding{Type: t})
+		}
+	}
+
+	define(opFunc(num(), num(), num()), "+", "-", "*", "/")
+	define(opFunc(boolean(), num(), num()), "<", ">", "<=", ">=")
+	define(opFunc(boolean(), unknown(), unknown()), "==", "!=")
+	define(opFunc(boolean(), boolean(), boolean()), "&&", "||")
+	define(opFunc(boolean(), boolean()), "!")
+	define(opFunc(str(), str(), str()), "++")
+}
+
+// stdlibTypePlaceholders are the names downstream type rules reference (await,
+// for-in, yield, iteration built-ins). M2 must make them *resolve* even though
+// the rules that consume them — and the real generic definitions — land later
+// (real ingestion is M7).
+var stdlibTypePlaceholders = []string{
+	"Promise",
+	"Iterable",
+	"AsyncIterable",
+	"Generator",
+	"AsyncGenerator",
+	"IteratorResult",
+}
+
+// addStdlibTypePlaceholders seeds each stdlib type name as an opaque unknown
+// stub so a reference resolves without an unbound-name error. No structure, no
+// arity — M7 swaps these for real types.
+func addStdlibTypePlaceholders(s *Scope) {
+	for _, name := range stdlibTypePlaceholders {
+		s.defineType(name, TypeBinding{Type: &soltype.UnknownType{}})
+	}
+}

--- a/internal/solver/prelude_test.go
+++ b/internal/solver/prelude_test.go
@@ -1,0 +1,61 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreludeOperatorBindings(t *testing.T) {
+	s := NewPrelude()
+	tests := []struct {
+		op   string
+		want string
+	}{
+		{"+", "fn (a: number, b: number) -> number"},
+		{"-", "fn (a: number, b: number) -> number"},
+		{"*", "fn (a: number, b: number) -> number"},
+		{"/", "fn (a: number, b: number) -> number"},
+		{"<", "fn (a: number, b: number) -> boolean"},
+		{">", "fn (a: number, b: number) -> boolean"},
+		{"<=", "fn (a: number, b: number) -> boolean"},
+		{">=", "fn (a: number, b: number) -> boolean"},
+		{"==", "fn (a: unknown, b: unknown) -> boolean"},
+		{"!=", "fn (a: unknown, b: unknown) -> boolean"},
+		{"&&", "fn (a: boolean, b: boolean) -> boolean"},
+		{"||", "fn (a: boolean, b: boolean) -> boolean"},
+		{"!", "fn (a: boolean) -> boolean"},
+		{"++", "fn (a: string, b: string) -> string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op, func(t *testing.T) {
+			b, ok := s.GetValue(tt.op)
+			require.True(t, ok, "operator %q should be bound in the prelude", tt.op)
+			require.Equal(t, tt.want, soltype.Print(b.Type))
+		})
+	}
+}
+
+func TestPreludeStdlibTypePlaceholders(t *testing.T) {
+	s := NewPrelude()
+	for _, name := range []string{
+		"Promise", "Iterable", "AsyncIterable",
+		"Generator", "AsyncGenerator", "IteratorResult",
+	} {
+		t.Run(name, func(t *testing.T) {
+			b, ok := s.GetType(name)
+			require.True(t, ok, "stdlib type %q should resolve to a placeholder", name)
+			require.IsType(t, &soltype.UnknownType{}, b.Type)
+		})
+	}
+}
+
+// A stdlib type name lives in the type sort, not the value sort: looking it up
+// as a value must miss (so a value-position reference would error, not silently
+// resolve to the placeholder).
+func TestPreludeStdlibNamesAreTypesNotValues(t *testing.T) {
+	s := NewPrelude()
+	_, ok := s.GetValue("Promise")
+	require.False(t, ok)
+}

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -38,6 +38,19 @@ type Namespace struct {
 // Scope is the package-owned, multi-sorted analogue of type_system's scope (the
 // milestone forbids reusing type_system's). It has one map per binding sort plus
 // a parent link for lexical lookup.
+//
+// Why namespaces are stored by pointer while values/types are stored by value:
+// the distinction is by *kind*, not by slot. A Namespace is a shared, mutable,
+// recursive container — keyed by its qualified dep_graph BindingKey, referenced
+// from several scopes/files (so a pointer gives it one identity), populated
+// incrementally after insertion (a struct value in a map can't be field-mutated
+// in place), and recursive (Namespace.Nested is also *Namespace). A
+// ValueBinding/TypeBinding, by contrast, is a tiny identity-free record that is
+// replaced wholesale — defineValue is a plain map overwrite, and redeclaration
+// and the rec-group rebind both swap the entry rather than mutate it — so
+// storing it by value avoids a per-binding allocation and a nil case for no
+// loss. (Namespace.Values/Types follow the same value rule; Namespace.Nested
+// follows the same pointer rule.)
 type Scope struct {
 	values     map[string]ValueBinding
 	types      map[string]TypeBinding

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -1,0 +1,114 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// ValueBinding is a name's value-sort binding. In M2 it holds a plain
+// MONOMORPHIC soltype.Type — M1 ships no schemes, so there is no generalization
+// yet. M3 swaps Type for a TypeScheme when let-generalization lands (open
+// question §7 (a): take the mechanical field-swap churn then rather than
+// over-abstract now).
+type ValueBinding struct {
+	Type   soltype.Type          // M2: monomorphic. M3 replaces with a TypeScheme.
+	Source provenance.Provenance // the introducing VarDecl/FuncDecl/param; nil for prelude
+}
+
+// TypeBinding is a name's type-sort binding. M2 only ever populates this with
+// the hand-seeded stdlib-type placeholders (§3.8); real type aliases/classes are
+// M3+. The shape lands now because it is load-bearing for the two-map test
+// harness.
+type TypeBinding struct {
+	Type   soltype.Type
+	Source provenance.Provenance
+}
+
+// Namespace is the third binding sort — a separate kind from a soltype.Type, so
+// a namespace never flows as a value. M2 keeps the structure (for qualified
+// BindingKey resolution across files) and the free-floating
+// NamespaceUsedAsValueError; the member-access *lookup* (Foo.bar) is M4.
+type Namespace struct {
+	Name   string // qualified, from dep_graph.GetNamespace
+	Values map[string]ValueBinding
+	Types  map[string]TypeBinding
+	Nested map[string]*Namespace
+}
+
+// Scope is the package-owned, multi-sorted analogue of type_system's scope (the
+// milestone forbids reusing type_system's). It has one map per binding sort plus
+// a parent link for lexical lookup.
+type Scope struct {
+	values     map[string]ValueBinding
+	types      map[string]TypeBinding
+	namespaces map[string]*Namespace
+	parent     *Scope
+}
+
+// NewScope returns an empty root scope (no parent).
+func NewScope() *Scope {
+	return &Scope{
+		values:     map[string]ValueBinding{},
+		types:      map[string]TypeBinding{},
+		namespaces: map[string]*Namespace{},
+	}
+}
+
+// Child returns a fresh scope whose parent is s, for entering a nested lexical
+// region (a function body, a block).
+func (s *Scope) Child() *Scope {
+	child := NewScope()
+	child.parent = s
+	return child
+}
+
+// defineValue inserts b under name in THIS scope's value map. It OVERWRITES any
+// existing binding for name in this scope — it does not panic or error on a
+// duplicate the way the old checker's setValue does. Two M2 paths rely on the
+// overwrite: body-level variable redeclaration (§3.2) and inferComponent, which
+// binds each rec-group name twice (fresh var, then coalesced type) (§3.7).
+func (s *Scope) defineValue(name string, b ValueBinding) {
+	s.values[name] = b
+}
+
+// defineType inserts b under name in this scope's type map (overwrite, as above).
+func (s *Scope) defineType(name string, b TypeBinding) {
+	s.types[name] = b
+}
+
+// defineNamespace inserts ns under name in this scope's namespace map.
+func (s *Scope) defineNamespace(name string, ns *Namespace) {
+	s.namespaces[name] = ns
+}
+
+// GetValue resolves name in the value sort by lexical lookup: this scope's own
+// map, then up the parent chain. The comma-ok form makes the not-found case
+// explicit at every call site.
+func (s *Scope) GetValue(name string) (ValueBinding, bool) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if b, ok := cur.values[name]; ok {
+			return b, true
+		}
+	}
+	return ValueBinding{}, false
+}
+
+// GetType resolves name in the type sort by the same lexical walk.
+func (s *Scope) GetType(name string) (TypeBinding, bool) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if b, ok := cur.types[name]; ok {
+			return b, true
+		}
+	}
+	return TypeBinding{}, false
+}
+
+// GetNamespace resolves name in the namespace sort by the same lexical walk.
+func (s *Scope) GetNamespace(name string) (*Namespace, bool) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if ns, ok := cur.namespaces[name]; ok {
+			return ns, true
+		}
+	}
+	return nil, false
+}


### PR DESCRIPTION
This PR implements the core scaffolding for M2 constraint-based type inference, landing the first phase of the walk that handles literals and identifiers.

## Summary

Introduces the multi-sorted scope system, prelude with operator bindings and stdlib type placeholders, and the expression inference dispatcher. These are the foundational pieces for the constraint-generating AST walk described in the m2-implementation-plan.

## Key changes

- **Scope system** (`scope.go`): Multi-sorted scope with separate maps for values, types, and namespaces. Supports lexical lookup through parent chain. Values and types stored by value (identity-free, wholesale replacement); namespaces stored by pointer (mutable, recursive, shared identity).

- **Prelude** (`prelude.go`, `prelude_test.go`): Hand-seeded global scope with monomorphic operator bindings (arithmetic, comparison, logical, string concatenation) and placeholder stdlib type bindings (Promise, Iterable, Generator, etc.). Operators are seeded with fresh types per call to keep bindings independent.

- **Expression inference** (`infer.go`, `infer_expr.go`, `infer_expr_test.go`): 
  - `checker` struct threads the M1 Context (fresh-var counter, Constrain), Info side table, and error accumulation
  - `inferExpr` dispatcher with concrete implementations for literals and identifiers; all other node kinds fall through to UnsupportedNodeError
  - Literal inference produces singleton LitTypes; identifier inference resolves through scope chain with proper error handling for unknown names and namespace-as-value misuse

- **Error types** (`errors.go`): Added M2 bridge errors (UnknownIdentifierError, NamespaceUsedAsValueError, UnsupportedNodeError, BodyDeclNotAllowedError) with span tracking. Refactored constraint engine errors to carry spans via embeddable `errSpan` struct, populated at the constrain call site.

## Notable implementation details

- The walk is a direct recursive switch over AST nodes, not the shared visitor, because constraint generation is bottom-up and value-producing — the visitor shape doesn't model this cleanly.
- Spans are stamped onto constraint engine errors after the fact via `setSpan` at the constrain call site; bridge errors carry their span from construction.
- Namespace names in value position correctly error in M2 (no qualified member access yet); the error moves to the consumer in M4 once MemberExpr lands.
- A latent trap is documented in prelude.go: equality operators are seeded with `unknown` parameters, but the engine has no `T <: UnknownType` rule. This is inert until BinaryExpr wiring lands in PR-3; the fix is deferred to that PR.

https://claude.ai/code/session_01BryG6LeqAgjQrS9RjHfrg5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Error diagnostics now display source location information for faster issue identification and debugging.
  * Enhanced error detection for undefined identifiers, invalid namespace usage, and unsupported language constructs.
  * Expanded support for expression type inference to handle literals and identifier resolution.
  * Improved scope management and built-in operator support for type checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/escalier-lang/escalier/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->