### PR TITLE
PR6: Function overloading for free functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Escalier is a programming language with a Go-based compiler. The compiler pipeli
 - When traversing tree-like structures, use the existing visitor for that tree — see [internal/ast/visitor.go](internal/ast/visitor.go) for AST and [internal/type_system/visitor.go](internal/type_system/visitor.go) for types. Don't hand-roll a new traversal.
 - Use the `Set` ADT from [internal/set/](internal/set/) (`set.NewSet[T]()`, `set.FromSlice(...)`) instead of `map[T]struct{}` or `map[T]bool`.
 - Don't shadow Go builtins (`any`, `error`, `new`, `len`, etc.) or imported type/package aliases with local identifiers. Pick a distinct name (e.g. `anyT`, `errVal`).
+- Avoid parentheticals in comments — they make comments hard to read, especially when nested or combined with em-dashes. Rewrite the aside as a plain sentence, fold it into the main clause, or drop it. Reserve parentheses for short, essential clarifications like a code reference or a concrete example. Prefer several short sentences over one sentence carrying multiple asides.
 
 ## Writing tests
 
@@ -48,3 +49,33 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 ## GitHub issues
 
 - When creating issues with `gh`, do not escape strings or backticks in the Markdown body — `gh` passes the body through as-is, and escaping produces literal backslashes in the rendered issue.
+
+# Writing Prose: Punctuation and sentence structure
+
+- Use colons only for their standard jobs: introducing a list, a definition, or
+  a direct elaboration that completes the clause before it. Do not use a colon
+  mid-sentence to tack on an aside or a second thought. If you're tempted to
+  write "X does Y: which means Z", rewrite it as two sentences or join with a
+  conjunction.
+- Don't use a colon where a comma, dash, or period would read more naturally.
+  A colon makes the reader stop and expect a list or payoff; if none follows,
+  it's jarring.
+- Avoid parentheticals. They interrupt the sentence and force the reader to
+  hold the main clause in mind while processing the aside. In almost every case
+  one of these is better:
+    - Cut the parenthetical entirely if it's not load-bearing.
+    - Promote it to its own sentence if it matters.
+    - Fold it into the sentence with a comma if it's short and essential.
+- Never nest a parenthetical inside another, and never stack two parentheticals
+  in one sentence.
+- Don't use parentheses to define or gloss a term inline. Define it in the
+  preceding or following sentence instead.
+- Prefer short, complete sentences over long ones held together by dashes,
+  semicolons, and asides. One idea per sentence.
+- When explaining a process with multiple steps, lay the steps out as a list
+  rather than stringing them through a paragraph. Use a numbered list when the
+  order matters and a bulleted list when it doesn't. One step per item reads far
+  more easily than steps joined by semicolons or "then ... then ...".
+- Read each sentence as if a human has to parse it left to right with no
+  rereading. If understanding it requires jumping back to an earlier clause,
+  restructure it.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -244,28 +244,36 @@ func LevelOf(t Type) int {
 		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
+	// Union and Intersection recurse into their members for the same reason, but only
+	// the IntersectionType arm is load-bearing today. overloadIntersection (solver) is
+	// the ONE producer of a lattice node carrying LIVE inference variables that flows
+	// into freshenAbove — a let-bound overload's value-position type, whose generic arm
+	// holds a Level>0 var. If LevelOf returned 0 here, freshenAbove's level prune would
+	// treat the whole intersection as level 0, SHARE it, and alias that var across
+	// instantiations (two uses of the overload would cross-contaminate). So the level
+	// MUST reflect the members. UnionType has no such producer — every soltype.UnionType
+	// is coalesce OUTPUT (var-free) — so its recursion is currently dead, kept for
+	// symmetry and for when the type set grows a union with live vars (e.g. a generic
+	// union annotation). Coalesced-output unions/intersections hold no live vars, so
+	// both arms still return 0 for them.
 	case *UnionType:
-		m := 0
-		for _, e := range t.Types {
-			m = max(m, LevelOf(e))
-		}
-		return m
+		return maxMemberLevel(t.Types)
 	case *IntersectionType:
-		// PR6: an overloaded value's arm IntersectionType is a constrain/freshen INPUT
-		// (the scoped lattice exception), and a generic arm carries variables, so the
-		// level MUST reflect its members — otherwise freshenAbove's level prune treats
-		// the whole intersection as level 0 and SHARES the generic arm's variables across
-		// instantiations (aliasing two uses of a let-bound overload). UnionType recurses
-		// for symmetry. (Coalesced-output unions/intersections contain no live vars, so
-		// this still returns 0 for them.)
-		m := 0
-		for _, e := range t.Types {
-			m = max(m, LevelOf(e))
-		}
-		return m
+		return maxMemberLevel(t.Types)
 	default:
 		// PrimType, LitType, Void, NeverType, UnknownType, ErrorType: childless leaves
 		// (ErrorType is a sentinel, level 0).
 		return 0
 	}
+}
+
+// maxMemberLevel returns the highest LevelOf across a Union/Intersection's members,
+// 0 for an empty slice. Shared by the two lattice arms of LevelOf so their identical
+// recursion lives in one place.
+func maxMemberLevel(types []Type) int {
+	m := 0
+	for _, e := range types {
+		m = max(m, LevelOf(e))
+	}
+	return m
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -244,14 +244,28 @@ func LevelOf(t Type) int {
 		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
+	case *UnionType:
+		m := 0
+		for _, e := range t.Types {
+			m = max(m, LevelOf(e))
+		}
+		return m
+	case *IntersectionType:
+		// PR6: an overloaded value's arm IntersectionType is a constrain/freshen INPUT
+		// (the scoped lattice exception), and a generic arm carries variables, so the
+		// level MUST reflect its members — otherwise freshenAbove's level prune treats
+		// the whole intersection as level 0 and SHARES the generic arm's variables across
+		// instantiations (aliasing two uses of a let-bound overload). UnionType recurses
+		// for symmetry. (Coalesced-output unions/intersections contain no live vars, so
+		// this still returns 0 for them.)
+		m := 0
+		for _, e := range t.Types {
+			m = max(m, LevelOf(e))
+		}
+		return m
 	default:
-		// PrimType, LitType, Void, NeverType, UnknownType, ErrorType, UnionType,
-		// IntersectionType: ErrorType is a childless sentinel (level 0);
-		// UnionType/IntersectionType only appear in coalesced
-		// output, where every TypeVarType has been inlined — so they contain no
-		// level-bearing nodes reachable to LevelOf in M1. M6 (when these become
-		// constrain inputs via user annotations) adds the recursive arms
-		// alongside the distributivity rules in constrain.
+		// PrimType, LitType, Void, NeverType, UnknownType, ErrorType: childless leaves
+		// (ErrorType is a sentinel, level 0).
 		return 0
 	}
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -49,16 +49,12 @@ type coalescer struct {
 func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
-		// Union/Intersection are coalesced OUTPUT only — they must never reach
-		// coalesce INPUT (type.go: "appear only as coalesced output, never as
-		// constrain inputs"). Assert that invariant, as the pre-visitor coalesceRec
-		// did with its unhandled-type panic; every other structural/atom node is
-		// rebuilt by Accept.
-		switch t.(type) {
-		case *soltype.UnionType, *soltype.IntersectionType:
-			panic(fmt.Sprintf("coalesce: unexpected coalesced-output node %T in input", t))
-		}
-		return soltype.EnterResult{} // atom / structural node: let Accept rebuild it
+		// Atom or structural node — let Accept rebuild it from coalesced children.
+		// This includes a UnionType/IntersectionType: pre-PR6 those appeared only as
+		// coalesced OUTPUT, but PR6 feeds an overloaded value's arm IntersectionType as
+		// INPUT (the scoped lattice exception; see overloadIntersection), so coalesce
+		// must recurse into its members rather than reject it.
+		return soltype.EnterResult{}
 	}
 	// Re-entering a variable already on the current path is an ungrounded recursive
 	// position (no concrete type breaks the cycle). It collapses to the polarity
@@ -130,6 +126,18 @@ func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.T
 		}
 	case *soltype.PromiseType:
 		analyzeOccurrences(t.Inner, pol, occ, seen)
