### PR TITLE
M2: Add function expressions, calls, and statement inference

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -27,9 +27,9 @@ func typePrec(t Type) int {
 	case *IntersectionType:
 		return precIntersection
 	default:
-		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms.
-		// TypeVarType never appears in coalesced output (coalesce inlines every
-		// variable, m1-implementation-plan Delta #1), so it has no printer arm.
+		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms. A
+		// raw TypeVarType (which appears only when printing an un-coalesced type,
+		// see printType) is also an atom (rendered as `t{ID}`), so it lands here.
 		return precAtom
 	}
 }
@@ -50,6 +50,12 @@ func typePrec(t Type) int {
 // uncoalesced type (t0, function, number) mid-constrain for error messages,
 // whereas Print renders a COALESCED type as user-facing syntax. They look
 // similar but operate at different stages and must not be merged (§2.2).
+//
+// Print's normal input is a coalesced type, but it also tolerates a raw,
+// un-coalesced TypeVarType (rendering it as `t{ID}`) rather than panicking: the
+// M2 walk records var-carrying types in its Info side table and coalesces only
+// at binding boundaries, so a consumer may legitimately print an inner node's
+// still-raw type (M2 plan §7).
 func Print(t Type) string {
 	return printType(t)
 }
@@ -68,6 +74,14 @@ func printTypeMinPrec(t Type, minPrec int) string {
 
 func printType(t Type) string {
 	switch t := t.(type) {
+	case *TypeVarType:
+		// A raw, un-coalesced variable. Coalesced output never contains one (every
+		// variable is inlined to its bounds, m1-implementation-plan Delta #1), but
+		// the M2 walk records raw, var-carrying types in its Info side table and
+		// only coalesces at binding boundaries — so a consumer printing an inner
+		// node's type directly may hand Print a live variable. Render it as `t{ID}`
+		// (matching solver's describe()) rather than panicking. See the M2 plan §7.
+		return "t" + strconv.Itoa(t.ID)
 	case *PrimType:
 		return printPrim(t.Prim)
 	case *LitType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -93,6 +93,25 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
+// TestPrintRawTypeVar verifies that Print tolerates a raw, un-coalesced
+// TypeVarType (rendering it as `t{ID}`) instead of panicking — the M2 walk
+// records var-carrying types in Info and only coalesces at binding boundaries,
+// so a consumer can hand Print a live variable, standalone or nested in a
+// function. See print.go's printType TypeVarType arm.
+func TestPrintRawTypeVar(t *testing.T) {
+	t.Run("bare variable", func(t *testing.T) {
+		require.Equal(t, "t7", Print(&TypeVarType{ID: 7}))
+	})
+
+	t.Run("variable nested in a function", func(t *testing.T) {
+		fn := &FuncType{
+			Params: []*FuncParam{identP("x", &TypeVarType{ID: 0})},
+			Ret:    &TypeVarType{ID: 0},
+		}
+		require.Equal(t, "fn (x: t0) -> t0", Print(fn))
+	})
+}
+
 // TestPrintUnnamedParamFallback verifies that a parameter with no IdentPat
 // pattern falls back to a positional name (arg0, arg1, ...), numbered by param
 // index. This path isn't reachable in M1 (params are always IdentPat), but the

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -60,16 +60,21 @@ func (c *checker) recordType(n ast.Node, t soltype.Type) {
 	c.info.setType(n, t)
 }
 
-// inferExpr dispatches on the concrete expression kind. PR-1 wires only the two
-// leaf cases (literals, identifiers); every other kind falls through to a clean
-// UnsupportedNodeError (never a panic). Later PRs replace fall-through arms with
-// real cases: fn/call/block (PR-3), objects/members/tuples (PR-4).
+// inferExpr dispatches on the concrete expression kind. PR-1 wired the two leaf
+// cases (literals, identifiers); PR-3 adds the function/application walk
+// (FuncExpr, CallExpr — the block/statement walk they drive lives in
+// infer_stmt.go). Every remaining kind falls through to a clean
+// UnsupportedNodeError (never a panic); PR-4 adds objects/members/tuples.
 func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
 		return c.inferLiteral(e)
 	case *ast.IdentExpr:
 		return c.inferIdent(scope, lvl, e)
+	case *ast.FuncExpr:
+		return c.inferFuncExpr(scope, lvl, e)
+	case *ast.CallExpr:
+		return c.inferCall(scope, lvl, e)
 	default:
 		return c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: e.Span()},

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -1,0 +1,41 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferVarDecl types a val/var declaration's initializer into a monomorphic
+// ValueBinding (no generalization in M2). When the decl carries a type
+// annotation the initializer is constrained against it and the annotated type
+// becomes the binding's type; a missing initializer (rare in M2) takes a fresh
+// var. The binding is returned, not defined — the caller decides which scope it
+// lands in (the body walk overwrites the current scope; the module driver, PR-2,
+// seeds the module scope).
+//
+// This helper is shared with PR-2's single-module decl driver; the body-level
+// DeclStmt walk (PR-3, infer_stmt.go) is its first consumer.
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) ValueBinding {
+	var t soltype.Type
+	if d.Init != nil {
+		t = c.inferExpr(scope, lvl, d.Init)
+	} else {
+		t = c.freshAt(lvl)
+	}
+	if d.TypeAnn != nil {
+		annT := c.resolveTypeAnn(d.TypeAnn)
+		c.constrain(d, t, annT) // initializer <: declared type
+		t = annT
+	}
+	return ValueBinding{Type: t, Source: d.Provenance()}
+}
+
+// inferFuncDecl types a top-level function declaration into a monomorphic
+// ValueBinding, reusing the shared inferFunc core on the decl's signature and
+// body. Like inferVarDecl it returns the binding rather than defining it; the
+// SCC driver (PR-5) binds the name (a self/mutually recursive group is bound to
+// a fresh var first so the body can see itself — that wiring is PR-5's).
+func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
+	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
+	return ValueBinding{Type: t, Source: d.Provenance()}
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -60,15 +60,100 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 	})
 }
 
