### PR TITLE
PR-4: Add tuple, object literal, and member access inference

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // Precedence levels for type operators, matching the Escalier parser (and
@@ -102,7 +103,7 @@ func printType(t Type) string {
 	case *RecordType:
 		fields := make([]string, len(t.Fields))
 		for i, f := range t.Fields {
-			fields[i] = f.Name + ": " + printType(f.Type)
+			fields[i] = printRecordFieldName(f.Name) + ": " + printType(f.Type)
 		}
 		return "{" + strings.Join(fields, ", ") + "}"
 	case *FuncType:
@@ -142,6 +143,37 @@ func paramName(p *FuncParam, i int) string {
 		return pat.Name
 	}
 	return "arg" + strconv.Itoa(i)
+}
+
+// printRecordFieldName renders a record field name as Escalier surface syntax:
+// a bare label when the name is a valid identifier, otherwise a quoted string
+// key (e.g. "a-b", a key that came from a string-literal property). This keeps
+// the rendered record parseable; an unquoted "a-b" would corrupt the type.
+func printRecordFieldName(name string) string {
+	if isIdent(name) {
+		return name
+	}
+	return strconv.Quote(name)
+}
+
+// isIdent reports whether name is a valid Escalier identifier: non-empty, with a
+// leading letter or underscore and letter/underscore/digit runes thereafter.
+func isIdent(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 // printPrim maps a Prim to its Escalier surface name — mirrors

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -27,7 +27,8 @@ func typePrec(t Type) int {
 	case *IntersectionType:
 		return precIntersection
 	default:
-		// PrimType, LitType, TupleType, Void, NeverType, UnknownType — atoms. A
+		// PrimType, LitType, TupleType, RecordType, Void, NeverType, UnknownType —
+		// atoms (RecordType is brace-delimited, so it never needs parens). A
 		// raw TypeVarType (which appears only when printing an un-coalesced type,
 		// see printType) is also an atom (rendered as `t{ID}`), so it lands here.
 		return precAtom
@@ -98,6 +99,12 @@ func printType(t Type) string {
 			elems[i] = printType(e)
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
+	case *RecordType:
+		fields := make([]string, len(t.Fields))
+		for i, f := range t.Fields {
+			fields[i] = f.Name + ": " + printType(f.Type)
+		}
+		return "{" + strings.Join(fields, ", ") + "}"
 	case *FuncType:
 		return "fn " + printFuncTail(t)
 	case *UnionType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -52,6 +52,13 @@ func TestPrintRoundTrips(t *testing.T) {
 			&RecordType{Fields: []*RecordField{{Name: "a", Type: numP()}, {Name: "b", Type: strP()}}},
 			"{a: number, b: string}",
 		},
+		{
+			// A field name that isn't a valid identifier (e.g. from a string-literal
+			// key) is quoted so the rendered record stays parseable.
+			"non-identifier field name is quoted",
+			&RecordType{Fields: []*RecordField{{Name: "a-b", Type: numP()}}},
+			`{"a-b": number}`,
+		},
 
 		// Functions.
 		{"nullary fn", &FuncType{Ret: numP()}, "fn () -> number"},
@@ -70,6 +77,28 @@ func TestPrintRoundTrips(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+func TestIsIdent(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"a", true},
+		{"_x", true},
+		{"a1", true},
+		{"camelCase_9", true},
+		{"", false},
+		{"1a", false},  // leading digit
+		{"a-b", false}, // hyphen
+		{"a b", false}, // space
+		{"a.b", false}, // dot
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isIdent(tt.name))
 		})
 	}
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -45,6 +45,14 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"empty tuple", &TupleType{}, "[]"},
 		{"pair tuple", &TupleType{Elems: []Type{numP(), strP()}}, "[number, string]"},
 
+		// Records.
+		{"empty record", &RecordType{}, "{}"},
+		{
+			"two-field record",
+			&RecordType{Fields: []*RecordField{{Name: "a", Type: numP()}, {Name: "b", Type: strP()}}},
+			"{a: number, b: string}",
+		},
+
 		// Functions.
 		{"nullary fn", &FuncType{Ret: numP()}, "fn () -> number"},
 		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}, "fn (x: number) -> string"},
