### PR TITLE
Add module-level inference and top-level declaration handling

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -100,13 +100,45 @@ type BodyDeclNotAllowedError struct {
 	Kind string
 }
 
+// MissingInitializerError fires when a `val`/`var` declaration has no
+// initializer. M2 has no way to bind such a name yet — annotation-only binding
+// needs TypeAnn→soltype resolution that lands in a later PR — so this is its own
+// kind rather than a generic UnsupportedNodeError: it marks an annotation-driven
+// binding the walk can't infer, not an AST node shape outside the subset.
+type MissingInitializerError struct {
+	errSpan
+	Name string // the bound name when the pattern is an IdentPat; "" otherwise
+}
+
+// DuplicateDeclarationError fires when a top-level `val`/`var` rebinds a name
+// already declared in the module scope. Unlike a function (whose repeated
+// top-level declarations are overloads, supported from PR-3), a variable may be
+// declared only once per scope; the first binding is kept.
+type DuplicateDeclarationError struct {
+	errSpan
+	Name string
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*UnsupportedNodeError) isSolverError()      {}
 func (*BodyDeclNotAllowedError) isSolverError()   {}
+func (*MissingInitializerError) isSolverError()   {}
+func (*DuplicateDeclarationError) isSolverError() {}
 
 func (e *UnknownIdentifierError) Message() string {
 	return "Unknown identifier: " + e.Name
+}
+
+func (e *MissingInitializerError) Message() string {
+	if e.Name != "" {
+		return "Variable declaration requires an initializer: " + e.Name
+	}
+	return "Variable declaration requires an initializer"
+}
+
+func (e *DuplicateDeclarationError) Message() string {
+	return "Duplicate declaration: " + e.Name
 }
 
 func (e *NamespaceUsedAsValueError) Message() string {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -73,7 +73,7 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	default:
 		return c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: e.Span()},
-			Kind:    exprKind(e),
+			Kind:    astKind(e),
 		})
 	}
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -1,69 +1,89 @@
 package solver
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
 // inferDecl types a single top-level declaration and binds its name into scope.
-// PR-2 wires only VarDecl (the `val`/`var` path); FuncDecl lands in PR-3 and the
-// remaining decl kinds in later milestones. Any not-yet-supported kind reports a
-// clean UnsupportedNodeError (never a panic) and binds nothing.
+// PR-2 wires only VarDecl (the `val`/`var` path); FuncDecl lands in PR-3 (where
+// repeated top-level functions become overloads) and the remaining decl kinds in
+// later milestones. Any not-yet-supported kind reports a clean
+// UnsupportedNodeError (never a panic) and binds nothing.
+//
+// The VarDecl path always walks the initializer first (so its errors surface
+// even when the binding itself can't be formed), then decides whether to bind:
+//   - no initializer            → MissingInitializerError, bind nothing
+//   - non-IdentPat (destructure) → UnsupportedNodeError, bind nothing
+//   - name already bound here   → DuplicateDeclarationError, keep the first
+//   - otherwise                  → defineValue
 func (c *checker) inferDecl(scope *Scope, lvl int, d ast.Decl) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
-		name, ok := varName(d)
+		b, ok := c.inferVarDecl(scope, lvl, d)
 		if !ok {
+			// No initializer: inferVarDecl already reported it and there is no
+			// type to bind. Don't pollute the scope with a placeholder binding —
+			// a later reference should still fail as an unknown identifier.
+			return
+		}
+		name, named := varName(d)
+		if !named {
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
-			// types that arrive in M4; until then a non-IdentPat binding is
-			// outside the M2 subset. Report and bind nothing.
+			// types that arrive in M4. The initializer was already walked above
+			// (its errors surfaced); report the pattern and bind nothing.
 			c.report(&UnsupportedNodeError{
 				errSpan: errSpan{span: d.Pattern.Span()},
-				Kind:    patKind(d.Pattern),
+				Kind:    astKind(d.Pattern),
 			})
 			return
 		}
