### PR TITLE
PR3: async/await, block return-point join, and if/else expressions

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -148,6 +148,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, f := range t.Fields {
 				walk(f.Type)
 			}
+		case *PromiseType:
+			walk(t.Inner)
 		case *UnionType:
 			for _, m := range t.Types {
 				walk(m)
@@ -221,6 +223,8 @@ func (p *namedPrinter) printType(t Type) string {
 		return "{" + strings.Join(fields, ", ") + "}"
 	case *FuncType:
 		return "fn " + p.printFuncTail(t)
+	case *PromiseType:
+		return "Promise<" + p.printType(t.Inner) + ">"
 	case *UnionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -98,6 +98,10 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"union pair", &UnionType{Types: []Type{numP(), strP()}}, "number | string"},
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
+
+		// Promises (M3).
+		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
+		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -152,6 +152,18 @@ func (r *RecordType) Field(name string) (Type, bool) {
 	return nil, false
 }
 
+// PromiseType is the result of an `async fn` and the requirement of an `await`.
+// M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
+// scope narrow: it is the one stdlib generic the milestone needs typed (Iterable/
+// Generator wait until M5+). The real, alias-driven `Promise<T>` lookup arrives
+// with TypeRef ingestion in M7; until then, an `async fn () -> T` mints a
+// PromiseType{T} externally and `await e` constrains `e <: PromiseType{U}` for a
+// fresh U. Inner is covariant under subtyping (Promise<L> <: Promise<R> iff
+// L <: R) and the `await` rule does NOT recursively flatten (so awaiting
+// `Promise<Promise<T>>` yields `Promise<T>`, matching the milestone's
+// no-auto-flatten contract — flattening is `Awaited<T>`, M9).
+type PromiseType struct{ Inner Type }
+
 // Void is the result type of a statement block with no value.
 type Void struct{}
 
@@ -177,6 +189,7 @@ func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
 func (*TupleType) isType()        {}
 func (*RecordType) isType()       {}
+func (*PromiseType) isType()      {}
 func (*Void) isType()             {}
 func (*NeverType) isType()        {}
 func (*UnknownType) isType()      {}
@@ -207,6 +220,8 @@ func LevelOf(t Type) int {
 			m = max(m, LevelOf(f.Type))
 		}
 		return m
+	case *PromiseType:
+		return LevelOf(t.Inner)
 	default:
 		// PrimType, LitType, Void, NeverType, UnknownType, UnionType,
 		// IntersectionType: UnionType/IntersectionType only appear in coalesced

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -65,6 +65,9 @@ func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.Typ
 			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesceRec(f.Type, pol, seen)} // covariant fields
 		}
 		return &soltype.RecordType{Fields: fields}
+	case *soltype.PromiseType:
+		// Covariant inner (no auto-flatten of nested Promise<Promise<T>>).
+		return &soltype.PromiseType{Inner: coalesceRec(t.Inner, pol, seen)}
 	case *soltype.TypeVarType:
 		// Re-entering a variable already on the current path is an ungrounded
 		// recursive position (no concrete type breaks the cycle). It collapses to
@@ -133,6 +136,8 @@ func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.T
 		for _, f := range t.Fields {
 			analyzeOccurrences(f.Type, pol, occ, seen)
 		}
+	case *soltype.PromiseType:
+		analyzeOccurrences(t.Inner, pol, occ, seen)
 	case *soltype.TypeVarType:
 		if pol == soltype.Positive {
 			occ[t] |= occPos
@@ -197,6 +202,8 @@ func coalesceSchemeRec(
 			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesceSchemeRec(f.Type, pol, genLevel, occ, seen)}
 		}
 		return &soltype.RecordType{Fields: fields}
+	case *soltype.PromiseType:
+		return &soltype.PromiseType{Inner: coalesceSchemeRec(t.Inner, pol, genLevel, occ, seen)}
 	case *soltype.TypeVarType:
 		retain := t.Level > genLevel && occ[t].both()
 		if seen.Contains(t) {
@@ -372,6 +379,9 @@ func equalType(a, b soltype.Type) bool {
 			}
 		}
 		return true
+	case *soltype.PromiseType:
+		b, ok := b.(*soltype.PromiseType)
+		return ok && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		return ok && equalTypeSlice(a.Types, b.Types)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -195,6 +195,15 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			}
 			return errs
 		}
+	case *soltype.PromiseType:
+		if r, ok := rhs.(*soltype.PromiseType); ok {
+			// PromiseType is covariant in its Inner: Promise<L> <: Promise<R> iff
+			// L <: R. No auto-flatten — `await Promise<Promise<T>>` yields
+			// `Promise<T>` (Awaited<T> lands in M9). When the two sides are unrelated
+			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
+			// CannotConstrainError below, matching the function/tuple/record arms.
+			return c.constrain(l.Inner, r.Inner, seen)
+		}
 	case *soltype.Void:
 		if _, ok := rhs.(*soltype.Void); ok {
 			return nil
@@ -285,6 +294,9 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.extrude(f.Type, pol, lvl, cache)}
 		}
 		return &soltype.RecordType{Fields: fields}
