### PR TITLE
PR-5: Wire dep_graph SCC ordering into module inference

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"fmt"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -19,11 +20,26 @@ import (
 // occurrence-analysis input, no named-ref output node. That whole
 // polymorphism-rendering bundle lands in M3 (§3.3).
 //
-// M1 needs no `seen` recursion guard: the M1 type set has no recursive formers
-// (no aliases, no recursive types), so a uniform-inline walk terminates on the
-// bound graph as-is. M3 adds the guard when bipolar retention and aliases make
-// recursive structures in coalesced output possible.
+// M1 had no `seen` recursion guard: the M1 type set has no recursive formers
+// (no aliases, no recursive types), so a uniform-inline walk terminates on a
+// bound graph built from non-recursive source. M2's SCC driver (PR-5) breaks
+// that assumption — a mutually-recursive group can build a cyclic var↔var bound
+// graph (constrain appends var-to-var bounds and terminates on cycles via its
+// own coinductive seen-set; coalesce would not) — so PR-5 pulls forward the
+// path-scoped recursion guard the plan slated for M3 (m2-implementation-plan §7).
+// See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
+// recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return coalesceRec(t, pol, set.NewSet[*soltype.TypeVarType]())
+}
+
+// coalesceRec is coalesce's worker, threading the path-scoped set of type
+// variables currently being inlined. seen holds only the variables on the
+// *current* recursion path (added on entry, removed on exit), so a variable
+// reused in independent branches — e.g. the identity function's shared param
+// (negative) and return (positive) var — is unaffected; only re-entering a
+// variable already on the path is a genuine cycle.
+func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.TypeVarType]) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.PrimType, *soltype.LitType, *soltype.Void,
 		*soltype.NeverType, *soltype.UnknownType:
@@ -32,13 +48,13 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
 			// Params are contravariant, so flip polarity.
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesce(p.Type, pol.Flip())}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen)}
 		}
-		return &soltype.FuncType{Params: params, Ret: coalesce(t.Ret, pol)} // covariant return
+		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen)} // covariant return
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
-			elems[i] = coalesce(e, pol) // covariant elements
+			elems[i] = coalesceRec(e, pol, seen) // covariant elements
 		}
 		return &soltype.TupleType{Elems: elems}
 	case *soltype.RecordType:
@@ -48,21 +64,39 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 		}
 		return &soltype.RecordType{Fields: fields}
 	case *soltype.TypeVarType:
+		// Re-entering a variable already on the current path is an ungrounded
+		// recursive position (no concrete type breaks the cycle). It collapses to
+		// the polarity identity — the same value the position degenerates to when
+		// its bounds are empty — which keeps the inline walk total. A precise
+		// μ-bound rendering of such recursion is M3.
+		if seen.Contains(t) {
+			return emptyOf(pol)
+		}
+		seen.Add(t)
+		defer seen.Remove(t)
 		// Uniform inline: drop the variable, keep only its (recursively
 		// coalesced) bounds in the current polarity.
 		bounds := make([]soltype.Type, 0, len(t.BoundsAt(pol)))
 		for _, b := range t.BoundsAt(pol) {
-			bounds = append(bounds, coalesce(b, pol))
+			bounds = append(bounds, coalesceRec(b, pol, seen))
 		}
 		if len(bounds) == 0 {
-			if pol == soltype.Positive {
-				return &soltype.NeverType{} // ⊥ — empty positive (the identity of |)
-			}
-			return &soltype.UnknownType{} // ⊤ — empty negative (the identity of &)
+			return emptyOf(pol)
 		}
 		return combine(pol, dedup(bounds))
 	}
 	panic(fmt.Sprintf("coalesce: unhandled %T", t))
+}
+
+// emptyOf returns the lattice identity for a polarity: never (⊥, the identity of
+// |) for a positive position with no lower bounds, unknown (⊤, the identity of &)
+// for a negative position with no upper bounds. Shared by the empty-bounds and
+// recursion-cycle cases, which collapse to the same value.
+func emptyOf(pol soltype.Polarity) soltype.Type {
+	if pol == soltype.Positive {
+		return &soltype.NeverType{}
+	}
+	return &soltype.UnknownType{}
 }
 
 // combine builds a soltype.UnionType (Positive) or soltype.IntersectionType

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -132,12 +132,24 @@ type DuplicateDeclarationError struct {
 	Name string
 }
 
+// OverloadNotSupportedError fires when a name has more than one top-level
+// FuncDecl. Function overloading needs the overload-intersection representation
+// that lands in M3; M2 keeps the first declaration (so the binding stays
+// callable with that signature) and reports each extra arm, rather than merging
+// the arms into the same var — which yields an uncallable union-of-functions
+// binding whose every call fails with an opaque `function | function` mismatch.
+type OverloadNotSupportedError struct {
+	errSpan
+	Name string
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*UnsupportedNodeError) isSolverError()      {}
 func (*BodyDeclNotAllowedError) isSolverError()   {}
 func (*MissingInitializerError) isSolverError()   {}
 func (*DuplicateDeclarationError) isSolverError() {}
+func (*OverloadNotSupportedError) isSolverError() {}
 
 func (e *UnknownIdentifierError) Message() string {
 	return "Unknown identifier: " + e.Name
@@ -152,6 +164,10 @@ func (e *MissingInitializerError) Message() string {
 
 func (e *DuplicateDeclarationError) Message() string {
 	return "Duplicate declaration: " + e.Name
+}
+
+func (e *OverloadNotSupportedError) Message() string {
+	return "Function overloads are not supported in M2: " + e.Name
 }
 
 func (e *NamespaceUsedAsValueError) Message() string {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -6,26 +6,22 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferDeclDef infers a single top-level declaration's definition for the SCC
-// driver (inferComponent) and returns the RAW (un-coalesced) soltype.Type to
-// constrain against the binding's group var, the introducing decl's source
-// provenance, and ok=false when the decl introduces no value. It does NOT bind
-// the name — inferComponent owns scope placement, so the group var stays visible
-// to every body before any of them is constrained (the LetRecGroup discipline).
+// inferDeclDef infers one top-level declaration for the SCC driver
+// (inferComponent) and returns its RAW (un-coalesced, variable-carrying) type to
+// constrain against the binding's group var, the decl's provenance, and ok=false
+// when it introduces no value. It does NOT bind the name — inferComponent owns
+// scope placement.
 //
-// The type is returned RAW (variable-carrying), not coalesced: inferComponent
-// coalesces the group var once, after every member has constrained it (phase 3).
-// Coalescing a `val` initializer here instead would read a recursive peer's group
-// var while it is still empty and freeze the binding to `never` — the bug a `val`
-// inside a recursive group hit before this was split out of inferVarDecl.
+// The type MUST stay raw: inferComponent coalesces the group var once, after every
+// group member has constrained it (phase 3). Coalescing a `val` initializer here
+// would read a recursive peer's still-empty group var and freeze the binding to
+// `never` — the bug behind splitting this out of inferVarDecl.
 //
 // ok=false cases, each already reported:
 //   - VarDecl without an initializer → MissingInitializerError
-//   - VarDecl with a destructuring pattern → UnsupportedNodeError
+//   - VarDecl with a destructuring pattern → UnsupportedNodeError (initializer
+//     still walked first, so a malformed RHS surfaces its own errors)
 //   - any decl kind outside the M2 subset → UnsupportedNodeError
-//
-// The VarDecl path walks the initializer first (so a malformed RHS still surfaces
-// its errors) before reporting an unsupported pattern.
 func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
@@ -46,7 +42,9 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		return initType, &ast.NodeProvenance{Node: d}, true
 	case *ast.FuncDecl:
 		b := c.inferFuncDecl(scope, lvl, d)
-		return b.Type, b.Source, true
+		// inferFuncDecl always records exactly one source (this decl); inferComponent
+		// accumulates these per-decl sources into the binding's Sources slice.
+		return b.Type, b.Sources[0], true
 	default:
 		c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: d.Span()},
@@ -56,19 +54,16 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 	}
 }
 
