### PR TITLE
PR4: Function exactness and accept-set subtyping (#677)

### DIFF
--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -330,6 +330,7 @@ type FuncSig struct {
 	Return         TypeAnn // optional
 	Throws         TypeAnn // optional
 	Async          bool    // whether this is an async function
+	Inexact        bool    // trailing `...` marker: fn(a, ...) tolerates extra args (#677 §4.1)
 }
 
 type FuncExpr struct {

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -439,6 +439,7 @@ type FuncTypeAnn struct {
 	Params         []*Param
 	Return         TypeAnn
 	Throws         TypeAnn // optionanl
+	Inexact        bool    // trailing `...` marker: fn(a, ...) tolerates extra args (#677 §4.1)
 	span           Span
 	inferredType   Type
 }

--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -1,5 +1,56 @@
 package parser
 
+import "github.com/escalier-lang/escalier/internal/ast"
+
+// parseFuncParams parses a function parameter list up to (but not consuming) the
+// closing paren, returning the params and whether the list ends with a bare
+// trailing `...` inexact marker (#677 §4.1: `fn(a, ...)` tolerates extra arguments
+// when used as a callback). A bare `...` immediately before `)` is the inexact
+// marker; `...pattern` stays an ordinary rest param handled by p.param. It mirrors
+// parseDelimSeq's comma handling (including a tolerated trailing comma) so the
+// three function forms — decl, expr, type annotation — parse identically.
+func (p *Parser) parseFuncParams() (params []*ast.Param, inexact bool) {
+	// Match parseDelimSeq's empty-but-non-nil result so callers (and AST snapshots)
+	// see the same Params slice they did before this helper existed.
+	params = []*ast.Param{}
+	if p.lexer.peek().Type == CloseParen {
+		return params, false
+	}
+	for {
+		select {
+		case <-p.ctx.Done():
+			return params, inexact
+		default:
+		}
+
+		// A bare `...` (the next token after it is the closing paren) marks the
+		// function inexact. Anything else after `...` is a rest param (`...rest`),
+		// which p.param parses, so back the lexer up and fall through.
+		if p.lexer.peek().Type == DotDotDot {
+			saved := p.lexer.saveState()
+			p.lexer.consume() // tentatively consume '...'
+			if p.lexer.peek().Type == CloseParen {
+				return params, true
+			}
+			p.lexer.restoreState(saved)
+		}
+
+		param := p.param()
+		if param == nil {
+			return params, inexact
+		}
+		params = append(params, param)
+
+		if p.lexer.peek().Type != Comma {
+			return params, inexact
+		}
+		p.lexer.consume() // consume separator
+		if p.lexer.peek().Type == CloseParen {
+			return params, inexact // tolerated trailing comma
+		}
+	}
+}
+
 func parseDelimSeq[T any](
 	p *Parser,
 	terminator TokenType,

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -1073,7 +1073,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async boo
 		p.lexer.consume()
 	}
 
-	params := parseDelimSeq(p, CloseParen, Comma, p.param)
+	params, inexact := p.parseFuncParams()
 
 	token = p.lexer.peek()
 	if token.Type != CloseParen {
@@ -1122,6 +1122,7 @@ func (p *Parser) fnDecl(start ast.Location, export bool, declare bool, async boo
 		ident, lifetimeParams, typeParams, params, returnType, throwsType, &body, export, declare, async,
 		ast.NewSpan(start, end, p.lexer.source.ID),
 	)
+	fd.Inexact = inexact
 	return fd
 }
 

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -523,7 +523,7 @@ func (p *Parser) fnExpr(start ast.Location, async bool) ast.Expr {
 	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams()
 
 	p.expect(OpenParen, ConsumeOnMatch)
-	params := parseDelimSeq(p, CloseParen, Comma, p.param)
+	params, inexact := p.parseFuncParams()
 	p.expect(CloseParen, ConsumeOnMatch)
 
 	var returnType ast.TypeAnn
@@ -564,6 +564,7 @@ func (p *Parser) fnExpr(start ast.Location, async bool) ast.Expr {
 		&body,
 		ast.NewSpan(start, end, p.lexer.source.ID),
 	)
+	fn.Inexact = inexact
 	return fn
 }
 

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// The trailing `...` inexact marker (#677 §4.1) parses on all three function forms
+// — declaration, expression, and type annotation — setting Inexact on the node and
+// leaving the named params intact. A bare `fn(...)` (no params) is also inexact.
+func TestParseInexactMarker(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("func decl", func(t *testing.T) {
+		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: "fn f(x: number, ...) { x }"})
+		require.Empty(t, errs)
+		fd, ok := decls[0].(*ast.FuncDecl)
+		require.True(t, ok)
+		require.True(t, fd.Inexact)
+		require.Len(t, fd.Params, 1) // the `...` does not become a param
+	})
+
+	t.Run("func expr", func(t *testing.T) {
+		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: "val g = fn (x: number, ...) { x }"})
+		require.Empty(t, errs)
+		vd, ok := decls[0].(*ast.VarDecl)
+		require.True(t, ok)
+		fe, ok := vd.Init.(*ast.FuncExpr)
+		require.True(t, ok)
+		require.True(t, fe.Inexact)
+		require.Len(t, fe.Params, 1)
+	})
+
+	t.Run("func type annotation", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, "fn(x: number, ...) -> number")
+		require.Empty(t, errs)
+		fn, ok := ta.(*ast.FuncTypeAnn)
+		require.True(t, ok)
+		require.True(t, fn.Inexact)
+		require.Len(t, fn.Params, 1)
+	})
+
+	t.Run("bare nullary inexact", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, "fn(...) -> number")
+		require.Empty(t, errs)
+		fn, ok := ta.(*ast.FuncTypeAnn)
+		require.True(t, ok)
+		require.True(t, fn.Inexact)
+		require.Empty(t, fn.Params)
+	})
+}
+
+// A bare function (no trailing `...`) is exact, and a `...rest` is an ordinary rest
+// param — NOT the inexact marker. The lookahead in parseFuncParams must keep these
+// distinct.
+func TestParseExactAndRestAreNotInexact(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("bare function is exact", func(t *testing.T) {
+		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: "fn f(x: number, y: number) { x }"})
+		require.Empty(t, errs)
+		require.False(t, decls[0].(*ast.FuncDecl).Inexact)
+	})
+
+	t.Run("rest param is not the inexact marker", func(t *testing.T) {
+		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: "fn f(x: number, ...rest) { x }"})
+		require.Empty(t, errs)
+		fd := decls[0].(*ast.FuncDecl)
+		require.False(t, fd.Inexact)
+		require.Len(t, fd.Params, 2) // x and the rest param
+		_, isRest := fd.Params[1].Pattern.(*ast.RestPat)
+		require.True(t, isRest)
+	})
+}

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -320,7 +320,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 
 			p.expect(OpenParen, AlwaysConsume)
 
-			funcParams := parseDelimSeq(p, CloseParen, Comma, p.param)
+			funcParams, inexact := p.parseFuncParams()
 
 			p.expect(CloseParen, AlwaysConsume)
 
@@ -346,6 +346,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 				throwsType,
 				ast.NewSpan(token.Span.Start, endSpan.End, p.lexer.source.ID),
 			)
+			fnAnn.Inexact = inexact
 			typeAnn = fnAnn
 		case If: // conditional type
 			p.lexer.consume() // consume 'if'

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1004,6 +1004,12 @@ func (p *Printer) printFuncSig(sig *ast.FuncSig) {
 			p.writeString(", ")
 		}
 	}
+	if sig.Inexact {
+		if len(sig.Params) > 0 {
+			p.writeString(", ")
+		}
+		p.writeString("...")
+	}
 	p.writeString(")")
 
 	if sig.Return != nil {
@@ -1430,6 +1436,12 @@ func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
 		if i < len(typ.Params)-1 {
 			p.writeString(", ")
 		}
+	}
+	if typ.Inexact {
+		if len(typ.Params) > 0 {
+			p.writeString(", ")
+		}
+		p.writeString("...")
 	}
 	p.writeString(")")
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -59,6 +59,55 @@ func parseTypeAnn(t *testing.T, input string) ast.TypeAnn {
 	return typeAnn
 }
 
+// The trailing `...` inexact marker round-trips through the printer on function
+// declarations, expressions, and type annotations (#677 §4.1).
+func TestPrintInexactFunctions(t *testing.T) {
+	opts := DefaultOptions()
+
+	// Assert on the signature substring (the body's indentation is incidental).
+	declTests := []struct {
+		name    string
+		input   string
+		wantSig string
+	}{
+		{"inexact decl", "fn f(x: number, ...) { x }", "fn f(x: number, ...) {"},
+		{"inexact nullary decl", "fn f(...) { 1 }", "fn f(...) {"},
+		{"exact decl unchanged", "fn f(x: number) { x }", "fn f(x: number) {"},
+	}
+	for _, tt := range declTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseDecl(t, tt.input), opts)
+			if err != nil {
+				t.Fatalf("Print error: %v", err)
+			}
+			if !strings.HasPrefix(result, tt.wantSig) {
+				t.Errorf("Expected prefix %q, got %q", tt.wantSig, result)
+			}
+		})
+	}
+
+	annTests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"inexact annotation", "fn(x: number, ...) -> number", "fn (x: number, ...) -> number"},
+		{"inexact nullary annotation", "fn(...) -> number", "fn (...) -> number"},
+		{"exact annotation unchanged", "fn(x: number) -> number", "fn (x: number) -> number"},
+	}
+	for _, tt := range annTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseTypeAnn(t, tt.input), opts)
+			if err != nil {
+				t.Fatalf("Print error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestPrintLiterals(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -254,7 +254,7 @@ func (p *namedPrinter) printFuncTail(t *FuncType) string {
 		}
 		ps = append(ps, paramName(param, i)+opt+": "+p.printType(param.Type))
 	}
