### PR TITLE
M2.5 implementation plan: provenance side table + precise error spans

### DIFF
--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -162,7 +162,10 @@ reassess.
 
 ## M2.5 — Provenance side table + precise error spans
 
-A focused infra milestone, **not** a language feature. M2 stamps the *umbrella*
+A focused infra milestone, **not** a language feature. See
+[m2.5-implementation-plan.md](m2.5-implementation-plan.md) for the full PR
+breakdown, the per-operand blame design, and the construction-site population
+table. M2 stamps the *umbrella*
 node's span on every constraint error — `constrain(n, lhs, rhs)` sets `n.Span()`
 on each returned error ([internal/solver/infer.go](../../internal/solver/infer.go)
 `(*checker).constrain`), so a mismatch deep inside a large declaration blames the

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -935,6 +935,52 @@ reduce through the M9 operator machinery.
   ([exact-types/requirements.md](../exact-types/requirements.md) §9) is also
   codegen work.
 - **M11 — LSP.** Switch the LSP to the new checker's `Scope`/`Info`.
+- **M11.5 — Diagnostics quality & error-rendering capstone.** A late,
+  corpus-driven pass that owns the **error-reporting gestalt** no single feature
+  milestone sees, and discharges the diagnostics work deferred through M2.5+. It is
+  deliberately *not* a re-litigation of per-feature message wording — that stays
+  incremental, asserted as each feature lands (the CLAUDE.md "assert the full error
+  message" convention). Its charter is the cross-cutting rendering + audit layer:
+  - **The multi-hop provenance renderer.** M2.5 ships only the `FromAST` *leaf* and
+    a single-lookup `NodeFor`; the interior `Origin` edges
+    (`FromInstantiation`/`FromBoundPropagation`/`FromExtrusion`/`FromCoalesce`) are
+    minted by M3+ but nobody *renders* the chains they form. This milestone builds
+    the renderer that walks the provenance DAG to its AST leaves — "α is `number`
+    because the literal `42` flowed into it at line 17" — the "why this type" story
+    [02-design-notes.md](02-design-notes.md) §"Provenance side table" describes and
+    M2.5 explicitly defers.
+  - **Multi-span / related-span rendering.** M2.5 *records* `Related()` (the
+    expected-source alongside the actual-source, the prior declaration alongside the
+    duplicate, the "defined here" companion to an ident-use error) but leaves
+    presentation to "when the CLI is wired." This milestone renders related spans in
+    both the CLI diagnostics and the LSP (hovers / related-information) — the surface
+    M11 stands up.
+  - **Cascading-error suppression + ordering/dedup.** Suppress derived errors that
+    exist only because of an upstream failure, and order/dedup a file's diagnostics
+    so one root cause doesn't read as ten.
+  - **Corpus-wide audit, differential against the old checker.** Run the audit over
+    the M8 fixture corpus with the old checker *still present* (this is why the
+    milestone precedes the M12 flip): its diagnostics are the parity baseline M12
+    deletes. Acceptance is a checklist applied corpus-wide — every error has a
+    precise primary span, sensible related spans, consistent expected/actual
+    framing, no duplicate/cascaded noise — with any per-feature wording fix filed in
+    place.
+
+  This milestone is also the **named home for the deferred-diagnostics backlog**, so
+  those notes get a due date rather than drifting: M2.5's "defined here" related span
+  (the `FromInstantiation` companion to an ident-use error), the zero-span fallback
+  footguns M2.5 flags for the M4-reachable error kinds, and the multi-hop renderer
+  above. Having this backstop is what lets M3–M9 ship *good-enough* errors and defer
+  polish here instead of being side-tracked chasing perfect diagnostics mid-feature.
+
+  **Accept:** the audit checklist passes across the M8 corpus (precise primary span,
+  coherent related spans, no cascades/dupes), with no diagnostic worse than the old
+  checker's; a provenance chain renders its full why-chain to AST leaves; an
+  ident-use type error shows both the use (primary) and the definition ("defined
+  here"). **Depends on:** M9 (full feature set ⇒ complete provenance DAG), M8
+  (fixture corpus + differential harness), M11 (the LSP rendering surface).
+  **Precedes:** M12 — the new checker's diagnostics should be at least at parity with
+  the old checker *before* the flip deletes the baseline.
 - **M12 — Flip & cleanup.** Make the new checker the default; retire the old
   checker + its tests; **delete** the AST `inferredType` field, the
   `type Type = type_system.Type` alias, and `tools/gen_ast`'s generation of the
@@ -973,3 +1019,13 @@ reduce through the M9 operator machinery.
   along with the M3+ features that introduce deep provenance chains, so M2.5 stays
   a small, independently-verifiable infra step (golden span fixtures) and does not
   enlarge M3's language-feature acceptance bar.
+- M11.5 (diagnostics capstone) is numbered `.5` for the same reason M2.5 is — to
+  slot between M11 and M12 without renumbering — and sits *before* the M12 flip on
+  purpose: the old checker is the parity baseline for the error-quality differential,
+  and M12 deletes it. It rides after M11 because the LSP is the rendering surface for
+  the multi-span/chain work, and after M9 because the provenance DAG it renders
+  (the M3+ interior edges) isn't complete until the last feature lands. Folding the
+  error-rendering gestalt into one late, corpus-driven pass is also what lets M3–M9
+  defer diagnostics polish — `Span()` precision and full messages still land with
+  each feature, but rendering, chain-following, and cross-feature consistency wait
+  for the capstone instead of being gold-plated mid-feature.

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -925,11 +925,14 @@ PR-3 adds fixtures and decides §3.7.
   span set (constraint + bridge fixtures); update existing M2 error tests to
   assert the narrow spans.
 - Update `01-milestones.md` M2.5 status.
-- **Exit (M2.5 exit criteria):** `val x: number = "hi"` blames the `"hi"`
-  literal; a field-type mismatch blames the offending field value; a
-  tuple-length mismatch points at the tuple literal; a missing-property read
-  blames the member's prop, not the receiver. Existing M2 error fixtures assert
-  the narrowest real spans.
+- **Exit (PR-3 / M2.5 exit criteria):** the M2.5-reachable golden fixtures
+  (Section 3.10) pass — `val x: number = "hi"` blames the `"hi"` literal; a
+  call-arg mismatch blames the offending argument; a call-arity mismatch points at
+  the call; a missing-property read blames the member's prop, not the receiver.
+  The **record field-type mismatch** and **tuple-length mismatch** fixtures are
+  **excluded** from the M2.5 exit bar — both need a record/tuple *sink* M2.5 cannot
+  produce, so they are deferred to M4 (Section 3.10). Existing M2 error fixtures
+  assert the narrowest real spans.
 
 ## 6. Risks & mitigations
 

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -72,10 +72,10 @@ Per the milestone, M2.5 delivers:
   of a freshly-minted type. The multi-hop interior edges that chase a
   *synthesized* operand (a coalesced or propagated bound) back to its AST roots
   are deferred to the M3+ features that introduce deep provenance chains
-  (`FromInstantiation` is M3; the renderer for `FromBoundPropagation` /
-  `FromCoalesce` / `FromExtrusion` lands with the features that make those chains
-  deep). M2.5's fallback-to-`n` keeps the un-chaseable cases **no worse than
-  today**.
+  (`FromInstantiation` is M3; the multi-hop *renderer* that walks
+  `FromBoundPropagation` / `FromCoalesce` / `FromExtrusion` chains to their AST
+  leaves is the **M11.5** diagnostics capstone). M2.5's fallback-to-`n` keeps the
+  un-chaseable cases **no worse than today**.
 - **No new lattice/inference behavior.** M2.5 changes *where errors point*, not
   *which constraints fire* or *what types infer*. The one small non-provenance
   addition it carries — the `val`-annotation subtype check needed to realize the
@@ -664,7 +664,9 @@ today, not a regression. That zero-span branch *is* a latent footgun, though: wh
 one of those kinds becomes reachable on a miss — `Tuple`/`Missing` via M4
 record/tuple sinks, or a higher-order `FuncArity` whose RHS isn't the recorded
 call-shape — pick a real fallback (the other operand, or a `site`) instead of the
-zero span. Decide that with the milestone that makes the kind reachable.
+zero span. Decide that with the milestone that makes the kind reachable (M4 for the
+record/tuple sinks); the latent branch is logged in the **M11.5** diagnostics
+backlog so it isn't forgotten.
 
 ### 3.6 Multi-span (related) errors
 
@@ -749,10 +751,11 @@ It is **imprecise** in three cases (no regression vs. M2 in any):
 2. **Synthesized operands (M3+ only — does not arise in M2.5).** A coalesced
    upper-bound, a propagated bound, or a multi-branch join has no single AST node;
    chasing its blame needs the interior edges
-   (`FromBoundPropagation`/`FromCoalesce`), deferred to M3+. These don't occur as
-   constraint operands in M2.5 — `extrude` never runs (flat levels) and `coalesce`
-   is display-only — so this is a forward-looking note; when they arrive, a
-   `site`-carrying kind falls back to its `site`.
+   (`FromBoundPropagation`/`FromCoalesce`), minted by M3+ and *rendered* by the
+   **M11.5** capstone. These don't occur as constraint operands in M2.5 — `extrude`
+   never runs (flat levels) and `coalesce` is display-only — so this is a
+   forward-looking note; when they arrive, a `site`-carrying kind falls back to its
+   `site`.
 3. **Identifier uses resolve to the definition, not per-use (`inferIdent`).** M2
    returns `b.Type` directly — the *same* pointer for every use of a name (no
    `instantiate` until M3) — and for an atom-typed binding that pointer is the very
@@ -768,7 +771,8 @@ It is **imprecise** in three cases (no regression vs. M2 in any):
    What's deferred to M3 is only the **secondary** "defined here" related span:
    `FromInstantiation` gives each use a fresh instance whose origin *is* the use,
    with the definition reachable as an interior edge — primary-use plus
-   related-definition, automatically. (A composite-typed binding — record/tuple/
+   related-definition, automatically — which the **M11.5** capstone then renders in
+   the CLI/LSP. (A composite-typed binding — record/tuple/
    function — coalesces to a *fresh* pointer with no entry, so it already falls to
    `site`; only the atom case needed the guard.)
 

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -42,9 +42,10 @@ Per the milestone, M2.5 delivers:
    operations that mint them.
 2. **A `FromAST` entry written into `Prov` at each M2 construction site** —
    `FromAST` is the value stored in the table, not a second table (§3.2). The
-   sites are literal inference, ident resolution, param binding, function types,
-   application result var, the call-shape, tuple elements, object field values,
-   member-access result var, and annotation prims (§3.3).
+   sites are literal inference, param binding, function types, application result
+   var, the call-shape, tuple elements, object field values, member-access result
+   var, and annotation prims (§3.3) — **not** ident uses, which record nothing and
+   blame the use via the containment-guarded `site` (§3.5/§3.8).
 3. **Errors carry AST nodes, not strings.** An audit of all eleven `SolverError`
    kinds (§3.4) partitions them: *bridge* errors (born in the walk, with an
    `ast.Node` in hand) hold that node directly and **self-blame**; *constraint*
@@ -196,7 +197,6 @@ type ASTOriginKind int
 
 const (
 	LiteralInference ASTOriginKind = iota // a LitType from inferLiteral
-	IdentRef                              // a value-binding ref from inferIdent (see §3.8 limitation)
 	ParamBinding                          // a fresh param var from inferFunc
 	Application                           // a fresh call-result var from inferCall
 	TupleElem                             // a TupleType from inferTuple
@@ -304,8 +304,17 @@ Population per site (each is a single added line next to the existing mint +
 | `inferTuple` | `c.recordProv(t, e, TupleElem)` on the `TupleType` |
 | `inferObject` | `c.recordProv(t, e, ObjectField)` on the `RecordType` |
 | `inferMember` | `c.recordProv(res, e.Prop, MemberAccess)` on the fresh result var — recorded against the `.prop` **identifier** node (not the whole `MemberExpr`), so blame is the property, not `recv.foo` including the receiver |
-| `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.8**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
 | `resolveTypeAnn` | `c.recordProv(t, ta, AnnotationType)` on each fresh `PrimType` it mints — **the fresh-atom discipline** (below) makes this precise |
+
+**`inferIdent` records nothing — deliberately.** A value-position identifier
+returns the binding's shared `b.Type` pointer, and for an atom-typed binding that
+is the *same* `LitType`/`PrimType` already recorded at the **definition**
+(`coalesce` passes atoms through unchanged, coalesce.go:44-46). Recording an
+`IdentRef` against it would *overwrite* the definition's origin with a
+last-write-wins use node — corrupting the shared atom's provenance for every other
+reader — and still wouldn't give per-use blame. So M2.5 records no ident origin;
+ident-use blame instead rides on the containment-guarded `site` (§3.5/§3.8), and
+per-use provenance arrives with M3's `FromInstantiation`.
 
 Notes:
 
@@ -460,30 +469,38 @@ needs (this is the directive: storage specific to each struct):
 
 The asymmetry is deliberate:
 
-- **`CannotConstrainError` — `prov` + `site` (the only M2.5-reachable `site`).** LHS
-  is the "actual" value and now resolves in the common cases: a literal (`"hi" <:
-  number` ⇒ the `"hi"`, recorded at `inferLiteral`) **and a function** (`val x:
-  number = fn () => 1` ⇒ `FuncType <: number` via the fall-through,
-  [constrain.go:160](../../internal/solver/constrain.go), blames the function
-  expression now that `inferFunc` records the `FuncType`). `site` survives here for a
-  reason that *doesn't* apply to `FuncArity`: **neither operand is a type synthesized
-  at the constraint node** — the actual value comes from wherever it was inferred and
-  the requirement is usually a real recorded annotation — so when the actual-value
-  operand is unrecorded there is nothing built-at-`n` to resolve to. In M2.5 the one
-  reachable such operand is **`Void`** (a function/block that yields no value; minted
-  at [infer_expr.go:120](../../internal/solver/infer_expr.go) /
-  [infer_stmt.go](../../internal/solver/infer_stmt.go), never recorded):
-  `val f = fn (): number => {}` ⇒ `Void <: number` blames the function, and
-  `val x: number = f()` for a void-returning `f` ⇒ `Void <: number` blames the `f()`
-  call — `site` is the right answer in both (pointing at the *use* beats pointing at
-  the far-away void source), and the only available one. (M3+ adds synthesized
-  operands — coalesced/extruded — as a second such source. Prelude/operator types are
-  *not* a source: operators aren't walked in M2, and any named binding is recorded by
-  `inferIdent`.) `site` (the walk's record of "this constraint arose at this source
-  node") is the only honest fallback. (A bare type *var* is never an operand: the var
-  cases at [constrain.go:134-158](../../internal/solver/constrain.go) decompose it to
-  its concrete bounds before any error fires, and `extrude` doesn't run in M2.5 —
-  levels are flat.) RHS is the expected-source → related.
+- **`CannotConstrainError` — `prov` (containment-guarded) + `site`.** LHS is the
+  "actual" value; `Span()` blames its recorded source node **when that node lies
+  inside the constraint site `n`**, and `site` itself otherwise (`spanOf`/`within`
+  below). One rule, three shapes:
+  - **operand inside the construct → the operand.** `"hi" <: number` for `f("hi")`
+    blames the `"hi"` argument (recorded `LiteralInference`, inside the call);
+    `val x: number = "hi"` blames the `"hi"` literal (operand == site); `val x:
+    number = fn () => 1` ⇒ `FuncType <: number` (fall-through,
+    [constrain.go:160](../../internal/solver/constrain.go)) blames the `fn` expr,
+    recorded `FuncInference` at the same node.
+  - **operand from elsewhere → the use (`site`).** `val a: number = x` where
+    `x: string` constrains `x`'s type `<: number`; that type traces to **x's
+    definition** (its atom passes through `coalesce` as the same pointer, so `Prov`
+    resolves it to the def — coalesce.go:44-46), which is *not* inside the use site
+    `n = d.Init`, so the guard falls through and blame is the **use** `x` — the
+    behavior we want (§3.8). The definition becomes a "defined here" *related* span
+    only in M3 (`FromInstantiation`).
+  - **unrecorded operand → `site`.** The one M2.5-reachable unrecorded subject is
+    **`Void`** (a function/block yielding no value; minted at
+    [infer_expr.go:120](../../internal/solver/infer_expr.go) /
+    [infer_stmt.go](../../internal/solver/infer_stmt.go), never recorded):
+    `val f = fn (): number => {}` and `val x: number = f()` (void-returning `f`)
+    both blame the **use** via `site`. (M3+ adds coalesced/extruded synthesized
+    operands as a second unrecorded source.)
+
+  `site` is why `CannotConstrainError` is the **only** kind that keeps a fallback
+  node: its actual-value operand can legitimately resolve *outside* the constraint
+  (an ident's definition) or not at all (`Void`), and in both the local use is the
+  right place to point. (A bare type *var* is never an operand — the var cases at
+  [constrain.go:134-158](../../internal/solver/constrain.go) decompose to concrete
+  bounds before any error fires, and `extrude` doesn't run in M2.5.) RHS is the
+  expected-source → related.
 - **`TupleLengthMismatchError` — `prov` only, no `site`.** Both operands are
   `TupleType`s, and in M2.5 every `TupleType` comes from `inferTuple` (recorded
   `TupleElem`) — so `LHS` (the tuple literal) resolves and `RHS` is the related
@@ -515,14 +532,28 @@ everything as arguments) do the lookups; each kind's methods call them with its 
 fields:
 
 ```go
-// spanOf follows op's provenance to its AST node's span, falling back to the
-// constraint site when op has no entry. In M3+, NodeFor chases interior Origin
-// edges to the nearest AST leaf; in M2.5 it is a single lookup.
+// spanOf blames op's own source node when that node lies *within* the constraint
+// site, and the site itself otherwise (or when op has no entry). The containment
+// guard is the M2.5 fix for identifier-flow blame: for `f("hi")` the operand
+// ("hi") is minted inside the call, so the narrower operand wins; for
+// `val a: number = x` the operand (x's type) traces to x's *definition*, which is
+// NOT inside the use site, so the use (site) wins — an ident-use error points at
+// the use, not the definition (§3.8). site is the constraint node n, always
+// non-nil for a CannotConstrainError. In M3+, NodeFor chases interior Origin edges
+// to the nearest AST leaf; in M2.5 it is a single lookup.
 func spanOf(p Provenance, op soltype.Type, site ast.Node) ast.Span {
-	if n, ok := p.NodeFor(op); ok {
+	if n, ok := p.NodeFor(op); ok && within(site.Span(), n.Span()) {
 		return n.Span()
 	}
 	return site.Span()
+}
+
+// within reports whether inner sits inside outer (same source, both of inner's
+// endpoints within outer). ast.Span.Contains takes a Location (ast/span.go), so a
+// span is contained when its Start and End both are.
+func within(outer, inner ast.Span) bool {
+	return outer.SourceID == inner.SourceID &&
+		outer.Contains(inner.Start) && outer.Contains(inner.End)
 }
 
 // relatedOf resolves each operand that has an entry to a related span and drops
@@ -706,9 +737,10 @@ It is **imprecise** in three cases (no regression vs. M2 in any):
    [infer_stmt.go](../../internal/solver/infer_stmt.go) without an AST node and is
    never recorded, so when it is the *subject* of the one M2.5 `site`-carrying kind
    (`CannotConstrainError`) it falls back to `site` — `val f = fn (): number => {}`
-   and `val x: number = f()` (void-returning `f`) both blame the use via `site`. This
-   is the only reachable unrecorded subject in M2.5: prelude/operator types aren't a
-   source (operators aren't walked, and named bindings are recorded by `inferIdent`).
+   and `val x: number = f()` (void-returning `f`) both blame the use via `site`.
+   Apart from identifier uses (case 3 below, also routed to `site`), `Void` is the
+   only reachable unrecorded subject in M2.5: prelude/operator types aren't a source
+   (operators aren't walked in M2).
    (Directly-inferred source aggregates — literals, tuples, objects, **functions**
    (`FuncInference`), and the **call-shape** (`CallShape`) — are all recorded, so they
    are no longer blind spots; recording the `FuncType` and the call-shape is what let
@@ -721,19 +753,24 @@ It is **imprecise** in three cases (no regression vs. M2 in any):
    constraint operands in M2.5 — `extrude` never runs (flat levels) and `coalesce`
    is display-only — so this is a forward-looking note; when they arrive, a
    `site`-carrying kind falls back to its `site`.
-3. **Shared monomorphic bindings (`inferIdent`).** M2 returns `b.Type` directly
-   — the *same* pointer for every use of a name (no `instantiate` until M3). A
-   `Prov[b.Type]` entry is therefore **per-shape, not per-occurrence**: the last
-   `inferIdent` to record wins, and the recorded node may be a different use than
-   the one in the failing constraint. So an `x`-flows-into-mismatch error
-   (`val y: number = x` where `x: string`) cannot reliably blame *this* `x` use
-   in M2.5; it blames the initializer node `n` (the fallback) or, with annotation
-   checking from §3.7, the initializer expression — already an improvement over
-   the whole-decl umbrella. **Per-use ident blame arrives with M3's
-   `FromInstantiation`** (each use gets a fresh instance with its own origin),
-   exactly as the milestone sequences it. The `IdentRef` population is wired now
-   (cheap, and correct for the leaf-direct cases) but documented as last-write-
-   wins until M3.
+3. **Identifier uses resolve to the definition, not per-use (`inferIdent`).** M2
+   returns `b.Type` directly — the *same* pointer for every use of a name (no
+   `instantiate` until M3) — and for an atom-typed binding that pointer is the very
+   `LitType`/`PrimType` minted and recorded at the **definition** (`coalesce`
+   passes atoms through unchanged, coalesce.go:44-46). So `Prov` resolves an
+   ident's type to where it was *defined*, not where it is *used*. M2.5 therefore
+   records **no** `inferIdent` origin (§3.3): doing so would overwrite the shared
+   atom's definition entry with a last-write-wins use node and corrupt it for every
+   other reader. Instead, ident-use blame rides on the **containment-guarded
+   `site`** (§3.5): the definition is not inside the use's constraint node, so
+   `CannotConstrainError.Span()` falls through to the use — `val a: number = x`
+   blames the `x` use, the desired behavior, with no regression in any other case.
+   What's deferred to M3 is only the **secondary** "defined here" related span:
+   `FromInstantiation` gives each use a fresh instance whose origin *is* the use,
+   with the definition reachable as an interior edge — primary-use plus
+   related-definition, automatically. (A composite-typed binding — record/tuple/
+   function — coalesces to a *fresh* pointer with no entry, so it already falls to
+   `site`; only the atom case needed the guard.)
 
 This split is *why* the milestone scopes M2.5 to leaves: the precise-span wins
 land where operands are node-local atoms, and the interior chains are deferred to
@@ -774,6 +811,7 @@ The golden set (each grounded in a constraint M2.5 actually emits):
 | `f("hi")` where `f` has a `number` param | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | f's `number` param annotation (RHS, recorded `AnnotationType`) |
 | `f(1, 2)` where `f` takes one param | `inferCall`; `FuncArityMismatchError` (RHS call-shape) | the **call** `f(1, 2)` | the function `f` |
 | `recv.foo` where `recv` lacks `foo` | `inferMember`; `MissingPropertyError` | the **member's prop** (`.foo`), not the receiver | the receiver |
+| `val x = "hi"` then `val a: number = x` | §3.7 val-annotation; `CannotConstrainError` LHS = x's (def-recorded) type, **not** inside the use | the **use** `x` (containment guard → `site`), not x's definition | — (x's definition becomes a "defined here" related span only in M3) |
 
 **Deferred to M4 (not yet reachable):** record field-value mismatches and
 tuple-length/element mismatches need a record/tuple *sink* (annotation or param) to
@@ -875,10 +913,10 @@ PR-3 adds fixtures and decides §3.7.
 - `prov.go`: `Prov`, `Origin`, `FromAST`, `ASTOriginKind` (+ its constants),
   `recordProv` (§3.2–3.3).
 - `infer.go`: add `prov Prov` to the `checker` carrier; init in `newChecker`.
-- `infer_expr.go` / `type_ann.go`: one `recordProv` call at each of the 10 sites
+- `infer_expr.go` / `type_ann.go`: one `recordProv` call at each of the 9 sites
   (`inferLiteral`, `inferFunc` param, `inferFunc` type, `inferCall` result,
-  `inferCall` shape, `inferTuple`, `inferObject`, `inferMember`, `inferIdent`,
-  `resolveTypeAnn`) per the §3.3 table. `inferFunc` records the returned `FuncType`
+  `inferCall` shape, `inferTuple`, `inferObject`, `inferMember`,
+  `resolveTypeAnn`) per the §3.3 table — `inferIdent` is **not** a site (§3.3). `inferFunc` records the returned `FuncType`
   and `inferCall` records the synthesized call-shape `FuncType{args, res}` (both
   parallel to `inferTuple`/`inferObject`); `resolveTypeAnn` already mints a fresh
   `PrimType` per annotation (the fresh-atom discipline). All are added recording
@@ -948,13 +986,15 @@ PR-3 adds fixtures and decides §3.7.
   *Mitigation:* verify the decl name accessor in PR-A; retain `Name string`
   alongside the nodes on just those two kinds if the canonical name isn't
   node-derivable (§7).
-- **Shared-pointer `inferIdent` provenance is last-write-wins.** Recording
-  against the shared monomorphic binding type can attach a stale node.
-  *Mitigation:* document it as a known leaf/interior-split limitation (§3.8);
-  blame for ident-flow mismatches falls back to the constraint node (no
-  regression), and per-use precision arrives with M3's `FromInstantiation`. The
-  golden set deliberately does **not** include an ident-flow case as a precise
-  win.
+- **Ident-flow blame must land on the use, not the definition.** An atom-typed
+  binding's `b.Type` is the *same* pointer recorded at its definition, so a naive
+  `Prov` lookup would blame the definition (and recording an `inferIdent` origin
+  would corrupt that shared entry — last-write-wins). *Mitigation:* record nothing
+  for idents (§3.3) and resolve `CannotConstrainError`'s subject through the
+  **containment-guarded `site`** (§3.5) — the definition is outside the use's
+  constraint node, so blame falls to the use. The golden set pins this
+  (`val a: number = x` → the `x` use, §3.10). The secondary "defined here" related
+  span arrives with M3's `FromInstantiation`.
 - **Operand isn't actually a leaf.** If a future `constrain` arm returns an error
   whose `LHS`/`RHS` is an aggregate rather than the decomposed atom, blame would
   point coarsely. *Mitigation:* the four M2 kinds already carry the decomposed
@@ -999,10 +1039,11 @@ PR-3 adds fixtures and decides §3.7.
 
 - [ ] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`
       leaf variant and `ASTOriginKind`; interior variants deferred to M3+.
-- [ ] `FromAST` populated at all ten construction sites via `recordProv`
-      (literal, ident, param, function-type, call-result, call-shape, tuple,
-      object, member-result, annotation-prim), with the `inferIdent` last-write-wins
-      limitation documented.
+- [ ] `FromAST` populated at all nine construction sites via `recordProv`
+      (literal, param, function-type, call-result, call-shape, tuple, object,
+      member-result, annotation-prim). `inferIdent` records **nothing** (recording
+      against the shared atom would corrupt its definition origin); ident-use blame
+      rides on the containment-guarded `site` (§3.5/§3.8).
 - [ ] Fresh-atom discipline: `resolveTypeAnn` mints a fresh `PrimType` per
       annotation and records it (`AnnotationType`), so atoms are no blind spot.
 - [ ] `SolverError` reshaped: node-derived `Span()` + `Related()`; `setSpan` /

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -203,7 +203,7 @@ const (
 	ObjectField                           // a RecordType from inferObject
 	FuncInference                         // a FuncType from inferFunc (the function expr/decl)
 	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
-	MemberAccess                          // a fresh member-result var from inferMember
+	MemberAccess                          // a fresh member-result var from inferMember (recorded against the .prop ident)
 	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
 )
 ```
@@ -235,8 +235,7 @@ func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 	if o, ok := p[t].(FromAST); ok {
 		return o.Node, true
 	}
-	return nil, false // unrecorded operand (e.g. a FuncType, a prelude type, or an
-	                  // M3+ synthesized type): an honest miss
+	return nil, false // unrecorded operand (a Void result, or an M3+ synthesized type): an honest miss
 }
 ```
 
@@ -304,7 +303,7 @@ Population per site (each is a single added line next to the existing mint +
 | `inferCall` (shape) | `c.recordProv(callShape, e, CallShape)` on the synthesized `FuncType{args, res}` — so `FuncArityMismatchError` resolves its blame to the call (no `site` needed) |
 | `inferTuple` | `c.recordProv(t, e, TupleElem)` on the `TupleType` |
 | `inferObject` | `c.recordProv(t, e, ObjectField)` on the `RecordType` |
-| `inferMember` | `c.recordProv(res, e, MemberAccess)` on the fresh result var |
+| `inferMember` | `c.recordProv(res, e.Prop, MemberAccess)` on the fresh result var — recorded against the `.prop` **identifier** node (not the whole `MemberExpr`), so blame is the property, not `recv.foo` including the receiver |
 | `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.8**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
 | `resolveTypeAnn` | `c.recordProv(t, ta, AnnotationType)` on each fresh `PrimType` it mints — **the fresh-atom discipline** (below) makes this precise |
 
@@ -496,10 +495,11 @@ The asymmetry is deliberate:
   annotations; recording those (the same aggregate discipline as `inferTuple`) keeps
   `RHS` resolvable then too, so `site` is never needed.
 - **`MissingPropertyError` — `prov` only, no `site`.** The field's *inner* var
-  (`RHS.Field(Name)`) was minted at `inferMember` (`MemberAccess`) → blames the
-  **member's prop**, not the receiver — and it is **always recorded**, so the kind
-  needs no `site`; in the unreachable miss it degrades to the receiver (`LHS`).
-  `RecordType.Field(Name)` already exists (used in `constrain.go`).
+  (`RHS.Field(Name)`) was minted at `inferMember` and recorded against the **`.prop`
+  ident** (`MemberAccess`, §3.3) → blames the member's prop (`.foo`), not the
+  receiver — and it is **always recorded**, so the kind needs no `site`; in the
+  unreachable miss it degrades to the receiver (`LHS`). `RecordType.Field(Name)`
+  already exists (used in `constrain.go`).
 - **`FuncArityMismatchError` — `prov` only, no `site`.** The subject is the **RHS
   call-shape** `FuncType{args, res}`, which `inferCall` records (`CallShape`) against
   the `CallExpr` — a fresh, unique pointer per call, so it always resolves precisely
@@ -538,6 +538,19 @@ func relatedOf(p Provenance, ops ...soltype.Type) []ast.Span {
 	return spans
 }
 
+// appendUnique appends s unless an equal span is already present. ast.Span is a
+// plain comparable value (Start/End Location of ints + SourceID — see
+// ast/span.go), so == suffices; this keeps Related() free of duplicate spans
+// (e.g. when two operands resolve to the same node — §3.6/§7).
+func appendUnique(spans []ast.Span, s ast.Span) []ast.Span {
+	for _, e := range spans {
+		if e == s {
+			return spans
+		}
+	}
+	return append(spans, s)
+}
+
 func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.LHS, e.site) }
 func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
@@ -564,7 +577,7 @@ func (e *FuncArityMismatchError) Span() ast.Span {
 func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the fn
 
 func (e *MissingPropertyError) Span() ast.Span {
-	if f, ok := e.RHS.Field(e.Name); ok { // the field's inner var → the .foo member
+	if f, ok := e.RHS.Field(e.Name); ok { // the field's inner var → the .foo prop ident
 		if n, ok := e.prov.NodeFor(f); ok {
 			return n.Span()
 		}
@@ -609,8 +622,18 @@ Because `constrain` decomposes structurally to **leaf** operands before failing
 aggregate), the operands each method follows are already narrow — there is no
 span-size comparison to do. The umbrella problem was *only* that M2 ignored the
 operands and used `n`; following `Prov` from the leaves in the methods fixes it
-directly, and an unresolved operand falls back to exactly that umbrella `site` —
-no regression.
+directly.
+
+**On the fallback — no regression, two different reasons.** Only
+`CannotConstrainError` keeps a `site`, and it falls back to it for the one reachable
+unrecorded subject (`Void`, §3.8) — exactly the M2 umbrella, so no regression. The
+other three (`Tuple`/`Missing`/`FuncArity`) resolve a recorded operand and have **no
+reachable miss in M2.5**, so their `return ast.Span{}` degrade branch is dead code
+today, not a regression. That zero-span branch *is* a latent footgun, though: when
+one of those kinds becomes reachable on a miss — `Tuple`/`Missing` via M4
+record/tuple sinks, or a higher-order `FuncArity` whose RHS isn't the recorded
+call-shape — pick a real fallback (the other operand, or a `site`) instead of the
+zero span. Decide that with the milestone that makes the kind reachable.
 
 ### 3.6 Multi-span (related) errors
 
@@ -748,7 +771,7 @@ The golden set (each grounded in a constraint M2.5 actually emits):
 | Fixture | Constraint source | Primary blame | Related |
 |---------|-------------------|---------------|---------|
 | `val x: number = "hi"` | §3.7 val-annotation check; `CannotConstrainError` LHS `"hi"` | the `"hi"` literal | the `number` annotation |
-| `f("hi")` where `f` has a `number` param | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | — |
+| `f("hi")` where `f` has a `number` param | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | f's `number` param annotation (RHS, recorded `AnnotationType`) |
 | `f(1, 2)` where `f` takes one param | `inferCall`; `FuncArityMismatchError` (RHS call-shape) | the **call** `f(1, 2)` | the function `f` |
 | `recv.foo` where `recv` lacks `foo` | `inferMember`; `MissingPropertyError` | the **member's prop** (`.foo`), not the receiver | the receiver |
 
@@ -807,7 +830,8 @@ M2 (every constraint kind carries a `site` and `Span()` returns it; the constrai
 switch sets only `site`). PR-1 adds the inert `Prov` table. PR-2 is then small: it
 adds the `prov` field to the resolving kinds, adds the `spanOf`/`relatedOf` helpers,
 rewrites each kind's `Span()`/`Related()` to follow operands through `Prov` first,
-and drops `site` from the kinds that no longer need it (`MissingPropertyError`).
+and drops `site` from the three kinds that no longer need it (`Tuple`,
+`MissingProperty`, and `FuncArity` — only `CannotConstrainError` keeps it).
 PR-3 adds fixtures and decides §3.7.
 
 ## 5. PR breakdown
@@ -827,9 +851,10 @@ PR-3 adds fixtures and decides §3.7.
     needed (§7).
   - Constraint kinds: give **each** kind its own `site ast.Node` field, a `Span()`
     returning `site.Span()`, and a `Related()` returning `nil` (no `prov` field
-    yet — added in PR-2). No shared embed. (PR-2 later drops `site` from
-    `MissingProperty` and `FuncArity` once they resolve a recorded operand via
-    `Prov`; PR-A keeps it on all four for uniform M2-precision spans.)
+    yet — added in PR-2). No shared embed. (PR-2 later drops `site` from `Tuple`,
+    `MissingProperty`, and `FuncArity` once they resolve a recorded operand via
+    `Prov` — only `CannotConstrainError` keeps it; PR-A keeps it on all four for
+    uniform M2-precision spans.)
 - `infer.go`: `(*checker).constrain` sets `err.site = n` in a per-kind type switch
   over the four constraint kinds — the span source, now node-based (precision
   unchanged from M2; `Prov` wiring is PR-2).

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -1,0 +1,611 @@
+# M2.5 Implementation Plan — Provenance side table + precise error spans
+
+> Companion to [`01-milestones.md`](01-milestones.md) (the **M2.5 — Provenance
+> side table + precise error spans** entry) and
+> [`02-design-notes.md`](02-design-notes.md) (§"Provenance side table (the
+> inverse of `Info`)"). Status legend: `[ ]` not started · `[~]` in progress ·
+> `[x]` complete.
+
+## 1. What M2.5 is (and is not)
+
+**M2.5 is a focused infra milestone, not a language feature.** M2 ships a
+constraint-generating walk whose blame is coarse: `(*checker).constrain`
+([internal/solver/infer.go](../../internal/solver/infer.go) lines 41–46) stamps
+the *umbrella* node's span on **every** error a single `constrain` call returns:
+
+```go
+func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
+	for _, e := range c.ctx.Constrain(lhs, rhs) {
+		e.setSpan(n.Span()) // ← every error gets the SAME umbrella span
+		c.errs = append(c.errs, e)
+	}
+}
+```
+
+So a mismatch deep inside a large declaration blames the whole declaration. M2.5
+makes blame point at the **narrowest source of each type that actually
+contributed** to the failure — the literal, argument, field, or member that
+minted the offending operand.
+
+This is **"born-with-the-type" infra** (the lifetime/exactness lesson again):
+threading a provenance entry at each construction site is cheap done once across
+M2's handful of sites, painful to retrofit once M3–M6 multiply them. So it lands
+*before* M3.
+
+Per the milestone, M2.5 delivers:
+
+1. **A `Prov: Type → Origin` side table** — the inverse of `Info`, the deferred
+   design from [02-design-notes.md](02-design-notes.md) §"Provenance side
+   table". M2.5 ships the **leaf** variant `FromAST{Node, Kind}` only. The
+   interior edge kinds (`FromBoundPropagation`, `FromInstantiation`,
+   `FromExtrusion`, `FromCoalesce`) are deferred and **ride along** with the M3+
+   operations that mint them.
+2. **`FromAST` populated at the M2 construction sites** — literal inference,
+   ident resolution, param binding, application result var, tuple elements,
+   object field values, member-access result var (§3.3).
+3. **Per-operand blame at the error path** — replace the single umbrella stamp
+   with a lookup that maps each failed operand to its narrowest `FromAST` span
+   via `Prov`, falling back to `n` when an operand has no entry (§3.4).
+4. **Multi-span errors** — extend `errSpan` to carry a primary span plus
+   *related* spans, so a mismatch can point at **both** the expected-source and
+   the actual-source location (§3.5).
+
+### Scope boundary against neighbouring milestones
+
+- **M2 (prerequisite) has landed.** The constraint-generating walk
+  (`infer.go`/`infer_expr.go`/`infer_decl.go`/`infer_stmt.go`), the `Info` side
+  table ([info.go](../../internal/solver/info.go)), and the `SolverError`
+  interface with typed `LHS`/`RHS` operand references
+  ([errors.go](../../internal/solver/errors.go)) all exist. M2.5 builds directly
+  on them — see §2 for the exact surface.
+- **Leaf-only, by design.** M2.5 records only `FromAST` — the direct AST cause
+  of a freshly-minted type. The multi-hop interior edges that chase a
+  *synthesized* operand (a coalesced or propagated bound) back to its AST roots
+  are deferred to the M3+ features that introduce deep provenance chains
+  (`FromInstantiation` is M3; the renderer for `FromBoundPropagation` /
+  `FromCoalesce` / `FromExtrusion` lands with the features that make those chains
+  deep). M2.5's fallback-to-`n` keeps the un-chaseable cases **no worse than
+  today**.
+- **No new lattice/inference behavior.** M2.5 changes *where errors point*, not
+  *which constraints fire* or *what types infer*. The one small non-provenance
+  addition it carries — the `val`-annotation subtype check needed to realize the
+  canonical `val x: number = "hi"` fixture — is called out explicitly in §3.6
+  and flagged as a judgment call, not smuggled in.
+- **Precedes M3.** The table and the `FromAST` discipline must exist *before*
+  scheme instantiation introduces the first interior origin
+  (`FromInstantiation`). M3 then extends, rather than retrofits, the table.
+
+## 2. Current state this builds on
+
+The M2 surface M2.5 touches, with exact references:
+
+- **`(*checker).constrain(n, lhs, rhs)`**
+  ([infer.go:41](../../internal/solver/infer.go)) — the single chokepoint that
+  stamps spans. Every constraint error in the codebase flows through here. M2.5
+  rewrites its stamping loop (§3.4); nothing else calls `setSpan` on a
+  constraint error.
+- **`SolverError` carries typed operands.** Each constraint kind already holds
+  the `soltype.Type` values that failed
+  ([errors.go](../../internal/solver/errors.go)):
+  - `CannotConstrainError{ LHS, RHS soltype.Type }`
+  - `FuncArityMismatchError{ LHS, RHS *soltype.FuncType }`
+  - `TupleLengthMismatchError{ LHS, RHS *soltype.TupleType }`
+  - `MissingPropertyError{ LHS, RHS *soltype.RecordType; Name string }`
+
+  These typed references are exactly what per-operand blame needs — no message
+  scraping. They are minted span-free inside `constrain.go` (which has no AST
+  node in hand) and stamped later by `(*checker).constrain`.
+- **`errSpan` is the embeddable span carrier**
+  ([errors.go:34–37](../../internal/solver/errors.go)): a single
+  `span ast.Span` with `Span()`/`setSpan`. Every error kind embeds it. M2.5
+  extends it with related spans (§3.5).
+- **The construction sites** that mint a type from a node, all in the M2 walk:
+
+  | Site | Function | Minted type |
+  |------|----------|-------------|
+  | literal inference | `inferLiteral` ([infer_expr.go:16](../../internal/solver/infer_expr.go)) | `&soltype.LitType{...}` (fresh per literal) |
+  | ident resolution | `inferIdent` ([infer_expr.go:43](../../internal/solver/infer_expr.go)) | returns `b.Type` (shared binding — see §3.7) |
+  | param binding | `inferFunc` ([infer_expr.go:92](../../internal/solver/infer_expr.go)) | `c.freshAt(lvl)` per un-annotated param |
+  | application result var | `inferCall` ([infer_expr.go:159](../../internal/solver/infer_expr.go)) | `res := c.freshAt(lvl)` |
+  | tuple elements | `inferTuple` ([infer_expr.go:179](../../internal/solver/infer_expr.go)) | `&soltype.TupleType{Elems}` |
+  | object field values | `inferObject` ([infer_expr.go:203](../../internal/solver/infer_expr.go)) | `&soltype.RecordType{Fields}` |
+  | member-access result var | `inferMember` ([infer_expr.go:243](../../internal/solver/infer_expr.go)) | `res := c.freshAt(lvl)` |
+
+- **`Info`** ([info.go](../../internal/solver/info.go)): `map[ast.Node]
+  soltype.Type` + `TypeOf`/`setType`. `Prov` is its structural twin (a
+  `map[soltype.Type]Origin`), populated by the **same** walk at the **same**
+  sites, and queried by the **same** downstream consumers (error messages, future
+  LSP hovers, the M8 differential harness).
+- **Test posture.** M2 tests assert error **messages** but not yet spans
+  ([infer_test.go](../../internal/solver/infer_test.go), e.g. `require.Equal(t,
+  "object is missing property: b", errs[0].Message())`). M2.5 adds **span**
+  assertions on top (§3.9) and is the first milestone to do so.
+
+## 3. Design
+
+### 3.1 New files & package layout
+
+All M2.5 code lives in `internal/solver/` alongside the M2 walk. No new packages.
+
+```
+internal/solver/
+  prov.go        # M2.5: Prov table, Origin/FromAST, ASTOriginKind, population helpers
+  prov_test.go   # M2.5: unit tests for the table + population discipline
+  errors.go      # M2.5: extend errSpan with related spans; add operands() per kind
+  infer.go       # M2.5: rewrite (*checker).constrain stamping to per-operand blame;
+                 #       carrier gains the prov field + recordProv helper
+  infer_expr.go  # M2.5: add prov population at the construction sites
+  infer_decl.go  # (no change beyond population already covered via infer_expr)
+  *_test.go      # M2.5: span-assertion harness + golden span fixtures
+```
+
+`Prov` is keyed by `soltype.Type` (pointer identity, matching `Info`). No
+`soltype` change is needed — the table lives entirely in `package solver`.
+
+### 3.2 The `Prov` side table (`prov.go`)
+
+Promote exactly the leaf slice of the design-notes sketch
+([02-design-notes.md](02-design-notes.md) §"Provenance side table"):
+
+```go
+// Prov is the inverse of Info: soltype.Type → the origin that minted it. Sparse —
+// shared/interned/synthesized nodes may be absent (an honest miss, not a lie; see
+// the design notes on per-occurrence provenance vs. per-shape structure). Keyed by
+// pointer identity, exactly like Info.
+type Prov map[soltype.Type]Origin
+
+// Origin is a tagged sum naming the kind of hop. M2.5 ships only the FromAST leaf;
+// the interior edge variants (FromBoundPropagation/FromInstantiation/
+// FromExtrusion/FromCoalesce) ride along with the M3+ operations that mint them.
+type Origin interface{ isOrigin() }
+
+// FromAST is the leaf: a direct AST cause for a freshly-minted type.
+type FromAST struct {
+	Node ast.Node
+	Kind ASTOriginKind
+}
+
+func (FromAST) isOrigin() {}
+
+// ASTOriginKind tags WHY a node minted a type, so a renderer/LSP can phrase blame
+// ("the literal here", "this argument", "field `x`") without re-deriving it from
+// the AST node's concrete type.
+type ASTOriginKind int
+
+const (
+	LiteralInference ASTOriginKind = iota // a LitType from inferLiteral
+	IdentRef                              // a value-binding ref from inferIdent (see §3.7 limitation)
+	ParamBinding                          // a fresh param var from inferFunc
+	Application                           // a fresh call-result var from inferCall
+	TupleElem                             // a TupleType from inferTuple
+	ObjectField                           // a RecordType from inferObject
+	MemberAccess                          // a fresh member-result var from inferMember
+)
+```
+
+`Prov` hangs off the `checker` carrier (per-run, like `Info`/`errs`):
+
+```go
+// infer.go — carrier gains prov
+type checker struct {
+	ctx  *Context
+	info *Info
+	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only)
+	errs []SolverError
+}
+// newChecker: prov: Prov{}
+```
+
+`InferModule`/`InferModules` return signatures **may** widen to expose `Prov`
+alongside `*Info` for downstream consumers (LSP/differential); this is an open
+question (§7) — the table can stay internal to the run if no M2.5 consumer needs
+it externally, since its only M2.5 reader is the error path inside the same run.
+
+### 3.3 Population at the construction sites (`prov.go` helpers + `infer_expr.go`)
+
+The **Population discipline** from the design notes: one helper, one line per
+site. Mirror M2's `recordType` (which wraps `info.setType`):
+
+```go
+// recordProv records that t was minted from node n for reason kind. The inverse
+// of recordType. Sparse by intent: only the node-derived construction sites call
+// it; shared atoms and synthesized types get no entry.
+func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
+	c.prov[t] = FromAST{Node: n, Kind: kind}
+}
+```
+
+Population per site (each is a single added line next to the existing mint +
+`recordType`):
+
+| Site | Added call |
+|------|-----------|
+| `inferLiteral` | `c.recordProv(t, e, LiteralInference)` on the fresh `LitType` |
+| `inferFunc` (param) | `c.recordProv(pt, p, ParamBinding)` when `pt` is the fresh var (un-annotated param) |
+| `inferCall` | `c.recordProv(res, e, Application)` on the fresh result var |
+| `inferTuple` | `c.recordProv(t, e, TupleElem)` on the `TupleType` |
+| `inferObject` | `c.recordProv(t, e, ObjectField)` on the `RecordType` |
+| `inferMember` | `c.recordProv(res, e, MemberAccess)` on the fresh result var |
+| `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.7**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
+
+Notes:
+
+- **Only fresh/node-local types get useful entries.** Literals, param vars,
+  call/member result vars, and tuple/object literals are minted *at* the node
+  and are unique pointers — their `Prov` entry is precise and stable.
+- **Annotated param types are not recorded against the param node.** When a param
+  carries an annotation, `paramType` returns `resolveTypeAnn(...)`, a type
+  sourced from the annotation, not the param-as-binding. Record the
+  `ParamBinding` origin only on the fresh-var branch; an annotated param's
+  *annotation* type can carry its own origin if/when annotation provenance is
+  wired (a candidate related-span source — §3.5).
+- **The hot path stays untouched.** `recordProv` is called only in the walk
+  (construction), never in `constrain`/`coalesce` (§3.8).
+
+### 3.4 Per-operand blame at the error path (`infer.go` + `errors.go`)
+
+Replace the umbrella stamp in `(*checker).constrain` with a per-error resolution
+that consults `Prov`.
+
+**Step 1 — each error kind exposes its blame operands.** Add a method to the
+`SolverError` interface returning the typed operands whose provenance to consult,
+in priority order (most-specific "subject" first):
+
+```go
+// errors.go — extend the interface
+type SolverError interface {
+	isSolverError()
+	Message() string
+	Span() ast.Span
+	setSpan(ast.Span)
+	addRelated(ast.Span)        // NEW (§3.5)
+	blameOperands() []soltype.Type // NEW: leaf operands to resolve via Prov, priority order
+}
+```
+
+Per kind:
+
+| Error | `blameOperands()` | Rationale |
+|-------|-------------------|-----------|
+| `CannotConstrainError` | `[LHS, RHS]` | the LHS is the "actual" value flowing into the RHS requirement (`"hi" <: number` ⇒ LHS `"hi"` is the offending literal); RHS is the expected-source → related span |
+| `FuncArityMismatchError` | `[LHS, RHS]` | the declared function (LHS, minted at `inferFunc`) vs. the synthesized call shape (RHS, usually no entry) |
+| `TupleLengthMismatchError` | `[LHS, RHS]` | the tuple literal (whichever side was minted at `inferTuple`) |
+| `MissingPropertyError` | `[RHS.Field(Name), LHS]` | the field's type var was minted at `inferMember` with `MemberAccess` origin → blames the **member's prop**, not the receiver; LHS receiver is the related span |
+
+`MissingPropertyError` is the one that needs the field's *inner* type, not the
+record itself: the synthesized requirement record `{foo: res}` has no `Prov`
+entry, but `res` (its field type) was minted at the member site. A small accessor
+`RecordType.Field(Name)` already exists (used in `constrain.go`), so
+`blameOperands` returns that inner var.
+
+**Step 2 — resolve operands to spans.** The new stamping loop:
+
+```go
+func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
+	for _, e := range c.ctx.Constrain(lhs, rhs) {
+		c.stampBlame(n, e)
+		c.errs = append(c.errs, e)
+	}
+}
+
+// stampBlame sets e's primary span to the narrowest contributing operand's
+// FromAST node, and attaches any other resolved operands as related spans.
+// Falls back to n.Span() when NO operand resolves (a synthesized/shared operand
+// with no Prov entry) — keeping such cases no worse than M2's umbrella stamp.
+func (c *checker) stampBlame(n ast.Node, e SolverError) {
+	var primary *ast.Span
+	for _, op := range e.blameOperands() {
+		if o, ok := c.prov[op].(FromAST); ok {
+			if primary == nil {
+				s := o.Node.Span()
+				primary = &s
+			} else {
+				e.addRelated(o.Node.Span()) // expected-source / second contributor
+			}
+		}
+	}
+	if primary != nil {
+		e.setSpan(*primary)
+	} else {
+		e.setSpan(n.Span()) // honest fallback — same as M2 today
+	}
+}
+```
+
+Because `constrain` decomposes structurally to **leaf** operands before failing
+(a prim/lit/missing-field mismatch fires on the atoms, not the enclosing
+aggregate), the operands handed to `blameOperands` are already narrow — there is
+no span-size comparison to do. The umbrella problem was *only* that M2 ignored
+the operands and stamped `n`; consulting `Prov` on the leaves fixes it directly.
+
+### 3.5 Multi-span errors (`errors.go`)
+
+Extend the shared `errSpan` carrier so any error can point at a primary span plus
+related contributors:
+
+```go
+// errSpan carries the primary blame span plus zero or more related spans (e.g.
+// the annotation/expected-source location alongside the offending literal).
+type errSpan struct {
+	span    ast.Span
+	related []ast.Span
+}
+
+func (e *errSpan) Span() ast.Span      { return e.span }
+func (e *errSpan) setSpan(s ast.Span)  { e.span = s }
+func (e *errSpan) Related() []ast.Span { return e.related }
+func (e *errSpan) addRelated(s ast.Span) {
+	e.related = append(e.related, s)
+}
+```
+
+This is additive — every existing kind embeds `errSpan`, so they all gain
+`Related()`/`addRelated` for free, and existing single-span assertions keep
+working (`related` is empty unless populated). Downstream rendering (CLI
+diagnostics, LSP) can show the related spans as "expected here" / "originates
+here" annotations; M2.5 only needs them *recorded* and *assertable* — rich
+rendering is consumer work that lands when the CLI is wired (M8+).
+
+### 3.6 The one non-provenance addition: `val`-annotation checking
+
+The milestone's first acceptance example — `val x: number = "hi"` blames the
+`"hi"` literal — requires a constraint that **M2 does not currently emit**:
+`inferVarDeclInit`
+([infer_decl.go:61](../../internal/solver/infer_decl.go)) walks the initializer
+but never constrains it against `d.TypeAnn` (annotation-driven binding was
+deferred in M2). Without that constraint there is no error to blame.
+
+M2.5 adds the minimal check so the canonical fixture is real:
+
+```go
+// inferVarDeclInit (sketch) — constrain the initializer against the annotation
+// when present, so val x: number = "hi" produces a CannotConstrainError whose
+// LHS ("hi" literal) carries a LiteralInference origin → precise blame.
+initT := c.inferExpr(scope, lvl, d.Init)
+if d.TypeAnn != nil {
+	annT := c.resolveTypeAnn(d.TypeAnn)
+	c.constrain(d.Init, initT, annT) // node = the initializer, so even the
+	                                  // fallback span is the RHS, not the whole decl
+	initT = annT                      // the binding takes the annotated type
+}
+```
+
+**This is flagged as a judgment call, not silent scope creep.** Two honest
+framings:
+
+- **Include it (recommended).** It is ~5 lines, `resolveTypeAnn` already exists
+  and is exercised by `inferFunc`, and it is the *only* way to realize the
+  milestone's headline fixture. The provenance machinery is what makes its blame
+  precise, so it belongs with M2.5.
+- **Defer it.** If the team would rather keep M2.5 strictly provenance-only,
+  drop the `val x: number = "hi"` fixture and ground the golden set entirely in
+  constraints M2 already emits (call-arg mismatch, member missing-property,
+  tuple-length — §3.9 marks which are which). The provenance design is unchanged
+  either way.
+
+Resolve this in review before PR-3 (§5). The plan assumes **include**.
+
+### 3.7 Honest limitation — the leaf/interior split
+
+Leaf-only blame is precise whenever an operand traces directly to a
+literal/param/field/member. It is **imprecise** in two cases, both of which fall
+back to `n` (no regression vs. M2):
+
+1. **Synthesized operands.** A coalesced upper-bound, a propagated bound, or a
+   multi-branch join has no single AST node. Chasing its blame needs the interior
+   edges (`FromBoundPropagation`/`FromCoalesce`) — deferred to M3+. M2.5 records
+   no entry, so `stampBlame` falls back.
+2. **Shared monomorphic bindings (`inferIdent`).** M2 returns `b.Type` directly
+   — the *same* pointer for every use of a name (no `instantiate` until M3). A
+   `Prov[b.Type]` entry is therefore **per-shape, not per-occurrence**: the last
+   `inferIdent` to record wins, and the recorded node may be a different use than
+   the one in the failing constraint. So an `x`-flows-into-mismatch error
+   (`val y: number = x` where `x: string`) cannot reliably blame *this* `x` use
+   in M2.5; it blames the initializer node `n` (the fallback) or, with annotation
+   checking from §3.6, the initializer expression — already an improvement over
+   the whole-decl umbrella. **Per-use ident blame arrives with M3's
+   `FromInstantiation`** (each use gets a fresh instance with its own origin),
+   exactly as the milestone sequences it. The `IdentRef` population is wired now
+   (cheap, and correct for the leaf-direct cases) but documented as last-write-
+   wins until M3.
+
+This split is *why* the milestone scopes M2.5 to leaves: the precise-span wins
+land where operands are node-local atoms, and the interior chains are deferred to
+the milestones that make them deep.
+
+### 3.8 Perf invariant
+
+The hot `constrain` ([constrain.go](../../internal/solver/constrain.go)) and
+`coalesce` ([coalesce.go](../../internal/solver/coalesce.go)) loops must **never**
+consult `Prov`. It is written only in the walk (`recordProv`) and read only on
+the error path (`stampBlame`) and by future LSP/diagnostic consumers, so the
+map-lookup cost stays off the inference critical path. This is structurally
+guaranteed: `Prov` lives on the `checker` carrier (the walk), not on `Context`
+(the engine), so `constrain`/`coalesce` have no handle to it. A package-boundary
+note in the PR records the invariant; no runtime check is needed because the
+engine literally cannot reach the table.
+
+### 3.9 Test/fixture harness for spans
+
+M2's harness ([infer_test.go](../../internal/solver/infer_test.go)) returns
+`[]SolverError` and asserts `Message()`. M2.5 extends the assertions to spans.
+Because spans are line/column pairs over the test source (`ast.Span.String()` ⇒
+`"start-end"`, e.g. `2:17-2:21`), the golden set asserts the rendered span string
+per error — a **golden span fixture** per the milestone.
+
+```go
+// helper: assert primary span (and optionally related spans) of the sole error
+func requireBlame(t *testing.T, errs []SolverError, msg, primary string, related ...string)
+```
+
+The golden set (each grounded in a constraint M2.5 actually emits):
+
+| Fixture | Constraint source | Primary blame | Related |
+|---------|-------------------|---------------|---------|
+| `val x: number = "hi"` | §3.6 val-annotation check; `CannotConstrainError` LHS `"hi"` | the `"hi"` literal | the `number` annotation |
+| `f("hi")` where `f: fn(x: number) -> number` | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | — |
+| a record field-value mismatch fed to an annotated/param sink | object field value origin | the offending **field value** | the field annotation |
+| `[1, "a"]` against a `[number, number]` sink (length/elem) | `inferTuple` element / `TupleLengthMismatchError` | the **tuple literal** (length) or offending element (elem) | — |
+| `recv.foo` where `recv` lacks `foo` | `inferMember`; `MissingPropertyError` | the **member's prop** (`.foo`), not the receiver | the receiver |
+
+Plus: **existing M2 error fixtures that assert spans are updated to the narrowest
+real spans** (the milestone's "Existing M2 error fixtures … updated" clause). M2
+currently asserts only messages, so this is mostly *adding* span assertions; any
+test that already pinned an umbrella span flips to the narrow one.
+
+Assertions use `testify/require` and full messages (CLAUDE.md); for multi-span
+cases prefer a single rendered-string assertion over field-by-field drilling.
+
+## 4. Sequencing
+
+Three PRs, each one reviewable concern, ordered by hard dependency. The table +
+population (PR-1) is inert until the error path consumes it (PR-2); the
+golden fixtures + the §3.6 val-annotation enabler (PR-3) come last.
+
+```text
+        M2 shipped: walk + Info + SolverError(LHS/RHS) + errSpan(single span)
+                        │
+                        ▼
+        ┌────────────────────────────────┐
+        │ PR-1  Prov table + population   │  prov.go: Prov/Origin/FromAST/ASTOriginKind,
+        │       (inert — no reader yet)   │  recordProv; wire the 7 sites; carrier.prov
+        └───────────────┬────────────────┘
+                        ▼
+        ┌────────────────────────────────┐
+        │ PR-2  per-operand blame +       │  errors.go: blameOperands() per kind,
+        │       multi-span errSpan        │  errSpan.related/addRelated/Related;
+        │                                 │  infer.go: stampBlame replaces umbrella stamp
+        └───────────────┬────────────────┘
+                        ▼
+        ┌────────────────────────────────┐
+        │ PR-3  golden span fixtures +    │  §3.6 val-annotation check (decision gate);
+        │       val-annotation enabler    │  span-assertion harness; update M2 fixtures;
+        │                                 │  milestone status
+        └────────────────────────────────┘
+```
+
+PR-1 ∥ nothing (foundation). PR-2 depends on PR-1 (reads `Prov`). PR-3 depends on
+PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
+
+## 5. PR breakdown
+
+> Each PR lists owned files, the §3 sketches it implements, its tests, and an
+> exit line. LoC estimates are non-test code.
+
+### PR-1 — `Prov` table + population at construction sites  (~120 LoC)
+- `prov.go`: `Prov`, `Origin`, `FromAST`, `ASTOriginKind` (+ its constants),
+  `recordProv` (§3.2–3.3).
+- `infer.go`: add `prov Prov` to the `checker` carrier; init in `newChecker`.
+- `infer_expr.go`: one `recordProv` call at each of the 7 sites
+  (`inferLiteral`, `inferFunc` param, `inferCall`, `inferTuple`, `inferObject`,
+  `inferMember`, `inferIdent`) per the §3.3 table.
+- `prov_test.go`: after inferring a snippet, assert each minted type has the
+  expected `FromAST{Node, Kind}` (literal → its `LiteralExpr`/`LiteralInference`;
+  call result → the `CallExpr`/`Application`; member result → the
+  `MemberExpr`/`MemberAccess`; tuple/object → their literal nodes). Assert the
+  honest **absences**: a shared atom / synthesized coalesced type has no entry.
+- **Exit:** the table is populated at every M2 construction site; no reader yet,
+  so behavior is unchanged (the table is inert). Perf invariant noted (§3.8):
+  `Context` has no handle to `Prov`.
+
+### PR-2 — Per-operand blame + multi-span errors  (~150 LoC)
+*(depends on PR-1)*
+- `errors.go`: extend `errSpan` with `related []ast.Span` + `addRelated`/
+  `Related`; add `blameOperands()` to the `SolverError` interface and implement
+  it on the four constraint kinds per the §3.4 table (the bridge kinds —
+  `UnknownIdentifierError` etc. — return `nil`, keeping their construction-time
+  span).
+- `infer.go`: replace the umbrella stamp loop in `(*checker).constrain` with
+  `stampBlame` (§3.4) — primary = narrowest resolved operand, others → related,
+  fallback → `n`.
+- Tests: unit-level `stampBlame` cases over hand-built errors + a seeded `Prov`
+  (operand resolves → its node; no operand resolves → fallback `n`; two operands
+  resolve → primary + one related). Confirm bridge errors are untouched.
+- **Exit:** constraint errors point at the narrowest contributing node;
+  synthesized/shared operands fall back to `n` (no regression); multi-span
+  recorded.
+
+### PR-3 — Golden span fixtures + `val`-annotation enabler  (~60 LoC + tests)
+*(depends on PR-2)*
+- **Decision gate (§3.6):** include the `val`-annotation subtype check
+  (recommended) or drop the corresponding fixture. If included:
+  `infer_decl.go` `inferVarDeclInit` constrains `init <: resolveTypeAnn(TypeAnn)`
+  with the initializer as the constraint node and the binding adopting the
+  annotated type.
+- `infer_test.go`: the `requireBlame` span-assertion helper (§3.9); the golden
+  span set; update existing M2 error tests to assert the now-narrow spans.
+- Update `01-milestones.md` M2.5 status.
+- **Exit (M2.5 exit criteria):** `val x: number = "hi"` blames the `"hi"`
+  literal; a field-type mismatch blames the offending field value; a
+  tuple-length mismatch points at the tuple literal; a missing-property read
+  blames the member's prop, not the receiver. Existing M2 error fixtures assert
+  the narrowest real spans.
+
+## 6. Risks & mitigations
+
+- **Shared-pointer `inferIdent` provenance is last-write-wins.** Recording
+  against the shared monomorphic binding type can attach a stale node.
+  *Mitigation:* document it as a known leaf/interior-split limitation (§3.7);
+  blame for ident-flow mismatches falls back to the constraint node (no
+  regression), and per-use precision arrives with M3's `FromInstantiation`. The
+  golden set deliberately does **not** include an ident-flow case as a precise
+  win.
+- **Operand isn't actually a leaf.** If a future `constrain` arm returns an error
+  whose `LHS`/`RHS` is an aggregate rather than the decomposed atom, blame would
+  point coarsely. *Mitigation:* the four M2 kinds already carry the decomposed
+  operands (prim/lit atoms, the field's inner var); a `prov_test` asserts the
+  operand is the expected leaf, catching any future arm that regresses this.
+- **Scope creep via §3.6.** The val-annotation check is real type-checking
+  behavior, not provenance. *Mitigation:* it is isolated to PR-3 behind an
+  explicit decision gate; the table/blame design (PR-1/PR-2) is independent of it
+  and lands regardless.
+- **Perf regression from `Prov` lookups on the hot path.** *Mitigation:*
+  structurally impossible — `Prov` is on the carrier, not `Context`; the engine
+  has no handle (§3.8). No lookup appears in `constrain`/`coalesce`.
+- **Multi-span churn in downstream consumers.** Adding `related` to every error
+  could ripple into CLI/LSP rendering. *Mitigation:* the field is additive and
+  defaults empty; no current consumer reads it, and rich rendering is explicitly
+  deferred to the CLI-wiring milestone. M2.5 only records and asserts spans.
+
+## 7. Open questions to resolve during M2.5
+
+- **Expose `Prov` from `InferModule`/`InferModules`? — lean: not yet.** The only
+  M2.5 reader is `stampBlame`, inside the same run, so the table can stay on the
+  carrier. Widen the return signature when the first *external* consumer (LSP
+  hover, M8 differential) needs it — that consumer can drive the exact shape.
+  Revisit if M3's `FromInstantiation` work wants the table threaded out.
+- **`val`-annotation check: in or out (§3.6)? — recommended: in.** Decide in
+  review before PR-3. "In" realizes the milestone's headline fixture for ~5 lines
+  and is the natural home for the precision it enables; "out" keeps M2.5
+  strictly provenance-only and drops one fixture.
+- **`ASTOriginKind` granularity.** The seven-constant set above is the minimum
+  the population sites distinguish. Whether to split (e.g. `ArgExpr` distinct
+  from `Application` for the call-result var vs. the argument) can wait until a
+  consumer (LSP phrasing) needs the distinction — M2.5's blame only needs the
+  *node*, not the kind, so kinds are forward-looking metadata.
+- **Related-span ordering/dedup.** When both operands resolve, is the related
+  list ordered (expected-source first) and deduped (same node on both sides)?
+  *Lean:* dedup by span equality, append in `blameOperands` priority order;
+  pin it with a multi-operand `stampBlame` test in PR-2.
+
+## 8. M2.5 exit checklist
+
+- [ ] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`
+      leaf variant and `ASTOriginKind`; interior variants deferred to M3+.
+- [ ] `FromAST` populated at all seven M2 construction sites via `recordProv`
+      (literal, ident, param, call-result, tuple, object, member-result), with
+      the `inferIdent` last-write-wins limitation documented.
+- [ ] `(*checker).constrain` blame rewritten: per-operand `Prov` lookup
+      (`stampBlame`) replaces the umbrella stamp; fallback to `n` when no operand
+      resolves.
+- [ ] `blameOperands()` implemented per constraint kind (the four M2 kinds; bridge
+      kinds return `nil`).
+- [ ] `errSpan` carries primary + related spans (`addRelated`/`Related`); the
+      change is additive and existing single-span assertions still pass.
+- [ ] Golden span fixtures assert exact spans: `"hi"`-literal blame, field-value
+      mismatch, tuple-length at the literal, missing-property at the member prop.
+- [ ] Existing M2 error fixtures updated to assert the narrowest real spans.
+- [ ] Perf invariant honored: no `Prov` access in `constrain`/`coalesce` (the
+      engine has no handle to the table).
+- [ ] `val`-annotation enabler decision (§3.6/§7) resolved and reflected.
+- [ ] `01-milestones.md` M2.5 status updated.

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -42,9 +42,9 @@ Per the milestone, M2.5 delivers:
    operations that mint them.
 2. **A `FromAST` entry written into `Prov` at each M2 construction site** —
    `FromAST` is the value stored in the table, not a second table (§3.2). The
-   sites are literal inference, ident resolution, param binding, application
-   result var, tuple elements, object field values, and member-access result
-   var (§3.3).
+   sites are literal inference, ident resolution, param binding, function types,
+   application result var, the call-shape, tuple elements, object field values,
+   member-access result var, and annotation prims (§3.3).
 3. **Errors carry AST nodes, not strings.** An audit of all eleven `SolverError`
    kinds (§3.4) partitions them: *bridge* errors (born in the walk, with an
    `ast.Node` in hand) hold that node directly and **self-blame**; *constraint*
@@ -147,12 +147,12 @@ All M2.5 code lives in `internal/solver/` alongside the M2 walk. No new packages
 
 ```
 internal/solver/
-  prov.go        # M2.5: Prov table, Origin/FromAST, ASTOriginKind, population helpers
+  prov.go        # M2.5: Prov table + Provenance/NodeFor, Origin/FromAST, ASTOriginKind, population helpers
   prov_test.go   # M2.5: unit tests for the table + population discipline
   errors.go      # M2.5: reshape SolverError (node-derived Span/Related, drop setSpan);
                  #       bridge errors carry ast.Node fields; split UnsupportedNodeError;
-                 #       constraint errors gain blameNodes + the blamable interface
-  infer.go       # M2.5: rewrite (*checker).constrain stamping to per-operand blame;
+                 #       constraint errors carry a Provenance handle + site, resolve Span/Related on demand
+  infer.go       # M2.5: (*checker).constrain assigns prov/site per kind via a type switch (no stamping);
                  #       carrier gains the prov field + recordProv helper
   infer_expr.go  # M2.5: add prov population at the construction sites; pass nodes to bridge errors
   infer_stmt.go  # M2.5: pass the offending Decl node to BodyDeclNotAllowedError
@@ -201,7 +201,10 @@ const (
 	Application                           // a fresh call-result var from inferCall
 	TupleElem                             // a TupleType from inferTuple
 	ObjectField                           // a RecordType from inferObject
+	FuncInference                         // a FuncType from inferFunc (the function expr/decl)
+	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
 	MemberAccess                          // a fresh member-result var from inferMember
+	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
 )
 ```
 
@@ -212,8 +215,34 @@ the single assignment `prov[t] = FromAST{Node: n, Kind: k}`. The error path hold
 a *type* (`CannotConstrainError.LHS`, say) and needs the *source node* that
 minted it; `Prov` is the type→node index that delivers it. `Info` cannot serve
 this — it is the opposite direction (node→type), so recovering a node from it
-means an O(n) scan for a value equal to the operand, ambiguous because one shared
-atom (`number`) is the value at many nodes. `Prov` is the direct inverse.
+means an O(n) scan, and matching by value is ambiguous (many nodes carry an equal
+type). `Prov` is the direct, pointer-keyed inverse — which is why each operand
+must be its **own** pointer (see the fresh-`PrimType` discipline in §3.3).
+
+**The read side: a `Provenance` interface.** The error path doesn't read the map
+directly — it goes through a one-method interface that `Prov` satisfies:
+
+```go
+// Provenance resolves an operand type to the AST node that minted it. M2.5's Prov
+// implements it as a single map lookup; M3+ can supply a resolver that chases
+// interior Origin edges (FromInstantiation, …) to the nearest AST leaf without
+// changing any caller — that is the "follow the provenance chain" path.
+type Provenance interface {
+	NodeFor(soltype.Type) (ast.Node, bool)
+}
+
+func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
+	if o, ok := p[t].(FromAST); ok {
+		return o.Node, true
+	}
+	return nil, false // unrecorded operand (e.g. a FuncType, a prelude type, or an
+	                  // M3+ synthesized type): an honest miss
+}
+```
+
+The four constraint errors hold this interface (not the concrete map), so the
+chain-following story is theirs to implement and M3's richer resolver drops in
+unchanged (§3.4–3.5).
 
 **Why an `Origin` interface and not just `map[soltype.Type]ast.Node`.** For M2.5
 *alone*, the table could store a bare node (plus kind) and skip `Origin`
@@ -246,7 +275,8 @@ type checker struct {
 `InferModule`/`InferModules` return signatures **may** widen to expose `Prov`
 alongside `*Info` for downstream consumers (LSP/differential); this is an open
 question (§7) — the table can stay internal to the run if no M2.5 consumer needs
-it externally, since its only M2.5 reader is the error path inside the same run.
+it externally, since its only M2.5 readers are the constraint errors' own
+`Span()`/`Related()`, through the handle bound to them inside the same run.
 
 ### 3.3 Population at the construction sites (`prov.go` helpers + `infer_expr.go`)
 
@@ -256,7 +286,7 @@ site. Mirror M2's `recordType` (which wraps `info.setType`):
 ```go
 // recordProv records that t was minted from node n for reason kind. The inverse
 // of recordType. Sparse by intent: only the node-derived construction sites call
-// it; shared atoms and synthesized types get no entry.
+// it; synthesized types (coalesced/extruded, M3+) get no entry.
 func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }
@@ -269,23 +299,49 @@ Population per site (each is a single added line next to the existing mint +
 |------|-----------|
 | `inferLiteral` | `c.recordProv(t, e, LiteralInference)` on the fresh `LitType` |
 | `inferFunc` (param) | `c.recordProv(pt, p, ParamBinding)` when `pt` is the fresh var (un-annotated param) |
-| `inferCall` | `c.recordProv(res, e, Application)` on the fresh result var |
+| `inferFunc` (type) | `c.recordProv(ft, node, FuncInference)` on the returned `FuncType` — the function expr/decl, exactly parallel to `inferTuple`/`inferObject` |
+| `inferCall` (result) | `c.recordProv(res, e, Application)` on the fresh result var |
+| `inferCall` (shape) | `c.recordProv(callShape, e, CallShape)` on the synthesized `FuncType{args, res}` — so `FuncArityMismatchError` resolves its blame to the call (no `site` needed) |
 | `inferTuple` | `c.recordProv(t, e, TupleElem)` on the `TupleType` |
 | `inferObject` | `c.recordProv(t, e, ObjectField)` on the `RecordType` |
 | `inferMember` | `c.recordProv(res, e, MemberAccess)` on the fresh result var |
 | `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.8**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
+| `resolveTypeAnn` | `c.recordProv(t, ta, AnnotationType)` on each fresh `PrimType` it mints — **the fresh-atom discipline** (below) makes this precise |
 
 Notes:
 
 - **Only fresh/node-local types get useful entries.** Literals, param vars,
-  call/member result vars, and tuple/object literals are minted *at* the node
-  and are unique pointers — their `Prov` entry is precise and stable.
-- **Annotated param types are not recorded against the param node.** When a param
-  carries an annotation, `paramType` returns `resolveTypeAnn(...)`, a type
-  sourced from the annotation, not the param-as-binding. Record the
-  `ParamBinding` origin only on the fresh-var branch; an annotated param's
-  *annotation* type can carry its own origin if/when annotation provenance is
-  wired (a candidate related-node source — §3.6).
+  call/member result vars, tuple/object literals, **and the `FuncType` from
+  `inferFunc`** are minted *at* the node and are unique pointers — their `Prov`
+  entry is precise and stable. (Recording the `FuncType` is what lets a function
+  flowing into a non-function requirement blame the *function*, and lets
+  `FuncArityMismatchError` carry a "defined here" related span — §3.5.)
+- **Record a synthesized requirement shape only when it's the blame target.** A
+  requirement shape is built by the walk *at* a node, so it has a perfectly good
+  source node to record against — but record it only if some error blames the shape
+  itself. The **call-shape `FuncType{args, res}`** is recorded (`CallShape`, against
+  the `CallExpr`) because `FuncArityMismatchError` blames the *call*. The **member
+  requirement record `{foo: res}`** is *not* recorded, because `MissingPropertyError`
+  blames the field's inner `res` var (recorded `MemberAccess`), not the record — so
+  recording the record would be a dead entry. Record what you blame; leave the rest.
+- **The fresh-atom discipline (annotation prims).** `resolveTypeAnn` already mints
+  a brand-new `&soltype.PrimType{...}` per annotation
+  ([type_ann.go:15-22](../../internal/solver/type_ann.go)) — there is no interned
+  `number` singleton to share — so each annotation's atom is its own pointer and is
+  directly recordable. M2.5 records it (`AnnotationType`) against the `TypeAnn`
+  node. This is what makes the `number` in `val x: number = "hi"` resolve to the
+  annotation (the related-node source — §3.6), and what lets a prim/prim mismatch
+  blame the offending annotation rather than fall back. Subtyping is unaffected:
+  `constrain` compares `PrimType.Prim` by **value**, not pointer
+  ([constrain.go:45](../../internal/solver/constrain.go)), so distinct-but-equal
+  prims still match — they only ever add redundant `seen`-set entries, never loops
+  (constrain.go's `constraintKey` note). The same discipline extends to any future
+  annotation-derived composite (tuple/object/function anns) as those land.
+- **Annotated param types.** When a param carries an annotation, `paramType`
+  returns `resolveTypeAnn(...)`, which now records the `AnnotationType` origin
+  itself — so the `ParamBinding` origin is recorded only on the fresh-var
+  (un-annotated) branch, and the annotated branch's blame comes from the
+  annotation entry.
 - **The hot path stays untouched.** `recordProv` is called only in the walk
   (construction), never in `constrain`/`coalesce` (§3.9).
 
@@ -296,15 +352,16 @@ the construction site have an `ast.Node` in hand?** — and the reshape it impli
 
 **Constraint errors (engine-minted, AST-free).** They already carry the typed
 *operands* that failed; they **cannot** carry an AST node (`constrain.go` sees
-only `soltype.Type`). Their AST node is injected from `Prov` (§3.5). **No operand
-fields change.**
+only `soltype.Type`). Their blame nodes are resolved from `Prov` *on demand* by
+their own `Span()`/`Related()` (§3.5) — nothing is resolved or stored at
+construction. **No operand fields change.**
 
-| Kind | Carries (unchanged) | AST node from |
+| Kind | Carries (unchanged) | Blame node resolved from (§3.5) |
 |---|---|---|
-| `CannotConstrainError` | `LHS, RHS soltype.Type` | `Prov` (§3.5) |
-| `FuncArityMismatchError` | `LHS, RHS *soltype.FuncType` | `Prov` |
-| `TupleLengthMismatchError` | `LHS, RHS *soltype.TupleType` | `Prov` |
-| `MissingPropertyError` | `LHS, RHS *soltype.RecordType; Name string` | `Prov` |
+| `CannotConstrainError` | `LHS, RHS soltype.Type` | `Prov` (operand), else its `site` |
+| `FuncArityMismatchError` | `LHS, RHS *soltype.FuncType` | `Prov` (RHS call-shape → the call); related = the fn |
+| `TupleLengthMismatchError` | `LHS, RHS *soltype.TupleType` | `Prov` (LHS literal); related = RHS (M4-reachable) |
+| `MissingPropertyError` | `LHS, RHS *soltype.RecordType; Name string` | `Prov` (field var); no `site` |
 
 `MissingPropertyError.Name` **stays** — the absent field name isn't recoverable
 from a single node (the RHS may require several fields; `Name` says which is
@@ -366,117 +423,205 @@ type SolverError interface {
   (`[]ast.Span{e.Previous.Span()}`). `Message()` derives from the node too
   (e.g. `"Unknown identifier: " + e.Ident.Name`,
   `"Declaration not allowed in function body: " + astKind(e.Decl)`).
-- **Constraint errors** get their AST node *injected* through a narrow internal
-  interface only they implement:
-
-  ```go
-  type blamable interface {
-  	blameOperands() []soltype.Type            // type operands to resolve via Prov (§3.5)
-  	setBlame(primary ast.Node, related ...ast.Node)
-  }
-  ```
-
-  They embed a small helper supplying `Span()`/`Related()`/`setBlame`:
-
-  ```go
-  type blameNodes struct {
-  	primary ast.Node   // set by setBlame before the error is surfaced
-  	related []ast.Node
-  }
-  func (b *blameNodes) Span() ast.Span    { return b.primary.Span() }
-  func (b *blameNodes) Related() []ast.Span { /* map each related node → its Span() */ }
-  func (b *blameNodes) setBlame(primary ast.Node, related ...ast.Node) {
-  	b.primary, b.related = primary, related
-  }
-  ```
-
-  `stampBlame` (§3.5) type-asserts to `blamable`; bridge errors aren't `blamable`,
-  so the error path skips them entirely — **they self-blame from their own node.**
+- **Constraint errors** can't carry a node (minted AST-free in the engine), so
+  they resolve their blame nodes *on demand* from `Prov`. There is **no shared
+  embed**: each kind declares only the fields it needs — a `prov Provenance` handle
+  on the kinds that resolve an operand, and a `site ast.Node` fallback only on the
+  kinds whose subject operand can fail to resolve. `Span()`/`Related()` compute
+  lazily from the operands when asked — nothing is resolved or stored at
+  construction. The fields are assigned once, *after* the engine returns, by a
+  small per-kind type switch in `(*checker).constrain` (§3.5); the engine itself
+  never sets them, and bridge errors carry neither (they self-blame from their own
+  node). §3.5 gives the exact per-kind field set and why it differs.
 
 The upshot: `errSpan`/`setSpan` disappear, every `Span()` is some `ast.Node`'s
-span, and **`Prov` is consulted only for the four constraint kinds** — the bridge
-kinds never touch it. That narrows the table's reader set and is the cleaner
-blame story the audit buys.
+span (an operand's, or the kind's own `site` fallback), and **`Prov` is consulted
+only by the four constraint kinds' own methods** — the bridge kinds never touch it,
+and the engine never touches it. That narrows the table's reader set and is the
+cleaner blame story the audit buys.
 
-### 3.5 Per-operand blame at the error path (`infer.go` + `errors.go`)
+### 3.5 Per-operand blame in the error methods (`errors.go` + `infer.go`)
 
-With the reshape in place, the umbrella stamp becomes a per-operand `Prov`
-resolution that injects **nodes** (not spans) into the blamable constraint errors.
+With the reshape in place, the umbrella stamp is **gone**: each constraint kind's
+own `Span()`/`Related()` follows its operands through `Prov` on demand, falling
+back to its own `site` (where it has one) when an operand has no entry. No
+resolution pass — the per-kind blame choice is the body of each method; the only
+shared step is a one-line-per-kind field assignment when the errors come back.
 
-**Step 1 — each constraint kind exposes its blame operands.** `blameOperands()`
-returns the typed operands whose provenance to consult, in priority order
-(most-specific "subject" first):
+**Step 1 — each kind names its operands *and its storage*.** What drives `Span()`,
+what drives `Related()`, and the per-kind fields that implies — only what each
+needs (this is the directive: storage specific to each struct):
 
-| Error | `blameOperands()` | Rationale |
-|-------|-------------------|-----------|
-| `CannotConstrainError` | `[LHS, RHS]` | the LHS is the "actual" value flowing into the RHS requirement (`"hi" <: number` ⇒ LHS `"hi"` is the offending literal); RHS is the expected-source → related node |
-| `FuncArityMismatchError` | `[LHS, RHS]` | the declared function (LHS, minted at `inferFunc`) vs. the synthesized call shape (RHS, usually no entry) |
-| `TupleLengthMismatchError` | `[LHS, RHS]` | the tuple literal (whichever side was minted at `inferTuple`) |
-| `MissingPropertyError` | `[RHS.Field(Name), LHS]` | the field's type var was minted at `inferMember` with `MemberAccess` origin → blames the **member's prop**, not the receiver; LHS receiver is the related node |
+| Error | `Span()` | `Related()` | Fields (beyond operands) |
+|-------|----------|-------------|--------------------------|
+| `CannotConstrainError` | `spanOf(prov, LHS, site)` | `relatedOf(prov, RHS)` | `prov`, `site` |
+| `TupleLengthMismatchError` | `LHS` via `prov`, then `RHS` | `relatedOf(prov, RHS)` | `prov` |
+| `MissingPropertyError` | field var via `prov`, then `LHS` | `relatedOf(prov, LHS)` | `prov` |
+| `FuncArityMismatchError` | RHS call-shape via `prov`, then `LHS` | `relatedOf(prov, LHS)` (the fn) | `prov` |
 
-`MissingPropertyError` needs the field's *inner* type, not the record: the
-synthesized requirement record `{foo: res}` has no `Prov` entry, but `res` (its
-field type) was minted at the member site. `RecordType.Field(Name)` already
-exists (used in `constrain.go`), so `blameOperands` returns that inner var.
+The asymmetry is deliberate:
 
-**Step 2 — resolve operands to nodes.** `stampBlame` runs in
-`(*checker).constrain` before each error is accumulated:
+- **`CannotConstrainError` — `prov` + `site` (the only M2.5-reachable `site`).** LHS
+  is the "actual" value and now resolves in the common cases: a literal (`"hi" <:
+  number` ⇒ the `"hi"`, recorded at `inferLiteral`) **and a function** (`val x:
+  number = fn () => 1` ⇒ `FuncType <: number` via the fall-through,
+  [constrain.go:160](../../internal/solver/constrain.go), blames the function
+  expression now that `inferFunc` records the `FuncType`). `site` survives here for a
+  reason that *doesn't* apply to `FuncArity`: **neither operand is a type synthesized
+  at the constraint node** — the actual value comes from wherever it was inferred and
+  the requirement is usually a real recorded annotation — so when the actual-value
+  operand is unrecorded there is nothing built-at-`n` to resolve to. In M2.5 the one
+  reachable such operand is **`Void`** (a function/block that yields no value; minted
+  at [infer_expr.go:120](../../internal/solver/infer_expr.go) /
+  [infer_stmt.go](../../internal/solver/infer_stmt.go), never recorded):
+  `val f = fn (): number => {}` ⇒ `Void <: number` blames the function, and
+  `val x: number = f()` for a void-returning `f` ⇒ `Void <: number` blames the `f()`
+  call — `site` is the right answer in both (pointing at the *use* beats pointing at
+  the far-away void source), and the only available one. (M3+ adds synthesized
+  operands — coalesced/extruded — as a second such source. Prelude/operator types are
+  *not* a source: operators aren't walked in M2, and any named binding is recorded by
+  `inferIdent`.) `site` (the walk's record of "this constraint arose at this source
+  node") is the only honest fallback. (A bare type *var* is never an operand: the var
+  cases at [constrain.go:134-158](../../internal/solver/constrain.go) decompose it to
+  its concrete bounds before any error fires, and `extrude` doesn't run in M2.5 —
+  levels are flat.) RHS is the expected-source → related.
+- **`TupleLengthMismatchError` — `prov` only, no `site`.** Both operands are
+  `TupleType`s, and in M2.5 every `TupleType` comes from `inferTuple` (recorded
+  `TupleElem`) — so `LHS` (the tuple literal) resolves and `RHS` is the related
+  expected-source; like `MissingProperty`/`FuncArity` it resolves a recorded operand
+  and needs no `site`. **Caveat: the kind can't actually fire in M2.5** — a
+  `tuple <: tuple` constraint needs a tuple *sink*, and `resolveTypeAnn` has no tuple
+  case ([type_ann.go](../../internal/solver/type_ann.go) handles only the prims), so
+  no tuple annotation/param exists yet. It becomes reachable at M4 with tuple
+  annotations; recording those (the same aggregate discipline as `inferTuple`) keeps
+  `RHS` resolvable then too, so `site` is never needed.
+- **`MissingPropertyError` — `prov` only, no `site`.** The field's *inner* var
+  (`RHS.Field(Name)`) was minted at `inferMember` (`MemberAccess`) → blames the
+  **member's prop**, not the receiver — and it is **always recorded**, so the kind
+  needs no `site`; in the unreachable miss it degrades to the receiver (`LHS`).
+  `RecordType.Field(Name)` already exists (used in `constrain.go`).
+- **`FuncArityMismatchError` — `prov` only, no `site`.** The subject is the **RHS
+  call-shape** `FuncType{args, res}`, which `inferCall` records (`CallShape`) against
+  the `CallExpr` — a fresh, unique pointer per call, so it always resolves precisely
+  to the call (the right place to point an arity error). That makes the kind
+  structurally identical to `MissingPropertyError`: it resolves a requirement-derived
+  operand via `prov` and needs no `site`. `Related()` follows the callee (`LHS`), now
+  recorded by `inferFunc`, to add a "function defined here" span. (For a *named*
+  callee that `FuncType` is shared, so last-write-wins, §3.8, may resolve it to the
+  reference rather than the definition until M3; for an inline callee it is exact.)
+
+**Step 2 — resolve lazily.** Two stateless free helpers (not storage — they take
+everything as arguments) do the lookups; each kind's methods call them with its own
+fields:
+
+```go
+// spanOf follows op's provenance to its AST node's span, falling back to the
+// constraint site when op has no entry. In M3+, NodeFor chases interior Origin
+// edges to the nearest AST leaf; in M2.5 it is a single lookup.
+func spanOf(p Provenance, op soltype.Type, site ast.Node) ast.Span {
+	if n, ok := p.NodeFor(op); ok {
+		return n.Span()
+	}
+	return site.Span()
+}
+
+// relatedOf resolves each operand that has an entry to a related span and drops
+// the ones that don't (no fallback — a missing related node is simply omitted),
+// deduped by span (§3.6).
+func relatedOf(p Provenance, ops ...soltype.Type) []ast.Span {
+	var spans []ast.Span
+	for _, op := range ops {
+		if n, ok := p.NodeFor(op); ok {
+			spans = appendUnique(spans, n.Span())
+		}
+	}
+	return spans
+}
+
+func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.LHS, e.site) }
+func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *TupleLengthMismatchError) Span() ast.Span {
+	if n, ok := e.prov.NodeFor(e.LHS); ok { // the tuple literal
+		return n.Span()
+	}
+	if n, ok := e.prov.NodeFor(e.RHS); ok { // degrade → the other tuple
+		return n.Span()
+	}
+	return ast.Span{}
+}
+func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *FuncArityMismatchError) Span() ast.Span {
+	if n, ok := e.prov.NodeFor(e.RHS); ok { // the call-shape → the CallExpr
+		return n.Span()
+	}
+	if n, ok := e.prov.NodeFor(e.LHS); ok { // degrade → the callee function
+		return n.Span()
+	}
+	return ast.Span{}
+}
+func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the fn
+
+func (e *MissingPropertyError) Span() ast.Span {
+	if f, ok := e.RHS.Field(e.Name); ok { // the field's inner var → the .foo member
+		if n, ok := e.prov.NodeFor(f); ok {
+			return n.Span()
+		}
+	}
+	if n, ok := e.prov.NodeFor(e.LHS); ok { // unreachable in practice → the receiver
+		return n.Span()
+	}
+	return ast.Span{}
+}
+func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the receiver
+```
+
+**The hand-off.** `(*checker).constrain` no longer stamps or resolves anything; a
+small type switch assigns each kind its own fields, then accumulates. The
+assignment is per-struct and explicit — no shared embed, no generic setter. Bridge
+errors fall through untouched:
 
 ```go
 func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 	for _, e := range c.ctx.Constrain(lhs, rhs) {
-		c.stampBlame(n, e)
+		switch err := e.(type) {
+		case *CannotConstrainError:
+			err.prov, err.site = c.prov, n // the only kind that still needs site
+		case *TupleLengthMismatchError:
+			err.prov = c.prov
+		case *MissingPropertyError:
+			err.prov = c.prov
+		case *FuncArityMismatchError:
+			err.prov = c.prov
+		}
 		c.errs = append(c.errs, e)
 	}
 }
-
-// stampBlame injects the narrowest contributing AST node into a constraint error.
-// Bridge errors aren't blamable (they self-blame from their own node), so they
-// pass through untouched. For a blamable error, resolve each type operand to its
-// FromAST node via Prov: the first hit is the primary blame node, the rest become
-// related nodes. Fall back to n when no operand resolves (a synthesized/shared
-// operand with no Prov entry) — no worse than M2's umbrella.
-func (c *checker) stampBlame(n ast.Node, e SolverError) {
-	b, ok := e.(blamable)
-	if !ok {
-		return // bridge error: span already node-derived
-	}
-	var primary ast.Node
-	var related []ast.Node
-	for _, op := range b.blameOperands() {
-		o, ok := c.prov[op].(FromAST)
-		if !ok {
-			continue
-		}
-		if primary == nil {
-			primary = o.Node
-		} else {
-			related = append(related, o.Node)
-		}
-	}
-	if primary == nil {
-		primary = n // honest fallback — same node M2 would have stamped
-	}
-	b.setBlame(primary, related...)
-}
 ```
+
+The engine's construction sites in `constrain.go` are **unchanged** — they still
+mint `&CannotConstrainError{LHS, RHS}` with the new fields zero; the switch fills
+them after `Constrain` returns, so `constrain`/`coalesce` never touch `Prov` (§3.9).
 
 Because `constrain` decomposes structurally to **leaf** operands before failing
 (a prim/lit/missing-field mismatch fires on the atoms, not the enclosing
-aggregate), the operands handed to `blameOperands` are already narrow — there is
-no span-size comparison to do. The umbrella problem was *only* that M2 ignored
-the operands and stamped `n`; consulting `Prov` on the leaves fixes it directly.
+aggregate), the operands each method follows are already narrow — there is no
+span-size comparison to do. The umbrella problem was *only* that M2 ignored the
+operands and used `n`; following `Prov` from the leaves in the methods fixes it
+directly, and an unresolved operand falls back to exactly that umbrella `site` —
+no regression.
 
 ### 3.6 Multi-span (related) errors
 
 `Related()` is already wired by §3.4 — there is no separate span-list type to
 build. The two sources of related nodes:
 
-- **Constraint errors:** `stampBlame` (§3.5) collects every *additional* operand
-  that resolves through `Prov` as a related node — e.g. for
-  `val x: number = "hi"`, primary = the `"hi"` literal, related = the `number`
-  annotation. So a mismatch can point at **both** the actual-source and the
-  expected-source.
+- **Constraint errors:** each kind's `Related()` (§3.5) resolves its *additional*
+  operands through `Prov` (via `relatedOf`), dropping any that don't resolve —
+  e.g. for `val x: number = "hi"`, `Span()` → the `"hi"` literal, `Related()` →
+  the `number` annotation. So a mismatch can point at **both** the actual-source
+  and the expected-source.
 - **Bridge errors:** the two redeclaration kinds carry `Previous` (the kept
   first declaration); `Related()` returns its span — "previously declared here."
 
@@ -521,7 +666,7 @@ framings:
 - **Defer it.** If the team would rather keep M2.5 strictly provenance-only,
   drop the `val x: number = "hi"` fixture and ground the golden set entirely in
   constraints M2 already emits (call-arg mismatch, member missing-property,
-  tuple-length — §3.10 marks which are which). The provenance design is unchanged
+  call-arity — §3.10 marks which are which). The provenance design is unchanged
   either way.
 
 Resolve this in review before PR-3 (§5). The plan assumes **include**.
@@ -529,14 +674,31 @@ Resolve this in review before PR-3 (§5). The plan assumes **include**.
 ### 3.8 Honest limitation — the leaf/interior split
 
 Leaf-only blame is precise whenever an operand traces directly to a
-literal/param/field/member. It is **imprecise** in two cases, both of which fall
-back to `n` (no regression vs. M2):
+literal/param/field/member/**annotation atom** — the fresh-atom discipline (§3.3)
+now records annotation prims too, so a shared `number` is no longer a blind spot.
+It is **imprecise** in three cases (no regression vs. M2 in any):
 
-1. **Synthesized operands.** A coalesced upper-bound, a propagated bound, or a
-   multi-branch join has no single AST node. Chasing its blame needs the interior
-   edges (`FromBoundPropagation`/`FromCoalesce`) — deferred to M3+. M2.5 records
-   no entry, so `stampBlame` falls back.
-2. **Shared monomorphic bindings (`inferIdent`).** M2 returns `b.Type` directly
+1. **`Void` results.** `Void` (a function/block that yields no value) is minted at
+   [infer_expr.go:120](../../internal/solver/infer_expr.go) /
+   [infer_stmt.go](../../internal/solver/infer_stmt.go) without an AST node and is
+   never recorded, so when it is the *subject* of the one M2.5 `site`-carrying kind
+   (`CannotConstrainError`) it falls back to `site` — `val f = fn (): number => {}`
+   and `val x: number = f()` (void-returning `f`) both blame the use via `site`. This
+   is the only reachable unrecorded subject in M2.5: prelude/operator types aren't a
+   source (operators aren't walked, and named bindings are recorded by `inferIdent`).
+   (Directly-inferred source aggregates — literals, tuples, objects, **functions**
+   (`FuncInference`), and the **call-shape** (`CallShape`) — are all recorded, so they
+   are no longer blind spots; recording the `FuncType` and the call-shape is what let
+   `CannotConstrain`'s `val x: number = fn …` case and `FuncArity` resolve through
+   `Prov` instead of `site`.)
+2. **Synthesized operands (M3+ only — does not arise in M2.5).** A coalesced
+   upper-bound, a propagated bound, or a multi-branch join has no single AST node;
+   chasing its blame needs the interior edges
+   (`FromBoundPropagation`/`FromCoalesce`), deferred to M3+. These don't occur as
+   constraint operands in M2.5 — `extrude` never runs (flat levels) and `coalesce`
+   is display-only — so this is a forward-looking note; when they arrive, a
+   `site`-carrying kind falls back to its `site`.
+3. **Shared monomorphic bindings (`inferIdent`).** M2 returns `b.Type` directly
    — the *same* pointer for every use of a name (no `instantiate` until M3). A
    `Prov[b.Type]` entry is therefore **per-shape, not per-occurrence**: the last
    `inferIdent` to record wins, and the recorded node may be a different use than
@@ -559,12 +721,14 @@ the milestones that make them deep.
 The hot `constrain` ([constrain.go](../../internal/solver/constrain.go)) and
 `coalesce` ([coalesce.go](../../internal/solver/coalesce.go)) loops must **never**
 consult `Prov`. It is written only in the walk (`recordProv`) and read only on
-the error path (`stampBlame`) and by future LSP/diagnostic consumers, so the
-map-lookup cost stays off the inference critical path. This is structurally
-guaranteed: `Prov` lives on the `checker` carrier (the walk), not on `Context`
-(the engine), so `constrain`/`coalesce` have no handle to it. A package-boundary
-note in the PR records the invariant; no runtime check is needed because the
-engine literally cannot reach the table.
+the diagnostic path (the constraint errors' own `Span()`/`Related()`) and by
+future LSP/diagnostic consumers, so the map-lookup cost stays off the inference
+critical path. This is structurally guaranteed for the engine: `Prov` lives on
+the `checker` carrier (the walk), not on `Context`, and each error's `prov` field
+is assigned by the type switch in `(*checker).constrain` *after* `Context.Constrain`
+returns, so `constrain`/`coalesce` mint errors with that field zero and never reach
+the table. A package-boundary note in the PR records the invariant; no runtime
+check is needed because the engine literally cannot reach `Prov`.
 
 ### 3.10 Test/fixture harness for spans
 
@@ -584,10 +748,18 @@ The golden set (each grounded in a constraint M2.5 actually emits):
 | Fixture | Constraint source | Primary blame | Related |
 |---------|-------------------|---------------|---------|
 | `val x: number = "hi"` | §3.7 val-annotation check; `CannotConstrainError` LHS `"hi"` | the `"hi"` literal | the `number` annotation |
-| `f("hi")` where `f: fn(x: number) -> number` | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | — |
-| a record field-value mismatch fed to an annotated/param sink | object field value origin | the offending **field value** | the field annotation |
-| `[1, "a"]` against a `[number, number]` sink (length/elem) | `inferTuple` element / `TupleLengthMismatchError` | the **tuple literal** (length) or offending element (elem) | — |
+| `f("hi")` where `f` has a `number` param | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | — |
+| `f(1, 2)` where `f` takes one param | `inferCall`; `FuncArityMismatchError` (RHS call-shape) | the **call** `f(1, 2)` | the function `f` |
 | `recv.foo` where `recv` lacks `foo` | `inferMember`; `MissingPropertyError` | the **member's prop** (`.foo`), not the receiver | the receiver |
+
+**Deferred to M4 (not yet reachable):** record field-value mismatches and
+tuple-length/element mismatches need a record/tuple *sink* (annotation or param) to
+produce a `record <: record` or `tuple <: tuple` constraint, and `resolveTypeAnn`
+supports only the prims ([type_ann.go](../../internal/solver/type_ann.go)) — so the
+`MissingProperty`-via-annotation, field-value, and `TupleLengthMismatchError`
+fixtures land when those annotations do. Their blame is already wired (§3.5); only
+the triggering constraint is missing. (M2.5's reachable `MissingPropertyError` comes
+from member access, the `recv.foo` row above, not from a record annotation.)
 
 Plus **bridge-error span fixtures** (self-blaming, no `Prov`): an unknown
 identifier blames the ident; a duplicate `val x` blames the second decl with the
@@ -620,8 +792,8 @@ golden fixtures + the §3.7 `val`-annotation enabler (PR-3) come last.
            └───────────┬─────────────┘
                        ▼
             ┌────────────────────────┐
-            │ PR-2 per-operand blame │   stampBlame: blameOperands × Prov,
-            │ (stampBlame via Prov)  │   inject nodes, fallback n
+            │ PR-2 per-operand blame │   per-kind Span()/Related() resolve
+            │ (Span/Related via Prov)│   operands via Prov, fallback site
             └───────────┬────────────┘
                         ▼
             ┌────────────────────────┐
@@ -631,10 +803,12 @@ golden fixtures + the §3.7 `val`-annotation enabler (PR-3) come last.
 ```
 
 PR-A reshapes the errors to node-carrying and keeps blame precision identical to
-M2 (constraint errors stamped with the umbrella node `n` via `setBlame(n)`).
-PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
-`setBlame(n)` for the Prov-resolving `stampBlame`. PR-3 adds fixtures and decides
-§3.7.
+M2 (every constraint kind carries a `site` and `Span()` returns it; the constrain
+switch sets only `site`). PR-1 adds the inert `Prov` table. PR-2 is then small: it
+adds the `prov` field to the resolving kinds, adds the `spanOf`/`relatedOf` helpers,
+rewrites each kind's `Span()`/`Related()` to follow operands through `Prov` first,
+and drops `site` from the kinds that no longer need it (`MissingPropertyError`).
+PR-3 adds fixtures and decides §3.7.
 
 ## 5. PR breakdown
 
@@ -651,10 +825,14 @@ PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
     `UnsupportedNodeError`; add `UnsupportedFeatureError`. Verify the
     `Duplicate`/`Overload` decl-name accessor; retain `Name` there only if
     needed (§7).
-  - Constraint kinds: embed `blameNodes`; implement `blamable`
-    (`blameOperands` + `setBlame`). `Span()` from the injected primary node.
-- `infer.go`: `(*checker).constrain` stamps via `setBlame(n)` — the umbrella
-  node, now node-based (precision unchanged from M2; `Prov` wiring is PR-2).
+  - Constraint kinds: give **each** kind its own `site ast.Node` field, a `Span()`
+    returning `site.Span()`, and a `Related()` returning `nil` (no `prov` field
+    yet — added in PR-2). No shared embed. (PR-2 later drops `site` from
+    `MissingProperty` and `FuncArity` once they resolve a recorded operand via
+    `Prov`; PR-A keeps it on all four for uniform M2-precision spans.)
+- `infer.go`: `(*checker).constrain` sets `err.site = n` in a per-kind type switch
+  over the four constraint kinds — the span source, now node-based (precision
+  unchanged from M2; `Prov` wiring is PR-2).
 - `infer_expr.go` / `infer_stmt.go` / `infer_decl.go` / `module.go`: update every
   bridge-error construction site to pass the node(s); `reportUnsupported` passes
   `ast.Node`; add a `reportUnsupportedFeature` for the OptionalChain-style cases;
@@ -664,39 +842,51 @@ PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
   expected node span, and that `Duplicate`/`Overload` expose the prior decl via
   `Related()`.
 - **Exit:** every error's `Span()` is node-derived; bridge errors self-blame;
-  constraint errors are stamped with the umbrella node. Pure refactor — **no
-  blame-precision change** (that's PR-2).
+  each constraint kind carries its own `site` and resolves `Span()` from it. Pure
+  refactor — **no blame-precision change** (that's PR-2).
 
 ### PR-1 — `Prov` table + population at construction sites  (~120 LoC)
 *(independent of PR-A; parallel)*
 - `prov.go`: `Prov`, `Origin`, `FromAST`, `ASTOriginKind` (+ its constants),
   `recordProv` (§3.2–3.3).
 - `infer.go`: add `prov Prov` to the `checker` carrier; init in `newChecker`.
-- `infer_expr.go`: one `recordProv` call at each of the 7 sites
-  (`inferLiteral`, `inferFunc` param, `inferCall`, `inferTuple`, `inferObject`,
-  `inferMember`, `inferIdent`) per the §3.3 table.
+- `infer_expr.go` / `type_ann.go`: one `recordProv` call at each of the 10 sites
+  (`inferLiteral`, `inferFunc` param, `inferFunc` type, `inferCall` result,
+  `inferCall` shape, `inferTuple`, `inferObject`, `inferMember`, `inferIdent`,
+  `resolveTypeAnn`) per the §3.3 table. `inferFunc` records the returned `FuncType`
+  and `inferCall` records the synthesized call-shape `FuncType{args, res}` (both
+  parallel to `inferTuple`/`inferObject`); `resolveTypeAnn` already mints a fresh
+  `PrimType` per annotation (the fresh-atom discipline). All are added recording
+  lines, no minting change.
 - `prov_test.go`: after inferring a snippet, assert each minted type has the
   expected `FromAST{Node, Kind}` (literal → its `LiteralExpr`/`LiteralInference`;
   call result → the `CallExpr`/`Application`; member result → the
-  `MemberExpr`/`MemberAccess`; tuple/object → their literal nodes). Assert the
-  honest **absences**: a shared atom / synthesized coalesced type has no entry.
+  `MemberExpr`/`MemberAccess`; tuple/object → their literal nodes; annotation prim
+  → its `TypeAnn`/`AnnotationType`). Assert the honest **absence**: a synthesized
+  coalesced type has no entry.
 - **Exit:** the table is populated at every M2 construction site; no reader yet,
   so behavior is unchanged (the table is inert). Perf invariant noted (§3.9):
   `Context` has no handle to `Prov`.
 
 ### PR-2 — Per-operand blame via `Prov`  (~80 LoC)
 *(depends on PR-A + PR-1)*
-- `errors.go`: implement `blameOperands()` on the four constraint kinds per the
-  §3.5 table (the `blamable` interface and `setBlame` already exist from PR-A;
-  this fills in *which* operands to resolve).
-- `infer.go`: replace PR-A's umbrella `setBlame(n)` with `stampBlame` (§3.5) —
-  resolve each operand through `Prov`, primary + related nodes, fallback `n`.
-- Tests: unit-level `stampBlame` cases over hand-built errors + a seeded `Prov`
-  (operand resolves → its node; no operand resolves → fallback `n`; two operands
-  resolve → primary + one related). Confirm bridge errors (not `blamable`) pass
-  through untouched.
+- `errors.go`: add the `Provenance` interface + `Prov.NodeFor`; add a `prov` field
+  to all four constraint kinds and **drop** `site` from `Tuple`, `MissingProperty`,
+  *and* `FuncArity` (each resolves a recorded operand — the tuple literal / the field
+  var / the call-shape — so none needs a fallback node); add the `spanOf` /
+  `relatedOf` helpers; rewrite each kind's `Span()`/`Related()` per the §3.5 table
+  (`Span()` the subject, `Related()` the rest), falling back to `site` only on the one
+  kind that keeps it (`CannotConstrainError`).
+- `infer.go`: extend PR-A's per-kind switch to set `err.prov = c.prov` on all four
+  kinds, and stop setting `err.site` for the three that dropped it (only
+  `CannotConstrainError` still gets `err.site = n`) — §3.5. Still just field
+  assignment, no resolution here.
+- Tests: unit-level `Span()`/`Related()` cases over hand-built errors + a seeded
+  `Prov` (operand resolves → its node; no operand resolves → fallback `site`; two
+  operands resolve → subject span + one related). Confirm bridge errors are
+  untouched by the switch.
 - **Exit:** constraint errors point at the narrowest contributing node;
-  synthesized/shared operands fall back to `n` (no regression); multi-span
+  synthesized operands fall back to `site` (no regression); multi-span
   related populated.
 
 ### PR-3 — Golden span fixtures + `val`-annotation enabler  (~60 LoC + tests)
@@ -747,8 +937,10 @@ PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
   explicit decision gate; the table/blame design (PR-A/PR-1/PR-2) is independent
   of it and lands regardless.
 - **Perf regression from `Prov` lookups on the hot path.** *Mitigation:*
-  structurally impossible — `Prov` is on the carrier, not `Context`; the engine
-  has no handle (§3.9). No lookup appears in `constrain`/`coalesce`.
+  structurally impossible for the engine — `Prov` is on the carrier, not
+  `Context`, and an error's `Provenance` handle is bound *after* `Context.Constrain`
+  returns (§3.9), so `constrain`/`coalesce` never reach the table. The only lookups
+  are lazy, inside the errors' `Span()`/`Related()` on the diagnostic path.
 
 ## 7. Open questions to resolve during M2.5
 
@@ -756,9 +948,10 @@ PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
   cheaply exposes the canonical binding-key name, drop the string (carry only
   `Decl`/`Previous`); otherwise keep `Name` for the message. Decide in PR-A.
 - **Expose `Prov` from `InferModule`/`InferModules`? — lean: not yet.** The only
-  M2.5 reader is `stampBlame`, inside the same run, so the table can stay on the
-  carrier. Widen the return signature when the first *external* consumer (LSP
-  hover, M8 differential) needs it — that consumer can drive the exact shape.
+  M2.5 readers are the constraint errors' own `Span()`/`Related()`, inside the same
+  run, so the table can stay on the carrier. Widen the return signature when the
+  first *external* consumer (LSP hover, M8 differential) needs it — that consumer
+  can drive the exact shape.
   Revisit if M3's `FromInstantiation` work wants the table threaded out.
 - **`val`-annotation check: in or out (§3.7)? — recommended: in.** Decide in
   review before PR-3. "In" realizes the milestone's headline fixture for ~5 lines
@@ -771,30 +964,39 @@ PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
   *node*, not the kind, so kinds are forward-looking metadata.
 - **Related-node ordering/dedup.** When several operands resolve, is the related
   list ordered (expected-source first) and deduped (same node on both sides)?
-  *Lean:* dedup by span equality, append in `blameOperands` priority order;
-  pin it with a multi-operand `stampBlame` test in PR-2.
+  *Lean:* dedup by span equality (the `appendUnique` in `relatedOf`), append in
+  the method's operand order; pin it with a multi-operand `Related()` test in PR-2.
 
 ## 8. M2.5 exit checklist
 
 - [ ] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`
       leaf variant and `ASTOriginKind`; interior variants deferred to M3+.
-- [ ] `FromAST` populated at all seven M2 construction sites via `recordProv`
-      (literal, ident, param, call-result, tuple, object, member-result), with
-      the `inferIdent` last-write-wins limitation documented.
+- [ ] `FromAST` populated at all ten construction sites via `recordProv`
+      (literal, ident, param, function-type, call-result, call-shape, tuple,
+      object, member-result, annotation-prim), with the `inferIdent` last-write-wins
+      limitation documented.
+- [ ] Fresh-atom discipline: `resolveTypeAnn` mints a fresh `PrimType` per
+      annotation and records it (`AnnotationType`), so atoms are no blind spot.
 - [ ] `SolverError` reshaped: node-derived `Span()` + `Related()`; `setSpan` /
       `errSpan` removed.
 - [ ] Bridge errors carry `ast.Node` fields and self-blame; `UnsupportedNodeError`
       split into the node-kind form and `UnsupportedFeatureError`;
       `Duplicate`/`Overload` carry `Previous` and expose it via `Related()`.
-- [ ] Constraint errors embed `blameNodes` + implement `blamable`; `Prov` is
-      consulted only for these four kinds.
-- [ ] `(*checker).constrain` blame rewritten: per-operand `Prov` lookup
-      (`stampBlame`) injects the narrowest node; fallback to `n` when no operand
-      resolves.
-- [ ] `blameOperands()` implemented per constraint kind (the four M2 kinds).
-- [ ] Golden span fixtures assert exact spans: `"hi"`-literal blame, field-value
-      mismatch, tuple-length at the literal, missing-property at the member prop;
-      plus bridge-error spans (unknown ident, duplicate decl + related prior).
+- [ ] `Provenance` interface + `Prov.NodeFor`; **no shared embed** — each constraint
+      kind declares only the fields it needs (`prov` on all four, `site` only on
+      `CannotConstrainError`; see §3.5 table); `Prov` is consulted only by their own
+      `Span()`/`Related()`.
+- [ ] `(*checker).constrain` blame rewritten: a per-kind type switch assigns each
+      kind's own `prov` (and `site` for `CannotConstrainError` only); the error's
+      `Span()`/`Related()` do the per-operand `Prov` lookup, falling back to `site`
+      where present.
+- [ ] `Span()`/`Related()` implemented per constraint kind (the four M2 kinds),
+      each naming which operand is the subject vs. related (§3.5 table).
+- [ ] Golden span fixtures assert exact spans for the M2.5-reachable cases:
+      `"hi"`-literal blame, call-arg mismatch, call-arity at the call,
+      missing-property at the member prop; plus bridge-error spans (unknown ident,
+      duplicate decl + related prior). Record/tuple-sink fixtures deferred to M4
+      (§3.10).
 - [ ] Existing M2 error fixtures updated to assert the narrowest real spans.
 - [ ] Perf invariant honored: no `Prov` access in `constrain`/`coalesce` (the
       engine has no handle to the table).

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -45,12 +45,19 @@ Per the milestone, M2.5 delivers:
    sites are literal inference, ident resolution, param binding, application
    result var, tuple elements, object field values, and member-access result
    var (§3.3).
-3. **Per-operand blame at the error path** — replace the single umbrella stamp
-   with a lookup that maps each failed operand to its narrowest `FromAST` span
-   via `Prov`, falling back to `n` when an operand has no entry (§3.4).
-4. **Multi-span errors** — extend `errSpan` to carry a primary span plus
-   *related* spans, so a mismatch can point at **both** the expected-source and
-   the actual-source location (§3.5).
+3. **Errors carry AST nodes, not strings.** An audit of all eleven `SolverError`
+   kinds (§3.4) partitions them: *bridge* errors (born in the walk, with an
+   `ast.Node` in hand) hold that node directly and **self-blame**; *constraint*
+   errors (born in the AST-free engine) carry typed `soltype` operands and get
+   their AST node **injected** from `Prov`. `setSpan`/`errSpan` give way to
+   node-derived `Span()`/`Related()`.
+4. **Per-operand blame at the error path** — replace the single umbrella stamp
+   with a lookup that maps each failed constraint operand to its narrowest
+   `FromAST` node via `Prov`, falling back to `n` when an operand has no entry
+   (§3.5).
+5. **Multi-span (related) errors** — `Related()` exposes secondary contributing
+   nodes (the expected-source alongside the actual-source; the prior declaration
+   alongside the duplicate), node-derived rather than separately stamped (§3.6).
 
 ### Scope boundary against neighbouring milestones
 
@@ -71,7 +78,7 @@ Per the milestone, M2.5 delivers:
 - **No new lattice/inference behavior.** M2.5 changes *where errors point*, not
   *which constraints fire* or *what types infer*. The one small non-provenance
   addition it carries — the `val`-annotation subtype check needed to realize the
-  canonical `val x: number = "hi"` fixture — is called out explicitly in §3.6
+  canonical `val x: number = "hi"` fixture — is called out explicitly in §3.7
   and flagged as a judgment call, not smuggled in.
 - **Precedes M3.** The table and the `FromAST` discipline must exist *before*
   scheme instantiation introduces the first interior origin
@@ -79,34 +86,43 @@ Per the milestone, M2.5 delivers:
 
 ## 2. Current state this builds on
 
-The M2 surface M2.5 touches, with exact references:
+The M2 surface M2.5 touches, with exact references. The crucial structural fact —
+the one the §3.4 audit turns on — is **where each error is born**:
 
 - **`(*checker).constrain(n, lhs, rhs)`**
   ([infer.go:41](../../internal/solver/infer.go)) — the single chokepoint that
-  stamps spans. Every constraint error in the codebase flows through here. M2.5
-  rewrites its stamping loop (§3.4); nothing else calls `setSpan` on a
-  constraint error.
-- **`SolverError` carries typed operands.** Each constraint kind already holds
-  the `soltype.Type` values that failed
-  ([errors.go](../../internal/solver/errors.go)):
-  - `CannotConstrainError{ LHS, RHS soltype.Type }`
-  - `FuncArityMismatchError{ LHS, RHS *soltype.FuncType }`
-  - `TupleLengthMismatchError{ LHS, RHS *soltype.TupleType }`
-  - `MissingPropertyError{ LHS, RHS *soltype.RecordType; Name string }`
+  stamps spans. Every *constraint* error flows through here. M2.5 rewrites its
+  stamping (§3.5); nothing else stamps a constraint error.
+- **Two populations of errors.** The construction site decides what an error can
+  hold:
+  - **Constraint errors are born in `constrain.go`** — the engine, which sees
+    only `soltype.Type` and has **no `ast.Node`**. They already carry the typed
+    operands that failed
+    ([errors.go](../../internal/solver/errors.go)):
+    - `CannotConstrainError{ LHS, RHS soltype.Type }`
+    - `FuncArityMismatchError{ LHS, RHS *soltype.FuncType }`
+    - `TupleLengthMismatchError{ LHS, RHS *soltype.TupleType }`
+    - `MissingPropertyError{ LHS, RHS *soltype.RecordType; Name string }`
 
-  These typed references are exactly what per-operand blame needs — no message
-  scraping. They are minted span-free inside `constrain.go` (which has no AST
-  node in hand) and stamped later by `(*checker).constrain`.
+    These typed references are exactly what per-operand blame needs — no message
+    scraping — but they are span-free at birth and an AST node is **not**
+    available to them. That node must be supplied from the type→node index
+    (`Prov`).
+  - **Bridge errors are born in the walk** — `inferIdent`, `inferStmt`,
+    `inferVarDeclInit`, `module.go`, the `reportUnsupported` sites — each of
+    which **has the offending `ast.Node` in hand**. Today they flatten it into a
+    `Kind string` / `Name string` and then restamp a span via `setSpan`. That is
+    redundant: the node was right there. §3.4 has them hold the node instead.
 - **`errSpan` is the embeddable span carrier**
   ([errors.go:34–37](../../internal/solver/errors.go)): a single
-  `span ast.Span` with `Span()`/`setSpan`. Every error kind embeds it. M2.5
-  extends it with related spans (§3.5).
+  `span ast.Span` with `Span()`/`setSpan`. Every error kind embeds it today. M2.5
+  retires it in favor of node-derived spans (§3.4).
 - **The construction sites** that mint a type from a node, all in the M2 walk:
 
   | Site | Function | Minted type |
   |------|----------|-------------|
   | literal inference | `inferLiteral` ([infer_expr.go:16](../../internal/solver/infer_expr.go)) | `&soltype.LitType{...}` (fresh per literal) |
-  | ident resolution | `inferIdent` ([infer_expr.go:43](../../internal/solver/infer_expr.go)) | returns `b.Type` (shared binding — see §3.7) |
+  | ident resolution | `inferIdent` ([infer_expr.go:43](../../internal/solver/infer_expr.go)) | returns `b.Type` (shared binding — see §3.8) |
   | param binding | `inferFunc` ([infer_expr.go:92](../../internal/solver/infer_expr.go)) | `c.freshAt(lvl)` per un-annotated param |
   | application result var | `inferCall` ([infer_expr.go:159](../../internal/solver/infer_expr.go)) | `res := c.freshAt(lvl)` |
   | tuple elements | `inferTuple` ([infer_expr.go:179](../../internal/solver/infer_expr.go)) | `&soltype.TupleType{Elems}` |
@@ -121,7 +137,7 @@ The M2 surface M2.5 touches, with exact references:
 - **Test posture.** M2 tests assert error **messages** but not yet spans
   ([infer_test.go](../../internal/solver/infer_test.go), e.g. `require.Equal(t,
   "object is missing property: b", errs[0].Message())`). M2.5 adds **span**
-  assertions on top (§3.9) and is the first milestone to do so.
+  assertions on top (§3.10) and is the first milestone to do so.
 
 ## 3. Design
 
@@ -133,11 +149,15 @@ All M2.5 code lives in `internal/solver/` alongside the M2 walk. No new packages
 internal/solver/
   prov.go        # M2.5: Prov table, Origin/FromAST, ASTOriginKind, population helpers
   prov_test.go   # M2.5: unit tests for the table + population discipline
-  errors.go      # M2.5: extend errSpan with related spans; add operands() per kind
+  errors.go      # M2.5: reshape SolverError (node-derived Span/Related, drop setSpan);
+                 #       bridge errors carry ast.Node fields; split UnsupportedNodeError;
+                 #       constraint errors gain blameNodes + the blamable interface
   infer.go       # M2.5: rewrite (*checker).constrain stamping to per-operand blame;
                  #       carrier gains the prov field + recordProv helper
-  infer_expr.go  # M2.5: add prov population at the construction sites
-  infer_decl.go  # (no change beyond population already covered via infer_expr)
+  infer_expr.go  # M2.5: add prov population at the construction sites; pass nodes to bridge errors
+  infer_stmt.go  # M2.5: pass the offending Decl node to BodyDeclNotAllowedError
+  infer_decl.go  # M2.5: pass the VarDecl node to MissingInitializerError
+  module.go      # M2.5: pass Decl + Previous nodes to Duplicate/Overload errors
   *_test.go      # M2.5: span-assertion harness + golden span fixtures
 ```
 
@@ -176,7 +196,7 @@ type ASTOriginKind int
 
 const (
 	LiteralInference ASTOriginKind = iota // a LitType from inferLiteral
-	IdentRef                              // a value-binding ref from inferIdent (see §3.7 limitation)
+	IdentRef                              // a value-binding ref from inferIdent (see §3.8 limitation)
 	ParamBinding                          // a fresh param var from inferFunc
 	Application                           // a fresh call-result var from inferCall
 	TupleElem                             // a TupleType from inferTuple
@@ -253,7 +273,7 @@ Population per site (each is a single added line next to the existing mint +
 | `inferTuple` | `c.recordProv(t, e, TupleElem)` on the `TupleType` |
 | `inferObject` | `c.recordProv(t, e, ObjectField)` on the `RecordType` |
 | `inferMember` | `c.recordProv(res, e, MemberAccess)` on the fresh result var |
-| `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.7**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
+| `inferIdent` | `c.recordProv(b.Type, e, IdentRef)` — **but see §3.8**: `b.Type` is shared monomorphic, so this entry is last-write-wins and load-bearing only for the leaf-direct cases; per-use ident provenance is M3 (`FromInstantiation`). |
 
 Notes:
 
@@ -265,47 +285,142 @@ Notes:
   sourced from the annotation, not the param-as-binding. Record the
   `ParamBinding` origin only on the fresh-var branch; an annotated param's
   *annotation* type can carry its own origin if/when annotation provenance is
-  wired (a candidate related-span source — §3.5).
+  wired (a candidate related-node source — §3.6).
 - **The hot path stays untouched.** `recordProv` is called only in the walk
-  (construction), never in `constrain`/`coalesce` (§3.8).
+  (construction), never in `constrain`/`coalesce` (§3.9).
 
-### 3.4 Per-operand blame at the error path (`infer.go` + `errors.go`)
+### 3.4 Errors carry AST nodes, not strings
 
-Replace the umbrella stamp in `(*checker).constrain` with a per-error resolution
-that consults `Prov`.
+An audit of all eleven `SolverError` kinds against the §2 dividing line — **does
+the construction site have an `ast.Node` in hand?** — and the reshape it implies.
 
-**Step 1 — each error kind exposes its blame operands.** Add a method to the
-`SolverError` interface returning the typed operands whose provenance to consult,
-in priority order (most-specific "subject" first):
+**Constraint errors (engine-minted, AST-free).** They already carry the typed
+*operands* that failed; they **cannot** carry an AST node (`constrain.go` sees
+only `soltype.Type`). Their AST node is injected from `Prov` (§3.5). **No operand
+fields change.**
+
+| Kind | Carries (unchanged) | AST node from |
+|---|---|---|
+| `CannotConstrainError` | `LHS, RHS soltype.Type` | `Prov` (§3.5) |
+| `FuncArityMismatchError` | `LHS, RHS *soltype.FuncType` | `Prov` |
+| `TupleLengthMismatchError` | `LHS, RHS *soltype.TupleType` | `Prov` |
+| `MissingPropertyError` | `LHS, RHS *soltype.RecordType; Name string` | `Prov` |
+
+`MissingPropertyError.Name` **stays** — the absent field name isn't recoverable
+from a single node (the RHS may require several fields; `Name` says which is
+missing).
+
+**Bridge errors (walk-minted).** Today each flattens the node it already holds
+into a `Kind`/`Name` string and restamps a span. Replace the string with the
+node; derive message + span from it; drop the stamping.
+
+| Kind | Was | Now | Derived | Site |
+|---|---|---|---|---|
+| `UnknownIdentifierError` | `Name string` | `Ident *ast.IdentExpr` | name, span | `inferIdent` |
+| `NamespaceUsedAsValueError` | `Name string` | `Ident *ast.IdentExpr` | name, span | `inferIdent` |
+| `BodyDeclNotAllowedError` | `Kind string` | `Decl ast.Decl` | kind, span | `inferStmt` |
+| `MissingInitializerError` | `Name string` | `Decl *ast.VarDecl` | name, span | `inferVarDeclInit` |
+| `DuplicateDeclarationError` | `Name string` | `Decl, Previous ast.Decl` | name, span, **related** | `module.go` |
+| `OverloadNotSupportedError` | `Name string` | `Decl, Previous ast.Decl` | name, span, **related** | `module.go` |
+| `UnsupportedNodeError` | `Kind string` | `Node ast.Node` (+ split, below) | kind, span | many |
+
+- `Decl`/`Previous` on the two redeclaration kinds make the milestone's "related
+  span" a node field for free: `Previous` is `b.primary`
+  ([module.go](../../internal/solver/module.go)), the first decl the walk kept
+  ("previously declared here").
+- **`Name` derivation caveat.** The two redeclaration messages currently use the
+  resolved `key.Name()`, which may be a qualified binding-key name distinct from
+  the decl's local identifier. If the decl node doesn't cheaply expose the
+  canonical name, **retain a `Name string`** on those two kinds alongside the
+  nodes — the nodes drive span/navigation, the string drives the message. Verify
+  the decl name accessor in PR-A (§5) and keep `Name` only where needed (open
+  question, §7).
+
+**`UnsupportedNodeError` splits in two.** One string hides two distinct uses:
+
+1. *"this node kind isn't in the M2 subset"* — `astKind(node)`, fully
+   node-derivable ⇒ `UnsupportedNodeError{ Node ast.Node }` (kind = `astKind(Node)`,
+   span = `Node.Span()`). Verified: `Decl`/`Expr`/`Lit`/`ObjKey`/`Pat` all embed
+   `ast.Node`, so every kind-node the current callers pass has a `Span()`.
+2. *"the node is fine, this **feature** of it isn't"* — `inferMember` reports a
+   literal `"OptionalChain"`, which is **not** `astKind(MemberExpr)` ⇒ a new
+   `UnsupportedFeatureError{ Node ast.Node; Feature string }`. The nil-pattern
+   case in `inferFunc` (a possibly-nil `p.Pattern`) carries the enclosing
+   `*ast.Param` instead of the nil child, so the span is always non-nil.
+
+**Interface reshape.** Because every kind's primary span is now node-derived, the
+public interface drops `setSpan`/`errSpan` and exposes `Related()`:
 
 ```go
-// errors.go — extend the interface
 type SolverError interface {
 	isSolverError()
 	Message() string
-	Span() ast.Span
-	setSpan(ast.Span)
-	addRelated(ast.Span)        // NEW (§3.5)
-	blameOperands() []soltype.Type // NEW: leaf operands to resolve via Prov, priority order
+	Span() ast.Span        // ALWAYS derived from a primary ast.Node
+	Related() []ast.Span   // node-derived; empty unless the kind carries related nodes
 }
 ```
 
-Per kind:
+- **Bridge errors** implement `Span()` from their own node — `e.Ident.Span()`,
+  `e.Decl.Span()`, `e.Node.Span()` — complete at construction, no stamping.
+  `Related()` returns `nil` except the two redeclaration kinds
+  (`[]ast.Span{e.Previous.Span()}`). `Message()` derives from the node too
+  (e.g. `"Unknown identifier: " + e.Ident.Name`,
+  `"Declaration not allowed in function body: " + astKind(e.Decl)`).
+- **Constraint errors** get their AST node *injected* through a narrow internal
+  interface only they implement:
+
+  ```go
+  type blamable interface {
+  	blameOperands() []soltype.Type            // type operands to resolve via Prov (§3.5)
+  	setBlame(primary ast.Node, related ...ast.Node)
+  }
+  ```
+
+  They embed a small helper supplying `Span()`/`Related()`/`setBlame`:
+
+  ```go
+  type blameNodes struct {
+  	primary ast.Node   // set by setBlame before the error is surfaced
+  	related []ast.Node
+  }
+  func (b *blameNodes) Span() ast.Span    { return b.primary.Span() }
+  func (b *blameNodes) Related() []ast.Span { /* map each related node → its Span() */ }
+  func (b *blameNodes) setBlame(primary ast.Node, related ...ast.Node) {
+  	b.primary, b.related = primary, related
+  }
+  ```
+
+  `stampBlame` (§3.5) type-asserts to `blamable`; bridge errors aren't `blamable`,
+  so the error path skips them entirely — **they self-blame from their own node.**
+
+The upshot: `errSpan`/`setSpan` disappear, every `Span()` is some `ast.Node`'s
+span, and **`Prov` is consulted only for the four constraint kinds** — the bridge
+kinds never touch it. That narrows the table's reader set and is the cleaner
+blame story the audit buys.
+
+### 3.5 Per-operand blame at the error path (`infer.go` + `errors.go`)
+
+With the reshape in place, the umbrella stamp becomes a per-operand `Prov`
+resolution that injects **nodes** (not spans) into the blamable constraint errors.
+
+**Step 1 — each constraint kind exposes its blame operands.** `blameOperands()`
+returns the typed operands whose provenance to consult, in priority order
+(most-specific "subject" first):
 
 | Error | `blameOperands()` | Rationale |
 |-------|-------------------|-----------|
-| `CannotConstrainError` | `[LHS, RHS]` | the LHS is the "actual" value flowing into the RHS requirement (`"hi" <: number` ⇒ LHS `"hi"` is the offending literal); RHS is the expected-source → related span |
+| `CannotConstrainError` | `[LHS, RHS]` | the LHS is the "actual" value flowing into the RHS requirement (`"hi" <: number` ⇒ LHS `"hi"` is the offending literal); RHS is the expected-source → related node |
 | `FuncArityMismatchError` | `[LHS, RHS]` | the declared function (LHS, minted at `inferFunc`) vs. the synthesized call shape (RHS, usually no entry) |
 | `TupleLengthMismatchError` | `[LHS, RHS]` | the tuple literal (whichever side was minted at `inferTuple`) |
-| `MissingPropertyError` | `[RHS.Field(Name), LHS]` | the field's type var was minted at `inferMember` with `MemberAccess` origin → blames the **member's prop**, not the receiver; LHS receiver is the related span |
+| `MissingPropertyError` | `[RHS.Field(Name), LHS]` | the field's type var was minted at `inferMember` with `MemberAccess` origin → blames the **member's prop**, not the receiver; LHS receiver is the related node |
 
-`MissingPropertyError` is the one that needs the field's *inner* type, not the
-record itself: the synthesized requirement record `{foo: res}` has no `Prov`
-entry, but `res` (its field type) was minted at the member site. A small accessor
-`RecordType.Field(Name)` already exists (used in `constrain.go`), so
-`blameOperands` returns that inner var.
+`MissingPropertyError` needs the field's *inner* type, not the record: the
+synthesized requirement record `{foo: res}` has no `Prov` entry, but `res` (its
+field type) was minted at the member site. `RecordType.Field(Name)` already
+exists (used in `constrain.go`), so `blameOperands` returns that inner var.
 
-**Step 2 — resolve operands to spans.** The new stamping loop:
+**Step 2 — resolve operands to nodes.** `stampBlame` runs in
+`(*checker).constrain` before each error is accumulated:
 
 ```go
 func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
@@ -315,27 +430,34 @@ func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 	}
 }
 
-// stampBlame sets e's primary span to the narrowest contributing operand's
-// FromAST node, and attaches any other resolved operands as related spans.
-// Falls back to n.Span() when NO operand resolves (a synthesized/shared operand
-// with no Prov entry) — keeping such cases no worse than M2's umbrella stamp.
+// stampBlame injects the narrowest contributing AST node into a constraint error.
+// Bridge errors aren't blamable (they self-blame from their own node), so they
+// pass through untouched. For a blamable error, resolve each type operand to its
+// FromAST node via Prov: the first hit is the primary blame node, the rest become
+// related nodes. Fall back to n when no operand resolves (a synthesized/shared
+// operand with no Prov entry) — no worse than M2's umbrella.
 func (c *checker) stampBlame(n ast.Node, e SolverError) {
-	var primary *ast.Span
-	for _, op := range e.blameOperands() {
-		if o, ok := c.prov[op].(FromAST); ok {
-			if primary == nil {
-				s := o.Node.Span()
-				primary = &s
-			} else {
-				e.addRelated(o.Node.Span()) // expected-source / second contributor
-			}
+	b, ok := e.(blamable)
+	if !ok {
+		return // bridge error: span already node-derived
+	}
+	var primary ast.Node
+	var related []ast.Node
+	for _, op := range b.blameOperands() {
+		o, ok := c.prov[op].(FromAST)
+		if !ok {
+			continue
+		}
+		if primary == nil {
+			primary = o.Node
+		} else {
+			related = append(related, o.Node)
 		}
 	}
-	if primary != nil {
-		e.setSpan(*primary)
-	} else {
-		e.setSpan(n.Span()) // honest fallback — same as M2 today
+	if primary == nil {
+		primary = n // honest fallback — same node M2 would have stamped
 	}
+	b.setBlame(primary, related...)
 }
 ```
 
@@ -345,35 +467,26 @@ aggregate), the operands handed to `blameOperands` are already narrow — there 
 no span-size comparison to do. The umbrella problem was *only* that M2 ignored
 the operands and stamped `n`; consulting `Prov` on the leaves fixes it directly.
 
-### 3.5 Multi-span errors (`errors.go`)
+### 3.6 Multi-span (related) errors
 
-Extend the shared `errSpan` carrier so any error can point at a primary span plus
-related contributors:
+`Related()` is already wired by §3.4 — there is no separate span-list type to
+build. The two sources of related nodes:
 
-```go
-// errSpan carries the primary blame span plus zero or more related spans (e.g.
-// the annotation/expected-source location alongside the offending literal).
-type errSpan struct {
-	span    ast.Span
-	related []ast.Span
-}
+- **Constraint errors:** `stampBlame` (§3.5) collects every *additional* operand
+  that resolves through `Prov` as a related node — e.g. for
+  `val x: number = "hi"`, primary = the `"hi"` literal, related = the `number`
+  annotation. So a mismatch can point at **both** the actual-source and the
+  expected-source.
+- **Bridge errors:** the two redeclaration kinds carry `Previous` (the kept
+  first declaration); `Related()` returns its span — "previously declared here."
 
-func (e *errSpan) Span() ast.Span      { return e.span }
-func (e *errSpan) setSpan(s ast.Span)  { e.span = s }
-func (e *errSpan) Related() []ast.Span { return e.related }
-func (e *errSpan) addRelated(s ast.Span) {
-	e.related = append(e.related, s)
-}
-```
+Downstream rendering (CLI diagnostics, LSP) can show related spans as "expected
+here" / "originates here" / "previously declared here" annotations; M2.5 only
+needs them *recorded* and *assertable* — rich rendering is consumer work that
+lands when the CLI is wired (M8+). Ordering/dedup of the related list is an open
+question (§7).
 
-This is additive — every existing kind embeds `errSpan`, so they all gain
-`Related()`/`addRelated` for free, and existing single-span assertions keep
-working (`related` is empty unless populated). Downstream rendering (CLI
-diagnostics, LSP) can show the related spans as "expected here" / "originates
-here" annotations; M2.5 only needs them *recorded* and *assertable* — rich
-rendering is consumer work that lands when the CLI is wired (M8+).
-
-### 3.6 The one non-provenance addition: `val`-annotation checking
+### 3.7 The one non-provenance addition: `val`-annotation checking
 
 The milestone's first acceptance example — `val x: number = "hi"` blames the
 `"hi"` literal — requires a constraint that **M2 does not currently emit**:
@@ -387,7 +500,8 @@ M2.5 adds the minimal check so the canonical fixture is real:
 ```go
 // inferVarDeclInit (sketch) — constrain the initializer against the annotation
 // when present, so val x: number = "hi" produces a CannotConstrainError whose
-// LHS ("hi" literal) carries a LiteralInference origin → precise blame.
+// LHS ("hi" literal) carries a LiteralInference origin → precise blame, with the
+// annotation as the related node.
 initT := c.inferExpr(scope, lvl, d.Init)
 if d.TypeAnn != nil {
 	annT := c.resolveTypeAnn(d.TypeAnn)
@@ -407,12 +521,12 @@ framings:
 - **Defer it.** If the team would rather keep M2.5 strictly provenance-only,
   drop the `val x: number = "hi"` fixture and ground the golden set entirely in
   constraints M2 already emits (call-arg mismatch, member missing-property,
-  tuple-length — §3.9 marks which are which). The provenance design is unchanged
+  tuple-length — §3.10 marks which are which). The provenance design is unchanged
   either way.
 
 Resolve this in review before PR-3 (§5). The plan assumes **include**.
 
-### 3.7 Honest limitation — the leaf/interior split
+### 3.8 Honest limitation — the leaf/interior split
 
 Leaf-only blame is precise whenever an operand traces directly to a
 literal/param/field/member. It is **imprecise** in two cases, both of which fall
@@ -429,7 +543,7 @@ back to `n` (no regression vs. M2):
    the one in the failing constraint. So an `x`-flows-into-mismatch error
    (`val y: number = x` where `x: string`) cannot reliably blame *this* `x` use
    in M2.5; it blames the initializer node `n` (the fallback) or, with annotation
-   checking from §3.6, the initializer expression — already an improvement over
+   checking from §3.7, the initializer expression — already an improvement over
    the whole-decl umbrella. **Per-use ident blame arrives with M3's
    `FromInstantiation`** (each use gets a fresh instance with its own origin),
    exactly as the milestone sequences it. The `IdentRef` population is wired now
@@ -440,7 +554,7 @@ This split is *why* the milestone scopes M2.5 to leaves: the precise-span wins
 land where operands are node-local atoms, and the interior chains are deferred to
 the milestones that make them deep.
 
-### 3.8 Perf invariant
+### 3.9 Perf invariant
 
 The hot `constrain` ([constrain.go](../../internal/solver/constrain.go)) and
 `coalesce` ([coalesce.go](../../internal/solver/coalesce.go)) loops must **never**
@@ -452,7 +566,7 @@ guaranteed: `Prov` lives on the `checker` carrier (the walk), not on `Context`
 note in the PR records the invariant; no runtime check is needed because the
 engine literally cannot reach the table.
 
-### 3.9 Test/fixture harness for spans
+### 3.10 Test/fixture harness for spans
 
 M2's harness ([infer_test.go](../../internal/solver/infer_test.go)) returns
 `[]SolverError` and asserts `Message()`. M2.5 extends the assertions to spans.
@@ -469,57 +583,92 @@ The golden set (each grounded in a constraint M2.5 actually emits):
 
 | Fixture | Constraint source | Primary blame | Related |
 |---------|-------------------|---------------|---------|
-| `val x: number = "hi"` | §3.6 val-annotation check; `CannotConstrainError` LHS `"hi"` | the `"hi"` literal | the `number` annotation |
+| `val x: number = "hi"` | §3.7 val-annotation check; `CannotConstrainError` LHS `"hi"` | the `"hi"` literal | the `number` annotation |
 | `f("hi")` where `f: fn(x: number) -> number` | `inferCall` contravariant arg; `CannotConstrainError` LHS `"hi"` | the `"hi"` argument | — |
 | a record field-value mismatch fed to an annotated/param sink | object field value origin | the offending **field value** | the field annotation |
 | `[1, "a"]` against a `[number, number]` sink (length/elem) | `inferTuple` element / `TupleLengthMismatchError` | the **tuple literal** (length) or offending element (elem) | — |
 | `recv.foo` where `recv` lacks `foo` | `inferMember`; `MissingPropertyError` | the **member's prop** (`.foo`), not the receiver | the receiver |
 
-Plus: **existing M2 error fixtures that assert spans are updated to the narrowest
-real spans** (the milestone's "Existing M2 error fixtures … updated" clause). M2
-currently asserts only messages, so this is mostly *adding* span assertions; any
-test that already pinned an umbrella span flips to the narrow one.
+Plus **bridge-error span fixtures** (self-blaming, no `Prov`): an unknown
+identifier blames the ident; a duplicate `val x` blames the second decl with the
+first as a related span; an unsupported node blames that node; an
+`UnsupportedFeatureError` (`recv?.foo`) blames the member.
+
+Plus: **existing M2 error fixtures that assert messages gain span assertions** at
+the narrowest real spans (the milestone's "Existing M2 error fixtures … updated"
+clause). M2 currently asserts only messages, so this is mostly *adding* span
+assertions.
 
 Assertions use `testify/require` and full messages (CLAUDE.md); for multi-span
 cases prefer a single rendered-string assertion over field-by-field drilling.
 
 ## 4. Sequencing
 
-Three PRs, each one reviewable concern, ordered by hard dependency. The table +
-population (PR-1) is inert until the error path consumes it (PR-2); the
-golden fixtures + the §3.6 val-annotation enabler (PR-3) come last.
+Four PRs. The error-node reshape (PR-A) and the `Prov` table (PR-1) are
+independent and can land in parallel; per-operand blame (PR-2) needs both; the
+golden fixtures + the §3.7 `val`-annotation enabler (PR-3) come last.
 
 ```text
         M2 shipped: walk + Info + SolverError(LHS/RHS) + errSpan(single span)
                         │
+            ┌───────────┴───────────┐
+            ▼                       ▼
+   ┌──────────────────┐   ┌───────────────────────┐
+   │ PR-A error-node  │   │ PR-1 Prov table +     │   (PR-A ∥ PR-1:
+   │ reshape + iface  │   │ population (inert)    │    independent)
+   └───────┬──────────┘   └──────────┬────────────┘
+           └───────────┬─────────────┘
+                       ▼
+            ┌────────────────────────┐
+            │ PR-2 per-operand blame │   stampBlame: blameOperands × Prov,
+            │ (stampBlame via Prov)  │   inject nodes, fallback n
+            └───────────┬────────────┘
                         ▼
-        ┌────────────────────────────────┐
-        │ PR-1  Prov table + population   │  prov.go: Prov/Origin/FromAST/ASTOriginKind,
-        │       (inert — no reader yet)   │  recordProv; wire the 7 sites; carrier.prov
-        └───────────────┬────────────────┘
-                        ▼
-        ┌────────────────────────────────┐
-        │ PR-2  per-operand blame +       │  errors.go: blameOperands() per kind,
-        │       multi-span errSpan        │  errSpan.related/addRelated/Related;
-        │                                 │  infer.go: stampBlame replaces umbrella stamp
-        └───────────────┬────────────────┘
-                        ▼
-        ┌────────────────────────────────┐
-        │ PR-3  golden span fixtures +    │  §3.6 val-annotation check (decision gate);
-        │       val-annotation enabler    │  span-assertion harness; update M2 fixtures;
-        │                                 │  milestone status
-        └────────────────────────────────┘
+            ┌────────────────────────┐
+            │ PR-3 golden fixtures + │
+            │ val-annotation enabler │
+            └────────────────────────┘
 ```
 
-PR-1 ∥ nothing (foundation). PR-2 depends on PR-1 (reads `Prov`). PR-3 depends on
-PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
+PR-A reshapes the errors to node-carrying and keeps blame precision identical to
+M2 (constraint errors stamped with the umbrella node `n` via `setBlame(n)`).
+PR-1 adds the inert `Prov` table. PR-2 is then small: it swaps PR-A's umbrella
+`setBlame(n)` for the Prov-resolving `stampBlame`. PR-3 adds fixtures and decides
+§3.7.
 
 ## 5. PR breakdown
 
 > Each PR lists owned files, the §3 sketches it implements, its tests, and an
 > exit line. LoC estimates are non-test code.
 
+### PR-A — Errors carry AST nodes; interface reshape  (~150 LoC)
+*(independent of `Prov`; parallel with PR-1)*
+- `errors.go`:
+  - Reshape `SolverError`: node-derived `Span()`, add `Related()`, **drop**
+    `setSpan`/`errSpan` (§3.4).
+  - Bridge kinds: replace `Kind`/`Name` strings with `ast.Node` fields per the
+    §3.4 table; implement `Span()`/`Related()`/`Message()` from the node. Split
+    `UnsupportedNodeError`; add `UnsupportedFeatureError`. Verify the
+    `Duplicate`/`Overload` decl-name accessor; retain `Name` there only if
+    needed (§7).
+  - Constraint kinds: embed `blameNodes`; implement `blamable`
+    (`blameOperands` + `setBlame`). `Span()` from the injected primary node.
+- `infer.go`: `(*checker).constrain` stamps via `setBlame(n)` — the umbrella
+  node, now node-based (precision unchanged from M2; `Prov` wiring is PR-2).
+- `infer_expr.go` / `infer_stmt.go` / `infer_decl.go` / `module.go`: update every
+  bridge-error construction site to pass the node(s); `reportUnsupported` passes
+  `ast.Node`; add a `reportUnsupportedFeature` for the OptionalChain-style cases;
+  the nil-pattern param case passes the enclosing `*ast.Param`.
+- Tests: existing `Message()` assertions still pass (messages derived
+  identically); add span assertions confirming each bridge error carries the
+  expected node span, and that `Duplicate`/`Overload` expose the prior decl via
+  `Related()`.
+- **Exit:** every error's `Span()` is node-derived; bridge errors self-blame;
+  constraint errors are stamped with the umbrella node. Pure refactor — **no
+  blame-precision change** (that's PR-2).
+
 ### PR-1 — `Prov` table + population at construction sites  (~120 LoC)
+*(independent of PR-A; parallel)*
 - `prov.go`: `Prov`, `Origin`, `FromAST`, `ASTOriginKind` (+ its constants),
   `recordProv` (§3.2–3.3).
 - `infer.go`: add `prov Prov` to the `checker` carrier; init in `newChecker`.
@@ -532,35 +681,34 @@ PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
   `MemberExpr`/`MemberAccess`; tuple/object → their literal nodes). Assert the
   honest **absences**: a shared atom / synthesized coalesced type has no entry.
 - **Exit:** the table is populated at every M2 construction site; no reader yet,
-  so behavior is unchanged (the table is inert). Perf invariant noted (§3.8):
+  so behavior is unchanged (the table is inert). Perf invariant noted (§3.9):
   `Context` has no handle to `Prov`.
 
-### PR-2 — Per-operand blame + multi-span errors  (~150 LoC)
-*(depends on PR-1)*
-- `errors.go`: extend `errSpan` with `related []ast.Span` + `addRelated`/
-  `Related`; add `blameOperands()` to the `SolverError` interface and implement
-  it on the four constraint kinds per the §3.4 table (the bridge kinds —
-  `UnknownIdentifierError` etc. — return `nil`, keeping their construction-time
-  span).
-- `infer.go`: replace the umbrella stamp loop in `(*checker).constrain` with
-  `stampBlame` (§3.4) — primary = narrowest resolved operand, others → related,
-  fallback → `n`.
+### PR-2 — Per-operand blame via `Prov`  (~80 LoC)
+*(depends on PR-A + PR-1)*
+- `errors.go`: implement `blameOperands()` on the four constraint kinds per the
+  §3.5 table (the `blamable` interface and `setBlame` already exist from PR-A;
+  this fills in *which* operands to resolve).
+- `infer.go`: replace PR-A's umbrella `setBlame(n)` with `stampBlame` (§3.5) —
+  resolve each operand through `Prov`, primary + related nodes, fallback `n`.
 - Tests: unit-level `stampBlame` cases over hand-built errors + a seeded `Prov`
   (operand resolves → its node; no operand resolves → fallback `n`; two operands
-  resolve → primary + one related). Confirm bridge errors are untouched.
+  resolve → primary + one related). Confirm bridge errors (not `blamable`) pass
+  through untouched.
 - **Exit:** constraint errors point at the narrowest contributing node;
   synthesized/shared operands fall back to `n` (no regression); multi-span
-  recorded.
+  related populated.
 
 ### PR-3 — Golden span fixtures + `val`-annotation enabler  (~60 LoC + tests)
 *(depends on PR-2)*
-- **Decision gate (§3.6):** include the `val`-annotation subtype check
+- **Decision gate (§3.7):** include the `val`-annotation subtype check
   (recommended) or drop the corresponding fixture. If included:
   `infer_decl.go` `inferVarDeclInit` constrains `init <: resolveTypeAnn(TypeAnn)`
   with the initializer as the constraint node and the binding adopting the
   annotated type.
-- `infer_test.go`: the `requireBlame` span-assertion helper (§3.9); the golden
-  span set; update existing M2 error tests to assert the now-narrow spans.
+- `infer_test.go`: the `requireBlame` span-assertion helper (§3.10); the golden
+  span set (constraint + bridge fixtures); update existing M2 error tests to
+  assert the narrow spans.
 - Update `01-milestones.md` M2.5 status.
 - **Exit (M2.5 exit criteria):** `val x: number = "hi"` blames the `"hi"`
   literal; a field-type mismatch blames the offending field value; a
@@ -570,9 +718,21 @@ PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
 
 ## 6. Risks & mitigations
 
+- **`UnsupportedNodeError` split + bridge-site churn.** Replacing strings with
+  nodes touches every `reportUnsupported` caller and splits one kind into two.
+  *Mitigation:* it is mechanical and confined to PR-A; the verified fact that
+  `Decl`/`Expr`/`Lit`/`ObjKey`/`Pat` all embed `ast.Node` means every kind-node
+  already has a `Span()`, and the two genuinely node-less cases (OptionalChain
+  feature string, nil pattern) are handled explicitly (`UnsupportedFeatureError`,
+  enclosing `*ast.Param`).
+- **`Duplicate`/`Overload` name derivation.** The message wants the resolved
+  binding-key name, which may differ from the decl's local identifier.
+  *Mitigation:* verify the decl name accessor in PR-A; retain `Name string`
+  alongside the nodes on just those two kinds if the canonical name isn't
+  node-derivable (§7).
 - **Shared-pointer `inferIdent` provenance is last-write-wins.** Recording
   against the shared monomorphic binding type can attach a stale node.
-  *Mitigation:* document it as a known leaf/interior-split limitation (§3.7);
+  *Mitigation:* document it as a known leaf/interior-split limitation (§3.8);
   blame for ident-flow mismatches falls back to the constraint node (no
   regression), and per-use precision arrives with M3's `FromInstantiation`. The
   golden set deliberately does **not** include an ident-flow case as a precise
@@ -582,26 +742,25 @@ PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
   point coarsely. *Mitigation:* the four M2 kinds already carry the decomposed
   operands (prim/lit atoms, the field's inner var); a `prov_test` asserts the
   operand is the expected leaf, catching any future arm that regresses this.
-- **Scope creep via §3.6.** The val-annotation check is real type-checking
+- **Scope creep via §3.7.** The val-annotation check is real type-checking
   behavior, not provenance. *Mitigation:* it is isolated to PR-3 behind an
-  explicit decision gate; the table/blame design (PR-1/PR-2) is independent of it
-  and lands regardless.
+  explicit decision gate; the table/blame design (PR-A/PR-1/PR-2) is independent
+  of it and lands regardless.
 - **Perf regression from `Prov` lookups on the hot path.** *Mitigation:*
   structurally impossible — `Prov` is on the carrier, not `Context`; the engine
-  has no handle (§3.8). No lookup appears in `constrain`/`coalesce`.
-- **Multi-span churn in downstream consumers.** Adding `related` to every error
-  could ripple into CLI/LSP rendering. *Mitigation:* the field is additive and
-  defaults empty; no current consumer reads it, and rich rendering is explicitly
-  deferred to the CLI-wiring milestone. M2.5 only records and asserts spans.
+  has no handle (§3.9). No lookup appears in `constrain`/`coalesce`.
 
 ## 7. Open questions to resolve during M2.5
 
+- **Retain a resolved `Name` on `Duplicate`/`Overload`?** If the decl node
+  cheaply exposes the canonical binding-key name, drop the string (carry only
+  `Decl`/`Previous`); otherwise keep `Name` for the message. Decide in PR-A.
 - **Expose `Prov` from `InferModule`/`InferModules`? — lean: not yet.** The only
   M2.5 reader is `stampBlame`, inside the same run, so the table can stay on the
   carrier. Widen the return signature when the first *external* consumer (LSP
   hover, M8 differential) needs it — that consumer can drive the exact shape.
   Revisit if M3's `FromInstantiation` work wants the table threaded out.
-- **`val`-annotation check: in or out (§3.6)? — recommended: in.** Decide in
+- **`val`-annotation check: in or out (§3.7)? — recommended: in.** Decide in
   review before PR-3. "In" realizes the milestone's headline fixture for ~5 lines
   and is the natural home for the precision it enables; "out" keeps M2.5
   strictly provenance-only and drops one fixture.
@@ -610,7 +769,7 @@ PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
   from `Application` for the call-result var vs. the argument) can wait until a
   consumer (LSP phrasing) needs the distinction — M2.5's blame only needs the
   *node*, not the kind, so kinds are forward-looking metadata.
-- **Related-span ordering/dedup.** When both operands resolve, is the related
+- **Related-node ordering/dedup.** When several operands resolve, is the related
   list ordered (expected-source first) and deduped (same node on both sides)?
   *Lean:* dedup by span equality, append in `blameOperands` priority order;
   pin it with a multi-operand `stampBlame` test in PR-2.
@@ -622,17 +781,22 @@ PR-2 (asserts the spans PR-2 produces) and decides the §3.6 question.
 - [ ] `FromAST` populated at all seven M2 construction sites via `recordProv`
       (literal, ident, param, call-result, tuple, object, member-result), with
       the `inferIdent` last-write-wins limitation documented.
+- [ ] `SolverError` reshaped: node-derived `Span()` + `Related()`; `setSpan` /
+      `errSpan` removed.
+- [ ] Bridge errors carry `ast.Node` fields and self-blame; `UnsupportedNodeError`
+      split into the node-kind form and `UnsupportedFeatureError`;
+      `Duplicate`/`Overload` carry `Previous` and expose it via `Related()`.
+- [ ] Constraint errors embed `blameNodes` + implement `blamable`; `Prov` is
+      consulted only for these four kinds.
 - [ ] `(*checker).constrain` blame rewritten: per-operand `Prov` lookup
-      (`stampBlame`) replaces the umbrella stamp; fallback to `n` when no operand
+      (`stampBlame`) injects the narrowest node; fallback to `n` when no operand
       resolves.
-- [ ] `blameOperands()` implemented per constraint kind (the four M2 kinds; bridge
-      kinds return `nil`).
-- [ ] `errSpan` carries primary + related spans (`addRelated`/`Related`); the
-      change is additive and existing single-span assertions still pass.
+- [ ] `blameOperands()` implemented per constraint kind (the four M2 kinds).
 - [ ] Golden span fixtures assert exact spans: `"hi"`-literal blame, field-value
-      mismatch, tuple-length at the literal, missing-property at the member prop.
+      mismatch, tuple-length at the literal, missing-property at the member prop;
+      plus bridge-error spans (unknown ident, duplicate decl + related prior).
 - [ ] Existing M2 error fixtures updated to assert the narrowest real spans.
 - [ ] Perf invariant honored: no `Prov` access in `constrain`/`coalesce` (the
       engine has no handle to the table).
-- [ ] `val`-annotation enabler decision (§3.6/§7) resolved and reflected.
+- [ ] `val`-annotation enabler decision (§3.7/§7) resolved and reflected.
 - [ ] `01-milestones.md` M2.5 status updated.

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -732,7 +732,10 @@ Resolve this in review before PR-3 (§5). The plan assumes **include**.
 Leaf-only blame is precise whenever an operand traces directly to a
 literal/param/field/member/**annotation atom** — the fresh-atom discipline (§3.3)
 now records annotation prims too, so a shared `number` is no longer a blind spot.
-It is **imprecise** in three cases (no regression vs. M2 in any):
+In three cases the failing *operand* has no usable `Prov` node of its own — but in
+**all three the primary blame still lands on the `site`, i.e. the use** (no
+regression vs. M2); what waits for M3+ is only the deeper "where this value came
+from" *related* span:
 
 1. **`Void` results.** `Void` (a function/block that yields no value) is minted at
    [infer_expr.go:120](../../internal/solver/infer_expr.go) /
@@ -756,18 +759,19 @@ It is **imprecise** in three cases (no regression vs. M2 in any):
    never runs (flat levels) and `coalesce` is display-only — so this is a
    forward-looking note; when they arrive, a `site`-carrying kind falls back to its
    `site`.
-3. **Identifier uses resolve to the definition, not per-use (`inferIdent`).** M2
-   returns `b.Type` directly — the *same* pointer for every use of a name (no
-   `instantiate` until M3) — and for an atom-typed binding that pointer is the very
-   `LitType`/`PrimType` minted and recorded at the **definition** (`coalesce`
-   passes atoms through unchanged, coalesce.go:44-46). So `Prov` resolves an
-   ident's type to where it was *defined*, not where it is *used*. M2.5 therefore
-   records **no** `inferIdent` origin (§3.3): doing so would overwrite the shared
+3. **Identifier uses — blame the use via `site`, not the definition via `Prov`
+   (`inferIdent`).** M2 returns `b.Type` directly — the *same* pointer for every use
+   of a name (no `instantiate` until M3) — and for an atom-typed binding that
+   pointer is the very `LitType`/`PrimType` minted and recorded at the
+   **definition** (`coalesce` passes atoms through unchanged, coalesce.go:44-46), so
+   a *raw* `Prov` lookup would resolve an ident's type to where it was *defined*.
+   That is exactly why ident blame does **not** go through `Prov`: M2.5 records
+   **no** `inferIdent` origin (§3.3) — recording one would overwrite the shared
    atom's definition entry with a last-write-wins use node and corrupt it for every
-   other reader. Instead, ident-use blame rides on the **containment-guarded
-   `site`** (§3.5): the definition is not inside the use's constraint node, so
-   `CannotConstrainError.Span()` falls through to the use — `val a: number = x`
-   blames the `x` use, the desired behavior, with no regression in any other case.
+   other reader — and resolves ident-use blame through the **containment-guarded
+   `site`** (§3.5) instead. The definition is not inside the use's constraint node,
+   so `CannotConstrainError.Span()` falls through to the use: `val a: number = x`
+   blames the `x` use, as required (§6), with no regression in any other case.
    What's deferred to M3 is only the **secondary** "defined here" related span:
    `FromInstantiation` gives each use a fresh instance whose origin *is* the use,
    with the definition reachable as an interior edge — primary-use plus

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -40,9 +40,11 @@ Per the milestone, M2.5 delivers:
    interior edge kinds (`FromBoundPropagation`, `FromInstantiation`,
    `FromExtrusion`, `FromCoalesce`) are deferred and **ride along** with the M3+
    operations that mint them.
-2. **`FromAST` populated at the M2 construction sites** — literal inference,
-   ident resolution, param binding, application result var, tuple elements,
-   object field values, member-access result var (§3.3).
+2. **A `FromAST` entry written into `Prov` at each M2 construction site** —
+   `FromAST` is the value stored in the table, not a second table (§3.2). The
+   sites are literal inference, ident resolution, param binding, application
+   result var, tuple elements, object field values, and member-access result
+   var (§3.3).
 3. **Per-operand blame at the error path** — replace the single umbrella stamp
    with a lookup that maps each failed operand to its narrowest `FromAST` span
    via `Prov`, falling back to `n` when an operand has no entry (§3.4).
@@ -182,6 +184,31 @@ const (
 	MemberAccess                          // a fresh member-result var from inferMember
 )
 ```
+
+**`Prov` vs. `FromAST` — container vs. contents.** These are one nested
+structure, not two parallel mechanisms: `Prov` is the **map**, `FromAST` is the
+**value stored at each key**. "Populate `FromAST`" everywhere in this plan means
+the single assignment `prov[t] = FromAST{Node: n, Kind: k}`. The error path holds
+a *type* (`CannotConstrainError.LHS`, say) and needs the *source node* that
+minted it; `Prov` is the type→node index that delivers it. `Info` cannot serve
+this — it is the opposite direction (node→type), so recovering a node from it
+means an O(n) scan for a value equal to the operand, ambiguous because one shared
+atom (`number`) is the value at many nodes. `Prov` is the direct inverse.
+
+**Why an `Origin` interface and not just `map[soltype.Type]ast.Node`.** For M2.5
+*alone*, the table could store a bare node (plus kind) and skip `Origin`
+entirely — the interface is single-variant here and looks like overkill. It earns
+its keep in M3+, which store origins that point at **no AST node at all**:
+`FromInstantiation` ("a fresh copy of scheme S at call site C"),
+`FromBoundPropagation`/`FromCoalesce`/`FromExtrusion` ("the join/propagation of
+these other types"). Those let a renderer chase a *synthesized* operand back
+through a DAG to its AST leaves, and they live in the **same** `Prov` map as
+sibling `Origin` variants. Introducing the interface now means M3 *adds a
+variant* instead of *changing the map's value type* — the "born-with-the-type,
+cheap now / painful to retrofit" reason M2.5 precedes M3. The `Kind` field is the
+same forward bet: M2.5 blame reads only `.Node`, but `Kind` lets a later LSP
+phrase *why* ("the literal here" vs. "this argument") without re-deriving it from
+the node's concrete type.
 
 `Prov` hangs off the `checker` carrier (per-run, like `Info`/`errs`):
 


### PR DESCRIPTION
Add the M2.5 implementation plan document, which details the design and sequencing for introducing a provenance side table and precise error spans to the type checker.

## Summary

This PR adds `planning/simple_sub/m2.5-implementation-plan.md`, a comprehensive design document for M2.5, a focused infrastructure milestone that improves error blame precision by tracking where each inferred type originates in the source code.

## Key changes

- **New planning document** (`m2.5-implementation-plan.md`): A 1000+ line specification covering:
  - **What M2.5 is**: A focused infra milestone (not a language feature) that replaces coarse "umbrella" error spans with precise per-operand blame by introducing a `Prov` side table (the inverse of the existing `Info` table).
  - **Current state**: Documents the M2 surface that M2.5 builds on—the constraint-generating walk, the two populations of errors (constraint vs. bridge), and the construction sites that mint types.
  - **Design** (§3): Detailed design of the `Prov` table, population discipline at construction sites, error interface reshape (node-carrying instead of string-based), per-operand blame resolution via `Prov`, multi-span related errors, and test harness.
  - **Scope boundaries**: Clarifies that M2.5 records only `FromAST` (direct AST causes); interior edges (`FromInstantiation`, `FromBoundPropagation`, etc.) are deferred to M3+. No new lattice/inference behavior—only where errors point.
  - **Sequencing and PR breakdown**: Four-PR plan (PR-A through PR-3) with dependencies, file ownership, and exit criteria.
  - **Honest limitations**: Documents three cases where leaf-only blame is imprecise (Void results, synthesized operands in M3+, shared monomorphic bindings until M3).

- **Updated milestone entry** (`01-milestones.md`): Cross-reference to the new implementation plan.

## Notable design points

- **`Prov` as a map, `FromAST` as its value**: The table is `map[soltype.Type]Origin`, where `Origin` is a tagged sum. M2.5 ships only the `FromAST` leaf variant; interior edges ride along with M3+ features.
- **Node-derived spans**: Bridge errors (walk-minted) now carry `ast.Node` fields directly instead of flattened strings; constraint errors (engine-minted) resolve their blame nodes on demand from `Prov` in their own `Span()`/`Related()` methods.
- **Per-operand blame**: Replaces the single umbrella stamp with operand-specific lookups—e.g., `CannotConstrainError.Span()` follows `LHS` through `Prov`, falling back to the constraint site only for unrecorded operands like `Void`.
- **Fresh-atom discipline**: Annotation prims are minted fresh per annotation (not interned), so each is its own pointer and directly recordable in `Prov`.
- **Perf invariant**: `Prov` is never consulted by the hot `constrain`/`coalesce` loops—only by the diagnostic path (error methods and future LSP consumers).
- **One non-provenance addition**: A minimal `val`-annotation subtype check in `inferVarDeclInit` to realize the canonical `val x: number = "hi"` fixture (flagged as a judgment call, not silent scope creep).

The plan is structured to be implementable in four independent or sequenced PRs, with clear ownership, test harness design, and golden fixtures grounded in constraints M2.5 actually emits.

https://claude.ai/code/session_01QKDDjY3EEu9MC7RjXq6xEm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated M2.5 milestone description to clarify it as an infrastructure-only milestone preceding deeper language features
  * Added comprehensive M2.5 implementation plan outlining infrastructure components, sequencing across planned work items, and exit criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->