-		b := c.inferVarDecl(scope, lvl, d)
+		if scope.hasOwnValue(name) {
+			// A duplicate top-level `val`/`var` is a redeclaration error (unlike a
+			// FuncDecl, whose duplicates are overloads). Keep the first binding.
+			c.report(&DuplicateDeclarationError{
+				errSpan: errSpan{span: d.Span()},
+				Name:    name,
+			})
+			return
+		}
 		scope.defineValue(name, b)
 	default:
 		c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: d.Span()},
-			Kind:    declKind(d),
+			Kind:    astKind(d),
 		})
 	}
 }
 
 // inferVarDecl types a `val`/`var` declaration's initializer and returns the
-// resulting MONOMORPHIC ValueBinding. The initializer is typed via inferExpr and
-// coalesced at Positive polarity (coalesce-at-binding, §7) so the stored type is
-// var-free and stable: a later SCC can't mutate it, ValueBinding.Type stays
-// inspectable, and it is the natural monomorphic stand-in for M3's PolyScheme.
+// resulting MONOMORPHIC ValueBinding, with ok=false when there is no initializer
+// to infer from. The initializer is typed via inferExpr and coalesced at
+// Positive polarity (coalesce-at-binding, §7) so the stored type is var-free and
+// stable: a later SCC can't mutate it, ValueBinding.Type stays inspectable, and
+// it is the natural monomorphic stand-in for M3's PolyScheme.
 //
-// The caller (inferDecl, and the body walk in a later PR) owns the name lookup
-// and defineValue, so this routine serves both the module driver and body-level
-// redeclaration (§3.2) unchanged.
+// inferVarDecl always walks the initializer (so a malformed RHS still surfaces
+// its errors) and records the type, but it does NOT bind anything — the caller
+// owns the name lookup, duplicate check, and defineValue, so this routine serves
+// both the module driver and the body-level redeclaration path (§3.2) unchanged.
 //
 // A `val`/`var` with no initializer needs a type annotation to infer from;
 // annotation-driven binding lands with TypeAnn support in a later PR, so for now
-// it is outside the PR-2 subset and reports UnsupportedNodeError.
-func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding {
-	source := &ast.NodeProvenance{Node: d}
+// it reports MissingInitializerError and returns ok=false.
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
 	if d.Init == nil {
-		return ValueBinding{
-			Type: c.report(&UnsupportedNodeError{
-				errSpan: errSpan{span: d.Span()},
-				Kind:    "VarDecl without initializer",
-			}),
-			Source: source,
-		}
+		name, _ := varName(d)
+		c.report(&MissingInitializerError{
+			errSpan: errSpan{span: d.Span()},
+			Name:    name,
+		})
+		return ValueBinding{}, false
 	}
 	initType := c.inferExpr(scope, lvl, d.Init)
 	t := coalesce(initType, soltype.Positive)
 	c.recordType(d.Pattern, t)
-	return ValueBinding{Type: t, Source: source}
+	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}, true
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
@@ -75,17 +95,4 @@ func varName(d *ast.VarDecl) (string, bool) {
 		return p.Name, true
 	}
 	return "", false