-	if !t.Exact {
+	if t.Inexact {
 		ps = append(ps, "...")
 	}
 	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -248,11 +248,15 @@ func (p *namedPrinter) printType(t Type) string {
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	ps := make([]string, 0, len(t.Params)+1)
 	for i, param := range t.Params {
+		rest := ""
+		if param.Rest {
+			rest = "..." // a typed rest param renders `...xs: T`
+		}
 		opt := ""
 		if param.Optional {
 			opt = "?"
 		}
-		ps = append(ps, paramName(param, i)+opt+": "+p.printType(param.Type))
+		ps = append(ps, rest+paramName(param, i)+opt+": "+p.printType(param.Type))
 	}
 	if t.Inexact {
 		ps = append(ps, "...")

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -240,17 +240,31 @@ func (p *namedPrinter) printType(t Type) string {
 // printFuncTail renders the "(params) -> ret" portion of a function, without the
 // leading "fn" keyword. Kept as a separate helper so PrintAsScheme can compose it
 // with a <...> quantifier prefix without byte-slicing the "fn " back off.
+//
+// PR4 markers: an optional parameter renders as `x?: T`, and an INEXACT function
+// renders a trailing `...` entry (`fn (x: T, ...) -> R`) so the exactness it
+// carries round-trips to surface syntax. An exact function (the common case)
+// renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
-	ps := make([]string, len(t.Params))
+	ps := make([]string, 0, len(t.Params)+1)
 	for i, param := range t.Params {
-		ps[i] = paramName(param, i) + ": " + p.printType(param.Type)
+		opt := ""
+		if param.Optional {
+			opt = "?"
+		}
+		ps = append(ps, paramName(param, i)+opt+": "+p.printType(param.Type))
+	}
+	if !t.Exact {
+		ps = append(ps, "...")
 	}
 	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or
 // otherwise-unknown pattern falls back to a positional name ("arg0", "arg1",
-// ...). M2's destructuring Pat concretes add their own arms here.
+// ...). M2's destructuring Pat concretes add their own arms here. The optional
+// `?` marker is appended by printFuncTail, not here, so callers that only want
+// the bare name (none today) stay unaffected.
 func paramName(p *FuncParam, i int) string {
 	if pat, ok := p.Pattern.(*IdentPat); ok {
 		return pat.Name

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -19,6 +19,10 @@ func optP(name string, t Type) *FuncParam {
 	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t, Optional: true}
 }
 
+func restP(name string, t Type) *FuncParam {
+	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t, Rest: true}
+}
+
 // TestPrintRoundTrips covers the short, stable round-trips for the M1 coalesced
 // type set: primitives, literals, the lattice bounds, tuples, multi-arg
 // functions, and multi-element unions/intersections. Per CLAUDE.md these are the
@@ -83,6 +87,11 @@ func TestPrintRoundTrips(t *testing.T) {
 			"optional param renders with ?",
 			&FuncType{Params: []*FuncParam{identP("a", numP()), optP("b", strP())}, Ret: boolP()},
 			"fn (a: number, b?: string) -> boolean",
+		},
+		{
+			"rest param renders with ...",
+			&FuncType{Params: []*FuncParam{identP("a", numP()), restP("rest", strP())}, Ret: boolP()},
+			"fn (a: number, ...rest: string) -> boolean",
 		},
 
 		// Unions and intersections.

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -15,6 +15,10 @@ func identP(name string, t Type) *FuncParam {
 	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t}
 }
 
+func optP(name string, t Type) *FuncParam {
+	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t, Optional: true}
+}
+
 // TestPrintRoundTrips covers the short, stable round-trips for the M1 coalesced
 // type set: primitives, literals, the lattice bounds, tuples, multi-arg
 // functions, and multi-element unions/intersections. Per CLAUDE.md these are the
@@ -60,13 +64,25 @@ func TestPrintRoundTrips(t *testing.T) {
 			`{"a-b": number}`,
 		},
 
-		// Functions.
-		{"nullary fn", &FuncType{Ret: numP()}, "fn () -> number"},
-		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}, "fn (x: number) -> string"},
+		// Functions. A bare (exact) function renders with no trailing marker; an
+		// inexact one renders a trailing `...`, and an optional param renders `x?: T`.
+		{"nullary fn", &FuncType{Ret: numP(), Exact: true}, "fn () -> number"},
+		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true}, "fn (x: number) -> string"},
 		{
 			"multi-arg fn",
-			&FuncType{Params: []*FuncParam{identP("a", numP()), identP("b", strP())}, Ret: boolP()},
+			&FuncType{Params: []*FuncParam{identP("a", numP()), identP("b", strP())}, Ret: boolP(), Exact: true},
 			"fn (a: number, b: string) -> boolean",
+		},
+		{"inexact nullary fn", &FuncType{Ret: numP()}, "fn (...) -> number"},
+		{
+			"inexact fn with params",
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
+			"fn (x: number, ...) -> string",
+		},
+		{
+			"optional param renders with ?",
+			&FuncType{Params: []*FuncParam{identP("a", numP()), optP("b", strP())}, Ret: boolP(), Exact: true},
+			"fn (a: number, b?: string) -> boolean",
 		},
 
 		// Unions and intersections.
@@ -115,7 +131,7 @@ func TestIsIdent(t *testing.T) {
 func TestPrintNestedPrecedence(t *testing.T) {
 	// A function inside a union: precFunc < precUnion, so the function is parenthesized.
 	t.Run("function in union", func(t *testing.T) {
-		ty := &UnionType{Types: []Type{&FuncType{Ret: numP()}, strP()}}
+		ty := &UnionType{Types: []Type{&FuncType{Ret: numP(), Exact: true}, strP()}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`(fn () -> number) | string`))
 	})
 
@@ -129,7 +145,7 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	// A function inside a tuple is delimited by brackets, so it needs no parens.
 	t.Run("function in tuple", func(t *testing.T) {
 		ty := &TupleType{Elems: []Type{
-			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true},
 			boolP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
@@ -139,7 +155,7 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	// no parens, and a function as a field value is delimited by the field's `:`.
 	t.Run("record in union", func(t *testing.T) {
 		ty := &UnionType{Types: []Type{
-			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP()}}}},
+			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP(), Exact: true}}}},
 			strP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`{f: fn () -> number} | string`))
@@ -160,6 +176,7 @@ func TestPrintRawTypeVar(t *testing.T) {
 		fn := &FuncType{
 			Params: []*FuncParam{identP("x", &TypeVarType{ID: 0})},
 			Ret:    &TypeVarType{ID: 0},
+			Exact:  true,
 		}
 		require.Equal(t, "fn (x: t0) -> t0", Print(fn))
 	})
@@ -175,7 +192,8 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 			{Pattern: nil, Type: numP()},
 			{Pattern: nil, Type: strP()},
 		},
-		Ret: boolP(),
+		Ret:   boolP(),
+		Exact: true,
 	}
 	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
 }
@@ -186,13 +204,13 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 // type renders exactly as Print would.
 func TestPrintScheme(t *testing.T) {
 	t.Run("no free vars renders as Print", func(t *testing.T) {
-		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}
+		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true}
 		require.Equal(t, "fn (x: number) -> string", PrintAsScheme(ty))
 	})
 
 	t.Run("identity gets one type parameter", func(t *testing.T) {
 		a := &TypeVarType{ID: 7, Level: 1}
-		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a}
+		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a, Exact: true}
 		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintAsScheme(ty))
 	})
 
@@ -203,6 +221,7 @@ func TestPrintScheme(t *testing.T) {
 		ty := &FuncType{
 			Params: []*FuncParam{identP("x", a), identP("y", b)},
 			Ret:    &TupleType{Elems: []Type{b, a}},
+			Exact:  true,
 		}
 		require.Equal(t, "fn <T0, T1>(x: T0, y: T1) -> [T1, T0]", PrintAsScheme(ty))
 	})
@@ -225,6 +244,7 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 	ty := &FuncType{
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
+		Exact:  true,
 	}
 	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 })
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -66,22 +66,22 @@ func TestPrintRoundTrips(t *testing.T) {
 
 		// Functions. A bare (exact) function renders with no trailing marker; an
 		// inexact one renders a trailing `...`, and an optional param renders `x?: T`.
-		{"nullary fn", &FuncType{Ret: numP(), Exact: true}, "fn () -> number"},
-		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true}, "fn (x: number) -> string"},
+		{"nullary fn", &FuncType{Ret: numP()}, "fn () -> number"},
+		{"unary fn", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}, "fn (x: number) -> string"},
 		{
 			"multi-arg fn",
-			&FuncType{Params: []*FuncParam{identP("a", numP()), identP("b", strP())}, Ret: boolP(), Exact: true},
+			&FuncType{Params: []*FuncParam{identP("a", numP()), identP("b", strP())}, Ret: boolP()},
 			"fn (a: number, b: string) -> boolean",
 		},
-		{"inexact nullary fn", &FuncType{Ret: numP()}, "fn (...) -> number"},
+		{"inexact nullary fn", &FuncType{Ret: numP(), Inexact: true}, "fn (...) -> number"},
 		{
 			"inexact fn with params",
-			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Inexact: true},
 			"fn (x: number, ...) -> string",
 		},
 		{
 			"optional param renders with ?",
-			&FuncType{Params: []*FuncParam{identP("a", numP()), optP("b", strP())}, Ret: boolP(), Exact: true},
+			&FuncType{Params: []*FuncParam{identP("a", numP()), optP("b", strP())}, Ret: boolP()},
 			"fn (a: number, b?: string) -> boolean",
 		},
 
@@ -131,7 +131,7 @@ func TestIsIdent(t *testing.T) {
 func TestPrintNestedPrecedence(t *testing.T) {
 	// A function inside a union: precFunc < precUnion, so the function is parenthesized.
 	t.Run("function in union", func(t *testing.T) {
-		ty := &UnionType{Types: []Type{&FuncType{Ret: numP(), Exact: true}, strP()}}
+		ty := &UnionType{Types: []Type{&FuncType{Ret: numP()}, strP()}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`(fn () -> number) | string`))
 	})
 
@@ -145,7 +145,7 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	// A function inside a tuple is delimited by brackets, so it needs no parens.
 	t.Run("function in tuple", func(t *testing.T) {
 		ty := &TupleType{Elems: []Type{
-			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true},
+			&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
 			boolP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
@@ -155,7 +155,7 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	// no parens, and a function as a field value is delimited by the field's `:`.
 	t.Run("record in union", func(t *testing.T) {
 		ty := &UnionType{Types: []Type{
-			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP(), Exact: true}}}},
+			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP()}}}},
 			strP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`{f: fn () -> number} | string`))
@@ -176,7 +176,6 @@ func TestPrintRawTypeVar(t *testing.T) {
 		fn := &FuncType{
 			Params: []*FuncParam{identP("x", &TypeVarType{ID: 0})},
 			Ret:    &TypeVarType{ID: 0},
-			Exact:  true,
 		}
 		require.Equal(t, "fn (x: t0) -> t0", Print(fn))
 	})
@@ -192,8 +191,7 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 			{Pattern: nil, Type: numP()},
 			{Pattern: nil, Type: strP()},
 		},
-		Ret:   boolP(),
-		Exact: true,
+		Ret: boolP(),
 	}
 	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
 }
@@ -204,13 +202,13 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 // type renders exactly as Print would.
 func TestPrintScheme(t *testing.T) {
 	t.Run("no free vars renders as Print", func(t *testing.T) {
-		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP(), Exact: true}
+		ty := &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}
 		require.Equal(t, "fn (x: number) -> string", PrintAsScheme(ty))
 	})
 
 	t.Run("identity gets one type parameter", func(t *testing.T) {
 		a := &TypeVarType{ID: 7, Level: 1}
-		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a, Exact: true}
+		ty := &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: a}
 		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintAsScheme(ty))
 	})
 
@@ -221,7 +219,6 @@ func TestPrintScheme(t *testing.T) {
 		ty := &FuncType{
 			Params: []*FuncParam{identP("x", a), identP("y", b)},
 			Ret:    &TupleType{Elems: []Type{b, a}},
-			Exact:  true,
 		}
 		require.Equal(t, "fn <T0, T1>(x: T0, y: T1) -> [T1, T0]", PrintAsScheme(ty))
 	})
@@ -244,7 +241,6 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 	ty := &FuncType{
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
-		Exact:  true,
 	}
 	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 })
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -95,21 +95,21 @@ type FuncParam struct {
 	Optional bool // PR4: x? — lowers `required` without changing arity (len(Params))
 }
 
-// FuncType is a (possibly multi-argument) function type. M3 (PR4) adds Exact: a
-// bare `fn(p1..pn)` is exact (it tolerates at most n arguments — accept-set
+// FuncType is a (possibly multi-argument) function type. M3 (PR4) adds Inexact: a
+// bare `fn(p1..pn)` is exact (tolerates at most n arguments — accept-set
 // [required, n]); a `fn(p1..pn, ...)` written with a trailing `...` is inexact (it
 // tolerates extra arguments when used as a callback — accept-set [required, ∞)).
 // Exactness governs callback subtyping, not direct calls (#677); see solver's
 // acceptSet / the FuncType<:FuncType constrain rule.
 //
-// CAUTION: the zero value is Exact=false (inexact). A bare function VALUE is exact,
-// so every site that mints a concrete function (inferFunc, the inferCall demand,
-// prelude operators) sets Exact:true explicitly, and the structural rewriters
-// (coalesce, extrude, freshenAbove) carry the flag through unchanged.
+// The flag is Inexact (not Exact) so the ZERO VALUE is exact, matching Escalier's
+// exact-by-default semantics: a function minted without thinking about exactness is
+// correctly exact, and the structural rewriters (coalesce, extrude, freshenAbove)
+// carry the flag through unchanged. Only the parser's `...` marker sets it.
 type FuncType struct {
-	Params []*FuncParam
-	Ret    Type
-	Exact  bool // PR4: bare fn(...) ⇒ true; fn(..., ...) ⇒ false (the zero value)
+	Params  []*FuncParam
+	Ret     Type
+	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 }
 
 // TupleType is a fixed-length tuple type.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -93,6 +93,12 @@ type FuncParam struct {
 	Pattern  Pat
 	Type     Type
 	Optional bool // PR4: x? — lowers `required` without changing arity (len(Params))
+	// Rest marks a typed rest param (`...xs: T[]`), which must be the LAST param: it
+	// binds zero or more trailing arguments, so it is never required and lifts the
+	// function's accept-set upper bound to ∞ (#677 §4.2.3) — distinct from the inexact
+	// `...` marker (which is callback-only). Per-extra element-type checking (§4.2.2)
+	// needs Array types and is M4; M3 models only the arity effect.
+	Rest bool
 }
 
 // FuncType is a (possibly multi-argument) function type. M3 (PR4) adds Inexact: a

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -84,18 +84,32 @@ type IdentPat struct{ Name string }
 
 func (*IdentPat) isPat() {}
 
