### PR TITLE
M3 PR1: Let-generalization and polymorphic type schemes

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -43,10 +43,8 @@ func typePrec(t Type) int {
 // forms so the two checkers' rendered types stay string-comparable in M7's
 // differential harness. It renders the M1 coalesced type set only
 // (PrimType/LitType/FuncType/TupleType/Void/NeverType/UnknownType/UnionType/
-// IntersectionType). There is no <T0, ...> quantifier prefix in M1 — no named
-// refs exist to collect, since coalescing always inlines variables; that
-// machinery lands in M3 with the rest of the polymorphism-rendering bundle
-// (§3.3).
+// IntersectionType). Print itself emits no <T0, ...> quantifier prefix — a
+// monotype has no parameters to name; PrintScheme renders the generalized form.
 //
 // Print is distinct from solver's describe(): describe renders a RAW,
 // uncoalesced type (t0, function, number) mid-constrain for error messages,
@@ -59,30 +57,124 @@ func typePrec(t Type) int {
 // at binding boundaries, so a consumer may legitimately print an inner node's
 // still-raw type (M2 plan §7).
 func Print(t Type) string {
-	return printType(t)
+	return (&namedPrinter{}).printType(t)
+}
+
+// PrintScheme renders a coalesced GENERALIZED type (M3): it collects the type's
+// free variables into a <T0, T1, …> quantifier prefix and renders each as its
+// assigned name. A type with no free variables renders exactly as Print would (no
+// prefix), so PrintScheme is safe on a monotype. The prefix attaches to a
+// function (`fn <T0>(…) -> …`, matching Escalier's generic-function surface
+// syntax); a non-function body carrying free variables — not produced by M3's
+// generalization, which only generalizes function values — falls back to a
+// leading <…> group.
+//
+// Variables are named by first appearance in print order (params left to right,
+// then return; tuple elements; record fields), so the same coalesced variable
+// renders under one name everywhere it occurs.
+func PrintScheme(t Type) string {
+	vars := freeTypeVars(t)
+	if len(vars) == 0 {
+		return Print(t)
+	}
+	names := make(map[*TypeVarType]string, len(vars))
+	labels := make([]string, len(vars))
+	for i, v := range vars {
+		name := typeParamName(i)
+		names[v] = name
+		labels[i] = name
+	}
+	p := &namedPrinter{names: names}
+	prefix := "<" + strings.Join(labels, ", ") + ">"
+	if ft, ok := t.(*FuncType); ok {
+		return "fn " + prefix + p.printFuncTail(ft)
+	}
+	return prefix + " " + p.printType(t)
+}
+
+// typeParamName is the surface name for the i-th quantified type parameter: T0,
+// T1, …, matching the planned `fn <T0>(x: T0) -> T0` rendering.
+func typeParamName(i int) string {
+	return "T" + strconv.Itoa(i)
+}
+
+// freeTypeVars collects the TypeVarTypes appearing in t in first-appearance print
+// order. It does NOT descend into a variable's bound lists — a coalesced display
+// type already carries the relevant structure inline (a retained variable's
+// bounds are sibling union/intersection members), so the variable node is a leaf
+// here.
+func freeTypeVars(t Type) []*TypeVarType {
+	var out []*TypeVarType
+	seen := map[*TypeVarType]bool{}
+	var walk func(Type)
+	walk = func(t Type) {
+		switch t := t.(type) {
+		case *TypeVarType:
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
+		case *FuncType:
+			for _, p := range t.Params {
+				walk(p.Type)
+			}
+			walk(t.Ret)
+		case *TupleType:
+			for _, e := range t.Elems {
+				walk(e)
+			}
+		case *RecordType:
+			for _, f := range t.Fields {
+				walk(f.Type)
+			}
+		case *UnionType:
+			for _, m := range t.Types {
+				walk(m)
+			}
+		case *IntersectionType:
+			for _, m := range t.Types {
+				walk(m)
+			}
+		}
+	}
+	walk(t)
+	return out
+}
+
+// namedPrinter carries the optional retained-variable → quantifier-name map for a
+// single render. names is nil for plain Print (a raw variable then renders as
+// `t{ID}`) and populated by PrintScheme (a retained variable renders as `T{i}`).
+type namedPrinter struct {
+	names map[*TypeVarType]string
 }
 
 // printTypeMinPrec prints a child type, wrapping it in parentheses when its
 // precedence is below the required minimum — mirrors type_system's helper of the
 // same shape, so e.g. a function inside a union renders as
 // `(fn () -> number) | string`.
-func printTypeMinPrec(t Type, minPrec int) string {
-	result := printType(t)
+func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
+	result := p.printType(t)
 	if typePrec(t) < minPrec {
 		return "(" + result + ")"
 	}
 	return result
 }
 
-func printType(t Type) string {
+func (p *namedPrinter) printType(t Type) string {
 	switch t := t.(type) {
 	case *TypeVarType:
-		// A raw, un-coalesced variable. Coalesced output never contains one (every
-		// variable is inlined to its bounds, m1-implementation-plan Delta #1), but
-		// the M2 walk records raw, var-carrying types in its Info side table and
-		// only coalesces at binding boundaries — so a consumer printing an inner
-		// node's type directly may hand Print a live variable. Render it as `t{ID}`
-		// (matching solver's describe()) rather than panicking. See the M2 plan §7.
+		// A retained type parameter renders under its assigned name; otherwise a
+		// raw, un-coalesced variable. Coalesced monotype output never contains one
+		// (every variable is inlined to its bounds, m1-implementation-plan Delta #1),
+		// but the M2 walk records raw, var-carrying types in Info and only coalesces
+		// at binding boundaries — so a consumer printing an inner node's type
+		// directly may hand Print a live variable. Render it as `t{ID}` (matching
+		// solver's describe()) rather than panicking. See the M2 plan §7.
+		if p.names != nil {
+			if name, ok := p.names[t]; ok {
+				return name
+			}
+		}
 		return "t" + strconv.Itoa(t.ID)
 	case *PrimType:
 		return printPrim(t.Prim)
@@ -97,27 +189,27 @@ func printType(t Type) string {
 	case *TupleType:
 		elems := make([]string, len(t.Elems))
 		for i, e := range t.Elems {
-			elems[i] = printType(e)
+			elems[i] = p.printType(e)
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
 	case *RecordType:
 		fields := make([]string, len(t.Fields))
 		for i, f := range t.Fields {
-			fields[i] = printRecordFieldName(f.Name) + ": " + printType(f.Type)
+			fields[i] = printRecordFieldName(f.Name) + ": " + p.printType(f.Type)
 		}
 		return "{" + strings.Join(fields, ", ") + "}"
 	case *FuncType:
-		return "fn " + printFuncTail(t)
+		return "fn " + p.printFuncTail(t)
 	case *UnionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {
-			parts[i] = printTypeMinPrec(m, precUnion)
+			parts[i] = p.printTypeMinPrec(m, precUnion)
 		}
 		return strings.Join(parts, " | ")
 	case *IntersectionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {
-			parts[i] = printTypeMinPrec(m, precIntersection)
+			parts[i] = p.printTypeMinPrec(m, precIntersection)
 		}
 		return strings.Join(parts, " & ")
 	}
@@ -125,14 +217,14 @@ func printType(t Type) string {
 }
 
 // printFuncTail renders the "(params) -> ret" portion of a function, without the
-// leading "fn" keyword. Kept as a separate helper so M3 can compose it with a
-// <...> quantifier prefix without byte-slicing the "fn " back off.
-func printFuncTail(t *FuncType) string {
+// leading "fn" keyword. Kept as a separate helper so PrintScheme can compose it
+// with a <...> quantifier prefix without byte-slicing the "fn " back off.
+func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	ps := make([]string, len(t.Params))
-	for i, p := range t.Params {
-		ps[i] = paramName(p, i) + ": " + printType(p.Type)
+	for i, param := range t.Params {
+		ps[i] = paramName(param, i) + ": " + p.printType(param.Type)
 	}
-	return "(" + strings.Join(ps, ", ") + ") -> " + printType(t.Ret)
+	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -46,7 +46,7 @@ func typePrec(t Type) int {
 // differential harness. It renders the M1 coalesced type set only
 // (PrimType/LitType/FuncType/TupleType/Void/NeverType/UnknownType/UnionType/
 // IntersectionType). Print itself emits no <T0, ...> quantifier prefix — a
-// monotype has no parameters to name; PrintScheme renders the generalized form.
+// monotype has no parameters to name; PrintAsScheme renders the generalized form.
 //
 // Print is distinct from solver's describe(): describe renders a RAW,
 // uncoalesced type (t0, function, number) mid-constrain for error messages,
@@ -62,10 +62,10 @@ func Print(t Type) string {
 	return (&namedPrinter{}).printType(t)
 }
 
-// PrintScheme renders a coalesced GENERALIZED type (M3): it collects the type's
+// PrintAsScheme renders a coalesced GENERALIZED type (M3): it collects the type's
 // free variables into a <T0, T1, …> quantifier prefix and renders each as its
 // assigned name. A type with no free variables renders exactly as Print would (no
-// prefix), so PrintScheme is safe on a monotype. The prefix attaches to a
+// prefix), so PrintAsScheme is safe on a monotype. The prefix attaches to a
 // function (`fn <T0>(…) -> …`, matching Escalier's generic-function surface
 // syntax); a non-function body carrying free variables — not produced by M3's
 // generalization, which only generalizes function values — falls back to a
@@ -75,25 +75,21 @@ func Print(t Type) string {
 // then return; tuple elements; record fields), so the same coalesced variable
 // renders under one name everywhere it occurs.
 //
-// PrintScheme treats EVERY free variable as a quantified parameter — for a caller
+// PrintAsScheme treats EVERY free variable as a quantified parameter — for a caller
 // that trusts its input is a fully-generalized type. The solver's renderScheme
-// uses PrintSchemeParams to restrict naming to the variables generalization
+// uses PrintAsSchemeWith to restrict naming to the variables generalization
 // actually quantified, so a stray variable is not disguised as a parameter.
-func PrintScheme(t Type) string {
-	return printScheme(t, func(*TypeVarType) bool { return true })
+func PrintAsScheme(t Type) string {
+	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true })
 }
 
-// PrintSchemeParams renders a generalized type, naming ONLY the free variables
+// PrintAsSchemeWith renders a generalized type, naming ONLY the free variables
 // isParam accepts as quantified type parameters; any other free variable renders
 // as the raw `t{ID}` debug form instead of being masked as a parameter. This
 // preserves the leak anchor: a variable coalescing failed to inline (a captured
 // var that escaped, a stray inference var) shows as `t{ID}` rather than a spurious
 // `<Tn>` that would make a malformed signature look valid.
-func PrintSchemeParams(t Type, isParam func(*TypeVarType) bool) string {
-	return printScheme(t, isParam)
-}
-
-func printScheme(t Type, isParam func(*TypeVarType) bool) string {
+func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 	names := map[*TypeVarType]string{}
 	var labels []string
 	for _, v := range freeTypeVars(t) {
@@ -168,7 +164,7 @@ func freeTypeVars(t Type) []*TypeVarType {
 
 // namedPrinter carries the optional retained-variable → quantifier-name map for a
 // single render. names is nil for plain Print (a raw variable then renders as
-// `t{ID}`) and populated by PrintScheme (a retained variable renders as `T{i}`).
+// `t{ID}`) and populated by PrintAsScheme (a retained variable renders as `T{i}`).
 type namedPrinter struct {
 	names map[*TypeVarType]string
 }
@@ -242,7 +238,7 @@ func (p *namedPrinter) printType(t Type) string {
 }
 
 // printFuncTail renders the "(params) -> ret" portion of a function, without the
-// leading "fn" keyword. Kept as a separate helper so PrintScheme can compose it
+// leading "fn" keyword. Kept as a separate helper so PrintAsScheme can compose it
 // with a <...> quantifier prefix without byte-slicing the "fn " back off.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	ps := make([]string, len(t.Params))

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // Precedence levels for type operators, matching the Escalier parser (and
@@ -72,17 +74,40 @@ func Print(t Type) string {
 // Variables are named by first appearance in print order (params left to right,
 // then return; tuple elements; record fields), so the same coalesced variable
 // renders under one name everywhere it occurs.
+//
+// PrintScheme treats EVERY free variable as a quantified parameter — for a caller
+// that trusts its input is a fully-generalized type. The solver's renderScheme
+// uses PrintSchemeParams to restrict naming to the variables generalization
+// actually quantified, so a stray variable is not disguised as a parameter.
 func PrintScheme(t Type) string {
-	vars := freeTypeVars(t)
-	if len(vars) == 0 {
-		return Print(t)
-	}
-	names := make(map[*TypeVarType]string, len(vars))
-	labels := make([]string, len(vars))
-	for i, v := range vars {
-		name := typeParamName(i)
+	return printScheme(t, func(*TypeVarType) bool { return true })
+}
+
+// PrintSchemeParams renders a generalized type, naming ONLY the free variables
+// isParam accepts as quantified type parameters; any other free variable renders
+// as the raw `t{ID}` debug form instead of being masked as a parameter. This
+// preserves the leak anchor: a variable coalescing failed to inline (a captured
+// var that escaped, a stray inference var) shows as `t{ID}` rather than a spurious
+// `<Tn>` that would make a malformed signature look valid.
+func PrintSchemeParams(t Type, isParam func(*TypeVarType) bool) string {
+	return printScheme(t, isParam)
+}
+
+func printScheme(t Type, isParam func(*TypeVarType) bool) string {
+	names := map[*TypeVarType]string{}
+	var labels []string
+	for _, v := range freeTypeVars(t) {
+		if !isParam(v) {
+			continue // non-parameter free var → left unnamed → renders as t{ID}
+		}
+		name := typeParamName(len(labels))
 		names[v] = name
-		labels[i] = name
+		labels = append(labels, name)
+	}
+	if len(labels) == 0 {
+		// No quantified parameters: render as a plain (possibly raw-var) type, which
+		// keeps a leaked variable visible as t{ID}.
+		return Print(t)
 	}
 	p := &namedPrinter{names: names}
 	prefix := "<" + strings.Join(labels, ", ") + ">"
@@ -105,13 +130,13 @@ func typeParamName(i int) string {
 // here.
 func freeTypeVars(t Type) []*TypeVarType {
 	var out []*TypeVarType
-	seen := map[*TypeVarType]bool{}
+	seen := set.NewSet[*TypeVarType]()
 	var walk func(Type)
 	walk = func(t Type) {
 		switch t := t.(type) {
 		case *TypeVarType:
-			if !seen[t] {
-				seen[t] = true
+			if !seen.Contains(t) {
+				seen.Add(t)
 				out = append(out, t)
 			}
 		case *FuncType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -90,11 +90,11 @@ func TestIsIdent(t *testing.T) {
 		{"_x", true},
 		{"a1", true},
 		{"camelCase_9", true},
-		{"café", true},     // unicode letter (continue)
-		{"naïve", true},    // unicode letter (continue)
-		{"数値", true},       // non-Latin letters
-		{"Ωmega", true},     // unicode letter (leading)
-		{"x٢", true},        // unicode digit (Arabic-Indic) after letter
+		{"café", true},  // unicode letter (continue)
+		{"naïve", true}, // unicode letter (continue)
+		{"数値", true},    // non-Latin letters
+		{"Ωmega", true}, // unicode letter (leading)
+		{"x٢", true},    // unicode digit (Arabic-Indic) after letter
 		{"", false},
 		{"1a", false},  // leading digit
 		{"٢x", false},  // leading unicode digit
@@ -178,4 +178,38 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 		Ret: boolP(),
 	}
 	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
+}
+
+// TestPrintScheme covers the M3 quantifier-prefix rendering: a generalized type's
+// free variables are collected into a <T0, T1, …> prefix (named by first
+// appearance in print order) and rendered under those names, while a variable-free
+// type renders exactly as Print would.
+func TestPrintScheme(t *testing.T) {
+	t.Run("no free vars renders as Print", func(t *testing.T) {
+		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}
+		require.Equal(t, "fn (x: number) -> string", PrintScheme(ty))
+	})
+
+	t.Run("identity gets one type parameter", func(t *testing.T) {
+		a := &TypeVarType{ID: 7, Level: 1}
+		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a}
+		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintScheme(ty))
+	})
+
+	t.Run("distinct vars are named by first appearance", func(t *testing.T) {
+		a := &TypeVarType{ID: 1, Level: 1}
+		b := &TypeVarType{ID: 2, Level: 1}
+		// fn (x: a, y: b) -> [b, a]: a appears first (param x), then b (param y).
+		ty := &FuncType{
+			Params: []*FuncParam{identP("x", a), identP("y", b)},
+			Ret:    &TupleType{Elems: []Type{b, a}},
+		}
+		require.Equal(t, "fn <T0, T1>(x: T0, y: T1) -> [T1, T0]", PrintScheme(ty))
+	})
+
+	t.Run("a free var keeps one name across positions", func(t *testing.T) {
+		a := &TypeVarType{ID: 3, Level: 1}
+		ty := &TupleType{Elems: []Type{a, a}}
+		require.Equal(t, "<T0> [T0, T0]", PrintScheme(ty))
+	})
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -187,13 +187,13 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 func TestPrintScheme(t *testing.T) {
 	t.Run("no free vars renders as Print", func(t *testing.T) {
 		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}
-		require.Equal(t, "fn (x: number) -> string", PrintScheme(ty))
+		require.Equal(t, "fn (x: number) -> string", PrintAsScheme(ty))
 	})
 
 	t.Run("identity gets one type parameter", func(t *testing.T) {
 		a := &TypeVarType{ID: 7, Level: 1}
 		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a}
-		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintScheme(ty))
+		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintAsScheme(ty))
 	})
 
 	t.Run("distinct vars are named by first appearance", func(t *testing.T) {
@@ -204,20 +204,20 @@ func TestPrintScheme(t *testing.T) {
 			Params: []*FuncParam{identP("x", a), identP("y", b)},
 			Ret:    &TupleType{Elems: []Type{b, a}},
 		}
-		require.Equal(t, "fn <T0, T1>(x: T0, y: T1) -> [T1, T0]", PrintScheme(ty))
+		require.Equal(t, "fn <T0, T1>(x: T0, y: T1) -> [T1, T0]", PrintAsScheme(ty))
 	})
 
 	t.Run("a free var keeps one name across positions", func(t *testing.T) {
 		a := &TypeVarType{ID: 3, Level: 1}
 		ty := &TupleType{Elems: []Type{a, a}}
-		require.Equal(t, "<T0> [T0, T0]", PrintScheme(ty))
+		require.Equal(t, "<T0> [T0, T0]", PrintAsScheme(ty))
 	})
 }
 
-// PrintSchemeParams names ONLY the variables the predicate accepts as quantified
+// PrintAsSchemeWith names ONLY the variables the predicate accepts as quantified
 // type parameters; a variable it rejects (one coalescing should have inlined)
 // renders as the raw t{ID} debug anchor instead of being masked as a <Tn>
-// parameter. This preserves the leak signal that plain PrintScheme (which names
+// parameter. This preserves the leak signal that plain PrintAsScheme (which names
 // every free var) would hide.
 func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 	param := &TypeVarType{ID: 1, Level: 2}   // a genuine type parameter (Level > 1)
@@ -226,6 +226,6 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
 	}
-	got := PrintSchemeParams(ty, func(v *TypeVarType) bool { return v.Level > 1 })
+	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 })
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -213,3 +213,19 @@ func TestPrintScheme(t *testing.T) {
 		require.Equal(t, "<T0> [T0, T0]", PrintScheme(ty))
 	})
 }
+
+// PrintSchemeParams names ONLY the variables the predicate accepts as quantified
+// type parameters; a variable it rejects (one coalescing should have inlined)
+// renders as the raw t{ID} debug anchor instead of being masked as a <Tn>
+// parameter. This preserves the leak signal that plain PrintScheme (which names
+// every free var) would hide.
+func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
+	param := &TypeVarType{ID: 1, Level: 2}   // a genuine type parameter (Level > 1)
+	leaked := &TypeVarType{ID: 99, Level: 0} // a var that should have been inlined
+	ty := &FuncType{
+		Params: []*FuncParam{identP("x", param)},
+		Ret:    &TupleType{Elems: []Type{param, leaked}},
+	}
+	got := PrintSchemeParams(ty, func(v *TypeVarType) bool { return v.Level > 1 })
+	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -65,10 +65,13 @@ func TestBlameCallArgument(t *testing.T) {
 // A call-arity mismatch points at the whole call, with the callee's definition as
 // the related "function defined here" span. M2.5 resolved that related span only
 // for inline callees: a named callee's binding was COALESCED to a fresh FuncType
-// pointer with no Prov entry. M3 (PR1) generalizes instead of coalescing and
-// instantiation shares the monomorphic body unchanged, so the original FuncType
-// (recorded FuncInference against the decl) survives and the related span now
-// resolves for named callees too.
+// pointer with no Prov entry. M3 (PR1) generalizes instead of coalescing, and for
+// a VAR-FREE (monomorphic) callee like `f` here, instantiation shares its FuncType
+// unchanged — so the original (recorded FuncInference against the decl) survives
+// and the related span now resolves. This bound matters: a POLYMORPHIC callee,
+// whose type freshenAbove rebuilds into fresh prov-less nodes, still drops the
+// related span (the receiver analogue is documented in
+// TestBlameMissingPropertyPolymorphicReceiverLosesRelated).
 func TestBlameCallArity(t *testing.T) {
 	src := "fn f(x: number) -> number { x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
@@ -81,12 +84,29 @@ func TestBlameCallArity(t *testing.T) {
 // the receiver's definition as the related span. Like TestBlameCallArity, M2.5
 // resolved that related span only for an inline receiver (a named receiver was
 // coalesced to a fresh RecordType with no Prov entry); M3's generalize-and-share
-// instantiation keeps the original record (recorded ObjectField against the
-// literal), so the named receiver's related span now resolves.
+// instantiation keeps a VAR-FREE receiver's original record — here `{a: 5}` is
+// monomorphic, so it is shared unchanged through instantiation (recorded
+// ObjectField against the literal) — so the named receiver's related span now
+// resolves. A receiver whose value flowed through an instantiation that REBUILT it
+// (e.g. the result of a polymorphic call) does not keep the entry; see
+// TestBlameMissingPropertyPolymorphicReceiverLosesRelated.
 func TestBlameMissingProperty(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o.b"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
+}
+
+// The bound of M3's related-span improvement: a receiver derived from a
+// POLYMORPHIC call loses its related "defined here" span. Instantiating `mk`
+// freshens its body, rebuilding the record into a fresh pointer with no Prov
+// entry, so the missing-property error carries no related receiver span — unlike
+// the direct var-free literal in TestBlameMissingProperty. Documents that the
+// improvement holds for var-free callees/receivers, not values that flowed through
+// instantiation.
+func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
+	src := "val mk = fn (v) { {a: v} }\nval o = mk(5)\nval x = o.b"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "object is missing property: b", "b")
 }
 
 // An identifier-flow mismatch blames the USE, not the definition: x's type traces

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -62,24 +62,31 @@ func TestBlameCallArgument(t *testing.T) {
 	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
 }
 
-// A call-arity mismatch points at the whole call. (The callee `f` is named, so its
-// binding is coalesced to a fresh FuncType pointer that has no Prov entry — the
-// "function defined here" related span resolves only for inline callees in M2.5
-// and is made precise for named callees by M3's FromInstantiation.)
+// A call-arity mismatch points at the whole call, with the callee's definition as
+// the related "function defined here" span. M2.5 resolved that related span only
+// for inline callees: a named callee's binding was COALESCED to a fresh FuncType
+// pointer with no Prov entry. M3 (PR1) generalizes instead of coalescing and
+// instantiation shares the monomorphic body unchanged, so the original FuncType
+// (recorded FuncInference against the decl) survives and the related span now
+// resolves for named callees too.
 func TestBlameCallArity(t *testing.T) {
 	src := "fn f(x: number) -> number { x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"cannot constrain function of arity 1 <: function of arity 2", "f(1, 2)")
+		"cannot constrain function of arity 1 <: function of arity 2", "f(1, 2)",
+		"fn f(x: number) -> number { x }")
 }
 
-// A missing-property read blames the member's prop (.foo), not the receiver. (The
-// receiver `o` is named/coalesced, so its related span resolves only for an inline
-// receiver in M2.5.)
+// A missing-property read blames the member's prop (.foo), not the receiver, with
+// the receiver's definition as the related span. Like TestBlameCallArity, M2.5
+// resolved that related span only for an inline receiver (a named receiver was
+// coalesced to a fresh RecordType with no Prov entry); M3's generalize-and-share
+// instantiation keeps the original record (recorded ObjectField against the
+// literal), so the named receiver's related span now resolves.
 func TestBlameMissingProperty(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o.b"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "object is missing property: b", "b")
+	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
 }
 
 // An identifier-flow mismatch blames the USE, not the definition: x's type traces

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -242,8 +242,23 @@ func schemeType(s TypeScheme) soltype.Type {
 
 // renderScheme renders a scheme to its Escalier type-annotation string, with a
 // <T0, …> quantifier prefix when generalization left type parameters behind.
+//
+// For a PolyScheme it names only the variables generalization quantified — those
+// with Level > sc.Level, the exact retention criterion coalesceScheme uses — so a
+// variable that escaped coalescing (a captured var at Level <= sc.Level that was
+// not inlined) renders as the raw t{ID} debug form instead of being disguised as a
+// spurious type parameter. A MonoScheme coalesces to a var-free type, so plain
+// PrintScheme suffices.
 func renderScheme(s TypeScheme) string {
-	return soltype.PrintScheme(schemeType(s))
+	switch sc := s.(type) {
+	case *MonoScheme:
+		return soltype.PrintScheme(coalesce(sc.Ty, soltype.Positive))
+	case *PolyScheme:
+		return soltype.PrintSchemeParams(coalesceScheme(sc.Body, sc.Level), func(v *soltype.TypeVarType) bool {
+			return v.Level > sc.Level
+		})
+	}
+	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
 }
 
 // emptyOf returns the lattice identity for a polarity: never (⊥, the identity of

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -227,7 +227,7 @@ func coalesceSchemeRec(
 }
 
 // schemeType returns a scheme's coalesced DISPLAY type (variable-free except for
-// retained type parameters), the soltype handed to soltype.PrintScheme and
+// retained type parameters), the soltype handed to soltype.PrintAsScheme and
 // recorded in Info. A MonoScheme coalesces uniformly (no retained parameters); a
 // PolyScheme retains its quantified parameters via coalesceScheme.
 func schemeType(s TypeScheme) soltype.Type {
@@ -248,13 +248,13 @@ func schemeType(s TypeScheme) soltype.Type {
 // variable that escaped coalescing (a captured var at Level <= sc.Level that was
 // not inlined) renders as the raw t{ID} debug form instead of being disguised as a
 // spurious type parameter. A MonoScheme coalesces to a var-free type, so plain
-// PrintScheme suffices.
+// PrintAsScheme suffices.
 func renderScheme(s TypeScheme) string {
 	switch sc := s.(type) {
 	case *MonoScheme:
-		return soltype.PrintScheme(coalesce(sc.Ty, soltype.Positive))
+		return soltype.PrintAsScheme(coalesce(sc.Ty, soltype.Positive))
 	case *PolyScheme:
-		return soltype.PrintSchemeParams(coalesceScheme(sc.Body, sc.Level), func(v *soltype.TypeVarType) bool {
+		return soltype.PrintAsSchemeWith(coalesceScheme(sc.Body, sc.Level), func(v *soltype.TypeVarType) bool {
 			return v.Level > sc.Level
 		})
 	}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -88,6 +88,164 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 	panic(fmt.Sprintf("coalesce: unhandled %T", t))
 }
 
+// occPolarity is the set of polarities a variable occurs in within a type — the
+// occurrence input single-polarity elimination needs to decide which variables a
+// generalized scheme can drop.
+type occPolarity uint8
+
+const (
+	occPos occPolarity = 1 << iota
+	occNeg
+)
+
+func (o occPolarity) both() bool { return o == occPos|occNeg }
+
+// occKey keys the occurrence walk's seen-set by (variable, polarity) so a cyclic
+// var↔var bound graph terminates while still recording every polarity a variable
+// is reached in.
+type occKey struct {
+	v   *soltype.TypeVarType
+	pol soltype.Polarity
+}
+
+// analyzeOccurrences walks the bound graph rooted at t (the same traversal
+// coalesce uses: covariant children at pol, contravariant func params flipped,
+// each variable's BoundsAt(pol)) recording into occ which polarities every
+// variable occurs in. A variable appearing in both a covariant and a
+// contravariant position — the identity function's shared param/return var — comes
+// out as occPos|occNeg; a result/indirection variable that only ever flows
+// outward comes out as occPos alone. coalesceScheme then retains the former as a
+// quantified type parameter and inlines the latter to its bound.
+func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.TypeVarType]occPolarity, seen set.Set[occKey]) {
+	switch t := t.(type) {
+	case *soltype.FuncType:
+		for _, p := range t.Params {
+			analyzeOccurrences(p.Type, pol.Flip(), occ, seen) // params contravariant
+		}
+		analyzeOccurrences(t.Ret, pol, occ, seen) // covariant return
+	case *soltype.TupleType:
+		for _, e := range t.Elems {
+			analyzeOccurrences(e, pol, occ, seen)
+		}
+	case *soltype.RecordType:
+		for _, f := range t.Fields {
+			analyzeOccurrences(f.Type, pol, occ, seen)
+		}
+	case *soltype.TypeVarType:
+		if pol == soltype.Positive {
+			occ[t] |= occPos
+		} else {
+			occ[t] |= occNeg
+		}
+		k := occKey{t, pol}
+		if seen.Contains(k) {
+			return
+		}
+		seen.Add(k)
+		for _, b := range t.BoundsAt(pol) {
+			analyzeOccurrences(b, pol, occ, seen)
+		}
+	}
+}
+
+// coalesceScheme coalesces a generalized scheme's RAW body for DISPLAY, retaining
+// the variables that are genuine type parameters as named references while
+// inlining the rest to their bounds. A variable is retained iff it is
+// quantifiable (Level > genLevel) AND occurs in both polarities (single-polarity
+// elimination); every other variable is inlined exactly as coalesce does — so on
+// a body with no both-polarity quantifiable variable this reduces, node for node,
+// to coalesce(t, Positive), keeping every monomorphic render unchanged.
+//
+// This is the minimum needed to render a generalized scheme without the
+// always-pre-bound SCC indirection variable (a positive-only var) corrupting the
+// output. The remaining simplification — CO-OCCURRENCE merging of *distinct*
+// variables that always appear together, and the `parameter-only var ⇒ unknown`
+// case for variables genuinely used in one polarity — is PR2's; PR1 retains a
+// type parameter only where it is literally the same variable across positions,
+// so renders stay non-compact until then.
+func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
+	occ := map[*soltype.TypeVarType]occPolarity{}
+	analyzeOccurrences(t, soltype.Positive, occ, set.NewSet[occKey]())
+	return coalesceSchemeRec(t, soltype.Positive, genLevel, occ, set.NewSet[*soltype.TypeVarType]())
+}
+
+func coalesceSchemeRec(
+	t soltype.Type, pol soltype.Polarity, genLevel int,
+	occ map[*soltype.TypeVarType]occPolarity, seen set.Set[*soltype.TypeVarType],
+) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.PrimType, *soltype.LitType, *soltype.Void,
+		*soltype.NeverType, *soltype.UnknownType:
+		return t
+	case *soltype.FuncType:
+		params := make([]*soltype.FuncParam, len(t.Params))
+		for i, p := range t.Params {
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen)}
+		}
+		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen)}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = coalesceSchemeRec(e, pol, genLevel, occ, seen)
+		}
+		return &soltype.TupleType{Elems: elems}
+	case *soltype.RecordType:
+		fields := make([]*soltype.RecordField, len(t.Fields))
+		for i, f := range t.Fields {
+			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesceSchemeRec(f.Type, pol, genLevel, occ, seen)}
+		}
+		return &soltype.RecordType{Fields: fields}
+	case *soltype.TypeVarType:
+		retain := t.Level > genLevel && occ[t].both()
+		if seen.Contains(t) {
+			// A cycle back to a variable already on the path: a retained type
+			// parameter keeps its name (a rough μ-reference, refined in M3's precise
+			// μ-rendering), an inlined variable collapses to the polarity identity.
+			if retain {
+				return t
+			}
+			return emptyOf(pol)
+		}
+		seen.Add(t)
+		defer seen.Remove(t)
+		bounds := make([]soltype.Type, 0, len(t.BoundsAt(pol)))
+		for _, b := range t.BoundsAt(pol) {
+			bounds = append(bounds, coalesceSchemeRec(b, pol, genLevel, occ, seen))
+		}
+		if retain {
+			// Keep the variable as a named type parameter, merged with its coalesced
+			// bounds (variable first, so it names earliest): v | bounds in positive
+			// position, v & bounds in negative. Empty bounds ⇒ just the variable.
+			return combine(pol, dedup(append([]soltype.Type{t}, bounds...)))
+		}
+		if len(bounds) == 0 {
+			return emptyOf(pol)
+		}
+		return combine(pol, dedup(bounds))
+	}
+	panic(fmt.Sprintf("coalesceScheme: unhandled %T", t))
+}
+
+// schemeType returns a scheme's coalesced DISPLAY type (variable-free except for
+// retained type parameters), the soltype handed to soltype.PrintScheme and
+// recorded in Info. A MonoScheme coalesces uniformly (no retained parameters); a
+// PolyScheme retains its quantified parameters via coalesceScheme.
+func schemeType(s TypeScheme) soltype.Type {
+	switch sc := s.(type) {
+	case *MonoScheme:
+		return coalesce(sc.Ty, soltype.Positive)
+	case *PolyScheme:
+		return coalesceScheme(sc.Body, sc.Level)
+	}
+	panic(fmt.Sprintf("schemeType: unknown TypeScheme %T", s))
+}
+
+// renderScheme renders a scheme to its Escalier type-annotation string, with a
+// <T0, …> quantifier prefix when generalization left type parameters behind.
+func renderScheme(s TypeScheme) string {
+	return soltype.PrintScheme(schemeType(s))
+}
+
 // emptyOf returns the lattice identity for a polarity: never (⊥, the identity of
 // |) for a positive position with no lower bounds, unknown (⊤, the identity of &)
 // for a negative position with no upper bounds. Shared by the empty-bounds and
@@ -134,11 +292,16 @@ func dedup(parts []soltype.Type) []soltype.Type {
 	return out
 }
 
-// equalType is structural equality over the M1 coalesced type set. Coalesced
-// output contains no TypeVarTypes (every variable has been inlined), so the
-// variable case is unreachable here and intentionally omitted.
+// equalType is structural equality over the coalesced type set. A monomorphic
+// coalesce produces no TypeVarTypes, but coalesceScheme RETAINS quantified type
+// parameters as named references, so a generalized scheme's display type can carry
+// variables — compared here by pointer identity (the same var is one type
+// parameter), which is what lets dedup collapse `T0 & T0` to `T0`.
 func equalType(a, b soltype.Type) bool {
 	switch a := a.(type) {
+	case *soltype.TypeVarType:
+		b, ok := b.(*soltype.TypeVarType)
+		return ok && a == b
 	case *soltype.PrimType:
 		b, ok := b.(*soltype.PrimType)
 		return ok && a.Prim == b.Prim

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -24,7 +24,7 @@
 // FromInstantiation provenance edge (prov.go), and scheme rendering — occurrence
 // analysis + single-polarity elimination retaining genuine type parameters
 // (coalesce.go's coalesceScheme) with the printer's <T0, …> quantifier prefix
-// (soltype.PrintScheme). What remains of the polymorphism-rendering bundle is
+// (soltype.PrintAsScheme). What remains of the polymorphism-rendering bundle is
 // PR2's CO-OCCURRENCE merging (distinct variables that always appear together),
 // which makes renders compact where the same variable isn't already shared across
 // positions; generalize's simplify hook is a no-op until then.

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -17,12 +17,21 @@
 // Info side table's key type); neither ast nor type_system imports solver, so
 // the package is acyclic and additive — it shares no code with type_system.
 //
-// What M1 deliberately omits (each lands in a later milestone): the AST-driven
-// inference walk and parser/resolver bridge (M2), let-generalization and type
-// schemes (M3), the polymorphism-rendering bundle — occurrence analysis,
-// bipolar-variable retention, named-type-param refs, co-occurrence merging, and
-// the quantifier prefix in the printer (M3), records / mut / lifetimes (M4),
-// classes and the union/intersection *subtyping rules* in constrain (M5/M6), and
-// type-level operators (M5/M8). M1 ships UnionType/IntersectionType *nodes* for
-// coalesced output, but their lattice rules in constrain remain deferred.
+// M3 (PR1) adds let-generalization on top of M2's walk: TypeSchemes (poly.go —
+// MonoScheme/PolyScheme + ValueBinding.Schemes), instantiate/freshenAbove for
+// per-use fresh variables, generalization at the SCC boundary (module.go) and at
+// body-level `val`s (infer_decl.go), the inferIdent instantiation hook, the
+// FromInstantiation provenance edge (prov.go), and scheme rendering — occurrence
+// analysis + single-polarity elimination retaining genuine type parameters
+// (coalesce.go's coalesceScheme) with the printer's <T0, …> quantifier prefix
+// (soltype.PrintScheme). What remains of the polymorphism-rendering bundle is
+// PR2's CO-OCCURRENCE merging (distinct variables that always appear together),
+// which makes renders compact where the same variable isn't already shared across
+// positions; generalize's simplify hook is a no-op until then.
+//
+// What is still deferred (each lands in a later milestone): records / mut /
+// lifetimes (M4), function overloading (M3 PR6) and the probe (PR5), classes and
+// the union/intersection *subtyping rules* in constrain (M5/M6), and type-level
+// operators (M5/M8). M1 ships UnionType/IntersectionType *nodes* for coalesced
+// output, but their lattice rules in constrain remain deferred.
 package solver

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -46,9 +46,11 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		return initType, &ast.NodeProvenance{Node: d}, true
 	case *ast.FuncDecl:
 		b := c.inferFuncDecl(scope, lvl, d)
-		// inferFuncDecl always records exactly one source (this decl); inferComponent
+		// inferFuncDecl always records exactly one source (this decl) and wraps the
+		// RAW func type in a single MonoScheme; inferComponent constrains that raw
+		// type into the group var and generalizes once the group is complete, and
 		// accumulates these per-decl sources into the binding's Sources slice.
-		return b.Type, b.Sources[0], true
+		return b.Schemes[0].(*MonoScheme).Ty, b.Sources[0], true
 	default:
 		c.reportUnsupported(d)
 		return nil, nil, false
@@ -93,20 +95,24 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	return initT, true
 }
 
-// inferVarDecl types a `val`/`var` into a MONOMORPHIC ValueBinding, coalescing the
-// initializer at Positive polarity now (coalesce-at-binding, §7) so the stored type
-// is var-free and stable. This is the body-level path (§3.2), safe to coalesce
-// eagerly because a body-level `val` is never part of a recursive top-level group;
-// the SCC driver keeps the raw type instead (see inferDeclDef). ok=false when there
-// is no initializer.
+// inferVarDecl types a body-level `val`/`var` into a GENERALIZED ValueBinding —
+// the let-polymorphism rule (M3, PR1) that replaces M2's coalesce-at-binding
+// freeze. It infers the initializer one level deeper (lvl+1) and generalizes at
+// lvl: variables created in the RHS (level > lvl) become reusable type parameters,
+// while variables captured from an enclosing scope (level <= lvl) stay shared — so
+// `fn (y) { val getY = fn () { y }; [getY(), getY()] }` keeps getY's captured `y`
+// instead of freezing it to `never`, the bug eager coalescing caused. A body-level
+// `val` is never recursive (the name is bound only after its initializer is typed),
+// so there is no pre-binding/group var; the SCC driver owns the recursive top-level
+// path (see inferDeclDef). ok=false when there is no initializer.
 func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
-	initType, ok := c.inferVarDeclInit(scope, lvl, d)
+	initType, ok := c.inferVarDeclInit(scope, lvl+1, d)
 	if !ok {
 		return ValueBinding{}, false
 	}
-	t := coalesce(initType, soltype.Positive)
-	c.recordType(d.Pattern, t)
-	return ValueBinding{Type: t, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true
+	scheme := c.generalize(initType, lvl)
+	c.recordType(d.Pattern, schemeType(scheme))
+	return ValueBinding{Schemes: []TypeScheme{scheme}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
@@ -130,5 +136,9 @@ func varName(d *ast.VarDecl) (string, bool) {
 // overload arms; the overload-intersection representation is M3.
 func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
 	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
-	return ValueBinding{Type: t, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}
+	// The binding holds the RAW func type in a single MonoScheme; the SCC driver
+	// (inferComponent) constrains it into the group var and generalizes the group
+	// once complete (PR1). inferDeclDef unwraps this MonoScheme to recover the raw
+	// type.
+	return ValueBinding{Schemes: []TypeScheme{monoScheme(t)}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -112,7 +112,7 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	}
 	scheme := c.generalize(initType, lvl)
 	// The recorded display type retains any quantified type-parameter vars (it is
-	// not var-free), so Info consumers must render it with soltype.PrintScheme, not
+	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
 	// plain soltype.Print — same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
 	return ValueBinding{Schemes: []TypeScheme{scheme}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -45,12 +45,12 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		}
 		return initType, &ast.NodeProvenance{Node: d}, true
 	case *ast.FuncDecl:
-		b := c.inferFuncDecl(scope, lvl, d)
-		// inferFuncDecl always records exactly one source (this decl) and wraps the
-		// RAW func type in a single MonoScheme; inferComponent constrains that raw
-		// type into the group var and generalizes once the group is complete, and
-		// accumulates these per-decl sources into the binding's Sources slice.
-		return b.Schemes[0].(*MonoScheme).Ty, b.Sources[0], true
+		// inferFuncDecl returns the RAW func type and its source directly;
+		// inferComponent constrains that raw type into the group var, generalizes
+		// once the group is complete, and accumulates the per-decl source into the
+		// binding's Sources slice.
+		t, src := c.inferFuncDecl(scope, lvl, d)
+		return t, src, true
 	default:
 		c.reportUnsupported(d)
 		return nil, nil, false
@@ -111,6 +111,9 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 		return ValueBinding{}, false
 	}
 	scheme := c.generalize(initType, lvl)
+	// The recorded display type retains any quantified type-parameter vars (it is
+	// not var-free), so Info consumers must render it with soltype.PrintScheme, not
+	// plain soltype.Print — same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
 	return ValueBinding{Schemes: []TypeScheme{scheme}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true
 }
@@ -126,19 +129,17 @@ func varName(d *ast.VarDecl) (string, bool) {
 	return "", false
 }
 
-// inferFuncDecl types a function declaration into a monomorphic ValueBinding,
-// reusing the shared inferFunc core (infer_expr.go) on the decl's signature and
-// body. Like inferVarDecl it returns the binding rather than defining it, so the
-// caller owns scope placement: the SCC driver (inferComponent) binds a
+// inferFuncDecl types a function declaration and returns its RAW (un-coalesced,
+// variable-carrying) func type plus its provenance, NOT a ValueBinding: the SCC
+// driver (inferComponent) owns scope placement and generalization. It binds a
 // self/mutually recursive group to a fresh var first so each body can see itself
-// (and its group peers), then rebinds to the inferred type. Repeated top-level
-// FuncDecls under one name are constrained into the same var as monomorphic
-// overload arms; the overload-intersection representation is M3.
-func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) ValueBinding {
+// (and its group peers), constrains this raw type into that var, and generalizes
+// the group once complete (PR1). Returning the raw type directly (rather than
+// round-tripping through a single-MonoScheme ValueBinding) removes the unchecked
+// `.(*MonoScheme)` assertion the SCC driver would otherwise need. Repeated
+// top-level FuncDecls under one name are constrained into the same var as
+// monomorphic overload arms; the overload-intersection representation is M3.
+func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) (soltype.Type, provenance.Provenance) {
 	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
-	// The binding holds the RAW func type in a single MonoScheme; the SCC driver
-	// (inferComponent) constrains it into the group var and generalizes the group
-	// once complete (PR1). inferDeclDef unwraps this MonoScheme to recover the raw
-	// type.
-	return ValueBinding{Schemes: []TypeScheme{monoScheme(t)}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}
+	return t, &ast.NodeProvenance{Node: d}
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -33,8 +33,15 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 
 // inferIdent resolves a value-position identifier through the scope chain — the
 // production form of the spike's *Var case crossed with design-notes §"The
-// constraint-generating AST walk". In M2 (monomorphic, no schemes) it returns
-// the binding's type directly; M3 slots instantiate() in once schemes exist.
+// constraint-generating AST walk". M3 (PR1) slots in the instantiation hook M2
+// left as a TODO: an ordinary binding instantiates its sole scheme at the current
+// level, so a polymorphic let gives each use fresh variables (a MonoScheme
+// instantiates to itself, preserving M2's behavior for the monomorphic bindings).
+//
+// An overloaded binding's value-position type is the intersection of its arms,
+// resolved through the probe — that is PR6 and unreachable today (M2 rejects
+// multi-FuncDecl names, so no overloaded binding is ever bound), so PR1 asserts
+// the single-scheme invariant rather than branching on it.
 //
 // A namespace name in value position can only fail in M2: there is no legal
 // namespace-member position yet (MemberExpr is value-only and there is no
@@ -43,8 +50,11 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 // qualified Foo.bar access lands.
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
 	if b, ok := scope.GetValue(e.Name); ok {
-		c.recordType(e, b.Type)
-		return b.Type
+		// PR1 never builds an overloaded binding; the IsOverloaded value-position
+		// branch (arm intersection) is PR6.
+		t := c.instantiate(b.Schemes[0], lvl)
+		c.recordType(e, t)
+		return t
 	}
 	if _, ok := scope.GetNamespace(e.Name); ok {
 		return c.report(&NamespaceUsedAsValueError{Ident: e})
@@ -118,7 +128,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// by resolveTypeAnn.
 			c.recordProv(pt, p.Pattern, ParamBinding)
 		}
-		fnScope.defineValue(name, ValueBinding{Type: pt})
+		// A parameter binding never generalizes — its var is fixed for the body — so
+		// it is a MonoScheme; instantiate returns pt unchanged at every use.
+		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
 		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt}
 	}
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -49,9 +49,14 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 // correct here. M4 moves that error to the value-position consumer once
 // qualified Foo.bar access lands.
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
-	if b, ok := scope.GetValue(e.Name); ok {
-		// PR1 never builds an overloaded binding; the IsOverloaded value-position
-		// branch (arm intersection) is PR6.
+	// A live binding always has at least one scheme (inferComponent pre-binds a
+	// fresh MonoScheme before inferring, and a failed binding is removeValue'd, not
+	// left at len 0). Guard the index anyway: the slice representation makes len>=1
+	// an invariant rather than a non-nilable field, so a malformed empty binding
+	// degrades to an unknown-identifier error here instead of an index-out-of-range
+	// panic. PR1 never builds an overloaded binding; the IsOverloaded value-position
+	// branch (arm intersection) is PR6.
+	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
 		t := c.instantiate(b.Schemes[0], lvl)
 		c.recordType(e, t)
 		return t
@@ -199,7 +204,10 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // declared return type even when the arguments don't match, so a downstream
 // expression sees the real return type rather than a poisoned `never`. constrain
 // short-circuits its FuncType arity arm before propagating the return into res,
-// so when the callee is a concrete function its return is wired through directly.
+// so the return is wired through directly here. The callee is concrete either as a
+// bare FuncType (an inline callee) OR as a var whose lower bound is a FuncType (a
+// named/generalized callee, which inferIdent now resolves through instantiate — see
+// concreteFunc); both recover, so recovery no longer regresses for named callees.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
 	callee := c.inferExpr(scope, lvl, e.Callee)
 	args := make([]*soltype.FuncParam, len(e.Args))
@@ -213,11 +221,35 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// resolves its blame to the call.
 	c.recordProv(callShape, e, CallShape)
 	c.constrain(e, callee, callShape)
-	if fn, ok := callee.(*soltype.FuncType); ok {
+	if fn, ok := concreteFunc(callee); ok {
 		c.constrain(e, fn.Ret, res)
 	}
 	c.recordType(e, res)
 	return res
+}
+
+// concreteFunc resolves a callee to the concrete FuncType to recover a call's
+// return type from. M2's inferIdent returned a binding's coalesced FuncType
+// directly, so a bare type-assertion sufficed; M3's inferIdent returns
+// instantiate(scheme), which for a named/generalized callee is a fresh var whose
+// (freshened) lower bound is the FuncType. So look through a var to its first
+// FuncType lower bound — otherwise an arity-mismatched call to a named function
+// would lose return recovery and yield `never` (the inline-callee path kept it).
+// A deferred callee with no concrete lower bound yet yields ok=false (no recovery,
+// as before). PR1 bindings have at most one func lower bound; overload sets (PR6)
+// resolve through resolveOverload, not here.
+func concreteFunc(t soltype.Type) (*soltype.FuncType, bool) {
+	switch t := t.(type) {
+	case *soltype.FuncType:
+		return t, true
+	case *soltype.TypeVarType:
+		for _, lb := range t.LowerBounds {
+			if fn, ok := lb.(*soltype.FuncType); ok {
+				return fn, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // inferTuple types a tuple literal as a soltype.TupleType of its element types

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -49,13 +49,15 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 // correct here. M4 moves that error to the value-position consumer once
 // qualified Foo.bar access lands.
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
-	// A live binding always has at least one scheme (inferComponent pre-binds a
-	// fresh MonoScheme before inferring, and a failed binding is removeValue'd, not
-	// left at len 0). Guard the index anyway: the slice representation makes len>=1
-	// an invariant rather than a non-nilable field, so a malformed empty binding
-	// degrades to an unknown-identifier error here instead of an index-out-of-range
-	// panic. PR1 never builds an overloaded binding; the IsOverloaded value-position
-	// branch (arm intersection) is PR6.
+	// Any binding still in scope has at least one scheme: inferComponent pre-binds
+	// each group member to a fresh MonoScheme, and on failure deletes the binding
+	// (scope.removeValue) rather than leaving it with an empty Schemes slice. So the
+	// len > 0 check below should never fail in practice — but Schemes is a slice, not
+	// a guaranteed-non-empty field, so we guard it anyway: a malformed empty binding
+	// degrades to an unknown-identifier error here instead of panicking on Schemes[0].
+	//
+	// PR1 never builds an overloaded binding; the IsOverloaded value-position branch
+	// (arm intersection) is PR6.
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
 		t := c.instantiate(b.Schemes[0], lvl)
 		c.recordType(e, t)
@@ -228,16 +230,16 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	return res
 }
 
-// concreteFunc resolves a callee to the concrete FuncType to recover a call's
-// return type from. M2's inferIdent returned a binding's coalesced FuncType
-// directly, so a bare type-assertion sufficed; M3's inferIdent returns
-// instantiate(scheme), which for a named/generalized callee is a fresh var whose
-// (freshened) lower bound is the FuncType. So look through a var to its first
-// FuncType lower bound — otherwise an arity-mismatched call to a named function
-// would lose return recovery and yield `never` (the inline-callee path kept it).
-// A deferred callee with no concrete lower bound yet yields ok=false (no recovery,
-// as before). PR1 bindings have at most one func lower bound; overload sets (PR6)
-// resolve through resolveOverload, not here.
+// concreteFunc resolves a callee to its concrete FuncType, used to recover a
+// call's return type. The callee is either a FuncType directly (an inline callee)
+// or a var whose first FuncType lower bound is the function (a named/generalized
+// callee, since inferIdent returns instantiate(scheme) — a fresh var). Looking
+// through the var matters because otherwise an arity-mismatched call to a named
+// function would lose return recovery and yield `never`.
+//
+// ok=false means no concrete func was found (e.g. a deferred callee with no lower
+// bound yet) — the caller skips return recovery. PR1 bindings have at most one
+// func lower bound; overload sets (PR6) resolve through resolveOverload, not here.
 func concreteFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -54,7 +54,7 @@ func TestInferLiteralUnsupported(t *testing.T) {
 func TestInferIdentResolvesBinding(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	scope.defineValue("x", ValueBinding{Type: &soltype.PrimType{Prim: soltype.NumPrim}})
+	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}})
 
 	e := ast.NewIdent("x", testSpan())
 	got := c.inferExpr(scope, 0, e)
@@ -66,7 +66,7 @@ func TestInferIdentResolvesBinding(t *testing.T) {
 func TestInferIdentResolvesThroughParent(t *testing.T) {
 	c := newChecker()
 	parent := NewScope()
-	parent.defineValue("y", ValueBinding{Type: &soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}}})
+	parent.defineValue("y", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.LitType{Lit: &soltype.StrLit{Value: "hi"}})}})
 	child := parent.Child()
 
 	e := ast.NewIdent("y", testSpan())

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -113,9 +113,9 @@ func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
 		false, true, false, testSpan(),
 	)
 
-	b := c.inferFuncDecl(NewScope(), 0, d)
+	ty, _ := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn () -> number", renderBinding(b))
+	require.Equal(t, "fn () -> number", render(ty))
 }
 
 // A bodyless function with an UNSUPPORTED return annotation recovers to `unknown`
@@ -133,10 +133,10 @@ func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 		false, true, false, testSpan(),
 	)
 