+	case *soltype.UnionType:
+		// PR6: an overloaded value's arm intersection can carry variables (a generic
+		// overload arm); record them so coalesceScheme retains genuine type parameters
+		// rather than rendering them raw. UnionType is here for symmetry — coalesced
+		// output never re-enters occurrence analysis, but a synthesized one is harmless.
+		for _, m := range t.Types {
+			analyzeOccurrences(m, pol, occ, seen)
+		}
+	case *soltype.IntersectionType:
+		for _, m := range t.Types {
+			analyzeOccurrences(m, pol, occ, seen)
+		}
 	case *soltype.TypeVarType:
 		if pol == soltype.Positive {
 			occ[t] |= occPos
@@ -189,13 +197,11 @@ type schemeCoalescer struct {
 func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
-		// Same invariant as coalescer: Union/Intersection are coalesced OUTPUT only
-		// and must never appear in a raw scheme body.
-		switch t.(type) {
-		case *soltype.UnionType, *soltype.IntersectionType:
-			panic(fmt.Sprintf("coalesceScheme: unexpected coalesced-output node %T in input", t))
-		}
-		return soltype.EnterResult{} // atom / structural node: let Accept rebuild it
+		// Atom or structural node — let Accept rebuild it from coalesced children. As
+		// in coalescer, this now includes a UnionType/IntersectionType (PR6 feeds an
+		// overloaded value's arm intersection through here as a raw scheme body, the
+		// scoped lattice exception).
+		return soltype.EnterResult{}
 	}
 	retain := v.Level > c.genLevel && c.occ[v].both()
 	if c.seen.Contains(v) {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -49,11 +49,8 @@ type coalescer struct {
 func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
-		// Atom or structural node — let Accept rebuild it from coalesced children.
-		// This includes a UnionType/IntersectionType: pre-PR6 those appeared only as
-		// coalesced OUTPUT, but PR6 feeds an overloaded value's arm IntersectionType as
-		// INPUT (the scoped lattice exception; see overloadIntersection), so coalesce
-		// must recurse into its members rather than reject it.
+		// Atom or structural node — let Accept rebuild it from coalesced children
+		// (including an overload-arm Union/Intersection input — the scoped lattice exception; see overloadIntersection).
 		return soltype.EnterResult{}
 	}
 	// Re-entering a variable already on the current path is an ungrounded recursive
@@ -110,50 +107,48 @@ type occKey struct {
 // outward comes out as occPos alone. coalesceScheme then retains the former as a
 // quantified type parameter and inlines the latter to its bound.
 func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.TypeVarType]occPolarity, seen set.Set[occKey]) {
-	switch t := t.(type) {
-	case *soltype.FuncType:
-		for _, p := range t.Params {
-			analyzeOccurrences(p.Type, pol.Flip(), occ, seen) // params contravariant
-		}
-		analyzeOccurrences(t.Ret, pol, occ, seen) // covariant return
-	case *soltype.TupleType:
-		for _, e := range t.Elems {
-			analyzeOccurrences(e, pol, occ, seen)
-		}
-	case *soltype.RecordType:
-		for _, f := range t.Fields {
-			analyzeOccurrences(f.Type, pol, occ, seen)
-		}
-	case *soltype.PromiseType:
-		analyzeOccurrences(t.Inner, pol, occ, seen)
-	case *soltype.UnionType:
-		// PR6: an overloaded value's arm intersection can carry variables (a generic
-		// overload arm); record them so coalesceScheme retains genuine type parameters
-		// rather than rendering them raw. UnionType is here for symmetry — coalesced
-		// output never re-enters occurrence analysis, but a synthesized one is harmless.
-		for _, m := range t.Types {
-			analyzeOccurrences(m, pol, occ, seen)
-		}
-	case *soltype.IntersectionType:
-		for _, m := range t.Types {
-			analyzeOccurrences(m, pol, occ, seen)
-		}
-	case *soltype.TypeVarType:
-		if pol == soltype.Positive {
-			occ[t] |= occPos
-		} else {
-			occ[t] |= occNeg
-		}
-		k := occKey{t, pol}
-		if seen.Contains(k) {
-			return
-		}
-		seen.Add(k)
-		for _, b := range t.BoundsAt(pol) {
-			analyzeOccurrences(b, pol, occ, seen)
-		}
-	}
+	// Drive the structural descent through the shared soltype visitor (the same
+	// rewriting walk coalescer/schemeCoalescer use), so the variance flip on func
+	// params and the recursion into every former — FuncType/Tuple/Record/Promise AND
+	// the overload-arm Union/Intersection PR6 feeds as input — live in one place
+	// (soltype.Accept) instead of a hand-rolled switch that must track every type kind.
+	// The returned (identity-preserving) type is discarded; the analysis is the
+	// EnterType side effect on occ/seen.
+	t.Accept(&occVisitor{occ: occ, seen: seen}, pol)
 }
+
+// occVisitor is the soltype-visitor form of analyzeOccurrences. Like coalescer it
+// handles the var node itself in EnterType — recording the polarity it was reached in,
+// then walking the var's BoundsAt(pol) side graph (guarded by the (var, pol) seen-set)
+// — and lets Accept descend every structural node (atoms pass through, func params
+// flip).
+type occVisitor struct {
+	occ  map[*soltype.TypeVarType]occPolarity
+	seen set.Set[occKey]
+}
+
+func (o *occVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural/atom node: let Accept descend
+	}
+	if pol == soltype.Positive {
+		o.occ[v] |= occPos
+	} else {
+		o.occ[v] |= occNeg
+	}
+	k := occKey{v, pol}
+	if o.seen.Contains(k) {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	o.seen.Add(k)
+	for _, b := range v.BoundsAt(pol) {
+		b.Accept(o, pol)
+	}
+	return soltype.EnterResult{SkipChildren: true}
+}
+
+func (o *occVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // coalesceScheme coalesces a generalized scheme's RAW body for DISPLAY, retaining
 // the variables that are genuine type parameters as named references while
@@ -197,10 +192,8 @@ type schemeCoalescer struct {
 func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
-		// Atom or structural node — let Accept rebuild it from coalesced children. As
-		// in coalescer, this now includes a UnionType/IntersectionType (PR6 feeds an
-		// overloaded value's arm intersection through here as a raw scheme body, the
-		// scoped lattice exception).
+		// Atom or structural node — let Accept rebuild it from coalesced children
+		// (including an overload-arm Union/Intersection input — the scoped lattice exception; see overloadIntersection).
 		return soltype.EnterResult{}
 	}
 	retain := v.Level > c.genLevel && c.occ[v].both()

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -237,12 +237,13 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		// intersection never reaches constrain as input (the design keeps these
 		// output-only), so this arm is overload-synthesis-only.
 		//
-		// Collapse only against a CONCRETE demand. When rhs is a variable (the overloaded
-		// value flowing INTO a binding, `intersection <: b.v`), fall through to the var
-		// arm below so the intersection is recorded WHOLE as a lower bound and preserved
-		// — collapsing it here would prematurely pick one arm and lose the overload set.
-		// The collapse then fires later, when the var is constrained against a concrete
-		// function demand (a call shape) and the intersection propagates to it.
+		// Collapse only against a CONCRETE demand. If rhs is a variable — the overloaded
+		// value is flowing INTO a binding (`intersection <: b.v`) — don't collapse here.
+		// Fall through to the var arm below, which records the intersection WHOLE as a
+		// lower bound. Collapsing now would commit to one arm prematurely and discard the
+		// rest of the overload set. The collapse fires later instead, once that var is
+		// constrained against a concrete function demand (a call shape) and the whole
+		// intersection propagates to it.
 		if _, rhsIsVar := rhs.(*soltype.TypeVarType); !rhsIsVar && len(l.Types) > 0 {
 			funcs := make([]*soltype.FuncType, len(l.Types))
 			for i, m := range l.Types {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -229,12 +229,13 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		// the lattice — reached only when an overloaded value (inferIdent synthesizes the
 		// arm intersection) flows into a constraint, e.g. a let-bound overload called
 		// through the binding (`g = f; g(x)`). The disjunction stays confined to the
-		// speculation phase: each member is trialled under a probe in declaration order,
-		// the first success commits its bounds and the losers roll back — the same
-		// ordered first-match resolveOverload uses, relocated into constrain. General
-		// IntersectionType subtyping (objects, distribution, normalization) is out of M3;
-		// a coalesced intersection never reaches constrain as input (the design keeps
-		// these output-only), so this arm is overload-synthesis-only.
+		// speculation phase: each member is trialled under a probe in SPECIFICITY order
+		// (the same specificityOrder resolveOverload uses for a direct call, so a call
+		// through a binding resolves to the same arm a direct call would), the first
+		// success commits its bounds and the losers roll back. General IntersectionType
+		// subtyping (objects, distribution, normalization) is out of M3; a coalesced
+		// intersection never reaches constrain as input (the design keeps these
+		// output-only), so this arm is overload-synthesis-only.
 		//
 		// Collapse only against a CONCRETE demand. When rhs is a variable (the overloaded
 		// value flowing INTO a binding, `intersection <: b.v`), fall through to the var
@@ -242,14 +243,18 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		// — collapsing it here would prematurely pick one arm and lose the overload set.
 		// The collapse then fires later, when the var is constrained against a concrete
 		// function demand (a call shape) and the intersection propagates to it.
-		if _, rhsIsVar := rhs.(*soltype.TypeVarType); !rhsIsVar {
+		if _, rhsIsVar := rhs.(*soltype.TypeVarType); !rhsIsVar && len(l.Types) > 0 {
+			funcs := make([]*soltype.FuncType, len(l.Types))
+			for i, m := range l.Types {
+				funcs[i], _ = m.(*soltype.FuncType)
+			}
 			var lastErrs []SolverError
-			for _, m := range l.Types {
+			for _, idx := range specificityOrder(funcs) {
 				p := newProbe(c.probe)
 				c.probe = p
 				// A cloned seen keeps each arm's coinductive cache independent, so a failed
 				// arm's entries can't wrongly short-circuit a later arm to success.
-				errs := c.constrain(m, rhs, seen.Clone())
+				errs := c.constrain(l.Types[idx], rhs, seen.Clone())
 				c.probe = p.parent
 				if len(errs) == 0 {
 					p.Commit()

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -223,6 +223,43 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		if _, ok := rhs.(*soltype.Void); ok {
 			return nil
 		}
+	case *soltype.IntersectionType:
+		// Function-intersection LHS (PR6 scoped lattice exception): (A & B & …) <: rhs
+		// iff SOME member <: rhs. This is the ONE place the overload disjunction touches
+		// the lattice — reached only when an overloaded value (inferIdent synthesizes the
+		// arm intersection) flows into a constraint, e.g. a let-bound overload called
+		// through the binding (`g = f; g(x)`). The disjunction stays confined to the
+		// speculation phase: each member is trialled under a probe in declaration order,
+		// the first success commits its bounds and the losers roll back — the same
+		// ordered first-match resolveOverload uses, relocated into constrain. General
+		// IntersectionType subtyping (objects, distribution, normalization) is out of M3;
+		// a coalesced intersection never reaches constrain as input (the design keeps
+		// these output-only), so this arm is overload-synthesis-only.
+		//
+		// Collapse only against a CONCRETE demand. When rhs is a variable (the overloaded
+		// value flowing INTO a binding, `intersection <: b.v`), fall through to the var
+		// arm below so the intersection is recorded WHOLE as a lower bound and preserved
+		// — collapsing it here would prematurely pick one arm and lose the overload set.
+		// The collapse then fires later, when the var is constrained against a concrete
+		// function demand (a call shape) and the intersection propagates to it.
+		if _, rhsIsVar := rhs.(*soltype.TypeVarType); !rhsIsVar {
+			var lastErrs []SolverError
+			for _, m := range l.Types {
+				p := newProbe(c.probe)
+				c.probe = p
+				// A cloned seen keeps each arm's coinductive cache independent, so a failed
+				// arm's entries can't wrongly short-circuit a later arm to success.
+				errs := c.constrain(m, rhs, seen.Clone())
+				c.probe = p.parent
+				if len(errs) == 0 {
+					p.Commit()
+					return nil
+				}
+				p.Discard()
+				lastErrs = errs
+			}
+			return lastErrs
+		}
 	}
 
 	// lhs is a variable: record rhs as an upper bound, propagate existing lowers.

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -40,29 +40,21 @@
 //
 // M3 (PR6) adds function overloading for free functions (overload.go): a name with
 // more than one top-level FuncDecl binds to a multi-scheme ValueBinding
-// (b.IsOverloaded()), one scheme per arm in declaration order. Resolution is a phase
-// DISTINCT from constrain — the "callable in several ways" disjunction stays out of
-// the subtype lattice — so inferCall routes a direct overloaded call through
-// resolveOverload, which trials each arm under a PR5 probe and commits the winner.
-// The ONE documented specificity rule (reused by M4 object-arg and M5 method
-// overloads): for ground-enough arguments, arms are tried most-specific-first, where
-// arm A outranks B iff they share an arity and A's parameters are pointwise
-// structural subtypes of B's with at least one strict — so a concrete `(x: number)`
-// beats a generic `(x: T)`; incomparable arms (and arms ranked under
-// not-ground-enough arguments) fall back to DECLARATION ORDER via a stable sort. A
-// mutually-recursive overloaded function must have fully-annotated arms (the overload
-// set has to be ground before bodies are inferred); self-recursion is softer and
-// ungated. The one scoped lattice exception is the VALUE-position type of an
-// overloaded name — the IntersectionType of its arms (overloadIntersection), built
-// lazily at inferIdent — which flows into a function slot via constrain's
-// function-intersection-LHS arm `(A & B) <: C` iff `A <: C` or `B <: C`, itself
-// implemented as the same ordered probe first-match (not naive constraint
-// propagation).
+// (b.IsOverloaded()), one scheme per arm. Resolution is a phase DISTINCT from
+// constrain — the "callable in several ways" disjunction stays out of the subtype
+// lattice — so a direct overloaded call routes through resolveOverload, which trials
+// the arms (reusing the PR5 probe) and commits the winner. Arms are tried
+// most-specific-first when no argument is an unconstrained variable, and fall back to
+// declaration order otherwise. The one scoped lattice exception is the VALUE-position
+// type of an overloaded name — the intersection of its arms — which is collapsed back to a
+// single arm only when it meets a concrete call shape.
 //
 // What is still deferred (each lands in a later milestone): records / mut /
 // lifetimes (M4), classes and the general union/intersection *subtyping rules* in
-// constrain (M5/M6), and type-level operators (M5/M8). M1 ships
-// UnionType/IntersectionType *nodes* for coalesced output; their general lattice
-// rules in constrain remain deferred (PR6 adds only the function-intersection-LHS
-// arm above).
+// constrain (M5/M6), type-level operators (M5/M8), and DEFERRED OVERLOAD RESOLUTION
+// when a call argument is still an unconstrained variable — today's first-match
+// fallback over-narrows the enclosing function, and the real fix rides with M4/M5
+// object-arg and method overloads (#723). M1 ships UnionType/IntersectionType *nodes*
+// for coalesced output; their general lattice rules in constrain remain deferred (PR6
+// adds only the function-intersection-LHS arm above).
 package solver

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -38,9 +38,31 @@
 // is its first consumer — each candidate is trialled under a probe and the losers
 // rolled back — but it is general speculation infrastructure reused beyond M3.
 //
+// M3 (PR6) adds function overloading for free functions (overload.go): a name with
+// more than one top-level FuncDecl binds to a multi-scheme ValueBinding
+// (b.IsOverloaded()), one scheme per arm in declaration order. Resolution is a phase
+// DISTINCT from constrain — the "callable in several ways" disjunction stays out of
+// the subtype lattice — so inferCall routes a direct overloaded call through
+// resolveOverload, which trials each arm under a PR5 probe and commits the winner.
+// The ONE documented specificity rule (reused by M4 object-arg and M5 method
+// overloads): for ground-enough arguments, arms are tried most-specific-first, where
+// arm A outranks B iff they share an arity and A's parameters are pointwise
+// structural subtypes of B's with at least one strict — so a concrete `(x: number)`
+// beats a generic `(x: T)`; incomparable arms (and arms ranked under
+// not-ground-enough arguments) fall back to DECLARATION ORDER via a stable sort. A
+// mutually-recursive overloaded function must have fully-annotated arms (the overload
+// set has to be ground before bodies are inferred); self-recursion is softer and
+// ungated. The one scoped lattice exception is the VALUE-position type of an
+// overloaded name — the IntersectionType of its arms (overloadIntersection), built
+// lazily at inferIdent — which flows into a function slot via constrain's
+// function-intersection-LHS arm `(A & B) <: C` iff `A <: C` or `B <: C`, itself
+// implemented as the same ordered probe first-match (not naive constraint
+// propagation).
+//
 // What is still deferred (each lands in a later milestone): records / mut /
-// lifetimes (M4), function overloading (M3 PR6), classes and the
-// union/intersection *subtyping rules* in constrain (M5/M6), and type-level
-// operators (M5/M8). M1 ships UnionType/IntersectionType *nodes* for coalesced
-// output, but their lattice rules in constrain remain deferred.
+// lifetimes (M4), classes and the general union/intersection *subtyping rules* in
+// constrain (M5/M6), and type-level operators (M5/M8). M1 ships
+// UnionType/IntersectionType *nodes* for coalesced output; their general lattice
+// rules in constrain remain deferred (PR6 adds only the function-intersection-LHS
+// arm above).
 package solver

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -308,6 +308,20 @@ type UnannotatedRecursiveOverloadError struct {
 	Name string
 }
 
+// DuplicateOverloadError fires when two arms of an overload set (PR6) are
+// indistinguishable for dispatch: they share an arity and have pointwise-equal
+// parameter types, so no call could ever select one over the other. An overload set
+// compiles to a single runtime function that dispatches on argument types, so two
+// arms accepting exactly the same arguments cannot be told apart at codegen.
+//
+// It is a BRIDGE error: born in the overload-set builder (module.go) with the
+// colliding arms in hand, so it self-blames the duplicate (later) arm and relates the
+// earlier arm it collides with. Name is the overloaded binding's name for the message.
+type DuplicateOverloadError struct {
+	Decl, Previous ast.Decl
+	Name           string
+}
+
 // TooManyArgsError fires when a DIRECT call supplies more arguments than the
 // (concrete) callee declares — the #677 §4.2.3 extra-arg lint, which rejects
 // too-many for exact AND inexact callees alike (an inexact function tolerates
@@ -419,6 +433,7 @@ func (*MissingInitializerError) isSolverError()           {}
 func (*DuplicateDeclarationError) isSolverError()         {}
 func (*NoMatchingOverloadError) isSolverError()           {}
 func (*UnannotatedRecursiveOverloadError) isSolverError() {}
+func (*DuplicateOverloadError) isSolverError()            {}
 func (*AwaitOutsideAsyncError) isSolverError()            {}
 func (*ReturnOutsideFunctionError) isSolverError()        {}
 func (*AsyncReturnNotPromiseError) isSolverError()        {}
@@ -536,6 +551,12 @@ func (e *UnannotatedRecursiveOverloadError) Span() ast.Span      { return e.Decl
 func (e *UnannotatedRecursiveOverloadError) Related() []ast.Span { return nil }
 func (e *UnannotatedRecursiveOverloadError) Message() string {
 	return "Overloaded function in a recursive group must have fully-annotated signatures: " + e.Name
+}
+
+func (e *DuplicateOverloadError) Span() ast.Span      { return e.Decl.Span() }
+func (e *DuplicateOverloadError) Related() []ast.Span { return []ast.Span{e.Previous.Span()} }
+func (e *DuplicateOverloadError) Message() string {
+	return "Overload arms must have distinguishable parameter types: " + e.Name
 }
 
 func (e *AwaitOutsideAsyncError) Span() ast.Span { return e.Await.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -278,17 +278,34 @@ type DuplicateDeclarationError struct {
 	Name           string
 }
 
-// OverloadNotSupportedError fires when a name has more than one top-level
-// FuncDecl. Function overloading needs the overload-intersection representation
-// that lands in M3; M2 keeps the first declaration (so the binding stays
-// callable with that signature) and reports each extra arm, rather than merging
-// the arms into the same var — which yields an uncallable union-of-functions
-// binding whose every call fails with an opaque `function | function` mismatch.
+// NoMatchingOverloadError fires when a call to an overloaded name (PR6) matches
+// none of the overload set's arms — every candidate either disagreed on arity or
+// failed to accept the supplied argument types. It replaces M2's interim
+// OverloadNotSupportedError (overloading is now real).
 //
-// Decl/Previous/Name mirror DuplicateDeclarationError.
-type OverloadNotSupportedError struct {
-	Decl, Previous ast.Decl
-	Name           string
+// It is a BRIDGE error: born in resolveOverload with the *ast.CallExpr in hand, so
+// it self-blames (Span() is the call) and relates the callee expression. Candidates
+// holds the overload arms (declaration order) so the message can list the
+// signatures that were tried.
+type NoMatchingOverloadError struct {
+	Call       *ast.CallExpr
+	Candidates []TypeScheme
+}
+
+// UnannotatedRecursiveOverloadError fires when an overloaded function participates
+// in a mutually-recursive group (a dep-graph component with more than one binding)
+// without fully-annotated overload signatures (PR6). Fixed-point iteration over
+// overload choices is not guaranteed to converge under subtyping, so the overload
+// set must be ground before the group is inferred; self-recursion (a singleton
+// component) is softer and does not trip this. The binding degrades to its first
+// arm so a later reference still resolves.
+//
+// It is a BRIDGE error: born in checkOverloadAnnotations with the offending arm's
+// declaration in hand, so it self-blames (Span() is the first unannotated arm).
+// Name is the overloaded binding's name for the message.
+type UnannotatedRecursiveOverloadError struct {
+	Decl ast.Decl
+	Name string
 }
 
 // TooManyArgsError fires when a DIRECT call supplies more arguments than the
@@ -389,21 +406,22 @@ type CannotAssignToImmutableError struct {
 	Decl   ast.Node        // the introducing decl, related; nil for prelude bindings
 }
 
-func (*UnknownIdentifierError) isSolverError()       {}
-func (*NamespaceUsedAsValueError) isSolverError()    {}
-func (*InvalidAssignmentTargetError) isSolverError() {}
-func (*CannotAssignToImmutableError) isSolverError() {}
-func (*TooManyArgsError) isSolverError()             {}
-func (*NotEnoughArgsError) isSolverError()           {}
-func (*UnsupportedNodeError) isSolverError()         {}
-func (*UnsupportedFeatureError) isSolverError()      {}
-func (*BodyDeclNotAllowedError) isSolverError()      {}
-func (*MissingInitializerError) isSolverError()      {}
-func (*DuplicateDeclarationError) isSolverError()    {}
-func (*OverloadNotSupportedError) isSolverError()    {}
-func (*AwaitOutsideAsyncError) isSolverError()       {}
-func (*ReturnOutsideFunctionError) isSolverError()   {}
-func (*AsyncReturnNotPromiseError) isSolverError()   {}
+func (*UnknownIdentifierError) isSolverError()            {}
+func (*NamespaceUsedAsValueError) isSolverError()         {}
+func (*InvalidAssignmentTargetError) isSolverError()      {}
+func (*CannotAssignToImmutableError) isSolverError()      {}
+func (*TooManyArgsError) isSolverError()                  {}
+func (*NotEnoughArgsError) isSolverError()                {}
+func (*UnsupportedNodeError) isSolverError()              {}
+func (*UnsupportedFeatureError) isSolverError()           {}
+func (*BodyDeclNotAllowedError) isSolverError()           {}
+func (*MissingInitializerError) isSolverError()           {}
+func (*DuplicateDeclarationError) isSolverError()         {}
+func (*NoMatchingOverloadError) isSolverError()           {}
+func (*UnannotatedRecursiveOverloadError) isSolverError() {}
+func (*AwaitOutsideAsyncError) isSolverError()            {}
+func (*ReturnOutsideFunctionError) isSolverError()        {}
+func (*AsyncReturnNotPromiseError) isSolverError()        {}
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
@@ -497,10 +515,27 @@ func (e *DuplicateDeclarationError) Message() string {
 	return "Duplicate declaration: " + e.Name
 }
 
-func (e *OverloadNotSupportedError) Span() ast.Span      { return e.Decl.Span() }
-func (e *OverloadNotSupportedError) Related() []ast.Span { return []ast.Span{e.Previous.Span()} }
-func (e *OverloadNotSupportedError) Message() string {
-	return "Function overloads are not supported in M2: " + e.Name
+func (e *NoMatchingOverloadError) Span() ast.Span { return e.Call.Span() }
+func (e *NoMatchingOverloadError) Related() []ast.Span {
+	if e.Call.Callee == nil {
+		return nil
+	}
+	return []ast.Span{e.Call.Callee.Span()}
+}
+func (e *NoMatchingOverloadError) Message() string {
+	var sb strings.Builder
+	sb.WriteString("No matching overload for this call")
+	for _, s := range e.Candidates {
+		sb.WriteString("\n  ")
+		sb.WriteString(renderScheme(s))
+	}
+	return sb.String()
+}
+
+func (e *UnannotatedRecursiveOverloadError) Span() ast.Span      { return e.Decl.Span() }
+func (e *UnannotatedRecursiveOverloadError) Related() []ast.Span { return nil }
+func (e *UnannotatedRecursiveOverloadError) Message() string {
+	return "Overloaded function in a recursive group must have fully-annotated signatures: " + e.Name
 }
 
 func (e *AwaitOutsideAsyncError) Span() ast.Span { return e.Await.Span() }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -8,13 +8,13 @@ import (
 
 // inferDeclDef infers one top-level declaration for the SCC driver
 // (inferComponent) and returns its RAW (un-coalesced, variable-carrying) type to
-// constrain against the binding's group var, the decl's provenance, and ok=false
+// constrain against the binding's binding var, the decl's provenance, and ok=false
 // when it introduces no value. It does NOT bind the name — inferComponent owns
 // scope placement.
 //
-// The type MUST stay raw: inferComponent coalesces the group var once, after every
+// The type MUST stay raw: inferComponent coalesces the binding var once, after every
 // group member has constrained it (phase 3). Coalescing a `val` initializer here
-// would read a recursive peer's still-empty group var and freeze the binding to
+// would read a recursive peer's still-empty binding var and freeze the binding to
 // `never` — the bug behind splitting this out of inferVarDecl.
 //
 // ok=false cases, each already reported:
@@ -46,7 +46,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		return initType, &ast.NodeProvenance{Node: d}, true
 	case *ast.FuncDecl:
 		// inferFuncDecl returns the RAW func type and its source directly;
-		// inferComponent constrains that raw type into the group var, generalizes
+		// inferComponent constrains that raw type into the binding var, generalizes
 		// once the group is complete, and accumulates the per-decl source into the
 		// binding's Sources slice.
 		t, src := c.inferFuncDecl(scope, lvl, d)
@@ -61,7 +61,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 // (un-coalesced) type, ok=false when there's no initializer (MissingInitializerError
 // reported). Shared core of both binding paths; they differ only in WHEN they
 // coalesce: inferDeclDef (SCC driver) keeps it raw so inferComponent coalesces the
-// group var once at completion, while inferVarDecl (body-level) coalesces it now.
+// binding var once at completion, while inferVarDecl (body-level) coalesces it now.
 // Walks the initializer regardless so a malformed RHS still surfaces errors, and
 // binds nothing — the caller owns scope placement.
 //
@@ -103,7 +103,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // `fn (y) { val getY = fn () { y }; [getY(), getY()] }` keeps getY's captured `y`
 // instead of freezing it to `never`, the bug eager coalescing caused. A body-level
 // `val` is never recursive (the name is bound only after its initializer is typed),
-// so there is no pre-binding/group var; the SCC driver owns the recursive top-level
+// so there is no pre-binding or binding var; the SCC driver owns the recursive top-level
 // path (see inferDeclDef). ok=false when there is no initializer.
 func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBinding, bool) {
 	initType, ok := c.inferVarDeclInit(scope, lvl+1, d)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -336,12 +336,11 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // PR4 adds two #677 pieces: an EXACT all-required call demand, and the extra-arg
 // lint that rejects passing more arguments than a concrete callee declares.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
-	// PR6: a DIRECT call to an overloaded name resolves against the overload set
-	// (resolveOverload, a phase distinct from constrain) rather than the
-	// single-subtype-constraint path — the disjunction stays out of the lattice for
-	// call resolution. A call THROUGH an intermediate binding (`g = f; g(x)`) does not
-	// match here (the callee is not the overloaded name itself); it routes through the
-	// value-position intersection and constrain's IntersectionType arm instead.
+	// PR6: a DIRECT call to an overloaded name resolves against the overload set via
+	// resolveOverload, a phase distinct from constrain — so the disjunction stays out of
+	// the lattice. A call through an intermediate binding (`g = f; g(x)`) doesn't match
+	// here; it routes through the value-position intersection (constrain's
+	// IntersectionType arm) instead.
 	if ident, ok := e.Callee.(*ast.IdentExpr); ok {
 		if b, found := scope.GetValue(ident.Name); found && b.IsOverloaded() {
 			return c.inferOverloadedCall(scope, lvl, e, b)
@@ -403,13 +402,13 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	return res
 }
 
-// inferOverloadedCall types a direct call to an overloaded name (PR6). It types the
-// arguments, records the callee's overload type (the arm intersection) for Info, and
-// resolves the call against the overload set through resolveOverload — which trials
-// each arm under a probe and commits the winner. Unlike the ordinary path it emits no
-// callee <: callShape constraint: overload resolution is a separate phase that owns
-// the arity/argument checking (the TooManyArgs/NotEnoughArgs lints do not apply —
-// arity is the per-arm gate, and a no-match is a NoMatchingOverloadError).
+// inferOverloadedCall types a direct call to an overloaded name (PR6). It infers
+// the types of the arguments, records the callee's overload type for Info, and
+// resolves the call through resolveOverload, which trials each arm under a probe
+// and commits the winner. Unlike the ordinary path it emits no callee <: callShape
+// constraint.  Overload resolution is a separate phase that owns arity and argument
+// checking. The TooManyArgs and NotEnoughArgs lints don't apply – arity is the
+// per-arm gate, and a no-match becomes a NoMatchingOverloadError.
 func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b ValueBinding) soltype.Type {
 	args := make([]soltype.Type, len(e.Args))
 	for i, a := range e.Args {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -415,7 +415,10 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 	for i, a := range e.Args {
 		args[i] = c.inferExpr(scope, lvl, a)
 	}
-	c.recordType(e.Callee, c.overloadIntersection(lvl, b))
+	// Record the callee's display type for Info (hover) via overloadDisplayType, which
+	// coalesces the schemes rather than instantiating them — resolveOverload below does
+	// the (only) per-arm instantiation needed to type the call.
+	c.recordType(e.Callee, overloadDisplayType(b))
 	ret := c.resolveOverload(lvl, b, args, e)
 	c.recordType(e, ret)
 	return ret

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -57,10 +57,18 @@ func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Ty
 	// a guaranteed-non-empty field, so we guard it anyway: a malformed empty binding
 	// degrades to an unknown-identifier error here instead of panicking on Schemes[0].
 	//
-	// PR1 never builds an overloaded binding; the IsOverloaded value-position branch
-	// (arm intersection) is PR6.
+	// An overloaded name in VALUE position (PR6) — `val g = f`, or `f` passed as an
+	// argument — is the intersection of its arms (the one scoped lattice exception;
+	// see overloadIntersection and constrain's IntersectionType arm). A direct call
+	// `f(x)` never reaches here: inferCall intercepts the overloaded callee and routes
+	// it through resolveOverload before typing the callee as a value.
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
-		t := c.instantiate(b.Schemes[0], lvl)
+		var t soltype.Type
+		if b.IsOverloaded() {
+			t = c.overloadIntersection(lvl, b)
+		} else {
+			t = c.instantiate(b.Schemes[0], lvl)
+		}
 		c.recordType(e, t)
 		return t
 	}
@@ -328,6 +336,17 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // PR4 adds two #677 pieces: an EXACT all-required call demand, and the extra-arg
 // lint that rejects passing more arguments than a concrete callee declares.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
+	// PR6: a DIRECT call to an overloaded name resolves against the overload set
+	// (resolveOverload, a phase distinct from constrain) rather than the
+	// single-subtype-constraint path — the disjunction stays out of the lattice for
+	// call resolution. A call THROUGH an intermediate binding (`g = f; g(x)`) does not
+	// match here (the callee is not the overloaded name itself); it routes through the
+	// value-position intersection and constrain's IntersectionType arm instead.
+	if ident, ok := e.Callee.(*ast.IdentExpr); ok {
+		if b, found := scope.GetValue(ident.Name); found && b.IsOverloaded() {
+			return c.inferOverloadedCall(scope, lvl, e, b)
+		}
+	}
 	callee := c.inferExpr(scope, lvl, e.Callee)
 	args := make([]*soltype.FuncParam, len(e.Args))
 	for i, a := range e.Args {
@@ -382,6 +401,24 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	}
 	c.recordType(e, res)
 	return res
+}
+
+// inferOverloadedCall types a direct call to an overloaded name (PR6). It types the
+// arguments, records the callee's overload type (the arm intersection) for Info, and
+// resolves the call against the overload set through resolveOverload — which trials
+// each arm under a probe and commits the winner. Unlike the ordinary path it emits no
+// callee <: callShape constraint: overload resolution is a separate phase that owns
+// the arity/argument checking (the TooManyArgs/NotEnoughArgs lints do not apply —
+// arity is the per-arm gate, and a no-match is a NoMatchingOverloadError).
+func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b ValueBinding) soltype.Type {
+	args := make([]soltype.Type, len(e.Args))
+	for i, a := range e.Args {
+		args[i] = c.inferExpr(scope, lvl, a)
+	}
+	c.recordType(e.Callee, c.overloadIntersection(lvl, b))
+	ret := c.resolveOverload(lvl, b, args, e)
+	c.recordType(e, ret)
+	return ret
 }
 
 // resolveFunc resolves a callee to its concrete FuncType, used to recover a

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -111,6 +111,38 @@ func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
 		errs[0].Message())
 }
 
+// A self-recursive fully-annotated overload type-checks: each arm's recursive call
+// resolves against the whole pre-bound overload set (the number arm's f(x) hits the
+// number arm, the string arm's hits the string arm), so neither arm is wrongly
+// checked against the other. (Before the pre-binding fix this reported two spurious
+// `cannot constrain` errors because the recursive reference saw only the first arm.)
+func TestInferOverloadSelfRecursiveAnnotated(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { f(x) }
+		fn f(x: string) -> string { f(x) }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
+}
+
+// A fully-annotated overload that is MUTUALLY recursive with another binding which
+// also CAPTURES it as a value resolves cleanly: the overload set is pre-bound before
+// any body, so both the recursive calls and the value capture (`val h = f`) inside
+// the component see the whole set, not a single first-arm var.
+func TestInferOverloadMutualRecursionValueCapture(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { g(x) }
+		fn f(x: string) -> number { g(5) }
+		fn g(n: number) -> number {
+			val h = f
+			h(n)
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> number)", values["f"])
+	require.Equal(t, "fn (n: number) -> number", values["g"])
+}
+
 // The gate is scoped to MUTUAL recursion: a non-recursive annotated overload whose
 // arms merely call another (non-recursive) function is fine, since its component is
 // a singleton — the gate never fires and the set binds normally.

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -1,0 +1,178 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// PR6 — function overloading for free functions. A name with more than one
+// top-level FuncDecl is an overload set; a direct call resolves to the arm whose
+// parameter accepts the argument, via resolveOverload (a phase distinct from
+// constrain, driven by the PR5 probe).
+
+// Per-argument-type resolution: f(5) picks the number arm, f("hi") the string arm,
+// each call yielding that arm's return type.
+func TestInferOverloadResolvesByArgType(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val r = f(5)
+		val s = f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"])
+	require.Equal(t, "string", values["s"])
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
+}
+
+// Unannotated overloads are allowed when NOT recursive — arms are inferred
+// independently and resolution dispatches on arity: f(5) hits the 1-param arm,
+// f(5, "hi") the 2-param arm.
+func TestInferOverloadDispatchesOnArity(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x, y) { x }
+		val a = f(5)
+		val b = f(5, "hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["a"])
+	require.Equal(t, "5", values["b"])
+}
+
+// Declaration-order tie-break: when two arms both accept the argument and neither
+// is more specific (here identical parameter types), the FIRST-declared arm wins,
+// so r takes the first arm's return type.
+func TestInferOverloadDeclarationOrderTieBreak(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> string { "a" }
+		fn f(x: number) -> boolean { true }
+		val r = f(5)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["r"], "the first-declared matching arm wins on a specificity tie")
+}
+
+// Specificity beats declaration order: a concrete arm declared AFTER a generic one
+// still wins for a matching concrete argument (most-specific-first). f("hi") picks
+// the string arm even though the generic arm is declared first and would also match.
+func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x: string) -> boolean { true }
+		val r = f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "boolean", values["r"], "the more specific (string) arm outranks the earlier generic arm")
+}
+
+// A not-ground-enough call (the argument is a still-unconstrained parameter
+// variable) falls back to declaration-order first-match: f(y) inside `fn (y) {…}`
+// resolves to the first arm and pins y to that arm's parameter type.
+func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val g = fn (y) { f(y) }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (y: number) -> number", values["g"],
+		"an unground argument defers to declaration-order first-match, pinning y to the first arm")
+}
+
+// No arm accepts the argument ⇒ NoMatchingOverloadError listing the candidates.
+func TestInferOverloadNoMatch(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val r = f(true)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"No matching overload for this call\n  fn (x: number) -> number\n  fn (x: string) -> string",
+		errs[0].Message())
+}
+
+// A mutually-recursive group containing an overloaded function with un-annotated
+// arms is rejected: the overload set must be ground before the group's bodies are
+// inferred. The error blames the offending overloaded participant.
+func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(x) { g(x) }
+		fn f(y) { g(y) }
+		fn g(z) { f(z) }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"Overloaded function in a recursive group must have fully-annotated signatures: f",
+		errs[0].Message())
+}
+
+// The gate is scoped to MUTUAL recursion: a non-recursive annotated overload whose
+// arms merely call another (non-recursive) function is fine, since its component is
+// a singleton — the gate never fires and the set binds normally.
+func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn g(z: number) -> number { z }
+		fn f(x: number) -> number { g(x) }
+		fn f(x: number) -> string { "s" }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: number) -> string)", values["f"])
+}
+
+// Value-position use (PR6 scoped lattice exception): a let-bound overloaded name is
+// the INTERSECTION of its arms, and calling THROUGH that binding resolves each call
+// via constrain's function-intersection-LHS arm — g(5) ⇒ number, g("hi") ⇒ string.
+func TestInferOverloadValuePosition(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val g = f
+		val r = g(5)
+		val s = g("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["g"],
+		"a let-bound overloaded name carries the intersection of its arms")
+	require.Equal(t, "number", values["r"])
+	require.Equal(t, "string", values["s"])
+}
+
+// Resolution rollback (exercising the PR5 probe): the first-tried arm (string) is a
+// non-match for a number-bounded argument variable; its speculative `arg <: string`
+// upper bound must be rolled back, so after resolution the argument var carries ONLY
+// the winning (number) arm's bound — never the loser's. Built directly so the
+// argument variable is inspectable.
+func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
+	c := newChecker()
+
+	str := func() soltype.Type { return &soltype.PrimType{Prim: soltype.StrPrim} }
+	num := func() soltype.Type { return &soltype.PrimType{Prim: soltype.NumPrim} }
+	strFn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: str()}},
+		Ret:    str(),
+	}
+	numFn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: num()}},
+		Ret:    num(),
+	}
+	// Overload set in declaration order: string arm first, number arm second.
+	b := ValueBinding{Schemes: []TypeScheme{monoScheme(strFn), monoScheme(numFn)}}
+
+	// The argument is a variable carrying a number-literal lower bound — ground enough
+	// to rank, but incompatible with the string arm (5 </: string).
+	argVar := c.freshAt(0)
+	argVar.LowerBounds = []soltype.Type{&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}}
+
+	call := ast.NewCall(identExpr("f"), []ast.Expr{numExpr(5)}, false, testSpan())
+	ret := c.resolveOverload(0, b, []soltype.Type{argVar}, call)
+
+	require.Empty(t, c.errs, "the losing arm's trial error is rolled back, not accumulated")
+	require.Equal(t, "number", soltype.Print(ret))
+	require.Len(t, argVar.UpperBounds, 1, "the losing string arm's speculative upper bound was rolled back")
+	require.Equal(t, num(), argVar.UpperBounds[0], "only the winning number arm's bound survives")
+}

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -266,3 +266,34 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 	require.Len(t, argVar.UpperBounds, 1, "the losing string arm's speculative upper bound was rolled back")
 	require.Equal(t, num(), argVar.UpperBounds[0], "only the winning number arm's bound survives")
 }