-// inferVarDeclInit types a `val`/`var` declaration's initializer and returns its
-// RAW (un-coalesced, variable-carrying) type, with ok=false when there is no
-// initializer to infer from (MissingInitializerError reported). It is the shared
-// core of both binding paths: the SCC driver (inferDeclDef) constrains this raw
-// type against the binding's group var and coalesces the var once at group
-// completion, while the body-level path (inferVarDecl) coalesces it immediately
-// for a stable stored binding. It walks the initializer regardless (so a
-// malformed RHS still surfaces its errors) and binds nothing — the caller owns
-// scope placement.
+// inferVarDeclInit types a `val`/`var` initializer and returns its RAW
+// (un-coalesced) type, ok=false when there's no initializer (MissingInitializerError
+// reported). Shared core of both binding paths; they differ only in WHEN they
+// coalesce: inferDeclDef (SCC driver) keeps it raw so inferComponent coalesces the
+// group var once at completion, while inferVarDecl (body-level) coalesces it now.
+// Walks the initializer regardless so a malformed RHS still surfaces errors, and
+// binds nothing — the caller owns scope placement.
 //
-// A `val`/`var` with no initializer needs a type annotation to infer from;
-// annotation-driven binding lands with TypeAnn support in a later PR, so for now
-// it reports MissingInitializerError and returns ok=false.
+// A `val`/`var` with no initializer needs a type annotation (TypeAnn support lands
+// in a later PR); for now it reports MissingInitializerError and returns ok=false.
 func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (soltype.Type, bool) {
 	if d.Init == nil {
 		name, _ := varName(d)
@@ -81,12 +76,12 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	return c.inferExpr(scope, lvl, d.Init), true
 }
 
-// inferVarDecl types a `val`/`var` declaration into a MONOMORPHIC ValueBinding,
-// coalescing the initializer at Positive polarity (coalesce-at-binding, §7) so
-// the stored type is var-free and stable. This is the body-level redeclaration
-// path (§3.2); the module/SCC driver instead uses inferVarDeclInit's raw type so
-// a recursive group coalesces only at completion (see inferDeclDef). ok=false
-// when there is no initializer to infer from.
+// inferVarDecl types a `val`/`var` into a MONOMORPHIC ValueBinding, coalescing the
+// initializer at Positive polarity now (coalesce-at-binding, §7) so the stored type
+// is var-free and stable. This is the body-level path (§3.2), safe to coalesce
+// eagerly because a body-level `val` is never part of a recursive top-level group;
+// the SCC driver keeps the raw type instead (see inferDeclDef). ok=false when there
+// is no initializer.
 func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
 	initType, ok := c.inferVarDeclInit(scope, lvl, d)
 	if !ok {
@@ -94,7 +89,7 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	}
 	t := coalesce(initType, soltype.Positive)
 	c.recordType(d.Pattern, t)
-	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}, true
+	return ValueBinding{Type: t, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
@@ -118,5 +113,5 @@ func varName(d *ast.VarDecl) (string, bool) {
 // overload arms; the overload-intersection representation is M3.
 func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
 	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
-	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}
+	return ValueBinding{Type: t, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -7,13 +7,20 @@ import (
 )
 
 // inferDeclDef infers a single top-level declaration's definition for the SCC
-// driver (inferComponent) and returns the soltype.Type to constrain against the
-// binding's group var, the introducing decl's source provenance, and ok=false
-// when the decl introduces no value. It does NOT bind the name — inferComponent
-// owns scope placement, so the group var stays visible to every body before any
-// of them is constrained (the LetRecGroup discipline). ok=false cases, each
-// already reported:
-//   - VarDecl without an initializer → MissingInitializerError (via inferVarDecl)
+// driver (inferComponent) and returns the RAW (un-coalesced) soltype.Type to
+// constrain against the binding's group var, the introducing decl's source
+// provenance, and ok=false when the decl introduces no value. It does NOT bind
+// the name — inferComponent owns scope placement, so the group var stays visible
+// to every body before any of them is constrained (the LetRecGroup discipline).
+//
+// The type is returned RAW (variable-carrying), not coalesced: inferComponent
+// coalesces the group var once, after every member has constrained it (phase 3).
+// Coalescing a `val` initializer here instead would read a recursive peer's group
+// var while it is still empty and freeze the binding to `never` — the bug a `val`
+// inside a recursive group hit before this was split out of inferVarDecl.
+//
+// ok=false cases, each already reported:
+//   - VarDecl without an initializer → MissingInitializerError
 //   - VarDecl with a destructuring pattern → UnsupportedNodeError
 //   - any decl kind outside the M2 subset → UnsupportedNodeError
 //
@@ -22,13 +29,13 @@ import (
 func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
-		b, ok := c.inferVarDecl(scope, lvl, d)
+		initType, ok := c.inferVarDeclInit(scope, lvl, d)
 		if !ok {
 			return nil, nil, false
 		}
 		if _, named := varName(d); !named {
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
-			// types that arrive in M4. inferVarDecl already walked the initializer
+			// types that arrive in M4. The initializer was already walked above
 			// (its errors surfaced); report the pattern and produce no binding.
 			c.report(&UnsupportedNodeError{
 				errSpan: errSpan{span: d.Pattern.Span()},
@@ -36,7 +43,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 			})
 			return nil, nil, false
 		}
-		return b.Type, b.Source, true
+		return initType, &ast.NodeProvenance{Node: d}, true
 	case *ast.FuncDecl:
 		b := c.inferFuncDecl(scope, lvl, d)
 		return b.Type, b.Source, true
@@ -49,31 +56,42 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 	}
 }
 
-// inferVarDecl types a `val`/`var` declaration's initializer and returns the
-// resulting MONOMORPHIC ValueBinding, with ok=false when there is no initializer
-// to infer from. The initializer is typed via inferExpr and coalesced at
-// Positive polarity (coalesce-at-binding, §7) so the stored type is var-free and
-// stable: a later SCC can't mutate it, ValueBinding.Type stays inspectable, and
-// it is the natural monomorphic stand-in for M3's PolyScheme.
-//
-// inferVarDecl always walks the initializer (so a malformed RHS still surfaces
-// its errors) and records the type, but it does NOT bind anything — the caller
-// owns the name lookup, duplicate check, and defineValue, so this routine serves
-// both the module driver and the body-level redeclaration path (§3.2) unchanged.
+// inferVarDeclInit types a `val`/`var` declaration's initializer and returns its
+// RAW (un-coalesced, variable-carrying) type, with ok=false when there is no
+// initializer to infer from (MissingInitializerError reported). It is the shared
+// core of both binding paths: the SCC driver (inferDeclDef) constrains this raw
+// type against the binding's group var and coalesces the var once at group
+// completion, while the body-level path (inferVarDecl) coalesces it immediately
+// for a stable stored binding. It walks the initializer regardless (so a
+// malformed RHS still surfaces its errors) and binds nothing — the caller owns
+// scope placement.
 //
 // A `val`/`var` with no initializer needs a type annotation to infer from;
 // annotation-driven binding lands with TypeAnn support in a later PR, so for now
 // it reports MissingInitializerError and returns ok=false.
-func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
+func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (soltype.Type, bool) {
 	if d.Init == nil {
 		name, _ := varName(d)
 		c.report(&MissingInitializerError{
 			errSpan: errSpan{span: d.Span()},
 			Name:    name,
 		})
+		return nil, false
+	}
+	return c.inferExpr(scope, lvl, d.Init), true
+}
+
+// inferVarDecl types a `val`/`var` declaration into a MONOMORPHIC ValueBinding,
+// coalescing the initializer at Positive polarity (coalesce-at-binding, §7) so
+// the stored type is var-free and stable. This is the body-level redeclaration
+// path (§3.2); the module/SCC driver instead uses inferVarDeclInit's raw type so
+// a recursive group coalesces only at completion (see inferDeclDef). ok=false
+// when there is no initializer to infer from.
+func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
+	initType, ok := c.inferVarDeclInit(scope, lvl, d)
+	if !ok {
 		return ValueBinding{}, false
 	}
-	initType := c.inferExpr(scope, lvl, d.Init)
 	t := coalesce(initType, soltype.Positive)
 	c.recordType(d.Pattern, t)
 	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -2,57 +2,50 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferDecl types a single top-level declaration and binds its name into scope.
-// PR-2 wires only VarDecl (the `val`/`var` path); FuncDecl lands in PR-3 (where
-// repeated top-level functions become overloads) and the remaining decl kinds in
-// later milestones. Any not-yet-supported kind reports a clean
-// UnsupportedNodeError (never a panic) and binds nothing.
+// inferDeclDef infers a single top-level declaration's definition for the SCC
+// driver (inferComponent) and returns the soltype.Type to constrain against the
+// binding's group var, the introducing decl's source provenance, and ok=false
+// when the decl introduces no value. It does NOT bind the name — inferComponent
+// owns scope placement, so the group var stays visible to every body before any
+// of them is constrained (the LetRecGroup discipline). ok=false cases, each
+// already reported:
+//   - VarDecl without an initializer → MissingInitializerError (via inferVarDecl)
+//   - VarDecl with a destructuring pattern → UnsupportedNodeError
+//   - any decl kind outside the M2 subset → UnsupportedNodeError
 //
-// The VarDecl path always walks the initializer first (so its errors surface
-// even when the binding itself can't be formed), then decides whether to bind:
-//   - no initializer            → MissingInitializerError, bind nothing
-//   - non-IdentPat (destructure) → UnsupportedNodeError, bind nothing
-//   - name already bound here   → DuplicateDeclarationError, keep the first
-//   - otherwise                  → defineValue
-func (c *checker) inferDecl(scope *Scope, lvl int, d ast.Decl) {
+// The VarDecl path walks the initializer first (so a malformed RHS still surfaces
+// its errors) before reporting an unsupported pattern.
+func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
 		b, ok := c.inferVarDecl(scope, lvl, d)
 		if !ok {
-			// No initializer: inferVarDecl already reported it and there is no
-			// type to bind. Don't pollute the scope with a placeholder binding —
-			// a later reference should still fail as an unknown identifier.
-			return
+			return nil, nil, false
 		}
-		name, named := varName(d)
-		if !named {
+		if _, named := varName(d); !named {
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
-			// types that arrive in M4. The initializer was already walked above
-			// (its errors surfaced); report the pattern and bind nothing.
+			// types that arrive in M4. inferVarDecl already walked the initializer
+			// (its errors surfaced); report the pattern and produce no binding.
 			c.report(&UnsupportedNodeError{
 				errSpan: errSpan{span: d.Pattern.Span()},
 				Kind:    astKind(d.Pattern),
 			})
-			return
+			return nil, nil, false
 		}
-		if scope.hasOwnValue(name) {
-			// A duplicate top-level `val`/`var` is a redeclaration error (unlike a
-			// FuncDecl, whose duplicates are overloads). Keep the first binding.
-			c.report(&DuplicateDeclarationError{
-				errSpan: errSpan{span: d.Span()},
-				Name:    name,
-			})
-			return
-		}
-		scope.defineValue(name, b)
+		return b.Type, b.Source, true
+	case *ast.FuncDecl:
+		b := c.inferFuncDecl(scope, lvl, d)
+		return b.Type, b.Source, true
 	default:
 		c.report(&UnsupportedNodeError{
 			errSpan: errSpan{span: d.Span()},
 			Kind:    astKind(d),
 		})
+		return nil, nil, false
 	}
 }
 
@@ -100,11 +93,11 @@ func varName(d *ast.VarDecl) (string, bool) {
 // inferFuncDecl types a function declaration into a monomorphic ValueBinding,
 // reusing the shared inferFunc core (infer_expr.go) on the decl's signature and
 // body. Like inferVarDecl it returns the binding rather than defining it, so the
-// caller owns scope placement: the SCC driver (PR-5) binds a self/mutually
-// recursive group to a fresh var first so each body can see itself, then rebinds
-// to the inferred type. inferDecl does not yet wire FuncDecl into the module
-// walk — that, with the recursive-group ordering and top-level overloads, is
-// PR-5/M3.
+// caller owns scope placement: the SCC driver (inferComponent) binds a
+// self/mutually recursive group to a fresh var first so each body can see itself
+// (and its group peers), then rebinds to the inferred type. Repeated top-level
+// FuncDecls under one name are constrained into the same var as monomorphic
+// overload arms; the overload-intersection representation is M3.
 func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
 	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
 	return ValueBinding{Type: t, Source: &ast.NodeProvenance{Node: d}}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -61,7 +61,7 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 // literal, declaration, or pattern — used in the M2 subset-guard error messages.
 // It strips the leading "*ast." from the Go type name so e.g. *ast.BinaryExpr
 // renders as "BinaryExpr". One helper serves every guard site (inferExpr,
-// inferLiteral, inferDecl) so the format lives in a single place.
+// inferLiteral, inferDeclDef) so the format lives in a single place.
 func astKind(n any) string {
 	return strings.TrimPrefix(fmt.Sprintf("%T", n), "*ast.")
 }

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -60,7 +60,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			})
 			return &soltype.Void{}
 		}