-	b := c.inferFuncDecl(NewScope(), 0, d)
+	ty, _ := c.inferFuncDecl(NewScope(), 0, d)
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: BigintTypeAnn", c.errs[0].Message())
-	require.Equal(t, "fn () -> unknown", renderBinding(b))
+	require.Equal(t, "fn () -> unknown", render(ty))
 }
 
 // A param that arrives without a pattern must report a clean error, not panic on
@@ -306,9 +306,9 @@ func TestInferFuncDecl(t *testing.T) {
 		false, false, false, testSpan(),
 	)
 
-	b := c.inferFuncDecl(NewScope(), 0, d)
+	ty, _ := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn (x: number) -> number", renderBinding(b))
+	require.Equal(t, "fn (x: number) -> number", render(ty))
 }
 
 // A truly recursive function: foo's body calls itself. PR-3 has no SCC driver
@@ -330,9 +330,9 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 		false, false, false, testSpan(),
 	)
 
-	b := c.inferFuncDecl(scope, 0, d)
+	ty, _ := c.inferFuncDecl(scope, 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn (x: number) -> never", renderBinding(b))
+	require.Equal(t, "fn (x: number) -> never", render(ty))
 }
 
 // A FuncExpr may be assigned to a body-level `val` inside a FuncDecl (the way a
