### PR TITLE
Implement co-occurrence merging for polymorphic scheme rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,23 @@ When a one-off task needs more logic than a short shell pipeline (parsing JSON, 
 - Read each sentence as if a human has to parse it left to right with no
   rereading. If understanding it requires jumping back to an earlier clause,
   restructure it.
+
+# Writing Prose: Word choice and explaining code
+
+- Define a technical or coined term the first time you use it. Terms like
+  "co-occurrence", "representative", or "closure" mean nothing to a reader who
+  lacks your context. Give a one-line plain-language definition before you rely
+  on the term, not after.
+- Ground an abstract claim in a concrete example. When a comment cites specific
+  output such as a rendered type or an inferred value, include the source
+  snippet that produces it. The reader can then trace where the output comes
+  from instead of taking it on faith.
+- Use precise verbs. Replace vague verbs like "supplies", "handles", "drives",
+  and "manages" with the actual action: produces, reads, returns, mutates,
+  consults. A vague verb hides what the code does.
+- Name the value, not the technique that produced it. Don't write "union-find"
+  when you mean the merge classes it computed, or "the visitor" when you mean
+  the walk's result. Refer to the thing the code hands around.
+- Treat a comment as draft-then-revise, not one-shot. After writing any comment
+  longer than a sentence or two, reread it as someone with no prior context.
+  Fix every unexplained term and every sentence that needs a second pass.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -107,12 +107,16 @@ type occKey struct {
 // reduces, node for node, to coalesce(t, Positive), keeping every monomorphic
 // render unchanged.
 //
-// simplifyScheme (PR2) supplies the co-occurrence union-find: distinct quantified
-// variables that always appear together resolve to one representative, so they
-// share a single type parameter — outer's `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`
-// renders `fn <T0>(y: T0) -> [T0, T0]`. With no merges and no symmetrized
-// occurrence, each variable is its own representative and the retain decision is
-// exactly PR1's per-variable both-polarities check.
+// simplifyScheme (PR2) runs the co-occurrence analysis up front and hands the
+// coalescer the resulting merge classes, which it only reads. Distinct quantified
+// variables that always appear together resolve to one representative and so share
+// a single type parameter. That collapses outer's
+// `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` to `fn <T0>(y: T0) -> [T0, T0]`.
+//
+// The retain decision degenerates to PR1's when nothing merges and symmetrization
+// surfaces no extra occurrence. Each variable is then its own representative with
+// its own polarities, so the check is exactly PR1's per-variable both-polarities
+// test.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 	return t.Accept(&schemeCoalescer{
 		simp:     simplifyScheme(t, genLevel),
@@ -121,16 +125,20 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 	}, soltype.Positive)
 }
 
-// schemeCoalescer is the soltype-visitor form of coalesceScheme — same shape as
-// coalescer (the structural arms and the pol.Flip() variance come from
-// soltype.Accept; the var node's side-graph bounds are walked here in EnterType),
-// extended with the retain decision: a variable whose representative is
-// quantifiable at genLevel and occurs in both polarities is KEPT as a named type
-// parameter (merged with its coalesced bounds) instead of being inlined. Every
-// other variable is inlined exactly as coalescer does — so on a body with no
-// both-polarity quantifiable variable this reduces, node for node, to a plain
-// coalesce. Each variable resolves through simp to its co-occurrence
-// representative, so every member of a merged class renders as the same parameter.
+// schemeCoalescer is the soltype-visitor form of coalesceScheme. It has the same
+// shape as coalescer. The structural arms and the pol.Flip() variance come from
+// soltype.Accept, and the var node's side-graph bounds are walked here in
+// EnterType.
+//
+// It adds the retain decision. A variable is KEPT as a named type parameter when
+// its representative is quantifiable at genLevel and occurs in both polarities. A
+// kept variable is merged with its coalesced bounds rather than inlined. Every
+// other variable is inlined exactly as coalescer does. So on a body with no
+// both-polarity quantifiable variable, this reduces node for node to a plain
+// coalesce.
+//
+// Each variable resolves through simp to its co-occurrence representative, so
+// every member of a merged class renders as the same parameter.
 type schemeCoalescer struct {
 	simp     *schemeSimplification
 	genLevel int
@@ -157,20 +165,13 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	}
 	c.seen.Add(rep)
 	defer c.seen.Remove(rep) // path-scoped: pop on the way back up (panic-safe)
-	// Representative first when retained, so it names earliest in combine and stays
-	// distinct in dedup from any bound that resolves back to it (via cycle). Pre-size
-	// the slice with rep at index 0 instead of appending then prepending.
-	//
-	// The cycle guard is keyed by rep, but the bounds walked here are v's OWN
-	// (v.BoundsAt), not the representative's. When a sibling class member nested in
-	// v's bounds resolves to a rep already on the path, it short-circuits to the name
-	// without walking its bounds. That drops no information because constrain
-	// propagates a concrete bound to every variable along a var↔var subtyping chain,
-	// so the merged class's reachable concrete bounds already sit on v (the
-	// first-encountered member). This relies on the body being propagation-closed —
-	// which every body reaching coalesceScheme is, since it is rendered only after
-	// its component is fully constrained.
+
+	// v's own bounds, not the representative's.
 	bs := v.BoundsAt(pol)
