### PR TITLE
M2.5: Provenance side table and node-derived error spans

### DIFF
--- a/internal/ast/span.go
+++ b/internal/ast/span.go
@@ -32,6 +32,14 @@ func (s Span) Contains(loc Location) bool {
 		(s.End.Line > loc.Line || (s.End.Line == loc.Line && s.End.Column >= loc.Column))
 }
 
+// ContainsSpan reports whether inner lies entirely within s: the same source, and
+// both of inner's endpoints are contained in s. Used to decide whether a
+// finer-grained span (e.g. an operand's source node) sits inside a coarser one
+// (e.g. a constraint site) before preferring it for blame.
+func (s Span) ContainsSpan(inner Span) bool {
+	return s.SourceID == inner.SourceID && s.Contains(inner.Start) && s.Contains(inner.End)
+}
+
 func NewSpan(start, end Location, sourceID int) Span {
 	return Span{Start: start, End: end, SourceID: sourceID}
 }

--- a/internal/ast/span_test.go
+++ b/internal/ast/span_test.go
@@ -1,0 +1,41 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func sp(sl, sc, el, ec, srcID int) Span {
+	return NewSpan(Location{Line: sl, Column: sc}, Location{Line: el, Column: ec}, srcID)
+}
+
+// ContainsSpan reports whether inner lies entirely within the receiver, requiring
+// the same source and both endpoints contained.
+func TestSpanContainsSpan(t *testing.T) {
+	outer := sp(1, 1, 1, 20, 0)
+
+	t.Run("strictly inside", func(t *testing.T) {
+		require.True(t, outer.ContainsSpan(sp(1, 5, 1, 9, 0)))
+	})
+	t.Run("equal span is contained", func(t *testing.T) {
+		require.True(t, outer.ContainsSpan(outer))
+	})
+	t.Run("flush at the end (exclusive end) is contained", func(t *testing.T) {
+		require.True(t, outer.ContainsSpan(sp(1, 17, 1, 20, 0)))
+	})
+	t.Run("starts before is not contained", func(t *testing.T) {
+		require.False(t, outer.ContainsSpan(sp(1, 0, 1, 9, 0)))
+	})
+	t.Run("ends after is not contained", func(t *testing.T) {
+		require.False(t, outer.ContainsSpan(sp(1, 5, 1, 21, 0)))
+	})
+	t.Run("different source is not contained", func(t *testing.T) {
+		require.False(t, outer.ContainsSpan(sp(1, 5, 1, 9, 1)))
+	})
+	t.Run("multi-line containment", func(t *testing.T) {
+		multi := sp(1, 1, 5, 10, 0)
+		require.True(t, multi.ContainsSpan(sp(2, 1, 4, 3, 0)))
+		require.False(t, multi.ContainsSpan(sp(2, 1, 6, 1, 0)))
+	})
+}

--- a/internal/ast/span_test.go
+++ b/internal/ast/span_test.go
@@ -21,7 +21,7 @@ func TestSpanContainsSpan(t *testing.T) {
 	t.Run("equal span is contained", func(t *testing.T) {
 		require.True(t, outer.ContainsSpan(outer))
 	})
-	t.Run("flush at the end (exclusive end) is contained", func(t *testing.T) {
+	t.Run("flush at the end (inclusive boundary) is contained", func(t *testing.T) {
 		require.True(t, outer.ContainsSpan(sp(1, 17, 1, 20, 0)))
 	})
 	t.Run("starts before is not contained", func(t *testing.T) {

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -1,0 +1,206 @@
+package solver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// spanText returns the source substring covered by s. Columns are 1-indexed and
+// the end is exclusive (the lexer's convention), so a token at columns [c, c+n)
+// renders n characters. M2.5's error spans are single-line; a multi-line span is
+// not expected here and yields "".
+func spanText(src string, s ast.Span) string {
+	lines := strings.Split(src, "\n")
+	if s.Start.Line < 1 || s.Start.Line > len(lines) || s.Start.Line != s.End.Line {
+		return ""
+	}
+	line := lines[s.Start.Line-1]
+	if s.Start.Column < 1 || s.End.Column-1 > len(line) || s.Start.Column > s.End.Column {
+		return ""
+	}
+	return line[s.Start.Column-1 : s.End.Column-1]
+}
+
+// requireBlame asserts the sole error's message, the source text its primary span
+// covers, and the source text each related span covers (in order). The golden
+// span fixtures (§3.10) use it to pin exact blame against real-parser spans.
+func requireBlame(t *testing.T, src string, errs []SolverError, msg, primary string, related ...string) {
+	t.Helper()
+	require.Len(t, errs, 1)
+	require.Equal(t, msg, errs[0].Message())
+	require.Equal(t, primary, spanText(src, errs[0].Span()), "primary blame")
+	got := []string{}
+	for _, s := range errs[0].Related() {
+		got = append(got, spanText(src, s))
+	}
+	want := related
+	if want == nil {
+		want = []string{}
+	}
+	require.Equal(t, want, got, "related blame")
+}
+
+// --- Golden span fixtures (§3.10): exact blame against real-parser spans ---
+
+// A val-annotation mismatch blames the offending literal, with the annotation as
+// the related expected-source — the milestone's headline fixture (§3.7).
+func TestBlameValAnnotationLiteral(t *testing.T) {
+	src := `val x: number = "hi"`
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
+}
+
+// A call-arg mismatch blames the offending argument, with the callee's param
+// annotation as the related source.
+func TestBlameCallArgument(t *testing.T) {
+	src := "fn f(x: number) -> number { x }\nval r = f(\"hi\")"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
+}
+
+// A call-arity mismatch points at the whole call. (The callee `f` is named, so its
+// binding is coalesced to a fresh FuncType pointer that has no Prov entry — the
+// "function defined here" related span resolves only for inline callees in M2.5
+// and is made precise for named callees by M3's FromInstantiation.)
+func TestBlameCallArity(t *testing.T) {
+	src := "fn f(x: number) -> number { x }\nval r = f(1, 2)"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"cannot constrain function of arity 1 <: function of arity 2", "f(1, 2)")
+}
+
+// A missing-property read blames the member's prop (.foo), not the receiver. (The
+// receiver `o` is named/coalesced, so its related span resolves only for an inline
+// receiver in M2.5.)
+func TestBlameMissingProperty(t *testing.T) {
+	src := "val o = {a: 5}\nval x = o.b"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "object is missing property: b", "b")
+}
+
+// An identifier-flow mismatch blames the USE, not the definition: x's type traces
+// to its definition, which is not inside the use's constraint node, so the
+// containment guard falls back to the use (§3.8). The annotation is the related
+// expected-source.
+func TestBlameIdentifierUseNotDefinition(t *testing.T) {
+	src := "val x = \"hi\"\nval a: number = x"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, "x", "number")
+}
+
+// An inline receiver DOES resolve its related span: {a: 5} is used directly (not
+// coalesced through a binding), so its Prov entry survives and surfaces as the
+// receiver-related span.
+func TestBlameMissingPropertyInlineReceiverRelated(t *testing.T) {
+	src := `val x = {a: 5}.b`
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
+}
+
+// --- Bridge-error span fixtures (self-blaming, no Prov) ---
+
+// An unknown identifier blames the ident itself.
+func TestBlameUnknownIdentifier(t *testing.T) {
+	src := `val y = missing`
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Unknown identifier: missing", "missing")
+}
+
+// A duplicate top-level `val` blames the second decl and exposes the first as a
+// related "previously declared here" span.
+func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
+	src := "val x = 5\nval x = \"hi\""
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Duplicate declaration: x", `val x = "hi"`, "val x = 5")
+}
+
+// An unsupported feature (optional chaining) blames the member, not a separate
+// node, and reports the feature name.
+func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
+	src := "val o = {a: 5}\nval x = o?.a"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Unsupported in M2: OptionalChain", "o?.a")
+}
+
+// --- PR-2 unit tests: Span()/Related() over hand-built errors + a seeded Prov ---
+
+func tspan(sl, sc, el, ec int) ast.Span {
+	return ast.NewSpan(ast.Location{Line: sl, Column: sc}, ast.Location{Line: el, Column: ec}, 0)
+}
+
+// CannotConstrainError blames the LHS operand's node when it lies WITHIN the
+// constraint site (the f("hi") shape), and the related node follows the RHS.
+func TestCannotConstrainBlameOperandWithinSite(t *testing.T) {
+	lit := &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}
+	litNode := ast.NewLitExpr(ast.NewString("hi", tspan(1, 11, 1, 15)))
+	prim := &soltype.PrimType{Prim: soltype.NumPrim}
+	annNode := ast.NewNumberTypeAnn(tspan(1, 20, 1, 26))
+	site := ast.NewIdent("call", tspan(1, 1, 1, 30)) // a node whose span contains litNode
+
+	prov := Prov{lit: FromAST{Node: litNode, Kind: LiteralInference}, prim: FromAST{Node: annNode, Kind: AnnotationType}}
+	e := &CannotConstrainError{LHS: lit, RHS: prim, prov: prov, site: site}
+
+	require.Equal(t, litNode.Span(), e.Span(), "operand inside the site wins")
+	require.Equal(t, []ast.Span{annNode.Span()}, e.Related(), "RHS is the related expected-source")
+}
+
+// When the LHS operand resolves OUTSIDE the constraint site (an ident's
+// definition), the containment guard falls back to the site — the use.
+func TestCannotConstrainBlameFallsBackToSiteWhenOperandOutside(t *testing.T) {
+	lit := &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}
+	defNode := ast.NewLitExpr(ast.NewString("hi", tspan(1, 9, 1, 13))) // on line 1
+	use := ast.NewIdent("x", tspan(2, 17, 2, 18))                      // the use, on line 2 — does NOT contain defNode
+
+	prov := Prov{lit: FromAST{Node: defNode, Kind: LiteralInference}}
+	e := &CannotConstrainError{LHS: lit, RHS: &soltype.PrimType{Prim: soltype.NumPrim}, prov: prov, site: use}
+
+	require.Equal(t, use.Span(), e.Span(), "operand outside the site → blame the use")
+}
+
+// An unrecorded operand (no Prov entry) falls back to the site.
+func TestCannotConstrainBlameFallsBackForUnrecordedOperand(t *testing.T) {
+	site := ast.NewIdent("use", tspan(3, 1, 3, 10))
+	e := &CannotConstrainError{
+		LHS:  &soltype.Void{}, // never recorded
+		RHS:  &soltype.PrimType{Prim: soltype.NumPrim},
+		prov: Prov{},
+		site: site,
+	}
+	require.Equal(t, site.Span(), e.Span())
+	require.Empty(t, e.Related())
+}
+
+// FuncArityMismatchError blames the RHS call-shape (the call) and relates the LHS
+// callee.
+func TestFuncArityBlameCallAndRelatesCallee(t *testing.T) {
+	callee := &soltype.FuncType{Ret: &soltype.Void{}}
+	calleeNode := ast.NewIdent("f", tspan(1, 1, 1, 2))
+	shape := &soltype.FuncType{Ret: &soltype.Void{}}
+	callNode := ast.NewIdent("call", tspan(1, 1, 1, 8))
+
+	prov := Prov{callee: FromAST{Node: calleeNode, Kind: FuncInference}, shape: FromAST{Node: callNode, Kind: CallShape}}
+	e := &FuncArityMismatchError{LHS: callee, RHS: shape, prov: prov}
+
+	require.Equal(t, callNode.Span(), e.Span())
+	require.Equal(t, []ast.Span{calleeNode.Span()}, e.Related())
+}
+
+// MissingPropertyError blames the field's inner var (the .prop ident) and relates
+// the receiver.
+func TestMissingPropertyBlamePropAndRelatesReceiver(t *testing.T) {
+	fieldVar := &soltype.TypeVarType{ID: 1}
+	recv := &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "a", Type: &soltype.PrimType{Prim: soltype.NumPrim}}}}
+	req := &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "b", Type: fieldVar}}}
+	propNode := ast.NewIdentifier("b", tspan(2, 9, 2, 10))
+	recvNode := ast.NewIdent("o", tspan(1, 9, 1, 15))
+
+	prov := Prov{fieldVar: FromAST{Node: propNode, Kind: MemberAccess}, recv: FromAST{Node: recvNode, Kind: ObjectField}}
+	e := &MissingPropertyError{LHS: recv, RHS: req, Name: "b", prov: prov}
+
+	require.Equal(t, propNode.Span(), e.Span())
+	require.Equal(t, []ast.Span{recvNode.Span()}, e.Related())
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -204,3 +204,62 @@ func TestMissingPropertyBlamePropAndRelatesReceiver(t *testing.T) {
 	require.Equal(t, propNode.Span(), e.Span())
 	require.Equal(t, []ast.Span{recvNode.Span()}, e.Related())
 }