@@ -353,7 +353,7 @@ func TestInferFuncDeclBodyFuncValDecl(t *testing.T) {
 		false, false, false, testSpan(),
 	)
 
-	b := c.inferFuncDecl(NewScope(), 0, d)
+	ty, _ := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn () -> fn (x: number) -> number", renderBinding(b))
+	require.Equal(t, "fn () -> fn (x: number) -> number", render(ty))
 }

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -17,6 +17,13 @@ func render(t soltype.Type) string {
 	return soltype.Print(coalesce(t, soltype.Positive))
 }
 
+// renderBinding renders a value binding's (sole, in PR1) scheme to its Escalier
+// type string — the test-side view of what a name resolves to, including any
+// <T0, …> quantifier prefix generalization left behind.
+func renderBinding(b ValueBinding) string {
+	return renderScheme(b.Schemes[0])
+}
+
 // --- FuncExpr ---
 
 func TestInferFuncExprAnnotated(t *testing.T) {
@@ -108,7 +115,7 @@ func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
 
 	b := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn () -> number", render(b.Type))
+	require.Equal(t, "fn () -> number", renderBinding(b))
 }
 
 // A bodyless function with an UNSUPPORTED return annotation recovers to `unknown`
@@ -129,7 +136,7 @@ func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 	b := c.inferFuncDecl(NewScope(), 0, d)
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: BigintTypeAnn", c.errs[0].Message())
-	require.Equal(t, "fn () -> unknown", render(b.Type))
+	require.Equal(t, "fn () -> unknown", renderBinding(b))
 }
 
 // A param that arrives without a pattern must report a clean error, not panic on