@@ -90,6 +98,16 @@ func TestPrintNestedPrecedence(t *testing.T) {
 			boolP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
+	})
+
+	// A record is brace-delimited (an atom), so a record nested in a union needs
+	// no parens, and a function as a field value is delimited by the field's `:`.
+	t.Run("record in union", func(t *testing.T) {
+		ty := &UnionType{Types: []Type{
+			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP()}}}},
+			strP(),
+		}}
+		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`{f: fn () -> number} | string`))
 	})
 }
 

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -90,8 +90,14 @@ func TestIsIdent(t *testing.T) {
 		{"_x", true},
 		{"a1", true},
 		{"camelCase_9", true},
+		{"café", true},     // unicode letter (continue)
+		{"naïve", true},    // unicode letter (continue)
+		{"数値", true},       // non-Latin letters
+		{"Ωmega", true},     // unicode letter (leading)
+		{"x٢", true},        // unicode digit (Arabic-Indic) after letter
 		{"", false},
 		{"1a", false},  // leading digit
+		{"٢x", false},  // leading unicode digit
 		{"a-b", false}, // hyphen
 		{"a b", false}, // space
 		{"a.b", false}, // dot

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -117,6 +117,21 @@ type RecordField struct {
 	Type Type
 }
 
+// Field returns the type of the named field and whether it is present. Field
+// names are unique in a well-formed RecordType — the constraint solver dedups
+// duplicate keys (last value wins) when it builds a record from a literal — so
+// the first match is the field. The scan is linear because records are small;
+// it is the single canonical field lookup shared by constraining, structural
+// equality, and member access.
+func (r *RecordType) Field(name string) (Type, bool) {
+	for _, f := range r.Fields {
+		if f.Name == name {
+			return f.Type, true
+		}
+	}
+	return nil, false
+}
+
 // Void is the result type of a statement block with no value.
 type Void struct{}
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -101,6 +101,22 @@ type FuncType struct {
 // TupleType is a fixed-length tuple type.
 type TupleType struct{ Elems []Type }
 
+// RecordType is a record/object type with named value fields. M2 ships the
+// BASIC width-and-depth-subtyping form that record literals and field reads
+// need ({a: 5}, recv.a); the richer object system — optional fields, methods,
+// getters/setters, index signatures, spreads, `mut`, and usage-inference — is
+// M4. It mirrors the role of type_system.ObjectType but carries only named
+// value fields (no method/getter/setter/mapped elements yet), so it stays a
+// flat list of Name→Type fields. Subtyping matches fields by name (order is
+// irrelevant); the slice order is preserved only for stable rendering.
+type RecordType struct{ Fields []*RecordField }
+
+// RecordField is one named field of a RecordType.
+type RecordField struct {
+	Name string
+	Type Type
+}
+
 // Void is the result type of a statement block with no value.
 type Void struct{}
 
@@ -125,6 +141,7 @@ func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
 func (*TupleType) isType()        {}
+func (*RecordType) isType()       {}
 func (*Void) isType()             {}
 func (*NeverType) isType()        {}
 func (*UnknownType) isType()      {}
@@ -147,6 +164,12 @@ func LevelOf(t Type) int {
 		m := 0
 		for _, e := range t.Elems {
 			m = max(m, LevelOf(e))
+		}
+		return m
+	case *RecordType:
+		m := 0
+		for _, f := range t.Fields {
+			m = max(m, LevelOf(f.Type))
 		}
 		return m
 	default:

--- a/internal/solver/astbuild.go
+++ b/internal/solver/astbuild.go
@@ -46,3 +46,17 @@ func valDecl(name string, ann ast.TypeAnn, init ast.Expr) *ast.VarDecl {
 func funcExpr(params []*ast.Param, ret ast.TypeAnn, body *ast.Block) *ast.FuncExpr {
 	return ast.NewFuncExpr(nil, nil, params, ret, nil, false, body, builderSpan())
 }
+
+func tupleExpr(elems ...ast.Expr) *ast.TupleExpr { return ast.NewArray(elems, builderSpan()) }
+
+// prop builds a `name: value` object property with an identifier key.
+func prop(name string, value ast.Expr) *ast.PropertyExpr {
+	return ast.NewProperty(ast.NewIdent(name, builderSpan()), false, false, value, builderSpan())
+}
+
+func objExpr(elems ...ast.ObjExprElem) *ast.ObjectExpr { return ast.NewObject(elems, builderSpan()) }
+
+// memberExpr builds a non-optional `obj.prop` field read.
+func memberExpr(obj ast.Expr, name string) *ast.MemberExpr {
+	return ast.NewMember(obj, ast.NewIdentifier(name, builderSpan()), false, builderSpan())
+}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -147,13 +147,12 @@ func equalType(a, b soltype.Type) bool {
 		if !ok || len(a.Fields) != len(b.Fields) {
 			return false
 		}
-		// Records are equal up to field order — match by name, not position.
-		bf := make(map[string]soltype.Type, len(b.Fields))
-		for _, f := range b.Fields {
-			bf[f.Name] = f.Type
-		}
+		// Records are equal up to field order — match by name (RecordType.Field),
+		// not position. Well-formed records have unique field names (the solver
+		// dedups on construction), so equal lengths plus every a-field matching a
+		// b-field by name is a full structural match.
 		for _, f := range a.Fields {
-			bt, ok := bf[f.Name]
+			bt, ok := b.Field(f.Name)
 			if !ok || !equalType(f.Type, bt) {
 				return false
 			}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -41,6 +41,12 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 			elems[i] = coalesce(e, pol) // covariant elements
 		}
 		return &soltype.TupleType{Elems: elems}
+	case *soltype.RecordType:
+		fields := make([]*soltype.RecordField, len(t.Fields))
+		for i, f := range t.Fields {
+			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesce(f.Type, pol)} // covariant fields
+		}
+		return &soltype.RecordType{Fields: fields}
 	case *soltype.TypeVarType:
 		// Uniform inline: drop the variable, keep only its (recursively
 		// coalesced) bounds in the current polarity.
@@ -132,6 +138,23 @@ func equalType(a, b soltype.Type) bool {
 		}
 		for i := range a.Elems {
 			if !equalType(a.Elems[i], b.Elems[i]) {
+				return false
+			}
+		}
+		return true
+	case *soltype.RecordType:
+		b, ok := b.(*soltype.RecordType)
+		if !ok || len(a.Fields) != len(b.Fields) {
+			return false
+		}
+		// Records are equal up to field order — match by name, not position.
+		bf := make(map[string]soltype.Type, len(b.Fields))
+		for _, f := range b.Fields {
+			bf[f.Name] = f.Type
+		}
+		for _, f := range a.Fields {
+			bt, ok := bf[f.Name]
+			if !ok || !equalType(f.Type, bt) {
 				return false
 			}
 		}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -92,6 +92,28 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			}
 			return errs
 		}
+	case *soltype.RecordType:
+		if r, ok := rhs.(*soltype.RecordType); ok {
+			// Width + depth subtyping: every field the RHS requires must be present
+			// on the LHS (the LHS may carry MORE fields — width), and the shared
+			// fields are covariant (depth). M2 records are read-only — `mut` makes a
+			// field invariant, and that lands in M4 — so there is no invariance arm
+			// here. Fields are matched by name, so source order is irrelevant.
+			lf := make(map[string]soltype.Type, len(l.Fields))
+			for _, f := range l.Fields {
+				lf[f.Name] = f.Type
+			}
+			var errs []SolverError
+			for _, rf := range r.Fields {
+				lt, ok := lf[rf.Name]
+				if !ok {
+					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rf.Name})
+					continue
+				}
+				errs = append(errs, c.constrain(lt, rf.Type, seen)...) // covariant
+			}
+			return errs
+		}
 	case *soltype.Void:
 		if _, ok := rhs.(*soltype.Void); ok {
 			return nil
@@ -171,6 +193,13 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 			elems[i] = c.extrude(e, pol, lvl, cache)
 		}
 		return &soltype.TupleType{Elems: elems}