-// FuncParam mirrors type_system.FuncParam. M1 omits Optional (no optional
-// params until M3+); Pattern is reachable only through Pat concretes M1
-// defines (IdentPat).
+// FuncParam mirrors type_system.FuncParam. Pattern is reachable only through Pat
+// concretes M1 defines (IdentPat). M3 (PR4) adds Optional: an `x?` parameter
+// lowers the function's `required` count (the accept-set lower bound) without
+// removing the parameter from the declared list — it stays at its position with
+// its type, the slot simply may go unsupplied.
 type FuncParam struct {
-	Pattern Pat
-	Type    Type
+	Pattern  Pat
+	Type     Type
+	Optional bool // PR4: x? — lowers `required` without changing arity (len(Params))
 }
 
-// FuncType is a (possibly multi-argument) function type.
+// FuncType is a (possibly multi-argument) function type. M3 (PR4) adds Exact: a
+// bare `fn(p1..pn)` is exact (it tolerates at most n arguments — accept-set
+// [required, n]); a `fn(p1..pn, ...)` written with a trailing `...` is inexact (it
+// tolerates extra arguments when used as a callback — accept-set [required, ∞)).
+// Exactness governs callback subtyping, not direct calls (#677); see solver's
+// acceptSet / the FuncType<:FuncType constrain rule.
+//
+// CAUTION: the zero value is Exact=false (inexact). A bare function VALUE is exact,
+// so every site that mints a concrete function (inferFunc, the inferCall demand,
+// prelude operators) sets Exact:true explicitly, and the structural rewriters
+// (coalesce, extrude, freshenAbove) carry the flag through unchanged.
 type FuncType struct {
 	Params []*FuncParam
 	Ret    Type
+	Exact  bool // PR4: bare fn(...) ⇒ true; fn(..., ...) ⇒ false (the zero value)
 }
 
 // TupleType is a fixed-length tuple type.

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -75,18 +75,15 @@ func TestBlameCallTooManyArgs(t *testing.T) {
 		"Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
 }
 
-// A too-few-args direct call still surfaces as a FuncArityMismatch through the
-// call-shape constraint (the surviving "required" check): `f` declares two params,
-// the call supplies one, so the exact demand's accept-set [1,1] is not contained in
-// the callee's [2,2]. Blame points at the whole call, with the callee's definition
-// as the related span (var-free callee, shared through instantiation — see
-// TestBlameCallTooManyArgs's note on the polymorphic bound).
+// A too-few-args direct call is the PR4 too-few lint (NotEnoughArgsError), a BRIDGE
+// error symmetric to TooManyArgsError: it self-blames the whole call and relates the
+// callee expression (`f` here, from the AST — not the callee's definition resolved
+// through Prov). `f` requires two params; the call supplies one.
 func TestBlameCallTooFewArgs(t *testing.T) {
 	src := "fn f(x: number, y: number) -> number { x }\nval r = f(1)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"cannot constrain function of arity 2 <: function of arity 1", "f(1)",
-		"fn f(x: number, y: number) -> number { x }")
+		"Not enough arguments: expected at least 2, but got 1", "f(1)", "f")
 }
 
 // A missing-property read blames the member's prop (.foo), not the receiver, with

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -62,22 +62,31 @@ func TestBlameCallArgument(t *testing.T) {
 	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
 }
 
-// A call-arity mismatch points at the whole call, with the callee's definition as
-// the related "function defined here" span. M2.5 resolved that related span only
-// for inline callees: a named callee's binding was COALESCED to a fresh FuncType
-// pointer with no Prov entry. M3 (PR1) generalizes instead of coalescing, and for
-// a VAR-FREE (monomorphic) callee like `f` here, instantiation shares its FuncType
-// unchanged — so the original (recorded FuncInference against the decl) survives
-// and the related span now resolves. This bound matters: a POLYMORPHIC callee,
-// whose type freshenAbove rebuilds into fresh prov-less nodes, still drops the
-// related span (the receiver analogue is documented in
-// TestBlameMissingPropertyPolymorphicReceiverLosesRelated).
-func TestBlameCallArity(t *testing.T) {
+// A too-many-args direct call is the PR4 extra-arg lint (TooManyArgsError), a
+// BRIDGE error that self-blames the whole call and relates the callee expression.
+// (It supersedes the FuncArityMismatch this fixture asserted before PR4 — too-many
+// is now the lint's uniform message, while FuncArityMismatch keeps the too-few /
+// callback-arity failures. The related span is the callee `f` here, derived from
+// the AST, not the callee's definition span resolved through Prov.)
+func TestBlameCallTooManyArgs(t *testing.T) {
 	src := "fn f(x: number) -> number { x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"cannot constrain function of arity 1 <: function of arity 2", "f(1, 2)",
-		"fn f(x: number) -> number { x }")
+		"Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
+}
+
+// A too-few-args direct call still surfaces as a FuncArityMismatch through the
+// call-shape constraint (the surviving "required" check): `f` declares two params,
+// the call supplies one, so the exact demand's accept-set [1,1] is not contained in
+// the callee's [2,2]. Blame points at the whole call, with the callee's definition
+// as the related span (var-free callee, shared through instantiation — see
+// TestBlameCallTooManyArgs's note on the polymorphic bound).
+func TestBlameCallTooFewArgs(t *testing.T) {
+	src := "fn f(x: number, y: number) -> number { x }\nval r = f(1)"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"cannot constrain function of arity 2 <: function of arity 1", "f(1)",
+		"fn f(x: number, y: number) -> number { x }")
 }
 
 // A missing-property read blames the member's prop (.foo), not the receiver, with
@@ -168,18 +177,17 @@ func TestBlameVoidSubjectFallsBackToCallSite(t *testing.T) {
 	requireBlame(t, src, errs, "cannot constrain void <: number", "f()", "number")
 }
 
-// An INLINE callee resolves its "defined here" related span — its FuncType is
-// recorded (FuncInference) against the fn expression — unlike the named callee in
-// TestBlameCallArity, whose coalesced binding has no Prov entry. So a call-arity
-// mismatch on an immediately-invoked function blames the call AND relates the
-// inline function. (The primary is the call expression; for a parenthesized callee
-// the parser's span begins at the inner `fn`, so the leading `(` is not part of
-// it.)
-func TestBlameCallArityInlineCalleeRelated(t *testing.T) {
+// The too-many-args lint on an immediately-invoked function blames the call and
+// relates the inline callee expression. TooManyArgsError is a bridge error, so the
+// related span is the callee node directly (Call.Callee.Span()), not a Prov
+// resolution — for an inline FuncExpr that is the function expression itself. (The
+// primary is the call expression; for a parenthesized callee the parser's span
+// begins at the inner `fn`, so the leading `(` is not part of it.)
+func TestBlameCallTooManyArgsInlineCalleeRelated(t *testing.T) {
 	src := `val r = (fn (x: number) -> number { x })(1, 2)`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"cannot constrain function of arity 1 <: function of arity 2",
+		"Too many arguments: expected at most 1, but got 2",
 		`fn (x: number) -> number { x })(1, 2)`,
 		`fn (x: number) -> number { x }`)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -47,10 +47,11 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			// Params are contravariant, so flip polarity.
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen)}
+			// Params are contravariant, so flip polarity. Exact/Optional are surface
+			// markers, not bound-carrying, so they ride through coalescing unchanged.
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen)} // covariant return
+		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen), Exact: t.Exact} // covariant return
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
@@ -180,9 +181,9 @@ func coalesceSchemeRec(
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen)}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen)}
+		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen), Exact: t.Exact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
@@ -334,11 +335,11 @@ func equalType(a, b soltype.Type) bool {
 		return ok
 	case *soltype.FuncType:
 		b, ok := b.(*soltype.FuncType)
-		if !ok || len(a.Params) != len(b.Params) {
+		if !ok || len(a.Params) != len(b.Params) || a.Exact != b.Exact {
 			return false
 		}
 		for i := range a.Params {
-			if !equalType(a.Params[i].Type, b.Params[i].Type) {
+			if a.Params[i].Optional != b.Params[i].Optional || !equalType(a.Params[i].Type, b.Params[i].Type) {
 				return false
 			}
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -47,9 +47,10 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			// Params are contravariant, so flip polarity. Exact/Optional are surface
-			// markers, not bound-carrying, so they ride through coalescing unchanged.
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen), Optional: p.Optional}
+			// Params are contravariant, so flip polarity. Inexact/Optional/Rest are
+			// surface markers, not bound-carrying, so they ride through coalescing
+			// unchanged.
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen), Optional: p.Optional, Rest: p.Rest}
 		}
 		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen), Inexact: t.Inexact} // covariant return
 	case *soltype.TupleType:
@@ -181,7 +182,7 @@ func coalesceSchemeRec(
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen), Optional: p.Optional}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen), Optional: p.Optional, Rest: p.Rest}
 		}
 		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen), Inexact: t.Inexact}
 	case *soltype.TupleType:
@@ -339,7 +340,7 @@ func equalType(a, b soltype.Type) bool {
 			return false
 		}
 		for i := range a.Params {
-			if a.Params[i].Optional != b.Params[i].Optional || !equalType(a.Params[i].Type, b.Params[i].Type) {
+			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalType(a.Params[i].Type, b.Params[i].Type) {
 				return false
 			}
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -51,7 +51,7 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 			// markers, not bound-carrying, so they ride through coalescing unchanged.
 			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen), Exact: t.Exact} // covariant return
+		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen), Inexact: t.Inexact} // covariant return
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
@@ -183,7 +183,7 @@ func coalesceSchemeRec(
 		for i, p := range t.Params {
 			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceSchemeRec(p.Type, pol.Flip(), genLevel, occ, seen), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen), Exact: t.Exact}
