### PR TITLE
Add reassignment typing and error-recovery sentinel (PR8)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -207,6 +207,8 @@ func (p *namedPrinter) printType(t Type) string {
 		return "never"
 	case *UnknownType:
 		return "unknown"
+	case *ErrorType:
+		return "error"
 	case *Void:
 		return "void"
 	case *TupleType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -44,10 +44,11 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"str literal", &LitType{Lit: &StrLit{Value: "hello"}}, `"hello"`},
 		{"bool literal", &LitType{Lit: &BoolLit{Value: true}}, "true"},
 
-		// Lattice bounds and void.
+		// Lattice bounds, void, and the error-recovery sentinel.
 		{"never", &NeverType{}, "never"},
 		{"unknown", &UnknownType{}, "unknown"},
 		{"void", &Void{}, "void"},
+		{"error", &ErrorType{}, "error"}, // PR8 recovery sentinel
 
 		// Tuples.
 		{"empty tuple", &TupleType{}, "[]"},

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -192,6 +192,18 @@ type UnknownType struct{}
 type UnionType struct{ Types []Type }
 type IntersectionType struct{ Types []Type }
 
+// ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct
+// from never (⊥) and unknown (⊤). Unlike those two, which are coalesced-OUTPUT
+// only ("appear only as coalesced output, never as constrain inputs", above),
+// ErrorType is a legal constrain INPUT that ABSORBS in both directions: any
+// constraint with an ErrorType operand trivially succeeds. report (solver) mints
+// it as the value-position placeholder after emitting a diagnostic, so the
+// placeholder never cascades a second, spurious failure — the standard "error
+// type" of TS / Roslyn / GHC. It is never user-spellable (distinct from a future
+// `any`) and never produced from user syntax; it renders as `error` for
+// diagnostics/debug only.
+type ErrorType struct{} // ⊤⊥ absorbing sentinel; see PR8
+
 func (*TypeVarType) isType()      {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -204,6 +216,7 @@ func (*NeverType) isType()        {}
 func (*UnknownType) isType()      {}
 func (*UnionType) isType()        {}
 func (*IntersectionType) isType() {}
+func (*ErrorType) isType()        {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).
@@ -232,8 +245,9 @@ func LevelOf(t Type) int {
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	default:
-		// PrimType, LitType, Void, NeverType, UnknownType, UnionType,
-		// IntersectionType: UnionType/IntersectionType only appear in coalesced
+		// PrimType, LitType, Void, NeverType, UnknownType, ErrorType, UnionType,
+		// IntersectionType: ErrorType is a childless sentinel (level 0);
+		// UnionType/IntersectionType only appear in coalesced
 		// output, where every TypeVarType has been inlined — so they contain no
 		// level-bearing nodes reachable to LevelOf in M1. M6 (when these become
 		// constrain inputs via user annotations) adds the recursive arms

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -80,6 +80,7 @@ func (t *LitType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLe
 func (t *Void) Accept(v TypeVisitor, pol Polarity) Type        { return acceptLeaf(t, v, pol) }
 func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
+func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -340,6 +340,9 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.UnknownType:
 		_, ok := b.(*soltype.UnknownType)
 		return ok
+	case *soltype.ErrorType:
+		_, ok := b.(*soltype.ErrorType)
+		return ok
 	case *soltype.FuncType:
 		b, ok := b.(*soltype.FuncType)
 		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact {

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -17,6 +17,7 @@ func TestCoalesceAtomsPassThrough(t *testing.T) {
 		{"void", &soltype.Void{}},
 		{"never", &soltype.NeverType{}},
 		{"unknown", &soltype.UnknownType{}},
+		{"error", &soltype.ErrorType{}}, // PR8 recovery sentinel: a childless atom
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -87,6 +87,21 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	}
 	seen.Add(key)
 
+	// Error-recovery sentinel (PR8): an ErrorType operand carries an
+	// already-reported diagnostic, so it ABSORBS in both directions — the
+	// constraint trivially succeeds. Short-circuiting here, ABOVE the structural
+	// switch and the variable arms, keeps it out of every bound list, so a
+	// reported diagnostic's placeholder never cascades a second, spurious failure
+	// (and coalesce / extrude / freshenAbove never see it propagated through
+	// bounds). Unlike never (⊥) / unknown (⊤), which are coalesced-output only,
+	// ErrorType is a legal constrain input.
+	if _, ok := lhs.(*soltype.ErrorType); ok {
+		return nil
+	}
+	if _, ok := rhs.(*soltype.ErrorType); ok {
+		return nil
+	}
+
 	// Structural cases first; fall through to the variable cases when a side
 	// that didn't match here is a TypeVarType.
 	switch l := lhs.(type) {

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -350,6 +350,46 @@ func TestConstrainVoid(t *testing.T) {
 		Messages(c.Constrain(&soltype.Void{}, num())))
 }
 
+// PR8: the ErrorType recovery sentinel ABSORBS in both directions — a constraint
+// with an ErrorType operand trivially succeeds, so a reported diagnostic's
+// placeholder never cascades. Pinned against every concrete shape, on both sides.
+func TestConstrainErrorTypeAbsorbs(t *testing.T) {
+	errT := func() soltype.Type { return &soltype.ErrorType{} }
+	concretes := []struct {
+		name string
+		t    soltype.Type
+	}{
+		{"number", num()},
+		{"literal", numLit(5)},
+		{"function", exactFn(num(), identParam("x", num()))},
+		{"tuple", &soltype.TupleType{Elems: []soltype.Type{num()}}},
+		{"void", &soltype.Void{}},
+		{"error", errT()},
+	}
+	for _, tc := range concretes {
+		t.Run("error <: "+tc.name, func(t *testing.T) {
+			c := &Context{}
+			require.Empty(t, c.Constrain(errT(), tc.t))
+		})
+		t.Run(tc.name+" <: error", func(t *testing.T) {
+			c := &Context{}
+			require.Empty(t, c.Constrain(tc.t, errT()))
+		})
+	}
+}
+
+// PR8: ErrorType short-circuits ABOVE the variable arms, so it never enters a
+// var's bound list — coalesce / extrude / freshenAbove then never see it
+// propagated through bounds.
+func TestConstrainErrorTypeNeverEntersVarBounds(t *testing.T) {
+	c := &Context{}
+	a := c.freshVar(0)
+	require.Empty(t, c.Constrain(a, &soltype.ErrorType{}))
+	require.Empty(t, a.UpperBounds, "ErrorType must not be recorded as an upper bound")
+	require.Empty(t, c.Constrain(&soltype.ErrorType{}, a))
+	require.Empty(t, a.LowerBounds, "ErrorType must not be recorded as a lower bound")
+}
+
 func TestConstrainVariableBinding(t *testing.T) {
 	// α <: number records number as an upper bound of α.
 	c := &Context{}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -379,13 +379,14 @@ type InvalidAssignmentTargetError struct {
 //
 // It is a BRIDGE error: born in inferAssign with the assignment node in hand, so
 // it self-blames the whole assignment (Span()). Decl is the introducing
-// declaration — surfaced via Related() as the "declared immutable here" span — or
-// nil for a parameter / prelude binding that carries no source node. Name is the
-// target identifier, for the message.
+// declaration — surfaced via Related() as the "declared immutable here" span,
+// resolved for a `val`/`fn` decl AND for a parameter (its pattern) — or nil for a
+// prelude binding that carries no source node. Name is the target identifier, for
+// the message.
 type CannotAssignToImmutableError struct {
 	Assign *ast.BinaryExpr // the assignment (blame span)
 	Name   string          // the target binding's name
-	Decl   ast.Node        // the introducing decl, related; nil for params/prelude
+	Decl   ast.Node        // the introducing decl, related; nil for prelude bindings
 }
 
 func (*UnknownIdentifierError) isSolverError()       {}
@@ -425,8 +426,8 @@ func (e *InvalidAssignmentTargetError) Message() string {
 func (e *CannotAssignToImmutableError) Span() ast.Span { return e.Assign.Span() }
 func (e *CannotAssignToImmutableError) Related() []ast.Span {
 	// Point at the introducing declaration (the "declared immutable here" span) when
-	// there is one; a parameter or prelude binding carries no source node, so the
-	// related list is then empty.
+	// there is one — a `val`/`fn` decl or a parameter's pattern; a prelude binding
+	// carries no source node, so the related list is then empty.
 	if e.Decl == nil {
 		return nil
 	}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -360,19 +360,49 @@ type AsyncReturnNotPromiseError struct {
 	Fn     ast.Node    // the enclosing async function, surfaced via Related()
 }
 
-func (*UnknownIdentifierError) isSolverError()    {}
-func (*NamespaceUsedAsValueError) isSolverError() {}
-func (*TooManyArgsError) isSolverError()          {}
-func (*NotEnoughArgsError) isSolverError()        {}
-func (*UnsupportedNodeError) isSolverError()      {}
-func (*UnsupportedFeatureError) isSolverError()   {}
-func (*BodyDeclNotAllowedError) isSolverError()   {}
-func (*MissingInitializerError) isSolverError()   {}
-func (*DuplicateDeclarationError) isSolverError() {}
-func (*OverloadNotSupportedError) isSolverError() {}
-func (*AwaitOutsideAsyncError) isSolverError()      {}
-func (*ReturnOutsideFunctionError) isSolverError()  {}
-func (*AsyncReturnNotPromiseError) isSolverError()  {}
+// InvalidAssignmentTargetError fires when the left-hand side of an assignment
+// (`a = expr`) is not an assignable place. M3's only assignable target is an
+// IdentExpr resolving to a `var` binding; a literal, call, or any other non-place
+// LHS is rejected here. (A member target `obj.x = …` needs record types and lands
+// in M4 — it is also reported here until then.)
+//
+// It is a BRIDGE error: born in inferAssign with the offending LHS node in hand,
+// so it self-blames (Span() is the LHS's own span); it carries no related node.
+type InvalidAssignmentTargetError struct {
+	Target ast.Expr // the non-place LHS (blame span)
+}
+
+// CannotAssignToImmutableError fires when a reassignment (`a = expr`) targets a
+// binding that is not a `var` — a `val`, a function, a parameter, or a prelude
+// binding. The binding-level mutability gate (PR8); `mut`-field / alias / lifetime
+// mutability is M4.
+//
+// It is a BRIDGE error: born in inferAssign with the assignment node in hand, so
+// it self-blames the whole assignment (Span()). Decl is the introducing
+// declaration — surfaced via Related() as the "declared immutable here" span — or
+// nil for a parameter / prelude binding that carries no source node. Name is the
+// target identifier, for the message.
+type CannotAssignToImmutableError struct {
+	Assign *ast.BinaryExpr // the assignment (blame span)
+	Name   string          // the target binding's name
+	Decl   ast.Node        // the introducing decl, related; nil for params/prelude
+}
+
+func (*UnknownIdentifierError) isSolverError()       {}
+func (*NamespaceUsedAsValueError) isSolverError()    {}
+func (*InvalidAssignmentTargetError) isSolverError() {}
+func (*CannotAssignToImmutableError) isSolverError() {}
+func (*TooManyArgsError) isSolverError()             {}
+func (*NotEnoughArgsError) isSolverError()           {}
+func (*UnsupportedNodeError) isSolverError()         {}
+func (*UnsupportedFeatureError) isSolverError()      {}
+func (*BodyDeclNotAllowedError) isSolverError()      {}
+func (*MissingInitializerError) isSolverError()      {}
+func (*DuplicateDeclarationError) isSolverError()    {}
+func (*OverloadNotSupportedError) isSolverError()    {}
+func (*AwaitOutsideAsyncError) isSolverError()       {}
+func (*ReturnOutsideFunctionError) isSolverError()   {}
+func (*AsyncReturnNotPromiseError) isSolverError()   {}
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
@@ -384,6 +414,26 @@ func (e *NamespaceUsedAsValueError) Span() ast.Span      { return e.Ident.Span()
 func (e *NamespaceUsedAsValueError) Related() []ast.Span { return nil }
 func (e *NamespaceUsedAsValueError) Message() string {
 	return "Namespace used as a value: " + e.Ident.Name
+}
+
+func (e *InvalidAssignmentTargetError) Span() ast.Span      { return e.Target.Span() }
+func (e *InvalidAssignmentTargetError) Related() []ast.Span { return nil }
+func (e *InvalidAssignmentTargetError) Message() string {
+	return "Invalid assignment target: " + astKind(e.Target)
+}
+
+func (e *CannotAssignToImmutableError) Span() ast.Span { return e.Assign.Span() }
+func (e *CannotAssignToImmutableError) Related() []ast.Span {
+	// Point at the introducing declaration (the "declared immutable here" span) when
+	// there is one; a parameter or prelude binding carries no source node, so the
+	// related list is then empty.
+	if e.Decl == nil {
+		return nil
+	}
+	return []ast.Span{e.Decl.Span()}
+}
+func (e *CannotAssignToImmutableError) Message() string {
+	return "Cannot assign to immutable binding: " + e.Name
 }
 
 func (e *TooManyArgsError) Span() ast.Span { return e.Call.Span() }
@@ -546,6 +596,8 @@ func describe(t soltype.Type) string {
 		return "never"
 	case *soltype.UnknownType:
 		return "unknown"
+	case *soltype.ErrorType:
+		return "error"
 	case *soltype.UnionType:
 		return joinDescribe(t.Types, " | ")
 	case *soltype.IntersectionType:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -116,11 +116,17 @@ func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 	}
 }
 
-// report accumulates a structured error and returns a placeholder type so a
-// caller can `return c.report(...)` in value position.
+// report accumulates a structured error and returns the error-recovery sentinel
+// (PR8) so a caller can `return c.report(...)` in value position. ErrorType
+// absorbs in both directions inside constrain, so this placeholder never cascades
+// a second, spurious failure — replacing M2's overloaded `never` placeholder
+// (never is the lattice bottom, coalesced-output only, with no constrain-input
+// rule). It is minted ONLY here, where a diagnostic was definitely emitted, never
+// by freshVar — the discipline that keeps absorption from silently hiding a
+// genuine checker bug.
 func (c *checker) report(e SolverError) soltype.Type {
 	c.errs = append(c.errs, e)
-	return &soltype.NeverType{}
+	return &soltype.ErrorType{}
 }
 
 // reportUnsupported records an UnsupportedNodeError for an AST node whose kind is
@@ -158,8 +164,9 @@ func (c *checker) recordType(n ast.Node, t soltype.Type) {
 // inferExpr dispatches on the concrete expression kind. PR-1 wired the two leaf
 // cases (literals, identifiers); PR-3 adds the function/application walk
 // (FuncExpr, CallExpr — the block/statement walk they drive lives in
-// infer_stmt.go); PR-4 adds tuples, object literals, and member access. Every
-// remaining kind falls through to a clean UnsupportedNodeError (never a panic).
+// infer_stmt.go); PR-4 adds tuples, object literals, and member access; M3 adds
+// await/if-else and (PR8) the assignment form of BinaryExpr. Every remaining kind
+// falls through to a clean UnsupportedNodeError (never a panic).
 func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
@@ -180,6 +187,14 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferAwait(scope, lvl, e)
 	case *ast.IfElseExpr:
 		return c.inferIfElse(scope, lvl, e)
+	case *ast.BinaryExpr:
+		// PR8 handles the ASSIGNMENT op only (`a = expr`); every other binary
+		// operator (+, ==, &&, ++, …) needs the operator-scheme walk over the prelude
+		// bindings, a separate unlanded PR, so it stays UnsupportedNodeError.
+		if e.Op == ast.Assign {
+			return c.inferAssign(scope, lvl, e)
+		}
+		return c.reportUnsupported(e)
 	default:
 		return c.reportUnsupported(e)
 	}

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,4 +120,106 @@ func TestInferAssignUnknownTarget(t *testing.T) {
 	src := "fn f() { nope = 5 }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "Unknown identifier: nope", "nope")
+}
+
+// Reassigning a POLYMORPHIC var must not corrupt the binding. inferAssign freshens
+// the binding's coalesced slot type before constraining, so the RHS flows into
+// throwaway copies rather than the binding's retained type-parameter vars; `id`
+// keeps its generic type and a later `id("hello")` still type-checks.
+func TestInferAssignPolyVarNoCorruption(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		var id = fn (x) { x }
+		fn f() { id = fn (n: number) -> number { n } }
+		val r = id("hello")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(x: T0) -> T0", values["id"]) // not the corrupted fn <T0>(x: T0 & number) -> T0 | number
+	require.Equal(t, `"hello"`, values["r"])
+}
+
+// A broken TOP-LEVEL binding recovers AS the error sentinel (Fix A), so reassigning
+// it yields exactly one diagnostic — the same single-error guarantee the body-level
+// path gives. Before the fix the top-level group var coalesced to `never` and the
+// reassignment cascaded `cannot constrain 5 <: never`.
+func TestInferAssignTopLevelBrokenBindingNoCascade(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		var a = missing
+		fn f() { a = 5 }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "error", values["a"]) // recovered as the sentinel, not never
+}
+
+// Reassigning a union-typed var applies the union-RHS rule: a member assigns, a
+// non-member is rejected once. (Union subtyping in general is M6; inferAssign trials
+// the members under a probe so a legal member assignment isn't wrongly rejected.)
+func TestInferAssignUnionTarget(t *testing.T) {
+	t.Run("member assigns", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(c: boolean) {
+				var a = if c { 1 } else { 2 }
+				a = 1
+			}
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("non-member rejected once", func(t *testing.T) {
+		src := "fn f(c: boolean) {\n  var a = if c { 1 } else { 2 }\n  a = 3\n}"
+		_, _, errs := inferSource(t, src)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain 3 <: 1 | 2", errs[0].Message())
+	})
+}
+
+// A namespace name as an assignment target reports NamespaceUsedAsValue, mirroring
+// inferIdent's value-position behavior (not UnknownIdentifier). Hand-built because
+// namespace declarations are themselves unsupported in M3, so a namespace never
+// enters scope via real source — same construction as TestInferIdentNamespaceUsedAsValue.
+func TestInferAssignNamespaceTarget(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
+	e := ast.NewBinary(identExpr("Foo"), numExpr(5), ast.Assign, testSpan())
+	c.inferExpr(scope, 0, e)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
+}
+
+// A member target (obj.x = …) is a valid-but-deferred (M4) place, reported as an
+// unsupported feature — distinct from a fundamentally invalid target like `5 = a`.
+func TestInferAssignMemberTargetUnsupported(t *testing.T) {
+	src := "val o = {x: 5}\nfn f() { o.x = 6 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Unsupported in M2: assignment to a member or index", "o.x")
+}
+
+// An immutable target with an independently-broken RHS reports BOTH errors — they
+// are two distinct problems, not a cascade (the immutable target never reaches
+// constrain). Pinned so the behavior is explicit.
+func TestInferAssignImmutableWithBadRHSReportsBoth(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		val a = 5
+		fn f() { a = missing }
+	`)
+	require.Equal(t, []string{
+		"Unknown identifier: missing",
+		"Cannot assign to immutable binding: a",
+	}, Messages(errs))
+}
+
+// A malformed assignment node with a nil operand (hand-built; the real parser
+// substitutes ast.NewError) must not panic — it blames the whole expression.
+func TestInferAssignNilOperandDoesNotPanic(t *testing.T) {
+	c := newChecker()
+	e := ast.NewBinary(nil, numExpr(5), ast.Assign, testSpan())
+	require.NotPanics(t, func() {
+		c.inferExpr(NewScope(), 0, e)
+		for _, er := range c.errs { // force lazy Span()/Message()
+			_ = er.Span()
+			_ = er.Message()
+		}
+	})
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: BinaryExpr", c.errs[0].Message())
 }

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -11,9 +11,10 @@ import (
 //
 // `a = expr` parses as an ast.BinaryExpr with Op == ast.Assign — the only binary
 // operator the M3 walk handles. The target must be a mutable (`var`) place; the
-// RHS must be a subtype of the binding's type; the assignment expression itself is
-// void. Reassignment lives in expression position, so these tests exercise it
-// inside a function body (or a top-level `val` initializer).
+// RHS must be a subtype of the binding's type; the assignment expression evaluates
+// to the value just stored, so its type is the target's slot type. Reassignment
+// lives in expression position, so these tests exercise it inside a function body
+// (or a top-level `val` initializer).
 
 // An annotated `var` reassignment type-checks when the RHS is a subtype of the
 // declared type, and reports a single CannotConstrainError otherwise. The `var` is
@@ -27,7 +28,7 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 		`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["a"])
-		require.Equal(t, "fn () -> void", values["f"]) // the assignment expr is void
+		require.Equal(t, "fn () -> number", values["f"]) // the tail assignment evaluates to a's slot type
 	})
 	t.Run("mismatched type reports one subtype error", func(t *testing.T) {
 		src := "var a: number = 5\nfn f() { a = \"x\" }"
@@ -67,8 +68,9 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 	t.Run("parameter", func(t *testing.T) {
 		src := "fn f(p: number) { p = 6 }"
 		_, _, errs := inferSource(t, src)
-		// A parameter has no source decl node, so Related() is empty.
-		requireBlame(t, src, errs, "Cannot assign to immutable binding: p", "p = 6")
+		// A parameter's binding records its pattern as the source, so Related() points
+		// at the param ("declared immutable here").
+		requireBlame(t, src, errs, "Cannot assign to immutable binding: p", "p = 6", "p")
 	})
 }
 
@@ -87,14 +89,15 @@ func TestInferAssignInvalidTarget(t *testing.T) {
 	})
 }
 
-// The assignment expression's own value type is void: `val b = (a = 6)` ⇒ b: void.
-func TestInferAssignValuePositionIsVoid(t *testing.T) {
+// The assignment expression evaluates to the value just stored, so its type is the
+// target's slot type: `val b = (a = 6)` for `var a: number` ⇒ b: number.
+func TestInferAssignValuePositionIsTargetType(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		var a: number = 5
 		val b = (a = 6)
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "void", values["b"])
+	require.Equal(t, "number", values["b"])
 }
 
 // Headline synergy with Part 1 (the ErrorType sentinel): reassigning THROUGH a
@@ -170,6 +173,28 @@ func TestInferAssignUnionTarget(t *testing.T) {
 		require.Len(t, errs, 1)
 		require.Equal(t, "cannot constrain 3 <: 1 | 2", errs[0].Message())
 	})
+}
+
+// KNOWN GAP (M6): assigning an inference-variable RHS into a union target
+// over-narrows the variable. `a = x` for an un-annotated param `x` and `a: 1 | 2`
+// commits the first matching member (`x <: 1`), so `x` infers as `1` rather than
+// the sound `1 | 2`. This is INCOMPLETE, not unsound (the committed bound is always
+// stronger than required, so no invalid program is accepted), and it is not fixable
+// in constrainAssign — falling through to constrain(rhs, union) injects the
+// coalesced union node into rhs's bound list and panics the coalescer. The correct
+// fix is M6's first-class union subtyping with inference variables. This pins the
+// interim behavior so the M6 change is visible: when it lands, `x` becomes `1 | 2`
+// and this assertion must be updated. See constrainAssign's KNOWN GAP note.
+func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(c: boolean, x) {
+			var a = if c { 1 } else { 2 }
+			a = x
+		}
+	`)
+	require.Empty(t, errs)
+	// M6 target: "fn (c: boolean, x: 1 | 2) -> 1 | 2".
+	require.Equal(t, "fn (c: boolean, x: 1) -> 1 | 2", values["f"])
 }
 
 // A namespace name as an assignment target reports NamespaceUsedAsValue, mirroring

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -1,0 +1,122 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- PR8: reassignment typing (`a = expr`) ---
+//
+// `a = expr` parses as an ast.BinaryExpr with Op == ast.Assign — the only binary
+// operator the M3 walk handles. The target must be a mutable (`var`) place; the
+// RHS must be a subtype of the binding's type; the assignment expression itself is
+// void. Reassignment lives in expression position, so these tests exercise it
+// inside a function body (or a top-level `val` initializer).
+
+// An annotated `var` reassignment type-checks when the RHS is a subtype of the
+// declared type, and reports a single CannotConstrainError otherwise. The `var` is
+// annotated because un-annotated `var` literal widening is M4 (see the literal case
+// below).
+func TestInferAssignAnnotatedVar(t *testing.T) {
+	t.Run("matching type checks", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			var a: number = 5
+			fn f() { a = 6 }
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["a"])
+		require.Equal(t, "fn () -> void", values["f"]) // the assignment expr is void
+	})
+	t.Run("mismatched type reports one subtype error", func(t *testing.T) {
+		src := "var a: number = 5\nfn f() { a = \"x\" }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs, `cannot constrain "x" <: number`, `"x"`, "number")
+	})
+}
+
+// An un-annotated `var a = 5` infers the literal type `5`, so reassigning a
+// DIFFERENT literal (`a = 6` ⇒ `6 <: 5`) does NOT check in M3 — `var` literal
+// widening is deferred to M4. This pins the interim behavior so the M4 change is
+// visible: when widening lands, this assignment will type-check.
+func TestInferAssignUnannotatedVarLiteralNotWidened(t *testing.T) {
+	src := "var a = 5\nfn f() { a = 6 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "cannot constrain 6 <: 5", "6", "5")
+}
+
+// Reassigning a `val` is rejected: only a `var` is reassignable. The error blames
+// the assignment and relates the `val` declaration ("declared immutable here").
+func TestInferAssignToValRejected(t *testing.T) {
+	src := "val a = 5\nfn f() { a = 6 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs,
+		"Cannot assign to immutable binding: a", "a = 6", "val a = 5")
+}
+
+// A function name and a parameter are likewise immutable. A parameter carries no
+// introducing declaration source node, so its error has no related span.
+func TestInferAssignToImmutableNonVal(t *testing.T) {
+	t.Run("function name", func(t *testing.T) {
+		src := "fn h() -> number { 5 }\nfn f() { h = 6 }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs,
+			"Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { 5 }")
+	})
+	t.Run("parameter", func(t *testing.T) {
+		src := "fn f(p: number) { p = 6 }"
+		_, _, errs := inferSource(t, src)
+		// A parameter has no source decl node, so Related() is empty.
+		requireBlame(t, src, errs, "Cannot assign to immutable binding: p", "p = 6")
+	})
+}
+
+// A non-place LHS — a literal or a call — is an InvalidAssignmentTargetError that
+// blames the LHS. (Member targets `obj.x = …` need record types and land in M4.)
+func TestInferAssignInvalidTarget(t *testing.T) {
+	t.Run("literal target", func(t *testing.T) {
+		src := "val a = 5\nfn g() { 5 = a }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs, "Invalid assignment target: LiteralExpr", "5")
+	})
+	t.Run("call target", func(t *testing.T) {
+		src := "fn f() -> number { 5 }\nvar a: number = 0\nfn g() { f() = a }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs, "Invalid assignment target: CallExpr", "f()")
+	})
+}
+
+// The assignment expression's own value type is void: `val b = (a = 6)` ⇒ b: void.
+func TestInferAssignValuePositionIsVoid(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		var a: number = 5
+		val b = (a = 6)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "void", values["b"])
+}
+
+// Headline synergy with Part 1 (the ErrorType sentinel): reassigning THROUGH a
+// broken binding reports exactly ONE error — the UnknownIdentifierError on the
+// declaration. `a` recovers to ErrorType, so `5 <: error` and `"hello" <: error`
+// both absorb; without the sentinel each reassignment would cascade a spurious
+// `cannot constrain … <: never`.
+func TestInferAssignThroughBrokenBindingNoCascade(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f() {
+			var a = missing
+			a = 5
+			a = "hello"
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+}
+
+// Assigning to an undeclared name surfaces an UnknownIdentifierError on the target
+// (an assignment must not silently accept an unbound place).
+func TestInferAssignUnknownTarget(t *testing.T) {
+	src := "fn f() { nope = 5 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Unknown identifier: nope", "nope")
+}

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -130,8 +130,8 @@ func TestInferAsyncPromiseWildcardReturnInferred(t *testing.T) {
 }
 
 // `await` outside an `async fn` is a WALK rejection — not a type rule failure.
-// The AwaitOutsideAsyncError carries the await node and produces a `never`
-// placeholder so a downstream consumer doesn't cascade.
+// The AwaitOutsideAsyncError carries the await node and produces the ErrorType
+// recovery placeholder (PR8) so a downstream consumer doesn't cascade.
 func TestInferAwaitOutsideAsyncRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(p: Promise<string>) {
@@ -362,12 +362,12 @@ func TestInferNestedFnReturnsScoped(t *testing.T) {
 
 // --- Error-recovery: no cascading on a failed sub-expression ---
 //
-// A reported diagnostic leaves a `never` placeholder in expression position
-// (c.report). Feeding that back into constrain has no `never <: T` input rule, so
-// the if-condition and await-argument checks would each cascade a spurious second
-// `cannot constrain never <: …` on top of the real error. inferIfElse/inferAwait
-// guard against the placeholder so exactly ONE diagnostic surfaces. (PR8 replaces
-// the guard with a dedicated error-recovery type that absorbs in constrain.)
+// A reported diagnostic leaves the ErrorType recovery placeholder in expression
+// position (c.report, PR8). ErrorType absorbs in both directions inside constrain,
+// so the if-condition and await-argument checks no longer cascade a spurious second
+// `cannot constrain … <: …` on top of the real error — exactly ONE diagnostic
+// surfaces. (Before PR8, inferIfElse/inferAwait hand-guarded against a `never`
+// placeholder at each site; PR8 retired those guards for the absorbing sentinel.)
 
 // A failed `if` condition (unknown identifier) yields a single UnknownIdentifierError
 // — not also a `never <: boolean`. The branches still type, so the if value is their

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -115,12 +115,12 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
 	// plain soltype.Print — same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
-	// PR8: a `var` binding is reassignable; a `val` is not. Mutability is a property
-	// of the introducing decl's kind, carried so inferAssign can gate reassignment.
+	// PR8: carry the introducing decl's kind so inferAssign can gate reassignment —
+	// only a `var` is reassignable, a `val` is not.
 	return ValueBinding{
 		Schemes: []TypeScheme{scheme},
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}},
-		Mutable: d.Kind == ast.VarKind,
+		Kind:    d.Kind,
 	}, true
 }
 

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -115,7 +115,13 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
 	// plain soltype.Print — same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
-	return ValueBinding{Schemes: []TypeScheme{scheme}, Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}}}, true
+	// PR8: a `var` binding is reassignable; a `val` is not. Mutability is a property
+	// of the introducing decl's kind, carried so inferAssign can gate reassignment.
+	return ValueBinding{
+		Schemes: []TypeScheme{scheme},
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}},
+		Mutable: d.Kind == ast.VarKind,
+	}, true
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -115,6 +116,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
 		name, ok := identPatName(p.Pattern)
+		var sources []provenance.Provenance
 		if !ok {
 			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
 			// they arrive in M4. M2 binds IdentPat only. A non-nil pattern blames
@@ -127,17 +129,24 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				c.reportUnsupported(node)
 			}
 			name = fmt.Sprintf("arg%d", i)
-		} else if p.TypeAnn == nil {
-			// An un-annotated param's type is the fresh var minted here, so a
-			// param-type mismatch blames the param. Record against the pattern (an
-			// ast.Node; *ast.Param is not) — for an IdentPat its span is the param's.
-			// An annotated param's blame instead rides on its annotation, recorded
-			// by resolveTypeAnn.
-			c.recordProv(pt, p.Pattern, ParamBinding)
+			// Leave sources empty: the synthetic arg%d name is not a real place, so
+			// there is nothing useful for go-to-definition or a related span to point at.
+		} else {
+			// The param's IdentPat IS its definition site, so record it as the binding's
+			// source — symmetric to a val/var/fn binding (inferVarDecl/module.go). This
+			// lets CannotAssignToImmutableError point "declared immutable here" at the
+			// parameter (see bindingDecl). p.Pattern is an ast.Node (*ast.Param is not).
+			sources = []provenance.Provenance{&ast.NodeProvenance{Node: p.Pattern}}
+			if p.TypeAnn == nil {
+				// An un-annotated param's type is the fresh var minted here, so a
+				// param-type mismatch blames the param. An annotated param's blame
+				// instead rides on its annotation, recorded by resolveTypeAnn.
+				c.recordProv(pt, p.Pattern, ParamBinding)
+			}
 		}
 		// A parameter binding never generalizes — its var is fixed for the body — so
 		// it is a MonoScheme; instantiate returns pt unchanged at every use.
-		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
+		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}, Sources: sources})
 		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
 		// `required` count without dropping the param — carried onto the soltype so
 		// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
@@ -407,8 +416,8 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 //     literal, call, member, or any other non-place LHS is an
 //     InvalidAssignmentTargetError (member targets `obj.x = …` need record types,
 //     M4). An ident that resolves to no binding is an UnknownIdentifierError.
-//   - The binding must be mutable: only a `var` is reassignable. A `val`, function,
-//     parameter, or prelude binding is a CannotAssignToImmutableError.
+//   - The binding must be reassignable: only a `var` (Kind == VarKind) is. A `val`,
+//     function, parameter, or prelude binding is a CannotAssignToImmutableError.
 //
 // On success the RHS is constrained `<: target` (the binding's coalesced type),
 // the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
@@ -416,8 +425,10 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 // number = 5` with `a = 6` checks; an un-annotated `var a = 5` keeps the literal
 // type `5`, so `a = 6` does NOT check until `var` literal widening (M4).
 //
-// The assignment EXPRESSION's own value type is void (assignment is
-// statement-shaped); flowing it through a binding yields `void`.
+// The assignment EXPRESSION evaluates to the value just stored, so its type is the
+// target binding's slot type — `val b = (a = 6)` for `var a: number` yields
+// `b: number`. On an error path (invalid / immutable / unknown target) no value is
+// stored, so it recovers to `void`.
 func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.Type {
 	voidT := soltype.Type(&soltype.Void{})
 	// Guard a malformed assignment node (the real parser substitutes ast.NewError for
@@ -456,7 +467,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		}
 		return voidT
 	}
-	if !b.Mutable {
+	if b.Kind != ast.VarKind {
 		c.report(&CannotAssignToImmutableError{
 			Assign: e,
 			Name:   target.Name,
@@ -479,13 +490,22 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// polymorphic var would poison it for every later use. A var-free coalesced type
 	// (the common annotated/literal case) freshens to itself.
 	//
-	// b.Schemes[0]: a mutable binding is always single-scheme — overload sets come
-	// only from FuncDecls, which are immutable (Mutable is false), so they are
-	// rejected by the !b.Mutable gate above before reaching here.
+	// b.Schemes[0]: a reassignable binding is always single-scheme — overload sets
+	// come only from FuncDecls, whose Kind is never VarKind, so they are rejected by
+	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
 	c.constrainAssign(e, rhs, targetT)
-	return voidT
+	// The assignment evaluates to the value just stored — the SAME read face as
+	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
+	// instantiate (the read face), NOT the coalesced write-face targetT: targetT is a
+	// display type that may be a Union/Intersection node, and re-injecting it into the
+	// constraint graph here would later crash the coalescer when this value flows on
+	// (e.g. as a function-body tail). This overwrites the `void` recorded for e above,
+	// which now serves only as the error-path recovery value.
+	valueT := c.instantiate(b.Schemes[0], lvl)
+	c.recordType(e, valueT)
+	return valueT
 }
 
 // constrainAssign asserts `rhs <: targetT` for a reassignment. For a UNION target it
@@ -494,6 +514,18 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 // itself has no UnionType-RHS rule until M6, so without this a legal assignment of a
 // union member (`var a = if c { 1 } else { 2 }; a = 1`) would be wrongly rejected.
 // A non-union target takes the ordinary single-constraint path.
+//
+// KNOWN GAP (M6): when `rhs` is (or contains) an inference variable, committing the
+// first matching member over-narrows it. `var a = 1 | 2; a = x` for an un-annotated
+// param `x` commits `x <: 1` and infers `x: 1` instead of the sound `x: 1 | 2`,
+// which can wrongly reject a later use of `x` that needs `2`. This is INCOMPLETE,
+// not unsound — the committed bound is always stronger than required, so no invalid
+// program is accepted. It is not fixable here: the obvious "don't commit, fall
+// through to constrain(rhs, targetT)" injects the COALESCED union node into rhs's
+// bound list and panics the coalescer (coalesced output must never re-enter the
+// graph). A correct fix needs first-class union subtyping with inference variables
+// — M6's deferred union/intersection rules in constrain. Pinned by
+// TestInferAssignUnionTargetVarRHSOverNarrows.
 func (c *checker) constrainAssign(n ast.Node, rhs, targetT soltype.Type) {
 	union, ok := targetT.(*soltype.UnionType)
 	if !ok {
@@ -515,8 +547,9 @@ func (c *checker) constrainAssign(n ast.Node, rhs, targetT soltype.Type) {
 
 // bindingDecl returns the AST node of the binding's introducing declaration — the
 // "declared immutable here" related span for CannotAssignToImmutableError — or nil
-// when the binding has no source node (a parameter or prelude binding). It reads
-// the first Source: a plain `val`/`var`/`fn` has exactly one.
+// when the binding has no source node (a prelude binding, or the synthetic
+// placeholder for an unsupported param). It reads the first Source: a plain
+// `val`/`var`/`fn` — and now a parameter — has exactly one.
 func bindingDecl(b ValueBinding) ast.Node {
 	if len(b.Sources) == 0 {
 		return nil

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -439,6 +439,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		return c.reportUnsupported(e)
 	}
 	rhs := c.inferExpr(scope, lvl, e.Right)
+	// Record void on e up front as the recovery type: every error path below returns
+	// voidT without recording a type, so this guarantees the node is typed on failure.
+	// The success path overwrites it with the stored value's type (see end of function).
 	c.recordType(e, voidT)
 
 	target, ok := e.Left.(*ast.IdentExpr)
@@ -489,6 +492,10 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// (coalesceScheme retains them by pointer): without the copy, reassigning a
 	// polymorphic var would poison it for every later use. A var-free coalesced type
 	// (the common annotated/literal case) freshens to itself.
+	//
+	// A probe can't do this: Discard would also roll back the constraint's real errors
+	// and the RHS's bound, while Commit would keep the binding poisoning — we need to
+	// suppress one side effect, not the whole trial. freshenAll isolates just the var.
 	//
 	// b.Schemes[0]: a reassignable binding is always single-scheme — overload sets
 	// come only from FuncDecls, whose Kind is never VarKind, so they are rejected by

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -419,22 +419,41 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 // The assignment EXPRESSION's own value type is void (assignment is
 // statement-shaped); flowing it through a binding yields `void`.
 func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.Type {
-	rhs := c.inferExpr(scope, lvl, e.Right)
 	voidT := soltype.Type(&soltype.Void{})
+	// Guard a malformed assignment node (the real parser substitutes ast.NewError for
+	// a missing operand, so this is unreachable from source — but a hand-built AST
+	// could have a nil operand). Blame the whole expression rather than dereferencing
+	// a nil operand in inferExpr / InvalidAssignmentTargetError later.
+	if e.Left == nil || e.Right == nil {
+		return c.reportUnsupported(e)
+	}
+	rhs := c.inferExpr(scope, lvl, e.Right)
 	c.recordType(e, voidT)
 
 	target, ok := e.Left.(*ast.IdentExpr)
 	if !ok {
-		// A non-place LHS (literal, call, member, …). Member targets land in M4; every
-		// other shape is never assignable.
-		c.report(&InvalidAssignmentTargetError{Target: e.Left})
+		// A member/index target (obj.x = …, xs[i] = …) is a structurally VALID place
+		// whose type rule needs record/array types — deferred to M4 — so report it as
+		// an unsupported feature, distinct from a fundamentally invalid target like
+		// `5 = x` or `f() = x`, which is an InvalidAssignmentTargetError.
+		switch e.Left.(type) {
+		case *ast.MemberExpr, *ast.IndexExpr:
+			c.reportUnsupportedFeature(e.Left, "assignment to a member or index")
+		default:
+			c.report(&InvalidAssignmentTargetError{Target: e.Left})
+		}
 		return voidT
 	}
 	b, found := scope.GetValue(target.Name)
 	if !found || len(b.Schemes) == 0 {
-		// Surface the unbound target the same way a value-position read would, so an
-		// assignment to an undeclared name isn't silently accepted.
-		c.report(&UnknownIdentifierError{Ident: target})
+		// Not a value binding. Mirror inferIdent's value-position behavior: a name that
+		// resolves to a namespace reports NamespaceUsedAsValue; otherwise it is an
+		// unknown identifier.
+		if _, isNS := scope.GetNamespace(target.Name); isNS {
+			c.report(&NamespaceUsedAsValueError{Ident: target})
+		} else {
+			c.report(&UnknownIdentifierError{Ident: target})
+		}
 		return voidT
 	}
 	if !b.Mutable {
@@ -452,12 +471,46 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// number` would merely add another lower bound and wrongly succeed. The coalesced
 	// type is the concrete slot type — `number` for an annotated var, the literal `5`
 	// for an un-annotated one (so `a = 6` ⇒ `6 <: 5` does NOT check until M4 `var`
-	// literal widening). The constraint node is the whole assignment, so a mismatch
-	// blames the assignment via the existing CannotConstrainError.
-	targetT := schemeType(b.Schemes[0])
+	// literal widening).
+	//
+	// freshenAll copies the coalesced type so constraining the RHS cannot mutate
+	// type-parameter vars the coalesced form still shares with the binding
+	// (coalesceScheme retains them by pointer): without the copy, reassigning a
+	// polymorphic var would poison it for every later use. A var-free coalesced type
+	// (the common annotated/literal case) freshens to itself.
+	//
+	// b.Schemes[0]: a mutable binding is always single-scheme — overload sets come
+	// only from FuncDecls, which are immutable (Mutable is false), so they are
+	// rejected by the !b.Mutable gate above before reaching here.
+	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
-	c.constrain(e, rhs, targetT)
+	c.constrainAssign(e, rhs, targetT)
 	return voidT
+}
+
+// constrainAssign asserts `rhs <: targetT` for a reassignment. For a UNION target it
+// applies the union-RHS rule — X <: (A | B) iff X <: A or X <: B — by trying each
+// member speculatively under a probe, committing the first that holds. constrain
+// itself has no UnionType-RHS rule until M6, so without this a legal assignment of a
+// union member (`var a = if c { 1 } else { 2 }; a = 1`) would be wrongly rejected.
+// A non-union target takes the ordinary single-constraint path.
+func (c *checker) constrainAssign(n ast.Node, rhs, targetT soltype.Type) {
+	union, ok := targetT.(*soltype.UnionType)
+	if !ok {
+		c.constrain(n, rhs, targetT)
+		return
+	}
+	for _, member := range union.Types {
+		p := c.openProbe()
+		errs := c.ctx.Constrain(rhs, member)
+		c.closeProbe(p, len(errs) == 0) // commit the first member that holds; else roll back
+		if len(errs) == 0 {
+			return
+		}
+	}
+	// No member matched: report once against the whole union (CannotConstrainError),
+	// blaming the assignment.
+	c.constrain(n, rhs, targetT)
 }
 
 // bindingDecl returns the AST node of the binding's introducing declaration — the
@@ -560,8 +613,11 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 		// A malformed `recv.` with no valid property name: the parser already
 		// reported the missing identifier, so constraining recv <: {"": res} here
 		// would only layer a spurious "object is missing property: " on top. Yield
-		// a never placeholder without reporting or constraining.
-		t := soltype.Type(&soltype.NeverType{})
+		// the ErrorType recovery sentinel (PR8) — NOT a raw never — so that if this
+		// read flows into a sink (`if recv. {}`, `await recv.`, `var x = recv.`) the
+		// sentinel absorbs in constrain rather than cascading `never <: …`. report
+		// already emitted the diagnostic here (via the parser), so no extra error.
+		t := soltype.Type(&soltype.ErrorType{})
 		c.recordType(e, t)
 		return t
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -399,6 +399,81 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	return nil, false
 }
 
+// inferAssign types a reassignment `target = rhs` — the only BinaryExpr form the
+// M3 walk handles. The RHS is typed first (so its own errors surface regardless of
+// the target's validity), then the target is resolved and gated:
+//
+//   - The target must be a place: an IdentExpr resolving to a value binding. A
+//     literal, call, member, or any other non-place LHS is an
+//     InvalidAssignmentTargetError (member targets `obj.x = …` need record types,
+//     M4). An ident that resolves to no binding is an UnknownIdentifierError.
+//   - The binding must be mutable: only a `var` is reassignable. A `val`, function,
+//     parameter, or prelude binding is a CannotAssignToImmutableError.
+//
+// On success the RHS is constrained `<: target` (the binding's coalesced type),
+// the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
+// being stored must be a subtype of the slot. Reassigning an annotated `var a:
+// number = 5` with `a = 6` checks; an un-annotated `var a = 5` keeps the literal
+// type `5`, so `a = 6` does NOT check until `var` literal widening (M4).
+//
+// The assignment EXPRESSION's own value type is void (assignment is
+// statement-shaped); flowing it through a binding yields `void`.
+func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.Type {
+	rhs := c.inferExpr(scope, lvl, e.Right)
+	voidT := soltype.Type(&soltype.Void{})
+	c.recordType(e, voidT)
+
+	target, ok := e.Left.(*ast.IdentExpr)
+	if !ok {
+		// A non-place LHS (literal, call, member, …). Member targets land in M4; every
+		// other shape is never assignable.
+		c.report(&InvalidAssignmentTargetError{Target: e.Left})
+		return voidT
+	}
+	b, found := scope.GetValue(target.Name)
+	if !found || len(b.Schemes) == 0 {
+		// Surface the unbound target the same way a value-position read would, so an
+		// assignment to an undeclared name isn't silently accepted.
+		c.report(&UnknownIdentifierError{Ident: target})
+		return voidT
+	}
+	if !b.Mutable {
+		c.report(&CannotAssignToImmutableError{
+			Assign: e,
+			Name:   target.Name,
+			Decl:   bindingDecl(b),
+		})
+		return voidT
+	}
+	// The RHS must be a subtype of the target binding's type. Use the binding's
+	// COALESCED type (schemeType — what Info records and the printer renders), not a
+	// fresh instantiation: instantiating a generalized binding yields a var carrying
+	// only its LOWER bounds (the read/covariant face), so `a = "x"` for `var a:
+	// number` would merely add another lower bound and wrongly succeed. The coalesced
+	// type is the concrete slot type — `number` for an annotated var, the literal `5`
+	// for an un-annotated one (so `a = 6` ⇒ `6 <: 5` does NOT check until M4 `var`
+	// literal widening). The constraint node is the whole assignment, so a mismatch
+	// blames the assignment via the existing CannotConstrainError.
+	targetT := schemeType(b.Schemes[0])
+	c.recordType(target, targetT)
+	c.constrain(e, rhs, targetT)
+	return voidT
+}
+
+// bindingDecl returns the AST node of the binding's introducing declaration — the
+// "declared immutable here" related span for CannotAssignToImmutableError — or nil
+// when the binding has no source node (a parameter or prelude binding). It reads
+// the first Source: a plain `val`/`var`/`fn` has exactly one.
+func bindingDecl(b ValueBinding) ast.Node {
+	if len(b.Sources) == 0 {
+		return nil
+	}
+	if np, ok := b.Sources[0].(*ast.NodeProvenance); ok {
+		return np.Node
+	}
+	return nil
+}
+
 // inferTuple types a tuple literal as a soltype.TupleType of its element types
 // and records it in Info. Elements are typed left-to-right in the current scope.
 // A spread element ([...xs]) is an ArraySpreadExpr, which is not in the M2 walk,
@@ -546,27 +621,26 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 		if c.fn != nil {
 			enclosing = c.fn.node
 		}
-		c.report(&AwaitOutsideAsyncError{Await: e, EnclosingFn: enclosing})
-		t := soltype.Type(&soltype.NeverType{})
+		// report returns the ErrorType recovery placeholder (PR8), so the rejected
+		// await never cascades a downstream `<unknown> <: T` on top of this error.
+		t := c.report(&AwaitOutsideAsyncError{Await: e, EnclosingFn: enclosing})
 		c.recordType(e, t)
 		return t
 	}
 	arg := c.inferExpr(scope, lvl, e.Arg)
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, AwaitResult)
-	// Skip the `arg <: Promise<U>` requirement when the argument already failed to
-	// type — its value is the `never` recovery placeholder, and constraining `never
-	// <: Promise<U>` would cascade a spurious second diagnostic on top of the one
-	// already reported. res then stays unbound and coalesces to `never`, the right
-	// recovery for awaiting something broken. PR8's error-recovery type makes this
-	// guard unnecessary (it absorbs in constrain); see isRecoveryPlaceholder.
-	if !isRecoveryPlaceholder(arg) {
-		// Synthesize the Promise<U> requirement at this call site. It isn't given its
-		// own provenance — the operand the user sees blame on is the awaited expression
-		// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
-		// internal scaffolding for the constraint, not a user-authored type.
-		c.constrain(e, arg, &soltype.PromiseType{Inner: res})
-	}
+	// Synthesize the Promise<U> requirement at this call site. It isn't given its
+	// own provenance — the operand the user sees blame on is the awaited expression
+	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
+	// internal scaffolding for the constraint, not a user-authored type.
+	//
+	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
+	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second
+	// diagnostic — res then stays unbound and coalesces to `never`, the right
+	// recovery for awaiting something broken. The M2-era isRecoveryPlaceholder guard
+	// this site used is gone.
+	c.constrain(e, arg, &soltype.PromiseType{Inner: res})
 	c.recordType(e, res)
 	return res
 }
@@ -592,20 +666,17 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 // X is a return point, but not part of the if-EXPRESSION's value.
 func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.Type {
 	cond := c.inferExpr(scope, lvl, e.Cond)
-	// Skip the `cond <: boolean` check when the condition already failed to type —
-	// its value is the `never` recovery placeholder, and constraining `never <:
-	// boolean` would cascade a spurious second diagnostic on top of the one already
-	// reported. PR8's error-recovery type makes this guard unnecessary (it absorbs
-	// in constrain); see isRecoveryPlaceholder.
-	if !isRecoveryPlaceholder(cond) {
-		// The synthesized `boolean` requirement is intentionally NOT recorded in Prov
-		// (so a `string <: boolean` failure has no "expected boolean here" related
-		// span): it is a language rule, not a user-authored annotation, so there is no
-		// source node to anchor it to — recording it against e.Cond would only make
-		// Related() echo Span(). This matches inferAwait's synthesized Promise and
-		// inferMember's synthesized record requirement, both deliberately unrecorded.
-		c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
-	}
+	// The synthesized `boolean` requirement is intentionally NOT recorded in Prov
+	// (so a `string <: boolean` failure has no "expected boolean here" related
+	// span): it is a language rule, not a user-authored annotation, so there is no
+	// source node to anchor it to — recording it against e.Cond would only make
+	// Related() echo Span(). This matches inferAwait's synthesized Promise and
+	// inferMember's synthesized record requirement, both deliberately unrecorded.
+	//
+	// PR8: a failed condition is the ErrorType recovery placeholder, which absorbs
+	// in constrain, so `<unknown> <: boolean` no longer cascades a spurious second
+	// diagnostic — the M2-era isRecoveryPlaceholder guard this site used is gone.
+	c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
 	consT, consDiverges := c.inferBlock(scope.Child(), lvl, &e.Cons)
 	var altT soltype.Type = &soltype.Void{}
 	altDiverges := false
@@ -739,22 +810,4 @@ func (c *checker) inferBlockOrExpr(scope *Scope, lvl int, b *ast.BlockOrExpr) (s
 	default:
 		return &soltype.Void{}, false
 	}
-}
-
-// isRecoveryPlaceholder reports whether t is the `never` value c.report leaves in
-// expression position after it has ALREADY emitted a diagnostic. The walk never
-// mints a raw NeverType any other way — never/unknown are coalesced-OUTPUT only
-// (soltype/type.go), so a raw NeverType flowing out of inferExpr is always that
-// recovery placeholder. Callers skip constraining against it so the single error
-// already reported doesn't cascade a second, spurious `cannot constrain never <:
-// …` (constrain has no `never <: T` input rule today, and adding one would not
-// help — recovery must also absorb on the RHS, which a real bottom must not).
-//
-// PR8 (planning/simple_sub/m3-implementation-plan.md) introduces a dedicated
-// ErrorType recovery sentinel that absorbs in BOTH directions inside constrain;
-// once it lands, report returns that sentinel and these guard call sites — and
-// this helper — are removed.
-func isRecoveryPlaceholder(t soltype.Type) bool {
-	_, ok := t.(*soltype.NeverType)
-	return ok
 }

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -45,7 +45,7 @@ func TestInferLiteralUnsupported(t *testing.T) {
 	c := newChecker()
 	e := ast.NewLitExpr(ast.NewNull(testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: NullLit", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -79,7 +79,7 @@ func TestInferIdentUnknown(t *testing.T) {
 	c := newChecker()
 	e := ast.NewIdent("nope", testSpan())
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unknown identifier: nope", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -92,7 +92,7 @@ func TestInferIdentNamespaceUsedAsValue(t *testing.T) {
 
 	e := ast.NewIdent("Foo", testSpan())
 	got := c.inferExpr(scope, 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -105,7 +105,7 @@ func TestInferExprUnsupportedNode(t *testing.T) {
 	e := ast.NewBinary(left, right, ast.Plus, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: BinaryExpr", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -29,16 +29,16 @@ func TestInferTupleEmpty(t *testing.T) {
 }
 
 // A spread element ([...a]) is an ArraySpreadExpr, which the M2 walk does not
-// cover; inferExpr reports it as unsupported and drops a never placeholder into
-// the tuple slot, so the tuple still builds (no panic) and the spread's value `a`
-// is never walked — so no cascading unknown-identifier error. Tuple/array spread
-// is M4.
+// cover; inferExpr reports it as unsupported and drops the error-recovery
+// placeholder (PR8) into the tuple slot, so the tuple still builds (no panic) and
+// the spread's value `a` is never walked — so no cascading unknown-identifier
+// error. Tuple/array spread is M4.
 func TestInferTupleSpreadUnsupported(t *testing.T) {
 	c := newChecker()
 	// [...a]
 	e := tupleExpr(ast.NewArraySpread(identExpr("a"), testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
-	require.Equal(t, "[never]", render(got))
+	require.Equal(t, "[error]", render(got))
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: ArraySpreadExpr", c.errs[0].Message())
 }
@@ -158,7 +158,7 @@ func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("a", testSpan()), true, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -179,15 +179,17 @@ func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
 
 // A malformed `recv.` (no valid property name) leaves Prop.Name empty; the
 // parser has already reported the missing identifier, so the walk must NOT layer
-// a spurious "object is missing property: " on top. It yields a never
-// placeholder and reports nothing.
+// a spurious "object is missing property: " on top. It yields the ErrorType
+// recovery sentinel (PR8) — not a raw never — so that if the read flows into a
+// sink (`if recv. {}`, `await recv.`, `var x = recv.`) the sentinel absorbs in
+// constrain rather than cascading `never <: …`. It reports nothing itself.
 func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
 	c := newChecker()
 	// recv = {a: 5}; access with an empty property name (as the parser builds for `recv.`)
 	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("", testSpan()), false, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.NeverType{}, got)
+	require.IsType(t, &soltype.ErrorType{}, got)
 	require.Empty(t, c.errs) // no spurious MissingPropertyError
 	require.Same(t, got, c.info.TypeOf(e))
 }

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -1,0 +1,48 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- PR8 Part 1: the ErrorType error-recovery sentinel, end-to-end ---
+//
+// report mints ErrorType (not never) as the value-position recovery placeholder
+// after emitting a diagnostic. ErrorType absorbs in both directions inside
+// constrain, so a single reported error never cascades a spurious second one — at
+// any sink the broken value later flows into. These exercise that through the real
+// parser, complementing the constrain-level unit tests (constrain_test.go) and the
+// if/await cascade tests (infer_async_test.go).
+
+// A value bound to a broken (unknown-identifier) initializer flows into a call
+// argument WITHOUT producing a second error: the ErrorType placeholder absorbs the
+// `error <: number` parameter constraint, so only the original unknown-identifier
+// error survives.
+func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn id(x: number) -> number { x }
+		fn f() {
+			var a = missing
+			id(a)
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	// id's call still recovers its declared return type — the error arg absorbs.
+	require.Equal(t, "fn () -> number", values["f"])
+}
+
+// An unsupported expression (here an array spread, an M4 construct) recovers to the
+// ErrorType sentinel and flows on without cascading: the only error is the
+// unsupported-node one, and the surrounding tuple still builds.
+func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val t = [...xs]
+	`)
+	// One error for the spread itself; `xs` is never walked (so no extra
+	// unknown-identifier), and the broken element does not cascade.
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported in M2: ArraySpreadExpr", errs[0].Message())
+	require.Equal(t, "[error]", values["t"])
+}

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -252,11 +252,10 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Len(t, errs, 2)
 	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
 	require.Equal(t, "Unknown identifier: x", errs[1].Message())
-	// PR8: the unknown reference recovers to the ErrorType sentinel, but on the
-	// top-level SCC path that placeholder is constrained into the binding's group var
-	// — where the absorbing short-circuit records NO bound, so the var stays unbound
-	// and coalesces to `never` (a fresh unbound var at each use, which can't cascade).
-	require.Equal(t, map[string]string{"y": "never"}, values)
+	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
+	// sentinel (`val y = <unknown>`) recovers AS `error` rather than freezing to
+	// `never`, so downstream uses of y absorb instead of cascading `<: never`.
+	require.Equal(t, map[string]string{"y": "error"}, values)
 }
 
 // A destructuring pattern is IdentPat-only-gated in M2 (M4 adds tuple/record
@@ -515,10 +514,9 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
 	// M2.5: the error self-blames from the ident node.
 	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
-	// PR8: the unknown reference recovers to the ErrorType sentinel; on the top-level
-	// SCC path that absorbs into the binding's group var (no bound recorded), so the
-	// var stays unbound and coalesces to `never`.
-	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
+	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
+	// sentinel recovers AS `error` rather than freezing to `never`.
+	require.Equal(t, map[string]string{"y": "error", "z": "5"}, values)
 }
 
 // Error recovery for a NAMED callee: a too-many-args call still yields the

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -252,6 +252,10 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Len(t, errs, 2)
 	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
 	require.Equal(t, "Unknown identifier: x", errs[1].Message())
+	// PR8: the unknown reference recovers to the ErrorType sentinel, but on the
+	// top-level SCC path that placeholder is constrained into the binding's group var
+	// — where the absorbing short-circuit records NO bound, so the var stays unbound
+	// and coalesces to `never` (a fresh unbound var at each use, which can't cascade).
 	require.Equal(t, map[string]string{"y": "never"}, values)
 }
 
@@ -511,6 +515,9 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
 	// M2.5: the error self-blames from the ident node.
 	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
+	// PR8: the unknown reference recovers to the ErrorType sentinel; on the top-level
+	// SCC path that absorbs into the binding's group var (no bound recorded), so the
+	// var stays unbound and coalesces to `never`.
 	require.Equal(t, map[string]string{"y": "never", "z": "5"}, values)
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -85,9 +85,9 @@ type componentBinding struct {
 	// the full arm set does, and `sources` already holds it. The phase-3 VarDecl
 	// pattern recording would then key off the lone value decl directly instead.
 	primary ast.Decl
-	bound   bool // a definition was inferred and constrained
-	isVar   bool // the primary definition is a `val`/`var`
-	mutable bool // PR8: the primary definition is a `var` (VarKind) — reassignable
+	bound   bool             // a definition was inferred and constrained
+	isVar   bool             // the primary definition is a `val`/`var`
+	kind    ast.VariableKind // PR8: the primary definition's kind — VarKind ⇒ reassignable
 	// recovered marks that a contributing definition was WHOLLY the ErrorType recovery
 	// sentinel (e.g. `val a = <unknown ident>`). ErrorType absorbs in constrain, so it
 	// leaves no bound on the group var; phase 3 uses this to recover the binding AS
@@ -172,9 +172,12 @@ func (c *checker) inferComponent(
 				b.bound = true
 				vd, isVarDecl := d.(*ast.VarDecl)
 				b.isVar = isVarDecl
-				// PR8: a top-level `var` is reassignable (e.g. from a function body that
-				// closes over it); `val`/`fn` are not.
-				b.mutable = isVarDecl && vd.Kind == ast.VarKind
+				// PR8: carry the decl's kind so phase 3 can gate reassignment — a top-level
+				// `var` is reassignable (e.g. from a function body that closes over it);
+				// a `val`/`fn` is not. A FuncDecl leaves kind at its ValKind zero value.
+				if isVarDecl {
+					b.kind = vd.Kind
+				}
 				continue
 			}
 			// The binding already has its primary definition. A repeated FuncDecl is
@@ -248,7 +251,7 @@ func (c *checker) inferComponent(
 		} else {
 			scheme = c.generalize(b.v, lvl)
 		}
-		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Mutable: b.mutable})
+		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Kind: b.kind})
 		// Record the binding's final (coalesced) DISPLAY type in Info on the name
 		// node, so it is queryable even for a `val` in a recursive group (where
 		// coalescing at definition time would have frozen it to `never`). A VarDecl

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -88,6 +88,12 @@ type componentBinding struct {
 	bound   bool // a definition was inferred and constrained
 	isVar   bool // the primary definition is a `val`/`var`
 	mutable bool // PR8: the primary definition is a `var` (VarKind) — reassignable
+	// recovered marks that a contributing definition was WHOLLY the ErrorType recovery
+	// sentinel (e.g. `val a = <unknown ident>`). ErrorType absorbs in constrain, so it
+	// leaves no bound on the group var; phase 3 uses this to recover the binding AS
+	// ErrorType rather than freezing an unbound var to `never` (which would cascade
+	// `<: never` at every later use). See PR8 / inferComponent phase 3.
+	recovered bool
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -154,6 +160,12 @@ func (c *checker) inferComponent(
 			// go-to-definition can reach all of them. Only the primary's type is kept;
 			// M2 has no overload-merge (that is M3), so the extra arms still error.
 			b.sources = append(b.sources, src)
+			// PR8: a definition that is wholly the ErrorType recovery sentinel leaves no
+			// bound on the group var (ErrorType absorbs in constrain). Remember it so
+			// phase 3 can recover the binding as ErrorType instead of `never`.
+			if _, isErr := t.(*soltype.ErrorType); isErr {
+				b.recovered = true
+			}
 			if !b.bound {
 				c.constrain(d, t, b.v)
 				b.primary = d
@@ -222,7 +234,20 @@ func (c *checker) inferComponent(
 		// monotype). Every variable at Level > lvl becomes a quantified type
 		// parameter, captured outer variables do not — turning M2's monomorphic
 		// freeze into real let-polymorphism (PR1).
-		scheme := c.generalize(b.v, lvl)
+		//
+		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
+		// group var with no bound (ErrorType absorbs in constrain), so generalizing it
+		// would freeze the binding to `never` and cascade `<: never` at every later use
+		// (a reassignment, a call arg, …). Recover it AS the error sentinel instead,
+		// matching the body-level path (inferVarDecl) and keeping downstream uses
+		// absorbing. Guarded by an empty group var so a binding that ALSO picked up a
+		// real type (a recovered overload arm alongside a good one) still generalizes.
+		var scheme TypeScheme
+		if b.recovered && len(b.v.LowerBounds) == 0 {
+			scheme = &MonoScheme{Ty: &soltype.ErrorType{}}
+		} else {
+			scheme = c.generalize(b.v, lvl)
+		}
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Mutable: b.mutable})
 		// Record the binding's final (coalesced) DISPLAY type in Info on the name
 		// node, so it is queryable even for a `val` in a recursive group (where

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -87,6 +87,7 @@ type componentBinding struct {
 	primary ast.Decl
 	bound   bool // a definition was inferred and constrained
 	isVar   bool // the primary definition is a `val`/`var`
+	mutable bool // PR8: the primary definition is a `var` (VarKind) — reassignable
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -157,7 +158,11 @@ func (c *checker) inferComponent(
 				c.constrain(d, t, b.v)
 				b.primary = d
 				b.bound = true
-				_, b.isVar = d.(*ast.VarDecl)
+				vd, isVarDecl := d.(*ast.VarDecl)
+				b.isVar = isVarDecl
+				// PR8: a top-level `var` is reassignable (e.g. from a function body that
+				// closes over it); `val`/`fn` are not.
+				b.mutable = isVarDecl && vd.Kind == ast.VarKind
 				continue
 			}
 			// The binding already has its primary definition. A repeated FuncDecl is
@@ -218,7 +223,7 @@ func (c *checker) inferComponent(
 		// parameter, captured outer variables do not — turning M2's monomorphic
 		// freeze into real let-polymorphism (PR1).
 		scheme := c.generalize(b.v, lvl)
-		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources})
+		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Mutable: b.mutable})
 		// Record the binding's final (coalesced) DISPLAY type in Info on the name
 		// node, so it is queryable even for a `val` in a recursive group (where
 		// coalescing at definition time would have frozen it to `never`). A VarDecl

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -142,6 +142,59 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 
 func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
+// freshenAll returns a copy of t with EVERY TypeVarType replaced by a fresh var at
+// lvl (its bounds copied), sharing no var with the input. Unlike freshenAbove it
+// applies no level prune, so it descends through every former — including the
+// coalesced Union/Intersection nodes whose LevelOf is 0 (which freshenAbove's
+// LevelOf prune would skip) — and freshens vars wherever they occur.
+//
+// inferAssign uses it on a binding's coalesced slot type: coalesceScheme RETAINS
+// type-parameter vars by pointer, so constraining the RHS against that type would
+// mutate the binding's own vars and poison a reassigned polymorphic var for every
+// later use. Freshening first makes the constraint mutate throwaway copies instead.
+// A var-free input (the common annotated/literal case) is returned unchanged.
+func (c *checker) freshenAll(t soltype.Type, lvl int) soltype.Type {
+	return t.Accept(&allFreshener{c: c, lvl: lvl, cache: map[*soltype.TypeVarType]*soltype.TypeVarType{}}, soltype.Positive)
+}
+
+// allFreshener is the soltype-visitor form of freshenAll: it replaces every var
+// (no level prune; that is the only difference from freshener) and lets Accept
+// rebuild/descend through the structural and union/intersection nodes. It ignores
+// polarity (it freshens uniformly).
+type allFreshener struct {
+	c     *checker
+	lvl   int
+	cache map[*soltype.TypeVarType]*soltype.TypeVarType
+}
+
+func (f *allFreshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural / atom node: let Accept rebuild or descend
+	}
+	if nv, ok := f.cache[v]; ok {
+		return soltype.EnterResult{Type: nv, SkipChildren: true}
+	}
+	nv := f.c.freshAt(f.lvl)
+	f.cache[v] = nv // populate BEFORE bounds so a cyclic bound referencing v resolves to nv
+	nv.LowerBounds = f.freshenBounds(v.LowerBounds)
+	nv.UpperBounds = f.freshenBounds(v.UpperBounds)
+	return soltype.EnterResult{Type: nv, SkipChildren: true}
+}
+
+func (f *allFreshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
+	if len(bounds) == 0 {
+		return nil
+	}
+	out := make([]soltype.Type, len(bounds))
+	for i, b := range bounds {
+		out[i] = b.Accept(f, soltype.Positive)
+	}
+	return out
+}
+
 // freshenBounds freshens a var's bound list, preserving the nil-for-empty shape.
 // Freshening ignores polarity (no variance flip), so it walks at a fixed Positive.
 func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -179,6 +179,9 @@ func (f *allFreshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Ent
 	f.cache[v] = nv // populate BEFORE bounds so a cyclic bound referencing v resolves to nv
 	nv.LowerBounds = f.freshenBounds(v.LowerBounds)
 	nv.UpperBounds = f.freshenBounds(v.UpperBounds)
+	// SkipChildren is a no-op for a var (Accept treats it as a leaf), but we set it
+	// honestly: the var's bounds are a side graph, not tree children, so we freshen
+	// them above rather than letting the walk descend.
 	return soltype.EnterResult{Type: nv, SkipChildren: true}
 }
 

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -20,12 +21,14 @@ type ValueBinding struct {
 	// accumulates one entry per arm, including arms M2 currently rejects. This lets
 	// a future go-to-definition navigate to all of them. Empty for prelude bindings.
 	Sources []provenance.Provenance
-	// Mutable reports whether the binding may be REASSIGNED (`a = expr`). PR8 sets it
-	// true only for a `var` declaration (VarKind); a `val`, a function, a parameter,
-	// and every prelude binding leave it at the zero value (false), so reassigning
-	// any of those is a CannotAssignToImmutableError. This is the binding-level gate
-	// only — `mut`-field / aliasing / lifetime-transition mutability is M4.
-	Mutable bool
+	// Kind is the binding's declaration kind: VarKind for a reassignable `var`,
+	// ValKind for everything else (a `val`, a function, a parameter, and every
+	// prelude binding — all left at the zero value, ValKind). inferAssign gates
+	// reassignment on Kind == VarKind, reporting CannotAssignToImmutableError for any
+	// other kind. This is the binding-level REASSIGNABILITY gate only — deliberately
+	// SEPARATE from type-level mutability (`mut`-field / aliasing / lifetime
+	// transitions, M4), which is a property of the TYPE, not of this binding.
+	Kind ast.VariableKind
 }
 
 // IsOverloaded reports whether this binding is an overload set. Consumers MUST

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -20,6 +20,12 @@ type ValueBinding struct {
 	// accumulates one entry per arm, including arms M2 currently rejects. This lets
 	// a future go-to-definition navigate to all of them. Empty for prelude bindings.
 	Sources []provenance.Provenance
+	// Mutable reports whether the binding may be REASSIGNED (`a = expr`). PR8 sets it
+	// true only for a `var` declaration (VarKind); a `val`, a function, a parameter,
+	// and every prelude binding leave it at the zero value (false), so reassigning
+	// any of those is a CannotAssignToImmutableError. This is the binding-level gate
+	// only — `mut`-field / aliasing / lifetime-transition mutability is M4.
+	Mutable bool
 }
 
 // IsOverloaded reports whether this binding is an overload set. Consumers MUST

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -61,9 +61,11 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 				// `unknown` inner would instead cascade a spurious `<: never` / `<:
 				// unknown`, since constrain has no rule for either as an input).
 				//
-				// PR8 (planning/simple_sub/m3-implementation-plan.md) replaces this
-				// fresh var with the dedicated error-recovery type, so the recovered
-				// inner reads as `error` rather than as an anonymous coalesced var.
+				// PR8 (planning/simple_sub/m3-implementation-plan.md) deliberately
+				// KEEPS this fresh var rather than substituting its ErrorType sentinel:
+				// PR8 repoints only the no-good-type recovery, and this one yields a
+				// strictly better type — the fresh var generalizes (`Promise<_>` ⇒
+				// `Promise<T0>`) where ErrorType would freeze it to `Promise<error>`.
 				inner = c.freshAt(lvl)
 			}
 			t := &soltype.PromiseType{Inner: inner}


### PR DESCRIPTION
## Summary

Implements reassignment typing (`a = expr`) for M3 and introduces the ErrorType error-recovery sentinel to prevent diagnostic cascades. This is a two-part change:

**Part 1: ErrorType recovery sentinel** — Replaces the overloaded `NeverType` placeholder that `report()` left in expression position. ErrorType is a dedicated atom that absorbs constraints in both directions (`error <: T` and `T <: error` both succeed), so a single reported diagnostic never cascades a spurious second failure downstream. This fixes cascading errors in if/await conditions, member access, and other sinks.

**Part 2: Reassignment typing** — Adds `inferAssign()` to type binary expressions with `Op == Assign`. A reassignment `target = rhs` requires:
- The target to be a mutable place (an IdentExpr resolving to a `var` binding)
- The RHS to be a subtype of the binding's type
- The assignment expression itself to be void

Immutable bindings (`val`, function names, parameters) are rejected with `CannotAssignToImmutableError`. Non-place targets (literals, calls) are rejected with `InvalidAssignmentTargetError`. Member targets (`obj.x = …`) are reported as unsupported (M4). Union-typed vars apply the union-RHS rule via `constrainAssign()`, which trials each member under a probe.

## Key Changes

- **soltype/type.go**: Add `ErrorType` struct — the error-recovery sentinel distinct from `never` and `unknown`
- **soltype/print.go, visitor.go**: Render and visit ErrorType
- **solver/infer.go**: Change `report()` to return `ErrorType` instead of `NeverType`
- **solver/constrain.go**: Add short-circuit absorption rule for ErrorType in both directions, above all structural/variable logic
- **solver/infer_expr.go**: 
  - Add `inferAssign()` to handle reassignment with target/mutability/type checking
  - Add `constrainAssign()` for union-RHS rule
  - Add `bindingDecl()` helper to extract introducing declaration for error reporting
  - Update `inferMember()` to return ErrorType (not NeverType) for malformed member access
  - Update `inferAwait()` and `inferIfElse()` to remove `isRecoveryPlaceholder()` guards (ErrorType absorbs now)
- **solver/poly.go**: Add `freshenAll()` and `allFreshener` to freshen every type-var in a coalesced type without level prune — prevents polymorphic var corruption on reassignment
- **solver/errors.go**: Add `InvalidAssignmentTargetError` and `CannotAssignToImmutableError` with proper Span/Related/Message implementations
- **solver/scope.go**: Add `Mutable` field to `ValueBinding` to track reassignability
- **solver/module.go**: Track `mutable` and `recovered` flags in `componentBinding` for top-level var/val distinction and error recovery
- **solver/infer_decl.go**: Set `Mutable: true` for `var` declarations
- **solver/infer_assign_test.go** (new): 225 tests covering annotated/unannotated vars, immutable targets, invalid targets, void value type, error cascading, polymorphic var corruption, union targets, namespace targets, member targets, and edge cases
- **solver/infer_recovery_test.go** (new): End-to-end tests for ErrorType absorption through call arguments and unsupported expressions
- **solver/constrain_test.go**: Add tests pinning ErrorType absorption in both directions and confirming it never enters var bounds
- **solver/infer_test.go, infer_expr_test.go, infer_obj_test.go, infer_async_test.go**: Update expectations from `never` to `error` for recovery placeholders

## Notable Implementation Details

- **Polymorphic var safety**: `freshenAll()` copies the coalesced type before constraining the RHS, so reassigning a polymorphic var (e.g., `var

https://claude.ai/code/session_01FgccGn8YX62iJPZVYqVFJf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for variable reassignment using the assignment operator.
  * Implemented type checking for reassignment with error detection for invalid targets and immutable bindings.

* **Bug Fixes**
  * Improved error recovery behavior to prevent cascading diagnostics during inference.

* **Tests**
  * Added comprehensive test coverage for assignment validation and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->