+	case *soltype.RecordType:
+		fields := make([]*soltype.RecordField, len(t.Fields))
+		for i, f := range t.Fields {
+			// Fields are covariant (read-only records in M2), so no polarity flip.
+			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.extrude(f.Type, pol, lvl, cache)}
+		}
+		return &soltype.RecordType{Fields: fields}
 	default:
 		return t
 	}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -98,14 +98,11 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			// on the LHS (the LHS may carry MORE fields — width), and the shared
 			// fields are covariant (depth). M2 records are read-only — `mut` makes a
 			// field invariant, and that lands in M4 — so there is no invariance arm
-			// here. Fields are matched by name, so source order is irrelevant.
-			lf := make(map[string]soltype.Type, len(l.Fields))
-			for _, f := range l.Fields {
-				lf[f.Name] = f.Type
-			}
+			// here. Fields are matched by name (RecordType.Field), so source order is
+			// irrelevant.
 			var errs []SolverError
 			for _, rf := range r.Fields {
-				lt, ok := lf[rf.Name]
+				lt, ok := l.Field(rf.Name)
 				if !ok {
 					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rf.Name})
 					continue

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -94,12 +94,25 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		}
 	case *soltype.RecordType:
 		if r, ok := rhs.(*soltype.RecordType); ok {
-			// Width + depth subtyping: every field the RHS requires must be present
-			// on the LHS (the LHS may carry MORE fields — width), and the shared
-			// fields are covariant (depth). M2 records are read-only — `mut` makes a
-			// field invariant, and that lands in M4 — so there is no invariance arm
-			// here. Fields are matched by name (RecordType.Field), so source order is
-			// irrelevant.
+			// M2 serves exactly one consumer through this arm: member-access field
+			// selection. inferMember lowers `recv.foo` to `constrain(recv, {foo:
+			// fresh})` (m2-implementation-plan.md §3.2), where the RHS lists only the
+			// field being read. That is a "has-field" REQUIREMENT, not a concrete
+			// record type, so the rule here is intentionally width-tolerant: every
+			// field the RHS requires must be present on the LHS (the LHS may carry
+			// MORE fields), and the shared fields are covariant (depth). Fields are
+			// matched by name (RecordType.Field), so source order is irrelevant.
+			//
+			// This is NOT the final record-subtyping semantics. Escalier records are
+			// exact-by-default (01-milestones.md:278-282): exact <: exact requires the
+			// SAME field set (no width), and width is only the inexact <: inexact case
+			// behind the `...` flag. M4 differentiates the two uses the plan conflates
+			// here — the member-access field-selection requirement (width-tolerant,
+			// this arm) vs. concrete record <: record subtyping for record-typed
+			// params/annotations (exact, like the tuple same-length and function
+			// same-arity arms above). M2 has neither record annotations nor deep
+			// record params, so the exact path is unreachable and only this
+			// selection arm exists; `mut`-driven field invariance also lands in M4.
 			var errs []SolverError
 			for _, rf := range r.Fields {
 				lt, ok := l.Field(rf.Name)

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -62,9 +62,22 @@ type TupleLengthMismatchError struct {
 	LHS, RHS *soltype.TupleType
 }
 
+// MissingPropertyError fires on RecordType <: RecordType when the RHS requires a
+// field the LHS lacks — the record analogue of FuncArityMismatchError /
+// TupleLengthMismatchError. It is the failure behind a field read on a record
+// without that field (recv.foo where recv has no foo): the walk constrains
+// recv <: {foo: fresh}, and the absent field surfaces here. Holds both records
+// plus the missing name so consumers can inspect what was required.
+type MissingPropertyError struct {
+	errSpan
+	LHS, RHS *soltype.RecordType
+	Name     string
+}
+
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
+func (*MissingPropertyError) isSolverError()     {}
 
 // --- M2 bridge errors (carry their span from construction) ---
 
@@ -167,6 +180,10 @@ func (e *TupleLengthMismatchError) Message() string {
 		len(e.LHS.Elems), len(e.RHS.Elems))
 }
 
+func (e *MissingPropertyError) Message() string {
+	return "object is missing property: " + e.Name
+}
+
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,
 // function, number). Distinct from soltype.Print, which renders coalesced
 // output as user-facing Escalier syntax (see m1-implementation-plan §2.2). It
@@ -195,6 +212,8 @@ func describe(t soltype.Type) string {
 		return "function"
 	case *soltype.TupleType:
 		return "tuple"
+	case *soltype.RecordType:
+		return "object"
 	case *soltype.Void:
 		return "void"
 	case *soltype.NeverType:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -52,6 +52,16 @@ func (c *checker) report(e SolverError) soltype.Type {
 	return &soltype.NeverType{}
 }
 
+// reportUnsupported records an UnsupportedNodeError for an AST node outside the
+// M2 subset: the span comes from spanNode, the rendered kind name from kindNode
+// (astKind). The two are usually the same node but differ when the unsupported
+// thing is a child carried by its parent — e.g. an object property's key, whose
+// span we report against the property. Returns the never placeholder so a caller
+// can `return c.reportUnsupported(...)` in value position.
+func (c *checker) reportUnsupported(spanNode ast.Node, kindNode any) soltype.Type {
+	return c.report(&UnsupportedNodeError{errSpan: errSpan{span: spanNode.Span()}, Kind: astKind(kindNode)})
+}
+
 // recordType records t as the inferred type of n in the Info side table. Wraps
 // the unexported setType — which is why the whole M2 walk lives in package
 // solver. The AST stays untouched (no InferredType() writes); Info is the single
@@ -82,9 +92,6 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	case *ast.MemberExpr:
 		return c.inferMember(scope, lvl, e)
 	default:
-		return c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: e.Span()},
-			Kind:    astKind(e),
-		})
+		return c.reportUnsupported(e, e)
 	}
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -63,8 +63,8 @@ func (c *checker) recordType(n ast.Node, t soltype.Type) {
 // inferExpr dispatches on the concrete expression kind. PR-1 wired the two leaf
 // cases (literals, identifiers); PR-3 adds the function/application walk
 // (FuncExpr, CallExpr — the block/statement walk they drive lives in
-// infer_stmt.go). Every remaining kind falls through to a clean
-// UnsupportedNodeError (never a panic); PR-4 adds objects/members/tuples.
+// infer_stmt.go); PR-4 adds tuples, object literals, and member access. Every
+// remaining kind falls through to a clean UnsupportedNodeError (never a panic).
 func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
@@ -75,6 +75,12 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferFuncExpr(scope, lvl, e)
 	case *ast.CallExpr:
 		return c.inferCall(scope, lvl, e)
+	case *ast.TupleExpr:
+		return c.inferTuple(scope, lvl, e)
+	case *ast.ObjectExpr:
+		return c.inferObject(scope, lvl, e)
+	case *ast.MemberExpr:
+		return c.inferMember(scope, lvl, e)
 	default:
 		return c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: e.Span()},

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -177,6 +177,90 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	return res
 }
 