@@ -218,10 +225,10 @@ func TestInferCallArityMismatch(t *testing.T) {
 func TestInferCallThroughBinding(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	scope.defineValue("inc", ValueBinding{Type: &soltype.FuncType{
+	scope.defineValue("inc", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
 		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
-	}})
+	})}})
 	// inc(7)
 	e := ast.NewCall(identExpr("inc"), []ast.Expr{numExpr(7)}, false, testSpan())
 
@@ -301,7 +308,7 @@ func TestInferFuncDecl(t *testing.T) {
 
 	b := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn (x: number) -> number", render(b.Type))
+	require.Equal(t, "fn (x: number) -> number", renderBinding(b))
 }
 
 // A truly recursive function: foo's body calls itself. PR-3 has no SCC driver
@@ -314,7 +321,7 @@ func TestInferFuncDecl(t *testing.T) {
 func TestInferFuncDeclSelfReference(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	scope.defineValue("foo", ValueBinding{Type: c.freshAt(1)})
+	scope.defineValue("foo", ValueBinding{Schemes: []TypeScheme{monoScheme(c.freshAt(1))}})
 	// fn foo(x: number) { foo(x) }
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("foo", testSpan()), nil, nil,
@@ -325,7 +332,7 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 
 	b := c.inferFuncDecl(scope, 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn (x: number) -> never", render(b.Type))
+	require.Equal(t, "fn (x: number) -> never", renderBinding(b))
 }
 
 // A FuncExpr may be assigned to a body-level `val` inside a FuncDecl (the way a
@@ -348,5 +355,5 @@ func TestInferFuncDeclBodyFuncValDecl(t *testing.T) {
 
 	b := c.inferFuncDecl(NewScope(), 0, d)
 	require.Empty(t, c.errs)
-	require.Equal(t, "fn () -> fn (x: number) -> number", render(b.Type))
+	require.Equal(t, "fn () -> fn (x: number) -> number", renderBinding(b))
 }

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -1,0 +1,132 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// PR1 let-generalization, Category-A acceptance against real source. M2 froze
+// every top-level binding to a coalesced monotype; PR1 generalizes at the SCC
+// boundary so a polymorphic binding is instantiated fresh per use.
+//
+// Where a render is compact already in PR1 (the type parameter is literally the
+// same variable across positions, e.g. identity) the test pins the rendered
+// signature, exercising the printer's <T0, …> prefix. Where the compact form
+// needs simplification (PR2's co-occurrence merging), the test asserts the
+// two-types-of-use BEHAVIOR instead — per the plan, "assert two-types-of-use
+// behavior rather than the printed signature where simplification is
+// load-bearing."
+
+// A top-level identity generalizes to fn <T0>(x: T0) -> T0. The two-types-of-use
+// behavior is the real proof of polymorphism: a monomorphic id would constrain
+// its one param var with BOTH 5 and "hi", rendering a: 5 | "hi"; generalization
+// instantiates id fresh per call, so a: 5 and b: "hi" stay distinct.
+func TestInferModuleTopLevelLetPolymorphism(t *testing.T) {
+	t.Run("render", func(t *testing.T) {
+		// Identity's param and return are the same variable, so its render is
+		// compact even before PR2 — this pins the <T0> quantifier prefix.
+		values, _, errs := inferSource(t, `fn id(x) { x }`)
+		require.Empty(t, errs)
+		require.Equal(t, map[string]string{"id": "fn <T0>(x: T0) -> T0"}, values)
+	})
+
+	t.Run("two types of use", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			val id = fn (x) { x }
+			val a = id(5)
+			val b = id("hi")
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, map[string]string{
+			"id": "fn <T0>(x: T0) -> T0",
+			"a":  "5", // not 5 | "hi" — id is instantiated fresh per call
+			"b":  `"hi"`,
+		}, values)
+	})
+}
+
+// Applying a polymorphic identity at two different argument types in one
+// expression yields each argument's own type (not their union), so the tuple is
+// ["hello", 5]. This is the headline Category-A render — compact in PR1 because
+// every remaining variable coalesces to a concrete literal.
+func TestInferModuleIdentityPolymorphism(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val identity = fn (x) { x }
+		val pair = fn () { [identity("hello"), identity(5)] }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{
+		"identity": "fn <T0>(x: T0) -> T0",
+		"pair":     `fn () -> ["hello", 5]`,
+	}, values)
+}
+
+// A body-level inner function that captures an outer parameter keeps the capture
+// through generalization (M2's eager body-level coalescing froze it to `never`).
+// PR1's render is non-compact — `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`, which PR2's
+// co-occurrence merging collapses to `fn <T0>(y: T0) -> [T0, T0]` — so the
+// contract here is BEHAVIOR: applying outer to 5 yields [5, 5], proving y reaches
+// both result positions through the captured inner function.
+func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val outer = fn (y) {
+			val getY = fn () { y }
+			[getY(), getY()]
+		}
+		val r = outer(5)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "[5, 5]", values["r"], "the captured outer param reaches both result positions")
+	// outer is generalized (not frozen): its signature carries a quantifier prefix.
+	require.Contains(t, values["outer"], "fn <", "outer should generalize over its captured param")
+}
+
+// Let-polymorphism extends to body-level `val`s: an inner polymorphic function
+// used at two types within the same body resolves each use independently. A
+// monomorphic body-level binding (M2) would render [5 | "hi", 5 | "hi"].
+func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val f = fn () {
+			val id = fn (x) { x }
+			[id(5), id("hi")]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{"f": `fn () -> [5, "hi"]`}, values)
+}
+
+// A polymorphic function with a parameter-only variable: the second param is
+// never used, so its variable occurs only negatively and coalesces to `unknown`
+// (single-polarity elimination), while the first param stays a type parameter.
+// Per-call instantiation keeps k(1, "z") and k("s", true) at distinct types.
+func TestInferModulePolymorphicWithParameterOnlyVar(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val k = fn (x, y) { x }
+		val a = k(1, "z")
+		val b = k("s", true)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{
+		"k": "fn <T0>(x: T0, y: unknown) -> T0",
+		"a": "1",
+		"b": `"s"`,
+	}, values)
+}
+
+// A recursive group generalizes without looping (the coalesce seen-guard, shipped
+// in M2 PR-5, keeps the cyclic var↔var bound graph total under generalization too).
+// The ungrounded mutual recursion bottoms out: each param is unused (parameter-only
+// ⇒ unknown) and each return is an ungrounded recursive position (⇒ never). The
+// real contract is that inference TERMINATES rather than hangs.
+func TestInferModuleRecursiveGroupGeneralizesWithoutLooping(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn ping(n) { pong(n) }
+		fn pong(n) { ping(n) }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{
+		"ping": "fn (n: unknown) -> never",
+		"pong": "fn (n: unknown) -> never",
+	}, values)
+}

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -52,7 +52,12 @@ func parseModule(t *testing.T, src string) *ast.Module {
 // Only inference errors flow back; parse errors fail the test in parseModuleFiles.
 func inferModule(module *ast.Module) (values, types map[string]string, errs []SolverError) {
 	scope, _, errs := InferModule(module)
-	values = renderBindings(scope.values, func(b ValueBinding) soltype.Type { return b.Type })
+	values = make(map[string]string, len(scope.values))
+	for name, b := range scope.values {
+		// PR1: every binding holds exactly one scheme; renderScheme adds the
+		// <T0, …> quantifier prefix when generalization left type parameters behind.
+		values[name] = renderScheme(b.Schemes[0])
+	}
 	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
 	return values, types, errs
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -513,3 +513,18 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
 	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
 }
+
+// Error recovery for a NAMED callee: an arity-mismatched call still yields the
+// callee's declared return type (not `never`), matching the inline-callee recovery
+// asserted by TestInferCallArityMismatch. M3's inferIdent returns an instantiated
+// var rather than a concrete FuncType, so inferCall recovers the return through the
+// var's FuncType lower bound (concreteFunc); without that, `r` regressed to `never`.
+func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		val r = f(1, 2)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", errs[0].Message())
+	require.Equal(t, "number", values["r"], "the result recovers to the declared return, not never")
+}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -227,7 +227,7 @@ func (c *checker) inferComponent(
 		//
 		// NOTE: for a GENERALIZED binding this display type RETAINS its quantified
 		// type-parameter variables (it is not var-free), so consumers must render it
-		// with soltype.PrintScheme — plain soltype.Print renders those vars as the
+		// with soltype.PrintAsScheme — plain soltype.Print renders those vars as the
 		// raw `t{ID}` debug form. (renderScheme is the canonical renderer.)
 		display := schemeType(scheme)
 		switch d := b.primary.(type) {

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -220,11 +220,15 @@ func (c *checker) inferComponent(
 		scheme := c.generalize(b.v, lvl)
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources})
 		// Record the binding's final (coalesced) DISPLAY type in Info on the name
-		// node. The raw initializer path (inferDeclDef) no longer records it, so this
-		// is where the var-free type lands — and it is correct even for a `val` in a
-		// recursive group, where coalescing at definition time would have frozen it
-		// to `never`. A VarDecl records on its pattern, a FuncDecl on its name, so a
-		// top-level `fn` is queryable through Info exactly like a `val`.
+		// node, so it is queryable even for a `val` in a recursive group (where
+		// coalescing at definition time would have frozen it to `never`). A VarDecl
+		// records on its pattern, a FuncDecl on its name, so a top-level `fn` is
+		// queryable through Info exactly like a `val`.
+		//
+		// NOTE: for a GENERALIZED binding this display type RETAINS its quantified
+		// type-parameter variables (it is not var-free), so consumers must render it
+		// with soltype.PrintScheme — plain soltype.Print renders those vars as the
+		// raw `t{ID}` debug form. (renderScheme is the canonical renderer.)
 		display := schemeType(scheme)
 		switch d := b.primary.(type) {
 		case *ast.VarDecl:

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -123,7 +123,10 @@ func (c *checker) inferComponent(
 		}
 		v := c.freshAt(inner)
 		bindings[key] = &componentBinding{v: v}
-		scope.defineValue(key.Name(), ValueBinding{Type: v})
+		// Pre-bind the group var as a MonoScheme so a mutually-recursive reference
+		// resolves through the var itself (instantiate returns it unchanged) before
+		// generalization happens in phase 3.
+		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{monoScheme(v)}})
 	}
 
 	// Phase 2: infer each declaration's definition and constrain it <: its var.