+		return &soltype.FuncType{Params: params, Ret: coalesceSchemeRec(t.Ret, pol, genLevel, occ, seen), Inexact: t.Inexact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
@@ -335,7 +335,7 @@ func equalType(a, b soltype.Type) bool {
 		return ok
 	case *soltype.FuncType:
 		b, ok := b.(*soltype.FuncType)
-		if !ok || len(a.Params) != len(b.Params) || a.Exact != b.Exact {
+		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact {
 			return false
 		}
 		for i := range a.Params {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -1,9 +1,42 @@
 package solver
 
 import (
+	"math"
+
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
+
+// unboundedArity is the upper end of an inexact function's accept-set ([req, ∞)):
+// an inexact function tolerates any number of trailing arguments as a callback.
+const unboundedArity = math.MaxInt
+
+// requiredCount is the number of required (non-optional) parameters of f — the
+// LOWER bound of its accept-set. An optional (`x?`) parameter does not count.
+func requiredCount(f *soltype.FuncType) int {
+	n := 0
+	for _, p := range f.Params {
+		if !p.Optional {
+			n++
+		}
+	}
+	return n
+}
+
+// acceptSet is the inclusive range [lo, hi] of argument counts f tolerates when
+// invoked (#677 §4.2.1): lo = requiredCount(f); hi = len(f.Params) when f is exact
+// (a finite upper bound) and unboundedArity when f is inexact. Read a supertype
+// callback slot's accept-set as "the argument counts whoever holds this slot may
+// invoke the supplied function with."
+func acceptSet(f *soltype.FuncType) (lo, hi int) {
+	lo = requiredCount(f)
+	if f.Exact {
+		hi = len(f.Params)
+	} else {
+		hi = unboundedArity
+	}
+	return lo, hi
+}
 
 // constraintKey keys the coinductive seen-set by pointer identity (Go's
 // interface == on pointer-backed soltype concretes). Sufficient for M1: cycles
@@ -62,18 +95,29 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		}
 	case *soltype.FuncType:
 		if r, ok := rhs.(*soltype.FuncType); ok {
-			// Exact arity: M1 functions are exact (Escalier is exact-by-default),
-			// so subtyping requires the SAME number of params — parallel to the
-			// exact-tuple same-length rule below. The inexact
-			// "fewer-params-is-subtype" arm (a function ignoring extra trailing
-			// args) lands in M3 with the exactness flag (`...`), exactly as the
-			// inexact-tuple arm lands in M4. See
-			// planning/simple_sub/01-milestones.md.
-			if len(l.Params) != len(r.Params) {
+			// Accept-set subtyping (#677 §4.2.1): read r as a callback slot. l <: r
+			// iff accept(l) ⊇ accept(r) — l must tolerate every argument count a
+			// holder of r may invoke it with. With accept(l) = [loL, hiL] and
+			// accept(r) = [loR, hiR]:
+			//   - loL <= loR — l must not DEMAND more args than r might supply, and
+			//   - hiL >= hiR — l must not REFUSE an arg count r might supply.
+			// The upper-bound clause is what exactness governs (an exact l caps hiL at
+			// len(l.Params), so it can't fill a wider/inexact slot); the lower-bound
+			// clause is the `required` part (a typed-rest/optional lowers it). This
+			// subsumes M2's exact-same-arity rule: two EXACT functions have accept
+			// [r, n], so ⊇ forces equal upper bounds, i.e. the old same-arity check.
+			loL, hiL := acceptSet(l)
+			loR, hiR := acceptSet(r)
+			if loL > loR || hiL < hiR {
 				return []SolverError{&FuncArityMismatchError{LHS: l, RHS: r}}
 			}
+			// Shared positions are checked per-parameter (params contravariant,
+			// return covariant); positions only one side declares are covered by the
+			// accept-set gate above (the slot never supplies them, or the inexact
+			// supplier tolerates them).
 			var errs []SolverError
-			for i := range l.Params {
+			n := min(len(l.Params), len(r.Params))
+			for i := 0; i < n; i++ {
 				errs = append(errs, c.constrain(r.Params[i].Type, l.Params[i].Type, seen)...) // contravariant
 			}
 			return append(errs, c.constrain(l.Ret, r.Ret, seen)...) // covariant
@@ -194,9 +238,9 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache)}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache)}
+		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache), Exact: t.Exact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -34,10 +34,10 @@ func requiredCount(f *soltype.FuncType) int {
 // invoke the supplied function with."
 func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	lo = requiredCount(f)
-	if f.Exact {
-		hi = len(f.Params)
-	} else {
+	if f.Inexact {
 		hi = unboundedArity
+	} else {
+		hi = len(f.Params)
 	}
 	return lo, hi
 }
@@ -254,7 +254,7 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 		for i, p := range t.Params {
 			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache), Exact: t.Exact}
+		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache), Inexact: t.Inexact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -11,14 +11,18 @@ import (
 // an inexact function tolerates any number of trailing arguments as a callback.
 const unboundedArity = math.MaxInt
 
-// requiredCount is the number of required (non-optional) parameters of f — the
-// LOWER bound of its accept-set. An optional (`x?`) parameter does not count.
+// requiredCount is the number of arguments a positional call must supply — the
+// LOWER bound of f's accept-set. Because arguments bind positionally, an optional
+// (`x?`) parameter only lowers the requirement when it is TRAILING: in fn(a, b?)
+// you may omit b, but in fn(a?, b) you cannot omit a while still supplying b, so a
+// is effectively required. So required = the position after the last non-optional
+// param = len(Params) minus the count of TRAILING optionals — NOT the count of all
+// non-optional params, which would wrongly treat a leading optional as droppable
+// and let a call leave a required trailing param unbound.
 func requiredCount(f *soltype.FuncType) int {
-	n := 0
-	for _, p := range f.Params {
-		if !p.Optional {
-			n++
-		}
+	n := len(f.Params)
+	for n > 0 && f.Params[n-1].Optional {
+		n--
 	}
 	return n
 }
@@ -112,9 +116,19 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 				return []SolverError{&FuncArityMismatchError{LHS: l, RHS: r}}
 			}
 			// Shared positions are checked per-parameter (params contravariant,
-			// return covariant); positions only one side declares are covered by the
-			// accept-set gate above (the slot never supplies them, or the inexact
-			// supplier tolerates them).
+			// return covariant). When r is EXACT this is complete: r never supplies an
+			// argument beyond its declared params, and any extra param l declares there
+			// must be optional (the lo gate forced loL <= loR) and so is simply never
+			// passed.
+			//
+			// KNOWN GAP (M4): when r is INEXACT and l declares MORE params than r, r's
+			// `...` tail may supply arbitrarily-typed args at l's extra positions, so
+			// soundness demands `unknown <: l.Params[i].Type` there — exact-types
+			// §4.2.1.2 "Variation B", the load-bearing rejection. That check needs the
+			// `_ <: unknown` (⊤) rule constrain lacks until M6, and an inexact function
+			// is unreachable from M3 source anyway (resolveTypeAnn resolves no function
+			// annotations), so the extra positions are left unchecked here for now. For
+			// every M3-reachable input (exact functions only) the shared loop is complete.
 			var errs []SolverError
 			n := min(len(l.Params), len(r.Params))
 			for i := 0; i < n; i++ {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -11,16 +11,28 @@ import (
 // an inexact function tolerates any number of trailing arguments as a callback.
 const unboundedArity = math.MaxInt
 
+// hasRest reports whether f's LAST parameter is a typed rest param (`...xs: T[]`).
+// A rest param binds zero or more trailing arguments, so it never counts toward the
+// required floor and lifts the accept-set upper bound to ∞ (#677 §4.2.3) — the same
+// upper-bound effect as the inexact `...` marker, reached a different way.
+func hasRest(f *soltype.FuncType) bool {
+	n := len(f.Params)
+	return n > 0 && f.Params[n-1].Rest
+}
+
 // requiredCount is the number of arguments a positional call must supply — the
-// LOWER bound of f's accept-set. Because arguments bind positionally, an optional
-// (`x?`) parameter only lowers the requirement when it is TRAILING: in fn(a, b?)
-// you may omit b, but in fn(a?, b) you cannot omit a while still supplying b, so a
-// is effectively required. So required = the position after the last non-optional
-// param = len(Params) minus the count of TRAILING optionals — NOT the count of all
-// non-optional params, which would wrongly treat a leading optional as droppable
-// and let a call leave a required trailing param unbound.
+// LOWER bound of f's accept-set. Because arguments bind positionally, a parameter
+// only lowers the requirement when it is TRAILING: a trailing rest param (zero or
+// more) and trailing optionals (`x?`) may be omitted, but in fn(a?, b) you cannot
+// omit a while still supplying b, so a is effectively required. So required = the
+// position after the last non-optional, non-rest param — NOT the count of all
+// non-optional params, which would wrongly treat a leading optional (or the rest
+// param) as droppable and let a call leave a required param unbound.
 func requiredCount(f *soltype.FuncType) int {
 	n := len(f.Params)
+	if n > 0 && f.Params[n-1].Rest {
+		n-- // a trailing rest param binds zero-or-more args, so it is never required
+	}
 	for n > 0 && f.Params[n-1].Optional {
 		n--
 	}
@@ -28,13 +40,14 @@ func requiredCount(f *soltype.FuncType) int {
 }
 
 // acceptSet is the inclusive range [lo, hi] of argument counts f tolerates when
-// invoked (#677 §4.2.1): lo = requiredCount(f); hi = len(f.Params) when f is exact
-// (a finite upper bound) and unboundedArity when f is inexact. Read a supertype
-// callback slot's accept-set as "the argument counts whoever holds this slot may
-// invoke the supplied function with."
+// invoked (#677 §4.2.1): lo = requiredCount(f); hi = len(f.Params) when f has a
+// finite arity, and unboundedArity when its upper bound is open — either because it
+// is inexact (the `...` marker) OR because its last param is a typed rest (§4.2.3).
+// Read a supertype callback slot's accept-set as "the argument counts whoever holds
+// this slot may invoke the supplied function with."
 func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	lo = requiredCount(f)
-	if f.Inexact {
+	if f.Inexact || hasRest(f) {
 		hi = unboundedArity
 	} else {
 		hi = len(f.Params)
@@ -252,7 +265,7 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache), Optional: p.Optional}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache), Optional: p.Optional, Rest: p.Rest}
 		}
 		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache), Inexact: t.Inexact}
 	case *soltype.TupleType:

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -35,6 +35,11 @@ func optParam(name string, t soltype.Type) *soltype.FuncParam {
 	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t, Optional: true}
 }
 
+// restParam builds a typed rest param (`...name: t`), which must be the last param.
+func restParam(name string, t soltype.Type) *soltype.FuncParam {
+	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t, Rest: true}
+}
+
 // exactFn / inexactFn build function types so the accept-set tests read at a glance
 // which arm they exercise. Exact is the zero value of Inexact, so exactFn sets no
 // flag; inexactFn sets Inexact.
@@ -235,6 +240,69 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 			exactFn(num(), identParam("a", num()), optParam("b", num())),
 			exactFn(num(), identParam("a", num())),
 		))
+	})
+}
+
+// TestAcceptSetRestParam pins the arity arithmetic for a typed rest param: it lifts
+// the upper bound to ∞ and never counts toward the required floor (#677 §4.2.3).
+func TestAcceptSetRestParam(t *testing.T) {
+	t.Run("fn(a, b, ...rest): required 2, upper unbounded", func(t *testing.T) {
+		f := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("a", num()), identParam("b", num()), restParam("rest", num())}, Ret: num()}
+		require.Equal(t, 2, requiredCount(f))
+		lo, hi := acceptSet(f)
+		require.Equal(t, 2, lo)
+		require.Equal(t, unboundedArity, hi)
+	})
+
+	t.Run("fn(...rest): required 0, upper unbounded", func(t *testing.T) {
+		f := &soltype.FuncType{Params: []*soltype.FuncParam{restParam("rest", num())}, Ret: num()}
+		require.Equal(t, 0, requiredCount(f))
+		lo, hi := acceptSet(f)
+		require.Equal(t, 0, lo)
+		require.Equal(t, unboundedArity, hi)
+	})
+
+	t.Run("fn(a, b?, ...rest): required 1 (rest and trailing optional both drop out)", func(t *testing.T) {
+		f := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("a", num()), optParam("b", num()), restParam("rest", num())}, Ret: num()}
+		require.Equal(t, 1, requiredCount(f))
+	})
+}
+
+// TestConstrainFunctionRestParam exercises the accept-set subtyping rule for a typed
+// rest param, whose ∞ upper bound mirrors the inexact `...` marker.
+func TestConstrainFunctionRestParam(t *testing.T) {
+	restFn := func(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
+		return &soltype.FuncType{Params: params, Ret: ret}
+	}
+
+	// fn(a, ...rest) (accept [1, ∞)) fills a WIDER exact slot fn(a, b, c) (accept
+	// [3, 3]): the rest absorbs the slot's extra arguments — the case rest exists for.
+	t.Run("rest fn fills a wider exact slot", func(t *testing.T) {
+		c := &Context{}
+		g := restFn(num(), identParam("a", num()), restParam("rest", num()))
+		f := exactFn(num(), identParam("a", num()), identParam("b", num()), identParam("c", num()))
+		require.Empty(t, c.Constrain(g, f))
+	})
+
+	// A rest fn and an inexact fn have the same ∞ upper bound, so a rest fn fills an
+	// inexact slot of matching required arity.
+	t.Run("rest fn fills an inexact slot", func(t *testing.T) {
+		c := &Context{}
+		g := restFn(num(), identParam("a", num()), restParam("rest", num()))
+		f := inexactFn(num(), identParam("a", num()))
+		require.Empty(t, c.Constrain(g, f))
+	})
+
+	// An exact fn(a, b) (accept [2, 2]) is REJECTED by a `fn(...rest)` slot (accept
+	// [0, ∞)): the slot may invoke with zero args, but g demands two — a lower-bound
+	// failure (loG=2 > loF=0), exactness aside.
+	t.Run("exact fn rejected by a zero-required rest slot", func(t *testing.T) {
+		c := &Context{}
+		g := exactFn(num(), identParam("a", num()), identParam("b", num()))
+		f := restFn(num(), restParam("rest", num()))
+		require.Equal(t,
+			[]string{"cannot constrain function of arity 2 <: function of arity 1"},
+			Messages(c.Constrain(g, f)))
 	})
 }
 

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -35,14 +35,15 @@ func optParam(name string, t soltype.Type) *soltype.FuncParam {
 	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t, Optional: true}
 }
 
