### PR TITLE
Fix recursive record type inference and record FuncDecl types in Info

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -60,7 +60,7 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 	case *soltype.RecordType:
 		fields := make([]*soltype.RecordField, len(t.Fields))
 		for i, f := range t.Fields {
-			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesce(f.Type, pol)} // covariant fields
+			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesceRec(f.Type, pol, seen)} // covariant fields
 		}
 		return &soltype.RecordType{Fields: fields}
 	case *soltype.TypeVarType:

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -33,10 +33,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
 			// types that arrive in M4. The initializer was already walked above
 			// (its errors surfaced); report the pattern and produce no binding.
-			c.report(&UnsupportedNodeError{
-				errSpan: errSpan{span: d.Pattern.Span()},
-				Kind:    astKind(d.Pattern),
-			})
+			c.reportUnsupported(d.Pattern, d.Pattern)
 			return nil, nil, false
 		}
 		return initType, &ast.NodeProvenance{Node: d}, true
@@ -46,10 +43,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		// accumulates these per-decl sources into the binding's Sources slice.
 		return b.Type, b.Sources[0], true
 	default:
-		c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: d.Span()},
-			Kind:    astKind(d),
-		})
+		c.reportUnsupported(d, d)
 		return nil, nil, false
 	}
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// parseModule parses a single in-memory .esc source, fails the test on parse
+// errors, and returns the module for inference and inspection (the Info side
+// table, decl nodes). Shared by inferSource and tests that need the module
+// itself.
+func parseModule(t *testing.T, src string) *ast.Module {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
+		{ID: 0, Path: "input.esc", Contents: src},
+	})
+	require.Empty(t, parseErrors, "expected no parse errors")
+	return module
+}
+
 // inferSource parses a single in-memory .esc source, runs InferModule, and
 // returns the rendered top-level value/type bindings plus any SolverErrors. This
 // is the PR-2 single-file table harness (§3.6) — fast, no on-disk fixtures.
@@ -20,13 +35,7 @@ import (
 // a case can assert on them (e.g. the forward-reference limitation).
 func inferSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
 	t.Helper()
-	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{source})
-	require.Empty(t, parseErrors, "expected no parse errors")
-
+	module := parseModule(t, src)
 	scope, _, errs := InferModule(module)
 	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
 	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -51,10 +51,7 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
 		for _, d := range ns.Decls {
 			if !handled.Contains(d) {
-				c.report(&UnsupportedNodeError{
-					errSpan: errSpan{span: d.Span()},
-					Kind:    astKind(d),
-				})
+				c.reportUnsupported(d, d)
 			}
 		}
 		return true
@@ -183,10 +180,7 @@ func (c *checker) inferComponent(
 				continue
 			}
 			handled.Add(d)
-			c.report(&UnsupportedNodeError{
-				errSpan: errSpan{span: d.Span()},
-				Kind:    astKind(d),
-			})
+			c.reportUnsupported(d, d)
 		}
 	}
 
@@ -206,13 +200,19 @@ func (c *checker) inferComponent(
 		}
 		t := coalesce(b.v, soltype.Positive)
 		scope.defineValue(key.Name(), ValueBinding{Type: t, Sources: b.sources})
-		// Record the binding's final (coalesced) type in Info on the pattern. The
+		// Record the binding's final (coalesced) type in Info on the name node. The
 		// raw initializer path (inferDeclDef) no longer records it, so this is where
 		// the var-free type lands — and it is correct even for a `val` in a
 		// recursive group, where coalescing at definition time would have frozen it