+
+// Site fallback (M2.5 finding #2): when no operand resolves through Prov, the
+// three site-carrying constraint kinds blame the constraint node rather than
+// returning the zero span (which a consumer would mis-render as 0:0). This degrade
+// path is unreachable in M2.5 but becomes live with M4 record/tuple sinks.
+func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
+	site := ast.NewIdent("site", tspan(7, 3, 7, 12))
+
+	t.Run("FuncArity", func(t *testing.T) {
+		e := &FuncArityMismatchError{
+			LHS: &soltype.FuncType{}, RHS: &soltype.FuncType{}, prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
+	t.Run("TupleLength", func(t *testing.T) {
+		e := &TupleLengthMismatchError{
+			LHS: &soltype.TupleType{}, RHS: &soltype.TupleType{}, prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
+	t.Run("MissingProperty", func(t *testing.T) {
+		e := &MissingPropertyError{
+			LHS:  &soltype.RecordType{},
+			RHS:  &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			Name: "b", prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
+}
+
+// --- M2.5 finding #1: unsupported-annotation recovery (no spurious `<: never`) ---
+
+// An unsupported val annotation reports ITS OWN error once and the binding
+// recovers to the initializer's inferred type — no cascade `cannot constrain e <:
+// never`, no `never`-poisoned binding.
+func TestUnsupportedValAnnotationRecovers(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: Foo = 5`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
+	require.Equal(t, map[string]string{"x": "5"}, values)
+}
+
+// An unsupported function-return annotation likewise recovers: one error, and the
+// function keeps its inferred body return type instead of `never`.
+func TestUnsupportedReturnAnnotationRecovers(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() -> Foo { 5 }`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
+	require.Equal(t, map[string]string{"f": "fn () -> 5"}, values)
+}
+
+// An unsupported param annotation recovers the param to a fresh var (rendering as
+// `unknown` in contravariant position), not `never`.
+func TestUnsupportedParamAnnotationRecovers(t *testing.T) {
+	values, _, errs := inferSource(t, `fn g(x: Foo) -> number { 5 }`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
+	require.Equal(t, map[string]string{"g": "fn (x: unknown) -> number"}, values)
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -126,89 +126,50 @@ func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
 	requireBlame(t, src, errs, "Unsupported in M2: OptionalChain", "o?.a")
 }
 
-// --- PR-2 unit tests: Span()/Related() over hand-built errors + a seeded Prov ---
+// --- Site-fallback fixtures ---
 
+// A void result has no Prov entry — it is minted without an AST node — so a
+// constraint with void as its subject falls back to the constraint site, the use.
+// `fn f() {}` returns void, and `val x: number = f()` blames the `f()` call with
+// the annotation as the related expected-source. (Replaces the hand-built
+// CannotConstrain "unrecorded operand → site" unit test; its operand-within-site
+// and operand-outside-site branches are already covered by TestBlameCallArgument
+// and TestBlameIdentifierUseNotDefinition above.)
+func TestBlameVoidSubjectFallsBackToCallSite(t *testing.T) {
+	src := "fn f() {}\nval x: number = f()"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "cannot constrain void <: number", "f()", "number")
+}
+
+// An INLINE callee resolves its "defined here" related span — its FuncType is
+// recorded (FuncInference) against the fn expression — unlike the named callee in
+// TestBlameCallArity, whose coalesced binding has no Prov entry. So a call-arity
+// mismatch on an immediately-invoked function blames the call AND relates the
+// inline function. (The primary is the call expression; for a parenthesized callee
+// the parser's span begins at the inner `fn`, so the leading `(` is not part of
+// it.)
+func TestBlameCallArityInlineCalleeRelated(t *testing.T) {
+	src := `val r = (fn (x: number) -> number { x })(1, 2)`
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"cannot constrain function of arity 1 <: function of arity 2",
+		`fn (x: number) -> number { x })(1, 2)`,
+		`fn (x: number) -> number { x }`)
+}
+
+// tspan builds a single-SourceID span from 1-indexed line/column ints — only the
+// hand-built degrade-path test below needs it.
 func tspan(sl, sc, el, ec int) ast.Span {
 	return ast.NewSpan(ast.Location{Line: sl, Column: sc}, ast.Location{Line: el, Column: ec}, 0)
 }
 
-// CannotConstrainError blames the LHS operand's node when it lies WITHIN the
-// constraint site (the f("hi") shape), and the related node follows the RHS.
-func TestCannotConstrainBlameOperandWithinSite(t *testing.T) {
-	lit := &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}
-	litNode := ast.NewLitExpr(ast.NewString("hi", tspan(1, 11, 1, 15)))
-	prim := &soltype.PrimType{Prim: soltype.NumPrim}
-	annNode := ast.NewNumberTypeAnn(tspan(1, 20, 1, 26))
-	site := ast.NewIdent("call", tspan(1, 1, 1, 30)) // a node whose span contains litNode
-
-	prov := Prov{lit: FromAST{Node: litNode, Kind: LiteralInference}, prim: FromAST{Node: annNode, Kind: AnnotationType}}
-	e := &CannotConstrainError{LHS: lit, RHS: prim, prov: prov, site: site}
-
-	require.Equal(t, litNode.Span(), e.Span(), "operand inside the site wins")
-	require.Equal(t, []ast.Span{annNode.Span()}, e.Related(), "RHS is the related expected-source")
-}
-
-// When the LHS operand resolves OUTSIDE the constraint site (an ident's
-// definition), the containment guard falls back to the site — the use.
-func TestCannotConstrainBlameFallsBackToSiteWhenOperandOutside(t *testing.T) {
-	lit := &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}
-	defNode := ast.NewLitExpr(ast.NewString("hi", tspan(1, 9, 1, 13))) // on line 1
-	use := ast.NewIdent("x", tspan(2, 17, 2, 18))                      // the use, on line 2 — does NOT contain defNode
-
-	prov := Prov{lit: FromAST{Node: defNode, Kind: LiteralInference}}
-	e := &CannotConstrainError{LHS: lit, RHS: &soltype.PrimType{Prim: soltype.NumPrim}, prov: prov, site: use}
-
-	require.Equal(t, use.Span(), e.Span(), "operand outside the site → blame the use")
-}
-
-// An unrecorded operand (no Prov entry) falls back to the site.
-func TestCannotConstrainBlameFallsBackForUnrecordedOperand(t *testing.T) {
-	site := ast.NewIdent("use", tspan(3, 1, 3, 10))
-	e := &CannotConstrainError{
-		LHS:  &soltype.Void{}, // never recorded
-		RHS:  &soltype.PrimType{Prim: soltype.NumPrim},
-		prov: Prov{},
-		site: site,
-	}
-	require.Equal(t, site.Span(), e.Span())
-	require.Empty(t, e.Related())
-}
-
-// FuncArityMismatchError blames the RHS call-shape (the call) and relates the LHS
-// callee.
-func TestFuncArityBlameCallAndRelatesCallee(t *testing.T) {
-	callee := &soltype.FuncType{Ret: &soltype.Void{}}
-	calleeNode := ast.NewIdent("f", tspan(1, 1, 1, 2))
-	shape := &soltype.FuncType{Ret: &soltype.Void{}}
-	callNode := ast.NewIdent("call", tspan(1, 1, 1, 8))
-
-	prov := Prov{callee: FromAST{Node: calleeNode, Kind: FuncInference}, shape: FromAST{Node: callNode, Kind: CallShape}}
-	e := &FuncArityMismatchError{LHS: callee, RHS: shape, prov: prov}
-
-	require.Equal(t, callNode.Span(), e.Span())
-	require.Equal(t, []ast.Span{calleeNode.Span()}, e.Related())
-}
-
-// MissingPropertyError blames the field's inner var (the .prop ident) and relates
-// the receiver.
-func TestMissingPropertyBlamePropAndRelatesReceiver(t *testing.T) {
-	fieldVar := &soltype.TypeVarType{ID: 1}
-	recv := &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "a", Type: &soltype.PrimType{Prim: soltype.NumPrim}}}}
-	req := &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "b", Type: fieldVar}}}
-	propNode := ast.NewIdentifier("b", tspan(2, 9, 2, 10))
-	recvNode := ast.NewIdent("o", tspan(1, 9, 1, 15))
-
-	prov := Prov{fieldVar: FromAST{Node: propNode, Kind: MemberAccess}, recv: FromAST{Node: recvNode, Kind: ObjectField}}
-	e := &MissingPropertyError{LHS: recv, RHS: req, Name: "b", prov: prov}
-
-	require.Equal(t, propNode.Span(), e.Span())
-	require.Equal(t, []ast.Span{recvNode.Span()}, e.Related())
-}
-
-// Site fallback (M2.5 finding #2): when no operand resolves through Prov, the
-// three site-carrying constraint kinds blame the constraint node rather than
-// returning the zero span (which a consumer would mis-render as 0:0). This degrade
-// path is unreachable in M2.5 but becomes live with M4 record/tuple sinks.
+// The three site-carrying constraint kinds degrade to the constraint site when
+// NEITHER operand resolves through Prov, rather than returning the zero span
+// (which a consumer would mis-render as 0:0). Unlike every fixture above, this path
+// is UNREACHABLE from M2.5 source — FuncArity always records the call-shape,
+// MissingProperty always records the field var, and tuple <: tuple cannot fire
+// without a tuple sink — so it must be exercised with hand-built errors and a
+// seeded Prov here; it becomes live with M4 record/tuple sinks.
 func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 	site := ast.NewIdent("site", tspan(7, 3, 7, 12))
 

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -224,3 +224,19 @@ func TestUnsupportedParamAnnotationRecovers(t *testing.T) {
 	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
 	require.Equal(t, map[string]string{"g": "fn (x: unknown) -> number"}, values)
 }
