### PR TITLE
Add M3 implementation plan and update milestones doc

### DIFF
--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -25,8 +25,9 @@ rules. The **default is settled**: Escalier code is exact-by-default, TypeScript
 imports are inexact-by-default, and each former implements its default *as it
 lands* (M3 functions, M4 records/tuples, M5 class instances via `final`,
 M6 unions) — tests at each milestone assert what the implementation produces.
-(The usage-inferred-shape default — Policy A — and the `open` parameter marker
-that opts back into row polymorphism are not yet reflected in
+(The usage-inferred-shape default — that usage-collected shapes coalesce as
+**exact** — and the `open` parameter marker that opts back into row polymorphism
+are not yet reflected in
 [exact-types/requirements.md](../exact-types/requirements.md); the spec needs
 a section recording both before M3 lands.)
 
@@ -378,8 +379,9 @@ wrapper) are what first populate a lifetime. Land them together.
   β})`; field requirements accumulate as upper bounds and coalesce (negative
   position) to a record. This is what replaces `Open`/`Widenable`/
   `ArrayConstraint`. (Spike M2.) The usage-collected shape **coalesces as
-  exact** by default (Policy A — see [02-design-notes.md](02-design-notes.md)
-  §"Exactness"): the row is closed once body inference completes. Row
+  exact** by default (the exact-by-default rule — see
+  [02-design-notes.md](02-design-notes.md) §"Exactness"): the row is closed once
+  body inference completes. Row
   polymorphism is opt-in via an `open` parameter marker (keyword provisional)
   — `fn dist(open p) => ...` keeps `p` inexact so callers can pass records
   richer than the field set the body touches. The `open` marker lands here

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -241,8 +241,9 @@ scheme instantiation introduces the first interior origin (`FromInstantiation`).
 - Level-based let-generalization (instantiate / freshenAbove): replace M2's
   monomorphic SCC freeze (`coalesce` to a monotype) with generalization into a
   `PolyScheme` at the binding boundary, swap `ValueBinding.Type` for a scheme
-  (retaining its `Sources`), add the `<T0, …>` quantifier prefix to the printer,
-  and add the `coalesce` `seen`-guard M2 deferred here.
+  (retaining its `Sources`), and add the `<T0, …>` quantifier prefix to the
+  printer. (The `coalesce` recursion `seen`-guard already shipped in M2 PR-5;
+  what remains for M3 is the precise μ-bound recursive *rendering*.)
 - The simplification pass: single-polarity elimination + co-occurrence variable
   merging (so generalized signatures render compactly, and parameter-only
   variables coalesce to `unknown` rather than a vacuous `<T0>` — a blessed

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -227,8 +227,21 @@ scheme instantiation introduces the first interior origin (`FromInstantiation`).
 
 ## M3 — Functions, application, let-polymorphism
 
-- Lambda/`fn` decls, application, multi-arg functions.
-- Level-based let-generalization (instantiate / freshenAbove).
+> **Baseline:** M2 already shipped the **monomorphic** function/application/block
+> walk (`inferFuncExpr`/`inferFunc`/`inferCall`/`inferBlock`), the dep-graph SCC
+> ordering, and recursive-group resolution (freezing each group to a coalesced
+> monotype). M3 does **not** rebuild that walk — it layers the **polymorphic**
+> machinery (and async, exactness, overloading) on top. See
+> [m3-implementation-plan.md](m3-implementation-plan.md) for the PR-by-PR plan.
+
+- Lambda/`fn` decls, application, multi-arg functions — **monomorphic forms
+  already done in M2**; M3's contribution here is making them *polymorphic* (the
+  generalization + simplification below), not building the walk.
+- Level-based let-generalization (instantiate / freshenAbove): replace M2's
+  monomorphic SCC freeze (`coalesce` to a monotype) with generalization into a
+  `PolyScheme` at the binding boundary, swap `ValueBinding.Type` for a scheme
+  (retaining its `Sources`), add the `<T0, …>` quantifier prefix to the printer,
+  and add the `coalesce` `seen`-guard M2 deferred here.
 - The simplification pass: single-polarity elimination + co-occurrence variable
   merging (so generalized signatures render compactly, and parameter-only
   variables coalesce to `unknown` rather than a vacuous `<T0>` — a blessed

--- a/planning/simple_sub/02-design-notes.md
+++ b/planning/simple_sub/02-design-notes.md
@@ -687,7 +687,7 @@ subset, else an error. The `exact` flag then lands on the resulting
 
 **Inference defaults:** object/tuple/union *literals* infer as **exact**; a
 *usage-inferred* shape (from member access) **also infers as exact** — the row
-is closed once body inference completes (Policy A). Row-polymorphism is opt-in
+is closed once body inference completes (the **exact-by-default** rule). Row-polymorphism is opt-in
 via an `open` parameter marker (keyword provisional): `fn dist(open p) => ...`
 keeps `p` inexact so callers can pass records richer than the field set the body
 touches. **TS imports are inexact** for all categories
@@ -696,9 +696,9 @@ touches. **TS imports are inexact** for all categories
 Rationale: most Escalier code is application code, not generic library code, so
 biasing the default toward "exact = catch extra-field bugs at the call site" is
 the better fit for the typical audience. Library authors writing row-polymorphic
-helpers pay a one-keyword cost. The alternative (Policy B — usage-inferred
-shapes default inexact, treating the row variable as the natural meaning of a
-lower bound) was considered and rejected on default-audience grounds.
+helpers pay a one-keyword cost. The alternative (**inexact-by-default** —
+usage-inferred shapes default inexact, treating the row variable as the natural
+meaning of a lower bound) was considered and rejected on default-audience grounds.
 
 **This decision is not yet reflected in `planning/exact-types/requirements.md`;
 the spec needs a section recording it before M3 lands.**

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -47,34 +47,80 @@ exist in `internal/solver/`:
 > `fn <T0>(x: T0) -> T0`") is over a **hand-built** soltype term, exercising the
 > printer + coalescing on a single variable. M3 is where that render is produced
 > **from real source** end-to-end, which additionally requires generalization
-> (PR 3) and the simplification pass (PR 4). The `freshenAbove`/`instantiate`
+> (PR2) and the simplification pass (PR3). The `freshenAbove`/`instantiate`
 > and `analyze`/`mergeCoOccurring` code in the spike (`scheme.go`, `simplify.go`)
 > is *promoted* here, not invented.
 
 ## Sequencing rationale
 
-```text
-PR1 funcs+app ──► PR2 schemes/generalization ──► PR3 simplification ──► PR4 exactness
-                                                          │
-                                                          └──► PR5 overloading (+ probe API)
-spec-sync (PR0) ────────────────────────────────────────────────────► (gates PR4)
+Seven PRs (PR0–PR6) across two prerequisites (M1, M2). The diagram shows the
+dependency edges; solid = hard dependency (the downstream PR can't compile or
+pass its tests without the upstream one), dashed = soft (downstream lands
+correctly without it, but produces a degraded result — non-compact renders, or a
+specificity rule that doesn't yet account for exactness — until the upstream PR
+fills it in).
+
+```mermaid
+flowchart TD
+    M1([M1: soltype core]):::prereq
+    M2([M2: AST walk + Scope]):::prereq
+
+    PR0[PR0: spec sync]
+    PR1[PR1: functions + application]
+    PR2[PR2: let-polymorphism]
+    PR3[PR3: simplification]
+    PR4[PR4: function exactness]
+    PR5[PR5: probe API]
+    PR6[PR6: overloading]
+
+    M1 --> PR1
+    M2 --> PR1
+    M1 --> PR5
+    PR0 --> PR4
+    PR1 --> PR2
+    PR2 --> PR3
+    PR1 --> PR4
+    PR2 --> PR6
+    PR5 --> PR6
+    PR3 -. compact renders .-> PR2
+    PR4 -. specificity accounts for exactness .-> PR6
+
+    classDef prereq fill:#eee,stroke:#999,stroke-dasharray:3 3;
 ```
+
+Three independent tracks fall out of the graph, exploitable for parallelism:
+the **function-core chain** (PR1 → PR2 → PR3), **exactness** (PR0 → PR4, joining
+after PR1), and the **probe API** (PR5, gated only on M1). Overloading (PR6) is
+the join point where the schemes track (PR2), the probe (PR5), and — softly —
+exactness (PR4) all converge.
 
 - **PR1 → PR2 → PR3 is a hard chain.** Application needs function types (PR1).
   Generalization needs application working so that polymorphic uses actually
   instantiate (PR2). The Category-A acceptance renders (`fn <T0>(x: T0) -> T0`,
   the `unknown` improvement) only become *correct and compact* once
   simplification runs (PR3) — before it, generalized signatures render with
-  redundant or single-polarity variables.
-- **PR4 (exactness) depends on PR1** (it adds a flag + rule to the function
-  case) but is independent of PR2/PR3, so it can land in parallel with PR3
-  once PR1 is in. It is gated on **PR0 (spec-sync)** because the default it
-  encodes (exact bare `fn`, inexact `fn(..., ...)`) must be recorded in the
-  spec before the implementation asserts it.
-- **PR5 (overloading) depends on PR2** (it bundles per-overload *schemes*) and
-  introduces the **probe API**, but is otherwise the most self-contained piece
-  and can proceed alongside PR3/PR4. It is the largest and highest-uncertainty
-  PR; keeping it last lets the simpler function core settle first.
+  redundant or single-polarity variables. (PR2's `generalize` calls `simplify`,
+  so the PR3 → PR2 edge is soft: PR2 lands with a no-op `simplify` and PR3 makes
+  the renders compact.)
+- **PR4 (exactness) depends on PR1** (it reworks the function subtyping case)
+  but is independent of PR2/PR3, so it can land in parallel with PR2/PR3 once
+  PR1 is in. It is gated on **PR0 (spec-sync)** because the default it encodes
+  (exact bare `fn`, inexact `fn(..., ...)`) must be recorded in the spec before
+  the implementation asserts it. Direct-call arity and the `constrainCall`
+  obligation live in **PR1**, not here — PR4 owns only the `exact`/`required`
+  representation and the accept-set *subtyping* rule.
+- **PR5 (probe API) depends only on M1.** It is general speculation
+  infrastructure (length-snapshot journal over bound lists + side-table cleanup
+  closures), independently unit-testable, and reused well beyond M3 (M4
+  mutability transitions, M8 conditional-branch selection, `satisfies`). Split
+  out of overloading so it can be built and reviewed on its own and so PR6's
+  risk is contained to the resolution logic.
+- **PR6 (overloading) depends on PR2** (it bundles per-overload *schemes*) and
+  **PR5** (each candidate trial runs under a probe), and softly on **PR4** (the
+  one specificity ordering must account for the exact/inexact distinction). It
+  is the highest-uncertainty PR; keeping it last lets the function core and the
+  probe settle first, and it is the one piece that can ship in a reduced form
+  (declaration-order first-match) without blocking M4.
 
 ## Core types added or changed in M3
 