-		// to `never`.
-		if vd, ok := b.primary.(*ast.VarDecl); ok {
-			c.recordType(vd.Pattern, t)
+		// to `never`. A VarDecl records on its pattern, a FuncDecl on its name, so a
+		// top-level `fn` is queryable through Info exactly like a `val`.
+		switch d := b.primary.(type) {
+		case *ast.VarDecl:
+			c.recordType(d.Pattern, t)
+		case *ast.FuncDecl:
+			if d.Name != nil {
+				c.recordType(d.Name, t)
+			}
 		}
 	}
 }

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -1,0 +1,61 @@
+package solver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// parseModule parses a single in-memory source and fails the test on parse
+// errors, returning the module for inspection (the Info side table, decl nodes).
+func parseModule(t *testing.T, src string) *ast.Module {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
+		{ID: 0, Path: "input.esc", Contents: src},
+	})
+	require.Empty(t, parseErrors, "expected no parse errors")
+	return module
+}
+
+// A recursive function whose body is a record literal containing the recursive
+// call builds a cyclic var graph THROUGH a record field. coalesce's RecordType
+// case must thread the path-scoped `seen` set (like the FuncType/TupleType cases)
+// or the cycle is never detected and coalescing never terminates. A regression
+// here manifests as non-termination (runaway recursion / stack overflow) on this
+// otherwise trivial input.
+func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
+	values, _, _ := inferSource(t, `fn f() { {x: f()} }`)
+	require.Equal(t, "fn () -> {x: {x: never}}", values["f"])
+}
+
+// A top-level FuncDecl's inferred type must be recorded in the Info side table on
+// its name node, the same way a top-level `val` records on its pattern. Without
+// this, tooling can query a `val`'s type via Info but not a `fn`'s.
+func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
+	module := parseModule(t, `fn foo(x: number) -> number { x }`)
+	_, info, errs := InferModule(module)
+	require.Empty(t, errs)
+
+	var foo *ast.FuncDecl
+	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, d := range ns.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Name != nil && fd.Name.Name == "foo" {
+				foo = fd
+				return false
+			}
+		}
+		return true
+	})
+	require.NotNil(t, foo, "foo decl not found")
+
+	got := info.TypeOf(foo.Name)
+	require.NotNil(t, got, "FuncDecl type not recorded in Info")
+	require.Equal(t, "fn (x: number) -> number", soltype.Print(got))
+}

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -27,7 +27,8 @@ import (
 // https://github.com/escalier-lang/escalier/issues/702 (add a recursion-depth
 // ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
-	values, _, _ := inferSource(t, `fn f() { {x: f()} }`)
+	values, _, errs := inferSource(t, `fn f() { {x: f()} }`)
+	require.Empty(t, errs, "unexpected inference errors")
 	got := values["f"]
 	require.True(t, strings.HasPrefix(got, "fn () -> {x:"),
 		"want a function returning a record with field x, got %q", got)

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -1,38 +1,38 @@
 package solver
 
 import (
-	"context"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
-	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
-// parseModule parses a single in-memory source and fails the test on parse
-// errors, returning the module for inspection (the Info side table, decl nodes).
-func parseModule(t *testing.T, src string) *ast.Module {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
-		{ID: 0, Path: "input.esc", Contents: src},
-	})
-	require.Empty(t, parseErrors, "expected no parse errors")
-	return module
-}
-
 // A recursive function whose body is a record literal containing the recursive
 // call builds a cyclic var graph THROUGH a record field. coalesce's RecordType
 // case must thread the path-scoped `seen` set (like the FuncType/TupleType cases)
-// or the cycle is never detected and coalescing never terminates. A regression
-// here manifests as non-termination (runaway recursion / stack overflow) on this
-// otherwise trivial input.
+// or the cycle is never detected and coalescing never terminates.
+//
+// The assertion is intentionally loose: the test's real contract is that
+// inference TERMINATES (reaching the assertions at all proves that) and produces
+// a sane shape — a function returning a record bottoming out in `never`. The
+// exact unrolling depth (`{x: {x: never}}`) is a monomorphic-recursion artifact
+// that later coalesce/printer changes may legitimately alter; pinning it would
+// conflate "terminates" with "renders this exact shape".
+//
+// NOTE: a regression that bypasses the `seen` guard stack-overflows here, which
+// is a fatal (uncatchable) crash that takes down the whole package test binary
+// rather than failing this test in isolation. Tracked in
+// https://github.com/escalier-lang/escalier/issues/702 (add a recursion-depth
+// ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 	values, _, _ := inferSource(t, `fn f() { {x: f()} }`)
-	require.Equal(t, "fn () -> {x: {x: never}}", values["f"])
+	got := values["f"]
+	require.True(t, strings.HasPrefix(got, "fn () -> {x:"),
+		"want a function returning a record with field x, got %q", got)
+	require.Contains(t, got, "never",
+		"ungrounded recursion should bottom out in never, got %q", got)
 }
 
 // A top-level FuncDecl's inferred type must be recorded in the Info side table on


### PR DESCRIPTION
## Summary

This PR fixes two issues in type inference:

1. **Recursive record cycle detection**: The `coalesce` function was not threading the `seen` set through `RecordType` field coalescing, causing infinite loops when inferring types for recursive functions whose bodies contain record literals with recursive calls. This is now fixed by calling `coalesceRec` (which maintains the `seen` set) instead of `coalesce` for record fields.

2. **FuncDecl type recording**: Top-level function declarations were not recording their inferred types in the `Info` side table, making them unqueryable by tooling (unlike `val` declarations). Function declaration types are now recorded on the function's name node, matching the pattern used for variable declarations.

## Key Changes

- **coalesce.go**: Changed `RecordType` field coalescing to use `coalesceRec(f.Type, pol, seen)` instead of `coalesce(f.Type, pol)` to properly thread the cycle-detection `seen` set through record fields.

- **module.go**: Extended the type-recording logic after coalescing to handle both `VarDecl` (recording on pattern) and `FuncDecl` (recording on name node), ensuring function types are available in `Info` for tooling queries.

- **infer_decl.go**: Refactored three error reporting sites to use a new `reportUnsupported` helper method for consistency.

- **infer_test.go**: Extracted `parseModule` helper to support new regression tests that need access to the parsed AST.

- **regression_test.go** (new): Added two regression tests:
  - `TestInferModuleRecursiveRecordTerminates`: Verifies that recursive functions with record-literal bodies terminate during inference (previously would stack-overflow).
  - `TestInferModuleFuncDeclRecordsInfoType`: Verifies that function declaration types are recorded in `Info` and queryable by tooling.

https://claude.ai/code/session_01KpAx9vTv1xHz21hsSUn8ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference termination for mutually-recursive variable cycles in record types
  * Corrected type information recording for top-level function declarations
  * Improved error reporting for unsupported declaration patterns

* **Tests**
  * Added regression tests for recursive type inference and function declaration type recording

<!-- end of auto-generated comment: release notes by coderabbit.ai -->