### PR TITLE
Function bodies: explicit returns only, no implicit tail

### DIFF
--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -57,7 +57,7 @@ func TestBlameValAnnotationLiteral(t *testing.T) {
 // A call-arg mismatch blames the offending argument, with the callee's param
 // annotation as the related source.
 func TestBlameCallArgument(t *testing.T) {
-	src := "fn f(x: number) -> number { x }\nval r = f(\"hi\")"
+	src := "fn f(x: number) -> number { return x }\nval r = f(\"hi\")"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
 }
@@ -69,7 +69,7 @@ func TestBlameCallArgument(t *testing.T) {
 // callback-arity failures. The related span is the callee `f` here, derived from
 // the AST, not the callee's definition span resolved through Prov.)
 func TestBlameCallTooManyArgs(t *testing.T) {
-	src := "fn f(x: number) -> number { x }\nval r = f(1, 2)"
+	src := "fn f(x: number) -> number { return x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
@@ -80,7 +80,7 @@ func TestBlameCallTooManyArgs(t *testing.T) {
 // callee expression (`f` here, from the AST — not the callee's definition resolved
 // through Prov). `f` requires two params; the call supplies one.
 func TestBlameCallTooFewArgs(t *testing.T) {
-	src := "fn f(x: number, y: number) -> number { x }\nval r = f(1)"
+	src := "fn f(x: number, y: number) -> number { return x }\nval r = f(1)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"Not enough arguments: expected at least 2, but got 1", "f(1)", "f")
@@ -110,7 +110,7 @@ func TestBlameMissingProperty(t *testing.T) {
 // improvement holds for var-free callees/receivers, not values that flowed through
 // instantiation.
 func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
-	src := "val mk = fn (v) { {a: v} }\nval o = mk(5)\nval x = o.b"
+	src := "val mk = fn (v) { return {a: v} }\nval o = mk(5)\nval x = o.b"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "object is missing property: b", "b")
 }
@@ -181,12 +181,12 @@ func TestBlameVoidSubjectFallsBackToCallSite(t *testing.T) {
 // primary is the call expression; for a parenthesized callee the parser's span
 // begins at the inner `fn`, so the leading `(` is not part of it.)
 func TestBlameCallTooManyArgsInlineCalleeRelated(t *testing.T) {
-	src := `val r = (fn (x: number) -> number { x })(1, 2)`
+	src := `val r = (fn (x: number) -> number { return x })(1, 2)`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"Too many arguments: expected at most 1, but got 2",
-		`fn (x: number) -> number { x })(1, 2)`,
-		`fn (x: number) -> number { x }`)
+		`fn (x: number) -> number { return x })(1, 2)`,
+		`fn (x: number) -> number { return x }`)
 }
 
 // tspan builds a single-SourceID span from 1-indexed line/column ints — only the
@@ -242,8 +242,8 @@ func TestUnsupportedAnnotationRecovers(t *testing.T) {
 		want map[string]string
 	}{
 		{"val", `val x: Foo = 5`, map[string]string{"x": "5"}},
-		{"return", `fn f() -> Foo { 5 }`, map[string]string{"f": "fn () -> 5"}},
-		{"param", `fn g(x: Foo) -> number { 5 }`, map[string]string{"g": "fn (x: unknown) -> number"}},
+		{"return", `fn f() -> Foo { return 5 }`, map[string]string{"f": "fn () -> 5"}},
+		{"param", `fn g(x: Foo) -> number { return 5 }`, map[string]string{"g": "fn (x: unknown) -> number"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -48,8 +48,8 @@ type checker struct {
 // function's AST node, surfaced as the "make this async" related span on an
 // await-outside-async error; returns accumulates every ReturnStmt expression type
 // collected from the body (in source order, valued AND bare — bare returns
-// contribute Void) so inferFunc can join them with the block tail before
-// constraining against the return annotation, finishing M2's carried-over TODO.
+// contribute Void) so inferFunc can join them into the function's return type
+// before constraining against the return annotation.
 //
 // Nesting is handled by save/restore through the pointer pushFuncCtx returns, not a
 // parent chain on the struct: a nested fn opens its own ctx (so its returns never
@@ -74,7 +74,7 @@ func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
 
 // popFuncCtx restores the previous function context (the pointer pushFuncCtx
 // returned) and hands back the return-point types collected from the body just
-// walked, so the caller can join them with the block's tail value.
+// walked, so the caller can join them into the function's return type.
 func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 	collected := c.fn.returns
 	c.fn = saved

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -28,7 +28,7 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 		`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["a"])
-		require.Equal(t, "fn () -> number", values["f"]) // the tail assignment evaluates to a's slot type
+		require.Equal(t, "fn () -> void", values["f"]) // no return, so the body produces no value
 	})
 	t.Run("mismatched type reports one subtype error", func(t *testing.T) {
 		src := "var a: number = 5\nfn f() { a = \"x\" }"
@@ -60,10 +60,10 @@ func TestInferAssignToValRejected(t *testing.T) {
 // introducing declaration source node, so its error has no related span.
 func TestInferAssignToImmutableNonVal(t *testing.T) {
 	t.Run("function name", func(t *testing.T) {
-		src := "fn h() -> number { 5 }\nfn f() { h = 6 }"
+		src := "fn h() -> number { return 5 }\nfn f() { h = 6 }"
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs,
-			"Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { 5 }")
+			"Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { return 5 }")
 	})
 	t.Run("parameter", func(t *testing.T) {
 		src := "fn f(p: number) { p = 6 }"
@@ -83,7 +83,7 @@ func TestInferAssignInvalidTarget(t *testing.T) {
 		requireBlame(t, src, errs, "Invalid assignment target: LiteralExpr", "5")
 	})
 	t.Run("call target", func(t *testing.T) {
-		src := "fn f() -> number { 5 }\nvar a: number = 0\nfn g() { f() = a }"
+		src := "fn f() -> number { return 5 }\nvar a: number = 0\nfn g() { f() = a }"
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, "Invalid assignment target: CallExpr", "f()")
 	})
@@ -131,8 +131,8 @@ func TestInferAssignUnknownTarget(t *testing.T) {
 // keeps its generic type and a later `id("hello")` still type-checks.
 func TestInferAssignPolyVarNoCorruption(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		var id = fn (x) { x }
-		fn f() { id = fn (n: number) -> number { n } }
+		var id = fn (x) { return x }
+		fn f() { id = fn (n: number) -> number { return n } }
 		val r = id("hello")
 	`)
 	require.Empty(t, errs)
@@ -193,8 +193,8 @@ func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// M6 target: "fn (c: boolean, x: 1 | 2) -> 1 | 2".
-	require.Equal(t, "fn (c: boolean, x: 1) -> 1 | 2", values["f"])
+	// M6 target: "fn (c: boolean, x: 1 | 2) -> void".
+	require.Equal(t, "fn (c: boolean, x: 1) -> void", values["f"])
 }
 
 // A namespace name as an assignment target reports NamespaceUsedAsValue, mirroring

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -8,13 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PR3 — async / await / block return-point join, against real source through
+// PR3 — async / await / return-point join, against real source through
 // inferSource. The PR builds on M2's monomorphic walk: the body of an `async fn`
 // types exactly like a plain function, then its EXTERNAL return wraps in
-// Promise<T>; `await e` constrains `e <: Promise<U>` and yields `U`; non-tail
-// ReturnStmts join with the block tail before constraining against the return
-// annotation. No auto-flatten of nested Promise<Promise<T>> — that is M9's
-// Awaited<T>.
+// Promise<T>; `await e` constrains `e <: Promise<U>` and yields `U`; the
+// collected ReturnStmts join before constraining against the return annotation.
+// No auto-flatten of nested Promise<Promise<T>> — that is M9's Awaited<T>.
 
 // --- async fn external wrap ---
 
@@ -31,17 +30,17 @@ func TestInferAsyncFnWrapsReturnInPromise(t *testing.T) {
 	require.Equal(t, "fn () -> Promise<number>", values["f"])
 }
 
-// An async fn with no explicit return — the body's tail is its return — still
-// wraps externally. Here the tail value is the literal "hi", so externally
-// `Promise<"hi">`.
-func TestInferAsyncFnTailReturnWrapped(t *testing.T) {
+// An async fn with no explicit return produces no value — a body's last
+// expression is NOT an implicit return — so the external wrap is Promise<void>,
+// not Promise<"hi">.
+func TestInferAsyncFnNoReturnIsPromiseVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn greet() {
 			"hi"
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn () -> Promise<"hi">`, values["greet"])
+	require.Equal(t, `fn () -> Promise<void>`, values["greet"])
 }
 
 // --- await ---
@@ -191,7 +190,7 @@ func TestInferAwaitInNestedAsyncOK(t *testing.T) {
 			val inner = async fn () {
 				return await p
 			}
-			inner
+			return inner
 		}
 	`)
 	require.Empty(t, errs)
@@ -230,11 +229,9 @@ func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
 	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["h"])
 }
 
-// An early return inside one branch, with the other branch producing the tail.
-// Both return points contribute to the function's return type — neither path is
-// dropped. With no else, the if's value is `void | <cons>`; the tail `"x"` is
-// the fall-through; together with the collected `return 1`, the function
-// returns `1 | "x"`.
+// An early return inside one branch plus a fall-through return: both return
+// points contribute to the function's return type — neither path is dropped —
+// and the join checks against the annotation.
 func TestInferBlockReturnAnnotationCheckedAgainstAllReturns(t *testing.T) {
 	// `return 1` inside the if, return-annotation number — should type-check.
 	_, _, errs := inferSource(t, `
@@ -279,25 +276,26 @@ func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 
 // --- IfElseExpr value ---
 
-// An if/else used as an expression is the join of its branches. Without
+// An if/else used as an expression is the join of its branches, observed
+// through an explicit `return` (a bare tail would be discarded). Without
 // generalization on the binding (PR1's value-only generalization for `val =
 // fn`), the binding here is monomorphic-frozen to the join.
 func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {
-			if c { 1 } else { "x" }
+			return if c { 1 } else { "x" }
 		}
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["pick"])
 }
 
-// An if WITHOUT else folds in void from the missing alt — `if c { 5 }` as a
-// tail expression is `5 | void`.
+// An if WITHOUT else folds in void from the missing alt — `return if c { 5 }`
+// returns `5 | void`.
 func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {
-			if c { 5 }
+			return if c { 5 }
 		}
 	`)
 	require.Empty(t, errs)
@@ -346,14 +344,14 @@ func TestInferFnMultipleBareReturnsCollapse(t *testing.T) {
 }
 
 // A nested return is collected on the INNER funcCtx, not the outer one. After
-// the inner fn ends, the outer's returns list is still empty — the body's tail
-// (the inner fn's type) is the outer return, unwrapped.
+// the inner fn ends, the outer's returns list holds only the outer's own
+// `return` of the inner fn — the inner's `return x` never leaks out.
 func TestInferNestedFnReturnsScoped(t *testing.T) {
 	c := newChecker()
-	// fn outer() { fn (x: number) { return x } }
+	// fn outer() { return fn (x: number) { return x } }
 	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil,
 		block(returnStmt(identExpr("x"))))
-	outer := funcExpr(nil, nil, block(exprStmt(inner)))
+	outer := funcExpr(nil, nil, block(returnStmt(inner)))
 
 	got := c.inferExpr(NewScope(), 0, outer)
 	require.Empty(t, c.errs)
@@ -375,7 +373,7 @@ func TestInferNestedFnReturnsScoped(t *testing.T) {
 func TestInferIfElseUnknownConditionNoCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick() {
-			if undeclared { 1 } else { 2 }
+			return if undeclared { 1 } else { 2 }
 		}
 	`)
 	require.Len(t, errs, 1)
@@ -390,7 +388,7 @@ func TestInferIfElseUnknownConditionNoCascade(t *testing.T) {
 func TestInferAwaitUnknownArgNoCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn f() {
-			await undeclared
+			return await undeclared
 		}
 	`)
 	require.Len(t, errs, 1)
@@ -406,7 +404,7 @@ func TestInferAwaitUnknownArgNoCascade(t *testing.T) {
 func TestInferPromiseUnsupportedInnerKeepsWrapper(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: Promise<bigint>) {
-			0
+			return 0
 		}
 	`)
 	require.Len(t, errs, 1)
@@ -421,7 +419,7 @@ func TestInferPromiseUnsupportedInnerKeepsWrapper(t *testing.T) {
 func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: Promise<bigint>) {
-			p
+			return p
 		}
 	`)
 	require.Len(t, errs, 1)
@@ -468,37 +466,38 @@ func TestInferReturnOutsideFunctionRejected(t *testing.T) {
 // reaches `val x = …`, the `c == true` path has already returned from the
 // function, so the only path that produces a value for x is the `else`.
 //
-// The tail wraps x in a tuple — `[x]` — so x's inferred type is OBSERVABLE in the
-// function's return distinctly from the early-return point. A bare `x` tail would
-// not discriminate: `return 1` makes `1` a function return point regardless, so
-// both the correct `x : "y"` and the buggy `x : 1 | "y"` render the function as
-// `1 | "y"` (the leaked `1` is absorbed by the return point). Inside the tuple the
-// leak cannot hide — correct gives `["y"]`, the bug would give `[1 | "y"]`.
+// The final statement returns x wrapped in a tuple — `return [x]` — so x's
+// inferred type is OBSERVABLE in the function's return distinctly from the
+// early-return point. A bare `return x` would not discriminate: `return 1` makes
+// `1` a function return point regardless, so both the correct `x : "y"` and the
+// buggy `x : 1 | "y"` render the function as `1 | "y"` (the leaked `1` is
+// absorbed by the return point). Inside the tuple the leak cannot hide — correct
+// gives `["y"]`, the bug would give `[1 | "y"]`.
 func TestInferIfElseDivergingBranchDropsFromValue(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(c: boolean) {
 			val x = if c { return 1 } else { "y" }
-			[x]
+			return [x]
 		}
 	`)
 	require.Empty(t, errs)
-	// x is "y", not 1 | "y" — so the tuple tail is ["y"]. The function returns
+	// x is "y", not 1 | "y" — so the returned tuple is ["y"]. The function returns
 	// 1 | ["y"]: the early `return 1` IS a function return point (joined with the
-	// tail), even though it is not part of x's value. A buggy leak would surface
-	// here as 1 | [1 | "y"].
+	// final return), even though it is not part of x's value. A buggy leak would
+	// surface here as 1 | [1 | "y"].
 	require.Equal(t, `fn (c: boolean) -> 1 | ["y"]`, values["f"])
 }
 
-// The dual of the above: when the diverging-branch `if` is the function's TAIL
-// value, the function's return type still includes the early return. The if's
-// value is the non-diverging branch ("z"), wrapped in a tuple so it is observable
-// distinctly from the collected `return 3`; the block return-point join folds in
-// that return, so the function returns 3 | ["z"] (a bug that leaked the diverging
-// branch into the if's value would render 3 | [3 | "z"]).
-func TestInferIfElseDivergingBranchTailReturnJoin(t *testing.T) {
+// The dual of the above: when the diverging-branch `if` is part of the RETURNED
+// expression, the function's return type still includes the early return. The
+// if's value is the non-diverging branch ("z"), wrapped in a tuple so it is
+// observable distinctly from the collected `return 3`; the return-point join
+// folds in that return, so the function returns 3 | ["z"] (a bug that leaked the
+// diverging branch into the if's value would render 3 | [3 | "z"]).
+func TestInferIfElseDivergingBranchReturnJoin(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(c: boolean) {
-			[if c { return 3 } else { "z" }]
+			return [if c { return 3 } else { "z" }]
 		}
 	`)
 	require.Empty(t, errs)
@@ -507,17 +506,10 @@ func TestInferIfElseDivergingBranchTailReturnJoin(t *testing.T) {
 
 // When BOTH branches of an `if` diverge, the if's VALUE has no contributing branch
 // and coalesces to `never` (the bottom type — no path through the `if` yields a
-// value). Observed at top level so the if-value is read straight off the binding,
-// with no dead-code tail to muddy it: each `return` outside a function is also
-// reported (symmetric to TestInferReturnOutsideFunctionRejected). A bug that failed
-// to drop a diverging branch would surface here as `1 | 2` instead of `never`.
-//
-// NOTE: this deliberately observes the if-EXPRESSION's value, not a function's
-// return type. Inside a function, `val x = if c { return 1 } else { return 2 }`
-// makes every following statement unreachable, but the solver does not yet drop
-// that dead code from the block/function value (it still contributes `[never]` for
-// a `[x]` tail). That statement-level reachability gap is tracked in #719; #714
-// scoped only the if-expression value, which this test pins.
+// value). Observed at top level so the if-value is read straight off the binding:
+// each `return` outside a function is also reported (symmetric to
+// TestInferReturnOutsideFunctionRejected). A bug that failed to drop a diverging
+// branch would surface here as `1 | 2` instead of `never`.
 func TestInferIfElseBothBranchesDivergeYieldsNever(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val x = if true { return 1 } else { return 2 }
@@ -526,4 +518,32 @@ func TestInferIfElseBothBranchesDivergeYieldsNever(t *testing.T) {
 	require.Equal(t, "return can only be used inside a function", errs[0].Message())
 	require.Equal(t, "return can only be used inside a function", errs[1].Message())
 	require.Equal(t, "never", values["x"])
+}
+
+// #719/#720: dead code after a diverging statement no longer contributes to the
+// function's value. Both branches return, so x's initializer diverges entirely
+// and the unreachable `[x]` statement is walked but discarded — the function's
+// return type is exactly the join of its return points, 1 | 2.
+func TestInferDeadTailAfterDivergingValDiscarded(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(c: boolean) {
+			val x = if c { return 1 } else { return 2 }
+			[x]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (c: boolean) -> 1 | 2", values["f"])
+}
+
+// #719/#720: a statement after a `return` is dead code and does not contribute
+// to the function's value — `fn g() { return 1; 2 }` is `1`, not `1 | 2`.
+func TestInferStatementAfterReturnDiscarded(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn g() {
+			return 1
+			2
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> 1", values["g"])
 }

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -16,7 +16,7 @@ import (
 // force the callee inexact, rejecting every call to an exact function.
 func TestInferCallExactArityTypeChecks(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number, y: number) -> number { x }
+		fn f(x: number, y: number) -> number { return x }
 		val r = f(1, 2)
 	`)
 	require.Empty(t, errs)
@@ -28,7 +28,7 @@ func TestInferCallExactArityTypeChecks(t *testing.T) {
 // receives only the arity-matched prefix, so its accept-set gate stays silent.
 func TestInferCallExactTooManyArgsSingleDiagnostic(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x: number, y: number) -> number { x }
+		fn f(x: number, y: number) -> number { return x }
 		val r = f(1, 2, 3)
 	`)
 	require.Len(t, errs, 1)
@@ -39,7 +39,7 @@ func TestInferCallExactTooManyArgsSingleDiagnostic(t *testing.T) {
 // renders as `y?: T` and lowers the function's required count (the accept-set lower
 // bound) without changing arity.
 func TestInferOptionalParamRenders(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(x: number, y?: number) -> number { x }`)
+	values, _, errs := inferSource(t, `fn f(x: number, y?: number) -> number { return x }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (x: number, y?: number) -> number", values["f"])
 }
@@ -49,7 +49,7 @@ func TestInferOptionalParamRenders(t *testing.T) {
 func TestInferOptionalParamCallArity(t *testing.T) {
 	t.Run("omitted and supplied both type-check", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
-			fn f(x: number, y?: number) -> number { x }
+			fn f(x: number, y?: number) -> number { return x }
 			val a = f(1)
 			val b = f(1, 2)
 		`)
@@ -58,7 +58,7 @@ func TestInferOptionalParamCallArity(t *testing.T) {
 
 	t.Run("overflow trips the lint", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
-			fn f(x: number, y?: number) -> number { x }
+			fn f(x: number, y?: number) -> number { return x }
 			val c = f(1, 2, 3)
 		`)
 		require.Len(t, errs, 1)
@@ -73,7 +73,7 @@ func TestInferOptionalParamCallArity(t *testing.T) {
 // the too-few lint reports a required count of 2.
 func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(a?: number, b: number) -> number { b }
+		fn f(a?: number, b: number) -> number { return b }
 		val r = f(1)
 	`)
 	require.Len(t, errs, 1)
@@ -86,14 +86,14 @@ func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 // subtyping, not direct calls).
 func TestInferInexactFunctionValue(t *testing.T) {
 	t.Run("renders with the inexact marker", func(t *testing.T) {
-		values, _, errs := inferSource(t, `fn f(x: number, ...) -> number { x }`)
+		values, _, errs := inferSource(t, `fn f(x: number, ...) -> number { return x }`)
 		require.Empty(t, errs)
 		require.Equal(t, "fn (x: number, ...) -> number", values["f"])
 	})
 
 	t.Run("direct call still rejects extra args", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
-			fn f(x: number, ...) -> number { x }
+			fn f(x: number, ...) -> number { return x }
 			val r = f(1, 2)
 		`)
 		require.Len(t, errs, 1)
@@ -105,7 +105,7 @@ func TestInferInexactFunctionValue(t *testing.T) {
 // optional may be omitted, so `fn(x, y?)` called with no args needs at least 1.
 func TestInferTooFewArgsRespectsOptional(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x: number, y?: number) -> number { x }
+		fn f(x: number, y?: number) -> number { return x }
 		val r = f()
 	`)
 	require.Len(t, errs, 1)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -104,12 +104,13 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // inferFunc is the shared function-typing core for FuncExpr and FuncDecl. It
 // opens a child scope, binds each param (its annotation resolved to a soltype,
 // or a fresh var when un-annotated), types the body block in that scope, and
-// builds the n-ary soltype.FuncType. When the signature carries a return
-// annotation the inferred body type is constrained against it and the annotated
-// type becomes the function's return type; otherwise the body type is the
-// return type directly. A bodyless (declare/ambient) function adopts its return
-// annotation without constraining anything. node supplies the span stamped onto
-// a return-annotation constraint failure.
+// builds the n-ary soltype.FuncType. The return type is built solely from the
+// body's `return` statements (joinReturnPoints); a body with no return produces
+// void. When the signature carries a return annotation the inferred return is
+// constrained against it and the annotated type becomes the function's return
+// type. A bodyless (declare/ambient) function adopts its return annotation
+// without constraining anything. node supplies the span stamped onto a
+// return-annotation constraint failure.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
@@ -166,42 +167,19 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 
 	var ret soltype.Type = &soltype.Void{}
 	hasBody := body != nil
-	var collected []soltype.Type
 	if hasBody {
 		// PR3: open a fresh function context so every ReturnStmt encountered while
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node)
-		// The function body wants the TAIL value for the return-point join (a
-		// diverging `{ return 5 }` body still returns 5, collected into c.fn.returns
-		// below), so the divergence flag is irrelevant here — only value-position
-		// callers (inferIfElse) consult it.
-		ret, _ = c.inferBlock(fnScope, lvl, body)
-		collected = c.popFuncCtx(saved)
-	}
-	// PR3 — block return-point join. M2 only used the block tail and dropped non-
-	// tail returns; M3 joins EVERY ReturnStmt (collected above) with the tail. The
-	// join is a fresh var with each return point as a lower bound: when there is
-	// no explicit return, ret stays the tail unchanged (preserving M2's monomorphic
-	// renders); when there is at least one, all paths flow through one variable
-	// whose coalesced positive face is their union.
-	//
-	// Fast path: a single return that IS the block tail (`fn f() { … return X }`,
-	// where inferStmt returns the return's value as the tail too — same pointer).
-	// ret already IS that return, so minting a join var would add a pointless
-	// indirection plus two redundant constraints the coalescer must later dedup.
-	if len(collected) > 0 && !(len(collected) == 1 && collected[0] == ret) {
-		joinVar := c.freshAt(lvl)
-		c.recordProv(joinVar, node, ReturnJoin)
-		// Source-order constraint: collected returns first (in source order), then
-		// the block tail. When the tail IS one of the collected returns, the
-		// duplicate bound is dedup'd at render time — the rendered union reflects
-		// source order, not constraint order.
-		for _, rt := range collected {
-			c.constrain(node, rt, joinVar)
-		}
-		c.constrain(node, ret, joinVar)
-		ret = joinVar
+		// Walk the body for type-checking and to collect its ReturnStmts; the
+		// block's TAIL value is intentionally discarded. Unlike a value-position
+		// block, where the last expression IS the block's value, a function body's
+		// last expression is NOT an implicit return — only an explicit `return`
+		// produces the function's value. This mirrors the old checker's
+		// inferFuncBody.
+		c.inferBlock(fnScope, lvl, body)
+		ret = c.joinReturnPoints(node, lvl, c.popFuncCtx(saved))
 	}
 	// Return-annotation handling diverges by async-ness.
 	//
@@ -248,6 +226,31 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// callees; M3's FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
 	return ft
+}
+
+// joinReturnPoints builds a function's return type from the ReturnStmt types
+// collected while walking its body. No returns means the body produces no value,
+// so the function returns void. A return-less body that always diverges via
+// `throw` would be `never` in the old checker, but that case is deferred: throw,
+// do, and match are not walked yet, and a raw NeverType here would break the
+// recovery-placeholder invariant (see isRecoveryPlaceholder). A single return is
+// the return type directly — no join var, no indirection. Multiple returns flow
+// through a fresh join variable whose coalesced positive face is their union,
+// constrained in source order so the rendered union reflects source order.
+func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.Type) soltype.Type {
+	switch len(collected) {
+	case 0:
+		return &soltype.Void{}
+	case 1:
+		return collected[0]
+	default:
+		joinVar := c.freshAt(lvl)
+		c.recordProv(joinVar, node, ReturnJoin)
+		for _, rt := range collected {
+			c.constrain(node, rt, joinVar)
+		}
+		return joinVar
+	}
 }
 
 // asyncReturn computes an `async fn`'s external return type, which always faces
@@ -547,7 +550,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// instantiate (the read face), NOT the coalesced write-face targetT: targetT is a
 	// display type that may be a Union/Intersection node, and re-injecting it into the
 	// constraint graph here would later crash the coalescer when this value flows on
-	// (e.g. as a function-body tail). This overwrites the `void` recorded for e above,
+	// (e.g. through a `return`). This overwrites the `void` recorded for e above,
 	// which now serves only as the error-path recovery value.
 	valueT := c.instantiate(b.Schemes[0], lvl)
 	c.recordType(e, valueT)
@@ -795,10 +798,10 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 //
 // Block return-point interaction: any ReturnStmt inside either branch is still
 // collected on the enclosing function's funcCtx by inferStmt — independent of the
-// if's value contribution — so `fn f(c) { if c { return X } else { Y } }` flows X
-// into the function's return type (via the block return-point join) AND Y into
-// the if's value, which the enclosing block joins. The two roles are orthogonal:
-// X is a return point, but not part of the if-EXPRESSION's value.
+// if's value contribution — so `fn f(c) { val x = if c { return X } else { Y } }`
+// flows X into the function's return type (via joinReturnPoints) AND Y into the
+// if's value, which binds x. The two roles are orthogonal: X is a return point,
+// but not part of the if-EXPRESSION's value.
 func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.Type {
 	cond := c.inferExpr(scope, lvl, e.Cond)
 	// The synthesized `boolean` requirement is intentionally NOT recorded in Prov

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -232,11 +232,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 // collected while walking its body. No returns means the body produces no value,
 // so the function returns void. A return-less body that always diverges via
 // `throw` would be `never` in the old checker, but that case is deferred: throw,
-// do, and match are not walked yet, and a raw NeverType here would break the
-// recovery-placeholder invariant (see isRecoveryPlaceholder). A single return is
-// the return type directly — no join var, no indirection. Multiple returns flow
-// through a fresh join variable whose coalesced positive face is their union,
-// constrained in source order so the rendered union reflects source order.
+// do, and match are not walked yet, so such a body cannot be recognized as
+// diverging, and constrain has no `never <: T` arm — a raw NeverType minted here
+// would spuriously fail the body-vs-annotation check. Recovery placeholders are
+// the absorbing ErrorType sentinel (PR8), never a raw NeverType. A single return
+// is the return type directly — no join var, no indirection. Multiple returns
+// flow through a fresh join variable whose coalesced positive face is their
+// union, constrained in source order so the rendered union reflects source
+// order.
 func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.Type) soltype.Type {
 	switch len(collected) {
 	case 0:

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -28,8 +28,8 @@ func renderBinding(b ValueBinding) string {
 
 func TestInferFuncExprAnnotated(t *testing.T) {
 	c := newChecker()
-	// fn (x: number) { x }
-	e := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// fn (x: number) { return x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Empty(t, c.errs)
@@ -43,8 +43,8 @@ func TestInferFuncExprAnnotated(t *testing.T) {
 // a <T0> quantifier.
 func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
 	c := newChecker()
-	// fn (x) { x }
-	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(exprStmt(identExpr("x"))))
+	// fn (x) { return x }
+	e := funcExpr([]*ast.Param{param("x", nil)}, nil, block(returnStmt(identExpr("x"))))
 
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Empty(t, c.errs)
@@ -53,11 +53,11 @@ func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
 
 func TestInferFuncExprMultiParam(t *testing.T) {
 	c := newChecker()
-	// fn (x: number, y: string) { y }
+	// fn (x: number, y: string) { return y }
 	e := funcExpr(
 		[]*ast.Param{param("x", numAnn()), param("y", strAnn())},
 		nil,
-		block(exprStmt(identExpr("y"))),
+		block(returnStmt(identExpr("y"))),
 	)
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -67,8 +67,8 @@ func TestInferFuncExprMultiParam(t *testing.T) {
 
 func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
 	c := newChecker()
-	// fn (x: number) -> number { x }
-	e := funcExpr([]*ast.Param{param("x", numAnn())}, numAnn(), block(exprStmt(identExpr("x"))))
+	// fn (x: number) -> number { return x }
+	e := funcExpr([]*ast.Param{param("x", numAnn())}, numAnn(), block(returnStmt(identExpr("x"))))
 
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Empty(t, c.errs)
@@ -77,8 +77,8 @@ func TestInferFuncExprReturnAnnotationAccepted(t *testing.T) {
 
 func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
 	c := newChecker()
-	// fn () -> number { "hello" }
-	e := funcExpr(nil, numAnn(), block(exprStmt(strExpr("hello"))))
+	// fn () -> number { return "hello" }
+	e := funcExpr(nil, numAnn(), block(returnStmt(strExpr("hello"))))
 
 	c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
@@ -86,14 +86,14 @@ func TestInferFuncExprReturnAnnotationMismatch(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// A body-level val is visible to later statements and to the tail expression
-// that becomes the function's result.
+// A body-level val is visible to later statements, including the return that
+// becomes the function's result.
 func TestInferFuncExprBodyValDecl(t *testing.T) {
 	c := newChecker()
-	// fn () { val y = 5; y }
+	// fn () { val y = 5; return y }
 	e := funcExpr(nil, nil, block(
 		ast.NewDeclStmt(valDecl("y", nil, numExpr(5)), testSpan()),
-		exprStmt(identExpr("y")),
+		returnStmt(identExpr("y")),
 	))
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -184,8 +184,8 @@ func TestInferFuncExprGenericUnsupported(t *testing.T) {
 
 func TestInferCallResolvesReturn(t *testing.T) {
 	c := newChecker()
-	// (fn (x: number) { x })(5)
-	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// (fn (x: number) { return x })(5)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(5)}, false, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -196,8 +196,8 @@ func TestInferCallResolvesReturn(t *testing.T) {
 
 func TestInferCallArgMismatch(t *testing.T) {
 	c := newChecker()
-	// (fn (x: number) { x })("hello")
-	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// (fn (x: number) { return x })("hello")
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{strExpr("hello")}, false, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -213,8 +213,8 @@ func TestInferCallArgMismatch(t *testing.T) {
 // only the arity-matched prefix, so the lint is the SOLE diagnostic.
 func TestInferCallTooManyArgs(t *testing.T) {
 	c := newChecker()
-	// (fn (x: number) { x })(1, 2)
-	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// (fn (x: number) { return x })(1, 2)
+	callee := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(1), numExpr(2)}, false, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -230,8 +230,8 @@ func TestInferCallTooManyArgs(t *testing.T) {
 // so the lint is the SOLE diagnostic, not a doubled lint + FuncArityMismatch.
 func TestInferCallTooFewArgs(t *testing.T) {
 	c := newChecker()
-	// (fn (x: number, y: number) { x })(1)
-	callee := funcExpr([]*ast.Param{param("x", numAnn()), param("y", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// (fn (x: number, y: number) { return x })(1)
+	callee := funcExpr([]*ast.Param{param("x", numAnn()), param("y", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	e := ast.NewCall(callee, []ast.Expr{numExpr(1)}, false, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
@@ -287,9 +287,10 @@ func TestInferBlockReturnStmt(t *testing.T) {
 	got, diverges := c.inferBlock(NewScope(), 0, block(returnStmt(numExpr(5))))
 	c.popFuncCtx(saved)
 	require.Empty(t, c.errs)
-	// The block's tail VALUE is still 5 (inferFunc uses it for the return-point
-	// join, so `fn () { return 5 }` returns 5), but the block DIVERGES — a
-	// value-position consumer (an if/else branch) drops it from its branch union.
+	// The block's tail VALUE is still 5 (a value-position block keeps it), but the
+	// block DIVERGES — a value-position consumer (an if/else branch) drops it from
+	// its branch union. inferFunc itself ignores the tail; the return reaches the
+	// function's type as a collected return point.
 	require.True(t, diverges)
 	require.Equal(t, "5", render(got))
 }
@@ -329,11 +330,11 @@ func TestInferStmtBodyDeclNotAllowed(t *testing.T) {
 
 func TestInferFuncDecl(t *testing.T) {
 	c := newChecker()
-	// fn id(x: number) { x }
+	// fn id(x: number) { return x }
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("id", testSpan()), nil, nil,
 		[]*ast.Param{param("x", numAnn())}, nil, nil,
-		block(exprStmt(identExpr("x"))),
+		block(returnStmt(identExpr("x"))),
 		false, false, false, testSpan(),
 	)
 
@@ -353,11 +354,11 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
 	scope.defineValue("foo", ValueBinding{Schemes: []TypeScheme{monoScheme(c.freshAt(1))}})
-	// fn foo(x: number) { foo(x) }
+	// fn foo(x: number) { return foo(x) }
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("foo", testSpan()), nil, nil,
 		[]*ast.Param{param("x", numAnn())}, nil, nil,
-		block(exprStmt(ast.NewCall(identExpr("foo"), []ast.Expr{identExpr("x")}, false, testSpan()))),
+		block(returnStmt(ast.NewCall(identExpr("foo"), []ast.Expr{identExpr("x")}, false, testSpan()))),
 		false, false, false, testSpan(),
 	)
 
@@ -369,17 +370,17 @@ func TestInferFuncDeclSelfReference(t *testing.T) {
 // A FuncExpr may be assigned to a body-level `val` inside a FuncDecl (the way a
 // function value is introduced in a body, since body decls are VarDecl-only).
 // The bound name resolves to the function type, and the enclosing function
-// returns it as its tail value.
+// returns it.
 func TestInferFuncDeclBodyFuncValDecl(t *testing.T) {
 	c := newChecker()
-	// fn outer() { val f = fn (x: number) { x }; f }
-	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(exprStmt(identExpr("x"))))
+	// fn outer() { val f = fn (x: number) { return x }; return f }
+	inner := funcExpr([]*ast.Param{param("x", numAnn())}, nil, block(returnStmt(identExpr("x"))))
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("outer", testSpan()), nil, nil,
 		nil, nil, nil,
 		block(
 			ast.NewDeclStmt(valDecl("f", nil, inner), testSpan()),
-			exprStmt(identExpr("f")),
+			returnStmt(identExpr("f")),
 		),
 		false, false, false, testSpan(),
 	)

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -20,8 +20,8 @@ import (
 // each call yielding that arm's return type.
 func TestInferOverloadResolvesByArgType(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 		val r = f(5)
 		val s = f("hi")
 	`)
@@ -36,8 +36,8 @@ func TestInferOverloadResolvesByArgType(t *testing.T) {
 // f(5, "hi") the 2-param arm.
 func TestInferOverloadDispatchesOnArity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x, y) { x }
+		fn f(x) { return x }
+		fn f(x, y) { return x }
 		val a = f(5)
 		val b = f(5, "hi")
 	`)
@@ -52,8 +52,8 @@ func TestInferOverloadDispatchesOnArity(t *testing.T) {
 // later arm and relates the earlier one.
 func TestInferOverloadDuplicateParamTypesRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x: number) -> string { "a" }
-		fn f(x: number) -> boolean { true }
+		fn f(x: number) -> string { return "a" }
+		fn f(x: number) -> boolean { return true }
 		val r = f(5)
 	`)
 	require.Len(t, errs, 1)
@@ -73,8 +73,8 @@ func TestInferOverloadCrossFileDeclarationOrder(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	sources := []*ast.Source{
-		{ID: 0, Path: "b.esc", Contents: `fn f(x: string) -> boolean { true }`},
-		{ID: 1, Path: "a.esc", Contents: "fn f(x: number) -> string { \"s\" }\nval r = f(5)"},
+		{ID: 0, Path: "b.esc", Contents: `fn f(x: string) -> boolean { return true }`},
+		{ID: 1, Path: "a.esc", Contents: "fn f(x: number) -> string { return \"s\" }\nval r = f(5)"},
 	}
 	module, parseErrs := parser.ParseLibFiles(ctx, sources)
 	require.Empty(t, parseErrs, "expected no parse errors")
@@ -91,8 +91,8 @@ func TestInferOverloadCrossFileDeclarationOrder(t *testing.T) {
 // the string arm even though the generic arm is declared first and would also match.
 func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x: string) -> boolean { true }
+		fn f(x) { return x }
+		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
 	require.Empty(t, errs)
@@ -106,9 +106,9 @@ func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 // whose real fix (deferred resolution) is tracked in #723.
 func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
-		val g = fn (y) { f(y) }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
+		val g = fn (y) { return f(y) }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (y: number) -> number", values["g"],
@@ -118,8 +118,8 @@ func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 // No arm accepts the argument ⇒ NoMatchingOverloadError listing the candidates.
 func TestInferOverloadNoMatch(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 		val r = f(true)
 	`)
 	require.Len(t, errs, 1)
@@ -150,8 +150,8 @@ func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
 // `cannot constrain` errors because the recursive reference saw only the first arm.)
 func TestInferOverloadSelfRecursiveAnnotated(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { f(x) }
-		fn f(x: string) -> string { f(x) }
+		fn f(x: number) -> number { return f(x) }
+		fn f(x: string) -> string { return f(x) }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
@@ -163,11 +163,11 @@ func TestInferOverloadSelfRecursiveAnnotated(t *testing.T) {
 // the component see the whole set, not a single first-arm var.
 func TestInferOverloadMutualRecursionValueCapture(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { g(x) }
-		fn f(x: string) -> number { g(5) }
+		fn f(x: number) -> number { return g(x) }
+		fn f(x: string) -> number { return g(5) }
 		fn g(n: number) -> number {
 			val h = f
-			h(n)
+			return h(n)
 		}
 	`)
 	require.Empty(t, errs)
@@ -180,9 +180,9 @@ func TestInferOverloadMutualRecursionValueCapture(t *testing.T) {
 // a singleton — the gate never fires and the set binds normally.
 func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn g(z: number) -> number { z }
-		fn f(x: number) -> number { g(x) }
-		fn f(x: string) -> string { "s" }
+		fn g(z: number) -> number { return z }
+		fn f(x: number) -> number { return g(x) }
+		fn f(x: string) -> string { return "s" }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
@@ -193,8 +193,8 @@ func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
 // via constrain's function-intersection-LHS arm — g(5) ⇒ number, g("hi") ⇒ string.
 func TestInferOverloadValuePosition(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 		val g = f
 		val r = g(5)
 		val s = g("hi")
@@ -213,8 +213,8 @@ func TestInferOverloadValuePosition(t *testing.T) {
 // the level-0 intersection and aliases the arm's type variable across uses.)
 func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x, y) { x }
+		fn f(x) { return x }
+		fn f(x, y) { return x }
 		val g = f
 		val a = g("hi")
 		val b = g(true)
@@ -229,16 +229,16 @@ func TestInferOverloadGenericArmValuePositionNoAlias(t *testing.T) {
 // whether the callee is the overloaded name directly or a let-bound alias.
 func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 	direct, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x: string) -> boolean { true }
+		fn f(x) { return x }
+		fn f(x: string) -> boolean { return true }
 		val r = f("hi")
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "boolean", direct["r"], "direct call picks the more specific arm")
 
 	binding, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x: string) -> boolean { true }
+		fn f(x) { return x }
+		fn f(x: string) -> boolean { return true }
 		val g = f
 		val r = g("hi")
 	`)
@@ -251,9 +251,9 @@ func TestInferOverloadValuePositionMatchesDirectOrder(t *testing.T) {
 // selects the arm that accepts it, most-specific-first with declaration-order tiebreak.
 func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x) { x }
-		fn f(x: number) -> boolean { true }
-		fn f(x: string) -> string { x }
+		fn f(x) { return x }
+		fn f(x: number) -> boolean { return true }
+		fn f(x: string) -> string { return x }
 		val p = f(5)
 		val q = f("hi")
 		val r = f(true)
@@ -304,8 +304,8 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 // the decl at Sources[i].
 func TestInferOverloadBindingSourcesAlignWithSchemes(t *testing.T) {
 	scope, _, errs := InferModule(parseModule(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 	`))
 	require.Empty(t, errs)
 	b, ok := scope.GetValue("f")
@@ -320,8 +320,8 @@ func TestInferOverloadBindingSourcesAlignWithSchemes(t *testing.T) {
 // shared funcOnlyDecls classifier keeps the gate and the binding consistent.
 func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 		val f = 5
 	`)
 	require.Len(t, errs, 1)
@@ -337,7 +337,7 @@ func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
 // b.esc's val is reported.
 func TestInferOverloadMixedWithValCrossFileIsDuplicate(t *testing.T) {
 	values, _, errs := inferSources(t, map[string]string{
-		"a.esc": `fn f(x: number) -> number { x }`,
+		"a.esc": `fn f(x: number) -> number { return x }`,
 		"b.esc": `val f = 5`,
 	})
 	require.Len(t, errs, 1)

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -26,14 +26,14 @@ func TestInferModuleTopLevelLetPolymorphism(t *testing.T) {
 	t.Run("render", func(t *testing.T) {
 		// Identity's param and return are the same variable, so its render is
 		// compact even before PR2 — this pins the <T0> quantifier prefix.
-		values, _, errs := inferSource(t, `fn id(x) { x }`)
+		values, _, errs := inferSource(t, `fn id(x) { return x }`)
 		require.Empty(t, errs)
 		require.Equal(t, map[string]string{"id": "fn <T0>(x: T0) -> T0"}, values)
 	})
 
 	t.Run("two types of use", func(t *testing.T) {
 		values, _, errs := inferSource(t, `
-			val id = fn (x) { x }
+			val id = fn (x) { return x }
 			val a = id(5)
 			val b = id("hi")
 		`)
@@ -52,8 +52,8 @@ func TestInferModuleTopLevelLetPolymorphism(t *testing.T) {
 // every remaining variable coalesces to a concrete literal.
 func TestInferModuleIdentityPolymorphism(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		val identity = fn (x) { x }
-		val pair = fn () { [identity("hello"), identity(5)] }
+		val identity = fn (x) { return x }
+		val pair = fn () { return [identity("hello"), identity(5)] }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{
@@ -71,8 +71,8 @@ func TestInferModuleIdentityPolymorphism(t *testing.T) {
 func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val outer = fn (y) {
-			val getY = fn () { y }
-			[getY(), getY()]
+			val getY = fn () { return y }
+			return [getY(), getY()]
 		}
 		val r = outer(5)
 	`)
@@ -88,8 +88,8 @@ func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val f = fn () {
-			val id = fn (x) { x }
-			[id(5), id("hi")]
+			val id = fn (x) { return x }
+			return [id(5), id("hi")]
 		}
 	`)
 	require.Empty(t, errs)
@@ -102,7 +102,7 @@ func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
 // Per-call instantiation keeps k(1, "z") and k("s", true) at distinct types.
 func TestInferModulePolymorphicWithParameterOnlyVar(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		val k = fn (x, y) { x }
+		val k = fn (x, y) { return x }
 		val a = k(1, "z")
 		val b = k("s", true)
 	`)
@@ -121,8 +121,8 @@ func TestInferModulePolymorphicWithParameterOnlyVar(t *testing.T) {
 // real contract is that inference TERMINATES rather than hangs.
 func TestInferModuleRecursiveGroupGeneralizesWithoutLooping(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn ping(n) { pong(n) }
-		fn pong(n) { ping(n) }
+		fn ping(n) { return pong(n) }
+		fn pong(n) { return ping(n) }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -21,10 +21,10 @@ import (
 // error survives.
 func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn id(x: number) -> number { x }
+		fn id(x: number) -> number { return x }
 		fn f() {
 			var a = missing
-			id(a)
+			return id(a)
 		}
 	`)
 	require.Len(t, errs, 1)

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -20,14 +20,15 @@ import (
 // every present and future block-as-value consumer reads it instead of
 // re-deriving divergence syntactically at each call site.
 //
-// Block-as-value is distinct from FUNCTION-return: a non-tail ReturnStmt is not
-// part of the block's tail value, but it IS one of the function's return points
-// — inferStmt routes those into the enclosing funcCtx for inferFunc to join with
-// the tail (PR3, replacing M2's TODO that dropped non-tail returns). inferFunc
-// therefore IGNORES the divergence flag: it wants the tail value for the join, so
-// `fn f() { return 5 }` still returns `5` (the operand, collected and joined),
-// while `val x = if c { return 5 } else { 6 }` sees the cons branch diverge and
-// binds `x : 6`.
+// Block-as-value is distinct from FUNCTION-return: a ReturnStmt is one of the
+// function's return points whether or not it is the block's last statement —
+// inferStmt routes every return into the enclosing funcCtx for inferFunc to
+// join into the function's return type. inferFunc IGNORES both the tail and the
+// divergence flag: a function body's last expression is NOT an implicit return
+// (mirroring the old checker's inferFuncBody), so `fn f() { 5 }` returns void
+// while `fn f() { return 5 }` returns `5` (the operand, collected and joined).
+// Value-position consumers still use the tail: `val x = if c { return 5 } else
+// { 6 }` sees the cons branch diverge and binds `x : 6`.
 func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) (soltype.Type, bool) {
 	var result soltype.Type = &soltype.Void{}
 	for _, s := range b.Stmts {
@@ -48,10 +49,10 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 	case *ast.ExprStmt:
 		return c.inferExpr(scope, lvl, s.Expr)
 	case *ast.ReturnStmt:
-		// PR3: a return contributes both as a candidate block-tail value (kept for
-		// continuity with M2's `{ return 5 }` block-as-expression test) AND as one
-		// of the enclosing function's return points. Bare `return` contributes Void
-		// in both slots.
+		// A return contributes both as the block's tail value (consumed only by
+		// value-position blocks; inferFunc discards the tail) AND as one of the
+		// enclosing function's return points. Bare `return` contributes Void in
+		// both slots.
 		var t soltype.Type = &soltype.Void{}
 		if s.Expr != nil {
 			t = c.inferExpr(scope, lvl, s.Expr)

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -299,6 +299,30 @@ func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
 	require.Equal(t, map[string]string{"x": "5"}, values)
 }
 
+// #720: a function body's last expression is NOT an implicit return — only an
+// explicit `return` produces the function's value, mirroring the old checker's
+// inferFuncBody. The bare tail is still walked for its checking side effects,
+// but its value is discarded and the body returns void.
+func TestInferFuncBodyTailIsNotImplicitReturn(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f() { 5 }
+		fn g() { return 5 }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> void", values["f"])
+	require.Equal(t, "fn () -> 5", values["g"])
+}
+
+// The discarded tail is still type-checked: an error inside it is reported even
+// though its value never reaches the function's return type.
+func TestInferFuncBodyDiscardedTailStillChecked(t *testing.T) {
+	src := `fn f() { missing }`
+	values, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "fn () -> void", values["f"])
+}
+
 // PR-5: dep_graph SCC ordering wires top-level FuncDecls into the module walk and
 // makes inference order-independent. Each case asserts the rendered MONOMORPHIC
 // binding types end-to-end — recursion resolves through the group var, but M1
@@ -314,8 +338,8 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 			// component is inferred first, so the call sees its concrete type.
 			name: "OutOfOrderFuncReference",
 			src: `
-				fn caller(n: number) { callee(n) }
-				fn callee(n: number) -> number { n }
+				fn caller(n: number) { return callee(n) }
+				fn callee(n: number) -> number { return n }
 			`,
 			want: map[string]string{
 				"caller": "fn (n: number) -> number",
@@ -327,7 +351,7 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 			// never returns, so its return type coalesces to never. It resolves
 			// because the SCC driver pre-binds foo to a var before its body.
 			name: "SelfRecursive",
-			src:  `fn foo(x: number) { foo(x) }`,
+			src:  `fn foo(x: number) { return foo(x) }`,
 			want: map[string]string{"foo": "fn (x: number) -> never"},
 		},
 		{
@@ -336,8 +360,8 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 			// the annotated function type.
 			name: "MutuallyRecursiveGrounded",
 			src: `
-				fn ping(n: number) -> number { pong(n) }
-				fn pong(n: number) -> number { ping(n) }
+				fn ping(n: number) -> number { return pong(n) }
+				fn pong(n: number) -> number { return ping(n) }
 			`,
 			want: map[string]string{
 				"ping": "fn (n: number) -> number",
@@ -374,8 +398,8 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 // than hang.
 func TestInferModuleUngroundedMutualRecursionTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn a(n: number) { b(n) }
-		fn b(n: number) { a(n) }
+		fn a(n: number) { return b(n) }
+		fn b(n: number) { return a(n) }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{
@@ -395,7 +419,7 @@ func TestInferModuleUngroundedMutualRecursionTerminates(t *testing.T) {
 func TestInferModuleValInRecursiveGroupUsesRawType(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val a = z
-		fn z() -> number { a() }
+		fn z() -> number { return a() }
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{
@@ -410,8 +434,8 @@ func TestInferModuleValInRecursiveGroupUsesRawType(t *testing.T) {
 // string arm. (This replaces M2's interim OverloadNotSupportedError.)
 func TestInferModuleFunctionOverloadResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
-		fn f(x: string) -> string { x }
+		fn f(x: number) -> number { return x }
+		fn f(x: string) -> string { return x }
 		val r = f(5)
 		val s = f("hi")
 	`)
@@ -479,7 +503,7 @@ func TestInferMultiFile(t *testing.T) {
 			// resolves the callee's cross-file signature.
 			name: "CallFunctionFromOtherFile",
 			srcs: map[string]string{
-				"a.esc": `fn id(n: number) -> number { n }`,
+				"a.esc": `fn id(n: number) -> number { return n }`,
 				"b.esc": `val r = id(5)`,
 			},
 			want: map[string]string{
@@ -492,8 +516,8 @@ func TestInferMultiFile(t *testing.T) {
 			// the shared group var, grounded by their return annotations.
 			name: "MutualRecursionAcrossFiles",
 			srcs: map[string]string{
-				"a.esc": `fn ping(n: number) -> number { pong(n) }`,
-				"b.esc": `fn pong(n: number) -> number { ping(n) }`,
+				"a.esc": `fn ping(n: number) -> number { return pong(n) }`,
+				"b.esc": `fn pong(n: number) -> number { return ping(n) }`,
 			},
 			want: map[string]string{
 				"ping": "fn (n: number) -> number",
@@ -536,7 +560,7 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 // PR4: too-many is the extra-arg lint (TooManyArgsError), not a FuncArityMismatch.
 func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f(x: number) -> number { x }
+		fn f(x: number) -> number { return x }
 		val r = f(1, 2)
 	`)
 	require.Len(t, errs, 1)

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -27,7 +27,7 @@ import (
 // https://github.com/escalier-lang/escalier/issues/702 (add a recursion-depth
 // ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() { {x: f()} }`)
+	values, _, errs := inferSource(t, `fn f() { return {x: f()} }`)
 	require.Empty(t, errs, "unexpected inference errors")
 	got := values["f"]
 	require.True(t, strings.HasPrefix(got, "fn () -> {x:"),
@@ -40,7 +40,7 @@ func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 // its name node, the same way a top-level `val` records on its pattern. Without
 // this, tooling can query a `val`'s type via Info but not a `fn`'s.
 func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
-	module := parseModule(t, `fn foo(x: number) -> number { x }`)
+	module := parseModule(t, `fn foo(x: number) -> number { return x }`)
 	_, info, errs := InferModule(module)
 	require.Empty(t, errs)
 
@@ -67,7 +67,7 @@ func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
 // NOT var-free for generalized bindings — the inverse of
 // TestInferModuleFuncDeclRecordsInfoType, whose fixture is monomorphic.)
 func TestInferModulePolymorphicFuncDeclInfoNeedsPrintScheme(t *testing.T) {
-	module := parseModule(t, `fn id(x) { x }`)
+	module := parseModule(t, `fn id(x) { return x }`)
 	_, info, errs := InferModule(module)
 	require.Empty(t, errs)
 


### PR DESCRIPTION
A function body's last expression is no longer an implicit return. Only explicit `return` statements produce the function's value; a body with no return produces `void`. This mirrors the old checker's `inferFuncBody` behavior and fixes issues #719 and #720.

## Changes

- **Function return type inference**: Refactored `inferFunc` to discard the block's tail value and build the return type solely from collected `ReturnStmt` expressions via a new `joinReturnPoints` helper. A function with no explicit returns now types as returning `void`, not the tail expression's type.

- **Block value semantics**: Blocks still compute a tail value for value-position consumers (e.g., `if/else` branches), but function bodies ignore it. The tail is walked for type-checking side effects but does not contribute to the function's return type.

- **Dead code handling**: Statements after a diverging statement (e.g., `return` or a fully-diverging `if`) are now correctly discarded and do not contribute to the function's value. This includes unreachable code after an early return or after a `val` binding that diverges entirely.

- **Test updates**: Updated ~100 test cases across `infer_async_test.go`, `infer_func_test.go`, `infer_test.go`, `infer_stmt.go`, and related files to add explicit `return` statements where function bodies previously relied on implicit tail returns. Added new tests (`TestInferFuncBodyTailIsNotImplicitReturn`, `TestInferFuncBodyDiscardedTailStillChecked`, `TestInferDeadTailAfterDivergingValDiscarded`, `TestInferStatementAfterReturnDiscarded`) to pin the new behavior.

- **Documentation**: Updated comments in `infer_expr.go` and `infer_stmt.go` to clarify the distinction between block-as-value (tail-based) and function-return (return-point-based) semantics, and to document the new `joinReturnPoints` logic.

## Implementation details

The key insight is that `inferFunc` now calls `c.inferBlock(fnScope, lvl, body)` but discards its return value, instead building the function's return type from `c.popFuncCtx(saved)` — the list of `ReturnStmt` types collected during the walk. The `joinReturnPoints` helper handles the three cases: no returns (void), one return (direct), or multiple returns (join variable with source-order constraints).

This change is backward-incompatible for code that relied on implicit tail returns, but aligns the language with common practice in languages like TypeScript, Rust, and Go, where explicit `return` is required.

https://claude.ai/code/session_01U8SeP92vmQ23b8H3TCSGn7