-// exprKind returns a short surface name for an expression node, used in the M2
-// subset-guard error message. It strips the leading "*ast." from the Go type
-// name so e.g. *ast.BinaryExpr renders as "BinaryExpr".
-func exprKind(e ast.Expr) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", e), "*ast.")
+// inferFuncExpr types a function expression as a soltype.FuncType and records it
+// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl
+// (the plan's "reuse inferFuncExpr on the decl's sig+body", factored so neither
+// side owns the other). M2 is monomorphic: any TypeParams on the signature are a
+// generic function (M3) and are ignored here — an un-annotated param simply gets
+// a fresh var, which coalesces to unknown/never at render time rather than a
+// <T0> quantifier (generalization is M3).
+func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type {
+	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e)
+	c.recordType(e, t)
+	return t
 }
 
-// litKind returns a short surface name for a literal node, used when a literal
-// kind is outside M1's soltype.Lit set.
-func litKind(l ast.Lit) string {
-	return strings.TrimPrefix(fmt.Sprintf("%T", l), "*ast.")
+// inferFunc is the shared function-typing core for FuncExpr and FuncDecl. It
+// opens a child scope, binds each param (its annotation resolved to a soltype,
+// or a fresh var when un-annotated), types the body block in that scope, and
+// builds the n-ary soltype.FuncType. When the signature carries a return
+// annotation the inferred body type is constrained against it and the annotated
+// type becomes the function's return type; otherwise the body type is the
+// return type directly. node supplies the span stamped onto a return-annotation
+// constraint failure.
+func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
+	fnScope := scope.Child()
+	params := make([]*soltype.FuncParam, len(sig.Params))
+	for i, p := range sig.Params {
+		pt := c.paramType(p, lvl)
+		name, ok := identPatName(p.Pattern)
+		if !ok {
+			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
+			// they arrive in M4. M2 binds IdentPat only.
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: p.Span()}, Kind: patKind(p.Pattern)})
+			name = fmt.Sprintf("arg%d", i)
+		}
+		fnScope.defineValue(name, ValueBinding{Type: pt})
+		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt}
+	}
+
+	var ret soltype.Type = &soltype.Void{}
+	if body != nil {
+		ret = c.inferBlock(fnScope, lvl, body)
+	}
+	if sig.Return != nil {
+		annT := c.resolveTypeAnn(sig.Return)
+		c.constrain(node, ret, annT) // body <: declared return
+		ret = annT
+	}
+	return &soltype.FuncType{Params: params, Ret: ret}
+}
+
+// paramType resolves a param's type: its annotation when present, else a fresh
+// inference variable at the current level (the spike's "fresh var per param").
+func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
+	if p.TypeAnn != nil {
+		return c.resolveTypeAnn(p.TypeAnn)
+	}
+	return c.freshAt(lvl)
+}
+
+// inferCall types a function application. It types the callee and each argument,
+// allocates a fresh result var, and constrains callee <: fn(args) -> res — the
+// production form of the spike's *App case. The result var picks up the callee's
+// return type (covariantly) and renders as that once coalesced; an arity or
+// argument mismatch surfaces as a constraint error stamped with the call's span.
+func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
+	callee := c.inferExpr(scope, lvl, e.Callee)
+	args := make([]*soltype.FuncParam, len(e.Args))
+	for i, a := range e.Args {
+		args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)}
+	}
+	res := c.freshAt(lvl)
+	c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+	c.recordType(e, res)
+	return res
+}
+
+// astKind returns a short surface name for an AST node, used in the M2
+// subset-guard error messages. It strips the leading "*ast." from the Go type
+// name so e.g. *ast.BinaryExpr renders as "BinaryExpr".
+func astKind(n any) string {
+	return strings.TrimPrefix(fmt.Sprintf("%T", n), "*ast.")
+}
+
+// exprKind/litKind/patKind name an expression, literal, or pattern node for the
+// subset-guard error message.
+func exprKind(e ast.Expr) string { return astKind(e) }
+func litKind(l ast.Lit) string   { return astKind(l) }
+func patKind(p ast.Pat) string   { return astKind(p) }
+
+// identPatName reads the name of an IdentPat. M2 binds IdentPat-only patterns
+// (mirroring M1's IdentPat-only FuncParam); the comma-ok form lets callers raise
+// a structured error for the destructuring patterns deferred to M4.
+func identPatName(pat ast.Pat) (string, bool) {
+	if ip, ok := pat.(*ast.IdentPat); ok {
+		return ip.Name, true
+	}
+	return "", false
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -79,8 +79,9 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // builds the n-ary soltype.FuncType. When the signature carries a return
 // annotation the inferred body type is constrained against it and the annotated
 // type becomes the function's return type; otherwise the body type is the
-// return type directly. node supplies the span stamped onto a return-annotation
-// constraint failure.
+// return type directly. A bodyless (declare/ambient) function adopts its return
+// annotation without constraining anything. node supplies the span stamped onto
+// a return-annotation constraint failure.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
@@ -89,8 +90,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		name, ok := identPatName(p.Pattern)
 		if !ok {
 			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
-			// they arrive in M4. M2 binds IdentPat only.
-			c.report(&UnsupportedNodeError{errSpan: errSpan{span: p.Span()}, Kind: patKind(p.Pattern)})
+			// they arrive in M4. M2 binds IdentPat only. p.Span() dereferences
+			// p.Pattern, so fall back to the function node's span for a pattern-less
+			// param to honor M2's "never a panic" guarantee.
+			span := node.Span()
+			if p.Pattern != nil {
+				span = p.Span()
+			}
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: span}, Kind: patKind(p.Pattern)})
 			name = fmt.Sprintf("arg%d", i)
 		}
 		fnScope.defineValue(name, ValueBinding{Type: pt})
