### PR TITLE
M2 PR-3: Function / application / block walk

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -27,9 +27,9 @@ func typePrec(t Type) int {
 	case *IntersectionType:
 		return precIntersection
 	default:
-		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms.
-		// TypeVarType never appears in coalesced output (coalesce inlines every
-		// variable, m1-implementation-plan Delta #1), so it has no printer arm.
+		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms. A
+		// raw TypeVarType (which appears only when printing an un-coalesced type,
+		// see printType) is also an atom (rendered as `t{ID}`), so it lands here.
 		return precAtom
 	}
 }
@@ -50,6 +50,12 @@ func typePrec(t Type) int {
 // uncoalesced type (t0, function, number) mid-constrain for error messages,
 // whereas Print renders a COALESCED type as user-facing syntax. They look
 // similar but operate at different stages and must not be merged (§2.2).
+//
+// Print's normal input is a coalesced type, but it also tolerates a raw,
+// un-coalesced TypeVarType (rendering it as `t{ID}`) rather than panicking: the
+// M2 walk records var-carrying types in its Info side table and coalesces only
+// at binding boundaries, so a consumer may legitimately print an inner node's
+// still-raw type (M2 plan §7).
 func Print(t Type) string {
 	return printType(t)
 }
@@ -68,6 +74,14 @@ func printTypeMinPrec(t Type, minPrec int) string {
 
 func printType(t Type) string {
 	switch t := t.(type) {
+	case *TypeVarType:
+		// A raw, un-coalesced variable. Coalesced output never contains one (every
+		// variable is inlined to its bounds, m1-implementation-plan Delta #1), but
+		// the M2 walk records raw, var-carrying types in its Info side table and
+		// only coalesces at binding boundaries — so a consumer printing an inner
+		// node's type directly may hand Print a live variable. Render it as `t{ID}`
+		// (matching solver's describe()) rather than panicking. See the M2 plan §7.
+		return "t" + strconv.Itoa(t.ID)
 	case *PrimType:
 		return printPrim(t.Prim)
 	case *LitType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -93,6 +93,25 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
+// TestPrintRawTypeVar verifies that Print tolerates a raw, un-coalesced
+// TypeVarType (rendering it as `t{ID}`) instead of panicking — the M2 walk
+// records var-carrying types in Info and only coalesces at binding boundaries,
+// so a consumer can hand Print a live variable, standalone or nested in a
+// function. See print.go's printType TypeVarType arm.
+func TestPrintRawTypeVar(t *testing.T) {
+	t.Run("bare variable", func(t *testing.T) {
+		require.Equal(t, "t7", Print(&TypeVarType{ID: 7}))
+	})
+
+	t.Run("variable nested in a function", func(t *testing.T) {
+		fn := &FuncType{
+			Params: []*FuncParam{identP("x", &TypeVarType{ID: 0})},
+			Ret:    &TypeVarType{ID: 0},
+		}
+		require.Equal(t, "fn (x: t0) -> t0", Print(fn))
+	})
+}
+
 // TestPrintUnnamedParamFallback verifies that a parameter with no IdentPat
 // pattern falls back to a positional name (arg0, arg1, ...), numbered by param
 // index. This path isn't reachable in M1 (params are always IdentPat), but the

--- a/internal/solver/astbuild.go
+++ b/internal/solver/astbuild.go
@@ -1,0 +1,48 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// AST builders — convenience constructors for hand-assembling the small ast
+// nodes the solver walk operates on, without going through the parser. They live
+// in a non-test file (rather than alongside the tests) so both the package's
+// test files and non-test code can share them.
+//
+// Every builder stamps builderSpan() on the nodes it creates: a hand-built node
+// has no real source position, so a single shared placeholder span keeps
+// constructed nodes comparable and lets error-span assertions check against
+// builderSpan(). Code that needs real positions should construct nodes directly
+// via the ast.New* constructors with a genuine span.
+
+// builderSpan is the fixed placeholder span stamped on every builder-made node.
+func builderSpan() ast.Span {
+	return ast.NewSpan(ast.Location{Line: 1, Column: 1}, ast.Location{Line: 1, Column: 2}, 0)
+}
+
+func numExpr(v float64) *ast.LiteralExpr { return ast.NewLitExpr(ast.NewNumber(v, builderSpan())) }
+func strExpr(s string) *ast.LiteralExpr  { return ast.NewLitExpr(ast.NewString(s, builderSpan())) }
+func identExpr(name string) *ast.IdentExpr {
+	return ast.NewIdent(name, builderSpan())
+}
+
+func numAnn() ast.TypeAnn { return ast.NewNumberTypeAnn(builderSpan()) }
+func strAnn() ast.TypeAnn { return ast.NewStringTypeAnn(builderSpan()) }
+
+func param(name string, ann ast.TypeAnn) *ast.Param {
+	return &ast.Param{Pattern: ast.NewIdentPat(name, false, nil, nil, builderSpan()), TypeAnn: ann}
+}
+
+func block(stmts ...ast.Stmt) *ast.Block {
+	return &ast.Block{Stmts: stmts, Span: builderSpan()}
+}
+
+func exprStmt(e ast.Expr) ast.Stmt   { return ast.NewExprStmt(e, builderSpan()) }
+func returnStmt(e ast.Expr) ast.Stmt { return ast.NewReturnStmt(e, builderSpan()) }
+
+func valDecl(name string, ann ast.TypeAnn, init ast.Expr) *ast.VarDecl {
+	return ast.NewVarDecl(ast.ValKind, ast.NewIdentPat(name, false, nil, nil, builderSpan()),
+		ann, init, false, false, builderSpan())
+}
+
+func funcExpr(params []*ast.Param, ret ast.TypeAnn, body *ast.Block) *ast.FuncExpr {
+	return ast.NewFuncExpr(nil, nil, params, ret, nil, false, body, builderSpan())
+}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -60,16 +60,21 @@ func (c *checker) recordType(n ast.Node, t soltype.Type) {
 	c.info.setType(n, t)
 }
 
-// inferExpr dispatches on the concrete expression kind. PR-1 wires only the two
-// leaf cases (literals, identifiers); every other kind falls through to a clean
-// UnsupportedNodeError (never a panic). Later PRs replace fall-through arms with
-// real cases: fn/call/block (PR-3), objects/members/tuples (PR-4).
+// inferExpr dispatches on the concrete expression kind. PR-1 wired the two leaf
+// cases (literals, identifiers); PR-3 adds the function/application walk
+// (FuncExpr, CallExpr — the block/statement walk they drive lives in
+// infer_stmt.go). Every remaining kind falls through to a clean
+// UnsupportedNodeError (never a panic); PR-4 adds objects/members/tuples.
 func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
 		return c.inferLiteral(e)
 	case *ast.IdentExpr:
 		return c.inferIdent(scope, lvl, e)
+	case *ast.FuncExpr:
+		return c.inferFuncExpr(scope, lvl, e)
+	case *ast.CallExpr:
+		return c.inferCall(scope, lvl, e)
 	default:
 		return c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: e.Span()},

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -96,3 +96,16 @@ func varName(d *ast.VarDecl) (string, bool) {
 	}
 	return "", false
 }
+
+// inferFuncDecl types a function declaration into a monomorphic ValueBinding,
+// reusing the shared inferFunc core (infer_expr.go) on the decl's signature and
+// body. Like inferVarDecl it returns the binding rather than defining it, so the
+// caller owns scope placement: the SCC driver (PR-5) binds a self/mutually
+// recursive group to a fresh var first so each body can see itself, then rebinds
+// to the inferred type. inferDecl does not yet wire FuncDecl into the module
+// walk — that, with the recursive-group ordering and top-level overloads, is
+// PR-5/M3.
+func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
+	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
+	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -68,3 +68,102 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 func astKind(n any) string {
 	return strings.TrimPrefix(fmt.Sprintf("%T", n), "*ast.")
 }
+
+// inferFuncExpr types a function expression as a soltype.FuncType and records it
+// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl
+// (the plan's "reuse inferFuncExpr on the decl's sig+body", factored so neither
+// side owns the other). M2 is monomorphic: any TypeParams on the signature are a
+// generic function (M3) and are ignored here — an un-annotated param simply gets
+// a fresh var, which coalesces to unknown/never at render time rather than a
+// <T0> quantifier (generalization is M3).
+func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type {
+	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e)
+	c.recordType(e, t)
+	return t
+}
+
+// inferFunc is the shared function-typing core for FuncExpr and FuncDecl. It
+// opens a child scope, binds each param (its annotation resolved to a soltype,
+// or a fresh var when un-annotated), types the body block in that scope, and
+// builds the n-ary soltype.FuncType. When the signature carries a return
+// annotation the inferred body type is constrained against it and the annotated
+// type becomes the function's return type; otherwise the body type is the
+// return type directly. A bodyless (declare/ambient) function adopts its return
+// annotation without constraining anything. node supplies the span stamped onto
+// a return-annotation constraint failure.
+func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
+	fnScope := scope.Child()
+	params := make([]*soltype.FuncParam, len(sig.Params))
+	for i, p := range sig.Params {
+		pt := c.paramType(p, lvl)
+		name, ok := identPatName(p.Pattern)
+		if !ok {
+			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
+			// they arrive in M4. M2 binds IdentPat only. p.Span() dereferences
+			// p.Pattern, so fall back to the function node's span for a pattern-less
+			// param to honor M2's "never a panic" guarantee.
+			span := node.Span()
+			if p.Pattern != nil {
+				span = p.Span()
+			}
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: span}, Kind: astKind(p.Pattern)})
+			name = fmt.Sprintf("arg%d", i)
+		}
+		fnScope.defineValue(name, ValueBinding{Type: pt})
+		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt}
+	}
+
+	var ret soltype.Type = &soltype.Void{}
+	hasBody := body != nil
+	if hasBody {
+		ret = c.inferBlock(fnScope, lvl, body)
+	}
+	if sig.Return != nil {
+		annT := c.resolveTypeAnn(sig.Return)
+		// Only check the inferred body against the declared return when there IS a
+		// body. A bodyless (declare/ambient) function has no body to constrain, so
+		// it simply adopts the annotation; constraining the synthetic Void return
+		// would raise a spurious `void <: T` error.
+		if hasBody {
+			c.constrain(node, ret, annT) // body <: declared return
+		}
+		ret = annT
+	}
+	return &soltype.FuncType{Params: params, Ret: ret}
+}
+
+// paramType resolves a param's type: its annotation when present, else a fresh
+// inference variable at the current level (the spike's "fresh var per param").
+func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
+	if p.TypeAnn != nil {
+		return c.resolveTypeAnn(p.TypeAnn)
+	}
+	return c.freshAt(lvl)
+}
+
+// inferCall types a function application. It types the callee and each argument,
+// allocates a fresh result var, and constrains callee <: fn(args) -> res — the
+// production form of the spike's *App case. The result var picks up the callee's
+// return type (covariantly) and renders as that once coalesced; an arity or
+// argument mismatch surfaces as a constraint error stamped with the call's span.
+func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
+	callee := c.inferExpr(scope, lvl, e.Callee)
+	args := make([]*soltype.FuncParam, len(e.Args))
+	for i, a := range e.Args {
+		args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)}
+	}
+	res := c.freshAt(lvl)
+	c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+	c.recordType(e, res)
+	return res
+}
+
+// identPatName reads the name of an IdentPat. M2 binds IdentPat-only patterns
+// (mirroring M1's IdentPat-only FuncParam); the comma-ok form lets callers raise
+// a structured error for the destructuring patterns deferred to M4.
+func identPatName(pat ast.Pat) (string, bool) {
+	if ip, ok := pat.(*ast.IdentPat); ok {
+		return ip.Name, true
+	}
+	return "", false
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -73,9 +73,10 @@ func astKind(n any) string {
 // in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl
 // (the plan's "reuse inferFuncExpr on the decl's sig+body", factored so neither
 // side owns the other). M2 is monomorphic: any TypeParams on the signature are a
-// generic function (M3) and are ignored here — an un-annotated param simply gets
-// a fresh var, which coalesces to unknown/never at render time rather than a
-// <T0> quantifier (generalization is M3).
+// generic function (M3) and are diagnosed as unsupported by inferFunc, not
+// silently erased; an un-annotated param simply gets a fresh var, which
+// coalesces to unknown/never at render time rather than a <T0> quantifier
+// (generalization is M3).
 func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type {
 	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e)
 	c.recordType(e, t)
@@ -92,6 +93,15 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // annotation without constraining anything. node supplies the span stamped onto
 // a return-annotation constraint failure.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
+	if len(sig.TypeParams) > 0 {
+		// Generic functions (fn <T>(...)) need type schemes / generalization,
+		// which are M3. M2 is monomorphic, so diagnose the type parameters rather
+		// than silently erasing them, then continue inferring monomorphically.
+		c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: node.Span()},
+			Kind:    astKind(sig.TypeParams[0]),
+		})
+	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
 	for i, p := range sig.Params {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -146,6 +146,12 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // production form of the spike's *App case. The result var picks up the callee's
 // return type (covariantly) and renders as that once coalesced; an arity or
 // argument mismatch surfaces as a constraint error stamped with the call's span.
+//
+// Error recovery: a call to a known function still yields that function's
+// declared return type even when the arguments don't match, so a downstream
+// expression sees the real return type rather than a poisoned `never`. constrain
+// short-circuits its FuncType arity arm before propagating the return into res,
+// so when the callee is a concrete function its return is wired through directly.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
 	callee := c.inferExpr(scope, lvl, e.Callee)
 	args := make([]*soltype.FuncParam, len(e.Args))
@@ -154,6 +160,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	}
 	res := c.freshAt(lvl)
 	c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+	if fn, ok := callee.(*soltype.FuncType); ok {
+		c.constrain(e, fn.Ret, res)
+	}
 	c.recordType(e, res)
 	return res
 }

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testSpan is a fixed, non-zero span used to build the AST nodes these unit
-// tests feed directly into the walk (the source-driven harness arrives in PR-2).
+// testSpan is the fixed, non-zero placeholder span these unit tests stamp on the
+// AST nodes they feed directly into the walk. It delegates to the shared
+// builderSpan() (astbuild.go) so a node from a builder and a node built inline in
+// a test carry the same span, keeping error-span assertions consistent.
 func testSpan() ast.Span {
-	return ast.NewSpan(ast.Location{Line: 1, Column: 1}, ast.Location{Line: 1, Column: 2}, 0)
+	return builderSpan()
 }
 
 func TestInferLiteral(t *testing.T) {

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// AST builders for hand-assembling test inputs live in astbuild.go (a non-test
-// file, so they're shared across the package). They stamp builderSpan(), which
-// testSpan() also returns, so error-span assertions below stay consistent.
-
 // render coalesces a (possibly variable-carrying) inferred type at Positive
 // polarity — the binding view — and prints it. soltype.Print panics on a raw
 // TypeVarType, so every function/call result must be coalesced before printing.
@@ -159,10 +155,12 @@ func TestInferCallArgMismatch(t *testing.T) {
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{strExpr("hello")}, false, testSpan())
 
-	c.inferExpr(NewScope(), 0, e)
+	got := c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
 	require.Equal(t, `cannot constrain "hello" <: number`, c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
+	// The result is still the callee's return type despite the bad argument.
+	require.Equal(t, "number", render(got))
 }
 
 func TestInferCallArityMismatch(t *testing.T) {
@@ -171,10 +169,12 @@ func TestInferCallArityMismatch(t *testing.T) {
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
 
-	c.inferExpr(NewScope(), 0, e)
+	got := c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
+	// Error recovery: the result is still the callee's return type, not `never`.
+	require.Equal(t, "number", render(got))
 }
 
 func TestInferCallThroughBinding(t *testing.T) {
@@ -285,4 +285,27 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 	b := c.inferFuncDecl(scope, 0, d)
 	require.Empty(t, c.errs)
 	require.IsType(t, &soltype.FuncType{}, b.Type)
+}
+
+// A FuncExpr may be assigned to a body-level `val` inside a FuncDecl (the way a
+// function value is introduced in a body, since body decls are VarDecl-only).
+// The bound name resolves to the function type, and the enclosing function
+// returns it as its tail value.
+func TestInferFuncDeclBodyFuncValDecl(t *testing.T) {
+	c := newChecker()
+	// fn outer() { val f = fn (x: number) { x }; f }
+	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("outer", testSpan()), nil, nil,
+		nil, nil, nil,
+		block(
+			ast.NewDeclStmt(valDecl("f", nil, inner), testSpan()),
+			exprStmt(identExpr("f")),
+		),
+		false, false, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> fn (x: number) -> number", render(b.Type))
 }

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 // render coalesces a (possibly variable-carrying) inferred type at Positive
-// polarity — the binding view — and prints it. soltype.Print panics on a raw
-// TypeVarType, so every function/call result must be coalesced before printing.
+// polarity — the binding view — and prints it via soltype.Print, giving the
+// stable, var-free form a binding would render as. soltype.Print also handles a
+// raw TypeVarType safely (rendering it as t{ID}), so coalescing here is for the
+// consistent binding-view rendering, not to avoid a panic.
 func render(t soltype.Type) string {
 	return soltype.Print(coalesce(t, soltype.Positive))
 }
@@ -133,6 +135,21 @@ func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
 	c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: TuplePat", c.errs[0].Message())
+}
+
+// A generic function (fn <T>() { ... }) is diagnosed rather than silently erased
+// to a monomorphic type — type schemes / generalization are M3.
+func TestInferFuncExprGenericUnsupported(t *testing.T) {
+	c := newChecker()
+	// fn <T>() { 1 }
+	tp := ast.NewTypeParam("T", nil, nil)
+	e := ast.NewFuncExpr(nil, []*ast.TypeParam{&tp}, nil, nil, nil, false,
+		block(exprStmt(numExpr(1))), testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: TypeParam", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
 // --- CallExpr ---

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -8,36 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- AST builders (PR-3 hand-builds nodes; the source-driven harness is PR-2) ---
-
-func numExpr(v float64) *ast.LiteralExpr { return ast.NewLitExpr(ast.NewNumber(v, testSpan())) }
-func strExpr(s string) *ast.LiteralExpr  { return ast.NewLitExpr(ast.NewString(s, testSpan())) }
-func identExpr(name string) *ast.IdentExpr {
-	return ast.NewIdent(name, testSpan())
-}
-
-func numAnn() ast.TypeAnn { return ast.NewNumberTypeAnn(testSpan()) }
-func strAnn() ast.TypeAnn { return ast.NewStringTypeAnn(testSpan()) }
-
-func param(name string, ann ast.TypeAnn) *ast.Param {
-	return &ast.Param{Pattern: ast.NewIdentPat(name, false, nil, nil, testSpan()), TypeAnn: ann}
-}
-
-func block(stmts ...ast.Stmt) *ast.Block {
-	return &ast.Block{Stmts: stmts, Span: testSpan()}
-}
-
-func exprStmt(e ast.Expr) ast.Stmt   { return ast.NewExprStmt(e, testSpan()) }
-func returnStmt(e ast.Expr) ast.Stmt { return ast.NewReturnStmt(e, testSpan()) }
-
-func valDecl(name string, ann ast.TypeAnn, init ast.Expr) *ast.VarDecl {
-	return ast.NewVarDecl(ast.ValKind, ast.NewIdentPat(name, false, nil, nil, testSpan()),
-		ann, init, false, false, testSpan())
-}
-
-func funcExpr(params []*ast.Param, ret ast.TypeAnn, body *ast.Block) *ast.FuncExpr {
-	return ast.NewFuncExpr(nil, nil, params, ret, nil, false, body, testSpan())
-}
+// AST builders for hand-assembling test inputs live in astbuild.go (a non-test
+// file, so they're shared across the package). They stamp builderSpan(), which
+// testSpan() also returns, so error-span assertions below stay consistent.
 
 // render coalesces a (possibly variable-carrying) inferred type at Positive
 // polarity — the binding view — and prints it. soltype.Print panics on a raw

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -266,25 +266,28 @@ func TestInferFuncDecl(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", render(b.Type))
 }
 
-// A recursive reference resolves when the name is pre-bound (the SCC wiring that
-// arranges this for real top-level groups is PR-5; here we bind the name by hand
-// to exercise the body walk seeing itself).
+// A truly recursive function: foo's body calls itself. PR-3 has no SCC driver
+// (that's PR-5), so foo is pre-bound to a fresh var the way inferComponent will,
+// letting the body reference itself through inferCall. With unconditional
+// recursion the function never returns — a base case would need a conditional,
+// which arrives in a later milestone — so its return type coalesces to `never`.
+// (`foo(x + 1)` would be the textbook shape, but `+` is a BinaryExpr, which
+// PR-3 doesn't type yet; `foo(x)` exercises the same recursive-call path.)
 func TestInferFuncDeclSelfReference(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	self := c.freshAt(1)
-	scope.defineValue("loop", ValueBinding{Type: self})
-	// fn loop(x: number) { loop }
+	scope.defineValue("foo", ValueBinding{Type: c.freshAt(1)})
+	// fn foo(x: number) { foo(x) }
 	d := ast.NewFuncDecl(
-		ast.NewIdentifier("loop", testSpan()), nil, nil,
+		ast.NewIdentifier("foo", testSpan()), nil, nil,
 		[]*ast.Param{param("x", numAnn())}, nil, nil,
-		block(exprStmt(identExpr("loop"))),
+		block(exprStmt(ast.NewCall(identExpr("foo"), []ast.Expr{identExpr("x")}, false, testSpan()))),
 		false, false, false, testSpan(),
 	)
 
 	b := c.inferFuncDecl(scope, 0, d)
 	require.Empty(t, c.errs)
-	require.IsType(t, &soltype.FuncType{}, b.Type)
+	require.Equal(t, "fn (x: number) -> never", render(b.Type))
 }
 
 // A FuncExpr may be assigned to a body-level `val` inside a FuncDecl (the way a

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -1,0 +1,315 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- AST builders (PR-3 hand-builds nodes; the source-driven harness is PR-2) ---
+
+func numExpr(v float64) *ast.LiteralExpr { return ast.NewLitExpr(ast.NewNumber(v, testSpan())) }
+func strExpr(s string) *ast.LiteralExpr  { return ast.NewLitExpr(ast.NewString(s, testSpan())) }
+func identExpr(name string) *ast.IdentExpr {
+	return ast.NewIdent(name, testSpan())
+}
+
+func numAnn() ast.TypeAnn { return ast.NewNumberTypeAnn(testSpan()) }
+func strAnn() ast.TypeAnn { return ast.NewStringTypeAnn(testSpan()) }
+
+func param(name string, ann ast.TypeAnn) *ast.Param {
+	return &ast.Param{Pattern: ast.NewIdentPat(name, false, nil, nil, testSpan()), TypeAnn: ann}
+}
+
+func block(stmts ...ast.Stmt) *ast.Block {
+	return &ast.Block{Stmts: stmts, Span: testSpan()}
+}
+
+func exprStmt(e ast.Expr) ast.Stmt   { return ast.NewExprStmt(e, testSpan()) }
+func returnStmt(e ast.Expr) ast.Stmt { return ast.NewReturnStmt(e, testSpan()) }
+
+func valDecl(name string, ann ast.TypeAnn, init ast.Expr) *ast.VarDecl {
+	return ast.NewVarDecl(ast.ValKind, ast.NewIdentPat(name, false, nil, nil, testSpan()),
+		ann, init, false, false, testSpan())
+}
+
+func funcExpr(params []*ast.Param, ret ast.TypeAnn, body *ast.Block) *ast.FuncExpr {
+	return ast.NewFuncExpr(nil, nil, params, ret, nil, false, body, testSpan())
+}
+
+// render coalesces a (possibly variable-carrying) inferred type at Positive
+// polarity — the binding view — and prints it. soltype.Print panics on a raw
+// TypeVarType, so every function/call result must be coalesced before printing.
+func render(t soltype.Type) string {
+	return soltype.Print(coalesce(t, soltype.Positive))
+}
+
+// --- FuncExpr ---
+
+func TestInferFuncExprAnnotated(t *testing.T) {
+	c := newChecker()
+	// fn (x: number) { x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+// An un-annotated param gets a fresh var. M2 is monomorphic — without
+// generalization (M3) the var coalesces to the lattice bounds (unknown in
+// contravariant param position, never in covariant return position) rather than
+// a <T0> quantifier.
+func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
+	c := newChecker()
+	// fn (x) { x }
+	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: unknown) -> never", render(got))
+}
+
+func TestInferFuncExprMultiParam(t *testing.T) {
+	c := newChecker()
+	// fn (x: number, y: string) { y }
+	e := funcExpr(
+		[]*ast.Param{param("x", numAnn()), param("y", strAnn())},
+		nil,
+		block(exprStmt(identExpr("y"))),
+	)
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number, y: string) -> string", render(got))
+}
+
+func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
+	c := newChecker()
+	// fn (x: number) -> number { x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, numAnn(), block(exprStmt(identExpr("x"))))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(got))
+}
+
+func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
+	c := newChecker()
+	// fn () -> number { "hello" }
+	e := funcExpr(nil, numAnn(), block(exprStmt(strExpr("hello"))))
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, `cannot constrain "hello" <: number`, c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// A body-level val is visible to later statements and to the tail expression
+// that becomes the function's result.
+func TestInferFuncExprBodyValDecl(t *testing.T) {
+	c := newChecker()
+	// fn () { val y = 5; y }
+	e := funcExpr(nil, nil, block(
+		ast.NewDeclStmt(valDecl("y", nil, numExpr(5)), testSpan()),
+		exprStmt(identExpr("y")),
+	))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> 5", render(got))
+}
+
+// A bodyless (declare/ambient) function adopts its return annotation without
+// constraining a synthetic Void against it (which would error spuriously).
+func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
+	c := newChecker()
+	// declare fn now() -> number
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("now", testSpan()), nil, nil,
+		nil, numAnn(), nil,
+		nil, // no body
+		false, true, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> number", render(b.Type))
+}
+
+// A param that arrives without a pattern must report a clean error, not panic on
+// p.Span() (which dereferences the nil pattern). Not reachable from the real
+// parser, but the walk must uphold M2's "never a panic" guarantee.
+func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
+	c := newChecker()
+	e := funcExpr([]*ast.Param{{Pattern: nil}}, nil, block(exprStmt(numExpr(1))))
+
+	require.NotPanics(t, func() { c.inferExpr(NewScope(), 0, e) })
+	require.Len(t, c.errs, 1)
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
+	c := newChecker()
+	// fn ([a, b]) { ... } — destructuring params are M4.
+	tuplePat := ast.NewTuplePat([]ast.Pat{
+		ast.NewIdentPat("a", false, nil, nil, testSpan()),
+		ast.NewIdentPat("b", false, nil, nil, testSpan()),
+	}, testSpan())
+	e := funcExpr([]*ast.Param{{Pattern: tuplePat}}, nil, block(exprStmt(numExpr(1))))
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: TuplePat", c.errs[0].Message())
+}
+
+// --- CallExpr ---
+
+func TestInferCallResolvesReturn(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })(5)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{numExpr(5)}, false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+func TestInferCallArgMismatch(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })("hello")
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{strExpr("hello")}, false, testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, `cannot constrain "hello" <: number`, c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferCallArityMismatch(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number) { x })(1, 2)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+func TestInferCallThroughBinding(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("inc", ValueBinding{Type: &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
+		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
+	}})
+	// inc(7)
+	e := ast.NewCall(identExpr("inc"), []ast.Expr{numExpr(7)}, false, testSpan())
+
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", render(got))
+}
+
+// --- Block / statements ---
+
+func TestInferBlockResultIsLastStmt(t *testing.T) {
+	c := newChecker()
+	// { 1; "two" }
+	b := block(exprStmt(numExpr(1)), exprStmt(strExpr("two")))
+
+	got := c.inferBlock(NewScope(), 0, b)
+	require.Empty(t, c.errs)
+	require.Equal(t, `"two"`, render(got))
+}
+
+func TestInferBlockEmptyIsVoid(t *testing.T) {
+	c := newChecker()
+	got := c.inferBlock(NewScope(), 0, block())
+	require.Empty(t, c.errs)
+	require.Equal(t, "void", render(got))
+}
+
+func TestInferBlockReturnStmt(t *testing.T) {
+	c := newChecker()
+	// { return 5 }
+	got := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+}
+
+// Each val introduces a fresh, independent binding; a later val of the same name
+// rebinds it (overwrite, no constraint linking the two), so the tail sees the
+// later type even though it is unrelated to the earlier one (§3.2).
+func TestInferBlockRedeclarationRebinds(t *testing.T) {
+	c := newChecker()
+	// { val x = "hello"; val x = 5; x }
+	b := block(
+		ast.NewDeclStmt(valDecl("x", nil, strExpr("hello")), testSpan()),
+		ast.NewDeclStmt(valDecl("x", nil, numExpr(5)), testSpan()),
+		exprStmt(identExpr("x")),
+	)
+	got := c.inferBlock(NewScope(), 0, b)
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+}
+
+func TestInferStmtBodyDeclNotAllowed(t *testing.T) {
+	c := newChecker()
+	// A nested FuncDecl as a body statement is a permanent language error.
+	inner := ast.NewFuncDecl(ast.NewIdentifier("f", testSpan()), nil, nil, nil, nil, nil,
+		block(), false, false, false, testSpan())
+	s := ast.NewDeclStmt(inner, testSpan())
+
+	got := c.inferStmt(NewScope(), 0, s)
+	require.IsType(t, &soltype.Void{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Declaration not allowed in function body: FuncDecl", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// --- FuncDecl ---
+
+func TestInferFuncDecl(t *testing.T) {
+	c := newChecker()
+	// fn id(x: number) { x }
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("id", testSpan()), nil, nil,
+		[]*ast.Param{param("x", numAnn())}, nil, nil,
+		block(exprStmt(identExpr("x"))),
+		false, false, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn (x: number) -> number", render(b.Type))
+}
+
+// A recursive reference resolves when the name is pre-bound (the SCC wiring that
+// arranges this for real top-level groups is PR-5; here we bind the name by hand
+// to exercise the body walk seeing itself).
+func TestInferFuncDeclSelfReference(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	self := c.freshAt(1)
+	scope.defineValue("loop", ValueBinding{Type: self})
+	// fn loop(x: number) { loop }
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("loop", testSpan()), nil, nil,
+		[]*ast.Param{param("x", numAnn())}, nil, nil,
+		block(exprStmt(identExpr("loop"))),
+		false, false, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(scope, 0, d)
+	require.Empty(t, c.errs)
+	require.IsType(t, &soltype.FuncType{}, b.Type)
+}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -1,0 +1,77 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferBlock types a block's statements in source order and returns the block's
+// value: the type of its last statement, or void for an empty block. The block
+// runs in the scope it is given — the caller establishes it (inferFunc passes
+// the param scope, so body-level val/var redeclarations overwrite alongside the
+// params, per §3.2). soltype.Void is the result of a block that ends in a
+// declaration or a value-free statement.
+//
+// TODO(M3): a non-tail ReturnStmt only contributes the last statement's type to
+// the block value, so an early return (`{ return X; Y }`) is dropped and never
+// checked against the declared return type. Harmless at the M2 bar — there is no
+// IfElseExpr (control flow), so an early return cannot arise from a real branch —
+// but once M3 adds conditionals the walk must collect every return-point type and
+// join it with the tail before constraining against the annotation. Tracked in
+// planning/simple_sub/01-milestones.md (M3).
+func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type {
+	var result soltype.Type = &soltype.Void{}
+	for _, s := range b.Stmts {
+		result = c.inferStmt(scope, lvl, s)
+	}
+	return result
+}
+
+// inferStmt types a single statement and returns the value it contributes to
+// the enclosing block (void for declarations and bare returns without an
+// operand). Body-level declarations are VarDecl-only: a DeclStmt wrapping any
+// other decl kind is a permanent BodyDeclNotAllowedError (§3.2), not the
+// temporary subset gate. Each val/var introduces a fresh, independent binding
+// and overwrites the name's slot in the current scope, so redeclaration rebinds
+// without constraining the old and new types together.
+func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
+	switch s := s.(type) {
+	case *ast.ExprStmt:
+		return c.inferExpr(scope, lvl, s.Expr)
+	case *ast.ReturnStmt:
+		if s.Expr == nil {
+			return &soltype.Void{}
+		}
+		return c.inferExpr(scope, lvl, s.Expr)
+	case *ast.DeclStmt:
+		vd, ok := s.Decl.(*ast.VarDecl)
+		if !ok {
+			c.report(&BodyDeclNotAllowedError{
+				errSpan: errSpan{span: s.Span()},
+				Kind:    astKind(s.Decl),
+			})
+			return &soltype.Void{}
+		}
+		name, named := varName(vd)
+		if !named {
+			c.report(&UnsupportedNodeError{
+				errSpan: errSpan{span: vd.Pattern.Span()},
+				Kind:    astKind(vd.Pattern),
+			})
+			return &soltype.Void{}
+		}
+		// Unlike the module driver (inferDecl), a body-level redeclaration is
+		// allowed and overwrites the name's slot (§3.2). inferVarDecl reports a
+		// missing initializer itself and returns ok=false; bind only when it
+		// produced a type.
+		if b, ok := c.inferVarDecl(scope, lvl, vd); ok {
+			scope.defineValue(name, b) // overwrite ⇒ same-name redeclaration rebinds
+		}
+		return &soltype.Void{}
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: s.Span()},
+			Kind:    astKind(s),
+		})
+	}
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -1,0 +1,29 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type.
+// M2 needs only the primitive annotations that annotated params and return
+// types use (number/string/boolean); everything richer — type references,
+// generics, object/tuple/function annotations, unions — is represented by types
+// later milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here.
+// It takes no scope: the supported set is all closed primitives, with no name to
+// look up. Name resolution against the type scope arrives with TypeRef support.
+func (c *checker) resolveTypeAnn(ta ast.TypeAnn) soltype.Type {
+	switch ta := ta.(type) {
+	case *ast.NumberTypeAnn:
+		return &soltype.PrimType{Prim: soltype.NumPrim}
+	case *ast.StringTypeAnn:
+		return &soltype.PrimType{Prim: soltype.StrPrim}
+	case *ast.BooleanTypeAnn:
+		return &soltype.PrimType{Prim: soltype.BoolPrim}
+	default:
+		return c.report(&UnsupportedNodeError{
+			errSpan: errSpan{span: ta.Span()},
+			Kind:    astKind(ta),
+		})
+	}
+}

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -193,6 +193,14 @@ reassess.
   exists to opt into it. (This corrects the merged spec's §4.2, which had
   exactness govern call-sites rather than subtyping — see
   escalier-lang/escalier#677.)
+- **Block return-point join (carried over from M2).** M2's block walk uses the
+  *last statement* as the block's value and only constrains that tail against a
+  declared return type; a non-tail `return` (`{ return X; Y }`) is dropped. This
+  is harmless at the M2 bar (no `IfElseExpr`, so an early return cannot come from
+  a real branch), but once this milestone adds conditionals/early return the walk
+  must collect **every** `ReturnStmt` type (valued and bare) and join them with
+  the tail expression before constraining against the return annotation. See
+  `internal/solver/infer_stmt.go` (`inferBlock` TODO(M3)).
 
 **Accept:** the spike's Category-A cases against real source:
 `TopLevelLetPolymorphism` ⇒ `fn <T0>(x: T0) -> T0`; `IdentityPolymorphism` ⇒


### PR DESCRIPTION
Reintroduces the M2 PR-3 work that was merged in #697 and then reverted in #698. Same changes, rebased onto the revert. Implements PR-3 from `planning/simple_sub/m2-implementation-plan.md` — the function / application / block walk — extending the solver's constraint-generating walk (PR-1 wired literals and identifiers) so top-level `fn` declarations and calls infer end-to-end, monomorphically.

## Summary

- **`infer_expr.go`** — `inferFuncExpr` + the shared `inferFunc` core (child scope per function, fresh var or resolved annotation per param, n-ary `FuncType`, optional return-annotation constraint), `inferCall` (`constrain(callee <: fn(args) -> res)`), `paramType`, and the `astKind`/`exprKind`/`litKind`/`patKind`/`identPatName` helpers.
- **`infer_stmt.go`** — `inferBlock` (result = last statement, `void` when empty) and `inferStmt` (`ExprStmt`/`ReturnStmt` plus the §3.2 body-level `DeclStmt` rule: `VarDecl`-only, redeclaration overwrites, other decl kinds → `BodyDeclNotAllowedError`).
- **`infer_decl.go`** — `inferFuncDecl` (reuses `inferFunc`) and `inferVarDecl` (shared with PR-2's decl driver; the body walk is its first consumer).
- **`type_ann.go`** — minimal type-annotation resolver for the primitive annotations annotated params/returns use (number/string/boolean); richer annotations are `UnsupportedNodeError` until later milestones add the types to represent them.
- **`soltype/print.go`** — `Print` tolerates a raw, un-coalesced `TypeVarType` (rendered as `t{ID}`) instead of panicking, since the M2 walk records var-carrying types in `Info` and coalesces only at binding boundaries.

## Notes

- Inference stays monomorphic per M1's deferral of schemes/generalization to M3: an un-annotated param coalesces to `unknown`/`never` rather than a `<T0>` quantifier.
- Params are `IdentPat`-only in M2; destructuring patterns raise `UnsupportedNodeError` (deferred to M4). A pattern-less param falls back to the function node's span to honor the "never a panic" guarantee.
- Bodyless (declare/ambient) functions adopt their return annotation without constraining a synthetic `Void`.
- The block return-point join (collecting all return-point types and joining with the tail before constraining against a declared return) is deferred to M3, when `IfElseExpr` makes early returns reachable from real branches — tracked via a `TODO(M3)` in `inferBlock` and a milestone bullet.
- Tests hand-build AST nodes (the source-driven harness is PR-2), asserting full messages and rendered types via the soltype printer.

This commit includes the review fixes applied after the original #697 (bodyless-fn return handling, raw-`TypeVarType` print tolerance, nil-param span guard).

https://claude.ai/code/session_0137jcq69G82CSqFL1LwL4JK

---
_Generated by [Claude Code](https://claude.ai/code/session_0137jcq69G82CSqFL1LwL4JK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for function types and function expressions with optional parameter and return type annotations.
  * Implemented function call inference with automatic type resolution through calls.
  * Added block and statement type inference, including support for return statements and variable declarations.
  
* **Tests**
  * Comprehensive test suite covering function inference, calls, blocks, and declarations.
  
* **Documentation**
  * Updated milestone documentation regarding block value inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->