### PR TITLE
M2 exit: multi-file module resolution via dep graph

### DIFF
--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -37,6 +38,42 @@ func inferSource(t *testing.T, src string) (values, types map[string]string, err
 	t.Helper()
 	module := parseModule(t, src)
 	scope, _, errs := InferModule(module)
+	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
+	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
+	return values, types, errs
+}
+
+// inferSources is the PR-6 multi-file table harness (§3.6): it takes several
+// in-memory sources keyed by file path, parses each into its own module, runs
+// InferModules over the set, and returns the rendered top-level value/type
+// bindings plus any SolverErrors. This exercises the exact dep-graph-spanning-
+// files path an on-disk fixture would, with no package.json / file-discovery
+// ceremony (the real fixture harness is M8).
+//
+// Files are processed in sorted path order so SourceIDs (and any error ordering)
+// are deterministic across runs; each file gets a distinct SourceID so the merged
+// source table has no collisions. Like inferSource, bindings are read off the
+// module scope's own maps, excluding the prelude parent.
+func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string, errs []SolverError) {
+	t.Helper()
+	paths := make([]string, 0, len(srcs))
+	for path := range srcs {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	modules := make([]*ast.Module, 0, len(paths))
+	for id, path := range paths {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
+			{ID: id, Path: path, Contents: srcs[path]},
+		})
+		cancel()
+		require.Empty(t, parseErrors, "expected no parse errors in %s", path)
+		modules = append(modules, module)
+	}
+
+	scope, _, errs := InferModules(modules)
 	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
 	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
 	return values, types, errs
@@ -373,4 +410,85 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 	require.Empty(t, values)
 	// The unsupported decl must not leak a type binding for the namespace.
 	require.NotContains(t, types, "Foo")