+// inferTuple types a tuple literal as a soltype.TupleType of its element types
+// and records it in Info. Elements are typed left-to-right in the current scope.
+// A spread element ([...xs]) is an ArraySpreadExpr, which is not in the M2 walk,
+// so inferExpr reports it as unsupported and contributes a never placeholder in
+// its slot — the tuple is still built (error already accumulated), never a panic.
+func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
+	elems := make([]soltype.Type, len(e.Elems))
+	for i, el := range e.Elems {
+		elems[i] = c.inferExpr(scope, lvl, el)
+	}
+	t := &soltype.TupleType{Elems: elems}
+	c.recordType(e, t)
+	return t
+}
+
+// inferObject types an object literal as a soltype.RecordType. M2 covers the
+// basic case only: a `name: value` property with a static (identifier or string)
+// key. The forms it does not cover each report an UnsupportedNodeError and are
+// skipped rather than panicking (the deeper object system is M4):
+//   - spreads ({...o}) and method/constructor elements,
+//   - computed ({[k]: v}) and numeric ({0: v}) keys,
+//   - shorthand ({x}, i.e. a property with no value).
+//
+// Usage-inference depth (e.g. inferring an open record from how a value is used)
+// is explicitly M4; M2 builds the closed record the literal spells out.
+func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
+	fields := make([]*soltype.RecordField, 0, len(e.Elems))
+	for _, elem := range e.Elems {
+		prop, ok := elem.(*ast.PropertyExpr)
+		if !ok {
+			// ObjSpreadExpr, CallableExpr (method), ConstructorExpr — all M4.
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: elem.Span()}, Kind: astKind(elem)})
+			continue
+		}
+		if prop.Value == nil {
+			// Shorthand ({x}) needs the ident's binding folded in as the value — M4.
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: prop.Span()}, Kind: astKind(prop)})
+			continue
+		}
+		name, ok := objKeyName(prop.Name)
+		if !ok {
+			// Computed/numeric keys carry no static field name — M4.
+			c.report(&UnsupportedNodeError{errSpan: errSpan{span: prop.Span()}, Kind: astKind(prop.Name)})
+			continue
+		}
+		fields = append(fields, &soltype.RecordField{Name: name, Type: c.inferExpr(scope, lvl, prop.Value)})
+	}
+	t := &soltype.RecordType{Fields: fields}
+	c.recordType(e, t)
+	return t
+}
+
+// inferMember types a field read (recv.prop). It types the receiver, allocates a
+// fresh result var, and constrains recv <: {prop: res} — the basic form from the
+// plan's §3.2 table. The record <: record arm of constrain lowers res from the
+// receiver's matching field (so res coalesces to that field's type); a receiver
+// missing the field surfaces as a MissingPropertyError stamped with the member's
+// span. Optional chaining (recv?.prop) needs union/undefined handling and is M6.
+func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
+	recv := c.inferExpr(scope, lvl, e.Object)
+	if e.OptChain {
+		return c.report(&UnsupportedNodeError{errSpan: errSpan{span: e.Span()}, Kind: "OptionalChain"})
+	}
+	res := c.freshAt(lvl)
+	c.constrain(e, recv, &soltype.RecordType{Fields: []*soltype.RecordField{{Name: e.Prop.Name, Type: res}}})
+	c.recordType(e, res)
+	return res
+}
+
+// objKeyName reads the static field name of an object-literal key. M2 records
+// have string field names, so an identifier label or a string-literal key maps
+// to a field; numeric and computed keys do not (they need M4's wider object
+// system) and return false so the caller can raise a structured error.
+func objKeyName(k ast.ObjKey) (string, bool) {
+	switch k := k.(type) {
+	case *ast.IdentExpr:
+		return k.Name, true
+	case *ast.StrLit:
+		return k.Value, true
+	default:
+		return "", false
+	}
+}
+
 // identPatName reads the name of an IdentPat. M2 binds IdentPat-only patterns
 // (mirroring M1's IdentPat-only FuncParam); the comma-ok form lets callers raise
 // a structured error for the destructuring patterns deferred to M4.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -241,10 +241,13 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 // missing the field surfaces as a MissingPropertyError stamped with the member's
 // span. Optional chaining (recv?.prop) needs union/undefined handling and is M6.
 func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