-}
-
-// declKind returns a short surface name for a declaration node, used in the M2
-// subset-guard error message. It strips the leading "*ast." from the Go type
-// name so e.g. *ast.TypeDecl renders as "TypeDecl". Mirrors exprKind.
-func declKind(d ast.Decl) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", d), "*ast.")
-}
-
-// patKind returns a short surface name for a pattern node, used when a binding
-// pattern is outside M2's IdentPat-only subset.
-func patKind(p ast.Pat) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", p), "*ast.")
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -1,0 +1,91 @@
+package solver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferDecl types a single top-level declaration and binds its name into scope.
+// PR-2 wires only VarDecl (the `val`/`var` path); FuncDecl lands in PR-3 and the
+// remaining decl kinds in later milestones. Any not-yet-supported kind reports a
+// clean UnsupportedNodeError (never a panic) and binds nothing.
+func (c *checker) inferDecl(scope *Scope, lvl int, d ast.Decl) {
+	switch d := d.(type) {
+	case *ast.VarDecl:
+		name, ok := varName(d)
+		if !ok {
+			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
+			// types that arrive in M4; until then a non-IdentPat binding is
+			// outside the M2 subset. Report and bind nothing.
+			c.report(&UnsupportedNodeError{
+				errSpan: errSpan{span: d.Pattern.Span()},
+				Kind:    patKind(d.Pattern),
+			})
+			return
+		}
+		b := c.inferVarDecl(scope, lvl, d)
+		scope.defineValue(name, b)
+	default:
+		c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: d.Span()},
+			Kind:    declKind(d),
+		})
+	}
+}
+
+// inferVarDecl types a `val`/`var` declaration's initializer and returns the
+// resulting MONOMORPHIC ValueBinding. The initializer is typed via inferExpr and
+// coalesced at Positive polarity (coalesce-at-binding, §7) so the stored type is
+// var-free and stable: a later SCC can't mutate it, ValueBinding.Type stays
+// inspectable, and it is the natural monomorphic stand-in for M3's PolyScheme.
+//
+// The caller (inferDecl, and the body walk in a later PR) owns the name lookup
+// and defineValue, so this routine serves both the module driver and body-level
+// redeclaration (§3.2) unchanged.
+//
+// A `val`/`var` with no initializer needs a type annotation to infer from;
+// annotation-driven binding lands with TypeAnn support in a later PR, so for now
+// it is outside the PR-2 subset and reports UnsupportedNodeError.
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding {
+	source := &ast.NodeProvenance{Node: d}
+	if d.Init == nil {
+		return ValueBinding{
+			Type: c.report(&UnsupportedNodeError{
+				errSpan: errSpan{span: d.Span()},
+				Kind:    "VarDecl without initializer",
+			}),
+			Source: source,
+		}
+	}
+	initType := c.inferExpr(scope, lvl, d.Init)
+	t := coalesce(initType, soltype.Positive)
+	c.recordType(d.Pattern, t)
+	return ValueBinding{Type: t, Source: source}
+}
+
+// varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
+// ok=false for any other pattern shape. M2 binds IdentPat-only patterns,
+// mirroring M1's IdentPat-only FuncParam; destructuring (`val [a, b] = …`)
+// arrives in M4 once tuple/record types exist (§3.2).
+func varName(d *ast.VarDecl) (string, bool) {
+	if p, ok := d.Pattern.(*ast.IdentPat); ok {
+		return p.Name, true
+	}
+	return "", false
+}
+
+// declKind returns a short surface name for a declaration node, used in the M2
+// subset-guard error message. It strips the leading "*ast." from the Go type
+// name so e.g. *ast.TypeDecl renders as "TypeDecl". Mirrors exprKind.
+func declKind(d ast.Decl) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", d), "*ast.")
+}
+
+// patKind returns a short surface name for a pattern node, used when a binding
+// pattern is outside M2's IdentPat-only subset.
+func patKind(p ast.Pat) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", p), "*ast.")
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -25,7 +25,7 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 	default:
 		return c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: e.Span()},
-			Kind:    litKind(e.Lit),
+			Kind:    astKind(e.Lit),
 		})
 	}
 	t := &soltype.LitType{Lit: lit}
@@ -60,15 +60,11 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 	})
 }
 