+	case *soltype.PromiseType:
+		// Covariant inner — no polarity flip.
+		return &soltype.PromiseType{Inner: c.extrude(t.Inner, pol, lvl, cache)}
 	default:
 		return t
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -327,8 +327,13 @@ type NotEnoughArgsError struct {
 // "Awaiting outside an `async` function is rejected by the AST walk, not by the
 // type rule"). The argument is still walked (so any errors inside it surface),
 // but the await contributes a `never` placeholder so callers don't cascade.
+//
+// EnclosingFn is the (non-async) function the await sits in, when there is one —
+// the function the user would mark `async` to fix the error, surfaced via
+// Related(). It is nil when the await is at module top-level (no enclosing fn).
 type AwaitOutsideAsyncError struct {
-	Await *ast.AwaitExpr
+	Await       *ast.AwaitExpr
+	EnclosingFn ast.Node
 }
 
 // ReturnOutsideFunctionError fires when a `return` statement is reached outside
@@ -431,8 +436,15 @@ func (e *OverloadNotSupportedError) Message() string {
 	return "Function overloads are not supported in M2: " + e.Name
 }
 
-func (e *AwaitOutsideAsyncError) Span() ast.Span      { return e.Await.Span() }
-func (e *AwaitOutsideAsyncError) Related() []ast.Span { return nil }
+func (e *AwaitOutsideAsyncError) Span() ast.Span { return e.Await.Span() }
+func (e *AwaitOutsideAsyncError) Related() []ast.Span {
+	// Point at the enclosing function (the one to make `async`) when there is one;
+	// empty at module top-level.
+	if e.EnclosingFn != nil {
+		return []ast.Span{e.EnclosingFn.Span()}
+	}
+	return nil
+}
 func (e *AwaitOutsideAsyncError) Message() string {
 	return "await can only be used inside an async function"
 }
@@ -492,6 +504,11 @@ func describe(t soltype.Type) string {
 	case *soltype.RecordType:
 		return "object"
 	case *soltype.PromiseType:
+		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
+		// object above. That is deliberate and consistent with the Union/Intersection
+		// arms below, which also recurse: a Promise's single type argument is compact
+		// and informative (`Promise<number>`), whereas a function/tuple/record would
+		// be verbose spelled out, so those stay nominal.
 		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.Void:
 		return "void"

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -345,6 +345,21 @@ type ReturnOutsideFunctionError struct {
 	Return *ast.ReturnStmt
 }
 
+// AsyncReturnNotPromiseError fires when an `async fn` declares a return annotation
+// that is not a `Promise<…>`. An async function's external type is always
+// `Promise<T>`, so the annotation NAMES that Promise; a bare type
+// (`async fn () -> number`) is rejected — write `-> Promise<number>`, or
+// `-> Promise<_>` to let the checker infer the inner from the body.
+//
+// Like AwaitOutsideAsyncError it is a WALK rejection, not a type-rule failure:
+// born in inferFunc (asyncReturn) with the annotation and function nodes in hand,
+// so it self-blames from the annotation's span and relates the function via
+// Related() (the signature the user would fix).
+type AsyncReturnNotPromiseError struct {
+	Return ast.TypeAnn // the offending (non-Promise) return annotation
+	Fn     ast.Node    // the enclosing async function, surfaced via Related()
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*TooManyArgsError) isSolverError()          {}
@@ -355,8 +370,9 @@ func (*BodyDeclNotAllowedError) isSolverError()   {}
 func (*MissingInitializerError) isSolverError()   {}
 func (*DuplicateDeclarationError) isSolverError() {}
 func (*OverloadNotSupportedError) isSolverError() {}
-func (*AwaitOutsideAsyncError) isSolverError()     {}
-func (*ReturnOutsideFunctionError) isSolverError() {}
+func (*AwaitOutsideAsyncError) isSolverError()      {}
+func (*ReturnOutsideFunctionError) isSolverError()  {}
+func (*AsyncReturnNotPromiseError) isSolverError()  {}
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
@@ -453,6 +469,20 @@ func (e *ReturnOutsideFunctionError) Span() ast.Span      { return e.Return.Span
 func (e *ReturnOutsideFunctionError) Related() []ast.Span { return nil }
 func (e *ReturnOutsideFunctionError) Message() string {
 	return "return can only be used inside a function"
+}
+
+func (e *AsyncReturnNotPromiseError) Span() ast.Span { return e.Return.Span() }
+func (e *AsyncReturnNotPromiseError) Related() []ast.Span {
+	// Point at the enclosing async function (the signature to fix). Guard a nil Fn
+	// to uphold the "never panic on malformed AST" guarantee, even though inferFunc
+	// always supplies the function node.
+	if e.Fn == nil {
+		return nil
+	}
+	return []ast.Span{e.Fn.Span()}
+}
+func (e *AsyncReturnNotPromiseError) Message() string {
+	return "async function return type must be a Promise; write Promise<...> or Promise<_>"
 }
 
 func (e *CannotConstrainError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -331,6 +331,15 @@ type AwaitOutsideAsyncError struct {
 	Await *ast.AwaitExpr
 }
 
+// ReturnOutsideFunctionError fires when a `return` statement is reached outside
+// any function body — e.g. inside an `if` that is part of a top-level `val`
+// initializer. Symmetric to AwaitOutsideAsyncError: the walk rejects it rather
+// than silently dropping the return point (a return collected against no enclosing
+// function would otherwise vanish).
+type ReturnOutsideFunctionError struct {
+	Return *ast.ReturnStmt
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*TooManyArgsError) isSolverError()          {}
@@ -341,7 +350,8 @@ func (*BodyDeclNotAllowedError) isSolverError()   {}
 func (*MissingInitializerError) isSolverError()   {}
 func (*DuplicateDeclarationError) isSolverError() {}
 func (*OverloadNotSupportedError) isSolverError() {}
-func (*AwaitOutsideAsyncError) isSolverError()    {}
+func (*AwaitOutsideAsyncError) isSolverError()     {}
+func (*ReturnOutsideFunctionError) isSolverError() {}
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
@@ -425,6 +435,12 @@ func (e *AwaitOutsideAsyncError) Span() ast.Span      { return e.Await.Span() }
 func (e *AwaitOutsideAsyncError) Related() []ast.Span { return nil }
 func (e *AwaitOutsideAsyncError) Message() string {
 	return "await can only be used inside an async function"
+}
+
+func (e *ReturnOutsideFunctionError) Span() ast.Span      { return e.Return.Span() }
+func (e *ReturnOutsideFunctionError) Related() []ast.Span { return nil }
+func (e *ReturnOutsideFunctionError) Message() string {
+	return "return can only be used inside a function"
 }
 
 func (e *CannotConstrainError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -322,6 +322,15 @@ type NotEnoughArgsError struct {
 	Fn   *soltype.FuncType
 }
 
+// AwaitOutsideAsyncError fires when an `await` expression appears outside the
+// body of an `async fn` (the walk's rule, not the type rule — per M3's plan,
+// "Awaiting outside an `async` function is rejected by the AST walk, not by the
+// type rule"). The argument is still walked (so any errors inside it surface),
+// but the await contributes a `never` placeholder so callers don't cascade.
+type AwaitOutsideAsyncError struct {
+	Await *ast.AwaitExpr
+}
+
 func (*UnknownIdentifierError) isSolverError()    {}
 func (*NamespaceUsedAsValueError) isSolverError() {}
 func (*TooManyArgsError) isSolverError()          {}
@@ -332,6 +341,7 @@ func (*BodyDeclNotAllowedError) isSolverError()   {}
 func (*MissingInitializerError) isSolverError()   {}
 func (*DuplicateDeclarationError) isSolverError() {}
 func (*OverloadNotSupportedError) isSolverError() {}
+func (*AwaitOutsideAsyncError) isSolverError()    {}
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
@@ -411,6 +421,12 @@ func (e *OverloadNotSupportedError) Message() string {
 	return "Function overloads are not supported in M2: " + e.Name
 }
 
+func (e *AwaitOutsideAsyncError) Span() ast.Span      { return e.Await.Span() }
+func (e *AwaitOutsideAsyncError) Related() []ast.Span { return nil }
+func (e *AwaitOutsideAsyncError) Message() string {
+	return "await can only be used inside an async function"
+}
+
 func (e *CannotConstrainError) Message() string {
 	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.LHS), describe(e.RHS))
 }
@@ -459,6 +475,8 @@ func describe(t soltype.Type) string {
 		return "tuple"
 	case *soltype.RecordType:
 		return "object"
+	case *soltype.PromiseType:
+		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.Void:
 		return "void"
 	case *soltype.NeverType:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -23,12 +23,56 @@ type checker struct {
 	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only), the inverse of info
 	errs []SolverError // accumulated; mirrors the spike's []error threading
 
+	// fn is the enclosing function context for the body currently being walked —
+	// async flag (does `await` here resolve?), the live list of every ReturnStmt
+	// expression type collected from within the body so far, and the return-join
+	// var (PR3). It is nil when nothing is being walked / when we are at module
+	// top-level: a top-level `await` or `return` is therefore rejected by
+	// inferAwait / unreachable for inferStmt (top-level statements are decls).
+	// inferFunc pushes a fresh context on entry and pops it on exit, so a nested
+	// function definition has its own returns collection (a return inside an inner
+	// fn never escapes to the outer).
+	fn *funcCtx
+
 	// debugProv, when set, makes recordProv panic on a conflicting overwrite (the
 	// same type pointer recorded against a *different* node) — turning the
 	// implicit "every minted type is a unique pointer" invariant into an enforced
 	// one. Off in production (a span bug must never crash the compiler); flipped on
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
+}
+
+// funcCtx is the per-function inference context — pushed by inferFunc on entry
+// to a function body and popped on exit, with a parent pointer so a nested fn
+// can find its own (immediate) context without seeing the outer one's returns.
+// The async flag lets inferAwait diagnose a non-async use; returns accumulates
+// every ReturnStmt expression type collected from within the body (in source
+// order, valued AND bare — bare returns contribute Void) so inferFunc can join
+// them with the block tail before constraining against the return annotation,
+// finishing M2's carried-over TODO.
+type funcCtx struct {
+	async   bool
+	returns []soltype.Type
+	parent  *funcCtx
+}
+
+// pushFuncCtx enters a function body's inference context — async controls
+// whether `await` is allowed and the externally-wrapped return type. The caller
+// (inferFunc) defers popFuncCtx with the returned saved pointer; popFuncCtx
+// returns the collected returns to the caller (which joins them with the tail).
+func (c *checker) pushFuncCtx(async bool) *funcCtx {
+	saved := c.fn
+	c.fn = &funcCtx{async: async, parent: saved}
+	return saved
+}
+
+// popFuncCtx restores the previous function context and returns the collected
+// return-point types from the body just walked, so the caller can join them
+// with the block's tail value.
+func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
+	collected := c.fn.returns
+	c.fn = saved
+	return collected
 }
 
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
@@ -126,6 +170,10 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferObject(scope, lvl, e)
 	case *ast.MemberExpr:
 		return c.inferMember(scope, lvl, e)
+	case *ast.AwaitExpr:
+		return c.inferAwait(scope, lvl, e)
+	case *ast.IfElseExpr:
+		return c.inferIfElse(scope, lvl, e)
 	default:
 		return c.reportUnsupported(e)
 	}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -24,14 +24,14 @@ type checker struct {
 	errs []SolverError // accumulated; mirrors the spike's []error threading
 
 	// fn is the enclosing function context for the body currently being walked —
-	// async flag (does `await` here resolve?), the live list of every ReturnStmt
-	// expression type collected from within the body so far, and the return-join
-	// var (PR3). It is nil when nothing is being walked / when we are at module
-	// top-level: a top-level `await` or `return` is therefore rejected by
-	// inferAwait / unreachable for inferStmt (top-level statements are decls).
-	// inferFunc pushes a fresh context on entry and pops it on exit, so a nested
-	// function definition has its own returns collection (a return inside an inner
-	// fn never escapes to the outer).
+	// its async flag (does `await` here resolve?), the function's AST node (for
+	// await-outside-async blame), and the live list of every ReturnStmt expression
+	// type collected from the body so far (PR3). It is nil at module top-level (and
+	// inside a top-level `val` initializer): a top-level `await` is rejected by
+	// inferAwait, and a top-level `return` — reachable inside an `if` in a `val`
+	// initializer — by inferStmt's ReturnOutsideFunctionError. inferFunc pushes a
+	// fresh context on entry and pops it on exit, so a nested function has its own
+	// returns collection (a return inside an inner fn never escapes to the outer).
 	fn *funcCtx
 
 	// debugProv, when set, makes recordProv panic on a conflicting overwrite (the
@@ -42,33 +42,39 @@ type checker struct {
 	debugProv bool
 }
 
-// funcCtx is the per-function inference context — pushed by inferFunc on entry
-// to a function body and popped on exit, with a parent pointer so a nested fn
-// can find its own (immediate) context without seeing the outer one's returns.
-// The async flag lets inferAwait diagnose a non-async use; returns accumulates
-// every ReturnStmt expression type collected from within the body (in source
-// order, valued AND bare — bare returns contribute Void) so inferFunc can join
-// them with the block tail before constraining against the return annotation,
-// finishing M2's carried-over TODO.
+// funcCtx is the per-function inference context — pushed by inferFunc on entry to
+// a function body and popped on exit. The async flag lets inferAwait diagnose a
+// non-async use (and drives the external Promise wrap); node is the enclosing
+// function's AST node, surfaced as the "make this async" related span on an
+// await-outside-async error; returns accumulates every ReturnStmt expression type
+// collected from the body (in source order, valued AND bare — bare returns
+// contribute Void) so inferFunc can join them with the block tail before
+// constraining against the return annotation, finishing M2's carried-over TODO.
+//
+// Nesting is handled by save/restore through the pointer pushFuncCtx returns, not a
+// parent chain on the struct: a nested fn opens its own ctx (so its returns never
+// leak to the outer), and the outer is restored verbatim on pop.
 type funcCtx struct {
 	async   bool
+	node    ast.Node
 	returns []soltype.Type
-	parent  *funcCtx
 }
 
-// pushFuncCtx enters a function body's inference context — async controls
-// whether `await` is allowed and the externally-wrapped return type. The caller
-// (inferFunc) defers popFuncCtx with the returned saved pointer; popFuncCtx
-// returns the collected returns to the caller (which joins them with the tail).
-func (c *checker) pushFuncCtx(async bool) *funcCtx {
+// pushFuncCtx enters the inference context for function `node` (async controls
+// whether `await` is allowed and the external Promise wrap). It returns the
+// PREVIOUS context; the caller restores it by handing that pointer to popFuncCtx
+// after walking the body. Push/pop is straight-line, not deferred: the caller needs
+// popFuncCtx's returned return-points as a value, and the walk reports errors rather
+// than panicking, so there is no unwind to guard against.
+func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
 	saved := c.fn
-	c.fn = &funcCtx{async: async, parent: saved}
+	c.fn = &funcCtx{async: async, node: node}
 	return saved
 }
 
-// popFuncCtx restores the previous function context and returns the collected
-// return-point types from the body just walked, so the caller can join them
-// with the block's tail value.
+// popFuncCtx restores the previous function context (the pointer pushFuncCtx
+// returned) and hands back the return-point types collected from the body just
+// walked, so the caller can join them with the block's tail value.
 func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 	collected := c.fn.returns
 	c.fn = saved

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -18,11 +18,12 @@ import (
 
 // --- async fn external wrap ---
 
-// `async fn () -> number { return 5 }` externally renders as
-// `fn () -> Promise<number>` — the headline async-wrap.
+// `async fn () -> Promise<number> { return 5 }`: the annotation names the EXTERNAL
+// Promise, and the body returns the unwrapped inner (`5`), constrained `5 <:
+// number`. Externally `fn () -> Promise<number>`.
 func TestInferAsyncFnWrapsReturnInPromise(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		async fn f() -> number {
+		async fn f() -> Promise<number> {
 			return 5
 		}
 	`)
@@ -46,10 +47,11 @@ func TestInferAsyncFnTailReturnWrapped(t *testing.T) {
 // --- await ---
 
 // `await p` where `p: Promise<string>` yields `string`. The fresh `U` from the
-// constraint `p <: Promise<U>` flows to `string` through bound propagation.
+// constraint `p <: Promise<U>` flows to `string` through bound propagation, and
+// that `string` body return satisfies the declared inner of `-> Promise<string>`.
 func TestInferAwaitUnwrapsPromise(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		async fn f(p: Promise<string>) -> string {
+		async fn f(p: Promise<string>) -> Promise<string> {
 			return await p
 		}
 	`)
@@ -73,19 +75,58 @@ func TestInferAwaitNoAutoFlatten(t *testing.T) {
 	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<Promise<number>>", values["f"])
 }
 
-// Detect-and-don't-rewrap (#5): an async fn whose return annotation is ALREADY a
-// Promise is NOT double-wrapped — `async fn () -> Promise<T>` types externally as
-// `Promise<T>`, not `Promise<Promise<T>>`. Here the body's `await p` yields
-// `Promise<number>`, which satisfies the declared `-> Promise<number>`, and the
-// external face is that same `Promise<number>` rather than a re-wrapped layer.
-func TestInferAsyncPromiseReturnAnnotationNotDoubleWrapped(t *testing.T) {
+// An explicit Promise return annotation names the EXTERNAL type directly — it is
+// not re-wrapped, and the body returns the unwrapped inner. Here `await p` (p:
+// Promise<Promise<number>>) yields `Promise<number>`, which satisfies the declared
+// inner of `-> Promise<Promise<number>>`, and the external face is exactly that
+// annotation.
+func TestInferAsyncExplicitPromiseAnnotationGovernsReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		async fn f(p: Promise<Promise<number>>) -> Promise<number> {
+		async fn f(p: Promise<Promise<number>>) -> Promise<Promise<number>> {
 			return await p
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<number>", values["f"])
+	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<Promise<number>>", values["f"])
+}
+
+// A bare (non-Promise) return annotation on an `async fn` is rejected: an async
+// function's external type is always Promise<…>, so `-> number` must be written
+// `-> Promise<number>`. Recovery wraps the inferred body return, so the function
+// still faces callers as a Promise (`Promise<5>` here).
+func TestInferAsyncBareReturnAnnotationRejected(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f() -> number {
+			return 5
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "async function return type must be a Promise; write Promise<...> or Promise<_>", errs[0].Message())
+	require.Equal(t, "fn () -> Promise<5>", values["f"])
+}
+
+// The bare-async-return error blames the offending annotation and relates the
+// enclosing function (the signature to fix).
+func TestInferAsyncBareReturnAnnotationBlame(t *testing.T) {
+	src := "async fn f() -> number { return 5 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"async function return type must be a Promise; write Promise<...> or Promise<_>",
+		"number",
+		"async fn f() -> number { return 5 }")
+}
+
+// `Promise<_>` lets the checker infer the inner from the body: the `_` resolves to
+// a fresh var the body's return flows into. Here `await p` yields `string`, so the
+// inferred inner is `string` and the external type is `Promise<string>`.
+func TestInferAsyncPromiseWildcardReturnInferred(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f(p: Promise<string>) -> Promise<_> {
+			return await p
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Promise<string>) -> Promise<string>", values["f"])
 }
 
 // `await` outside an `async fn` is a WALK rejection — not a type rule failure.

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -272,3 +272,72 @@ func TestInferNestedFnReturnsScoped(t *testing.T) {
 	require.Empty(t, c.errs)
 	require.Equal(t, "fn () -> fn (x: number) -> number", render(got))
 }
+
+// --- Error-recovery: no cascading on a failed sub-expression ---
+//
+// A reported diagnostic leaves a `never` placeholder in expression position
+// (c.report). Feeding that back into constrain has no `never <: T` input rule, so
+// the if-condition and await-argument checks would each cascade a spurious second
+// `cannot constrain never <: …` on top of the real error. inferIfElse/inferAwait
+// guard against the placeholder so exactly ONE diagnostic surfaces. (PR8 replaces
+// the guard with a dedicated error-recovery type that absorbs in constrain.)
+
+// A failed `if` condition (unknown identifier) yields a single UnknownIdentifierError
+// — not also a `never <: boolean`. The branches still type, so the if value is their
+// join.
+func TestInferIfElseUnknownConditionNoCascade(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn pick() {
+			if undeclared { 1 } else { 2 }
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: undeclared", errs[0].Message())
+	require.Equal(t, "fn () -> 1 | 2", values["pick"])
+}
+
+// A failed `await` argument (unknown identifier) yields a single
+// UnknownIdentifierError — not also a `never <: Promise<…>`. The await result is
+// left unbound and coalesces to `never`, so the async fn externally returns
+// Promise<never>.
+func TestInferAwaitUnknownArgNoCascade(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f() {
+			await undeclared
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: undeclared", errs[0].Message())
+	require.Equal(t, "fn () -> Promise<never>", values["f"])
+}
+
+// An unsupported INNER of a supported `Promise<…>` keeps the Promise wrapper: the
+// param stays Promise-shaped (recovered inner = a fresh var) rather than collapsing
+// to a bare var, and only the inner's own unsupported error is reported. Here the
+// param is unused, so its recovered inner var coalesces to `unknown` (contravariant,
+// no bounds).
+func TestInferPromiseUnsupportedInnerKeepsWrapper(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: Promise<bigint>) {
+			0
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "fn (p: Promise<unknown>) -> 0", values["f"])
+}
+
+// When the recovered Promise inner is actually used (returned), it behaves like any
+// unconstrained variable: it generalizes to a type parameter, so the wrapper carries
+// through both positions as Promise<T0>. Proves the recovery is a real fresh var,
+// not a poisoned `never`/`unknown` (which would have cascaded or frozen).
+func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: Promise<bigint>) {
+			p
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "fn <T0>(p: Promise<T0>) -> Promise<T0>", values["f"])
+}

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -1,0 +1,274 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// PR3 — async / await / block return-point join, against real source through
+// inferSource. The PR builds on M2's monomorphic walk: the body of an `async fn`
+// types exactly like a plain function, then its EXTERNAL return wraps in
+// Promise<T>; `await e` constrains `e <: Promise<U>` and yields `U`; non-tail
+// ReturnStmts join with the block tail before constraining against the return
+// annotation. No auto-flatten of nested Promise<Promise<T>> — that is M9's
+// Awaited<T>.
+
+// --- async fn external wrap ---
+
+// `async fn () -> number { return 5 }` externally renders as
+// `fn () -> Promise<number>` — the headline async-wrap.
+func TestInferAsyncFnWrapsReturnInPromise(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f() -> number {
+			return 5
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> Promise<number>", values["f"])
+}
+
+// An async fn with no explicit return — the body's tail is its return — still
+// wraps externally. Here the tail value is the literal "hi", so externally
+// `Promise<"hi">`.
+func TestInferAsyncFnTailReturnWrapped(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn greet() {
+			"hi"
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn () -> Promise<"hi">`, values["greet"])
+}
+
+// --- await ---
+
+// `await p` where `p: Promise<string>` yields `string`. The fresh `U` from the
+// constraint `p <: Promise<U>` flows to `string` through bound propagation.
+func TestInferAwaitUnwrapsPromise(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f(p: Promise<string>) -> string {
+			return await p
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Promise<string>) -> Promise<string>", values["f"])
+}
+
+// No auto-flatten: `await p` where `p: Promise<Promise<number>>` yields
+// `Promise<number>`. The constraint is `p <: Promise<U>`, so U = Promise<number>
+// — one layer peeled, the rest preserved. Awaited<T>'s recursive flatten is M9.
+func TestInferAwaitNoAutoFlatten(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f(p: Promise<Promise<number>>) -> Promise<number> {
+			return await p
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<Promise<number>>", values["f"])
+}
+
+// `await` outside an `async fn` is a WALK rejection — not a type rule failure.
+// The AwaitOutsideAsyncError carries the await node and produces a `never`
+// placeholder so a downstream consumer doesn't cascade.
+func TestInferAwaitOutsideAsyncRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: Promise<string>) {
+			await p
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+}
+
+// `await` of a non-Promise concrete fails through constrain — the rule
+// constrain(e <: Promise<U>) lowers `number <: Promise<U>` to a
+// CannotConstrainError because the concrete shapes don't match.
+func TestInferAwaitOfNonPromiseFails(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		async fn f(n: number) {
+			await n
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain number <: Promise<t1>", errs[0].Message())
+}
+
+// `await` inside an async fn nested under a non-async outer must still resolve
+// against the inner's funcCtx — the push/pop discipline. The nested return type
+// of `inner` wraps in Promise<…>; the outer is non-async so does NOT wrap.
+func TestInferAwaitInNestedAsyncOK(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn outer(p: Promise<number>) {
+			val inner = async fn () {
+				return await p
+			}
+			inner
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Promise<number>) -> fn () -> Promise<number>", values["outer"])
+}
+
+// Symmetric: an `await` in the OUTER function — which is non-async — fires the
+// walk rejection even though an inner async fn exists. The inner async context
+// is popped before the outer's `await` is walked.
+func TestInferAwaitInOuterAfterInnerAsync(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn outer(p: Promise<number>) {
+			val inner = async fn () { 1 }
+			await p
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+}
+
+// --- Block return-point join ---
+
+// The headline PR3 join: `fn () { if c { return 1 } return "x" }` collects BOTH
+// returns and joins them with the tail. The function externally returns
+// 1 | "x".
+func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn h(c: boolean) {
+			if c { return 1 }
+			return "x"
+		}
+	`)
+	require.Empty(t, errs)
+	// The two return points coalesce into a union; the renderer orders by
+	// first-occurrence in the join var's lower-bound list (declaration order).
+	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["h"])
+}
+
+// An early return inside one branch, with the other branch producing the tail.
+// Both return points contribute to the function's return type — neither path is
+// dropped. With no else, the if's value is `void | <cons>`; the tail `"x"` is
+// the fall-through; together with the collected `return 1`, the function
+// returns `1 | "x"`.
+func TestInferBlockReturnAnnotationCheckedAgainstAllReturns(t *testing.T) {
+	// `return 1` inside the if, return-annotation number — should type-check.
+	_, _, errs := inferSource(t, `
+		fn f(c: boolean) -> number {
+			if c { return 1 }
+			return 2
+		}
+	`)
+	require.Empty(t, errs)
+}
+
+// A non-tail return whose type CONFLICTS with the declared return annotation
+// must be reported. Pre-PR3 (M2) the non-tail return was dropped silently; PR3
+// joins it with the tail and constrains the join against the annotation.
+func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(c: boolean) -> number {
+			if c { return "oops" }
+			return 1
+		}
+	`)
+	// The bad return surfaces through the constrain "joined <: number" path: the
+	// join var has "oops" as a lower bound, propagated through constrain to the
+	// return annotation. The string literal's primitive does not satisfy number.
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].Message(), `"oops"`)
+	require.Contains(t, errs[0].Message(), "number")
+}
+
+// `async fn` joined with multiple returns wraps the join in Promise<…>. The
+// external return is Promise<1 | "x">.
+func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f(c: boolean) {
+			if c { return 1 }
+			return "x"
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (c: boolean) -> Promise<1 | "x">`, values["f"])
+}
+
+// --- IfElseExpr value ---
+
+// An if/else used as an expression is the join of its branches. Without
+// generalization on the binding (PR1's value-only generalization for `val =
+// fn`), the binding here is monomorphic-frozen to the join.
+func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn pick(c: boolean) {
+			if c { 1 } else { "x" }
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["pick"])
+}
+
+// An if WITHOUT else folds in void from the missing alt — `if c { 5 }` as a
+// tail expression is `5 | void`.
+func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn pick(c: boolean) {
+			if c { 5 }
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (c: boolean) -> 5 | void`, values["pick"])
+}
+
+// The if's condition must be boolean; a string condition is rejected.
+func TestInferIfElseConditionMustBeBool(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn pick(c: string) {
+			if c { 1 } else { 2 }
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain string <: boolean", errs[0].Message())
+}
+
+// --- Unit-level (against hand-built AST) ---
+
+// Bare `return` (no expr) inside async wraps Void: the external return is
+// Promise<void>. Exercises the funcCtx collection of a bare return.
+func TestInferAsyncBareReturnIsPromiseVoid(t *testing.T) {
+	c := newChecker()
+	// async fn () { return }
+	e := ast.NewFuncExpr(nil, nil, nil, nil, nil, true,
+		block(returnStmt(nil)), testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> Promise<void>", render(got))
+}
+
+// Multiple bare returns + a void tail all join through one var, all void,
+// coalescing to plain `void` (no degenerate `void | void` union).
+func TestInferFnMultipleBareReturnsCollapse(t *testing.T) {
+	c := newChecker()
+	// fn () { return; return; }
+	e := funcExpr(nil, nil, block(
+		returnStmt(nil),
+		returnStmt(nil),
+	))
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> void", render(got))
+}
+
+// A nested return is collected on the INNER funcCtx, not the outer one. After
+// the inner fn ends, the outer's returns list is still empty — the body's tail
+// (the inner fn's type) is the outer return, unwrapped.
+func TestInferNestedFnReturnsScoped(t *testing.T) {
+	c := newChecker()
+	// fn outer() { fn (x: number) { return x } }
+	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil,
+		block(returnStmt(identExpr("x"))))
+	outer := funcExpr(nil, nil, block(exprStmt(inner)))
+
+	got := c.inferExpr(NewScope(), 0, outer)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn () -> fn (x: number) -> number", render(got))
+}

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +99,33 @@ func TestInferAwaitOutsideAsyncRejected(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+}
+
+// The await-outside-async error points Related() at the enclosing (non-async)
+// function — the one to mark `async` — so an IDE can offer the fix. Primary span is
+// the await; related is the whole enclosing fn.
+func TestInferAwaitOutsideAsyncBlamesEnclosingFn(t *testing.T) {
+	src := "fn f(p: Promise<string>) { await p }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"await can only be used inside an async function", "await p",
+		"fn f(p: Promise<string>) { await p }")
+}
+
+// At module top-level there is no enclosing function, so Related() is empty (there
+// is nothing to mark `async`). Built directly so the awaited value resolves cleanly
+// and the only error is the await itself.
+func TestInferAwaitOutsideAsyncTopLevelNoRelated(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("x", ValueBinding{Schemes: []TypeScheme{
+		monoScheme(&soltype.PromiseType{Inner: &soltype.PrimType{Prim: soltype.StrPrim}}),
+	}})
+	// await x, with no enclosing function context (c.fn == nil).
+	c.inferExpr(scope, 0, ast.NewAwait(identExpr("x"), testSpan()))
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "await can only be used inside an async function", c.errs[0].Message())
+	require.Empty(t, c.errs[0].Related())
 }
 
 // `await` of a non-Promise concrete fails through constrain — the rule

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -57,16 +57,34 @@ func TestInferAwaitUnwrapsPromise(t *testing.T) {
 }
 
 // No auto-flatten: `await p` where `p: Promise<Promise<number>>` yields
-// `Promise<number>`. The constraint is `p <: Promise<U>`, so U = Promise<number>
-// — one layer peeled, the rest preserved. Awaited<T>'s recursive flatten is M9.
+// `Promise<number>` — one layer peeled, the rest preserved (the constraint is
+// `p <: Promise<U>`, so U = Promise<number>; Awaited<T>'s recursive flatten is M9).
+// With NO return annotation the async fn wraps that inferred return, so the external
+// type is Promise<Promise<number>> — which only holds if await peeled exactly one
+// layer (a full flatten would give `number`, wrapping to `Promise<number>`).
 func TestInferAwaitNoAutoFlatten(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		async fn f(p: Promise<Promise<number>>) {
+			return await p
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<Promise<number>>", values["f"])
+}
+
+// Detect-and-don't-rewrap (#5): an async fn whose return annotation is ALREADY a
+// Promise is NOT double-wrapped — `async fn () -> Promise<T>` types externally as
+// `Promise<T>`, not `Promise<Promise<T>>`. Here the body's `await p` yields
+// `Promise<number>`, which satisfies the declared `-> Promise<number>`, and the
+// external face is that same `Promise<number>` rather than a re-wrapped layer.
+func TestInferAsyncPromiseReturnAnnotationNotDoubleWrapped(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn f(p: Promise<Promise<number>>) -> Promise<number> {
 			return await p
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<Promise<number>>", values["f"])
+	require.Equal(t, "fn (p: Promise<Promise<number>>) -> Promise<number>", values["f"])
 }
 
 // `await` outside an `async fn` is a WALK rejection — not a type rule failure.
@@ -340,4 +358,37 @@ func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported in M2: BigintTypeAnn", errs[0].Message())
 	require.Equal(t, "fn <T0>(p: Promise<T0>) -> Promise<T0>", values["f"])
+}
+
+// --- Rejected forms (#6, #7) ---
+
+// A lifetime-annotated Promise is rejected, not silently coerced to a plain
+// Promise<T> — the soltype PromiseType carries no lifetime, so accepting it would
+// drop the annotation. Both surface forms: `Promise<'a, T>` (lifetime arg) and
+// `'a Promise<T>` (leading lifetime).
+func TestInferPromiseLifetimeRejected(t *testing.T) {
+	tests := map[string]string{
+		"lifetime arg":     "fn f(p: Promise<'a, number>) { 0 }",
+		"leading lifetime": "fn f(p: 'a Promise<number>) { 0 }",
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Len(t, errs, 1)
+			require.Equal(t, "Unsupported in M2: lifetime annotation on Promise", errs[0].Message())
+		})
+	}
+}
+
+// A `return` reached outside any function — here inside an `if` that is part of a
+// top-level `val` initializer — is rejected by the walk (symmetric to
+// await-outside-async), not silently dropped. The `if` still types its branches, so
+// the binding recovers to their join.
+func TestInferReturnOutsideFunctionRejected(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val x = if true { return 5 } else { 6 }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "return can only be used inside a function", errs[0].Message())
+	require.Equal(t, "5 | 6", values["x"])
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -87,7 +87,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// placeholder, so constraining `initT <: never` would cascade a spurious
 		// error and adopting `never` would poison the binding. Keep the inferred
 		// initializer type instead (error recovery).