@@ -210,20 +213,25 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
-		t := coalesce(b.v, soltype.Positive)
-		scope.defineValue(key.Name(), ValueBinding{Type: t, Sources: b.sources})
-		// Record the binding's final (coalesced) type in Info on the name node. The
-		// raw initializer path (inferDeclDef) no longer records it, so this is where
-		// the var-free type lands — and it is correct even for a `val` in a
+		// Generalize the group var at the component's level (was: coalesce to a
+		// monotype). Every variable at Level > lvl becomes a quantified type
+		// parameter, captured outer variables do not — turning M2's monomorphic
+		// freeze into real let-polymorphism (PR1).
+		scheme := c.generalize(b.v, lvl)
+		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources})
+		// Record the binding's final (coalesced) DISPLAY type in Info on the name
+		// node. The raw initializer path (inferDeclDef) no longer records it, so this
+		// is where the var-free type lands — and it is correct even for a `val` in a
 		// recursive group, where coalescing at definition time would have frozen it
 		// to `never`. A VarDecl records on its pattern, a FuncDecl on its name, so a
 		// top-level `fn` is queryable through Info exactly like a `val`.
+		display := schemeType(scheme)
 		switch d := b.primary.(type) {
 		case *ast.VarDecl:
-			c.recordType(d.Pattern, t)
+			c.recordType(d.Pattern, display)
 		case *ast.FuncDecl:
 			if d.Name != nil {
-				c.recordType(d.Name, t)
+				c.recordType(d.Name, display)
 			}
 		}
 	}

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -75,7 +75,25 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 // three onto a shared soltype rewriting visitor with no behavior change. Unlike
 // those two it ignores polarity (it freshens uniformly, no variance flip).
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
-	// Every variable inside t is at or below lim: nothing to freshen, share it.
+	// Every variable inside t is at or below lim: nothing to freshen, SHARE the node
+	// (the original pointer flows through unchanged). Two consequences worth naming:
+	//
+	//  1. (Soundness coupling) LevelOf returns a *TypeVarType's own Level only — it
+	//     does NOT descend into the var's bounds, and returns 0 for Union/Intersection.
+	//     This early return is therefore sound only because the MLsub level invariant
+	//     holds (a var's level >= the level of everything in its bounds, maintained by
+	//     constrain/extrude) and raw scheme bodies contain no Union/Intersection. The
+	//     analogous extrude (constrain.go) rests on the same assumption. If a future
+	//     change breaks either, a Level>lim var could hide under a shared node and two
+	//     instantiations would alias a variable that should have been fresh — revisit
+	//     when Union/Intersection become constrain inputs (M6).
+	//  2. (Identity) The shared subtree's pointer is reused across every instantiation
+	//     and the scheme body, so compound nodes are NOT uniquely minted per use. Prov
+	//     and Info are pointer-keyed; a shared monomorphic node keeps its one original
+	//     entry (which is what lets a concrete callee's blame resolve), but the
+	//     "unique pointer per mint" property recordProv's debugProv guard assumes does
+	//     not hold for these shared nodes. Anything recording provenance against an
+	//     instantiated node must account for the sharing.
 	if soltype.LevelOf(t) <= lim {
 		return t
 	}