+
+// A VarDecl with a nil pattern (not produced by the parser, which synthesizes a
+// placeholder, but possible in a hand-built AST) must blame the decl without
+// panicking — honoring M2's "never a panic" guarantee now that Span() is lazy
+// (it derefs the stored node on demand). Mirrors inferFunc's nil-param fallback.
+func TestNilVarDeclPatternBlamesDeclWithoutPanic(t *testing.T) {
+	c := newChecker()
+	d := ast.NewVarDecl(ast.ValKind, nil, nil, numExpr(5), false, false, testSpan())
+	require.NotPanics(t, func() {
+		_, _, ok := c.inferDeclDef(NewScope(), 0, d)
+		require.False(t, ok)
+	})
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: VarDecl", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span()) // derefs the decl node, not a nil pattern
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -197,32 +197,30 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 
 // --- M2.5 finding #1: unsupported-annotation recovery (no spurious `<: never`) ---
 
-// An unsupported val annotation reports ITS OWN error once and the binding
-// recovers to the initializer's inferred type — no cascade `cannot constrain e <:
-// never`, no `never`-poisoned binding.
-func TestUnsupportedValAnnotationRecovers(t *testing.T) {
-	values, _, errs := inferSource(t, `val x: Foo = 5`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
-	require.Equal(t, map[string]string{"x": "5"}, values)
-}
-
-// An unsupported function-return annotation likewise recovers: one error, and the
-// function keeps its inferred body return type instead of `never`.
-func TestUnsupportedReturnAnnotationRecovers(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() -> Foo { 5 }`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
-	require.Equal(t, map[string]string{"f": "fn () -> 5"}, values)
-}
-
-// An unsupported param annotation recovers the param to a fresh var (rendering as
-// `unknown` in contravariant position), not `never`.
-func TestUnsupportedParamAnnotationRecovers(t *testing.T) {
-	values, _, errs := inferSource(t, `fn g(x: Foo) -> number { 5 }`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
-	require.Equal(t, map[string]string{"g": "fn (x: unknown) -> number"}, values)
+// An unsupported annotation reports ITS OWN error once and the binding recovers to
+// the type it would otherwise infer — no cascade `cannot constrain e <: never`, no
+// `never`-poisoned binding. Covers each annotation position:
+//   - val: keeps the initializer's inferred type;
+//   - function return: keeps the inferred body return type;
+//   - param: recovers to a fresh var (rendering `unknown` in contravariant position).
+func TestUnsupportedAnnotationRecovers(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{"val", `val x: Foo = 5`, map[string]string{"x": "5"}},
+		{"return", `fn f() -> Foo { 5 }`, map[string]string{"f": "fn () -> 5"}},
+		{"param", `fn g(x: Foo) -> number { 5 }`, map[string]string{"g": "fn (x: unknown) -> number"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
+			require.Equal(t, tt.want, values)
+		})
+	}
 }
 
 // A VarDecl with a nil pattern (not produced by the parser, which synthesizes a

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -40,8 +40,8 @@ type SolverError interface {
 // constraint (an ident's definition) or not at all (a Void result).
 type CannotConstrainError struct {
 	LHS, RHS soltype.Type
-	prov     Provenance // M2.5: type→node index; assigned after Constrain returns (§3.5)
-	site     ast.Node   // M2.5: the constraint node n — the use, the fallback when LHS has no entry
+	prov     NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
+	site     ast.Node     // M2.5: the constraint node n — the use, the fallback when LHS has no entry
 }
 
 // FuncArityMismatchError fires on FuncType <: FuncType when the two arities
@@ -52,10 +52,14 @@ type CannotConstrainError struct {
 //
 // The subject is the RHS call-shape (a fresh FuncType{args, res} minted per call,
 // recorded against the CallExpr), so Span() resolves precisely to the call;
-// Related() follows the LHS callee to a "defined here" span.
+// Related() follows the LHS callee to a "defined here" span. site is the
+// constraint node, used as a coarse fallback when neither operand resolves (e.g.
+// once M3 produces higher-order FuncArity errors whose RHS isn't a recorded
+// call-shape) so blame never degrades to the zero span.
 type FuncArityMismatchError struct {
 	LHS, RHS *soltype.FuncType
-	prov     Provenance // M2.5: type→node index (§3.5)
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback when no operand resolves
 }
 
 // TupleLengthMismatchError fires on TupleType <: TupleType with different
@@ -65,10 +69,14 @@ type FuncArityMismatchError struct {
 // The subject is the LHS tuple literal (recorded by inferTuple); Related() points
 // at the RHS expected-source. Not actually reachable in M2.5 — a tuple <: tuple
 // constraint needs a tuple sink (annotation/param) resolveTypeAnn does not yet
-// produce — so its blame is wired but exercised from M4.
+// produce — so its blame is wired but exercised from M4. site is the constraint
+// node, the coarse fallback when neither tuple resolves (e.g. an M4 tuple
+// annotation whose elements aren't recorded) so blame never degrades to the zero
+// span.
 type TupleLengthMismatchError struct {
 	LHS, RHS *soltype.TupleType
-	prov     Provenance // M2.5: type→node index (§3.5)
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback when no operand resolves
 }
 
 // MissingPropertyError fires on RecordType <: RecordType when the RHS requires a
@@ -81,11 +89,16 @@ type TupleLengthMismatchError struct {
 // The subject is the field's inner result var (RHS.Field(Name)), minted by
 // inferMember and recorded against the .prop identifier — so Span() blames the
 // member's prop (.foo), not the receiver. Name stays: the absent field name is
-// not recoverable from a single node (the RHS may require several fields).
+// not recoverable from a single node (the RHS may require several fields). site
+// is the constraint node, the coarse fallback when the field var has no entry —
+// reachable once M4 builds concrete record <: record requirements whose field
+// types are coalesced/annotation-minted (and therefore not recorded by
+// inferMember); until then it never fires, but it keeps blame off the zero span.
 type MissingPropertyError struct {
 	LHS, RHS *soltype.RecordType
 	Name     string
-	prov     Provenance // M2.5: type→node index (§3.5)
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback when the field var has no entry
 }
 
 func (*CannotConstrainError) isSolverError()     {}
@@ -100,43 +113,28 @@ func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.LH
 func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
 func (e *FuncArityMismatchError) Span() ast.Span {
-	if e.prov != nil {
-		if n, ok := e.prov.NodeFor(e.RHS); ok { // the call-shape → the CallExpr
-			return n.Span()
-		}
-		if n, ok := e.prov.NodeFor(e.LHS); ok { // degrade → the callee function
-			return n.Span()
-		}
-	}
-	return ast.Span{}
+	// RHS call-shape → the CallExpr; degrade → the callee function; else the site.
+	return spanOfFirst(e.prov, e.site, e.RHS, e.LHS)
 }
 func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the fn
 
 func (e *TupleLengthMismatchError) Span() ast.Span {
-	if e.prov != nil {
-		if n, ok := e.prov.NodeFor(e.LHS); ok { // the tuple literal
-			return n.Span()
-		}
-		if n, ok := e.prov.NodeFor(e.RHS); ok { // degrade → the other tuple
-			return n.Span()
-		}
-	}
-	return ast.Span{}
+	// LHS tuple literal → degrade to the other tuple → else the site.
+	return spanOfFirst(e.prov, e.site, e.LHS, e.RHS)
 }
 func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
 func (e *MissingPropertyError) Span() ast.Span {
-	if e.prov != nil {
-		if f, ok := e.RHS.Field(e.Name); ok { // the field's inner var → the .foo prop ident
-			if n, ok := e.prov.NodeFor(f); ok {
-				return n.Span()
-			}
-		}
-		if n, ok := e.prov.NodeFor(e.LHS); ok { // unreachable in practice → the receiver
-			return n.Span()
-		}
+	// The field's inner var → the .foo prop ident; degrade to the receiver; else
+	// the site. The field-var arm is the only one reachable in M2.5 (member
+	// access always records it); the receiver/site arms cover the M4 concrete
+	// record <: record case where the field type may be unrecorded.
+	ops := make([]soltype.Type, 0, 2)
+	if f, ok := e.RHS.Field(e.Name); ok {
+		ops = append(ops, f)
 	}
-	return ast.Span{}
+	ops = append(ops, e.LHS)
+	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the receiver
 
@@ -148,30 +146,47 @@ func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e
 // site, so the use (site) wins — an ident-use error points at the use, not the
 // definition (§3.8). In M3+, NodeFor chases interior Origin edges to the nearest
 // AST leaf; in M2.5 it is a single lookup.
-func spanOf(p Provenance, op soltype.Type, site ast.Node) ast.Span {
+func spanOf(p NodeResolver, op soltype.Type, site ast.Node) ast.Span {
 	if p != nil && site != nil {
-		if n, ok := p.NodeFor(op); ok && within(site.Span(), n.Span()) {
+		if n, ok := p.NodeFor(op); ok && site.Span().ContainsSpan(n.Span()) {
 			return n.Span()
 		}
 	}
+	return spanOfNode(site)
+}
+
+// spanOfFirst returns the span of the first operand that resolves through p, in
+// the order given, falling back to the site's span (and finally the zero span
+// when there is no site). Unlike spanOf it applies no containment guard — its
+// callers' subject operands are minted *at* the constraint (a call-shape, a tuple
+// literal, a member's field var), so the first resolved operand is already the
+// narrowest blame. The site fallback keeps blame off the zero span when an
+// operand is unrecorded (a degrade path reachable from M4).
+func spanOfFirst(p NodeResolver, site ast.Node, ops ...soltype.Type) ast.Span {
+	if p != nil {
+		for _, op := range ops {
+			if n, ok := p.NodeFor(op); ok {
+				return n.Span()
+			}
+		}
+	}
+	return spanOfNode(site)
+}
+
+// spanOfNode returns site.Span(), or the zero span when site is nil. The zero
+// span only arises for a hand-built error with no site; every error the walk
+// produces carries one.
+func spanOfNode(site ast.Node) ast.Span {
 	if site != nil {
 		return site.Span()
 	}
 	return ast.Span{}
 }
 
-// within reports whether inner sits inside outer (same source, both of inner's
-// endpoints within outer). ast.Span.Contains takes a Location, so a span is
-// contained when its Start and End both are.
-func within(outer, inner ast.Span) bool {
-	return outer.SourceID == inner.SourceID &&
-		outer.Contains(inner.Start) && outer.Contains(inner.End)
-}
-
 // relatedOf resolves each operand that has an entry to a related span and drops
 // the ones that don't (no fallback — a missing related node is simply omitted),
 // deduped by span (§3.6).
-func relatedOf(p Provenance, ops ...soltype.Type) []ast.Span {
+func relatedOf(p NodeResolver, ops ...soltype.Type) []ast.Span {
 	if p == nil {
 		return nil
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -15,33 +15,33 @@ import (
 // error refers to — e.g. navigate to a type's declaration — without reparsing
 // the message. Modeled on internal/checker/error.go's shape.
 //
-// M2 adds Span() ast.Span. The constraint kinds (CannotConstrainError, …) are
-// still constructed span-free inside the engine (constrain.go has no AST node
-// in hand); the M2 walk stamps the offending node's span onto each returned
-// error via the unexported setSpan at the constrain call site (see
-// (*checker).constrain). The M2 bridge kinds below carry their span from
-// construction.
+// M2.5 makes every Span() node-derived: bridge kinds self-blame from the AST node
+// they carry, and constraint kinds resolve their offending operand to its minting
+// node through the Prov side table (per-operand blame, §3.5). Related() exposes
+// secondary contributing nodes (the expected-source alongside the actual-source;
+// the prior declaration alongside the duplicate). errSpan/setSpan are gone — no
+// error is stamped after the fact.
 type SolverError interface {
 	isSolverError()
 	Message() string
-	Span() ast.Span
-	setSpan(ast.Span)
+	Span() ast.Span      // ALWAYS derived from a primary ast.Node
+	Related() []ast.Span // node-derived; empty unless the kind carries related nodes
 }
-
-// errSpan is the embeddable span carrier shared by every SolverError kind. It
-// supplies Span()/setSpan so a span-free engine error can be stamped after the
-// fact and a bridge error can be built with its span in place.
-type errSpan struct{ span ast.Span }
-
-func (e *errSpan) Span() ast.Span     { return e.span }
-func (e *errSpan) setSpan(s ast.Span) { e.span = s }
 
 // CannotConstrainError fires when a non-variable LHS/RHS pair fails to match:
 // prim/prim mismatch, lit/lit mismatch, lit/prim mismatch, and the generic
 // "no rule applies" fall-through at the end of constrain.
+//
+// LHS is the "actual" value, RHS the "expected"; blame follows LHS to its minting
+// node (when that node lies inside the constraint site — the containment guard
+// that keeps identifier-flow blame on the use, not the definition, §3.8) and falls
+// back to site otherwise. This is the only constraint kind that keeps a site
+// fallback: its actual-value operand can legitimately resolve outside the
+// constraint (an ident's definition) or not at all (a Void result).
 type CannotConstrainError struct {
-	errSpan
 	LHS, RHS soltype.Type
+	prov     Provenance // M2.5: type→node index; assigned after Constrain returns (§3.5)
+	site     ast.Node   // M2.5: the constraint node n — the use, the fallback when LHS has no entry
 }
 
 // FuncArityMismatchError fires on FuncType <: FuncType when the two arities
@@ -49,17 +49,26 @@ type CannotConstrainError struct {
 // of params). Holds the full FuncTypes, not just the arities, so consumers can
 // report param/return types too. M3 narrows the firing conditions when the
 // exactness flag adds the inexact fewer-params-is-subtype arm.
+//
+// The subject is the RHS call-shape (a fresh FuncType{args, res} minted per call,
+// recorded against the CallExpr), so Span() resolves precisely to the call;
+// Related() follows the LHS callee to a "defined here" span.
 type FuncArityMismatchError struct {
-	errSpan
 	LHS, RHS *soltype.FuncType
+	prov     Provenance // M2.5: type→node index (§3.5)
 }
 
 // TupleLengthMismatchError fires on TupleType <: TupleType with different
 // lengths (M1's exact-tuple case; M4 may narrow the firing conditions when the
 // inexact flag is added).
+//
+// The subject is the LHS tuple literal (recorded by inferTuple); Related() points
+// at the RHS expected-source. Not actually reachable in M2.5 — a tuple <: tuple
+// constraint needs a tuple sink (annotation/param) resolveTypeAnn does not yet
+// produce — so its blame is wired but exercised from M4.
 type TupleLengthMismatchError struct {
-	errSpan
 	LHS, RHS *soltype.TupleType
+	prov     Provenance // M2.5: type→node index (§3.5)
 }
 
 // MissingPropertyError fires on RecordType <: RecordType when the RHS requires a
@@ -68,10 +77,15 @@ type TupleLengthMismatchError struct {
 // without that field (recv.foo where recv has no foo): the walk constrains
 // recv <: {foo: fresh}, and the absent field surfaces here. Holds both records
 // plus the missing name so consumers can inspect what was required.
+//
+// The subject is the field's inner result var (RHS.Field(Name)), minted by
+// inferMember and recorded against the .prop identifier — so Span() blames the
+// member's prop (.foo), not the receiver. Name stays: the absent field name is
+// not recoverable from a single node (the RHS may require several fields).
 type MissingPropertyError struct {
-	errSpan
 	LHS, RHS *soltype.RecordType
 	Name     string
+	prov     Provenance // M2.5: type→node index (§3.5)
 }
 
 func (*CannotConstrainError) isSolverError()     {}
@@ -79,13 +93,115 @@ func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*MissingPropertyError) isSolverError()     {}
 
-// --- M2 bridge errors (carry their span from construction) ---
+// --- Per-operand blame (§3.5): each constraint kind follows its operands through
+// Prov on demand, falling back to its own site (where it keeps one) ---
+
+func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.LHS, e.site) }
+func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *FuncArityMismatchError) Span() ast.Span {
+	if e.prov != nil {
+		if n, ok := e.prov.NodeFor(e.RHS); ok { // the call-shape → the CallExpr
+			return n.Span()
+		}
+		if n, ok := e.prov.NodeFor(e.LHS); ok { // degrade → the callee function
+			return n.Span()
+		}
+	}
+	return ast.Span{}
+}
+func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the fn
+
+func (e *TupleLengthMismatchError) Span() ast.Span {
+	if e.prov != nil {
+		if n, ok := e.prov.NodeFor(e.LHS); ok { // the tuple literal
+			return n.Span()
+		}
+		if n, ok := e.prov.NodeFor(e.RHS); ok { // degrade → the other tuple
+			return n.Span()
+		}
+	}
+	return ast.Span{}
+}
+func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *MissingPropertyError) Span() ast.Span {
+	if e.prov != nil {
+		if f, ok := e.RHS.Field(e.Name); ok { // the field's inner var → the .foo prop ident
+			if n, ok := e.prov.NodeFor(f); ok {
+				return n.Span()
+			}
+		}
+		if n, ok := e.prov.NodeFor(e.LHS); ok { // unreachable in practice → the receiver
+			return n.Span()
+		}
+	}
+	return ast.Span{}
+}
+func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the receiver
+
+// spanOf blames op's own source node when that node lies *within* the constraint
+// site, and the site itself otherwise (or when op has no entry). The containment
+// guard is the M2.5 fix for identifier-flow blame: for f("hi") the operand ("hi")
+// is minted inside the call, so the narrower operand wins; for val a: number = x
+// the operand (x's type) traces to x's *definition*, which is NOT inside the use
+// site, so the use (site) wins — an ident-use error points at the use, not the
+// definition (§3.8). In M3+, NodeFor chases interior Origin edges to the nearest
+// AST leaf; in M2.5 it is a single lookup.
+func spanOf(p Provenance, op soltype.Type, site ast.Node) ast.Span {
+	if p != nil && site != nil {
+		if n, ok := p.NodeFor(op); ok && within(site.Span(), n.Span()) {
+			return n.Span()
+		}
+	}
+	if site != nil {
+		return site.Span()
+	}
+	return ast.Span{}
+}
+
+// within reports whether inner sits inside outer (same source, both of inner's
+// endpoints within outer). ast.Span.Contains takes a Location, so a span is
+// contained when its Start and End both are.
+func within(outer, inner ast.Span) bool {
+	return outer.SourceID == inner.SourceID &&
+		outer.Contains(inner.Start) && outer.Contains(inner.End)
+}
+
+// relatedOf resolves each operand that has an entry to a related span and drops
+// the ones that don't (no fallback — a missing related node is simply omitted),
+// deduped by span (§3.6).
+func relatedOf(p Provenance, ops ...soltype.Type) []ast.Span {
+	if p == nil {
+		return nil
+	}
+	var spans []ast.Span
+	for _, op := range ops {
+		if n, ok := p.NodeFor(op); ok {
+			spans = appendUnique(spans, n.Span())
+		}
+	}
+	return spans
+}
+
+// appendUnique appends s unless an equal span is already present. ast.Span is a
+// plain comparable value (Start/End Location of ints + SourceID), so == suffices.
+func appendUnique(spans []ast.Span, s ast.Span) []ast.Span {
+	for _, e := range spans {
+		if e == s {
+			return spans
+		}
+	}
+	return append(spans, s)
+}
+
+// --- M2 bridge errors (born in the walk with the offending ast.Node in hand,
+// so they self-blame: Span() is the node's own span, no post-hoc stamping) ---
 
 // UnknownIdentifierError fires when a value-position identifier resolves to no
 // binding in the scope chain.
 type UnknownIdentifierError struct {
-	errSpan
-	Name string
+	Ident *ast.IdentExpr
 }
 
 // NamespaceUsedAsValueError fires when an identifier resolves to a namespace
@@ -93,24 +209,34 @@ type UnknownIdentifierError struct {
 // values; in M2 a namespace name in value position can only fail (qualified
 // member access — Foo.bar — is M4).
 type NamespaceUsedAsValueError struct {
-	errSpan
-	Name string
+	Ident *ast.IdentExpr
 }
 
-// UnsupportedNodeError is the M2-subset guard: an AST node outside the M2 walk's
-// coverage. Unlike BodyDeclNotAllowedError this is a temporary scope gate, not a
-// permanent language rule — later milestones widen coverage and remove arms.
+// UnsupportedNodeError is the M2-subset guard: an AST node whose KIND is outside
+// the M2 walk's coverage (kind = astKind(Node)). Unlike BodyDeclNotAllowedError
+// this is a temporary scope gate, not a permanent language rule — later milestones
+// widen coverage and remove arms. The "the node is fine, a FEATURE of it isn't"
+// case (e.g. optional chaining on a supported MemberExpr) is UnsupportedFeatureError.
 type UnsupportedNodeError struct {
-	errSpan
-	Kind string
+	Node ast.Node
+}
+
+// UnsupportedFeatureError is the sibling of UnsupportedNodeError for the case
+// where the node kind IS supported but a feature of it is not — e.g. a generic
+// function (the FuncExpr is fine, type params are M3) or optional chaining (the
+// MemberExpr is fine, recv?.foo is M6). The node carries the blame span; Feature
+// names what is unsupported (not derivable from astKind, which would name the
+// supported parent).
+type UnsupportedFeatureError struct {
+	Node    ast.Node
+	Feature string
 }
 
 // BodyDeclNotAllowedError fires when a statement-level declaration in a function
 // body is anything other than a VarDecl. This is a permanent language rule
 // (§3.2), not the temporary subset gate above: body decls are VarDecl-only.
 type BodyDeclNotAllowedError struct {
-	errSpan
-	Kind string
+	Decl ast.Decl
 }
 
 // MissingInitializerError fires when a `val`/`var` declaration has no
@@ -119,17 +245,22 @@ type BodyDeclNotAllowedError struct {
 // kind rather than a generic UnsupportedNodeError: it marks an annotation-driven
 // binding the walk can't infer, not an AST node shape outside the subset.
 type MissingInitializerError struct {
-	errSpan
-	Name string // the bound name when the pattern is an IdentPat; "" otherwise
+	Decl *ast.VarDecl
 }
 
 // DuplicateDeclarationError fires when a top-level `val`/`var` rebinds a name
 // already declared in the module scope. Unlike a function (whose repeated
 // top-level declarations are overloads, supported from PR-3), a variable may be
 // declared only once per scope; the first binding is kept.
+//
+// Decl is the rejected redeclaration (the blame span); Previous is the kept first
+// declaration, surfaced via Related() as "previously declared here". Name is the
+// resolved binding-key name — retained alongside the nodes because it may be a
+// qualified key name distinct from the decl's local identifier, and the message
+// wants the canonical name (§3.4 caveat).
 type DuplicateDeclarationError struct {
-	errSpan
-	Name string
+	Decl, Previous ast.Decl
+	Name           string
 }
 
 // OverloadNotSupportedError fires when a name has more than one top-level
@@ -138,48 +269,71 @@ type DuplicateDeclarationError struct {
 // callable with that signature) and reports each extra arm, rather than merging
 // the arms into the same var — which yields an uncallable union-of-functions
 // binding whose every call fails with an opaque `function | function` mismatch.
+//
+// Decl/Previous/Name mirror DuplicateDeclarationError.
 type OverloadNotSupportedError struct {
-	errSpan
-	Name string
+	Decl, Previous ast.Decl
+	Name           string
 }
 
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*UnsupportedNodeError) isSolverError()      {}
+func (*UnsupportedFeatureError) isSolverError()   {}
 func (*BodyDeclNotAllowedError) isSolverError()   {}
 func (*MissingInitializerError) isSolverError()   {}
 func (*DuplicateDeclarationError) isSolverError() {}
 func (*OverloadNotSupportedError) isSolverError() {}
 
+func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
+func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
 func (e *UnknownIdentifierError) Message() string {
-	return "Unknown identifier: " + e.Name
+	return "Unknown identifier: " + e.Ident.Name
 }
 
+func (e *NamespaceUsedAsValueError) Span() ast.Span      { return e.Ident.Span() }
+func (e *NamespaceUsedAsValueError) Related() []ast.Span { return nil }
+func (e *NamespaceUsedAsValueError) Message() string {
+	return "Namespace used as a value: " + e.Ident.Name
+}
+
+func (e *UnsupportedNodeError) Span() ast.Span      { return e.Node.Span() }
+func (e *UnsupportedNodeError) Related() []ast.Span { return nil }
+func (e *UnsupportedNodeError) Message() string {
+	return "Unsupported in M2: " + astKind(e.Node)
+}
+
+func (e *UnsupportedFeatureError) Span() ast.Span      { return e.Node.Span() }
+func (e *UnsupportedFeatureError) Related() []ast.Span { return nil }
+func (e *UnsupportedFeatureError) Message() string {
+	return "Unsupported in M2: " + e.Feature
+}
+
+func (e *BodyDeclNotAllowedError) Span() ast.Span      { return e.Decl.Span() }
+func (e *BodyDeclNotAllowedError) Related() []ast.Span { return nil }
+func (e *BodyDeclNotAllowedError) Message() string {
+	return "Declaration not allowed in function body: " + astKind(e.Decl)
+}
+
+func (e *MissingInitializerError) Span() ast.Span      { return e.Decl.Span() }
+func (e *MissingInitializerError) Related() []ast.Span { return nil }
 func (e *MissingInitializerError) Message() string {
-	if e.Name != "" {
-		return "Variable declaration requires an initializer: " + e.Name
+	if name, ok := varName(e.Decl); ok {
+		return "Variable declaration requires an initializer: " + name
 	}
 	return "Variable declaration requires an initializer"
 }
 
+func (e *DuplicateDeclarationError) Span() ast.Span      { return e.Decl.Span() }
+func (e *DuplicateDeclarationError) Related() []ast.Span { return []ast.Span{e.Previous.Span()} }
 func (e *DuplicateDeclarationError) Message() string {
 	return "Duplicate declaration: " + e.Name
 }
 
+func (e *OverloadNotSupportedError) Span() ast.Span      { return e.Decl.Span() }
+func (e *OverloadNotSupportedError) Related() []ast.Span { return []ast.Span{e.Previous.Span()} }
 func (e *OverloadNotSupportedError) Message() string {
 	return "Function overloads are not supported in M2: " + e.Name
-}
-
-func (e *NamespaceUsedAsValueError) Message() string {
-	return "Namespace used as a value: " + e.Name
-}
-
-func (e *UnsupportedNodeError) Message() string {
-	return "Unsupported in M2: " + e.Kind
-}
-
-func (e *BodyDeclNotAllowedError) Message() string {
-	return "Declaration not allowed in function body: " + e.Kind
 }
 
 func (e *CannotConstrainError) Message() string {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -20,27 +20,41 @@ import (
 type checker struct {
 	ctx  *Context      // M1: freshVar(level), Constrain(lhs, rhs) []SolverError
 	info *Info         // M1: node → soltype.Type side table (unexported setType)
+	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only), the inverse of info
 	errs []SolverError // accumulated; mirrors the spike's []error threading
 }
 
-// newChecker returns a checker with a fresh Context and an empty Info table.
+// newChecker returns a checker with a fresh Context, an empty Info table, and an
+// empty Prov side table.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo()}
+	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}}
 }
 
-// freshAt allocates a fresh inference variable at the given level. No provenance
-// recording in M2 — the Prov side table is deferred to M3+.
+// freshAt allocates a fresh inference variable at the given level. Provenance for
+// a fresh var is recorded by its construction site (recordProv), not here.
 func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 	return c.ctx.freshVar(lvl)
 }
 
-// constrain asserts lhs <: rhs and stamps the offending node's span onto any
-// resulting SolverErrors before accumulating them. M2 does not look provenance
-// up from a side table — the span is taken directly from the AST node being
-// walked (§3.5).
+// constrain asserts lhs <: rhs and, for each resulting constraint error, hands it
+// the provenance table (and, for CannotConstrainError, the constraint node n as a
+// blame fallback) so its own Span()/Related() can resolve per-operand blame
+// through Prov on demand (§3.5). The engine itself never touches Prov — the fields
+// are assigned here, after Constrain returns, so the hot loop stays off the table
+// (the perf invariant, §3.9). Bridge errors never flow through here; they
+// self-blame from their own node.
 func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 	for _, e := range c.ctx.Constrain(lhs, rhs) {
-		e.setSpan(n.Span())
+		switch err := e.(type) {
+		case *CannotConstrainError:
+			err.prov, err.site = c.prov, n // the only kind that still needs a site fallback
+		case *TupleLengthMismatchError:
+			err.prov = c.prov
+		case *MissingPropertyError:
+			err.prov = c.prov
+		case *FuncArityMismatchError:
+			err.prov = c.prov
+		}
 		c.errs = append(c.errs, e)
 	}
 }
@@ -52,14 +66,23 @@ func (c *checker) report(e SolverError) soltype.Type {
 	return &soltype.NeverType{}
 }
 
-// reportUnsupported records an UnsupportedNodeError for an AST node outside the
-// M2 subset: the span comes from spanNode, the rendered kind name from kindNode
-// (astKind). The two are usually the same node but differ when the unsupported
-// thing is a child carried by its parent — e.g. an object property's key, whose
-// span we report against the property. Returns the never placeholder so a caller
-// can `return c.reportUnsupported(...)` in value position.
-func (c *checker) reportUnsupported(spanNode ast.Node, kindNode any) soltype.Type {
-	return c.report(&UnsupportedNodeError{errSpan: errSpan{span: spanNode.Span()}, Kind: astKind(kindNode)})
+// reportUnsupported records an UnsupportedNodeError for an AST node whose kind is
+// outside the M2 subset. The node self-blames: both the span and the rendered kind
+// (astKind) come from it. When the unsupported thing is a child carried by its
+// parent — an object property's computed key, a function's destructuring pattern —
+// pass that child node directly (it embeds ast.Node and carries its own, narrower
+// span). Returns the never placeholder so a caller can `return c.reportUnsupported(n)`
+// in value position.
+func (c *checker) reportUnsupported(node ast.Node) soltype.Type {
+	return c.report(&UnsupportedNodeError{Node: node})
+}
+
+// reportUnsupportedFeature records an UnsupportedFeatureError: the node's KIND is
+// supported but a feature of it is not (optional chaining on a MemberExpr, type
+// params on a FuncExpr). The node carries the blame span; feature names what is
+// unsupported, since astKind would name the supported parent.
+func (c *checker) reportUnsupportedFeature(node ast.Node, feature string) soltype.Type {
+	return c.report(&UnsupportedFeatureError{Node: node, Feature: feature})
 }
 
 // recordType records t as the inferred type of n in the Info side table. Wraps
@@ -92,6 +115,6 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	case *ast.MemberExpr:
 		return c.inferMember(scope, lvl, e)
 	default:
-		return c.reportUnsupported(e, e)
+		return c.reportUnsupported(e)
 	}
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -22,6 +22,13 @@ type checker struct {
 	info *Info         // M1: node → soltype.Type side table (unexported setType)
 	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only), the inverse of info
 	errs []SolverError // accumulated; mirrors the spike's []error threading
+
+	// debugProv, when set, makes recordProv panic on a conflicting overwrite (the
+	// same type pointer recorded against a *different* node) — turning the
+	// implicit "every minted type is a unique pointer" invariant into an enforced
+	// one. Off in production (a span bug must never crash the compiler); flipped on
+	// by tests that exercise the guard. See recordProv.
+	debugProv bool
 }
 
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
@@ -37,23 +44,23 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 }
 
 // constrain asserts lhs <: rhs and, for each resulting constraint error, hands it
-// the provenance table (and, for CannotConstrainError, the constraint node n as a
-// blame fallback) so its own Span()/Related() can resolve per-operand blame
-// through Prov on demand (§3.5). The engine itself never touches Prov — the fields
-// are assigned here, after Constrain returns, so the hot loop stays off the table
-// (the perf invariant, §3.9). Bridge errors never flow through here; they
-// self-blame from their own node.
+// the provenance table and the constraint node n as a blame fallback, so its own
+// Span()/Related() can resolve per-operand blame through Prov on demand and fall
+// back to n's span (never the zero span) when an operand has no entry (§3.5). The
+// engine itself never touches Prov — the fields are assigned here, after Constrain
+// returns, so the hot loop stays off the table (the perf invariant, §3.9). Bridge
+// errors never flow through here; they self-blame from their own node.
 func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 	for _, e := range c.ctx.Constrain(lhs, rhs) {
 		switch err := e.(type) {
 		case *CannotConstrainError:
-			err.prov, err.site = c.prov, n // the only kind that still needs a site fallback
+			err.prov, err.site = c.prov, n
 		case *TupleLengthMismatchError:
-			err.prov = c.prov
+			err.prov, err.site = c.prov, n
 		case *MissingPropertyError:
-			err.prov = c.prov
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
-			err.prov = c.prov
+			err.prov, err.site = c.prov, n
 		}
 		c.errs = append(c.errs, e)
 	}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -32,8 +32,15 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		if _, named := varName(d); !named {
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
 			// types that arrive in M4. The initializer was already walked above
-			// (its errors surfaced); report the pattern and produce no binding.
-			c.reportUnsupported(d.Pattern)
+			// (its errors surfaced); report the pattern and produce no binding. A
+			// nil pattern (not produced by the parser, which synthesizes a
+			// placeholder, but possible in a hand-built AST) blames the decl instead,
+			// mirroring inferFunc — never a nil-node Span() panic.
+			if d.Pattern != nil {
+				c.reportUnsupported(d.Pattern)
+			} else {
+				c.reportUnsupported(d)
+			}
 			return nil, nil, false
 		}
 		return initType, &ast.NodeProvenance{Node: d}, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -33,7 +33,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
 			// types that arrive in M4. The initializer was already walked above
 			// (its errors surfaced); report the pattern and produce no binding.
-			c.reportUnsupported(d.Pattern, d.Pattern)
+			c.reportUnsupported(d.Pattern)
 			return nil, nil, false
 		}
 		return initType, &ast.NodeProvenance{Node: d}, true
@@ -43,7 +43,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		// accumulates these per-decl sources into the binding's Sources slice.
 		return b.Type, b.Sources[0], true
 	default:
-		c.reportUnsupported(d, d)
+		c.reportUnsupported(d)
 		return nil, nil, false
 	}
 }
@@ -60,14 +60,23 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 // in a later PR); for now it reports MissingInitializerError and returns ok=false.
 func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (soltype.Type, bool) {
 	if d.Init == nil {
-		name, _ := varName(d)
-		c.report(&MissingInitializerError{
-			errSpan: errSpan{span: d.Span()},
-			Name:    name,
-		})
+		c.report(&MissingInitializerError{Decl: d})
 		return nil, false
 	}
-	return c.inferExpr(scope, lvl, d.Init), true
+	initT := c.inferExpr(scope, lvl, d.Init)
+	if d.TypeAnn != nil {
+		// M2.5: constrain the initializer against the annotation (the one
+		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
+		// CannotConstrainError whose LHS (the "hi" literal) carries a
+		// LiteralInference origin — precise blame, with the annotation as the
+		// related node. The constraint node is the initializer, so even the
+		// fallback span is the RHS, not the whole decl; the binding then adopts the
+		// annotated type.
+		annT := c.resolveTypeAnn(d.TypeAnn)
+		c.constrain(d.Init, initT, annT)
+		initT = annT
+	}
+	return initT, true
 }
 
 // inferVarDecl types a `val`/`var` into a MONOMORPHIC ValueBinding, coalescing the

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -72,9 +72,16 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// related node. The constraint node is the initializer, so even the
 		// fallback span is the RHS, not the whole decl; the binding then adopts the
 		// annotated type.
-		annT := c.resolveTypeAnn(d.TypeAnn)
-		c.constrain(d.Init, initT, annT)
-		initT = annT
+		//
+		// Skip both the check and the adoption when the annotation is unsupported
+		// (ok=false): resolveTypeAnn already reported it and returned a `never`
+		// placeholder, so constraining `initT <: never` would cascade a spurious
+		// error and adopting `never` would poison the binding. Keep the inferred
+		// initializer type instead (error recovery).
+		if annT, ok := c.resolveTypeAnn(d.TypeAnn); ok {
+			c.constrain(d.Init, initT, annT)
+			initT = annT
+		}
 	}
 	return initT, true
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -23,10 +23,11 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 	case *ast.BoolLit:
 		lit = &soltype.BoolLit{Value: l.Value}
 	default:
-		return c.reportUnsupported(e, e.Lit)
+		return c.reportUnsupported(e.Lit)
 	}
 	t := &soltype.LitType{Lit: lit}
 	c.recordType(e, t)
+	c.recordProv(t, e, LiteralInference)
 	return t
 }
 
@@ -46,15 +47,9 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 		return b.Type
 	}
 	if _, ok := scope.GetNamespace(e.Name); ok {
-		return c.report(&NamespaceUsedAsValueError{
-			errSpan: errSpan{span: e.Span()},
-			Name:    e.Name,
-		})
+		return c.report(&NamespaceUsedAsValueError{Ident: e})
 	}
-	return c.report(&UnknownIdentifierError{
-		errSpan: errSpan{span: e.Span()},
-		Name:    e.Name,
-	})
+	return c.report(&UnknownIdentifierError{Ident: e})
 }
 
 // astKind returns a short surface name for any AST node — an expression,
@@ -92,9 +87,11 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
-		// which are M3. M2 is monomorphic, so diagnose the type parameters rather
-		// than silently erasing them, then continue inferring monomorphically.
-		c.reportUnsupported(node, sig.TypeParams[0])
+		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the
+		// type-param feature that is not — so diagnose it as an unsupported feature
+		// (blaming the function node) rather than silently erasing the params, then
+		// continue inferring monomorphically.
+		c.reportUnsupportedFeature(node, "TypeParam")
 	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
@@ -103,15 +100,23 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		name, ok := identPatName(p.Pattern)
 		if !ok {
 			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
-			// they arrive in M4. M2 binds IdentPat only. p.Span() dereferences
-			// p.Pattern, so fall back to the function node's span for a pattern-less
-			// param to honor M2's "never a panic" guarantee.
-			span := node.Span()
+			// they arrive in M4. M2 binds IdentPat only. A non-nil pattern blames
+			// itself (its own narrower span); a pattern-less param (not reachable
+			// from the real parser) blames the enclosing function, since Param.Span()
+			// dereferences the nil pattern — honoring M2's "never a panic" guarantee.
 			if p.Pattern != nil {
-				span = p.Span()
+				c.reportUnsupported(p.Pattern)
+			} else {
+				c.reportUnsupported(node)
 			}
-			c.report(&UnsupportedNodeError{errSpan: errSpan{span: span}, Kind: astKind(p.Pattern)})
 			name = fmt.Sprintf("arg%d", i)
+		} else if p.TypeAnn == nil {
+			// An un-annotated param's type is the fresh var minted here, so a
+			// param-type mismatch blames the param. Record against the pattern (an
+			// ast.Node; *ast.Param is not) — for an IdentPat its span is the param's.
+			// An annotated param's blame instead rides on its annotation, recorded
+			// by resolveTypeAnn.
+			c.recordProv(pt, p.Pattern, ParamBinding)
 		}
 		fnScope.defineValue(name, ValueBinding{Type: pt})
 		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt}
@@ -133,7 +138,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		}
 		ret = annT
 	}
-	return &soltype.FuncType{Params: params, Ret: ret}
+	ft := &soltype.FuncType{Params: params, Ret: ret}
+	// Record the function's own type against its node so a function flowing into a
+	// non-function requirement blames the function, and FuncArityMismatchError can
+	// carry a "defined here" related span. (For a named callee this raw FuncType is
+	// re-minted by coalescing at binding time, so the entry is exact for inline
+	// callees; M3's FromInstantiation makes named-callee blame precise.)
+	c.recordProv(ft, node, FuncInference)
+	return ft
 }
 
 // paramType resolves a param's type: its annotation when present, else a fresh
@@ -163,7 +175,12 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)}
 	}
 	res := c.freshAt(lvl)
-	c.constrain(e, callee, &soltype.FuncType{Params: args, Ret: res})
+	c.recordProv(res, e, Application)
+	callShape := &soltype.FuncType{Params: args, Ret: res}
+	// Record the synthesized call-shape against the CallExpr so FuncArityMismatchError
+	// resolves its blame to the call.
+	c.recordProv(callShape, e, CallShape)
+	c.constrain(e, callee, callShape)
 	if fn, ok := callee.(*soltype.FuncType); ok {
 		c.constrain(e, fn.Ret, res)
 	}
@@ -183,6 +200,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 	}
 	t := &soltype.TupleType{Elems: elems}
 	c.recordType(e, t)
+	c.recordProv(t, e, TupleElem)
 	return t
 }
 
@@ -207,18 +225,19 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
 			// ObjSpreadExpr, CallableExpr (method), ConstructorExpr — all M4.
-			c.reportUnsupported(elem, elem)
+			c.reportUnsupported(elem)
 			continue
 		}
 		if prop.Value == nil {
 			// Shorthand ({x}) needs the ident's binding folded in as the value — M4.
-			c.reportUnsupported(prop, prop)
+			c.reportUnsupported(prop)
 			continue
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
-			// Computed/numeric keys carry no static field name — M4.
-			c.reportUnsupported(prop, prop.Name)
+			// Computed/numeric keys carry no static field name — M4. Blame the key
+			// itself (its own narrower span), not the whole property.
+			c.reportUnsupported(prop.Name)
 			continue
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
@@ -231,6 +250,7 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	}
 	t := &soltype.RecordType{Fields: fields}
 	c.recordType(e, t)
+	c.recordProv(t, e, ObjectField)
 	return t
 }
 
@@ -244,8 +264,10 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 	if e.OptChain {
 		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
 		// up front and do NOT descend into the receiver, so a single diagnostic
-		// stands for the construct instead of cascading the receiver's errors.
-		return c.report(&UnsupportedNodeError{errSpan: errSpan{span: e.Span()}, Kind: "OptionalChain"})
+		// stands for the construct instead of cascading the receiver's errors. The
+		// MemberExpr kind is supported — it is the optional-chain feature that is
+		// not — so this is an UnsupportedFeatureError blaming the member.
+		return c.reportUnsupportedFeature(e, "OptionalChain")
 	}
 	recv := c.inferExpr(scope, lvl, e.Object)
 	if e.Prop == nil || e.Prop.Name == "" {
@@ -258,6 +280,12 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 		return t
 	}
 	res := c.freshAt(lvl)
+	// Record the fresh result var against the .prop IDENTIFIER (not the whole
+	// MemberExpr), so a missing-property read blames the property (.foo), not the
+	// receiver. The member-requirement record {prop: res} is deliberately NOT
+	// recorded — MissingPropertyError blames this inner res var, so the record
+	// would be a dead entry (§3.3).
+	c.recordProv(res, e.Prop, MemberAccess)
 	c.constrain(e, recv, &soltype.RecordType{Fields: []*soltype.RecordField{{Name: e.Prop.Name, Type: res}}})
 	c.recordType(e, res)
 	return res

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -142,6 +142,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				c.constrain(node, ret, annT) // body <: declared return
 			}
 			ret = annT
+		} else if !hasBody {
+			// Bodyless function with an unsupported return annotation: there is no
+			// body to recover the return type from, and leaving the synthetic Void
+			// would falsely signal "returns nothing" to callers. Fall back to
+			// unknown (⊤) — the honest "couldn't resolve the declared return"
+			// recovery. (A fresh var would coalesce to `never` in return position,
+			// which is worse.)
+			ret = &soltype.UnknownType{}
 		}
 	}
 	ft := &soltype.FuncType{Params: params, Ret: ret}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -128,15 +128,21 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		ret = c.inferBlock(fnScope, lvl, body)
 	}
 	if sig.Return != nil {
-		annT := c.resolveTypeAnn(sig.Return)
-		// Only check the inferred body against the declared return when there IS a
-		// body. A bodyless (declare/ambient) function has no body to constrain, so
-		// it simply adopts the annotation; constraining the synthetic Void return
-		// would raise a spurious `void <: T` error.
-		if hasBody {
-			c.constrain(node, ret, annT) // body <: declared return
+		// Skip the check and adopt-the-annotation when the return annotation is
+		// unsupported (ok=false): resolveTypeAnn already reported it and handed back
+		// a `never` placeholder, so constraining the body `<: never` would cascade a
+		// spurious error and adopting it would poison the return type. Keep the
+		// inferred body type instead (error recovery).
+		if annT, ok := c.resolveTypeAnn(sig.Return); ok {
+			// Only check the inferred body against the declared return when there IS a
+			// body. A bodyless (declare/ambient) function has no body to constrain, so
+			// it simply adopts the annotation; constraining the synthetic Void return
+			// would raise a spurious `void <: T` error.
+			if hasBody {
+				c.constrain(node, ret, annT) // body <: declared return
+			}
+			ret = annT
 		}
-		ret = annT
 	}
 	ft := &soltype.FuncType{Params: params, Ret: ret}
 	// Record the function's own type against its node so a function flowing into a
@@ -150,9 +156,15 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 // paramType resolves a param's type: its annotation when present, else a fresh
 // inference variable at the current level (the spike's "fresh var per param").
+// An unsupported annotation (ok=false) already reported its own error; the param
+// adopts a fresh var rather than the `never` placeholder so the body and any
+// call site recover against an unconstrained variable instead of cascading
+// `<: never` failures.
 func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 	if p.TypeAnn != nil {
-		return c.resolveTypeAnn(p.TypeAnn)
+		if t, ok := c.resolveTypeAnn(p.TypeAnn); ok {
+			return t
+		}
 	}
 	return c.freshAt(lvl)
 }

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -111,6 +111,27 @@ func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
 	require.Equal(t, "fn () -> number", render(b.Type))
 }
 
+// A bodyless function with an UNSUPPORTED return annotation recovers to `unknown`
+// (the honest "couldn't resolve the declared return"), not the synthetic `void`
+// (which would falsely signal "returns nothing" to callers). The annotation error
+// is still reported once. Reachable only via a nil-body AST — from source the
+// parser gives a declare fn a non-nil empty block (so hasBody is true).
+func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
+	c := newChecker()
+	// declare fn now() -> bigint   (bigint is unsupported in M2)
+	d := ast.NewFuncDecl(
+		ast.NewIdentifier("now", testSpan()), nil, nil,
+		nil, ast.NewBigintTypeAnn(testSpan()), nil,
+		nil, // no body
+		false, true, false, testSpan(),
+	)
+
+	b := c.inferFuncDecl(NewScope(), 0, d)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: BigintTypeAnn", c.errs[0].Message())
+	require.Equal(t, "fn () -> unknown", render(b.Type))
+}
+
 // A param that arrives without a pattern must report a clean error, not panic on
 // p.Span() (which dereferences the nil pattern). Not reachable from the real
 // parser, but the walk must uphold M2's "never a panic" guarantee.

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -46,18 +46,12 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 	case *ast.DeclStmt:
 		vd, ok := s.Decl.(*ast.VarDecl)
 		if !ok {
-			c.report(&BodyDeclNotAllowedError{
-				errSpan: errSpan{span: s.Span()},
-				Kind:    astKind(s.Decl),
-			})
+			c.report(&BodyDeclNotAllowedError{Decl: s.Decl})
 			return &soltype.Void{}
 		}
 		name, named := varName(vd)
 		if !named {
-			c.report(&UnsupportedNodeError{
-				errSpan: errSpan{span: vd.Pattern.Span()},
-				Kind:    astKind(vd.Pattern),
-			})
+			c.reportUnsupported(vd.Pattern)
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is
@@ -69,9 +63,6 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		return &soltype.Void{}
 	default:
-		return c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: s.Span()},
-			Kind:    astKind(s),
-		})
+		return c.reportUnsupported(s)
 	}
 }

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -51,7 +51,13 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		name, named := varName(vd)
 		if !named {
-			c.reportUnsupported(vd.Pattern)
+			// A nil pattern (hand-built AST; the parser synthesizes a placeholder)
+			// blames the decl, mirroring inferFunc — never a nil-node Span() panic.
+			if vd.Pattern != nil {
+				c.reportUnsupported(vd.Pattern)
+			} else {
+				c.reportUnsupported(vd)
+			}
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -182,12 +182,15 @@ func TestInferModuleObjectsAndTuples(t *testing.T) {
 // Reading a field the receiver lacks is a constraint failure (MissingProperty);
 // the binding for the failed read resolves to the never placeholder.
 func TestInferModuleFieldReadMissingProperty(t *testing.T) {
-	values, _, errs := inferSource(t, `
+	src := `
 		val o = {a: 5}
 		val x = o.b
-	`)
+	`
+	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "object is missing property: b", errs[0].Message())
+	// M2.5: blame the member's prop, not the whole decl.
+	require.Equal(t, "b", spanText(src, errs[0].Span()))
 	require.Equal(t, map[string]string{"o": "{a: 5}", "x": "never"}, values)
 }
 
@@ -209,9 +212,12 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 // reports as unsupported. (FuncDecl, unsupported at the module level through
 // PR-2, is now wired in by PR-5; see the func/recursion tests.)
 func TestInferModuleUnsupportedDecl(t *testing.T) {
-	_, types, errs := inferSource(t, `type Foo = number`)
+	src := `type Foo = number`
+	_, types, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported in M2: TypeDecl", errs[0].Message())
+	// M2.5: the error self-blames from the decl node.
+	require.Equal(t, src, spanText(src, errs[0].Span()))
 	// The unsupported decl must not leak a type binding.
 	require.NotContains(t, types, "Foo")
 }
@@ -221,9 +227,13 @@ func TestInferModuleUnsupportedDecl(t *testing.T) {
 // binds NOTHING, so a later reference still fails as an unknown identifier rather
 // than silently resolving to a placeholder.
 func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
-	values, _, errs := inferSource(t, `declare val x: number`)
+	src := `declare val x: number`
+	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
+	// M2.5: the error self-blames from the decl node (whose span, per the parser,
+	// covers the binder but not the trailing annotation).
+	require.Equal(t, "declare val x", spanText(src, errs[0].Span()))
 	require.Empty(t, values)
 }
 
@@ -245,21 +255,29 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 // The initializer `[1, 2]` is a tuple expression, which PR-4 now infers, so the
 // only remaining error is the destructuring pattern on the binding side.
 func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
-	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
+	src := `val [a, b] = [1, 2]`
+	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported in M2: TuplePat", errs[0].Message())
+	// M2.5: blame the offending pattern, not the whole decl.
+	require.Equal(t, "[a, b]", spanText(src, errs[0].Span()))
 	require.Empty(t, values)
 }
 
 // A duplicate top-level `val` is a redeclaration error (unlike FuncDecl
 // overloads); the first binding is kept and the second reports cleanly.
 func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
-	values, _, errs := inferSource(t, `
+	src := `
 		val x = 5
 		val x = "hi"
-	`)
+	`
+	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Duplicate declaration: x", errs[0].Message())
+	// M2.5: blame the second decl; relate the first ("previously declared here").
+	require.Equal(t, `val x = "hi"`, spanText(src, errs[0].Span()))
+	require.Len(t, errs[0].Related(), 1)
+	require.Equal(t, `val x = 5`, spanText(src, errs[0].Related()[0]))
 	require.Equal(t, map[string]string{"x": "5"}, values)
 }
 
@@ -479,11 +497,14 @@ func TestInferMultiFile(t *testing.T) {
 // the multi-file path: the combined dep graph has no binding for it, so the
 // reference resolves to the never placeholder and reports cleanly.
 func TestInferMultiFileUnknownIdentifier(t *testing.T) {
+	srcA := `val y = missing`
 	values, _, errs := inferSources(t, map[string]string{
-		"a.esc": `val y = missing`,
+		"a.esc": srcA,
 		"b.esc": `val z = 5`,
 	})
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	// M2.5: the error self-blames from the ident node.
+	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
 	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -61,7 +61,7 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
 		for _, d := range ns.Decls {
 			if !handled.Contains(d) {
-				c.reportUnsupported(d, d)
+				c.reportUnsupported(d)
 			}
 		}
 		return true
@@ -166,14 +166,16 @@ func (c *checker) inferComponent(
 			// variable binding — likewise keeps the first and reports.
 			if _, isFunc := d.(*ast.FuncDecl); isFunc && !b.isVar {
 				c.report(&OverloadNotSupportedError{
-					errSpan: errSpan{span: d.Span()},
-					Name:    key.Name(),
+					Decl:     d,
+					Previous: b.primary,
+					Name:     key.Name(),
 				})
 				continue
 			}
 			c.report(&DuplicateDeclarationError{
-				errSpan: errSpan{span: d.Span()},
-				Name:    key.Name(),
+				Decl:     d,
+				Previous: b.primary,
+				Name:     key.Name(),
 			})
 		}
 	}
@@ -190,7 +192,7 @@ func (c *checker) inferComponent(
 				continue
 			}
 			handled.Add(d)
-			c.reportUnsupported(d, d)
+			c.reportUnsupported(d)
 		}
 	}
 

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -1,0 +1,74 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Prov is the inverse of Info: soltype.Type → the origin that minted it. Sparse —
+// shared/interned/synthesized types may be absent (an honest miss, not a lie: see
+// the leaf/interior split in planning/simple_sub/m2.5-implementation-plan.md §3.8).
+// Keyed by pointer identity, exactly like Info.
+//
+// M2.5 ships only the FromAST leaf variant. The interior edge variants
+// (FromBoundPropagation/FromInstantiation/FromExtrusion/FromCoalesce) ride along
+// with the M3+ operations that mint them — which is why Origin is an interface,
+// so M3 adds a variant rather than changing the map's value type.
+type Prov map[soltype.Type]Origin
+
+// Origin is a tagged sum naming the kind of hop that minted a type. M2.5 ships only
+// the FromAST leaf; the interior edge variants are deferred to M3+.
+type Origin interface{ isOrigin() }
+
+// FromAST is the leaf: a direct AST cause for a freshly-minted type.
+type FromAST struct {
+	Node ast.Node
+	Kind ASTOriginKind
+}
+
+func (FromAST) isOrigin() {}
+
+// ASTOriginKind tags WHY a node minted a type, so a renderer/LSP can phrase blame
+// ("the literal here", "this argument", "field `x`") without re-deriving it from
+// the AST node's concrete type. M2.5's blame only needs the node, so the kind is
+// forward-looking metadata.
+type ASTOriginKind int
+
+const (
+	LiteralInference ASTOriginKind = iota // a LitType from inferLiteral
+	ParamBinding                          // a fresh param var from inferFunc
+	Application                           // a fresh call-result var from inferCall
+	TupleElem                             // a TupleType from inferTuple
+	ObjectField                           // a RecordType from inferObject
+	FuncInference                         // a FuncType from inferFunc (the function expr/decl)
+	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
+	MemberAccess                          // a fresh member-result var from inferMember (recorded against the .prop ident)
+	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
+)
+
+// Provenance resolves an operand type to the AST node that minted it. M2.5's Prov
+// implements it as a single map lookup; M3+ can supply a resolver that chases
+// interior Origin edges (FromInstantiation, …) to the nearest AST leaf without
+// changing any caller — that is the "follow the provenance chain" path.
+type Provenance interface {
+	NodeFor(soltype.Type) (ast.Node, bool)
+}
+
+// NodeFor returns the AST node that minted t, when one was recorded. An
+// unrecorded operand (a Void result, a shared atom resolved elsewhere, or an
+// M3+ synthesized type) is an honest miss.
+func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
+	if o, ok := p[t].(FromAST); ok {
+		return o.Node, true
+	}
+	return nil, false
+}
+
+// recordProv records that t was minted from node n for reason kind — the inverse
+// of recordType (info.setType). Sparse by intent: only the node-derived
+// construction sites call it; synthesized types (coalesced/extruded, M3+) get no
+// entry. Called only in the walk (construction), never in constrain/coalesce, so
+// the hot inference path never consults Prov (the perf invariant, §3.9).
+func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
+	c.prov[t] = FromAST{Node: n, Kind: kind}
+}

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"fmt"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -46,11 +48,15 @@ const (
 	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
 )
 
-// Provenance resolves an operand type to the AST node that minted it. M2.5's Prov
-// implements it as a single map lookup; M3+ can supply a resolver that chases
-// interior Origin edges (FromInstantiation, …) to the nearest AST leaf without
-// changing any caller — that is the "follow the provenance chain" path.
-type Provenance interface {
+// NodeResolver resolves an operand type to the AST node that minted it. M2.5's
+// Prov implements it as a single map lookup; M3+ can supply a resolver that
+// chases interior Origin edges (FromInstantiation, …) to the nearest AST leaf
+// without changing any caller — that is the "follow the provenance chain" path.
+//
+// Named NodeResolver rather than Provenance to avoid shadowing the imported
+// `provenance` package / `provenance.Provenance` binding-source marker used
+// elsewhere in this package (per CLAUDE.md).
+type NodeResolver interface {
 	NodeFor(soltype.Type) (ast.Node, bool)
 }
 
@@ -69,6 +75,19 @@ func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 // construction sites call it; synthesized types (coalesced/extruded, M3+) get no
 // entry. Called only in the walk (construction), never in constrain/coalesce, so
 // the hot inference path never consults Prov (the perf invariant, §3.9).
+//
+// Invariant: every type passed here is a FRESHLY-minted, unique pointer, so a
+// record never collides with a different node. Blame correctness depends on it —
+// a reused/interned/coalesced pointer recorded twice would silently overwrite an
+// earlier node and mis-blame with no crash. The c.debugProv guard makes that
+// violation loud in tests (re-recording the same pointer against a *different*
+// node panics); it stays off in production so a span bug can never crash the
+// compiler. Re-recording the same node is idempotent and allowed.
 func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
+	if c.debugProv {
+		if prev, ok := c.prov[t].(FromAST); ok && prev.Node != n {
+			panic(fmt.Sprintf("recordProv: type %p re-recorded against a different node (was %T, now %T) — the unique-pointer invariant is violated", t, prev.Node, n))
+		}
+	}
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -1,0 +1,135 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// requireOrigin asserts the Prov table records ty as minted from node for reason
+// kind — the FromAST leaf the M2.5 population sites write (§3.3).
+func requireOrigin(t *testing.T, c *checker, ty soltype.Type, node ast.Node, kind ASTOriginKind) {
+	t.Helper()
+	o, ok := c.prov[ty]
+	require.True(t, ok, "expected a Prov entry for the minted type")
+	fa, ok := o.(FromAST)
+	require.True(t, ok, "expected a FromAST origin")
+	require.Same(t, node, fa.Node, "origin node")
+	require.Equal(t, kind, fa.Kind, "origin kind")
+}
+
+// A literal mints a LitType recorded against its LiteralExpr.
+func TestProvLiteralInference(t *testing.T) {
+	c := newChecker()
+	e := numExpr(5)
+	ty := c.inferExpr(NewScope(), 0, e)
+	requireOrigin(t, c, ty, e, LiteralInference)
+}
+
+// A tuple/object literal records its aggregate type against the literal node.
+func TestProvTupleAndObject(t *testing.T) {
+	c := newChecker()
+	tup := tupleExpr(numExpr(1), strExpr("hi"))
+	tupTy := c.inferExpr(NewScope(), 0, tup)
+	requireOrigin(t, c, tupTy, tup, TupleElem)
+
+	obj := objExpr(prop("a", numExpr(5)))
+	objTy := c.inferExpr(NewScope(), 0, obj)
+	requireOrigin(t, c, objTy, obj, ObjectField)
+}
+
+// A call records its fresh result var (Application) against the CallExpr and the
+// synthesized call-shape (CallShape) against the same node.
+func TestProvCallResultAndShape(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("inc", ValueBinding{Type: &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
+		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
+	}})
+	e := ast.NewCall(identExpr("inc"), []ast.Expr{numExpr(7)}, false, testSpan())
+
+	res := c.inferExpr(scope, 0, e)
+	requireOrigin(t, c, res, e, Application)
+
+	// The call-shape FuncType{args, res} is not returned, so find it in the table:
+	// the sole CallShape entry, recorded against the CallExpr.
+	var shapeNode ast.Node
+	var shapes int
+	for _, o := range c.prov {
+		if fa, ok := o.(FromAST); ok && fa.Kind == CallShape {
+			shapeNode = fa.Node
+			shapes++
+		}
+	}
+	require.Equal(t, 1, shapes, "exactly one CallShape entry")
+	require.Same(t, ast.Node(e), shapeNode)
+}
+
+// A member read records its fresh result var against the .prop IDENTIFIER, not the
+// whole MemberExpr — so missing-property blame is the property, not the receiver.
+func TestProvMemberAccessRecordedAgainstProp(t *testing.T) {
+	c := newChecker()
+	e := memberExpr(objExpr(prop("a", numExpr(5))), "a")
+	res := c.inferExpr(NewScope(), 0, e)
+	requireOrigin(t, c, res, e.Prop, MemberAccess)
+}
+
+// A function records its own FuncType (FuncInference) against the function node and
+// each un-annotated param's fresh var (ParamBinding) against the param's pattern.
+func TestProvFuncTypeAndParamBinding(t *testing.T) {
+	c := newChecker()
+	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(exprStmt(identExpr("x"))))
+	ty := c.inferExpr(NewScope(), 0, e)
+	requireOrigin(t, c, ty, e, FuncInference)
+
+	ft, ok := ty.(*soltype.FuncType)
+	require.True(t, ok)
+	requireOrigin(t, c, ft.Params[0].Type, e.Params[0].Pattern, ParamBinding)
+}
+
+// An annotated param's fresh PrimType is recorded against its annotation
+// (AnnotationType), and the ParamBinding origin is NOT recorded for it — its blame
+// rides on the annotation (the fresh-atom discipline, §3.3).
+func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
+	c := newChecker()
+	ann := numAnn()
+	e := funcExpr([]*ast.Param{param("x", ann)}, nil, block(exprStmt(identExpr("x"))))
+	ty := c.inferExpr(NewScope(), 0, e)
+
+	ft := ty.(*soltype.FuncType)
+	requireOrigin(t, c, ft.Params[0].Type, ann, AnnotationType)
+}
+
+// resolveTypeAnn mints a fresh PrimType per annotation and records it
+// (AnnotationType) — the fresh-atom discipline that makes a shared `number` no
+// longer a blind spot.
+func TestProvAnnotationType(t *testing.T) {
+	c := newChecker()
+	ta := numAnn()
+	ty := c.resolveTypeAnn(ta)
+	requireOrigin(t, c, ty, ta, AnnotationType)
+}
+
+// An identifier use records NOTHING (§3.3): recording against the binding's shared
+// atom would overwrite the definition's origin. So inferring a bare ident over a
+// pre-bound atom leaves the table empty.
+func TestProvIdentRecordsNothing(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("x", ValueBinding{Type: &soltype.PrimType{Prim: soltype.NumPrim}})
+	c.inferExpr(scope, 0, identExpr("x"))
+	require.Empty(t, c.prov, "an ident use must record no provenance")
+}
+
+// The honest absence (§3.2): a synthesized (coalesced) type has no Prov entry, so
+// NodeFor reports a miss rather than lying.
+func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
+	c := newChecker()
+	v := c.freshAt(0)
+	co := coalesce(v, soltype.Positive) // empty bounds → never, a fresh synthesized atom
+	_, ok := c.prov.NodeFor(co)
+	require.False(t, ok, "a coalesced type must have no provenance entry")
+}

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -109,7 +109,8 @@ func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
 func TestProvAnnotationType(t *testing.T) {
 	c := newChecker()
 	ta := numAnn()
-	ty := c.resolveTypeAnn(ta)
+	ty, ok := c.resolveTypeAnn(ta)
+	require.True(t, ok)
 	requireOrigin(t, c, ty, ta, AnnotationType)
 }
 
@@ -132,4 +133,29 @@ func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
 	co := coalesce(v, soltype.Positive) // empty bounds → never, a fresh synthesized atom
 	_, ok := c.prov.NodeFor(co)
 	require.False(t, ok, "a coalesced type must have no provenance entry")
+}
+
+// The debugProv guard (finding #5) enforces the unique-pointer invariant: recording
+// the SAME type pointer against a DIFFERENT node panics (catching a future
+// interned/coalesced-pointer reuse that would silently mis-blame), while
+// re-recording against the same node is idempotent and allowed.
+func TestProvDebugGuardCatchesConflictingOverwrite(t *testing.T) {
+	c := newChecker()
+	c.debugProv = true
+	ty := &soltype.PrimType{Prim: soltype.NumPrim}
+	nodeA := numAnn()
+	nodeB := strAnn()
+
+	c.recordProv(ty, nodeA, AnnotationType)
+	require.NotPanics(t, func() { c.recordProv(ty, nodeA, AnnotationType) }, "re-recording the same node is idempotent")
+	require.Panics(t, func() { c.recordProv(ty, nodeB, AnnotationType) }, "re-recording a different node violates the invariant")
+}
+
+// With the guard OFF (production default), a conflicting overwrite does not panic —
+// a span bug must never crash the compiler (it degrades to last-write-wins blame).
+func TestProvDebugGuardOffDoesNotPanic(t *testing.T) {
+	c := newChecker() // debugProv defaults false
+	ty := &soltype.PrimType{Prim: soltype.NumPrim}
+	c.recordProv(ty, numAnn(), AnnotationType)
+	require.NotPanics(t, func() { c.recordProv(ty, strAnn(), AnnotationType) })
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -30,12 +30,31 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn) (soltype.Type, bool) {
 }
 
 // annPrim mints a FRESH PrimType for an annotation and records it against the
-// annotation node (AnnotationType origin). The fresh-atom discipline (§3.3):
-// there is no interned `number` singleton, so each annotation's atom is its own
-// pointer and is directly recordable — which is what lets the `number` in
-// `val x: number = "hi"` resolve to the annotation as the related blame node, and
-// a prim/prim mismatch blame the offending annotation. Subtyping is unaffected:
-// constrain compares PrimType.Prim by value, not pointer.
+// annotation node (AnnotationType origin) — the "fresh-atom discipline" (§3.3).
+//
+// Why fresh, rather than a single shared/interned `number` value? Provenance is
+// the reason. The Prov side table is keyed by POINTER IDENTITY
+// (soltype.Type -> Origin), so the only way to record "this primitive came from
+// THIS annotation node" is for the primitive to be its own pointer, unique to this
+// annotation. Three consequences follow:
+//
+//   - Precise blame. A unique atom per annotation lets `val x: number = "hi"`
+//     resolve its `number` operand back to the exact annotation node — surfaced as
+//     the related "expected here" span — and lets a prim/prim mismatch blame the
+//     offending annotation instead of degrading to the constraint site (§3.3, §3.7).
+//   - No Prov-invariant conflict. recordProv requires each type pointer to map to a
+//     single node; the debugProv guard panics when a pointer is re-recorded against
+//     a DIFFERENT node (prov.go). A shared `number` would be recorded against every
+//     `number` annotation's node in turn — a conflicting overwrite. Fresh atoms each
+//     write a distinct pointer, so there is never a conflict and no last-write-wins
+//     blame.
+//   - Free, because correctness ignores identity. constrain compares PrimType.Prim
+//     BY VALUE (`r.Prim == l.Prim`, constrain.go), never by pointer, so two
+//     distinct-but-equal `number`s still subtype-match. Freshness only ever adds a
+//     redundant coinductive-`seen` entry, never a loop or a spurious mismatch.
+//
+// (soltype interns no primitive singletons anyway, so there is nothing to share —
+// minting fresh is the natural choice here, not an added cost.)
 func (c *checker) annPrim(ta ast.TypeAnn, p soltype.Prim) soltype.Type {
 	t := &soltype.PrimType{Prim: p}
 	c.recordProv(t, ta, AnnotationType)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -5,23 +5,27 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type.
-// M2 needs only the primitive annotations that annotated params and return
-// types use (number/string/boolean); everything richer — type references,
-// generics, object/tuple/function annotations, unions — is represented by types
-// later milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here.
-// It takes no scope: the supported set is all closed primitives, with no name to
-// look up. Name resolution against the type scope arrives with TypeRef support.
-func (c *checker) resolveTypeAnn(ta ast.TypeAnn) soltype.Type {
+// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type,
+// returning ok=false when the annotation is outside the supported set. M2 needs
+// only the primitive annotations that annotated params and return types use
+// (number/string/boolean); everything richer — type references, generics,
+// object/tuple/function annotations, unions — is represented by types later
+// milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here, with
+// ok=false and a `never` placeholder so a caller can recover by keeping the type
+// it already inferred (rather than constraining against / adopting `never`, which
+// would cascade a spurious `<: never` error and poison the binding). It takes no
+// scope: the supported set is all closed primitives, with no name to look up.
+// Name resolution against the type scope arrives with TypeRef support.
+func (c *checker) resolveTypeAnn(ta ast.TypeAnn) (soltype.Type, bool) {
 	switch ta := ta.(type) {
 	case *ast.NumberTypeAnn:
-		return c.annPrim(ta, soltype.NumPrim)
+		return c.annPrim(ta, soltype.NumPrim), true
 	case *ast.StringTypeAnn:
-		return c.annPrim(ta, soltype.StrPrim)
+		return c.annPrim(ta, soltype.StrPrim), true
 	case *ast.BooleanTypeAnn:
-		return c.annPrim(ta, soltype.BoolPrim)
+		return c.annPrim(ta, soltype.BoolPrim), true
 	default:
-		return c.reportUnsupported(ta)
+		return c.reportUnsupported(ta), false
 	}
 }
 

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -15,15 +15,25 @@ import (
 func (c *checker) resolveTypeAnn(ta ast.TypeAnn) soltype.Type {
 	switch ta := ta.(type) {
 	case *ast.NumberTypeAnn:
-		return &soltype.PrimType{Prim: soltype.NumPrim}
+		return c.annPrim(ta, soltype.NumPrim)
 	case *ast.StringTypeAnn:
-		return &soltype.PrimType{Prim: soltype.StrPrim}
+		return c.annPrim(ta, soltype.StrPrim)
 	case *ast.BooleanTypeAnn:
-		return &soltype.PrimType{Prim: soltype.BoolPrim}
+		return c.annPrim(ta, soltype.BoolPrim)
 	default:
-		return c.report(&UnsupportedNodeError{
-			errSpan: errSpan{span: ta.Span()},
-			Kind:    astKind(ta),
-		})
+		return c.reportUnsupported(ta)
 	}
+}
+
+// annPrim mints a FRESH PrimType for an annotation and records it against the
+// annotation node (AnnotationType origin). The fresh-atom discipline (§3.3):
+// there is no interned `number` singleton, so each annotation's atom is its own
+// pointer and is directly recordable — which is what lets the `number` in
+// `val x: number = "hi"` resolve to the annotation as the related blame node, and
+// a prim/prim mismatch blame the offending annotation. Subtyping is unaffected:
+// constrain compares PrimType.Prim by value, not pointer.
+func (c *checker) annPrim(ta ast.TypeAnn, p soltype.Prim) soltype.Type {
+	t := &soltype.PrimType{Prim: p}
+	c.recordProv(t, ta, AnnotationType)
+	return t
 }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -166,6 +166,15 @@ reassess.
 
 ## M2.5 — Provenance side table + precise error spans
 
+**Status: landed** (see [m2.5-implementation-plan.md](m2.5-implementation-plan.md)
+§8 exit checklist — all items complete). The `Prov` side table, the node-derived
+`SolverError` reshape (`Span()`/`Related()`, `errSpan`/`setSpan` removed), the
+per-operand blame via `Prov`, and the `val`-annotation enabler all live in
+[internal/solver/](../../internal/solver/) ([prov.go](../../internal/solver/prov.go),
+[errors.go](../../internal/solver/errors.go)), with golden span fixtures in
+[blame_test.go](../../internal/solver/blame_test.go) and population tests in
+[prov_test.go](../../internal/solver/prov_test.go).
+
 A focused infra milestone, **not** a language feature. See
 [m2.5-implementation-plan.md](m2.5-implementation-plan.md) for the full PR
 breakdown, the per-operand blame design, and the construction-site population

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -1043,6 +1043,34 @@ PR-3 adds fixtures and decides §3.7.
   *Lean:* dedup by span equality (the `appendUnique` in `relatedOf`), append in
   the method's operand order; pin it with a multi-operand `Related()` test in PR-2.
 
+## 7a. Post-review hardening
+
+A code review after the initial landing surfaced refinements applied on top of the
+§3.5 design (tests in `blame_test.go`/`prov_test.go`/`internal/ast/span_test.go`):
+
+- **Unsupported-annotation recovery.** `resolveTypeAnn` now returns
+  `(soltype.Type, bool)`. `inferVarDeclInit`, the function-return annotation in
+  `inferFunc`, and `paramType` skip the subtype check and the adoption when
+  resolution fails — keeping the inferred initializer/body type (or a fresh param
+  var) instead of constraining against / adopting the `never` placeholder. This
+  removes a spurious cascade (`cannot constrain e <: never`) and the `never`-poisoned
+  binding for `val x: Foo = e`, `fn f() -> Foo {…}`, and `fn g(x: Foo) {…}`.
+- **All four constraint kinds carry `site`** (not just `CannotConstrainError`). The
+  three formerly site-less kinds (`FuncArity`/`Tuple`/`MissingProperty`) now fall
+  back to the constraint node's span instead of returning the zero `ast.Span{}`
+  (which a consumer would mis-render as `0:0`) when no operand resolves — closing
+  the latent footgun the original §3.5 deferred. The shared lookup is factored into
+  `spanOfFirst`/`spanOfNode`.
+- **`Provenance` interface renamed to `NodeResolver`** to avoid shadowing the
+  imported `provenance` package / `provenance.Provenance` marker used elsewhere in
+  the package (CLAUDE.md).
+- **Unique-pointer invariant enforced.** `recordProv` gains a `debugProv`-gated
+  guard (off in production) that panics on re-recording the same type pointer
+  against a different node, turning the implicit "every minted type is a unique
+  pointer" assumption into a test-enforced one.
+- **`within` promoted to `ast.Span.ContainsSpan`** so span-in-span containment is
+  reusable (LSP, old checker) instead of a private solver helper.
+
 ## 8. M2.5 exit checklist
 
 - [x] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -1045,37 +1045,60 @@ PR-3 adds fixtures and decides §3.7.
 
 ## 8. M2.5 exit checklist
 
-- [ ] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`
+- [x] `Prov: soltype.Type → Origin` side table with the `FromAST{Node, Kind}`
       leaf variant and `ASTOriginKind`; interior variants deferred to M3+.
-- [ ] `FromAST` populated at all nine construction sites via `recordProv`
+      ([prov.go](../../internal/solver/prov.go))
+- [x] `FromAST` populated at all nine construction sites via `recordProv`
       (literal, param, function-type, call-result, call-shape, tuple, object,
       member-result, annotation-prim). `inferIdent` records **nothing** (recording
       against the shared atom would corrupt its definition origin); ident-use blame
-      rides on the containment-guarded `site` (§3.5/§3.8).
-- [ ] Fresh-atom discipline: `resolveTypeAnn` mints a fresh `PrimType` per
+      rides on the containment-guarded `site` (§3.5/§3.8). Population verified by
+      [prov_test.go](../../internal/solver/prov_test.go).
+- [x] Fresh-atom discipline: `resolveTypeAnn` mints a fresh `PrimType` per
       annotation and records it (`AnnotationType`), so atoms are no blind spot.
-- [ ] `SolverError` reshaped: node-derived `Span()` + `Related()`; `setSpan` /
-      `errSpan` removed.
-- [ ] Bridge errors carry `ast.Node` fields and self-blame; `UnsupportedNodeError`
+      ([type_ann.go](../../internal/solver/type_ann.go) `annPrim`)
+- [x] `SolverError` reshaped: node-derived `Span()` + `Related()`; `setSpan` /
+      `errSpan` removed. ([errors.go](../../internal/solver/errors.go))
+- [x] Bridge errors carry `ast.Node` fields and self-blame; `UnsupportedNodeError`
       split into the node-kind form and `UnsupportedFeatureError`;
       `Duplicate`/`Overload` carry `Previous` and expose it via `Related()`.
-- [ ] `Provenance` interface + `Prov.NodeFor`; **no shared embed** — each constraint
+- [x] `Provenance` interface + `Prov.NodeFor`; **no shared embed** — each constraint
       kind declares only the fields it needs (`prov` on all four, `site` only on
       `CannotConstrainError`; see §3.5 table); `Prov` is consulted only by their own
       `Span()`/`Related()`.
-- [ ] `(*checker).constrain` blame rewritten: a per-kind type switch assigns each
+- [x] `(*checker).constrain` blame rewritten: a per-kind type switch assigns each
       kind's own `prov` (and `site` for `CannotConstrainError` only); the error's
       `Span()`/`Related()` do the per-operand `Prov` lookup, falling back to `site`
-      where present.
-- [ ] `Span()`/`Related()` implemented per constraint kind (the four M2 kinds),
+      where present. ([infer.go](../../internal/solver/infer.go))
+- [x] `Span()`/`Related()` implemented per constraint kind (the four M2 kinds),
       each naming which operand is the subject vs. related (§3.5 table).
-- [ ] Golden span fixtures assert exact spans for the M2.5-reachable cases:
+- [x] Golden span fixtures assert exact spans for the M2.5-reachable cases:
       `"hi"`-literal blame, call-arg mismatch, call-arity at the call,
       missing-property at the member prop; plus bridge-error spans (unknown ident,
       duplicate decl + related prior). Record/tuple-sink fixtures deferred to M4
-      (§3.10).
-- [ ] Existing M2 error fixtures updated to assert the narrowest real spans.
-- [ ] Perf invariant honored: no `Prov` access in `constrain`/`coalesce` (the
-      engine has no handle to the table).
-- [ ] `val`-annotation enabler decision (§3.7/§7) resolved and reflected.
-- [ ] `01-milestones.md` M2.5 status updated.
+      (§3.10). ([blame_test.go](../../internal/solver/blame_test.go))
+- [x] Existing M2 error fixtures updated to assert the narrowest real spans.
+      ([infer_test.go](../../internal/solver/infer_test.go))
+- [x] Perf invariant honored: no `Prov` access in `constrain`/`coalesce` (the
+      engine has no handle to the table; the `prov` field is bound by the walk
+      *after* `Context.Constrain` returns).
+- [x] `val`-annotation enabler decision (§3.7/§7) resolved and reflected:
+      **included** ([infer_decl.go](../../internal/solver/infer_decl.go)
+      `inferVarDeclInit`).
+- [x] `01-milestones.md` M2.5 status updated.
+
+### Open questions — resolutions (§7)
+
+- **Retain a resolved `Name` on `Duplicate`/`Overload`?** **Yes, retained.** Both
+  kinds carry `Decl`/`Previous` (driving span + `Related()`) *and* a `Name` string
+  (driving the message), because the message uses the resolved binding-key name
+  (`key.Name()`), which a decl node does not cheaply expose.
+- **Expose `Prov` from `InferModule`/`InferModules`?** **Not yet** — the only M2.5
+  readers are the constraint errors' own `Span()`/`Related()`, bound to the table
+  inside the run, so `InferModule`'s signature is unchanged. Revisit when the first
+  external consumer (LSP hover, M8 differential) needs it.
+- **`ASTOriginKind` granularity.** Kept the nine-constant set; M2.5 blame reads
+  only the node, so finer kinds wait for a consumer (LSP phrasing).
+- **Related-node ordering/dedup.** Deduped by span equality (`appendUnique` in
+  `relatedOf`), appended in each method's operand order; pinned by the multi-operand
+  `Related()` unit tests in [blame_test.go](../../internal/solver/blame_test.go).

--- a/planning/simple_sub/m2.5-implementation-plan.md
+++ b/planning/simple_sub/m2.5-implementation-plan.md
@@ -780,6 +780,71 @@ from" *related* span:
    function — coalesces to a *fresh* pointer with no entry, so it already falls to
    `site`; only the atom case needed the guard.)
 