-		// Unlike the module driver (inferDecl), a body-level redeclaration is
+		// Unlike the module driver (inferComponent), a body-level redeclaration is
 		// allowed and overwrites the name's slot (§3.2). inferVarDecl reports a
 		// missing initializer itself and returns ok=false; bind only when it
 		// produced a type.

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -305,3 +305,59 @@ func TestInferModuleUngroundedMutualRecursionTerminates(t *testing.T) {
 		"b": "fn (n: number) -> never",
 	}, values)
 }
+
+// A `val` that participates in a recursive group must be constrained against its
+// peer's group var RAW and coalesced only once the group is complete. `a` (a
+// `val`) references `z`, and `z` calls `a` back, so they form one SCC; `a` sorts
+// first and is inferred before `z`. Coalescing `a`'s initializer at definition
+// time (as inferVarDecl does for body-level binds) would read `z`'s still-empty
+// var and freeze `a` to `never`; inferDeclDef instead returns the raw type, so
+// `a` correctly resolves to `z`'s function type once `z`'s body grounds the
+// return via its `-> number` annotation.
+func TestInferModuleValInRecursiveGroupUsesRawType(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val a = z
+		fn z() -> number { a() }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{
+		"a": "fn () -> number",
+		"z": "fn () -> number",
+	}, values)
+}
+
+// Repeated top-level functions of the same name are overloads, which M2 does not
+// represent (overload-intersection is M3). Rather than merge the arms into one
+// var — yielding an uncallable union-of-functions binding — M2 keeps the first
+// arm (so the binding stays callable with that signature) and reports each extra
+// arm with a clear diagnostic.
+func TestInferModuleFunctionOverloadNotSupported(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val r = f(5)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Function overloads are not supported in M2: f", errs[0].Message())
+	// The first arm is kept, so f stays callable and the call to f(5) resolves.
+	require.Equal(t, map[string]string{
+		"f": "fn (x: number) -> number",
+		"r": "number",
+	}, values)
+}
+
+// A declaration kind the dep graph does not model — here a `namespace` block,
+// which BuildDepGraph produces no binding key for — must still report a clean
+// UnsupportedNodeError rather than vanishing silently. The reconciliation pass in
+// inferDepGraph walks the module's own declarations and flags any the SCC walk
+// never visited.
+func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		namespace Foo {
+			val x = 5
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: NamespaceDecl", errs[0].Message())
+	require.Empty(t, values)
+}

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -169,9 +169,11 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 // reports as unsupported. (FuncDecl, unsupported at the module level through
 // PR-2, is now wired in by PR-5; see the func/recursion tests.)
 func TestInferModuleUnsupportedDecl(t *testing.T) {
-	_, _, errs := inferSource(t, `type Foo = number`)
+	_, types, errs := inferSource(t, `type Foo = number`)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported in M2: TypeDecl", errs[0].Message())
+	// The unsupported decl must not leak a type binding.
+	require.NotContains(t, types, "Foo")
 }
 
 // A `val` with no initializer can't be inferred in M2 (annotation-driven binding