-// exactFn / inexactFn build function types with the PR4 exactness flag set
-// explicitly, so the accept-set tests read at a glance which arm they exercise.
+// exactFn / inexactFn build function types so the accept-set tests read at a glance
+// which arm they exercise. Exact is the zero value of Inexact, so exactFn sets no
+// flag; inexactFn sets Inexact.
 func exactFn(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
-	return &soltype.FuncType{Params: params, Ret: ret, Exact: true}
+	return &soltype.FuncType{Params: params, Ret: ret}
 }
 
 func inexactFn(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
-	return &soltype.FuncType{Params: params, Ret: ret, Exact: false}
+	return &soltype.FuncType{Params: params, Ret: ret, Inexact: true}
 }
 
 func TestConstrainPrim(t *testing.T) {

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -31,6 +31,20 @@ func identParam(name string, t soltype.Type) *soltype.FuncParam {
 	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t}
 }
 
+func optParam(name string, t soltype.Type) *soltype.FuncParam {
+	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t, Optional: true}
+}
+
+// exactFn / inexactFn build function types with the PR4 exactness flag set
+// explicitly, so the accept-set tests read at a glance which arm they exercise.
+func exactFn(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
+	return &soltype.FuncType{Params: params, Ret: ret, Exact: true}
+}
+
+func inexactFn(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType {
+	return &soltype.FuncType{Params: params, Ret: ret, Exact: false}
+}
+
 func TestConstrainPrim(t *testing.T) {
 	tests := []struct {
 		name string
@@ -96,8 +110,8 @@ func TestConstrainFunctionVariance(t *testing.T) {
 	// (number) -> number  <:  (number) -> number
 	t.Run("same shape", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
+		f1 := exactFn(num(), identParam("x", num()))
+		f2 := exactFn(num(), identParam("x", num()))
 		require.Empty(t, c.Constrain(f1, f2))
 	})
 
@@ -105,8 +119,8 @@ func TestConstrainFunctionVariance(t *testing.T) {
 	// 5 <: number on the param (rhs param <: lhs param), which holds.
 	t.Run("contravariant params (ok)", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", numLit(5))}, Ret: num()}
+		f1 := exactFn(num(), identParam("x", num()))
+		f2 := exactFn(num(), identParam("x", numLit(5)))
 		require.Empty(t, c.Constrain(f1, f2))
 	})
 
@@ -114,65 +128,112 @@ func TestConstrainFunctionVariance(t *testing.T) {
 	// number <: 5, which fails.
 	t.Run("contravariant params (fail)", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", numLit(5))}, Ret: num()}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
+		f1 := exactFn(num(), identParam("x", numLit(5)))
+		f2 := exactFn(num(), identParam("x", num()))
 		require.Equal(t, []string{"cannot constrain number <: 5"}, Messages(c.Constrain(f1, f2)))
 	})
 
 	// Covariant return: (number) -> 5 <: (number) -> number requires 5 <: number.
 	t.Run("covariant return (ok)", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: numLit(5)}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
+		f1 := exactFn(numLit(5), identParam("x", num()))
+		f2 := exactFn(num(), identParam("x", num()))
 		require.Empty(t, c.Constrain(f1, f2))
 	})
 }
 
-func TestConstrainFunctionArity(t *testing.T) {
-	// M1 functions are exact (Escalier is exact-by-default), so subtyping
-	// requires the SAME arity — both fewer and more params are rejected,
-	// parallel to the exact-tuple same-length rule. The inexact
-	// fewer-params-is-subtype arm lands in M3 with the exactness flag; see
-	// planning/simple_sub/01-milestones.md M1 scope and accept criteria.
-
-	// Fewer params is NOT a subtype under exact arity: arity 1 <: arity 2 fails.
-	t.Run("fewer params rejected", func(t *testing.T) {
+// TestConstrainFunctionAcceptSet exercises the PR4 accept-set rule (#677 §4.2.1):
+// G <: F iff accept(G) ⊇ accept(F), with params contravariant and return covariant.
+// Read F (the RHS) as the callback slot.
+func TestConstrainFunctionAcceptSet(t *testing.T) {
+	// Two EXACT functions relate by the old same-arity rule: accept is [n, n] on both
+	// sides, so ⊇ forces equal arity.
+	t.Run("exact same arity ok", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		f2 := &soltype.FuncType{
-			Params: []*soltype.FuncParam{identParam("x", num()), identParam("y", num())},
-			Ret:    num(),
-		}
-		errs := c.Constrain(f1, f2)
+		require.Empty(t, c.Constrain(
+			exactFn(num(), identParam("x", num())),
+			exactFn(num(), identParam("x", num())),
+		))
+	})
+
+	// An exact supplier cannot fill a WIDER exact slot: accept [1,1] does not contain
+	// the slot's count 2 (upper-bound failure, hiG < hiF).
+	t.Run("exact fn(x) rejected by fn(x, y) slot", func(t *testing.T) {
+		c := &Context{}
+		g := exactFn(num(), identParam("x", num()))
+		f := exactFn(num(), identParam("x", num()), identParam("y", num()))
+		errs := c.Constrain(g, f)
 		require.Equal(t, []string{"cannot constrain function of arity 1 <: function of arity 2"}, Messages(errs))
 		fa, ok := errs[0].(*FuncArityMismatchError)
 		require.True(t, ok)
-		require.Same(t, f1, fa.LHS)
-		require.Same(t, f2, fa.RHS)
+		require.Same(t, g, fa.LHS)
+		require.Same(t, f, fa.RHS)
 	})
 
-	// More params is also NOT a subtype: arity 2 <: arity 1 fails.
-	t.Run("more params rejected", func(t *testing.T) {
+	// The #677 callback matrix for an exact fn(x, y) slot: fn(x, y), fn(x, ...), and
+	// fn(...) are all accepted; exact fn(x) (too narrow upper bound) and a 3-param
+	// function (demands more than the slot supplies) are rejected.
+	slot := func() *soltype.FuncType { return exactFn(num(), identParam("x", num()), identParam("y", num())) }
+	t.Run("exact fn(x, y) fills fn(x, y) slot", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{
-			Params: []*soltype.FuncParam{identParam("x", num()), identParam("y", num())},
-			Ret:    num(),
-		}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		errs := c.Constrain(f1, f2)
-		require.Equal(t, []string{"cannot constrain function of arity 2 <: function of arity 1"}, Messages(errs))
-		fa, ok := errs[0].(*FuncArityMismatchError)
-		require.True(t, ok)
-		require.Same(t, f1, fa.LHS)
-		require.Same(t, f2, fa.RHS)
+		require.Empty(t, c.Constrain(exactFn(num(), identParam("x", num()), identParam("y", num())), slot()))
+	})
+	t.Run("inexact fn(x, ...) fills fn(x, y) slot", func(t *testing.T) {
+		c := &Context{}
+		// accept(G) = [1, ∞) ⊇ accept(slot) = [2, 2]; the slot's arg 2 is tolerated,
+		// the single shared param checked contravariantly.
+		require.Empty(t, c.Constrain(inexactFn(num(), identParam("x", num())), slot()))
+	})
+	t.Run("inexact fn(...) fills fn(x, y) slot", func(t *testing.T) {
+		c := &Context{}
+		// accept(G) = [0, ∞) ⊇ [2, 2]: a zero-param inexact function fills any exact
+		// slot whose required count it meets. This is the case exactness exists to permit.
+		require.Empty(t, c.Constrain(inexactFn(num()), slot()))
+	})
+	t.Run("exact fn(x) rejected by fn(x, y) slot (matrix)", func(t *testing.T) {
+		c := &Context{}
+		require.Equal(t,
+			[]string{"cannot constrain function of arity 1 <: function of arity 2"},
+			Messages(c.Constrain(exactFn(num(), identParam("x", num())), slot())))
+	})
+	t.Run("3-param fn rejected by fn(x, y) slot", func(t *testing.T) {
+		c := &Context{}
+		g := exactFn(num(), identParam("x", num()), identParam("y", num()), identParam("z", num()))
+		// accept(G) = [3, 3]; the slot supplies 2, below G's required 3 → lower-bound
+		// failure (loG > loF).
+		require.Equal(t,
+			[]string{"cannot constrain function of arity 3 <: function of arity 2"},
+			Messages(c.Constrain(g, slot())))
 	})
 
-	// Same arity is fine; variance is then checked element-wise.
-	t.Run("same arity ok", func(t *testing.T) {
+	// Exact </: inexact: an exact function's finite upper bound cannot cover an
+	// inexact slot's ∞ (the asymmetry §4.2.1.1 explains).
+	t.Run("exact fn(x) rejected by inexact fn(x, ...) slot", func(t *testing.T) {
 		c := &Context{}
-		f1 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		f2 := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("x", num())}, Ret: num()}
-		require.Empty(t, c.Constrain(f1, f2))
+		require.Equal(t,
+			[]string{"cannot constrain function of arity 1 <: function of arity 1"},
+			Messages(c.Constrain(exactFn(num(), identParam("x", num())), inexactFn(num(), identParam("x", num())))))
+	})
+
+	// Inexact <: inexact: the classic "fewer params is okay" rule — both upper bounds
+	// are ∞, the supplier just needs to handle the consumer's required params.
+	t.Run("inexact fn(x, ...) fills inexact fn(x, y, ...) slot", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(
+			inexactFn(num(), identParam("x", num())),
+			inexactFn(num(), identParam("x", num()), identParam("y", num())),
+		))
+	})
+
+	// Optional params lower `required` without changing arity: exact fn(a, b?)
+	// (accept [1, 2]) fills the narrower exact fn(a) slot (accept [1, 1]) — the slot
+	// never supplies the optional argument.
+	t.Run("exact fn(a, b?) fills fn(a) slot", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(
+			exactFn(num(), identParam("a", num()), optParam("b", num())),
+			exactFn(num(), identParam("a", num())),
+		))
 	})
 }
 

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -329,8 +329,16 @@ func (e *NamespaceUsedAsValueError) Message() string {
 	return "Namespace used as a value: " + e.Ident.Name
 }
 