-// exprKind returns a short surface name for an expression node, used in the M2
-// subset-guard error message. It strips the leading "*ast." from the Go type
-// name so e.g. *ast.BinaryExpr renders as "BinaryExpr".
-func exprKind(e ast.Expr) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", e), "*ast.")
-}
-
-// litKind returns a short surface name for a literal node, used when a literal
-// kind is outside M1's soltype.Lit set.
-func litKind(l ast.Lit) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", l), "*ast.")
+// astKind returns a short surface name for any AST node — an expression,
+// literal, declaration, or pattern — used in the M2 subset-guard error messages.
+// It strips the leading "*ast." from the Go type name so e.g. *ast.BinaryExpr
+// renders as "BinaryExpr". One helper serves every guard site (inferExpr,
+// inferLiteral, inferDecl) so the format lives in a single place.
+func astKind(n any) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", n), "*ast.")
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -1,0 +1,137 @@
+package solver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// inferSource parses a single in-memory .esc source, runs InferModule, and
+// returns the rendered top-level value/type bindings plus any SolverErrors. This
+// is the PR-2 single-file table harness (§3.6) — fast, no on-disk fixtures.
+// Bindings are read straight off the module scope's own maps (not the prelude
+// parent), so operators and the stdlib-type placeholders are excluded. Parse
+// errors fail the test outright; only inference errors flow back to the caller so
+// a case can assert on them (e.g. the forward-reference limitation).
+func inferSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
+	t.Helper()
+	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
+	require.Empty(t, parseErrors, "expected no parse errors")
+
+	scope, _, errs := InferModule(module)
+	return renderValueBindings(scope.values), renderTypeBindings(scope.types), errs
+}
+
+// renderValueBindings renders each value binding to its soltype string.
+func renderValueBindings(m map[string]ValueBinding) map[string]string {
+	out := make(map[string]string, len(m))
+	for name, b := range m {
+		out[name] = soltype.Print(b.Type)
+	}
+	return out
+}
+
+// renderTypeBindings renders each type binding to its soltype string.
+func renderTypeBindings(m map[string]TypeBinding) map[string]string {
+	out := make(map[string]string, len(m))
+	for name, b := range m {
+		out[name] = soltype.Print(b.Type)
+	}
+	return out
+}
+
+func TestInferModuleValDecls(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "NumberLiteral",
+			src:  `val x = 5`,
+			want: map[string]string{"x": "5"},
+		},
+		{
+			name: "StringLiteral",
+			src:  `val s = "hi"`,
+			want: map[string]string{"s": `"hi"`},
+		},
+		{
+			name: "BoolLiteral",
+			src:  `val b = true`,
+			want: map[string]string{"b": "true"},
+		},
+		{
+			name: "MultipleDecls",
+			src: `
+				val x = 5
+				val s = "hi"
+			`,
+			want: map[string]string{"x": "5", "s": `"hi"`},
+		},
+		{
+			name: "IdentifierInitializerReferencesEarlierDecl",
+			src: `
+				val x = 5
+				val y = x
+			`,
+			want: map[string]string{"x": "5", "y": "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// A forward reference — a decl that uses a name defined later in the source —
+// fails in PR-2 because the module driver walks decls in source order with no
+// dep-graph ordering. PR-5 adds SCC ordering and this case flips to success.
+func TestInferModuleForwardReferenceIsError(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val y = x
+		val x = 5
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: x", errs[0].Message())
+	// x is bound by the time the loop reaches it; only the forward use of x in y
+	// failed (y therefore resolves to the never placeholder report() returns).
+	require.Equal(t, map[string]string{"x": "5", "y": "never"}, values)
+}
+
+// A top-level declaration outside PR-2's VarDecl coverage reports a clean
+// UnsupportedNodeError rather than panicking. (FuncDecl support lands in PR-3.)
+func TestInferModuleUnsupportedDecl(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f() {}`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: FuncDecl", errs[0].Message())
+}
+
+// A `val` with no initializer is outside the PR-2 subset (annotation-driven
+// binding needs TypeAnn support that lands later) and reports cleanly.
+func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
+	_, _, errs := inferSource(t, `declare val x: number`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: VarDecl without initializer", errs[0].Message())
+}
+
+// A destructuring pattern is IdentPat-only-gated in M2 (M4 adds tuple/record
+// binding); the binding reports UnsupportedNodeError and introduces no value.
+func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: TuplePat", errs[0].Message())
+	require.Empty(t, values)
+}

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -28,23 +28,18 @@ func inferSource(t *testing.T, src string) (values, types map[string]string, err
 	require.Empty(t, parseErrors, "expected no parse errors")
 
 	scope, _, errs := InferModule(module)
-	return renderValueBindings(scope.values), renderTypeBindings(scope.types), errs
+	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
+	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
+	return values, types, errs
 }
 
-// renderValueBindings renders each value binding to its soltype string.
-func renderValueBindings(m map[string]ValueBinding) map[string]string {
+// renderBindings renders each binding in m to its soltype string, using typeOf
+// to pull the soltype.Type out of the binding. One helper serves both the value
+// and type sorts.
+func renderBindings[B any](m map[string]B, typeOf func(B) soltype.Type) map[string]string {
 	out := make(map[string]string, len(m))
 	for name, b := range m {
-		out[name] = soltype.Print(b.Type)
-	}
-	return out
-}
-
-// renderTypeBindings renders each type binding to its soltype string.
-func renderTypeBindings(m map[string]TypeBinding) map[string]string {
-	out := make(map[string]string, len(m))
-	for name, b := range m {
-		out[name] = soltype.Print(b.Type)
+		out[name] = soltype.Print(typeOf(b))
 	}
 	return out
 }
@@ -119,19 +114,50 @@ func TestInferModuleUnsupportedDecl(t *testing.T) {
 	require.Equal(t, "Unsupported in M2: FuncDecl", errs[0].Message())
 }
 
-// A `val` with no initializer is outside the PR-2 subset (annotation-driven
-// binding needs TypeAnn support that lands later) and reports cleanly.
+// A `val` with no initializer can't be inferred in M2 (annotation-driven binding
+// needs TypeAnn support that lands later); it reports MissingInitializerError and
+// binds NOTHING, so a later reference still fails as an unknown identifier rather
+// than silently resolving to a placeholder.
 func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
-	_, _, errs := inferSource(t, `declare val x: number`)
+	values, _, errs := inferSource(t, `declare val x: number`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: VarDecl without initializer", errs[0].Message())
+	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
+	require.Empty(t, values)
+}
+
+// A no-initializer decl must not leak a binding: a later use of the name is a
+// genuine unknown-identifier error, not a silent resolution to a placeholder.
+func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		declare val x: number
+		val y = x
+	`)
+	require.Len(t, errs, 2)
+	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
+	require.Equal(t, "Unknown identifier: x", errs[1].Message())
+	require.Equal(t, map[string]string{"y": "never"}, values)
 }
 
 // A destructuring pattern is IdentPat-only-gated in M2 (M4 adds tuple/record
 // binding); the binding reports UnsupportedNodeError and introduces no value.
+// The initializer is still walked, so its own errors (here the as-yet-unsupported
+// tuple expression) surface too rather than being dropped.
 func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
 	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TuplePat", errs[0].Message())
+	require.Len(t, errs, 2)
+	require.Equal(t, "Unsupported in M2: TupleExpr", errs[0].Message())
+	require.Equal(t, "Unsupported in M2: TuplePat", errs[1].Message())
 	require.Empty(t, values)
+}
+
+// A duplicate top-level `val` is a redeclaration error (unlike FuncDecl
+// overloads); the first binding is kept and the second reports cleanly.
+func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val x = 5
+		val x = "hi"
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Duplicate declaration: x", errs[0].Message())
+	require.Equal(t, map[string]string{"x": "5"}, values)
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -1,0 +1,34 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// InferModule infers every top-level declaration in a single parsed module and
+// returns the populated module Scope (a child of the prelude, so operators and
+// the stdlib-type placeholders resolve through the parent), the Info side table,
+// and any SolverErrors.
+//
+// PR-2 walks declarations in SOURCE ORDER — the order they appear within each
+// namespace — with no dep_graph SCC ordering yet. A forward reference (a decl
+// that uses a name defined later in the source) therefore fails with
+// UnknownIdentifierError; PR-5 replaces this loop with dep_graph SCC ordering so
+// out-of-order and recursive decls resolve. Source order is sufficient for
+// PR-2's literal/identifier-initializer bar.
+func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
+	c := newChecker()
+	scope := NewPrelude().Child()
+	c.inferModule(scope, 0, module)
+	return scope, c.info, c.errs
+}
+
+// inferModule iterates the module's namespaces (in key order) and, within each,
+// its declarations in source order, typing each through inferDecl. The module
+// Scope is mutated in place as bindings are introduced, so a decl sees every
+// earlier decl's binding (the basis for the forward-reference limitation above).
+func (c *checker) inferModule(scope *Scope, lvl int, module *ast.Module) {
+	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, d := range ns.Decls {
+			c.inferDecl(scope, lvl, d)
+		}
+		return true
+	})
+}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -7,23 +7,26 @@ import "github.com/escalier-lang/escalier/internal/ast"
 // the stdlib-type placeholders resolve through the parent), the Info side table,
 // and any SolverErrors.
 //