+
+// An overload binding's Sources lines up one-to-one with its Schemes (each arm
+// contributes one of each), so a multi-target go-to-definition can map Schemes[i] to
+// the decl at Sources[i].
+func TestInferOverloadBindingSourcesAlignWithSchemes(t *testing.T) {
+	scope, _, errs := InferModule(parseModule(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+	`))
+	require.Empty(t, errs)
+	b, ok := scope.GetValue("f")
+	require.True(t, ok)
+	require.True(t, b.IsOverloaded())
+	require.Len(t, b.Schemes, 2)
+	require.Len(t, b.Sources, 2, "Sources lines up one-to-one with Schemes")
+}
+
+// A name bound by FuncDecls AND a `val` is not a pure overload set: the functions
+// overload and the `val` is reported as a duplicate declaration (the shared
+// pure-overload classifier keeps the gate and the binding consistent).
+func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x: number) -> number { x }
+		fn f(x: string) -> string { x }
+		val f = 5
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Duplicate declaration: f", errs[0].Message())
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"],
+		"the two functions still overload; only the val is rejected")
+}

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -1,9 +1,12 @@
 package solver
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -43,17 +46,44 @@ func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	require.Equal(t, "5", values["b"])
 }
 
-// Declaration-order tie-break: when two arms both accept the argument and neither
-// is more specific (here identical parameter types), the FIRST-declared arm wins,
-// so r takes the first arm's return type.
-func TestInferOverloadDeclarationOrderTieBreak(t *testing.T) {
-	values, _, errs := inferSource(t, `
+// Two arms with identical parameter types are REJECTED: an overload set compiles to a
+// single runtime function that dispatches on argument types, so two arms accepting
+// exactly the same arguments cannot be told apart at codegen. The error blames the
+// later arm and relates the earlier one.
+func TestInferOverloadDuplicateParamTypesRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
 		fn f(x: number) -> string { "a" }
 		fn f(x: number) -> boolean { true }
 		val r = f(5)
 	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"Overload arms must have distinguishable parameter types: f",
+		errs[0].Message())
+}
+
+// Cross-file declaration order is pinned to SOURCE POSITION (file path alphabetically,
+// then line/column), NOT to the order the parser received the files. Two arms of f
+// live in separate files with DISTINCT parameter types (a.esc takes number, b.esc
+// takes string); the value-position intersection must list them in path-alphabetical
+// order — a.esc's number arm first, b.esc's string arm second. The files are handed to
+// the parser in REVERSE-alphabetical order (b.esc first, so it gets the lower
+// SourceID); the path-alphabetical arm (a.esc) must still come first regardless.
+func TestInferOverloadCrossFileDeclarationOrder(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	sources := []*ast.Source{
+		{ID: 0, Path: "b.esc", Contents: `fn f(x: string) -> boolean { true }`},
+		{ID: 1, Path: "a.esc", Contents: "fn f(x: number) -> string { \"s\" }\nval r = f(5)"},
+	}
+	module, parseErrs := parser.ParseLibFiles(ctx, sources)
+	require.Empty(t, parseErrs, "expected no parse errors")
+	values, _, errs := inferModule(module)
 	require.Empty(t, errs)
-	require.Equal(t, "string", values["r"], "the first-declared matching arm wins on a specificity tie")
+	require.Equal(t, "string", values["r"],
+		"f(5) selects a.esc's number arm")
+	require.Equal(t, "(fn (x: number) -> string) & (fn (x: string) -> boolean)", values["f"],
+		"the value-position intersection lists arms in path-alphabetical order (a.esc, then b.esc)")
 }
 
 // Specificity beats declaration order: a concrete arm declared AFTER a generic one
@@ -69,9 +99,11 @@ func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	require.Equal(t, "boolean", values["r"], "the more specific (string) arm outranks the earlier generic arm")
 }
 
-// A not-ground-enough call (the argument is a still-unconstrained parameter
-// variable) falls back to declaration-order first-match: f(y) inside `fn (y) {…}`
-// resolves to the first arm and pins y to that arm's parameter type.
+// A call with an unconstrained argument (a still-unconstrained parameter variable)
+// falls back to declaration-order first-match: f(y) inside `fn (y) {…}` resolves to
+// the first arm and pins y to that arm's parameter type. This over-narrows the
+// enclosing function (g then rejects a later g("hi")) — a documented MVP limitation
+// whose real fix (deferred resolution) is tracked in #723.
 func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { x }
@@ -80,7 +112,7 @@ func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (y: number) -> number", values["g"],
-		"an unground argument defers to declaration-order first-match, pinning y to the first arm")
+		"an unconstrained argument defers to declaration-order first-match, pinning y to the first arm")
 }
 
 // No arm accepts the argument ⇒ NoMatchingOverloadError listing the candidates.
@@ -150,10 +182,10 @@ func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn g(z: number) -> number { z }
 		fn f(x: number) -> number { g(x) }
-		fn f(x: number) -> string { "s" }
+		fn f(x: string) -> string { "s" }
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "(fn (x: number) -> number) & (fn (x: number) -> string)", values["f"])
+	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
 }
 
 // Value-position use (PR6 scoped lattice exception): a let-bound overloaded name is
@@ -215,8 +247,8 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 }
 
 // Three mixed arms (concrete-literal-ish, concrete-prim, generic) rank by specificity
-// without relying on a non-transitive comparator: each ground call selects the arm
-// that accepts its argument, most-specific-first with declaration-order tiebreak.
+// without relying on a non-transitive comparator: each call with a concrete argument
+// selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x) { x }
@@ -253,8 +285,8 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 	// Overload set in declaration order: string arm first, number arm second.
 	b := ValueBinding{Schemes: []TypeScheme{monoScheme(strFn), monoScheme(numFn)}}
 
-	// The argument is a variable carrying a number-literal lower bound — ground enough
-	// to rank, but incompatible with the string arm (5 </: string).
+	// The argument is a variable carrying a number-literal lower bound — constrained
+	// enough to rank, but incompatible with the string arm (5 </: string).
 	argVar := c.freshAt(0)
 	argVar.LowerBounds = []soltype.Type{&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}}
 
@@ -283,9 +315,9 @@ func TestInferOverloadBindingSourcesAlignWithSchemes(t *testing.T) {
 	require.Len(t, b.Sources, 2, "Sources lines up one-to-one with Schemes")
 }
 