@@ -89,7 +107,7 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 		// Mint the FromInstantiation interior edge: the fresh var was copied from t.
 		// PR1 only records the edge; the multi-hop renderer that chases it back to an
 		// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
-		c.prov[nv] = FromInstantiation{From: t}
+		c.recordInstantiation(nv, t)
 		nv.LowerBounds = c.freshenBounds(lim, t.LowerBounds, lvl, cache)
 		nv.UpperBounds = c.freshenBounds(lim, t.UpperBounds, lvl, cache)
 		return nv

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -1,0 +1,150 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/soltype"
+
+// TypeScheme is a name's generalized type — the M3 replacement for M2's plain
+// soltype.Type binding. A MonoScheme is a value that does not generalize (a
+// parameter, a current-level RHS during inference, a body-level `val`, a prelude
+// operator); a PolyScheme carries a generalize-level so each use can be
+// instantiated with fresh variables (let-polymorphism). The IsAnnotated bit is
+// forward-looking metadata for PR6's overload-recursion gate — PR1 sets it false
+// and never reads it.
+type TypeScheme interface {
+	isScheme()
+	// IsAnnotated reports whether this scheme came from a user-written signature.
+	// PR1 always returns false; PR6 sets it per overload arm and folds it over a
+	// binding's arms for the mutual-recursion-needs-annotation rule.
+	IsAnnotated() bool
+}
+
+// MonoScheme is a non-generalized type. instantiate returns its Ty unchanged, so
+// every use shares the same variables — the monomorphic discipline M2 had for
+// every binding, now scoped to the bindings that genuinely must not generalize.
+type MonoScheme struct {
+	Ty        soltype.Type
+	Annotated bool // PR6 only — consulted solely for overload arms
+}
+
+// PolyScheme is a generalized type. Body is the RAW (variable-carrying) type so
+// instantiate can freshen it; every variable in Body with Level > Level is a
+// quantified type parameter (freshened per use), variables at Level <= Level are
+// captured from an enclosing scope (shared across uses). Level is the level the
+// binding was generalized at (the SCC component's level).
+type PolyScheme struct {
+	Level     int
+	Body      soltype.Type
+	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
+}
+
+func (*MonoScheme) isScheme() {}
+func (*PolyScheme) isScheme() {}
+
+func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
+func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }
+
+// monoScheme wraps a raw type as a single-scheme value binding's scheme — the
+// common case for the param/prelude/body-level/raw-def bindings PR1 does not
+// generalize.
+func monoScheme(t soltype.Type) TypeScheme { return &MonoScheme{Ty: t} }
+
+// instantiate produces a usable type from a scheme at level lvl. A MonoScheme
+// instantiates to its type unchanged; a PolyScheme freshens every quantified
+// variable (Level > scheme.Level) with a fresh variable at lvl, bounds and all,
+// so two uses of a polymorphic binding never share inference variables. This is
+// the inferIdent value-position hook M2 left as a TODO — M2 returned the binding
+// type directly; PR1 routes it through here.
+func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
+	switch sc := s.(type) {
+	case *MonoScheme:
+		return sc.Ty
+	case *PolyScheme:
+		return c.freshenAbove(sc.Level, sc.Body, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	}
+	panic("instantiate: unknown TypeScheme")
+}
+
+// freshenAbove copies t, replacing each variable with Level > lim by a fresh
+// variable at lvl (its bounds freshened too) and sharing every variable at
+// Level <= lim. It is the per-use instantiation copy: the cache maps an original
+// variable to its single fresh counterpart so repeated occurrences (and cyclic
+// bounds) of one variable stay one variable. The fresh variable is inserted into
+// the cache BEFORE its bounds are freshened so a recursive bound that references
+// the original resolves to the in-progress copy rather than looping.
+//
+// PR1 lands this hand-rolled, parallel to coalesce/extrude; PR7 collapses all
+// three onto a shared soltype rewriting visitor with no behavior change. Unlike
+// those two it ignores polarity (it freshens uniformly, no variance flip).
+func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
+	// Every variable inside t is at or below lim: nothing to freshen, share it.
+	if soltype.LevelOf(t) <= lim {
+		return t
+	}
+	switch t := t.(type) {
+	case *soltype.TypeVarType:
+		if nv, ok := cache[t]; ok {
+			return nv
+		}
+		nv := c.freshAt(lvl)
+		cache[t] = nv
+		// Mint the FromInstantiation interior edge: the fresh var was copied from t.
+		// PR1 only records the edge; the multi-hop renderer that chases it back to an
+		// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
+		c.prov[nv] = FromInstantiation{From: t}
+		nv.LowerBounds = c.freshenBounds(lim, t.LowerBounds, lvl, cache)
+		nv.UpperBounds = c.freshenBounds(lim, t.UpperBounds, lvl, cache)
+		return nv
+	case *soltype.FuncType:
+		params := make([]*soltype.FuncParam, len(t.Params))
+		for i, p := range t.Params {
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache)}
+		}
+		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache)}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = c.freshenAbove(lim, e, lvl, cache)
+		}
+		return &soltype.TupleType{Elems: elems}
+	case *soltype.RecordType:
+		fields := make([]*soltype.RecordField, len(t.Fields))
+		for i, f := range t.Fields {
+			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.freshenAbove(lim, f.Type, lvl, cache)}
+		}
+		return &soltype.RecordType{Fields: fields}
+	default:
+		// PrimType/LitType/Void/NeverType/UnknownType and the coalesced-only
+		// Union/IntersectionType have no level-bearing children reachable here.
+		return t
+	}
+}
+
+func (c *checker) freshenBounds(lim int, bounds []soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) []soltype.Type {
+	if len(bounds) == 0 {
+		return nil
+	}
+	out := make([]soltype.Type, len(bounds))
+	for i, b := range bounds {
+		out[i] = c.freshenAbove(lim, b, lvl, cache)
+	}
+	return out
+}
+
+// generalize turns the inferred type of a binding (its SCC group var) into a
+// PolyScheme quantified at lvl: every variable with Level > lvl becomes a type
+// parameter, captured outer variables (Level <= lvl) stay monomorphic. Body is
+// kept RAW for instantiation — coalescing for display happens later (schemeType /
+// renderScheme), never here.
+//
+// simplify is the PR2 hook (single-polarity elimination + co-occurrence merging);
+// PR1 lands it as a no-op so renders are non-compact until PR2 wires it in.
+func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
+	t = c.simplify(t, lvl)
+	return &PolyScheme{Level: lvl, Body: t}
+}
+
+// simplify is the PR2 simplification pass, a no-op in PR1. PR2 replaces the body
+// with occurrence analysis → co-occurrence union-find → rewrite so generalized
+// signatures render compactly and parameter-only variables coalesce to `unknown`.
+func (c *checker) simplify(t soltype.Type, _ int) soltype.Type {
+	return t
+}