-	recv := c.inferExpr(scope, lvl, e.Object)
 	if e.OptChain {
+		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
+		// up front and do NOT descend into the receiver, so a single diagnostic
+		// stands for the construct instead of cascading the receiver's errors.
 		return c.report(&UnsupportedNodeError{errSpan: errSpan{span: e.Span()}, Kind: "OptionalChain"})
 	}
+	recv := c.inferExpr(scope, lvl, e.Object)
 	if e.Prop == nil || e.Prop.Name == "" {
 		// A malformed `recv.` with no valid property name: the parser already
 		// reported the missing identifier, so constraining recv <: {"": res} here

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -23,10 +23,7 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 	case *ast.BoolLit:
 		lit = &soltype.BoolLit{Value: l.Value}
 	default:
-		return c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: e.Span()},
-			Kind:    astKind(e.Lit),
-		})
+		return c.reportUnsupported(e, e.Lit)
 	}
 	t := &soltype.LitType{Lit: lit}
 	c.recordType(e, t)
@@ -97,10 +94,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
 		// which are M3. M2 is monomorphic, so diagnose the type parameters rather
 		// than silently erasing them, then continue inferring monomorphically.
-		c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: node.Span()},
-			Kind:    astKind(sig.TypeParams[0]),
-		})
+		c.reportUnsupported(node, sig.TypeParams[0])
 	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
@@ -202,27 +196,38 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 //
 // Usage-inference depth (e.g. inferring an open record from how a value is used)
 // is explicitly M4; M2 builds the closed record the literal spells out.
+//
+// Duplicate keys follow JavaScript semantics: the last value wins, keeping the
+// field at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
+// field names unique, the invariant RecordType.Field / equalType rely on.
 func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
 	fields := make([]*soltype.RecordField, 0, len(e.Elems))
+	pos := make(map[string]int, len(e.Elems)) // field name → index in fields, for last-wins dedup
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
 			// ObjSpreadExpr, CallableExpr (method), ConstructorExpr — all M4.
-			c.report(&UnsupportedNodeError{errSpan: errSpan{span: elem.Span()}, Kind: astKind(elem)})
+			c.reportUnsupported(elem, elem)
 			continue
 		}
 		if prop.Value == nil {
 			// Shorthand ({x}) needs the ident's binding folded in as the value — M4.
-			c.report(&UnsupportedNodeError{errSpan: errSpan{span: prop.Span()}, Kind: astKind(prop)})
+			c.reportUnsupported(prop, prop)
 			continue
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
 			// Computed/numeric keys carry no static field name — M4.
-			c.report(&UnsupportedNodeError{errSpan: errSpan{span: prop.Span()}, Kind: astKind(prop.Name)})
+			c.reportUnsupported(prop, prop.Name)
 			continue
 		}
-		fields = append(fields, &soltype.RecordField{Name: name, Type: c.inferExpr(scope, lvl, prop.Value)})
+		ft := c.inferExpr(scope, lvl, prop.Value)
+		if i, dup := pos[name]; dup {
+			fields[i] = &soltype.RecordField{Name: name, Type: ft} // last value wins, first position kept
+			continue
+		}
+		pos[name] = len(fields)
+		fields = append(fields, &soltype.RecordField{Name: name, Type: ft})
 	}
 	t := &soltype.RecordType{Fields: fields}
 	c.recordType(e, t)
