### PR TITLE
PR5: Add probe - speculation journal for type inference trials

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -204,6 +204,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	// lhs is a variable: record rhs as an upper bound, propagate existing lowers.
 	if lv, ok := lhs.(*soltype.TypeVarType); ok {
 		if soltype.LevelOf(rhs) <= lv.Level {
+			c.recordMutation(lv)
 			lv.UpperBounds = append(lv.UpperBounds, rhs)
 			var errs []SolverError
 			for _, lb := range lv.LowerBounds {
@@ -218,6 +219,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	// rhs is a variable: symmetric — record lhs as a lower bound, propagate uppers.
 	if rv, ok := rhs.(*soltype.TypeVarType); ok {
 		if soltype.LevelOf(lhs) <= rv.Level {
+			c.recordMutation(rv)
 			rv.LowerBounds = append(rv.LowerBounds, lhs)
 			var errs []SolverError
 			for _, ub := range rv.UpperBounds {
@@ -251,13 +253,17 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 		nv := c.freshVar(lvl)
 		cache[key] = nv
 		if pol == soltype.Positive {
+			c.recordMutation(t)
 			t.UpperBounds = append(t.UpperBounds, nv)
 			for _, lb := range t.LowerBounds {
+				c.recordMutation(nv)
 				nv.LowerBounds = append(nv.LowerBounds, c.extrude(lb, pol, lvl, cache))
 			}
 		} else {
+			c.recordMutation(t)
 			t.LowerBounds = append(t.LowerBounds, nv)
 			for _, ub := range t.UpperBounds {
+				c.recordMutation(nv)
 				nv.UpperBounds = append(nv.UpperBounds, c.extrude(ub, pol, lvl, cache))
 			}
 		}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -204,8 +204,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	// lhs is a variable: record rhs as an upper bound, propagate existing lowers.
 	if lv, ok := lhs.(*soltype.TypeVarType); ok {
 		if soltype.LevelOf(rhs) <= lv.Level {
-			c.recordMutation(lv)
-			lv.UpperBounds = append(lv.UpperBounds, rhs)
+			c.addUpperBound(lv, rhs)
 			var errs []SolverError
 			for _, lb := range lv.LowerBounds {
 				errs = append(errs, c.constrain(lb, rhs, seen)...)
@@ -219,8 +218,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	// rhs is a variable: symmetric — record lhs as a lower bound, propagate uppers.
 	if rv, ok := rhs.(*soltype.TypeVarType); ok {
 		if soltype.LevelOf(lhs) <= rv.Level {
-			c.recordMutation(rv)
-			rv.LowerBounds = append(rv.LowerBounds, lhs)
+			c.addLowerBound(rv, lhs)
 			var errs []SolverError
 			for _, ub := range rv.UpperBounds {
 				errs = append(errs, c.constrain(lhs, ub, seen)...)
@@ -252,19 +250,19 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 		}
 		nv := c.freshVar(lvl)
 		cache[key] = nv
+		// t is the original (possibly pre-probe) var — its append is the one a
+		// Discard must truncate. nv was just minted here, so journaling it is a
+		// harmless no-op (a fresh var is unreachable after a Discard); it goes
+		// through the helpers only to keep a single uniform append path.
 		if pol == soltype.Positive {
-			c.recordMutation(t)
-			t.UpperBounds = append(t.UpperBounds, nv)
+			c.addUpperBound(t, nv)
 			for _, lb := range t.LowerBounds {
-				c.recordMutation(nv)
-				nv.LowerBounds = append(nv.LowerBounds, c.extrude(lb, pol, lvl, cache))
+				c.addLowerBound(nv, c.extrude(lb, pol, lvl, cache))
 			}
 		} else {
-			c.recordMutation(t)
-			t.LowerBounds = append(t.LowerBounds, nv)
+			c.addLowerBound(t, nv)
 			for _, ub := range t.UpperBounds {
-				c.recordMutation(nv)
-				nv.UpperBounds = append(nv.UpperBounds, c.extrude(ub, pol, lvl, cache))
+				c.addUpperBound(nv, c.extrude(ub, pol, lvl, cache))
 			}
 		}
 		return nv

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -9,10 +9,16 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // M3 (PR5) adds the nullable probe pointer. The engine's bound-mutating core
 // (constrain/extrude) lives on *Context, so the speculation journal must live
 // here too: when probe is non-nil, every bound append snapshots the variable's
-// bound-list lengths through recordMutation so a discarded trial can truncate
-// them back. nil is the non-speculative path — the common case — and pays only a
-// nil check per append. The push/pop discipline (openProbe/closeProbe) lives on
-// the checker carrier, which also owns the side-table cleanups (Info/Prov).
+// bound-list lengths so a discarded trial can truncate them back. nil is the
+// non-speculative path — the common case — and pays only a nil check per append.
+// The push/pop discipline (openProbe/closeProbe) lives on the checker carrier,
+// which also owns the side-table cleanups (Info/Prov).
+//
+// Bound lists are extended ONLY through addLowerBound/addUpperBound, which fuse
+// the probe snapshot with the append. A bare `v.LowerBounds = append(...)` must
+// never appear — routing every append through the two helpers is what makes
+// "forgot to journal the mutation" structurally impossible (an un-journaled
+// append would silently survive a Discard and corrupt committed state).
 type Context struct {
 	varCounter int
 	probe      *Probe
@@ -26,11 +32,26 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	return v
 }
 
+// addLowerBound appends t to v's lower bounds, journaling the mutation in the
+// active probe first so a discarded trial truncates it away. This (and
+// addUpperBound) is the ONLY sanctioned way to extend a bound list.
+func (c *Context) addLowerBound(v *soltype.TypeVarType, t soltype.Type) {
+	c.recordMutation(v)
+	v.LowerBounds = append(v.LowerBounds, t)
+}
+
+// addUpperBound is the upper-bound counterpart of addLowerBound.
+func (c *Context) addUpperBound(v *soltype.TypeVarType, t soltype.Type) {
+	c.recordMutation(v)
+	v.UpperBounds = append(v.UpperBounds, t)
+}
+
 // recordMutation snapshots v's bound-list lengths in the active probe, if any,
 // BEFORE a bound append mutates v. A no-op when no probe is open. record itself
 // dedups (only the first touch of v in a probe snapshots), so calling this at
 // every append site is cheap and correct: append-only bound lists mean the first
-// snapshot already covers every later append to v under the same probe.
+// snapshot already covers every later append to v under the same probe. Reached
+// only through addLowerBound/addUpperBound.
 func (c *Context) recordMutation(v *soltype.TypeVarType) {
 	if c.probe != nil {
 		c.probe.record(v)

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -5,8 +5,17 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // Context owns the engine's mutable counters. M1 carries ONLY varCounter; the
 // spike's lifetimeCounter / paramLifetimes / written fields are M4 (lifetimes
 // and records/mut), so M1's Context is correspondingly lean.
+//
+// M3 (PR5) adds the nullable probe pointer. The engine's bound-mutating core
+// (constrain/extrude) lives on *Context, so the speculation journal must live
+// here too: when probe is non-nil, every bound append snapshots the variable's
+// bound-list lengths through recordMutation so a discarded trial can truncate
+// them back. nil is the non-speculative path — the common case — and pays only a
+// nil check per append. The push/pop discipline (openProbe/closeProbe) lives on
+// the checker carrier, which also owns the side-table cleanups (Info/Prov).
 type Context struct {
 	varCounter int
+	probe      *Probe
 }
 
 // freshVar allocates a new inference variable at the given level, assigning it
@@ -15,4 +24,15 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	v := &soltype.TypeVarType{ID: c.varCounter, Level: level}
 	c.varCounter++
 	return v
+}
+
+// recordMutation snapshots v's bound-list lengths in the active probe, if any,
+// BEFORE a bound append mutates v. A no-op when no probe is open. record itself
+// dedups (only the first touch of v in a probe snapshots), so calling this at
+// every append site is cheap and correct: append-only bound lists mean the first
+// snapshot already covers every later append to v under the same probe.
+func (c *Context) recordMutation(v *soltype.TypeVarType) {
+	if c.probe != nil {
+		c.probe.record(v)
+	}
 }

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -31,8 +31,8 @@
 //
 // M3 (PR5) adds the probe (probe.go): a speculation journal over the engine's
 // bound-list mutations (a per-variable length snapshot, truncated back on
-// discard) plus side-table (Info/Prov) rollback closures, with push/pop nesting
-// that hands a committed child's rollback obligation up to its parent. The active
+// discard) plus side-table (Info/Prov/errs) rollback closures, with push/pop
+// nesting that hands a committed child's rollback obligation up to its parent. The active
 // probe lives on *Context (next to the bound-mutating constrain/extrude); the
 // open/close discipline lives on the checker carrier. PR6's overload resolution
 // is its first consumer — each candidate is trialled under a probe and the losers

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -29,9 +29,18 @@
 // which makes renders compact where the same variable isn't already shared across
 // positions; generalize's simplify hook is a no-op until then.
 //
+// M3 (PR5) adds the probe (probe.go): a speculation journal over the engine's
+// bound-list mutations (a per-variable length snapshot, truncated back on
+// discard) plus side-table (Info/Prov) rollback closures, with push/pop nesting
+// that hands a committed child's rollback obligation up to its parent. The active
+// probe lives on *Context (next to the bound-mutating constrain/extrude); the
+// open/close discipline lives on the checker carrier. PR6's overload resolution
+// is its first consumer — each candidate is trialled under a probe and the losers
+// rolled back — but it is general speculation infrastructure reused beyond M3.
+//
 // What is still deferred (each lands in a later milestone): records / mut /
-// lifetimes (M4), function overloading (M3 PR6) and the probe (PR5), classes and
-// the union/intersection *subtyping rules* in constrain (M5/M6), and type-level
+// lifetimes (M4), function overloading (M3 PR6), classes and the
+// union/intersection *subtyping rules* in constrain (M5/M6), and type-level
 // operators (M5/M8). M1 ships UnionType/IntersectionType *nodes* for coalesced
 // output, but their lattice rules in constrain remain deferred.
 package solver

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -96,7 +96,21 @@ func (c *checker) reportUnsupportedFeature(node ast.Node, feature string) soltyp
 // the unexported setType — which is why the whole M2 walk lives in package
 // solver. The AST stays untouched (no InferredType() writes); Info is the single
 // source of truth for node→type.
+//
+// Under a probe (M3 PR5) the prior entry is captured and a rollback closure
+// registered, so a discarded speculative trial leaves Info exactly as it was —
+// the entry restored if n had one, deleted if it did not.
 func (c *checker) recordType(n ast.Node, t soltype.Type) {
+	if c.ctx.probe != nil {
+		prev, had := c.info.types[n]
+		c.ctx.probe.onRollback(func() {
+			if had {
+				c.info.types[n] = prev
+			} else {
+				delete(c.info.types, n)
+			}
+		})
+	}
 	c.info.setType(n, t)
 }
 

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -97,20 +97,11 @@ func (c *checker) reportUnsupportedFeature(node ast.Node, feature string) soltyp
 // solver. The AST stays untouched (no InferredType() writes); Info is the single
 // source of truth for node→type.
 //
-// Under a probe (M3 PR5) the prior entry is captured and a rollback closure
-// registered, so a discarded speculative trial leaves Info exactly as it was —
-// the entry restored if n had one, deleted if it did not.
+// Under a probe (M3 PR5) snapshotMapEntry captures the prior entry and registers
+// a rollback closure, so a discarded speculative trial leaves Info exactly as it
+// was — the entry restored if n had one, deleted if it did not.
 func (c *checker) recordType(n ast.Node, t soltype.Type) {
-	if c.ctx.probe != nil {
-		prev, had := c.info.types[n]
-		c.ctx.probe.onRollback(func() {
-			if had {
-				c.info.types[n] = prev
-			} else {
-				delete(c.info.types, n)
-			}
-		})
-	}
+	snapshotMapEntry(c, c.info.types, n)
 	c.info.setType(n, t)
 }
 

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -108,6 +108,11 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 		// PR1 only records the edge; the multi-hop renderer that chases it back to an
 		// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
 		c.recordInstantiation(nv, t)
+		// nv is freshly minted here, so these whole-slice bound assignments are
+		// intentionally NOT journaled by the probe (see Probe's doc): a fresh var
+		// is unreachable after a Discard, so it self-rolls-back. This is the one
+		// sanctioned non-append bound write — it touches only fresh vars, never a
+		// var the probe has recorded.
 		nv.LowerBounds = c.freshenBounds(lim, t.LowerBounds, lvl, cache)
 		nv.UpperBounds = c.freshenBounds(lim, t.UpperBounds, lvl, cache)
 		return nv

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -1,0 +1,156 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Probe is the M3 (PR5) speculation journal: it records the mutations a
+// tentative inference does so a *discarded* trial leaves no trace. Two kinds of
+// mutation are journaled:
+//
+//  1. Bound appends. Every TypeVarType the trial appends a bound to is recorded
+//     once, with its bound-list lengths at first touch (record). Because bound
+//     lists are append-only, that single length snapshot covers every later
+//     append, and a discard is a slice truncation back to the snapshot.
+//  2. Side-table writes. Writes to the carrier's Info / Prov tables under the
+//     probe register an onRollback closure (the carrier owns those tables, so
+//     it registers the closures — see recordType/recordProv). A discard runs
+//     them so no stray node→type / type→origin entry survives a losing trial.
+//
+// Probes nest. A committed child hands its rollback obligation up to its parent
+// (Commit), so a later parent discard still undoes the committed child's work; a
+// top-level commit makes the mutations permanent and drops the journal. The
+// active probe lives on *Context (the engine's bound-mutating core is there); the
+// push/pop discipline and side-table registration live on the checker carrier
+// (openProbe/closeProbe), which owns Info/Prov. PR6 (overloading) is the first
+// consumer: each candidate overload is trialled under a probe and the losers
+// rolled back.
+//
+// Deviation from the plan's sketch: the plan typed the journal over a `Bounded`
+// interface (boundLengths/truncateBounds) to abstract "things with bound lists".
+// Go can't add those (unexported) methods to soltype.TypeVarType from this
+// package, and M3 has exactly one bounded type, so the journal holds the concrete
+// *soltype.TypeVarType and truncates its exported bound fields directly — keeping
+// the speculation-only truncate out of soltype's public surface. If a second
+// bounded type appears, reintroduce the interface (with exported methods on the
+// soltype types) then.
+type Probe struct {
+	entries  []probeEntry                  // one per touched variable, in first-touch order
+	touched  set.Set[*soltype.TypeVarType] // dedup: a var is journaled at most once per probe
+	cleanups []func()                      // Info / Prov rollback closures, registration order
+	parent   *Probe                        // enclosing probe (nil at top level)
+	done     bool                          // Commit/Discard are idempotent and mutually exclusive
+}
+
+// probeEntry snapshots one variable's bound-list lengths at the moment the probe
+// first touched it. A discard truncates LowerBounds/UpperBounds back to these
+// lengths, dropping exactly the bounds the trial appended.
+type probeEntry struct {
+	v         *soltype.TypeVarType
+	prevLower int
+	prevUpper int
+}
+
+// newProbe returns a probe whose parent is the currently-active probe (or nil),
+// with its dedup set initialized so record/Commit never touch a nil map.
+func newProbe(parent *Probe) *Probe {
+	return &Probe{parent: parent, touched: set.NewSet[*soltype.TypeVarType]()}
+}
+
+// record snapshots v's current bound-list lengths the first time this probe sees
+// v. It MUST be called before the append that mutates v, so the snapshot captures
+// the pre-append lengths; later appends to the same v are no-ops (the lists are
+// append-only, so the first snapshot already covers them).
+func (p *Probe) record(v *soltype.TypeVarType) {
+	if p.touched.Contains(v) {
+		return
+	}
+	p.touched.Add(v)
+	p.entries = append(p.entries, probeEntry{v: v, prevLower: len(v.LowerBounds), prevUpper: len(v.UpperBounds)})
+}
+
+// onRollback registers a closure to undo a side-table write (Info / Prov) made
+// under this probe. A discard runs the closures (see rollback); a commit hands
+// them to the parent (or drops them at top level).
+func (p *Probe) onRollback(f func()) {
+	p.cleanups = append(p.cleanups, f)
+}
+
+// rollback reverts every mutation journaled under this probe. Cleanups run before
+// bound truncation (side tables first) and in REVERSE registration order (LIFO):
+// a single Info/Prov key may be written more than once under the probe, and each
+// closure captured that key's prior value at registration time, so only unwinding
+// newest-first restores the original value. Entry truncation is reverse for
+// symmetry only — touched dedups to one entry per var, so order is moot there.
+func (p *Probe) rollback() {
+	for i := len(p.cleanups) - 1; i >= 0; i-- {
+		p.cleanups[i]()
+	}
+	for i := len(p.entries) - 1; i >= 0; i-- {
+		e := p.entries[i]
+		e.v.LowerBounds = e.v.LowerBounds[:e.prevLower]
+		e.v.UpperBounds = e.v.UpperBounds[:e.prevUpper]
+	}
+}
+
+// Discard rolls back every mutation journaled under this probe. Idempotent: a
+// second Discard (or a Discard after Commit) is a no-op.
+func (p *Probe) Discard() {
+	if p.done {
+		return
+	}
+	p.rollback()
+	p.done = true
+}
+
+// Commit keeps this probe's mutations. At top level the mutations become
+// permanent and the journal is dropped. With a parent, the rollback obligation is
+// handed up so a later parent Discard still undoes this committed child's work:
+// each touched var the parent has NOT yet journaled is inherited with the child's
+// snapshot (the var's state before any parent-or-child mutation); a var the parent
+// already journaled keeps the parent's earlier (≤) snapshot. Cleanups append after
+// the parent's so global registration order — and thus the LIFO rollback — is
+// preserved. Idempotent and mutually exclusive with Discard.
+func (p *Probe) Commit() {
+	if p.done {
+		return
+	}
+	p.done = true
+	parent := p.parent
+	if parent == nil {
+		p.entries = nil
+		p.cleanups = nil
+		return
+	}
+	for _, e := range p.entries {
+		if parent.touched.Contains(e.v) {
+			continue
+		}
+		parent.touched.Add(e.v)
+		parent.entries = append(parent.entries, e)
+	}
+	parent.cleanups = append(parent.cleanups, p.cleanups...)
+	p.entries = nil
+	p.cleanups = nil
+}
+
+// openProbe pushes a fresh probe as the active one and returns it. Pair every
+// openProbe with a closeProbe so ctx.probe never dangles.
+func (c *checker) openProbe() *Probe {
+	p := newProbe(c.ctx.probe)
+	c.ctx.probe = p
+	return p
+}
+
+// closeProbe runs the probe's outcome (Commit when commit is true, else Discard)
+// and restores the engine's active-probe pointer to the enclosing probe, so the
+// current-probe pointer follows the open/close stack exactly.
+func (c *checker) closeProbe(p *Probe, commit bool) {
+	if commit {
+		p.Commit()
+	} else {
+		p.Discard()
+	}
+	c.ctx.probe = p.parent
+}

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -19,19 +19,28 @@ import (
 //     rides a journaled append that gets truncated), so it self-rolls-back. What
 //     must never happen is whole-slice replacement of a var that has already been
 //     recorded under the probe; rollback asserts against that.
-//  2. Side-table writes. Writes to the carrier's Info / Prov tables under the
-//     probe register an onRollback closure (the carrier owns those tables, so
-//     it registers the closures — see recordType/recordProv). A discard runs
-//     them so no stray node→type / type→origin entry survives a losing trial.
+//  2. Side-table writes. Writes to the carrier's Info / Prov tables (and the
+//     checker's accumulated errs) under the probe register an onRollback closure
+//     (the carrier owns those, so it registers the closures — see
+//     recordType/recordProv and openProbe's errs snapshot). A discard runs them
+//     so no stray node→type / type→origin entry or accumulated diagnostic
+//     survives a losing trial.
+//
+// "Leaves no trace" is scoped to those two: bound mutations and the carrier's
+// Info/Prov/errs state. The fresh-var counter (Context.varCounter) is
+// deliberately NOT rewound — IDs are monotonic and never reused, so a discarded
+// trial's vars simply leave a gap. Rewinding it would risk handing a live var an
+// ID a discarded var still holds; the only visible effect of the gap is raw
+// `t{ID}` debug renders, which is a printer concern, not a soundness one.
 //
 // Probes nest. A committed child hands its rollback obligation up to its parent
 // (Commit), so a later parent discard still undoes the committed child's work; a
 // top-level commit makes the mutations permanent and drops the journal. The
 // active probe lives on *Context (the engine's bound-mutating core is there); the
 // push/pop discipline and side-table registration live on the checker carrier
-// (openProbe/closeProbe), which owns Info/Prov. PR6 (overloading) is the first
-// consumer: each candidate overload is trialled under a probe and the losers
-// rolled back.
+// (openProbe/closeProbe), which owns Info/Prov/errs. PR6 (overloading) is the
+// first consumer: each candidate overload is trialled under a probe and the
+// losers rolled back.
 //
 // Deviation from the plan's sketch: the plan typed the journal over a `Bounded`
 // interface (boundLengths/truncateBounds) to abstract "things with bound lists".
@@ -58,10 +67,26 @@ type probeEntry struct {
 	prevUpper int
 }
 
-// newProbe returns a probe whose parent is the currently-active probe (or nil),
-// with its dedup set initialized so record/Commit never touch a nil map.
+// newProbe returns a probe whose parent is the currently-active probe (or nil).
+// touched is lazily created on first use (markTouched), so a probe is usable even
+// if built directly as &Probe{} rather than through here.
 func newProbe(parent *Probe) *Probe {
-	return &Probe{parent: parent, touched: set.NewSet[*soltype.TypeVarType]()}
+	return &Probe{parent: parent}
+}
+
+// markTouched adds v to the dedup set, lazily creating the set so a probe built
+// as a bare &Probe{} (bypassing newProbe) never writes to a nil map. It returns
+// true if v was newly added (the caller should journal it) and false if this
+// probe had already seen v.
+func (p *Probe) markTouched(v *soltype.TypeVarType) bool {
+	if p.touched == nil {
+		p.touched = set.NewSet[*soltype.TypeVarType]()
+	}
+	if p.touched.Contains(v) {
+		return false
+	}
+	p.touched.Add(v)
+	return true
 }
 
 // record snapshots v's current bound-list lengths the first time this probe sees
@@ -69,10 +94,9 @@ func newProbe(parent *Probe) *Probe {
 // the pre-append lengths; later appends to the same v are no-ops (the lists are
 // append-only, so the first snapshot already covers them).
 func (p *Probe) record(v *soltype.TypeVarType) {
-	if p.touched.Contains(v) {
+	if !p.markTouched(v) {
 		return
 	}
-	p.touched.Add(v)
 	p.entries = append(p.entries, probeEntry{v: v, prevLower: len(v.LowerBounds), prevUpper: len(v.UpperBounds)})
 }
 
@@ -139,11 +163,11 @@ func (p *Probe) Commit() {
 		return
 	}
 	for _, e := range p.entries {
-		if parent.touched.Contains(e.v) {
-			continue
+		// Inherit the child's snapshot only for a var the parent hasn't journaled;
+		// a var the parent already saw keeps the parent's earlier (≤) snapshot.
+		if parent.markTouched(e.v) {
+			parent.entries = append(parent.entries, e)
 		}
-		parent.touched.Add(e.v)
-		parent.entries = append(parent.entries, e)
 	}
 	parent.cleanups = append(parent.cleanups, p.cleanups...)
 	p.entries = nil
@@ -152,10 +176,38 @@ func (p *Probe) Commit() {
 
 // openProbe pushes a fresh probe as the active one and returns it. Pair every
 // openProbe with a closeProbe so ctx.probe never dangles.
+//
+// It also journals the checker's diagnostic list: errs is append-only, so a
+// snapshot of its length lets a discarded trial drop any diagnostics it
+// accumulated through c.constrain / c.report (a committed probe keeps them). This
+// completes the "leaves no trace" guarantee alongside the bound + Info/Prov
+// journaling, so a speculative trial may safely route failures through the
+// error-accumulating walk, not only the error-returning Constrain.
 func (c *checker) openProbe() *Probe {
 	p := newProbe(c.ctx.probe)
 	c.ctx.probe = p
+	errsLen := len(c.errs)
+	p.onRollback(func() { c.errs = c.errs[:errsLen] })
 	return p
+}
+
+// snapshotMapEntry registers, under the active probe (else a no-op), a closure
+// that restores m[k] to its current value — or deletes the key if it is currently
+// absent — so a discarded trial leaves m exactly as it was. Shared by the Info
+// and Prov side-table writers (recordType, snapshotProv) so both roll back
+// identically; a fix to the restore/delete semantics lands in one place.
+func snapshotMapEntry[K comparable, V any](c *checker, m map[K]V, k K) {
+	if c.ctx.probe == nil {
+		return
+	}
+	prev, had := m[k]
+	c.ctx.probe.onRollback(func() {
+		if had {
+			m[k] = prev
+		} else {
+			delete(m, k)
+		}
+	})
 }
 
 // closeProbe runs the probe's outcome (Commit when commit is true, else Discard)

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -9,10 +9,16 @@ import (
 // tentative inference does so a *discarded* trial leaves no trace. Two kinds of
 // mutation are journaled:
 //
-//  1. Bound appends. Every TypeVarType the trial appends a bound to is recorded
-//     once, with its bound-list lengths at first touch (record). Because bound
-//     lists are append-only, that single length snapshot covers every later
-//     append, and a discard is a slice truncation back to the snapshot.
+//  1. Bound appends. Every TypeVarType the trial appends a bound to (via
+//     addLowerBound/addUpperBound) is recorded once, with its bound-list lengths
+//     at first touch (record). The length-snapshot rollback is sound only under
+//     one precondition: a journaled var's bound lists are extended by APPEND and
+//     never replaced or shortened. Initializing a FRESHLY-minted var's bounds by
+//     whole-slice assignment (freshenAbove) is exempt and need not be journaled —
+//     a fresh var is unreachable after a Discard (every surviving reference to it
+//     rides a journaled append that gets truncated), so it self-rolls-back. What
+//     must never happen is whole-slice replacement of a var that has already been
+//     recorded under the probe; rollback asserts against that.
 //  2. Side-table writes. Writes to the carrier's Info / Prov tables under the
 //     probe register an onRollback closure (the carrier owns those tables, so
 //     it registers the closures — see recordType/recordProv). A discard runs
@@ -83,12 +89,21 @@ func (p *Probe) onRollback(f func()) {
 // closure captured that key's prior value at registration time, so only unwinding
 // newest-first restores the original value. Entry truncation is reverse for
 // symmetry only — touched dedups to one entry per var, so order is moot there.
+//
+// The truncation asserts the append-only precondition rather than silently
+// clamping: a snapshot length above the current list length means a recorded
+// var's bound slice was REPLACED or shortened mid-trial (not appended to), which
+// would otherwise corrupt the var on rollback. Failing loudly turns that into an
+// immediate, located error instead of silent under-constraint.
 func (p *Probe) rollback() {
 	for i := len(p.cleanups) - 1; i >= 0; i-- {
 		p.cleanups[i]()
 	}
 	for i := len(p.entries) - 1; i >= 0; i-- {
 		e := p.entries[i]
+		if e.prevLower > len(e.v.LowerBounds) || e.prevUpper > len(e.v.UpperBounds) {
+			panic("probe.rollback: a journaled var's bounds were replaced or shortened, not appended — the append-only invariant is violated")
+		}
 		e.v.LowerBounds = e.v.LowerBounds[:e.prevLower]
 		e.v.UpperBounds = e.v.UpperBounds[:e.prevUpper]
 	}

--- a/internal/solver/probe_test.go
+++ b/internal/solver/probe_test.go
@@ -237,3 +237,60 @@ func TestProbeRollsBackExtrudeBounds(t *testing.T) {
 	require.Empty(t, high.LowerBounds, "extrude's append to the original var is rolled back")
 	require.Empty(t, high.UpperBounds)
 }
+
+// A discarded probe drops diagnostics the trial accumulated via the
+// error-collecting walk (c.report / c.constrain), so a losing speculative
+// candidate leaves no spurious errors behind; a committed probe keeps them.
+func TestProbeRollsBackErrs(t *testing.T) {
+	c := newChecker()
+	n := &ast.IdentExpr{Name: "boom"}
+
+	// A pre-probe diagnostic stays regardless of the trial's outcome.
+	c.report(&UnsupportedNodeError{Node: n})
+	require.Len(t, c.errs, 1)
+
+	discarded := c.openProbe()
+	c.report(&UnsupportedNodeError{Node: n}) // accumulated under the probe
+	require.Len(t, c.errs, 2)
+	c.closeProbe(discarded, false) // discard
+	require.Len(t, c.errs, 1, "the trial's diagnostic is dropped; the pre-probe one survives")
+
+	committed := c.openProbe()
+	c.report(&UnsupportedNodeError{Node: n})
+	c.closeProbe(committed, true) // commit
+	require.Len(t, c.errs, 2, "a committed probe keeps its diagnostics")
+}
+
+// A committed child's diagnostics are covered by a later parent discard, exactly
+// like its bound mutations — the errs snapshot rides the same nesting handoff.
+func TestProbeErrsCommittedChildCoveredByParentDiscard(t *testing.T) {
+	c := newChecker()
+	n := &ast.IdentExpr{Name: "boom"}
+
+	parent := c.openProbe()
+	c.report(&UnsupportedNodeError{Node: n}) // parent-era diagnostic
+
+	child := c.openProbe()
+	c.report(&UnsupportedNodeError{Node: n}) // child-era diagnostic
+	c.closeProbe(child, true)                // child commits
+	require.Len(t, c.errs, 2)
+
+	c.closeProbe(parent, false) // parent discards
+	require.Empty(t, c.errs, "the parent discard drops both its own and the committed child's diagnostics")
+}
+
+// A probe built directly as &Probe{} (bypassing newProbe) is still safe: touched
+// is lazily created on first record, so there is no nil-map panic.
+func TestProbeBareLiteralIsNilMapSafe(t *testing.T) {
+	c := newChecker()
+	v := c.freshAt(0)
+
+	c.ctx.probe = &Probe{} // deliberately skip newProbe
+	require.NotPanics(t, func() {
+		require.Empty(t, c.ctx.Constrain(num(), v)) // appends a bound ⇒ record(v)
+	})
+	require.Len(t, v.LowerBounds, 1)
+
+	c.ctx.probe.Discard()
+	require.Empty(t, v.LowerBounds, "the bare-literal probe still rolls back")
+}

--- a/internal/solver/probe_test.go
+++ b/internal/solver/probe_test.go
@@ -1,0 +1,239 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// A discarded probe truncates every bound the trial appended back to the exact
+// pre-probe length, while leaving bounds added BEFORE the probe untouched. The
+// bounds flow through the real constrain path (the append sites that call
+// recordMutation), not hand-appends, so this also proves the wiring.
+func TestProbeDiscardRestoresBoundLengths(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+	b := c.freshAt(0)
+
+	// Pre-probe bound on a: number <: a ⇒ a gains one lower bound, permanently.
+	require.Empty(t, c.ctx.Constrain(num(), a))
+	require.Len(t, a.LowerBounds, 1)
+
+	p := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(str(), a)) // a.LowerBounds: +1 ⇒ 2
+	require.Empty(t, c.ctx.Constrain(b, num())) // b.UpperBounds: +1 ⇒ 1
+	require.Len(t, a.LowerBounds, 2)
+	require.Len(t, b.UpperBounds, 1)
+
+	c.closeProbe(p, false) // discard
+
+	require.Len(t, a.LowerBounds, 1, "the speculative lower bound on a is truncated away")
+	require.Equal(t, num(), a.LowerBounds[0], "the pre-probe bound survives")
+	require.Empty(t, b.UpperBounds, "b's only bound was speculative")
+	require.Nil(t, c.ctx.probe, "the active probe is cleared after close")
+}
+
+// A committed top-level probe keeps every mutation: discard is what reverts, not
+// the journal's existence.
+func TestProbeCommitKeepsBounds(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+
+	p := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a))
+	require.Len(t, a.LowerBounds, 1)
+	c.closeProbe(p, true) // commit
+
+	require.Len(t, a.LowerBounds, 1, "a committed probe makes the bound permanent")
+	require.Nil(t, c.ctx.probe)
+}
+
+// record snapshots a variable at most once per probe (first touch), so repeated
+// appends to the same var all roll back to the single pre-touch length.
+func TestProbeRecordDedupsPerVariable(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+
+	p := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a))
+	require.Empty(t, c.ctx.Constrain(str(), a))
+	require.Empty(t, c.ctx.Constrain(boolT(), a))
+	require.Len(t, a.LowerBounds, 3)
+	require.Len(t, p.entries, 1, "a is journaled exactly once despite three appends")
+	c.closeProbe(p, false)
+
+	require.Empty(t, a.LowerBounds, "all three speculative bounds are truncated")
+}
+
+// A discarded probe runs the registered side-table cleanups so neither Info nor
+// Prov keeps a stray entry from a losing trial — covering both the "node had no
+// prior entry" (delete) and "node had a prior entry" (restore) cases.
+func TestProbeDiscardRunsSideTableCleanups(t *testing.T) {
+	c := newChecker()
+	fresh := &ast.IdentExpr{Name: "fresh"}
+	existing := &ast.IdentExpr{Name: "existing"}
+
+	// `existing` already has Info/Prov entries before the probe opens.
+	pre := num()
+	c.recordType(existing, pre)
+	c.recordProv(pre, existing, LiteralInference)
+
+	p := c.openProbe()
+	// A brand-new node typed under the probe...
+	speculative := str()
+	c.recordType(fresh, speculative)
+	c.recordProv(speculative, fresh, LiteralInference)
+	// ...and an overwrite of the pre-existing node's entries.
+	c.recordType(existing, speculative)
+	c.recordProv(pre, existing, ParamBinding) // re-record same type pointer, different kind
+
+	require.Same(t, speculative, c.info.TypeOf(fresh))
+	require.Same(t, speculative, c.info.TypeOf(existing))
+
+	c.closeProbe(p, false) // discard
+
+	require.Nil(t, c.info.TypeOf(fresh), "a node first typed under the probe loses its entry")
+	require.NotContains(t, c.prov, speculative, "its provenance is gone too")
+
+	require.Same(t, pre, c.info.TypeOf(existing), "the pre-probe Info entry is restored")
+	o, ok := c.prov[pre].(FromAST)
+	require.True(t, ok)
+	require.Equal(t, LiteralInference, o.Kind, "the pre-probe Prov entry (kind) is restored")
+}
+
+// A committed probe's side-table writes survive — only a discard reverts them.
+func TestProbeCommitKeepsSideTableWrites(t *testing.T) {
+	c := newChecker()
+	n := &ast.IdentExpr{Name: "x"}
+
+	p := c.openProbe()
+	ty := num()
+	c.recordType(n, ty)
+	c.recordProv(ty, n, LiteralInference)
+	c.closeProbe(p, true) // commit
+
+	require.Same(t, ty, c.info.TypeOf(n), "committed Info write survives")
+	require.Contains(t, c.prov, ty, "committed Prov write survives")
+}
+
+// A nested probe that COMMITS hands its rollback obligation up to its parent, so
+// the parent's later DISCARD still reverts the committed child's mutations.
+func TestCommittedChildCoveredByParentDiscard(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+
+	parent := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a)) // parent mutates a (1 bound)
+
+	child := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(str(), a)) // child mutates a too (2 bounds)
+	c.closeProbe(child, true)                   // child commits — but a is now the parent's obligation
+	require.Same(t, parent, c.ctx.probe, "after closing the child, the parent is active again")
+	require.Len(t, a.LowerBounds, 2)
+
+	c.closeProbe(parent, false) // parent discards
+	require.Empty(t, a.LowerBounds, "the parent discard reverts BOTH its own and the committed child's bounds")
+	require.Nil(t, c.ctx.probe)
+}
+
+// When the parent has NOT touched a variable the committed child did, the child's
+// snapshot is inherited so the parent discard reverts the child's bounds to the
+// var's pre-child length (here: empty).
+func TestCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0) // only the child will touch a
+
+	parent := c.openProbe()
+	child := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a))
+	require.Len(t, a.LowerBounds, 1)
+	c.closeProbe(child, true) // commit: parent inherits a at snapshot 0
+
+	c.closeProbe(parent, false) // discard
+	require.Empty(t, a.LowerBounds, "the inherited child snapshot truncates a back to empty")
+}
+
+// A discarded child leaves the parent's own journal — and the variable's
+// parent-era bounds — intact; only the child's appends are reverted.
+func TestDiscardedChildLeavesParentJournalIntact(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+
+	parent := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a)) // parent: a has 1 bound
+
+	child := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(str(), a)) // child: a has 2
+	c.closeProbe(child, false)                  // child discards ⇒ back to 1
+	require.Len(t, a.LowerBounds, 1, "the child discard reverts only the child's bound")
+
+	c.closeProbe(parent, false) // parent discards ⇒ back to 0
+	require.Empty(t, a.LowerBounds, "the parent discard reverts its own bound")
+}
+
+// The active-probe pointer follows the open/close stack exactly: nil → p1 → p2 →
+// back to p1 → back to nil, regardless of commit/discard outcome.
+func TestProbePointerFollowsOpenCloseStack(t *testing.T) {
+	c := newChecker()
+	require.Nil(t, c.ctx.probe)
+
+	p1 := c.openProbe()
+	require.Same(t, p1, c.ctx.probe)
+	require.Nil(t, p1.parent)
+
+	p2 := c.openProbe()
+	require.Same(t, p2, c.ctx.probe)
+	require.Same(t, p1, p2.parent)
+
+	c.closeProbe(p2, true) // commit
+	require.Same(t, p1, c.ctx.probe, "closing the inner probe restores the outer")
+
+	c.closeProbe(p1, false) // discard
+	require.Nil(t, c.ctx.probe, "closing the outer probe restores the non-speculative state")
+}
+
+// Commit and Discard are idempotent and mutually exclusive: a second outcome call
+// is a no-op, so a double-close (or commit-then-discard) can't double-truncate.
+func TestProbeOutcomeIsIdempotent(t *testing.T) {
+	c := newChecker()
+	a := c.freshAt(0)
+
+	p := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(num(), a))
+	require.Len(t, a.LowerBounds, 1)
+	c.ctx.probe = p.parent // detach without going through closeProbe
+
+	p.Commit()
+	p.Discard() // no-op: already done
+	require.Len(t, a.LowerBounds, 1, "Discard after Commit does not revert")
+
+	q := c.freshAt(0)
+	p2 := newProbe(nil)
+	c.ctx.probe = p2
+	require.Empty(t, c.ctx.Constrain(num(), q))
+	p2.Discard()
+	p2.Discard() // no-op: already done
+	require.Empty(t, q.LowerBounds)
+}
+
+// Bounds appended by extrude (extrusion of a higher-level rhs down to lv's level)
+// are journaled too: extrude mutates the ORIGINAL variable's bounds, and a
+// discard must truncate those back. Constraining a low-level var against a
+// higher-level var forces extrusion through the recorded append sites.
+func TestProbeRollsBackExtrudeBounds(t *testing.T) {
+	c := newChecker()
+	low := c.freshAt(0)
+	high := c.freshAt(1) // higher level ⇒ constraining low <: high extrudes high down
+
+	p := c.openProbe()
+	require.Empty(t, c.ctx.Constrain(low, high))
+	// The constraint wired bounds onto both vars (extrusion + bound propagation).
+	require.NotEmpty(t, high.LowerBounds)
+	c.closeProbe(p, false)
+
+	require.Empty(t, low.LowerBounds)
+	require.Empty(t, low.UpperBounds)
+	require.Empty(t, high.LowerBounds, "extrude's append to the original var is rolled back")
+	require.Empty(t, high.UpperBounds)
+}

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -105,23 +105,13 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 	c.prov[t] = FromAST{Node: n, Kind: kind}
 }
 
-// snapshotProv captures t's current Prov entry and, under an active probe (M3
-// PR5), registers a rollback closure so a discarded speculative trial leaves Prov
-// exactly as it was. A no-op when no probe is open. Shared by both Prov writers
-// (recordProv, recordInstantiation) so every speculative side-table write is
-// reversible.
+// snapshotProv registers a probe rollback for a pending write to t's Prov entry,
+// so a discarded speculative trial leaves Prov exactly as it was. A no-op when no
+// probe is open. Shared by both Prov writers (recordProv, recordInstantiation) so
+// every speculative side-table write is reversible; delegates to the same
+// snapshotMapEntry helper as recordType's Info write.
 func (c *checker) snapshotProv(t soltype.Type) {
-	if c.ctx.probe == nil {
-		return
-	}
-	prev, had := c.prov[t]
-	c.ctx.probe.onRollback(func() {
-		if had {
-			c.prov[t] = prev
-		} else {
-			delete(c.prov, t)
-		}
-	})
+	snapshotMapEntry(c, c.prov, t)
 }
 
 // recordInstantiation records the FromInstantiation interior edge minted by

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -101,7 +101,27 @@ func (c *checker) recordProv(t soltype.Type, n ast.Node, kind ASTOriginKind) {
 			panic(fmt.Sprintf("recordProv: type %p re-recorded against a different node (was %T, now %T) — the unique-pointer invariant is violated", t, prev.Node, n))
 		}
 	}
+	c.snapshotProv(t)
 	c.prov[t] = FromAST{Node: n, Kind: kind}
+}
+
+// snapshotProv captures t's current Prov entry and, under an active probe (M3
+// PR5), registers a rollback closure so a discarded speculative trial leaves Prov
+// exactly as it was. A no-op when no probe is open. Shared by both Prov writers
+// (recordProv, recordInstantiation) so every speculative side-table write is
+// reversible.
+func (c *checker) snapshotProv(t soltype.Type) {
+	if c.ctx.probe == nil {
+		return
+	}
+	prev, had := c.prov[t]
+	c.ctx.probe.onRollback(func() {
+		if had {
+			c.prov[t] = prev
+		} else {
+			delete(c.prov, t)
+		}
+	})
 }
 
 // recordInstantiation records the FromInstantiation interior edge minted by
@@ -116,5 +136,6 @@ func (c *checker) recordInstantiation(nv *soltype.TypeVarType, from soltype.Type
 			panic(fmt.Sprintf("recordInstantiation: var %p already has provenance (%T) — the unique-pointer invariant is violated", nv, prev))
 		}
 	}