@@ -83,9 +129,10 @@ The sketches below use design-notes `soltype` naming (`FunctionType`,
 shapes are settled in code review. `// ...` marks elisions. They show *what M3
 adds on top of M1/M2*, not the whole package.
 
-**`FunctionType` grows three fields** beyond the spike's `Function` — `exact`
-(PR4), and the `required` count that lets optionals lower the accept-set lower
-bound without changing arity (PR4):
+**`FunctionType` grows two fields** beyond the spike's `Function`. Both are
+introduced in PR1 with trivial values (`exact: true`, `required: len(params)`)
+so the call path compiles; PR4 gives `exact` real variance and refines
+`required` from optional-param (`x?`) detection:
 
 ```go
 // soltype/type.go — promoted from spike Function, extended for M3.
@@ -94,7 +141,7 @@ type FunctionType struct {
     paramNames []string // parallel to params; for rendering only
     required   int      // # of args that MUST be supplied (optionals lower this)
     ret        Type
-    exact      bool     // bare fn(...) ⇒ true; fn(..., ...) ⇒ false  (PR4)
+    exact      bool     // bare fn(...) ⇒ true; fn(..., ...) ⇒ false  (varies in PR4)
 }
 ```
 
@@ -111,7 +158,7 @@ func (*MonoScheme) isScheme() {}
 func (*PolyScheme) isScheme() {}
 ```
 
-**`ValueBinding` carries either a scheme or an overload set** (PR5). An
+**`ValueBinding` carries either a scheme or an overload set** (PR6). An
 overloaded symbol is *not* a single `soltype.Type` — the disjunction never
 enters the lattice:
 
@@ -188,15 +235,20 @@ single-arg `App`.
   params take their `TypeAnn`); infer the body in a child scope binding each
   param to a `MonoScheme`; build `FunctionType{params, paramNames, ret}`.
   `info.setType` on the node and each param.
-- **`*ast.CallExpr`** → infer callee and each arg, allocate a fresh result var,
-  and emit a **call obligation** (`constrainCall`, defined in PR4) — not a
-  `FunctionType <: FunctionType` subtype assertion — so direct-call arity stays
-  owned by `checkDirectCallArity` and isn't re-checked by the accept-set gate.
-  Generalize the spike's single-arg `App` to N args.
+- **`*ast.CallExpr`** → infer callee and each arg; run `checkDirectCallArity`
+  for the call-site arity check (too-many / too-few args); then allocate a fresh
+  result var and emit a **call obligation** (`constrainCall`, sketched below) —
+  *not* a `FunctionType <: FunctionType` subtype assertion. Arity is owned by the
+  call-site check, so the obligation only relates arg/return types and lets an
+  unresolved callee resolve structurally. Generalize the spike's single-arg `App`
+  to N args. (In PR1 `required == len(params)`, so `checkDirectCallArity` rejects
+  any omitted arg; PR4's optional-param detection relaxes that for `x?` params.)
 - **Function `constrain` rule** (already in M1 from the spike, `constrain.go:137`)
-  — verify the multi-arg/variance path: `len(l.params) <= len(r.params)` arity
-  check (the *inexact* fewer-params rule, refined in PR4), params contravariant,
-  return covariant.
+  — verify the multi-arg/variance path used by **function-to-function**
+  subtyping (assignment, callback slots): `len(l.params) <= len(r.params)` arity
+  check (the *inexact* fewer-params rule, replaced by the accept-set rule in
+  PR4), params contravariant, return covariant. Direct calls do **not** go
+  through this rule — they use `constrainCall`.
 - **Multi-statement bodies / `return`** as needed by real `FuncExpr` bodies
   (the spike's IR had expression bodies only); a body with no value infers
   `Void`.
@@ -233,10 +285,10 @@ func (c *checker) inferCallExpr(n *ast.CallExpr, s *Scope) Type {
     for i, a := range n.Args {
         args[i] = c.inferExpr(a, s)
     }
+    c.checkDirectCallArity(n, callee, len(args)) // call-site arity (too many / too few)
     res := c.freshVarAt(n, Application)
-    // Call obligation, NOT function subtyping (see PR4 constrainCall): relates
-    // arg/return types and lets an unresolved callee resolve structurally, but
-    // never gates on arity — direct-call arity is owned solely by checkDirectCallArity.
+    // Call obligation, NOT function subtyping: relates arg/return types and lets
+    // an unresolved callee resolve structurally; arity is owned above.
     c.constrainCall(callee, args, res)
     c.info.setType(n, res)
     return res
@@ -244,7 +296,8 @@ func (c *checker) inferCallExpr(n *ast.CallExpr, s *Scope) Type {
 ```
 
 ```go
-// solver/constrain.go — function case (PR1 baseline; refined in PR4).
+// solver/constrain.go — function-to-function subtyping (PR1 baseline; reworked
+// to the accept-set rule in PR4). Direct calls use constrainCall, not this rule.
 case *FunctionType:
     if r, ok := rhs.(*FunctionType); ok {
         if len(l.params) > len(r.params) { // fewer-params-is-subtype (inexact case)
@@ -256,6 +309,38 @@ case *FunctionType:
         }
         return append(errs, c.constrain(l.ret, r.ret, seen)...) // covariant
     }
+```
+
+```go
+// solver/constrain.go — direct-call obligation; no accept-set arity gate.
+func (c *checker) constrainCall(callee Type, args []Type, res Type) {
+    if f, ok := peelToFunc(callee); ok {
+        n := min(len(args), len(f.params))
+        for i := 0; i < n; i++ {
+            c.constrain(args[i], f.params[i]) // arg flows into param
+        }
+        c.constrain(f.ret, res)
+        return
+    }
+    // Unresolved callee: record the call shape as an application-tagged bound so
+    // resolution relates it structurally, not via the accept-set <: rule.
+    c.recordCallObligation(callee, args, res)
+}
+
+// solver/infer.go — call-site arity; in PR1 every param is required, so this also
+// catches omitted args. PR4's optional-param detection lowers f.required for x?.
+func (c *checker) checkDirectCallArity(n *ast.CallExpr, callee Type, argc int) {
+    f, ok := peelToFunc(callee) // through aliases / a resolved var bound
+    if !ok {
+        return // not (yet) known to be a function; the obligation handles it
+    }
+    switch {
+    case argc > len(f.params):
+        c.error(n, TooManyArgsError{Got: argc, Want: len(f.params)})
+    case argc < f.required:
+        c.error(n, TooFewArgsError{Got: argc, Required: f.required})
+    }
+}
 ```
 
 **Tests:** monomorphic function inference from real source — application type
@@ -330,7 +415,7 @@ func (c *checker) generalize(body Type, lvl int) TypeScheme {
 // solver/infer.go — module-level: dep-graph SCC order drives declaration order.
 func (c *checker) inferModule(m *ast.Module) {
     for _, scc := range c.deps.SCCsInTopoOrder(m) {
-        c.checkOverloadAnnotations(scc) // PR5 gate
+        c.checkOverloadAnnotations(scc) // PR6 gate (no-op until overloading lands)
         c.inferSCC(scc)                 // fresh var per binding, constrain RHS <: var, generalize
     }
 }
@@ -419,36 +504,34 @@ It is well-covered by the spike's existing tests, which port directly.
 
 ### PR4 — Function exactness (accept-set model, #677)
 
-Add exactness to functions per the now-synced spec (PR0). Depends on PR1; can
-land in parallel with PR3.
+Give `exact` real meaning per the now-synced spec (PR0), and rework
+function-to-function subtyping to the accept-set rule. Depends on PR1 (which
+introduced the fields and the call-site machinery) and PR0; can land in parallel
+with PR2/PR3. Scope is deliberately narrow: the call-site mechanics
+(`constrainCall`, `checkDirectCallArity`) already shipped in PR1 — PR4 changes
+only the *subtyping* rule and `required` derivation.
 
-- **Representation.** Add `exact bool` to `soltype.FunctionType`
-  ([02-design-notes.md](02-design-notes.md) §"Exactness"). A bare `fn(...)` is
-  exact; `fn(..., ...)` (trailing `...`) is inexact. Parser support for the
-  trailing-marker on function types if not already present from M2; old checker
-  ignores the flag (parser-level tolerance, per M7's strategy).
-- **Direct-call arity (both exactness modes reject extra args).** In the
-  `CallExpr` path, reject supplying more args than the function declares
-  regardless of `exact` — matching TypeScript. Keep the `>= required` lower
-  bound. This is a call-site check, *not* a `constrain` rule.
-- **The call obligation skips the accept-set gate.** The constraint
-  `inferCallExpr` emits (PR1) must *not* run the `lo/hi` accept-set check, or it
-  would re-reject the same arity mismatches `checkDirectCallArity` reports, with
-  a less specific message. Emit it via a dedicated `constrainCall`, distinct
-  from `FunctionType <: FunctionType`: when the callee is concrete, relate
-  `arg_i <: param_i` (contravariant) and `ret <: res` directly; when it is still
-  a variable, record the call shape as a bound **tagged as an application
-  obligation** so later resolution relates it structurally rather than
-  re-running the accept-set gate. The `lo/hi` gate fires *only* for genuine
-  function-to-function (callback) subtyping.
+- **Representation + parser.** `exact bool` is already on `soltype.FunctionType`
+  (PR1, default `true`); PR4 makes it vary. A bare `fn(...)` stays exact;
+  `fn(..., ...)` (trailing `...`) is inexact. Add parser support for the
+  trailing-marker on function types if not already present from M2; the old
+  checker ignores the flag (parser-level tolerance, per M7's strategy).
 - **Callback subtyping = accept-set rule.** Rework the function case of
-  `constrain`: `G <: F` iff `accept(G) ⊇ accept(F)`, i.e. `rG <= rF` (required)
-  **and** `uG >= uF` (upper bound: `n` if exact, `∞` if inexact). Params remain
-  contravariant per shared position, return covariant. The spike's current
-  "fewer params is a subtype" becomes exactly the **inexact** case (`uG = ∞`).
+  `constrain` (the function-to-function rule from PR1, not the direct-call
+  `constrainCall`): `G <: F` iff `accept(G) ⊇ accept(F)`, i.e. `rG <= rF`
+  (required) **and** `uG >= uF` (upper bound: `n` if exact, `∞` if inexact).
+  Params remain contravariant per shared position, return covariant. The spike's
+  current "fewer params is a subtype" becomes exactly the **inexact** case
+  (`uG = ∞`).
+- **Direct-call arity is unchanged by exactness.** `checkDirectCallArity` (PR1)
+  already rejects extra args regardless of `exact` — matching TypeScript — and
+  it never went through the subtyping rule, so reworking the rule here doesn't
+  touch it. Confirm with a test that an *inexact* function still rejects a
+  too-many-args direct call.
 - **`required` vs `n`.** Optional params lower `required` without changing `n`.
-  Wire optional-param detection from the AST (`x?`-style) into the accept-set
-  computation.
+  Wire optional-param detection from the AST (`x?`-style) into `required` (set in
+  PR1 to `len(params)`); this simultaneously relaxes `checkDirectCallArity`'s
+  lower bound and the accept-set rule's `r`.
 
 **Sketch:**
 
@@ -484,38 +567,9 @@ case *FunctionType:
     }
 ```
 
-```go
-// solver/infer.go — direct-call arity, independent of exactness (from inferCallExpr).
-func (c *checker) checkDirectCallArity(n *ast.CallExpr, callee Type, argc int) {
-    f, ok := peelToFunc(callee) // through aliases / a resolved var bound
-    if !ok {
-        return // not (yet) known to be a function; the constraint handles it
-    }
-    switch {
-    case argc > len(f.params):
-        c.error(n, TooManyArgsError{Got: argc, Want: len(f.params)})
-    case argc < f.required:
-        c.error(n, TooFewArgsError{Got: argc, Required: f.required})
-    }
-}
-```
-
-```go
-// solver/constrain.go — direct-call obligation; no accept-set arity gate.
-func (c *checker) constrainCall(callee Type, args []Type, res Type) {
-    if f, ok := peelToFunc(callee); ok {
-        n := min(len(args), len(f.params))
-        for i := 0; i < n; i++ {
-            c.constrain(args[i], f.params[i]) // arg flows into param
-        }
-        c.constrain(f.ret, res)
-        return
-    }
-    // Unresolved callee: record the call shape as an application-tagged bound so
-    // resolution relates it structurally, not via the accept-set <: rule.
-    c.recordCallObligation(callee, args, res)
-}
-```
+(The direct-call path — `constrainCall` and `checkDirectCallArity` — shipped in
+PR1 and is unchanged here; this rule governs only function-to-function
+subtyping.)
 
 **Tests (the milestone's exactness acceptance):**
 
@@ -531,43 +585,32 @@ acceptance rows exactly right.
 
 ---
 
-### PR5 — Function overloading (free functions) + the probe API
+### PR5 — Probe API (speculation infrastructure)
 
-The largest and least mechanical PR. Lands overloaded free `fn` declarations and
-the **probe API** they need. Depends on PR2 (per-overload schemes).
+The **only** new soltype infrastructure in M3, split out from overloading so it
+can be built and reviewed on its own. Depends only on M1 (`TypeVarType` bound
+lists), so it can proceed in parallel with PR1–PR4. Baseline (A) + (D) from
+[02-design-notes.md](02-design-notes.md) §"Speculative checks."
 
-- **Probe API (baseline A + D)** from [02-design-notes.md](02-design-notes.md)
-  §"Speculative checks." A length-snapshot journal (`*Probe` on `Context`,
-  nullable; record first-touch `(len(lower), len(upper))` per touched
-  `TypeVarType`, truncate on discard; `cleanups` closures for `Info`/`Prov`
-  side-table rollback; nested-probe commit propagates `touched` to parent). Plus
-  fresh-instance retry (D) for per-candidate `freshenAbove`. This is the **only**
-  new soltype infrastructure in M3, and it is built here because overload
-  resolution is the first speculative consumer. Keep it minimal — no overlay
-  map, generation tags, or `Prune`/`InstanceChain` (none exist in soltype).
-- **Overload sets as side-channel metadata.** An overloaded symbol's binding
-  holds a *set* of declared/inferred schemes, **not** a single `soltype.Type`.
-  Infer each overload body individually (each is a normal `fn` with its own
-  principal type), then bundle. Never inject the disjunction into the lattice —
-  there is no SimpleSub type for "either this arrow or that arrow."
-- **Call-site resolution as a separate phase from `constrain`.** At each call,
-  collect the argument types' bounds, then pick a single overload and emit
-  constraints only for the chosen branch — under a probe (D + A), committing the
-  first success and rolling back losers' caller-side bounds.
-- **Ground-enough deferral.** If an argument is still a fully unconstrained
-  variable, **defer the call** (preferred — let bounds accumulate) or fall back
-  to declaration-order first-match. No speculative pinning + backtrack.
-- **One documented specificity ordering.** Declaration-order + best-match
-  (TypeScript-style), documented in a `doc.go` comment and chosen to interact
-  cleanly with subtyping and the exact/inexact distinction from PR4 (M4's
-  object-arg overloads will reuse this one rule).
-- **Mutual recursion forces annotations.** If an overloaded function
-  participates in a mutually recursive group, **its overload signatures must be
-  annotated** (bodies still checked against them; only the set itself must be
-  ground before the group starts) — fixed-point iteration over overload choices
-  isn't guaranteed to converge under subtyping. Self-recursion is softer (each
-  body inferred with the *other* overload signatures visible). Emit a clear
-  error pointing at the unannotated overloaded participant.
+- **Length-snapshot journal (A).** A nullable `*Probe` on `Context`. The first
+  mutation of each variable records `(len(lower), len(upper))`; discard truncates
+  each touched var's bound slices back. Commit on a nested probe propagates its
+  touched set to the parent so an outer discard still covers them.
+- **Side-table cleanup closures.** `Info` (node → type) and `Prov` (type →
+  origin) writes register an `onRollback` closure so a discarded trial leaves no
+  stray hover/error entries. The `seen` cache inside a single `constrain` call is
+  *not* a probe concern — it dies with the call frame.
+- **Push/pop discipline.** `openProbe` pushes the current-probe pointer;
+  `closeProbe(p, commit)` runs `Commit`/`Discard` and pops it back to
+  `p.parent`, so `c.probe` never dangles at a finished probe.
+- **Fresh-instance retry (D)** is just the existing `instantiate`/`freshenAbove`
+  used per-candidate by consumers — no probe state of its own; it composes with
+  (A) for the caller-side bounds. No standalone code here beyond documenting the
+  pattern.
+- Keep it minimal — **no** overlay map, generation tags, or
+  `Prune`/`InstanceChain` (none exist in soltype). This API is reused well beyond
+  M3 (M4 mutability transitions, M8 conditional-branch selection, `satisfies`,
+  `NoInfer`), so getting the shape right here pays off repeatedly.
 
 **Sketch:**
 
@@ -607,6 +650,51 @@ func (c *checker) closeProbe(p *Probe, commit bool) {
 }
 ```
 
+**Tests:** a discarded probe restores bound-list lengths exactly (append-then-
+discard is a no-op on the var); a discarded probe runs `Info`/`Prov` cleanups
+(no stray entries); a committed nested probe leaves its touched vars covered by
+the parent's later discard; nesting depth is balanced (`c.probe` returns to its
+original value after paired open/close). All unit tests over hand-built terms —
+no overload machinery needed, which is the point of the split.
+
+**Risk:** low. Small, self-contained, and exactly specified by the design notes;
+the append-only bound-list representation makes rollback a slice truncation.
+
+---
+
+### PR6 — Function overloading (free functions)
+
+The highest-uncertainty PR. Lands overloaded free `fn` declarations and their
+call-site resolution. Depends on **PR2** (per-overload schemes) and **PR5** (each
+candidate trial runs under a probe), and softly on **PR4** (the specificity
+ordering must account for the exact/inexact distinction).
+
+- **Overload sets as side-channel metadata.** An overloaded symbol's binding
+  holds a *set* of declared/inferred schemes, **not** a single `soltype.Type`.
+  Infer each overload body individually (each is a normal `fn` with its own
+  principal type), then bundle. Never inject the disjunction into the lattice —
+  there is no SimpleSub type for "either this arrow or that arrow."
+- **Call-site resolution as a separate phase from `constrain`.** At each call,
+  collect the argument types' bounds, then pick a single overload and emit
+  constraints only for the chosen branch — under a probe (PR5), committing the
+  first success and rolling back losers' caller-side bounds.
+- **Ground-enough deferral.** If an argument is still a fully unconstrained
+  variable, **defer the call** (preferred — let bounds accumulate) or fall back
+  to declaration-order first-match. No speculative pinning + backtrack.
+- **One documented specificity ordering.** Declaration-order + best-match
+  (TypeScript-style), documented in a `doc.go` comment and chosen to interact
+  cleanly with subtyping and the exact/inexact distinction from PR4 (M5's
+  method overloads and M4's object-arg overloads will reuse this one rule).
+- **Mutual recursion forces annotations.** If an overloaded function
+  participates in a mutually recursive group, **its overload signatures must be
+  annotated** (bodies still checked against them; only the set itself must be
+  ground before the group starts) — fixed-point iteration over overload choices
+  isn't guaranteed to converge under subtyping. Self-recursion is softer (each
+  body inferred with the *other* overload signatures visible). Emit a clear
+  error pointing at the unannotated overloaded participant.
+
+**Sketch:**
+
 ```go
 // solver/overload.go — call-site resolution (D + A), a phase distinct from constrain.
 func (c *checker) resolveOverload(set *OverloadSet, args []Type, call ast.Node) (res Type, decided bool) {
@@ -615,7 +703,7 @@ func (c *checker) resolveOverload(set *OverloadSet, args []Type, call ast.Node) 
     }
     for _, sig := range orderBySpecificity(set.branches) { // ONE documented ordering
         inst := c.instantiate(sig, c.level).(*FunctionType) // (D) fresh per candidate; branches are fn schemes
-        p := c.openProbe()                                  // (A) wrap caller-side bounds
+        p := c.openProbe()                                  // (A, PR5) wrap caller-side bounds
         ok := c.tryConstrainArgs(args, inst, p)
         c.closeProbe(p, ok) // commit on success, roll back on failure; always pops the stack
         if ok {
@@ -647,22 +735,24 @@ func (c *checker) checkOverloadAnnotations(scc []ast.Decl) {
 **Tests:** a two-overload free `fn` resolves per-argument-type at call sites;
 declaration-order tie-break is asserted; a deferred-then-resolved call (argument
 ground only after later constraints); the mutual-recursion-without-annotation
-error (full message); a probe-rollback test (a losing overload leaves no bounds
-on argument vars and no stray `Info` entries).
+error (full message); a resolution-rollback test (a losing overload leaves no
+bounds on argument vars and no stray `Info` entries — exercising PR5's probe).
 
 **Risk:** **highest in M3.** Overloading is a poor fit for "one principal type
-per expression," and the probe API is new. Mitigations: the design notes specify
-the composition (D + A) precisely; keep the specificity rule deliberately simple
-and documented; lean on the ground-enough *defer* path over guessing. If
-resolution proves intractable against the real AST, the fallback is
-declaration-order first-match for the MVP with a tracked follow-up — overloading
-is the one M3 piece that can ship in a reduced form without blocking M4.
+per expression." Mitigations: the probe (PR5) is already proven by the time this
+lands; the design notes specify the (D + A) composition precisely; keep the
+specificity rule deliberately simple and documented; lean on the ground-enough
+*defer* path over guessing. If resolution proves intractable against the real
+AST, the fallback is declaration-order first-match for the MVP with a tracked
+follow-up — overloading is the one M3 piece that can ship in a reduced form
+without blocking M4.
 
 ## Risks & gates
 
 - **No M3-level go/no-go gate** (those live at M4's `Ref` rule and M7's
-  differential). M3's risk is concentrated in **PR5**; the function core
-  (PR1–PR4) is high-confidence promotion of spike code.
+  differential). M3's risk is concentrated in **PR6 (overloading)**; the
+  function core (PR1–PR4) and the probe (PR5) are high-confidence promotion of
+  spike / design-notes work.
 - **Simplification correctness (PR3)** is the subtlest core algorithm — but it
   is the most thoroughly spike-tested, so the risk is "port faithfully," not
   "design."
@@ -683,7 +773,7 @@ M3 is done when, against **real source**:
   rejected. *(PR4)*
 - Overloaded free `fn` declarations resolve at call sites per the documented
   specificity rule; mutually-recursive overloaded participants without
-  annotations are rejected with a full error message. *(PR5)*
+  annotations are rejected with a full error message. *(PR6, on the PR5 probe)*
 
 All assertions are full error messages and Escalier-syntax rendered types, in
 the new package's table-test harness (CLAUDE.md test conventions; the M7

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -84,8 +84,9 @@ earlier drafts of this plan assumed spike-era names that never shipped.
 1. **Let-generalization** — schemes, `instantiate`/`freshenAbove`, generalize at
    the SCC boundary (replacing M2's monomorphic freeze), the `<T0, …>` quantifier
    prefix in the printer, and the `inferIdent` instantiation hook. Plus the
-   `coalesce` `seen`-guard (M2 PR-5 forward-referenced it) and the
-   `FromInstantiation` provenance variant (extends M2.5's `Prov`).
+   `FromInstantiation` provenance variant (extends M2.5's `Prov`). (The
+   `coalesce` recursion `seen`-guard this would otherwise need already shipped in
+   M2 PR-5; M3 owns only the precise μ-bound recursive *rendering*.)
 2. **The simplification pass** — single-polarity elimination + co-occurrence
    merging, so generalized signatures render compactly and parameter-only
    variables coalesce to `unknown` rather than a vacuous `<T0>`.
@@ -424,9 +425,11 @@ to coalesced monotypes; PR1 turns that into real let-polymorphism.
   `coalesce(b.v, Positive)` → a monotype. PR1 changes it to generalize: variables
   at `Level > lvl` become quantifiable; captured outer vars do not. The result is
   a `PolyScheme`.
-- **`coalesce` `seen`-guard.** M2 PR-5 noted `coalesce` has no recursion guard;
-  generalizing recursive-group types can loop. Add the `seen`-guard here (the M1
-  deferral M2 forward-referenced).
+- **Recursive-group rendering (not the `seen`-guard).** The `coalesce`
+  path-scoped `seen`-guard that keeps the walk total over a cyclic var↔var bound
+  graph **already shipped in M2 PR-5** (`coalesceRec` in `coalesce.go`) — M3 does
+  *not* re-add it. M3 owns only the precise μ-bound recursive *rendering* of a
+  generalized recursive type.
 - **Printer `<T0, …>` prefix.** Extend `soltype.Print` to render a quantifier
   prefix for a generalized scheme's free variables (M2's printer renders only
   monotypes).
@@ -497,7 +500,8 @@ before the printer.
   parameter.
 - **Wire into `generalize`** (PR1's no-op `simplify` becomes real): occurrence
   analysis → co-occurrence → union-find → rewrite, feeding `coalesce` + the
-  printer. The `seen`-guard from PR1 covers the cyclic bound graphs this walks.
+  printer. The `coalesce` `seen`-guard (shipped in M2 PR-5) covers the cyclic
+  bound graphs this walks.
 
 **Sketch:**
 

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -1,0 +1,339 @@
+# M3 — Functions, application, let-polymorphism — implementation plan
+
+Concrete, PR-by-PR plan for landing milestone **M3** of the SimpleSub checker
+(`internal/solver/`). Read [01-milestones.md](01-milestones.md) §"M3" for the
+milestone definition and [02-design-notes.md](02-design-notes.md) for the
+`soltype` shapes this plan promotes. Names are provisional and follow the
+design-notes leaf-name decision (`internal/solver/`, types in `soltype/`).
+
+## What M3 delivers
+
+M3 turns the soltype scaffolding from M1/M2 into a real function-language
+checker. Five workstreams, in dependency order:
+
+1. **Functions + application + multi-arg** — lambda/`fn` decls and call
+   expressions inferred against the real AST, with the function `constrain`
+   rule (params contravariant, return covariant).
+2. **Level-based let-polymorphism** — schemes (`MonoScheme`/`PolyScheme`),
+   `instantiate`, `freshenAbove`, and generalization at binding boundaries
+   threaded through the AST walk by level.
+3. **The simplification pass** — single-polarity elimination + co-occurrence
+   variable merging, so generalized signatures render compactly and
+   parameter-only variables coalesce to `unknown` rather than a vacuous `<T0>`.
+4. **Function exactness** — the `exact` flag on `FunctionType` plus the
+   accept-set subtyping model and direct-call arity rule from
+   escalier-lang/escalier#677.
+5. **Function overloading (free functions)** — overload sets as side-channel
+   metadata, call-site resolution as a separate phase from `constrain`, with
+   the ground-enough / specificity / mutual-recursion-needs-annotation rules.
+
+## Prerequisites (M1 + M2 must be merged)
+
+M3 has no new infrastructure of its own except the **probe API** (see PR 5); it
+builds entirely on what M1 and M2 stand up. Before starting, the following must
+exist in `internal/solver/`:
+
+- **From M1:** `soltype.TypeVarType` (bound lists + level), `PrimitiveType`,
+  `LiteralType`, `FunctionType`, `TupleType`; `constrain(lhs <: rhs)` with the
+  coinductive seen-cache, levels + extrusion; polarity-driven `coalesce`; the
+  `soltype` printer; the `Info` side table (`map[ast.Node]soltype.Type` +
+  `TypeOf`/`setType`).
+- **From M2:** the constraint-generating AST walk (`infer.go`) driving from
+  real `*ast.Module` via `dep_graph`/`resolver`; the owned
+  `Scope`/`Binding`/`Namespace`; the fixture-style table-test harness that
+  asserts rendered binding types from `.esc` source.
+
+> **Note on the M1/M3 boundary.** M1's acceptance ("an identity term renders
+> `fn <T0>(x: T0) -> T0`") is over a **hand-built** soltype term, exercising the
+> printer + coalescing on a single variable. M3 is where that render is produced
+> **from real source** end-to-end, which additionally requires generalization
+> (PR 3) and the simplification pass (PR 4). The `freshenAbove`/`instantiate`
+> and `analyze`/`mergeCoOccurring` code in the spike (`scheme.go`, `simplify.go`)
+> is *promoted* here, not invented.
+
+## Sequencing rationale
+
+```text
+PR1 funcs+app ──► PR2 schemes/generalization ──► PR3 simplification ──► PR4 exactness
+                                                          │
+                                                          └──► PR5 overloading (+ probe API)
+spec-sync (PR0) ────────────────────────────────────────────────────► (gates PR4)
+```
+
+- **PR1 → PR2 → PR3 is a hard chain.** Application needs function types (PR1).
+  Generalization needs application working so that polymorphic uses actually
+  instantiate (PR2). The Category-A acceptance renders (`fn <T0>(x: T0) -> T0`,
+  the `unknown` improvement) only become *correct and compact* once
+  simplification runs (PR3) — before it, generalized signatures render with
+  redundant or single-polarity variables.
+- **PR4 (exactness) depends on PR1** (it adds a flag + rule to the function
+  case) but is independent of PR2/PR3, so it can land in parallel with PR3
+  once PR1 is in. It is gated on **PR0 (spec-sync)** because the default it
+  encodes (exact bare `fn`, inexact `fn(..., ...)`) must be recorded in the
+  spec before the implementation asserts it.
+- **PR5 (overloading) depends on PR2** (it bundles per-overload *schemes*) and
+  introduces the **probe API**, but is otherwise the most self-contained piece
+  and can proceed alongside PR3/PR4. It is the largest and highest-uncertainty
+  PR; keeping it last lets the simpler function core settle first.
+
+## PR breakdown
+
+### PR0 — Spec sync: Policy A, the `open` marker, and #677's accept-set model
+
+Pure documentation; no code. Unblocks PR4's assertions and records decisions
+the milestones doc flags as "not yet in the spec."
+
+- Add a section to `planning/exact-types/requirements.md` recording **Policy A**
+  (usage-inferred record shapes coalesce as *exact*; row polymorphism is opt-in
+  via the `open` parameter marker) and the `open` keyword (provisional). This is
+  the M3 prerequisite called out in
+  [01-milestones.md](01-milestones.md) and [02-design-notes.md](02-design-notes.md)
+  §"Exactness".
+- Rewrite §4.2 per escalier-lang/escalier#677: **direct calls reject extra args
+  regardless of exactness**; **exactness governs callback subtyping** via the
+  accept-set model (`G <: F` iff `accept(G) ⊇ accept(F)`, params contravariant,
+  return covariant; exact `fn(p1..pn)` accepts `[required, n]`, inexact accepts
+  `[required, ∞)`).
+- Close the loop on #677's "knock-on": the M3 acceptance line in the milestones
+  doc already reflects the accept-set model — confirm and cross-link.
+
+**Why first:** PR4's tests assert exact-by-default function behavior; that
+default must be blessed in the spec before it is encoded in tests
+(Settled Decision #6 — "tests assert what the implementation produces").
+
+---
+
+### PR1 — Function inference + application + multi-arg
+
+Promote the spike's `*Lambda`/`*App` handling (`infer.go:140–170`) onto the real
+AST. Most of the constrain machinery already exists from M1; this PR is the
+**AST walk** for functions plus multi-arg generalization of the spike's
+single-arg `App`.
+
+- **`*ast.FuncExpr` / `fn` decl** → a fresh var per unannotated param (annotated
+  params take their `TypeAnn`); infer the body in a child scope binding each
+  param to a `MonoScheme`; build `FunctionType{params, paramNames, ret}`.
+  `info.setType` on the node and each param.
+- **`*ast.CallExpr`** → infer callee and each arg, allocate a fresh result var,
+  and emit `constrain(callee <: FunctionType{args, result})`. Generalize the
+  spike's single-arg `App` to N args.
+- **Function `constrain` rule** (already in M1 from the spike, `constrain.go:137`)
+  — verify the multi-arg/variance path: `len(l.params) <= len(r.params)` arity
+  check (the *inexact* fewer-params rule, refined in PR4), params contravariant,
+  return covariant.
+- **Multi-statement bodies / `return`** as needed by real `FuncExpr` bodies
+  (the spike's IR had expression bodies only); a body with no value infers
+  `Void`.
+
+**Tests:** monomorphic function inference from real source — application type
+flows (`val n = (fn (x) { return x + 1 })(5)` ⇒ `n: number`), arity mismatch
+errors (full message), contravariant-param / covariant-return acceptance and
+rejection cases. No generalization yet — top-level `fn id` still renders with a
+raw inference variable at this point (a temporary, asserted as such or deferred
+to PR3).
+
+**Risk:** low. This is mechanical promotion of proven spike code; the constrain
+rule is already M1-tested on hand-built terms.
+
+---
+
+### PR2 — Level-based let-polymorphism
+
+Promote `scheme.go` (`TypeScheme`/`MonoScheme`/`PolyScheme`, `instantiate`,
+`freshenAbove`) and wire level discipline through the AST walk.
+
+- **Schemes in the scope.** `ValueBinding` carries a `TypeScheme`. Param
+  bindings and current-level `let` RHS-during-inference and `LetRec` self-refs
+  are `MonoScheme` (returned as-is by `instantiate`); generalized top-level/inner
+  `let`/`fn` decls are `PolyScheme` (trigger `freshenAbove` + a
+  `FromInstantiation` provenance entry).
+- **Level threading.** Type a binding's RHS at `lvl+1`, then generalize:
+  variables created at `> lvl` become quantifiable; captured outer variables
+  (`level <= lvl`) do not. This is the spike's `*Let` rule
+  (`infer.go:171–179`) over real decls, with module-level declaration order
+  driven by the existing `dep_graph` SCC order (matching how the old checker
+  handles mutual recursion).
+- **Recursive groups.** Promote `*LetRecGroup` (`infer.go:185–216`): one fresh
+  var per binding, all visible in every RHS, constrain each RHS `<:` its var,
+  generalize the whole SCC at the shared level boundary. No placeholder phase,
+  no `typeRefsToUpdate` patching.
+- **`IdentExpr` value-position lookup** calls `instantiate` uniformly; only the
+  `PolyScheme` case does work. Namespace-in-value-position is a
+  `NamespaceUsedAsValueError` (per [02-design-notes.md](02-design-notes.md)
+  §"infer.go"); unknown identifiers are `UnknownIdentifierError`.
+- **`freshenAbove` lifetime caveat.** The spike copies a carrier's lifetime by
+  reference rather than freshening it (`scheme.go:29–39`). M4 introduces
+  lifetimes properly; for M3 there are no lifetime-carrying types yet, so this
+  is a non-issue — but leave a `// M4:` marker where `freshenAbove` will need a
+  lifetime cache.
+
+**Tests:** polymorphic instantiation — `val id = fn (x) { return x }` used at two
+types; let-bound polymorphism captured correctly (inner `let` generalizes after
+its RHS finishes); recursive and mutually-recursive groups infer without
+annotations. Renders may still be non-compact until PR3 — assert via the
+two-types-of-use behavior rather than the printed signature where simplification
+is load-bearing.
+
+**Risk:** low–medium. The level discipline is the subtle part; the spike proves
+it, and the dep-graph SCC ordering is the only new (M2-provided) ingredient.
+
+---
+
+### PR3 — The simplification pass
+
+Promote `simplify.go` (`analyze` single-polarity elimination, `symmetrize`,
+co-occurrence collection, union-find `mergeCoOccurring`) and run it at
+generalization boundaries before coalescing.
+
+- **Single-polarity elimination.** A variable that occurs only positively or
+  only negatively in the generalized type is replaced by its bound (or by
+  `never`/`unknown` for the empty case) — this is what turns a parameter-only
+  variable with no lower bounds into `unknown` in negative position (the
+  blessed `unknown`-vs-vacuous-`<T0>` improvement, [03-references.md](03-references.md)
+  §"Lattice 1").
+- **Co-occurrence merging.** Variables that co-occur in every polarity they
+  appear in are merged via union-find, so `fn <T0>(x: T0) -> T0` renders with one
+  type parameter, not several aliased ones.
+- **Wire into the pipeline:** run `analyze` → `symmetrize` → `collectCoOcc` →
+  `mergeCoOccurring` on a `PolyScheme`'s body at generalization time, feeding the
+  merged result into `coalesce` and then the printer.
+
+**Tests — the Category-A acceptance from the milestone, against real source:**
+
+| Case | Expected render |
+|---|---|
+| `TopLevelLetPolymorphism` (`val id = fn (x) { return x }`) | `fn <T0>(x: T0) -> T0` |
+| `IdentityPolymorphism` | `fn () -> ["hello", 5]` |
+| `InnerCapturesOuterParam` | `fn <T0>(y: T0) -> [T0, T0]` |
+| parameter-only var (unused param) | coalesces to `unknown`, not `<T0>` |
+
+These are the spike's M1 differential cases (`simplesub_test.go` /
+`differential_test.go`); port the assertions into the new package's table tests
+with the **improved** forms.
+
+**Risk:** medium. Simplification is the subtlest algorithm in the set
+(occurrence analysis polarity, the `Mut`/`ResidualOp` bipolarity special cases).
+It is well-covered by the spike's existing tests, which port directly.
+
+---
+
+### PR4 — Function exactness (accept-set model, #677)
+
+Add exactness to functions per the now-synced spec (PR0). Depends on PR1; can
+land in parallel with PR3.
+
+- **Representation.** Add `exact bool` to `soltype.FunctionType`
+  ([02-design-notes.md](02-design-notes.md) §"Exactness"). A bare `fn(...)` is
+  exact; `fn(..., ...)` (trailing `...`) is inexact. Parser support for the
+  trailing-marker on function types if not already present from M2; old checker
+  ignores the flag (parser-level tolerance, per M7's strategy).
+- **Direct-call arity (both exactness modes reject extra args).** In the
+  `CallExpr` path, reject supplying more args than the function declares
+  regardless of `exact` — matching TypeScript. Keep the `>= required` lower
+  bound. This is a call-site check, *not* a `constrain` rule.
+- **Callback subtyping = accept-set rule.** Rework the function case of
+  `constrain`: `G <: F` iff `accept(G) ⊇ accept(F)`, i.e. `rG <= rF` (required)
+  **and** `uG >= uF` (upper bound: `n` if exact, `∞` if inexact). Params remain
+  contravariant per shared position, return covariant. The spike's current
+  "fewer params is a subtype" becomes exactly the **inexact** case (`uG = ∞`).
+- **`required` vs `n`.** Optional params lower `required` without changing `n`.
+  Wire optional-param detection from the AST (`x?`-style) into the accept-set
+  computation.
+
+**Tests (the milestone's exactness acceptance):**
+
+- Direct calls: both exact `fn(x, y)` and inexact `fn(x, y, ...)` **reject** a
+  3-arg call (full error message); both accept 2 args.
+- Into a `fn(x, y)` callback slot: `fn(x, y)`, `fn(x, ...)`, `fn(...)` are
+  **accepted**; exact `fn(x)` and any 3+-param function are **rejected**.
+- Round-trip exact/inexact function types through the printer.
+
+**Risk:** low–medium. The rule is small and precisely specified by #677; the
+care is in the `required`/`n`/`exact` bookkeeping and getting the four
+acceptance rows exactly right.
+
+---
+
+### PR5 — Function overloading (free functions) + the probe API
+
+The largest and least mechanical PR. Lands overloaded free `fn` declarations and
+the **probe API** they need. Depends on PR2 (per-overload schemes).
+
+- **Probe API (baseline A + D)** from [02-design-notes.md](02-design-notes.md)
+  §"Speculative checks." A length-snapshot journal (`*Probe` on `Context`,
+  nullable; record first-touch `(len(lower), len(upper))` per touched
+  `TypeVarType`, truncate on discard; `cleanups` closures for `Info`/`Prov`
+  side-table rollback; nested-probe commit propagates `touched` to parent). Plus
+  fresh-instance retry (D) for per-candidate `freshenAbove`. This is the **only**
+  new soltype infrastructure in M3, and it is built here because overload
+  resolution is the first speculative consumer. Keep it minimal — no overlay
+  map, generation tags, or `Prune`/`InstanceChain` (none exist in soltype).
+- **Overload sets as side-channel metadata.** An overloaded symbol's binding
+  holds a *set* of declared/inferred schemes, **not** a single `soltype.Type`.
+  Infer each overload body individually (each is a normal `fn` with its own
+  principal type), then bundle. Never inject the disjunction into the lattice —
+  there is no SimpleSub type for "either this arrow or that arrow."
+- **Call-site resolution as a separate phase from `constrain`.** At each call,
+  collect the argument types' bounds, then pick a single overload and emit
+  constraints only for the chosen branch — under a probe (D + A), committing the
+  first success and rolling back losers' caller-side bounds.
+- **Ground-enough deferral.** If an argument is still a fully unconstrained
+  variable, **defer the call** (preferred — let bounds accumulate) or fall back
+  to declaration-order first-match. No speculative pinning + backtrack.
+- **One documented specificity ordering.** Declaration-order + best-match
+  (TypeScript-style), documented in a `doc.go` comment and chosen to interact
+  cleanly with subtyping and the exact/inexact distinction from PR4 (M4's
+  object-arg overloads will reuse this one rule).
+- **Mutual recursion forces annotations.** If an overloaded function
+  participates in a mutually recursive group, **its overload signatures must be
+  annotated** (bodies still checked against them; only the set itself must be
+  ground before the group starts) — fixed-point iteration over overload choices
+  isn't guaranteed to converge under subtyping. Self-recursion is softer (each
+  body inferred with the *other* overload signatures visible). Emit a clear
+  error pointing at the unannotated overloaded participant.
+
+**Tests:** a two-overload free `fn` resolves per-argument-type at call sites;
+declaration-order tie-break is asserted; a deferred-then-resolved call (argument
+ground only after later constraints); the mutual-recursion-without-annotation
+error (full message); a probe-rollback test (a losing overload leaves no bounds
+on argument vars and no stray `Info` entries).
+
+**Risk:** **highest in M3.** Overloading is a poor fit for "one principal type
+per expression," and the probe API is new. Mitigations: the design notes specify
+the composition (D + A) precisely; keep the specificity rule deliberately simple
+and documented; lean on the ground-enough *defer* path over guessing. If
+resolution proves intractable against the real AST, the fallback is
+declaration-order first-match for the MVP with a tracked follow-up — overloading
+is the one M3 piece that can ship in a reduced form without blocking M4.
+
+## Risks & gates
+
+- **No M3-level go/no-go gate** (those live at M4's `Ref` rule and M7's
+  differential). M3's risk is concentrated in **PR5**; the function core
+  (PR1–PR4) is high-confidence promotion of spike code.
+- **Simplification correctness (PR3)** is the subtlest core algorithm — but it
+  is the most thoroughly spike-tested, so the risk is "port faithfully," not
+  "design."
+- **Probe API scope creep (PR5)** — resist building beyond baseline A + D.
+  Everything heavier (overlay, generation tags) is explicitly deferred by the
+  design notes.
+
+## Acceptance (maps to [01-milestones.md](01-milestones.md) §"M3")
+
+M3 is done when, against **real source**:
+
+- Category-A renders: `TopLevelLetPolymorphism` ⇒ `fn <T0>(x: T0) -> T0`;
+  `IdentityPolymorphism` ⇒ `fn () -> ["hello", 5]`; `InnerCapturesOuterParam`
+  ⇒ `fn <T0>(y: T0) -> [T0, T0]`; parameter-only var ⇒ `unknown`. *(PR2+PR3)*
+- Function exactness (#677): both exact `fn(x, y)` and inexact `fn(x, y, ...)`
+  reject a 3-arg direct call; into a `fn(x, y)` slot, `fn(x, y)`/`fn(x, ...)`/
+  `fn(...)` are accepted while exact `fn(x)` and any 3+-param function are
+  rejected. *(PR4)*
+- Overloaded free `fn` declarations resolve at call sites per the documented
+  specificity rule; mutually-recursive overloaded participants without
+  annotations are rejected with a full error message. *(PR5)*
+
+All assertions are full error messages and Escalier-syntax rendered types, in
+the new package's table-test harness (CLAUDE.md test conventions; the M7
+`*_test.go` table shape from [02-design-notes.md](02-design-notes.md)
+§"Granular semantics").

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -99,15 +99,19 @@ earlier drafts of this plan assumed spike-era names that never shipped.
    direct-call extra-arg rejection as a call-site lint.
 5. **The probe API** — speculation infrastructure (length-snapshot journal over
    bound lists + side-table cleanup), needed by overloading and reused later.
-6. **Function overloading** (free functions) — overload sets as side-channel
-   metadata, call-site resolution as a separate phase, the ground-enough /
-   specificity / mutual-recursion-needs-annotation rules.
+6. **Function overloading** (free functions) — overload sets as a multi-scheme
+   `ValueBinding`, call-site resolution as a separate phase, value-position
+   references as an intersection of the arms (the one scoped lattice exception,
+   resolved via the probe), the ground-enough / specificity /
+   mutual-recursion-needs-annotation rules.
 
 ## Sequencing rationale
 
-Seven PRs (PR0–PR6) on three landed prerequisites (M1, M2, M2.5). Solid edges =
+Eight PRs (PR0–PR7) on three landed prerequisites (M1, M2, M2.5). Solid edges =
 hard dependency (downstream won't compile / pass tests without upstream); dashed
-= soft (downstream lands correctly but degraded until upstream fills it in).
+= soft (downstream lands correctly but degraded until upstream fills it in). PR7
+is a behavior-preserving refactor (the shared `soltype` rewriting visitor) — it
+depends only on PR1 and is otherwise independent.
 
 ```mermaid
 flowchart TD
@@ -122,6 +126,7 @@ flowchart TD
     PR4[PR4: function exactness]
     PR5[PR5: probe API]
     PR6[PR6: overloading]
+    PR7[PR7: soltype rewriting visitor — refactor]
 
     M2 --> PR1
     M25 --> PR1
@@ -133,18 +138,25 @@ flowchart TD
     PR1 --> PR2
     PR1 --> PR6
     PR5 --> PR6
+    PR1 --> PR7
     PR2 -. compact renders .-> PR1
     PR4 -. specificity accounts for exactness .-> PR6
+    PR7 -. visitor available for simplify's rewrite .-> PR2
 
     classDef prereq fill:#eee,stroke:#999,stroke-dasharray:3 3;
+    classDef refactor fill:#f5f5ff,stroke:#88a,stroke-dasharray:2 2;
+    class PR7 refactor;
 ```
 
 Parallelizable tracks: the **polymorphism chain** (PR1 → PR2), **async + block
 join** (PR3, only needs M2's walk), **exactness** (PR0 → PR4, reworking M2's
 `inferCall` + the `FuncType` rule), and the **probe** (PR5, only needs M1).
 Overloading (PR6) is the join of schemes (PR1), the probe (PR5), and — softly —
-exactness (PR4). M2.5's error model is a universal prerequisite for every
-error-emitting PR; only the strongest edges are drawn.
+exactness (PR4). **PR7** (the `soltype` rewriting visitor) is a non-blocking
+refactor off PR1, ideally sequenced right after it and before PR2 (so PR2's
+`rewrite` builds on the visitor rather than hand-rolling a fourth walk), but it
+can slip later with no correctness cost. M2.5's error model is a universal
+prerequisite for every error-emitting PR; only the strongest edges are drawn.
 
 - **PR1 → PR2 is the core chain.** Generalization (PR1) is what mints the
   quantified signatures; they only render *compact* once simplification (PR2)
@@ -164,6 +176,50 @@ error-emitting PR; only the strongest edges are drawn.
 - **PR6 (overloading) depends on PR1** (per-overload schemes) and **PR5** (each
   candidate trial runs under a probe), softly on **PR4** (the specificity rule
   must account for exact/inexact). Highest-uncertainty; last.
+- **PR7 (`soltype` rewriting visitor) depends only on PR1.** A behavior-preserving
+  refactor that extracts one polarity-threading rewriting visitor and reimplements
+  the three structural type→type transforms — `coalesce`, `extrude`, and PR1's
+  `freshenAbove` — on top of it. It needs `freshenAbove` to exist as the third
+  concrete instance (the trigger to extract), hence the PR1 edge; nothing depends
+  on it. Numbered last as a non-blocking cleanup, but lands cleanest right after
+  PR1 so PR2's `rewrite` can reuse the visitor.
+
+### Shared files & merge ordering
+
+"Parallelizable" above means **no hard dependency edge** — not file-disjoint.
+Several parallel-track PRs edit the same files (different functions within them),
+so concurrent development produces *merge* conflicts even where the logic is
+independent. The collisions are mechanical (adjacent hunks, shared import blocks),
+not semantic. Tracks: **A** = PR1→PR2, **B** = PR3, **C** = PR0→PR4, **D** = PR5.
+
+| File | A (PR1) | B (PR3) | C (PR4) | D (PR5) |
+|---|---|---|---|---|
+| `internal/solver/infer_expr.go` | `inferIdent` | `inferFuncExpr`/`inferFunc` + new `await` | `inferCall` lint | — |
+| `internal/solver/constrain.go` | — | — | `FuncType<:FuncType` case | bound-append sites |
+| `internal/soltype/print.go` | `<T0,…>` prefix | — | `Exact`/`Optional` in `printFuncTail`/`paramName` | — |
+| `internal/solver/errors.go` | — | await-outside-`async` error | `TooManyArgsError` | — |
+
+- **`infer_expr.go` is the one real hotspot** — three tracks (A/B/C) edit it, but
+  each touches a *different* `infer*` function, so conflicts are rebase-mechanical.
+- **Single-owner in the parallel set:** PR1 also owns `scope.go`, `module.go`,
+  `coalesce.go`, `infer_decl.go`, new `poly.go`; PR3 owns `infer_stmt.go`; PR4 owns
+  `soltype/type.go` and the `internal/parser/` `...`/`x?` changes; PR5 owns
+  `context.go` and new `probe.go`.
+- **Suggested merge order to minimize churn:** land the two structure-reshaping
+  PRs — **PR1** (`ValueBinding`/printer) and **PR4** (`FuncType` fields, `constrain`
+  `FuncType` case, printer markers) — *before* **PR3** and **PR5**, which then rebase
+  onto the settled shape of `infer_expr.go`/`constrain.go`/`print.go`.
+- Note: PR1's `coalesce` `seen`-guard sub-task is **already shipped** —
+  `coalesceRec` in `coalesce.go` already threads a `seen` set; verify before
+  re-adding.
+- **PR7 (refactor) rewrites the transforms the others edit, so land it after
+  them.** It touches new `soltype/visitor.go`, `soltype/type.go` (an `Accept`
+  method per type node), `coalesce.go`, `constrain.go` (`extrude`), and `poly.go`
+  (`freshenAbove`). Those overlap PR1 (`coalesce.go`/`poly.go`), PR4
+  (`constrain.go` `FuncType` case + `soltype/type.go` fields), and PR5
+  (`constrain.go` bound-append sites). Since PR7 is a pure refactor with no
+  behavior change, sequence it *after* PR1/PR4/PR5 have settled those regions and
+  rebase onto them — don't run it concurrently.
 
 ## Core types added or changed in M3
 
@@ -189,37 +245,120 @@ type FuncParam struct {
 **Schemes** (PR1) — new file `internal/solver/poly.go`:
 
 ```go
-type TypeScheme interface{ isScheme() }
+type TypeScheme interface {
+    isScheme()
+    IsAnnotated() bool // PR6: this arm came from a user-written signature
+}
 
-type MonoScheme struct{ Ty soltype.Type }            // param, current-level RHS, rec self-ref
-type PolyScheme struct{ Level int; Body soltype.Type } // generalize vars with Level > Level
+type MonoScheme struct {
+    Ty        soltype.Type // param, current-level RHS, rec self-ref
+    Annotated bool         // PR6 only — consulted solely for overload arms
+}
+type PolyScheme struct {
+    Level     int          // generalize vars with Level > Level
+    Body      soltype.Type
+    Annotated bool         // PR6 only — set per overload arm; folds for the recursion gate
+}
 
-func (*MonoScheme) isScheme() {}
-func (*PolyScheme) isScheme() {}
+func (*MonoScheme) isScheme()           {}
+func (*PolyScheme) isScheme()           {}
+func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
+func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }
 ```
 
-**`ValueBinding` swaps `Type` for a scheme but keeps `Sources`** (PR1; M2 PR-5
-sanctioned the field swap, but the `Sources` field is load-bearing for M2.5 blame
-and go-to-definition and must be retained):
+**`ValueBinding` swaps `Type` for a *slice* of schemes and keeps `Sources`** (PR1
+introduces the slice; PR6 reuses it). M2 PR-5 sanctioned the `Type`→scheme swap;
+`Sources` stays (load-bearing for M2.5 blame / go-to-definition). A binding holds
+**one** scheme for an ordinary value and **N** for an overload set — collapsing
+PR6's would-be `OverloadSet` into the same slice rather than a separate
+nullable field. This parallels `Sources`, which *already* carries one entry per
+arm (`scope.go` documents the multi-`FuncDecl` accumulation today), so `Schemes[i]`
+lines up with the arm at `Sources[i]`; and it makes the "is the scheme `nil` when
+overloaded?" footgun unrepresentable — cardinality is just `len(Schemes)`.
 
 ```go
 // internal/solver/scope.go — was {Type soltype.Type; Sources []provenance.Provenance}.
 type ValueBinding struct {
-    Scheme   TypeScheme               // PR1: replaces the monomorphic Type
-    Sources  []provenance.Provenance  // RETAINED — M2.5 blame / go-to-definition
-    Overload *OverloadSet             // PR6: non-nil for overloaded fn decls
+    Schemes []TypeScheme            // 1 = ordinary binding; >1 = overload set (declaration order)
+    Sources []provenance.Provenance // RETAINED — M2.5 blame / go-to-definition; parallels Schemes
 }
+
+// IsOverloaded reports whether this binding is an overload set. Consumers MUST
+// check it before routing (expected to be a common call): an ordinary call
+// (false) keeps M2's shipped subtype-constraint path and its FuncArityMismatch /
+// deferred-callee behavior; an overloaded call (true) goes through resolveOverload
+// (PR6). inferIdent's value-position lookup branches on it too.
+func (b ValueBinding) IsOverloaded() bool { return len(b.Schemes) > 1 }
 ```
 
-**`OverloadSet`** (PR6) — an overloaded symbol is a *set of schemes*, not a
-single `soltype.Type`:
+**No separate `OverloadSet` type.** What was `OverloadSet.Branches` *is*
+`ValueBinding.Schemes`; what was `OverloadSet.Annotated` (the recursion gate)
+folds over the arms — `all(s.IsAnnotated() for s in b.Schemes)` — with
+annotated-ness riding on the scheme, where it belongs (a per-arm property, not a
+binding-wide one). Invariant to record: `Schemes` is never empty for a live
+binding — `inferComponent` pre-binds a fresh `MonoScheme` before inferring, and a
+failed binding is `removeValue`'d, not left at `len == 0`.
 
-```go
-type OverloadSet struct {
-    Branches  []TypeScheme // one per declared/inferred overload, declaration order
-    Annotated bool         // every branch annotated? (gates recursive groups)
-}
-```
+**Value-position type of an overloaded name = an intersection of the arms**
+(`let g = f` where `f` has `len(Schemes) > 1`). `inferIdent`, on the
+`b.IsOverloaded()` branch, instantiates each arm and synthesizes
+`IntersectionType{arm₁, …, armₙ}` (arm order preserved). This is the
+TS-compatible, codebase-sanctioned representation — the old checker did exactly
+this, and [module.go:81](../../internal/solver/module.go) already names the
+"overloads as an IntersectionType of the per-arm signatures" destination. It
+matches what a user writing the explicit `F1 & F2` annotation
+([intersection_types/requirements.md](../intersection_types/requirements.md)
+§"Intersection with Functions") would get.
+
+**Caveat — this carries a *scoped exception* to "the disjunction never enters the
+lattice".** A first-class overloaded *value* flowing into a function-typed slot
+needs `(F1 & F2) <: F` — the **disjunctive** intersection-LHS rule (`(A & B) <: C`
+iff `A <: C` *or* `B <: C`), i.e. ordered speculative arm-trial, the very thing
+`resolveOverload` was split out to contain. Synthesizing the intersection does not
+*remove* overload resolution; it *relocates* it into `constrain`. So M3 scopes it
+deliberately:
+
+1. **`b.Schemes` stays the source of truth.** The intersection is synthesized
+   **lazily, only at value-position `inferIdent`** — never eagerly per binding
+   (most overloaded fns are only ever called directly).
+2. **Only the function-intersection-LHS rule ships**, and it is implemented by
+   **reusing PR5's probe + `resolveOverload`'s ordered first-match** — the
+   disjunction lives in the existing speculation phase, not in naive constraint
+   propagation. General intersection support (objects, distribution,
+   normalization) is **out of M3** (its own milestone; today the new solver's
+   `constrain` has *no* `IntersectionType` case at all).
+3. **The exception is documented as exactly that** — function-intersection LHS,
+   resolved via the probe — so the lattice's principal-type/determinism story
+   stays intact everywhere else.
+4. **Two known costs accepted:** the scheme-slice ↔ intersection-type
+   representations must be kept consistent (one synthesis helper), and the
+   declaration-order tie-break depends on the intersection *retaining arm order*
+   (don't let normalization reorder/dedup it).
+
+`inferIdent` still branches on `IsOverloaded()`; the non-overloaded path is the
+plain `c.instantiate(b.Schemes[0], lvl)`.
+
+**Why not call-signature objects (a TS-interface-style object with N call
+signatures) instead of an intersection?** It was considered and **deferred to M4**.
+An object-with-call-signatures is the *same type* as the intersection of those
+signatures (TS treats `{ (x:string):number; (x:number):string }` and
+`((x:string)=>number) & ((x:number)=>string)` as interconvertible), so it has
+**identical subtyping behavior in both directions** and the **same disjunctive
+use-direction rule** — the disjunction is intrinsic to "callable in multiple ways,"
+not to the intersection encoding, so the object model would not avoid the scoped
+lattice exception above; it would only move it to a different node. For *pure
+overloading* it buys nothing and costs more than intersection: `RecordType` has no
+call-signature slot today (`{Fields []*RecordField}`, [type.go](../../internal/soltype/type.go)),
+whereas `IntersectionType` nodes already ship in M1, and Escalier already specs the
+writable `F1 & F2` syntax but no call-signature-object syntax. Its genuine wins are
+all **M4+ object-system** territory: **hybrid callable types** (a value both
+callable *and* carrying properties — `f.version`, jQuery's `$` — plus construct
+signatures), and the richer **LSP** surface that a unified object representation
+gives (hover/signature-help/members on a callable that also has fields). The clean
+future framing: an overload is the degenerate callable-object with N call
+signatures and 0 properties, so M4's object model can later **subsume** this
+intersection encoding without a representational fork — adopting it in M3 would pay
+M4 cost for no M3 gain.
 
 **The probe** (PR5) — `internal/solver/probe.go`:
 
@@ -238,14 +377,14 @@ type Probe struct {
 
 ## PR breakdown
 
-### PR0 — Spec sync: Policy A, the `open` marker, and #677's accept-set model
+### PR0 — Spec sync: exact-by-default, the `open` marker, and #677's accept-set model
 
 Pure documentation; unblocks PR4. Records decisions the milestones doc flags as
 "not yet in the spec."
 
-- Add a section to `planning/exact-types/requirements.md` recording **Policy A**
-  (usage-inferred record shapes coalesce as *exact*; row polymorphism is opt-in
-  via the `open` parameter marker). (Records the decision now even though
+- Add a section to `planning/exact-types/requirements.md` recording the
+  **exact-by-default** rule (usage-inferred record shapes coalesce as *exact*; row
+  polymorphism is opt-in via the `open` parameter marker). (Records the decision now even though
   usage-inference itself is M4 — exactness defaults must be settled before PR4.)
 - Rewrite §4.2 per escalier-lang/escalier#677: **direct calls reject extra args
   regardless of exactness** (a call-site lint); **exactness governs callback
@@ -263,9 +402,11 @@ in the spec before the implementation asserts it.
 The core M3 PR. M2 infers functions monomorphically and freezes recursive groups
 to coalesced monotypes; PR1 turns that into real let-polymorphism.
 
-- **Schemes in the scope.** `ValueBinding.Type` → `ValueBinding.Scheme`
-  (`poly.go`/`scope.go`); keep `Sources`. Param bindings and current-level RHS
-  during inference are `MonoScheme`; generalized decls are `PolyScheme`.
+- **Schemes in the scope.** `ValueBinding.Type` → `ValueBinding.Schemes`
+  (`poly.go`/`scope.go`); keep `Sources`. PR1 only ever sets `len(Schemes) == 1`
+  (PR6 grows it); add the `IsOverloaded()` helper now so the single-scheme call
+  path reads `!b.IsOverloaded()` from the start. Param bindings and current-level
+  RHS during inference are `MonoScheme`; generalized decls are `PolyScheme`.
 - **`instantiate` / `freshenAbove`** (`poly.go`): `instantiate(MonoScheme)`
   returns as-is; `instantiate(PolyScheme)` calls `freshenAbove` (fresh var per
   var with `Level > scheme.Level`, bounds freshened) and records a
@@ -275,7 +416,10 @@ to coalesced monotypes; PR1 turns that into real let-polymorphism.
   M11.5; PR1 only mints the edge.
 - **`inferIdent` instantiation hook.** M2 returns `b.Type` directly with a
   `// M3: instantiate` comment; PR1 makes value-position lookup
-  `c.instantiate(b.Scheme, lvl)`.
+  `c.instantiate(b.Schemes[0], lvl)` for the ordinary (`!b.IsOverloaded()`) case.
+  The `b.IsOverloaded()` value-position branch — synthesizing the arm intersection
+  (see "Core types") — is PR6's; PR1 can leave it as a TODO, since M2 rejects
+  multi-`FuncDecl` names today so no overloaded binding reaches here yet.
 - **Generalize at the SCC boundary.** `inferComponent` phase 3 today does
   `coalesce(b.v, Positive)` → a monotype. PR1 changes it to generalize: variables
   at `Level > lvl` become quantifiable; captured outer vars do not. The result is
@@ -303,7 +447,9 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 
 // freshenAbove copies t, replacing each var with Level > lim by a fresh var at
 // lvl (bounds freshened); vars at Level <= lim are shared. // M4: thread a
-// lifetime cache once lifetime-bearing types exist.
+// lifetime cache once lifetime-bearing types exist. // PR1 lands this hand-rolled,
+// parallel to coalesce/extrude; PR7 collapses all three onto a shared rewriting
+// visitor (no behavior change).
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[int]*soltype.TypeVarType) soltype.Type { /* ... */ }
 
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
@@ -318,7 +464,7 @@ for _, key := range component {
     b := bindings[key]
     if !b.bound { scope.removeValue(key.Name()); continue }
     scheme := c.generalize(b.v, lvl) // was: coalesce(b.v, Positive) → monotype
-    scope.defineValue(key.Name(), ValueBinding{Scheme: scheme, Sources: b.sources})
+    scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources})
     // ... recordType on the name/pattern as today
 }
 ```
@@ -430,6 +576,25 @@ and M2's `inferCall`/`FuncType` rule.
   callee is concrete, reject `argc > len(Params)`. For an unresolved callee the
   lint is best-effort (skipped) while "too few / required" still flows through the
   constraint — so nothing regresses for deferred calls.
+- **The synthesized call demand is EXACT + all-required — and the M2 sketch's
+  default is a latent bug.** `inferCall` constrains `callee <: FuncType{args →
+  res}`; that synth must be `Exact: true` with non-optional params, so `accept(synth)
+  = [N, N]` (N = arg count) and the constraint reads exactly "callee accepts being
+  called with N args" (`required(callee) ≤ N ≤ upper(callee)`). An **inexact** synth
+  has `accept = [N, ∞)`, which forces `upper(callee) = ∞` — i.e. rejects every call
+  to an *exact* function. M2 builds the synth with no flag, so the Go zero value is
+  `Exact: false` (inexact) — PR4 **must** set it `true`.
+- **Reconcile the exact synth with the lint so too-many isn't double-reported.** An
+  exact synth's accept-set gate *already* rejects too-many for an *exact* concrete
+  callee (`upper(callee) = M < N`), which would fire `FuncArityMismatchError`
+  alongside the `TooManyArgsError` lint. So when the lint fires (concrete callee,
+  `argc > len(Params)`), hand the constraint only the arity-matched prefix
+  `args[:len(fn.Params)]`: the lint owns the single, uniform too-many message and the
+  constraint does pure type-flow. The lint remains the *only* catch for an *inexact*
+  concrete callee (whose `upper = ∞` the gate can't reject — #677's deliberate case).
+  For a deferred (var) callee neither fires up front; too-many still surfaces from the
+  gate as `FuncArityMismatchError` if it later resolves to an exact-with-fewer-params
+  function.
 - **`required` from `Optional`.** `required` = count of non-optional params;
   `Optional` lowers it without changing `len(Params)`.
 
@@ -459,18 +624,26 @@ case *soltype.FuncType:
 ```
 
 ```go
-// internal/solver/infer_expr.go — inferCall gains the extra-arg lint; the
-// existing subtype constraint is unchanged (it carries type flow + the required
-// lower bound, deferred-callee-safe).
+// internal/solver/infer_expr.go — inferCall gains the extra-arg lint and an
+// EXACT, all-required call demand (the type-flow constraint is otherwise the
+// shipped one: it carries the required lower bound, deferred-callee-safe).
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
     callee := c.inferExpr(scope, lvl, e.Callee)
     args := make([]*soltype.FuncParam, len(e.Args))
     for i, a := range e.Args { args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)} }
+    // Too-many is the lint's job (uniform message; fires for exact AND inexact).
+    // When it fires on a concrete callee, hand the constraint only the arity-matched
+    // prefix so the exact synth's accept-set gate doesn't ALSO report arity.
+    demand := args
     if fn, ok := callee.(*soltype.FuncType); ok && len(e.Args) > len(fn.Params) {
-        c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn}) // bridge error: carries the node (M2.5)
+        c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn}) // bridge error (M2.5)
+        demand = args[:len(fn.Params)]
     }
     res := c.freshAt(lvl)
-    c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+    // EXACT + all-required ⇒ accept(synth) = [N, N], so the constraint demands
+    // "callee accepts N args" (required(callee) ≤ N ≤ upper(callee)). Inexact here
+    // would force the callee inexact and reject every exact-fn call.
+    c.constrain(e, callee, &soltype.FuncType{Params: demand, Ret: res, Exact: true})
     if fn, ok := callee.(*soltype.FuncType); ok { c.constrain(e, fn.Ret, res) }
     c.recordType(e, res)
     return res
@@ -480,16 +653,25 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 `TooManyArgsError` is a new **bridge** error per M2.5 — it holds the `*ast.CallExpr`
 and derives `Span()` from it (and `Related()` to the callee), not the retired
 `c.error(n, …)` stamp. The existing `FuncArityMismatchError` continues to cover
-the "too few / required" and callback-arity failures from the constraint.
+the "too few / required" failures, callback-arity failures, and — for a *deferred*
+callee that resolves to an exact-with-fewer-params function — the too-many case the
+up-front lint had to skip.
 
 **Tests (#677 acceptance):** both exact `fn(x, y)` and inexact `fn(x, y, ...)`
 reject a 3-arg direct call (full message via `requireBlame`); both accept 2 args.
 Into a `fn(x, y)` callback slot, `fn(x, y)`/`fn(x, ...)`/`fn(...)` are accepted
-while exact `fn(x)` and any 3+-param function are rejected.
+while exact `fn(x)` and any 3+-param function are rejected. Plus two regressions
+the exact synth guards: an exact `fn(x, y)` called with 2 args **type-checks**
+(an inexact synth would reject it); a 3-arg call to exact `fn(x, y)` yields
+**exactly one** diagnostic (the `TooManyArgsError` lint), not a doubled
+lint + `FuncArityMismatchError`.
 
 **Risk:** medium. The accept-set rule is small and precisely specified; the care
-is the `required`/`Exact`/`Optional` bookkeeping and keeping the extra-arg lint
-distinct from the constraint (so deferred calls don't lose the required check).
+is the `required`/`Exact`/`Optional` bookkeeping, setting the call demand
+`Exact: true` (the inexact default silently rejects every exact-fn call), and
+keeping the extra-arg lint distinct from the constraint — both so deferred calls
+don't lose the required check and so the exact synth's gate doesn't double-report
+too-many alongside the lint.
 
 ---
 
@@ -526,7 +708,13 @@ func (p *Probe) record(v Bounded) {
 }
 func (p *Probe) onRollback(f func()) { p.cleanups = append(p.cleanups, f) }
 func (p *Probe) rollback() {
-    for i := len(p.cleanups) - 1; i >= 0; i-- { p.cleanups[i]() } // side tables first
+    // Cleanups run before entries (side tables first) and in reverse (LIFO).
+    // Reverse is *required*, not stylistic: a single Info/Prov key may be
+    // written more than once under the probe, and each closure captured that
+    // key's prior value at registration time — only unwinding newest-first
+    // restores the original. (Entry truncation below is reverse for symmetry
+    // only; touched dedupes to one entry per var, so order there is moot.)
+    for i := len(p.cleanups) - 1; i >= 0; i-- { p.cleanups[i]() }
     for i := len(p.entries) - 1; i >= 0; i-- { e := p.entries[i]; e.v.truncateBounds(e.prevLower, e.prevUpper) }
 }
 func (p *Probe) Discard() { if !p.done { p.rollback(); p.done = true } }
@@ -557,13 +745,31 @@ candidate trial runs under a probe), softly on PR4 (specificity must account for
 exact/inexact). M2 currently *rejects* multiple top-level `FuncDecl`s of one name
 with `OverloadNotSupportedError`; PR6 replaces that with real overloading.
 
-- **Overload sets as side-channel metadata.** `ValueBinding.Overload` holds a set
-  of schemes — not a single `soltype.Type`; the disjunction never enters the
-  lattice. `inferComponent` collects the per-name `FuncDecl` arms (which M2
-  already gathers into `Sources`) and infers each body independently.
+- **Overload sets as a multi-scheme binding.** An overloaded symbol is a
+  `ValueBinding` with `len(Schemes) > 1` (`b.IsOverloaded()`) — a set of schemes,
+  not a single `soltype.Type`; the disjunction stays out of the lattice for call
+  resolution (the value-position intersection below is the one scoped exception).
+  `inferComponent` collects the per-name `FuncDecl` arms (which M2 already gathers
+  into `Sources`, index-aligned with `Schemes`) and infers each body
+  independently, setting each arm scheme's `Annotated` from its signature.
 - **Call-site resolution as a separate phase from `constrain`.** At each call,
   collect the args' bounds, pick one overload under a probe (PR5), commit the
   first success, roll back losers' caller-side bounds.
+- **Value-position reference ⇒ intersection of arms (scoped lattice exception).**
+  On `inferIdent`'s `b.IsOverloaded()` branch, synthesize
+  `IntersectionType{arm₁, …, armₙ}` (arm order preserved) — lazily, only here, with
+  `b.Schemes` staying the source of truth (see "Core types"). This is the *only*
+  place the disjunction touches the lattice: a value flowing into a function-typed
+  slot needs the **function-intersection-LHS** rule `(A & B) <: C` iff `A <: C` *or*
+  `B <: C`. Implement *only* that rule, and implement it by **reusing the PR5 probe
+  + this PR's ordered first-match** (the same `resolveOverload` machinery), so the
+  disjunction stays confined to the speculation phase rather than leaking into naive
+  constraint propagation. General `IntersectionType` subtyping (objects,
+  distribution, normalization) is explicitly **out of M3** — the new solver's
+  `constrain` has no `IntersectionType` case today, and full intersection support is
+  its own milestone. A value-position call on a `let`-bound overload (`g = f; g(x)`)
+  therefore routes through this intersection-LHS arm of `constrain`, which re-enters
+  the ordered probe — *not* a second copy of the resolver.
 - **Ground-enough deferral.** If an argument is still a fully unconstrained
   variable, defer the call (preferred) or fall back to declaration-order
   first-match. No speculative pinning + backtrack.
@@ -582,9 +788,9 @@ with `OverloadNotSupportedError`; PR6 replaces that with real overloading.
 
 ```go
 // internal/solver/overload.go — resolution is a phase distinct from constrain.
-func (c *checker) resolveOverload(scope *Scope, lvl int, set *OverloadSet, args []soltype.Type, call ast.Node) (soltype.Type, bool) {
+func (c *checker) resolveOverload(scope *Scope, lvl int, schemes []TypeScheme, args []soltype.Type, call ast.Node) (soltype.Type, bool) {
     if !groundEnough(args) { return nil, false } // defer
-    for _, sig := range orderBySpecificity(set.Branches) {
+    for _, sig := range orderBySpecificity(schemes) { // schemes = b.Schemes, b.IsOverloaded()
         inst := c.instantiate(sig, lvl).(*soltype.FuncType) // (D) fresh per candidate; branches are fn schemes
         p := c.openProbe()                                  // (A, PR5) wrap caller-side bounds
         ok := c.tryConstrainArgs(args, inst, p)
@@ -600,7 +806,7 @@ func (c *checker) resolveOverload(scope *Scope, lvl int, set *OverloadSet, args 
 // internal/solver/module.go — gate before inferring a recursive component.
 func (c *checker) checkOverloadAnnotations(component []dep_graph.BindingKey, g *dep_graph.DepGraph) {
     if len(component) <= 1 { return } // self-recursion is softer
-    // for each overloaded member of the group whose branches aren't all annotated:
+    // for each overloaded member (b.IsOverloaded()) whose arms aren't all IsAnnotated():
     //   c.errs = append(c.errs, &UnannotatedRecursiveOverloadError{...}) // bridge error
 }
 ```
@@ -621,6 +827,111 @@ the specificity rule simple and documented; prefer the ground-enough *defer* pat
 over guessing. If resolution proves intractable, the fallback is declaration-order
 first-match for the MVP with a tracked follow-up — overloading is the one M3 piece
 that can ship reduced without blocking M4.
+
+---
+
+### PR7 — `soltype` rewriting visitor (refactor)
+
+Behavior-preserving cleanup. After PR1, the solver has **three** near-identical
+structural type→type transforms — `coalesce` ([coalesce.go](../../internal/solver/coalesce.go)),
+`extrude` ([constrain.go](../../internal/solver/constrain.go)), and PR1's
+`freshenAbove` (new `poly.go`) — that each re-spell the same `FuncType`/`TupleType`/
+`RecordType` rebuild-from-children boilerplate *and* the same variance knowledge
+(`pol.Flip()` on func params). `soltype` has no visitor today, even though
+`type_system` already ships the rewriting pattern ([visitor.go](../../internal/type_system/visitor.go):
+`Accept(TypeVisitor) Type`, `ExitType(t) Type`) and CLAUDE.md mandates "use the
+existing visitor for that tree … don't hand-roll a new traversal." PR7 fills that
+gap and reimplements the three transforms on it.
+
+- **A polarity-threading rewriting visitor in `soltype`.** Unlike
+  `type_system`'s visitor, it threads `Polarity` and the walker flips it on
+  contravariant positions (func params) so variance lives in **one** place instead
+  of being re-spelled per transform. **Replacement can happen in either phase:**
+  `EnterType` may return a replacement node (optionally with `SkipChildren`) and
+  `ExitType` may replace the rebuilt node — enter fires *before* child traversal
+  (so it can prune, break a cycle, or take over the recursion), exit fires *after*
+  (bottom-up, a function of already-rewritten children). Each `soltype.Type` gains
+  an `Accept(v, pol)` method that rebuilds `Func`/`Tuple`/`Record` from visited
+  children (atoms pass through).
+- **Identity-preserving rebuild.** `Accept` allocates a new node only when a child
+  actually changed (`pt != p.Type`, `ret != t.Ret`); when nothing changed it returns
+  the original `t`. Unchanged subtrees keep pointer identity — no needless
+  allocation, and identity-keyed caches / `seen` sets stay valid across a walk. The
+  structural arms copy the child slice on first change (copy-on-write) so the
+  original is never mutated.
+- **The var case stays bespoke — by design.** A `TypeVarType`'s bounds are a side
+  graph, not tree children (polarity-and-direction-selected; `extrude` even mutates
+  the original var mid-walk). So each transform handles the var node entirely in
+  its own `EnterType` returning `{Type: replacement, SkipChildren: true}`, with its
+  auxiliary state (coalesce's path-scoped `seen`; extrude's `(ID, pol)` cache;
+  freshenAbove's `ID` cache) living on the visitor struct. The visitor unifies the
+  *structural arms and the variance*, not the algorithmic core.
+- **`freshenAbove` ignores `pol`** (it freshens uniformly — no variance needed), so
+  the one visitor serves all three; the polarity machinery is what `coalesce`/
+  `extrude` need.
+- **No new behavior.** This is a pure refactor; the contract is that existing
+  snapshots/fixtures are untouched.
+
+**Sketch:**
+
+```go
+// internal/soltype/visitor.go
+type EnterResult struct {
+    Type         Type // nil = keep the node; non-nil = replace it
+    SkipChildren bool // true = skip the structural rebuild, go straight to ExitType
+}
+type TypeVisitor interface {
+    EnterType(t Type, pol Polarity) EnterResult
+    ExitType(t Type, pol Polarity) Type
+}
+
+// per node — the walker owns variance (callers never re-spell pol.Flip()) and
+// rebuilds IDENTITY-PRESERVINGLY: a fresh node is allocated only when a child
+// actually changed; otherwise the original t flows through unchanged.
+func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
+    e := v.EnterType(t, pol)
+    cur := t
+    if e.Type != nil { cur = e.Type.(*FuncType) }
+    if e.SkipChildren { return v.ExitType(cur, pol) }
+    changed := false
+    params := cur.Params                 // copy-on-write: alias until a param changes
+    for i, p := range cur.Params {
+        pt := p.Type.Accept(v, pol.Flip()) // params contravariant
+        if pt != p.Type {
+            if !changed { params = append([]*FuncParam(nil), cur.Params...); changed = true }
+            params[i] = &FuncParam{Pattern: p.Pattern, Type: pt}
+        }
+    }
+    ret := cur.Ret.Accept(v, pol)        // return covariant
+    out := cur
+    if changed || ret != cur.Ret { out = &FuncType{Params: params, Ret: ret} }
+    return v.ExitType(out, pol)
+}
+```
+
+```go
+// internal/solver/coalesce.go — coalesce becomes a visitor; the var case is the
+// whole content, the Func/Tuple/Record arms come from Accept.
+type coalescer struct{ seen set.Set[*soltype.TypeVarType] }
+func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+    v, ok := t.(*soltype.TypeVarType)
+    if !ok { return soltype.EnterResult{} } // structural node: let Accept rebuild it
+    // ... seen-guard + combine(pol, freshened bounds) ..., SkipChildren: true
+}
+func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+```
+
+**Tests:** the existing `coalesce`/`extrude`/`freshenAbove` suites and all
+checker snapshots/fixtures pass **unchanged** (the behavior-preservation contract).
+Plus a few unit tests for the visitor itself: contravariant `pol` flip on func
+params, `EnterType` replacement + `SkipChildren`, atom pass-through, and identity
+preservation (a no-op rewrite returns the *same* `FuncType` pointer; changing one
+param's type allocates a new node but reuses the unchanged `*FuncParam`s).
+
+**Risk:** low. Pure refactor guarded by the existing snapshot/fixture suites; the
+subtlety is getting the polarity-flip and the var-case `SkipChildren` short-circuit
+right, both directly asserted. Lands cleanest after PR1/PR4/PR5 settle
+`coalesce.go`/`constrain.go`/`poly.go` (see "Shared files & merge ordering").
 
 ## Risks & gates
 

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -1,199 +1,238 @@
 # M3 — Functions, application, let-polymorphism — implementation plan
 
-Concrete, PR-by-PR plan for landing milestone **M3** of the SimpleSub checker
-(`internal/solver/`). Read [01-milestones.md](01-milestones.md) §"M3" for the
-milestone definition and [02-design-notes.md](02-design-notes.md) for the
-`soltype` shapes this plan promotes. Names are provisional and follow the
-design-notes leaf-name decision (`internal/solver/`, types in `soltype/`).
+Concrete, PR-by-PR plan for milestone **M3** of the SimpleSub checker. Read
+[01-milestones.md](01-milestones.md) §"M3" for the milestone definition,
+[m2-implementation-plan.md](m2-implementation-plan.md) and
+[m2.5-implementation-plan.md](m2.5-implementation-plan.md) for the surface this
+builds on, and [02-design-notes.md](02-design-notes.md) for the longer-range
+shapes. Sketches below use the **shipped** names (`FuncType`, `checker`, …) and
+are illustrative — `// ...` marks elisions.
 
-## What M3 delivers
+> **This plan was revised to match shipped reality.** M1, M2, and the M2.5 plan
+> have landed (`main`, PRs #686–#705). M2 already shipped the
+> function/application/block walk monomorphically, so M3 is **not** "build the
+> function walk" — it is "add polymorphism, async, exactness, and overloading on
+> top of M2's monomorphic walk, and finish the carried-over block semantics."
 
-M3 turns the soltype scaffolding from M1/M2 into a real function-language
-checker. Five workstreams, in dependency order:
+## Prerequisites (what M1, M2, and M2.5 shipped)
 
-1. **Functions + application + multi-arg** — lambda/`fn` decls and call
-   expressions inferred against the real AST, with the function `constrain`
-   rule (params contravariant, return covariant).
-2. **Level-based let-polymorphism** — schemes (`MonoScheme`/`PolyScheme`),
-   `instantiate`, `freshenAbove`, and generalization at binding boundaries
-   threaded through the AST walk by level.
-3. **The simplification pass** — single-polarity elimination + co-occurrence
-   variable merging, so generalized signatures render compactly and
-   parameter-only variables coalesce to `unknown` rather than a vacuous `<T0>`.
-4. **Function exactness** — the `exact` flag on `FunctionType` plus the
-   accept-set subtyping model and direct-call arity rule from
-   escalier-lang/escalier#677.
-5. **Function overloading (free functions)** — overload sets as side-channel
-   metadata, call-site resolution as a separate phase from `constrain`, with
-   the ground-enough / specificity / mutual-recursion-needs-annotation rules.
+M3 builds directly on the landed packages. The exact surface matters because
+earlier drafts of this plan assumed spike-era names that never shipped.
 
-## Prerequisites (M1 + M2 must be merged)
+**Packages.** Two top-level siblings (not one nested package):
 
-M3 has no new infrastructure of its own except the **probe API** (see PR 5); it
-builds entirely on what M1 and M2 stand up. Before starting, the following must
-exist in `internal/solver/`:
+- `internal/soltype/` — the type representation. `Type` (sealed, marker
+  `isType()`); `TypeVarType{ID, Level, LowerBounds, UpperBounds}` +
+  `BoundsAt(pol)`; `PrimType{Prim}`, `LitType{Lit}` (`NumLit`/`StrLit`/`BoolLit`);
+  `FuncType{Params []*FuncParam, Ret}`, `FuncParam{Pattern Pat, Type}` (name via
+  `IdentPat`); `TupleType{Elems}`; `RecordType{Fields []*RecordField}` + `Field`;
+  `Void`, `NeverType`, `UnknownType`, `UnionType`, `IntersectionType`; `LevelOf`;
+  `Polarity`; `soltype.Print` (the coalesced-output renderer).
+- `internal/solver/` — the engine + walk. `Context{…}` with `freshVar(level)` and
+  `Constrain(lhs, rhs) []SolverError`; the `checker` carrier `{ctx *Context; info
+  *Info; errs []SolverError}` (method receiver for the whole walk) with
+  `freshAt(lvl)`, `constrain(n, lhs, rhs)`, `report`, `reportUnsupported`,
+  `recordType`; `Info{TypeOf, setType}`; `Scope` (three-sorted: `values`/`types`/
+  `namespaces`, with `Child()`, `defineValue`/`removeValue`/`defineType`/
+  `defineNamespace`, `GetValue`/`GetType`/`GetNamespace`); `ValueBinding{Type
+  soltype.Type; Sources []provenance.Provenance}`; `coalesce(t, pol)`; the
+  `SolverError` hierarchy (`errors.go`); the module driver `InferModule` →
+  `inferDepGraph` → `inferComponent`.
 
-- **From M1:** `soltype.TypeVarType` (bound lists + level), `PrimitiveType`,
-  `LiteralType`, `FunctionType`, `TupleType`; `constrain(lhs <: rhs)` with the
-  coinductive seen-cache, levels + extrusion; polarity-driven `coalesce`; the
-  `soltype` printer; the `Info` side table (`map[ast.Node]soltype.Type` +
-  `TypeOf`/`setType`).
-- **From M2:** the constraint-generating AST walk (`infer.go`) driving from
-  real `*ast.Module` via `dep_graph`/`resolver`; the owned
-  `Scope`/`Binding`/`Namespace`; the fixture-style table-test harness that
-  asserts rendered binding types from `.esc` source.
+**M2 already implements (all MONOMORPHIC):**
 
-> **Note on the M1/M3 boundary.** M1's acceptance ("an identity term renders
-> `fn <T0>(x: T0) -> T0`") is over a **hand-built** soltype term, exercising the
-> printer + coalescing on a single variable. M3 is where that render is produced
-> **from real source** end-to-end, which additionally requires generalization
-> (PR2) and the simplification pass (PR3). The `freshenAbove`/`instantiate`
-> and `analyze`/`mergeCoOccurring` code in the spike (`scheme.go`, `simplify.go`)
-> is *promoted* here, not invented.
+- Function expressions and declarations — `inferFuncExpr` → `inferFunc`
+  (`infer_expr.go`): child scope, fresh var per un-annotated param, body inferred,
+  return annotation constrained, builds `*soltype.FuncType`. **This is the work an
+  earlier draft of this plan put in "PR1"; it is done.**
+- Application — `inferCall` (`infer_expr.go`): types callee and args, mints a
+  fresh result var, and emits **`constrain(callee <: FuncType{args → res})`** (a
+  single subtype constraint — the design M3 builds on, *not* a separate
+  obligation). N-ary already.
+- Blocks / `return` / `Void` — `inferBlock`/`inferStmt` (`infer_stmt.go`): block
+  value is its **last statement** (or `Void`); `ReturnStmt` handled.
+- Tuples, object literals, member access — `inferTuple`/`inferObject`/
+  `inferMember` (`infer_expr.go`).
+- Module ordering + recursive groups — `inferComponent` (`module.go`): dep-graph
+  SCC order, fresh var per binding, define-before-infer, constrain each def `<:`
+  its var, then **phase 3 coalesces each var to a monomorphic type** (`coalesce(b.v,
+  Positive)`) and rebinds. No generalization.
+- The `FuncType <: FuncType` constrain rule is **exact same-arity** today
+  (`len(l.Params) != len(r.Params)` → `FuncArityMismatchError`); a code comment
+  notes the inexact arm "lands in M3 with the exactness flag."
+- Diagnostics for out-of-scope constructs: `NamespaceUsedAsValueError`,
+  `UnknownIdentifierError`, `OverloadNotSupportedError` (M2 rejects multiple
+  top-level `FuncDecl`s of one name), `UnsupportedNodeError`, etc.
+
+**M2.5 (precedes M3 — its plan has landed, the work lands before M3):**
+
+- The **`Prov: Type → Origin` side table** — ships the **leaf** `FromAST{Node,
+  Kind}` only. The interior edge kinds ride along with the M3+ operations that
+  mint them; **`FromInstantiation` is explicitly assigned to M3** (added below in
+  PR1). `Prov` lives on the `checker` carrier.
+- **Errors carry AST nodes, not strings.** M2.5 reshapes `SolverError`:
+  `setSpan`/`errSpan` give way to node-derived `Span()` + `Related()`. Errors
+  partition into **bridge** errors (born in the walk with an `ast.Node` in hand —
+  self-blame) and **constraint** errors (born in the AST-free engine — carry typed
+  `soltype` operands and get their node injected from `Prov`). **Every new M3
+  error follows this model** — no `c.error(n, …)` span-stamping.
+- The `val`-annotation subtype check and the **span-fixture harness**
+  (`requireBlame`) — M3's "full error message / blame" tests use these.
+
+## What M3 adds (the genuine delta over M2)
+
+1. **Let-generalization** — schemes, `instantiate`/`freshenAbove`, generalize at
+   the SCC boundary (replacing M2's monomorphic freeze), the `<T0, …>` quantifier
+   prefix in the printer, and the `inferIdent` instantiation hook. Plus the
+   `coalesce` `seen`-guard (M2 PR-5 forward-referenced it) and the
+   `FromInstantiation` provenance variant (extends M2.5's `Prov`).
+2. **The simplification pass** — single-polarity elimination + co-occurrence
+   merging, so generalized signatures render compactly and parameter-only
+   variables coalesce to `unknown` rather than a vacuous `<T0>`.
+3. **`async fn` / `await`** — `async fn () -> T` types externally as `fn () ->
+   Promise<T>`; `await e` requires `e <: Promise<U>` and yields `U`. No
+   auto-flatten (that is `Awaited<T>`, M9). Plus the **block return-point join**
+   carried over from M2 (`inferBlock` TODO(M3)): collect *every* `ReturnStmt` and
+   join with the tail.
+4. **Function exactness** (#677) — an `Exact` flag on `FuncType` and `Optional` on
+   `FuncParam`; the inexact accept-set arm in the subtyping rule; and the
+   direct-call extra-arg rejection as a call-site lint.
+5. **The probe API** — speculation infrastructure (length-snapshot journal over
+   bound lists + side-table cleanup), needed by overloading and reused later.
+6. **Function overloading** (free functions) — overload sets as side-channel
+   metadata, call-site resolution as a separate phase, the ground-enough /
+   specificity / mutual-recursion-needs-annotation rules.
 
 ## Sequencing rationale
 
-Seven PRs (PR0–PR6) across two prerequisites (M1, M2). The diagram shows the
-dependency edges; solid = hard dependency (the downstream PR can't compile or
-pass its tests without the upstream one), dashed = soft (downstream lands
-correctly without it, but produces a degraded result — non-compact renders, or a
-specificity rule that doesn't yet account for exactness — until the upstream PR
-fills it in).
+Seven PRs (PR0–PR6) on three landed prerequisites (M1, M2, M2.5). Solid edges =
+hard dependency (downstream won't compile / pass tests without upstream); dashed
+= soft (downstream lands correctly but degraded until upstream fills it in).
 
 ```mermaid
 flowchart TD
-    M1([M1: soltype core]):::prereq
-    M2([M2: AST walk + Scope]):::prereq
+    M1([M1: soltype core — landed]):::prereq
+    M2([M2: AST walk + SCC — landed]):::prereq
+    M25([M2.5: Prov + error model — precedes M3]):::prereq
 
     PR0[PR0: spec sync]
-    PR1[PR1: functions + application]
-    PR2[PR2: let-polymorphism]
-    PR3[PR3: simplification]
+    PR1[PR1: let-generalization]
+    PR2[PR2: simplification]
+    PR3[PR3: async/await + block join]
     PR4[PR4: function exactness]
     PR5[PR5: probe API]
     PR6[PR6: overloading]
 
-    M1 --> PR1
     M2 --> PR1
+    M25 --> PR1
+    M2 --> PR3
+    M2 --> PR4
+    M25 --> PR4
     M1 --> PR5
     PR0 --> PR4
     PR1 --> PR2
-    PR2 --> PR3
-    PR1 --> PR4
-    PR2 --> PR6
+    PR1 --> PR6
     PR5 --> PR6
-    PR3 -. compact renders .-> PR2
+    PR2 -. compact renders .-> PR1
     PR4 -. specificity accounts for exactness .-> PR6
 
     classDef prereq fill:#eee,stroke:#999,stroke-dasharray:3 3;
 ```
 
-Three independent tracks fall out of the graph, exploitable for parallelism:
-the **function-core chain** (PR1 → PR2 → PR3), **exactness** (PR0 → PR4, joining
-after PR1), and the **probe API** (PR5, gated only on M1). Overloading (PR6) is
-the join point where the schemes track (PR2), the probe (PR5), and — softly —
-exactness (PR4) all converge.
+Parallelizable tracks: the **polymorphism chain** (PR1 → PR2), **async + block
+join** (PR3, only needs M2's walk), **exactness** (PR0 → PR4, reworking M2's
+`inferCall` + the `FuncType` rule), and the **probe** (PR5, only needs M1).
+Overloading (PR6) is the join of schemes (PR1), the probe (PR5), and — softly —
+exactness (PR4). M2.5's error model is a universal prerequisite for every
+error-emitting PR; only the strongest edges are drawn.
 
-- **PR1 → PR2 → PR3 is a hard chain.** Application needs function types (PR1).
-  Generalization needs application working so that polymorphic uses actually
-  instantiate (PR2). The Category-A acceptance renders (`fn <T0>(x: T0) -> T0`,
-  the `unknown` improvement) only become *correct and compact* once
-  simplification runs (PR3) — before it, generalized signatures render with
-  redundant or single-polarity variables. (PR2's `generalize` calls `simplify`,
-  so the PR3 → PR2 edge is soft: PR2 lands with a no-op `simplify` and PR3 makes
-  the renders compact.)
-- **PR4 (exactness) depends on PR1** (it reworks the function subtyping case)
-  but is independent of PR2/PR3, so it can land in parallel with PR2/PR3 once
-  PR1 is in. It is gated on **PR0 (spec-sync)** because the default it encodes
-  (exact bare `fn`, inexact `fn(..., ...)`) must be recorded in the spec before
-  the implementation asserts it. Direct-call arity and the `constrainCall`
-  obligation live in **PR1**, not here — PR4 owns only the `exact`/`required`
-  representation and the accept-set *subtyping* rule.
-- **PR5 (probe API) depends only on M1.** It is general speculation
-  infrastructure (length-snapshot journal over bound lists + side-table cleanup
-  closures), independently unit-testable, and reused well beyond M3 (M4
-  mutability transitions, M8 conditional-branch selection, `satisfies`). Split
-  out of overloading so it can be built and reviewed on its own and so PR6's
-  risk is contained to the resolution logic.
-- **PR6 (overloading) depends on PR2** (it bundles per-overload *schemes*) and
-  **PR5** (each candidate trial runs under a probe), and softly on **PR4** (the
-  one specificity ordering must account for the exact/inexact distinction). It
-  is the highest-uncertainty PR; keeping it last lets the function core and the
-  probe settle first, and it is the one piece that can ship in a reduced form
-  (declaration-order first-match) without blocking M4.
+- **PR1 → PR2 is the core chain.** Generalization (PR1) is what mints the
+  quantified signatures; they only render *compact* once simplification (PR2)
+  runs (the `PR2 ⇢ PR1` soft edge: PR1 lands with a no-op `simplify`, PR2 makes
+  renders compact). The Category-A acceptance is PR1+PR2.
+- **PR3 (async + block join) depends only on M2's walk.** `async`/`await` is a
+  self-contained feature (gated on the `Promise<T>` placeholder M2 seeded); the
+  block return-point join finishes `inferBlock`'s carried-over TODO. Independent
+  of generalization, so it can land in parallel with PR1/PR2.
+- **PR4 (exactness) reworks M2's shipped call path.** It depends on PR0 (the
+  default must be in the spec first) and on M2's `inferCall`/`FuncType` rule. It
+  does **not** introduce a separate call obligation — see PR4 for why the shipped
+  single-constraint path is kept.
+- **PR5 (probe) depends only on M1.** General speculation infrastructure, reused
+  beyond M3 (M4 mutability transitions, M9 conditional-branch selection,
+  `satisfies`); split from overloading so it lands and is unit-tested alone.
+- **PR6 (overloading) depends on PR1** (per-overload schemes) and **PR5** (each
+  candidate trial runs under a probe), softly on **PR4** (the specificity rule
+  must account for exact/inexact). Highest-uncertainty; last.
 
 ## Core types added or changed in M3
 
-The sketches below use design-notes `soltype` naming (`FunctionType`,
-`TypeVarType`, …) and are **illustrative, not final** — field names and exact
-shapes are settled in code review. `// ...` marks elisions. They show *what M3
-adds on top of M1/M2*, not the whole package.
-
-**`FunctionType` grows two fields** beyond the spike's `Function`. Both are
-introduced in PR1 with trivial values (`exact: true`, `required: len(params)`)
-so the call path compiles; PR4 gives `exact` real variance and refines
-`required` from optional-param (`x?`) detection:
+**`FuncType` gains `Exact`; `FuncParam` gains `Optional`** (PR4). The shipped
+type has neither; M3 adds them (exported, matching soltype's style):
 
 ```go
-// soltype/type.go — promoted from spike Function, extended for M3.
-type FunctionType struct {
-    params     []Type   // parameter types, in declared order
-    paramNames []string // parallel to params; for rendering only
-    required   int      // # of args that MUST be supplied (optionals lower this)
-    ret        Type
-    exact      bool     // bare fn(...) ⇒ true; fn(..., ...) ⇒ false  (varies in PR4)
+// internal/soltype/type.go — shipped today: FuncType{Params, Ret},
+// FuncParam{Pattern, Type}. M3 adds the two flags.
+type FuncType struct {
+    Params []*FuncParam
+    Ret    Type
+    Exact  bool // PR4: bare fn(...) ⇒ true; fn(..., ...) ⇒ false
+}
+
+type FuncParam struct {
+    Pattern  Pat
+    Type     Type
+    Optional bool // PR4: x? — lowers `required` without changing arity
 }
 ```
 
-**Schemes** (let-polymorphism, PR2) — promoted verbatim from `scheme.go`:
+**Schemes** (PR1) — new file `internal/solver/poly.go`:
 
 ```go
-// solver/poly.go
 type TypeScheme interface{ isScheme() }
 
-type MonoScheme struct{ ty Type }            // param, current-level RHS, LetRec self-ref
-type PolyScheme struct{ level int; body Type } // generalized: freshen vars with level > level
+type MonoScheme struct{ Ty soltype.Type }            // param, current-level RHS, rec self-ref
+type PolyScheme struct{ Level int; Body soltype.Type } // generalize vars with Level > Level
 
 func (*MonoScheme) isScheme() {}
 func (*PolyScheme) isScheme() {}
 ```
 
-**`ValueBinding` carries either a scheme or an overload set** (PR6). An
-overloaded symbol is *not* a single `soltype.Type` — the disjunction never
-enters the lattice:
+**`ValueBinding` swaps `Type` for a scheme but keeps `Sources`** (PR1; M2 PR-5
+sanctioned the field swap, but the `Sources` field is load-bearing for M2.5 blame
+and go-to-definition and must be retained):
 
 ```go
-// solver/scope.go
+// internal/solver/scope.go — was {Type soltype.Type; Sources []provenance.Provenance}.
 type ValueBinding struct {
-    scheme   TypeScheme   // nil iff this is an overload set
-    overload *OverloadSet // non-nil for overloaded fn declarations
-}
-
-type OverloadSet struct {
-    branches  []TypeScheme // one per declared/inferred overload, declaration order
-    annotated bool         // every branch explicitly annotated? (gates recursive groups)
+    Scheme   TypeScheme               // PR1: replaces the monomorphic Type
+    Sources  []provenance.Provenance  // RETAINED — M2.5 blame / go-to-definition
+    Overload *OverloadSet             // PR6: non-nil for overloaded fn decls
 }
 ```
 
-**The probe** (PR5) — baseline (A) from
-[02-design-notes.md](02-design-notes.md) §"Speculative checks," the only new
-infrastructure in M3:
+**`OverloadSet`** (PR6) — an overloaded symbol is a *set of schemes*, not a
+single `soltype.Type`:
 
 ```go
-// solver/probe.go
-type Bounded interface { // implemented by *TypeVarType (and *LifetimeVar in M4)
-    boundLengths() (lower, upper int)
-    truncateBounds(lower, upper int)
+type OverloadSet struct {
+    Branches  []TypeScheme // one per declared/inferred overload, declaration order
+    Annotated bool         // every branch annotated? (gates recursive groups)
 }
+```
 
+**The probe** (PR5) — `internal/solver/probe.go`:
+
+```go
+type Bounded interface { boundLengths() (lower, upper int); truncateBounds(lower, upper int) }
 type probeEntry struct{ v Bounded; prevLower, prevUpper int }
 
 type Probe struct {
     entries  []probeEntry
-    touched  set.Set[Bounded] // dedupe — snapshot only first touch
-    cleanups []func()         // Info/Prov side-table rollback closures
-    parent   *Probe           // nested probes
-    done     bool             // idempotent Discard/Commit
+    touched  set.Set[Bounded]
+    cleanups []func()  // Info / Prov side-table rollback closures (Prov is M2.5's)
+    parent   *Probe
+    done     bool
 }
 ```
 
@@ -201,581 +240,418 @@ type Probe struct {
 
 ### PR0 — Spec sync: Policy A, the `open` marker, and #677's accept-set model
 
-Pure documentation; no code. Unblocks PR4's assertions and records decisions
-the milestones doc flags as "not yet in the spec."
+Pure documentation; unblocks PR4. Records decisions the milestones doc flags as
+"not yet in the spec."
 
 - Add a section to `planning/exact-types/requirements.md` recording **Policy A**
   (usage-inferred record shapes coalesce as *exact*; row polymorphism is opt-in
-  via the `open` parameter marker) and the `open` keyword (provisional). This is
-  the M3 prerequisite called out in
-  [01-milestones.md](01-milestones.md) and [02-design-notes.md](02-design-notes.md)
-  §"Exactness".
+  via the `open` parameter marker). (Records the decision now even though
+  usage-inference itself is M4 — exactness defaults must be settled before PR4.)
 - Rewrite §4.2 per escalier-lang/escalier#677: **direct calls reject extra args
-  regardless of exactness**; **exactness governs callback subtyping** via the
-  accept-set model (`G <: F` iff `accept(G) ⊇ accept(F)`, params contravariant,
-  return covariant; exact `fn(p1..pn)` accepts `[required, n]`, inexact accepts
-  `[required, ∞)`).
-- Close the loop on #677's "knock-on": the M3 acceptance line in the milestones
-  doc already reflects the accept-set model — confirm and cross-link.
+  regardless of exactness** (a call-site lint); **exactness governs callback
+  subtyping** via the accept-set model (`G <: F` iff `accept(G) ⊇ accept(F)`,
+  params contravariant, return covariant; exact `fn(p1..pn)` accepts `[required,
+  n]`, inexact accepts `[required, ∞)`).
 
-**Why first:** PR4's tests assert exact-by-default function behavior; that
-default must be blessed in the spec before it is encoded in tests
-(Settled Decision #6 — "tests assert what the implementation produces").
+**Why first:** PR4's tests assert exact-by-default behavior, which must be blessed
+in the spec before the implementation asserts it.
 
 ---
 
-### PR1 — Function inference + application + multi-arg
+### PR1 — Let-generalization
 
-Promote the spike's `*Lambda`/`*App` handling (`infer.go:140–170`) onto the real
-AST. Most of the constrain machinery already exists from M1; this PR is the
-**AST walk** for functions plus multi-arg generalization of the spike's
-single-arg `App`.
+The core M3 PR. M2 infers functions monomorphically and freezes recursive groups
+to coalesced monotypes; PR1 turns that into real let-polymorphism.
 
-- **`*ast.FuncExpr` / `fn` decl** → a fresh var per unannotated param (annotated
-  params take their `TypeAnn`); infer the body in a child scope binding each
-  param to a `MonoScheme`; build `FunctionType{params, paramNames, ret}`.
-  `info.setType` on the node and each param.
-- **`*ast.CallExpr`** → infer callee and each arg; run `checkDirectCallArity`
-  for the call-site arity check (too-many / too-few args); then allocate a fresh
-  result var and emit a **call obligation** (`constrainCall`, sketched below) —
-  *not* a `FunctionType <: FunctionType` subtype assertion. Arity is owned by the
-  call-site check, so the obligation only relates arg/return types and lets an
-  unresolved callee resolve structurally. Generalize the spike's single-arg `App`
-  to N args. (In PR1 `required == len(params)`, so `checkDirectCallArity` rejects
-  any omitted arg; PR4's optional-param detection relaxes that for `x?` params.)
-- **Function `constrain` rule** (already in M1 from the spike, `constrain.go:137`)
-  — verify the multi-arg/variance path used by **function-to-function**
-  subtyping (assignment, callback slots): `len(l.params) <= len(r.params)` arity
-  check (the *inexact* fewer-params rule, replaced by the accept-set rule in
-  PR4), params contravariant, return covariant. Direct calls do **not** go
-  through this rule — they use `constrainCall`.
-- **Multi-statement bodies / `return`** as needed by real `FuncExpr` bodies
-  (the spike's IR had expression bodies only); a body with no value infers
-  `Void`.
+- **Schemes in the scope.** `ValueBinding.Type` → `ValueBinding.Scheme`
+  (`poly.go`/`scope.go`); keep `Sources`. Param bindings and current-level RHS
+  during inference are `MonoScheme`; generalized decls are `PolyScheme`.
+- **`instantiate` / `freshenAbove`** (`poly.go`): `instantiate(MonoScheme)`
+  returns as-is; `instantiate(PolyScheme)` calls `freshenAbove` (fresh var per
+  var with `Level > scheme.Level`, bounds freshened) and records a
+  **`FromInstantiation`** entry — the first interior `Origin`, *added to M2.5's
+  existing `Prov` sum* (M2.5 ships `FromAST`; this extends it). The multi-hop
+  *renderer* that walks `FromInstantiation` chains to AST leaves is deferred to
+  M11.5; PR1 only mints the edge.
+- **`inferIdent` instantiation hook.** M2 returns `b.Type` directly with a
+  `// M3: instantiate` comment; PR1 makes value-position lookup
+  `c.instantiate(b.Scheme, lvl)`.
+- **Generalize at the SCC boundary.** `inferComponent` phase 3 today does
+  `coalesce(b.v, Positive)` → a monotype. PR1 changes it to generalize: variables
+  at `Level > lvl` become quantifiable; captured outer vars do not. The result is
+  a `PolyScheme`.
+- **`coalesce` `seen`-guard.** M2 PR-5 noted `coalesce` has no recursion guard;
+  generalizing recursive-group types can loop. Add the `seen`-guard here (the M1
+  deferral M2 forward-referenced).
+- **Printer `<T0, …>` prefix.** Extend `soltype.Print` to render a quantifier
+  prefix for a generalized scheme's free variables (M2's printer renders only
+  monotypes).
 
 **Sketch:**
 
 ```go
-// solver/infer.go — the constraint-generating walk (replaces spike typeTerm).
-func (c *checker) inferFuncExpr(n *ast.FuncExpr, s *Scope) Type {
-    child := s.child()
-    params := make([]Type, len(n.Params))
-    names := make([]string, len(n.Params))
-    for i, p := range n.Params {
-        var pt Type
-        if p.TypeAnn != nil {
-            pt = c.typeFromAnn(p.TypeAnn, child)
-        } else {
-            pt = c.freshVarAt(p, ParamBinding) // fresh inference var + Prov entry
-        }
-        params[i] = pt
-        names[i] = p.Name
-        child.values[p.Name] = ValueBinding{scheme: &MonoScheme{ty: pt}}
-    }
-    ret := c.inferBlock(n.Body, child) // Void if the body yields no value
-    f := &FunctionType{params: params, paramNames: names,
-        required: len(params), ret: ret, exact: true} // exact/required refined in PR4
-    c.info.setType(n, f)
-    return f
-}
-
-func (c *checker) inferCallExpr(n *ast.CallExpr, s *Scope) Type {
-    callee := c.inferExpr(n.Callee, s)
-    args := make([]Type, len(n.Args))
-    for i, a := range n.Args {
-        args[i] = c.inferExpr(a, s)
-    }
-    c.checkDirectCallArity(n, callee, len(args)) // call-site arity (too many / too few)
-    res := c.freshVarAt(n, Application)
-    // Call obligation, NOT function subtyping: relates arg/return types and lets
-    // an unresolved callee resolve structurally; arity is owned above.
-    c.constrainCall(callee, args, res)
-    c.info.setType(n, res)
-    return res
-}
-```
-
-```go
-// solver/constrain.go — function-to-function subtyping (PR1 baseline; reworked
-// to the accept-set rule in PR4). Direct calls use constrainCall, not this rule.
-case *FunctionType:
-    if r, ok := rhs.(*FunctionType); ok {
-        if len(l.params) > len(r.params) { // fewer-params-is-subtype (inexact case)
-            return arityError(l, r)
-        }
-        var errs []error
-        for i := range l.params {
-            errs = append(errs, c.constrain(r.params[i], l.params[i], seen)...) // contravariant
-        }
-        return append(errs, c.constrain(l.ret, r.ret, seen)...) // covariant
-    }
-```
-
-```go
-// solver/constrain.go — direct-call obligation; no accept-set arity gate.
-func (c *checker) constrainCall(callee Type, args []Type, res Type) {
-    if f, ok := peelToFunc(callee); ok {
-        n := min(len(args), len(f.params))
-        for i := 0; i < n; i++ {
-            c.constrain(args[i], f.params[i]) // arg flows into param
-        }
-        c.constrain(f.ret, res)
-        return
-    }
-    // Unresolved callee: record the call shape as an application-tagged bound so
-    // resolution relates it structurally, not via the accept-set <: rule.
-    c.recordCallObligation(callee, args, res)
-}
-
-// solver/infer.go — call-site arity; in PR1 every param is required, so this also
-// catches omitted args. PR4's optional-param detection lowers f.required for x?.
-func (c *checker) checkDirectCallArity(n *ast.CallExpr, callee Type, argc int) {
-    f, ok := peelToFunc(callee) // through aliases / a resolved var bound
-    if !ok {
-        return // not (yet) known to be a function; the obligation handles it
-    }
-    switch {
-    case argc > len(f.params):
-        c.error(n, TooManyArgsError{Got: argc, Want: len(f.params)})
-    case argc < f.required:
-        c.error(n, TooFewArgsError{Got: argc, Required: f.required})
-    }
-}
-```
-
-**Tests:** monomorphic function inference from real source — application type
-flows (`val n = (fn (x) { return x + 1 })(5)` ⇒ `n: number`), arity mismatch
-errors (full message), contravariant-param / covariant-return acceptance and
-rejection cases. No generalization yet — top-level `fn id` still renders with a
-raw inference variable at this point (a temporary, asserted as such or deferred
-to PR3).
-
-**Risk:** low. This is mechanical promotion of proven spike code; the constrain
-rule is already M1-tested on hand-built terms.
-
----
-
-### PR2 — Level-based let-polymorphism
-
-Promote `scheme.go` (`TypeScheme`/`MonoScheme`/`PolyScheme`, `instantiate`,
-`freshenAbove`) and wire level discipline through the AST walk.
-
-- **Schemes in the scope.** `ValueBinding` carries a `TypeScheme`. Param
-  bindings and current-level `let` RHS-during-inference and `LetRec` self-refs
-  are `MonoScheme` (returned as-is by `instantiate`); generalized top-level/inner
-  `let`/`fn` decls are `PolyScheme` (trigger `freshenAbove` + a
-  `FromInstantiation` provenance entry).
-- **Level threading.** Type a binding's RHS at `lvl+1`, then generalize:
-  variables created at `> lvl` become quantifiable; captured outer variables
-  (`level <= lvl`) do not. This is the spike's `*Let` rule
-  (`infer.go:171–179`) over real decls, with module-level declaration order
-  driven by the existing `dep_graph` SCC order (matching how the old checker
-  handles mutual recursion).
-- **Recursive groups.** Promote `*LetRecGroup` (`infer.go:185–216`): one fresh
-  var per binding, all visible in every RHS, constrain each RHS `<:` its var,
-  generalize the whole SCC at the shared level boundary. No placeholder phase,
-  no `typeRefsToUpdate` patching.
-- **`IdentExpr` value-position lookup** calls `instantiate` uniformly; only the
-  `PolyScheme` case does work. Namespace-in-value-position is a
-  `NamespaceUsedAsValueError` (per [02-design-notes.md](02-design-notes.md)
-  §"infer.go"); unknown identifiers are `UnknownIdentifierError`.
-- **`freshenAbove` lifetime caveat.** The spike copies a carrier's lifetime by
-  reference rather than freshening it (`scheme.go:29–39`). M4 introduces
-  lifetimes properly; for M3 there are no lifetime-carrying types yet, so this
-  is a non-issue — but leave a `// M4:` marker where `freshenAbove` will need a
-  lifetime cache.
-
-**Sketch:**
-
-```go
-// solver/poly.go — promoted from scheme.go.
-func (c *checker) instantiate(s TypeScheme, lvl int) Type {
+// internal/solver/poly.go
+func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
     switch sc := s.(type) {
     case *MonoScheme:
-        return sc.ty // no freshening
+        return sc.Ty
     case *PolyScheme:
-        return c.freshenAbove(sc.level, sc.body, lvl, map[int]*TypeVarType{}) // + FromInstantiation Prov
+        return c.freshenAbove(sc.Level, sc.Body, lvl, map[int]*soltype.TypeVarType{}) // + FromInstantiation in Prov
     }
     panic("unreachable")
 }
 
-// freshenAbove copies ty, replacing each var with level > lim by a fresh var at
-// lvl (bounds freshened too); vars at level <= lim are shared. // M4: thread a
-// lifetime cache here so generalized lifetimes freshen per-instance.
-func (c *checker) freshenAbove(lim int, ty Type, lvl int, cache map[int]*TypeVarType) Type { /* ... */ }
+// freshenAbove copies t, replacing each var with Level > lim by a fresh var at
+// lvl (bounds freshened); vars at Level <= lim are shared. // M4: thread a
+// lifetime cache once lifetime-bearing types exist.
+func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[int]*soltype.TypeVarType) soltype.Type { /* ... */ }
 
-// generalize runs at a binding boundary once the RHS has finished inferring.
-func (c *checker) generalize(body Type, lvl int) TypeScheme {
-    body = c.simplify(body, lvl) // PR3 — compact the signature before quantifying
-    return &PolyScheme{level: lvl, body: body}
+func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
+    t = c.simplify(t, lvl) // PR2 — compact before quantifying (no-op until PR2)
+    return &PolyScheme{Level: lvl, Body: t}
 }
 ```
 
 ```go
-// solver/infer.go — module-level: dep-graph SCC order drives declaration order.
-func (c *checker) inferModule(m *ast.Module) {
-    for _, scc := range c.deps.SCCsInTopoOrder(m) {
-        c.checkOverloadAnnotations(scc) // PR6 gate (no-op until overloading lands)
-        c.inferSCC(scc)                 // fresh var per binding, constrain RHS <: var, generalize
-    }
+// internal/solver/module.go — inferComponent phase 3, generalize instead of freeze.
+for _, key := range component {
+    b := bindings[key]
+    if !b.bound { scope.removeValue(key.Name()); continue }
+    scheme := c.generalize(b.v, lvl) // was: coalesce(b.v, Positive) → monotype
+    scope.defineValue(key.Name(), ValueBinding{Scheme: scheme, Sources: b.sources})
+    // ... recordType on the name/pattern as today
 }
 ```
 
-**Tests:** polymorphic instantiation — `val id = fn (x) { return x }` used at two
-types; let-bound polymorphism captured correctly (inner `let` generalizes after
-its RHS finishes); recursive and mutually-recursive groups infer without
-annotations. Renders may still be non-compact until PR3 — assert via the
-two-types-of-use behavior rather than the printed signature where simplification
-is load-bearing.
+**Tests (Category-A, against real source):** `TopLevelLetPolymorphism` ⇒
+`fn <T0>(x: T0) -> T0`; `IdentityPolymorphism` ⇒ `fn () -> ["hello", 5]`;
+`InnerCapturesOuterParam` ⇒ `fn <T0>(y: T0) -> [T0, T0]`. Renders are
+non-compact until PR2 — until then assert two-types-of-use behavior rather than
+the printed signature where simplification is load-bearing. A recursive group
+generalizes without looping (exercises the `seen`-guard).
 
-**Risk:** low–medium. The level discipline is the subtle part; the spike proves
-it, and the dep-graph SCC ordering is the only new (M2-provided) ingredient.
+**Risk:** medium. Level discipline + the SCC generalization change are the subtle
+parts; M2's `inferComponent` already proves the ordering, so PR1 changes only
+phase 3.
 
 ---
 
-### PR3 — The simplification pass
+### PR2 — The simplification pass
 
-Promote `simplify.go` (`analyze` single-polarity elimination, `symmetrize`,
-co-occurrence collection, union-find `mergeCoOccurring`) and run it at
-generalization boundaries before coalescing.
+Single-polarity elimination + co-occurrence merging, run at generalization time
+before the printer.
 
-- **Single-polarity elimination.** A variable that occurs only positively or
-  only negatively in the generalized type is replaced by its bound (or by
-  `never`/`unknown` for the empty case) — this is what turns a parameter-only
-  variable with no lower bounds into `unknown` in negative position (the
-  blessed `unknown`-vs-vacuous-`<T0>` improvement, [03-references.md](03-references.md)
-  §"Lattice 1").
-- **Co-occurrence merging.** Variables that co-occur in every polarity they
-  appear in are merged via union-find, so `fn <T0>(x: T0) -> T0` renders with one
-  type parameter, not several aliased ones.
-- **Wire into the pipeline:** run `analyze` → `symmetrize` → `collectCoOcc` →
-  `mergeCoOccurring` on a `PolyScheme`'s body at generalization time, feeding the
-  merged result into `coalesce` and then the printer.
+- **Single-polarity elimination.** A variable occurring only positively /
+  negatively in a generalized type is replaced by its bound (or `never`/`unknown`
+  for the empty case) — this is what turns a parameter-only variable into
+  `unknown` (the blessed `unknown`-vs-vacuous-`<T0>` improvement,
+  [03-references.md](03-references.md) §"Lattice 1").
+- **Co-occurrence merging.** Variables co-occurring in every polarity they appear
+  in merge (union-find), so `fn <T0>(x: T0) -> T0` renders with one type
+  parameter.
+- **Wire into `generalize`** (PR1's no-op `simplify` becomes real): occurrence
+  analysis → co-occurrence → union-find → rewrite, feeding `coalesce` + the
+  printer. The `seen`-guard from PR1 covers the cyclic bound graphs this walks.
 
 **Sketch:**
 
 ```go
-// solver/simplify.go — promoted from simplify.go; pipeline orchestrated here.
-func (c *checker) simplify(ty Type, lvl int) Type {
-    // 1. occurrence analysis: which polarities does each var appear in?
-    occ := map[int]map[Polarity]bool{}
-    analyze(ty, Positive, occ, map[polKey]bool{})
-
-    // 2. co-occurrence: which vars share a union/intersection node, per polarity?
-    vars := map[int]*TypeVarType{}
-    collectVars(ty, vars)
-    symmetrize(vars) // mirror one-sided var<:var bounds so each var sees all its facts
-    coOcc := map[polKey]map[int]bool{}
-    collectCoOcc(ty, Positive, coOcc, map[polKey]bool{})
-
-    // 3. merge vars that co-occur in EVERY polarity they appear in.
-    uf := mergeCoOccurring(vars, occ, coOcc)
-
-    // 4. rewrite: drop single-polarity vars (-> their bound, or unknown/never for
-    //    the empty case), apply union-find representatives.
-    return rewrite(ty, occ, uf)
+// internal/solver/simplify.go
+func (c *checker) simplify(t soltype.Type, lvl int) soltype.Type {
+    occ := analyze(t, soltype.Positive)            // polarities per var
+    uf := mergeCoOccurring(t, occ)                 // union-find of co-occurring vars
+    return rewrite(t, occ, uf)                     // drop single-polarity vars; apply merges
 }
-
-// analyze / collectVars / collectCoOcc / mergeCoOccurring port directly from the
-// spike; the Mut->Ref and ResidualOp bipolarity special cases come along in M4/M8.
-func analyze(st Type, pol Polarity, occ map[int]map[Polarity]bool, seen map[polKey]bool) { /* ... */ }
-func mergeCoOccurring(vars map[int]*TypeVarType, occ map[int]map[Polarity]bool,
-    coOcc map[polKey]map[int]bool) *unionFind { /* ... */ }
 ```
 
-**Tests — the Category-A acceptance from the milestone, against real source:**
+**Tests:** the Category-A renders now assert their *compact* form (the PR1 table,
+verbatim); parameter-only var ⇒ `unknown`. These port from the spike's
+`simplesub_test.go` with the improved forms.
 
-| Case | Expected render |
-|---|---|
-| `TopLevelLetPolymorphism` (`val id = fn (x) { return x }`) | `fn <T0>(x: T0) -> T0` |
-| `IdentityPolymorphism` | `fn () -> ["hello", 5]` |
-| `InnerCapturesOuterParam` | `fn <T0>(y: T0) -> [T0, T0]` |
-| parameter-only var (unused param) | coalesces to `unknown`, not `<T0>` |
+**Risk:** medium. The subtlest core algorithm, but the most spike-tested — "port
+faithfully," not "design."
 
-These are the spike's M1 differential cases (`simplesub_test.go` /
-`differential_test.go`); port the assertions into the new package's table tests
-with the **improved** forms.
+---
 
-**Risk:** medium. Simplification is the subtlest algorithm in the set
-(occurrence analysis polarity, the `Mut`/`ResidualOp` bipolarity special cases).
-It is well-covered by the spike's existing tests, which port directly.
+### PR3 — `async`/`await` + block return-point join
+
+Two self-contained completions of the function/block walk, grouped (both small,
+both independent of generalization); split into two PRs if review prefers.
+
+- **`async fn`.** Type the body exactly like a plain function (body return type
+  `T`), then wrap the *external* return in `Promise<T>` — `async fn () -> T`
+  externally is `fn () -> Promise<T>`. Uses the `Promise<T>` placeholder M2
+  seeded (real resolution is M7).
+- **`await e`.** Mint a fresh `U`, emit `constrain(e <: Promise<U>)`, yield `U`.
+  No auto-flatten — `await` of `Promise<Promise<T>>` yields `Promise<T>`
+  (`Awaited<T>` is M9). `await` outside an `async` function is rejected by the
+  **walk**, not the type rule.
+- **Block return-point join (carried over from M2).** M2's `inferBlock` uses the
+  *last statement* and drops non-tail `return`s — harmless at the M2 bar (no
+  `IfElseExpr`), but M3 must collect **every** `ReturnStmt` (valued and bare) and
+  join them with the tail before constraining against the return annotation. See
+  the `inferBlock` TODO(M3) in `infer_stmt.go`.
+
+**Tests:** `async fn () -> number` ⇒ `fn () -> Promise<number>`; `await p` with
+`p: Promise<string>` ⇒ `string`; `await p` with `p: Promise<Promise<number>>` ⇒
+`Promise<number>`; `await` outside `async` ⇒ walk error (full message). Block:
+`fn () { if c { return 1 } return "x" }` joins both return points.
+
+**Risk:** low–medium. `async`/`await` is a thin wrap + one constraint; the block
+join is a localized `inferBlock` change. The return-join interacts with whatever
+conditional/early-return support M3 adds — land them together.
 
 ---
 
 ### PR4 — Function exactness (accept-set model, #677)
 
-Give `exact` real meaning per the now-synced spec (PR0), and rework
-function-to-function subtyping to the accept-set rule. Depends on PR1 (which
-introduced the fields and the call-site machinery) and PR0; can land in parallel
-with PR2/PR3. Scope is deliberately narrow: the call-site mechanics
-(`constrainCall`, `checkDirectCallArity`) already shipped in PR1 — PR4 changes
-only the *subtyping* rule and `required` derivation.
+Add exactness to functions and rework the **subtyping** rule, reworking M2's
+shipped call path rather than introducing a parallel obligation. Depends on PR0
+and M2's `inferCall`/`FuncType` rule.
 
-- **Representation + parser.** `exact bool` is already on `soltype.FunctionType`
-  (PR1, default `true`); PR4 makes it vary. A bare `fn(...)` stays exact;
-  `fn(..., ...)` (trailing `...`) is inexact. Add parser support for the
-  trailing-marker on function types if not already present from M2; the old
-  checker ignores the flag (parser-level tolerance, per M7's strategy).
-- **Callback subtyping = accept-set rule.** Rework the function case of
-  `constrain` (the function-to-function rule from PR1, not the direct-call
-  `constrainCall`): `G <: F` iff `accept(G) ⊇ accept(F)`, i.e. `rG <= rF`
-  (required) **and** `uG >= uF` (upper bound: `n` if exact, `∞` if inexact).
-  Params remain contravariant per shared position, return covariant. The spike's
-  current "fewer params is a subtype" becomes exactly the **inexact** case
-  (`uG = ∞`).
-- **Direct-call arity is unchanged by exactness.** `checkDirectCallArity` (PR1)
-  already rejects extra args regardless of `exact` — matching TypeScript — and
-  it never went through the subtyping rule, so reworking the rule here doesn't
-  touch it. Confirm with a test that an *inexact* function still rejects a
-  too-many-args direct call.
-- **`required` vs `n`.** Optional params lower `required` without changing `n`.
-  Wire optional-param detection from the AST (`x?`-style) into `required` (set in
-  PR1 to `len(params)`); this simultaneously relaxes `checkDirectCallArity`'s
-  lower bound and the accept-set rule's `r`.
+- **Representation + parser.** Add `Exact` to `FuncType` and `Optional` to
+  `FuncParam`. A bare `fn(...)` is exact; `fn(..., ...)` is inexact. Add parser
+  support for the trailing-`...` marker and `x?` optional params if not already
+  present; the old checker ignores the flag (parser-level tolerance, per M7).
+- **Callback subtyping = accept-set rule.** Rework the `FuncType <: FuncType`
+  case (today exact same-arity, `len(l.Params) != len(r.Params)`): `G <: F` iff
+  `accept(G) ⊇ accept(F)`, i.e. `required_G <= required_F` **and** `upper_G >=
+  upper_F` (`upper = len(Params)` if exact, `∞` if inexact). Params contravariant
+  per shared position, return covariant. The spike's "fewer params is a subtype"
+  is exactly the **inexact** case.
+- **Direct-call arity: keep the shipped single-constraint path; add an extra-arg
+  lint.** M2's `inferCall` emits `constrain(callee <: FuncType{args → res})`,
+  which soundly enforces "at least `required` args" — including for an unresolved
+  callee, via bound propagation when it later resolves. **Keep that.** #677's
+  *extra-arg* rejection ("reject more args than declared, even for inexact
+  functions") is a deliberate **lint the subtype lattice does not model** (an
+  inexact function legitimately accepts extras), so it cannot come from the
+  constraint — it is a separate call-site check. Add it to `inferCall`: when the
+  callee is concrete, reject `argc > len(Params)`. For an unresolved callee the
+  lint is best-effort (skipped) while "too few / required" still flows through the
+  constraint — so nothing regresses for deferred calls.
+- **`required` from `Optional`.** `required` = count of non-optional params;
+  `Optional` lowers it without changing `len(Params)`.
 
 **Sketch:**
 
 ```go
-// solver/constrain.go — accept-set helper + refined function case.
+// internal/solver/constrain.go — FuncType case, reworked from exact-same-arity.
 const unboundedArity = math.MaxInt
-
-// acceptSet is the inclusive range of arg-counts a function accepts when invoked.
-func acceptSet(f *FunctionType) (lo, hi int) {
-    lo = f.required
-    if f.exact {
-        hi = len(f.params)
-    } else {
-        hi = unboundedArity
-    }
+func acceptSet(f *soltype.FuncType) (lo, hi int) {
+    lo = requiredCount(f)
+    if f.Exact { hi = len(f.Params) } else { hi = unboundedArity }
     return
 }
-
-case *FunctionType:
-    if r, ok := rhs.(*FunctionType); ok {
-        // l <: r  iff  accept(l) superset-of accept(r):  loL <= loR  AND  hiL >= hiR.
-        loL, hiL := acceptSet(l)
-        loR, hiR := acceptSet(r)
+case *soltype.FuncType:
+    if r, ok := rhs.(*soltype.FuncType); ok {
+        loL, hiL := acceptSet(l); loR, hiR := acceptSet(r) // l <: r  iff accept(l) ⊇ accept(r)
         if loL > loR || hiL < hiR {
-            return callContractError(l, r)
+            return []SolverError{&FuncArityMismatchError{LHS: l, RHS: r}} // existing kind
         }
-        var errs []error
-        n := min(len(l.params), len(r.params)) // relate shared positions only
+        var errs []SolverError
+        n := min(len(l.Params), len(r.Params))
         for i := 0; i < n; i++ {
-            errs = append(errs, c.constrain(r.params[i], l.params[i], seen)...) // contravariant
+            errs = append(errs, c.constrain(r.Params[i].Type, l.Params[i].Type, seen)...) // contravariant
         }
-        return append(errs, c.constrain(l.ret, r.ret, seen)...) // covariant
+        return append(errs, c.constrain(l.Ret, r.Ret, seen)...) // covariant
     }
 ```
 
-(The direct-call path — `constrainCall` and `checkDirectCallArity` — shipped in
-PR1 and is unchanged here; this rule governs only function-to-function
-subtyping.)
+```go
+// internal/solver/infer_expr.go — inferCall gains the extra-arg lint; the
+// existing subtype constraint is unchanged (it carries type flow + the required
+// lower bound, deferred-callee-safe).
+func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
+    callee := c.inferExpr(scope, lvl, e.Callee)
+    args := make([]*soltype.FuncParam, len(e.Args))
+    for i, a := range e.Args { args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)} }
+    if fn, ok := callee.(*soltype.FuncType); ok && len(e.Args) > len(fn.Params) {
+        c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn}) // bridge error: carries the node (M2.5)
+    }
+    res := c.freshAt(lvl)
+    c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+    if fn, ok := callee.(*soltype.FuncType); ok { c.constrain(e, fn.Ret, res) }
+    c.recordType(e, res)
+    return res
+}
+```
 
-**Tests (the milestone's exactness acceptance):**
+`TooManyArgsError` is a new **bridge** error per M2.5 — it holds the `*ast.CallExpr`
+and derives `Span()` from it (and `Related()` to the callee), not the retired
+`c.error(n, …)` stamp. The existing `FuncArityMismatchError` continues to cover
+the "too few / required" and callback-arity failures from the constraint.
 
-- Direct calls: both exact `fn(x, y)` and inexact `fn(x, y, ...)` **reject** a
-  3-arg call (full error message); both accept 2 args.
-- Into a `fn(x, y)` callback slot: `fn(x, y)`, `fn(x, ...)`, `fn(...)` are
-  **accepted**; exact `fn(x)` and any 3+-param function are **rejected**.
-- Round-trip exact/inexact function types through the printer.
+**Tests (#677 acceptance):** both exact `fn(x, y)` and inexact `fn(x, y, ...)`
+reject a 3-arg direct call (full message via `requireBlame`); both accept 2 args.
+Into a `fn(x, y)` callback slot, `fn(x, y)`/`fn(x, ...)`/`fn(...)` are accepted
+while exact `fn(x)` and any 3+-param function are rejected.
 
-**Risk:** low–medium. The rule is small and precisely specified by #677; the
-care is in the `required`/`n`/`exact` bookkeeping and getting the four
-acceptance rows exactly right.
+**Risk:** medium. The accept-set rule is small and precisely specified; the care
+is the `required`/`Exact`/`Optional` bookkeeping and keeping the extra-arg lint
+distinct from the constraint (so deferred calls don't lose the required check).
 
 ---
 
 ### PR5 — Probe API (speculation infrastructure)
 
-The **only** new soltype infrastructure in M3, split out from overloading so it
-can be built and reviewed on its own. Depends only on M1 (`TypeVarType` bound
-lists), so it can proceed in parallel with PR1–PR4. Baseline (A) + (D) from
-[02-design-notes.md](02-design-notes.md) §"Speculative checks."
+The only new soltype/solver infrastructure in M3, split out so it lands and is
+unit-tested alone. Depends only on M1 (`TypeVarType` bound lists). Baseline (A)+(D)
+from [02-design-notes.md](02-design-notes.md) §"Speculative checks."
 
-- **Length-snapshot journal (A).** A nullable `*Probe` on `Context`. The first
-  mutation of each variable records `(len(lower), len(upper))`; discard truncates
-  each touched var's bound slices back. Commit on a nested probe propagates its
-  touched set to the parent so an outer discard still covers them.
-- **Side-table cleanup closures.** `Info` (node → type) and `Prov` (type →
-  origin) writes register an `onRollback` closure so a discarded trial leaves no
-  stray hover/error entries. The `seen` cache inside a single `constrain` call is
-  *not* a probe concern — it dies with the call frame.
-- **Push/pop discipline.** `openProbe` pushes the current-probe pointer;
-  `closeProbe(p, commit)` runs `Commit`/`Discard` and pops it back to
-  `p.parent`, so `c.probe` never dangles at a finished probe.
-- **Fresh-instance retry (D)** is just the existing `instantiate`/`freshenAbove`
-  used per-candidate by consumers — no probe state of its own; it composes with
-  (A) for the caller-side bounds. No standalone code here beyond documenting the
-  pattern.
-- Keep it minimal — **no** overlay map, generation tags, or
-  `Prune`/`InstanceChain` (none exist in soltype). This API is reused well beyond
-  M3 (M4 mutability transitions, M8 conditional-branch selection, `satisfies`,
-  `NoInfer`), so getting the shape right here pays off repeatedly.
+- **Length-snapshot journal (A).** First mutation of each variable records
+  `(len(LowerBounds), len(UpperBounds))`; discard truncates back. The engine's
+  `constrain` is on `*Context`, so the probe lives there: `Context` gains a
+  nullable `probe *Probe`, and each bound append calls `probe.record(v)`.
+- **Side-table cleanup closures.** The carrier owns `Info` and (M2.5's) `Prov`;
+  writes to them under a probe register an `onRollback` closure so a discarded
+  trial leaves no stray entries. The `seen` cache inside a `constrain` call is not
+  a probe concern (dies with the call frame).
+- **Push/pop discipline.** `checker.openProbe()` sets `ctx.probe` (saving the
+  parent); `checker.closeProbe(p, commit)` runs `Commit`/`Discard` and restores
+  `ctx.probe = p.parent`, so the engine's current-probe pointer never dangles.
+  This reconciles "probe on `Context`" (engine bound-rollback) with "side tables
+  on the carrier" (Info/Prov cleanup).
+- **Fresh-instance retry (D)** is just `instantiate`/`freshenAbove` used
+  per-candidate by PR6; no probe state of its own. Keep the probe minimal — no
+  overlay map / generation tags.
 
 **Sketch:**
 
 ```go
-// solver/probe.go — baseline (A).
+// internal/solver/probe.go
 func (p *Probe) record(v Bounded) {
-    if p.touched.Contains(v) {
-        return
-    }
-    p.touched.Add(v)
-    lo, hi := v.boundLengths()
-    p.entries = append(p.entries, probeEntry{v, lo, hi})
+    if p.touched.Contains(v) { return }
+    p.touched.Add(v); lo, hi := v.boundLengths(); p.entries = append(p.entries, probeEntry{v, lo, hi})
 }
 func (p *Probe) onRollback(f func()) { p.cleanups = append(p.cleanups, f) }
-
 func (p *Probe) rollback() {
     for i := len(p.cleanups) - 1; i >= 0; i-- { p.cleanups[i]() } // side tables first
-    for i := len(p.entries) - 1; i >= 0; i-- {
-        e := p.entries[i]
-        e.v.truncateBounds(e.prevLower, e.prevUpper)
-    }
+    for i := len(p.entries) - 1; i >= 0; i-- { e := p.entries[i]; e.v.truncateBounds(e.prevLower, e.prevUpper) }
 }
 func (p *Probe) Discard() { if !p.done { p.rollback(); p.done = true } }
 func (p *Probe) Commit()  { /* hand touched + cleanups to parent; clear entries */ }
 
-func (c *checker) openProbe() *Probe { p := &Probe{parent: c.probe}; c.probe = p; return p }
-
-// closeProbe pops the probe stack after a trial — always paired with openProbe,
-// on both the commit and discard paths, so c.probe never dangles at a finished probe.
+func (c *checker) openProbe() *Probe { p := &Probe{parent: c.ctx.probe}; c.ctx.probe = p; return p }
 func (c *checker) closeProbe(p *Probe, commit bool) {
-    if commit {
-        p.Commit()
-    } else {
-        p.Discard()
-    }
-    c.probe = p.parent
+    if commit { p.Commit() } else { p.Discard() }
+    c.ctx.probe = p.parent
 }
 ```
 
-**Tests:** a discarded probe restores bound-list lengths exactly (append-then-
-discard is a no-op on the var); a discarded probe runs `Info`/`Prov` cleanups
-(no stray entries); a committed nested probe leaves its touched vars covered by
-the parent's later discard; nesting depth is balanced (`c.probe` returns to its
-original value after paired open/close). All unit tests over hand-built terms —
-no overload machinery needed, which is the point of the split.
+**Tests (unit, over hand-built terms — no overload machinery):** a discarded
+probe restores bound-list lengths exactly; a discarded probe runs Info/Prov
+cleanups (no stray entries); a committed nested probe leaves its touched vars
+covered by the parent's later discard; `ctx.probe` returns to its original value
+after paired open/close.
 
-**Risk:** low. Small, self-contained, and exactly specified by the design notes;
-the append-only bound-list representation makes rollback a slice truncation.
+**Risk:** low. Small, self-contained; append-only bound lists make rollback a
+slice truncation.
 
 ---
 
 ### PR6 — Function overloading (free functions)
 
-The highest-uncertainty PR. Lands overloaded free `fn` declarations and their
-call-site resolution. Depends on **PR2** (per-overload schemes) and **PR5** (each
-candidate trial runs under a probe), and softly on **PR4** (the specificity
-ordering must account for the exact/inexact distinction).
+Highest-uncertainty PR. Depends on PR1 (per-overload schemes), PR5 (each
+candidate trial runs under a probe), softly on PR4 (specificity must account for
+exact/inexact). M2 currently *rejects* multiple top-level `FuncDecl`s of one name
+with `OverloadNotSupportedError`; PR6 replaces that with real overloading.
 
-- **Overload sets as side-channel metadata.** An overloaded symbol's binding
-  holds a *set* of declared/inferred schemes, **not** a single `soltype.Type`.
-  Infer each overload body individually (each is a normal `fn` with its own
-  principal type), then bundle. Never inject the disjunction into the lattice —
-  there is no SimpleSub type for "either this arrow or that arrow."
+- **Overload sets as side-channel metadata.** `ValueBinding.Overload` holds a set
+  of schemes — not a single `soltype.Type`; the disjunction never enters the
+  lattice. `inferComponent` collects the per-name `FuncDecl` arms (which M2
+  already gathers into `Sources`) and infers each body independently.
 - **Call-site resolution as a separate phase from `constrain`.** At each call,
-  collect the argument types' bounds, then pick a single overload and emit
-  constraints only for the chosen branch — under a probe (PR5), committing the
-  first success and rolling back losers' caller-side bounds.
+  collect the args' bounds, pick one overload under a probe (PR5), commit the
+  first success, roll back losers' caller-side bounds.
 - **Ground-enough deferral.** If an argument is still a fully unconstrained
-  variable, **defer the call** (preferred — let bounds accumulate) or fall back
-  to declaration-order first-match. No speculative pinning + backtrack.
-- **One documented specificity ordering.** Declaration-order + best-match
-  (TypeScript-style), documented in a `doc.go` comment and chosen to interact
-  cleanly with subtyping and the exact/inexact distinction from PR4 (M5's
-  method overloads and M4's object-arg overloads will reuse this one rule).
-- **Mutual recursion forces annotations.** If an overloaded function
-  participates in a mutually recursive group, **its overload signatures must be
-  annotated** (bodies still checked against them; only the set itself must be
-  ground before the group starts) — fixed-point iteration over overload choices
-  isn't guaranteed to converge under subtyping. Self-recursion is softer (each
-  body inferred with the *other* overload signatures visible). Emit a clear
-  error pointing at the unannotated overloaded participant.
+  variable, defer the call (preferred) or fall back to declaration-order
+  first-match. No speculative pinning + backtrack.
+- **One documented specificity ordering** (declaration-order + best-match,
+  TypeScript-style), in a `doc.go` comment, chosen to interact cleanly with
+  subtyping and PR4's exact/inexact distinction (M4 object-arg and M5 method
+  overloads reuse this one rule).
+- **Mutual recursion forces annotations.** An overloaded function in a mutually
+  recursive group must have annotated overload signatures (bodies still checked
+  against them; only the set must be ground before the group starts) — fixed-point
+  iteration over overload choices isn't guaranteed to converge under subtyping.
+  Self-recursion is softer. Emit a clear error pointing at the unannotated
+  participant.
 
 **Sketch:**
 
 ```go
-// solver/overload.go — call-site resolution (D + A), a phase distinct from constrain.
-func (c *checker) resolveOverload(set *OverloadSet, args []Type, call ast.Node) (res Type, decided bool) {
-    if !groundEnough(args) {
-        return nil, false // defer: let more bounds accumulate before choosing
-    }
-    for _, sig := range orderBySpecificity(set.branches) { // ONE documented ordering
-        inst := c.instantiate(sig, c.level).(*FunctionType) // (D) fresh per candidate; branches are fn schemes
+// internal/solver/overload.go — resolution is a phase distinct from constrain.
+func (c *checker) resolveOverload(scope *Scope, lvl int, set *OverloadSet, args []soltype.Type, call ast.Node) (soltype.Type, bool) {
+    if !groundEnough(args) { return nil, false } // defer
+    for _, sig := range orderBySpecificity(set.Branches) {
+        inst := c.instantiate(sig, lvl).(*soltype.FuncType) // (D) fresh per candidate; branches are fn schemes
         p := c.openProbe()                                  // (A, PR5) wrap caller-side bounds
         ok := c.tryConstrainArgs(args, inst, p)
-        c.closeProbe(p, ok) // commit on success, roll back on failure; always pops the stack
-        if ok {
-            return inst.ret, true
-        }
+        c.closeProbe(p, ok)
+        if ok { return inst.Ret, true }
     }
-    c.error(call, NoMatchingOverloadError{Set: set, Args: args})
+    c.errs = append(c.errs, &NoMatchingOverloadError{Call: call /* ... */}) // bridge error (M2.5)
     return nil, true
 }
-
-// groundEnough: no argument is a fully-unconstrained variable.
-func groundEnough(args []Type) bool { /* ... */ }
 ```
 
 ```go
-// solver/infer.go — the mutual-recursion gate, run before inferring an SCC (PR2 hook).
-func (c *checker) checkOverloadAnnotations(scc []ast.Decl) {
-    if len(scc) <= 1 {
-        return // self-recursion is softer; only multi-member groups require annotation
-    }
-    for _, d := range scc {
-        if set := overloadSetOf(d); set != nil && !set.annotated {
-            c.error(d, UnannotatedRecursiveOverloadError{Decl: d})
-        }
-    }
+// internal/solver/module.go — gate before inferring a recursive component.
+func (c *checker) checkOverloadAnnotations(component []dep_graph.BindingKey, g *dep_graph.DepGraph) {
+    if len(component) <= 1 { return } // self-recursion is softer
+    // for each overloaded member of the group whose branches aren't all annotated:
+    //   c.errs = append(c.errs, &UnannotatedRecursiveOverloadError{...}) // bridge error
 }
 ```
 
-**Tests:** a two-overload free `fn` resolves per-argument-type at call sites;
-declaration-order tie-break is asserted; a deferred-then-resolved call (argument
-ground only after later constraints); the mutual-recursion-without-annotation
-error (full message); a resolution-rollback test (a losing overload leaves no
-bounds on argument vars and no stray `Info` entries — exercising PR5's probe).
+`NoMatchingOverloadError` and `UnannotatedRecursiveOverloadError` are new
+**bridge** errors (carry their AST node, derive `Span()`/`Related()`), replacing
+M2's interim `OverloadNotSupportedError`.
 
-**Risk:** **highest in M3.** Overloading is a poor fit for "one principal type
-per expression." Mitigations: the probe (PR5) is already proven by the time this
-lands; the design notes specify the (D + A) composition precisely; keep the
-specificity rule deliberately simple and documented; lean on the ground-enough
-*defer* path over guessing. If resolution proves intractable against the real
-AST, the fallback is declaration-order first-match for the MVP with a tracked
-follow-up — overloading is the one M3 piece that can ship in a reduced form
-without blocking M4.
+**Tests:** a two-overload free `fn` resolves per-arg-type at call sites;
+declaration-order tie-break asserted; a deferred-then-resolved call; the
+mutual-recursion-without-annotation error (full message); a resolution-rollback
+test (a losing overload leaves no bounds on arg vars and no stray `Info`/`Prov`
+entries — exercising PR5).
+
+**Risk:** **highest in M3.** Overloading is a poor fit for "one principal type per
+expression." Mitigations: the probe (PR5) is proven by the time this lands; keep
+the specificity rule simple and documented; prefer the ground-enough *defer* path
+over guessing. If resolution proves intractable, the fallback is declaration-order
+first-match for the MVP with a tracked follow-up — overloading is the one M3 piece
+that can ship reduced without blocking M4.
 
 ## Risks & gates
 
 - **No M3-level go/no-go gate** (those live at M4's `Ref` rule and M7's
   differential). M3's risk is concentrated in **PR6 (overloading)**; the
-  function core (PR1–PR4) and the probe (PR5) are high-confidence promotion of
-  spike / design-notes work.
-- **Simplification correctness (PR3)** is the subtlest core algorithm — but it
-  is the most thoroughly spike-tested, so the risk is "port faithfully," not
-  "design."
-- **Probe API scope creep (PR5)** — resist building beyond baseline A + D.
-  Everything heavier (overlay, generation tags) is explicitly deferred by the
-  design notes.
+  polymorphism core (PR1/PR2) is a focused change to M2's proven walk, and the
+  probe (PR5) is small.
+- **Simplification correctness (PR2)** is the subtlest core algorithm — but it is
+  the most spike-tested; the risk is "port faithfully," not "design."
+- **Exactness's extra-arg lint (PR4)** must stay distinct from the subtype
+  constraint, or the "too few / required" check regresses for deferred callees.
+- **Probe scope creep (PR5)** — resist building beyond baseline A + D.
 
 ## Acceptance (maps to [01-milestones.md](01-milestones.md) §"M3")
 
 M3 is done when, against **real source**:
 
 - Category-A renders: `TopLevelLetPolymorphism` ⇒ `fn <T0>(x: T0) -> T0`;
-  `IdentityPolymorphism` ⇒ `fn () -> ["hello", 5]`; `InnerCapturesOuterParam`
-  ⇒ `fn <T0>(y: T0) -> [T0, T0]`; parameter-only var ⇒ `unknown`. *(PR2+PR3)*
+  `IdentityPolymorphism` ⇒ `fn () -> ["hello", 5]`; `InnerCapturesOuterParam` ⇒
+  `fn <T0>(y: T0) -> [T0, T0]`; parameter-only var ⇒ `unknown`. *(PR1+PR2)*
+- Async: `async fn () -> number` ⇒ `fn () -> Promise<number>`; `await p`
+  (`p: Promise<string>`) ⇒ `string`; `await p` (`p: Promise<Promise<number>>`) ⇒
+  `Promise<number>` (no auto-flatten). Block return-point join over a conditional.
+  *(PR3)*
 - Function exactness (#677): both exact `fn(x, y)` and inexact `fn(x, y, ...)`
   reject a 3-arg direct call; into a `fn(x, y)` slot, `fn(x, y)`/`fn(x, ...)`/
   `fn(...)` are accepted while exact `fn(x)` and any 3+-param function are
   rejected. *(PR4)*
 - Overloaded free `fn` declarations resolve at call sites per the documented
-  specificity rule; mutually-recursive overloaded participants without
-  annotations are rejected with a full error message. *(PR6, on the PR5 probe)*
+  specificity rule; mutually-recursive overloaded participants without annotations
+  are rejected with a full error message. *(PR6, on the PR5 probe)*
 
-All assertions are full error messages and Escalier-syntax rendered types, in
-the new package's table-test harness (CLAUDE.md test conventions; the M7
-`*_test.go` table shape from [02-design-notes.md](02-design-notes.md)
-§"Granular semantics").
+All assertions are full error messages (via M2.5's `requireBlame` span harness)
+and Escalier-syntax rendered types in the solver package's table tests.

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -76,6 +76,80 @@ spec-sync (PR0) ─────────────────────�
   and can proceed alongside PR3/PR4. It is the largest and highest-uncertainty
   PR; keeping it last lets the simpler function core settle first.
 
+## Core types added or changed in M3
+
+The sketches below use design-notes `soltype` naming (`FunctionType`,
+`TypeVarType`, …) and are **illustrative, not final** — field names and exact
+shapes are settled in code review. `// ...` marks elisions. They show *what M3
+adds on top of M1/M2*, not the whole package.
+
+**`FunctionType` grows three fields** beyond the spike's `Function` — `exact`
+(PR4), and the `required` count that lets optionals lower the accept-set lower
+bound without changing arity (PR4):
+
+```go
+// soltype/type.go — promoted from spike Function, extended for M3.
+type FunctionType struct {
+    params     []Type   // parameter types, in declared order
+    paramNames []string // parallel to params; for rendering only
+    required   int      // # of args that MUST be supplied (optionals lower this)
+    ret        Type
+    exact      bool     // bare fn(...) ⇒ true; fn(..., ...) ⇒ false  (PR4)
+}
+```
+
+**Schemes** (let-polymorphism, PR2) — promoted verbatim from `scheme.go`:
+
+```go
+// solver/poly.go
+type TypeScheme interface{ isScheme() }
+
+type MonoScheme struct{ ty Type }            // param, current-level RHS, LetRec self-ref
+type PolyScheme struct{ level int; body Type } // generalized: freshen vars with level > level
+
+func (*MonoScheme) isScheme() {}
+func (*PolyScheme) isScheme() {}
+```
+
+**`ValueBinding` carries either a scheme or an overload set** (PR5). An
+overloaded symbol is *not* a single `soltype.Type` — the disjunction never
+enters the lattice:
+
+```go
+// solver/scope.go
+type ValueBinding struct {
+    scheme   TypeScheme   // nil iff this is an overload set
+    overload *OverloadSet // non-nil for overloaded fn declarations
+}
+
+type OverloadSet struct {
+    branches  []TypeScheme // one per declared/inferred overload, declaration order
+    annotated bool         // every branch explicitly annotated? (gates recursive groups)
+}
+```
+
+**The probe** (PR5) — baseline (A) from
+[02-design-notes.md](02-design-notes.md) §"Speculative checks," the only new
+infrastructure in M3:
+
+```go
+// solver/probe.go
+type Bounded interface { // implemented by *TypeVarType (and *LifetimeVar in M4)
+    boundLengths() (lower, upper int)
+    truncateBounds(lower, upper int)
+}
+
+type probeEntry struct{ v Bounded; prevLower, prevUpper int }
+
+type Probe struct {
+    entries  []probeEntry
+    touched  set.Set[Bounded] // dedupe — snapshot only first touch
+    cleanups []func()         // Info/Prov side-table rollback closures
+    parent   *Probe           // nested probes
+    done     bool             // idempotent Discard/Commit
+}
+```
+
 ## PR breakdown
 
 ### PR0 — Spec sync: Policy A, the `open` marker, and #677's accept-set model
@@ -125,6 +199,60 @@ single-arg `App`.
   (the spike's IR had expression bodies only); a body with no value infers
   `Void`.
 
+**Sketch:**
+
+```go
+// solver/infer.go — the constraint-generating walk (replaces spike typeTerm).
+func (c *checker) inferFuncExpr(n *ast.FuncExpr, s *Scope) Type {
+    child := s.child()
+    params := make([]Type, len(n.Params))
+    names := make([]string, len(n.Params))
+    for i, p := range n.Params {
+        var pt Type
+        if p.TypeAnn != nil {
+            pt = c.typeFromAnn(p.TypeAnn, child)
+        } else {
+            pt = c.freshVarAt(p, ParamBinding) // fresh inference var + Prov entry
+        }
+        params[i] = pt
+        names[i] = p.Name
+        child.values[p.Name] = ValueBinding{scheme: &MonoScheme{ty: pt}}
+    }
+    ret := c.inferBlock(n.Body, child) // Void if the body yields no value
+    f := &FunctionType{params: params, paramNames: names,
+        required: len(params), ret: ret, exact: true} // exact/required refined in PR4
+    c.info.setType(n, f)
+    return f
+}
+
+func (c *checker) inferCallExpr(n *ast.CallExpr, s *Scope) Type {
+    callee := c.inferExpr(n.Callee, s)
+    args := make([]Type, len(n.Args))
+    for i, a := range n.Args {
+        args[i] = c.inferExpr(a, s)
+    }
+    res := c.freshVarAt(n, Application)
+    c.constrain(callee, &FunctionType{params: args, required: len(args), ret: res, exact: true})
+    c.info.setType(n, res)
+    return res
+}
+```
+
+```go
+// solver/constrain.go — function case (PR1 baseline; refined in PR4).
+case *FunctionType:
+    if r, ok := rhs.(*FunctionType); ok {
+        if len(l.params) > len(r.params) { // fewer-params-is-subtype (inexact case)
+            return arityError(l, r)
+        }
+        var errs []error
+        for i := range l.params {
+            errs = append(errs, c.constrain(r.params[i], l.params[i], seen)...) // contravariant
+        }
+        return append(errs, c.constrain(l.ret, r.ret, seen)...) // covariant
+    }
+```
+
 **Tests:** monomorphic function inference from real source — application type
 flows (`val n = (fn (x) { return x + 1 })(5)` ⇒ `n: number`), arity mismatch
 errors (full message), contravariant-param / covariant-return acceptance and
@@ -167,6 +295,42 @@ Promote `scheme.go` (`TypeScheme`/`MonoScheme`/`PolyScheme`, `instantiate`,
   is a non-issue — but leave a `// M4:` marker where `freshenAbove` will need a
   lifetime cache.
 
+**Sketch:**
+
+```go
+// solver/poly.go — promoted from scheme.go.
+func (c *checker) instantiate(s TypeScheme, lvl int) Type {
+    switch sc := s.(type) {
+    case *MonoScheme:
+        return sc.ty // no freshening
+    case *PolyScheme:
+        return c.freshenAbove(sc.level, sc.body, lvl, map[int]*TypeVarType{}) // + FromInstantiation Prov
+    }
+    panic("unreachable")
+}
+
+// freshenAbove copies ty, replacing each var with level > lim by a fresh var at
+// lvl (bounds freshened too); vars at level <= lim are shared. // M4: thread a
+// lifetime cache here so generalized lifetimes freshen per-instance.
+func (c *checker) freshenAbove(lim int, ty Type, lvl int, cache map[int]*TypeVarType) Type { /* ... */ }
+
+// generalize runs at a binding boundary once the RHS has finished inferring.
+func (c *checker) generalize(body Type, lvl int) TypeScheme {
+    body = c.simplify(body, lvl) // PR3 — compact the signature before quantifying
+    return &PolyScheme{level: lvl, body: body}
+}
+```
+
+```go
+// solver/infer.go — module-level: dep-graph SCC order drives declaration order.
+func (c *checker) inferModule(m *ast.Module) {
+    for _, scc := range c.deps.SCCsInTopoOrder(m) {
+        c.checkOverloadAnnotations(scc) // PR5 gate
+        c.inferSCC(scc)                 // fresh var per binding, constrain RHS <: var, generalize
+    }
+}
+```
+
 **Tests:** polymorphic instantiation — `val id = fn (x) { return x }` used at two
 types; let-bound polymorphism captured correctly (inner `let` generalizes after
 its RHS finishes); recursive and mutually-recursive groups infer without
@@ -197,6 +361,37 @@ generalization boundaries before coalescing.
 - **Wire into the pipeline:** run `analyze` → `symmetrize` → `collectCoOcc` →
   `mergeCoOccurring` on a `PolyScheme`'s body at generalization time, feeding the
   merged result into `coalesce` and then the printer.
+
+**Sketch:**
+
+```go
+// solver/simplify.go — promoted from simplify.go; pipeline orchestrated here.
+func (c *checker) simplify(ty Type, lvl int) Type {
+    // 1. occurrence analysis: which polarities does each var appear in?
+    occ := map[int]map[Polarity]bool{}
+    analyze(ty, Positive, occ, map[polKey]bool{})
+
+    // 2. co-occurrence: which vars share a union/intersection node, per polarity?
+    vars := map[int]*TypeVarType{}
+    collectVars(ty, vars)
+    symmetrize(vars) // mirror one-sided var<:var bounds so each var sees all its facts
+    coOcc := map[polKey]map[int]bool{}
+    collectCoOcc(ty, Positive, coOcc, map[polKey]bool{})
+
+    // 3. merge vars that co-occur in EVERY polarity they appear in.
+    uf := mergeCoOccurring(vars, occ, coOcc)
+
+    // 4. rewrite: drop single-polarity vars (-> their bound, or unknown/never for
+    //    the empty case), apply union-find representatives.
+    return rewrite(ty, occ, uf)
+}
+
+// analyze / collectVars / collectCoOcc / mergeCoOccurring port directly from the
+// spike; the Mut->Ref and ResidualOp bipolarity special cases come along in M4/M8.
+func analyze(st Type, pol Polarity, occ map[int]map[Polarity]bool, seen map[polKey]bool) { /* ... */ }
+func mergeCoOccurring(vars map[int]*TypeVarType, occ map[int]map[Polarity]bool,
+    coOcc map[polKey]map[int]bool) *unionFind { /* ... */ }
+```
 
 **Tests — the Category-A acceptance from the milestone, against real source:**
 
@@ -239,6 +434,56 @@ land in parallel with PR3.
 - **`required` vs `n`.** Optional params lower `required` without changing `n`.
   Wire optional-param detection from the AST (`x?`-style) into the accept-set
   computation.
+
+**Sketch:**
+
+```go
+// solver/constrain.go — accept-set helper + refined function case.
+const unboundedArity = math.MaxInt
+
+// acceptSet is the inclusive range of arg-counts a function accepts when invoked.
+func acceptSet(f *FunctionType) (lo, hi int) {
+    lo = f.required
+    if f.exact {
+        hi = len(f.params)
+    } else {
+        hi = unboundedArity
+    }
+    return
+}
+
+case *FunctionType:
+    if r, ok := rhs.(*FunctionType); ok {
+        // l <: r  iff  accept(l) superset-of accept(r):  loL <= loR  AND  hiL >= hiR.
+        loL, hiL := acceptSet(l)
+        loR, hiR := acceptSet(r)
+        if loL > loR || hiL < hiR {
+            return callContractError(l, r)
+        }
+        var errs []error
+        n := min(len(l.params), len(r.params)) // relate shared positions only
+        for i := 0; i < n; i++ {
+            errs = append(errs, c.constrain(r.params[i], l.params[i], seen)...) // contravariant
+        }
+        return append(errs, c.constrain(l.ret, r.ret, seen)...) // covariant
+    }
+```
+
+```go
+// solver/infer.go — direct-call arity, independent of exactness (from inferCallExpr).
+func (c *checker) checkDirectCallArity(n *ast.CallExpr, callee Type, argc int) {
+    f, ok := peelToFunc(callee) // through aliases / a resolved var bound
+    if !ok {
+        return // not (yet) known to be a function; the constraint handles it
+    }
+    switch {
+    case argc > len(f.params):
+        c.error(n, TooManyArgsError{Got: argc, Want: len(f.params)})
+    case argc < f.required:
+        c.error(n, TooFewArgsError{Got: argc, Required: f.required})
+    }
+}
+```
 
 **Tests (the milestone's exactness acceptance):**
 
@@ -291,6 +536,70 @@ the **probe API** they need. Depends on PR2 (per-overload schemes).
   isn't guaranteed to converge under subtyping. Self-recursion is softer (each
   body inferred with the *other* overload signatures visible). Emit a clear
   error pointing at the unannotated overloaded participant.
+
+**Sketch:**
+
+```go
+// solver/probe.go — baseline (A).
+func (p *Probe) record(v Bounded) {
+    if p.touched.Contains(v) {
+        return
+    }
+    p.touched.Add(v)
+    lo, hi := v.boundLengths()
+    p.entries = append(p.entries, probeEntry{v, lo, hi})
+}
+func (p *Probe) onRollback(f func()) { p.cleanups = append(p.cleanups, f) }
+
+func (p *Probe) rollback() {
+    for i := len(p.cleanups) - 1; i >= 0; i-- { p.cleanups[i]() } // side tables first
+    for i := len(p.entries) - 1; i >= 0; i-- {
+        e := p.entries[i]
+        e.v.truncateBounds(e.prevLower, e.prevUpper)
+    }
+}
+func (p *Probe) Discard() { if !p.done { p.rollback(); p.done = true } }
+func (p *Probe) Commit()  { /* propagate touched + cleanups to parent; clear entries */ }
+
+func (c *checker) openProbe() *Probe { p := &Probe{parent: c.probe}; c.probe = p; return p }
+```
+
+```go
+// solver/overload.go — call-site resolution (D + A), a phase distinct from constrain.
+func (c *checker) resolveOverload(set *OverloadSet, args []Type, call ast.Node) (res Type, decided bool) {
+    if !groundEnough(args) {
+        return nil, false // defer: let more bounds accumulate before choosing
+    }
+    for _, sig := range orderBySpecificity(set.branches) { // ONE documented ordering
+        inst := c.freshenAbove(/* sig at curLevel */).(*FunctionType) // (D) fresh per candidate
+        p := c.openProbe()                                            // (A) wrap caller-side bounds
+        if c.tryConstrainArgs(args, inst, p) {
+            p.Commit()
+            return inst.ret, true
+        }
+        p.Discard() // unwind caller-side bounds; drop inst
+    }
+    c.error(call, NoMatchingOverloadError{Set: set, Args: args})
+    return nil, true
+}
+
+// groundEnough: no argument is a fully-unconstrained variable.
+func groundEnough(args []Type) bool { /* ... */ }
+```
+
+```go
+// solver/infer.go — the mutual-recursion gate, run before inferring an SCC (PR2 hook).
+func (c *checker) checkOverloadAnnotations(scc []ast.Decl) {
+    if len(scc) <= 1 {
+        return // self-recursion is softer; only multi-member groups require annotation
+    }
+    for _, d := range scc {
+        if set := overloadSetOf(d); set != nil && !set.annotated {
+            c.error(d, UnannotatedRecursiveOverloadError{Decl: d})
+        }
+    }
+}
+```
 
 **Tests:** a two-overload free `fn` resolves per-argument-type at call sites;
 declaration-order tie-break is asserted; a deferred-then-resolved call (argument

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -189,8 +189,10 @@ single-arg `App`.
   param to a `MonoScheme`; build `FunctionType{params, paramNames, ret}`.
   `info.setType` on the node and each param.
 - **`*ast.CallExpr`** → infer callee and each arg, allocate a fresh result var,
-  and emit `constrain(callee <: FunctionType{args, result})`. Generalize the
-  spike's single-arg `App` to N args.
+  and emit a **call obligation** (`constrainCall`, defined in PR4) — not a
+  `FunctionType <: FunctionType` subtype assertion — so direct-call arity stays
+  owned by `checkDirectCallArity` and isn't re-checked by the accept-set gate.
+  Generalize the spike's single-arg `App` to N args.
 - **Function `constrain` rule** (already in M1 from the spike, `constrain.go:137`)
   — verify the multi-arg/variance path: `len(l.params) <= len(r.params)` arity
   check (the *inexact* fewer-params rule, refined in PR4), params contravariant,
@@ -232,7 +234,10 @@ func (c *checker) inferCallExpr(n *ast.CallExpr, s *Scope) Type {
         args[i] = c.inferExpr(a, s)
     }
     res := c.freshVarAt(n, Application)
-    c.constrain(callee, &FunctionType{params: args, required: len(args), ret: res, exact: true})
+    // Call obligation, NOT function subtyping (see PR4 constrainCall): relates
+    // arg/return types and lets an unresolved callee resolve structurally, but
+    // never gates on arity — direct-call arity is owned solely by checkDirectCallArity.
+    c.constrainCall(callee, args, res)
     c.info.setType(n, res)
     return res
 }
@@ -426,6 +431,16 @@ land in parallel with PR3.
   `CallExpr` path, reject supplying more args than the function declares
   regardless of `exact` — matching TypeScript. Keep the `>= required` lower
   bound. This is a call-site check, *not* a `constrain` rule.
+- **The call obligation skips the accept-set gate.** The constraint
+  `inferCallExpr` emits (PR1) must *not* run the `lo/hi` accept-set check, or it
+  would re-reject the same arity mismatches `checkDirectCallArity` reports, with
+  a less specific message. Emit it via a dedicated `constrainCall`, distinct
+  from `FunctionType <: FunctionType`: when the callee is concrete, relate
+  `arg_i <: param_i` (contravariant) and `ret <: res` directly; when it is still
+  a variable, record the call shape as a bound **tagged as an application
+  obligation** so later resolution relates it structurally rather than
+  re-running the accept-set gate. The `lo/hi` gate fires *only* for genuine
+  function-to-function (callback) subtyping.
 - **Callback subtyping = accept-set rule.** Rework the function case of
   `constrain`: `G <: F` iff `accept(G) ⊇ accept(F)`, i.e. `rG <= rF` (required)
   **and** `uG >= uF` (upper bound: `n` if exact, `∞` if inexact). Params remain
@@ -482,6 +497,23 @@ func (c *checker) checkDirectCallArity(n *ast.CallExpr, callee Type, argc int) {
     case argc < f.required:
         c.error(n, TooFewArgsError{Got: argc, Required: f.required})
     }
+}
+```
+
+```go
+// solver/constrain.go — direct-call obligation; no accept-set arity gate.
+func (c *checker) constrainCall(callee Type, args []Type, res Type) {
+    if f, ok := peelToFunc(callee); ok {
+        n := min(len(args), len(f.params))
+        for i := 0; i < n; i++ {
+            c.constrain(args[i], f.params[i]) // arg flows into param
+        }
+        c.constrain(f.ret, res)
+        return
+    }
+    // Unresolved callee: record the call shape as an application-tagged bound so
+    // resolution relates it structurally, not via the accept-set <: rule.
+    c.recordCallObligation(callee, args, res)
 }
 ```
 
@@ -559,9 +591,20 @@ func (p *Probe) rollback() {
     }
 }
 func (p *Probe) Discard() { if !p.done { p.rollback(); p.done = true } }
-func (p *Probe) Commit()  { /* propagate touched + cleanups to parent; clear entries */ }
+func (p *Probe) Commit()  { /* hand touched + cleanups to parent; clear entries */ }
 
 func (c *checker) openProbe() *Probe { p := &Probe{parent: c.probe}; c.probe = p; return p }
+
+// closeProbe pops the probe stack after a trial — always paired with openProbe,
+// on both the commit and discard paths, so c.probe never dangles at a finished probe.
+func (c *checker) closeProbe(p *Probe, commit bool) {
+    if commit {
+        p.Commit()
+    } else {
+        p.Discard()
+    }
+    c.probe = p.parent
+}
 ```
 
 ```go
@@ -571,13 +614,13 @@ func (c *checker) resolveOverload(set *OverloadSet, args []Type, call ast.Node) 
         return nil, false // defer: let more bounds accumulate before choosing
     }
     for _, sig := range orderBySpecificity(set.branches) { // ONE documented ordering
-        inst := c.freshenAbove(/* sig at curLevel */).(*FunctionType) // (D) fresh per candidate
-        p := c.openProbe()                                            // (A) wrap caller-side bounds
-        if c.tryConstrainArgs(args, inst, p) {
-            p.Commit()
+        inst := c.instantiate(sig, c.level).(*FunctionType) // (D) fresh per candidate; branches are fn schemes
+        p := c.openProbe()                                  // (A) wrap caller-side bounds
+        ok := c.tryConstrainArgs(args, inst, p)
+        c.closeProbe(p, ok) // commit on success, roll back on failure; always pops the stack
+        if ok {
             return inst.ret, true
         }
-        p.Discard() // unwind caller-side bounds; drop inst
     }
     c.error(call, NoMatchingOverloadError{Set: set, Args: args})
     return nil, true


### PR DESCRIPTION
This PR documents the concrete, PR-by-PR plan for milestone M3 (Functions, application, let-polymorphism) of the SimpleSub checker.

## Summary

Adds a comprehensive implementation plan for M3 that builds on the monomorphic function/application/block walk already shipped in M2. M3 layers polymorphic machinery (let-generalization, simplification), async/await support, function exactness, and function overloading on top of M2's proven foundation.

## Key changes

- **New file: `planning/simple_sub/m3-implementation-plan.md`** — A detailed 657-line plan covering:
  - Prerequisites from M1, M2, and M2.5 (what's already shipped)
  - The genuine delta M3 adds (let-generalization, simplification, async/await, exactness, probe API, overloading)
  - Sequencing rationale with a dependency graph showing parallelizable tracks
  - Core types added or changed (schemes, `OverloadSet`, probe infrastructure)
  - PR-by-PR breakdown (PR0–PR6) with sketches, tests, and risk assessments
  - Acceptance criteria mapping to the milestone definition

- **Updated: `planning/simple_sub/01-milestones.md`** — Clarified the M3 baseline:
  - Added a note that M2 already shipped the monomorphic function/application/block walk
  - Emphasized that M3's contribution is making those forms *polymorphic*, not rebuilding the walk
  - Linked to the new implementation plan for the detailed PR-by-PR breakdown

## Implementation structure

The plan sequences seven PRs across three landed prerequisites:

1. **PR0** — Spec sync (Policy A, exactness defaults)
2. **PR1** — Let-generalization (core polymorphism)
3. **PR2** — Simplification pass (compact renders)
4. **PR3** — Async/await + block return-point join
5. **PR4** — Function exactness (accept-set model)
6. **PR5** — Probe API (speculation infrastructure)
7. **PR6** — Function overloading (free functions)

The plan identifies three parallelizable tracks: the polymorphism chain (PR1→PR2), async+block (PR3), and exactness (PR0→PR4), with overloading (PR6) as the join point. Risk is concentrated in PR6 (overloading); the polymorphism core is a focused change to M2's proven walk.

https://claude.ai/code/session_01R3Hm2EiD4KcnbxJvSBwgUd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified milestone descriptions and baseline layering, including let-polymorphism and rendering expectations.
  * Added a detailed M3 implementation plan with features, phased delivery, risks, and acceptance criteria.
  * Updated exactness-by-default wording: usage-inferred shapes closure and row-polymorphism opt-in are clarified.
  * Revised M4 wording around the exactness rule to remove prior policy phrasing while preserving guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->