@@ -239,6 +244,15 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 	recv := c.inferExpr(scope, lvl, e.Object)
 	if e.OptChain {
 		return c.report(&UnsupportedNodeError{errSpan: errSpan{span: e.Span()}, Kind: "OptionalChain"})
+	}
+	if e.Prop == nil || e.Prop.Name == "" {
+		// A malformed `recv.` with no valid property name: the parser already
+		// reported the missing identifier, so constraining recv <: {"": res} here
+		// would only layer a spurious "object is missing property: " on top. Yield
+		// a never placeholder without reporting or constraining.
+		t := soltype.Type(&soltype.NeverType{})
+		c.recordType(e, t)
+		return t
 	}
 	res := c.freshAt(lvl)
 	c.constrain(e, recv, &soltype.RecordType{Fields: []*soltype.RecordField{{Name: e.Prop.Name, Type: res}}})

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -1,0 +1,132 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- TupleExpr ---
+
+func TestInferTuple(t *testing.T) {
+	c := newChecker()
+	// [1, "hi"]
+	e := tupleExpr(numExpr(1), strExpr("hi"))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, `[1, "hi"]`, render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+func TestInferTupleEmpty(t *testing.T) {
+	c := newChecker()
+	got := c.inferExpr(NewScope(), 0, tupleExpr())
+	require.Empty(t, c.errs)
+	require.Equal(t, "[]", render(got))
+}
+
+// --- ObjectExpr ---
+
+func TestInferObject(t *testing.T) {
+	c := newChecker()
+	// {a: 5, b: "hi"}
+	e := objExpr(prop("a", numExpr(5)), prop("b", strExpr("hi")))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, `{a: 5, b: "hi"}`, render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+func TestInferObjectEmpty(t *testing.T) {
+	c := newChecker()
+	got := c.inferExpr(NewScope(), 0, objExpr())
+	require.Empty(t, c.errs)
+	require.Equal(t, "{}", render(got))
+}
+
+// A string-literal key maps to a field name just like an identifier label.
+func TestInferObjectStringKey(t *testing.T) {
+	c := newChecker()
+	// {"a": 5}
+	strKey := ast.NewProperty(ast.NewString("a", testSpan()), false, false, numExpr(5), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(strKey))
+	require.Empty(t, c.errs)
+	require.Equal(t, "{a: 5}", render(got))
+}
+
+// Shorthand ({x}) is a property with no value — deferred to M4. It reports a
+// clean UnsupportedNodeError and is skipped (the rest of the object still types).
+func TestInferObjectShorthandUnsupported(t *testing.T) {
+	c := newChecker()
+	shorthand := ast.NewProperty(ast.NewIdent("x", testSpan()), false, false, nil, testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(shorthand))
+	require.Equal(t, "{}", render(got))
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: PropertyExpr", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// A spread element ({...o}) is M4; it reports unsupported without walking its
+// value, so the unknown `o` inside it never surfaces a second error.
+func TestInferObjectSpreadUnsupported(t *testing.T) {
+	c := newChecker()
+	spread := ast.NewRestSpread(identExpr("o"), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(spread))
+	require.Equal(t, "{}", render(got))
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: ObjSpreadExpr", c.errs[0].Message())
+}
+
+// A computed key ({[k]: v}) carries no static field name — M4.
+func TestInferObjectComputedKeyUnsupported(t *testing.T) {
+	c := newChecker()
+	computed := ast.NewProperty(ast.NewComputedKey(identExpr("k")), false, false, numExpr(1), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(computed))
+	require.Equal(t, "{}", render(got))
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: ComputedKey", c.errs[0].Message())
+}
+
+// --- MemberExpr ---
+
+func TestInferMember(t *testing.T) {
+	c := newChecker()
+	// ({a: 5, b: "hi"}).a
+	recv := objExpr(prop("a", numExpr(5)), prop("b", strExpr("hi")))
+	e := memberExpr(recv, "a")
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+// Reading a field the receiver lacks fails with a MissingPropertyError carrying
+// the member node's span.
+func TestInferMemberMissingProperty(t *testing.T) {
+	c := newChecker()
+	// ({a: 5}).b
+	e := memberExpr(objExpr(prop("a", numExpr(5))), "b")
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Equal(t, "never", render(got)) // the fresh result var picks up no lower bound
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "object is missing property: b", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// Optional chaining (recv?.prop) needs union/undefined handling — M6.
+func TestInferMemberOptionalChainUnsupported(t *testing.T) {
+	c := newChecker()
+	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("a", testSpan()), true, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -28,6 +28,21 @@ func TestInferTupleEmpty(t *testing.T) {
 	require.Equal(t, "[]", render(got))
 }
 
+// A spread element ([...a]) is an ArraySpreadExpr, which the M2 walk does not
+// cover; inferExpr reports it as unsupported and drops a never placeholder into
+// the tuple slot, so the tuple still builds (no panic) and the spread's value `a`
+// is never walked — so no cascading unknown-identifier error. Tuple/array spread
+// is M4.
+func TestInferTupleSpreadUnsupported(t *testing.T) {
+	c := newChecker()
+	// [...a]
+	e := tupleExpr(ast.NewArraySpread(identExpr("a"), testSpan()))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Equal(t, "[never]", render(got))
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: ArraySpreadExpr", c.errs[0].Message())
+}
+
 // --- ObjectExpr ---
 
 func TestInferObject(t *testing.T) {

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -58,6 +58,24 @@ func TestInferObjectStringKey(t *testing.T) {
 	require.Equal(t, "{a: 5}", render(got))
 }
 
+// Duplicate keys follow JS last-wins semantics: the later value replaces the
+// earlier one while the field keeps its first position. This keeps field names
+// unique, so the record is well-formed (and equalType stays reflexive on it).
+func TestInferObjectDuplicateKeyLastWins(t *testing.T) {
+	c := newChecker()
+	// {a: 1, b: 2, a: "x"}  ⇒  {a: "x", b: 2}
+	e := objExpr(prop("a", numExpr(1)), prop("b", numExpr(2)), prop("a", strExpr("x")))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, `{a: "x", b: 2}`, render(got))
+
+	rec, ok := got.(*soltype.RecordType)
+	require.True(t, ok)
+	require.Len(t, rec.Fields, 2) // the duplicate `a` was collapsed, not appended
+	require.True(t, equalType(rec, rec), "equalType must be reflexive for a deduped record")
+}
+
 // Shorthand ({x}) is a property with no value — deferred to M4. It reports a
 // clean UnsupportedNodeError and is skipped (the rest of the object still types).
 func TestInferObjectShorthandUnsupported(t *testing.T) {
@@ -129,4 +147,19 @@ func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// A malformed `recv.` (no valid property name) leaves Prop.Name empty; the
+// parser has already reported the missing identifier, so the walk must NOT layer
+// a spurious "object is missing property: " on top. It yields a never
+// placeholder and reports nothing.
+func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
+	c := newChecker()
+	// recv = {a: 5}; access with an empty property name (as the parser builds for `recv.`)
+	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("", testSpan()), false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.IsType(t, &soltype.NeverType{}, got)
+	require.Empty(t, c.errs) // no spurious MissingPropertyError
+	require.Same(t, got, c.info.TypeOf(e))
 }

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -149,6 +149,19 @@ func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
+// Optional chaining is reported up front WITHOUT descending into the receiver:
+// an unbound receiver does not add a cascading "unknown identifier" error — the
+// single OptionalChain diagnostic stands for the whole unsupported construct.
+func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
+	c := newChecker()
+	// nope?.a — receiver `nope` is unbound and would error if typed.
+	e := ast.NewMember(identExpr("nope"), ast.NewIdentifier("a", testSpan()), true, testSpan())
+
+	c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
+}
+
 // A malformed `recv.` (no valid property name) leaves Prop.Name empty; the
 // parser has already reported the missing identifier, so the walk must NOT layer
 // a spurious "object is missing property: " on top. It yields a never

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -91,6 +91,66 @@ func TestInferModuleValDecls(t *testing.T) {
 	}
 }
 
+// PR-4: object literals, tuple literals, and member access infer end-to-end
+// through the real parser pipeline. Field reads resolve through a record-typed
+// binding (constrain's record <: record arm lowers the result from the matching
+// field), and a read of an absent field surfaces a MissingPropertyError.
+func TestInferModuleObjectsAndTuples(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "RecordLiteral",
+			src:  `val o = {a: 5, b: "hi"}`,
+			want: map[string]string{"o": `{a: 5, b: "hi"}`},
+		},
+		{
+			name: "EmptyRecord",
+			src:  `val o = {}`,
+			want: map[string]string{"o": "{}"},
+		},
+		{
+			name: "TupleLiteral",
+			src:  `val t = [1, "hi"]`,
+			want: map[string]string{"t": `[1, "hi"]`},
+		},
+		{
+			name: "NestedRecordInTuple",
+			src:  `val t = [{a: 1}, 2]`,
+			want: map[string]string{"t": `[{a: 1}, 2]`},
+		},
+		{
+			name: "FieldRead",
+			src: `
+				val o = {a: 5, b: "hi"}
+				val x = o.a
+			`,
+			want: map[string]string{"o": `{a: 5, b: "hi"}`, "x": "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// Reading a field the receiver lacks is a constraint failure (MissingProperty);
+// the binding for the failed read resolves to the never placeholder.
+func TestInferModuleFieldReadMissingProperty(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val o = {a: 5}
+		val x = o.b
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: b", errs[0].Message())
+	require.Equal(t, map[string]string{"o": "{a: 5}", "x": "never"}, values)
+}
+
 // A forward reference — a decl that uses a name defined later in the source —
 // fails in PR-2 because the module driver walks decls in source order with no
 // dep-graph ordering. PR-5 adds SCC ordering and this case flips to success.
@@ -140,13 +200,12 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 
 // A destructuring pattern is IdentPat-only-gated in M2 (M4 adds tuple/record
 // binding); the binding reports UnsupportedNodeError and introduces no value.
-// The initializer is still walked, so its own errors (here the as-yet-unsupported
-// tuple expression) surface too rather than being dropped.
+// The initializer `[1, 2]` is a tuple expression, which PR-4 now infers, so the
+// only remaining error is the destructuring pattern on the binding side.
 func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
 	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
-	require.Len(t, errs, 2)
-	require.Equal(t, "Unsupported in M2: TupleExpr", errs[0].Message())
-	require.Equal(t, "Unsupported in M2: TuplePat", errs[1].Message())
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: TuplePat", errs[0].Message())
 	require.Empty(t, values)
 }
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -283,6 +283,18 @@ wrapper) are what first populate a lifetime. Land them together.
   This is the spike's lifetime lesson applied again — a property carried with the
   former is cheap now, painful to retrofit; the spike today is uniformly inexact,
   so this is additive `constrain` cases plus a flag, not a rework.
+  - **Differentiate member-access selection from concrete record subtyping.** M2
+    routes both through one width-tolerant `RecordType <: RecordType` arm
+    ([solver/constrain.go](../../internal/solver/constrain.go) record case),
+    because its only consumer is member access — `recv.foo` lowers to
+    `constrain(recv, {foo: β})`, a "has-field" *requirement* that is inherently
+    width-tolerant (the receiver legitimately carries more fields). M4 must split
+    these: the field-selection requirement stays width-tolerant (or becomes its
+    own constraint form), while concrete record `<:` record (for record-typed
+    params/annotations, which M2 lacks) becomes **exact** — same field set, no
+    width — matching the tuple same-length and function same-arity arms. Until
+    that split, the M2 record arm's width subtyping is a member-access mechanism,
+    not the settled record-subtyping semantics.
 - **Usage-based inference**: member access `obj.bar` ⇒ `constrain(obj <: {bar:
   β})`; field requirements accumulate as upper bounds and coalesce (negative
   position) to a record. This is what replaces `Open`/`Widenable`/


### PR DESCRIPTION
Implements type inference for tuple literals, object literals, and member access (field reads) in the M2 subset of the type checker. This completes the expression walk needed for basic record and tuple types.

## Summary

PR-4 adds three new expression forms to the M2 type inference walk:
- **Tuple literals** (`[1, "hi"]`) infer as `TupleType` with element types
- **Object literals** (`{a: 5, b: "hi"}`) infer as `RecordType` with named fields
- **Member access** (`obj.a`) constrains the receiver and resolves field types

The implementation introduces `RecordType` and `RecordField` to `soltype` to represent record/object types with named value fields. M2 covers the basic width-and-depth-subtyping form; the richer object system (optional fields, methods, getters/setters, index signatures, spreads, `mut`, usage-inference) is deferred to M4.

## Key changes

- **New type: `RecordType`** (`internal/soltype/type.go`)
  - Represents objects with named value fields (flat list of `RecordField`)
  - Includes `Field(name)` lookup method for constraint solving and member access
  - Subtyping is width-and-depth covariant (read-only fields in M2)

- **Inference functions** (`internal/solver/infer_expr.go`)
  - `inferTuple`: Types tuple literals, handling spread elements as unsupported
  - `inferObject`: Types object literals with deduplication (last-wins semantics for duplicate keys); reports unsupported for spreads, computed/numeric keys, and shorthand properties
  - `inferMember`: Types field reads by constraining `recv <: {prop: res}` and extracting the result type; optional chaining is unsupported; silently handles malformed empty property names (parser already reported the error)
  - `objKeyName`: Extracts static field names from identifier or string-literal keys

- **Constraint solving** (`internal/solver/constrain.go`)
  - Record <: Record arm: width-and-depth subtyping with field-name matching; missing fields surface `MissingPropertyError`
  - Extrusion of `RecordType` preserves field covariance

- **Coalescing and equality** (`internal/solver/coalesce.go`)
  - Coalesce recursively through record fields (covariant)
  - `equalType` matches records by field name (order-independent), relying on unique field names from deduplication

- **Error handling** (`internal/solver/errors.go`)
  - New `MissingPropertyError` for field reads on records lacking the field
  - `reportUnsupported` helper to reduce boilerplate for unsupported node errors

- **Printing** (`internal/soltype/print.go`)
  - Render `RecordType` as `{a: T, b: U, ...}` with field names and types
  - Records are atoms (brace-delimited), so no parens needed in unions/intersections

- **Tests**
  - `infer_obj_test.go`: Unit tests for tuple, object, and member inference with edge cases (empty containers, duplicate keys, unsupported forms, missing properties, malformed syntax)
  - `infer_test.go`: End-to-end tests through the parser pipeline; updated destructuring test to reflect that tuple expressions now infer (only the pattern remains unsupported)

## Notable implementation details

- **Duplicate key handling**: Objects follow JavaScript last-wins semantics — the later value replaces the earlier one while the field keeps its first position. This ensures field names are unique, so `equalType` stays reflexive on records.
- **Unsupported forms**: Spreads, computed/numeric keys, shorthand properties, and optional chaining each report a clean `UnsupportedNodeError` and are skipped rather than panicking; the rest of the object/member still types.
- **Silent handling of malformed syntax**: An empty property name (from a malformed `recv.` with no identifier) yields a never placeholder without reporting, since the parser already reported the missing identifier.

https://claude.ai/code/session_01W3KyVQWS7Adrf21azXViq6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for object/record types with named fields and type annotations (e.g., `{a: number, b: string}`)
  * Added type inference for object literals and tuple expressions
  * Added property/member access typing for objects
  * Added detection and reporting of missing property errors during type checking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->