+	c.snapshotProv(nv)
 	c.prov[nv] = FromInstantiation{From: from}
 }


### PR DESCRIPTION
Implement M3 (PR5) — the probe, a speculation journal that records mutations during tentative type inference so discarded trials leave no trace. This is general infrastructure for speculative inference, with PR6's overload resolution as the first consumer.

## Summary

The probe journals two kinds of mutations:
1. **Bound appends**: snapshots each type variable's bound-list lengths on first touch, truncating back on discard
2. **Side-table writes**: registers rollback closures for Info/Prov/errs so discarded trials don't leave stray entries or diagnostics

Probes nest with a push/pop discipline: a committed child hands its rollback obligation to its parent, so a later parent discard still undoes the child's work. The active probe lives on `*Context` (where bound mutations happen); the open/close discipline and side-table registration live on the checker carrier.

## Key changes

- **probe.go** (new): Core journal implementation
  - `Probe` struct with entries (per-variable snapshots), cleanups (side-table rollbacks), and parent pointer for nesting
  - `record()` deduplicates: each variable is journaled at most once per probe
  - `rollback()` truncates bounds in reverse order and runs cleanups LIFO (newest-first) to restore prior values
  - `Commit()` / `Discard()` are idempotent and mutually exclusive; committed children hand obligations to parent
  - `openProbe()` / `closeProbe()` manage the push/pop stack and snapshot the diagnostic list

