### PR TITLE
Document usage-inferred shapes and `open` marker in spec

### DIFF
--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -1877,12 +1877,13 @@ structural-width behavior (accept any record with at least the required
 fields) for exactly the parameters that want it, while every other
 parameter stays exact.
 
-The asymmetry is deliberate. **Inexact-by-default** — treating the row
-variable as the natural meaning of an accumulated lower bound, which is
-closer to how the underlying inference engine works — was considered and
-rejected on default-audience grounds. Exact-by-default makes the common
-case (application code) safe by default and asks the rarer case
-(row-polymorphic library helpers) to pay a one-keyword cost.
+The asymmetry is deliberate. We considered and rejected
+**inexact-by-default** on default-audience grounds — that alternative
+treats the row variable as the natural meaning of an accumulated lower
+bound, which is closer to how the underlying inference engine works.
+Exact-by-default makes the common case (application code) safe by default
+and asks the rarer case (row-polymorphic library helpers) to pay a
+one-keyword cost.
 
 **Scope.** Usage-based inference and the `open` marker land with
 record-typed parameters in the implementation (the SimpleSub checker's

--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -1833,6 +1833,66 @@ inexact constraints accept either.
   Escalier projects while plain TypeScript consumers see the erased form.
   See §9 for the full mechanism.
 
+### 8.1. Usage-Inferred Shapes and the `open` Marker
+
+§2.2.1 covers object *literals*, which infer as exact. The complementary
+case is a shape inferred not from a literal but from how a value is
+*used* — when a function parameter's record type is reconstructed from
+the fields its body accesses (usage-based inference). The same default
+applies:
+
+- **Usage-inferred shapes coalesce as exact.** When the checker
+  reconstructs a record shape from member accesses in a function body
+  (`p.x`, `p.y`, …), the accumulated field requirements close into an
+  **exact** record once body inference completes. A parameter `p` whose
+  body reads only `p.x` and `p.y` is inferred as the exact
+  `{x: number, y: number}`, not an open row — there is no implicit row
+  variable left dangling after inference.
+
+This means a caller cannot pass a record carrying *extra* fields to such a
+parameter — the same extra-property rejection an explicit exact annotation
+gives (§2.3). The motivation matches the literal case (§2.2.1): most
+Escalier code is application code, and biasing the default toward "exact,
+catch extra-field bugs at the call site" fits that audience better than
+silently accepting wider records.
+
+**Opting into row polymorphism: the `open` parameter marker.** Library
+code that genuinely wants to accept any record richer than the fields it
+touches opts in per parameter with the `open` marker (keyword
+provisional):
+
+```
+// p is inferred as the inexact {x: number, y: number, ...}; callers may
+// pass any record that has at least x and y.
+fn dist(open p) -> number {
+    sqrt(p.x * p.x + p.y * p.y)
+}
+```
+
+`open p` keeps the usage-inferred row open — `p`'s inferred type is the
+**inexact** `{x: number, y: number, ...}` instead of the exact
+`{x: number, y: number}`. This is the usage-inference analogue of writing
+a trailing `...` on an explicit object type (§2.1): it restores
+structural-width behavior (accept any record with at least the required
+fields) for exactly the parameters that want it, while every other
+parameter stays exact.
+
+The asymmetry is deliberate. **Inexact-by-default** — treating the row
+variable as the natural meaning of an accumulated lower bound, which is
+closer to how the underlying inference engine works — was considered and
+rejected on default-audience grounds. Exact-by-default makes the common
+case (application code) safe by default and asks the rarer case
+(row-polymorphic library helpers) to pay a one-keyword cost.
+
+**Scope.** Usage-based inference and the `open` marker land with
+record-typed parameters in the implementation (the SimpleSub checker's
+milestone M4); the marker keyword is provisional. This subsection records
+the *default* — usage-inferred shapes are exact, `open` opts back into row
+polymorphism — so the exactness defaults are settled before the
+function-exactness work (M3) that builds on them. See
+`planning/simple_sub/02-design-notes.md` §"Exactness" and
+`planning/simple_sub/01-milestones.md` (M4) for the implementation plan.
+
 ## 9. TypeScript Interop
 
 This section consolidates the interop story spread across §5.5 (union

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -27,9 +27,8 @@ lands* (M3 functions, M4 records/tuples, M5 class instances via `final`,
 M6 unions) — tests at each milestone assert what the implementation produces.
 (The usage-inferred-shape default — that usage-collected shapes coalesce as
 **exact** — and the `open` parameter marker that opts back into row polymorphism
-are not yet reflected in
-[exact-types/requirements.md](../exact-types/requirements.md); the spec needs
-a section recording both before M3 lands.)
+are recorded in
+[exact-types/requirements.md](../exact-types/requirements.md) §8.1.)
 
 ## Contents
 

--- a/planning/simple_sub/02-design-notes.md
+++ b/planning/simple_sub/02-design-notes.md
@@ -700,8 +700,8 @@ helpers pay a one-keyword cost. The alternative (**inexact-by-default** —
 usage-inferred shapes default inexact, treating the row variable as the natural
 meaning of a lower bound) was considered and rejected on default-audience grounds.
 
-**This decision is not yet reflected in `planning/exact-types/requirements.md`;
-the spec needs a section recording it before M3 lands.**
+**This decision is recorded in `planning/exact-types/requirements.md` §8.1
+(Usage-Inferred Shapes and the `open` Marker).**
 
 **Day-one behavior.** Escalier code is exact-by-default and TypeScript-imported
 types are inexact-by-default *from the moment each former lands* — exact


### PR DESCRIPTION
Adds §8.1 to `planning/exact-types/requirements.md` documenting the design decision and behavior for usage-inferred record shapes and the `open` parameter marker that opts into row polymorphism.

## Summary

This PR formalizes the specification for how record shapes inferred from function parameter usage default to exact (rejecting extra fields), and how the `open` marker allows library code to opt back into row-polymorphic behavior. This design was previously documented only in design notes and milestone planning; it now has a dedicated spec section before the M3 implementation lands.

## Changes

- **planning/exact-types/requirements.md**: Added §8.1 covering:
  - Usage-inferred shapes coalesce as exact by default (matching literal-inferred behavior from §2.2.1)
  - Rationale: application-code bias toward catching extra-field bugs at call sites
  - The `open` parameter marker syntax and semantics for opting into row polymorphism
  - Justification for exact-by-default over inexact-by-default
  - Scope note: lands with M4 (record-typed parameters), marker keyword is provisional

- **planning/simple_sub/01-milestones.md**: Updated cross-reference to point to the new §8.1 instead of noting the spec gap

- **planning/simple_sub/02-design-notes.md**: Updated cross-reference to point to the new §8.1 instead of noting the spec gap

The spec section consolidates the design rationale already present in design notes and makes the default behavior explicit before function-exactness work (M3) that depends on it.

https://claude.ai/code/session_01QUHb1L86nXmQuzbiWLXvi8