+**Blame is captured at failure time, not reconstructed from the coalesced type.**
+This is the design rule that keeps case 2 tractable — and the reason leaves
+suffice. A synthesized union/intersection is **never constrained as a unit**:
+`constrain`'s variable case
+([constrain.go:134-158](../../internal/solver/constrain.go)) decomposes a
+variable's bounds and checks each one *individually*
+(`for _, lb := range lv.LowerBounds { constrain(lb, rhs) }`), so a failure is born
+from a single `lb <: ub` **leaf pair**. `"a" | true <: number` never fires as a
+unit — it surfaces as the two separate failures `constrain("a", number)` and
+`constrain(true, number)`, each already holding its own culprit operand with its
+own origin. The `"a" | true` union exists only as a later `coalesce` *rendering*
+for the message/binding; it plays no part in the constraint. So a `SolverError`
+must take its blame from the **failing operands at birth** (the `prov`-resolved
+`LHS`/`RHS` it already carries) — never by re-decomposing a finished coalesced
+type and re-checking its members. Inverting the rendering is both unnecessary (the
+solver already held the exact pair) and lossy: `coalesce`'s `dedup`
+([coalesce.go:120](../../internal/solver/coalesce.go)) collapses two
+structurally-equal members minted at different sites into one, so the rendered
+union can no longer tell them apart — yet the per-bound checks run over the *raw,
+pre-dedup* bounds (pointer-distinct, with `seen` keyed by pointer identity,
+[constrain.go:17](../../internal/solver/constrain.go)), so both still fail and both
+still blame. The corollary for M3+ (case 2): the work is to give each synthesized
+leaf its **own** interior origin edge so that when it is the failing operand
+`NodeFor` can chase *it* home — not to invert the union it would render into.
+Which *member* failed is therefore always known at the leaf; only resolving a
+synthesized leaf to a *source* waits for the edges. (Picking *which* of the
+implicated leaves to surface, and whether to show its mint site or its use, is the
+separate display policy of §3.5's containment guard — orthogonal to whether the
+culprit is determinable, which it is.)
+
+**Rejected alternative: a child→parent type-parentage side table.** A
+natural-looking extension is a second side table recording each type's *structural
+parent* — "this type is element 2 of that tuple / a member of that union / the `x`
+field of that record" — to enrich nested blame. It is **not** the design, for the
+same reasons the leaf table is sparse:
+
+- **The direction you'd query is many-valued.** Types are immutable, pointer-shared
+  values, so `child → parent` is a multimap: `val t1 = [x, 1]; val t2 = [x, 2]`
+  puts the *same* `x` pointer in two tuples, and the table cannot say which parent
+  is relevant to a given error — the identical which-of-many-sources ambiguity that
+  keeps `Prov` sparse. The functional direction, `parent → children`, is just the
+  type's own structure (`TupleType.Elems`, `RecordType.Fields`), already in hand — a
+  table would only duplicate it.
+- **Position is known at decomposition time.** The structural cases of `constrain`
+  descend with the index/field in hand (`l.Elems[i]`, the matched field name);
+  capture the path *there* (the capture-at-failure rule above), don't reconstruct it
+  from a global table. For *source*-built aggregates, `Prov` (type→node) plus the
+  AST tree already encode containment — the AST *is* the parentage tree — so a
+  type-level one is redundant; and `coalesce` rebuilds every wrapper as a *fresh*
+  pointer ([coalesce.go](../../internal/solver/coalesce.go)), so inference-time
+  parentage would be stale against the coalesced elements anyway.
+- **The real gap it targets is better closed elsewhere.** A nested leaf failure does
+  drop the enclosing path today — `[1, "hi"] <: [number, number]` blames `"hi"`
+  with no "2nd element of the tuple" context. The fix is to carry the container +
+  position **on the error, at decomposition time** (a path threaded through the
+  structural cases, or enclosing-operand fields), exactly as the existing kinds
+  already do — `TupleLengthMismatchError` holds both tuples, `MissingPropertyError`
+  holds the records plus `Name`. Not a global child→parent map.
+
+The one parent-keyed structure that *is* kept is the interior `Origin` edges of
+case 2 (`FromCoalesce`/`FromBoundPropagation`): keyed on the **freshly-built
+parent** (a unique pointer — a function, not a multimap) and traversed *up* via the
+failure context, never by a reverse `child → parents` lookup — which is exactly what
+sidesteps the many-valued problem.
+
 This split is *why* the milestone scopes M2.5 to leaves: the precise-span wins
 land where operands are node-local atoms, and the interior chains are deferred to
 the milestones that make them deep.