+
+	// Pre-size parts with rep at index 0 when retaining, rather than appending then
+	// prepending. At the front, rep appears first in the union or intersection combine
+	// builds, and dedup keeps it distinct from any bound that cycles back to it.
 	n := len(bs)
 	if retain {
 		n++
@@ -179,6 +180,14 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	if retain {
 		parts = append(parts, rep)
 	}
+	// Recursively coalesce each bound. When a bound is another member of v's class
+	// whose rep is already on the path, the seen guard short-circuits it to the name
+	// and its own bounds go unwalked. No information is lost. constrain copies a
+	// concrete bound to every variable along a var↔var subtyping chain, so the class's
+	// reachable concrete bounds already sit on v, the first member reached. This holds
+	// because the body is propagation-closed, meaning every variable already carries
+	// the bounds propagated to it. coalesceScheme renders a component only after it is
+	// fully constrained, so that is always true here.
 	for _, b := range bs {
 		parts = append(parts, b.Accept(c, pol))
 	}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -160,6 +160,16 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	// Representative first when retained, so it names earliest in combine and stays
 	// distinct in dedup from any bound that resolves back to it (via cycle). Pre-size
 	// the slice with rep at index 0 instead of appending then prepending.
+	//
+	// The cycle guard is keyed by rep, but the bounds walked here are v's OWN
+	// (v.BoundsAt), not the representative's. When a sibling class member nested in
+	// v's bounds resolves to a rep already on the path, it short-circuits to the name
+	// without walking its bounds. That drops no information because constrain
+	// propagates a concrete bound to every variable along a var↔var subtyping chain,
+	// so the merged class's reachable concrete bounds already sit on v (the
+	// first-encountered member). This relies on the body being propagation-closed —
+	// which every body reaching coalesceScheme is, since it is rendered only after
+	// its component is fully constrained.
 	bs := v.BoundsAt(pol)
 	n := len(bs)
 	if retain {
@@ -191,7 +201,7 @@ func schemeType(s TypeScheme) soltype.Type {
 	case *MonoScheme:
 		return coalesce(sc.Ty, soltype.Positive)
 	case *PolyScheme:
-		return coalesceScheme(sc.Body, sc.Level)
+		return sc.display()
 	}
 	panic(fmt.Sprintf("schemeType: unknown TypeScheme %T", s))
 }
@@ -210,7 +220,7 @@ func renderScheme(s TypeScheme) string {
 	case *MonoScheme:
 		return soltype.PrintAsScheme(coalesce(sc.Ty, soltype.Positive))
 	case *PolyScheme:
-		return soltype.PrintAsSchemeWith(coalesceScheme(sc.Body, sc.Level), func(v *soltype.TypeVarType) bool {
+		return soltype.PrintAsSchemeWith(sc.display(), func(v *soltype.TypeVarType) bool {
 			return v.Level > sc.Level
 		})
 	}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -98,78 +98,24 @@ type occKey struct {
 	pol soltype.Polarity
 }
 
-// analyzeOccurrences walks the bound graph rooted at t (the same traversal
-// coalesce uses: covariant children at pol, contravariant func params flipped,
-// each variable's BoundsAt(pol)) recording into occ which polarities every
-// variable occurs in. A variable appearing in both a covariant and a
-// contravariant position — the identity function's shared param/return var — comes
-// out as occPos|occNeg; a result/indirection variable that only ever flows
-// outward comes out as occPos alone. coalesceScheme then retains the former as a
-// quantified type parameter and inlines the latter to its bound.
-func analyzeOccurrences(t soltype.Type, pol soltype.Polarity, occ map[*soltype.TypeVarType]occPolarity, seen set.Set[occKey]) {
-	// Drive the structural descent through the shared soltype visitor (the same
-	// rewriting walk coalescer/schemeCoalescer use), so the variance flip on func
-	// params and the recursion into every former — FuncType/Tuple/Record/Promise AND
-	// the overload-arm Union/Intersection PR6 feeds as input — live in one place
-	// (soltype.Accept) instead of a hand-rolled switch that must track every type kind.
-	// The returned (identity-preserving) type is discarded; the analysis is the
-	// EnterType side effect on occ/seen.
-	t.Accept(&occVisitor{occ: occ, seen: seen}, pol)
-}
-
-// occVisitor is the soltype-visitor form of analyzeOccurrences. Like coalescer it
-// handles the var node itself in EnterType — recording the polarity it was reached in,
-// then walking the var's BoundsAt(pol) side graph (guarded by the (var, pol) seen-set)
-// — and lets Accept descend every structural node (atoms pass through, func params
-// flip).
-type occVisitor struct {
-	occ  map[*soltype.TypeVarType]occPolarity
-	seen set.Set[occKey]
-}
-
-func (o *occVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	v, ok := t.(*soltype.TypeVarType)
-	if !ok {
-		return soltype.EnterResult{} // structural/atom node: let Accept descend
-	}
-	if pol == soltype.Positive {
-		o.occ[v] |= occPos
-	} else {
-		o.occ[v] |= occNeg
-	}
-	k := occKey{v, pol}
-	if o.seen.Contains(k) {
-		return soltype.EnterResult{SkipChildren: true}
-	}
-	o.seen.Add(k)
-	for _, b := range v.BoundsAt(pol) {
-		b.Accept(o, pol)
-	}
-	return soltype.EnterResult{SkipChildren: true}
-}
-
-func (o *occVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
-
 // coalesceScheme coalesces a generalized scheme's RAW body for DISPLAY, retaining
 // the variables that are genuine type parameters as named references while
-// inlining the rest to their bounds. A variable is retained iff it is
-// quantifiable (Level > genLevel) AND occurs in both polarities (single-polarity
-// elimination); every other variable is inlined exactly as coalesce does — so on
-// a body with no both-polarity quantifiable variable this reduces, node for node,
-// to coalesce(t, Positive), keeping every monomorphic render unchanged.
+// inlining the rest to their bounds. A variable is retained iff its co-occurrence
+// representative is quantifiable (Level > genLevel) AND occurs in both polarities
+// (single-polarity elimination); every other variable is inlined exactly as
+// coalesce does — so on a body with no both-polarity quantifiable variable this
+// reduces, node for node, to coalesce(t, Positive), keeping every monomorphic
+// render unchanged.
 //
-// This is the minimum needed to render a generalized scheme without the
-// always-pre-bound SCC indirection variable (a positive-only var) corrupting the
-// output. The remaining simplification — CO-OCCURRENCE merging of *distinct*
-// variables that always appear together, and the `parameter-only var ⇒ unknown`
-// case for variables genuinely used in one polarity — is PR2's; PR1 retains a
-// type parameter only where it is literally the same variable across positions,
-// so renders stay non-compact until then.
+// simplifyScheme (PR2) supplies the co-occurrence union-find: distinct quantified
+// variables that always appear together resolve to one representative, so they
+// share a single type parameter — outer's `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`
+// renders `fn <T0>(y: T0) -> [T0, T0]`. With no merges and no symmetrized
+// occurrence, each variable is its own representative and the retain decision is
+// exactly PR1's per-variable both-polarities check.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
-	occ := map[*soltype.TypeVarType]occPolarity{}
-	analyzeOccurrences(t, soltype.Positive, occ, set.NewSet[occKey]())
 	return t.Accept(&schemeCoalescer{
-		occ:      occ,
+		simp:     simplifyScheme(t, genLevel),
 		genLevel: genLevel,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
@@ -178,13 +124,15 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 // schemeCoalescer is the soltype-visitor form of coalesceScheme — same shape as
 // coalescer (the structural arms and the pol.Flip() variance come from
 // soltype.Accept; the var node's side-graph bounds are walked here in EnterType),
-// extended with the retain decision: a variable quantifiable at genLevel that
-// occurs in both polarities is KEPT as a named type parameter (merged with its
-// coalesced bounds) instead of being inlined. Every other variable is inlined
-// exactly as coalescer does — so on a body with no both-polarity quantifiable
-// variable this reduces, node for node, to a plain coalesce.
+// extended with the retain decision: a variable whose representative is
+// quantifiable at genLevel and occurs in both polarities is KEPT as a named type
+// parameter (merged with its coalesced bounds) instead of being inlined. Every
+// other variable is inlined exactly as coalescer does — so on a body with no
+// both-polarity quantifiable variable this reduces, node for node, to a plain
+// coalesce. Each variable resolves through simp to its co-occurrence
+// representative, so every member of a merged class renders as the same parameter.
 type schemeCoalescer struct {
-	occ      map[*soltype.TypeVarType]occPolarity
+	simp     *schemeSimplification
 	genLevel int
 	seen     set.Set[*soltype.TypeVarType]
 }
@@ -196,21 +144,22 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		// (including an overload-arm Union/Intersection input — the scoped lattice exception; see overloadIntersection).
 		return soltype.EnterResult{}
 	}
-	retain := v.Level > c.genLevel && c.occ[v].both()
-	if c.seen.Contains(v) {
+	rep := c.simp.rep(v)
+	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both()
+	if c.seen.Contains(rep) {
 		// A cycle back to a variable already on the path: a retained type parameter
 		// keeps its name (a rough μ-reference, refined in M3's precise μ-rendering),
 		// an inlined variable collapses to the polarity identity.
 		if retain {
-			return soltype.EnterResult{Type: v, SkipChildren: true}
+			return soltype.EnterResult{Type: rep, SkipChildren: true}
 		}
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	c.seen.Add(v)
-	defer c.seen.Remove(v) // path-scoped: pop on the way back up (panic-safe)
-	// Variable first when retained, so it names earliest in combine and stays
-	// distinct in dedup from any bound that resolves back to v (via cycle). Pre-size
-	// the slice with v at index 0 instead of appending then prepending.
+	c.seen.Add(rep)
+	defer c.seen.Remove(rep) // path-scoped: pop on the way back up (panic-safe)
+	// Representative first when retained, so it names earliest in combine and stays
+	// distinct in dedup from any bound that resolves back to it (via cycle). Pre-size
+	// the slice with rep at index 0 instead of appending then prepending.
 	bs := v.BoundsAt(pol)
 	n := len(bs)
 	if retain {
@@ -218,14 +167,14 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	}
 	parts := make([]soltype.Type, 0, n)
 	if retain {
-		parts = append(parts, v)
+		parts = append(parts, rep)
 	}
 	for _, b := range bs {
 		parts = append(parts, b.Accept(c, pol))
 	}
 	if len(parts) == 0 {
 		// Only reachable with !retain and no bounds — empty bounds under retain
-		// already leave parts=[v]. Collapse to the polarity identity.
+		// already leave parts=[rep]. Collapse to the polarity identity.
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
 	return soltype.EnterResult{Type: combine(pol, dedup(parts)), SkipChildren: true}

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -24,10 +24,14 @@
 // FromInstantiation provenance edge (prov.go), and scheme rendering — occurrence
 // analysis + single-polarity elimination retaining genuine type parameters
 // (coalesce.go's coalesceScheme) with the printer's <T0, …> quantifier prefix
-// (soltype.PrintAsScheme). What remains of the polymorphism-rendering bundle is
-// PR2's CO-OCCURRENCE merging (distinct variables that always appear together),
-// which makes renders compact where the same variable isn't already shared across
-// positions; generalize's simplify hook is a no-op until then.
+// (soltype.PrintAsScheme).
+//
+// M3 (PR2) completes scheme rendering with CO-OCCURRENCE merging (simplify.go):
+// distinct quantified variables that always appear together are unioned over a
+// symmetrized bound graph, so coalesceScheme renders them as one type parameter —
+// `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` becomes `fn <T0>(y: T0) -> [T0, T0]`.
+// Simplification runs at display time, leaving the raw scheme body intact for
+// instantiation.
 //
 // M3 (PR5) adds the probe (probe.go): a speculation journal over the engine's
 // bound-list mutations (a per-variable length snapshot, truncated back on

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -28,7 +28,15 @@
 //
 // M3 (PR2) completes scheme rendering with CO-OCCURRENCE merging (simplify.go):
 // distinct quantified variables that always appear together are unioned over a
-// symmetrized bound graph, so coalesceScheme renders them as one type parameter —
+// symmetrized bound graph, so coalesceScheme renders them as one type parameter.
+// The parameter in
+//
+//	val outer = fn (y) {
+//		val getY = fn () { return y }
+//		return [getY(), getY()]
+//	}
+//
+// reaches both tuple slots through two result variables, so the raw
 // `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` becomes `fn <T0>(y: T0) -> [T0, T0]`.
 // Simplification runs at display time, leaving the raw scheme body intact for
 // instantiation.

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -100,7 +100,7 @@ func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
 // co-occurrence merging leaves them as distinct type parameters — the counterpart
 // to InnerCapturesOuterParam, where the variables always appeared together.
 func TestInferModuleDistinctParamsStayDistinct(t *testing.T) {
-	values, _, errs := inferSource(t, `fn pair(a, b) { [a, b] }`)
+	values, _, errs := inferSource(t, `fn pair(a, b) { return [a, b] }`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{"pair": "fn <T0, T1>(a: T0, b: T1) -> [T0, T1]"}, values)
 }

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -10,13 +10,12 @@ import (
 // every top-level binding to a coalesced monotype; PR1 generalizes at the SCC
 // boundary so a polymorphic binding is instantiated fresh per use.
 //
-// Where a render is compact already in PR1 (the type parameter is literally the
-// same variable across positions, e.g. identity) the test pins the rendered
-// signature, exercising the printer's <T0, …> prefix. Where the compact form
-// needs simplification (PR2's co-occurrence merging), the test asserts the
-// two-types-of-use BEHAVIOR instead — per the plan, "assert two-types-of-use
-// behavior rather than the printed signature where simplification is
-// load-bearing."
+// Each test pins the rendered signature, exercising the printer's <T0, …> prefix.
+// Identity is compact from the same variable appearing in both positions; the
+// captured-param case (InnerCapturesOuterParam) needs PR2's co-occurrence merging
+// to collapse its three always-together variables into one type parameter. The
+// two-types-of-use BEHAVIOR is asserted alongside the render as the real proof of
+// polymorphism.
 
 // A top-level identity generalizes to fn <T0>(x: T0) -> T0. The two-types-of-use
 // behavior is the real proof of polymorphism: a monomorphic id would constrain
@@ -64,10 +63,12 @@ func TestInferModuleIdentityPolymorphism(t *testing.T) {
 
 // A body-level inner function that captures an outer parameter keeps the capture
 // through generalization (M2's eager body-level coalescing froze it to `never`).
-// PR1's render is non-compact — `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`, which PR2's
-// co-occurrence merging collapses to `fn <T0>(y: T0) -> [T0, T0]` — so the
-// contract here is BEHAVIOR: applying outer to 5 yields [5, 5], proving y reaches
-// both result positions through the captured inner function.
+// The param flows to both tuple positions through two fresh result variables, so
+// the raw scheme carries three distinct quantified variables — PR1 rendered the
+// non-compact `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`. PR2's co-occurrence merging
+// recognises that the three always appear together and collapses them to one type
+// parameter: `fn <T0>(y: T0) -> [T0, T0]`. Applying outer to 5 still yields [5, 5],
+// confirming the merge preserves the input→output connection.
 func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val outer = fn (y) {
@@ -77,9 +78,8 @@ func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 		val r = outer(5)
 	`)
 	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(y: T0) -> [T0, T0]", values["outer"], "co-occurring variables merge to one type parameter")
 	require.Equal(t, "[5, 5]", values["r"], "the captured outer param reaches both result positions")
-	// outer is generalized (not frozen): its signature carries a quantifier prefix.
-	require.Contains(t, values["outer"], "fn <", "outer should generalize over its captured param")
 }
 
 // Let-polymorphism extends to body-level `val`s: an inner polymorphic function
@@ -94,6 +94,15 @@ func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, map[string]string{"f": `fn () -> [5, "hi"]`}, values)
+}
+
+// Two parameters that flow to independent result positions do NOT co-occur, so
+// co-occurrence merging leaves them as distinct type parameters — the counterpart
+// to InnerCapturesOuterParam, where the variables always appeared together.
+func TestInferModuleDistinctParamsStayDistinct(t *testing.T) {
+	values, _, errs := inferSource(t, `fn pair(a, b) { [a, b] }`)
+	require.Empty(t, errs)
+	require.Equal(t, map[string]string{"pair": "fn <T0, T1>(a: T0, b: T1) -> [T0, T1]"}, values)
 }
 
 // A polymorphic function with a parameter-only variable: the second param is

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -11,6 +11,9 @@ import (
 // boundary so a polymorphic binding is instantiated fresh per use.
 //
 // Each test pins the rendered signature, exercising the printer's <T0, …> prefix.
+// A render is COMPACT when the signature names the fewest type parameters it can,
+// with no two always-together variables left as separate parameters.
+//
 // Identity is compact from the same variable appearing in both positions; the
 // captured-param case (InnerCapturesOuterParam) needs PR2's co-occurrence merging
 // to collapse its three always-together variables into one type parameter. The

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -35,18 +35,23 @@ type PolyScheme struct {
 	Body      soltype.Type
 	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
 
-	// coalesced memoizes the display type. Body is immutable after generalization
-	// (later components instantiate fresh copies rather than constrain it), so the
-	// co-occurrence analysis behind coalesceScheme is run once and shared by both
-	// display consumers — schemeType (Info) and renderScheme (string).
+	// coalesced memoizes the display type. A Body is immutable after
+	// generalization. Later components instantiate fresh copies rather than
+	// constraining it. Because of that immutability, coalesceScheme's co-occurrence
+	// analysis runs once and is shared by both display consumers: schemeType for the
+	// Info side table and renderScheme for the printed string.
 	coalesced soltype.Type
 }
 
 func (*MonoScheme) isScheme() {}
 func (*PolyScheme) isScheme() {}
 
-// display returns the scheme's coalesced display type, computing it on first use
-// and caching it. See the coalesced field for why the cache never goes stale.
+// display returns the scheme's coalesced display type, computing it once via
+// coalesceScheme and caching it in sc.coalesced. The cache holds a DISPLAY type
+// only. Callers that need a usable scheme must not read it as one. The
+// reassignment path copies the result with freshenAll before constraining, so the
+// cached type is never mutated. See the coalesced field for why the cache never
+// goes stale.
 func (sc *PolyScheme) display() soltype.Type {
 	if sc.coalesced == nil {
 		sc.coalesced = coalesceScheme(sc.Body, sc.Level)
@@ -233,9 +238,9 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // kept RAW for instantiation — coalescing for display happens later (schemeType /
 // renderScheme), never here.
 //
-// Simplification (single-polarity elimination + co-occurrence merging, PR2) is not
-// applied to the raw body: it runs at DISPLAY time inside coalesceScheme, so the
-// body keeps every variable for instantiation while the rendered signature stays
+// Simplification is not applied to the raw body. Single-polarity elimination and
+// co-occurrence merging run at DISPLAY time inside coalesceScheme, so the body
+// keeps every variable for instantiation while the rendered signature stays
 // compact. See simplify.go.
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
 	return &PolyScheme{Level: lvl, Body: t}

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -34,10 +34,25 @@ type PolyScheme struct {
 	Level     int
 	Body      soltype.Type
 	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
+
+	// coalesced memoizes the display type. Body is immutable after generalization
+	// (later components instantiate fresh copies rather than constrain it), so the
+	// co-occurrence analysis behind coalesceScheme is run once and shared by both
+	// display consumers — schemeType (Info) and renderScheme (string).
+	coalesced soltype.Type
 }
 
 func (*MonoScheme) isScheme() {}
 func (*PolyScheme) isScheme() {}
+
+// display returns the scheme's coalesced display type, computing it on first use
+// and caching it. See the coalesced field for why the cache never goes stale.
+func (sc *PolyScheme) display() soltype.Type {
+	if sc.coalesced == nil {
+		sc.coalesced = coalesceScheme(sc.Body, sc.Level)
+	}
+	return sc.coalesced
+}
 
 func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
 func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -218,16 +218,10 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // kept RAW for instantiation — coalescing for display happens later (schemeType /
 // renderScheme), never here.
 //
-// simplify is the PR2 hook (single-polarity elimination + co-occurrence merging);
-// PR1 lands it as a no-op so renders are non-compact until PR2 wires it in.
+// Simplification (single-polarity elimination + co-occurrence merging, PR2) is not
+// applied to the raw body: it runs at DISPLAY time inside coalesceScheme, so the
+// body keeps every variable for instantiation while the rendered signature stays
+// compact. See simplify.go.
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
-	t = c.simplify(t, lvl)
 	return &PolyScheme{Level: lvl, Body: t}
-}
-
-// simplify is the PR2 simplification pass, a no-op in PR1. PR2 replaces the body
-// with occurrence analysis → co-occurrence union-find → rewrite so generalized
-// signatures render compactly and parameter-only variables coalesce to `unknown`.
-func (c *checker) simplify(t soltype.Type, _ int) soltype.Type {
-	return t
 }

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -154,7 +154,7 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 // graph terminating.
 type symOccVisitor struct {
 	m    *mirror
-	occ  map[*soltype.TypeVarType]occPolarity
+	occ  map[int]occPolarity // keyed by TypeVarType.ID
 	seen set.Set[occKey]
 }
 
@@ -164,9 +164,9 @@ func (o *symOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 		return soltype.EnterResult{} // structural / atom node: let Accept descend
 	}
 	if pol == soltype.Positive {
-		o.occ[v] |= occPos
+		o.occ[v.ID] |= occPos
 	} else {
-		o.occ[v] |= occNeg
+		o.occ[v.ID] |= occNeg
 	}
 	k := occKey{v, pol}
 	if o.seen.Contains(k) {
@@ -310,12 +310,8 @@ func simplifyScheme(body soltype.Type, genLevel int) *schemeSimplification {
 
 	m := buildMirror(vars)
 
-	occVar := map[*soltype.TypeVarType]occPolarity{}
-	body.Accept(&symOccVisitor{m: m, occ: occVar, seen: set.NewSet[occKey]()}, soltype.Positive)
-	occByID := make(map[int]occPolarity, len(occVar))
-	for v, o := range occVar {
-		occByID[v.ID] = o
-	}
+	occByID := map[int]occPolarity{}
+	body.Accept(&symOccVisitor{m: m, occ: occByID, seen: set.NewSet[occKey]()}, soltype.Positive)
 
 	coOcc := map[coKey]set.Set[int]{}
 	body.Accept(&coOccVisitor{m: m, coOcc: coOcc, seen: set.NewSet[coKey]()}, soltype.Positive)

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -11,8 +12,23 @@ import (
 // coalesceScheme — a variable occurring in only one polarity is dropped in favour
 // of its bound. The remaining simplification is merging DISTINCT quantified
 // variables that always appear together so a signature renders with one type
-// parameter instead of several: outer's `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`
-// collapses to `fn <T0>(y: T0) -> [T0, T0]`.
+// parameter instead of several.
+//
+// Two variables CO-OCCUR when they share a lattice node in every polarity each
+// appears in. That means the same union node wherever they appear positively, and
+// the same intersection node wherever they appear negatively. No caller can then
+// distinguish them, so they can safely collapse to one type parameter. For
+// example:
+//
+//	val outer = fn (y) {
+//		val getY = fn () { return y }
+//		return [getY(), getY()]
+//	}
+//
+// The parameter `y` reaches both tuple elements through two fresh result
+// variables, so outer's raw scheme carries three distinct quantified variables and
+// renders the non-compact `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`. Those three always
+// occur together, so merging collapses them to `fn <T0>(y: T0) -> [T0, T0]`.
 //
 // The algorithm ports internal/simplesub/simplify.go to soltype:
 //
@@ -98,18 +114,24 @@ func (vc *varCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 
 // mirror holds the var↔var subtyping edges in both directions. constrain records a
 // var-to-var bound on only one endpoint, so co-occurrence analysis would miss half
-// the edges; mirror precomputes, per variable, the var bounds stored on the OTHER
-// endpoint. This is the symmetric bound view the spike obtained by mutating the
-// bound lists, computed here without touching the canonical scheme body.
+// the edges. mirror precomputes, per variable, the var bounds stored on the OTHER
+// endpoint.
+//
+// It is a derived view, not a change to the stored bounds. coalesce and extrude
+// read the same bound lists, and coalesce inlines a variable to the union of its
+// lower bounds or the intersection of its uppers. Adding the reverse edge to those
+// lists would pull a spurious variable into that union or intersection and change
+// the rendered type. So the symmetric view is built here, leaving the canonical
+// scheme body untouched. The spike instead mutated the bound lists in place.
 type mirror struct {
-	lower map[int][]*soltype.TypeVarType // extra lower-bound vars: u <: v recorded on u.UpperBounds
-	upper map[int][]*soltype.TypeVarType // extra upper-bound vars: v <: u recorded on u.LowerBounds
+	lower map[int][]soltype.Type // extra lower-bound vars: u <: v recorded on u.UpperBounds
+	upper map[int][]soltype.Type // extra upper-bound vars: v <: u recorded on u.LowerBounds
 }
 
 func buildMirror(vars map[int]*soltype.TypeVarType) *mirror {
 	m := &mirror{
-		lower: map[int][]*soltype.TypeVarType{},
-		upper: map[int][]*soltype.TypeVarType{},
+		lower: map[int][]soltype.Type{},
+		upper: map[int][]soltype.Type{},
 	}
 	for _, u := range vars {
 		for _, b := range u.UpperBounds {
@@ -129,8 +151,7 @@ func buildMirror(vars map[int]*soltype.TypeVarType) *mirror {
 // effectiveBounds returns v's stored bounds at pol plus the mirrored var bounds —
 // the symmetric view occurrence and co-occurrence analysis walk.
 func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) []soltype.Type {
-	var stored []soltype.Type
-	var mirrored []*soltype.TypeVarType
+	var stored, mirrored []soltype.Type
 	if pol == soltype.Positive {
 		stored, mirrored = v.LowerBounds, m.lower[v.ID]
 	} else {
@@ -139,19 +160,14 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 	if len(mirrored) == 0 {
 		return stored
 	}
-	out := make([]soltype.Type, 0, len(stored)+len(mirrored))
-	out = append(out, stored...)
-	for _, w := range mirrored {
-		out = append(out, w)
-	}
-	return out
+	return slices.Concat(stored, mirrored)
 }
 
-// symOccVisitor records which polarities each variable occurs in, walking the
-// symmetric bound graph (mirror.effectiveBounds) so a variable reached only through
-// a one-sided edge — outer's param var, reached positively via a mirrored lower
-// bound — is still seen in that polarity. The (var, pol) seen-set keeps a cyclic
-// graph terminating.
+// symOccVisitor records which polarities each variable occurs in. It walks the
+// symmetric bound graph through mirror.effectiveBounds, so a variable reached only
+// through a one-sided edge is still seen in that polarity.
+//
+// The (var, pol) seen-set keeps a cyclic graph terminating.
 type symOccVisitor struct {
 	m    *mirror
 	occ  map[int]occPolarity // keyed by TypeVarType.ID
@@ -181,9 +197,12 @@ func (o *symOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 
 func (o *symOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// gatherGroup collects the transitive same-polarity variable closure of v: the
-// variables that end up in the same flattened union (positive) or intersection
-// (negative) as v, following the symmetric var bounds.
+// gatherGroup collects every variable that ends up in the same flattened union or
+// intersection node as v once coalescing runs. It starts from v and follows the
+// symmetric var↔var bounds at one fixed polarity. A positive walk follows lower
+// bounds, a negative walk upper bounds. It keeps following bounds-of-bounds, so the
+// result is the full transitive set, not just v's direct neighbours. Those
+// variables are exactly the ones that co-occur with v in that polarity.
 func (m *mirror) gatherGroup(v *soltype.TypeVarType, pol soltype.Polarity, g set.Set[int]) {
 	if g.Contains(v.ID) {
 		return
@@ -197,8 +216,14 @@ func (m *mirror) gatherGroup(v *soltype.TypeVarType, pol soltype.Polarity, g set
 }
 
 // coOccVisitor records, per (variable, polarity), the set of variables co-occurring
-// with it. Walking the body structurally, at each variable it gathers the
-// same-polarity group and links every pair within it.
+// with it. Walking the body structurally, at each NEWLY-visited variable it gathers
+// the same-polarity group and links every pair within it.
+//
+// Cost: the seen gate runs the gather-and-link once per distinct (variable,
+// polarity), not once per occurrence. The link step is O(g²) for a group of size g,
+// so the worst case is roughly O(Σ g²) over all groups — cubic when the whole scheme
+// collapses into a single co-occurring component. The variable count is that of one
+// rendered signature, so this stays cheap in practice.
 type coOccVisitor struct {
 	m     *mirror
 	coOcc map[coKey]set.Set[int]
@@ -210,6 +235,15 @@ func (c *coOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 	if !ok {
 		return soltype.EnterResult{} // structural / atom node: let Accept descend
 	}
+	// Gather and record below the seen gate. gatherGroup is a pure function of
+	// (v, pol) and the pair-recording is an idempotent set union, so running them
+	// once per distinct (v, pol) yields the same coOcc as running them on every
+	// entry — a variable reached n times no longer recomputes its group n times.
+	k := coKey{v.ID, pol}
+	if c.seen.Contains(k) {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	c.seen.Add(k)
 	g := set.NewSet[int]()
 	c.m.gatherGroup(v, pol, g)
 	for a := range g {
@@ -224,11 +258,6 @@ func (c *coOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 			c.coOcc[ck].Add(b)
 		}
 	}
-	k := coKey{v.ID, pol}
-	if c.seen.Contains(k) {
-		return soltype.EnterResult{SkipChildren: true}
-	}
-	c.seen.Add(k)
 	for _, b := range c.m.effectiveBounds(v, pol) {
 		b.Accept(c, pol)
 	}
@@ -237,7 +266,8 @@ func (c *coOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 
 func (c *coOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// occHas reports whether o records an occurrence in polarity pol.
+// occHas reports whether o records an occurrence in polarity pol. o is a bitset,
+// so o&occPos masks off the positive bit and is non-zero exactly when it is set.
 func occHas(o occPolarity, pol soltype.Polarity) bool {
 	if pol == soltype.Positive {
 		return o&occPos != 0
@@ -274,7 +304,7 @@ func mutualCoOcc(a, b int, occ map[int]occPolarity, coOcc map[coKey]set.Set[int]
 func mergeCoOccurring(ids []int, occ map[int]occPolarity, coOcc map[coKey]set.Set[int]) *unionFind {
 	uf := newUnionFind()
 	sort.Ints(ids)
-	for i := 0; i < len(ids); i++ {
+	for i := range ids {
 		for j := i + 1; j < len(ids); j++ {
 			if mutualCoOcc(ids[i], ids[j], occ, coOcc) {
 				uf.union(ids[i], ids[j])
@@ -285,17 +315,23 @@ func mergeCoOccurring(ids []int, occ map[int]occPolarity, coOcc map[coKey]set.Se
 }
 
 // schemeSimplification is the co-occurrence merging input coalesceScheme threads
-// into schemeCoalescer: the union-find collapsing quantifiable variables that
-// always occur together, the merged occurrence map keyed by representative id (so
-// single-polarity elimination sees a class's combined polarities), and the id→var
-// table to resolve a representative id back to its variable for naming.
+// into schemeCoalescer.
 type schemeSimplification struct {
-	uf        *unionFind
-	mergedOcc map[int]occPolarity // keyed by representative id
-	idToVar   map[int]*soltype.TypeVarType
+	// uf collapses quantifiable variables that always occur together into one class.
+	uf *unionFind
+
+	// mergedOcc is the occurrence map keyed by representative id, so single-polarity
+	// elimination sees a class's combined polarities.
+	mergedOcc map[int]occPolarity
+
+	// idToVar resolves a representative id back to its variable for naming.
+	idToVar map[int]*soltype.TypeVarType
 }
 
-// rep resolves a variable to its class representative variable.
+// rep resolves a variable to its class representative variable: the canonical
+// member of the merged class v belongs to. union keeps the smallest id as the
+// class root, so every member resolves to the same representative and renders as
+// one type parameter. A variable that never merged is its own representative.
 func (s *schemeSimplification) rep(v *soltype.TypeVarType) *soltype.TypeVarType {
 	return s.idToVar[s.uf.find(v.ID)]
 }
@@ -310,9 +346,11 @@ func simplifyScheme(body soltype.Type, genLevel int) *schemeSimplification {
 
 	m := buildMirror(vars)
 
+	// record which polarities each variable occurs in
 	occByID := map[int]occPolarity{}
 	body.Accept(&symOccVisitor{m: m, occ: occByID, seen: set.NewSet[occKey]()}, soltype.Positive)
 
+	// record set of type vars co-occuring with each type var
 	coOcc := map[coKey]set.Set[int]{}
 	body.Accept(&coOccVisitor{m: m, coOcc: coOcc, seen: set.NewSet[coKey]()}, soltype.Positive)
 

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -1,0 +1,337 @@
+package solver
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Co-occurrence merging (PR2). Single-polarity elimination already lives in
+// coalesceScheme — a variable occurring in only one polarity is dropped in favour
+// of its bound. The remaining simplification is merging DISTINCT quantified
+// variables that always appear together so a signature renders with one type
+// parameter instead of several: outer's `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`
+// collapses to `fn <T0>(y: T0) -> [T0, T0]`.
+//
+// The algorithm ports internal/simplesub/simplify.go to soltype:
+//
+//  1. collect every variable reachable from the scheme body,
+//  2. symmetrize the var↔var subtyping edges (constrain records each on one
+//     endpoint only; co-occurrence needs both endpoints to see it),
+//  3. record, per variable, the polarities it occurs in,
+//  4. record, per (variable, polarity), the variables sharing its union /
+//     intersection group,
+//  5. union two variables when they co-occur in every polarity each occurs in.
+//
+// coalesceScheme then resolves each variable to its union-find representative for
+// both the retain decision and the printed name, so every member of a class
+// renders as the same type parameter.
+
+// unionFind is the disjoint-set forest keyed by TypeVarType.ID. The smaller id is
+// kept as a class's representative so naming is stable across runs.
+type unionFind struct{ parent map[int]int }
+
+func newUnionFind() *unionFind { return &unionFind{parent: map[int]int{}} }
+
+func (u *unionFind) find(x int) int {
+	p, ok := u.parent[x]
+	if !ok {
+		u.parent[x] = x
+		return x
+	}
+	if p != x {
+		r := u.find(p)
+		u.parent[x] = r
+		return r
+	}
+	return x
+}
+
+func (u *unionFind) union(a, b int) {
+	ra, rb := u.find(a), u.find(b)
+	if ra == rb {
+		return
+	}
+	if rb < ra { // keep the smaller id as representative for stable naming
+		ra, rb = rb, ra
+	}
+	u.parent[rb] = ra
+}
+
+// coKey keys the co-occurrence table by (variable id, polarity): the set of
+// variables that share a union (positive) or intersection (negative) node with
+// this variable in this polarity.
+type coKey struct {
+	id  int
+	pol soltype.Polarity
+}
+
+// varCollector gathers every TypeVarType reachable from a type — structural
+// children via Accept, plus both bound lists walked here (a var's bounds are a side
+// graph, not tree children, so the visitor handles them explicitly).
+type varCollector struct {
+	out  map[int]*soltype.TypeVarType
+	seen set.Set[*soltype.TypeVarType]
+}
+
+func (vc *varCollector) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural / atom node: let Accept descend
+	}
+	if vc.seen.Contains(v) {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	vc.seen.Add(v)
+	vc.out[v.ID] = v
+	for _, b := range v.LowerBounds {
+		b.Accept(vc, pol)
+	}
+	for _, b := range v.UpperBounds {
+		b.Accept(vc, pol)
+	}
+	return soltype.EnterResult{SkipChildren: true}
+}
+
+func (vc *varCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// mirror holds the var↔var subtyping edges in both directions. constrain records a
+// var-to-var bound on only one endpoint, so co-occurrence analysis would miss half
+// the edges; mirror precomputes, per variable, the var bounds stored on the OTHER
+// endpoint. This is the symmetric bound view the spike obtained by mutating the
+// bound lists, computed here without touching the canonical scheme body.
+type mirror struct {
+	lower map[int][]*soltype.TypeVarType // extra lower-bound vars: u <: v recorded on u.UpperBounds
+	upper map[int][]*soltype.TypeVarType // extra upper-bound vars: v <: u recorded on u.LowerBounds
+}
+
+func buildMirror(vars map[int]*soltype.TypeVarType) *mirror {
+	m := &mirror{
+		lower: map[int][]*soltype.TypeVarType{},
+		upper: map[int][]*soltype.TypeVarType{},
+	}
+	for _, u := range vars {
+		for _, b := range u.UpperBounds {
+			if w, ok := b.(*soltype.TypeVarType); ok { // u <: w  =>  w has lower bound u
+				m.lower[w.ID] = append(m.lower[w.ID], u)
+			}
+		}
+		for _, b := range u.LowerBounds {
+			if w, ok := b.(*soltype.TypeVarType); ok { // w <: u  =>  w has upper bound u
+				m.upper[w.ID] = append(m.upper[w.ID], u)
+			}
+		}
+	}
+	return m
+}
+
+// effectiveBounds returns v's stored bounds at pol plus the mirrored var bounds —
+// the symmetric view occurrence and co-occurrence analysis walk.
+func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) []soltype.Type {
+	var stored []soltype.Type
+	var mirrored []*soltype.TypeVarType
+	if pol == soltype.Positive {
+		stored, mirrored = v.LowerBounds, m.lower[v.ID]
+	} else {
+		stored, mirrored = v.UpperBounds, m.upper[v.ID]
+	}
+	if len(mirrored) == 0 {
+		return stored
+	}
+	out := make([]soltype.Type, 0, len(stored)+len(mirrored))
+	out = append(out, stored...)
+	for _, w := range mirrored {
+		out = append(out, w)
+	}
+	return out
+}
+
+// symOccVisitor records which polarities each variable occurs in, walking the
+// symmetric bound graph (mirror.effectiveBounds) so a variable reached only through
+// a one-sided edge — outer's param var, reached positively via a mirrored lower
+// bound — is still seen in that polarity. The (var, pol) seen-set keeps a cyclic
+// graph terminating.
+type symOccVisitor struct {
+	m    *mirror
+	occ  map[*soltype.TypeVarType]occPolarity
+	seen set.Set[occKey]
+}
+
+func (o *symOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural / atom node: let Accept descend
+	}
+	if pol == soltype.Positive {
+		o.occ[v] |= occPos
+	} else {
+		o.occ[v] |= occNeg
+	}
+	k := occKey{v, pol}
+	if o.seen.Contains(k) {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	o.seen.Add(k)
+	for _, b := range o.m.effectiveBounds(v, pol) {
+		b.Accept(o, pol)
+	}
+	return soltype.EnterResult{SkipChildren: true}
+}
+
+func (o *symOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// gatherGroup collects the transitive same-polarity variable closure of v: the
+// variables that end up in the same flattened union (positive) or intersection
+// (negative) as v, following the symmetric var bounds.
+func (m *mirror) gatherGroup(v *soltype.TypeVarType, pol soltype.Polarity, g set.Set[int]) {
+	if g.Contains(v.ID) {
+		return
+	}
+	g.Add(v.ID)
+	for _, b := range m.effectiveBounds(v, pol) {
+		if bv, ok := b.(*soltype.TypeVarType); ok {
+			m.gatherGroup(bv, pol, g)
+		}
+	}
+}
+
+// coOccVisitor records, per (variable, polarity), the set of variables co-occurring
+// with it. Walking the body structurally, at each variable it gathers the
+// same-polarity group and links every pair within it.
+type coOccVisitor struct {
+	m     *mirror
+	coOcc map[coKey]set.Set[int]
+	seen  set.Set[coKey]
+}
+
+func (c *coOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	v, ok := t.(*soltype.TypeVarType)
+	if !ok {
+		return soltype.EnterResult{} // structural / atom node: let Accept descend
+	}
+	g := set.NewSet[int]()
+	c.m.gatherGroup(v, pol, g)
+	for a := range g {
+		for b := range g {
+			if a == b {
+				continue
+			}
+			ck := coKey{a, pol}
+			if c.coOcc[ck] == nil {
+				c.coOcc[ck] = set.NewSet[int]()
+			}
+			c.coOcc[ck].Add(b)
+		}
+	}
+	k := coKey{v.ID, pol}
+	if c.seen.Contains(k) {
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	c.seen.Add(k)
+	for _, b := range c.m.effectiveBounds(v, pol) {
+		b.Accept(c, pol)
+	}
+	return soltype.EnterResult{SkipChildren: true}
+}
+
+func (c *coOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// occHas reports whether o records an occurrence in polarity pol.
+func occHas(o occPolarity, pol soltype.Polarity) bool {
+	if pol == soltype.Positive {
+		return o&occPos != 0
+	}
+	return o&occNeg != 0
+}
+
+// mutualCoOcc reports whether a and b co-occur in every polarity each occurs in —
+// the condition under which they merge soundly. A variable pair failing it (e.g.
+// two tuple elements that share no union node) stays distinct.
+func mutualCoOcc(a, b int, occ map[int]occPolarity, coOcc map[coKey]set.Set[int]) bool {
+	oa, ob := occ[a], occ[b]
+	if oa == 0 || ob == 0 {
+		return false
+	}
+	for _, pol := range []soltype.Polarity{soltype.Positive, soltype.Negative} {
+		if occHas(oa, pol) {
+			s := coOcc[coKey{a, pol}]
+			if s == nil || !s.Contains(b) {
+				return false
+			}
+		}
+		if occHas(ob, pol) {
+			s := coOcc[coKey{b, pol}]
+			if s == nil || !s.Contains(a) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// mergeCoOccurring unions every mutually-co-occurring pair among ids.
+func mergeCoOccurring(ids []int, occ map[int]occPolarity, coOcc map[coKey]set.Set[int]) *unionFind {
+	uf := newUnionFind()
+	sort.Ints(ids)
+	for i := 0; i < len(ids); i++ {
+		for j := i + 1; j < len(ids); j++ {
+			if mutualCoOcc(ids[i], ids[j], occ, coOcc) {
+				uf.union(ids[i], ids[j])
+			}
+		}
+	}
+	return uf
+}
+
+// schemeSimplification is the co-occurrence merging input coalesceScheme threads
+// into schemeCoalescer: the union-find collapsing quantifiable variables that
+// always occur together, the merged occurrence map keyed by representative id (so
+// single-polarity elimination sees a class's combined polarities), and the id→var
+// table to resolve a representative id back to its variable for naming.
+type schemeSimplification struct {
+	uf        *unionFind
+	mergedOcc map[int]occPolarity // keyed by representative id
+	idToVar   map[int]*soltype.TypeVarType
+}
+
+// rep resolves a variable to its class representative variable.
+func (s *schemeSimplification) rep(v *soltype.TypeVarType) *soltype.TypeVarType {
+	return s.idToVar[s.uf.find(v.ID)]
+}
+
+// simplifyScheme runs the co-occurrence analysis over a generalized scheme's raw
+// body. Only quantifiable variables (Level > genLevel) are merge candidates:
+// captured outer variables are not type parameters and never merge into one, which
+// also keeps every representative quantifiable so the retain decision stays uniform.
+func simplifyScheme(body soltype.Type, genLevel int) *schemeSimplification {
+	vars := map[int]*soltype.TypeVarType{}
+	body.Accept(&varCollector{out: vars, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
+
+	m := buildMirror(vars)
+
+	occVar := map[*soltype.TypeVarType]occPolarity{}
+	body.Accept(&symOccVisitor{m: m, occ: occVar, seen: set.NewSet[occKey]()}, soltype.Positive)
+	occByID := make(map[int]occPolarity, len(occVar))
+	for v, o := range occVar {
+		occByID[v.ID] = o
+	}
+
+	coOcc := map[coKey]set.Set[int]{}
+	body.Accept(&coOccVisitor{m: m, coOcc: coOcc, seen: set.NewSet[coKey]()}, soltype.Positive)
+
+	candidates := make([]int, 0, len(vars))
+	for id, v := range vars {
+		if v.Level > genLevel {
+			candidates = append(candidates, id)
+		}
+	}
+	uf := mergeCoOccurring(candidates, occByID, coOcc)
+
+	mergedOcc := map[int]occPolarity{}
+	for id := range vars {
+		rep := uf.find(id)
+		mergedOcc[rep] |= occByID[id]
+	}
+	return &schemeSimplification{uf: uf, mergedOcc: mergedOcc, idToVar: vars}
+}

--- a/internal/solver/simplify_test.go
+++ b/internal/solver/simplify_test.go
@@ -1,0 +1,78 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// fparam builds a named function parameter for a hand-rolled FuncType body.
+func fparam(name string, t soltype.Type) *soltype.FuncParam {
+	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: t}
+}
+
+// Co-occurrence merging collapses distinct quantified variables that always appear
+// together. The shape mirrors `outer` from the polymorphism suite: a parameter
+// variable a flows to two result variables b, c (a's upper bounds), both returned
+// in a tuple. PR1 retained all three as separate type parameters
+// (`fn <T0, T1>(x: T0 & T1) -> [T0, T1]`); PR2 merges them to one.
+func TestCoalesceSchemeMergesCoOccurring(t *testing.T) {
+	b := &soltype.TypeVarType{ID: 2, Level: 1}
+	c := &soltype.TypeVarType{ID: 3, Level: 1}
+	a := &soltype.TypeVarType{ID: 1, Level: 1, UpperBounds: []soltype.Type{b, c}}
+	body := &soltype.FuncType{
+		Params: []*soltype.FuncParam{fparam("x", a)},
+		Ret:    &soltype.TupleType{Elems: []soltype.Type{b, c}},
+	}
+	scheme := &PolyScheme{Level: 0, Body: body}
+
+	require.Equal(t, "fn <T0>(x: T0) -> [T0, T0]", renderScheme(scheme))
+
+	// All three variables resolve to one representative.
+	simp := simplifyScheme(body, 0)
+	require.Equal(t, simp.uf.find(1), simp.uf.find(2))
+	require.Equal(t, simp.uf.find(2), simp.uf.find(3))
+}
+
+// Variables that do NOT co-occur stay distinct: two independent parameters each
+// flowing to its own tuple slot share no union/intersection group, so each remains
+// its own type parameter.
+func TestCoalesceSchemeKeepsDistinctParams(t *testing.T) {
+	a := &soltype.TypeVarType{ID: 1, Level: 1}
+	b := &soltype.TypeVarType{ID: 2, Level: 1}
+	body := &soltype.FuncType{
+		Params: []*soltype.FuncParam{fparam("a", a), fparam("b", b)},
+		Ret:    &soltype.TupleType{Elems: []soltype.Type{a, b}},
+	}
+	scheme := &PolyScheme{Level: 0, Body: body}
+
+	require.Equal(t, "fn <T0, T1>(a: T0, b: T1) -> [T0, T1]", renderScheme(scheme))
+
+	simp := simplifyScheme(body, 0)
+	require.NotEqual(t, simp.uf.find(1), simp.uf.find(2))
+}
+
+// Captured variables (Level <= genLevel) are not merge candidates: a parameter
+// variable at the generalize level never folds into a quantified one, so the
+// representative of every quantifiable variable stays quantifiable.
+func TestSimplifySchemeExcludesCapturedVars(t *testing.T) {
+	captured := &soltype.TypeVarType{ID: 1, Level: 0} // at genLevel: not quantifiable
+	quantified := &soltype.TypeVarType{ID: 2, Level: 1}
+	body := &soltype.TupleType{Elems: []soltype.Type{captured, quantified}}
+
+	simp := simplifyScheme(body, 0)
+	require.Equal(t, 1, simp.uf.find(1), "a captured var is its own (singleton) class")
+	require.Equal(t, 2, simp.uf.find(2), "a quantified var is its own class when nothing co-occurs")
+}
+
+// The union-find keeps the smaller id as a class's representative, so naming is
+// stable regardless of union order.
+func TestUnionFindSmallerIdRepresentative(t *testing.T) {
+	uf := newUnionFind()
+	uf.union(5, 3)
+	uf.union(3, 8)
+	require.Equal(t, 3, uf.find(5))
+	require.Equal(t, 3, uf.find(8))
+	require.Equal(t, 3, uf.find(3))
+}

--- a/internal/solver/simplify_test.go
+++ b/internal/solver/simplify_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -51,6 +52,67 @@ func TestCoalesceSchemeKeepsDistinctParams(t *testing.T) {
 
 	simp := simplifyScheme(body, 0)
 	require.NotEqual(t, simp.uf.find(1), simp.uf.find(2))
+}
+
+// runCoOcc runs the occurrence and co-occurrence passes over body exactly as
+// simplifyScheme does, returning the raw maps so a test can inspect which variables
+// the analysis treats as co-occurring.
+func runCoOcc(body soltype.Type) (map[int]occPolarity, map[coKey]set.Set[int]) {
+	vars := map[int]*soltype.TypeVarType{}
+	body.Accept(&varCollector{out: vars, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
+	m := buildMirror(vars)
+	occ := map[int]occPolarity{}
+	body.Accept(&symOccVisitor{m: m, occ: occ, seen: set.NewSet[occKey]()}, soltype.Positive)
+	coOcc := map[coKey]set.Set[int]{}
+	body.Accept(&coOccVisitor{m: m, coOcc: coOcc, seen: set.NewSet[coKey]()}, soltype.Positive)
+	return occ, coOcc
+}
+
+// The co-occurrence pass records a UNION of per-group peers, and the merge decision
+// is made by mutualCoOcc's bidirectional, all-polarities check — not by membership
+// in any single group. This pins that semantics on the `outer` shape: param a flows
+// to result vars b and c, both returned in a tuple.
+//
+// gatherGroup follows a transitive but ASYMMETRIC closure, so at positive polarity a
+// sits in its own group {a}, in b's group {a, b}, and in c's group {a, c}. So a
+// co-occurs with b in one positive group and with c in another, while b and c never
+// share a positive group. The union records a↔b and a↔c but never b↔c, which is what
+// keeps the analysis from merging genuinely unrelated peers.
+//
+// A rule requiring a peer to appear in EVERY group a is part of (intersection /
+// per-group counting) would reject the a–b and a–c pairs, since a sits in three
+// positive groups but co-occurs with each result var in only one. The scheme would
+// then regress to the non-compact `fn <T0, T1>(x: T0 & T1) -> [T0, T1]`. The
+// assertions below fail under that rule, so they document why union accumulation
+// plus a transitive union-find is required.
+func TestCoOccUnionMergesTransitively(t *testing.T) {
+	b := &soltype.TypeVarType{ID: 2, Level: 1}
+	c := &soltype.TypeVarType{ID: 3, Level: 1}
+	a := &soltype.TypeVarType{ID: 1, Level: 1, UpperBounds: []soltype.Type{b, c}}
+	body := &soltype.FuncType{
+		Params: []*soltype.FuncParam{fparam("x", a)},
+		Ret:    &soltype.TupleType{Elems: []soltype.Type{b, c}},
+	}
+
+	occ, coOcc := runCoOcc(body)
+
+	// a shares a positive group with each result var; b and c never share one. The
+	// full element sets capture both facts: a co-occurs with exactly {b, c}, while
+	// each result var co-occurs with exactly {a}, never with the other.
+	require.ElementsMatch(t, []int{2, 3}, coOcc[coKey{1, soltype.Positive}].ToSlice(), "a co-occurs with b and c positively")
+	require.ElementsMatch(t, []int{1}, coOcc[coKey{2, soltype.Positive}].ToSlice(), "b co-occurs with a only")
+	require.ElementsMatch(t, []int{1}, coOcc[coKey{3, soltype.Positive}].ToSlice(), "c co-occurs with a only")
+
+	// The merge relation: a is mutually-co-occurring with each result var, but b and c
+	// are NOT mutually-co-occurring — they only merge transitively through a.
+	require.True(t, mutualCoOcc(1, 2, occ, coOcc), "a and b co-occur in every polarity each occurs in")
+	require.True(t, mutualCoOcc(1, 3, occ, coOcc), "a and c co-occur in every polarity each occurs in")
+	require.False(t, mutualCoOcc(2, 3, occ, coOcc), "b and c never directly co-occur")
+
+	// The union-find still collapses all three into one class via a.
+	simp := simplifyScheme(body, 0)
+	require.Equal(t, simp.uf.find(1), simp.uf.find(2))
+	require.Equal(t, simp.uf.find(1), simp.uf.find(3))
 }
 
 // Captured variables (Level <= genLevel) are not merge candidates: a parameter


### PR DESCRIPTION
Completes the polymorphism rendering pipeline (M3, PR2) by adding co-occurrence analysis to collapse distinct quantified variables that always appear together into a single type parameter.

## Summary

When a generalized scheme contains multiple distinct type variables that always co-occur in the same union or intersection groups, they can be safely merged into one representative. This makes rendered signatures more compact — for example, a captured-parameter case that previously rendered as `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` now renders as `fn <T0>(y: T0) -> [T0, T0]`.

## Changes

- **New file: `internal/solver/simplify.go`** — Implements the co-occurrence merging algorithm:
  - `unionFind` — Disjoint-set forest to track variable equivalence classes, keeping the smaller ID as representative for stable naming.
  - `varCollector` — Visitor to gather all type variables reachable from a scheme body.
  - `mirror` — Precomputes symmetric var-to-var subtyping edges (constrain records edges on only one endpoint; co-occurrence analysis needs both directions).
  - `symOccVisitor` — Records which polarities each variable occurs in, walking the symmetric bound graph.
  - `coOccVisitor` — Records per (variable, polarity) which variables co-occur in the same union/intersection group.
  - `simplifyScheme()` — Main entry point that runs the full analysis and returns a `schemeSimplification` struct holding the union-find, merged occurrence map, and variable lookup table.

- **Modified: `internal/solver/coalesce.go`**:
  - Removed `analyzeOccurrences()` and `occVisitor` — occurrence analysis now lives in `simplify.go` as part of the broader co-occurrence pipeline.
  - Updated `coalesceScheme()` to call `simplifyScheme()` and thread its result into `schemeCoalescer`.
  - Updated `schemeCoalescer` to use the co-occurrence union-find: each variable resolves through its representative, so all members of a merged class render as the same type parameter.
  - Added detailed comments explaining the cycle guard and why bounds are walked from the original variable rather than its representative.

- **Modified: `internal/solver/poly.go`**:
  - Added `coalesced` field to `PolyScheme` to memoize the display type (computed once at first use, never stale since the body is immutable after generalization).
  - Added `display()` method to lazily compute and cache the coalesced type.
  - Removed `simplify()` hook from `generalize()` — simplification now runs at display time inside `coalesceScheme()`, keeping the raw body intact for instantiation.

- **Modified: `internal/solver/doc.go`** — Updated documentation to describe the co-occurrence merging pass and its role in compact scheme rendering.

- **New file: `internal/solver/simplify_test.go`** — Test suite covering:
  - Co-occurring variables merge to one representative.
  - Non-co-occurring variables stay distinct.
  - Captured variables (at or below genLevel) are excluded from merging.
  - Union-find representative selection (smaller ID wins).

- **Modified: `internal/solver/infer_poly_test.go`** — Updated test comments and assertions to reflect PR2's co-occurrence merging behavior. The `InnerCapturesOuterParam` test now asserts the compact rendered signature alongside the two-types-of-use behavior.

## Implementation notes

The algorithm walks a symmetrized bound graph because `constrain` records var-to-var subtyping edges on only one endpoint. Co-occurrence analysis needs to see both directions to correctly identify variables that always appear together. The `mirror` struct precomputes these symmetric edges without mutating the canonical scheme body.

Simplification runs at display time (in `coalesceScheme`) rather than during generalization. This keeps the raw scheme body intact for instantiation — each use gets a fresh copy with all original variables — while the rendered signature stays compact. The memoized `coalesced` field ensures the analysis runs only once

https://claude.ai/code/session_01QgNPSKzcTDA5C75uKYQzto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Type parameters that always co-occur are now merged into a single parameter in displayed signatures for clarity.
  * Distinct type parameters remain separate when they appear in different contexts.
  * Type signature rendering is cached for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->