-// A name bound by FuncDecls AND a `val` is not a pure overload set: the functions
-// overload and the `val` is reported as a duplicate declaration (the shared
-// pure-overload classifier keeps the gate and the binding consistent).
+// A name bound by FuncDecls AND a `val` is not function-only, so it is not an overload
+// set: the functions overload and the `val` is reported as a duplicate declaration. The
+// shared funcOnlyDecls classifier keeps the gate and the binding consistent.
 func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { x }
@@ -296,4 +328,20 @@ func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
 	require.Equal(t, "Duplicate declaration: f", errs[0].Message())
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"],
 		"the two functions still overload; only the val is rejected")
+}
+
+// The duplicate is rejected even when the val and the fn live in SEPARATE files of the
+// same lib namespace: the dep graph keys by qualified name across all files, so a fn
+// and a val sharing a name collide under one value binding regardless of file. The
+// first-declared decl wins and the other is a duplicate; here a.esc's fn is primary and
+// b.esc's val is reported.
+func TestInferOverloadMixedWithValCrossFileIsDuplicate(t *testing.T) {
+	values, _, errs := inferSources(t, map[string]string{
+		"a.esc": `fn f(x: number) -> number { x }`,
+		"b.esc": `val f = 5`,
+	})
+	require.Len(t, errs, 1)
+	require.Equal(t, "Duplicate declaration: f", errs[0].Message())
+	require.Equal(t, "fn (x: number) -> number", values["f"],
+		"the cross-file val is rejected; the fn binding survives")
 }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -142,6 +142,64 @@ func TestInferOverloadValuePosition(t *testing.T) {
 	require.Equal(t, "string", values["s"])
 }
 
+// A GENERIC overload arm used through a let-binding is freshened per use, not shared:
+// g("hi") and g(true) resolve the generic 1-param arm independently, so they keep
+// distinct types instead of cross-contaminating to "hi" | true. (Guards the
+// soltype.LevelOf recursion into IntersectionType — without it freshenAbove prunes
+// the level-0 intersection and aliases the arm's type variable across uses.)
+func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x, y) { x }
+		val g = f
+		val a = g("hi")
+		val b = g(true)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `"hi"`, values["a"], "the generic arm is freshened per use, not aliased")
+	require.Equal(t, "true", values["b"])
+}
+
+// Value-position resolution uses the SAME specificity order as a direct call: a
+// concrete arm declared after a generic one wins for a matching concrete argument,
+// whether the callee is the overloaded name directly or a let-bound alias.
+func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
+	direct, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x: string) -> boolean { true }
+		val r = f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "boolean", direct["r"], "direct call picks the more specific arm")
+
+	binding, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x: string) -> boolean { true }
+		val g = f
+		val r = g("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "boolean", binding["r"], "a call through a binding resolves to the same arm as the direct call")
+}
+
+// Three mixed arms (concrete-literal-ish, concrete-prim, generic) rank by specificity
+// without relying on a non-transitive comparator: each ground call selects the arm
+// that accepts its argument, most-specific-first with declaration-order tiebreak.
+func TestInferOverloadThreeArmSpecificity(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(x) { x }
+		fn f(x: number) -> boolean { true }
+		fn f(x: string) -> string { x }
+		val p = f(5)
+		val q = f("hi")
+		val r = f(true)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "boolean", values["p"], "number arm")
+	require.Equal(t, "string", values["q"], "string arm")
+	require.Equal(t, "true", values["r"], "falls back to the generic arm")
+}
+
 // Resolution rollback (exercising the PR5 probe): the first-tried arm (string) is a
 // non-match for a number-bounded argument variable; its speculative `arg <: string`
 // upper bound must be rolled back, so after resolution the argument var carries ONLY

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -54,7 +54,17 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 	scope, _, errs := InferModule(module)
 	values = make(map[string]string, len(scope.values))
 	for name, b := range scope.values {
-		// PR1: every binding holds exactly one scheme; renderScheme adds the
+		if b.IsOverloaded() {
+			// PR6: an overload set renders as the intersection of its arms (declaration
+			// order), matching the value-position type of the overloaded name.
+			arms := make([]soltype.Type, len(b.Schemes))
+			for i, s := range b.Schemes {
+				arms[i] = schemeType(s)
+			}
+			values[name] = soltype.Print(&soltype.IntersectionType{Types: arms})
+			continue
+		}
+		// PR1: an ordinary binding holds exactly one scheme; renderScheme adds the
 		// <T0, …> quantifier prefix when generalization left type parameters behind.
 		values[name] = renderScheme(b.Schemes[0])
 	}
@@ -394,23 +404,22 @@ func TestInferModuleValInRecursiveGroupUsesRawType(t *testing.T) {
 	}, values)
 }
 
-// Repeated top-level functions of the same name are overloads, which M2 does not
-// represent (overload-intersection is M3). Rather than merge the arms into one
-// var — yielding an uncallable union-of-functions binding — M2 keeps the first
-// arm (so the binding stays callable with that signature) and reports each extra
-// arm with a clear diagnostic.
-func TestInferModuleFunctionOverloadNotSupported(t *testing.T) {
+// PR6: repeated top-level functions of the same name are an OVERLOAD SET. The
+// binding renders as the intersection of its arms, and a call resolves to the arm
+// whose parameter accepts the argument — f(5) picks the number arm, f("hi") the
+// string arm. (This replaces M2's interim OverloadNotSupportedError.)
+func TestInferModuleFunctionOverloadResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { x }
 		fn f(x: string) -> string { x }
 		val r = f(5)
+		val s = f("hi")
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Function overloads are not supported in M2: f", errs[0].Message())
-	// The first arm is kept, so f stays callable and the call to f(5) resolves.
+	require.Empty(t, errs)
 	require.Equal(t, map[string]string{
-		"f": "fn (x: number) -> number",
+		"f": "(fn (x: number) -> number) & (fn (x: string) -> string)",
 		"r": "number",
+		"s": "string",
 	}, values)
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -68,22 +68,23 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	})
 }
 
+// overloadArm is one collected arm of an overload set (PR6): a top-level FuncDecl's
+// raw inferred type plus whether its signature is fully annotated (the recursion
+// gate) and the decl itself (for per-arm Info recording in phase 3).
+type overloadArm struct {
+	decl      *ast.FuncDecl
+	t         soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
+	annotated bool
+}
+
 // componentBinding tracks the in-flight state of one value binding while its
 // strongly connected component is inferred.
 type componentBinding struct {
 	v       *soltype.TypeVarType    // this binding's fresh var; every definition of this name is constrained <: it
-	sources []provenance.Provenance // every contributing decl, in source order (primary + rejected overload/duplicate arms)
-	// primary is the first successfully-inferred decl under this key. M2 keeps it
-	// as THE definition and rejects every later arm, so one handle suffices: it is
-	// read in phase 3 to recover a VarDecl's Pattern for Info recording, and (via
-	// isVar) to tell an overload arm from a duplicate.
-	//
-	// M3 retires it. Once overloads are represented as an IntersectionType of the
-	// per-arm signatures (the overload-intersection representation noted in
-	// inferComponent's doc; see planning/intersection_types), arms are merged
-	// rather than discarded, so a single "primary" no longer captures the binding —
-	// the full arm set does, and `sources` already holds it. The phase-3 VarDecl
-	// pattern recording would then key off the lone value decl directly instead.
+	sources []provenance.Provenance // every contributing decl, in source order (primary + overload/duplicate arms)
+	// primary is the first successfully-inferred decl under this key — read in phase
+	// 3 to recover a VarDecl's Pattern (or a single FuncDecl's Name) for Info
+	// recording, and (via isVar) to tell an overload arm from a duplicate.
 	primary ast.Decl
 	bound   bool             // a definition was inferred and constrained
 	isVar   bool             // the primary definition is a `val`/`var`
@@ -94,6 +95,11 @@ type componentBinding struct {
 	// ErrorType rather than freezing an unbound var to `never` (which would cascade
 	// `<: never` at every later use). See PR8 / inferComponent phase 3.
 	recovered bool
+	// arms collects every top-level FuncDecl under this key (PR6). len <= 1 is an
+	// ordinary function (or a non-function binding, len == 0); len > 1 is an overload
+	// set, bound as a multi-scheme ValueBinding in phase 3. arms[i] lines up with the
+	// FuncDecl's entry in sources.
+	arms []overloadArm
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -119,6 +125,15 @@ func (c *checker) inferComponent(
 	component []dep_graph.BindingKey, handled set.Set[ast.Decl],
 ) {
 	inner := lvl + 1
+
+	// Recursion gate (PR6): an overloaded function in a mutually-recursive component
+	// (more than one binding) must have fully-annotated arms, since the overload set
+	// has to be ground before bodies are inferred — fixed-point iteration over
+	// overload choices is not guaranteed to converge under subtyping. The gate reports
+	// the offending participants and returns the set of keys to degrade to a single
+	// arm (so a later reference still resolves). Self-recursion (a singleton
+	// component) is softer and is not gated.
+	rejected := c.checkOverloadAnnotations(g, component)
 
 	// Phase 1: a fresh var per value binding, all defined before any body so a
 	// mutually-recursive reference resolves through the var. M2 only infers value
@@ -155,10 +170,9 @@ func (c *checker) inferComponent(
 			if !ok {
 				continue
 			}
-			// Accumulate every contributing decl's provenance — including the overload
-			// or duplicate arms rejected below — so a future multi-target
-			// go-to-definition can reach all of them. Only the primary's type is kept;
-			// M2 has no overload-merge (that is M3), so the extra arms still error.
+			// Accumulate every contributing decl's provenance — every overload arm and
+			// any duplicate arm — so a future multi-target go-to-definition can reach
+			// all of them. sources[i] lines up with the overload arm at arms[i].
 			b.sources = append(b.sources, src)
 			// PR8: a definition that is wholly the ErrorType recovery sentinel leaves no
 			// bound on the group var (ErrorType absorbs in constrain). Remember it so
@@ -166,6 +180,7 @@ func (c *checker) inferComponent(
 			if _, isErr := t.(*soltype.ErrorType); isErr {
 				b.recovered = true
 			}
+			fd, isFunc := d.(*ast.FuncDecl)
 			if !b.bound {
 				c.constrain(d, t, b.v)
 				b.primary = d
@@ -178,21 +193,20 @@ func (c *checker) inferComponent(
 				if isVarDecl {
 					b.kind = vd.Kind
 				}
+				// PR6: the first FuncDecl arm of a (possibly overloaded) function.
+				if isFunc {
+					b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
+				}
 				continue
 			}
-			// The binding already has its primary definition. A repeated FuncDecl is
-			// a top-level overload: M2 has no overload-intersection representation
-			// (that is M3), so it keeps the first arm — leaving the binding callable
-			// with that signature — and reports each extra arm, rather than merging
-			// the arms into the same var (which yields an uncallable union binding).
-			// Any other repeat — a duplicate `val`/`var`, or a decl redeclaring a
-			// variable binding — likewise keeps the first and reports.
-			if _, isFunc := d.(*ast.FuncDecl); isFunc && !b.isVar {
-				c.report(&OverloadNotSupportedError{
-					Decl:     d,
-					Previous: b.primary,
-					Name:     key.Name(),
-				})
+			// The binding already has its primary definition. A repeated FuncDecl is a
+			// top-level OVERLOAD (PR6): collect the arm (already inferred independently
+			// above) rather than rejecting it; phase 3 binds the full set as a
+			// multi-scheme overload binding. Any other repeat — a duplicate `val`/`var`,
+			// or a FuncDecl repeating a variable binding (a value cannot be overloaded) —
+			// keeps the first and reports.
+			if isFunc && !b.isVar {
+				b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
 				continue
 			}
 			c.report(&DuplicateDeclarationError{
@@ -233,10 +247,31 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
+		// Overload set (PR6): a name with more than one FuncDecl arm, unless the
+		// recursion gate rejected it (a mutually-recursive unannotated overload, which
+		// degrades to its first arm below). Generalize each arm into its own scheme and
+		// bind the name to the multi-scheme overload set (b.IsOverloaded()); record each
+		// arm's display type on its own FuncDecl name for Info.
+		if len(b.arms) > 1 && !rejected.Contains(key) {
+			schemes := make([]TypeScheme, len(b.arms))
+			for i, arm := range b.arms {
+				sc := c.generalize(arm.t, lvl)
+				if ps, ok := sc.(*PolyScheme); ok {
+					ps.Annotated = arm.annotated
+				}
+				schemes[i] = sc
+				if arm.decl.Name != nil {
+					c.recordType(arm.decl.Name, schemeType(sc))
+				}
+			}
+			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: b.sources})
+			continue
+		}
 		// Generalize the group var at the component's level (was: coalesce to a
 		// monotype). Every variable at Level > lvl becomes a quantified type
 		// parameter, captured outer variables do not — turning M2's monomorphic
-		// freeze into real let-polymorphism (PR1).
+		// freeze into real let-polymorphism (PR1). A rejected overload degrades here to
+		// its first arm: b.v carries only the primary (first arm) definition.
 		//
 		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
 		// group var with no bound (ErrorType absorbs in constrain), so generalizing it
@@ -272,4 +307,42 @@ func (c *checker) inferComponent(
 			}
 		}
 	}
+}
+
+// checkOverloadAnnotations enforces the PR6 recursion gate and returns the set of
+// overloaded keys that failed it (to be degraded to their first arm in phase 3). A
+// singleton component is never gated — self-recursion is softer — so only a
+// genuinely mutually-recursive group (more than one binding) requires its overloaded
+// members to have fully-annotated arms. For each overloaded member whose arms are
+// not all annotated, it reports an UnannotatedRecursiveOverloadError blaming the
+// first unannotated arm.
+func (c *checker) checkOverloadAnnotations(
+	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
+) set.Set[dep_graph.BindingKey] {
+	rejected := set.NewSet[dep_graph.BindingKey]()
+	if len(component) <= 1 {
+		return rejected // self-recursion is softer; only mutual recursion is gated
+	}
+	for _, key := range component {
+		if key.Kind() != dep_graph.DepKindValue {
+			continue
+		}
+		var funcs []*ast.FuncDecl
+		for _, d := range g.GetDecls(key) {
+			if fd, ok := d.(*ast.FuncDecl); ok {
+				funcs = append(funcs, fd)
+			}
+		}
+		if len(funcs) <= 1 {
+			continue // not an overload set
+		}
+		for _, fd := range funcs {
+			if !isFullyAnnotated(fd.FuncSig) {
+				c.report(&UnannotatedRecursiveOverloadError{Decl: fd, Name: key.Name()})
+				rejected.Add(key)
+				break // one diagnostic per overloaded binding (blame the first gap)
+			}
+		}
+	}
+	return rejected
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -100,6 +100,15 @@ type componentBinding struct {
 	// set, bound as a multi-scheme ValueBinding in phase 3. arms[i] lines up with the
 	// FuncDecl's entry in sources.
 	arms []overloadArm
+	// prebound marks an overload set whose arms are ALL fully annotated, so phase 1
+	// could build their signatures (body-free) and pre-bind the whole set in scope
+	// (b.arms holds the signature types). References WITHIN the component — recursive
+	// calls and value captures — then resolve against the set rather than a single
+	// first-arm var; phase 2 only checks each arm's body. An overload with any
+	// un-annotated arm cannot be pre-bound (its signature isn't known without inferring
+	// the body), so it stays on the ordinary group-var path and cannot be mutually
+	// recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
+	prebound bool
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -143,6 +152,33 @@ func (c *checker) inferComponent(
 		if key.Kind() != dep_graph.DepKindValue {
 			continue
 		}
+		// PR6: a fully-annotated overload set is pre-bound to the whole SET, built from
+		// arm signatures alone (body-free), so references within the component resolve
+		// against every arm via resolveOverload instead of seeing only a single
+		// first-arm group var (which would make a recursive arm — or a value capture —
+		// type-check against the wrong overload). The recursion gate guarantees a
+		// mutually-recursive overload IS fully annotated, so this is exactly the set it
+		// requires to be ground before bodies are inferred.
+		if !rejected.Contains(key) {
+			if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
+				arms := make([]overloadArm, len(armDecls))
+				schemes := make([]TypeScheme, len(armDecls))
+				for i, fd := range armDecls {
+					// Build the signature body-free under a discarded probe: the arm is fully
+					// annotated, so the signature is concrete (no bounds to roll back), and
+					// discarding keeps phase 2's inferFunc — which re-derives the signature
+					// while checking the body — the single reporter of any signature error.
+					p := c.openProbe()
+					sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd)
+					c.closeProbe(p, false)
+					arms[i] = overloadArm{decl: fd, t: sig, annotated: true}
+					schemes[i] = monoScheme(sig)
+				}
+				bindings[key] = &componentBinding{arms: arms, bound: true, prebound: true}
+				scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
+				continue
+			}
+		}
 		v := c.freshAt(inner)
 		bindings[key] = &componentBinding{v: v}
 		// Pre-bind the group var as a MonoScheme so a mutually-recursive reference
@@ -156,6 +192,19 @@ func (c *checker) inferComponent(
 		b, isValue := bindings[key]
 		if !isValue {
 			continue // non-value keys handled below
+		}
+		if b.prebound {
+			// The signatures are already bound (phase 1); only check each arm's body. The
+			// body sees the whole overload set, so a recursive call resolves through
+			// resolveOverload against every arm. inferFunc re-derives the (concrete)
+			// signature and constrains the body against the return annotation, reporting
+			// any body error exactly once.
+			for _, arm := range b.arms {
+				handled.Add(arm.decl)
+				b.sources = append(b.sources, &ast.NodeProvenance{Node: arm.decl})
+				c.inferFunc(scope, inner, arm.decl.FuncSig, arm.decl.Body, arm.decl)
+			}
+			continue
 		}
 		for _, d := range g.GetDecls(key) {
 			if handled.Contains(d) {
@@ -345,4 +394,34 @@ func (c *checker) checkOverloadAnnotations(
 		}
 	}
 	return rejected
+}
+
+// annotatedOverloadArms returns key's FuncDecls when it is a pure function-overload
+// set that can be PRE-BOUND from signatures alone (PR6): more than one FuncDecl, NO
+// `val`/`var` mixed under the name (a value cannot be overloaded), and every arm fully
+// annotated (so its signature is known without inferring the body). Returns nil
+// otherwise — those keys take the ordinary group-var path, where each arm is inferred
+// independently and the set is assembled in phase 3.
+func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
+	if key.Kind() != dep_graph.DepKindValue {
+		return nil
+	}
+	decls := g.GetDecls(key)
+	funcs := make([]*ast.FuncDecl, 0, len(decls))
+	for _, d := range decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok {
+			return nil // a val/var shares this name: not a pure overload set
+		}
+		funcs = append(funcs, fd)
+	}
+	if len(funcs) <= 1 {
+		return nil // not an overload set
+	}
+	for _, fd := range funcs {
+		if !isFullyAnnotated(fd.FuncSig) {
+			return nil // an un-annotated arm can't be pre-bound from its signature
+		}
+	}
+	return funcs
 }

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -301,19 +301,26 @@ func (c *checker) inferComponent(
 		// degrades to its first arm below). Generalize each arm into its own scheme and
 		// bind the name to the multi-scheme overload set (b.IsOverloaded()); record each
 		// arm's display type on its own FuncDecl name for Info.
+		//
+		// Sources is built from the arms here (not b.sources), so Schemes[i], the arm at
+		// arms[i], and Sources[i] all line up — b.sources also carries any rejected
+		// duplicate-declaration decls, which would desync the per-scheme index a
+		// multi-target go-to-definition relies on.
 		if len(b.arms) > 1 && !rejected.Contains(key) {
 			schemes := make([]TypeScheme, len(b.arms))
+			srcs := make([]provenance.Provenance, len(b.arms))
 			for i, arm := range b.arms {
 				sc := c.generalize(arm.t, lvl)
 				if ps, ok := sc.(*PolyScheme); ok {
 					ps.Annotated = arm.annotated
 				}
 				schemes[i] = sc
+				srcs[i] = &ast.NodeProvenance{Node: arm.decl}
 				if arm.decl.Name != nil {
 					c.recordType(arm.decl.Name, schemeType(sc))
 				}
 			}
-			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: b.sources})
+			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: srcs})
 			continue
 		}
 		// Generalize the group var at the component's level (was: coalesce to a
@@ -373,17 +380,9 @@ func (c *checker) checkOverloadAnnotations(
 		return rejected // self-recursion is softer; only mutual recursion is gated
 	}
 	for _, key := range component {
-		if key.Kind() != dep_graph.DepKindValue {
-			continue
-		}
-		var funcs []*ast.FuncDecl
-		for _, d := range g.GetDecls(key) {
-			if fd, ok := d.(*ast.FuncDecl); ok {
-				funcs = append(funcs, fd)
-			}
-		}
+		funcs := pureFuncOverloadDecls(g, key)
 		if len(funcs) <= 1 {
-			continue // not an overload set
+			continue // not an overload set (a mixed val/var name is a duplicate, not gated here)
 		}
 		for _, fd := range funcs {
 			if !isFullyAnnotated(fd.FuncSig) {
@@ -396,13 +395,12 @@ func (c *checker) checkOverloadAnnotations(
 	return rejected
 }
 
-// annotatedOverloadArms returns key's FuncDecls when it is a pure function-overload
-// set that can be PRE-BOUND from signatures alone (PR6): more than one FuncDecl, NO
-// `val`/`var` mixed under the name (a value cannot be overloaded), and every arm fully
-// annotated (so its signature is known without inferring the body). Returns nil
-// otherwise — those keys take the ordinary group-var path, where each arm is inferred
-// independently and the set is assembled in phase 3.
-func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
+// pureFuncOverloadDecls returns the FuncDecls bound to key when the name is bound
+// ONLY by FuncDecls (a candidate overload set — the slice may have length 1), or nil
+// when a `val`/`var` shares the name (then it is a duplicate-declaration situation,
+// not an overload). Shared by the recursion gate and annotatedOverloadArms so both
+// classify a name as an overload set the same way.
+func pureFuncOverloadDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil
 	}
@@ -415,6 +413,17 @@ func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*a
 		}
 		funcs = append(funcs, fd)
 	}
+	return funcs
+}
+
+// annotatedOverloadArms returns key's FuncDecls when it is a pure function-overload
+// set that can be PRE-BOUND from signatures alone (PR6): more than one FuncDecl, NO
+// `val`/`var` mixed under the name, and every arm fully annotated (so its signature
+// is known without inferring the body). Returns nil otherwise — those keys take the
+// ordinary group-var path, where each arm is inferred independently and the set is
+// assembled in phase 3.
+func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
+	funcs := pureFuncOverloadDecls(g, key)
 	if len(funcs) <= 1 {
 		return nil // not an overload set
 	}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"sort"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/provenance"