-func (e *TooManyArgsError) Span() ast.Span      { return e.Call.Span() }
-func (e *TooManyArgsError) Related() []ast.Span { return []ast.Span{e.Call.Callee.Span()} }
+func (e *TooManyArgsError) Span() ast.Span { return e.Call.Span() }
+func (e *TooManyArgsError) Related() []ast.Span {
+	// Span() uses the call's own span and never derefs Callee; Related() does, so
+	// guard a nil Callee (not produced by the parser, but possible in a hand-built
+	// AST) to uphold the "never panic on malformed AST" guarantee.
+	if e.Call.Callee == nil {
+		return nil
+	}
+	return []ast.Span{e.Call.Callee.Span()}
+}
 func (e *TooManyArgsError) Message() string {
 	return fmt.Sprintf("Too many arguments: expected at most %d, but got %d",
 		len(e.Fn.Params), len(e.Call.Args))

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -291,8 +291,25 @@ type OverloadNotSupportedError struct {
 	Name           string
 }
 
+// TooManyArgsError fires when a DIRECT call supplies more arguments than the
+// (concrete) callee declares — the #677 §4.2.3 extra-arg lint, which rejects
+// too-many for exact AND inexact callees alike (an inexact function tolerates
+// extras only as a callback, not at a visible call site). It is the uniform
+// too-many message; the surviving FuncArityMismatchError covers "too few /
+// required" and the callback-subtyping accept-set failures.
+//
+// It is a BRIDGE error: born in inferCall with the *ast.CallExpr in hand, so it
+// self-blames (Span() is the call's own span) and relates the callee expression —
+// no Prov stamping. Fn is the resolved callee FuncType, retained so the message can
+// report the declared parameter count.
+type TooManyArgsError struct {
+	Call *ast.CallExpr
+	Fn   *soltype.FuncType
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
+func (*TooManyArgsError) isSolverError()          {}
 func (*UnsupportedNodeError) isSolverError()      {}
 func (*UnsupportedFeatureError) isSolverError()   {}
 func (*BodyDeclNotAllowedError) isSolverError()   {}
@@ -310,6 +327,13 @@ func (e *NamespaceUsedAsValueError) Span() ast.Span      { return e.Ident.Span()
 func (e *NamespaceUsedAsValueError) Related() []ast.Span { return nil }
 func (e *NamespaceUsedAsValueError) Message() string {
 	return "Namespace used as a value: " + e.Ident.Name
+}
+
+func (e *TooManyArgsError) Span() ast.Span      { return e.Call.Span() }
+func (e *TooManyArgsError) Related() []ast.Span { return []ast.Span{e.Call.Callee.Span()} }
+func (e *TooManyArgsError) Message() string {
+	return fmt.Sprintf("Too many arguments: expected at most %d, but got %d",
+		len(e.Fn.Params), len(e.Call.Args))
 }
 
 func (e *UnsupportedNodeError) Span() ast.Span      { return e.Node.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -307,9 +307,25 @@ type TooManyArgsError struct {
 	Fn   *soltype.FuncType
 }
 
+// NotEnoughArgsError fires when a DIRECT call supplies fewer arguments than the
+// (concrete) callee REQUIRES — the symmetric twin of TooManyArgsError. `required`
+// is the count of non-trailing-optional params (requiredCount), so an optional
+// trailing param may be omitted without tripping it. Like TooManyArgsError it is a
+// call-site lint over a concrete callee; a deferred (var) callee's too-few still
+// surfaces from the accept-set gate as FuncArityMismatchError.
+//
+// It is a BRIDGE error: born in inferCall with the *ast.CallExpr in hand, so it
+// self-blames (Span() is the call) and relates the callee expression. Fn is the
+// resolved callee FuncType, retained so the message can report the required count.
+type NotEnoughArgsError struct {
+	Call *ast.CallExpr
+	Fn   *soltype.FuncType
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*TooManyArgsError) isSolverError()          {}
+func (*NotEnoughArgsError) isSolverError()        {}
 func (*UnsupportedNodeError) isSolverError()      {}
 func (*UnsupportedFeatureError) isSolverError()   {}
 func (*BodyDeclNotAllowedError) isSolverError()   {}
@@ -342,6 +358,18 @@ func (e *TooManyArgsError) Related() []ast.Span {
 func (e *TooManyArgsError) Message() string {
 	return fmt.Sprintf("Too many arguments: expected at most %d, but got %d",
 		len(e.Fn.Params), len(e.Call.Args))
+}
+
+func (e *NotEnoughArgsError) Span() ast.Span { return e.Call.Span() }
+func (e *NotEnoughArgsError) Related() []ast.Span {
+	if e.Call.Callee == nil {
+		return nil
+	}
+	return []ast.Span{e.Call.Callee.Span()}
+}
+func (e *NotEnoughArgsError) Message() string {
+	return fmt.Sprintf("Not enough arguments: expected at least %d, but got %d",
+		requiredCount(e.Fn), len(e.Call.Args))
 }
 
 func (e *UnsupportedNodeError) Span() ast.Span      { return e.Node.Span() }

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -1,0 +1,87 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- PR4: function exactness (#677), source-level behaviors ---
+
+// A written function value is EXACT, so calling it with exactly its declared arity
+// type-checks. This is the regression the exact call-demand guards: an INEXACT
+// synthesized demand (the FuncType Go zero value) would have accept-set [N, ∞) and
+// force the callee inexact, rejecting every call to an exact function.
+func TestInferCallExactArityTypeChecks(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number, y: number) -> number { x }
+		val r = f(1, 2)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"])
+}
+
+// A too-many-args direct call to an exact function yields EXACTLY ONE diagnostic —
+// the TooManyArgsError lint — not a doubled lint + FuncArityMismatch. The constraint
+// receives only the arity-matched prefix, so its accept-set gate stays silent.
+func TestInferCallExactTooManyArgsSingleDiagnostic(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x: number, y: number) -> number { x }
+		val r = f(1, 2, 3)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Too many arguments: expected at most 2, but got 3", errs[0].Message())
+}
+
+// An `x?` optional parameter parsed from source carries onto the function type: it
+// renders as `y?: T` and lowers the function's required count (the accept-set lower
+// bound) without changing arity.
+func TestInferOptionalParamRenders(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(x: number, y?: number) -> number { x }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: number, y?: number) -> number", values["f"])
+}
+
+// The optional parameter's lower/upper bounds at a direct call: omitting it (1 arg)
+// and supplying it (2 args) both type-check; overflowing it (3 args) trips the lint.
+func TestInferOptionalParamCallArity(t *testing.T) {
+	t.Run("omitted and supplied both type-check", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(x: number, y?: number) -> number { x }
+			val a = f(1)
+			val b = f(1, 2)
+		`)
+		require.Empty(t, errs)
+	})
+
+	t.Run("overflow trips the lint", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(x: number, y?: number) -> number { x }
+			val c = f(1, 2, 3)
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "Too many arguments: expected at most 2, but got 3", errs[0].Message())
+	})
+}
+
+// The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls
+// reject extras regardless of exactness). An inexact function value has no source
+// syntax yet (the `...` marker rides on function-type annotations, which the solver
+// does not resolve), so this is exercised over a hand-built inexact binding.
+func TestInferCallInexactCalleeRejectsExtraArgs(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("g", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
+		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
+		Exact:  false, // inexact: tolerates extras as a CALLBACK, but not at a direct call
+	})}})
+	// g(1, 2) — one extra positional argument beyond the single declared param.
+	e := ast.NewCall(identExpr("g"), []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
+
+	c.inferExpr(scope, 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Too many arguments: expected at most 1, but got 2", c.errs[0].Message())
+}

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -79,6 +79,27 @@ func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 	require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", errs[0].Message())
 }
 
+// A function value declared with the trailing `...` marker now parses (PR4 parser
+// support) and is inferred INEXACT: its rendered type carries the `...`, but the
+// direct-call lint still rejects extra args (§4.2.3 — inexactness governs callback
+// subtyping, not direct calls).
+func TestInferInexactFunctionValue(t *testing.T) {
+	t.Run("renders with the inexact marker", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f(x: number, ...) -> number { x }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (x: number, ...) -> number", values["f"])
+	})
+
+	t.Run("direct call still rejects extra args", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(x: number, ...) -> number { x }
+			val r = f(1, 2)
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "Too many arguments: expected at most 1, but got 2", errs[0].Message())
+	})
+}
+
 // The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls
 // reject extras regardless of exactness). An inexact function value has no source
 // syntax yet (the `...` marker rides on function-type annotations, which the solver

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -69,14 +69,15 @@ func TestInferOptionalParamCallArity(t *testing.T) {
 // A NON-TRAILING optional does not lower the required count: arguments bind
 // positionally, so a required param after an optional is still required. `f(1)` on
 // `fn(a?, b)` must be rejected (it would leave the required `b` unbound), even
-// though `a` is marked optional. requiredCount counts trailing optionals only.
+// though `a` is marked optional. requiredCount counts trailing optionals only, so
+// the too-few lint reports a required count of 2.
 func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(a?: number, b: number) -> number { b }
 		val r = f(1)
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", errs[0].Message())
+	require.Equal(t, "Not enough arguments: expected at least 2, but got 1", errs[0].Message())
 }
 
 // A function value declared with the trailing `...` marker now parses (PR4 parser
@@ -98,6 +99,17 @@ func TestInferInexactFunctionValue(t *testing.T) {
 		require.Len(t, errs, 1)
 		require.Equal(t, "Too many arguments: expected at most 1, but got 2", errs[0].Message())
 	})
+}
+
+// The too-few lint reports the REQUIRED count, not the declared count: a trailing
+// optional may be omitted, so `fn(x, y?)` called with no args needs at least 1.
+func TestInferTooFewArgsRespectsOptional(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x: number, y?: number) -> number { x }
+		val r = f()
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Not enough arguments: expected at least 1, but got 0", errs[0].Message())
 }
 
 // The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -66,6 +66,19 @@ func TestInferOptionalParamCallArity(t *testing.T) {
 	})
 }
 
+// A NON-TRAILING optional does not lower the required count: arguments bind
+// positionally, so a required param after an optional is still required. `f(1)` on
+// `fn(a?, b)` must be rejected (it would leave the required `b` unbound), even
+// though `a` is marked optional. requiredCount counts trailing optionals only.
+func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(a?: number, b: number) -> number { b }
+		val r = f(1)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", errs[0].Message())
+}
+
 // The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls
 // reject extras regardless of exactness). An inexact function value has no source
 // syntax yet (the `...` marker rides on function-type annotations, which the solver

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -115,7 +115,8 @@ func TestInferTooFewArgsRespectsOptional(t *testing.T) {
 // A typed rest param absorbs trailing arguments, so a direct call with more args
 // than declared is NOT too-many (#677 §4.2.3) — but too-few still applies to the
 // fixed params. Rest params have no source syntax in M3 (inferFunc reports them
-// unsupported), so this is built by hand, like the inexact-callee test.
+// unsupported), so this is built by hand — unlike the inexact `...` marker, which is
+// source-expressible and covered via inferSource in TestInferInexactFunctionValue.
 func TestInferCallRestCalleeArity(t *testing.T) {
 	// fn g(x: number, ...rest: number): one fixed param + a rest.
 	restCallee := func() ValueBinding {
@@ -148,24 +149,4 @@ func TestInferCallRestCalleeArity(t *testing.T) {
 		require.Len(t, c.errs, 1)
 		require.Equal(t, "Not enough arguments: expected at least 1, but got 0", c.errs[0].Message())
 	})
-}
-
-// The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls
-// reject extras regardless of exactness). An inexact function value has no source
-// syntax yet (the `...` marker rides on function-type annotations, which the solver
-// does not resolve), so this is exercised over a hand-built inexact binding.
-func TestInferCallInexactCalleeRejectsExtraArgs(t *testing.T) {
-	c := newChecker()
-	scope := NewScope()
-	scope.defineValue("g", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
-		Params:  []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
-		Ret:     &soltype.PrimType{Prim: soltype.NumPrim},
-		Inexact: true, // inexact: tolerates extras as a CALLBACK, but not at a direct call
-	})}})
-	// g(1, 2) — one extra positional argument beyond the single declared param.
-	e := ast.NewCall(identExpr("g"), []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
-
-	c.inferExpr(scope, 0, e)
-	require.Len(t, c.errs, 1)
-	require.Equal(t, "Too many arguments: expected at most 1, but got 2", c.errs[0].Message())
 }

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -108,9 +108,9 @@ func TestInferCallInexactCalleeRejectsExtraArgs(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
 	scope.defineValue("g", ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
-		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
-		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
-		Exact:  false, // inexact: tolerates extras as a CALLBACK, but not at a direct call
+		Params:  []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}}},
+		Ret:     &soltype.PrimType{Prim: soltype.NumPrim},
+		Inexact: true, // inexact: tolerates extras as a CALLBACK, but not at a direct call
 	})}})
 	// g(1, 2) — one extra positional argument beyond the single declared param.
 	e := ast.NewCall(identExpr("g"), []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -112,6 +112,44 @@ func TestInferTooFewArgsRespectsOptional(t *testing.T) {
 	require.Equal(t, "Not enough arguments: expected at least 1, but got 0", errs[0].Message())
 }
 
+// A typed rest param absorbs trailing arguments, so a direct call with more args
+// than declared is NOT too-many (#677 §4.2.3) — but too-few still applies to the
+// fixed params. Rest params have no source syntax in M3 (inferFunc reports them
+// unsupported), so this is built by hand, like the inexact-callee test.
+func TestInferCallRestCalleeArity(t *testing.T) {
+	// fn g(x: number, ...rest: number): one fixed param + a rest.
+	restCallee := func() ValueBinding {
+		return ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.FuncType{
+			Params: []*soltype.FuncParam{
+				{Pattern: &soltype.IdentPat{Name: "x"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+				{Pattern: &soltype.IdentPat{Name: "rest"}, Type: &soltype.PrimType{Prim: soltype.NumPrim}, Rest: true},
+			},
+			Ret: &soltype.PrimType{Prim: soltype.NumPrim},
+		})}}
+	}
+
+	t.Run("absorbs extra args (no too-many)", func(t *testing.T) {
+		c := newChecker()
+		scope := NewScope()
+		scope.defineValue("g", restCallee())
+		// g(1, 2, 3) — two args beyond the fixed param; the rest absorbs them.
+		e := ast.NewCall(identExpr("g"), []ast.Expr{numExpr(1), numExpr(2), numExpr(3)}, false, testSpan())
+		c.inferExpr(scope, 0, e)
+		require.Empty(t, c.errs)
+	})
+
+	t.Run("still rejects too few (required fixed params)", func(t *testing.T) {
+		c := newChecker()
+		scope := NewScope()
+		scope.defineValue("g", restCallee())
+		// g() — zero args, but x is required (the rest may be empty, x may not).
+		e := ast.NewCall(identExpr("g"), nil, false, testSpan())
+		c.inferExpr(scope, 0, e)
+		require.Len(t, c.errs, 1)
+		require.Equal(t, "Not enough arguments: expected at least 1, but got 0", c.errs[0].Message())
+	})
+}
+
 // The extra-arg lint fires for an INEXACT callee too (#677 §4.2.3: direct calls
 // reject extras regardless of exactness). An inexact function value has no source
 // syntax yet (the `...` marker rides on function-type annotations, which the solver

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -248,7 +248,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	fn, isConcrete := concreteFunc(callee)
 	demand := args
 	switch {
-	case isConcrete && len(args) > len(fn.Params):
+	case isConcrete && !hasRest(fn) && len(args) > len(fn.Params):
+		// A typed rest param (hasRest) absorbs any number of trailing args, so it is
+		// never "too many" — only a fixed-arity (non-rest) callee trips this lint.
 		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
 		demand = args[:len(fn.Params)]
 	case isConcrete && len(args) < requiredCount(fn):

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -140,7 +140,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
 		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
 		// `required` count without dropping the param — carried onto the soltype so
-		// the accept-set rule and the printer (x?: T) see it.
+		// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
+		// in-body binding keeps the param's declared type (pt), NOT widened to
+		// `pt | undefined`, so a body that reads an omitted optional sees it at the
+		// narrower type. Widening needs undefined/unions (M6); M3 has neither.
 		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 	}
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -233,21 +233,31 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, Application)
 
-	// Extra-arg lint (#677 §4.2.3): a DIRECT call rejects more arguments than the
-	// callee declares — for exact AND inexact callees alike. This is a call-site
-	// check the subtype lattice deliberately does NOT model: an inexact callee
-	// tolerates extras as a *callback* (accept-set [required, ∞)), but supplying
-	// extras to a call you can see is treated as a mistake. It fires only when the
-	// callee is concrete; for a deferred (var) callee it is best-effort skipped while
-	// "too few / required" still flows through the constraint below.
+	// Arity lints (#677 §4.2.3): a DIRECT call rejects too-many AND too-few arguments
+	// — for exact AND inexact callees alike. These are call-site checks the subtype
+	// lattice does not model uniformly (an inexact callee tolerates extras as a
+	// *callback*, accept-set [required, ∞), but supplying extras to a call you can see
+	// is a mistake). They fire only when the callee is concrete; for a deferred (var)
+	// callee they are best-effort skipped while too-few still surfaces from the gate.
+	//
+	// When a lint fires, the demand is reshaped to the callee's declared arity
+	// (len(fn.Params)) so the EXACT synth's accept-set gate does NOT also report
+	// arity (the lint owns the single, uniform message; the constraint does pure
+	// type-flow on the supplied args). Too-many truncates to the prefix; too-few pads
+	// the missing slots with fresh vars, which impose no constraint on absent args.
 	fn, isConcrete := concreteFunc(callee)
 	demand := args
-	if isConcrete && len(args) > len(fn.Params) {
-		// Hand the constraint only the arity-matched prefix so the EXACT synth's
-		// accept-set gate does not ALSO report arity — the lint owns the single,
-		// uniform too-many message; the constraint does pure type-flow.
+	switch {
+	case isConcrete && len(args) > len(fn.Params):
 		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
 		demand = args[:len(fn.Params)]
+	case isConcrete && len(args) < requiredCount(fn):
+		c.errs = append(c.errs, &NotEnoughArgsError{Call: e, Fn: fn})
+		demand = make([]*soltype.FuncParam, len(fn.Params))
+		copy(demand, args)
+		for i := len(args); i < len(fn.Params); i++ {
+			demand[i] = &soltype.FuncParam{Type: c.freshAt(lvl)}
+		}
 	}
 
 	// EXACT + all-required call demand: accept(synth) = [N, N] (N = arg count), so
@@ -256,8 +266,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// the synth is exact by construction here; an INEXACT synth would have accept
 	// [N, ∞), forcing upper(callee) = ∞ and rejecting every call to an exact function.
 	callShape := &soltype.FuncType{Params: demand, Ret: res}
-	// Record the synthesized call-shape against the CallExpr so FuncArityMismatchError
-	// (the surviving "too few / required" path) resolves its blame to the call.
+	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
+	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
+	// concrete arity faults are owned by the lints above — resolves its blame to the call.
 	c.recordProv(callShape, e, CallShape)
 	c.constrain(e, callee, callShape)
 	if isConcrete {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -220,7 +220,7 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // so the return is wired through directly here. The callee is concrete either as a
 // bare FuncType (an inline callee) OR as a var whose lower bound is a FuncType (a
 // named/generalized callee, which inferIdent now resolves through instantiate — see
-// concreteFunc); both recover, so recovery no longer regresses for named callees.
+// resolveFunc); both recover, so recovery no longer regresses for named callees.
 //
 // PR4 adds two #677 pieces: an EXACT all-required call demand, and the extra-arg
 // lint that rejects passing more arguments than a concrete callee declares.
@@ -245,15 +245,15 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// arity (the lint owns the single, uniform message; the constraint does pure
 	// type-flow on the supplied args). Too-many truncates to the prefix; too-few pads
 	// the missing slots with fresh vars, which impose no constraint on absent args.
-	fn, isConcrete := concreteFunc(callee)
+	fn, resolved := resolveFunc(callee)
 	demand := args
 	switch {
-	case isConcrete && !hasRest(fn) && len(args) > len(fn.Params):
+	case resolved && !hasRest(fn) && len(args) > len(fn.Params):
 		// A typed rest param (hasRest) absorbs any number of trailing args, so it is
 		// never "too many" — only a fixed-arity (non-rest) callee trips this lint.
 		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
 		demand = args[:len(fn.Params)]
-	case isConcrete && len(args) < requiredCount(fn):
+	case resolved && len(args) < requiredCount(fn):
 		c.errs = append(c.errs, &NotEnoughArgsError{Call: e, Fn: fn})
 		demand = make([]*soltype.FuncParam, len(fn.Params))
 		copy(demand, args)
@@ -262,25 +262,26 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		}
 	}
 
-	// EXACT + all-required call demand: accept(synth) = [N, N] (N = arg count), so
-	// the constraint reads exactly "callee accepts being called with N args"
-	// (required(callee) <= N <= upper(callee)). Exact is the zero value of Inexact, so
-	// the synth is exact by construction here; an INEXACT synth would have accept
-	// [N, ∞), forcing upper(callee) = ∞ and rejecting every call to an exact function.
+	// callShape is built EXACT with all N params required, on purpose. That gives
+	// it accept-set [N, N] (N = arg count), so the callee <: callShape constraint
+	// reads "the callee must accept exactly N args" — it holds iff
+	// required(callee) <= N <= upper(callee). If callShape were INEXACT instead,
+	// its accept-set would widen to [N, ∞), demanding upper(callee) = ∞ and thus
+	// rejecting every call to a fixed-arity (exact) function.
 	callShape := &soltype.FuncType{Params: demand, Ret: res}
 	// Record the synthesized call-shape against the CallExpr so a FuncArityMismatchError
 	// — now only from a DEFERRED callee's too-few (or a callback-arity failure), since
 	// concrete arity faults are owned by the lints above — resolves its blame to the call.
 	c.recordProv(callShape, e, CallShape)
 	c.constrain(e, callee, callShape)
-	if isConcrete {
+	if resolved {
 		c.constrain(e, fn.Ret, res)
 	}
 	c.recordType(e, res)
 	return res
 }
 
-// concreteFunc resolves a callee to its concrete FuncType, used to recover a
+// resolveFunc resolves a callee to its concrete FuncType, used to recover a
 // call's return type. The callee is either a FuncType directly (an inline callee)
 // or a var whose first FuncType lower bound is the function (a named/generalized
 // callee, since inferIdent returns instantiate(scheme) — a fresh var). Looking
@@ -290,7 +291,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 // ok=false means no concrete func was found (e.g. a deferred callee with no lower
 // bound yet) — the caller skips return recovery. PR1 bindings have at most one
 // func lower bound; overload sets (PR6) resolve through resolveOverload, not here.
-func concreteFunc(t soltype.Type) (*soltype.FuncType, bool) {
+func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:
 		return t, true

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -177,12 +177,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			ret = &soltype.UnknownType{}
 		}
 	}
-	// A bare function value is EXACT (accept-set [required, len(Params)]): it rejects
+	// A bare function value is exact (accept-set [required, len(Params)]): it rejects
 	// extra arguments. A trailing `...` in the signature (sig.Inexact) marks it
 	// inexact — it tolerates extra args when used as a callback (#677 §4.1), accept
 	// [required, ∞). Note exactness governs callback subtyping, not direct calls: an
 	// inexact value still rejects extras at a visible call site (the inferCall lint).
-	ft := &soltype.FuncType{Params: params, Ret: ret, Exact: !sig.Inexact}
+	ft := &soltype.FuncType{Params: params, Ret: ret, Inexact: sig.Inexact}
 	// Record the function's own type against its node so a function flowing into a
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is
@@ -252,10 +252,10 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 
 	// EXACT + all-required call demand: accept(synth) = [N, N] (N = arg count), so
 	// the constraint reads exactly "callee accepts being called with N args"
-	// (required(callee) <= N <= upper(callee)). An INEXACT synth (the Go zero value)
-	// would have accept [N, ∞), forcing upper(callee) = ∞ and rejecting every call to
-	// an exact function — so Exact:true here is load-bearing, not decorative.
-	callShape := &soltype.FuncType{Params: demand, Ret: res, Exact: true}
+	// (required(callee) <= N <= upper(callee)). Exact is the zero value of Inexact, so
+	// the synth is exact by construction here; an INEXACT synth would have accept
+	// [N, ∞), forcing upper(callee) = ∞ and rejecting every call to an exact function.
+	callShape := &soltype.FuncType{Params: demand, Ret: res}
 	// Record the synthesized call-shape against the CallExpr so FuncArityMismatchError
 	// (the surviving "too few / required" path) resolves its blame to the call.
 	c.recordProv(callShape, e, CallShape)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -177,12 +177,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			ret = &soltype.UnknownType{}
 		}
 	}
-	// A written function value is EXACT (accept-set [required, len(Params)]): it has a
-	// definite parameter list and rejects extra arguments. Inexactness (`...`) is a
-	// property of function-type ANNOTATIONS describing callback slots, which the
-	// solver does not resolve yet (resolveTypeAnn handles primitives only), so every
-	// function value the walk builds is exact.
-	ft := &soltype.FuncType{Params: params, Ret: ret, Exact: true}
+	// A bare function value is EXACT (accept-set [required, len(Params)]): it rejects
+	// extra arguments. A trailing `...` in the signature (sig.Inexact) marks it
+	// inexact — it tolerates extra args when used as a callback (#677 §4.1), accept
+	// [required, ∞). Note exactness governs callback subtyping, not direct calls: an
+	// inexact value still rejects extras at a visible call site (the inferCall lint).
+	ft := &soltype.FuncType{Params: params, Ret: ret, Exact: !sig.Inexact}
 	// Record the function's own type against its node so a function flowing into a
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -138,7 +138,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// A parameter binding never generalizes — its var is fixed for the body — so
 		// it is a MonoScheme; instantiate returns pt unchanged at every use.
 		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
-		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt}
+		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
+		// `required` count without dropping the param — carried onto the soltype so
+		// the accept-set rule and the printer (x?: T) see it.
+		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 	}
 
 	var ret soltype.Type = &soltype.Void{}
@@ -171,7 +174,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			ret = &soltype.UnknownType{}
 		}
 	}
-	ft := &soltype.FuncType{Params: params, Ret: ret}
+	// A written function value is EXACT (accept-set [required, len(Params)]): it has a
+	// definite parameter list and rejects extra arguments. Inexactness (`...`) is a
+	// property of function-type ANNOTATIONS describing callback slots, which the
+	// solver does not resolve yet (resolveTypeAnn handles primitives only), so every
+	// function value the walk builds is exact.
+	ft := &soltype.FuncType{Params: params, Ret: ret, Exact: true}
 	// Record the function's own type against its node so a function flowing into a
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is
@@ -210,6 +218,9 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // bare FuncType (an inline callee) OR as a var whose lower bound is a FuncType (a
 // named/generalized callee, which inferIdent now resolves through instantiate — see
 // concreteFunc); both recover, so recovery no longer regresses for named callees.
+//
+// PR4 adds two #677 pieces: an EXACT all-required call demand, and the extra-arg
+// lint that rejects passing more arguments than a concrete callee declares.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
 	callee := c.inferExpr(scope, lvl, e.Callee)
 	args := make([]*soltype.FuncParam, len(e.Args))
@@ -218,12 +229,35 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, Application)
-	callShape := &soltype.FuncType{Params: args, Ret: res}
+
+	// Extra-arg lint (#677 §4.2.3): a DIRECT call rejects more arguments than the
+	// callee declares — for exact AND inexact callees alike. This is a call-site
+	// check the subtype lattice deliberately does NOT model: an inexact callee
+	// tolerates extras as a *callback* (accept-set [required, ∞)), but supplying
+	// extras to a call you can see is treated as a mistake. It fires only when the
+	// callee is concrete; for a deferred (var) callee it is best-effort skipped while
+	// "too few / required" still flows through the constraint below.
+	fn, isConcrete := concreteFunc(callee)
+	demand := args
+	if isConcrete && len(args) > len(fn.Params) {
+		// Hand the constraint only the arity-matched prefix so the EXACT synth's
+		// accept-set gate does not ALSO report arity — the lint owns the single,
+		// uniform too-many message; the constraint does pure type-flow.
+		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
+		demand = args[:len(fn.Params)]
+	}
+
+	// EXACT + all-required call demand: accept(synth) = [N, N] (N = arg count), so
+	// the constraint reads exactly "callee accepts being called with N args"
+	// (required(callee) <= N <= upper(callee)). An INEXACT synth (the Go zero value)
+	// would have accept [N, ∞), forcing upper(callee) = ∞ and rejecting every call to
+	// an exact function — so Exact:true here is load-bearing, not decorative.
+	callShape := &soltype.FuncType{Params: demand, Ret: res, Exact: true}
 	// Record the synthesized call-shape against the CallExpr so FuncArityMismatchError
-	// resolves its blame to the call.
+	// (the surviving "too few / required" path) resolves its blame to the call.
 	c.recordProv(callShape, e, CallShape)
 	c.constrain(e, callee, callShape)
-	if fn, ok := concreteFunc(callee); ok {
+	if isConcrete {
 		c.constrain(e, fn.Ret, res)
 	}
 	c.recordType(e, res)

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -225,9 +225,9 @@ func TestInferCallTooManyArgs(t *testing.T) {
 	require.Equal(t, "number", render(got))
 }
 
-// Too-few args still flows through the call-shape constraint as a FuncArityMismatch
-// (the surviving "required" check): the exact demand's accept-set [1,1] is not
-// contained in the callee's [2,2].
+// Too-few args at a direct call is the PR4 too-few lint (NotEnoughArgsError, the
+// symmetric twin of TooManyArgsError) — the demand is padded to the callee's arity
+// so the lint is the SOLE diagnostic, not a doubled lint + FuncArityMismatch.
 func TestInferCallTooFewArgs(t *testing.T) {
 	c := newChecker()
 	// (fn (x: number, y: number) { x })(1)
@@ -236,7 +236,7 @@ func TestInferCallTooFewArgs(t *testing.T) {
 
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", c.errs[0].Message())
+	require.Equal(t, "Not enough arguments: expected at least 2, but got 1", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 	// Error recovery: the result is still the callee's return type, not `never`.
 	require.Equal(t, "number", render(got))

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -208,7 +208,10 @@ func TestInferCallArgMismatch(t *testing.T) {
 	require.Equal(t, "number", render(got))
 }
 
-func TestInferCallArityMismatch(t *testing.T) {
+// Too-many args at a direct call is the PR4 extra-arg lint (TooManyArgsError, the
+// uniform too-many message), not a FuncArityMismatch — and the constraint receives
+// only the arity-matched prefix, so the lint is the SOLE diagnostic.
+func TestInferCallTooManyArgs(t *testing.T) {
 	c := newChecker()
 	// (fn (x: number) { x })(1, 2)
 	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
@@ -216,7 +219,24 @@ func TestInferCallArityMismatch(t *testing.T) {
 
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", c.errs[0].Message())
+	require.Equal(t, "Too many arguments: expected at most 1, but got 2", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+	// Error recovery: the result is still the callee's return type, not `never`.
+	require.Equal(t, "number", render(got))
+}
+
+// Too-few args still flows through the call-shape constraint as a FuncArityMismatch
+// (the surviving "required" check): the exact demand's accept-set [1,1] is not
+// contained in the callee's [2,2].
+func TestInferCallTooFewArgs(t *testing.T) {
+	c := newChecker()
+	// (fn (x: number, y: number) { x })(1)
+	callee := funcExpr([]*ast.Param{param("x", numAnn()), param("y", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	e := ast.NewCall(callee, []ast.Expr{numExpr(1)}, false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 	// Error recovery: the result is still the callee's return type, not `never`.
 	require.Equal(t, "number", render(got))

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -518,7 +518,7 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 // callee's declared return type (not `never`), matching the inline-callee recovery
 // asserted by TestInferCallTooManyArgs. M3's inferIdent returns an instantiated
 // var rather than a concrete FuncType, so inferCall recovers the return through the
-// var's FuncType lower bound (concreteFunc); without that, `r` regressed to `never`.
+// var's FuncType lower bound (resolveFunc); without that, `r` regressed to `never`.
 // PR4: too-many is the extra-arg lint (TooManyArgsError), not a FuncArityMismatch.
 func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -514,17 +514,18 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
 }
 
-// Error recovery for a NAMED callee: an arity-mismatched call still yields the
+// Error recovery for a NAMED callee: a too-many-args call still yields the
 // callee's declared return type (not `never`), matching the inline-callee recovery
-// asserted by TestInferCallArityMismatch. M3's inferIdent returns an instantiated
+// asserted by TestInferCallTooManyArgs. M3's inferIdent returns an instantiated
 // var rather than a concrete FuncType, so inferCall recovers the return through the
 // var's FuncType lower bound (concreteFunc); without that, `r` regressed to `never`.
+// PR4: too-many is the extra-arg lint (TooManyArgsError), not a FuncArityMismatch.
 func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { x }
 		val r = f(1, 2)
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain function of arity 1 <: function of arity 2", errs[0].Message())
+	require.Equal(t, "Too many arguments: expected at most 1, but got 2", errs[0].Message())
 	require.Equal(t, "number", values["r"], "the result recovers to the declared return, not never")
 }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -114,7 +114,7 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache), Optional: p.Optional}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache), Optional: p.Optional, Rest: p.Rest}
 		}
 		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache), Inexact: t.Inexact}
 	case *soltype.TupleType:

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -116,7 +116,7 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 		for i, p := range t.Params {
 			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache), Exact: t.Exact}
+		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache), Inexact: t.Inexact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -114,9 +114,9 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 	case *soltype.FuncType:
 		params := make([]*soltype.FuncParam, len(t.Params))
 		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache)}
+			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache), Optional: p.Optional}
 		}
-		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache)}
+		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache), Exact: t.Exact}
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -57,7 +57,8 @@ func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
 			Type:    p,
 		}
 	}
-	return &soltype.FuncType{Params: ps, Ret: ret}
+	// Operators are concrete function values, hence exact (accept-set [n, n]).
+	return &soltype.FuncType{Params: ps, Ret: ret, Exact: true}
 }
 
 // addOperatorBindings seeds the built-in operators, every one monomorphic over

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -57,8 +57,9 @@ func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
 			Type:    p,
 		}
 	}
-	// Operators are concrete function values, hence exact (accept-set [n, n]).
-	return &soltype.FuncType{Params: ps, Ret: ret, Exact: true}
+	// Operators are concrete function values, hence exact (accept-set [n, n]) — the
+	// zero value of Inexact.
+	return &soltype.FuncType{Params: ps, Ret: ret}
 }
 
 // addOperatorBindings seeds the built-in operators, every one monomorphic over


### PR DESCRIPTION
Implement PR4 of the M3 type system: function exactness and accept-set subtyping for callback slots, per #677 §4.2.1.

## Summary

This PR adds the `Exact` flag to `FuncType` to distinguish between exact functions (finite parameter count, reject extra arguments as callbacks) and inexact functions (unbounded parameter count via `...`, tolerate extra arguments). It replaces the M2 same-arity rule with accept-set subtyping: `G <: F` iff `accept(G) ⊇ accept(F)`, where `accept(f) = [required, hi]` with `required` = trailing-optional-aware parameter count and `hi` = `len(Params)` for exact, `∞` for inexact.

The PR also adds optional parameters (`x?`) that lower the required count without changing arity, and introduces the extra-arg lint (`TooManyArgsError`) that rejects passing more arguments than a concrete callee declares at direct call sites.

## Key Changes

- **FuncType exactness flag**: Added `Exact: bool` field to `soltype.FuncType`. Written function values are exact; inexact functions carry the `...` marker in type annotations (not yet parsed from source, but prepared for M4+).

- **Accept-set subtyping**: Replaced the M2 same-arity constraint rule with accept-set logic in `constrain()`:
  - Compute `accept(f) = [requiredCount(f), hi]` where `hi = len(Params)` (exact) or `math.MaxInt` (inexact)
  - Check `loL ≤ loR && hiL ≥ hiR` (lower and upper bounds)
  - This subsumes the old same-arity rule for exact functions and enables inexact callbacks to tolerate extra arguments

- **Optional parameters**: Added `Optional: bool` field to `soltype.FuncParam`. The `requiredCount()` helper counts trailing optionals only (positional binding semantics: a required param after an optional is still required).

- **Extra-arg lint**: New `TooManyArgsError` bridge error in `inferCall()` that fires when a direct call supplies more arguments than the concrete callee declares. The constraint receives only the arity-matched prefix so the lint is the sole too-many diagnostic.

- **Structural updates**: Propagated `Exact` and `Optional` flags through coalescing, extrusion, and freshening in `coalesce.go`, `constrain.go`, and `poly.go`. Updated the printer to render `x?: T` for optional params and `fn (...) -> R` for inexact functions.

- **Test coverage**: 
  - `TestConstrainFunctionAcceptSet` exercises the new accept-set rule with exact/inexact functions and optional params
  - `TestInferCallExactArityTypeChecks`, `TestInferCallExactTooManyArgsSingleDiagnostic`, `TestInferOptionalParamRenders`, etc. validate source-level behaviors
  - Updated blame tests to reflect the new TooManyArgsError and FuncArityMismatch split

## Notable Details

- **Exact by default**: Every written function value (from `inferFunc`) is marked `Exact: true`. Inexactness is a property of function-type annotations describing callback slots, which the solver does not yet resolve (M4+).

- **Known gap (M4)**: When a callback slot is inexact and the supplier declares more params, the extra positions are unchecked (would need `unknown <: T` rule from M6). This is safe for M3 because inexact functions are unreachable from source.

- **Optional semantics**: An optional parameter only lowers the required count when trailing. Non-trailing optionals are effectively required (positional binding prevents skipping them).

- **Bridge error**: `TooManyArgsError` is a bridge error (born in `inferCall` with the AST in hand), so it self-blames the call and relates the callee expression directly, without Prov resolution.

https://claude.ai/code/session_013G59P8wJVKYSFDs6GWT4b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Functions can now be declared with a trailing `...` marker to indicate they tolerate extra arguments.
  * Optional parameters are now supported using `param?: Type` syntax.

* **Bug Fixes**
  * Function call arity validation now provides distinct error messages for "too many arguments" versus "too few arguments" scenarios.

* **Tests**
  * Added comprehensive test coverage for inexact function markers and optional parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->