### PR TITLE
Add polarity-threading rewriting visitor for soltype.Type

### DIFF
--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -4,7 +4,16 @@ import "fmt"
 
 // Type is the sealed interface for all soltype nodes. (Production name for the
 // spike's SimpleType; marker renamed isSimpleType -> isType.)
-type Type interface{ isType() }
+//
+// Accept threads a polarity-flipping rewriting visitor over the node (visitor.go);
+// the structural type→type transforms (coalesce / extrude / freshenAbove) are
+// implemented on top of it so variance and the rebuild-from-children boilerplate
+// live in one place. The marker isType stays unexported so the interface is sealed
+// to this package.
+type Type interface {
+	isType()
+	Accept(v TypeVisitor, pol Polarity) Type
+}
 
 // TypeVarType is an inference variable carrying Simple-sub lower/upper bound
 // lists plus the level at which it was created (for let-generalization in M3).

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -1,0 +1,205 @@
+package soltype
+
+// EnterResult controls traversal after EnterType.
+//
+// A non-nil Type replaces the node: with SkipChildren=false it becomes the basis
+// for the structural rebuild (its children are walked), with SkipChildren=true it
+// is handed straight to ExitType without descending. A nil Type keeps the node.
+type EnterResult struct {
+	Type         Type // nil = keep the node; non-nil = replace it
+	SkipChildren bool // true = skip the structural rebuild, go straight to ExitType
+}
+
+// TypeVisitor is a polarity-threading rewriting visitor over soltype.Type. Unlike
+// type_system's visitor it carries Polarity, and Accept flips it on contravariant
+// positions (function parameters) so variance knowledge lives in ONE place rather
+// than being re-spelled in every type→type transform (coalesce / extrude /
+// freshenAbove). EnterType fires before child traversal — it may prune, replace,
+// or take over the recursion via SkipChildren (the var node's bounds are a side
+// graph, not tree children, so each transform handles TypeVarType itself in
+// EnterType). ExitType fires after, bottom-up, as a function of the
+// already-rewritten children.
+type TypeVisitor interface {
+	EnterType(t Type, pol Polarity) EnterResult
+	ExitType(t Type, pol Polarity) Type
+}
+
+// Accept methods rebuild structural nodes IDENTITY-PRESERVINGLY: a fresh node is
+// allocated only when a child actually changed; an unchanged subtree keeps its
+// pointer (no needless allocation, and identity-keyed caches / seen-sets stay
+// valid across a walk). The structural arms copy the child slice on first change
+// (copy-on-write) so the original is never mutated.
+
+// acceptLeaf handles a childless node (atoms, and TypeVarType — whose bounds are a
+// side graph the transforms walk themselves in EnterType): EnterType may replace
+// it, then ExitType finalizes. SkipChildren is irrelevant — there are no children.
+func acceptLeaf(t Type, v TypeVisitor, pol Polarity) Type {
+	cur := t
+	if e := v.EnterType(t, pol); e.Type != nil {
+		cur = e.Type
+	}
+	return v.ExitType(cur, pol)
+}
+
+// skipReplace resolves the node a SkipChildren EnterResult hands to ExitType: the
+// replacement when one was given, else the original. No structural rebuild follows,
+// so the replacement may be ANY kind (e.g. coalesce inlining a var to a union) —
+// the same-kind type assertion the descend path needs does not apply here.
+func skipReplace(t Type, e EnterResult) Type {
+	if e.Type != nil {
+		return e.Type
+	}
+	return t
+}
+
+func (t *TypeVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
+func (t *PrimType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
+func (t *LitType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
+func (t *Void) Accept(v TypeVisitor, pol Polarity) Type        { return acceptLeaf(t, v, pol) }
+func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
+func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
+
+func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		// Descending into the replacement's children: it must be the same kind.
+		cur = e.Type.(*FuncType)
+	}
+	params := cur.Params // copy-on-write: alias until a param's type changes
+	changed := false
+	for i, p := range cur.Params {
+		pt := p.Type.Accept(v, pol.Flip()) // params contravariant
+		if pt != p.Type {
+			if !changed {
+				params = append([]*FuncParam(nil), cur.Params...)
+				changed = true
+			}
+			// Surface markers (Optional / Rest) ride through unchanged.
+			params[i] = &FuncParam{Pattern: p.Pattern, Type: pt, Optional: p.Optional, Rest: p.Rest}
+		}
+	}
+	ret := cur.Ret.Accept(v, pol) // return covariant
+	out := cur
+	if changed || ret != cur.Ret {
+		out = &FuncType{Params: params, Ret: ret, Inexact: cur.Inexact}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *TupleType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		cur = e.Type.(*TupleType)
+	}
+	elems, changed := acceptTypes(cur.Elems, v, pol) // covariant
+	out := cur
+	if changed {
+		out = &TupleType{Elems: elems}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *RecordType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		cur = e.Type.(*RecordType)
+	}
+	fields := cur.Fields // copy-on-write
+	changed := false
+	for i, f := range cur.Fields {
+		ft := f.Type.Accept(v, pol) // fields covariant
+		if ft != f.Type {
+			if !changed {
+				fields = append([]*RecordField(nil), cur.Fields...)
+				changed = true
+			}
+			fields[i] = &RecordField{Name: f.Name, Type: ft}
+		}
+	}
+	out := cur
+	if changed {
+		out = &RecordType{Fields: fields}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		cur = e.Type.(*PromiseType)
+	}
+	inner := cur.Inner.Accept(v, pol) // covariant, no auto-flatten
+	out := cur
+	if inner != cur.Inner {
+		out = &PromiseType{Inner: inner}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		cur = e.Type.(*UnionType)
+	}
+	types, changed := acceptTypes(cur.Types, v, pol)
+	out := cur
+	if changed {
+		out = &UnionType{Types: types}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *IntersectionType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := t
+	if e.Type != nil {
+		cur = e.Type.(*IntersectionType)
+	}
+	types, changed := acceptTypes(cur.Types, v, pol)
+	out := cur
+	if changed {
+		out = &IntersectionType{Types: types}
+	}
+	return v.ExitType(out, pol)
+}
+
+// acceptTypes walks each element covariantly, returning (originalSlice, false)
+// when nothing changed and (copy-on-write slice, true) otherwise.
+func acceptTypes(ts []Type, v TypeVisitor, pol Polarity) ([]Type, bool) {
+	out := ts
+	changed := false
+	for i, el := range ts {
+		ne := el.Accept(v, pol)
+		if ne != el {
+			if !changed {
+				out = append([]Type(nil), ts...)
+				changed = true
+			}
+			out[i] = ne
+		}
+	}
+	return out, changed
+}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -1,10 +1,13 @@
 package soltype
 
+import "fmt"
+
 // EnterResult controls traversal after EnterType.
 //
 // A non-nil Type replaces the node: with SkipChildren=false it becomes the basis
-// for the structural rebuild (its children are walked), with SkipChildren=true it
-// is handed straight to ExitType without descending. A nil Type keeps the node.
+// for the structural rebuild (its children are walked, so it MUST be the same
+// concrete kind), with SkipChildren=true it is handed straight to ExitType without
+// descending (and may be ANY kind). A nil Type keeps the node.
 type EnterResult struct {
 	Type         Type // nil = keep the node; non-nil = replace it
 	SkipChildren bool // true = skip the structural rebuild, go straight to ExitType
@@ -44,12 +47,31 @@ func acceptLeaf(t Type, v TypeVisitor, pol Polarity) Type {
 // skipReplace resolves the node a SkipChildren EnterResult hands to ExitType: the
 // replacement when one was given, else the original. No structural rebuild follows,
 // so the replacement may be ANY kind (e.g. coalesce inlining a var to a union) —
-// the same-kind type assertion the descend path needs does not apply here.
+// the same-kind requirement the descend path enforces does not apply here.
 func skipReplace(t Type, e EnterResult) Type {
 	if e.Type != nil {
 		return e.Type
 	}
 	return t
+}
+
+// descendReplacement resolves the node the descend path rebuilds children from: the
+// EnterType replacement when one was given, else the original. Because the children
+// are walked with this node's child structure, a replacement MUST be the same
+// concrete kind; a different-kind replacement under SkipChildren=false is a visitor
+// contract violation, reported with a clear message rather than a bare
+// type-assertion fault. (Use SkipChildren=true to replace with a different kind.)
+func descendReplacement[T Type](original T, e EnterResult) T {
+	if e.Type == nil {
+		return original
+	}
+	repl, ok := e.Type.(T)
+	if !ok {
+		panic(fmt.Sprintf("soltype.Accept: EnterType replaced %T with %T under "+
+			"SkipChildren=false; a same-kind replacement is required to descend "+
+			"(set SkipChildren=true to replace with a different kind)", original, e.Type))
+	}
+	return repl
 }
 
 func (t *TypeVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
@@ -64,25 +86,9 @@ func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		// Descending into the replacement's children: it must be the same kind.
-		cur = e.Type.(*FuncType)
-	}
-	params := cur.Params // copy-on-write: alias until a param's type changes
-	changed := false
-	for i, p := range cur.Params {
-		pt := p.Type.Accept(v, pol.Flip()) // params contravariant
-		if pt != p.Type {
-			if !changed {
-				params = append([]*FuncParam(nil), cur.Params...)
-				changed = true
-			}
-			// Surface markers (Optional / Rest) ride through unchanged.
-			params[i] = &FuncParam{Pattern: p.Pattern, Type: pt, Optional: p.Optional, Rest: p.Rest}
-		}
-	}
-	ret := cur.Ret.Accept(v, pol) // return covariant
+	cur := descendReplacement(t, e)
+	params, changed := acceptParams(cur.Params, v, pol) // params contravariant
+	ret := cur.Ret.Accept(v, pol)                       // return covariant
 	out := cur
 	if changed || ret != cur.Ret {
 		out = &FuncType{Params: params, Ret: ret, Inexact: cur.Inexact}
@@ -95,10 +101,7 @@ func (t *TupleType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		cur = e.Type.(*TupleType)
-	}
+	cur := descendReplacement(t, e)
 	elems, changed := acceptTypes(cur.Elems, v, pol) // covariant
 	out := cur
 	if changed {
@@ -112,22 +115,8 @@ func (t *RecordType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		cur = e.Type.(*RecordType)
-	}
-	fields := cur.Fields // copy-on-write
-	changed := false
-	for i, f := range cur.Fields {
-		ft := f.Type.Accept(v, pol) // fields covariant
-		if ft != f.Type {
-			if !changed {
-				fields = append([]*RecordField(nil), cur.Fields...)
-				changed = true
-			}
-			fields[i] = &RecordField{Name: f.Name, Type: ft}
-		}
-	}
+	cur := descendReplacement(t, e)
+	fields, changed := acceptFields(cur.Fields, v, pol) // covariant
 	out := cur
 	if changed {
 		out = &RecordType{Fields: fields}
@@ -140,10 +129,7 @@ func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		cur = e.Type.(*PromiseType)
-	}
+	cur := descendReplacement(t, e)
 	inner := cur.Inner.Accept(v, pol) // covariant, no auto-flatten
 	out := cur
 	if inner != cur.Inner {
@@ -157,10 +143,7 @@ func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		cur = e.Type.(*UnionType)
-	}
+	cur := descendReplacement(t, e)
 	types, changed := acceptTypes(cur.Types, v, pol)
 	out := cur
 	if changed {
@@ -174,10 +157,7 @@ func (t *IntersectionType) Accept(v TypeVisitor, pol Polarity) Type {
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
-	cur := t
-	if e.Type != nil {
-		cur = e.Type.(*IntersectionType)
-	}
+	cur := descendReplacement(t, e)
 	types, changed := acceptTypes(cur.Types, v, pol)
 	out := cur
 	if changed {
@@ -199,6 +179,42 @@ func acceptTypes(ts []Type, v TypeVisitor, pol Polarity) ([]Type, bool) {
 				changed = true
 			}
 			out[i] = ne
+		}
+	}
+	return out, changed
+}
+
+// acceptParams walks each parameter's type CONTRAVARIANTLY (pol flipped),
+// copy-on-write like acceptTypes: a changed param gets a fresh *FuncParam (surface
+// markers Optional/Rest ride through), unchanged params keep their pointer.
+func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, bool) {
+	out := ps
+	changed := false
+	for i, p := range ps {
+		pt := p.Type.Accept(v, pol.Flip())
+		if pt != p.Type {
+			if !changed {
+				out = append([]*FuncParam(nil), ps...)
+				changed = true
+			}
+			out[i] = &FuncParam{Pattern: p.Pattern, Type: pt, Optional: p.Optional, Rest: p.Rest}
+		}
+	}
+	return out, changed
+}
+
+// acceptFields walks each field's type covariantly, copy-on-write like acceptParams.
+func acceptFields(fs []*RecordField, v TypeVisitor, pol Polarity) ([]*RecordField, bool) {
+	out := fs
+	changed := false
+	for i, f := range fs {
+		ft := f.Type.Accept(v, pol)
+		if ft != f.Type {
+			if !changed {
+				out = append([]*RecordField(nil), fs...)
+				changed = true
+			}
+			out[i] = &RecordField{Name: f.Name, Type: ft}
 		}
 	}
 	return out, changed

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -1,0 +1,158 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// identityVisitor rewrites nothing: every node is kept and every child walked.
+type identityVisitor struct{}
+
+func (identityVisitor) EnterType(Type, Polarity) EnterResult { return EnterResult{} }
+func (identityVisitor) ExitType(t Type, _ Polarity) Type     { return t }
+
+// recorder logs the (node, polarity) of every EnterType, rewriting nothing.
+type recorder struct{ seen map[Type]Polarity }
+
+func (r *recorder) EnterType(t Type, pol Polarity) EnterResult {
+	r.seen[t] = pol
+	return EnterResult{}
+}
+func (r *recorder) ExitType(t Type, _ Polarity) Type { return t }
+
+// Accept flips polarity on (contravariant) function parameters and keeps it on
+// the (covariant) return — and the flip composes through nesting, so a parameter
+// of a parameter is back to the outer polarity.
+func TestAcceptThreadsPolarity(t *testing.T) {
+	c := &PrimType{Prim: NumPrim}
+	d := &PrimType{Prim: StrPrim}
+	e := &PrimType{Prim: BoolPrim}
+	a := &TypeVarType{ID: 1}
+	b := &TypeVarType{ID: 2}
+
+	// fn(p: fn(q: C) -> D, a) -> fn() -> E, walked from Positive.
+	inner := &FuncType{
+		Params: []*FuncParam{{Pattern: &IdentPat{Name: "q"}, Type: c}},
+		Ret:    d,
+	}
+	retFn := &FuncType{Ret: e}
+	outer := &FuncType{
+		Params: []*FuncParam{
+			{Pattern: &IdentPat{Name: "p"}, Type: inner},
+			{Pattern: &IdentPat{Name: "a"}, Type: a},
+		},
+		Ret: retFn,
+	}
+	_ = b
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	outer.Accept(r, Positive)
+
+	require.Equal(t, Positive, r.seen[outer], "root keeps the start polarity")
+	require.Equal(t, Negative, r.seen[inner], "a parameter is contravariant")
+	require.Equal(t, Positive, r.seen[c], "a parameter of a parameter flips back")
+	require.Equal(t, Negative, r.seen[d], "the return of a contravariant fn stays flipped")
+	require.Equal(t, Negative, r.seen[a], "the second parameter is contravariant")
+	require.Equal(t, Positive, r.seen[retFn], "the return is covariant")
+	require.Equal(t, Positive, r.seen[e], "the return of a covariant fn stays positive")
+}
+
+// An atom is handed straight to the visitor and passes through unchanged: a no-op
+// rewrite returns the SAME pointer.
+func TestAcceptAtomPassThrough(t *testing.T) {
+	atoms := []Type{
+		&PrimType{Prim: NumPrim},
+		&LitType{Lit: &NumLit{Value: 5}},
+		&Void{},
+		&NeverType{},
+		&UnknownType{},
+		&TypeVarType{ID: 1},
+	}
+	for _, a := range atoms {
+		require.Same(t, a, a.Accept(identityVisitor{}, Positive))
+		require.Same(t, a, a.Accept(identityVisitor{}, Negative))
+	}
+}
+
+// A no-op rewrite over a compound node preserves identity all the way down: the
+// FuncType, its *FuncParams, and its return are the SAME pointers.
+func TestAcceptIdentityPreservation(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	fn := &FuncType{
+		Params:  []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: num, Optional: true}},
+		Ret:     num,
+		Inexact: true,
+	}
+	got := fn.Accept(identityVisitor{}, Positive)
+	require.Same(t, fn, got, "an unchanged FuncType keeps its pointer")
+}
+
+// replaceVar swaps one specific variable for repl; vars are leaves so SkipChildren
+// is set (there are no tree children to walk).
+type replaceVar struct {
+	target *TypeVarType
+	repl   Type
+}
+
+func (v *replaceVar) EnterType(t Type, _ Polarity) EnterResult {
+	if tv, ok := t.(*TypeVarType); ok && tv == v.target {
+		return EnterResult{Type: v.repl, SkipChildren: true}
+	}
+	return EnterResult{}
+}
+func (v *replaceVar) ExitType(t Type, _ Polarity) Type { return t }
+
+// Changing one child allocates a new parent but REUSES every unchanged sibling
+// (copy-on-write), and carries the surface markers (Optional/Rest/Inexact) through.
+func TestAcceptCopyOnWrite(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	p0 := &FuncParam{Pattern: &IdentPat{Name: "x"}, Type: a, Optional: true}
+	p1 := &FuncParam{Pattern: &IdentPat{Name: "y"}, Type: num, Rest: true}
+	fn := &FuncType{Params: []*FuncParam{p0, p1}, Ret: num, Inexact: true}
+
+	got := fn.Accept(&replaceVar{target: a, repl: str}, Positive).(*FuncType)
+
+	require.NotSame(t, fn, got, "a changed child forces a new parent")
+	require.Same(t, str, got.Params[0].Type, "the changed param took the replacement")
+	require.NotSame(t, p0, got.Params[0], "the changed param is a fresh *FuncParam")
+	require.True(t, got.Params[0].Optional, "the changed param keeps its Optional marker")
+	require.Same(t, p1, got.Params[1], "the unchanged param keeps its *FuncParam pointer")
+	require.Same(t, num, got.Ret, "the unchanged return keeps its pointer")
+	require.True(t, got.Inexact, "the FuncType keeps its Inexact marker")
+}
+
+// recordEntered logs every node EnterType reaches, replacing target with repl and
+// SKIPPING its children — so a skipped subtree is never entered.
+type recordEntered struct {
+	target  Type
+	repl    Type
+	entered map[Type]bool
+}
+
+func (v *recordEntered) EnterType(t Type, _ Polarity) EnterResult {
+	v.entered[t] = true
+	if t == v.target {
+		return EnterResult{Type: v.repl, SkipChildren: true}
+	}
+	return EnterResult{}
+}
+func (v *recordEntered) ExitType(t Type, _ Polarity) Type { return t }
+
+// EnterType's replacement is honored and SkipChildren prunes the subtree: the
+// replaced node's former children are never visited.
+func TestAcceptReplaceAndSkipChildren(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	leaf := &PrimType{Prim: StrPrim}
+	inner := &TupleType{Elems: []Type{leaf}}
+	outer := &TupleType{Elems: []Type{inner}}
+
+	v := &recordEntered{target: inner, repl: num, entered: map[Type]bool{}}
+	got := outer.Accept(v, Positive).(*TupleType)
+
+	require.Same(t, num, got.Elems[0], "inner was replaced by the substitute")
+	require.True(t, v.entered[inner], "the replaced node was itself entered")
+	require.False(t, v.entered[leaf], "a skipped subtree is never entered")
+}

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -29,7 +29,6 @@ func TestAcceptThreadsPolarity(t *testing.T) {
 	d := &PrimType{Prim: StrPrim}
 	e := &PrimType{Prim: BoolPrim}
 	a := &TypeVarType{ID: 1}
-	b := &TypeVarType{ID: 2}
 
 	// fn(p: fn(q: C) -> D, a) -> fn() -> E, walked from Positive.
 	inner := &FuncType{
@@ -44,7 +43,6 @@ func TestAcceptThreadsPolarity(t *testing.T) {
 		},
 		Ret: retFn,
 	}
-	_ = b
 
 	r := &recorder{seen: map[Type]Polarity{}}
 	outer.Accept(r, Positive)
@@ -155,4 +153,49 @@ func TestAcceptReplaceAndSkipChildren(t *testing.T) {
 	require.Same(t, num, got.Elems[0], "inner was replaced by the substitute")
 	require.True(t, v.entered[inner], "the replaced node was itself entered")
 	require.False(t, v.entered[leaf], "a skipped subtree is never entered")
+}
+
+// replaceDescend replaces the node matching target with repl and DESCENDS
+// (SkipChildren=false), recording every node EnterType reaches.
+type replaceDescend struct {
+	target  Type
+	repl    Type
+	entered map[Type]bool
+}
+
+func (v *replaceDescend) EnterType(t Type, _ Polarity) EnterResult {
+	v.entered[t] = true
+	if t == v.target {
+		return EnterResult{Type: v.repl} // SkipChildren=false: rebuild from repl's children
+	}
+	return EnterResult{}
+}
+func (v *replaceDescend) ExitType(t Type, _ Polarity) Type { return t }
+
+// A same-kind replacement with SkipChildren=false rebuilds from the REPLACEMENT's
+// children, not the original's, and preserves identity when nothing under it changed.
+func TestAcceptDescendsIntoSameKindReplacement(t *testing.T) {
+	origElem := &PrimType{Prim: NumPrim}
+	replElem := &PrimType{Prim: StrPrim}
+	orig := &TupleType{Elems: []Type{origElem}}
+	repl := &TupleType{Elems: []Type{replElem}}
+
+	v := &replaceDescend{target: orig, repl: repl, entered: map[Type]bool{}}
+	got := orig.Accept(v, Positive).(*TupleType)
+
+	require.True(t, v.entered[replElem], "the replacement's child is walked")
+	require.False(t, v.entered[origElem], "the original's child is not walked")
+	require.Same(t, repl, got, "nothing changed within repl, so identity is preserved")
+}
+
+// A different-kind replacement with SkipChildren=false violates the descend
+// contract and panics with a clear message (not a bare type-assertion fault).
+func TestAcceptDescendDifferentKindPanics(t *testing.T) {
+	orig := &TupleType{Elems: []Type{&PrimType{Prim: NumPrim}}}
+	v := &replaceDescend{target: orig, repl: &PrimType{Prim: StrPrim}, entered: map[Type]bool{}}
+	require.PanicsWithValue(t,
+		"soltype.Accept: EnterType replaced *soltype.TupleType with *soltype.PrimType under "+
+			"SkipChildren=false; a same-kind replacement is required to descend "+
+			"(set SkipChildren=true to replace with a different kind)",
+		func() { orig.Accept(v, Positive) })
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -3,6 +3,7 @@ package soltype
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,11 +128,11 @@ func TestAcceptCopyOnWrite(t *testing.T) {
 type recordEntered struct {
 	target  Type
 	repl    Type
-	entered map[Type]bool
+	entered set.Set[Type]
 }
 
 func (v *recordEntered) EnterType(t Type, _ Polarity) EnterResult {
-	v.entered[t] = true
+	v.entered.Add(t)
 	if t == v.target {
 		return EnterResult{Type: v.repl, SkipChildren: true}
 	}
@@ -147,12 +148,12 @@ func TestAcceptReplaceAndSkipChildren(t *testing.T) {
 	inner := &TupleType{Elems: []Type{leaf}}
 	outer := &TupleType{Elems: []Type{inner}}
 
-	v := &recordEntered{target: inner, repl: num, entered: map[Type]bool{}}
+	v := &recordEntered{target: inner, repl: num, entered: set.NewSet[Type]()}
 	got := outer.Accept(v, Positive).(*TupleType)
 
 	require.Same(t, num, got.Elems[0], "inner was replaced by the substitute")
-	require.True(t, v.entered[inner], "the replaced node was itself entered")
-	require.False(t, v.entered[leaf], "a skipped subtree is never entered")
+	require.True(t, v.entered.Contains(inner), "the replaced node was itself entered")
+	require.False(t, v.entered.Contains(leaf), "a skipped subtree is never entered")
 }
 
 // replaceDescend replaces the node matching target with repl and DESCENDS
@@ -160,11 +161,11 @@ func TestAcceptReplaceAndSkipChildren(t *testing.T) {
 type replaceDescend struct {
 	target  Type
 	repl    Type
-	entered map[Type]bool
+	entered set.Set[Type]
 }
 
 func (v *replaceDescend) EnterType(t Type, _ Polarity) EnterResult {
-	v.entered[t] = true
+	v.entered.Add(t)
 	if t == v.target {
 		return EnterResult{Type: v.repl} // SkipChildren=false: rebuild from repl's children
 	}
@@ -180,11 +181,11 @@ func TestAcceptDescendsIntoSameKindReplacement(t *testing.T) {
 	orig := &TupleType{Elems: []Type{origElem}}
 	repl := &TupleType{Elems: []Type{replElem}}
 
-	v := &replaceDescend{target: orig, repl: repl, entered: map[Type]bool{}}
+	v := &replaceDescend{target: orig, repl: repl, entered: set.NewSet[Type]()}
 	got := orig.Accept(v, Positive).(*TupleType)
 
-	require.True(t, v.entered[replElem], "the replacement's child is walked")
-	require.False(t, v.entered[origElem], "the original's child is not walked")
+	require.True(t, v.entered.Contains(replElem), "the replacement's child is walked")
+	require.False(t, v.entered.Contains(origElem), "the original's child is not walked")
 	require.Same(t, repl, got, "nothing changed within repl, so identity is preserved")
 }
 
@@ -192,7 +193,7 @@ func TestAcceptDescendsIntoSameKindReplacement(t *testing.T) {
 // contract and panics with a clear message (not a bare type-assertion fault).
 func TestAcceptDescendDifferentKindPanics(t *testing.T) {
 	orig := &TupleType{Elems: []Type{&PrimType{Prim: NumPrim}}}
-	v := &replaceDescend{target: orig, repl: &PrimType{Prim: StrPrim}, entered: map[Type]bool{}}
+	v := &replaceDescend{target: orig, repl: &PrimType{Prim: StrPrim}, entered: set.NewSet[Type]()}
 	require.PanicsWithValue(t,
 		"soltype.Accept: EnterType replaced *soltype.TupleType with *soltype.PrimType under "+
 			"SkipChildren=false; a same-kind replacement is required to descend "+

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -49,6 +49,15 @@ type coalescer struct {
 func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
+		// Union/Intersection are coalesced OUTPUT only — they must never reach
+		// coalesce INPUT (type.go: "appear only as coalesced output, never as
+		// constrain inputs"). Assert that invariant, as the pre-visitor coalesceRec
+		// did with its unhandled-type panic; every other structural/atom node is
+		// rebuilt by Accept.
+		switch t.(type) {
+		case *soltype.UnionType, *soltype.IntersectionType:
+			panic(fmt.Sprintf("coalesce: unexpected coalesced-output node %T in input", t))
+		}
 		return soltype.EnterResult{} // atom / structural node: let Accept rebuild it
 	}
 	// Re-entering a variable already on the current path is an ungrounded recursive
@@ -60,13 +69,13 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	c.seen.Add(v)
+	defer c.seen.Remove(v) // path-scoped: pop on the way back up (panic-safe)
 	// Uniform inline: drop the variable, keep only its (recursively coalesced)
 	// bounds in the current polarity.
 	bounds := make([]soltype.Type, 0, len(v.BoundsAt(pol)))
 	for _, b := range v.BoundsAt(pol) {
 		bounds = append(bounds, b.Accept(c, pol))
 	}
-	c.seen.Remove(v)
 	if len(bounds) == 0 {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
@@ -152,6 +161,11 @@ func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.T
 // case for variables genuinely used in one polarity — is PR2's; PR1 retains a
 // type parameter only where it is literally the same variable across positions,
 // so renders stay non-compact until then.
+//
+// TODO(#715): reimplement coalesceScheme/coalesceSchemeRec on the soltype rewriting
+// visitor (soltype.Accept), like coalesce/extrude/freshenAbove, so the structural
+// arms and the pol.Flip() variance live in one place rather than being re-spelled
+// here. PR7 left this hand-rolled because the var case carries extra retain logic.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 	occ := map[*soltype.TypeVarType]occPolarity{}
 	analyzeOccurrences(t, soltype.Positive, occ, set.NewSet[occKey]())

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -30,68 +30,50 @@ import (
 // See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	return coalesceRec(t, pol, set.NewSet[*soltype.TypeVarType]())
+	return t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
 }
 
-// coalesceRec is coalesce's worker, threading the path-scoped set of type
-// variables currently being inlined. seen holds only the variables on the
-// *current* recursion path (added on entry, removed on exit), so a variable
-// reused in independent branches — e.g. the identity function's shared param
-// (negative) and return (positive) var — is unaffected; only re-entering a
-// variable already on the path is a genuine cycle.
-func coalesceRec(t soltype.Type, pol soltype.Polarity, seen set.Set[*soltype.TypeVarType]) soltype.Type {
-	switch t := t.(type) {
-	case *soltype.PrimType, *soltype.LitType, *soltype.Void,
-		*soltype.NeverType, *soltype.UnknownType:
-		return t // atoms pass through
-	case *soltype.FuncType:
-		params := make([]*soltype.FuncParam, len(t.Params))
-		for i, p := range t.Params {
-			// Params are contravariant, so flip polarity. Inexact/Optional/Rest are
-			// surface markers, not bound-carrying, so they ride through coalescing
-			// unchanged.
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: coalesceRec(p.Type, pol.Flip(), seen), Optional: p.Optional, Rest: p.Rest}
-		}
-		return &soltype.FuncType{Params: params, Ret: coalesceRec(t.Ret, pol, seen), Inexact: t.Inexact} // covariant return
-	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = coalesceRec(e, pol, seen) // covariant elements
-		}
-		return &soltype.TupleType{Elems: elems}
-	case *soltype.RecordType:
-		fields := make([]*soltype.RecordField, len(t.Fields))
-		for i, f := range t.Fields {
-			fields[i] = &soltype.RecordField{Name: f.Name, Type: coalesceRec(f.Type, pol, seen)} // covariant fields
-		}
-		return &soltype.RecordType{Fields: fields}
-	case *soltype.PromiseType:
-		// Covariant inner (no auto-flatten of nested Promise<Promise<T>>).
-		return &soltype.PromiseType{Inner: coalesceRec(t.Inner, pol, seen)}
-	case *soltype.TypeVarType:
-		// Re-entering a variable already on the current path is an ungrounded
-		// recursive position (no concrete type breaks the cycle). It collapses to
-		// the polarity identity — the same value the position degenerates to when
-		// its bounds are empty — which keeps the inline walk total. A precise
-		// μ-bound rendering of such recursion is M3.
-		if seen.Contains(t) {
-			return emptyOf(pol)
-		}
-		seen.Add(t)
-		defer seen.Remove(t)
-		// Uniform inline: drop the variable, keep only its (recursively
-		// coalesced) bounds in the current polarity.
-		bounds := make([]soltype.Type, 0, len(t.BoundsAt(pol)))
-		for _, b := range t.BoundsAt(pol) {
-			bounds = append(bounds, coalesceRec(b, pol, seen))
-		}
-		if len(bounds) == 0 {
-			return emptyOf(pol)
-		}
-		return combine(pol, dedup(bounds))
-	}
-	panic(fmt.Sprintf("coalesce: unhandled %T", t))
+// coalescer is the soltype-visitor form of coalesce. The structural arms and the
+// variance flip come from soltype.Accept (the shared rewriting visitor); the var
+// node — whose bounds are a side graph, not tree children — is the whole content
+// here, handled in EnterType. seen is the path-scoped set of variables currently
+// being inlined: it holds only the variables on the *current* recursion path
+// (added before descending into bounds, removed after), so a variable reused in
+// independent branches — e.g. the identity function's shared param (negative) and
+// return (positive) var — is unaffected; only re-entering a variable already on
+// the path is a genuine cycle.
+type coalescer struct {
+	seen set.Set[*soltype.TypeVarType]
 }
+
+func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // atom / structural node: let Accept rebuild it
+	}
+	// Re-entering a variable already on the current path is an ungrounded recursive
+	// position (no concrete type breaks the cycle). It collapses to the polarity
+	// identity — the same value the position degenerates to when its bounds are
+	// empty — which keeps the inline walk total. A precise μ-bound rendering of
+	// such recursion is M3.
+	if c.seen.Contains(v) {
+		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
+	}
+	c.seen.Add(v)
+	// Uniform inline: drop the variable, keep only its (recursively coalesced)
+	// bounds in the current polarity.
+	bounds := make([]soltype.Type, 0, len(v.BoundsAt(pol)))
+	for _, b := range v.BoundsAt(pol) {
+		bounds = append(bounds, b.Accept(c, pol))
+	}
+	c.seen.Remove(v)
+	if len(bounds) == 0 {
+		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
+	}
+	return soltype.EnterResult{Type: combine(pol, dedup(bounds)), SkipChildren: true}
+}
+
+func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // occPolarity is the set of polarities a variable occurs in within a type — the
 // occurrence input single-polarity elimination needs to decide which variables a

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -248,56 +248,51 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 // cache). Keying by ID alone would reuse a Negative-polarity copy in Positive
 // position — skipping its covariant bounds — and vice versa.
 func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache map[extrudeKey]*soltype.TypeVarType) soltype.Type {
-	if soltype.LevelOf(t) <= lvl {
-		return t
-	}
-	switch t := t.(type) {
-	case *soltype.TypeVarType:
-		key := extrudeKey{id: t.ID, pol: pol}
-		if nv, ok := cache[key]; ok {
-			return nv
-		}
-		nv := c.freshVar(lvl)
-		cache[key] = nv
-		// t is the original (possibly pre-probe) var — its append is the one a
-		// Discard must truncate. nv was just minted here, so journaling it is a
-		// harmless no-op (a fresh var is unreachable after a Discard); it goes
-		// through the helpers only to keep a single uniform append path.
-		if pol == soltype.Positive {
-			c.addUpperBound(t, nv)
-			for _, lb := range t.LowerBounds {
-				c.addLowerBound(nv, c.extrude(lb, pol, lvl, cache))
-			}
-		} else {
-			c.addLowerBound(t, nv)
-			for _, ub := range t.UpperBounds {
-				c.addUpperBound(nv, c.extrude(ub, pol, lvl, cache))
-			}
-		}
-		return nv
-	case *soltype.FuncType:
-		params := make([]*soltype.FuncParam, len(t.Params))
-		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.extrude(p.Type, pol.Flip(), lvl, cache), Optional: p.Optional, Rest: p.Rest}
-		}
-		return &soltype.FuncType{Params: params, Ret: c.extrude(t.Ret, pol, lvl, cache), Inexact: t.Inexact}
-	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = c.extrude(e, pol, lvl, cache)
-		}
-		return &soltype.TupleType{Elems: elems}
-	case *soltype.RecordType:
-		fields := make([]*soltype.RecordField, len(t.Fields))
-		for i, f := range t.Fields {
-			// Fields are covariant (read-only records in M2), so no polarity flip.
-			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.extrude(f.Type, pol, lvl, cache)}
-		}
-		return &soltype.RecordType{Fields: fields}
-	case *soltype.PromiseType:
-		// Covariant inner — no polarity flip.
-		return &soltype.PromiseType{Inner: c.extrude(t.Inner, pol, lvl, cache)}
-	default:
-		return t
-	}
+	return t.Accept(&extruder{c: c, lvl: lvl, cache: cache}, pol)
 }
+
+// extruder is the soltype-visitor form of extrude. The structural arms and the
+// variance flip come from soltype.Accept; the level prune and the var node — which
+// mints a fresh var, wires it to the original through the polarity-appropriate
+// bound direction, and mutates the original mid-walk — are the bespoke content,
+// handled in EnterType.
+type extruder struct {
+	c     *Context
+	lvl   int
+	cache map[extrudeKey]*soltype.TypeVarType
+}
+
+func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	// A subtree with no variable above lvl extrudes to itself (identity-shared).
+	if soltype.LevelOf(t) <= e.lvl {
+		return soltype.EnterResult{Type: t, SkipChildren: true}
+	}
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural node: let Accept rebuild it
+	}
+	key := extrudeKey{id: v.ID, pol: pol}
+	if nv, ok := e.cache[key]; ok {
+		return soltype.EnterResult{Type: nv, SkipChildren: true}
+	}
+	nv := e.c.freshVar(e.lvl)
+	e.cache[key] = nv
+	// v is the original (possibly pre-probe) var — its append is the one a Discard
+	// must truncate. nv was just minted here, so journaling it is a harmless no-op
+	// (a fresh var is unreachable after a Discard); it goes through the helpers
+	// only to keep a single uniform append path.
+	if pol == soltype.Positive {
+		e.c.addUpperBound(v, nv)
+		for _, lb := range v.LowerBounds {
+			e.c.addLowerBound(nv, lb.Accept(e, pol))
+		}
+	} else {
+		e.c.addLowerBound(v, nv)
+		for _, ub := range v.UpperBounds {
+			e.c.addUpperBound(nv, ub.Accept(e, pol))
+		}
+	}
+	return soltype.EnterResult{Type: nv, SkipChildren: true}
+}
+
+func (e *extruder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -75,13 +75,32 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 // three onto a shared soltype rewriting visitor with no behavior change. Unlike
 // those two it ignores polarity (it freshens uniformly, no variance flip).
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
+	return t.Accept(&freshener{c: c, lim: lim, lvl: lvl, cache: cache}, soltype.Positive)
+}
+
+// freshener is the soltype-visitor form of freshenAbove. The structural arms come
+// from soltype.Accept; the level prune and the var node are the bespoke content.
+// Unlike coalesce/extrude it IGNORES polarity (it freshens uniformly, no variance
+// flip) — the shared visitor still flips on func params, harmlessly, because
+// EnterType/ExitType never consult pol. The start polarity is therefore arbitrary
+// (Positive).
+type freshener struct {
+	c     *checker
+	lim   int
+	lvl   int
+	cache map[*soltype.TypeVarType]*soltype.TypeVarType
+}
+
+func (f *freshener) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	// Every variable inside t is at or below lim: nothing to freshen, SHARE the node
-	// (the original pointer flows through unchanged). Two consequences worth naming:
+	// (the original pointer flows through unchanged — Accept's identity preservation
+	// gives the same result for the structural arms too). Two consequences worth
+	// naming:
 	//
 	//  1. (Soundness coupling) LevelOf returns a *TypeVarType's own Level only — it
 	//     does NOT descend into the var's bounds, and returns 0 for Union/Intersection.
-	//     This early return is therefore sound only because the MLsub level invariant
-	//     holds (a var's level >= the level of everything in its bounds, maintained by
+	//     This prune is therefore sound only because the MLsub level invariant holds
+	//     (a var's level >= the level of everything in its bounds, maintained by
 	//     constrain/extrude) and raw scheme bodies contain no Union/Intersection. The
 	//     analogous extrude (constrain.go) rests on the same assumption. If a future
 	//     change breaks either, a Level>lim var could hide under a shared node and two
@@ -94,62 +113,43 @@ func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*solt
 	//     "unique pointer per mint" property recordProv's debugProv guard assumes does
 	//     not hold for these shared nodes. Anything recording provenance against an
 	//     instantiated node must account for the sharing.
-	if soltype.LevelOf(t) <= lim {
-		return t
+	if soltype.LevelOf(t) <= f.lim {
+		return soltype.EnterResult{Type: t, SkipChildren: true}
 	}
-	switch t := t.(type) {
-	case *soltype.TypeVarType:
-		if nv, ok := cache[t]; ok {
-			return nv
-		}
-		nv := c.freshAt(lvl)
-		cache[t] = nv
-		// Mint the FromInstantiation interior edge: the fresh var was copied from t.
-		// PR1 only records the edge; the multi-hop renderer that chases it back to an
-		// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
-		c.recordInstantiation(nv, t)
-		// nv is freshly minted here, so these whole-slice bound assignments are
-		// intentionally NOT journaled by the probe (see Probe's doc): a fresh var
-		// is unreachable after a Discard, so it self-rolls-back. This is the one
-		// sanctioned non-append bound write — it touches only fresh vars, never a
-		// var the probe has recorded.
-		nv.LowerBounds = c.freshenBounds(lim, t.LowerBounds, lvl, cache)
-		nv.UpperBounds = c.freshenBounds(lim, t.UpperBounds, lvl, cache)
-		return nv
-	case *soltype.FuncType:
-		params := make([]*soltype.FuncParam, len(t.Params))
-		for i, p := range t.Params {
-			params[i] = &soltype.FuncParam{Pattern: p.Pattern, Type: c.freshenAbove(lim, p.Type, lvl, cache), Optional: p.Optional, Rest: p.Rest}
-		}
-		return &soltype.FuncType{Params: params, Ret: c.freshenAbove(lim, t.Ret, lvl, cache), Inexact: t.Inexact}
-	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = c.freshenAbove(lim, e, lvl, cache)
-		}
-		return &soltype.TupleType{Elems: elems}
-	case *soltype.RecordType:
-		fields := make([]*soltype.RecordField, len(t.Fields))
-		for i, f := range t.Fields {
-			fields[i] = &soltype.RecordField{Name: f.Name, Type: c.freshenAbove(lim, f.Type, lvl, cache)}
-		}
-		return &soltype.RecordType{Fields: fields}
-	case *soltype.PromiseType:
-		return &soltype.PromiseType{Inner: c.freshenAbove(lim, t.Inner, lvl, cache)}
-	default:
-		// PrimType/LitType/Void/NeverType/UnknownType and the coalesced-only
-		// Union/IntersectionType have no level-bearing children reachable here.
-		return t
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural node: let Accept rebuild it
 	}
+	if nv, ok := f.cache[v]; ok {
+		return soltype.EnterResult{Type: nv, SkipChildren: true}
+	}
+	nv := f.c.freshAt(f.lvl)
+	f.cache[v] = nv
+	// Mint the FromInstantiation interior edge: the fresh var was copied from v.
+	// PR1 only records the edge; the multi-hop renderer that chases it back to an
+	// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
+	f.c.recordInstantiation(nv, v)
+	// nv is freshly minted here, so these whole-slice bound assignments are
+	// intentionally NOT journaled by the probe (see Probe's doc): a fresh var is
+	// unreachable after a Discard, so it self-rolls-back. This is the one sanctioned
+	// non-append bound write — it touches only fresh vars, never a var the probe has
+	// recorded. The cache is populated BEFORE the bounds are freshened so a recursive
+	// bound referencing v resolves to the in-progress nv rather than looping.
+	nv.LowerBounds = f.freshenBounds(v.LowerBounds, pol)
+	nv.UpperBounds = f.freshenBounds(v.UpperBounds, pol)
+	return soltype.EnterResult{Type: nv, SkipChildren: true}
 }
 
-func (c *checker) freshenBounds(lim int, bounds []soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) []soltype.Type {
+func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// freshenBounds freshens a var's bound list, preserving the nil-for-empty shape.
+func (f *freshener) freshenBounds(bounds []soltype.Type, pol soltype.Polarity) []soltype.Type {
 	if len(bounds) == 0 {
 		return nil
 	}
 	out := make([]soltype.Type, len(bounds))
 	for i, b := range bounds {
-		out[i] = c.freshenAbove(lim, b, lvl, cache)
+		out[i] = b.Accept(f, pol)
 	}
 	return out
 }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -91,7 +91,7 @@ type freshener struct {
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
 }
 
-func (f *freshener) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
 	// Every variable inside t is at or below lim: nothing to freshen, SHARE the node
 	// (the original pointer flows through unchanged — Accept's identity preservation
 	// gives the same result for the structural arms too). Two consequences worth
@@ -135,21 +135,22 @@ func (f *freshener) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	// non-append bound write — it touches only fresh vars, never a var the probe has
 	// recorded. The cache is populated BEFORE the bounds are freshened so a recursive
 	// bound referencing v resolves to the in-progress nv rather than looping.
-	nv.LowerBounds = f.freshenBounds(v.LowerBounds, pol)
-	nv.UpperBounds = f.freshenBounds(v.UpperBounds, pol)
+	nv.LowerBounds = f.freshenBounds(v.LowerBounds)
+	nv.UpperBounds = f.freshenBounds(v.UpperBounds)
 	return soltype.EnterResult{Type: nv, SkipChildren: true}
 }
 
 func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // freshenBounds freshens a var's bound list, preserving the nil-for-empty shape.
-func (f *freshener) freshenBounds(bounds []soltype.Type, pol soltype.Polarity) []soltype.Type {
+// Freshening ignores polarity (no variance flip), so it walks at a fixed Positive.
+func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 	if len(bounds) == 0 {
 		return nil
 	}
 	out := make([]soltype.Type, len(bounds))
 	for i, b := range bounds {
-		out[i] = b.Accept(f, pol)
+		out[i] = b.Accept(f, soltype.Positive)
 	}
 	return out
 }


### PR DESCRIPTION
Introduce a shared `TypeVisitor` interface and `Accept` methods on all `soltype.Type` nodes to enable polarity-aware structural rewriting. This consolidates the boilerplate and variance logic that was previously hand-rolled in three separate transforms (coalesce, extrude, freshenAbove).

## Key changes

- **New visitor interface** (`soltype/visitor.go`):
  - `TypeVisitor` with `EnterType` (pre-traversal, may prune/replace) and `ExitType` (post-traversal, bottom-up) hooks
  - `EnterResult` to control traversal: replace the node, skip children, or keep it
  - `Accept` methods on all `Type` nodes that rebuild structurally with identity preservation (copy-on-write for changed children)
  - Polarity threading: `Accept` flips polarity on contravariant positions (function parameters) automatically, so variance knowledge lives in one place

- **Refactored transforms** to use the visitor:
  - `coalesce` (constrain.go): replaced recursive `coalesceRec` with `coalescer` visitor; handles type variables and their bounds in `EnterType`
  - `extrude` (constrain.go): replaced recursive hand-rolled traversal with `extruder` visitor; mints fresh variables and wires bounds mid-walk
  - `freshenAbove` (poly.go): replaced recursive traversal with `freshener` visitor; prunes subtrees below a level threshold and freshens variables

- **Comprehensive tests** (soltype/visitor_test.go):
  - Polarity threading through nested function types
  - Identity preservation for unchanged subtrees
  - Copy-on-write behavior when children change
  - `SkipChildren` pruning and replacement semantics
  - Same-kind vs. different-kind replacement validation

## Implementation details

- The visitor pattern carries `Polarity` through the walk, flipping it on function parameters (contravariant) so each transform doesn't need to re-spell variance logic
- Structural nodes (FuncType, TupleType, etc.) use copy-on-write: a fresh node is allocated only when a child actually changed; unchanged subtrees keep their pointer identity
- Type variables are handled as leaves in the visitor (their bounds are a side graph, not tree children), so each transform handles them in `EnterType`
- The level pruning in `freshenAbove` and `extrude` is preserved: subtrees with no variables above a threshold are identity-shared
- A same-kind replacement under `SkipChildren=false` is enforced with a clear panic message; different-kind replacements require `SkipChildren=true`

https://claude.ai/code/session_014aCjNdc4iLpNhzYjevr6TB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type-transformation and variance-handling mechanisms to use a consistent visitor pattern, improving code consistency and reducing duplication across the type system.

* **Tests**
  * Added comprehensive test coverage for type traversal and rewriting behavior, including polarity handling, copy-on-write semantics, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->