- **context.go** (modified): Add probe pointer and bound-append helpers
  - `probe *Probe` field on `Context` (nil in non-speculative path)
  - `addLowerBound()` / `addUpperBound()` fuse the probe snapshot with the append — the only sanctioned way to extend bound lists
  - `recordMutation()` snapshots a variable's bound lengths in the active probe

- **constrain.go** (modified): Route bound appends through the new helpers
  - Replace bare `append()` calls with `c.addLowerBound()` / `c.addUpperBound()`
  - Ensures every bound mutation is journaled (append-only invariant is structurally enforced)

- **prov.go** (modified): Register side-table rollbacks
  - `snapshotProv()` registers a closure to restore or delete a Prov entry on discard
  - Called by both `recordProv()` and `recordInstantiation()` so all Prov writes are reversible

- **infer.go** (modified): Snapshot Info side-table writes
  - `recordType()` calls `snapshotMapEntry()` to register Info rollback

- **poly.go** (modified): Document that fresh-var bound initialization is exempt
  - `freshenAbove()` assigns bounds by whole-slice (not append), so no journaling needed — fresh vars are unreachable after discard

- **doc.go** (modified): Document M3 and the probe's role in the solver architecture

## Notable implementation details

- **Append-only invariant**: Bound lists are extended *only* through `addLowerBound`/`addUpperBound`. A bare slice assignment would silently survive a discard and corrupt state; routing every append through the two helpers makes "forgot to journal" structurally impossible.

- **Deduplication**: `markTouched()` ensures each variable is recorded at most once per probe, so repeated appends to the same var all roll back to the single pre-touch length.

- **Lazy map creation**: `touched` is lazily created on first use, so a probe built as a bare `&Probe{}` (bypassing `newProbe`) never panics on a nil map.

- **LIFO cleanup order**: Cleanups run in reverse registration order so a key written multiple times under the probe restores to its original value (not an intermediate one).

- **Nesting handoff**: A committed child inherits untouched variables' snapshots to its parent, so a later parent discard still reverts the child's bounds to their pre-child state.

- **Var ID monotonicity**: The fresh-var counter is deliberately

https://claude.ai/code/session_014TzRofWAgp5DVSTWy3FS8U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for speculative type-inference trials, ensuring rollback preserves prior state and diagnostics.

* **Documentation**
  * Updated solver docs to describe the new speculation probe and its journaling/rollback behavior.

* **Refactor**
  * Improved speculative trial handling so temporary type-variable changes and diagnostic updates are journaled and cleanly reverted or committed, reducing spurious state after discarded trials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->