@@ -352,7 +354,7 @@ func TestInferModuleFunctionOverloadNotSupported(t *testing.T) {
 // inferDepGraph walks the module's own declarations and flags any the SCC walk
 // never visited.
 func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
-	values, _, errs := inferSource(t, `
+	values, types, errs := inferSource(t, `
 		namespace Foo {
 			val x = 5
 		}
@@ -360,4 +362,6 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported in M2: NamespaceDecl", errs[0].Message())
 	require.Empty(t, values)
+	// The unsupported decl must not leak a type binding for the namespace.
+	require.NotContains(t, types, "Foo")
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -152,26 +152,26 @@ func TestInferModuleFieldReadMissingProperty(t *testing.T) {
 }
 
 // A forward reference — a decl that uses a name defined later in the source —
-// fails in PR-2 because the module driver walks decls in source order with no
-// dep-graph ordering. PR-5 adds SCC ordering and this case flips to success.
-func TestInferModuleForwardReferenceIsError(t *testing.T) {
+// failed in PR-2 (source-order walk). PR-5 orders declarations by the dep graph,
+// so x's component is inferred before y's and the reference now resolves.
+func TestInferModuleForwardReferenceResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val y = x
 		val x = 5
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: x", errs[0].Message())
-	// x is bound by the time the loop reaches it; only the forward use of x in y
-	// failed (y therefore resolves to the never placeholder report() returns).
-	require.Equal(t, map[string]string{"x": "5", "y": "never"}, values)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{"x": "5", "y": "5"}, values)
 }
 
-// A top-level declaration outside PR-2's VarDecl coverage reports a clean
-// UnsupportedNodeError rather than panicking. (FuncDecl support lands in PR-3.)
+// A top-level declaration outside the M2 subset reports a clean
+// UnsupportedNodeError rather than panicking. A type alias is such a decl — type
+// bindings are M3+ — so it registers a type-sort dep_graph key the SCC driver
+// reports as unsupported. (FuncDecl, unsupported at the module level through
+// PR-2, is now wired in by PR-5; see the func/recursion tests.)
 func TestInferModuleUnsupportedDecl(t *testing.T) {
-	_, _, errs := inferSource(t, `fn f() {}`)
+	_, _, errs := inferSource(t, `type Foo = number`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: FuncDecl", errs[0].Message())
+	require.Equal(t, "Unsupported in M2: TypeDecl", errs[0].Message())
 }
 
 // A `val` with no initializer can't be inferred in M2 (annotation-driven binding
@@ -219,4 +219,89 @@ func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "Duplicate declaration: x", errs[0].Message())
 	require.Equal(t, map[string]string{"x": "5"}, values)
+}
+
+// PR-5: dep_graph SCC ordering wires top-level FuncDecls into the module walk and
+// makes inference order-independent. Each case asserts the rendered MONOMORPHIC
+// binding types end-to-end — recursion resolves through the group var, but M1
+// ships no schemes so nothing generalizes (no <T0>); that is M3.
+func TestInferModuleSCCOrdering(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			// A function declared before the one it calls still resolves: callee's
+			// component is inferred first, so the call sees its concrete type.
+			name: "OutOfOrderFuncReference",
+			src: `
+				fn caller(n: number) { callee(n) }
+				fn callee(n: number) -> number { n }
+			`,
+			want: map[string]string{
+				"caller": "fn (n: number) -> number",
+				"callee": "fn (n: number) -> number",
+			},
+		},
+		{
+			// A self-recursive function with no base case (M2 has no conditionals)
+			// never returns, so its return type coalesces to never. It resolves
+			// because the SCC driver pre-binds foo to a var before its body.
+			name: "SelfRecursive",
+			src:  `fn foo(x: number) { foo(x) }`,
+			want: map[string]string{"foo": "fn (x: number) -> never"},
+		},
+		{
+			// A mutually-recursive pair: each body calls the other. Return
+			// annotations ground the cycle in a concrete type, so both resolve to
+			// the annotated function type.
+			name: "MutuallyRecursiveGrounded",
+			src: `
+				fn ping(n: number) -> number { pong(n) }
+				fn pong(n: number) -> number { ping(n) }
+			`,
+			want: map[string]string{
+				"ping": "fn (n: number) -> number",
+				"pong": "fn (n: number) -> number",
+			},
+		},
+		{
+			// A chain of forward references across val and fn declarations,
+			// declared in reverse dependency order.
+			name: "ValChainForwardReference",
+			src: `
+				val z = y
+				val y = x
+				val x = 5
+			`,
+			want: map[string]string{"x": "5", "y": "5", "z": "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// An ungrounded mutually-recursive group — each body calls the other with no
+// return annotation and no base case — builds a cyclic var↔var bound graph.
+// M1's coalesce had no recursion guard, so a guard-free inline walk would loop
+// here forever; PR-5 pulls the M3 path-scoped guard forward (coalesce.go,
+// m2-implementation-plan §7), collapsing the ungrounded recursive return to
+// never (⊥). The assertion is really a termination test: it must complete rather
+// than hang.
+func TestInferModuleUngroundedMutualRecursionTerminates(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn a(n: number) { b(n) }
+		fn b(n: number) { a(n) }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{
+		"a": "fn (n: number) -> never",
+		"b": "fn (n: number) -> never",
+	}, values)
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -1,37 +1,172 @@
 package solver
 
-import "github.com/escalier-lang/escalier/internal/ast"
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
 
-// InferModule infers every top-level declaration in a single parsed module and
-// returns the populated module Scope (a child of the prelude, so operators and
-// the stdlib-type placeholders resolve through the parent), the Info side table,
-// and any SolverErrors.
+// InferModule builds the dep graph for a single parsed module, infers every
+// top-level declaration in dep_graph SCC order, populates Info, and returns the
+// populated module Scope (a child of the prelude, so operators and the
+// stdlib-type placeholders resolve through the parent), the Info side table, and
+// any SolverErrors.
 //
-// PR-2 walks namespaces in namespace-key order and, within each, declarations in
-// source order — with no dep_graph SCC ordering yet. So within a single
-// namespace a forward reference (a decl that uses a name defined later) fails
-// with UnknownIdentifierError, and across namespaces the visit order follows the
-// sorted namespace key rather than source/file order. PR-5 replaces this loop
-// with dep_graph SCC ordering, which makes both cases order-independent; the
-// source-order loop is sufficient only for PR-2's single-namespace
-// literal/identifier-initializer bar.
+// PR-5 replaces PR-2's source-order loop with dep_graph SCC ordering: a decl that
+// forward-references a name defined later in the source, or that mutually
+// recurses with another decl, now infers correctly because BuildDepGraph
+// topologically orders the strongly connected components and inferComponent makes
+// every member of a group visible before inferring any of their bodies.
+// Inference is MONOMORPHIC — M1 ships no schemes, so a group's vars stay as their
+// coalesced monomorphic types; the generalization that yields <T0> rendering is
+// M3.
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
-	c.inferModule(scope, 0, module)
+	c.inferDepGraph(scope, 0, dep_graph.BuildDepGraph(module))
 	return scope, c.info, c.errs
 }
 
-// inferModule iterates the module's namespaces (in sorted key order, per
-// btree.Map.Scan) and, within each, its declarations in source order, typing
-// each through inferDecl. The module Scope is mutated in place as bindings are
-// introduced, so a decl sees every earlier decl's binding (the basis for the
-// forward-reference limitation above).
-func (c *checker) inferModule(scope *Scope, lvl int, module *ast.Module) {
-	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
-		for _, d := range ns.Decls {
-			c.inferDecl(scope, lvl, d)
+// inferDepGraph infers every component of g into scope. BuildDepGraph returns
+// Components in topological order (a dependency's component precedes its
+// dependents'), so a straight iteration types each binding only after everything
+// it refers to — mirroring the old checker's InferDepGraph loop, over soltype
+// instead of type_system. The shared `handled` set guards against inferring a
+// single declaration twice when it contributes to several binding keys (a
+// destructuring `val [a, b] = …` registers under both value:a and value:b).
+func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) {
+	handled := set.NewSet[ast.Decl]()
+	for _, component := range g.Components {
+		c.inferComponent(scope, lvl, g, component, handled)
+	}
+}
+
+// componentBinding tracks the in-flight state of one value binding while its
+// strongly connected component is inferred.
+type componentBinding struct {
+	v      *soltype.TypeVarType  // the group var every body is constrained against
+	source provenance.Provenance // the introducing decl of the primary definition
+	bound  bool                  // a definition was inferred and constrained
+	isVar  bool                  // the primary definition is a `val`/`var`
+}
+
+// inferComponent infers one strongly connected component — a group of
+// mutually-recursive (or, in the singleton case, independent) top-level bindings
+// — and binds each name in scope. It follows the spike's LetRecGroup discipline
+// with NO placeholder/patching phase (the single biggest simplification the
+// simple-sub bridge buys over the old checker's two-phase
+// placeholder/definition pass):
+//
+//  1. give every VALUE binding in the component a fresh var at lvl+1 and define
+//     it in scope BEFORE any body is inferred, so a mutually-recursive reference
+//     resolves through the var;
+//  2. infer each declaration's definition at lvl+1 and constrain it <: its var;
+//  3. rebind each name to the coalesced MONOMORPHIC type of its var.
+//
+// M2 does NOT generalize (M1 ships no schemes): step 3 freezes each binding at
+// its coalesced monomorphic type rather than wrapping it in a PolyScheme. The
+// generalization that turns these into reusable polymorphic bindings — the <T0>
+// rendering — is M3. M2's contribution is correct ordering and recursive
+// resolution.
+func (c *checker) inferComponent(
+	scope *Scope, lvl int, g *dep_graph.DepGraph,
+	component []dep_graph.BindingKey, handled set.Set[ast.Decl],
+) {
+	inner := lvl + 1
+
+	// Phase 1: a fresh var per value binding, all defined before any body so a
+	// mutually-recursive reference resolves through the var. M2 only infers value
+	// bindings; type-sort keys are handled (as unsupported) after the value walk.
+	bindings := make(map[dep_graph.BindingKey]*componentBinding, len(component))
+	for _, key := range component {
+		if key.Kind() != dep_graph.DepKindValue {
+			continue
 		}
-		return true
-	})
+		v := c.freshAt(inner)
+		bindings[key] = &componentBinding{v: v}
+		scope.defineValue(key.Name(), ValueBinding{Type: v})
+	}
+
+	// Phase 2: infer each declaration's definition and constrain it <: its var.
+	for _, key := range component {
+		b, isValue := bindings[key]
+		if !isValue {
+			continue // non-value keys handled below
+		}
+		for _, d := range g.GetDecls(key) {
+			if handled.Contains(d) {
+				// Already inferred under another binding key. The only M2 decl that
+				// registers under several keys is a destructuring `val [a, b] = …`,
+				// which is unsupported and produces no binding either way; skipping
+				// the re-inference avoids reporting its errors once per name.
+				continue
+			}
+			handled.Add(d)
+			t, src, ok := c.inferDeclDef(scope, inner, d)
+			if !ok {
+				continue
+			}
+			if !b.bound {
+				c.constrain(d, t, b.v)
+				b.source = src
+				b.bound = true
+				_, b.isVar = d.(*ast.VarDecl)
+				continue
+			}
+			// The binding already has its primary definition. A repeated FuncDecl is
+			// a top-level overload, which M2 represents only monomorphically by
+			// constraining every arm into the same var (real overload-intersection
+			// resolution is M3). Any other repeat — a duplicate `val`/`var`, or a
+			// decl redeclaring a variable binding — keeps the first and reports.
+			if _, isFunc := d.(*ast.FuncDecl); isFunc && !b.isVar {
+				c.constrain(d, t, b.v)
+				continue
+			}
+			c.report(&DuplicateDeclarationError{
+				errSpan: errSpan{span: d.Span()},
+				Name:    key.Name(),
+			})
+		}
+	}
+
+	// Non-value keys (type aliases, classes, …) are outside the M2 subset. Report
+	// each contributing decl once, skipping any already handled by a value key (a
+	// class/enum contributes both a value and a type key for the same decl).
+	for _, key := range component {
+		if _, isValue := bindings[key]; isValue {
+			continue
+		}
+		for _, d := range g.GetDecls(key) {
+			if handled.Contains(d) {
+				continue
+			}
+			handled.Add(d)
+			c.report(&UnsupportedNodeError{
+				errSpan: errSpan{span: d.Span()},
+				Kind:    astKind(d),
+			})
+		}
+	}
+
+	// Phase 3: rebind each value name to its coalesced monomorphic type. A binding
+	// whose declarations all failed to produce a definition (missing initializer,
+	// destructuring, unsupported kind) is removed rather than left as a `never`
+	// placeholder, matching PR-2: a later reference to it is then a genuine
+	// unknown-identifier error instead of resolving to a stray binding.
+	for _, key := range component {
+		b, isValue := bindings[key]
+		if !isValue {
+			continue
+		}
+		if !b.bound {
+			delete(scope.values, key.Name())
+			continue
+		}
+		scope.defineValue(key.Name(), ValueBinding{
+			Type:   coalesce(b.v, soltype.Positive),
+			Source: b.source,
+		})
+	}
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -186,7 +186,7 @@ func (c *checker) inferComponent(
 			continue
 		}
 		if !b.bound {
-			delete(scope.values, key.Name())
+			scope.removeValue(key.Name())
 			continue
 		}
 		t := coalesce(b.v, soltype.Positive)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -25,7 +25,7 @@ import (
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
-	c.inferDepGraph(scope, 0, dep_graph.BuildDepGraph(module))
+	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
 	return scope, c.info, c.errs
 }
 
@@ -35,21 +35,40 @@ func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 // it refers to — mirroring the old checker's InferDepGraph loop, over soltype
 // instead of type_system. The shared `handled` set guards against inferring a
 // single declaration twice when it contributes to several binding keys (a
-// destructuring `val [a, b] = …` registers under both value:a and value:b).
-func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) {
+// destructuring `val [a, b] = …` registers under both value:a and value:b), and
+// drives the reconciliation pass that reports any top-level declaration the dep
+// graph did not model.
+func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph) {
 	handled := set.NewSet[ast.Decl]()
 	for _, component := range g.Components {
 		c.inferComponent(scope, lvl, g, component, handled)
 	}
+	// Reconcile against the source: BuildDepGraph only produces binding keys for
+	// the decl kinds it models, so a kind it does not descend into — e.g. a
+	// NamespaceDecl — yields no component and would vanish without a diagnostic.
+	// Report every top-level declaration that no component visited, so an
+	// unsupported decl always fails cleanly rather than being silently dropped.
+	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, d := range ns.Decls {
+			if !handled.Contains(d) {
+				c.report(&UnsupportedNodeError{
+					errSpan: errSpan{span: d.Span()},
+					Kind:    astKind(d),
+				})
+			}
+		}
+		return true
+	})
 }
 
 // componentBinding tracks the in-flight state of one value binding while its
 // strongly connected component is inferred.
 type componentBinding struct {
-	v      *soltype.TypeVarType  // the group var every body is constrained against
-	source provenance.Provenance // the introducing decl of the primary definition
-	bound  bool                  // a definition was inferred and constrained
-	isVar  bool                  // the primary definition is a `val`/`var`
+	v       *soltype.TypeVarType  // the group var every body is constrained against
+	source  provenance.Provenance // the introducing decl of the primary definition
+	primary ast.Decl              // the primary definition's decl (for phase-3 Info)
+	bound   bool                  // a definition was inferred and constrained
+	isVar   bool                  // the primary definition is a `val`/`var`
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -111,17 +130,23 @@ func (c *checker) inferComponent(
 			if !b.bound {
 				c.constrain(d, t, b.v)
 				b.source = src
+				b.primary = d
 				b.bound = true
 				_, b.isVar = d.(*ast.VarDecl)
 				continue
 			}
 			// The binding already has its primary definition. A repeated FuncDecl is
-			// a top-level overload, which M2 represents only monomorphically by
-			// constraining every arm into the same var (real overload-intersection
-			// resolution is M3). Any other repeat — a duplicate `val`/`var`, or a
-			// decl redeclaring a variable binding — keeps the first and reports.
+			// a top-level overload: M2 has no overload-intersection representation
+			// (that is M3), so it keeps the first arm — leaving the binding callable
+			// with that signature — and reports each extra arm, rather than merging
+			// the arms into the same var (which yields an uncallable union binding).
+			// Any other repeat — a duplicate `val`/`var`, or a decl redeclaring a
+			// variable binding — likewise keeps the first and reports.
 			if _, isFunc := d.(*ast.FuncDecl); isFunc && !b.isVar {
-				c.constrain(d, t, b.v)
+				c.report(&OverloadNotSupportedError{
+					errSpan: errSpan{span: d.Span()},
+					Name:    key.Name(),
+				})
 				continue
 			}
 			c.report(&DuplicateDeclarationError{
@@ -164,9 +189,15 @@ func (c *checker) inferComponent(
 			delete(scope.values, key.Name())
 			continue
 		}
-		scope.defineValue(key.Name(), ValueBinding{
-			Type:   coalesce(b.v, soltype.Positive),
-			Source: b.source,
-		})
+		t := coalesce(b.v, soltype.Positive)
+		scope.defineValue(key.Name(), ValueBinding{Type: t, Source: b.source})
+		// Record the binding's final (coalesced) type in Info on the pattern. The
+		// raw initializer path (inferDeclDef) no longer records it, so this is where
+		// the var-free type lands — and it is correct even for a `val` in a
+		// recursive group, where coalescing at definition time would have frozen it
+		// to `never`.
+		if vd, ok := b.primary.(*ast.VarDecl); ok {
+			c.recordType(vd.Pattern, t)
+		}
 	}
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -64,11 +64,22 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 // componentBinding tracks the in-flight state of one value binding while its
 // strongly connected component is inferred.
 type componentBinding struct {
-	v       *soltype.TypeVarType  // the group var every body is constrained against
-	source  provenance.Provenance // the introducing decl of the primary definition
-	primary ast.Decl              // the primary definition's decl (for phase-3 Info)
-	bound   bool                  // a definition was inferred and constrained
-	isVar   bool                  // the primary definition is a `val`/`var`
+	v       *soltype.TypeVarType    // this binding's fresh var; every definition of this name is constrained <: it
+	sources []provenance.Provenance // every contributing decl, in source order (primary + rejected overload/duplicate arms)
+	// primary is the first successfully-inferred decl under this key. M2 keeps it
+	// as THE definition and rejects every later arm, so one handle suffices: it is
+	// read in phase 3 to recover a VarDecl's Pattern for Info recording, and (via
+	// isVar) to tell an overload arm from a duplicate.
+	//
+	// M3 retires it. Once overloads are represented as an IntersectionType of the
+	// per-arm signatures (the overload-intersection representation noted in
+	// inferComponent's doc; see planning/intersection_types), arms are merged
+	// rather than discarded, so a single "primary" no longer captures the binding —
+	// the full arm set does, and `sources` already holds it. The phase-3 VarDecl
+	// pattern recording would then key off the lone value decl directly instead.
+	primary ast.Decl
+	bound   bool // a definition was inferred and constrained
+	isVar   bool // the primary definition is a `val`/`var`
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -127,9 +138,13 @@ func (c *checker) inferComponent(
 			if !ok {
 				continue
 			}
+			// Accumulate every contributing decl's provenance — including the overload
+			// or duplicate arms rejected below — so a future multi-target
+			// go-to-definition can reach all of them. Only the primary's type is kept;
+			// M2 has no overload-merge (that is M3), so the extra arms still error.
+			b.sources = append(b.sources, src)
 			if !b.bound {
 				c.constrain(d, t, b.v)
-				b.source = src
 				b.primary = d
 				b.bound = true
 				_, b.isVar = d.(*ast.VarDecl)
@@ -190,7 +205,7 @@ func (c *checker) inferComponent(
 			continue
 		}
 		t := coalesce(b.v, soltype.Positive)
-		scope.defineValue(key.Name(), ValueBinding{Type: t, Source: b.source})
+		scope.defineValue(key.Name(), ValueBinding{Type: t, Sources: b.sources})
 		// Record the binding's final (coalesced) type in Info on the pattern. The
 		// raw initializer path (inferDeclDef) no longer records it, so this is where
 		// the var-free type lands — and it is correct even for a `val` in a

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -11,8 +11,13 @@ import (
 // question §7 (a): take the mechanical field-swap churn then rather than
 // over-abstract now).
 type ValueBinding struct {
-	Type   soltype.Type          // M2: monomorphic. M3 replaces with a TypeScheme.
-	Source provenance.Provenance // the introducing VarDecl/FuncDecl/param; nil for prelude
+	Type soltype.Type // M2: monomorphic. M3 replaces with a TypeScheme.
+	// Sources holds every decl that contributes to this binding, in source order:
+	// for a plain `val`/`fn` that is the single introducing decl, but a name with
+	// multiple top-level FuncDecls (overloads) — or an erroneous redeclaration —
+	// accumulates one entry per arm, including arms M2 currently rejects. This lets
+	// a future go-to-definition navigate to all of them. Empty for prelude bindings.
+	Sources []provenance.Provenance
 }
 
 // TypeBinding is a name's type-sort binding. M2 only ever populates this with
@@ -20,8 +25,14 @@ type ValueBinding struct {
 // M3+. The shape lands now because it is load-bearing for the two-map test
 // harness.
 type TypeBinding struct {
-	Type   soltype.Type
-	Source provenance.Provenance
+	Type soltype.Type
+	// Sources holds every decl that contributes to this type binding, in source
+	// order — mirroring ValueBinding.Sources. A plain `type`/`class` has a single
+	// entry; interface declaration-merging (multiple `interface T` under one name)
+	// accumulates one per arm. Empty for the prelude type placeholders. Not yet
+	// populated — M2 only seeds stdlib-type placeholders here; real type aliases
+	// and classes (and their merging) land in M3+.
+	Sources []provenance.Provenance
 }
 
 // Namespace is the third binding sort — a separate kind from a soltype.Type, so

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -84,6 +84,14 @@ func (s *Scope) defineValue(name string, b ValueBinding) {
 	s.values[name] = b
 }
 
+// removeValue deletes name from THIS scope's value map (a no-op if absent). The
+// SCC driver uses it to retract a value binding it pre-bound to a fresh var but
+// whose declaration then failed to produce a definition, so the mutation goes
+// through Scope's API rather than touching the map directly.
+func (s *Scope) removeValue(name string) {
+	delete(s.values, name)
+}
+
 // defineType inserts b under name in this scope's type map (overwrite, as above).
 func (s *Scope) defineType(name string, b TypeBinding) {
 	s.types[name] = b

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -94,15 +94,6 @@ func (s *Scope) defineNamespace(name string, ns *Namespace) {
 	s.namespaces[name] = ns
 }
 
-// hasOwnValue reports whether name is bound in THIS scope's own value map,
-// without walking the parent chain. The module driver uses it to reject a
-// duplicate top-level `val`/`var` (a redeclaration in the same scope) while
-// still allowing a decl to shadow a prelude/parent binding.
-func (s *Scope) hasOwnValue(name string) bool {
-	_, ok := s.values[name]
-	return ok
-}
-
 // GetValue resolves name in the value sort by lexical lookup: this scope's own
 // map, then up the parent chain. The comma-ok form makes the not-found case
 // explicit at every call site.

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -34,6 +34,7 @@ a section recording both before M3 lands.)
 
 - [M1 — Package skeleton + `soltype`](#m1--package-skeleton--soltype)
 - [M2 — Parser/resolver bridge](#m2--parserresolver-bridge)
+- [M2.5 — Provenance side table + precise error spans](#m25--provenance-side-table--precise-error-spans)
 - [M3 — Functions, application, let-polymorphism](#m3--functions-application-let-polymorphism)
 - [M4 — Core value types: records + usage-based inference + `mut` + **lifetimes** + destructuring/`match`](#m4--core-value-types-records--usage-based-inference--mut--lifetimes--destructuringmatch)
 - [M5 — Nominal types (classes)](#m5--nominal-types-classes)
@@ -156,6 +157,64 @@ rules that *use* them land in M7 and the feature milestones).
 **Gate:** if driving from the real AST/dep-graph requires reaching back into the
 old checker's internals, the parallel-package boundary is wrong — stop and
 reassess.
+
+---
+
+## M2.5 — Provenance side table + precise error spans
+
+A focused infra milestone, **not** a language feature. M2 stamps the *umbrella*
+node's span on every constraint error — `constrain(n, lhs, rhs)` sets `n.Span()`
+on each returned error ([internal/solver/infer.go](../../internal/solver/infer.go)
+`(*checker).constrain`), so a mismatch deep inside a large declaration blames the
+whole declaration. This milestone makes blame point at the **narrowest source of
+each type that actually contributed** to the failure. It is "born-with-the-type"
+infra (the lifetime/exactness lesson again): threading a provenance entry at each
+construction site is cheap done once across M2's ~8 sites, painful to retrofit
+once M3–M6 multiply them — so it lands *before* M3.
+
+- **`Prov: Type → Origin` side table.** Promote the deferred design from
+  [02-design-notes.md §"Provenance side table"](02-design-notes.md) — a sparse
+  map keyed by `soltype.Type` pointer identity, the inverse of `Info`. M2.5 ships
+  the **leaf** variant `FromAST{Node, Kind}` only. The interior edge kinds
+  (`FromBoundPropagation`, `FromInstantiation`, `FromExtrusion`, `FromCoalesce`)
+  are deferred and **ride along** with the M3+ operations that mint them
+  (instantiation is M3; bound-propagation/coalesce/extrusion already exist but
+  their multi-hop *renderer* lands with the features that make the chains deep).
+- **Populate `FromAST` at the construction sites.** The places the M2 walk mints
+  a type from a node: literal inference, ident resolution, param binding
+  (`inferFunc`), application result var (`inferCall`), tuple elements, object
+  field values, member-access result var. A single `prov[t] = FromAST{n, kind}`
+  per site, via a node+kind-taking helper (design notes "Population discipline").
+- **Per-operand blame at the error path.** Each `SolverError` already carries
+  typed `LHS, RHS soltype.Type` references
+  ([internal/solver/errors.go](../../internal/solver/errors.go)). Replace the
+  single umbrella stamp with a lookup: map each failed operand to its narrowest
+  `FromAST` span via `Prov` and stamp the **most specific contributing node**,
+  falling back to `n` when an operand has no entry (a shared atom or a
+  synthesized bound).
+- **Multi-span errors.** Extend `errSpan` to carry a primary span plus *related*
+  spans, so a mismatch can point at **both** the expected-source and the
+  actual-source location (e.g. annotation site *and* offending literal) instead
+  of one node that merely dominates both.
+- **Honest limitation (drives the leaf/interior split).** Leaf-only blame is
+  precise whenever an operand traces directly to a literal/param/field. An
+  operand that is itself a *synthesized* type (a coalesced or propagated bound)
+  has no single AST node; chasing its blame back needs the interior edges, which
+  arrive with M3+. M2.5's fallback-to-`n` keeps those cases no worse than today.
+- **Perf invariant.** The hot `constrain`/`coalesce` loops must never consult
+  `Prov`; it is read only on error paths and by LSP/diagnostic consumers (design
+  notes), so the map-lookup cost stays off the inference critical path.
+
+**Accept:** a golden set of fixtures asserting *exact* error spans —
+`val x: number = "hi"` blames the `"hi"` literal, not the whole decl; a record
+field-type mismatch blames the offending field value; a tuple-length mismatch
+points at the tuple literal; a missing-property read blames the member's prop,
+not the receiver. Existing M2 error fixtures (which assert placeholder spans) are
+updated to the narrowest real spans.
+
+**Depends on:** M2 (the constraint-generating walk, `Info`, and the bridge error
+kinds). Precedes M3 so the table and the `FromAST` discipline exist *before*
+scheme instantiation introduces the first interior origin (`FromInstantiation`).
 
 ---
 
@@ -902,3 +961,12 @@ reduce through the M9 operator machinery.
   semantics (not old-checker output), and the second fixture harness's
   differential is a triage tool, not a parity gate. This is what lets
   intended improvements through instead of forcing old-checker parity.
+- M2.5 sits between M2 and M3 (rather than folding into M3 or deferring with the
+  rest of `Prov`) because the `FromAST` discipline is "born-with-the-type" infra:
+  threading one provenance line per construction site is cheap across M2's ~8
+  sites and compounds in cost as M3–M6 multiply them. Numbered `.5` to avoid
+  renumbering M3–M9 and their references across the docs and code comments. Its
+  scope is the *leaf* layer only; the multi-hop interior edges deliberately ride
+  along with the M3+ features that introduce deep provenance chains, so M2.5 stays
+  a small, independently-verifiable infra step (golden span fixtures) and does not
+  enlarge M3's language-feature acceptance bar.


### PR DESCRIPTION
## Summary

Replaces the source-order module declaration walk with dependency-graph strongly connected component (SCC) ordering, making type inference order-independent and enabling top-level function declarations and recursive groups.

## Key Changes

- **Module inference driver** (`module.go`): Replaced `inferModule`'s source-order loop with `inferDepGraph`, which walks `dep_graph.BuildDepGraph(module).Components` in topological order. Added `inferComponent` to implement the LetRecGroup discipline: pre-bind each value in a recursive group to a fresh type variable (phase 1), infer all declarations in the group (phase 2), then rebind to coalesced monomorphic types (phase 3).

- **Declaration inference** (`infer_decl.go`): Split `inferDecl` into `inferDeclDef` (returns raw un-coalesced type for SCC driver) and `inferVarDeclInit` (shared core for both module and body-level paths). Wired `FuncDecl` support into the module walk via `inferFuncDecl`. Removed duplicate-check logic from `inferVarDecl` — the SCC driver now owns scope placement and duplicate detection.

- **Coalescing** (`coalesce.go`): Added path-scoped recursion guard (`coalesceRec`, `seen` set) to handle cyclic var↔var bound graphs that can arise from mutually-recursive groups. Ungrounded recursive positions collapse to the polarity identity (`never` or `unknown`), keeping the inline walk total. Extracted `emptyOf` helper for the empty-bounds and cycle cases.

- **Error handling** (`errors.go`): Added `OverloadNotSupportedError` for repeated top-level `FuncDecl`s under one name. M2 keeps the first arm (so the binding stays callable) and reports each extra arm rather than merging into an uncallable union.

- **Scope** (`scope.go`): Removed `hasOwnValue` — the SCC driver's duplicate detection replaces the module-level check.

- **Tests** (`infer_test.go`): Updated `TestInferModuleForwardReferenceIsError` to `TestInferModuleForwardReferenceResolves` (now passes). Updated `TestInferModuleUnsupportedDecl` to use a type alias instead of `FuncDecl` (now supported). Added comprehensive test suite for SCC ordering: out-of-order function references, self-recursion, mutual recursion, forward-reference chains, ungrounded mutual recursion (termination test), `val` in recursive groups, and function overload rejection. Added `TestInferModuleNamespaceDeclUnsupported` for the reconciliation pass.

## Notable Implementation Details

- **Monomorphic inference**: M2 ships no schemes; recursive groups coalesce to concrete monomorphic types, not polymorphic bindings. The `<T0>` rendering is M3.

- **Raw vs. coalesced types**: `inferDeclDef` returns raw (variable-carrying) types so the SCC driver can constrain all group members against shared vars before coalescing. Coalescing a `val` initializer at definition time would read a recursive peer's still-empty var and freeze the binding to `never`.

- **Reconciliation pass**: `inferDepGraph` walks the module's own declarations after the SCC walk and reports any the dep graph did not model (e.g., `NamespaceDecl`), ensuring unsupported kinds fail cleanly rather than vanishing silently.

- **Overload handling**: Repeated `FuncDecl`s under one name are constrained into the same var as monomorphic overload arms. The first arm is kept (binding stays callable with that signature); each extra arm is reported with `OverloadNotSupportedError`. The overload-intersection representation is M3.

https://claude.ai/code/session_01KpAx9vTv1xHz21hsSUn8ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forward references in `val` declarations now resolve correctly through dependency-graph ordering.
  * Added explicit error reporting for unsupported function overloads.

* **Bug Fixes**
  * Fixed infinite recursion in type variable bound resolution.

* **Improvements**
  * Declarations are now inferred in proper dependency order, correctly handling self-recursion and mutual recursion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->