@@ -19,8 +21,8 @@ import (
 // recurses with another decl, now infers correctly because BuildDepGraph
 // topologically orders the strongly connected components and inferComponent makes
 // every member of a group visible before inferring any of their bodies.
-// Inference is MONOMORPHIC — M1 ships no schemes, so a group's vars stay as their
-// coalesced monomorphic types; the generalization that yields <T0> rendering is
+// Inference is MONOMORPHIC — M1 ships no schemes, so each binding's var stays as its
+// coalesced monomorphic type; the generalization that yields <T0> rendering is
 // M3.
 //
 // Multi-file (PR-6) needs no separate entry point: parser.ParseLibFiles already
@@ -51,7 +53,7 @@ func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph) {
 	handled := set.NewSet[ast.Decl]()
 	for _, component := range g.Components {
-		c.inferComponent(scope, lvl, g, component, handled)
+		c.inferComponent(scope, lvl, module, g, component, handled)
 	}
 	// Reconcile against the source: BuildDepGraph only produces binding keys for
 	// the decl kinds it models, so a kind it does not descend into — e.g. a
@@ -84,14 +86,16 @@ type componentBinding struct {
 	sources []provenance.Provenance // every contributing decl, in source order (primary + overload/duplicate arms)
 	// primary is the first successfully-inferred decl under this key — read in phase
 	// 3 to recover a VarDecl's Pattern (or a single FuncDecl's Name) for Info
-	// recording, and (via isVar) to tell an overload arm from a duplicate.
+	// recording, and (via isVarDecl) to tell an overload arm from a duplicate.
 	primary ast.Decl
-	bound   bool             // a definition was inferred and constrained
-	isVar   bool             // the primary definition is a `val`/`var`
-	kind    ast.VariableKind // PR8: the primary definition's kind — VarKind ⇒ reassignable
+	bound   bool // a definition was inferred and constrained
+	// isVarDecl reports whether the primary decl is a VarDecl, i.e. a `val` or a `var`
+	// rather than a function. It is NOT the `var`-vs-`val` distinction — that is kind.
+	isVarDecl bool
+	kind      ast.VariableKind // PR8: the primary definition's kind — VarKind ⇒ reassignable
 	// recovered marks that a contributing definition was WHOLLY the ErrorType recovery
 	// sentinel (e.g. `val a = <unknown ident>`). ErrorType absorbs in constrain, so it
-	// leaves no bound on the group var; phase 3 uses this to recover the binding AS
+	// leaves no bound on the binding var; phase 3 uses this to recover the binding AS
 	// ErrorType rather than freezing an unbound var to `never` (which would cascade
 	// `<: never` at every later use). See PR8 / inferComponent phase 3.
 	recovered bool
@@ -100,15 +104,15 @@ type componentBinding struct {
 	// set, bound as a multi-scheme ValueBinding in phase 3. arms[i] lines up with the
 	// FuncDecl's entry in sources.
 	arms []overloadArm
-	// prebound marks an overload set whose arms are ALL fully annotated, so phase 1
-	// could build their signatures (body-free) and pre-bind the whole set in scope
+	// signatureBound marks an overload set whose arms are ALL fully annotated, so phase
+	// 1 could build their signatures (body-free) and pre-bind the whole set in scope
 	// (b.arms holds the signature types). References WITHIN the component — recursive
 	// calls and value captures — then resolve against the set rather than a single
 	// first-arm var; phase 2 only checks each arm's body. An overload with any
-	// un-annotated arm cannot be pre-bound (its signature isn't known without inferring
-	// the body), so it stays on the ordinary group-var path and cannot be mutually
-	// recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
-	prebound bool
+	// un-annotated arm cannot be signature-bound (its signature isn't known without
+	// inferring the body), so it stays on the ordinary group-var path and cannot be
+	// mutually recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
+	signatureBound bool
 }
 
 // inferComponent infers one strongly connected component — a group of
@@ -130,7 +134,7 @@ type componentBinding struct {
 // rendering — is M3. M2's contribution is correct ordering and recursive
 // resolution.
 func (c *checker) inferComponent(
-	scope *Scope, lvl int, g *dep_graph.DepGraph,
+	scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph,
 	component []dep_graph.BindingKey, handled set.Set[ast.Decl],
 ) {
 	inner := lvl + 1
@@ -155,12 +159,13 @@ func (c *checker) inferComponent(
 		// PR6: a fully-annotated overload set is pre-bound to the whole SET, built from
 		// arm signatures alone (body-free), so references within the component resolve
 		// against every arm via resolveOverload instead of seeing only a single
-		// first-arm group var (which would make a recursive arm — or a value capture —
+		// first-arm binding var (which would make a recursive arm — or a value capture —
 		// type-check against the wrong overload). The recursion gate guarantees a
 		// mutually-recursive overload IS fully annotated, so this is exactly the set it
 		// requires to be ground before bodies are inferred.
 		if !rejected.Contains(key) {
 			if armDecls := annotatedOverloadArms(g, key); armDecls != nil {
+				sortArmDecls(module, armDecls)
 				arms := make([]overloadArm, len(armDecls))
 				schemes := make([]TypeScheme, len(armDecls))
 				for i, fd := range armDecls {
@@ -174,14 +179,14 @@ func (c *checker) inferComponent(
 					arms[i] = overloadArm{decl: fd, t: sig, annotated: true}
 					schemes[i] = monoScheme(sig)
 				}
-				bindings[key] = &componentBinding{arms: arms, bound: true, prebound: true}
+				bindings[key] = &componentBinding{arms: arms, bound: true, signatureBound: true}
 				scope.defineValue(key.Name(), ValueBinding{Schemes: schemes})
 				continue
 			}
 		}
 		v := c.freshAt(inner)
 		bindings[key] = &componentBinding{v: v}
-		// Pre-bind the group var as a MonoScheme so a mutually-recursive reference
+		// Pre-bind the binding var as a MonoScheme so a mutually-recursive reference
 		// resolves through the var itself (instantiate returns it unchanged) before
 		// generalization happens in phase 3.
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{monoScheme(v)}})
@@ -193,12 +198,13 @@ func (c *checker) inferComponent(
 		if !isValue {
 			continue // non-value keys handled below
 		}
-		if b.prebound {
-			// The signatures are already bound (phase 1); only check each arm's body. The
-			// body sees the whole overload set, so a recursive call resolves through
-			// resolveOverload against every arm. inferFunc re-derives the (concrete)
-			// signature and constrains the body against the return annotation, reporting
-			// any body error exactly once.
+		if b.signatureBound {
+			// The schemes are already bound in scope from phase 1, so phase 2 does not
+			// re-bind them; it re-infers each arm with its body. inferFunc re-derives the
+			// signature and checks the body against the return annotation. Phase 1 discarded
+			// its signature errors under a probe, so this pass is the single reporter of BOTH
+			// the signature and the body errors. The body sees the whole overload set, so a
+			// recursive call resolves through resolveOverload against every arm.
 			for _, arm := range b.arms {
 				handled.Add(arm.decl)
 				b.sources = append(b.sources, &ast.NodeProvenance{Node: arm.decl})
@@ -219,12 +225,19 @@ func (c *checker) inferComponent(
 			if !ok {
 				continue
 			}
-			// Accumulate every contributing decl's provenance — every overload arm and
-			// any duplicate arm — so a future multi-target go-to-definition can reach
-			// all of them. sources[i] lines up with the overload arm at arms[i].
+			// Accumulate every contributing decl's provenance in encounter order: the
+			// primary, every overload arm, and every decl later rejected as a duplicate.
+			// This append is unconditional, so a duplicate lands here even though it is NOT
+			// added to arms. b.sources can therefore DESYNC from arms when a duplicate
+			// interleaves: `fn f; val f; fn f` yields sources [fn, val, fn] against arms
+			// [fn, fn]. So do NOT index b.sources by arm position. Today only Sources[0],
+			// the primary decl, is ever read, by bindingDecl; phase 3's overload branch
+			// rebuilds its per-scheme sources from arms rather than from this list. The full
+			// list is kept only for a future multi-target go-to-definition that wants to
+			// reach every contributing decl, duplicates included.
 			b.sources = append(b.sources, src)
 			// PR8: a definition that is wholly the ErrorType recovery sentinel leaves no
-			// bound on the group var (ErrorType absorbs in constrain). Remember it so
+			// bound on the binding var (ErrorType absorbs in constrain). Remember it so
 			// phase 3 can recover the binding as ErrorType instead of `never`.
 			if _, isErr := t.(*soltype.ErrorType); isErr {
 				b.recovered = true
@@ -235,26 +248,28 @@ func (c *checker) inferComponent(
 				b.primary = d
 				b.bound = true
 				vd, isVarDecl := d.(*ast.VarDecl)
-				b.isVar = isVarDecl
+				b.isVarDecl = isVarDecl
 				// PR8: carry the decl's kind so phase 3 can gate reassignment — a top-level
 				// `var` is reassignable (e.g. from a function body that closes over it);
 				// a `val`/`fn` is not. A FuncDecl leaves kind at its ValKind zero value.
 				if isVarDecl {
 					b.kind = vd.Kind
 				}
-				// PR6: the first FuncDecl arm of a (possibly overloaded) function.
+				// PR6: when the primary decl is a function, record it as the first arm. If
+				// more FuncDecls follow under this name it becomes an overload set; otherwise
+				// it stays a lone function.
 				if isFunc {
 					b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
 				}
 				continue
 			}
-			// The binding already has its primary definition. A repeated FuncDecl is a
-			// top-level OVERLOAD (PR6): collect the arm (already inferred independently
-			// above) rather than rejecting it; phase 3 binds the full set as a
-			// multi-scheme overload binding. Any other repeat — a duplicate `val`/`var`,
-			// or a FuncDecl repeating a variable binding (a value cannot be overloaded) —
-			// keeps the first and reports.
-			if isFunc && !b.isVar {
+			// Past the first decl, the binding already has its primary definition. PR6
+			// treats a repeated FuncDecl as another overload arm. It was already inferred
+			// independently above, so collect it and let phase 3 bind the full set as a
+			// multi-scheme overload binding. Every other repeat keeps the first decl and
+			// reports a duplicate — a second `val`/`var`, or a FuncDecl colliding with a
+			// variable binding, since a value cannot be overloaded.
+			if isFunc && !b.isVarDecl {
 				b.arms = append(b.arms, overloadArm{decl: fd, t: t, annotated: isFullyAnnotated(fd.FuncSig)})
 				continue
 			}
@@ -296,17 +311,51 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
-		// Overload set (PR6): a name with more than one FuncDecl arm, unless the
-		// recursion gate rejected it (a mutually-recursive unannotated overload, which
-		// degrades to its first arm below). Generalize each arm into its own scheme and
-		// bind the name to the multi-scheme overload set (b.IsOverloaded()); record each
-		// arm's display type on its own FuncDecl name for Info.
+		// A PR6 overload set is a name with more than one FuncDecl arm. This branch binds
+		// such a set when the recursion gate did not reject it. A rejected set is a
+		// mutually-recursive unannotated overload. It is excluded here and degrades to its
+		// first arm below.
 		//
-		// Sources is built from the arms here (not b.sources), so Schemes[i], the arm at
-		// arms[i], and Sources[i] all line up — b.sources also carries any rejected
-		// duplicate-declaration decls, which would desync the per-scheme index a
-		// multi-target go-to-definition relies on.
+		// Binding an accepted set takes four steps, each detailed at its block below:
+		//
+		//  1. sort the arms into source-position order;
+		//  2. reject any two arms with indistinguishable parameter types;
+		//  3. generalize each arm into its own scheme and record its display type for Info;
+		//  4. bind the name to the multi-scheme overload set that b.IsOverloaded() detects.
+		//
+		// Sources is built from the arms here rather than from b.sources, so Schemes[i],
+		// the arm at arms[i], and Sources[i] all line up. b.sources also carries any
+		// rejected duplicate-declaration decls, which would desync the per-scheme index
+		// that a multi-target go-to-definition relies on.
 		if len(b.arms) > 1 && !rejected.Contains(key) {
+			// A signature-bound set was already sorted in phase 1, so this stable re-sort is
+			// a no-op for it. It also orders the ordinary group-var path's arms the same way.
+			sortArms(module, b.arms)
+			// An overload set compiles to a single runtime function that dispatches on
+			// argument types, so two arms accepting exactly the same arguments cannot be told
+			// apart at codegen. Report a DuplicateOverloadError on each such arm, pointing at
+			// the earlier arm it duplicates. The set is still bound below, a best-effort
+			// recovery so later references and value-position use still resolve.
+			for i := range b.arms {
+				fi, ok := b.arms[i].t.(*soltype.FuncType)
+				if !ok {
+					continue
+				}
+				for j := range i {
+					fj, ok := b.arms[j].t.(*soltype.FuncType)
+					if !ok {
+						continue
+					}
+					if equallySpecific(fj, fi) {
+						c.report(&DuplicateOverloadError{
+							Decl:     b.arms[i].decl,
+							Previous: b.arms[j].decl,
+							Name:     key.Name(),
+						})
+						break
+					}
+				}
+			}
 			schemes := make([]TypeScheme, len(b.arms))
 			srcs := make([]provenance.Provenance, len(b.arms))
 			for i, arm := range b.arms {
@@ -323,18 +372,18 @@ func (c *checker) inferComponent(
 			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: srcs})
 			continue
 		}
-		// Generalize the group var at the component's level (was: coalesce to a
+		// Generalize the binding var at the component's level (was: coalesce to a
 		// monotype). Every variable at Level > lvl becomes a quantified type
 		// parameter, captured outer variables do not — turning M2's monomorphic
 		// freeze into real let-polymorphism (PR1). A rejected overload degrades here to
 		// its first arm: b.v carries only the primary (first arm) definition.
 		//
 		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
-		// group var with no bound (ErrorType absorbs in constrain), so generalizing it
+		// binding var with no bound (ErrorType absorbs in constrain), so generalizing it
 		// would freeze the binding to `never` and cascade `<: never` at every later use
 		// (a reassignment, a call arg, …). Recover it AS the error sentinel instead,
 		// matching the body-level path (inferVarDecl) and keeping downstream uses
-		// absorbing. Guarded by an empty group var so a binding that ALSO picked up a
+		// absorbing. Guarded by an empty binding var so a binding that ALSO picked up a
 		// real type (a recovered overload arm alongside a good one) still generalizes.
 		var scheme TypeScheme
 		if b.recovered && len(b.v.LowerBounds) == 0 {
@@ -365,13 +414,13 @@ func (c *checker) inferComponent(
 	}
 }
 
-// checkOverloadAnnotations enforces the PR6 recursion gate and returns the set of
-// overloaded keys that failed it (to be degraded to their first arm in phase 3). A
-// singleton component is never gated — self-recursion is softer — so only a
-// genuinely mutually-recursive group (more than one binding) requires its overloaded
-// members to have fully-annotated arms. For each overloaded member whose arms are
-// not all annotated, it reports an UnannotatedRecursiveOverloadError blaming the
-// first unannotated arm.
+// checkOverloadAnnotations enforces the PR6 recursion gate. It returns the set of
+// overloaded keys that failed the gate; phase 3 degrades each of them to its first arm.
+// A singleton component is never gated, since self-recursion is softer. Only a
+// genuinely mutually-recursive group of more than one binding requires its overloaded
+// members to have fully-annotated arms. For each overloaded member whose arms are not
+// all annotated, it reports an UnannotatedRecursiveOverloadError blaming the first
+// unannotated arm.
 func (c *checker) checkOverloadAnnotations(
 	g *dep_graph.DepGraph, component []dep_graph.BindingKey,
 ) set.Set[dep_graph.BindingKey] {
@@ -380,7 +429,7 @@ func (c *checker) checkOverloadAnnotations(
 		return rejected // self-recursion is softer; only mutual recursion is gated
 	}
 	for _, key := range component {
-		funcs := pureFuncOverloadDecls(g, key)
+		funcs := funcOnlyDecls(g, key)
 		if len(funcs) <= 1 {
 			continue // not an overload set (a mixed val/var name is a duplicate, not gated here)
 		}
@@ -395,12 +444,13 @@ func (c *checker) checkOverloadAnnotations(
 	return rejected
 }
 
-// pureFuncOverloadDecls returns the FuncDecls bound to key when the name is bound
-// ONLY by FuncDecls (a candidate overload set — the slice may have length 1), or nil
-// when a `val`/`var` shares the name (then it is a duplicate-declaration situation,
-// not an overload). Shared by the recursion gate and annotatedOverloadArms so both
-// classify a name as an overload set the same way.
-func pureFuncOverloadDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
+// funcOnlyDecls returns the FuncDecls bound to key when the name is bound ONLY by
+// FuncDecls, or nil when any `val`/`var` shares the name. A func-only result is a
+// candidate overload set. Its slice may have length 1, so it is not necessarily an
+// overload yet. A mixed result is nil because the clash is a duplicate declaration, not
+// an overload. Shared by the recursion gate and annotatedOverloadArms so both classify
+// a name the same way.
+func funcOnlyDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil
 	}
@@ -409,21 +459,21 @@ func pureFuncOverloadDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*a
 	for _, d := range decls {
 		fd, ok := d.(*ast.FuncDecl)
 		if !ok {
-			return nil // a val/var shares this name: not a pure overload set
+			return nil // a val/var shares this name: the key is not function-only
 		}
 		funcs = append(funcs, fd)
 	}
 	return funcs
 }
 
-// annotatedOverloadArms returns key's FuncDecls when it is a pure function-overload
+// annotatedOverloadArms returns key's FuncDecls when it is a function-only overload
 // set that can be PRE-BOUND from signatures alone (PR6): more than one FuncDecl, NO
 // `val`/`var` mixed under the name, and every arm fully annotated (so its signature
 // is known without inferring the body). Returns nil otherwise — those keys take the
 // ordinary group-var path, where each arm is inferred independently and the set is
 // assembled in phase 3.
 func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncDecl {
-	funcs := pureFuncOverloadDecls(g, key)
+	funcs := funcOnlyDecls(g, key)
 	if len(funcs) <= 1 {
 		return nil // not an overload set
 	}
@@ -433,4 +483,41 @@ func annotatedOverloadArms(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*a
 		}
 	}
 	return funcs
+}
+
+// armPosLess orders two overload arms by SOURCE POSITION: file path (alphabetical),
+// then line, then column. This is the canonical "declaration order" the overload
+// resolver falls back to when specificity is a tie (see overload.go) — pinned to
+// position rather than to the order sources happened to reach the parser, so a name
+// whose arms span several files in a lib/ resolves as "first matching arm, reading
+// top-to-bottom, file by file alphabetically". module maps a Span's SourceID back to
+// its path; arms within one file compare by line then column.
+func armPosLess(module *ast.Module, a, b *ast.FuncDecl) bool {
+	as, bs := a.Span(), b.Span()
+	ap, bp := module.GetSourcePath(as.SourceID), module.GetSourcePath(bs.SourceID)
+	if ap != bp {
+		return ap < bp
+	}
+	if as.Start.Line != bs.Start.Line {
+		return as.Start.Line < bs.Start.Line
+	}
+	return as.Start.Column < bs.Start.Column
+}
+
+// sortArmDecls stable-sorts overload arm declarations into source-position order
+// (armPosLess). Used in phase 1 to order a signature-bound set's signatures so recursive
+// resolution within the component matches the final exported order.
+func sortArmDecls(module *ast.Module, decls []*ast.FuncDecl) {
+	sort.SliceStable(decls, func(i, j int) bool {
+		return armPosLess(module, decls[i], decls[j])
+	})
+}
+
+// sortArms stable-sorts collected overload arms into source-position order
+// (armPosLess), keeping each arm's scheme/source/Info index aligned. Used in phase 3
+// before the multi-scheme binding is assembled.
+func sortArms(module *ast.Module, arms []overloadArm) {
+	sort.SliceStable(arms, func(i, j int) bool {
+		return armPosLess(module, arms[i].decl, arms[j].decl)
+	})
 }

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -9,11 +9,10 @@ import (
 )
 
 // Overload resolution, introduced in PR6. A name with more than one top-level FuncDecl
-// is an overload set. Its ValueBinding carries one TypeScheme per arm, which is what
-// b.IsOverloaded() reports, ordered by source position. armPosLess in module.go defines
-// that order as file path, then line, then column. A set whose arms span several files
-// in a lib/ therefore reads top-to-bottom, file by file alphabetically, independent of
-// the order sources reached the parser.
+// is an overload set. Its ValueBinding carries one TypeScheme per arm ordered by source
+// position. armPosLess in module.go defines that order as file path, then line, then column.
+// A set whose arms span several files in a lib/ therefore reads top-to-bottom, file by
+// file alphabetically, independent of the order sources reached the parser.
 //
 // Resolution is a phase distinct from constrain. The disjunction "callable in several
 // ways" stays out of the subtype lattice. It is driven by the PR5 probe. Each candidate
@@ -34,7 +33,7 @@ import (
 // When an argument is still a fully-unconstrained variable, the call cannot rank arms
 // confidently, so resolution defers to plain declaration-order first-match. This is the
 // documented MVP fallback, with no speculative pinning and backtracking. The first arm
-// whose argument constraints succeed wins. Its bounds commit and the rest roll back.
+// whose argument constraints succeed wins. Its bounds are committed and the rest roll back.
 
 // resolveOverload picks one arm of the overload set b for the call and returns that
 // arm's instantiated return type. It commits the winning arm's argument constraints and
@@ -118,15 +117,25 @@ func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int
 }
 
 // specificityOrder returns funcs' indices most-specific-first, with declaration order
-// breaking ties. It ranks each arm by its domination count, the number of other arms
-// strictly more specific than it, and sorts ascending on that count.
+// breaking ties. It ranks each arm by its DOMINATION COUNT — the number of other arms
+// strictly more specific than it, i.e. that "dominate" it — and sorts ascending on that
+// count, so an arm dominated by nobody comes first and the generic catch-all that every
+// other arm beats comes last.
 //
-// This is the load-bearing fix for the partial-order sort hazard. The moreSpecific
-// relation is only a partial order, so feeding it straight to sort.SliceStable would
-// violate the strict-weak-ordering contract, because incomparability is non-transitive.
-// The domination count is a total order on integers, so the sort is well-defined. An arm
-// dominated by none gets count 0 and sorts first. Equal counts keep declaration order
-// through the stable sort.
+// For example, given arms (x: number), (x: T), and (x: string): each concrete arm is
+// dominated by nobody (number and string are incomparable), so both get count 0; the
+// generic (x: T) is dominated by both, count 2. Ascending order is therefore number,
+// string, T — the concretes first (their tie kept in declaration order), the generic last.
+//
+// The domination count exists to dodge a partial-order sort hazard. The moreSpecific
+// relation is only a partial order: some arm pairs are incomparable (the tie cases —
+// different literal tags, disjoint shapes, different arities), and incomparability is not
+// transitive (A incomparable to B and B to C does not make A incomparable to C). Feeding
+// moreSpecific straight to sort.SliceStable would therefore violate the strict-weak-ordering
+// contract and yield undefined results. Projecting each arm onto its integer domination
+// count yields a TOTAL order on integers, so the sort is well-defined. An arm dominated by
+// none gets count 0 and sorts first; equal counts keep declaration order through the
+// stable sort.
 //
 // overloadOrder uses this for direct calls and constrain's IntersectionType arm uses it
 // for value-position calls, so both resolve in the same order. A nil entry is a
@@ -157,21 +166,14 @@ func specificityOrder(funcs []*soltype.FuncType) []int {
 	return order
 }
 
-// hasUnconstrainedArg reports whether any call argument is a fully-unconstrained
-// inference variable, a bare var with no bounds in either direction. Such an argument
-// carries no type information to rank overloads by. A literal, a concrete type, or a var
-// already pinned by some bound is fine. An untouched parameter var is not, so its
-// presence makes the call fall back to declaration-order first-match. That fallback
-// over-narrows the enclosing function, since it pins the arg to the first arm. The real
-// fix is to defer resolution until the arg is grounded, tracked in #723.
+// hasUnconstrainedArg reports whether any top-level call argument is a fully-unconstrained
+// inference variable — a bare var with no bounds either way, which carries no type
+// information to rank overloads by. overloadOrder treats a true result as "can't rank the
+// arms" and falls back to declaration order (see there and #723).
 //
-// The check is intentionally shallow and looks at top-level args only. A structural
-// argument that merely WRAPS an unconstrained var does NOT count, for example a tuple,
-// record, or func holding a bare var. That is harmless, because such a compound never
-// disambiguates overloads under the specificity comparator. structuralSubtype returns
-// false for compound shapes, so they rank as a tie and the order collapses to
-// declaration order, exactly what this fallback would produce. Recursing would only
-// defer more calls with no change in the resolved arm.
+// The check is shallow by design: a compound that merely WRAPS a bare var (a tuple,
+// record, or func) doesn't count, since structuralSubtype ranks such shapes as a tie and
+// the order collapses to declaration order anyway.
 func hasUnconstrainedArg(args []soltype.Type) bool {
 	return slices.ContainsFunc(args, isUnconstrainedVar)
 }
@@ -212,11 +214,17 @@ func moreSpecific(a, b *soltype.FuncType) int {
 	}
 	aSubB, bSubA := true, true
 	for i := range a.Params {
-		if !structuralSubtype(a.Params[i].Type, b.Params[i].Type) {
+		// Each flag is monotonic (only ever flips true→false), so guard its call: once a
+		// direction is broken, further structuralSubtype calls for it are wasted. When BOTH
+		// are broken the result is already a 0 tie, so stop early.
+		if aSubB && !structuralSubtype(a.Params[i].Type, b.Params[i].Type) {
 			aSubB = false
 		}
-		if !structuralSubtype(b.Params[i].Type, a.Params[i].Type) {
+		if bSubA && !structuralSubtype(b.Params[i].Type, a.Params[i].Type) {
 			bSubA = false
+		}
+		if !aSubB && !bSubA {
+			return 0
 		}
 	}
 	if aSubB && !bSubA {
@@ -228,15 +236,15 @@ func moreSpecific(a, b *soltype.FuncType) int {
 	return 0
 }
 
-// equallySpecific reports whether two arms are INDISTINGUISHABLE for overload dispatch.
-// They share an arity and each parameter is a structural subtype of its counterpart in
-// BOTH directions, so neither arm is more specific and no argument could ever select one
-// over the other. This is a strict subset of moreSpecific's tie result, the 0 case,
-// which ALSO covers incomparable arms of disjoint shape such as number versus string
-// that a call CAN still tell apart. Two type-variable params count as equal, since
-// structuralSubtype treats a var as TOP in both directions, so two fully-generic arms
-// collide too. The overload-set builder in module.go uses this to reject a set whose
-// arms codegen could not tell apart, because codegen dispatches on parameter types.
+// equallySpecific reports whether two arms are INDISTINGUISHABLE for overload dispatch:
+// they share an arity and each parameter is structurally equivalent to its counterpart (a
+// mutual structural subtype — so two unconstrained-var params count as equal, both TOP).
+// Neither arm is then more specific and no argument could select one over the other.
+//
+// This is a STRICT subset of moreSpecific's 0 tie, which also covers incomparable arms of
+// disjoint shape (number vs string) that a call CAN still tell apart. The overload-set
+// builder in module.go uses it to reject a set whose arms codegen could not dispatch,
+// since codegen dispatches on parameter types.
 func equallySpecific(a, b *soltype.FuncType) bool {
 	if len(a.Params) != len(b.Params) {
 		return false

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -33,14 +33,19 @@ import (
 // NoMatchingOverloadError and returns the recovery placeholder.
 func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, call *ast.CallExpr) soltype.Type {
 	for _, idx := range c.overloadOrder(b.Schemes, args) {
+		// Open the probe BEFORE instantiating so the instantiation's side-table writes
+		// (freshenAbove's FromInstantiation Prov entries, recorded via snapshotProv only
+		// when a probe is active) are journaled and rolled back with a losing trial —
+		// upholding the "a losing trial leaves no Info/Prov entries" guarantee.
+		p := c.openProbe()
 		inst, ok := c.instantiate(b.Schemes[idx], lvl).(*soltype.FuncType)
 		if !ok {
 			// An overload arm that is not a function scheme cannot match a call. This
 			// should not arise (every arm comes from a FuncDecl), but skip rather than
 			// type-assert-panic on a malformed set.
+			c.closeProbe(p, false)
 			continue
 		}
-		p := c.openProbe()
 		matched := c.tryOverloadArm(args, inst)
 		c.closeProbe(p, matched)
 		if matched {
@@ -81,23 +86,56 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 }
 
 // overloadOrder returns the indices of schemes in the order arms should be tried:
-// most-specific-first (stable, so declaration order breaks specificity ties) when
-// the arguments are ground enough to rank, else plain declaration order.
+// most-specific-first (declaration order breaks specificity ties) when the arguments
+// are ground enough to rank, else plain declaration order.
 func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int {
-	order := make([]int, len(schemes))
+	if !groundEnough(args) {
+		order := make([]int, len(schemes))
+		for i := range order {
+			order[i] = i
+		}
+		return order // not ground enough to rank: declaration-order first-match
+	}
+	funcs := make([]*soltype.FuncType, len(schemes))
+	for i, s := range schemes {
+		funcs[i] = schemeFunc(s)
+	}
+	return specificityOrder(funcs)
+}
+
+// specificityOrder returns funcs' indices most-specific-first, with declaration
+// order breaking ties. It ranks each arm by its DOMINATION COUNT — how many other
+// arms are strictly more specific than it — and sorts ascending on that count. This
+// is the load-bearing fix for the partial-order/sort hazard: specificity
+// (moreSpecific) is only a PARTIAL order, so feeding it straight to sort.SliceStable
+// violates the strict-weak-ordering contract (incomparability is non-transitive).
+// The domination count is a total order on integers, so the sort is well-defined; a
+// maximal (dominated-by-none) arm gets count 0 and sorts first, and equal counts keep
+// declaration order via the stable sort. Shared by overloadOrder (direct calls) and
+// constrain's IntersectionType arm (value-position calls) so both resolve in the same
+// order. A nil entry (non-function arm) sorts last.
+func specificityOrder(funcs []*soltype.FuncType) []int {
+	order := make([]int, len(funcs))
 	for i := range order {
 		order[i] = i
 	}
-	if !groundEnough(args) {
-		return order // not ground enough to rank: declaration-order first-match
-	}
-	sort.SliceStable(order, func(i, j int) bool {
-		fi := schemeFunc(schemes[order[i]])
-		fj := schemeFunc(schemes[order[j]])
-		if fi == nil || fj == nil {
-			return false // a non-function arm cannot be ranked; leave order unchanged
+	dominators := make([]int, len(funcs))
+	for i := range funcs {
+		if funcs[i] == nil {
+			dominators[i] = len(funcs) + 1 // non-function arms sort last
+			continue
 		}
-		return moreSpecific(fi, fj) < 0
+		for j := range funcs {
+			if i == j || funcs[j] == nil {
+				continue
+			}
+			if moreSpecific(funcs[j], funcs[i]) < 0 {
+				dominators[i]++
+			}
+		}
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return dominators[order[a]] < dominators[order[b]]
 	})
 	return order
 }

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -1,0 +1,222 @@
+package solver
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Overload resolution (PR6). A name with more than one top-level FuncDecl is an
+// OVERLOAD SET: its ValueBinding carries one TypeScheme per arm (b.IsOverloaded()),
+// in declaration order. Resolution is a phase DISTINCT from constrain — the
+// disjunction "callable in several ways" stays out of the subtype lattice — driven
+// by the PR5 probe: each candidate is trialled under a probe and the losers rolled
+// back, so a failed trial leaves no bounds on the argument variables and no stray
+// Info/Prov entries.
+//
+// Specificity ordering (the one documented rule, reused by M4 object-arg and M5
+// method overloads): for a call whose arguments are GROUND ENOUGH, candidates are
+// tried most-specific-first, where arm A is more specific than B iff they share an
+// arity and A's parameters are pointwise structural subtypes of B's (with at least
+// one strict) — a concrete `(x: number)` outranks a generic `(x: T)`. Specificity
+// is a partial order, so incomparable arms (different literal tags, disjoint shapes,
+// different arities) fall back to DECLARATION ORDER via a stable sort. When an
+// argument is still a fully-unconstrained variable the call is not ground enough to
+// rank confidently, so resolution defers to plain declaration-order first-match
+// (the documented MVP fallback — no speculative pinning + backtrack). The first arm
+// whose argument constraints succeed wins; its bounds commit and the rest roll back.
+
+// resolveOverload picks one arm of the overload set b for the call and returns its
+// (instantiated) return type, committing the winning arm's argument constraints and
+// rolling back every losing trial. When no arm accepts the arguments it reports a
+// NoMatchingOverloadError and returns the recovery placeholder.
+func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, call *ast.CallExpr) soltype.Type {
+	for _, idx := range c.overloadOrder(b.Schemes, args) {
+		inst, ok := c.instantiate(b.Schemes[idx], lvl).(*soltype.FuncType)
+		if !ok {
+			// An overload arm that is not a function scheme cannot match a call. This
+			// should not arise (every arm comes from a FuncDecl), but skip rather than
+			// type-assert-panic on a malformed set.
+			continue
+		}
+		p := c.openProbe()
+		matched := c.tryOverloadArm(args, inst)
+		c.closeProbe(p, matched)
+		if matched {
+			return inst.Ret
+		}
+	}
+	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes})
+}
+
+// tryOverloadArm reports whether inst (a freshly-instantiated arm) accepts a call
+// with the given argument types, applying the argument constraints to inst's params
+// as it goes. It runs under a probe opened by the caller, so on failure (a false
+// return) closeProbe(_, false) rolls back every bound it appended. It uses the
+// error-RETURNING Context.Constrain (not the accumulating checker.constrain) so a
+// rejected argument never reaches c.errs even before the probe's errs rollback.
+//
+// Arity follows the direct-call rule (#677): too few (below requiredCount) or too
+// many (above the declared params, unless the arm is inexact or has a rest) is a
+// non-match. Extra arguments an inexact/rest arm absorbs impose no per-element
+// constraint here (that check needs Array types — M4).
+func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bool {
+	n := len(args)
+	if n < requiredCount(inst) {
+		return false
+	}
+	if !inst.Inexact && !hasRest(inst) && n > len(inst.Params) {
+		return false
+	}
+	for i, arg := range args {
+		if i >= len(inst.Params) {
+			break // extra args absorbed by a rest/inexact tail
+		}
+		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); len(errs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// overloadOrder returns the indices of schemes in the order arms should be tried:
+// most-specific-first (stable, so declaration order breaks specificity ties) when
+// the arguments are ground enough to rank, else plain declaration order.
+func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int {
+	order := make([]int, len(schemes))
+	for i := range order {
+		order[i] = i
+	}
+	if !groundEnough(args) {
+		return order // not ground enough to rank: declaration-order first-match
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		fi := schemeFunc(schemes[order[i]])
+		fj := schemeFunc(schemes[order[j]])
+		if fi == nil || fj == nil {
+			return false // a non-function arm cannot be ranked; leave order unchanged
+		}
+		return moreSpecific(fi, fj) < 0
+	})
+	return order
+}
+
+// groundEnough reports whether the call arguments carry enough type information to
+// rank overloads confidently — i.e. no argument is a fully-unconstrained inference
+// variable (a bare var with no bounds either way). A literal, a concrete type, or a
+// var already pinned by some bound is ground enough; an untouched parameter var is
+// not, so the call falls back to declaration-order first-match.
+func groundEnough(args []soltype.Type) bool {
+	for _, a := range args {
+		if v, ok := a.(*soltype.TypeVarType); ok && len(v.LowerBounds) == 0 && len(v.UpperBounds) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// schemeFunc extracts the FuncType body of an overload arm's scheme (the raw,
+// variable-carrying signature), or nil when the scheme's body is not a function.
+// Used by the specificity comparator, which ranks the signatures directly rather
+// than instantiating them (no fresh vars minted, no Prov entries written during
+// ranking).
+func schemeFunc(s TypeScheme) *soltype.FuncType {
+	var body soltype.Type
+	switch sc := s.(type) {
+	case *MonoScheme:
+		body = sc.Ty
+	case *PolyScheme:
+		body = sc.Body
+	}
+	ft, _ := body.(*soltype.FuncType)
+	return ft
+}
+
+// moreSpecific compares two overload arms by specificity: -1 when a is strictly more
+// specific than b, +1 when b is, 0 on a tie (incomparable or equally specific). Arms
+// of different arity are a tie here — the arity gate in tryOverloadArm already keeps
+// a call from reaching an arm of the wrong arity, so cross-arity ordering only needs
+// to preserve declaration order. Same-arity arms compare pointwise: a is more
+// specific iff every a.param is a structural subtype of the matching b.param and at
+// least one direction is strict.
+func moreSpecific(a, b *soltype.FuncType) int {
+	if len(a.Params) != len(b.Params) {
+		return 0
+	}
+	aSubB, bSubA := true, true
+	for i := range a.Params {
+		if !structuralSubtype(a.Params[i].Type, b.Params[i].Type) {
+			aSubB = false
+		}
+		if !structuralSubtype(b.Params[i].Type, a.Params[i].Type) {
+			bSubA = false
+		}
+	}
+	if aSubB && !bSubA {
+		return -1
+	}
+	if bSubA && !aSubB {
+		return 1
+	}
+	return 0
+}
+
+// structuralSubtype is a PURE (non-mutating) structural subtype test used ONLY for
+// ranking overload specificity — it never appends a bound, so it is safe to call on
+// the raw scheme bodies (which carry quantified variables) without corrupting them.
+// A type variable is treated as TOP: a concrete type is a subtype of a variable
+// (so a concrete param outranks a generic one), a variable is a subtype of nothing
+// concrete, and two variables tie. Beyond that it mirrors constrain's atom arms
+// (structural equality, plus a literal under its primitive); anything richer ranks
+// as incomparable (false), deferring to declaration order. It is deliberately NOT
+// the full subtype relation — resolution correctness comes from the constrain trial
+// in tryOverloadArm, not from this comparator.
+func structuralSubtype(a, b soltype.Type) bool {
+	if _, ok := b.(*soltype.TypeVarType); ok {
+		return true
+	}
+	if _, ok := a.(*soltype.TypeVarType); ok {
+		return false
+	}
+	if equalType(a, b) {
+		return true
+	}
+	if l, ok := a.(*soltype.LitType); ok {
+		if p, ok := b.(*soltype.PrimType); ok {
+			return primOf(l.Lit) == p.Prim
+		}
+	}
+	return false
+}
+
+// overloadIntersection synthesizes the value-position type of an overloaded name —
+// the IntersectionType of its arms (declaration order preserved), each instantiated
+// at lvl. This is the one scoped lattice exception (see constrain's IntersectionType
+// arm and the doc.go note): it is built LAZILY, only where an overloaded name is
+// used as a value (inferIdent) or recorded as a call's callee, never eagerly per
+// binding — b.Schemes stays the source of truth.
+func (c *checker) overloadIntersection(lvl int, b ValueBinding) soltype.Type {
+	arms := make([]soltype.Type, len(b.Schemes))
+	for i, s := range b.Schemes {
+		arms[i] = c.instantiate(s, lvl)
+	}
+	return &soltype.IntersectionType{Types: arms}
+}
+
+// isFullyAnnotated reports whether a function signature is ground from its
+// annotations alone — every parameter typed and a return type present. The
+// recursion gate (checkOverloadAnnotations) requires this of every arm of an
+// overloaded function in a mutually-recursive group, since an un-annotated arm's
+// signature is not known before its body is inferred.
+func isFullyAnnotated(sig ast.FuncSig) bool {
+	if sig.Return == nil {
+		return false
+	}
+	for _, p := range sig.Params {
+		if p.TypeAnn == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -1,47 +1,57 @@
 package solver
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Overload resolution (PR6). A name with more than one top-level FuncDecl is an
-// OVERLOAD SET: its ValueBinding carries one TypeScheme per arm (b.IsOverloaded()),
-// in declaration order. Resolution is a phase DISTINCT from constrain — the
-// disjunction "callable in several ways" stays out of the subtype lattice — driven
-// by the PR5 probe: each candidate is trialled under a probe and the losers rolled
-// back, so a failed trial leaves no bounds on the argument variables and no stray
-// Info/Prov entries.
+// Overload resolution, introduced in PR6. A name with more than one top-level FuncDecl
+// is an overload set. Its ValueBinding carries one TypeScheme per arm, which is what
+// b.IsOverloaded() reports, ordered by source position. armPosLess in module.go defines
+// that order as file path, then line, then column. A set whose arms span several files
+// in a lib/ therefore reads top-to-bottom, file by file alphabetically, independent of
+// the order sources reached the parser.
 //
-// Specificity ordering (the one documented rule, reused by M4 object-arg and M5
-// method overloads): for a call whose arguments are GROUND ENOUGH, candidates are
-// tried most-specific-first, where arm A is more specific than B iff they share an
-// arity and A's parameters are pointwise structural subtypes of B's (with at least
-// one strict) — a concrete `(x: number)` outranks a generic `(x: T)`. Specificity
-// is a partial order, so incomparable arms (different literal tags, disjoint shapes,
-// different arities) fall back to DECLARATION ORDER via a stable sort. When an
-// argument is still a fully-unconstrained variable the call is not ground enough to
-// rank confidently, so resolution defers to plain declaration-order first-match
-// (the documented MVP fallback — no speculative pinning + backtrack). The first arm
-// whose argument constraints succeed wins; its bounds commit and the rest roll back.
+// Resolution is a phase distinct from constrain. The disjunction "callable in several
+// ways" stays out of the subtype lattice. It is driven by the PR5 probe. Each candidate
+// is trialled under a probe and the losers are rolled back, so a failed trial leaves no
+// bounds on the argument variables and no stray Info or Prov entries.
+//
+// Specificity ordering is the one documented rule, reused by M4 object-arg and M5 method
+// overloads. When every argument carries type information, meaning none is an
+// unconstrained variable, candidates are tried most-specific-first. Arm A is more
+// specific than B when they share an arity and every parameter of A is a structural
+// subtype of B's, with at least one strict. So a concrete `(x: number)` outranks a
+// generic `(x: T)`.
+//
+// Specificity is only a partial order. Incomparable arms fall back to declaration order
+// through a stable sort. Arms are incomparable when they have different literal tags,
+// disjoint shapes, or different arities.
+//
+// When an argument is still a fully-unconstrained variable, the call cannot rank arms
+// confidently, so resolution defers to plain declaration-order first-match. This is the
+// documented MVP fallback, with no speculative pinning and backtracking. The first arm
+// whose argument constraints succeed wins. Its bounds commit and the rest roll back.
 
-// resolveOverload picks one arm of the overload set b for the call and returns its
-// (instantiated) return type, committing the winning arm's argument constraints and
-// rolling back every losing trial. When no arm accepts the arguments it reports a
+// resolveOverload picks one arm of the overload set b for the call and returns that
+// arm's instantiated return type. It commits the winning arm's argument constraints and
+// rolls back every losing trial. When no arm accepts the arguments, it reports a
 // NoMatchingOverloadError and returns the recovery placeholder.
 func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, call *ast.CallExpr) soltype.Type {
 	for _, idx := range c.overloadOrder(b.Schemes, args) {
-		// Open the probe BEFORE instantiating so the instantiation's side-table writes
-		// (freshenAbove's FromInstantiation Prov entries, recorded via snapshotProv only
-		// when a probe is active) are journaled and rolled back with a losing trial —
-		// upholding the "a losing trial leaves no Info/Prov entries" guarantee.
+		// Open the probe BEFORE instantiating so the instantiation's side-table writes are
+		// journaled and rolled back with a losing trial. Those writes are freshenAbove's
+		// FromInstantiation Prov entries, which snapshotProv records only when a probe is
+		// active. This upholds the guarantee that a losing trial leaves no Info or Prov
+		// entries.
 		p := c.openProbe()
 		inst, ok := c.instantiate(b.Schemes[idx], lvl).(*soltype.FuncType)
 		if !ok {
-			// An overload arm that is not a function scheme cannot match a call. This
-			// should not arise (every arm comes from a FuncDecl), but skip rather than
+			// An overload arm that is not a function scheme cannot match a call. This should
+			// not arise, since every arm comes from a FuncDecl. Skip it rather than
 			// type-assert-panic on a malformed set.
 			c.closeProbe(p, false)
 			continue
@@ -55,18 +65,19 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 	return c.report(&NoMatchingOverloadError{Call: call, Candidates: b.Schemes})
 }
 
-// tryOverloadArm reports whether inst (a freshly-instantiated arm) accepts a call
-// with the given argument types, applying the argument constraints to inst's params
-// as it goes. It runs under a probe opened by the caller, so on failure (a false
-// return) closeProbe(_, false) rolls back every bound it appended. It uses the
-// error-RETURNING Context.Constrain (not the accumulating checker.constrain) so a
+// tryOverloadArm reports whether inst accepts a call with the given argument types,
+// applying the argument constraints to inst's params as it goes. inst is a
+// freshly-instantiated arm. It runs under a probe opened by the caller, so on a false
+// return closeProbe(_, false) rolls back every bound it appended. It uses the
+// error-returning Context.Constrain rather than the accumulating checker.constrain, so a
 // rejected argument never reaches c.errs even before the probe's errs rollback.
 //
-// Arity follows the direct-call accept-set (#677), reusing acceptSet so the overload
-// arity gate and the FuncType<:FuncType constraint gate can never drift: a count
-// below the lower bound (too few) or above the upper bound (too many, unless the arm
-// is inexact or has a rest) is a non-match. Extra arguments an inexact/rest arm
-// absorbs impose no per-element constraint here (that check needs Array types — M4).
+// Arity follows the direct-call accept-set from #677, reusing acceptSet so the overload
+// arity gate and the FuncType<:FuncType constraint gate can never drift. A count below
+// acceptSet's lower bound is too few, and a count above its upper bound is too many.
+// Either is a non-match, unless the arm is inexact or has a rest. Extra arguments that
+// such an arm absorbs impose no per-element constraint here. That per-element check needs
+// Array types, which arrive in M4.
 func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bool {
 	n := len(args)
 	if lo, hi := acceptSet(inst); n < lo || n > hi {
@@ -74,10 +85,10 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 	}
 	for i, arg := range args {
 		if i >= len(inst.Params) || inst.Params[i].Rest {
-			// Past the fixed params, or AT a trailing rest param: the rest/inexact tail
+			// Past the fixed params, or AT a trailing rest param. The rest or inexact tail
 			// absorbs this and every later argument. Don't constrain a scalar argument
-			// against the rest param's ARRAY element type (Params[i].Type is `T[]`) —
-			// per-element checking is M4.
+			// against the rest param's ARRAY element type, since Params[i].Type is `T[]`.
+			// Per-element checking is M4.
 			break
 		}
 		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); len(errs) > 0 {
@@ -87,16 +98,17 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 	return true
 }
 
-// overloadOrder returns the indices of schemes in the order arms should be tried:
-// most-specific-first (declaration order breaks specificity ties) when the arguments
-// are ground enough to rank, else plain declaration order.
+// overloadOrder returns the indices of schemes in the order arms should be tried. When
+// every argument carries type information to rank by, the order is most-specific-first,
+// and declaration order breaks specificity ties. When any argument is an unconstrained
+// variable, the order is plain declaration order.
 func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int {
-	if !groundEnough(args) {
+	if hasUnconstrainedArg(args) {
 		order := make([]int, len(schemes))
 		for i := range order {
 			order[i] = i
 		}
-		return order // not ground enough to rank: declaration-order first-match
+		return order // an unconstrained arg can't rank arms, so try in declaration order
 	}
 	funcs := make([]*soltype.FuncType, len(schemes))
 	for i, s := range schemes {
@@ -105,17 +117,20 @@ func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int
 	return specificityOrder(funcs)
 }
 
-// specificityOrder returns funcs' indices most-specific-first, with declaration
-// order breaking ties. It ranks each arm by its DOMINATION COUNT — how many other
-// arms are strictly more specific than it — and sorts ascending on that count. This
-// is the load-bearing fix for the partial-order/sort hazard: specificity
-// (moreSpecific) is only a PARTIAL order, so feeding it straight to sort.SliceStable
-// violates the strict-weak-ordering contract (incomparability is non-transitive).
-// The domination count is a total order on integers, so the sort is well-defined; a
-// maximal (dominated-by-none) arm gets count 0 and sorts first, and equal counts keep
-// declaration order via the stable sort. Shared by overloadOrder (direct calls) and
-// constrain's IntersectionType arm (value-position calls) so both resolve in the same
-// order. A nil entry (non-function arm) sorts last.
+// specificityOrder returns funcs' indices most-specific-first, with declaration order
+// breaking ties. It ranks each arm by its domination count, the number of other arms
+// strictly more specific than it, and sorts ascending on that count.
+//
+// This is the load-bearing fix for the partial-order sort hazard. The moreSpecific
+// relation is only a partial order, so feeding it straight to sort.SliceStable would
+// violate the strict-weak-ordering contract, because incomparability is non-transitive.
+// The domination count is a total order on integers, so the sort is well-defined. An arm
+// dominated by none gets count 0 and sorts first. Equal counts keep declaration order
+// through the stable sort.
+//
+// overloadOrder uses this for direct calls and constrain's IntersectionType arm uses it
+// for value-position calls, so both resolve in the same order. A nil entry is a
+// non-function arm and sorts last.
 func specificityOrder(funcs []*soltype.FuncType) []int {
 	order := make([]int, len(funcs))
 	for i := range order {
@@ -142,33 +157,36 @@ func specificityOrder(funcs []*soltype.FuncType) []int {
 	return order
 }
 
-// groundEnough reports whether the call arguments carry enough type information to
-// rank overloads confidently — i.e. no argument is a fully-unconstrained inference
-// variable (a bare var with no bounds either way). A literal, a concrete type, or a
-// var already pinned by some bound is ground enough; an untouched parameter var is
-// not, so the call falls back to declaration-order first-match.
+// hasUnconstrainedArg reports whether any call argument is a fully-unconstrained
+// inference variable, a bare var with no bounds in either direction. Such an argument
+// carries no type information to rank overloads by. A literal, a concrete type, or a var
+// already pinned by some bound is fine. An untouched parameter var is not, so its
+// presence makes the call fall back to declaration-order first-match. That fallback
+// over-narrows the enclosing function, since it pins the arg to the first arm. The real
+// fix is to defer resolution until the arg is grounded, tracked in #723.
 //
-// The check is intentionally SHALLOW (top-level args only): a structural argument
-// that merely WRAPS an unconstrained var — a tuple/record/func holding a bare var —
-// is treated as ground. That is harmless because such a compound never disambiguates
-// overloads under the specificity comparator anyway: structuralSubtype returns false
-// for compound shapes, so they rank as a tie and the order collapses to declaration
-// order — exactly what the not-ground-enough fallback would produce. Recursing would
-// only defer more calls for no change in the resolved arm.
-func groundEnough(args []soltype.Type) bool {
-	for _, a := range args {
-		if v, ok := a.(*soltype.TypeVarType); ok && len(v.LowerBounds) == 0 && len(v.UpperBounds) == 0 {
-			return false
-		}
-	}
-	return true
+// The check is intentionally shallow and looks at top-level args only. A structural
+// argument that merely WRAPS an unconstrained var does NOT count, for example a tuple,
+// record, or func holding a bare var. That is harmless, because such a compound never
+// disambiguates overloads under the specificity comparator. structuralSubtype returns
+// false for compound shapes, so they rank as a tie and the order collapses to
+// declaration order, exactly what this fallback would produce. Recursing would only
+// defer more calls with no change in the resolved arm.
+func hasUnconstrainedArg(args []soltype.Type) bool {
+	return slices.ContainsFunc(args, isUnconstrainedVar)
 }
 
-// schemeFunc extracts the FuncType body of an overload arm's scheme (the raw,
-// variable-carrying signature), or nil when the scheme's body is not a function.
-// Used by the specificity comparator, which ranks the signatures directly rather
-// than instantiating them (no fresh vars minted, no Prov entries written during
-// ranking).
+// isUnconstrainedVar reports whether t is a type variable with no bounds in either
+// direction. Such an argument carries no type information to rank overloads by.
+func isUnconstrainedVar(t soltype.Type) bool {
+	v, ok := t.(*soltype.TypeVarType)
+	return ok && len(v.LowerBounds) == 0 && len(v.UpperBounds) == 0
+}
+
+// schemeFunc extracts the FuncType body of an overload arm's scheme, the raw
+// variable-carrying signature, or nil when the scheme's body is not a function. The
+// specificity comparator uses it to rank the signatures directly rather than
+// instantiating them, so ranking mints no fresh vars and writes no Prov entries.
 func schemeFunc(s TypeScheme) *soltype.FuncType {
 	var body soltype.Type
 	switch sc := s.(type) {
@@ -181,13 +199,13 @@ func schemeFunc(s TypeScheme) *soltype.FuncType {
 	return ft
 }
 
-// moreSpecific compares two overload arms by specificity: -1 when a is strictly more
-// specific than b, +1 when b is, 0 on a tie (incomparable or equally specific). Arms
-// of different arity are a tie here — the arity gate in tryOverloadArm already keeps
-// a call from reaching an arm of the wrong arity, so cross-arity ordering only needs
-// to preserve declaration order. Same-arity arms compare pointwise: a is more
-// specific iff every a.param is a structural subtype of the matching b.param and at
-// least one direction is strict.
+// moreSpecific compares two overload arms by specificity. It returns -1 when a is
+// strictly more specific than b, +1 when b is, and 0 on a tie. A tie means the arms are
+// either incomparable or equally specific. Arms of different arity are a tie here. The
+// arity gate in tryOverloadArm already keeps a call from reaching an arm of the wrong
+// arity, so cross-arity ordering only needs to preserve declaration order. Same-arity
+// arms compare pointwise. a is more specific when every a.param is a structural subtype
+// of the matching b.param and at least one direction is strict.
 func moreSpecific(a, b *soltype.FuncType) int {
 	if len(a.Params) != len(b.Params) {
 		return 0
@@ -210,16 +228,40 @@ func moreSpecific(a, b *soltype.FuncType) int {
 	return 0
 }
 
-// structuralSubtype is a PURE (non-mutating) structural subtype test used ONLY for
-// ranking overload specificity — it never appends a bound, so it is safe to call on
-// the raw scheme bodies (which carry quantified variables) without corrupting them.
-// A type variable is treated as TOP: a concrete type is a subtype of a variable
-// (so a concrete param outranks a generic one), a variable is a subtype of nothing
-// concrete, and two variables tie. Beyond that it mirrors constrain's atom arms
-// (structural equality, plus a literal under its primitive); anything richer ranks
-// as incomparable (false), deferring to declaration order. It is deliberately NOT
-// the full subtype relation — resolution correctness comes from the constrain trial
-// in tryOverloadArm, not from this comparator.
+// equallySpecific reports whether two arms are INDISTINGUISHABLE for overload dispatch.
+// They share an arity and each parameter is a structural subtype of its counterpart in
+// BOTH directions, so neither arm is more specific and no argument could ever select one
+// over the other. This is a strict subset of moreSpecific's tie result, the 0 case,
+// which ALSO covers incomparable arms of disjoint shape such as number versus string
+// that a call CAN still tell apart. Two type-variable params count as equal, since
+// structuralSubtype treats a var as TOP in both directions, so two fully-generic arms
+// collide too. The overload-set builder in module.go uses this to reject a set whose
+// arms codegen could not tell apart, because codegen dispatches on parameter types.
+func equallySpecific(a, b *soltype.FuncType) bool {
+	if len(a.Params) != len(b.Params) {
+		return false
+	}
+	for i := range a.Params {
+		if !structuralSubtype(a.Params[i].Type, b.Params[i].Type) ||
+			!structuralSubtype(b.Params[i].Type, a.Params[i].Type) {
+			return false
+		}
+	}
+	return true
+}
+
+// structuralSubtype is a pure, non-mutating structural subtype test used ONLY for
+// ranking overload specificity. It never appends a bound, so it is safe to call on the
+// raw scheme bodies, which carry quantified variables, without corrupting them.
+//
+// A type variable is treated as TOP. A concrete type is a subtype of a variable, so a
+// concrete param outranks a generic one. A variable is a subtype of nothing concrete.
+// Two variables tie. Beyond that it mirrors constrain's atom arms, namely structural
+// equality plus a literal under its primitive. Anything richer ranks as incomparable and
+// returns false, deferring to declaration order.
+//
+// It is deliberately NOT the full subtype relation. Resolution correctness comes from
+// the constrain trial in tryOverloadArm, not from this comparator.
 func structuralSubtype(a, b soltype.Type) bool {
 	if _, ok := b.(*soltype.TypeVarType); ok {
 		return true
@@ -238,12 +280,12 @@ func structuralSubtype(a, b soltype.Type) bool {
 	return false
 }
 
-// overloadIntersection synthesizes the value-position type of an overloaded name —
-// the IntersectionType of its arms (declaration order preserved), each instantiated
-// at lvl. This is the one scoped lattice exception (see constrain's IntersectionType
-// arm and the doc.go note): it is built LAZILY, only where an overloaded name is
-// used as a value (inferIdent) or recorded as a call's callee, never eagerly per
-// binding — b.Schemes stays the source of truth.
+// overloadIntersection synthesizes the value-position type of an overloaded name, the
+// IntersectionType of its arms in declaration order, each instantiated at lvl. This is
+// the one scoped lattice exception, described at constrain's IntersectionType arm and in
+// the doc.go note. It is built LAZILY, only where an overloaded name is used as a value
+// in inferIdent or recorded as a call's callee, never eagerly per binding. b.Schemes
+// stays the source of truth.
 func (c *checker) overloadIntersection(lvl int, b ValueBinding) soltype.Type {
 	arms := make([]soltype.Type, len(b.Schemes))
 	for i, s := range b.Schemes {
@@ -252,12 +294,13 @@ func (c *checker) overloadIntersection(lvl int, b ValueBinding) soltype.Type {
 	return &soltype.IntersectionType{Types: arms}
 }
 
-// overloadDisplayType builds the COALESCED display type of an overloaded name — the
-// IntersectionType of its arms' display types (schemeType per arm). Unlike
-// overloadIntersection it mints no fresh inference variables (it coalesces the schemes
-// rather than instantiating them), so it is the right form for an Info record such as
-// an overloaded call's callee, where the recorded type is for tooling/hover and no
-// inference flows out of it — avoiding a second per-arm instantiation per call.
+// overloadDisplayType builds the COALESCED display type of an overloaded name, the
+// IntersectionType of its arms' display types, one schemeType per arm. Unlike
+// overloadIntersection it mints no fresh inference variables, because it coalesces the
+// schemes rather than instantiating them. So it is the right form for an Info record
+// such as an overloaded call's callee, where the recorded type is for tooling and hover
+// and no inference flows out of it. This also avoids a second per-arm instantiation per
+// call.
 func overloadDisplayType(b ValueBinding) soltype.Type {
 	arms := make([]soltype.Type, len(b.Schemes))
 	for i, s := range b.Schemes {
@@ -266,11 +309,11 @@ func overloadDisplayType(b ValueBinding) soltype.Type {
 	return &soltype.IntersectionType{Types: arms}
 }
 
-// isFullyAnnotated reports whether a function signature is ground from its
-// annotations alone — every parameter typed and a return type present. The
-// recursion gate (checkOverloadAnnotations) requires this of every arm of an
-// overloaded function in a mutually-recursive group, since an un-annotated arm's
-// signature is not known before its body is inferred.
+// isFullyAnnotated reports whether a function signature is ground from its annotations
+// alone, with every parameter typed and a return type present. The recursion gate
+// checkOverloadAnnotations requires this of every arm of an overloaded function in a
+// mutually-recursive group, since an un-annotated arm's signature is not known before
+// its body is inferred.
 func isFullyAnnotated(sig ast.FuncSig) bool {
 	if sig.Return == nil {
 		return false

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -62,21 +62,23 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // error-RETURNING Context.Constrain (not the accumulating checker.constrain) so a
 // rejected argument never reaches c.errs even before the probe's errs rollback.
 //
-// Arity follows the direct-call rule (#677): too few (below requiredCount) or too
-// many (above the declared params, unless the arm is inexact or has a rest) is a
-// non-match. Extra arguments an inexact/rest arm absorbs impose no per-element
-// constraint here (that check needs Array types — M4).
+// Arity follows the direct-call accept-set (#677), reusing acceptSet so the overload
+// arity gate and the FuncType<:FuncType constraint gate can never drift: a count
+// below the lower bound (too few) or above the upper bound (too many, unless the arm
+// is inexact or has a rest) is a non-match. Extra arguments an inexact/rest arm
+// absorbs impose no per-element constraint here (that check needs Array types — M4).
 func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bool {
 	n := len(args)
-	if n < requiredCount(inst) {
-		return false
-	}
-	if !inst.Inexact && !hasRest(inst) && n > len(inst.Params) {
+	if lo, hi := acceptSet(inst); n < lo || n > hi {
 		return false
 	}
 	for i, arg := range args {
-		if i >= len(inst.Params) {
-			break // extra args absorbed by a rest/inexact tail
+		if i >= len(inst.Params) || inst.Params[i].Rest {
+			// Past the fixed params, or AT a trailing rest param: the rest/inexact tail
+			// absorbs this and every later argument. Don't constrain a scalar argument
+			// against the rest param's ARRAY element type (Params[i].Type is `T[]`) —
+			// per-element checking is M4.
+			break
 		}
 		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); len(errs) > 0 {
 			return false
@@ -145,6 +147,14 @@ func specificityOrder(funcs []*soltype.FuncType) []int {
 // variable (a bare var with no bounds either way). A literal, a concrete type, or a
 // var already pinned by some bound is ground enough; an untouched parameter var is
 // not, so the call falls back to declaration-order first-match.
+//
+// The check is intentionally SHALLOW (top-level args only): a structural argument
+// that merely WRAPS an unconstrained var — a tuple/record/func holding a bare var —
+// is treated as ground. That is harmless because such a compound never disambiguates
+// overloads under the specificity comparator anyway: structuralSubtype returns false
+// for compound shapes, so they rank as a tie and the order collapses to declaration
+// order — exactly what the not-ground-enough fallback would produce. Recursing would
+// only defer more calls for no change in the resolved arm.
 func groundEnough(args []soltype.Type) bool {
 	for _, a := range args {
 		if v, ok := a.(*soltype.TypeVarType); ok && len(v.LowerBounds) == 0 && len(v.UpperBounds) == 0 {
@@ -238,6 +248,20 @@ func (c *checker) overloadIntersection(lvl int, b ValueBinding) soltype.Type {
 	arms := make([]soltype.Type, len(b.Schemes))
 	for i, s := range b.Schemes {
 		arms[i] = c.instantiate(s, lvl)
+	}
+	return &soltype.IntersectionType{Types: arms}
+}
+
+// overloadDisplayType builds the COALESCED display type of an overloaded name — the
+// IntersectionType of its arms' display types (schemeType per arm). Unlike
+// overloadIntersection it mints no fresh inference variables (it coalesces the schemes
+// rather than instantiating them), so it is the right form for an Info record such as
+// an overloaded call's callee, where the recorded type is for tooling/hover and no
+// inference flows out of it — avoiding a second per-arm instantiation per call.
+func overloadDisplayType(b ValueBinding) soltype.Type {
+	arms := make([]soltype.Type, len(b.Schemes))
+	for i, s := range b.Schemes {
+		arms[i] = schemeType(s)
 	}
 	return &soltype.IntersectionType{Types: arms}
 }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -212,7 +212,7 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 	return out
 }
 
-// generalize turns the inferred type of a binding (its SCC group var) into a
+// generalize turns the inferred type of a binding (its binding var) into a
 // PolyScheme quantified at lvl: every variable with Level > lvl becomes a type
 // parameter, captured outer variables (Level <= lvl) stay monomorphic. Body is
 // kept RAW for instantiation — coalescing for display happens later (schemeType /

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -98,14 +98,15 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	// naming:
 	//
 	//  1. (Soundness coupling) LevelOf returns a *TypeVarType's own Level only — it
-	//     does NOT descend into the var's bounds, and returns 0 for Union/Intersection.
-	//     This prune is therefore sound only because the MLsub level invariant holds
-	//     (a var's level >= the level of everything in its bounds, maintained by
-	//     constrain/extrude) and raw scheme bodies contain no Union/Intersection. The
-	//     analogous extrude (constrain.go) rests on the same assumption. If a future
-	//     change breaks either, a Level>lim var could hide under a shared node and two
-	//     instantiations would alias a variable that should have been fresh — revisit
-	//     when Union/Intersection become constrain inputs (M6).
+	//     does NOT descend into the var's bounds — so this prune is sound only because
+	//     the MLsub level invariant holds (a var's level >= the level of everything in
+	//     its bounds, maintained by constrain/extrude). LevelOf DOES recurse into the
+	//     structural formers, INCLUDING Union/Intersection (PR6 made an overloaded
+	//     value's arm IntersectionType a legal scheme-body/constrain input — see
+	//     soltype.LevelOf): without that, a generic arm's Level>lim var would hide under
+	//     the level-0 intersection and two instantiations of a let-bound overload would
+	//     alias a variable that should have been fresh. The analogous extrude
+	//     (constrain.go) rests on the same level invariant.
 	//  2. (Identity) The shared subtree's pointer is reused across every instantiation
 	//     and the scheme body, so compound nodes are NOT uniquely minted per use. Prov
 	//     and Info are pointer-keyed; a shared monomorphic node keeps its one original


### PR DESCRIPTION
Implement function overloading for free functions (top-level FuncDecls with the same name). An overloaded name binds to a multi-scheme `ValueBinding` with one `TypeScheme` per arm in declaration order, and resolution is a distinct phase from constraint — the disjunction stays out of the subtype lattice.

## Summary

This PR adds the overload resolution infrastructure (PR6) that was previously stubbed as unsupported. A name with multiple top-level `FuncDecl`s now forms an overload set, resolved via `resolveOverload` when called directly. Each candidate arm is trialled under a PR5 probe; the first match commits its bounds and losers roll back, leaving no stray constraints.

## Key changes

- **overload.go** (new): Core overload resolution logic
  - `resolveOverload`: Picks one arm from an overload set, trialling each under a probe
  - `tryOverloadArm`: Tests whether an instantiated arm accepts the call arguments
  - `overloadOrder`: Ranks arms by specificity (most-specific-first) or declaration order
  - `specificityOrder`: Implements the documented specificity rule via domination-count sorting (fixes partial-order hazard)
  - `groundEnough`: Checks if arguments carry enough type info to rank confidently
  - `structuralSubtype`: Pure structural subtype test for ranking (no mutation)
  - `overloadIntersection` / `overloadDisplay`: Synthesize value-position types for overloaded names

- **module.go** (modified): Overload binding and recursion gate
  - `overloadArm` struct: Tracks each arm's decl, inferred type, and annotation status
  - `componentBinding.arms`: Collects all FuncDecl arms under a name
  - `componentBinding.prebound`: Marks fully-annotated overload sets pre-bound in phase 1
  - `checkOverloadAnnotations`: Recursion gate — rejects unannotated overloads in mutually-recursive groups (fixed-point iteration over overload choices is unsound)
  - `annotatedOverloadArms`: Extracts fully-annotated overload arms for pre-binding
  - Phase 1 pre-binding: Builds signatures body-free for annotated overloads, binds the whole set before any body
  - Phase 2 body checking: For pre-bound overloads, checks each arm's body against the pre-bound signature

- **infer_expr.go** (modified): Value-position overload handling
  - `inferIdent`: Synthesizes `IntersectionType` for overloaded names in value position (the one scoped lattice exception)
  - `inferCall`: Routes direct calls to overloaded names through `resolveOverload` instead of single-constraint path

- **constrain.go** (modified): Intersection-type constraint arm
  - `IntersectionType` LHS: `(A & B & …) <: rhs` iff SOME member `<: rhs`
  - Trials each member in specificity order under a probe; first success commits, losers roll back
  - Preserves the intersection whole when flowing into a variable (defers collapse until concrete demand)

- **coalesce.go** (modified): Occurrence analysis refactor
  - Refactored `analyzeOccurrences` to use the shared `soltype.Accept` visitor
  - Added `occVisitor` struct to handle variance flips and recursion uniformly
  - Enables proper handling of overload-arm `Union`/`Intersection` inputs (the scoped lattice exception)

- **soltype/type.go** (modified): Level computation for unions/intersections
  - `LevelOf` now recurses into `UnionType` and `IntersectionType` members
  - Critical for `freshenAbove` to avoid aliasing generic overload arms across instantiations

- **poly.go** (modified): Documentation update
  - Clarified soundness coupling of `LevelOf` and `freshenAbove` with the new union/intersection level handling

- **errors.go** (modified): New error types
  - Replaced `OverloadNotSupportedError` with `No

https://claude.ai/code/session_01QfrqdnzhCW39TvK9PtiUkA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full function overloading: call-site resolution by argument types/arity and value-position overloads that present as intersection types.

* **Bug Fixes**
  * More robust handling of union/intersection types in analysis and constraint solving.
  * Clearer diagnostics for no-matching-overload and unannotated recursive overloads; improved rollback/consistency during speculative resolution.

* **Documentation**
  * Package docs clarified for overload semantics and specificity rules; added writing/style guidance.

* **Tests**
  * Comprehensive unit tests covering overload resolution, ambiguity, recursion, value-position behavior, and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->