-		if annT, ok := c.resolveTypeAnn(d.TypeAnn); ok {
+		if annT, ok := c.resolveTypeAnn(d.TypeAnn, lvl); ok {
 			c.constrain(d.Init, initT, annT)
 			initT = annT
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -154,7 +154,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// PR3: open a fresh function context so every ReturnStmt encountered while
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
-		saved := c.pushFuncCtx(sig.Async)
+		saved := c.pushFuncCtx(sig.Async, node)
 		ret = c.inferBlock(fnScope, lvl, body)
 		collected = c.popFuncCtx(saved)
 	}
@@ -164,13 +164,18 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// no explicit return, ret stays the tail unchanged (preserving M2's monomorphic
 	// renders); when there is at least one, all paths flow through one variable
 	// whose coalesced positive face is their union.
-	if len(collected) > 0 {
+	//
+	// Fast path: a single return that IS the block tail (`fn f() { … return X }`,
+	// where inferStmt returns the return's value as the tail too — same pointer).
+	// ret already IS that return, so minting a join var would add a pointless
+	// indirection plus two redundant constraints the coalescer must later dedup.
+	if len(collected) > 0 && !(len(collected) == 1 && collected[0] == ret) {
 		joinVar := c.freshAt(lvl)
 		c.recordProv(joinVar, node, ReturnJoin)
 		// Source-order constraint: collected returns first (in source order), then
-		// the block tail. When the tail IS one of the collected returns (the common
-		// `{ ... return X }` case), the duplicate bound is dedup'd at render time
-		// — the rendered union reflects source order, not constraint order.
+		// the block tail. When the tail IS one of the collected returns, the
+		// duplicate bound is dedup'd at render time — the rendered union reflects
+		// source order, not constraint order.
 		for _, rt := range collected {
 			c.constrain(node, rt, joinVar)
 		}
@@ -490,7 +495,14 @@ func identPatName(pat ast.Pat) (string, bool) {
 func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Type {
 	if c.fn == nil || !c.fn.async {
 		c.inferExpr(scope, lvl, e.Arg) // surface argument-side errors anyway
-		c.report(&AwaitOutsideAsyncError{Await: e})
+		// When the await sits in a (non-async) function, point Related() at that
+		// function — it is the one to mark `async`. At module top-level there is no
+		// enclosing function, so EnclosingFn stays nil and Related() is empty.
+		var enclosing ast.Node
+		if c.fn != nil {
+			enclosing = c.fn.node
+		}
+		c.report(&AwaitOutsideAsyncError{Await: e, EnclosingFn: enclosing})
 		t := soltype.Type(&soltype.NeverType{})
 		c.recordType(e, t)
 		return t
@@ -533,6 +545,12 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 	// reported. PR8's error-recovery type makes this guard unnecessary (it absorbs
 	// in constrain); see isRecoveryPlaceholder.
 	if !isRecoveryPlaceholder(cond) {
+		// The synthesized `boolean` requirement is intentionally NOT recorded in Prov
+		// (so a `string <: boolean` failure has no "expected boolean here" related
+		// span): it is a language rule, not a user-authored annotation, so there is no
+		// source node to anchor it to — recording it against e.Cond would only make
+		// Related() echo Span(). This matches inferAwait's synthesized Promise and
+		// inferMember's synthesized record requirement, both deliberately unrecorded.
 		c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
 	}
 	consT := c.inferBlock(scope.Child(), lvl, &e.Cons)
@@ -552,6 +570,13 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 // single expression (`else if ...` chains, which the parser desugars into Alt =
 // expr). A nil-block-and-nil-expr alt is treated as Void (the only honest
 // recovery for a malformed AST shape that shouldn't arise from the real parser).
+//
+// Scoping: a BLOCK runs in a child scope (it may declare body-local val/var), an
+// EXPRESSION runs in the enclosing scope. This is not an asymmetry — it is the
+// walk's uniform rule (only blocks introduce a scope; sub-expressions are always
+// typed in the current scope, as inferCall/inferTuple/inferMember do, since an
+// expression never binds a name). An `else if`'s nested IfElseExpr childs its own
+// cons/alt in turn, so each block still gets exactly one scope.
 func (c *checker) inferBlockOrExpr(scope *Scope, lvl int, b *ast.BlockOrExpr) soltype.Type {
 	switch {
 	case b.Block != nil:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -183,7 +183,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// a `never` placeholder, so constraining the body `<: never` would cascade a
 		// spurious error and adopting it would poison the return type. Keep the
 		// inferred body type instead (error recovery).
-		if annT, ok := c.resolveTypeAnn(sig.Return); ok {
+		if annT, ok := c.resolveTypeAnn(sig.Return, lvl); ok {
 			// Only check the inferred body against the declared return when there IS a
 			// body. A bodyless (declare/ambient) function has no body to constrain, so
 			// it simply adopts the annotation; constraining the synthetic Void return
@@ -235,7 +235,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 // `<: never` failures.
 func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 	if p.TypeAnn != nil {
-		if t, ok := c.resolveTypeAnn(p.TypeAnn); ok {
+		if t, ok := c.resolveTypeAnn(p.TypeAnn, lvl); ok {
 			return t
 		}
 	}
@@ -488,11 +488,19 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, AwaitResult)
-	// Synthesize the Promise<U> requirement at this call site. It isn't given its
-	// own provenance — the operand the user sees blame on is the awaited expression
-	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
-	// internal scaffolding for the constraint, not a user-authored type.
-	c.constrain(e, arg, &soltype.PromiseType{Inner: res})
+	// Skip the `arg <: Promise<U>` requirement when the argument already failed to
+	// type — its value is the `never` recovery placeholder, and constraining `never
+	// <: Promise<U>` would cascade a spurious second diagnostic on top of the one
+	// already reported. res then stays unbound and coalesces to `never`, the right
+	// recovery for awaiting something broken. PR8's error-recovery type makes this
+	// guard unnecessary (it absorbs in constrain); see isRecoveryPlaceholder.
+	if !isRecoveryPlaceholder(arg) {
+		// Synthesize the Promise<U> requirement at this call site. It isn't given its
+		// own provenance — the operand the user sees blame on is the awaited expression
+		// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
+		// internal scaffolding for the constraint, not a user-authored type.
+		c.constrain(e, arg, &soltype.PromiseType{Inner: res})
+	}
 	c.recordType(e, res)
 	return res
 }
@@ -509,7 +517,14 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 // enclosing block joins.
 func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.Type {
 	cond := c.inferExpr(scope, lvl, e.Cond)
-	c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
+	// Skip the `cond <: boolean` check when the condition already failed to type —
+	// its value is the `never` recovery placeholder, and constraining `never <:
+	// boolean` would cascade a spurious second diagnostic on top of the one already
+	// reported. PR8's error-recovery type makes this guard unnecessary (it absorbs
+	// in constrain); see isRecoveryPlaceholder.
+	if !isRecoveryPlaceholder(cond) {
+		c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
+	}
 	consT := c.inferBlock(scope.Child(), lvl, &e.Cons)
 	var altT soltype.Type = &soltype.Void{}
 	if e.Alt != nil {
@@ -536,4 +551,22 @@ func (c *checker) inferBlockOrExpr(scope *Scope, lvl int, b *ast.BlockOrExpr) so
 	default:
 		return &soltype.Void{}
 	}
+}
+
+// isRecoveryPlaceholder reports whether t is the `never` value c.report leaves in
+// expression position after it has ALREADY emitted a diagnostic. The walk never
+// mints a raw NeverType any other way — never/unknown are coalesced-OUTPUT only
+// (soltype/type.go), so a raw NeverType flowing out of inferExpr is always that
+// recovery placeholder. Callers skip constraining against it so the single error
+// already reported doesn't cascade a second, spurious `cannot constrain never <:
+// …` (constrain has no `never <: T` input rule today, and adding one would not
+// help — recovery must also absorb on the RHS, which a real bottom must not).
+//
+// PR8 (planning/simple_sub/m3-implementation-plan.md) introduces a dedicated
+// ErrorType recovery sentinel that absorbs in BOTH directions inside constrain;
+// once it lands, report returns that sentinel and these guard call sites — and
+// this helper — are removed.
+func isRecoveryPlaceholder(t soltype.Type) bool {
+	_, ok := t.(*soltype.NeverType)
+	return ok
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -182,49 +182,36 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		c.constrain(node, ret, joinVar)
 		ret = joinVar
 	}
-	if sig.Return != nil {
-		// Skip the check and adopt-the-annotation when the return annotation is
-		// unsupported (ok=false): resolveTypeAnn already reported it and handed back
-		// a `never` placeholder, so constraining the body `<: never` would cascade a
-		// spurious error and adopting it would poison the return type. Keep the
-		// inferred body type instead (error recovery).
+	// Return-annotation handling diverges by async-ness.
+	//
+	// Async: the function's EXTERNAL type is always `Promise<T>`, and the return
+	// annotation — when present — names that external Promise, NOT the body's value.
+	// So it must itself be a `Promise<…>`; the body returns the unwrapped inner,
+	// constrained `<: inner`, and the annotation is presented as the external type
+	// (no extra wrap). `Promise<_>` is allowed — the `_` resolves to a fresh var the
+	// body flows into, inferring the inner. With no annotation the inferred body
+	// return is wrapped. asyncReturn carries all of this (and the error/recovery
+	// for a bare annotation like `async fn () -> number`).
+	//
+	// Non-async: the annotation governs the return directly — the body is
+	// constrained `<: annotation` and the function returns the annotation (M2's
+	// rule). An unsupported annotation (ok=false) was already reported by
+	// resolveTypeAnn; recover by keeping the inferred body type (or unknown when
+	// there is no body, since a synthetic Void would falsely signal "returns
+	// nothing").
+	if sig.Async {
+		ret = c.asyncReturn(node, sig.Return, ret, hasBody, lvl)
+	} else if sig.Return != nil {
 		if annT, ok := c.resolveTypeAnn(sig.Return, lvl); ok {
-			// Only check the inferred body against the declared return when there IS a
-			// body. A bodyless (declare/ambient) function has no body to constrain, so
-			// it simply adopts the annotation; constraining the synthetic Void return
-			// would raise a spurious `void <: T` error.
+			// Only constrain the body when there IS one; a bodyless (declare/ambient)
+			// function simply adopts the annotation (constraining the synthetic Void
+			// would raise a spurious `void <: T`).
 			if hasBody {
 				c.constrain(node, ret, annT) // body <: declared return
 			}
 			ret = annT
 		} else if !hasBody {
-			// Bodyless function with an unsupported return annotation: there is no
-			// body to recover the return type from, and leaving the synthetic Void
-			// would falsely signal "returns nothing" to callers. Fall back to
-			// unknown (⊤) — the honest "couldn't resolve the declared return"
-			// recovery. (A fresh var would coalesce to `never` in return position,
-			// which is worse.)
 			ret = &soltype.UnknownType{}
-		}
-	}
-	// PR3 — `async fn` external wrap: the body has return type T, but the function
-	// types externally as `fn (...) -> Promise<T>`. Done AFTER any return-annotation
-	// constrain so the annotation governs the body return; the wrap is the external
-	// face. Bodyless async fns wrap too — an ambient `async fn now() -> number`
-	// types as `fn () -> Promise<number>` for callers.
-	//
-	// Detect-and-don't-rewrap: when `ret` is ALREADY a Promise — the author wrote the
-	// external form `-> Promise<T>` — wrapping again would yield `Promise<Promise<T>>`,
-	// a silent double-wrap. Skip the wrap in that case and take the annotation as the
-	// external type. This only catches a *syntactically* Promise return (an explicit
-	// `Promise<…>` annotation, or an inlined Promise literal); a return that merely
-	// COALESCES to a Promise through a variable is still a bare var here and is
-	// wrapped, matching the plan's "wrap an inferred return" model.
-	if sig.Async {
-		if _, alreadyPromise := ret.(*soltype.PromiseType); !alreadyPromise {
-			wrapped := &soltype.PromiseType{Inner: ret}
-			c.recordProv(wrapped, node, PromiseWrap)
-			ret = wrapped
 		}
 	}
 	// A bare function value is exact (accept-set [required, len(Params)]): it rejects
@@ -240,6 +227,59 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// callees; M3's FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
 	return ft
+}
+
+// asyncReturn computes an `async fn`'s external return type, which always faces
+// callers as `Promise<T>`. When a return annotation is present it NAMES that
+// external Promise (not the body's value), so it must itself be a `Promise<…>`:
+// the body returns the unwrapped inner, constrained `<: inner`, and the annotation
+// IS the external type — no extra wrap. `Promise<_>` works because `_` resolved to
+// a fresh var the body's return flows into, inferring the inner. A bare annotation
+// (`async fn () -> number`) is an AsyncReturnNotPromiseError; recovery wraps the
+// inferred body return so the external face stays Promise-shaped. With no
+// annotation the inferred body return (bodyType) is wrapped directly — preserving
+// M3's "wrap an inferred return" model and its no-auto-flatten behavior (a body
+// that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
+// await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
+func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, bodyType soltype.Type, hasBody bool, lvl int) soltype.Type {
+	if ann == nil {
+		return c.wrapPromise(node, bodyType)
+	}
+	annT, ok := c.resolveTypeAnn(ann, lvl)
+	if !ok {
+		// Unsupported annotation — already reported by resolveTypeAnn. Recover as the
+		// no-annotation case would (wrap the inferred body return); a bodyless fn has
+		// no body to recover from, so wrap unknown rather than the synthetic Void.
+		if !hasBody {
+			bodyType = &soltype.UnknownType{}
+		}
+		return c.wrapPromise(node, bodyType)
+	}
+	promise, isPromise := annT.(*soltype.PromiseType)
+	if !isPromise {
+		// A non-Promise annotation on an async fn (`-> number`). Reject it, then
+		// recover exactly like the unsupported-annotation case so the external face
+		// stays Promise-shaped and callers don't cascade.
+		c.report(&AsyncReturnNotPromiseError{Return: ann, Fn: node})
+		if !hasBody {
+			bodyType = &soltype.UnknownType{}
+		}
+		return c.wrapPromise(node, bodyType)
+	}
+	// Constrain the body's (unwrapped) return against the annotation's inner, and
+	// present the annotation as the external type — it already IS the Promise.
+	if hasBody {
+		c.constrain(node, bodyType, promise.Inner) // body <: declared inner
+	}
+	return annT
+}
+
+// wrapPromise mints the external `Promise<inner>` face of an async function and
+// records its provenance (PromiseWrap) against the function node.
+func (c *checker) wrapPromise(node ast.Node, inner soltype.Type) soltype.Type {
+	wrapped := &soltype.PromiseType{Inner: inner}
+	c.recordProv(wrapped, node, PromiseWrap)
+	return wrapped
 }
 
 // paramType resolves a param's type: its annotation when present, else a fresh

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -207,10 +207,20 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// constrain so the annotation governs the body return; the wrap is the external
 	// face. Bodyless async fns wrap too — an ambient `async fn now() -> number`
 	// types as `fn () -> Promise<number>` for callers.
+	//
+	// Detect-and-don't-rewrap: when `ret` is ALREADY a Promise — the author wrote the
+	// external form `-> Promise<T>` — wrapping again would yield `Promise<Promise<T>>`,
+	// a silent double-wrap. Skip the wrap in that case and take the annotation as the
+	// external type. This only catches a *syntactically* Promise return (an explicit
+	// `Promise<…>` annotation, or an inlined Promise literal); a return that merely
+	// COALESCES to a Promise through a variable is still a bare var here and is
+	// wrapped, matching the plan's "wrap an inferred return" model.
 	if sig.Async {
-		wrapped := &soltype.PromiseType{Inner: ret}
-		c.recordProv(wrapped, node, PromiseWrap)
-		ret = wrapped
+		if _, alreadyPromise := ret.(*soltype.PromiseType); !alreadyPromise {
+			wrapped := &soltype.PromiseType{Inner: ret}
+			c.recordProv(wrapped, node, PromiseWrap)
+			ret = wrapped
+		}
 	}
 	// A bare function value is exact (accept-set [required, len(Params)]): it rejects
 	// extra arguments. A trailing `...` in the signature (sig.Inexact) marks it

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -149,8 +149,33 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 	var ret soltype.Type = &soltype.Void{}
 	hasBody := body != nil
+	var collected []soltype.Type
 	if hasBody {
+		// PR3: open a fresh function context so every ReturnStmt encountered while
+		// walking the body lands in our own returns list (a nested fn inside this
+		// body opens its own context, so its returns never leak out here).
+		saved := c.pushFuncCtx(sig.Async)
 		ret = c.inferBlock(fnScope, lvl, body)
+		collected = c.popFuncCtx(saved)
+	}
+	// PR3 — block return-point join. M2 only used the block tail and dropped non-
+	// tail returns; M3 joins EVERY ReturnStmt (collected above) with the tail. The
+	// join is a fresh var with each return point as a lower bound: when there is
+	// no explicit return, ret stays the tail unchanged (preserving M2's monomorphic
+	// renders); when there is at least one, all paths flow through one variable
+	// whose coalesced positive face is their union.
+	if len(collected) > 0 {
+		joinVar := c.freshAt(lvl)
+		c.recordProv(joinVar, node, ReturnJoin)
+		// Source-order constraint: collected returns first (in source order), then
+		// the block tail. When the tail IS one of the collected returns (the common
+		// `{ ... return X }` case), the duplicate bound is dedup'd at render time
+		// — the rendered union reflects source order, not constraint order.
+		for _, rt := range collected {
+			c.constrain(node, rt, joinVar)
+		}
+		c.constrain(node, ret, joinVar)
+		ret = joinVar
 	}
 	if sig.Return != nil {
 		// Skip the check and adopt-the-annotation when the return annotation is
@@ -176,6 +201,16 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// which is worse.)
 			ret = &soltype.UnknownType{}
 		}
+	}
+	// PR3 — `async fn` external wrap: the body has return type T, but the function
+	// types externally as `fn (...) -> Promise<T>`. Done AFTER any return-annotation
+	// constrain so the annotation governs the body return; the wrap is the external
+	// face. Bodyless async fns wrap too — an ambient `async fn now() -> number`
+	// types as `fn () -> Promise<number>` for callers.
+	if sig.Async {
+		wrapped := &soltype.PromiseType{Inner: ret}
+		c.recordProv(wrapped, node, PromiseWrap)
+		ret = wrapped
 	}
 	// A bare function value is exact (accept-set [required, len(Params)]): it rejects
 	// extra arguments. A trailing `...` in the signature (sig.Inexact) marks it
@@ -431,4 +466,74 @@ func identPatName(pat ast.Pat) (string, bool) {
 		return ip.Name, true
 	}
 	return "", false
+}
+
+// inferAwait types `await e`. The argument is constrained `<: Promise<U>` for a
+// fresh U, and U is the await's value type — exactly the rule M3's milestone
+// pins ("`await e` requires `e <: Promise<U>` for some `U` and produces `U`",
+// 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
+// `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). `await`
+// outside an `async` function is rejected by the WALK (this function), not the
+// type rule — the argument is still walked so its own errors surface, and the
+// await contributes a `never` placeholder so a downstream consumer doesn't see a
+// stray inference variable that would never be solved.
+func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Type {
+	if c.fn == nil || !c.fn.async {
+		c.inferExpr(scope, lvl, e.Arg) // surface argument-side errors anyway
+		c.report(&AwaitOutsideAsyncError{Await: e})
+		t := soltype.Type(&soltype.NeverType{})
+		c.recordType(e, t)
+		return t
+	}
+	arg := c.inferExpr(scope, lvl, e.Arg)
+	res := c.freshAt(lvl)
+	c.recordProv(res, e, AwaitResult)
+	// Synthesize the Promise<U> requirement at this call site. It isn't given its
+	// own provenance — the operand the user sees blame on is the awaited expression
+	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
+	// internal scaffolding for the constraint, not a user-authored type.
+	c.constrain(e, arg, &soltype.PromiseType{Inner: res})
+	c.recordType(e, res)
+	return res
+}
+
+// inferIfElse types `if cond { cons } else { alt }`. The condition is
+// constrained `<: boolean`; each branch is typed (an empty / missing else
+// contributes Void); the result is a fresh join var with each branch as a lower
+// bound, so the result coalesces to the union of the branches.
+//
+// Block return-point interaction: any ReturnStmt inside either branch is
+// collected on the enclosing function's funcCtx by inferStmt — independent of
+// the if's value contribution — so a `if c { return X } else { Y }` correctly
+// flows X into the function's return type AND Y into the if's value, which the
+// enclosing block joins.
+func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.Type {
+	cond := c.inferExpr(scope, lvl, e.Cond)
+	c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
+	consT := c.inferBlock(scope.Child(), lvl, &e.Cons)
+	var altT soltype.Type = &soltype.Void{}
+	if e.Alt != nil {
+		altT = c.inferBlockOrExpr(scope, lvl, e.Alt)
+	}
+	res := c.freshAt(lvl)
+	c.recordProv(res, e, IfElseBranch)
+	c.constrain(e, consT, res)
+	c.constrain(e, altT, res)
+	c.recordType(e, res)
+	return res
+}
+
+// inferBlockOrExpr types an `else` arm: either a block (`else { ... }`) or a
+// single expression (`else if ...` chains, which the parser desugars into Alt =
+// expr). A nil-block-and-nil-expr alt is treated as Void (the only honest
+// recovery for a malformed AST shape that shouldn't arise from the real parser).
+func (c *checker) inferBlockOrExpr(scope *Scope, lvl int, b *ast.BlockOrExpr) soltype.Type {
+	switch {
+	case b.Block != nil:
+		return c.inferBlock(scope.Child(), lvl, b.Block)
+	case b.Expr != nil:
+		return c.inferExpr(scope, lvl, b.Expr)
+	default:
+		return &soltype.Void{}
+	}
 }

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -280,7 +280,7 @@ func TestInferBlockReturnStmt(t *testing.T) {
 	c := newChecker()
 	// A return is only legal inside a function body, so push a func context the way
 	// inferFunc does — otherwise the walk (correctly) reports ReturnOutsideFunction.
-	saved := c.pushFuncCtx(false)
+	saved := c.pushFuncCtx(false, nil)
 	// { return 5 }
 	got := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
 	c.popFuncCtx(saved)

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -278,8 +278,12 @@ func TestInferBlockEmptyIsVoid(t *testing.T) {
 
 func TestInferBlockReturnStmt(t *testing.T) {
 	c := newChecker()
+	// A return is only legal inside a function body, so push a func context the way
+	// inferFunc does — otherwise the walk (correctly) reports ReturnOutsideFunction.
+	saved := c.pushFuncCtx(false)
 	// { return 5 }
 	got := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
+	c.popFuncCtx(saved)
 	require.Empty(t, c.errs)
 	require.Equal(t, "5", render(got))
 }

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -39,15 +39,19 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		// PR3: a return contributes both as a candidate block-tail value (kept for
 		// continuity with M2's `{ return 5 }` block-as-expression test) AND as one
 		// of the enclosing function's return points. Bare `return` contributes Void
-		// in both slots. Outside any function (a hand-built / malformed AST — the
-		// real walk never enters a return at top-level) the funcCtx is nil and we
-		// silently skip collection rather than panicking.
+		// in both slots.
 		var t soltype.Type = &soltype.Void{}
 		if s.Expr != nil {
 			t = c.inferExpr(scope, lvl, s.Expr)
 		}
 		if c.fn != nil {
 			c.fn.returns = append(c.fn.returns, t)
+		} else {
+			// A `return` reached outside any function body — e.g. inside an `if` that
+			// is part of a top-level `val` initializer (`val x = if c { return 1 }
+			// else { 2 }`). Reject it by the walk, symmetric to AwaitOutsideAsyncError,
+			// rather than silently dropping the return point.
+			c.report(&ReturnOutsideFunctionError{Return: s})
 		}
 		return t
 	case *ast.DeclStmt:

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -6,19 +6,16 @@ import (
 )
 
 // inferBlock types a block's statements in source order and returns the block's
-// value: the type of its last statement, or void for an empty block. The block
+// VALUE — the type of its last statement, or void for an empty block. The block
 // runs in the scope it is given — the caller establishes it (inferFunc passes
 // the param scope, so body-level val/var redeclarations overwrite alongside the
 // params, per §3.2). soltype.Void is the result of a block that ends in a
 // declaration or a value-free statement.
 //
-// TODO(M3): a non-tail ReturnStmt only contributes the last statement's type to
-// the block value, so an early return (`{ return X; Y }`) is dropped and never
-// checked against the declared return type. Harmless at the M2 bar — there is no
-// IfElseExpr (control flow), so an early return cannot arise from a real branch —
-// but once M3 adds conditionals the walk must collect every return-point type and
-// join it with the tail before constraining against the annotation. Tracked in
-// planning/simple_sub/01-milestones.md (M3).
+// Block-as-value is distinct from FUNCTION-return: a non-tail ReturnStmt is not
+// part of the block's tail value, but it IS one of the function's return points
+// — inferStmt routes those into the enclosing funcCtx for inferFunc to join with
+// the tail (PR3, replacing M2's TODO that dropped non-tail returns).
 func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) soltype.Type {
 	var result soltype.Type = &soltype.Void{}
 	for _, s := range b.Stmts {
@@ -39,10 +36,20 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 	case *ast.ExprStmt:
 		return c.inferExpr(scope, lvl, s.Expr)
 	case *ast.ReturnStmt:
-		if s.Expr == nil {
-			return &soltype.Void{}
+		// PR3: a return contributes both as a candidate block-tail value (kept for
+		// continuity with M2's `{ return 5 }` block-as-expression test) AND as one
+		// of the enclosing function's return points. Bare `return` contributes Void
+		// in both slots. Outside any function (a hand-built / malformed AST — the
+		// real walk never enters a return at top-level) the funcCtx is nil and we
+		// silently skip collection rather than panicking.
+		var t soltype.Type = &soltype.Void{}
+		if s.Expr != nil {
+			t = c.inferExpr(scope, lvl, s.Expr)
 		}
-		return c.inferExpr(scope, lvl, s.Expr)
+		if c.fn != nil {
+			c.fn.returns = append(c.fn.returns, t)
+		}
+		return t
 	case *ast.DeclStmt:
 		vd, ok := s.Decl.(*ast.VarDecl)
 		if !ok {

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -134,6 +134,8 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.freshenAbove(lim, f.Type, lvl, cache)}
 		}
 		return &soltype.RecordType{Fields: fields}
+	case *soltype.PromiseType:
+		return &soltype.PromiseType{Inner: c.freshenAbove(lim, t.Inner, lvl, cache)}
 	default:
 		// PrimType/LitType/Void/NeverType/UnknownType and the coalesced-only
 		// Union/IntersectionType have no level-bearing children reachable here.

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -58,6 +58,7 @@ const (
 	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
 	MemberAccess                          // a fresh member-result var from inferMember (recorded against the .prop ident)
 	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
+	WildcardAnnotation                    // a fresh var from a `_` type annotation (resolveTypeAnn), the inner the surrounding annotation infers
 	AwaitResult                           // a fresh `await`-result var from inferAwait
 	PromiseWrap                           // a PromiseType minted by wrapping an async function's external return
 	ReturnJoin                            // a fresh return-join var from inferFunc (the union of every return point)

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -58,6 +58,10 @@ const (
 	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
 	MemberAccess                          // a fresh member-result var from inferMember (recorded against the .prop ident)
 	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
+	AwaitResult                           // a fresh `await`-result var from inferAwait
+	PromiseWrap                           // a PromiseType minted by wrapping an async function's external return
+	ReturnJoin                            // a fresh return-join var from inferFunc (the union of every return point)
+	IfElseBranch                          // a fresh branch-join var from inferIfElse (the union of cons / alt)
 )
 
 // NodeResolver resolves an operand type to the AST node that minted it. M2.5's

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -109,7 +109,7 @@ func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
 func TestProvAnnotationType(t *testing.T) {
 	c := newChecker()
 	ta := numAnn()
-	ty, ok := c.resolveTypeAnn(ta)
+	ty, ok := c.resolveTypeAnn(ta, 0)
 	require.True(t, ok)
 	requireOrigin(t, c, ty, ta, AnnotationType)
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -24,6 +24,24 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn) (soltype.Type, bool) {
 		return c.annPrim(ta, soltype.StrPrim), true
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
+	case *ast.TypeRefTypeAnn:
+		// M3 (PR3) recognises a single generic stdlib reference: Promise<T>. The
+		// real, alias-driven TypeRef resolution arrives in M7 — until then, any
+		// other name (or arity) reports unsupported with a `never` placeholder so
+		// the caller can recover by keeping the inferred type.
+		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
+			inner, ok := c.resolveTypeAnn(ta.TypeArgs[0])
+			if !ok {
+				// The inner annotation already reported its own unsupported error and
+				// returned `never`; propagate ok=false so the caller doesn't constrain
+				// against `Promise<never>` and cascade a spurious failure.
+				return inner, false
+			}
+			t := &soltype.PromiseType{Inner: inner}
+			c.recordProv(t, ta, AnnotationType)
+			return t, true
+		}
+		return c.reportUnsupported(ta), false
 	default:
 		return c.reportUnsupported(ta), false
 	}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -71,6 +71,16 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 			return t, true
 		}
 		return c.reportUnsupported(ta), false
+	case *ast.WildcardTypeAnn:
+		// `_` in type-annotation position is an inference placeholder: mint a fresh
+		// var at the current level for the surrounding annotation to fill in. Today
+		// the only site that uses it is the inner of `Promise<_>` on an async fn's
+		// return, where the body's return flows into the var (asyncReturn), inferring
+		// the inner. Unlike the other arms it reports NO error — `_` is a supported,
+		// user-authored "infer this here" marker, not an unsupported feature.
+		t := c.freshAt(lvl)
+		c.recordProv(t, ta, WildcardAnnotation)
+		return t, true
 	default:
 		return c.reportUnsupported(ta), false
 	}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -13,10 +13,12 @@ import (
 // milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here, with
 // ok=false and a `never` placeholder so a caller can recover by keeping the type
 // it already inferred (rather than constraining against / adopting `never`, which
-// would cascade a spurious `<: never` error and poison the binding). It takes no
-// scope: the supported set is all closed primitives, with no name to look up.
-// Name resolution against the type scope arrives with TypeRef support.
-func (c *checker) resolveTypeAnn(ta ast.TypeAnn) (soltype.Type, bool) {
+// would cascade a spurious `<: never` error and poison the binding). It takes the
+// current inference level `lvl` so a supported generic with an UNSUPPORTED inner (a
+// malformed `Promise<…>`) can recover its inner to a fresh var at the right level
+// while keeping the wrapper; the primitive arms ignore lvl. Full name resolution
+// against the type scope still arrives with TypeRef support (M7).
+func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	switch ta := ta.(type) {
 	case *ast.NumberTypeAnn:
 		return c.annPrim(ta, soltype.NumPrim), true
@@ -30,12 +32,23 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn) (soltype.Type, bool) {
 		// other name (or arity) reports unsupported with a `never` placeholder so
 		// the caller can recover by keeping the inferred type.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
-			inner, ok := c.resolveTypeAnn(ta.TypeArgs[0])
+			inner, ok := c.resolveTypeAnn(ta.TypeArgs[0], lvl)
 			if !ok {
-				// The inner annotation already reported its own unsupported error and
-				// returned `never`; propagate ok=false so the caller doesn't constrain
-				// against `Promise<never>` and cascade a spurious failure.
-				return inner, false
+				// The inner annotation was unsupported and already reported its own
+				// error. The Promise itself IS supported, so keep the WRAPPER rather
+				// than collapsing the whole annotation to the bare-var recovery the
+				// caller applies on ok=false: `p: Promise<bad>` should stay Promise-
+				// shaped (so `await p` and the rendered signature read as a Promise),
+				// not degrade to an unconstrained var. Recover the inner to a fresh var
+				// — cascade-safe in BOTH directions (an initializer flowing into
+				// `Promise<freshVar>` constrains the var without failing; a `never` or
+				// `unknown` inner would instead cascade a spurious `<: never` / `<:
+				// unknown`, since constrain has no rule for either as an input).
+				//
+				// PR8 (planning/simple_sub/m3-implementation-plan.md) replaces this
+				// fresh var with the dedicated error-recovery type, so the recovered
+				// inner reads as `error` rather than as an anonymous coalesced var.
+				inner = c.freshAt(lvl)
 			}
 			t := &soltype.PromiseType{Inner: inner}
 			c.recordProv(t, ta, AnnotationType)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -32,6 +32,14 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 		// other name (or arity) reports unsupported with a `never` placeholder so
 		// the caller can recover by keeping the inferred type.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
+			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
+			// supported: M3's PromiseType carries no lifetime, so silently accepting it
+			// would drop the lifetime. Reject it as an unsupported feature rather than
+			// coercing to a plain Promise<T>. (Lifetimes on referenced types land with
+			// the wider TypeRef/lifetime work.)
+			if len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
+				return c.reportUnsupportedFeature(ta, "lifetime annotation on Promise"), false
+			}
 			inner, ok := c.resolveTypeAnn(ta.TypeArgs[0], lvl)
 			if !ok {
 				// The inner annotation was unsupported and already reported its own

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -31,6 +31,14 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 		// real, alias-driven TypeRef resolution arrives in M7 — until then, any
 		// other name (or arity) reports unsupported with a `never` placeholder so
 		// the caller can recover by keeping the inferred type.
+		//
+		// FOOTGUN (removed in M7): this matches the bare NAME "Promise" WITHOUT
+		// consulting the type scope, so it would preempt any user-defined
+		// `type Promise<T> = …` alias. That is harmless today (user type aliases
+		// don't resolve yet, and the prelude only seeds Promise as an opaque
+		// placeholder), but M7's scope-driven TypeRef resolution MUST replace this
+		// hardcoded check — resolve the name through the scope first — so a real
+		// alias wins instead of being silently shadowed by this stub.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
 			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
 			// supported: M3's PromiseType carries no lifetime, so silently accepting it

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -395,6 +395,18 @@ wrapper) are what first populate a lifetime. Land them together.
   — `fn dist(open p) => ...` keeps `p` inexact so callers can pass records
   richer than the field set the body touches. The `open` marker lands here
   (the first milestone where record-typed params exist).
+- **`var`-binding literal widening (reassignment ergonomics).** M3's PR8 ships
+  reassignment (`a = expr`) but constrains the RHS against the binding's type *as
+  inferred*, so an un-annotated `var a = 5; a = 6` rejects (`6 <: 5`) until a `var`
+  binding **widens its literal initializer to the primitive** (`5` ⇒ `number`,
+  `"x"` ⇒ `string`) — the binding-level analog of the `widen(v)` already applied to
+  field writes (`obj.x = v`, above). It is *not* PR1 generalization (that quantifies
+  free vars and is a no-op on a var-free literal). The principled M4 form is
+  usage-based: a `var`'s type is informed by **all** its assignment sites
+  (initializer + reassignments) via the same widen + coalescing machinery, with
+  `val` left un-widened (a fixed literal singleton). Defaulting to always-widen-`var`
+  is the simple rule; the open question this milestone settles is whether a later
+  narrowing use should be allowed to reclaim the literal.
 - **`Ref` constrain rule** (single rule for the unified borrow wrapper): inner
   variance is bidirectional iff `r.mut` (read/write decomposition: covariant
   read + contravariant write when the target writes), covariant otherwise;
@@ -696,6 +708,18 @@ recursive references (cf. `infer_module.go:431-872` and the discussion in
   [exact-types/requirements.md](../exact-types/requirements.md) §5.) `keyof` of an exact object and the
   element-union of an exact tuple are exact unions; their inexact counterparts
   are inexact — so this flag must be threaded by coalescing, not just stored.
+- **Former simplification — lattice identities and the `ErrorType` sentinel.** When
+  unions/intersections become real formers here, normalize them: drop duplicate and
+  subsumed members, and apply the lattice identities — `never` (⊥) drops from a
+  union (`A | never ⇒ A`), `unknown` (⊤) drops from an intersection (`A & unknown ⇒
+  A`). M3's `ErrorType` recovery sentinel ([m3 PR8](m3-implementation-plan.md)) is
+  the special case: it is elided from **both** a union and an intersection unless it
+  is the sole member (`A | error ⇒ A`, `A & error ⇒ A`; bare `error` stays) — it is
+  the join *and* meet identity, the former-level reflection of its absorbing
+  behavior in `constrain`, because it carries no information once the error is
+  reported. (In M3 this is an invariant freebie — `ErrorType` is short-circuited out
+  of every bound list, so it never reaches a former; M6 must keep it true once
+  formers can be built directly.)
 
 **Accept:** `number | string` annotation accepts `number`/rejects `boolean`;
 intersection annotation satisfied by a value at both member types; both

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -1064,6 +1064,48 @@ by short-circuiting at the top of `constrain` (it absorbs but does not spread). 
 `soltype/type.go` (+ print / describe), `constrain.go` (the two arms), `infer.go`
 (`report`), and the recovery sites whose `ok=false`-skips retire.
 
+**Future direction — marking / used holes (the principled end-state).** The
+`ErrorType` sentinel is the *minimal* recovery: a single absorbing wildcard that
+suppresses cascades but carries no information — every poisoned subterm looks the
+same and the surrounding context learns nothing from it. The principled version is
+**marking-based recovery with holes**, as in Hazel's "Total Type Error Localization
+and Recovery with Holes" (POPL 2024, https://hazel.org/papers/marking-popl24.pdf):
+an ill-fitting expression is wrapped in a **non-empty ("used") hole** that acts as a
+*membrane* — internally it holds the actual (wrong) type and the localized mark, but
+at its boundary it adopts the **expected** type, so the rest of the program type-
+checks against the precise expected type rather than against a wildcard. The payoff
+over a flat `ErrorType` is twofold: (1) *better recovery* — `val x: number = "hi"`
+leaves `x: number` (not `error`), so `x + 1` and downstream inference stay precise;
+and (2) *total, principled localization* — every program (however broken) has a
+well-defined marked typing, and the mark sits on the exact offending subterm rather
+than smearing an absorbing type outward. It also subsumes the ad-hoc "adopt the
+annotation on `ok=false`" recovery the walk already does in a couple of places
+(`inferVarDeclInit`, `inferFunc`) — those are hand-rolled non-empty holes.
+
+*Feasibility for this SimpleSub-based checker: promising in spirit, not a drop-in.*
+The marking calculus is formulated **bidirectionally** (synthesis ⇒ / analysis ⇐),
+and the totality theorem leans on that structure; we are **constraint-based
+subtyping (biunification)** with no published "marked biunification" to port, so we
+would be adapting the *idea*, not the calculus. The adaptation is natural, though:
+our `constrain(actual, expected)` is exactly the analysis judgment, so the
+membrane rule becomes "on a `constrain` failure, report + mark the node (via `Prov`,
+which already pins precise blame) + let the node's recovered type be the **RHS**
+(expected), and do not propagate the actual as a bound." The side tables (`Info` for
+node→type, `Prov` for node→origin) already give us the machinery to record marks and
+boundary types, and empty holes map onto the parser's existing error nodes
+(`ErrorStmt`/synthesized placeholders) seeded with a fresh var. The genuine open
+questions are (a) what "the expected type" means when the analysis RHS is itself an
+inference *variable* rather than a concrete type (the membrane still suppresses
+cascades, but the recovered type is as under-determined as the var — less
+informative than Hazel's often-concrete analysis types), and (b) re-checking
+SimpleSub's principal-type / determinism story under marking (how a marked subterm
+interacts with var bounds and generalization), which the bidirectional totality
+proof does not hand us for free. Net: `ErrorType` is the right MVP and a clean
+stepping stone — it is a degenerate hole with no boundary type — and "holes that
+carry the expected type" is the natural follow-on once the recovery mechanism needs
+to preserve information rather than merely stop cascades. Worth a spike, likely its
+own milestone rather than part of M3.
+
 ## Risks & gates
 
 - **No M3-level go/no-go gate** (those live at M4's `Ref` rule and M7's

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -108,11 +108,13 @@ earlier drafts of this plan assumed spike-era names that never shipped.
 
 ## Sequencing rationale
 
-Eight PRs (PR0–PR7) on three landed prerequisites (M1, M2, M2.5). Solid edges =
+Nine PRs (PR0–PR8) on three landed prerequisites (M1, M2, M2.5). Solid edges =
 hard dependency (downstream won't compile / pass tests without upstream); dashed
 = soft (downstream lands correctly but degraded until upstream fills it in). PR7
 is a behavior-preserving refactor (the shared `soltype` rewriting visitor) — it
-depends only on PR1 and is otherwise independent.
+depends only on PR1 and is otherwise independent. PR8 is a robustness fix (the
+error-recovery sentinel) — it depends only on M1 and M2.5, nothing depends on it,
+but it stops every error-emitting PR from cascading a spurious second diagnostic.
 
 ```mermaid
 flowchart TD
@@ -128,6 +130,7 @@ flowchart TD
     PR5[PR5: probe API]
     PR6[PR6: overloading]
     PR7[PR7: soltype rewriting visitor — refactor]
+    PR8[PR8: error-recovery type]
 
     M2 --> PR1
     M25 --> PR1
@@ -135,6 +138,8 @@ flowchart TD
     M2 --> PR4
     M25 --> PR4
     M1 --> PR5
+    M1 --> PR8
+    M25 --> PR8
     PR0 --> PR4
     PR1 --> PR2
     PR1 --> PR6
@@ -143,10 +148,11 @@ flowchart TD
     PR2 -. compact renders .-> PR1
     PR4 -. specificity accounts for exactness .-> PR6
     PR7 -. visitor available for simplify's rewrite .-> PR2
+    PR8 -. suppresses recovery cascades .-> PR3
 
     classDef prereq fill:#eee,stroke:#999,stroke-dasharray:3 3;
     classDef refactor fill:#f5f5ff,stroke:#88a,stroke-dasharray:2 2;
-    class PR7 refactor;
+    class PR7,PR8 refactor;
 ```
 
 Parallelizable tracks: the **polymorphism chain** (PR1 → PR2), **async + block
@@ -184,6 +190,13 @@ prerequisite for every error-emitting PR; only the strongest edges are drawn.
   concrete instance (the trigger to extract), hence the PR1 edge; nothing depends
   on it. Numbered last as a non-blocking cleanup, but lands cleanest right after
   PR1 so PR2's `rewrite` can reuse the visitor.
+- **PR8 (error-recovery type) depends only on M1 + M2.5.** A self-contained
+  robustness fix: one new `soltype` atom plus two short-circuit arms at the top of
+  `constrain`, repointing `report` off `never`. Nothing depends on it, but every
+  error-emitting site (PR3's `if`/`await` recovery, the `report` placeholder
+  generally) stops cascading a spurious second `cannot constrain never <: …` once
+  it lands. Numbered last alongside PR7 as a non-blocking quality fix; surfaced
+  while implementing PR3.
 
 ### Shared files & merge ordering
 
@@ -221,6 +234,15 @@ not semantic. Tracks: **A** = PR1→PR2, **B** = PR3, **C** = PR0→PR4, **D** =
   (`constrain.go` bound-append sites). Since PR7 is a pure refactor with no
   behavior change, sequence it *after* PR1/PR4/PR5 have settled those regions and
   rebase onto them — don't run it concurrently.
+- **PR8 (error-recovery type) touches `soltype/type.go` (the new `ErrorType` atom),
+  `constrain.go` (the two top-of-function short-circuits), `infer.go` (`report`),
+  and the recovery sites whose `ok=false`-skips retire.** It overlaps PR4
+  (`soltype/type.go` fields, `constrain.go` `FuncType` case) and PR5 (`constrain.go`
+  bound-append sites), but its `constrain` edit is a short-circuit *above* the
+  structural switch, so it rebases cleanly past either. Land it after PR3 (which
+  surfaces the cascade the tests assert away) and after PR7 if PR7 has landed (so
+  the `ErrorType` pass-through rides the visitor rather than another hand-rolled
+  arm); otherwise it stands alone.
 
 ## Core types added or changed in M3
 
@@ -241,6 +263,20 @@ type FuncParam struct {
     Type     Type
     Optional bool // PR4: x? — lowers `required` without changing arity
 }
+```
+
+**`ErrorType` — the error-recovery sentinel** (PR8). A new childless `soltype`
+atom, distinct from `never`/`unknown`. The latter two are coalesced-**output**
+only ([type.go](../../internal/soltype/type.go): "appear only as coalesced
+output, never as constrain inputs"); `ErrorType` is a legal constrain **input**
+that absorbs in both directions, so a reported diagnostic's placeholder never
+cascades a second one. Never user-spellable (distinct from a future `any`), minted
+only by `report`:
+
+```go
+// internal/soltype/type.go
+type ErrorType struct{} // ⊤⊥ absorbing sentinel; see PR8
+func (*ErrorType) isType() {}
 ```
 
 **Schemes** (PR1) — new file `internal/solver/poly.go`:
@@ -936,6 +972,97 @@ param's type allocates a new node but reuses the unchanged `*FuncParam`s).
 subtlety is getting the polarity-flip and the var-case `SkipChildren` short-circuit
 right, both directly asserted. Lands cleanest after PR1/PR4/PR5 settle
 `coalesce.go`/`constrain.go`/`poly.go` (see "Shared files & merge ordering").
+
+---
+
+### PR8 — Error-recovery type (the `ErrorType` absorbing sentinel)
+
+A robustness fix surfaced while implementing PR3. Today `report`
+([infer.go](../../internal/solver/infer.go)) hands back `&soltype.NeverType{}` as
+the value-position placeholder after emitting a diagnostic. But `never` (⊥) and
+`unknown` (⊤) are **coalesced-output only** in this design —
+[type.go](../../internal/soltype/type.go) is explicit that, like
+`Union`/`Intersection`, "their *subtyping rules* in constrain are M6 … these nodes
+appear only as coalesced output, never as constrain inputs." Error recovery is the
+one path that violates that invariant: it feeds a `never` back into `constrain`,
+where there is no `never <: T` (nor `T <: never`) input rule, so the placeholder
+**cascades a second, spurious `cannot constrain never <: …`** on top of the real
+error. PR3's `if <unknown> { … }` (constrains `never <: boolean`) and `await
+<unknown>` (constrains `never <: Promise<U>`) are the live cases; the walk already
+dodges the RHS half elsewhere with scattered `ok=false`-skip special-cases (e.g.
+`inferVarDeclInit`, `inferFunc`'s return-annotation arm, `resolveTypeAnn`
+recovery), which is the same problem patched site-by-site.
+
+PR8 replaces the overloaded `never` placeholder with a dedicated sentinel, so the
+fix is one mechanism instead of a guard at every constraint site:
+
+- **`soltype.ErrorType`** — a childless atom, distinct from `never`/`unknown`, that
+  is a *legal `constrain` input* and **absorbs in both directions**: any constraint
+  with an `ErrorType` operand trivially succeeds. This keeps `never` as the precise
+  lattice bottom (output-only, its M6 input rule still deferred) and gives recovery
+  its own input-legal, direction-agnostic behavior — the standard "error type" of
+  TS / Roslyn / GHC.
+- **Two short-circuit arms at the TOP of `constrain`** — before the structural
+  switch and the variable arms — so an `ErrorType` operand returns `nil`
+  immediately and **never enters a variable's bound list**. coalesce / extrude /
+  freshenAbove therefore never see it *propagated through bounds*; they need only
+  trivial childless-atom pass-through arms (since `report` can still hand an
+  `ErrorType` out as a binding's type, e.g. `val x = <unknown ident>`).
+- **`report` returns `&soltype.ErrorType{}`** instead of `&soltype.NeverType{}`.
+  Minted **only** by `report` (where a diagnostic was definitely already emitted),
+  never by `freshVar` — the discipline that keeps absorption from silently hiding a
+  genuine checker bug.
+- **Retire the now-redundant `ok=false`-skip guards** that exist purely to dodge a
+  `never`-in-RHS cascade — the constraint now absorbs on its own. *Keep* the cases
+  that adopt a **better inferred type** (a valued `val x: <bad ann> = 5` still keeps
+  `5` for downstream completions rather than poisoning `x` to `error`): PR8 changes
+  the *no-good-type* recovery, not every recovery.
+- **Internal-only.** `ErrorType` is never produced by `resolveTypeAnn` from user
+  syntax and never rendered into a signature a user authored — distinct from a
+  future user-facing `any`. It renders as `error` for diagnostics / debug only.
+
+**Sketch:**
+
+```go
+// internal/soltype/type.go — a new childless atom. LevelOf's default arm already
+// returns 0 for it; print/describe render "error".
+type ErrorType struct{}
+func (*ErrorType) isType() {}
+```
+
+```go
+// internal/solver/constrain.go — top of constrain, BEFORE the structural switch
+// and the var arms. An ErrorType operand carries an already-reported error; it
+// absorbs both ways so recovery never cascades, and short-circuiting here keeps it
+// out of every bound list.
+if _, ok := lhs.(*soltype.ErrorType); ok { return nil }
+if _, ok := rhs.(*soltype.ErrorType); ok { return nil }
+```
+
+```go
+// internal/solver/infer.go
+func (c *checker) report(e SolverError) soltype.Type {
+    c.errs = append(c.errs, e)
+    return &soltype.ErrorType{} // was &soltype.NeverType{}
+}
+```
+
+**Tests:** the PR3 cascade cases now yield **exactly one** diagnostic — `if
+<unknown> { … }` reports only the `UnknownIdentifierError` (no trailing `cannot
+constrain never <: boolean`); `await <unknown>` inside an `async fn` reports only
+the unknown identifier; an unsupported RHS annotation reports only its
+unsupported-node error. Unit `constrain` tests pin `ErrorType` absorbing as **both**
+LHS and RHS against every concrete and against a var. A value flowing through an
+error-typed binding produces no secondary errors. The existing blame / `requireBlame`
+suite passes unchanged once the redundant `ok=false`-skips are removed.
+
+**Risk:** low–medium. The real risk is **over-suppression** — an `ErrorType` that
+leaks too far would silence constraints that *should* fail, masking genuine checker
+bugs during development. Contained by the "minted only by `report`" discipline and
+by short-circuiting at the top of `constrain` (it absorbs but does not spread). The
+`soltype` fan-out is cheap (a childless atom, not a recursive former). Touches
+`soltype/type.go` (+ print / describe), `constrain.go` (the two arms), `infer.go`
+(`report`), and the recovery sites whose `ok=false`-skips retire.
 
 ## Risks & gates
 

--- a/planning/simple_sub/m3-implementation-plan.md
+++ b/planning/simple_sub/m3-implementation-plan.md
@@ -112,9 +112,11 @@ Nine PRs (PR0–PR8) on three landed prerequisites (M1, M2, M2.5). Solid edges =
 hard dependency (downstream won't compile / pass tests without upstream); dashed
 = soft (downstream lands correctly but degraded until upstream fills it in). PR7
 is a behavior-preserving refactor (the shared `soltype` rewriting visitor) — it
-depends only on PR1 and is otherwise independent. PR8 is a robustness fix (the
-error-recovery sentinel) — it depends only on M1 and M2.5, nothing depends on it,
-but it stops every error-emitting PR from cascading a spurious second diagnostic.
+depends only on PR1 and is otherwise independent. PR8 bundles the error-recovery
+sentinel (a robustness fix that depends only on M1 and M2.5, and stops every
+error-emitting PR from cascading a spurious second diagnostic) with reassignment
+typing (`a = expr`, the first `BinaryExpr` form the walk handles — needs M2's
+expression walk). Nothing depends on PR8.
 
 ```mermaid
 flowchart TD
@@ -130,7 +132,7 @@ flowchart TD
     PR5[PR5: probe API]
     PR6[PR6: overloading]
     PR7[PR7: soltype rewriting visitor — refactor]
-    PR8[PR8: error-recovery type]
+    PR8[PR8: error-recovery type + reassignment]
 
     M2 --> PR1
     M25 --> PR1
@@ -139,6 +141,7 @@ flowchart TD
     M25 --> PR4
     M1 --> PR5
     M1 --> PR8
+    M2 --> PR8
     M25 --> PR8
     PR0 --> PR4
     PR1 --> PR2
@@ -190,13 +193,16 @@ prerequisite for every error-emitting PR; only the strongest edges are drawn.
   concrete instance (the trigger to extract), hence the PR1 edge; nothing depends
   on it. Numbered last as a non-blocking cleanup, but lands cleanest right after
   PR1 so PR2's `rewrite` can reuse the visitor.
-- **PR8 (error-recovery type) depends only on M1 + M2.5.** A self-contained
-  robustness fix: one new `soltype` atom plus two short-circuit arms at the top of
-  `constrain`, repointing `report` off `never`. Nothing depends on it, but every
-  error-emitting site (PR3's `if`/`await` recovery, the `report` placeholder
-  generally) stops cascading a spurious second `cannot constrain never <: …` once
-  it lands. Numbered last alongside PR7 as a non-blocking quality fix; surfaced
-  while implementing PR3.
+- **PR8 (error-recovery type + reassignment) depends on M1 + M2 + M2.5.** Part 1,
+  the error-recovery sentinel, is a self-contained robustness fix on M1 + M2.5: one
+  new `soltype` atom plus two short-circuit arms at the top of `constrain`,
+  repointing `report` off `never`, so every error-emitting site (PR3's `if`/`await`
+  recovery, the `report` placeholder generally) stops cascading a spurious second
+  `cannot constrain never <: …`. Part 2, reassignment typing (`a = expr`), adds the
+  first `BinaryExpr` arm to the M2 expression walk (assignment op only; operator
+  schemes stay unsupported) plus a `Mutable` flag on `ValueBinding`. Nothing depends
+  on PR8. Numbered last alongside PR7 as a non-blocking quality fix / gap-closer;
+  the sentinel surfaced while implementing PR3.
 
 ### Shared files & merge ordering
 
@@ -234,15 +240,18 @@ not semantic. Tracks: **A** = PR1→PR2, **B** = PR3, **C** = PR0→PR4, **D** =
   (`constrain.go` bound-append sites). Since PR7 is a pure refactor with no
   behavior change, sequence it *after* PR1/PR4/PR5 have settled those regions and
   rebase onto them — don't run it concurrently.
-- **PR8 (error-recovery type) touches `soltype/type.go` (the new `ErrorType` atom),
-  `constrain.go` (the two top-of-function short-circuits), `infer.go` (`report`),
-  and the recovery sites whose `ok=false`-skips retire.** It overlaps PR4
-  (`soltype/type.go` fields, `constrain.go` `FuncType` case) and PR5 (`constrain.go`
-  bound-append sites), but its `constrain` edit is a short-circuit *above* the
-  structural switch, so it rebases cleanly past either. Land it after PR3 (which
-  surfaces the cascade the tests assert away) and after PR7 if PR7 has landed (so
-  the `ErrorType` pass-through rides the visitor rather than another hand-rolled
-  arm); otherwise it stands alone.
+- **PR8 (error-recovery type + reassignment) touches, for Part 1, `soltype/type.go`
+  (the new `ErrorType` atom), `constrain.go` (the two top-of-function
+  short-circuits), `infer.go` (`report`), and the recovery sites whose
+  `ok=false`-skips retire; for Part 2, `infer_expr.go` (the `BinaryExpr`/`Assign`
+  arm + `inferAssign`), `scope.go` (`ValueBinding.Mutable`), `infer_decl.go`
+  (set `Mutable` from `VarDecl.Kind`), and `errors.go` (the two assignment errors).** Part 1
+  overlaps PR4 (`soltype/type.go` fields, `constrain.go` `FuncType` case) and PR5
+  (`constrain.go` bound-append sites), but its `constrain` edit is a short-circuit
+  *above* the structural switch, so it rebases cleanly past either; Part 2's files
+  are otherwise PR8-private. Land it after PR3 (which surfaces the cascade the tests
+  assert away) and after PR7 if PR7 has landed (so the `ErrorType` pass-through rides
+  the visitor rather than another hand-rolled arm); otherwise it stands alone.
 
 ## Core types added or changed in M3
 
@@ -975,7 +984,19 @@ right, both directly asserted. Lands cleanest after PR1/PR4/PR5 settle
 
 ---
 
-### PR8 — Error-recovery type (the `ErrorType` absorbing sentinel)
+### PR8 — Error-recovery type (`ErrorType` sentinel) + reassignment typing
+
+PR8 bundles two pieces that are small on their own and reinforce each other in
+test: (1) the `ErrorType` absorbing sentinel (a robustness fix surfaced while
+implementing PR3), and (2) **reassignment typing** (`a = expr`) — the first
+`BinaryExpr` form the walk handles, an otherwise-untracked gap in the plan. The
+pairing is deliberate: reassigning *through* a broken binding (`var a = <unknown>;
+a = 5`) is exactly the case the sentinel must absorb cleanly, so the reassignment
+walk gives the sentinel a real binding-reuse test and the sentinel gives the
+reassignment walk its error-recovery story. They share no code, so review may split
+them; the two **Tests** / **Risk** notes below are tagged per piece.
+
+#### Part 1 — the `ErrorType` absorbing sentinel
 
 A robustness fix surfaced while implementing PR3. Today `report`
 ([infer.go](../../internal/solver/infer.go)) hands back `&soltype.NeverType{}` as
@@ -1008,6 +1029,21 @@ fix is one mechanism instead of a guard at every constraint site:
   freshenAbove therefore never see it *propagated through bounds*; they need only
   trivial childless-atom pass-through arms (since `report` can still hand an
   `ErrorType` out as a binding's type, e.g. `val x = <unknown ident>`).
+- **`ErrorType` is the identity element for type *formers* — dropped from unions
+  AND intersections (an M6 rule; a freebie invariant in M3).** Because the two
+  short-circuits keep it out of every bound list, `ErrorType` cannot reach a
+  coalesced `UnionType`/`IntersectionType` in M3 — `A | B | error` simply can't
+  arise (an erroring `if`/`return` branch is already dropped from the join; see
+  `TestInferIfElseUnknownConditionNoCascade`). When **M6** makes unions/intersections
+  real formers, preserve that: **elide `ErrorType` from a union or an intersection
+  unless it is the sole member** (then it stays, rendering `error`). It is the join
+  *and* meet identity — `A | error ⇒ A`, `A & error ⇒ A` — the former-level
+  reflection of its constrain-level absorption: it carries no information (the error
+  was already reported), so it must neither widen a union nor narrow an intersection.
+  This is what distinguishes it from the genuine lattice bounds M6 also simplifies:
+  `never` (⊥) is dropped from unions only, `unknown` (⊤) from intersections only;
+  `ErrorType` drops from **both**, marking it a sentinel *outside* the lattice rather
+  than a bound within it.
 - **`report` returns `&soltype.ErrorType{}`** instead of `&soltype.NeverType{}`.
   Minted **only** by `report` (where a diagnostic was definitely already emitted),
   never by `freshVar` — the discipline that keeps absorption from silently hiding a
@@ -1047,7 +1083,8 @@ func (c *checker) report(e SolverError) soltype.Type {
 }
 ```
 
-**Tests:** the PR3 cascade cases now yield **exactly one** diagnostic — `if
+**Tests (Part 1 — `ErrorType`).** the PR3 cascade cases now yield **exactly one**
+diagnostic — `if
 <unknown> { … }` reports only the `UnknownIdentifierError` (no trailing `cannot
 constrain never <: boolean`); `await <unknown>` inside an `async fn` reports only
 the unknown identifier; an unsupported RHS annotation reports only its
@@ -1056,7 +1093,7 @@ LHS and RHS against every concrete and against a var. A value flowing through an
 error-typed binding produces no secondary errors. The existing blame / `requireBlame`
 suite passes unchanged once the redundant `ok=false`-skips are removed.
 
-**Risk:** low–medium. The real risk is **over-suppression** — an `ErrorType` that
+**Risk (Part 1 — `ErrorType`).** low–medium. The real risk is **over-suppression** — an `ErrorType` that
 leaks too far would silence constraints that *should* fail, masking genuine checker
 bugs during development. Contained by the "minted only by `report`" discipline and
 by short-circuiting at the top of `constrain` (it absorbs but does not spread). The
@@ -1074,13 +1111,22 @@ an ill-fitting expression is wrapped in a **non-empty ("used") hole** that acts 
 *membrane* — internally it holds the actual (wrong) type and the localized mark, but
 at its boundary it adopts the **expected** type, so the rest of the program type-
 checks against the precise expected type rather than against a wildcard. The payoff
-over a flat `ErrorType` is twofold: (1) *better recovery* — `val x: number = "hi"`
-leaves `x: number` (not `error`), so `x + 1` and downstream inference stay precise;
-and (2) *total, principled localization* — every program (however broken) has a
-well-defined marked typing, and the mark sits on the exact offending subterm rather
-than smearing an absorbing type outward. It also subsumes the ad-hoc "adopt the
-annotation on `ok=false`" recovery the walk already does in a couple of places
-(`inferVarDeclInit`, `inferFunc`) — those are hand-rolled non-empty holes.
+over a flat `ErrorType` is twofold. (1) *Uniform recovery* — the membrane adopts
+the expected type at **every** analysis sink, generalizing the two adoptions the
+walk hand-rolls today (`inferVarDeclInit` constrains `val x: T = …` then adopts `T`;
+`inferFunc` adopts `-> T`) to the sinks they never reach: a call argument `f(bad)`
+would recover at `f`'s parameter type, a tuple element at its annotated slot, and so
+on — positions where flat `ErrorType` instead absorbs the constraint and records
+nothing about what was expected there. (The annotated binding the original draft
+cited, `val x: number = "hi"`, is *not* a motivator: that hand-rolled adoption
+already lands `x: number`, not `error` — [infer_decl.go](../../internal/solver/infer_decl.go)
+`initT = annT` after the failed `"hi" <: number` — so holes **subsume** it, they do
+not improve on it. And on the genuine gap, the un-adopted sinks, the recovered type
+is still only as good as the expected type the context supplies — see open question
+(a) below.) (2) *Total, principled localization* — every program (however broken)
+has a well-defined marked typing, with the mark on the exact offending subterm
+rather than an absorbing type smeared outward, folding the two hand-rolled adoptions
+into one rule.
 
 *Feasibility for this SimpleSub-based checker: promising in spirit, not a drop-in.*
 The marking calculus is formulated **bidirectionally** (synthesis ⇒ / analysis ⇐),
@@ -1105,6 +1151,93 @@ stepping stone — it is a degenerate hole with no boundary type — and "holes 
 carry the expected type" is the natural follow-on once the recovery mechanism needs
 to preserve information rather than merely stop cascades. Worth a spike, likely its
 own milestone rather than part of M3.
+
+#### Part 2 — reassignment typing (`a = expr`)
+
+`a = 5` parses as an `ast.BinaryExpr` with `Op = ast.Assign` (`"="`), today caught
+by `inferExpr`'s default arm → `UnsupportedNodeError`. PR8 wires the **assignment
+op only**; the arithmetic / comparison / logical operators (`+`, `==`, `&&`, `++`)
+stay unsupported — their operator-scheme walk over the M2 prelude bindings is a
+separate, still-unlanded PR (see the latent-trap note in `prelude.go`'s
+`addOperatorBindings`). So the new `BinaryExpr` arm dispatches `Op == ast.Assign`
+to a dedicated `inferAssign` and leaves every other op falling through unchanged.
+
+- **LValue.** M3's assignable target is an `IdentExpr` resolved to a `ValueBinding`
+  in scope. A member target (`obj.x = …`) needs record types and lands in M4; a
+  non-place LHS (literal, call, …) is an `InvalidAssignmentTargetError`. (The old
+  checker already branches IdentExpr vs member in its Assign arm,
+  [infer_expr.go](../../internal/checker/infer_expr.go).)
+- **Mutability.** Only a `var` binding is reassignable; reassigning a `val`, a
+  function, a parameter, or a prelude binding is a `CannotAssignToImmutableError`.
+  `ValueBinding` carries no mut-ness today ([scope.go](../../internal/solver/scope.go) —
+  only `Schemes`/`Sources`), so add a `Mutable bool` set from the introducing
+  `VarDecl.Kind == ast.VarKind` (the decl is already in `Sources`). This is the
+  **binding-level** gate only — `mut`-field / aliasing / lifetime-transition
+  mutability (the old checker's `check_transitions.go`: *"cannot assign … still used
+  mutably"*) is M4's, deferred here.
+- **Type rule.** `constrain(rhs, target)` — the RHS must be a subtype of the
+  target binding's (instantiated) type, the new-solver form of the old checker's
+  `Unify(rightType, leftType)` in its Assign arm. M3 constrains against the
+  binding's type **as inferred**: for an annotated `var a: number = 5` that is
+  `number`, so `a = 6` checks; for an un-annotated `var a = 5` it is the literal
+  `5`, so reassigning a *different* literal (`a = 6` ⇒ `6 <: 5`) does **not** check
+  until **literal widening of `var` bindings, deferred to M4** (it folds into M4's
+  usage-based inference and the `widen(v)` it already applies to field writes — see
+  M4 §"usage-based inference"). M3 tests therefore annotate the `var`. The
+  assignment **expression's** own value type is `void` (M3 choice: assignment is
+  statement-shaped; the old checker hands back `never`, but `void` fits the walk's
+  expression-value model and avoids minting a ⊥ in synthesized position).
+- **New errors** (M2.5 blame model): `InvalidAssignmentTargetError` (blames the
+  LHS) and `CannotAssignToImmutableError` (blames the assignment, relates the `val`
+  decl — the "declared immutable here" span). The RHS/target mismatch reuses
+  `constrain`'s existing `CannotConstrainError`.
+
+**Sketch:**
+
+```go
+// internal/solver/scope.go — ValueBinding gains a mut flag. Default false:
+// val / fn / param / prelude are immutable; only a `var` decl sets it true.
+type ValueBinding struct {
+    Schemes []TypeScheme
+    Sources []provenance.Provenance
+    Mutable bool // PR8: `var` bindings are reassignable; everything else is not
+}
+```
+
+```go
+// internal/solver/infer_expr.go — the ONLY BinaryExpr form PR8 handles. Every
+// other operator stays UnsupportedNodeError (the operator-scheme walk is a
+// separate, unlanded PR).
+case *ast.BinaryExpr:
+    if e.Op == ast.Assign {
+        return c.inferAssign(scope, lvl, e)
+    }
+    return c.reportUnsupported(e)
+```
+
+**Tests (Part 2 — reassignment).**
+- `var a: number = 5; a = 6` type-checks; `var a: number = 5; a = "x"` reports a
+  single `CannotConstrainError` (`"x" <: number`, full message). (Un-annotated
+  `var a = 5; a = 6` does **not** check in M3 — `6 <: 5` — pending M4 `var`
+  widening; assert that as the interim behavior so the M4 change is visible.)
+- `val a = 5; a = 6` reports `CannotAssignToImmutableError` blaming the assignment
+  and relating the `val a` decl; a parameter and a function name likewise reject
+  reassignment.
+- `5 = a` and `f() = a` report `InvalidAssignmentTargetError` (blames the LHS).
+- Value position: `var a: number = 5; val b = (a = 6)` ⇒ `b: void`.
+- **Synergy with Part 1 (the headline test the pairing buys):** `var a = missing;
+  a = 5; a = "hello"` reports **exactly one** error — the `UnknownIdentifierError`
+  on line 1. `a` is `ErrorType`, so `5 <: ErrorType` and `"hello" <: ErrorType` both
+  absorb; without Part 1 the two reassignments would each cascade a spurious
+  `cannot constrain … <: never`.
+
+**Risk (Part 2 — reassignment).** low. A localized `inferExpr` arm + `inferAssign`,
+a one-field `ValueBinding` addition, and one `constrain` against the binding's
+existing type — no novel design call now that widening moves to M4. Touches
+`infer_expr.go` (arm + `inferAssign`), `scope.go` (`Mutable` field), `infer_decl.go`
+(set `Mutable` from `VarDecl.Kind`), `errors.go` (two new errors). `var` literal
+widening (so un-annotated `var a = 5; a = 6` checks), member targets, and
+`mut`-field / alias / lifetime transitions all remain M4.
 
 ## Risks & gates
 
@@ -1136,6 +1269,11 @@ M3 is done when, against **real source**:
 - Overloaded free `fn` declarations resolve at call sites per the documented
   specificity rule; mutually-recursive overloaded participants without annotations
   are rejected with a full error message. *(PR6, on the PR5 probe)*
+- Reassignment: `var a: number = 5; a = 6` type-checks and `a = "x"` reports the
+  single subtype error; reassigning a `val` or a non-place target is rejected with a
+  full error message; reassigning *through* a broken binding (`var a = <unknown>;
+  a = 5`) yields exactly one diagnostic. (`var` literal widening so un-annotated
+  `var a = 5; a = 6` checks is M4.) *(PR8)*
 
 All assertions are full error messages (via M2.5's `requireBlame` span harness)
 and Escalier-syntax rendered types in the solver package's table tests.


### PR DESCRIPTION
Implements the M3 milestone's async/await support, block-level return-point collection, and if/else expressions as values. This is a substantial feature addition that enables control flow in type inference and async function handling.

## Summary

This PR adds three interconnected features to the type checker:

1. **Async/await support**: `async fn` declarations now wrap their inferred return type in `Promise<T>` externally, while `await` expressions unwrap a single layer of `Promise`. The `await` keyword is rejected outside async functions with a walk-level error (not a type rule failure).

2. **Block return-point join**: Non-tail `return` statements are now collected during function body inference and joined with the block's tail value before constraining against the return annotation. This fixes M2's TODO where early returns were silently dropped.

3. **If/else expressions**: `if`/`else` blocks now produce values (the join of their branches), enabling control flow as expressions. Missing `else` branches contribute `void`.

## Key Changes

- **New types and errors**:
  - `PromiseType` in `soltype/type.go` — represents `Promise<T>` with covariant inner type
  - `AwaitOutsideAsyncError` and `ReturnOutsideFunctionError` in `errors.go` — walk-level rejections with proper blame spans
  - `funcCtx` struct in `infer.go` — per-function context tracking async flag, AST node, and collected return points

- **Function inference (`infer_expr.go`)**:
  - `inferFunc` now pushes/pops a `funcCtx` to collect all `ReturnStmt` types
  - Joins collected returns with block tail via a fresh variable before constraining against return annotation
  - Wraps inferred return in `Promise<T>` for async functions (with detect-and-don't-rewrap for already-Promise annotations)
  - Updated `resolveTypeAnn` to accept `lvl` parameter for recovery of unsupported generic inners

- **New inference functions**:
  - `inferAwait` — constrains argument `<: Promise<U>`, yields `U`, rejects outside async with walk error
  - `inferIfElse` — types condition as boolean, joins branches with fresh variable, handles missing else as void

- **Type annotation resolution (`type_ann.go`)**:
  - Hardcoded recognition of `Promise<T>` generic (M7 will replace with scope-driven TypeRef resolution)
  - Rejects lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) as unsupported
  - Recovers unsupported inner types to fresh variables while preserving wrapper

- **Constraint and coalesce**:
  - `PromiseType` case in `constrain.go` — covariant subtyping rule
  - `PromiseType` case in `coalesce.go` — preserves inner through coalescing

- **Statement inference (`infer_stmt.go`)**:
  - `inferStmt` routes `ReturnStmt` into enclosing `funcCtx` (or rejects with `ReturnOutsideFunctionError` if none)
  - Block value is still the tail; returns are collected separately for function-level join

- **Test coverage** (`infer_async_test.go`):
  - 30+ tests covering async wrap, await unwrap, no auto-flatten, detect-and-don't-rewrap, await-outside-async errors, block return joins, if/else values, error recovery without cascading, and rejected forms (lifetime annotations, return outside function)

## Notable Implementation Details

- **Error recovery without cascading**: `inferAwait` and `inferIfElse` guard against `never` placeholders from failed sub-expressions to avoid spurious second diagnostics. (PR8 will replace these guards with a dedicated `ErrorType` sentinel.)

- **Detect-and-don't-rewrap**: When an async function's return annotation is already `Promise<T>`, the external type is `Promise<T>` (not `Promise<Promise<T>>`). This only catches syntactically Promise returns

https://claude.ai/code/session_019ujUJaptuoGm7XrBojsPsy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async functions and await fully supported; async returns are wrapped as Promise<T> and await unwraps Promise values.
  * If/else expressions produce joined branch values.

* **Bug Fixes**
  * Reject and report await used outside async contexts with clearer related spans.
  * Reject return outside functions and report related locations.

* **Tests**
  * Extensive tests added covering async/await behavior, return joining, and related error cases.

* **Documentation**
  * Milestone and planning docs updated with async/Promise and error-recovery notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->