+}
+
+// PR-6: multi-file resolution. Several in-memory files are parsed into separate
+// modules, merged, and inferred together; a top-level `val`/`fn` in one file
+// resolves a binding from another by root-namespace short name. This is the M2
+// exit criterion — a multi-file module resolving via the dep graph — exercised
+// end-to-end through the real parser + InferModules + soltype printer. All
+// inference is MONOMORPHIC (M1 ships no schemes; <T0> generalization is M3).
+func TestInferModulesMultiFile(t *testing.T) {
+	tests := []struct {
+		name string
+		srcs map[string]string
+		want map[string]string
+	}{
+		{
+			// File b reads a `val` defined in file a by short name. The dep graph
+			// spans both files, so a's component is inferred before b's.
+			name: "ValReferencesOtherFile",
+			srcs: map[string]string{
+				"a.esc": `val x = 5`,
+				"b.esc": `val y = x`,
+			},
+			want: map[string]string{"x": "5", "y": "5"},
+		},
+		{
+			// The defining file can come later in sorted order than the using
+			// file — SCC ordering, not file order, drives inference.
+			name: "ForwardReferenceAcrossFiles",
+			srcs: map[string]string{
+				"a.esc": `val y = x`,
+				"b.esc": `val x = 5`,
+			},
+			want: map[string]string{"x": "5", "y": "5"},
+		},
+		{
+			// A function defined in one file is applied in another; the call
+			// resolves the callee's cross-file signature.
+			name: "CallFunctionFromOtherFile",
+			srcs: map[string]string{
+				"a.esc": `fn id(n: number) -> number { n }`,
+				"b.esc": `val r = id(5)`,
+			},
+			want: map[string]string{
+				"id": "fn (n: number) -> number",
+				"r":  "number",
+			},
+		},
+		{
+			// Mutually-recursive functions split across two files resolve through
+			// the shared group var, grounded by their return annotations.
+			name: "MutualRecursionAcrossFiles",
+			srcs: map[string]string{
+				"a.esc": `fn ping(n: number) -> number { pong(n) }`,
+				"b.esc": `fn pong(n: number) -> number { ping(n) }`,
+			},
+			want: map[string]string{
+				"ping": "fn (n: number) -> number",
+				"pong": "fn (n: number) -> number",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSources(t, tt.srcs)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// An unknown identifier that no file defines stays an unbound-name error even in
+// the multi-file path: the merged dep graph has no binding for it, so the
+// reference resolves to the never placeholder and reports cleanly.
+func TestInferModulesMultiFileUnknownIdentifier(t *testing.T) {
+	values, _, errs := inferSources(t, map[string]string{
+		"a.esc": `val y = missing`,
+		"b.esc": `val z = 5`,
+	})
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -12,49 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// parseModule parses a single in-memory .esc source, fails the test on parse
-// errors, and returns the module for inference and inspection (the Info side
-// table, decl nodes). Shared by inferSource and tests that need the module
-// itself.
-func parseModule(t *testing.T, src string) *ast.Module {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
-		{ID: 0, Path: "input.esc", Contents: src},
-	})
-	require.Empty(t, parseErrors, "expected no parse errors")
-	return module
-}
-
-// inferSource parses a single in-memory .esc source, runs InferModule, and
-// returns the rendered top-level value/type bindings plus any SolverErrors. This
-// is the PR-2 single-file table harness (§3.6) — fast, no on-disk fixtures.
-// Bindings are read straight off the module scope's own maps (not the prelude
-// parent), so operators and the stdlib-type placeholders are excluded. Parse
-// errors fail the test outright; only inference errors flow back to the caller so
-// a case can assert on them (e.g. the forward-reference limitation).
-func inferSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
-	t.Helper()
-	module := parseModule(t, src)
-	scope, _, errs := InferModule(module)
-	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
-	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
-	return values, types, errs
-}
-
-// inferSources is the PR-6 multi-file table harness (§3.6): it takes several
-// in-memory sources keyed by file path, parses each into its own module, runs
-// InferModules over the set, and returns the rendered top-level value/type
-// bindings plus any SolverErrors. This exercises the exact dep-graph-spanning-
-// files path an on-disk fixture would, with no package.json / file-discovery
-// ceremony (the real fixture harness is M8).
-//
-// Files are processed in sorted path order so SourceIDs (and any error ordering)
-// are deterministic across runs; each file gets a distinct SourceID so the merged
-// source table has no collisions. Like inferSource, bindings are read off the
-// module scope's own maps, excluding the prelude parent.
-func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string, errs []SolverError) {
+// parseModuleFiles parses several in-memory sources (path → contents) into ONE
+// combined module via parser.ParseLibFiles. ParseLibFiles already unions multiple
+// files into shared, path-derived namespaces — exactly the multi-file assembly a
+// real build does — so there is no separate module-merge step. Sources are added
+// in sorted path order with distinct SourceIDs so spans and any error ordering
+// are deterministic across runs, and a single context spans the whole parse.
+func parseModuleFiles(t *testing.T, srcs map[string]string) *ast.Module {
 	t.Helper()
 	paths := make([]string, 0, len(srcs))
 	for path := range srcs {
@@ -62,21 +26,51 @@ func inferSources(t *testing.T, srcs map[string]string) (values, types map[strin
 	}
 	sort.Strings(paths)
 
-	modules := make([]*ast.Module, 0, len(paths))
+	sources := make([]*ast.Source, len(paths))
 	for id, path := range paths {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		module, parseErrors := parser.ParseLibFiles(ctx, []*ast.Source{
-			{ID: id, Path: path, Contents: srcs[path]},
-		})
-		cancel()
-		require.Empty(t, parseErrors, "expected no parse errors in %s", path)
-		modules = append(modules, module)
+		sources[id] = &ast.Source{ID: id, Path: path, Contents: srcs[path]}
 	}
 
-	scope, _, errs := InferModules(modules)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	module, parseErrors := parser.ParseLibFiles(ctx, sources)
+	require.Empty(t, parseErrors, "expected no parse errors")
+	return module
+}
+
+// parseModule parses a single in-memory .esc source and returns the module for
+// inference and inspection (the Info side table, decl nodes). A thin wrapper over
+// parseModuleFiles so all parsing flows through one helper.
+func parseModule(t *testing.T, src string) *ast.Module {
+	t.Helper()
+	return parseModuleFiles(t, map[string]string{"input.esc": src})
+}
+
+// inferModule runs InferModule on an already-parsed module and renders the
+// top-level value/type bindings straight off the module scope's own maps (not the
+// prelude parent), so operators and the stdlib-type placeholders are excluded.
+// Only inference errors flow back; parse errors fail the test in parseModuleFiles.
+func inferModule(module *ast.Module) (values, types map[string]string, errs []SolverError) {
+	scope, _, errs := InferModule(module)
 	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
 	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
 	return values, types, errs
+}
+
+// inferSource is the single-file table harness (§3.6) — fast, no on-disk
+// fixtures. It is the one-file case of inferSources.
+func inferSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
+	t.Helper()
+	return inferSources(t, map[string]string{"input.esc": src})
+}
+
+// inferSources is the multi-file table harness (§3.6): several in-memory sources
+// keyed by file path, parsed into one combined module and inferred together. This
+// exercises the exact dep-graph-spanning-files path an on-disk fixture would, with
+// no package.json / file-discovery ceremony (the real fixture harness is M8).
+func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string, errs []SolverError) {
+	t.Helper()
+	return inferModule(parseModuleFiles(t, srcs))
 }
 
 // renderBindings renders each binding in m to its soltype string, using typeOf
@@ -412,13 +406,14 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 	require.NotContains(t, types, "Foo")
 }
 
-// PR-6: multi-file resolution. Several in-memory files are parsed into separate
-// modules, merged, and inferred together; a top-level `val`/`fn` in one file
-// resolves a binding from another by root-namespace short name. This is the M2
-// exit criterion — a multi-file module resolving via the dep graph — exercised
-// end-to-end through the real parser + InferModules + soltype printer. All
+// PR-6: multi-file resolution. Several in-memory files are parsed into one
+// combined module (parser.ParseLibFiles unions files that share a path-derived
+// namespace) and inferred together; a top-level `val`/`fn` in one file resolves a
+// binding from another by root-namespace short name. This is the M2 exit
+// criterion — a multi-file module resolving via the dep graph — exercised
+// end-to-end through the real parser + InferModule + soltype printer. All
 // inference is MONOMORPHIC (M1 ships no schemes; <T0> generalization is M3).
-func TestInferModulesMultiFile(t *testing.T) {
+func TestInferMultiFile(t *testing.T) {
 	tests := []struct {
 		name string
 		srcs map[string]string
@@ -481,9 +476,9 @@ func TestInferModulesMultiFile(t *testing.T) {
 }
 
 // An unknown identifier that no file defines stays an unbound-name error even in
-// the multi-file path: the merged dep graph has no binding for it, so the
+// the multi-file path: the combined dep graph has no binding for it, so the
 // reference resolves to the never placeholder and reports cleanly.
-func TestInferModulesMultiFileUnknownIdentifier(t *testing.T) {
+func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	values, _, errs := inferSources(t, map[string]string{
 		"a.esc": `val y = missing`,
 		"b.esc": `val z = 5`,

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -6,6 +6,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/tidwall/btree"
 )
 
 // InferModule builds the dep graph for a single parsed module, infers every
@@ -23,10 +24,67 @@ import (
 // coalesced monomorphic types; the generalization that yields <T0> rendering is
 // M3.
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
+	return InferModules([]*ast.Module{module})
+}
+
+// InferModules infers a multi-file program spread across several parsed modules,
+// closing the M2 exit criterion "a multi-file module resolves via the dep graph".
+// It merges the modules into one combined *ast.Module (unioning their namespaces,
+// files, and source tables) and drives the SAME dep_graph-ordered walk as the
+// single-module path, so a `val`/`fn` in one file resolving a top-level
+// `val`/`fn` in another is just an ordinary cross-component reference that
+// BuildDepGraph topologically orders — no per-module passes, no cross-module
+// patching.
+//
+// Cross-file references in M2 use root-namespace short names (a file referring to
+// `foo` defined in a sibling file): both files derive the same namespace from
+// their paths, so their declarations land in the same dep_graph namespace and the
+// reference resolves through the shared BindingKey space. Qualified
+// namespace-member access (`Foo.bar`) is M4; third-party `@types`/`.d.ts`
+// ingestion (which would engage internal/resolver) is M7 — M2 engages neither.
+func InferModules(modules []*ast.Module) (*Scope, *Info, []SolverError) {
+	merged := mergeModules(modules)
 	c := newChecker()
 	scope := sharedPrelude().Child()
-	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
+	c.inferDepGraph(scope, 0, merged, dep_graph.BuildDepGraph(merged))
 	return scope, c.info, c.errs
+}
+
+// mergeModules unions several parsed modules into one. Declarations from files
+// that share a namespace (e.g. two root-level files, both in the "" namespace)
+// are concatenated, so BuildDepGraph sees the whole program and resolves
+// references that span files. A single-module call returns its module untouched —
+// the merge only allocates when there is more than one.
+//
+// The merge builds fresh Namespace values rather than mutating any input
+// module's, so InferModules never disturbs its arguments (a caller may infer the
+// same modules again, or hold them for the old checker). File and source tables
+// are unioned; a SourceID collision keeps the last writer, which callers avoid by
+// assigning each file a distinct ID.
+func mergeModules(modules []*ast.Module) *ast.Module {
+	if len(modules) == 1 {
+		return modules[0]
+	}
+	var namespaces btree.Map[string, *ast.Namespace]
+	files := []*ast.File{}
+	sources := map[int]*ast.Source{}
+	for _, module := range modules {
+		module.Namespaces.Scan(func(name string, ns *ast.Namespace) bool {
+			merged, ok := namespaces.Get(name)
+			if !ok {
+				merged = &ast.Namespace{Decls: []ast.Decl{}, Exported: ns.Exported}
+				namespaces.Set(name, merged)
+			}
+			merged.Decls = append(merged.Decls, ns.Decls...)
+			merged.Exported = merged.Exported || ns.Exported
+			return true
+		})
+		files = append(files, module.Files...)
+		for id, src := range module.Sources {
+			sources[id] = src
+		}
+	}
+	return ast.NewModuleWithFiles(namespaces, files, sources)
 }
 
 // inferDepGraph infers every component of g into scope. BuildDepGraph returns

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -6,7 +6,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
-	"github.com/tidwall/btree"
 )
 
 // InferModule builds the dep graph for a single parsed module, infers every
@@ -23,68 +22,21 @@ import (
 // Inference is MONOMORPHIC — M1 ships no schemes, so a group's vars stay as their
 // coalesced monomorphic types; the generalization that yields <T0> rendering is
 // M3.
-func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
-	return InferModules([]*ast.Module{module})
-}
-
-// InferModules infers a multi-file program spread across several parsed modules,
-// closing the M2 exit criterion "a multi-file module resolves via the dep graph".
-// It merges the modules into one combined *ast.Module (unioning their namespaces,
-// files, and source tables) and drives the SAME dep_graph-ordered walk as the
-// single-module path, so a `val`/`fn` in one file resolving a top-level
-// `val`/`fn` in another is just an ordinary cross-component reference that
-// BuildDepGraph topologically orders — no per-module passes, no cross-module
-// patching.
 //
-// Cross-file references in M2 use root-namespace short names (a file referring to
-// `foo` defined in a sibling file): both files derive the same namespace from
-// their paths, so their declarations land in the same dep_graph namespace and the
-// reference resolves through the shared BindingKey space. Qualified
-// namespace-member access (`Foo.bar`) is M4; third-party `@types`/`.d.ts`
-// ingestion (which would engage internal/resolver) is M7 — M2 engages neither.
-func InferModules(modules []*ast.Module) (*Scope, *Info, []SolverError) {
-	merged := mergeModules(modules)
+// Multi-file (PR-6) needs no separate entry point: parser.ParseLibFiles already
+// assembles several sources into one *ast.Module, unioning files that share a
+// path-derived namespace into the same Namespace.Decls. BuildDepGraph then spans
+// every file, so a `val`/`fn` in one file resolving a top-level `val`/`fn` in
+// another is just an ordinary cross-component reference the SCC ordering already
+// handles — that is the M2 "multi-file module resolves via the dep graph" exit
+// criterion. Cross-file references in M2 use root-namespace short names; qualified
+// namespace-member access (`Foo.bar`) is M4, and third-party `@types`/`.d.ts`
+// ingestion (internal/resolver) is M7 — M2 engages neither.
+func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
-	c.inferDepGraph(scope, 0, merged, dep_graph.BuildDepGraph(merged))
+	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
 	return scope, c.info, c.errs
-}
-
-// mergeModules unions several parsed modules into one. Declarations from files
-// that share a namespace (e.g. two root-level files, both in the "" namespace)
-// are concatenated, so BuildDepGraph sees the whole program and resolves
-// references that span files. A single-module call returns its module untouched —
-// the merge only allocates when there is more than one.
-//
-// The merge builds fresh Namespace values rather than mutating any input
-// module's, so InferModules never disturbs its arguments (a caller may infer the
-// same modules again, or hold them for the old checker). File and source tables
-// are unioned; a SourceID collision keeps the last writer, which callers avoid by
-// assigning each file a distinct ID.
-func mergeModules(modules []*ast.Module) *ast.Module {
-	if len(modules) == 1 {
-		return modules[0]
-	}
-	var namespaces btree.Map[string, *ast.Namespace]
-	files := []*ast.File{}
-	sources := map[int]*ast.Source{}
-	for _, module := range modules {
-		module.Namespaces.Scan(func(name string, ns *ast.Namespace) bool {
-			merged, ok := namespaces.Get(name)
-			if !ok {
-				merged = &ast.Namespace{Decls: []ast.Decl{}, Exported: ns.Exported}
-				namespaces.Set(name, merged)
-			}
-			merged.Decls = append(merged.Decls, ns.Decls...)
-			merged.Exported = merged.Exported || ns.Exported
-			return true
-		})
-		files = append(files, module.Files...)
-		for id, src := range module.Sources {
-			sources[id] = src
-		}
-	}
-	return ast.NewModuleWithFiles(namespaces, files, sources)
 }
 
 // inferDepGraph infers every component of g into scope. BuildDepGraph returns

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -120,6 +120,10 @@ polymorphism-rendering bundle — see [m1-implementation-plan.md](m1-implementat
 
 ## M2 — Parser/resolver bridge
 
+**Status: landed** (PRs #695–#703 + PR-6 multi-file resolution; see
+[m2-implementation-plan.md](m2-implementation-plan.md) §8 exit checklist — all
+items complete).
+
 Replace the spike's hand-built IR with a real constraint-generating walk over
 `*ast.Module`. This is the deferred spike "parser bridge."
 

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -936,22 +936,24 @@ multi-file sources, which exercises decls, functions, and SCC ordering together)
 
 ## 8. M2 exit checklist
 
-- [ ] Constraint-generating walk over `*ast.Module` produces `soltype` and
+- [x] Constraint-generating walk over `*ast.Module` produces `soltype` and
       populates `Info` (no AST `InferredType()` writes).
-- [ ] Package-owned `Scope`/`Binding`/`Namespace` in `internal/solver/` (no
+- [x] Package-owned `Scope`/`Binding`/`Namespace` in `internal/solver/` (no
       `type_system` reuse).
-- [ ] Top-level `val`/`fn` from real source infer correct **monomorphic**
+- [x] Top-level `val`/`fn` from real source infer correct **monomorphic**
       rendered types end-to-end (table harness). *(Polymorphic `<T0>` rendering
       is M3 — M1 deferred schemes/generalization.)*
-- [ ] Multi-file module resolves via the dep graph (in-memory multi-file table
-      test; no on-disk fixtures — those are M8).
-- [ ] Recursive SCC groups infer (monomorphically) with no placeholder/patching
+- [x] Multi-file module resolves via the dep graph (in-memory multi-file table
+      test; no on-disk fixtures — those are M8). *(PR-6: `InferModules` merges the
+      parsed modules and drives the same dep-graph walk; `inferSources` is the
+      multi-file table harness.)*
+- [x] Recursive SCC groups infer (monomorphically) with no placeholder/patching
       phase.
-- [ ] Stdlib type names (`Promise`/`Iterable`/`AsyncIterable`/`Generator`/
+- [x] Stdlib type names (`Promise`/`Iterable`/`AsyncIterable`/`Generator`/
       `AsyncGenerator`/`IteratorResult`) resolve to **placeholder** `soltype`
       stubs without unbound-name errors (seeded in the prelude; real ingestion
       is M7).
-- [ ] `SolverError` gained `Span()`; M2 error kinds carry spans.
-- [ ] No imports of `internal/checker/` or `internal/type_system/` from the new
+- [x] `SolverError` gained `Span()`; M2 error kinds carry spans.
+- [x] No imports of `internal/checker/` or `internal/type_system/` from the new
       package (gate honored).
-- [ ] `01-milestones.md` M2 status updated.
+- [x] `01-milestones.md` M2 status updated.

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -944,9 +944,13 @@ multi-file sources, which exercises decls, functions, and SCC ordering together)
       rendered types end-to-end (table harness). *(Polymorphic `<T0>` rendering
       is M3 — M1 deferred schemes/generalization.)*
 - [x] Multi-file module resolves via the dep graph (in-memory multi-file table
-      test; no on-disk fixtures — those are M8). *(PR-6: `InferModules` merges the
-      parsed modules and drives the same dep-graph walk; `inferSources` is the
-      multi-file table harness.)*
+      test; no on-disk fixtures — those are M8). *(PR-6: no separate `InferModules`
+      entry point was needed — `parser.ParseLibFiles` already unions multiple
+      sources into one `*ast.Module` with shared path-derived namespaces, so
+      `BuildDepGraph` spans every file and `InferModule` resolves cross-file
+      references as ordinary cross-component ones. `inferSources` is the multi-file
+      table harness. The earlier `InferModules`/`mergeModules` sketch in §3.7/§5
+      was dropped in review as a redundant re-implementation of `ParseLibFiles`.)*
 - [x] Recursive SCC groups infer (monomorphically) with no placeholder/patching
       phase.
 - [x] Stdlib type names (`Promise`/`Iterable`/`AsyncIterable`/`Generator`/

--- a/planning/simple_sub/m2-implementation-plan.md
+++ b/planning/simple_sub/m2-implementation-plan.md
@@ -163,7 +163,7 @@ internal/solver/        # M1: context.go, constrain.go, coalesce.go, info.go, er
   infer.go        # M2: constraint-generating walk over *ast.Module (production typeTerm)
   infer_expr.go   # M2: per-expression-kind constraint generation
   infer_decl.go   # M2: VarDecl / FuncDecl → bindings, SCC group inference
-  module.go       # M2: InferModule(s): dep_graph SCC ordering + drive the walk
+  module.go       # M2: InferModule: dep_graph SCC ordering + drive the walk
   scope.go        # M2: Scope / Binding / Namespace (own, not type_system)
   prelude.go      # M2: global scope — operator/builtin schemes + placeholder stdlib type bindings (§3.8)
   errors.go       # bridge errors (unbound name, unsupported node) with provenance/spans
@@ -307,8 +307,9 @@ Entry point (working signature, paralleling the old driver):
 // InferModule builds the dep graph for the parsed module, infers every
 // top-level declaration in SCC order, populates Info, and returns the module
 // Scope plus errors. The package-level entry constructs a fresh checker
-// internally; multi-file callers use InferModules (§3.7). Full signatures in
-// §3.7.
+// internally. Multi-file needs no separate entry point: parser.ParseLibFiles
+// unions several sources into one *ast.Module, so BuildDepGraph spans every file
+// and InferModule resolves cross-file references (§3.6). Full signatures in §3.7.
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError)
 ```
 
@@ -401,11 +402,12 @@ infrastructure that M8 owns deliberately.
   checker-tests pattern in `internal/checker/tests/`.
 - **Multi-file / dep-graph cases:** still table-driven, but the case supplies
   **several in-memory sources** instead of one. `ast.Module` already holds
-  `Files []*File` (and `Sources`), and `InferModule`/`InferModules` take parsed
-  modules — so a case parses each source string, assembles a multi-file `Module`
-  (or several modules), drives `BuildDepGraph` across them, and asserts the
-  rendered top-level types. This exercises the exact dep-graph-spanning-files
-  path on-disk fixtures would, without `package.json` / file-discovery ceremony.
+  `Files []*File` (and `Sources`), and `parser.ParseLibFiles` unions several
+  sources into one multi-file `Module` — so a case parses all source strings in a
+  single `ParseLibFiles` call, drives `BuildDepGraph` (which spans every file) +
+  `InferModule`, and asserts the rendered top-level types. This exercises the
+  exact dep-graph-spanning-files path on-disk fixtures would, without
+  `package.json` / file-discovery ceremony.
 
 **Why no on-disk fixtures in M2.** Real `fixtures/<name>/lib/index.esc` (+
 `package.json`) directories would pull in the `resolver` / file-discovery layer
@@ -555,8 +557,10 @@ checker's `InferDepGraph`/`InferComponent`, over `soltype`:
 
 ```go
 // module.go
-func InferModule(module *ast.Module) (*Scope, *Info, []SolverError)   // PR-2 (source-order), PR-5 (SCC)
-func InferModules(modules []*ast.Module) (*Scope, *Info, []SolverError) // PR-6 (multi-file)
+// Multi-file (PR-6) needs no separate entry point — parser.ParseLibFiles unions
+// sources into one *ast.Module, so BuildDepGraph spans every file and InferModule
+// resolves cross-file references.
+func InferModule(module *ast.Module) (*Scope, *Info, []SolverError)   // PR-2 (source-order), PR-5 (SCC), PR-6 (multi-file)
 
 func (c *checker) inferDepGraph(scope *Scope, lvl int, g *dep_graph.DepGraph) // PR-5
 func (c *checker) inferComponent(scope *Scope, lvl int, g *dep_graph.DepGraph, // PR-5
@@ -645,8 +649,9 @@ func inferSource(t *testing.T, src string) (values, types map[string]string)
 
 // infer_test.go — table harness, multi-file (in-memory; no on-disk fixtures)
 func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string)
-// parses each named source, assembles a multi-file Module / modules, drives
-// BuildDepGraph + InferModule(s), returns rendered top-level types
+// parses all named sources in one parser.ParseLibFiles call (which unions them
+// into a single multi-file Module), drives BuildDepGraph + InferModule, returns
+// rendered top-level types
 ```
 
 ### 3.8 Stdlib-type placeholder seeding
@@ -848,11 +853,14 @@ multi-file sources, which exercises decls, functions, and SCC ordering together)
 
 ### PR-6 — Multi-file (cross-module) resolution + multi-file table tests  (~250 LoC)
 *(depends on PR-4 + PR-5)*
-- `module.go`: `InferModules` over multiple parsed modules; build the dep graph
-  across them; cross-module references resolve through the qualified-`BindingKey`
-  `Namespace` (`dep_graph.GetNamespace`). **M2 does not engage `internal/resolver`**
-  (it resolves `@types/*` third-party packages; M2 has no such imports — that's
-  M7; see §7).
+- `module.go`: **no new entry point** — `parser.ParseLibFiles` already unions
+  multiple sources into one `*ast.Module`, so `BuildDepGraph` spans every file and
+  the existing `InferModule` resolves cross-file references through the
+  qualified-`BindingKey` `Namespace` (`dep_graph.GetNamespace`). *(An earlier draft
+  sketched `InferModules`/`mergeModules` over several parsed modules; that was
+  dropped in review as a redundant re-implementation of `ParseLibFiles`.)* **M2
+  does not engage `internal/resolver`** (it resolves `@types/*` third-party
+  packages; M2 has no such imports — that's M7; see §7).
 - `infer_test.go`: the `inferSources` multi-file table helper (§3.7) — in-memory
   sources, **no** on-disk `fixtures/` directories (those are M8; see §3.6).
 - Tests: a two-file table case where file B references a `val`/`fn` from file A


### PR DESCRIPTION
Closes M2 milestone by implementing multi-file module resolution. The solver now merges multiple parsed modules into a single combined module and drives the same dependency-graph-ordered inference walk, allowing declarations in one file to resolve references in another through the shared binding namespace.

## Key changes

- **`InferModules` function**: New entry point that accepts multiple `*ast.Module` instances, merges them into a combined module, and performs inference. Single-module calls now delegate to this function.
- **`mergeModules` helper**: Unions multiple modules by concatenating declarations in shared namespaces, merging file lists, and combining source tables. Preserves immutability of input modules.
- **`inferSources` test harness**: Multi-file table test helper that parses several in-memory sources into separate modules, runs `InferModules`, and returns rendered bindings. Processes files in sorted order for deterministic `SourceID` assignment and error ordering.
- **Test coverage**: Added `TestInferModulesMultiFile` with four scenarios (value references, forward references, cross-file function calls, mutual recursion across files) and `TestInferModulesMultiFileUnknownIdentifier` to verify error handling.
- **Planning updates**: Marked all M2 exit checklist items complete and updated milestone status in `01-milestones.md`.

## Implementation details

Cross-file references use root-namespace short names (e.g., a file referring to `foo` defined in a sibling). Both files derive the same namespace from their paths, so declarations land in the same `dep_graph` namespace and references resolve through the shared `BindingKey` space. The merge is transparent to `BuildDepGraph` — it sees the whole program and topologically orders all components, whether intra-file or cross-file.

All inference remains monomorphic (M1 deferred schemes; `<T0>` rendering is M3). Qualified namespace access (`Foo.bar`) and third-party type ingestion are deferred to M4 and M7 respectively.

https://claude.ai/code/session_01GME5yAesEmzDeMMnn9qNoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for multi-file module resolution, verifying cross-file declarations, forward references, and mutually-recursive functions resolve correctly
  * Added test verifying proper error handling for unknown identifiers across multi-file modules

* **Documentation**
  * Updated project milestones marking M2 (Parser/resolver bridge) as complete with implementation status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->