--- a/internal/solver/poly_test.go
+++ b/internal/solver/poly_test.go
@@ -1,0 +1,121 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A MonoScheme instantiates to its exact type — same pointer, no freshening — so a
+// monomorphic binding behaves as M2's plain type did.
+func TestInstantiateMonoSchemeReturnsSameType(t *testing.T) {
+	c := newChecker()
+	ty := &soltype.PrimType{Prim: soltype.NumPrim}
+	got := c.instantiate(monoScheme(ty), 0)
+	require.Same(t, ty, got)
+}
+
+// A PolyScheme instantiates each quantified variable (Level > scheme.Level) to a
+// FRESH variable, so two uses never share a variable; the freshened function keeps
+// the same shape (param var == return var for identity).
+func TestInstantiatePolySchemeFreshensQuantifiedVars(t *testing.T) {
+	c := newChecker()
+	// A generalized identity: fn(a) -> a, with `a` quantifiable (Level 1 > 0).
+	a := &soltype.TypeVarType{ID: 100, Level: 1}
+	body := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: a}},
+		Ret:    a,
+	}
+	scheme := &PolyScheme{Level: 0, Body: body}
+
+	first := c.instantiate(scheme, 0).(*soltype.FuncType)
+	second := c.instantiate(scheme, 0).(*soltype.FuncType)
+
+	fv1 := first.Params[0].Type.(*soltype.TypeVarType)
+	fv2 := second.Params[0].Type.(*soltype.TypeVarType)
+	// Each instantiation freshens `a` to a new variable...
+	require.NotSame(t, a, fv1)
+	require.NotSame(t, fv1, fv2)
+	// ...but within one instantiation the param var and return var stay shared.
+	require.Same(t, fv1, first.Ret)
+	require.Same(t, fv2, second.Ret)
+}
+
+// freshenAbove SHARES variables at or below the limit (captured outer variables)
+// while freshening those above it — the level discipline that keeps a captured
+// param monomorphic when an inner function is instantiated.
+func TestFreshenAboveSharesCapturedVars(t *testing.T) {
+	c := newChecker()
+	captured := &soltype.TypeVarType{ID: 1, Level: 1}   // at the limit → shared
+	quantified := &soltype.TypeVarType{ID: 2, Level: 2} // above the limit → freshened
+	body := &soltype.TupleType{Elems: []soltype.Type{captured, quantified}}
+
+	got := c.freshenAbove(1, body, 5, map[*soltype.TypeVarType]*soltype.TypeVarType{}).(*soltype.TupleType)
+	require.Same(t, captured, got.Elems[0], "a captured var (Level <= lim) is shared")
+	fresh := got.Elems[1].(*soltype.TypeVarType)
+	require.NotSame(t, quantified, fresh, "a quantified var (Level > lim) is freshened")
+	require.Equal(t, 5, fresh.Level, "the fresh var sits at the instantiation level")
+}
+
+// freshenAbove freshens a variable's BOUNDS too, and terminates on a cyclic bound
+// graph (the fresh var is cached before its bounds are freshened).
+func TestFreshenAboveFreshensBoundsAndHandlesCycles(t *testing.T) {
+	c := newChecker()
+	v := &soltype.TypeVarType{ID: 1, Level: 2}
+	v.LowerBounds = []soltype.Type{&soltype.PrimType{Prim: soltype.NumPrim}}
+	v.UpperBounds = []soltype.Type{v} // self-referential bound
+
+	require.NotPanics(t, func() {
+		got := c.freshenAbove(0, v, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{}).(*soltype.TypeVarType)
+		require.NotSame(t, v, got)
+		require.Len(t, got.LowerBounds, 1)
+		require.Equal(t, &soltype.PrimType{Prim: soltype.NumPrim}, got.LowerBounds[0])
+		// The cyclic upper bound is rewritten to the fresh var, not the original.
+		require.Same(t, got, got.UpperBounds[0])
+	})
+}
+
+// instantiate records a FromInstantiation provenance edge for each freshened
+// variable, pointing back at the variable it was copied from — the first interior
+// Origin (M3, PR1). A MonoScheme instantiation records nothing (it freshens no
+// variable).
+func TestInstantiateRecordsFromInstantiation(t *testing.T) {
+	c := newChecker()
+	a := &soltype.TypeVarType{ID: 1, Level: 1}
+	scheme := &PolyScheme{Level: 0, Body: a}
+
+	got := c.instantiate(scheme, 0)
+	o, ok := c.prov[got]
+	require.True(t, ok, "the freshened var should carry a provenance edge")
+	fi, ok := o.(FromInstantiation)
+	require.True(t, ok, "the edge is FromInstantiation")
+	require.Same(t, a, fi.From, "it points back at the original quantified var")
+
+	// NodeFor still resolves only FromAST leaves; the interior chain renderer is M11.5.
+	_, ok = c.prov.NodeFor(got)
+	require.False(t, ok)
+}
+
+// generalize wraps a type in a PolyScheme at the given level; the body is kept RAW
+// (the same variables, for instantiation) rather than coalesced.
+func TestGeneralizeWrapsRawBody(t *testing.T) {
+	c := newChecker()
+	a := &soltype.TypeVarType{ID: 1, Level: 1}
+	scheme := c.generalize(a, 0)
+	ps, ok := scheme.(*PolyScheme)
+	require.True(t, ok)
+	require.Equal(t, 0, ps.Level)
+	require.Same(t, a, ps.Body, "generalize keeps the raw body for instantiation")
+}
+
+// IsOverloaded reflects the scheme-slice cardinality: one scheme is an ordinary
+// binding, more than one is an overload set (PR6). PR1 only ever builds the former.
+func TestValueBindingIsOverloaded(t *testing.T) {
+	ordinary := ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.NeverType{})}}
+	require.False(t, ordinary.IsOverloaded())
+	overloaded := ValueBinding{Schemes: []TypeScheme{
+		monoScheme(&soltype.NeverType{}), monoScheme(&soltype.NeverType{}),
+	}}
+	require.True(t, overloaded.IsOverloaded())
+}

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -83,7 +83,9 @@ func addOperatorBindings(s *Scope) {
 
 	define := func(t soltype.Type, names ...string) {
 		for _, name := range names {
-			s.defineValue(name, ValueBinding{Type: t})
+			// Prelude operators are monomorphic over primitives — a MonoScheme that
+			// instantiates to itself (generic operators are a later milestone).
+			s.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
 		}
 	}
 

--- a/internal/solver/prelude_test.go
+++ b/internal/solver/prelude_test.go
@@ -32,7 +32,7 @@ func TestPreludeOperatorBindings(t *testing.T) {
 		t.Run(tt.op, func(t *testing.T) {
 			b, ok := s.GetValue(tt.op)
 			require.True(t, ok, "operator %q should be bound in the prelude", tt.op)
-			require.Equal(t, tt.want, soltype.Print(b.Type))
+			require.Equal(t, tt.want, renderBinding(b))
 		})
 	}
 }

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -103,3 +103,18 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 	}
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }
+
+// recordInstantiation records the FromInstantiation interior edge minted by
+// freshenAbove: nv (a freshly-minted instantiation var) was copied from `from`.
+// It routes through the same debugProv unique-pointer guard as recordProv rather
+// than writing c.prov directly, so an accidental double-mint against an existing
+// entry is loud in tests. nv is always fresh here, so the guard never fires in
+// practice — it backstops a future change that reuses a pointer.
+func (c *checker) recordInstantiation(nv *soltype.TypeVarType, from soltype.Type) {
+	if c.debugProv {
+		if prev, ok := c.prov[nv]; ok {
+			panic(fmt.Sprintf("recordInstantiation: var %p already has provenance (%T) — the unique-pointer invariant is violated", nv, prev))
+		}
+	}
+	c.prov[nv] = FromInstantiation{From: from}
+}

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -12,14 +12,15 @@ import (
 // the leaf/interior split in planning/simple_sub/m2.5-implementation-plan.md §3.8).
 // Keyed by pointer identity, exactly like Info.
 //
-// M2.5 ships only the FromAST leaf variant. The interior edge variants
-// (FromBoundPropagation/FromInstantiation/FromExtrusion/FromCoalesce) ride along
-// with the M3+ operations that mint them — which is why Origin is an interface,
-// so M3 adds a variant rather than changing the map's value type.
+// M2.5 shipped the FromAST leaf variant; M3 (PR1) adds the first interior edge,
+// FromInstantiation. The remaining interior variants
+// (FromBoundPropagation/FromExtrusion/FromCoalesce) ride along with the later
+// operations that mint them — which is why Origin is an interface, so each adds a
+// variant rather than changing the map's value type.
 type Prov map[soltype.Type]Origin
 
-// Origin is a tagged sum naming the kind of hop that minted a type. M2.5 ships only
-// the FromAST leaf; the interior edge variants are deferred to M3+.
+// Origin is a tagged sum naming the kind of hop that minted a type. M2.5 shipped
+// the FromAST leaf; M3 adds FromInstantiation; the rest are deferred.
 type Origin interface{ isOrigin() }
 
 // FromAST is the leaf: a direct AST cause for a freshly-minted type.
@@ -29,6 +30,17 @@ type FromAST struct {
 }
 
 func (FromAST) isOrigin() {}
+
+// FromInstantiation is the first interior edge (M3, PR1): a variable minted by
+// instantiating a polymorphic scheme (freshenAbove) copied it from From, the
+// pre-freshening type. It carries no AST node of its own — the renderer that
+// chases the From chain back to the nearest AST leaf is deferred to M11.5, so
+// NodeFor still resolves only FromAST. PR1 mints the edge; nothing reads it yet.
+type FromInstantiation struct {
+	From soltype.Type
+}
+
+func (FromInstantiation) isOrigin() {}
 
 // ASTOriginKind tags WHY a node minted a type, so a renderer/LSP can phrase blame
 // ("the literal here", "this argument", "field `x`") without re-deriving it from

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -45,10 +45,10 @@ func TestProvTupleAndObject(t *testing.T) {
 func TestProvCallResultAndShape(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	scope.defineValue("inc", ValueBinding{Type: &soltype.FuncType{
+	scope.defineValue("inc", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "n"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
 		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
-	}})
+	})}})
 	e := ast.NewCall(identExpr("inc"), []ast.Expr{numExpr(7)}, false, testSpan())
 
 	res := c.inferExpr(scope, 0, e)