### PR DESCRIPTION
Implements the M2.5 milestone: a `Prov` side table that maps inferred types to their originating AST nodes, enabling precise per-operand blame in constraint errors without post-hoc span stamping.

## Summary

This PR lands the complete M2.5 design from [m2.5-implementation-plan.md](planning/simple_sub/m2.5-implementation-plan.md). Every constraint error now derives its primary span from the operand that failed (via `Prov` lookup) and falls back to the constraint site when an operand is unrecorded, with related spans exposing secondary contributing nodes (expected-source, prior declaration, etc.). Bridge errors self-blame from their own AST node. The `setSpan`/`errSpan` post-hoc stamping pattern is removed entirely.

## Key changes

- **`Prov` side table** ([prov.go](internal/solver/prov.go)): `soltype.Type → Origin` map with the `FromAST{Node, Kind}` leaf variant. `ASTOriginKind` tags why a node minted a type (literal, param, function, call-result, call-shape, tuple, object, member-result, annotation). `NodeResolver` interface allows M3+ to chain through interior edges without changing callers.

- **Nine construction sites record provenance** via `recordProv`:
  - `inferLiteral`: `LiteralInference`
  - `inferFunc`: `FuncInference` (function type), `ParamBinding` (un-annotated param vars)
  - `inferCall`: `Application` (result var), `CallShape` (synthesized call-shape)
  - `inferTuple`/`inferObject`: `TupleElem`/`ObjectField`
  - `inferMember`: `MemberAccess` (recorded against `.prop` identifier, not receiver)
  - `resolveTypeAnn`: `AnnotationType` (fresh `PrimType` per annotation, closing the shared-atom blind spot)
  - `inferIdent` records **nothing** (recording against the shared atom would corrupt its definition origin)