-// PR-2 walks declarations in SOURCE ORDER — the order they appear within each
-// namespace — with no dep_graph SCC ordering yet. A forward reference (a decl
-// that uses a name defined later in the source) therefore fails with
-// UnknownIdentifierError; PR-5 replaces this loop with dep_graph SCC ordering so
-// out-of-order and recursive decls resolve. Source order is sufficient for
-// PR-2's literal/identifier-initializer bar.
+// PR-2 walks namespaces in namespace-key order and, within each, declarations in
+// source order — with no dep_graph SCC ordering yet. So within a single
+// namespace a forward reference (a decl that uses a name defined later) fails
+// with UnknownIdentifierError, and across namespaces the visit order follows the
+// sorted namespace key rather than source/file order. PR-5 replaces this loop
+// with dep_graph SCC ordering, which makes both cases order-independent; the
+// source-order loop is sufficient only for PR-2's single-namespace
+// literal/identifier-initializer bar.
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 	c := newChecker()
-	scope := NewPrelude().Child()
+	scope := sharedPrelude().Child()
 	c.inferModule(scope, 0, module)
 	return scope, c.info, c.errs
 }
 
-// inferModule iterates the module's namespaces (in key order) and, within each,
-// its declarations in source order, typing each through inferDecl. The module
-// Scope is mutated in place as bindings are introduced, so a decl sees every
-// earlier decl's binding (the basis for the forward-reference limitation above).
+// inferModule iterates the module's namespaces (in sorted key order, per
+// btree.Map.Scan) and, within each, its declarations in source order, typing
+// each through inferDecl. The module Scope is mutated in place as bindings are
+// introduced, so a decl sees every earlier decl's binding (the basis for the
+// forward-reference limitation above).
 func (c *checker) inferModule(scope *Scope, lvl int, module *ast.Module) {
 	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
 		for _, d := range ns.Decls {

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -1,6 +1,27 @@
 package solver
 
-import "github.com/escalier-lang/escalier/internal/soltype"
+import (
+	"sync"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+var (
+	preludeOnce sync.Once
+	sharedScope *Scope
+)
+
+// sharedPrelude returns a process-wide, lazily-built prelude scope reused across
+// InferModule calls instead of rebuilding the operator/stdlib table every time.
+// This is safe because the prelude is effectively immutable: every InferModule
+// run hangs its module scope off a fresh Child(), writes only to that child, and
+// the seeded prelude bindings are concrete types (no shared inference variables
+// for constrain to mutate). Tests that need a private prelude still call
+// NewPrelude() directly.
+func sharedPrelude() *Scope {
+	preludeOnce.Do(func() { sharedScope = NewPrelude() })
+	return sharedScope
+}
 
 // NewPrelude builds the global scope every inference run starts from. It holds
 // two hand-seeded sorts:

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -94,6 +94,15 @@ func (s *Scope) defineNamespace(name string, ns *Namespace) {
 	s.namespaces[name] = ns
 }
 
+// hasOwnValue reports whether name is bound in THIS scope's own value map,
+// without walking the parent chain. The module driver uses it to reject a
+// duplicate top-level `val`/`var` (a redeclaration in the same scope) while
+// still allowing a decl to shadow a prelude/parent binding.
+func (s *Scope) hasOwnValue(name string) bool {
+	_, ok := s.values[name]
+	return ok
+}
+
 // GetValue resolves name in the value sort by lexical lookup: this scope's own
 // map, then up the parent chain. The comma-ok form makes the not-found case
 // explicit at every call site.


### PR DESCRIPTION
## Summary

Implement module-level type inference for top-level declarations, completing the M2 milestone's support for `val`/`var` bindings at module scope. This adds the entry point for whole-module inference and the declaration-typing logic that walks the module's namespaces in order, types each declaration, and populates the module scope with bindings.

## Key changes

- **New `InferModule` entry point** (`module.go`): Public API that infers all top-level declarations in a parsed module, returning the populated module scope (a child of the prelude), the Info side table, and any SolverErrors. Walks namespaces in sorted key order and declarations in source order — a limitation that PR-5's SCC ordering will lift.

- **Declaration typing** (`infer_decl.go`): New `inferDecl` method that types a single top-level declaration and binds its name into scope. PR-2 supports only `VarDecl` (`val`/`var`); other declaration kinds report `UnsupportedNodeError` without panicking. The `VarDecl` path:
  - Always walks the initializer first (so its errors surface even when binding fails)
  - Rejects declarations without initializers with `MissingInitializerError` (annotation-driven binding lands later)
  - Rejects non-`IdentPat` patterns (destructuring arrives in M4 with tuple/record types)
  - Rejects duplicate top-level `val`/`var` with `DuplicateDeclarationError` (unlike functions, which support overloads)
  - Otherwise binds the name via `defineValue`

- **New error types** (`errors.go`): `MissingInitializerError` (for `val` without initializer) and `DuplicateDeclarationError` (for redeclared variables at module scope).

- **Prelude caching** (`prelude.go`): Add `sharedPrelude()` that lazily builds and caches a process-wide prelude scope, reused across `InferModule` calls instead of rebuilding the operator/stdlib table every time. Safe because the prelude is immutable and every module hangs its scope off a fresh `Child()`.

- **Scope helper** (`scope.go`): New `hasOwnValue` method to check if a name is bound in a scope's own value map (without walking parents), used to reject duplicate top-level declarations while allowing shadowing of prelude bindings.

- **Unified AST node naming** (`infer.go`, `infer_expr.go`): Consolidate `exprKind` and `litKind` into a single `astKind` helper that works for any AST node (expressions, literals, declarations, patterns), so the M2 subset-guard error message format lives in one place.

- **Comprehensive test suite** (`infer_test.go`): Table-driven tests covering literal inference, multiple declarations, identifier references, forward references (which fail in PR-2), unsupported declarations, missing initializers, destructuring patterns, and duplicate declarations. The `inferSource` harness parses in-memory source, runs `InferModule`, and returns rendered bindings and errors for assertion.

## Notable implementation details

- The module driver walks declarations in source order with no dependency-graph ordering, so forward references (a decl using a name defined later) fail with `UnknownIdentifierError`. This is a known PR-2 limitation; PR-5 replaces the loop with SCC ordering to make both within-namespace and cross-namespace references order-independent.

- A `val` without an initializer does not leak a binding — a later reference is a genuine unknown-identifier error, not a silent resolution to a placeholder. This ensures error clarity when annotation-driven binding lands.

- The `inferVarDecl` method always walks the initializer (so malformed RHS errors surface) and records the type, but does not bind anything — the caller owns the name lookup, duplicate check, and `defineValue`, allowing the same routine to serve both module-level and body-level redeclaration paths.

https://claude.ai/code/session_01G2FLysginU8mtU389qzqb2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added module-level type inference with support for variable declarations.
  * Enhanced error reporting for variable declarations without initializers and duplicate declarations.

* **Bug Fixes**
  * Improved error message accuracy in type inference.

* **Tests**
  * Comprehensive test coverage for variable declaration inference, error handling, and duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->