@@ -120,7 +120,7 @@ func TestProvAnnotationType(t *testing.T) {
 func TestProvIdentRecordsNothing(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
-	scope.defineValue("x", ValueBinding{Type: &soltype.PrimType{Prim: soltype.NumPrim}})
+	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}})
 	c.inferExpr(scope, 0, identExpr("x"))
 	require.Empty(t, c.prov, "an ident use must record no provenance")
 }

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -62,7 +62,7 @@ func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
 }
 
 // A POLYMORPHIC binding's Info entry retains its quantified type-parameter vars, so
-// it must be rendered with soltype.PrintScheme (the var-aware renderer); plain
+// it must be rendered with soltype.PrintAsScheme (the var-aware renderer); plain
 // soltype.Print shows the raw t{ID} debug form. (PR1: the recorded display type is
 // NOT var-free for generalized bindings — the inverse of
 // TestInferModuleFuncDeclRecordsInfoType, whose fixture is monomorphic.)
@@ -85,7 +85,7 @@ func TestInferModulePolymorphicFuncDeclInfoNeedsPrintScheme(t *testing.T) {
 
 	got := info.TypeOf(id.Name)
 	require.NotNil(t, got, "FuncDecl type not recorded in Info")
-	require.Equal(t, "fn <T0>(x: T0) -> T0", soltype.PrintScheme(got))
-	require.NotEqual(t, soltype.PrintScheme(got), soltype.Print(got),
-		"plain Print leaks raw var IDs for a generalized binding; consumers must use PrintScheme")
+	require.Equal(t, "fn <T0>(x: T0) -> T0", soltype.PrintAsScheme(got))
+	require.NotEqual(t, soltype.PrintAsScheme(got), soltype.Print(got),
+		"plain Print leaks raw var IDs for a generalized binding; consumers must use PrintAsScheme")
 }

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -60,3 +60,32 @@ func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
 	require.NotNil(t, got, "FuncDecl type not recorded in Info")
 	require.Equal(t, "fn (x: number) -> number", soltype.Print(got))
 }
+
+// A POLYMORPHIC binding's Info entry retains its quantified type-parameter vars, so
+// it must be rendered with soltype.PrintScheme (the var-aware renderer); plain
+// soltype.Print shows the raw t{ID} debug form. (PR1: the recorded display type is
+// NOT var-free for generalized bindings — the inverse of
+// TestInferModuleFuncDeclRecordsInfoType, whose fixture is monomorphic.)
+func TestInferModulePolymorphicFuncDeclInfoNeedsPrintScheme(t *testing.T) {
+	module := parseModule(t, `fn id(x) { x }`)
+	_, info, errs := InferModule(module)
+	require.Empty(t, errs)
+
+	var id *ast.FuncDecl
+	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, d := range ns.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Name != nil && fd.Name.Name == "id" {
+				id = fd
+				return false
+			}
+		}
+		return true
+	})
+	require.NotNil(t, id, "id decl not found")
+
+	got := info.TypeOf(id.Name)
+	require.NotNil(t, got, "FuncDecl type not recorded in Info")
+	require.Equal(t, "fn <T0>(x: T0) -> T0", soltype.PrintScheme(got))
+	require.NotEqual(t, soltype.PrintScheme(got), soltype.Print(got),
+		"plain Print leaks raw var IDs for a generalized binding; consumers must use PrintScheme")
+}

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -5,13 +5,15 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// ValueBinding is a name's value-sort binding. In M2 it holds a plain
-// MONOMORPHIC soltype.Type — M1 ships no schemes, so there is no generalization
-// yet. M3 swaps Type for a TypeScheme when let-generalization lands (open
-// question §7 (a): take the mechanical field-swap churn then rather than
-// over-abstract now).
+// ValueBinding is a name's value-sort binding. M3 (PR1) replaces M2's plain
+// MONOMORPHIC soltype.Type with a *slice* of TypeSchemes: exactly one for an
+// ordinary value (the let-generalization swap), and — once PR6 lands — more than
+// one for an overload set, in declaration order. Holding the slice now (rather
+// than a nullable OverloadSet field) makes "is the scheme nil when overloaded?"
+// unrepresentable: cardinality is just len(Schemes), and Schemes[i] lines up with
+// the arm at Sources[i].
 type ValueBinding struct {
-	Type soltype.Type // M2: monomorphic. M3 replaces with a TypeScheme.
+	Schemes []TypeScheme // 1 = ordinary binding; >1 = overload set (PR6)
 	// Sources holds every decl that contributes to this binding, in source order:
 	// for a plain `val`/`fn` that is the single introducing decl, but a name with
 	// multiple top-level FuncDecls (overloads) — or an erroneous redeclaration —
@@ -19,6 +21,14 @@ type ValueBinding struct {
 	// a future go-to-definition navigate to all of them. Empty for prelude bindings.
 	Sources []provenance.Provenance
 }
+
+// IsOverloaded reports whether this binding is an overload set. Consumers MUST
+// check it before routing: an ordinary call (false) keeps M2's shipped
+// subtype-constraint path, while an overloaded call (true) goes through
+// resolveOverload (PR6). inferIdent's value-position lookup branches on it too.
+// PR1 only ever builds single-scheme bindings, so this is always false today; the
+// helper lands now so the ordinary path reads !b.IsOverloaded() from the start.
+func (b ValueBinding) IsOverloaded() bool { return len(b.Schemes) > 1 }
 
 // TypeBinding is a name's type-sort binding. M2 only ever populates this with
 // the hand-seeded stdlib-type placeholders (§3.8); real type aliases/classes are


### PR DESCRIPTION
Implement let-generalization (M3, PR1) to replace M2's monomorphic type bindings with polymorphic schemes. This enables each use of a polymorphic binding to instantiate fresh type variables, fixing the bug where captured parameters were frozen to `never` under eager coalescing.

## Summary

M2 froze every binding to a coalesced monotype at definition time. M3 PR1 generalizes bindings at SCC boundaries instead: a `PolyScheme` carries a raw (variable-carrying) body and a generalization level, so each use instantiates fresh variables for quantified parameters (Level > scheme.Level) while sharing captured variables (Level ≤ scheme.Level). This fixes the eager-coalescing bug and enables polymorphic let-bindings like `val id = fn (x) { x }` to work correctly across multiple call sites.

## Key changes

- **New `TypeScheme` interface** (`poly.go`): `MonoScheme` (non-generalized) and `PolyScheme` (generalized with raw body and level). `ValueBinding.Schemes` now holds a slice of schemes instead of a plain type.

- **Instantiation and freshening** (`poly.go`): `instantiate()` freshens quantified variables in a `PolyScheme` at the current level, sharing captured variables. `freshenAbove()` copies a type, replacing variables above a level limit with fresh ones and caching to handle cycles. Records `FromInstantiation` provenance edges for freshened variables.

- **Generalization** (`module.go`): Phase 3 of `inferComponent` now calls `generalize()` to wrap the inferred group variable in a `PolyScheme` at the component's level, replacing the eager coalesce.

- **Occurrence analysis and scheme coalescing** (`coalesce.go`): `analyzeOccurrences()` walks the bound graph to record which polarities each variable appears in. `coalesceScheme()` and `coalesceSchemeRec()` coalesce a generalized scheme's display type, retaining only variables that are both quantifiable (Level > genLevel) AND occur in both polarities (single-polarity elimination). This inlines parameter-only and result-only variables to their bounds while keeping genuine type parameters as named references.

- **Scheme rendering** (`coalesce.go`, `print.go`): `renderScheme()` renders a scheme with a `<T0, …>` quantifier prefix for its quantified variables. `PrintScheme()` and `PrintSchemeParams()` in `soltype/print.go` collect free variables and render them under assigned names, with `PrintSchemeParams()` allowing filtering to distinguish quantified parameters from leaked variables.

- **Value-position instantiation** (`infer_expr.go`): `inferIdent()` now instantiates a binding's scheme at the current level instead of returning its type directly, enabling polymorphic uses.

- **Body-level let-polymorphism** (`infer_decl.go`): `inferVarDecl()` now generalizes body-level `val`/`var` initializers at the binding's level, replacing eager coalescing. This preserves captured outer parameters instead of freezing them to `never`.

- **Test coverage** (`infer_poly_test.go`, `poly_test.go`): New tests verify identity polymorphism, two-types-of-use behavior, captured parameter preservation, body-level let-polymorphism, parameter-only variables, and recursive group generalization.

## Notable implementation details

- **Raw scheme bodies**: `PolyScheme.Body` is kept RAW (variable-carrying) so instantiation can freshen it; display types are computed on-demand via `coalesceScheme()`.

- **Single-polarity elimination**: A variable occurring only in positive or negative position (e.g., a parameter never used, or a result never read) is inlined to its bound in the display type, keeping renders compact where possible.

- **Cyclic bound handling**: Both `analyzeOccurrences()` and `coalesceSchemeRec()` use occurrence-keyed and variable-keyed seen-sets respectively to terminate on cyclic var

https://claude.ai/code/session_01G1y6oDkdt8WyPBg3DPePH6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polymorphic type schemes with per-use instantiation and stable quantified printing for inferred signatures.
  * Bindings now record scheme(s), enabling overloaded and generalized value representations.

* **Bug Fixes**
  * Call-site error recovery preserves declared return types on arity mismatch.
  * Improved related-span reporting for several blame/error cases.

* **Tests**
  * Extensive new and updated tests covering polymorphism, printing, inference and provenance.

* **Documentation**
  * Updated package docs describing the new generalization and printing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->