- **`SolverError` reshaped**: Removed `setSpan`/`errSpan` embeddable carrier. Every error kind now implements `Span() ast.Span` (node-derived, never zero) and `Related() []ast.Span` (secondary nodes, deduped by span equality). Constraint kinds (`CannotConstrainError`, `FuncArityMismatchError`, `TupleLengthMismatchError`, `MissingPropertyError`) resolve operands through `Prov` on demand with containment-guarded fallback to the constraint site. Bridge errors (`UnknownIdentifierError`, `NamespaceUsedAsValueError`, `DuplicateDeclarationError`, `UnsupportedNodeError`, `MissingInitializerError`, `BodyDeclNotAllowedError`) carry `ast.Node` fields and self-blame.

- **Containment guard** (§3.8): `spanOf` applies `site.Span().ContainsSpan(operand.Span())` so identifier-flow blame stays on the use, not the definition. For `val a: number = x`, the operand (`x`'s type) traces to `x`'s definition (outside the use site), so the use wins.

- **Unsupported-annotation recovery**: `resolveTypeAnn` returns `(soltype.Type, bool)`. Callers skip the subtype check and adoption when resolution fails, keeping the inferred type instead of constraining against / adopting the `never` placeholder, removing spurious cascades.

- **All four constraint kinds carry `site`**: `FuncArityMismatchError`, `TupleLengthMismatchError`, `MissingPropertyError` now fall back to the constraint node's span instead of the zero span when no operand resolves — closing a latent footgun for M4 record/tuple sinks.

- **`Provenance` renamed to `NodeResolver`** to avoid shadowing the imported `provenance` package marker (CLAUDE.md).

- **

https://claude.ai/code/session_01UxSQQTzkmpN9wPHjCCkc6p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise error attribution: diagnostics now point to the exact failing operands or sites, reducing misleading spans and cascading errors.
  * Improved recovery when type annotations are unsupported to avoid spurious “never” cascades.

* **New Features**
  * Provenance-backed diagnostics that trace inferred types back to their originating source constructs for clearer blame.

* **Tests**
  * Extensive tests added for span containment, provenance recording, and many inference error cases.

* **Documentation**
  * Milestone and implementation-plan updates documenting the blame/provenance approach and status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->