@@ -98,12 +105,19 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	}
 
 	var ret soltype.Type = &soltype.Void{}
-	if body != nil {
+	hasBody := body != nil
+	if hasBody {
 		ret = c.inferBlock(fnScope, lvl, body)
 	}
 	if sig.Return != nil {
 		annT := c.resolveTypeAnn(sig.Return)
-		c.constrain(node, ret, annT) // body <: declared return
+		// Only check the inferred body against the declared return when there IS a
+		// body. A bodyless (declare/ambient) function has no body to constrain, so
+		// it simply adopts the annotation; constraining the synthetic Void return
+		// would raise a spurious `void <: T` error.
+		if hasBody {
+			c.constrain(node, ret, annT) // body <: declared return
+		}
 		ret = annT
 	}
 	return &soltype.FuncType{Params: params, Ret: ret}

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -123,6 +123,35 @@ func TestInferFuncExprBodyValDecl(t *testing.T) {
 	require.Equal(t, "fn () -> 5", render(got))
 }
 
+// A bodyless (declare/ambient) function adopts its return annotation without
+// constraining a synthetic Void against it (which would error spuriously).
+func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
+	c := newChecker()
+	// declare fn now() -> number
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("now", testSpan()), nil, nil,
+		nil, numAnn(), nil,
+		nil, // no body
+		false, true, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> number", render(b.Type))
+}
+
+// A param that arrives without a pattern must report a clean error, not panic on
+// p.Span() (which dereferences the nil pattern). Not reachable from the real
+// parser, but the walk must uphold M2's "never a panic" guarantee.
+func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
+	c := newChecker()
+	e := funcExpr([]*ast.Param{{Pattern: nil}}, nil, block(exprStmt(numExpr(1))))
+
+	require.NotPanics(t, func() { c.inferExpr(NewScope(), 0, e) })
+	require.Len(t, c.errs, 1)
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
 func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
 	c := newChecker()
 	// fn ([a, b]) { ... } — destructuring params are M4.

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -1,0 +1,286 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- AST builders (PR-3 hand-builds nodes; the source-driven harness is PR-2) ---
+
+func numExpr(v float64) *ast.LiteralExpr { return ast.NewLitExpr(ast.NewNumber(v, testSpan())) }
+func strExpr(s string) *ast.LiteralExpr  { return ast.NewLitExpr(ast.NewString(s, testSpan())) }
+func identExpr(name string) *ast.IdentExpr {
+	return ast.NewIdent(name, testSpan())
+}
+
+func numAnn() ast.TypeAnn { return ast.NewNumberTypeAnn(testSpan()) }
+func strAnn() ast.TypeAnn { return ast.NewStringTypeAnn(testSpan()) }
+
+func param(name string, ann ast.TypeAnn) *ast.Param {
+	return &ast.Param{Pattern: ast.NewIdentPat(name, false, nil, nil, testSpan()), TypeAnn: ann}
+}
+
+func block(stmts ...ast.Stmt) *ast.Block {
+	return &ast.Block{Stmts: stmts, Span: testSpan()}
+}
+
+func exprStmt(e ast.Expr) ast.Stmt   { return ast.NewExprStmt(e, testSpan()) }
+func returnStmt(e ast.Expr) ast.Stmt { return ast.NewReturnStmt(e, testSpan()) }
+
+func valDecl(name string, ann ast.TypeAnn, init ast.Expr) *ast.VarDecl {
+	return ast.NewVarDecl(ast.ValKind, ast.NewIdentPat(name, false, nil, nil, testSpan()),
+		ann, init, false, false, testSpan())
+}
+
+func funcExpr(params []*ast.Param, ret ast.TypeAnn, body *ast.Block) *ast.FuncExpr {
+	return ast.NewFuncExpr(nil, nil, params, ret, nil, false, body, testSpan())
+}
+
+// render coalesces a (possibly variable-carrying) inferred type at Positive
+// polarity — the binding view — and prints it. soltype.Print panics on a raw
+// TypeVarType, so every function/call result must be coalesced before printing.
+func render(t soltype.Type) string {
+	return soltype.Print(coalesce(t, soltype.Positive))
+}
+
+// --- FuncExpr ---
+
+func TestInferFuncExprAnnotated(t *testing.T) {
+	c := newChecker()
+	// fn (x: number) { x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+// An un-annotated param gets a fresh var. M2 is monomorphic — without
+// generalization (M3) the var coalesces to the lattice bounds (unknown in
+// contravariant param position, never in covariant return position) rather than
+// a <T0> quantifier.
+func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
+	c := newChecker()
+	// fn (x) { x }
+	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: unknown) -> never", render(got))
+}
+
+func TestInferFuncExprMultiParam(t *testing.T) {
+	c := newChecker()
+	// fn (x: number, y: string) { y }
+	e := funcExpr(
+		[]*ast.Param{param("x", numAnn()), param("y", strAnn())},
+		nil,
+		block(exprStmt(identExpr("y"))),
+	)
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number, y: string) -> string", render(got))
+}
+
+func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
+	c := newChecker()
+	// fn (x: number) -> number { x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, numAnn(), block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(got))
+}
+
+func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
+	c := newChecker()
+	// fn () -> number { "hello" }
+	e := funcExpr(nil, numAnn(), block(exprStmt(strExpr("hello"))))
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, `cannot constrain "hello" <: number`, c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// A body-level val is visible to later statements and to the tail expression
+// that becomes the function's result.
+func TestInferFuncExprBodyValDecl(t *testing.T) {
+	c := newChecker()
+	// fn () { val y = 5; y }
+	e := funcExpr(nil, nil, block(
+		ast.NewDeclStmt(valDecl("y", nil, numExpr(5)), testSpan()),
+		exprStmt(identExpr("y")),
+	))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> 5", render(got))
+}
+
+func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
+	c := newChecker()
+	// fn ([a, b]) { ... } — destructuring params are M4.
+	tuplePat := ast.NewTuplePat([]ast.Pat{
+		ast.NewIdentPat("a", false, nil, nil, testSpan()),
+		ast.NewIdentPat("b", false, nil, nil, testSpan()),
+	}, testSpan())
+	e := funcExpr([]*ast.Param{{Pattern: tuplePat}}, nil, block(exprStmt(numExpr(1))))
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: TuplePat", c.errs[0].Message())
+}
+
+// --- CallExpr ---
+
+func TestInferCallResolvesReturn(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })(5)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{numExpr(5)}, false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+func TestInferCallArgMismatch(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })("hello")
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{strExpr("hello")}, false, testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, `cannot constrain "hello" <: number`, c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferCallArityMismatch(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })(1, 2)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferCallThroughBinding(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("inc", ValueBinding{Type: &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
+		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
+	}})
+	// inc(7)
+	e := ast.NewCall(identExpr("inc"), []ast.Expr{numExpr(7)}, false, testSpan())
+
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", render(got))
+}
+
+// --- Block / statements ---
+
+func TestInferBlockResultIsLastStmt(t *testing.T) {
+	c := newChecker()
+	// { 1; "two" }
+	b := block(exprStmt(numExpr(1)), exprStmt(strExpr("two")))
+
+	got := c.inferBlock(NewScope(), 0, b)
+	require.Empty(t, c.errs)
+	require.Equal(t, `"two"`, render(got))
+}
+
+func TestInferBlockEmptyIsVoid(t *testing.T) {
+	c := newChecker()
+	got := c.inferBlock(NewScope(), 0, block())
+	require.Empty(t, c.errs)
+	require.Equal(t, "void", render(got))
+}
+
+func TestInferBlockReturnStmt(t *testing.T) {
+	c := newChecker()
+	// { return 5 }
+	got := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+}
+
+// Each val introduces a fresh, independent binding; a later val of the same name
+// rebinds it (overwrite, no constraint linking the two), so the tail sees the
+// later type even though it is unrelated to the earlier one (§3.2).
+func TestInferBlockRedeclarationRebinds(t *testing.T) {
+	c := newChecker()
+	// { val x = "hello"; val x = 5; x }
+	b := block(
+		ast.NewDeclStmt(valDecl("x", nil, strExpr("hello")), testSpan()),
+		ast.NewDeclStmt(valDecl("x", nil, numExpr(5)), testSpan()),
+		exprStmt(identExpr("x")),
+	)
+	got := c.inferBlock(NewScope(), 0, b)
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+}
+
+func TestInferStmtBodyDeclNotAllowed(t *testing.T) {
+	c := newChecker()
+	// A nested FuncDecl as a body statement is a permanent language error.
+	inner := ast.NewFuncDecl(ast.NewIdentifier("f", testSpan()), nil, nil, nil, nil, nil,
+		block(), false, false, false, testSpan())
+	s := ast.NewDeclStmt(inner, testSpan())
+
+	got := c.inferStmt(NewScope(), 0, s)
+	require.IsType(t, &soltype.Void{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Declaration not allowed in function body: FuncDecl", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// --- FuncDecl ---
+
+func TestInferFuncDecl(t *testing.T) {
+	c := newChecker()
+	// fn id(x: number) { x }
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("id", testSpan()), nil, nil,
+		[]*ast.Param{param("x", numAnn())}, nil, nil,
+		block(exprStmt(identExpr("x"))),
+		false, false, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(b.Type))
+}
+
+// A recursive reference resolves when the name is pre-bound (the SCC wiring that
+// arranges this for real top-level groups is PR-5; here we bind the name by hand
+// to exercise the body walk seeing itself).
+func TestInferFuncDeclSelfReference(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	self := c.freshAt(1)
+	scope.defineValue("loop", ValueBinding{Type: self})
+	// fn loop(x: number) { loop }
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("loop", testSpan()), nil, nil,
+		[]*ast.Param{param("x", numAnn())}, nil, nil,
+		block(exprStmt(identExpr("loop"))),
+		false, false, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(scope, 0, d)
+	require.Empty(t, c.errs)
+	require.IsType(t, &soltype.FuncType{}, b.Type)
+}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -11,6 +11,14 @@ import (
 // the param scope, so body-level val/var redeclarations overwrite alongside the
 // params, per §3.2). soltype.Void is the result of a block that ends in a
 // declaration or a value-free statement.
+//
+// TODO(M3): a non-tail ReturnStmt only contributes the last statement's type to
+// the block value, so an early return (`{ return X; Y }`) is dropped and never
+// checked against the declared return type. Harmless at the M2 bar — there is no
+// IfElseExpr (control flow), so an early return cannot arise from a real branch —
+// but once M3 adds conditionals the walk must collect every return-point type and
+// join it with the tail before constraining against the annotation. Tracked in
+// planning/simple_sub/01-milestones.md (M3).
 func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type {
 	var result soltype.Type = &soltype.Void{}
 	for _, s := range b.Stmts {

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -1,0 +1,69 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferBlock types a block's statements in source order and returns the block's
+// value: the type of its last statement, or void for an empty block. The block
+// runs in the scope it is given — the caller establishes it (inferFunc passes
+// the param scope, so body-level val/var redeclarations overwrite alongside the
+// params, per §3.2). soltype.Void is the result of a block that ends in a
+// declaration or a value-free statement.
+func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type {
+	var result soltype.Type = &soltype.Void{}
+	for _, s := range b.Stmts {
+		result = c.inferStmt(scope, lvl, s)
+	}
+	return result
+}
+
+// inferStmt types a single statement and returns the value it contributes to
+// the enclosing block (void for declarations and bare returns without an
+// operand). Body-level declarations are VarDecl-only: a DeclStmt wrapping any
+// other decl kind is a permanent BodyDeclNotAllowedError (§3.2), not the
+// temporary subset gate. Each val/var introduces a fresh, independent binding
+// and overwrites the name's slot in the current scope, so redeclaration rebinds
+// without constraining the old and new types together.
+func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
+	switch s := s.(type) {
+	case *ast.ExprStmt:
+		return c.inferExpr(scope, lvl, s.Expr)
+	case *ast.ReturnStmt:
+		if s.Expr == nil {
+			return &soltype.Void{}
+		}
+		return c.inferExpr(scope, lvl, s.Expr)
+	case *ast.DeclStmt:
+		vd, ok := s.Decl.(*ast.VarDecl)
+		if !ok {
+			c.report(&BodyDeclNotAllowedError{
+				errSpan: errSpan{span: s.Span()},
+				Kind:    declKind(s.Decl),
+			})
+			return &soltype.Void{}
+		}
+		name, ok := identPatName(vd.Pattern)
+		if !ok {
+			c.report(&UnsupportedNodeError{
+				errSpan: errSpan{span: vd.Span()},
+				Kind:    patKind(vd.Pattern),
+			})
+			return &soltype.Void{}
+		}
+		b := c.inferVarDecl(scope, lvl, vd)
+		scope.defineValue(name, b) // overwrite ⇒ same-name redeclaration rebinds
+		return &soltype.Void{}
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: s.Span()},
+			Kind:    stmtKind(s),
+		})
+	}
+}
+
+// stmtKind/declKind name a statement or declaration node for the subset-guard
+// and body-decl error messages.
+func stmtKind(s ast.Stmt) string { return astKind(s) }
+func declKind(d ast.Decl) string { return astKind(d) }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -1,0 +1,32 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type.
+// M2 needs only the primitive annotations that annotated params and return
+// types use (number/string/boolean); everything richer — type references,
+// generics, object/tuple/function annotations, unions — is represented by types
+// later milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here.
+// It takes no scope: the supported set is all closed primitives, with no name to
+// look up. Name resolution against the type scope arrives with TypeRef support.
+func (c *checker) resolveTypeAnn(ta ast.TypeAnn) soltype.Type {
+	switch ta := ta.(type) {
+	case *ast.NumberTypeAnn:
+		return &soltype.PrimType{Prim: soltype.NumPrim}
+	case *ast.StringTypeAnn:
+		return &soltype.PrimType{Prim: soltype.StrPrim}
+	case *ast.BooleanTypeAnn:
+		return &soltype.PrimType{Prim: soltype.BoolPrim}
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: ta.Span()},
+			Kind:    typeAnnKind(ta),
+		})
+	}
+}
+
+// typeAnnKind names a type-annotation node for the subset-guard error message.
+func typeAnnKind(ta ast.TypeAnn) string { return astKind(ta) }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -193,6 +193,14 @@ reassess.
   exists to opt into it. (This corrects the merged spec's §4.2, which had
   exactness govern call-sites rather than subtyping — see
   escalier-lang/escalier#677.)
+- **Block return-point join (carried over from M2).** M2's block walk uses the
+  *last statement* as the block's value and only constrains that tail against a
+  declared return type; a non-tail `return` (`{ return X; Y }`) is dropped. This
+  is harmless at the M2 bar (no `IfElseExpr`, so an early return cannot come from
+  a real branch), but once this milestone adds conditionals/early return the walk
+  must collect **every** `ReturnStmt` type (valued and bare) and join them with
+  the tail expression before constraining against the return annotation. See
+  `internal/solver/infer_stmt.go` (`inferBlock` TODO(M3)).
 
 **Accept:** the spike's Category-A cases against real source:
 `TopLevelLetPolymorphism` ⇒ `fn <T0>(x: T0) -> T0`; `IdentityPolymorphism` ⇒


### PR DESCRIPTION
This PR implements the core function-typing and statement-inference logic for the M2 milestone, completing the walk over function expressions, calls, blocks, and declarations.

## Summary

Adds `inferFuncExpr`, `inferCall`, `inferBlock`, `inferStmt`, and declaration-inference helpers to type function expressions and their applications, along with the statement and block walks that drive them. Introduces a shared `inferFunc` core reused by both function expressions and declarations, and adds type-annotation resolution for the M2-supported primitives (number, string, boolean). Extends the printer to tolerate raw, un-coalesced `TypeVarType` nodes for M2's side-table recording pattern.

## Key changes

- **Function expression typing** (`inferFuncExpr`, `inferFunc`): Types function expressions as `soltype.FuncType`, opening a child scope and binding each parameter (resolved from its annotation or a fresh inference variable). Constrains the inferred body type against a return annotation when present, otherwise uses the body type directly. Bodyless (declare/ambient) functions adopt their return annotation without constraining a synthetic Void.

- **Function call typing** (`inferCall`): Types a function application by typing the callee and arguments, allocating a fresh result variable, and constraining `callee <: fn(args) -> res`. Arity and argument-type mismatches surface as constraint errors.

- **Block and statement inference** (`inferBlock`, `inferStmt`): Blocks return the type of their last statement (or void for empty blocks). Statements dispatch on kind: expression statements and returns contribute their type; declarations (val/var only in M2) bind names and return void; nested declarations raise a permanent `BodyDeclNotAllowedError`. Redeclaration rebinds without constraining the old and new types together.

- **Declaration inference** (`inferVarDecl`, `inferFuncDecl`): Shared helpers that return `ValueBinding` rather than defining directly, allowing callers (the body walk, the module driver in PR-2, the SCC driver in PR-5) to decide scope placement. `inferVarDecl` constrains an initializer against its annotation; `inferFuncDecl` reuses `inferFunc`.

- **Type annotation resolution** (`resolveTypeAnn`): Converts M2-supported type annotations (number, string, boolean) to `soltype.Type`. Richer annotations (type references, generics, object/tuple/function types) raise `UnsupportedNodeError` and are deferred to later milestones.

- **Printer tolerance for raw type variables**: Extended `soltype.Print` to render un-coalesced `TypeVarType` nodes as `t{ID}` instead of panicking, supporting M2's pattern of recording var-carrying types in the Info side table and coalescing only at binding boundaries.

- **Test suite** (`infer_func_test.go`): Comprehensive tests for function expressions (annotated/unannotated params, return annotations, body declarations, self-reference), calls (resolution, arity/argument mismatches, through bindings), blocks (last-statement result, empty blocks, return statements, redeclaration rebinding), and declarations (bodyless functions, nested declarations).

## Notable implementation details

- M2 is monomorphic: un-annotated parameters receive fresh inference variables that coalesce to `unknown` (contravariant position) or `never` (covariant position) at render time, not quantified type variables.
- Parameter patterns are IdentPat-only in M2; destructuring patterns (TuplePat, ObjectPat) raise `UnsupportedNodeError` and are deferred to M4.
- A param without a pattern (defensive against malformed AST) falls back to the function node's span to honor M2's "never a panic" guarantee.
- Block return-point join (collecting all return-point types and joining them with the tail before constraining against a declared return) is deferred to M3, when `IfElseExpr` makes early returns reachable from real branches.

https://claude.ai/code/session_0137jcq69G82CSqFL1LwL4JK