### PR TITLE
M4 implementation plan: records, lifetimes, mut, destructuring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 Escalier is a programming language with a Go-based compiler. The compiler pipeline lives under [internal/](internal/) and the CLI entry points under [cmd/](cmd/).
 
+## Responding in conversation
+
+- Be concise. Lead with the direct answer, usually one or two sentences, and stop there.
+- Don't pre-empt follow-up questions with extra sections, caveats, or trade-off surveys. The user will ask about anything they want expanded.
+- Don't give a long version followed by a short recap — just give the short version.
+- No multi-heading structure unless asked. This applies to analysis and planning questions too, not just quick lookups.
+
 ## Repo layout
 
 - [internal/lexer_util/](internal/lexer_util/), [internal/parser/](internal/parser/) — lexing and parsing

--- a/planning/exact-types/requirements.md
+++ b/planning/exact-types/requirements.md
@@ -60,8 +60,8 @@ Object literals are inferred as **exact** types:
 
 ```
 val p = {x: 1, y: 2}                    // inferred as exact {x: number, y: number}
-val q: InexactPoint = {x: 1, y: 2}      // okay — exact widens to inexact on assignment
-val r: InexactPoint = {x: 1, y: 2, z: 3} // okay — assigning to inexact target
+val q: InexactPoint = {x: 1, y: 2}      // okay — declared properties only
+val r: InexactPoint = {x: 1, y: 2, z: 3} // Error — excess property `z` on a literal (see §2.2.4)
 val s: ExactPoint = {x: 1, y: 2, z: 3}   // Error — extra property `z` on exact target
 ```
 
@@ -99,6 +99,41 @@ For an inexact `o`, all three fall back to TypeScript's permissive types:
 `Object.keys(o): Array<string>`, `Object.values(o): Array<unknown>`, and
 `Object.entries(o): Array<[string, unknown]>` — the unknown extra properties
 prevent any tighter typing.
+
+#### 2.2.4. Excess Property Checking on Literals
+
+Assigning an object **literal** directly to a known or contextual type rejects
+properties the target does not declare, **regardless of the target's exactness**.
+This is the object twin of the direct-call rule (§4.2.3): the exact/inexact
+distinction governs **subtyping** — which *values* may flow into a slot — not
+direct literal construction. A property the target's shape does not name is
+statically inaccessible through that type and is almost always a typo or a
+leftover, so it is flagged where it is written.
+
+```
+type InexactPoint = { x: number, y: number, ... }
+
+val r: InexactPoint = { x: 1, y: 2, z: 3 }   // Error — excess property `z`
+```
+
+The check fires against the **untyped** open tail (`...`) only. A typed index
+signature (§2.7) *types* its extra properties instead of discarding them, so
+extras that satisfy the signature are accepted — exactly as a typed rest
+parameter admits extra arguments while an inexact `(...)` function does not
+(§4.2.3). A "bag" of arbitrary members is therefore expressed with an index
+signature, not a bare `...` (§10.4).
+
+Assigning through a variable opts out: a non-literal value is checked by ordinary
+width subtyping rather than as a fresh construction site.
+
+```
+val tmp = { x: 1, y: 2, z: 3 }       // exact { x: number, y: number, z: number }
+val r: InexactPoint = tmp            // okay — width subtyping; `z` is simply forgotten
+```
+
+The check applies wherever a literal meets a contextual type — annotated
+bindings, function arguments against a parameter type, and return positions — not
+only at `val`/`var` bindings.
 
 ### 2.3. Type-Checking Rules
 
@@ -343,7 +378,7 @@ Tuple literals are inferred as **exact**:
 
 ```
 val t = ["hello", 42]                // inferred as exact [string, number]
-val u: InexactTuple = ["hello", 42, true] // okay — extra element on inexact target
+val u: InexactTuple = ["hello", 42, true] // Error — excess element on a literal (see §3.2.4)
 val v: ExactTuple = ["hello", 42, true]   // Error — extra element on exact target
 ```
 
@@ -365,6 +400,34 @@ For an exact tuple, `length` is the literal numeric type (`2` for
 `[string, number]`). For an inexact tuple, `length` is `number` with a known
 lower bound (effectively `number`, with the documented minimum equal to the
 number of declared elements).
+
+#### 3.2.4. Excess Element Checking on Literals
+
+Assigning a tuple **literal** directly to a known or contextual type rejects
+elements beyond the target's declared shape, **regardless of exactness** — the
+positional twin of excess-property checking (§2.2.4) and the direct-call
+extra-argument rule (§4.2.3), since a tuple is an argument-list-shaped value.
+
+```
+type InexactPair = [number, number, ...]
+
+val u: InexactPair = [1, 2, 3]   // Error — excess element at index 2
+```
+
+As with objects, this fires against the **untyped** open tail (`...`) only. A
+typed rest element *types* its extras, so a literal's trailing elements that
+satisfy the rest element type are accepted:
+
+```
+val w: [string, ...Array<number>] = ["a", 1, 2]   // okay — 1, 2 typed by the rest element
+```
+
+Assigning through a variable opts out, as for objects:
+
+```
+val tmp = [1, 2, 3]
+val u: InexactPair = tmp          // okay — width subtyping; the third element is forgotten
+```
 
 ### 3.3. Type-Checking Rules
 
@@ -901,6 +964,12 @@ The exact/inexact distinction does **not** affect direct calls; it governs
 function-typed slot expects it. An inexact type's tolerance for extras is a
 statement about how the function may be *invoked through a slot that holds it*,
 not a license to pass extras at a visible call site.
+
+The same direct-construction-site principle governs object literals (§2.2.4) and
+tuple literals (§3.2.4): an excess property or element written on a literal is
+rejected regardless of the target's exactness, while a typed tail — a rest
+parameter, a typed tuple rest element, or an object index signature — types its
+extras and admits them.
 
 #### 4.2.4. `Parameters<T>` and `infer` on Function Parameter Lists
 
@@ -1992,21 +2061,32 @@ would be invoked with a second argument it refuses. This is exactly why
 `std:array` splits `map` (unary) from `mapi` (binary) rather than exposing
 one binary slot — see §11.1.
 
-### 10.4. Mixed: An Inexact Object as a Bag
+### 10.4. Mixed: A Typed Bag via an Index Signature
+
+A "bag" that carries arbitrary extra members declares a **typed index
+signature** so those members are typed rather than discarded. The extras are then
+accepted at a literal site because the index signature types them — the object
+analogue of a typed rest parameter (§4.2.3), not the untyped `...` tail.
 
 ```
 type Headers = {
     "content-type": string,
     "content-length": number,
-    ...                            // explicitly inexact: other headers are allowed
+    [key: string]: string | number,   // typed extras
 }
 
 val h: Headers = {
     "content-type": "text/plain",
     "content-length": 11,
-    "x-custom": "ok",              // okay — inexact permits extras
+    "x-custom": "ok",                  // okay — typed by the index signature
 }
 ```
+
+Writing the same extra against a bare untyped `...` tail is rejected at the
+literal site (§2.2.4), because an untyped extra is statically inaccessible and
+almost always a mistake. To attach genuinely untyped extra data, assign through a
+variable, which is checked by ordinary width subtyping rather than as a fresh
+literal.
 
 ## 11. `std:*` and `dom:*` Module Adjustments
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -512,6 +512,18 @@ production scale. If it cannot be encoded cleanly against the real AST, the
 whole migration is in question — this is the gate to clear before investing
 further.
 
+**Deferred out of M4** (tracked at their target milestones, not lost):
+
+- **Object-argument overload specificity (#723)** — records make the documented
+  first-match fallback observable; the principled field-subsumption ranking lands
+  in **M5**. M4 only pins the cases with `#723`-tagged tests.
+- **Function-arm Variation-B gap** — unchecked extra positions against an inexact
+  callback need the `_ <: unknown` (⊤) rule, which lands in **M6**. M4 excludes
+  function annotations and fails the branch loud, keeping the path closed.
+- **Rest-param element checking (#677)** — `...xs: T[]` element checking needs
+  `Array<T>`, so it lands in **M7**. M4 stays arity-only and marks the
+  `FuncParam.Rest` note "M7."
+
 ---
 
 ## M5 — Nominal types (classes)
@@ -651,6 +663,15 @@ two method-specific wrinkles:
   same one that resolves `p.x`). Plug overload selection into *that* path —
   it has the declared class in hand and never has to invent an arrow type for
   subtyping to chew on.
+- **Object-argument overload specificity (#723; deferred from M4).** M4's record
+  types made the documented first-match fallback observable on object-typed
+  arguments: `moreSpecific`/`structuralSubtype` (overload.go) ranks record-shaped
+  args as a tie, so resolution collapses to declaration order. M5 owns the fix —
+  classes are where multi-arm object overloads proliferate — ranking record/class
+  args by field-set subsumption and exactness (a superset-of-fields or exact arg
+  dominates), the object analogue of M3's arity/exactness ranking. M4 only pins
+  the observable cases with `#723`-tagged tests so any later arm-choice change is
+  intentional.
 
 See M3 for the full set of recommendations; everything there applies to
 methods unchanged.
@@ -720,6 +741,15 @@ recursive references (cf. `infer_module.go:431-872` and the discussion in
   reported. (In M3 this is an invariant freebie — `ErrorType` is short-circuited out
   of every bound list, so it never reaches a former; M6 must keep it true once
   formers can be built directly.)
+- **The `_ <: unknown` (⊤) subtyping rule — closes M4's Variation-B gap
+  (deferred from M4).** With `unknown` a real former here, add the rule that makes
+  it the top of the lattice (everything is a subtype of `unknown`). M4 left a
+  KNOWN GAP in `constrain`'s function arm: an inexact callback that may supply
+  extra arguments needs an `unknown`-against-param check at those positions
+  (exact-types §4.2.1.2 "Variation B"), which this rule supplies. M4 keeps the
+  path closed — A3 adds no function annotations and the extra-position branch
+  fails loud via `reportUnsupportedFeature` — so the gap is unreachable until this
+  rule lands and that guard is removed.
 
 **Accept:** `number | string` annotation accepts `number`/rejects `boolean`;
 intersection annotation satisfied by a value at both member types; both
@@ -779,6 +809,12 @@ now resolve to real `soltype` structures rather than opaque placeholders.
   from day one, so they live in the M2 prelude (a port of the old checker's
   `addOperatorBindings`). M7 ports *type* ingestion (`.d.ts`/interop → `soltype`),
   not the value-level operator env.
+- **Rest-param element checking (#677; deferred from M4).** Typed rest params
+  `...xs: T[]` check each trailing argument against `T`, which needs `Array<T>` to
+  resolve — so the element type only exists once this milestone lands. M4 kept
+  rest params arity-only (trailing args unchecked, a documented hole) and marked
+  `FuncParam.Rest`'s note "M7." Wire the element check here against the real
+  `Array<T>`, dropping the arity-only restriction.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -424,7 +424,7 @@ wrapper) are what first populate a lifetime. Land them together.
   'static`. (Spike M4.)
 - **Destructuring patterns + the `match` expression form.** `IdentPat` (M1, the
   only `Pat` concrete through M2–M3) is joined here by the structural concretes —
-  `TuplePat`, `RecordPat`, and literal patterns — now that tuple/record types
+  `TuplePat`, `ObjectPat`, and literal patterns — now that tuple/record types
   exist to type them. The *same* `Pat` machinery powers both **binding
   destructuring** (`val {x, y} = p`, `val [a, b] = t`, and the identical forms in
   function params) and **`match` arms**: a pattern dispatches through the usage /
@@ -529,18 +529,23 @@ further.
 ## M5 — Nominal types (classes)
 
 Escalier's `class` declarations introduce **nominal** types: a value of class
-`Point` is not assignable to a bare structural `{x: number}` (and vice versa)
-even when the fields line up. SimpleSub is fundamentally structural, so nominal
+`Point` is not assignable to an **exact** structural `{x: number}`, nor is a
+structural object ever assignable to `Point`, even when the fields line up. A
+class instance *does* satisfy an **inexact** object target structurally; the
+target-dispatched rule below makes the target's exactness the deciding factor.
+SimpleSub is fundamentally structural, so nominal
 types are layered on as atomic lattice elements with an explicit
 **declared-subtype graph** feeding `constrain` — the design sketched in
 [`03-references.md`](03-references.md). Lifetimes and `mut` ride on classes
 exactly as they do on records (introduced in M4), so this milestone reuses the
 M4 substrate without retrofitting.
 
-- A `Class` SimpleType `{name, args, lt, final}` that is **atomic from
-  `constrain`'s perspective**: subtyping never looks at its members structurally.
-  Member *lookup* (`p.x`, `p.method()`) resolves through the declared body —
-  that's a separate path from subtyping.
+- A `Class` SimpleType `{name, args, lt, final}` plus the structural member view
+  it projects. Against a **class target**, subtyping is nominal and never looks at
+  members structurally. Against a **structural object target**, the class projects
+  its members and the structural width rule applies — target-dispatched, per the
+  M4 plan's design-revision note. Member *lookup* (`p.x`, `p.method()`) resolves
+  through the declared body either way, a separate path from subtyping.
 - **Class-instance exactness comes from `final`**
   ([exact-types/requirements.md](../exact-types/requirements.md) §2.6). A class instance
   type is **inexact by default** (subclasses may add members, so it behaves like
@@ -552,9 +557,12 @@ M4 substrate without retrofitting.
 - **Nominal subtyping rule.** `Class<A, args_A> <: Class<B, args_B>` succeeds
   iff (a) `A == B` (per-position check on args, with variance per parameter —
   see below), or (b) `A extends B` (transitively) in the declared-subtype graph
-  built from each class's `Extends`/`Implements`. Mixed
-  `Class <: structural record` (and the reverse) rejects: a `Point` is not a
-  `{x: number}`.
+  built from each class's `Extends`/`Implements`. A `Class` against a structural
+  object target dispatches on the target's exactness: an **exact** object target
+  rejects, since a `Point` is not an exact `{x: number}`, while an **inexact**
+  `{x: number, ...}` target **admits** a structurally-conforming class instance
+  via the structural width rule. The reverse — a structural object against a
+  `Class` target — always rejects: a `{x: number}` is not a `Point`.
 - **`match` extends to nominal patterns; destructuring stays separate from
   assignability.** M5 adds **enum/class constructor patterns** to the `match`
   expression introduced in M4 (structural patterns there), plus
@@ -563,8 +571,11 @@ M4 substrate without retrofitting.
   `let {x, y} = point` (and the equivalent `match` arm) still succeeds against a
   `Point` because patterns dispatch through member lookup, **not** subtyping —
   the same path that resolves `p.x`. The assignment forms
-  `var foo: {x: number, y: number} = Point(5, 10)` and
-  `var bar: Point = {x: 5, y: 10}` both remain rejected by the nominal rule above.
+  `var foo: {x: number, y: number} = Point(5, 10)` (an exact target) and
+  `var bar: Point = {x: 5, y: 10}` both remain rejected. The inexact form
+  `var foo: {x: number, y: number, ...} = Point(5, 10)` is **accepted** under the
+  target-dispatched rule above: an inexact object target admits a
+  structurally-conforming class instance.
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,
   exactly as SimpleSub already does for inference variables. A parameter that
@@ -815,6 +826,15 @@ now resolve to real `soltype` structures rather than opaque placeholders.
   rest params arity-only (trailing args unchecked, a documented hole) and marked
   `FuncParam.Rest`'s note "M7." Wire the element check here against the real
   `Array<T>`, dropping the arity-only restriction.
+- **Variadic tuple types `[number, ...Array<number>]`.** A tuple with a fixed
+  prefix and a *typed*, unbounded, homogeneous tail — distinct from M4's `Inexact`
+  tuple flag `[A, B, ...]`, which means "at least these, then *unknown*." The typed
+  tail needs `Array<T>`, so it lands here with the rest of library type resolution.
+  Add a typed rest/variadic element to `TupleType` — a tail carrying its element
+  type, not just a boolean flag — plus the variadic-tuple subtyping rules, e.g.
+  `[number, number] <: [number, ...Array<number>]` and
+  `[number, ...Array<number>] <: Array<number>`. The `infer`-matching form
+  `T extends [any, ...infer R] ? R : never` is M9 (conditional + `infer`), not here.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
@@ -924,6 +944,27 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
   - Key remapping via `as` clauses.
   - Combinations with `keyof` / indexed access in the value position (the
     pattern underlying `Pick`, `Omit`, `Partial`, `Required`, `Readonly`).
+- **Object spread types `{...A, x: T}`** — first-class object spread types,
+  parallel to Escalier's tuple spread types and modeled on Flow; TypeScript has
+  no equivalent. A reducible operator: it reduces when the operand grounds, with
+  the rightmost field winning on overlap, and stays residual when the operand is
+  an abstract type parameter, reduced post-coalescing like the operators above.
+  Exactness threads from the operand, so a spread of an inexact object is inexact.
+  **Optional-field overlap uses Flow-faithful show-through union:** when a later
+  operand's *optional* field overlaps an earlier key, the values union rather than
+  override. Required-in-earlier with optional-in-later yields `T | U` **required**;
+  optional with optional yields `(T | U)?`. For example, `{...A, ...B}` with
+  `A = {k: number}` and `B = {k?: string}` reduces to `k: number | string`,
+  required. Object rest/spread in both literals and type annotations lands here,
+  not M4.
+- **Tuple spread types `[...P, x]`** — the positional analogue of object spread,
+  spreading one tuple type into another. Same reducible-operator shape: it splices
+  when the operand grounds to a concrete tuple and stays residual when the operand
+  is an abstract type parameter, reduced post-coalescing. M4 already handles the
+  concrete case for tuple *literals* — `[...pair, 3]` where `pair` is a known
+  tuple — but not the abstract-operand type. This is distinct from a typed variadic
+  tail like `[number, ...Array<number>]`, which is M7: that needs `Array` and is an
+  unbounded homogeneous tail, not a splice.
 - **Template literal types** — string-literal types built from interpolated
   type unions (e.g. `` `on${Capitalize<K>}` ``), including the intrinsic
   string-manipulation operators `Uppercase`/`Lowercase`/`Capitalize`/
@@ -931,7 +972,8 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
 - **Exactness propagation through operators**
   ([exact-types/requirements.md](../exact-types/requirements.md) §7): `keyof T`
   is exact iff `T`'s key set is exact; `T[K]`, conditional results, mapped
-  types, and template literals derive exactness from their inputs. This is the
+  types, object spread, and template literals derive exactness from their inputs.
+  This is the
   first milestone where exactness must *propagate through reduction*, not just
   be checked — it builds on the flag laid down in M3–M6. The
   `Exact<T>`/`Inexact<T>` type-level utilities also land here (they are type

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -25,24 +25,29 @@ Facts that changed or sharpened the original plan, from the code on main:
    `infer_expr.go` / `infer_decl.go` / `infer_stmt.go`, `module.go`,
    `overload.go`, `poly.go`, `prelude.go`, `probe.go`, `prov.go`, `scope.go`,
    `simplify.go`, `type_ann.go`.
-2. **`RecordType` already exists** (M2): `Fields []*RecordField{Name, Type}` —
-   an **ordered slice with last-wins dedup**, not a map; `Field(name)` is the
-   canonical lookup. Record/tuple **literal inference already works**
+2. **`RecordType` already exists** (M2) and **A1 promotes it to `ObjectType`**
+   (see Key types below): today it is `Fields []*RecordField{Name, Type}` — an
+   **ordered slice with last-wins dedup**, not a map; `Field(name)` is the
+   canonical lookup. A1 widens that to an ordered `[]ObjTypeElem` element list
+   carrying property elements only in M4; method/getter/setter members arrive in
+   M5, and index signatures plus the object rest/spread `RestElem` in M9.
+   Object/tuple **literal inference already works**
    (`inferObject` / tuple walk), as does **member-read usage inference**:
    `inferMember` lowers `recv.prop` to `constrain(recv, {prop: β})`
    ([infer_expr.go:716](../../internal/solver/infer_expr.go)). M4 does *not*
-   introduce these — it refines them.
+   introduce these — it refines them and ports them onto `ObjectType`.
 3. **The exactness flag is spelled `Inexact`**, not `exact` — `FuncType.Inexact`
    (M3 PR4) deliberately makes the **zero value exact**, matching
    exact-by-default, so structural rewriters carry the flag through unchanged.
-   `RecordType`/`TupleType` follow the same convention; conveniently, every
-   record/tuple M2 already mints becomes exact *by zero value*.
-4. **One width-tolerant record arm exists and is explicitly provisional.** The
+   `ObjectType`/`TupleType` follow the same convention; conveniently, every
+   object/tuple M2 already mints becomes exact *by zero value*.
+4. **One width-tolerant object arm exists and is explicitly provisional.** The
    `RecordType <: RecordType` case in
    [constrain.go:181](../../internal/solver/constrain.go) serves only member
    access and carries a long comment: M4 must split the **field-selection
-   requirement** (width-tolerant) from **concrete record `<:` record**
-   (exact-by-default). Likewise the tuple arm is exact-only ("M4 adds the exact
+   requirement** (width-tolerant) from **concrete object `<:` object**
+   (exact-by-default), reworking the arm as the `ObjectType` arm. Likewise the
+   tuple arm is exact-only ("M4 adds the exact
    flag and the inexact arm") and the function arm has a **KNOWN GAP (M4)**
    note for inexact-callback extra positions (Variation B, needs the `⊤` rule —
    see Open Questions).
@@ -84,7 +89,7 @@ Facts that changed or sharpened the original plan, from the code on main:
     the value-position consumer and adds member *lookup*.
 12. **`resolveTypeAnn` covers only primitives + `Promise<T>`**
     ([type_ann.go](../../internal/solver/type_ann.go)). M4's acceptance tests
-    need record/tuple annotations (incl. the trailing `...` and `mut`/lifetime
+    need object/tuple annotations (incl. the trailing `...` and `mut`/lifetime
     forms), so the annotation surface must grow accordingly.
 13. **Milestone renumbering**: library type resolution is the new M7, the
     fixture harness is **M8**, type-level operators **M9**, codegen **M10**.
@@ -92,14 +97,14 @@ Facts that changed or sharpened the original plan, from the code on main:
     the original plan's "spec must be written first" risk is **resolved**.
 14. **The milestone itself grew**: M4 now also owns **destructuring patterns +
     the `match` expression form**, **namespace member lookup**, **`var`-binding
-    literal widening**, and the selection-vs-concrete record split (all in
+    literal widening**, and the selection-vs-concrete object split (all in
     [01-milestones.md](01-milestones.md) §M4).
 
 ## Why M4 is "the big one"
 
 Records, `mut`, and lifetimes are inseparable: lifetimes ride on borrows,
-records are the first borrowable value, and `mut` borrows are what first
-populate a lifetime. The milestone names the `RefType` rule's `mut`-driven inner
+records are the first borrowable value, and borrows are what first populate a
+lifetime. The milestone names the `RefType` rule's `mut`-driven inner
 invariance as the **HIGHEST-RISK gate**: if it cannot be encoded cleanly against
 the real AST, the whole migration is in question. The PR sequence below reaches
 the gate after only the minimum prerequisite work, and nothing expensive
@@ -109,19 +114,21 @@ the gate after only the minimum prerequisite work, and nothing expensive
 
 In (per the updated milestone):
 
-1. `Inexact` flag on `RecordType`/`TupleType`; exact/inexact subtyping rules;
-   the selection-vs-concrete record split; tuple inexact arm + tuple spread.
-2. Record/tuple type annotations (incl. `...`, `mut`, lifetimes) in
+1. Promote `RecordType` to `ObjectType` (element list); `Inexact` flag on
+   `ObjectType`/`TupleType`; exact/inexact subtyping rules; the
+   selection-vs-concrete object split; tuple inexact arm + tuple spread.
+2. Object/tuple type annotations (incl. `...`, `mut`, lifetimes) in
    `resolveTypeAnn`.
-3. Usage-based inference *refinement*: negative-position record merging at
-   coalesce; Policy-A exact closing; the `open` parameter marker.
+3. Usage-based inference *refinement*: negative-position object merging at
+   coalesce; closing a usage-inferred object to exact once body inference
+   completes, so callers can't pass extra fields; the `open` parameter marker.
 4. `var`-binding literal widening (usage-based over all assignment sites).
 5. The unified `RefType{Mut, Lt, Inner}` wrapper + the single constrain rule
    (**the gate**); field-write inference via `inferAssign`'s member branch;
    read-after-write.
 6. Lifetimes as a second sort (`LifetimeVar`, `constrainLt`, probe extension,
    borrow origination, joins, escape, display-time coalescing + elision).
-7. Destructuring patterns (`TuplePat`/`RecordPat`/literal patterns) + the
+7. Destructuring patterns (`TuplePat`/`ObjectPat`/literal patterns) + the
    `match` expression over structural patterns, with exactness-driven
    exhaustiveness.
 8. Namespace member lookup (`resolvePath`, `Foo.bar`, `Foo["x"]`, new errors).
@@ -139,16 +146,44 @@ Out: classes (M5), union/intersection constrain rules and optional chaining
 Sketches use the **shipped conventions**: exported fields, `Inexact` (zero value
 = exact), `[]SolverError`, journal-gated bound appends, visitor `Accept`.
 
-### Exactness on the existing carriers (`soltype/type.go`)
+### Object & tuple carriers (`soltype/type.go`)
+
+M4 promotes M2's `RecordType{Fields}` to an **`ObjectType` carrying an ordered
+element list** — the structural member representation shared by object literals,
+object/interface annotations, and (M5) class instance bodies, so one
+structural-decomposition routine serves all three. M4 ships only
+`PropertyElem`; `MethodElem`/`GetterElem`/`SetterElem` arrive in M5, and
+`IndexSigElem` plus `RestElem` (object rest/spread) in M9, each a new
+`ObjTypeElem` arm.
 
 ```go
-// RecordType gains Inexact (M3's FuncType convention: zero value = exact, so
-// every record M2 already mints — literals, member requirements before this
-// milestone — is exact by default with no construction-site churn).
-type RecordType struct {
-    Fields  []*RecordField // ordered, name-deduped (last wins); Field(name) lookup
-    Inexact bool           // trailing `...` ⇒ true
+// ObjectType replaces RecordType. Inexact follows M3's FuncType convention
+// (zero value = exact), so every object M2 already mints — literals, member
+// requirements before this milestone — is exact by default with no
+// construction-site churn.
+type ObjectType struct {
+    Elems   []ObjTypeElem // ordered, name-deduped (last wins); Prop(name) lookup
+    Inexact bool          // trailing `...` ⇒ true
 }
+
+// ObjTypeElem is the sealed set of object members (mirrors type_system's
+// ObjTypeElem). M4 ships PropertyElem only.
+type ObjTypeElem interface{ isObjTypeElem() }
+
+type PropertyElem struct {
+    Name     string
+    Type     Type
+    Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
+}
+func (*PropertyElem) isObjTypeElem() {}
+// + MethodElem/GetterElem/SetterElem (M5), IndexSigElem and RestElem (M9; the
+// latter carries an object rest/spread `...P`). A method's type is a FuncType;
+// getters are covariant and setters contravariant, so each new arm also extends
+// the polarity-threading visitor — the standing-rule checklist.
+
+// Prop returns the named property and whether it is present. M4's Elems are all
+// PropertyElem; M5 widens the lookup to method/getter/setter members.
+func (o *ObjectType) Prop(name string) (*PropertyElem, bool)
 
 type TupleType struct {
     Elems   []Type
@@ -157,38 +192,53 @@ type TupleType struct {
 ```
 
 The **selection-vs-concrete split** falls out of the flag: `inferMember`'s
-synthesized requirement becomes `{prop: β, Inexact: true}` ("has at least this
-field" — width-tolerance *is* inexactness), and the record arm then implements
-the one-way rule uniformly instead of being unconditionally width-tolerant:
+synthesized requirement becomes an inexact one-property object `{prop: β, ...}`
+("has at least this field" — width-tolerance *is* inexactness), and the object
+arm then implements the one-way rule uniformly instead of being unconditionally
+width-tolerant:
 
 ```go
-case *soltype.RecordType:
-    if r, ok := rhs.(*soltype.RecordType); ok {
+case *soltype.ObjectType:
+    if r, ok := rhs.(*soltype.ObjectType); ok {
         var errs []SolverError
-        for _, rf := range r.Fields {               // depth: fields covariant
-            lt, ok := l.Field(rf.Name)
+        for _, re := range r.Elems {                 // depth: members covariant
+            rp := re.(*soltype.PropertyElem)         // M4: every elem is a property
+            lp, ok := l.Prop(rp.Name)
             if !ok {
-                errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rf.Name})
+                errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
                 continue
             }
-            errs = append(errs, c.constrain(lt, rf.Type, seen)...)
+            errs = append(errs, c.constrain(lp.Type, rp.Type, seen)...)
         }
         // One-way exactness (02-design-notes §"Exactness"):
-        //   exact <: inexact   ok (width)     inexact <: inexact   ok (width)
-        //   exact <: exact     same field set inexact <: exact     rejected
+        //   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
+        //   exact <: exact      same member set inexact <: exact     rejected
         if !r.Inexact {
             if l.Inexact {
                 errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
             }
-            for _, lf := range l.Fields {
-                if _, ok := r.Field(lf.Name); !ok {
-                    errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lf.Name})
+            for _, le := range l.Elems {
+                lp := le.(*soltype.PropertyElem)
+                if _, ok := r.Prop(lp.Name); !ok {
+                    errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lp.Name})
                 }
             }
         }
         return errs
     }
 ```
+
+**Target-dispatched subtyping (forward note for M5).** The arm above is the
+*structural-object target* case. M5 adds the dispatch keyed on the target's
+nature: a **class** target uses nominal subtyping (declared-subtype graph +
+per-parameter variance, subclasses allowed where covariant), while a class
+*source* against an **inexact** object target projects its members through this
+same structural width rule. So the `Inexact` flag is what gates whether a class
+instance satisfies a structural object type — an exact target rejects, an inexact
+target admits. M5's `ClassType` reuses this `ObjectType` element list for its body
+and adds the nominal identity on top. M4 has no classes, so only the object-target
+arm ships here; the dispatch shape is recorded so M5 slots into it. See
+[01-milestones.md](01-milestones.md) §M5.
 
 ### The borrow wrapper (`soltype/type.go`)
 
@@ -204,13 +254,19 @@ type RefType struct {
 }
 
 // RefInner is the sealed set of types that may sit inside a RefType.
-// PrimType/LitType/FuncType/PromiseType/nested RefType are deliberately excluded
-// (a promise/function reference is shared, not borrowed; mut number is a JS no-op).
+// PrimType/LitType/FuncType/PromiseType/nested RefType are deliberately excluded:
+// a promise/function reference is shared, not borrowed, and a mut number is a JS
+// no-op. Excluding PromiseType blocks borrowing the promise itself — there is no
+// `mut Promise` or `'a Promise`. It does NOT block the promise's PAYLOAD from
+// being a borrow: `Promise<mut 'a Point>` is a PromiseType whose type argument is
+// a RefType, which is well-formed. That payload lifetime propagates through
+// `await` and escapes to 'static only on the ordinary borrow-escape condition
+// (D3), not because it sits in a promise.
 type RefInner interface {
     Type
     isRefInner()
 }
-func (*RecordType) isRefInner()  {}
+func (*ObjectType) isRefInner()  {}
 func (*TupleType) isRefInner()   {}
 func (*TypeVarType) isRefInner() {} // mid-inference; checked at constrain time
 // + UnionType/IntersectionType (M6 inputs), AliasType (M7), ClassType (M5).
@@ -334,8 +390,11 @@ func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 
 ```go
 // NEW HELPER (B3 authors it; not yet in the production solver — only the spike
-// has it, internal/simplesub/constrain.go). widen generalizes a literal to its
-// primitive (5 ⇒ number, "x" ⇒ string) and passes non-literals through:
+// has it, internal/simplesub/constrain.go). widen lowers a literal to its
+// primitive (5 ⇒ number, "x" ⇒ string, true ⇒ boolean) and recurses into
+// ObjectType/TupleType, widening each member/element; a RefType is peeled, its
+// inner widened, and re-wrapped. Other types pass through. Mirrors
+// internal/checker's widenLiteral/widenObjectLiterals/widenTupleLiterals.
 //   func widen(t soltype.Type) soltype.Type
 //
 // Extends inferAssign's existing member/index branch (today:
@@ -348,8 +407,8 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
     rhs := c.inferExpr(scope, lvl, e.Right)
     w := widen(rhs) // 5 ⇒ number: a later write may store any number
     req := &soltype.RefType{Mut: true, Lt: nil /* D2: c.freshLifetime() */,
-        Inner: &soltype.RecordType{
-            Fields:  []*soltype.RecordField{{Name: m.Prop.Name, Type: w}},
+        Inner: &soltype.ObjectType{
+            Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
             Inexact: true, // "must accept a write to this field", not a full shape
         }}
     c.constrain(e, recv, req)
@@ -454,48 +513,56 @@ result (`LevelOf` defaulting to 0 — see its `IntersectionType` comment for why
 that corrupts `freshenAbove`). Each PR's "structures" list calls out which of
 these arms it must add.
 
-### Phase A — Records & tuples completion (the M2 leftovers)
+### Phase A — Objects & tuples completion (the M2 leftovers)
 
-- **A1 — `Inexact` flag + record exactness rules + the selection split**
-  (~200).
+- **A1 — `ObjectType` element list + `Inexact` flag + object exactness rules + the
+  selection split** (~230).
   - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
     `solver/constrain.go`, `solver/infer_expr.go`, `solver/errors.go`,
     `solver/coalesce.go`.
   - **Structures:**
-    - add `Inexact bool` to `RecordType` (zero value = exact, the
-      `FuncType.Inexact` convention — every record M2 mints stays exact with no
+    - **promote `RecordType{Fields []*RecordField}` to `ObjectType{Elems
+      []ObjTypeElem}`** (see Key types): a sealed `ObjTypeElem` interface with the
+      single `PropertyElem{Name, Type, Optional}` concrete in M4. The rename
+      threads through every site that switches over the type set; method/getter/
+      setter (M5), index signatures (M9), and the object rest/spread `RestElem`
+      (M9) add `ObjTypeElem` arms later.
+    - add `Inexact bool` to `ObjectType` (zero value = exact, the
+      `FuncType.Inexact` convention — every object M2 mints stays exact with no
       construction churn).
-    - `visitor.go`'s `RecordType.Accept` must carry the flag on rebuild:
-      `out = &RecordType{Fields: fields, Inexact: cur.Inexact}` (today line 123
-      drops it — a latent bug the new field exposes).
-    - `equalType`'s `RecordType` arm gains `a.Inexact != b.Inexact` as a
+    - `visitor.go`'s `ObjectType.Accept` must carry the flag on rebuild:
+      `out = &ObjectType{Elems: elems, Inexact: cur.Inexact}` (today the
+      `RecordType` rebuild at line 123 drops it — a latent bug the new field
+      exposes).
+    - `equalType`'s `ObjectType` arm gains `a.Inexact != b.Inexact` as a
       discriminator (mirrors the `FuncType` arm's `a.Inexact != b.Inexact` at
       coalesce.go:315).
-    - `print.go` appends a trailing `...` entry in the record case when `Inexact`
+    - `print.go` appends a trailing `...` entry in the object case when `Inexact`
       (mirroring `printFuncTail`'s `if t.Inexact { ps = append(ps, "...") }`).
-  - **Algorithm — the record constrain arm** (constrain.go:181, replacing the
-    "this is NOT the final semantics" body):
-    - keep the per-field covariant loop (depth subtyping)
+  - **Algorithm — the object constrain arm** (constrain.go:181, replacing the
+    "this is NOT the final semantics" body, now over `ObjectType`):
+    - keep the per-member covariant loop (depth subtyping); in M4 every elem is a
+      `PropertyElem`, so the loop reads `r.Prop(name)` / `l.Prop(name)`
     - then add the one-way exactness gate: when `!r.Inexact`, reject `l.Inexact`
-      (an `InexactIntoExactError`) and reject any field on `l` absent from `r`
-      (`ExtraPropertyError` per extra field)
+      (an `InexactIntoExactError`) and reject any property on `l` absent from `r`
+      (`ExtraPropertyError` per extra property)
     - when `r.Inexact`, the existing width-tolerant loop is complete and unchanged
   - **Algorithm — selection vs concrete:** flip `inferMember`'s synthesized
     requirement (infer_expr.go:716) to `Inexact: true` so member access stays
     "has at least this field," now expressed *as inexactness* rather than as an
     unconditionally width-tolerant arm. This is the split the milestone calls
-    for: the same `RecordType <: RecordType` rule serves both selection (RHS
+    for: the same `ObjectType <: ObjectType` rule serves both selection (RHS
     inexact) and concrete subtyping (RHS exact).
   - **Errors:** new, same field/blame shape as `MissingPropertyError`
     (errors.go:97):
-    - `InexactIntoExactError{LHS, RHS *soltype.RecordType}`
-    - `ExtraPropertyError{LHS, RHS *soltype.RecordType; Name string; prov; site}`
+    - `InexactIntoExactError{LHS, RHS *soltype.ObjectType}`
+    - `ExtraPropertyError{LHS, RHS *soltype.ObjectType; Name string; prov; site}`
   - **Accept:**
     - exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds
     - inexact `<:` exact and extra-member-on-exact reject (full messages)
     - existing member-access tests stay green (selection is now the inexact path)
 
-- **A2 — Tuple inexactness + tuple spread + computed-key story** (~170).
+- **A2 — Tuple inexactness + tuple spread + object-literal walk (computed keys, spread deferral)** (~170).
   - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
     `solver/constrain.go`, `solver/coalesce.go`, `solver/infer_expr.go`.
   - **Structures:** add `Inexact bool` to `TupleType` and thread it through:
@@ -516,43 +583,78 @@ these arms it must add.
     - require it to be a `TupleType`
     - splice its element types into the literal's `Elems`
 
-    A non-tuple spread operand is a typed error.
+    A non-tuple spread operand is a typed error. M4 handles only this **concrete
+    literal splice**. Two type-level cousins defer: a tuple spread *type* over an
+    abstract operand (`[...P, x]`) is M9 — reduce-when-ground, parallel to object
+    spread — and a typed variadic tail (`[number, ...Array<number>]`) is M7, which
+    needs `Array` plus a typed rest element on `TupleType`. See 01-milestones.md
+    §§M7, M9.
   - **Algorithm — object computed/numeric keys** (inferObject, infer_expr.go:660
     `objKeyName` fail path): a statically-constant string/numeric key resolves
     to a field name; a genuinely dynamic key (`{[k]: v}`) stays a typed error
     (full index-signature support rides M9 index types). Keep the last-wins
     dedup invariant.
+  - **Algorithm — object spread in literals is deferred to M9.** `{...p}` in an
+    object literal is *not* handled in M4. Object rest/spread lands in M9 as a
+    `RestElem` object element with the type-level-operator reduction machinery,
+    using Flow-faithful show-through
+    union for optional-field overlap — see the M9 object-spread note in
+    [01-milestones.md](01-milestones.md). M4's object-literal walk reports `{...p}`
+    as an unsupported feature. Only the concrete tuple-literal splice above stays
+    in M4; object rest/spread and the type-level tuple cousins defer, per the
+    tuple-spread note above.
   - **Accept:**
     - `[1, 2]` `<:` `[number, ...]` succeeds, `<:` `[number]` rejects
     - a spread `[...pair, 3]` builds the spliced tuple
     - a constant numeric key resolves, a dynamic key errors
 
-- **A3 — Record/tuple/`mut`/lifetime type annotations** (~180).
+- **A3 — Object/tuple/`mut`/lifetime type annotations** (~180).
   - **Files:** `solver/type_ann.go`, plus tests.
   - **Algorithm — extend `resolveTypeAnn`** (type_ann.go:21, today
     primitives + `Promise<T>` only):
     - add arms for object-type and tuple-type annotations (building
-      `RecordType`/`TupleType`, honoring a trailing `...` ⇒ `Inexact: true`)
+      `ObjectType`/`TupleType`, honoring a trailing `...` ⇒ `Inexact: true`).
+      Spread/variadic *elements* inside an annotation — object `{...P}`, tuple
+      `[...P]`, variadic `[number, ...Array<number>]` — are **not** handled here;
+      they defer with their type-level features (M9/M7, per A2's tuple-spread note)
     - add arms for the `mut`/lifetime annotation forms, which lower to `RefType`
       (`mut T` ⇒ `RefType{Mut: true}`, `'a T` ⇒ `RefType{Mut: false, Lt: …}`)
 
     **Ordering caveat:** `RefType` does not exist until C1, so A3 lands the
-    record/tuple annotation arms now and gates the `mut`/lifetime arms behind C1
+    object/tuple annotation arms now and gates the `mut`/lifetime arms behind C1
     (until then a `mut`/`'a` annotation keeps today's `reportUnsupportedFeature`
     + recovery-var behavior). Track the gated arms as a one-line follow-up in
     C1's checklist.
+  - **Algorithm — literal excess-member check** (new; exact-types §§2.2.4, 3.2.4):
+    once annotations resolve, a syntactic object/tuple **literal** checked against
+    an object/tuple annotation rejects members absent from the target's declared
+    set, **even when the target is inexact** — the construction-site twin of the
+    direct-call extra-arg rule. It fires in the walk at literal-vs-annotation sites
+    (annotated `val`/`var`, later call args and returns), not in the
+    `ObjectType <: ObjectType` / tuple constrain arm. Reuse A1's `ExtraPropertyError`
+    for objects; add an analogous excess-element error for tuples. A non-literal RHS
+    is unaffected — it takes ordinary width subtyping. M4 has only the untyped `...`
+    tail; the typed-tail escape (an index signature that types the extras) rides M9,
+    so until then an untyped-extras "bag" must use the variable escape hatch.
   - **Why first-ish:** every annotation-side acceptance test in Phase A/B/D
     (`var p: {x, y, ...} = …`, `fn f(p: mut {x: number}) …`) needs this; it is
     a leaf with no dependency on the constraint changes.
   - **Accept:**
-    - `val r: {x: number, ...} = {x: 1, y: 2}` checks (inexact target admits the
-      extra field)
-    - `val r: {x: number} = {x: 1, y: 2}` rejects (exact target)
+    - `val r: {x: number, y: number, ...} = {x: 1, y: 2}` checks (the literal's
+      fields are all declared; the inexact tail goes unused)
+    - `val r: {x: number, ...} = {x: 1, y: 2}` **rejects** — excess property `y` on
+      a literal even against an inexact target (exact-types §2.2.4, parallel to the
+      direct-call extra-arg rejection)
+    - the variable escape hatch checks: `val v = {x: 1, y: 2}; val r: {x: number,
+      ...} = v` (non-literal ⇒ width subtyping)
+    - `val r: {x: number} = {x: 1, y: 2}` rejects (exact target, `ExtraPropertyError`)
+    - tuple: `val t: [number, ...] = [1, 2, 3]` rejects (excess element on a
+      literal); the same RHS through a variable checks
     - tuple annotations round-trip through the printer
 
 ### Phase B — Usage-based inference refinement
 
-- **B1 — Negative-position record merging + Policy-A exact closing** (~190).
+- **B1 — Negative-position object merging + closing usage-inferred shapes to exact** (~190).
   - **Files:** `solver/coalesce.go`, plus tests.
   - **Background:** today `combine` (coalesce.go:254) builds a bare
     `IntersectionType` of a negative variable's upper bounds. When two of those
@@ -561,19 +663,19 @@ these arms it must add.
     `{a: β, b: γ}`.
   - **Algorithm — port the spike's `mergeObjects`** into the negative
     (`Negative` polarity) path of `combine`: before wrapping parts in an
-    `IntersectionType`, fold all `RecordType` parts into one record (union the
-    field sets; a field appearing in several parts becomes the intersection of
-    its types). This is the production analogue of `simplesub/coalesce.go`'s
-    `mergeObjects`/`mergeObjectGroup`, rewritten over `soltype.RecordType`'s
-    slice fields and `Field(name)` lookup, using the existing `combine`/`dedup`
-    structure. Mut-record merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is
+    `IntersectionType`, fold all `ObjectType` parts into one object (union the
+    property sets; a property appearing in several parts becomes the intersection
+    of its types). This is the production analogue of `simplesub/coalesce.go`'s
+    `mergeObjects`/`mergeObjectGroup`, rewritten over `soltype.ObjectType`'s
+    element list and `Prop(name)` lookup, using the existing `combine`/`dedup`
+    structure. Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is
     deferred to C3 once `RefType` exists.
-  - **Algorithm — Policy-A close:** the merged usage record closes to **exact**
+  - **Algorithm — Policy-A close:** the merged usage object closes to **exact**
     (`Inexact: false`) at this display-time fold — the row is sealed once body
     inference completes (spec §8.1). The per-access requirements stay inexact
     (A1); only the *coalesced* result is exact. `open` (B2) is the opt-out.
   - **Accept:** `fn (p) { p.a; p.b }` infers a param rendering `{a: …, b: …}`
-    (one exact record), not `{a: …} & {b: …}`.
+    (one exact object), not `{a: …} & {b: …}`.
 
 - **B2 — The `open` parameter marker** (~120).
   - **Files:** parser hook (provisional keyword), `solver/infer_expr.go` (param
@@ -582,8 +684,8 @@ these arms it must add.
     cheapest form is a `set.Set[*soltype.TypeVarType]` of open param vars on the
     checker, consulted in B1's close step.
   - **Algorithm:** when a param is marked `open`, B1's Policy-A close leaves its
-    usage record `Inexact: true` (row-polymorphic) so callers may pass richer
-    records. Everything else is unchanged.
+    usage object `Inexact: true` (row-polymorphic) so callers may pass richer
+    objects. Everything else is unchanged.
   - **Accept:**
     - `fn dist(open p) { p.x; p.y }` renders an inexact `{x, y, ...}` param
     - an un-`open` peer renders exact `{x, y}`
@@ -593,22 +695,37 @@ these arms it must add.
   - **Files:** `solver/constrain.go` or a new `solver/widen.go` (the helper),
     `solver/infer_decl.go`, plus tests.
   - **Structures/helper:** author `func widen(t soltype.Type) soltype.Type`
-    (ported from `simplesub/constrain.go`): a `LitType` widens to its `PrimType`
-    (`5` ⇒ `number`, `"x"` ⇒ `string`, `true` ⇒ `boolean`); every other type
-    passes through. C3's field-write reuses it.
+    (ported from `simplesub/constrain.go`, extended to match `internal/checker`'s
+    `widenLiteral`/`widenObjectLiterals`/`widenTupleLiterals` at unify.go:2614):
+    a `LitType` widens to its `PrimType` (`5` ⇒ `number`, `"x"` ⇒ `string`,
+    `true` ⇒ `boolean`); an `ObjectType`/`TupleType` widens **recursively** —
+    map `widen` over each property value / element, preserving `Inexact`; a
+    `RefType` is peeled, its inner widened, and re-wrapped
+    (`NewRef(mut, lt, widen(inner))`); every other type passes through. So
+    `{x: 0, y: 0}` widens to `{x: number, y: number}` and `[1, 2]` to
+    `[number, number]`, recursively through nesting. C3's field-write reuses it,
+    so writing a compound value widens it too.
   - **Algorithm:** in `inferVarDecl` (infer_decl.go:108), a `var` binding's
     initializer type is widened before generalization, and — the principled
     milestone form — informed by **all** assignment sites: collect the
     initializer plus every later `a = e` RHS and coalesce their widened types
-    (the binding's type is the join). A `val` is left un-widened (a fixed
-    literal singleton). This retires PR8's documented `var a = 5; a = 6` failure
-    (infer_expr.go:532 note). Reassignment's RHS-vs-binding constrain
-    (inferAssign, infer_expr.go:540s) now checks against the widened binding
-    type.
+    (the binding's type is the join). **Widening is gated on mutability** — only
+    a mutable cell widens, because only a mutable cell may later hold a different
+    value of the same primitive. A `var` binding widens; a `val` is left
+    un-widened (a fixed literal singleton); and C3's field-write path widens
+    because writing through a `mut` receiver is itself a mutation. This is the
+    new-checker form of the old checker's `Widenable` type-var flag, which gates
+    `widenLiteral` to mutable bindings (unify.go:2260). This retires PR8's
+    documented `var a = 5; a = 6` failure (infer_expr.go:532 note).
+    Reassignment's RHS-vs-binding constrain (inferAssign, infer_expr.go:540s) now
+    checks against the widened binding type.
   - **Accept:**
     - `var a = 5; a = 6` checks (binding is `number`)
     - `val a = 5; a = 6` still rejects (`CannotAssignToImmutableError`)
     - `var a = 5` with no reassignment still renders `number` (default-widen)
+    - `var p = {x: 0, y: 0}` renders `{x: number, y: number}` and `var t = [1, 2]`
+      renders `[number, number]` (recursive object/tuple widen)
+    - nesting widens through: `var n = {p: {x: 0}}` renders `{p: {x: number}}`
 
 ### Phase C — Borrows & mutability (**the gate**)
 
@@ -619,7 +736,7 @@ these arms it must add.
   - **Structures:**
     - add `RefType{Mut bool; Lt Lifetime; Inner RefInner}`
     - the sealed `RefInner interface { Type; isRefInner() }`, with `isRefInner`
-      on `RecordType`/`TupleType`/`TypeVarType` (and forward-declared for
+      on `ObjectType`/`TupleType`/`TypeVarType` (and forward-declared for
       `UnionType`/`IntersectionType`/`AliasType`/`ClassType`)
     - `Lifetime` is a placeholder interface here (`type Lifetime interface{
       isLifetime() }` with no concretes yet — D1 adds them); C1 only ever sets
@@ -671,9 +788,9 @@ these arms it must add.
     - `MutabilityMismatchError{LHS, RHS *soltype.RefType}`
     - `BorrowEscapeError{LHS, RHS}` (the latter's firing path is inert until D2)
   - **Accept (the gate):**
-    - `mut {x, y} <: mut {x}` **fails** (invariance — the write view's
-      contravariant `{x} <: {x, y}` is missing a field) while immutable
-      `{x, y} <: {x}` width-**succeeds** (inexact RHS)
+    - `mut {x, y} <: mut {x, ...}` **fails** (invariance — the write view's
+      contravariant `{x, ...} <: {x, y}` is missing a field) while immutable
+      `{x, y} <: {x, ...}` width-**succeeds** (inexact RHS)
     - mut-decay `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected
     - full messages
 
@@ -683,7 +800,7 @@ these arms it must add.
 - **C3 — Field-write inference + read-after-write** (~200).
   - **Files:** `solver/infer_expr.go` (the `inferAssign` member branch),
     `solver/infer.go` (the `written` map on the checker), `solver/coalesce.go`
-    (mut-record merge), plus tests.
+    (whole-object mut merge), plus tests.
   - **Structures:** add `written map[fieldKey]soltype.Type` to the checker
     (`fieldKey struct{ recvID int; field string }`, ported from
     `simplesub/constrain.go:14`); records the widened type stored into a
@@ -703,14 +820,48 @@ these arms it must add.
   - **Algorithm — read-after-write:** `inferMember` (infer_expr.go:687) consults
     `written` first: a read of a just-written field returns the recorded
     concrete type instead of a fresh var, so `obj.x = 5; obj.x` is `number`.
-  - **Algorithm — mut-record merge:** extend B1's `mergeObjects` fold to the
-    `RefType{Mut: true, Inner: RecordType}` case so multiple writes merge into
-    one mutable record (`mut {x} & mut {y}` ⇒ `mut {x, y}`) — the spike's
-    `mergeObjects` handled `Mut`-wrapped objects the same way.
+    **Write-after-read** needs no map support — it falls out of ordinary
+    constraint accumulation: the earlier read emits `recv <: {x: β, ...}` and the
+    later write emits `recv <: mut {x: widen(rhs), ...}`, both upper-bound
+    constraints that merge, so the read's `β` picks up the field type through the
+    bound graph. The `written` map is purely a read-after-write precision win
+    (return the concrete stored type, not a coalesced var); the reverse order
+    already works, and an incompatible read-then-write surfaces as a normal
+    constrain error.
+  - **Algorithm — whole-object `mut` merge (follows `internal/checker`, not the
+    spike's partition):** extend B1's `mergeObjects` fold over the receiver's
+    accumulated selections so that **if any field was written, every selection —
+    reads and writes alike — folds into one `mut` object**; with no write, the
+    reads fold into a bare (immutable) object. So `obj.x = 5; obj.y = 10` ⇒
+    `mut {x: number, y: number}` and the mixed `val x = obj.bar; obj.baz = 5` ⇒
+    `mut {bar: T0, baz: number}` — a single object, **not** the spike's
+    `{bar: T0} & mut {baz: number}` intersection. Read-only fields keep their
+    inferred (generalized) vars with no per-field mutability marker; this mirrors
+    `finalizeOpenObject` (generalize.go:510), which wraps the whole object in `mut`
+    once any property's `Written` flag is set, and matches the inferred types in
+    `internal/checker/tests/row_types_test.go` (`TestRowTypesPropertyAccess`).
+    Multiple writes still merge the same way (`mut {x} & mut {y}` ⇒ `mut {x, y}`);
+    the change is that bare reads now fold into the `mut` object too rather than
+    staying a separate intersection member.
+  - **Tradeoff (accepted):** wrapping the whole object in `mut` makes its
+    read-only fields invariant rather than covariant. For a **generalized**
+    function this is invisible — a read-only field is a fresh-per-call type
+    parameter (`T0` above), so each call instantiates it independently. It differs
+    from per-field variance only when the field var is *shared and not generalized*
+    — a recursive-group member checked before generalization, say — a narrow case
+    `internal/checker` already accepts in exchange for the simpler single-object
+    type. The spike's intersection is therefore dropped.
   - **Accept:**
     - `fn foo(obj) { obj.x = 5; obj.y = 10 }` ⇒ `(obj: mut {x: number, y: number})
       -> unit`
     - `fn foo(obj) { obj.x = 5; return obj.x }` ⇒ `... -> number`
+    - mixed read + write folds into one `mut` object:
+      `fn foo(obj) { val x = obj.bar; obj.baz = 5 }` ⇒
+      `fn <T0>(obj: mut {bar: T0, baz: number}) -> void` (row_types_test.go), not
+      an intersection
+    - a compound written value widens recursively via the shared `widen` (B3): in
+      `fn foo(obj) { obj.p = {x: 0} }`, `obj`'s `p` field is `{x: number}`, not
+      `{x: 0}`
 
 ### Phase D — Lifetimes (second sort)
 
@@ -778,7 +929,7 @@ these arms it must add.
   - **Files:** `solver/infer_stmt.go` / wherever the M3 return-point join lives,
     `solver/infer_expr.go` (escape sites).
   - **Algorithm — joins:** when the M3 return-point join (or an `if`/`match`
-    branch join) unifies two borrowed records with distinct lifetimes, mint a
+    branch join) unifies two borrowed objects with distinct lifetimes, mint a
     fresh **join** lifetime var and `constrainLt` each source lifetime into it
     (so it coalesces to `'a | 'b`). The join var is *not* a param lifetime —
     only its reachable param-lifetime members are named (the spike's
@@ -786,10 +937,30 @@ these arms it must add.
   - **Algorithm — escape:** a value flowing into module/static storage (a
     top-level binding, a global write) constrains its lifetime `<: 'static`
     (`constrainLt(lt, &StaticLifetime{})`), which coalesces to `'static`.
+  - **A promise payload is not a special escape site (no new code).** A borrow
+    inside a promise payload `Promise<mut 'a Point>` carries `'a` like any other
+    container — a record `{p: mut 'a Point}` behaves the same. `await` propagates
+    it unchanged: M3's rule `constrain(e <: Promise<U>)` resolves `U` to
+    `mut 'a Point`, so awaiting within `'a`'s region keeps the borrow at `'a`. The
+    payload escapes to `'static` only when the promise or the awaited result
+    actually outlives `'a` — stored in static/top-level storage, or returned past
+    `'a`'s scope — which is the same condition as the escape rule above. Excluding
+    `PromiseType` from `RefInner` forbids borrowing the promise itself, not a
+    borrowed payload, so this case falls out of the existing await + escape rules
+    with no promise-specific handling.
+  - **Finer point for a test, not a rule:** awaiting the same promise multiple
+    times returns the **exact same reference**, not a copy — promises memoize their
+    fulfillment value. So a *mutable*-borrow payload is not duplicated by repeated
+    awaits; two live bindings to that one reference are ordinary `mut` aliasing,
+    governed by the Phase-G liveness/uniqueness checking, not this lifetime rule or
+    anything promise-specific.
   - **Accept:**
     - `ConditionalUnionReturn` (return one of two mut borrows) ⇒ `mut ('a | 'b)
       {x: number}`
     - `EscapingRefIntoStatic` ⇒ `mut 'static`
+    - `AwaitedRefStaysBorrowed`: awaiting `Promise<mut 'a Point>` within `'a`'s
+      region yields `mut 'a Point` (no escape); storing that promise top-level
+      escapes it to `mut 'static`
 
 - **D4 — Display-time lifetime coalescing + elision** (~200).
   - **Files:** new lifetime-occurrence logic alongside `solver/simplify.go` /
@@ -832,7 +1003,7 @@ these arms it must add.
     general pattern binding), `solver/infer_expr.go` (param patterns), plus a
     pattern-typing helper.
   - **Structures:**
-    - add `TuplePat{Elems []Pat}`, `RecordPat{Fields []*RecordPatField}`, and
+    - add `TuplePat{Elems []Pat}`, `ObjectPat{Fields []*ObjectPatField}`, and
       literal patterns as `Pat` concretes (soltype's `Pat` interface was reserved
       for exactly this — type.go's `Pat` comment)
     - `print.go`'s `paramName` (print.go:278) gains arms for the new pattern
@@ -840,11 +1011,14 @@ these arms it must add.
     - `varName` (infer_decl.go:131, today IdentPat-only) generalizes to return the
       full set of bound names
   - **Algorithm — pattern typing:** a pattern dispatches through the
-    **member-lookup constraint path**, not subtyping: a `RecordPat{x, y}`
+    **member-lookup constraint path**, not subtyping: a `ObjectPat{x, y}`
     against a scrutinee `s` emits `constrain(s <: {x: βx, y: βy, Inexact:
     true})` (the same inexact requirement `inferMember` uses) and binds `x`/`y`
     to `βx`/`βy`; a `TuplePat[a, b]` emits `constrain(s <: [αa, αb])` (exact
-    length for an exact tuple pattern). A missing field / wrong arity surfaces
+    length for an exact tuple pattern). Because the object requirement is
+    **inexact**, a pattern may bind a *subset* of the scrutinee's fields —
+    `val {x} = p` on `p: {x, y}` binds `x` and tolerates the unmentioned `y`. Only
+    a field the scrutinee *lacks* (or a wrong tuple arity) is rejected, surfacing
     the existing `MissingPropertyError`/`TupleLengthMismatchError`. Patterns
     peel any `RefType` via `carrierOf` before matching (works on owned values
     before Phase D; borrowed scrutinees once D lands). Used uniformly by `val`
@@ -852,6 +1026,8 @@ these arms it must add.
   - **Accept:**
     - `val {x, y} = p` binds `x`/`y` at their field types and rejects a missing
       field
+    - partial destructuring is fine: `val p = {x: 5, y: 10}; val {x} = p` binds
+      `x` and tolerates the unmentioned `y` (the pattern requirement is inexact)
     - `val [a, b] = t` binds per slot and rejects wrong arity
     - a destructured param `fn (({x, y})) { … }` types the same way
 
@@ -862,15 +1038,17 @@ these arms it must add.
     pattern against the scrutinee (E1) in a child scope carrying the arm's
     bindings, then infer the arm body; join the arm body types via the M3
     return-point join (the same join D3 hooks lifetimes into).
-  - **Algorithm — exhaustiveness from exactness:** an **exact** record/tuple
+  - **Algorithm — exhaustiveness from exactness:** an **exact** object/tuple
     scrutinee whose arms cover its shape needs no catch-all; an **inexact**
-    scrutinee requires a catch-all arm (a missing one is a typed error).
-    Constructor/enum patterns and enum-exhaustive `match` are M5; union-scrutinee
-    exhaustiveness is M6 — E2 lays the form and the structural-pattern path they
-    both extend.
+    scrutinee requires a catch-all arm (a missing one is a typed error). E2 reads
+    only the `Inexact` field on `ObjectType`/`TupleType` (A1/A2); there is **no**
+    `UnionType.Inexact` in M4 — that flag, and the union-`match` exhaustiveness it
+    drives, lands with M6's "Union exactness flag." Constructor/enum patterns and
+    enum-exhaustive `match` are M5; union-scrutinee exhaustiveness is M6 — E2 lays
+    the form and the structural-pattern path they both extend.
   - **Accept:**
     - a `match` over structural patterns binds and type-checks each arm
-    - an exact-record scrutinee with a complete pattern set needs no catch-all, an
+    - an exact-object scrutinee with a complete pattern set needs no catch-all, an
       inexact one does (full error on the missing catch-all)
 
 ### Phase F — Namespace member lookup (parallel track)
@@ -921,13 +1099,34 @@ these arms it must add.
 
 - **G2 — Collapse the static-alias escape hatches** (~120).
   - **Files:** `solver/transitions.go`.
+  - **Background:** the old checker can't see a value that escapes past the call
+    boundary — stored via a `'static` callee parameter, say — so it approximates the
+    resulting permanent outside alias with two booleans on the alias set,
+    `HasStaticMutAlias` / `HasStaticImmAlias` (liveness/alias.go:32-33). They are set
+    by `AliasTracker.MarkStatic` at `'static`-param call sites and treated as
+    always-live aliases. Rule 1 consults the mut bit, Rule 2 the immut bit
+    (check_transitions.go:145, :149); the two are independent because one value can
+    escape twice, once each way.
   - **Algorithm:**
-    - drop the `HasStaticMutAlias` / `HasStaticImmAlias` bits
-    - where the old code consulted them, query the lifetime sort directly — a
-      value whose lifetime is constrained `<: 'static` (D3's escape output) is the
-      first-class signal the bits approximated
+    - drop `HasStaticMutAlias` / `HasStaticImmAlias`, `MarkStatic`, and the
+      call-site marking that sets them
+    - where the old code consulted them, query the lifetime sort directly — a value
+      whose borrow lifetime is constrained `<: 'static` (D3's escape output) is the
+      permanent outside alias the bit stood for, and the escaped borrow's
+      `RefType.Mut` supplies its mutability: Rule 1 fires when a *mutable* borrow
+      escaped to `'static`, Rule 2 when an *immutable* one did. `'static` gives the
+      always-live semantics for free — such a reference outlives the function by
+      definition, so no liveness check applies, exactly as the bits had none.
 
     This is the one genuinely new logic in the port; it depends on D3.
+  - **Coupling to pin down (AST ↔ type sides).** The transition checker runs over
+    liveness/AST, not `soltype` — `checkMutabilityTransition` talks only to
+    `liveness.Liveness`/`liveness.AliasTracker`, which G1 keeps verbatim. So G2 must
+    give it a way to reach the inferred `<: 'static` constraints for a value: a
+    bridge from a liveness `VarID` to that value's `soltype` borrow(s) and their
+    lifetime bounds. That bridge is the new seam the old boolean approximation
+    avoided — design it explicitly rather than letting the transition pass reach
+    into inference ad hoc.
   - **Accept:** the static-escape transition cases pass via lifetime queries
     rather than the dropped bits.
 
@@ -946,7 +1145,7 @@ F1             (independent; any time — only M2's Namespace)
 
 Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel
 tracks off A1; nothing downstream of the gate starts before C2 clears. B1's
-`mergeObjects` fold is reused by C3 (mut-record merge) and the `widen` helper
+`mergeObjects` fold is reused by C3 (whole-object mut merge) and the `widen` helper
 authored in B3 is reused by C3, so land B before C3 even though B is otherwise
 independent of the gate. Total ≈ 3.0k non-test LoC across 17 PRs, with the
 single highest-risk change (C2) isolated to ~180 reviewable lines.
@@ -960,7 +1159,7 @@ tests keyed by name over real parsed source where the walk supports it,
 asserting rendered types (`render`/`PrintAsScheme` output) and **full** error
 messages via the typed `SolverError`s — authored against intended semantics,
 not old-checker output. Blame-span assertions follow the M2.5 pattern
-(`blame_test.go`). Inline snapshots for large trees (nested borrowed records
+(`blame_test.go`). Inline snapshots for large trees (nested borrowed objects
 with per-field lifetimes). Each PR carries the acceptance set named above; the
 union is the milestone's M4 acceptance. No fixture harness yet (M8).
 
@@ -985,15 +1184,15 @@ union is the milestone's M4 acceptance. No fixture harness yet (M8).
 
 ## Open questions
 
-- **Deferred overload resolution (#723).** M4's record types make the
+- **Deferred overload resolution (#723).** M4's object types make the
   documented first-match fallback *observable* on object-typed arguments
   (today it only over-narrows function-typed ones). The real fix is scoped
   M4/M5; if object-arg overload tests start failing on arm choice rather than
   typing, that is #723, not a regression in these PRs.
   - **Decision (deferred to M5).** Keep resolution out of M4's scope. The
     fallback to declaration order fires because `moreSpecific`/`structuralSubtype`
-    (overload.go) ranks record-shaped args as a tie. The principled fix is to
-    rank record args by field-set subsumption and exactness — a record covering
+    (overload.go) ranks object-shaped args as a tie. The principled fix is to
+    rank object args by field-set subsumption and exactness — an object covering
     more required fields, or the exact one, dominates, the object analogue of the
     existing arity/exactness ranking for functions. Land that in M5, where
     classes first produce multi-arm object overloads. For M4, pin the observable

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1,0 +1,338 @@
+# M4 implementation plan — Core value types: records + usage-based inference + `mut` + lifetimes
+
+This is the implementation plan for **M4** as defined in
+[01-milestones.md](01-milestones.md) §"M4 — Core value types". It assumes M1
+(package skeleton + `soltype`), M2 (parser/resolver bridge), and M3 (functions,
+application, let-polymorphism, function exactness) have landed. It is grounded in
+the design in [02-design-notes.md](02-design-notes.md) (the `RefType` wrapper, the
+exactness flag, the `Probe` API, the provenance/`Info` side tables) and the
+lifetime lattice in [03-references.md](03-references.md).
+
+## Why M4 is "the big one"
+
+M4 promotes three spike milestones at once and they are **inseparable**:
+
+- **records/objects** (spike M2) — the first *value* type that can be borrowed;
+- **`mut`** (spike M3) — invariant mutable references, encoded by the read/write
+  decomposition; the **highest-risk gate** of the whole migration;
+- **lifetimes** (spike M4) — a *second sort* solved by the same `constrain`
+  machinery, riding on the `RefType` wrapper.
+
+Lifetimes ride on borrows, records are the first thing that can be borrowed, and
+`mut` borrows are what first populate a lifetime. Trying to land any one of them
+without the others produces a representation you immediately have to rework, so
+the milestone is deliberately scoped as a cluster. Exactness (the `exact` flag on
+`RecordType`/`TupleType`) also lands here because, per the settled exactness
+decision, the flag is introduced *with* each former rather than retrofitted.
+
+The plan below decomposes the cluster into a strictly-ordered PR sequence that
+keeps `go test ./...` green at every step and **clears the highest-risk gate as
+early as the representation allows**.
+
+## Scope (from the milestone definition)
+
+In:
+
+1. Owned `RecordType` / `TupleType` with the `exact` flag (default exact;
+   trailing `...` ⇒ inexact). Object/tuple **literals infer as exact**.
+2. The unified `RefType{mut, lt, inner}` borrow wrapper (per
+   [02-design-notes.md](02-design-notes.md) §"`soltype`"), with the `RefInner`
+   sealed marker and the `borrowableType` content predicate.
+3. **Usage-based inference**: member read `obj.bar` ⇒ `constrain(obj <:
+   RecordType{bar: β})`; field requirements accumulate as upper bounds and
+   coalesce (negative position) into a record/intersection. Replaces
+   `Open`/`Widenable`/`ArrayConstraint`. Usage-collected shape coalesces **exact**
+   by default (Policy A); the `open` parameter marker opts back into row
+   polymorphism.
+4. **The single `RefType` constrain rule**: mutability compatibility, `mut`-driven
+   inner invariance via read/write decomposition, covariant lifetime, mutability
+   decay, plus the two cross-cases (`bare <: RefType`, `RefType <: bare`).
+   Field-write inference (`obj.x = v` ⇒ `mut` record with a fresh lifetime) and
+   read-after-write field collapse.
+5. **Lifetimes as a second sort**: `LifetimeVar` (bound lists over the outlives
+   lattice, `'static` = top), `constrainLt`, lifetime coalescing + elision,
+   borrow origination at `RefType`-typed parameters, multi-source-return unioning,
+   escape ⇒ `<: 'static`.
+6. **Mutability-transition checking** ported from the old checker
+   (`internal/liveness/` verbatim + the two narrow predicates over `soltype`),
+   wired onto `solver.Context`.
+
+Out (deferred): nominal classes (M5), unions/intersections as *input annotations*
+(M6 — though M2/M4 already produce them as coalescing *output*), type-level
+operators (M8), codegen / value-level `exact<T>(v)` (M9).
+
+## Prerequisites and assumptions
+
+- `soltype` already has `TypeVarType` (bound lists + level), `PrimitiveType`,
+  `LiteralType`, `FunctionType`, `TupleType` scaffolding, `constrain`, extrusion,
+  let-polymorphism, simplification, and polarity-driven coalescing (M1–M3).
+- The `Info` side table and the `Prov` provenance side table exist (M1).
+- The `Probe` API (length-snapshot journal, design (A) in
+  [02-design-notes.md](02-design-notes.md)) exists; M4 does **not** need
+  speculation for its core path (bound-list monotonicity covers failed
+  constraints), but the field-write/read-after-write merge and any future
+  union-against-variable deferral should be probe-aware where they trial
+  constraints.
+- The constraint-generating AST walk (`infer.go`) handles `IdentExpr`,
+  `FuncExpr`, `CallExpr` (M2/M3). M4 adds `MemberExpr` (read + write),
+  `ObjectExpr`, `TupleExpr`, and conditional/branch joining.
+
+## Architecture / where the code lands
+
+Per the package layout in [02-design-notes.md](02-design-notes.md) (names
+provisional):
+
+```
+internal/solver/
+  soltype/
+    type.go        RecordType, TupleType (exact flag), RefType, RefInner marker
+    lifetime.go    LifetimeVar, StaticLifetime, LifetimeUnion (the second sort)
+    print.go       record / tuple / `mut 'a T` / `'a T` / exact `...` rendering
+  constrain.go     record & tuple structural+width rules (exact-aware);
+                   the single RefType rule; constrainLt; borrowableType
+  coalesce.go      negative-position record coalescing; lifetime join/meet;
+                   lifetime elision (mut elide-in-place vs immutable drop-wrapper)
+  simplify.go      occurrence analysis extended over record fields / Ref inner / lt
+  infer.go         MemberExpr read/write, ObjectExpr, TupleExpr, branch joining,
+                   attachParamLifetimes; field-write & read-after-write
+  transitions.go   ported checkMutabilityTransition over soltype (new in M4)
+  context.go       solver.Context gains Liveness / Aliases fields
+```
+
+`internal/liveness/` is reused **verbatim** (it operates on the name-resolved AST
+and has no `type_system` references — see the milestone note).
+
+## Sequencing rationale
+
+The ordering is driven by two forces that mostly agree:
+
+1. **Dependency order.** A carrier must exist before it can be borrowed; the
+   `RefType` wrapper must exist before a lifetime can ride on it; transition
+   checking consumes the lifetime sort.
+2. **Risk order.** The milestone names the `RefType` rule's `mut`-driven inner
+   invariance as the **HIGHEST-RISK gate**: *"if it cannot be encoded cleanly
+   against the real AST, the whole migration is in question."* So it must be hit
+   as early as the dependency order permits, and nothing expensive (lifetimes,
+   transition port) should be built before it is cleared.
+
+These agree: records (carrier) → usage-based reads (needed to produce non-trivial
+record shapes worth borrowing) → **`RefType` + `mut` gate** → lifetimes →
+transition checking. The gate lands third — right after the minimum needed to
+exercise it against the real AST.
+
+De-risking note: the spike already proved the `mut`-invariance encoding in
+isolation (`internal/simplesub` M3, `mut {x,y} <: mut {x}` fails while immutable
+succeeds). PR 3 is therefore **re-validation against the production AST/`soltype`
+representation**, not novel research — but it is still the go/no-go gate, so its
+acceptance set is the spike's `mut` cases reproduced end-to-end from real source.
+
+## PR breakdown
+
+Each PR is independently reviewable, lands behind no flag (the new checker is not
+yet wired into the compiler — that's M7), keeps `go test ./...` green, and ships
+its own table-driven tests asserting **rendered types** and **full error
+messages** (per CLAUDE.md). Sizes are rough.
+
+### PR 1 — Owned records & tuples + exactness + literal inference
+
+Representation and structural subtyping for the carriers, no borrows yet.
+
+- `RecordType{fields, exact}` and extend `TupleType` with `exact` (M1 stubbed
+  `TupleType`; this completes it). Smart constructors; printer support for
+  `{x: T, y: U}`, `[T, U]`, and the trailing `...` for inexact.
+- `constrain` structural cases:
+  - record `<:` record: per-field covariant; **width subtyping only in the
+    inexact `<:` inexact case**; exact `<:` exact requires the *same* field set;
+    exact `<:` inexact allowed; inexact `<:` exact rejected (the one-way rule
+    from [02-design-notes.md](02-design-notes.md) §"Exactness").
+  - tuple `<:` tuple: per-slot covariant; length rules mirror the exactness rule.
+- Inference (`infer.go`): `ObjectExpr` ⇒ `RecordType` (exact), `TupleExpr` ⇒
+  `TupleType` (exact), over inferred element types.
+- Coalescing: positive-position record/tuple recursion (fields are covariant).
+- **Tests**: object/tuple literal inference renders exact; exact `{x,y}` assignable
+  to inexact `{x,y,...}` but not the reverse; extra member on an exact target
+  rejected (full message); width subtyping works inexact-to-inexact.
+- **~Size**: medium. No `mut`, no lifetimes, no usage inference — deliberately the
+  smallest first slice so the carrier and exactness rule are reviewed alone.
+
+### PR 2 — Usage-based inference (member reads) + the `open` marker
+
+Turn member access into constraints; this is what makes record shapes worth
+borrowing in PR 3.
+
+- `infer.go` `MemberExpr` (value-typed receiver, read): `constrain(recv <:
+  RecordType{field: β})` with `β` fresh at the current level; record the field
+  type for the eventual read-after-write path (stubbed here, completed in PR 3).
+- Negative-position coalescing (`coalesce.go`): a variable's upper-bound record
+  requirements **merge into one record** (intersection of object bounds → single
+  record), coalescing as **exact** by default (Policy A — row closed once body
+  inference completes).
+- The `open` parameter marker (keyword provisional, e.g. `fn dist(open p) =>`):
+  keeps the usage-inferred param **inexact** so callers may pass richer records.
+  Lands here because this is the first milestone with record-typed params.
+- Namespace-qualified `MemberExpr` (`ns.foo`) routing is M2's concern; confirm the
+  value-typed-receiver path is correctly distinguished (see
+  [02-design-notes.md](02-design-notes.md) §"the constraint-generating AST walk").
+- **Tests**: `fn (p) => p.x + p.y` infers an (exact) `{x, y}`-shaped param; `open`
+  variant infers inexact `{x, y, ...}`; accessing a missing field on a known exact
+  record is rejected; the replacement of `Open`/`ArrayConstraint` behavior is
+  covered by re-expressing representative old-checker cases as intended-form table
+  tests.
+- **~Size**: medium.
+
+### PR 3 — `RefType` + `mut` (THE GATE)
+
+The single borrow wrapper and the one constrain rule. This clears the
+highest-risk gate.
+
+- `soltype`: `RefType{mut, lt, inner}` with `lt` left **nil** throughout this PR
+  (lifetimes arrive in PR 4); the `RefInner` sealed marker interface (only
+  `RecordType`/`TupleType`/`ClassType`(future)/`AliasType`/`UnionType`/
+  `IntersectionType`/`TypeVarType` qualify) and the `borrowableType` content
+  predicate. The `NewRef` smart constructor enforcing the degenerate-cell
+  invariant (`{false, nil}` ⇒ return bare `inner`). Helpers `unwrapRef` /
+  `carrierOf`. Printer: `mut Point`, and bare-inner pass-through for the
+  degenerate cell.
+- `constrain` — the **one** `RefType` rule (per
+  [02-design-notes.md](02-design-notes.md) §"The one `RefType` constrain rule"),
+  with lifetime steps written but inert while `lt == nil`:
+  1. mutability compatibility (`!l.mut && r.mut` ⇒ error);
+  2. inner variance — **bidirectional iff `r.mut`** (read view always +
+     contravariant write view when the target writes) = the read/write
+     decomposition that encodes invariance; covariant-only otherwise;
+  3. lifetime step (no-op here);
+  - plus `bare <: RefType` (wrap source as immutable/no-lt and re-dispatch) and
+    `RefType <: bare` (peel; escape-error guard becomes live in PR 4).
+- Field-write inference (`infer.go`): `obj.x = v` ⇒ `constrain(obj <: RefType{mut:
+  true, lt: nil, inner: RecordType{x: widen(v)}})` with literal widening; multiple
+  writes merge into one mutable record. Read-after-write: a read of a
+  just-written field returns the written type.
+- **Acceptance (the gate)**: reproduce the spike's `mut` cases from real source —
+  `mut {x,y} <: mut {x}` **fails** while immutable `{x,y} <: {x}` succeeds by
+  width subtyping; `fn foo(obj) { obj.x = 5; obj.y = 10 }` infers `(obj: mut {x:
+  number, y: number}) -> unit`; `fn foo(obj) { obj.x = 5; return obj.x }` infers
+  `(obj: mut {x: number}) -> number`; mut-borrow decay (`mut {x} <: {x}`) allowed,
+  the reverse rejected (full messages).
+- **Gate decision**: if the `mut`-driven invariance cannot be encoded cleanly here,
+  **stop and reassess** before PR 4/5 — that is the milestone's instruction.
+- **~Size**: medium-large. This is the conceptual core of M4.
+
+### PR 4 — Lifetimes as a second sort
+
+Populate the `lt` field that PR 3 left nil; activate the lifetime steps of the
+`RefType` rule.
+
+- `soltype/lifetime.go`: `LifetimeVar{lowerBounds, upperBounds}`,
+  `StaticLifetime` (top), and the single `LifetimeUnion` flow-set surface
+  representation (per [03-references.md](03-references.md) — one list, read as
+  join in positive position / meet in negative). `constrainLt` mirroring
+  `constrain` over the outlives lattice.
+- Activate `RefType` rule step 3 (covariant lifetime; the `RefType <: bare`
+  escape-error when `l.lt != nil`) and the `bare <: RefType` owned-satisfies-any
+  branch.
+- Borrow origination: `mut`/immutable `RefType`-typed parameters get a **fresh
+  lifetime** (`attachParamLifetimes` in `infer.go`); returning a borrow shares the
+  lifetime by value identity; multi-source returns **union** lifetimes via a fresh
+  join var; escape to module/static storage ⇒ `constrain(lt <: 'static)`.
+- Field-write target lifetime becomes a **fresh variable** (not nil) so the
+  receiver may be owned-mutable or a mut-borrow of any lifetime (per
+  [02-design-notes.md](02-design-notes.md) §"the constraint-generating AST walk",
+  assignment-to-member case).
+- Lifetime coalescing + **elision**, branching on `mut` at the elision site:
+  mutable borrow with elided lt ⇒ elide-in-place (`RefType{mut:true, lt:nil}`,
+  well-formed owned-mutable); **immutable** borrow with elided lt ⇒ **drop the
+  wrapper entirely** (else it becomes the forbidden degenerate cell).
+- **Acceptance**: the canonical lifetime cases from real source —
+  `IdentityRefReturn` ⇒ `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`;
+  `FreshObjectReturn` carries no lifetime; `ConditionalUnionReturn` ⇒ `mut ('a |
+  'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`; property-level and
+  tuple-per-slot lifetimes; read-after-write field collapse with a lifetime
+  present. Plus: `RefType` neither tightens nor loosens the inner's exactness (the
+  inner carrier's `exact` flag passes through unchanged).
+- **~Size**: large. The second-sort machinery + elision branching is the bulk.
+
+### PR 5 — Mutability-transition checking (port)
+
+The flow-sensitive mutable↔immutable alias-creation check, ported with minimal
+adaptation (per the milestone's "reuses existing infrastructure" note).
+
+- Reuse `internal/liveness/` **verbatim** (`VarID`/`CFG`/`AliasTracker`/
+  `LivenessInfo`); reuse `liveness_prepass.go`.
+- Reimplement the two narrow predicates over `soltype`: `isValueType(t)` and
+  `isMutableType(t)` (the latter becomes `if r, ok := t.(*soltype.RefType); ok {
+  return r.mut }; return false`).
+- `checkMutabilityTransition`'s Rule 1 / Rule 2 / Rule 3 logic is **unchanged** —
+  it talks only to `liveness.Liveness`/`liveness.AliasTracker`.
+- `solver.Context` gains `Liveness` / `Aliases` fields, populated by the existing
+  prepass.
+- **Simplification**: collapse the `HasStaticMutAlias` / `HasStaticImmAlias`
+  escape-hatch bits — under the new checker the escape is first-class
+  (`lt <: 'static` is in the inference output), so the transition checker queries
+  the lifetime sort directly. This depends on PR 4, which is why it is last.
+- **Acceptance**: port the old checker's transition-checking fixtures/cases as
+  intended-form table tests; the static-escape cases pass via lifetime queries
+  rather than the dropped bits.
+- **~Size**: medium (mostly a port; the simplification is the only genuinely new
+  logic).
+
+## Sequencing summary
+
+```
+PR1 records+tuples+exactness ─► PR2 usage-based reads ─► PR3 RefType + mut  (GATE)
+                                                              │
+                                                              ▼
+                                              PR4 lifetimes (second sort)
+                                                              │
+                                                              ▼
+                                              PR5 transition checking (port)
+```
+
+- PR1 → PR2: usage inference needs the record carrier and its coalescing.
+- PR2 → PR3: the `mut` write path and read-after-write build on the member-access
+  path; non-trivial inferred record shapes make the gate's tests meaningful.
+- **PR3 is the gate** — do not start PR4/PR5 until it is cleared.
+- PR3 → PR4: lifetimes ride on the `RefType` wrapper PR3 introduces.
+- PR4 → PR5: the transition-check simplification (dropping the static-alias bits)
+  consumes the lifetime sort.
+
+PR1 and the *test scaffolding* for PR2 can be drafted in parallel, but the merge
+order is strict. PR4 and PR5 cannot be meaningfully parallelized because PR5's
+simplification depends on PR4's escape-as-`'static` output.
+
+## Testing strategy
+
+Following [02-design-notes.md](02-design-notes.md) §"Test coverage" and CLAUDE.md:
+
+- **Granular semantics** as table-driven `*_test.go` in the new checker package,
+  keyed by test name with `expectedValues` / `expectedTypes` (rendered Escalier
+  type-annotation strings) and `expectedError` (**full** message). Authored
+  against intended semantics, not copied from the old checker.
+- Where a type tree is large (e.g. nested borrowed records with per-field
+  lifetimes), render the subtree and use an inline snapshot rather than many
+  drill-down assertions.
+- Each PR carries the acceptance set named in its section above; the union of
+  those sets is the milestone's M4 acceptance criteria from
+  [01-milestones.md](01-milestones.md).
+- No fixture-harness wiring yet (that is M7); M4 validation is entirely the new
+  package's own tests driven from real `.esc` source through the M2 parser bridge.
+
+## Risks and open questions
+
+- **The gate (PR 3)** is the dominant risk; it is front-loaded and has an explicit
+  stop-and-reassess decision. The spike de-risked the *algorithm*; the residual
+  risk is encoding it cleanly against the production AST and `soltype`.
+- **Lifetime elision branching on `mut`** (PR 4) is the subtlest non-gate piece —
+  the immutable-borrow-must-drop-the-wrapper rule is easy to get wrong and
+  reintroduce the forbidden degenerate cell. The `NewRef` smart-constructor
+  assertion is the backstop; the coalescer must branch on `mut` at the elision
+  site.
+- **`open` keyword** is provisional (PR 2). If naming is unsettled, gate the
+  surface syntax behind the parser and keep the semantic flag; the inference
+  behavior is what M4 must prove, not the spelling.
+- **Probe usage**: M4's core path is monotone and needs no rollback, but the
+  field-write merge and any union-against-variable deferral should be written
+  probe-aware so M6/M8 speculation composes without rework.
+- **`exact`-by-default surface**: per the milestone, the exactness default for
+  usage-inferred shapes (Policy A) and the `open` opt-out are **not yet reflected
+  in `planning/exact-types/requirements.md`**. That spec section should be written
+  before PR 2 lands so the tests assert an agreed default.

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -316,19 +316,52 @@ func (c *Context) constrainLt(lhs, rhs Lifetime)
 func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 
-// Probe today snapshots *TypeVarType lengths. M4 widens the journal entry to
-// the Bounded interface (02-design-notes §"probe-API sketches") so both sorts
-// share one entry shape and one rollback:
-type Bounded interface {
-    boundLengths() (lower, upper int)
-    truncateBounds(lower, upper int)
-}
-// implemented by *soltype.TypeVarType and *soltype.LifetimeVar
+// Probe today holds the CONCRETE *soltype.TypeVarType and truncates its exported
+// bound fields inline on discard (probe.go's probeEntry.v is *TypeVarType, not an
+// interface). The 02-design-notes "probe-API sketches" proposed a `Bounded`
+// interface with UNEXPORTED methods — but probe.go:45-52 records that this was
+// tried and REJECTED: Go won't let `solver` attach the unexported boundLengths/
+// truncateBounds to a `soltype` type, and an interface in `solver` over unexported
+// methods is unsatisfiable by a `soltype` type across the package boundary. M3 had
+// one bounded sort, so it kept the concrete entry.
+//
+// M4 adds a SECOND bounded sort (LifetimeVar), which is the trigger probe.go's
+// comment names ("if a second bounded type appears, reintroduce the interface with
+// EXPORTED methods on the soltype types"). So the correct M4 move is the EXPORTED
+// form:
+//
+//   // package soltype — exported, so cross-package satisfaction works:
+//   func (v *TypeVarType) BoundLengths() (int, int)
+//   func (v *TypeVarType) TruncateBounds(lower, upper int)
+//   func (v *LifetimeVar) BoundLengths() (int, int)
+//   func (v *LifetimeVar) TruncateBounds(lower, upper int)
+//
+//   // package solver:
+//   type Bounded interface {
+//       BoundLengths() (lower, upper int)
+//       TruncateBounds(lower, upper int)
+//   }
+//   // probeEntry.v becomes Bounded; *TypeVarType and *LifetimeVar both satisfy it.
+//
+// COST (eyes-open): exporting TruncateBounds publishes a speculation-only "rewind
+// my bounds to a checkpoint" verb on soltype's public surface, callable from any
+// importer with no probe checkpoint — a silent-corruption footgun (a stray
+// `v.TruncateBounds(0, 0)` drops solved bounds, surfacing later as a wrong
+// coalesced type, not a panic). Mitigation: a doc comment on the exported methods
+// ("speculation-internal; call only through Probe"). The alternative — duplicating
+// the inline truncate per sort, no interface — keeps the surface clean at the cost
+// of two near-identical discard paths; pick the interface only once the second
+// sort makes the duplication real.
 ```
 
 ### Field write + read-after-write (`solver/infer_expr.go`)
 
 ```go
+// NEW HELPER (B3 authors it; not yet in the production solver — only the spike
+// has it, internal/simplesub/constrain.go). widen generalizes a literal to its
+// primitive (5 ⇒ number, "x" ⇒ string) and passes non-literals through:
+//   func widen(t soltype.Type) soltype.Type
+//
 // Extends inferAssign's existing member/index branch (today:
 // reportUnsupportedFeature, infer_expr.go:495). C3 ships with Lt: nil — no
 // borrows exist yet, every receiver is owned — and D2 flips the requirement's
@@ -391,13 +424,20 @@ func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
 ### Namespace member lookup (`solver/infer_expr.go`, Phase F)
 
 ```go
-// resolvePath resolves an ident/member/index chain to Value | Namespace (a name
-// is never both — scope invariant). The object/index position tolerates a
-// namespace; every other value position rejects one — so
-// NamespaceUsedAsValueError moves OFF inferIdent to the value-position
-// consumer and fires once for both f(Foo) and f(A.B). Namespace lookup is a
-// direct, non-lexical read of the namespace's own maps (no parent walk).
-// Index keys must be statically constant strings.
+// resolvePath (NEW) resolves an ident/member/index chain to Value | Namespace (a
+// name is never both — scope invariant); pathResult (NEW) is its sum return. The
+// object/index position tolerates a namespace; every other value position rejects
+// one — so NamespaceUsedAsValueError moves OFF inferIdent to the value-position
+// consumer and fires once for both f(Foo) and f(A.B).
+//
+// Namespace lookup reads the namespace's OWN maps directly — soltype's `Namespace`
+// (scope.go:61-66) is a struct of FIELDS (Values / Types / Nested), with NO
+// methods today: read `ns.Values[name]` / `ns.Nested[name]` inline, non-lexical
+// (no parent walk), unlike Scope.GetValue/GetType/GetNamespace which DO walk
+// parents. (01-milestones.md names hypothetical LookupValue/LookupNamespace
+// helpers; those don't exist yet — add them as thin wrappers over the fields if
+// the inline reads get repetitive, but they are not shipped API.) Index keys must
+// be statically constant strings.
 // New errors: UnknownNamespaceMemberError, DynamicNamespaceIndexError.
 func (c *checker) resolvePath(scope *Scope, e ast.Expr) pathResult
 ```
@@ -454,9 +494,11 @@ messages. The gate (C2) sits 3rd on the critical path.
   A, spec §8.1). Mut-record merging is added by C3.
 - **B2 — The `open` parameter marker** (~120). Parser marker + keep-inexact
   flag on the closed shape. Spelling gated; semantics are what M4 proves.
-- **B3 — `var` literal widening** (~150). The principled usage-based form from
-  the milestone: a `var`'s type is informed by all assignment sites via
-  `widen` + the same coalescing; `val` stays a literal singleton. Retires
+- **B3 — `var` literal widening** (~150). **Authors the `widen` helper**
+  (`func widen(t soltype.Type) soltype.Type`, ported from the spike — not yet in
+  the production solver; C3's field-write reuses it). The principled usage-based
+  form from the milestone: a `var`'s type is informed by all assignment sites
+  via `widen` + the same coalescing; `val` stays a literal singleton. Retires
   PR8's documented `var a = 5; a = 6` failure.
 
 ### Phase C — Borrows & mutability (**the gate**)
@@ -473,8 +515,9 @@ messages. The gate (C2) sits 3rd on the critical path.
   mut-decay allowed, reverse rejected; full messages. **Stop and reassess
   before any later phase if this does not encode cleanly.**
 - **C3 — Field-write inference + read-after-write** (~200). Replace
-  `inferAssign`'s member-branch stub per the sketch (`Lt: nil`); `widen` on
-  write; multi-write merge (mut-record case of B1's merge); the `written`
+  `inferAssign`'s member-branch stub per the sketch (`Lt: nil`); reuse B3's
+  `widen` on write; multi-write merge (mut-record case of B1's merge); the
+  `written`
   read-after-write map on the checker. Acceptance: `fn foo(obj) { obj.x = 5;
   obj.y = 10 }` ⇒ `(obj: mut {x: number, y: number}) -> unit`; write-then-read
   ⇒ `number`.
@@ -483,8 +526,11 @@ messages. The gate (C2) sits 3rd on the critical path.
 
 - **D1 — Lifetime sort + probe extension** (~220). `LifetimeVar`/
   `StaticLifetime`; `constrainLt` with journal-gated appends
-  (`addLowerLtBound`/`addUpperLtBound`); the probe's entry widened to
-  `Bounded` so both sorts roll back through one journal; lifetime printing.
+  (`addLowerLtBound`/`addUpperLtBound`); extend the probe to the second sort by
+  reintroducing the `Bounded` interface with **exported** `BoundLengths`/
+  `TruncateBounds` on both soltype types (the path `probe.go:45-52` prescribes
+  for "a second bounded type" — *not* the rejected unexported form), so both
+  sorts roll back through one journal; lifetime printing.
 - **D2 — Activate the rule + borrow origination** (~160). Turn on step 3 and
   the escape guards; `attachParamLifetimes`; **flip C3's write-requirement
   lifetime from `nil` to a fresh var** and re-run C3's acceptance (borrowed
@@ -568,10 +614,14 @@ union is the milestone's M4 acceptance. No fixture harness yet (M8).
 - **The gate (C2)** remains the dominant risk, front-loaded with an explicit
   stop-and-reassess. The spike proved the algorithm; the residual risk is the
   production encoding (visitor, journal-gated bounds, blame spans).
-- **Probe × lifetimes (D1).** Widening the journal to `Bounded` touches M3's
-  speculation infrastructure used by overload resolution — the "appends only
-  through journaling helpers" invariant must hold for the new sort from day
-  one, or a discarded overload trial could leak lifetime bounds.
+- **Probe × lifetimes (D1).** Reintroducing the `Bounded` interface touches M3's
+  speculation infrastructure used by overload resolution. Two constraints:
+  (a) it must use **exported** methods on the soltype types — the unexported
+  form is unsatisfiable across the package boundary, which is why `probe.go`
+  shipped the concrete-type journal instead (probe.go:45-52); (b) the "appends
+  only through journaling helpers" invariant must hold for the new sort from day
+  one, or a discarded overload trial could leak lifetime bounds. The exported
+  `TruncateBounds` is a public-surface footgun — document it speculation-internal.
 - **Elision branching on `Mut` (D4)**: the immutable-elide case **must** drop
   the wrapper or it reconstructs the forbidden degenerate cell; `NewRef`'s
   invariant (plus a printer assertion) is the backstop.

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1,406 +1,596 @@
-# M4 implementation plan — Core value types: records + usage-based inference + `mut` + lifetimes
+# M4 implementation plan — Core value types: records + usage-based inference + `mut` + lifetimes + destructuring/`match`
 
 This is the implementation plan for **M4** as defined in
-[01-milestones.md](01-milestones.md) §"M4 — Core value types". It assumes M1
-(package skeleton + `soltype`), M2 (parser/resolver bridge), and M3 (functions,
-application, let-polymorphism, function exactness) have landed. It is grounded in
-[02-design-notes.md](02-design-notes.md) (the `RefType` wrapper, the exactness
-flag, the `Probe` API, the `Info`/`Prov` side tables) and the lifetime lattice in
-[03-references.md](03-references.md).
+[01-milestones.md](01-milestones.md) §"M4 — Core value types". M1
+(`internal/soltype/` + `internal/solver/`), M2 (parser/resolver bridge), M2.5
+(provenance + precise error spans), and M3 (let-polymorphism, function
+exactness, probe, overloading, async, `ErrorType` recovery) have **landed on
+main**; this plan is written against that code, not against the spike or the
+pre-M1 design sketches. Where the two disagree, the shipped code wins and is
+cited.
 
-The type/function sketches below are **adapted from the proven spike**
-(`internal/simplesub/` — `types.go`, `constrain.go`, `lifetime.go`,
-`coalesce.go`) into production `soltype` shapes. The spike's separate `Mut`
-wrapper + `lt`-on-`Record` is **replaced** by the unified `RefType{mut, lt,
-inner}` per the settled design; names are provisional.
+The design source remains [02-design-notes.md](02-design-notes.md) (the
+`RefType` wrapper, exactness, the probe) and the lifetime lattice in
+[03-references.md](03-references.md). Spike provenance: `internal/simplesub/`
+M2 (records), M3 (`mut`), M4 (lifetimes).
+
+## What M1–M3 actually shipped (ground truth this plan builds on)
+
+Facts that changed or sharpened the original plan, from the code on main:
+
+1. **Package layout.** Types live in **`internal/soltype/`** (a top-level
+   sibling, not `internal/solver/soltype/`): `type.go`, `print.go`,
+   `polarity.go`, `visitor.go`. The engine is `internal/solver/`:
+   `constrain.go`, `coalesce.go`, `context.go`, `errors.go`, `infer.go` /
+   `infer_expr.go` / `infer_decl.go` / `infer_stmt.go`, `module.go`,
+   `overload.go`, `poly.go`, `prelude.go`, `probe.go`, `prov.go`, `scope.go`,
+   `simplify.go`, `type_ann.go`.
+2. **`RecordType` already exists** (M2): `Fields []*RecordField{Name, Type}` —
+   an **ordered slice with last-wins dedup**, not a map; `Field(name)` is the
+   canonical lookup. Record/tuple **literal inference already works**
+   (`inferObject` / tuple walk), as does **member-read usage inference**:
+   `inferMember` lowers `recv.prop` to `constrain(recv, {prop: β})`
+   ([infer_expr.go:716](../../internal/solver/infer_expr.go)). M4 does *not*
+   introduce these — it refines them.
+3. **The exactness flag is spelled `Inexact`**, not `exact` — `FuncType.Inexact`
+   (M3 PR4) deliberately makes the **zero value exact**, matching
+   exact-by-default, so structural rewriters carry the flag through unchanged.
+   `RecordType`/`TupleType` follow the same convention; conveniently, every
+   record/tuple M2 already mints becomes exact *by zero value*.
+4. **One width-tolerant record arm exists and is explicitly provisional.** The
+   `RecordType <: RecordType` case in
+   [constrain.go:181](../../internal/solver/constrain.go) serves only member
+   access and carries a long comment: M4 must split the **field-selection
+   requirement** (width-tolerant) from **concrete record `<:` record**
+   (exact-by-default). Likewise the tuple arm is exact-only ("M4 adds the exact
+   flag and the inexact arm") and the function arm has a **KNOWN GAP (M4)**
+   note for inexact-callback extra positions (Variation B, needs the `⊤` rule —
+   see Open Questions).
+5. **Errors are typed `SolverError` structs with blame spans** (M2.5), reported
+   via `c.report(...)` — not `[]error`/`fmt.Errorf`. Several M4 error paths are
+   *already stubbed* in [errors.go](../../internal/solver/errors.go):
+   `MissingPropertyError`'s receiver/site blame arms "cover the M4 concrete
+   record cases", namespace member access "(`Foo.bar`) is M4",
+   member-assignment mutability "is M4".
+6. **Bound mutations are journal-gated.** Bound lists may be extended **only**
+   through `Context.addLowerBound`/`addUpperBound`, which fuse the probe
+   snapshot with the append ([context.go](../../internal/solver/context.go)).
+   The probe (M3 PR5) journals `*TypeVarType` plus Info/Prov/errs rollback
+   closures. M4's `LifetimeVar` is a second bound-list sort, so the **probe
+   must be extended** to journal it under the same discipline.
+7. **Structural rewrites ride a polarity-threading visitor.** Every
+   `soltype.Type` implements `Accept(v TypeVisitor, pol Polarity) Type`
+   (#716/#717); coalesce, extrude, and freshenAbove are built on it. New
+   formers (`RefType`) extend the visitor — no hand-rolled recursion. `LevelOf`,
+   `equalType`, `Print`/`PrintAsScheme` also need arms per new former.
+8. **Coalescing stays in the `soltype` universe.** Production coalesce returns
+   a native `soltype.Type` (the spike's `type_system` conversion is gone), and
+   **simplification runs at display time** (`coalesceScheme` + co-occurrence
+   merging in `simplify.go`), leaving raw scheme bodies intact for
+   instantiation. Lifetime naming/elision therefore happens at display time.
+9. **Reassignment exists for identifiers** (M3 PR8): `inferAssign` handles
+   `a = expr` with `CannotAssignToImmutableError`; the member/index target
+   branch currently reports "unsupported — deferred to M4"
+   ([infer_expr.go:495](../../internal/solver/infer_expr.go)). M4's field-write
+   path **extends that branch**, it does not build a new one. PR8 also left
+   `var a = 5; a = 6` failing until M4's `var` literal widening.
+10. **`ErrorType` absorbs at the top of `constrain`**, so every new M4 arm gets
+    error-recovery behavior for free. **`PromiseType` exists** and must be
+    classified by `RefInner`/`borrowableType` (excluded — a promise is shared,
+    not borrowed). **`UnionType`/`IntersectionType` are coalesced-output-only**
+    nodes; their general constrain rules remain M6.
+11. **`Scope`/`Namespace` exist** (`GetValue`/`GetType`/`GetNamespace`); a
+    namespace in value position errors in `inferIdent`. M4 moves that error to
+    the value-position consumer and adds member *lookup*.
+12. **`resolveTypeAnn` covers only primitives + `Promise<T>`**
+    ([type_ann.go](../../internal/solver/type_ann.go)). M4's acceptance tests
+    need record/tuple annotations (incl. the trailing `...` and `mut`/lifetime
+    forms), so the annotation surface must grow accordingly.
+13. **Milestone renumbering**: library type resolution is the new M7, the
+    fixture harness is **M8**, type-level operators **M9**, codegen **M10**.
+    The exact-types spec now records Policy A and the `open` marker (§8.1) —
+    the original plan's "spec must be written first" risk is **resolved**.
+14. **The milestone itself grew**: M4 now also owns **destructuring patterns +
+    the `match` expression form**, **namespace member lookup**, **`var`-binding
+    literal widening**, and the selection-vs-concrete record split (all in
+    [01-milestones.md](01-milestones.md) §M4).
 
 ## Why M4 is "the big one"
 
-M4 promotes three spike milestones at once and they are **inseparable**:
-records/objects (spike M2 — the first borrowable value), `mut` (spike M3 — the
-highest-risk gate), and lifetimes (spike M4 — a second sort solved by the same
-`constrain`). Lifetimes ride on borrows, records are the first thing that can be
-borrowed, `mut` borrows are what first populate a lifetime. Exactness (the
-`exact` flag on `RecordType`/`TupleType`) also lands here, because the settled
-decision is to introduce the flag *with* each former, not retrofit it.
+Records, `mut`, and lifetimes are inseparable: lifetimes ride on borrows,
+records are the first borrowable value, and `mut` borrows are what first
+populate a lifetime. The milestone names the `RefType` rule's `mut`-driven inner
+invariance as the **HIGHEST-RISK gate**: if it cannot be encoded cleanly against
+the real AST, the whole migration is in question. The PR sequence below reaches
+the gate after only the minimum prerequisite work, and nothing expensive
+(lifetimes, patterns, the transition port) starts before it is cleared.
 
 ## Scope
 
-In: owned `RecordType`/`TupleType` with the `exact` flag; the unified `RefType`
-borrow wrapper; usage-based inference (member reads → constraints); the single
-`RefType` constrain rule (mut invariance via read/write decomposition); field-write
-inference + read-after-write; lifetimes as a second sort; ported
-mutability-transition checking.
+In (per the updated milestone):
 
-Out (later milestones): nominal classes (M5); union/intersection *annotations*
-(M6 — M2/M4 already produce them as coalescing *output*); type-level operators
-(M8); codegen and value-level `exact<T>(v)` (M9).
+1. `Inexact` flag on `RecordType`/`TupleType`; exact/inexact subtyping rules;
+   the selection-vs-concrete record split; tuple inexact arm + tuple spread.
+2. Record/tuple type annotations (incl. `...`, `mut`, lifetimes) in
+   `resolveTypeAnn`.
+3. Usage-based inference *refinement*: negative-position record merging at
+   coalesce; Policy-A exact closing; the `open` parameter marker.
+4. `var`-binding literal widening (usage-based over all assignment sites).
+5. The unified `RefType{Mut, Lt, Inner}` wrapper + the single constrain rule
+   (**the gate**); field-write inference via `inferAssign`'s member branch;
+   read-after-write.
+6. Lifetimes as a second sort (`LifetimeVar`, `constrainLt`, probe extension,
+   borrow origination, joins, escape, display-time coalescing + elision).
+7. Destructuring patterns (`TuplePat`/`RecordPat`/literal patterns) + the
+   `match` expression over structural patterns, with exactness-driven
+   exhaustiveness.
+8. Namespace member lookup (`resolvePath`, `Foo.bar`, `Foo["x"]`, new errors).
+9. Mutability-transition checking ported (`internal/liveness/` verbatim + two
+   predicates over `soltype`).
+
+Out: classes (M5), union/intersection constrain rules and optional chaining
+(M6), TypeRef/alias resolution (M7), fixture harness (M8), type-level operators
+(M9), codegen / `exact<T>(v)` (M10).
 
 ---
 
 ## Key types and function sketches
 
-### Owned carriers + exactness (`soltype/type.go`)
+Sketches use the **shipped conventions**: exported fields, `Inexact` (zero value
+= exact), `[]SolverError`, journal-gated bound appends, visitor `Accept`.
+
+### Exactness on the existing carriers (`soltype/type.go`)
 
 ```go
-// RecordType is an owned structural object type. exact closes the type (no extra
-// members, no width subtyping); inexact (written `{... ...}`) permits width
-// subtyping. Owned — carries NO lifetime; a lifetime is a property of a borrow
-// and lives on the RefType wrapper.
+// RecordType gains Inexact (M3's FuncType convention: zero value = exact, so
+// every record M2 already mints — literals, member requirements before this
+// milestone — is exact by default with no construction-site churn).
 type RecordType struct {
-    fields map[string]Type
-    exact  bool
+    Fields  []*RecordField // ordered, name-deduped (last wins); Field(name) lookup
+    Inexact bool           // trailing `...` ⇒ true
 }
 
-// TupleType gains the same flag (M1 left it as a stub). exact ⇒ fixed length;
-// inexact ⇒ length-flexible tail.
 type TupleType struct {
-    elems []Type
-    exact bool
+    Elems   []Type
+    Inexact bool // `[A, B, ...]` ⇒ true: longer <: shorter becomes legal vs an inexact RHS
 }
+```
+
+The **selection-vs-concrete split** falls out of the flag: `inferMember`'s
+synthesized requirement becomes `{prop: β, Inexact: true}` ("has at least this
+field" — width-tolerance *is* inexactness), and the record arm then implements
+the one-way rule uniformly instead of being unconditionally width-tolerant:
+
+```go
+case *soltype.RecordType:
+    if r, ok := rhs.(*soltype.RecordType); ok {
+        var errs []SolverError
+        for _, rf := range r.Fields {               // depth: fields covariant
+            lt, ok := l.Field(rf.Name)
+            if !ok {
+                errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rf.Name})
+                continue
+            }
+            errs = append(errs, c.constrain(lt, rf.Type, seen)...)
+        }
+        // One-way exactness (02-design-notes §"Exactness"):
+        //   exact <: inexact   ok (width)     inexact <: inexact   ok (width)
+        //   exact <: exact     same field set inexact <: exact     rejected
+        if !r.Inexact {
+            if l.Inexact {
+                errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
+            }
+            for _, lf := range l.Fields {
+                if _, ok := r.Field(lf.Name); !ok {
+                    errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lf.Name})
+                }
+            }
+        }
+        return errs
+    }
 ```
 
 ### The borrow wrapper (`soltype/type.go`)
 
 ```go
-// RefType is the single wrapper for borrows and mutability (replaces the spike's
-// Mut + lt-on-carrier). See 02-design-notes.md §"soltype".
-//
-//   mut=false lt=nil  -> forbidden degenerate cell (smart ctor returns bare inner)
-//   mut=false lt='a   -> immutable borrow with lifetime 'a
-//   mut=true  lt=nil  -> owned mutable value
-//   mut=true  lt='a   -> mutable borrow with lifetime 'a
+// RefType is the single wrapper for borrows and mutability.
+//   Mut=false Lt=nil  -> forbidden degenerate cell (NewRef returns bare Inner)
+//   Mut=false Lt='a   -> immutable borrow      Mut=true Lt=nil -> owned mutable
+//   Mut=true  Lt='a   -> mutable borrow
 type RefType struct {
-    mut   bool
-    lt    Lifetime  // nilable; see table above
-    inner RefInner  // narrower than Type — see marker below
+    Mut   bool
+    Lt    Lifetime // nilable
+    Inner RefInner
 }
 
-// RefInner is the sealed set of types that may sit inside a RefType. Primitives,
-// literals, functions, and nested RefTypes are deliberately excluded.
+// RefInner is the sealed set of types that may sit inside a RefType.
+// PrimType/LitType/FuncType/PromiseType/nested RefType are deliberately excluded
+// (a promise/function reference is shared, not borrowed; mut number is a JS no-op).
 type RefInner interface {
     Type
     isRefInner()
 }
-
-func (*RecordType)  isRefInner() {}
-func (*TupleType)   isRefInner() {}
-func (*AliasType)   isRefInner() {}
+func (*RecordType) isRefInner()  {}
+func (*TupleType) isRefInner()   {}
 func (*TypeVarType) isRefInner() {} // mid-inference; checked at constrain time
-// + UnionType / IntersectionType once M6 lands; ClassType in M5.
+// + UnionType/IntersectionType (M6 inputs), AliasType (M7), ClassType (M5).
 
-// NewRef enforces the wrapper invariant: the degenerate (immutable, no-lifetime)
-// cell collapses to the bare inner so no downstream *RefType type-switch ever
-// sees a borrow-shaped value that isn't a borrow.
+// NewRef collapses the degenerate cell so no *RefType type-switch ever sees a
+// borrow-shaped value that isn't a borrow.
 func NewRef(mut bool, lt Lifetime, inner RefInner) Type {
     if !mut && lt == nil {
         return inner
     }
-    return &RefType{mut: mut, lt: lt, inner: inner}
+    return &RefType{Mut: mut, Lt: lt, Inner: inner}
 }
 
-// Peel helpers used everywhere a value is destructured (field access, etc.).
-func unwrapRef(t Type) (inner Type, mut bool, lt Lifetime)
-func carrierOf(t Type) Type // peel any RefType, return the inner carrier
+func unwrapRef(t Type) (inner Type, mut bool, lt Lifetime) // peel helpers used by
+func carrierOf(t Type) Type                                // member access, patterns, equalType
+func borrowableType(t Type) bool                           // content invariant behind TypeVarType
 
-// borrowableType is the content invariant the RefInner marker can't express
-// (e.g. it rejects Union{RecordType, PrimitiveType}); descends collections.
-func borrowableType(t Type) bool
+// Accept: RefType joins the rewriting visitor. The inner is reachable in BOTH
+// polarities when Mut (read+write views), but the REWRITERS visit it once in the
+// current polarity (the read view) — extrude/freshenAbove share fresh vars via
+// the cache, exactly as the spike's extrude did for Mut. The lifetime is NOT a
+// Type and is carried through unchanged by Accept; only the lifetime-aware
+// passes (D4) walk it.
+func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type
 ```
 
-### The lifetime sort (`soltype/lifetime.go`, faithful to spike)
+`LevelOf` gains a `case *RefType: return LevelOf(t.Inner)` arm; `equalType` and
+`Print` (`mut {x: number}`, `'a {x: number}`, `mut 'a Point`) get matching arms.
+
+### The single `RefType` constrain rule — **THE GATE** (`solver/constrain.go`)
 
 ```go
-type Lifetime interface{ isLifetime() }
-
-type LifetimeVar struct {
-    id          int
-    lowerBounds []Lifetime
-    upperBounds []Lifetime
-}
-type StaticLifetime struct{} // top of the outlives lattice ('static)
-
-func (c *checker) freshLifetime() *LifetimeVar
-
-// constrainLt mirrors constrain over the outlives lattice: a var on the left
-// gains an upper bound, on the right a lower bound; var-to-var records both
-// directions. 'static is top, so X <: 'static always holds. Uses a seen-set
-// keyed on (lhs, rhs) for cycle termination.
-func (c *checker) constrainLt(lhs, rhs Lifetime)
-```
-
-### `constrain`: record + exactness (`constrain.go`)
-
-```go
-func (c *checker) constrainRecords(l, r *RecordType, seen seenSet) []error {
-    var errs []error
-    // every field r requires must exist in l, covariantly (depth subtyping)
-    for name, rt := range r.fields {
-        lt, ok := l.fields[name]
-        if !ok {
-            errs = append(errs, missingFieldError(name)) // full message asserted in tests
-            continue
-        }
-        errs = append(errs, c.constrain(lt, rt, seen)...)
-    }
-    // one-way exactness rule (02-design-notes §"Exactness"):
-    //   exact <: inexact            ok
-    //   exact <: exact              same member set (no extra in l)
-    //   inexact <: exact            rejected
-    //   inexact <: inexact          width subtyping (the loop above already allows extra)
-    if r.exact {
-        if !l.exact {
-            errs = append(errs, inexactIntoExactError(l, r))
-        }
-        for name := range l.fields {
-            if _, ok := r.fields[name]; !ok {
-                errs = append(errs, extraMemberError(name, r))
-            }
-        }
-    }
-    return errs
-}
-```
-
-### `constrain`: the single `RefType` rule — **THE GATE** (`constrain.go`)
-
-```go
-// Adapted from the spike's *Mut case (constrain.go:182-198), generalized to the
-// unified wrapper. The mut-driven bidirectional inner sweep is the read/write
-// decomposition that encodes invariance — the highest-risk gate.
-case *RefType: // l := lhs.(*RefType)
-    if r, ok := rhs.(*RefType); ok {
+// Generalized from the spike's *Mut case (simplesub/constrain.go:182) to the
+// unified wrapper. Lifetime steps are written now, inert while Lt == nil (C2),
+// activated in D2.
+case *soltype.RefType:
+    if r, ok := rhs.(*soltype.RefType); ok {
         // 1. mutability compatibility — can't widen immutable to mutable.
-        if !l.mut && r.mut {
-            return []error{mutabilityError(l, r)}
+        if !l.Mut && r.Mut {
+            return []SolverError{&MutabilityMismatchError{LHS: l, RHS: r}}
         }
-        // 2. inner variance — bidirectional iff the TARGET is mutable.
-        errs := c.constrain(l.inner, r.inner, seen) // read view (covariant)
-        if r.mut {
-            errs = append(errs, c.constrain(r.inner, l.inner, seen)...) // write view (contra)
+        // 2. inner variance — bidirectional iff the TARGET writes (read/write
+        //    decomposition = invariance). Mut-decay (l.Mut && !r.Mut) falls
+        //    through to the covariant-only read view.
+        errs := c.constrain(l.Inner, r.Inner, seen)
+        if r.Mut {
+            errs = append(errs, c.constrain(r.Inner, l.Inner, seen)...)
         }
-        // 3. lifetime — covariant when both present (inert until Phase D).
+        // 3. lifetime — covariant when both present.
         switch {
-        case l.lt != nil && r.lt != nil:
-            c.constrainLt(r.lt, l.lt)
-        case l.lt == nil && r.lt != nil: // owned source into borrow slot: ok
-        case l.lt != nil && r.lt == nil: // borrow into owned slot: escape
-            errs = append(errs, escapeError(l, r))
+        case l.Lt != nil && r.Lt != nil:
+            c.constrainLt(r.Lt, l.Lt)
+        case l.Lt == nil && r.Lt != nil: // owned source satisfies any borrow slot
+        case l.Lt != nil && r.Lt == nil: // borrow into owned slot: escape
+            errs = append(errs, &BorrowEscapeError{LHS: l, RHS: r})
         }
         return errs
     }
-    // RefType <: bare: only valid when l is an owned value (no lifetime).
-    if l.lt != nil {
-        return []error{escapeError(l, rhs)}
+    // RefType <: bare: legal only for an owned value (no lifetime); peel.
+    if l.Lt != nil {
+        return []SolverError{&BorrowEscapeError{LHS: l, RHS: rhs}}
     }
-    return c.constrain(l.inner, rhs, seen)
-// (bare <: RefType handled symmetrically: wrap source as NewRef(false,nil,_)
-//  and re-dispatch into the RefType<:RefType branch.)
+    return c.constrain(l.Inner, rhs, seen)
 ```
 
-### Usage-based inference + field write (`infer.go`)
-
 ```go
-// MemberExpr read on a value-typed receiver: obj.field
-// The synthesized requirement is INEXACT ({field: β, ...}) — "recv must have AT
-// LEAST this field"; Policy-A coalescing closes the param to exact afterward.
-func (c *checker) inferMemberRead(recv Type, field string, n ast.Node) Type {
-    beta := c.freshVarAt(n, FieldAccess) // also writes Prov
-    req := &RecordType{fields: map[string]Type{field: beta}, exact: false}
-    c.constrain(recv, req, c.newSeen())
-    return beta
-}
-
-// Member write: obj.field = v  (constrain.go widen() reused)
-func (c *checker) inferFieldWrite(recv Type, field string, v Type, n ast.Node) {
-    lt := c.freshLifetime() // fresh: recv may be owned-mutable OR a mut-borrow of any lifetime
-    req := NewRef(true, lt, &RecordType{
-        fields: map[string]Type{field: widen(v)}, exact: false,
-    })
-    c.constrain(recv, req, c.newSeen())
-    c.recordWritten(recv, field, widen(v)) // read-after-write (spike's `written` map)
+// bare <: RefType (after the structural switch, before the variable arms):
+// wrap the source as an immutable no-lifetime view and re-dispatch into the
+// RefType<:RefType branch. Construct the struct literal DIRECTLY — NewRef would
+// collapse (false, nil) back to the bare inner and recurse forever.
+if r, ok := rhs.(*soltype.RefType); ok {
+    if inner, ok := asRefInner(lhs); ok {
+        return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, r, seen)
+    }
 }
 ```
 
-### Borrow origination + lifetime coalescing/elision (`infer.go` / `coalesce.go`)
+### The lifetime sort + probe extension (`soltype/lifetime.go`, `solver/probe.go`)
 
 ```go
-// A RefType-typed parameter is a borrow without a lifetime yet: give it a fresh
-// one and record it as a "param lifetime" (only these are named in output).
-// Adapted from spike attachParamLifetimes (lifetime.go:260).
-func (c *checker) attachParamLifetimes(t Type) Type {
-    r, ok := t.(*RefType)
-    if !ok || r.lt != nil {
+type Lifetime interface{ isLifetime() }
+type LifetimeVar struct {
+    ID          int
+    LowerBounds []Lifetime
+    UpperBounds []Lifetime
+}
+type StaticLifetime struct{} // 'static, top of the outlives lattice
+
+// Context grows the spike's M4 fields (context.go's own comment reserves them):
+type Context struct {
+    varCounter      int
+    probe           *Probe
+    lifetimeCounter int          // M4
+    // ... paramLifetimes / written live on the checker carrier (see C3/D2)
+}
+
+// constrainLt mirrors constrain over the outlives lattice: var-left gains an
+// upper bound, var-right a lower bound, var-to-var records both; 'static is
+// top (X <: 'static always holds); (lhs, rhs)-keyed seen-set for cycles.
+// Bound appends go ONLY through addLowerLtBound/addUpperLtBound — the journal
+// invariant extends to the second sort:
+func (c *Context) constrainLt(lhs, rhs Lifetime)
+func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
+func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
+
+// Probe today snapshots *TypeVarType lengths. M4 widens the journal entry to
+// the Bounded interface (02-design-notes §"probe-API sketches") so both sorts
+// share one entry shape and one rollback:
+type Bounded interface {
+    boundLengths() (lower, upper int)
+    truncateBounds(lower, upper int)
+}
+// implemented by *soltype.TypeVarType and *soltype.LifetimeVar
+```
+
+### Field write + read-after-write (`solver/infer_expr.go`)
+
+```go
+// Extends inferAssign's existing member/index branch (today:
+// reportUnsupportedFeature, infer_expr.go:495). C3 ships with Lt: nil — no
+// borrows exist yet, every receiver is owned — and D2 flips the requirement's
+// lifetime to a fresh var (so borrowed receivers of any lifetime are accepted)
+// and re-runs C3's acceptance.
+func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m *ast.MemberExpr) soltype.Type {
+    recv := c.inferExpr(scope, lvl, m.Object)
+    rhs := c.inferExpr(scope, lvl, e.Right)
+    w := widen(rhs) // 5 ⇒ number: a later write may store any number
+    req := &soltype.RefType{Mut: true, Lt: nil /* D2: c.freshLifetime() */,
+        Inner: &soltype.RecordType{
+            Fields:  []*soltype.RecordField{{Name: m.Prop.Name, Type: w}},
+            Inexact: true, // "must accept a write to this field", not a full shape
+        }}
+    c.constrain(e, recv, req)
+    c.recordWritten(recv, m.Prop.Name, w) // spike's `written` map: read-after-write
+    return w                               // assignment evaluates to the stored value
+}
+```
+
+### Display-time lifetime coalescing + elision (`solver/coalesce.go`, `simplify.go`)
+
+Production simplification runs at display time (`coalesceScheme`), so elision
+lives there — raw scheme bodies keep their `RefType`/lifetime structure for
+instantiation. Adapted from the spike's `analyzeLts`/`coalesceLifetime`:
+
+```go
+// Occurrence analysis (extended over RefType/lifetimes): a param lifetime kept
+// iff it occurs in both polarities (connects an input to an output) or is
+// forced to 'static. The RefType lifetime is COVARIANT — the mut-driven
+// bidirectional inner sweep never touches it (it lives on the wrapper, not in
+// the inner), so it cannot be accidentally invariated.
+//
+// Elision branches on Mut — the subtle case:
+//   mut, lifetime elided   ⇒ &RefType{Mut: true, Lt: nil, Inner: inner}  // owned-mutable
+//   immut, lifetime elided ⇒ inner                                       // MUST drop the
+//        // wrapper: RefType{false, nil, _} is the forbidden degenerate cell
+//
+// Naming: only param-originated lifetimes are named ('a, 'b, …); a join
+// variable renders as the union of the param lifetimes it reaches ('a | 'b);
+// 'static absorbs. Rendered via soltype Print/PrintAsScheme (fn <'a>(…)).
+```
+
+### Borrow origination (`solver/infer_expr.go`, D2)
+
+```go
+// A RefType-typed parameter without a lifetime is a borrow of whatever the
+// caller lends: attach a fresh lifetime var and record it as nameable.
+func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
+    r, ok := t.(*soltype.RefType)
+    if !ok || r.Lt != nil {
         return t
     }
     lt := c.freshLifetime()
-    c.paramLifetimes.Add(lt.id)
-    return &RefType{mut: r.mut, lt: lt, inner: r.inner}
-}
-
-// Coalescing a RefType, with the mut-vs-immutable elision branch (the subtle one).
-func (c *checker) coalesceRef(t *RefType, pol Polarity, st *coalesceState) Type {
-    inner := c.coalesceInner(t.inner, pol, st) // inner invariance handled by constrain, not here
-    name := c.lifetimeName(t.lt, pol)          // "" when the lifetime is elidable
-    if name == "" {
-        if t.mut {
-            return NewRef(true, nil, inner.(RefInner)) // owned-mutable, well-formed
-        }
-        return inner // immutable + elided ⇒ MUST drop the wrapper (else degenerate cell)
-    }
-    return type_system.NewBorrowType(nil, inner, name, t.mut) // `mut 'a T` / `'a T`
+    c.paramLifetimes.Add(lt.ID)
+    return &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}
 }
 ```
 
-### Transition checking (`transitions.go` / `context.go`)
+### Namespace member lookup (`solver/infer_expr.go`, Phase F)
 
 ```go
-// Two narrow predicates reimplemented over soltype (the rest of
-// internal/liveness ports verbatim).
-func isMutableType(t Type) bool {
-    if r, ok := t.(*RefType); ok {
-        return r.mut
+// resolvePath resolves an ident/member/index chain to Value | Namespace (a name
+// is never both — scope invariant). The object/index position tolerates a
+// namespace; every other value position rejects one — so
+// NamespaceUsedAsValueError moves OFF inferIdent to the value-position
+// consumer and fires once for both f(Foo) and f(A.B). Namespace lookup is a
+// direct, non-lexical read of the namespace's own maps (no parent walk).
+// Index keys must be statically constant strings.
+// New errors: UnknownNamespaceMemberError, DynamicNamespaceIndexError.
+func (c *checker) resolvePath(scope *Scope, e ast.Expr) pathResult
+```
+
+### Transition checking (`solver/transitions.go`, Phase G)
+
+```go
+// internal/liveness/ ports verbatim; only two predicates are reimplemented:
+func isMutableType(t soltype.Type) bool {
+    if r, ok := t.(*soltype.RefType); ok {
+        return r.Mut
     }
     return false
 }
-func isValueType(t Type) bool // ported from check_transitions.go:189-217
-
-// solver.Context gains the liveness fields the ported checker reads.
-type Context struct {
-    // ... existing M1–M3 fields (level, Probe, etc.)
-    Liveness *liveness.Liveness
-    Aliases  *liveness.AliasTracker
-}
+func isValueType(t soltype.Type) bool // from checker/check_transitions.go:189-217
+// solver.Context gains Liveness / Aliases, populated by the existing prepass.
+// G2: HasStaticMutAlias/HasStaticImmAlias collapse — query `lt <: 'static`
+// from the lifetime sort instead.
 ```
 
 ---
 
-## Revised PR breakdown (finer than the first cut)
+## PR breakdown
 
-The first draft of this plan used five PRs, two of them "large" (the `mut` gate
-and lifetimes lumped whole). For "the big one" that is too coarse to review
-well — the gate in particular deserves a PR where it is the *only* thing under
-review. The breakdown below is **13 PRs across 5 phases**, each independently
-mergeable, each keeping `go test ./...` green, each shipping its own
-table-driven tests (rendered types + **full** error messages, per CLAUDE.md).
-LoC figures are non-test estimates.
+17 PRs across 7 phases, each ~120–250 non-test LoC, independently mergeable and
+green, each with table-driven tests asserting rendered types and **full** error
+messages. The gate (C2) sits 3rd on the critical path.
 
-### Phase A — Records & tuples (carrier + exactness)
+### Phase A — Records & tuples completion (the M2 leftovers)
 
-- **A1 — Representation + literal inference + coalescing + printer** (~250).
-  `RecordType`/`TupleType` with the `exact` flag; smart constructors; `ObjectExpr`
-  ⇒ exact record, `TupleExpr` ⇒ exact tuple; positive-position coalescing
-  (covariant fields/elems); printer for `{x: T}`, `[T, U]`, trailing `...`.
-  *Mergeable alone:* infers and renders literals; no subtyping needed to test.
-- **A2 — Structural + exactness subtyping** (~200). `constrainRecords` /
-  `constrainTuples` with the one-way exact/inexact rule (width subtyping only
-  inexact↔inexact; exact↔exact same-set; extra-member rejection). *Builds on A1;
-  first PR that accepts/rejects against annotations.*
+- **A1 — `Inexact` flag + record exactness rules + the selection split**
+  (~200). Add `Inexact` to `RecordType`; rewrite the record constrain arm per
+  the sketch (one-way rule; new `InexactIntoExactError`/`ExtraPropertyError`);
+  flip `inferMember`'s requirement to `Inexact: true`; printer `...`. The M2
+  arm's "this is NOT the final semantics" comment is retired here.
+- **A2 — Tuple inexactness + tuple spread** (~150). `TupleType.Inexact`; the
+  `longer <: shorter`-vs-inexact arm (narrowing `TupleLengthMismatchError`'s
+  firing conditions per its own M4 note); tuple-typed spread in tuple literals
+  (the `infer_obj_test` "Tuple/array spread is M4" stub); the computed/numeric
+  object-key story (static-string keys resolve; dynamic keys get a typed
+  error, full support rides M9 index types).
+- **A3 — Record/tuple type annotations** (~180). Extend `resolveTypeAnn`:
+  object/tuple annotations incl. trailing `...`; `mut`/lifetime annotation
+  forms parse to `RefType` (consumed from C1 on — until then a `mut` annotation
+  reports unsupported, preserving today's behavior). Unblocks every
+  annotation-side acceptance test.
 
-### Phase B — Usage-based inference
+### Phase B — Usage-based inference refinement
 
-- **B1 — Member-read usage inference + negative-position record coalescing**
-  (~250). `MemberExpr` read ⇒ `constrain(recv <: {field: β, ...})`; merge object
-  upper-bounds into one record at coalescing; close to **exact** (Policy A).
-  Replaces `Open`/`Widenable`/`ArrayConstraint` (re-express representative
-  old-checker cases as intended-form tests).
-- **B2 — The `open` parameter marker** (~120). Parser keyword (provisional) +
-  semantic flag that keeps a usage-inferred param **inexact**. *Small, isolated;
-  the surface syntax can be gated if the spelling is unsettled.*
+- **B1 — Negative-position record merging + Policy-A closing** (~180). The
+  spike's `mergeObjects` brought to production coalesce: record upper bounds
+  in an intersection merge into one record (`{a: β} & {b: γ}` ⇒ `{a: β, b:
+  γ}`); the usage-collected shape **closes to exact** at display time (Policy
+  A, spec §8.1). Mut-record merging is added by C3.
+- **B2 — The `open` parameter marker** (~120). Parser marker + keep-inexact
+  flag on the closed shape. Spelling gated; semantics are what M4 proves.
+- **B3 — `var` literal widening** (~150). The principled usage-based form from
+  the milestone: a `var`'s type is informed by all assignment sites via
+  `widen` + the same coalescing; `val` stays a literal singleton. Retires
+  PR8's documented `var a = 5; a = 6` failure.
 
 ### Phase C — Borrows & mutability (**the gate**)
 
-- **C1 — `RefType` plumbing** (~200). The wrapper type, `RefInner` sealed marker,
-  `borrowableType`, `NewRef` smart constructor (degenerate-cell invariant),
-  `unwrapRef`/`carrierOf`, printer. **No constrain rule yet.** *Pure plumbing +
-  unit tests on the constructor/marker/printer; trivially green.*
-- **C2 — The `RefType` constrain rule** (~180). **← THE GATE.** The single rule:
-  mutability compatibility, mut-driven bidirectional inner sweep (read/write
-  decomposition), lifetime steps written but inert (`lt == nil`), and the two
-  cross-cases. *Scoped so the gate is the only thing under review.* Acceptance:
-  `mut {x,y} <: mut {x}` **fails** while immutable `{x,y} <: {x}` succeeds;
-  mut-borrow decay (`mut {x} <: {x}`) allowed, reverse rejected.
-  **If this can't be encoded cleanly against the real AST, stop and reassess
-  before Phase D/E** (the milestone's instruction).
-- **C3 — Field-write inference + read-after-write** (~180). `obj.x = v` ⇒ a `mut`
-  record requirement (lifetime nil for now); literal widening; multi-write merge;
-  read-after-write field collapse. Acceptance: `fn foo(obj){obj.x=5; obj.y=10}`
-  ⇒ `(obj: mut {x: number, y: number}) -> unit`; `{obj.x=5; return obj.x}` ⇒
-  `... -> number`.
+- **C1 — `RefType` plumbing** (~220). The node, `RefInner` (PromiseType/
+  FuncType/prims excluded), `borrowableType`, `NewRef`, `unwrapRef`/
+  `carrierOf`; visitor `Accept` (read-view polarity, cache-shared);
+  `LevelOf`/`equalType`/`Print` arms. **No constrain rule yet** — trivially
+  green.
+- **C2 — The `RefType` constrain rule** (~180). **← THE GATE.** The single rule
+  per the sketch, lifetime steps inert; the two cross-cases (struct-literal
+  construction in `bare <: RefType` — *not* `NewRef`). Acceptance: `mut {x,y}
+  <: mut {x}` **fails** while `{x,y} <: {x}` width-succeeds (inexact);
+  mut-decay allowed, reverse rejected; full messages. **Stop and reassess
+  before any later phase if this does not encode cleanly.**
+- **C3 — Field-write inference + read-after-write** (~200). Replace
+  `inferAssign`'s member-branch stub per the sketch (`Lt: nil`); `widen` on
+  write; multi-write merge (mut-record case of B1's merge); the `written`
+  read-after-write map on the checker. Acceptance: `fn foo(obj) { obj.x = 5;
+  obj.y = 10 }` ⇒ `(obj: mut {x: number, y: number}) -> unit`; write-then-read
+  ⇒ `number`.
 
 ### Phase D — Lifetimes (second sort)
 
-- **D1 — Lifetime sort plumbing** (~220). `LifetimeVar`/`StaticLifetime`/
-  `LifetimeUnion`, `constrainLt`, printer. *Standalone second-sort machinery +
-  unit tests on `constrainLt` (outlives, transitivity, cycles, `'static` top).*
-- **D2 — Activate lifetimes in the `RefType` rule + borrow origination** (~150).
-  Turn on step 3 of the gate rule and the escape guards; `attachParamLifetimes`.
-  Acceptance: `IdentityRefReturn` ⇒ `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x:
-  number}`; `FreshObjectReturn` carries no lifetime.
-- **D3 — Multi-source unioning + escape-to-`'static`** (~140). Join branch
-  lifetimes via a fresh join var; escape ⇒ `constrain(lt <: 'static)`. Acceptance:
-  `ConditionalUnionReturn` ⇒ `mut ('a | 'b) {x}`; `EscapingRefIntoStatic` ⇒
-  `mut 'static`.
-- **D4 — Lifetime coalescing + elision** (~200). `analyzeLts` occurrence pass;
-  drop a param-only lifetime that connects nothing; the **mut elide-in-place vs
-  immutable drop-the-wrapper** branch (the subtle one — isolated on purpose).
-  Acceptance: property-level / tuple-per-slot lifetimes; `RefType` passes the
-  inner carrier's `exact` flag through unchanged.
+- **D1 — Lifetime sort + probe extension** (~220). `LifetimeVar`/
+  `StaticLifetime`; `constrainLt` with journal-gated appends
+  (`addLowerLtBound`/`addUpperLtBound`); the probe's entry widened to
+  `Bounded` so both sorts roll back through one journal; lifetime printing.
+- **D2 — Activate the rule + borrow origination** (~160). Turn on step 3 and
+  the escape guards; `attachParamLifetimes`; **flip C3's write-requirement
+  lifetime from `nil` to a fresh var** and re-run C3's acceptance (borrowed
+  receivers now accepted). Acceptance: `IdentityRefReturn` ⇒ `fn <'a>(p: mut
+  'a {x: number}) -> mut 'a {x: number}`; `FreshObjectReturn` lifetime-free.
+- **D3 — Joins + escape** (~140). Multi-source returns union lifetimes via a
+  fresh join var (riding the M3 return-point join); escape to module/static
+  storage ⇒ `constrainLt(lt, 'static)`. Acceptance: `ConditionalUnionReturn` ⇒
+  `mut ('a | 'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`.
+- **D4 — Display-time coalescing + elision** (~200). `analyzeLts` occurrence
+  pass over scheme rendering; param-lifetime naming + `fn <'a>(…)` quantifier;
+  elision with the **mut elide-in-place vs immutable drop-the-wrapper**
+  branch; `RefType` passes the inner's `Inexact` through untouched (spec
+  §7.11). Property-level and tuple-per-slot lifetime acceptance.
 
-### Phase E — Mutability-transition checking (port)
+### Phase E — Destructuring + `match`
 
-- **E1 — Port liveness + predicates + wiring** (~220). Reuse `internal/liveness/`
-  verbatim and `liveness_prepass.go`; reimplement `isValueType`/`isMutableType`
-  over `soltype`; `checkMutabilityTransition` logic unchanged; add `Liveness`/
-  `Aliases` to `Context`. Port the old transition fixtures as intended-form tests.
-- **E2 — Collapse the static-alias escape hatches** (~120). Drop
-  `HasStaticMutAlias`/`HasStaticImmAlias`; the transition checker queries the
-  lifetime sort (`lt <: 'static`) directly. *Depends on Phase D, hence last; the
-  only genuinely new logic in the port.*
+- **E1 — Structural patterns** (~220). `TuplePat`/`RecordPat`/literal-pattern
+  `Pat` concretes (soltype's `Pat` reserved exactly this growth); binding
+  destructuring in `val` and params, dispatched through the member-lookup
+  constraint path (`constrain(scrutinee <: {x: β, …})`), not subtyping —
+  missing field / wrong arity reject. Patterns peel `RefType` via `carrierOf`
+  (works on owned values before Phase D completes).
+- **E2 — The `match` expression** (~220). The expression form over structural
+  patterns; arm binding + per-arm typing joined via the M3 return-point-join
+  machinery; exhaustiveness from exactness — an exact record/tuple scrutinee
+  with a complete pattern set needs no catch-all, an inexact one does.
+  Constructor/enum patterns are M5; union scrutinee exhaustiveness is M6.
+
+### Phase F — Namespace member lookup (parallel track)
+
+- **F1 — `resolvePath` + namespace access** (~180). Per the sketch: `Foo.bar`,
+  constant-keyed `Foo["x"]`; `NamespaceUsedAsValueError` moves off
+  `inferIdent` to the value-position consumer (its existing M4 note);
+  `UnknownNamespaceMemberError`, `DynamicNamespaceIndexError`. Depends only on
+  M2's `Namespace` — can land any time, parallel to every other phase.
+
+### Phase G — Mutability-transition checking (port)
+
+- **G1 — Port liveness + predicates + wiring** (~220). `internal/liveness/`
+  verbatim; `isValueType`/`isMutableType` over `soltype`;
+  `checkMutabilityTransition` rule logic unchanged; `Liveness`/`Aliases` on
+  the solver context; old transition cases as intended-form tests.
+- **G2 — Collapse the static-alias escape hatches** (~120). Drop
+  `HasStaticMutAlias`/`HasStaticImmAlias`; query the lifetime sort
+  (`lt <: 'static`) directly. Depends on D3 — the one genuinely new logic in
+  the port.
 
 ### Dependency graph
 
 ```
-A1 → A2 → B1 → B2
-            └─→ C1 → C2(GATE) → C3 → D1 → D2 → D3 → D4 → E1 → E2
+A1 → A2
+A1 → A3 ──────────────┐
+A1 → B1 → B2          │ (annotation-side acceptance tests)
+     B1 → B3          │
+A1 → C1 → C2(GATE) → C3 → D1 → D2 → D3 → D4 → G1 → G2
+A1 → E1 → E2   (independent of C/D; E1's RefType peel activates once C1 lands)
+F1             (independent; any time)
 ```
 
-A1→A2 (subtyping needs the carrier); B1 needs A's coalescing; C2 needs C1's
-wrapper; C3/Phase D ride on the gate; E2 needs Phase D's escape-as-`'static`.
-A and the test scaffolding for B can be drafted in parallel, but merge order is
-strict. The gate (C2) is reached after only the minimum needed to exercise it
-against the real AST, and nothing expensive (lifetimes, the port) is built before
-it is cleared.
-
-Total ≈ 2.4k LoC non-test across 13 PRs — a realistic shape for "the big one,"
-with the single highest-risk change (C2) isolated to ~180 reviewable lines.
-
----
+Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel
+tracks off A1; nothing downstream of the gate starts before C2 clears. Total
+≈ 3.0k non-test LoC across 17 PRs, with the single highest-risk change (C2)
+isolated to ~180 reviewable lines.
 
 ## Testing strategy
 
-Per [02-design-notes.md](02-design-notes.md) §"Test coverage" and CLAUDE.md:
-table-driven `*_test.go` keyed by name, with `expectedValues`/`expectedTypes`
-(rendered Escalier annotations) and `expectedError` (**full** message), authored
-against intended semantics — not copied from the old checker. Use inline snapshots
-for large type trees (nested borrowed records with per-field lifetimes). Each PR
-carries the acceptance set named in its section; the union is the milestone's M4
-criteria. No fixture-harness wiring yet (that's M7); M4 is validated entirely by
-the new package's own tests driven from real `.esc` source through the M2 bridge.
+Per the shipped test conventions (e.g.
+[infer_obj_test.go](../../internal/solver/infer_obj_test.go),
+[infer_func_test.go](../../internal/solver/infer_func_test.go)): table-driven
+tests keyed by name over real parsed source where the walk supports it,
+asserting rendered types (`render`/`PrintAsScheme` output) and **full** error
+messages via the typed `SolverError`s — authored against intended semantics,
+not old-checker output. Blame-span assertions follow the M2.5 pattern
+(`blame_test.go`). Inline snapshots for large trees (nested borrowed records
+with per-field lifetimes). Each PR carries the acceptance set named above; the
+union is the milestone's M4 acceptance. No fixture harness yet (M8).
 
 ## Risks / open questions
 
-- **The gate (C2)** is the dominant risk and is front-loaded with an explicit
-  stop-and-reassess. The spike de-risked the *algorithm*; residual risk is
-  encoding it cleanly against the production AST/`soltype`.
-- **Elision branching on `mut` (D4)** is the subtlest non-gate piece — the
-  immutable-borrow-must-drop-the-wrapper rule, if missed, reintroduces the
-  forbidden degenerate cell. The `NewRef` assertion is the backstop.
-- **`open` keyword (B2)** is provisional; gate the spelling, keep the semantic
-  flag — the inference behavior is what M4 must prove.
-- **Probe usage**: M4's core path is monotone (no rollback needed for failed
-  constraints), but the field-write merge and any future union-against-variable
-  deferral should be written probe-aware so M6/M8 speculation composes.
-- **Exact-by-default spec**: the Policy-A default and the `open` opt-out are **not
-  yet in `planning/exact-types/requirements.md`** — that section should be written
-  before B1 lands so the tests assert an agreed default.
+- **The gate (C2)** remains the dominant risk, front-loaded with an explicit
+  stop-and-reassess. The spike proved the algorithm; the residual risk is the
+  production encoding (visitor, journal-gated bounds, blame spans).
+- **Probe × lifetimes (D1).** Widening the journal to `Bounded` touches M3's
+  speculation infrastructure used by overload resolution — the "appends only
+  through journaling helpers" invariant must hold for the new sort from day
+  one, or a discarded overload trial could leak lifetime bounds.
+- **Elision branching on `Mut` (D4)**: the immutable-elide case **must** drop
+  the wrapper or it reconstructs the forbidden degenerate cell; `NewRef`'s
+  invariant (plus a printer assertion) is the backstop.
+- **Deferred overload resolution (#723).** M4's record types make the
+  documented first-match fallback *observable* on object-typed arguments
+  (today it only over-narrows function-typed ones). The real fix is scoped
+  M4/M5; if object-arg overload tests start failing on arm choice rather than
+  typing, that is #723, not a regression in these PRs.
+- **Rest-param element checking** (`FuncParam.Rest`'s "needs Array types and is
+  M4" note, #677 §4.2.3) — **needs an owner decision**: Array types are not
+  otherwise in M4's milestone scope. Recommendation: keep arity-only in M4 and
+  move element checking to wherever Array lands (M7 TypeRef ingestion),
+  updating the type.go comment.
+- **Function-arm Variation-B gap** (constrain.go's KNOWN GAP): unchecked extra
+  positions against an inexact callback need the `_ <: unknown` (⊤) rule slated
+  for M6. A3 does **not** add function annotations, so the gap stays
+  unreachable through M4 — but if function annotations slip in, the ⊤ rule must
+  come with them.
+- **`match` over borrowed scrutinees**: E2's structural exhaustiveness is
+  defined on the carrier; the `RefType` peel must not consult `Mut`/`Lt` for
+  completeness. Cheap to test once D-phase types exist; called out so E2
+  doesn't silently bake in owned-only assumptions.

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -317,41 +317,17 @@ func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 
 // Probe today holds the CONCRETE *soltype.TypeVarType and truncates its exported
-// bound fields inline on discard (probe.go's probeEntry.v is *TypeVarType, not an
-// interface). The 02-design-notes "probe-API sketches" proposed a `Bounded`
-// interface with UNEXPORTED methods — but probe.go:45-52 records that this was
-// tried and REJECTED: Go won't let `solver` attach the unexported boundLengths/
-// truncateBounds to a `soltype` type, and an interface in `solver` over unexported
-// methods is unsatisfiable by a `soltype` type across the package boundary. M3 had
-// one bounded sort, so it kept the concrete entry.
+// bound fields inline on discard (probe.go's probeEntry.v is *TypeVarType). M3 had
+// one bounded sort, so it kept the concrete entry rather than abstracting over
+// "things with bound lists".
 //
-// M4 adds a SECOND bounded sort (LifetimeVar), which is the trigger probe.go's
-// comment names ("if a second bounded type appears, reintroduce the interface with
-// EXPORTED methods on the soltype types"). So the correct M4 move is the EXPORTED
-// form:
-//
-//   // package soltype — exported, so cross-package satisfaction works:
-//   func (v *TypeVarType) BoundLengths() (int, int)
-//   func (v *TypeVarType) TruncateBounds(lower, upper int)
-//   func (v *LifetimeVar) BoundLengths() (int, int)
-//   func (v *LifetimeVar) TruncateBounds(lower, upper int)
-//
-//   // package solver:
-//   type Bounded interface {
-//       BoundLengths() (lower, upper int)
-//       TruncateBounds(lower, upper int)
-//   }
-//   // probeEntry.v becomes Bounded; *TypeVarType and *LifetimeVar both satisfy it.
-//
-// COST (eyes-open): exporting TruncateBounds publishes a speculation-only "rewind
-// my bounds to a checkpoint" verb on soltype's public surface, callable from any
-// importer with no probe checkpoint — a silent-corruption footgun (a stray
-// `v.TruncateBounds(0, 0)` drops solved bounds, surfacing later as a wrong
-// coalesced type, not a panic). Mitigation: a doc comment on the exported methods
-// ("speculation-internal; call only through Probe"). The alternative — duplicating
-// the inline truncate per sort, no interface — keeps the surface clean at the cost
-// of two near-identical discard paths; pick the interface only once the second
-// sort makes the duplication real.
+// M4 adds a SECOND bounded sort (LifetimeVar). RESOLVED: the probe stays concrete.
+// It gains a parallel journal for LifetimeVar — a second probeEntry kind keyed by
+// *soltype.LifetimeVar, with the same length-snapshot + truncate-on-discard
+// discipline as the *TypeVarType path. This keeps soltype's public surface clean:
+// no speculation-only truncate verb exported on the soltype types, and no
+// cross-package abstraction. The cost is two near-identical discard paths, which is
+// cheap and contained.
 ```
 
 ### Field write + read-after-write (`solver/infer_expr.go`)
@@ -485,41 +461,48 @@ these arms it must add.
   - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
     `solver/constrain.go`, `solver/infer_expr.go`, `solver/errors.go`,
     `solver/coalesce.go`.
-  - **Structures:** add `Inexact bool` to `RecordType` (zero value = exact, the
-    `FuncType.Inexact` convention — every record M2 mints stays exact with no
-    construction churn). `visitor.go`'s `RecordType.Accept` must carry the flag
-    on rebuild: `out = &RecordType{Fields: fields, Inexact: cur.Inexact}` (today
-    line 123 drops it — a latent bug the new field exposes). `equalType`'s
-    `RecordType` arm gains `a.Inexact != b.Inexact` as a discriminator (mirrors
-    the `FuncType` arm's `a.Inexact != b.Inexact` at coalesce.go:315).
-    `print.go` appends a trailing `...` entry in the record case when `Inexact`
-    (mirroring `printFuncTail`'s `if t.Inexact { ps = append(ps, "...") }`).
+  - **Structures:**
+    - add `Inexact bool` to `RecordType` (zero value = exact, the
+      `FuncType.Inexact` convention — every record M2 mints stays exact with no
+      construction churn).
+    - `visitor.go`'s `RecordType.Accept` must carry the flag on rebuild:
+      `out = &RecordType{Fields: fields, Inexact: cur.Inexact}` (today line 123
+      drops it — a latent bug the new field exposes).
+    - `equalType`'s `RecordType` arm gains `a.Inexact != b.Inexact` as a
+      discriminator (mirrors the `FuncType` arm's `a.Inexact != b.Inexact` at
+      coalesce.go:315).
+    - `print.go` appends a trailing `...` entry in the record case when `Inexact`
+      (mirroring `printFuncTail`'s `if t.Inexact { ps = append(ps, "...") }`).
   - **Algorithm — the record constrain arm** (constrain.go:181, replacing the
-    "this is NOT the final semantics" body): keep the per-field covariant loop
-    (depth subtyping), then add the one-way exactness gate — when `!r.Inexact`,
-    reject `l.Inexact` (an `InexactIntoExactError`) and reject any field on `l`
-    absent from `r` (`ExtraPropertyError` per extra field). When `r.Inexact`,
-    the existing width-tolerant loop is complete and unchanged.
+    "this is NOT the final semantics" body):
+    - keep the per-field covariant loop (depth subtyping)
+    - then add the one-way exactness gate: when `!r.Inexact`, reject `l.Inexact`
+      (an `InexactIntoExactError`) and reject any field on `l` absent from `r`
+      (`ExtraPropertyError` per extra field)
+    - when `r.Inexact`, the existing width-tolerant loop is complete and unchanged
   - **Algorithm — selection vs concrete:** flip `inferMember`'s synthesized
     requirement (infer_expr.go:716) to `Inexact: true` so member access stays
     "has at least this field," now expressed *as inexactness* rather than as an
     unconditionally width-tolerant arm. This is the split the milestone calls
     for: the same `RecordType <: RecordType` rule serves both selection (RHS
     inexact) and concrete subtyping (RHS exact).
-  - **Errors:** new `InexactIntoExactError{LHS, RHS *soltype.RecordType}` and
-    `ExtraPropertyError{LHS, RHS *soltype.RecordType; Name string; prov; site}`
-    — same field/blame shape as `MissingPropertyError` (errors.go:97).
-  - **Accept:** exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds; inexact `<:`
-    exact and extra-member-on-exact reject (full messages); existing
-    member-access tests stay green (selection is now the inexact path).
+  - **Errors:** new, same field/blame shape as `MissingPropertyError`
+    (errors.go:97):
+    - `InexactIntoExactError{LHS, RHS *soltype.RecordType}`
+    - `ExtraPropertyError{LHS, RHS *soltype.RecordType; Name string; prov; site}`
+  - **Accept:**
+    - exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds
+    - inexact `<:` exact and extra-member-on-exact reject (full messages)
+    - existing member-access tests stay green (selection is now the inexact path)
 
 - **A2 — Tuple inexactness + tuple spread + computed-key story** (~170).
   - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
     `solver/constrain.go`, `solver/coalesce.go`, `solver/infer_expr.go`.
-  - **Structures:** add `Inexact bool` to `TupleType`; thread it through
-    `TupleType.Accept` (visitor.go:109 — `&TupleType{Elems: elems, Inexact:
-    cur.Inexact}`), `equalType`'s tuple arm, and `printType`'s tuple case (a
-    trailing `, ...`).
+  - **Structures:** add `Inexact bool` to `TupleType` and thread it through:
+    - `TupleType.Accept` (visitor.go:109 — `&TupleType{Elems: elems, Inexact:
+      cur.Inexact}`)
+    - `equalType`'s tuple arm
+    - `printType`'s tuple case (a trailing `, ...`)
   - **Algorithm — tuple constrain arm** (constrain.go:162): replace the strict
     `len(l.Elems) != len(r.Elems)` reject with the exactness-aware rule — when
     `r` is exact, lengths must match; when `r` is inexact, `len(l) >= len(r)`
@@ -528,36 +511,44 @@ these arms it must add.
     conditions (its errors.go:66 note anticipates this).
   - **Algorithm — tuple spread:** in the tuple-literal walk, handle
     `ast.ArraySpreadExpr` (today `reportUnsupported` → `ErrorType` slot, see
-    `infer_obj_test.go:31` "Tuple/array spread is M4"): infer the spread
-    operand, require it to be a `TupleType`, and splice its element types into
-    the literal's `Elems`. A non-tuple spread operand is a typed error.
+    `infer_obj_test.go:31` "Tuple/array spread is M4"):
+    - infer the spread operand
+    - require it to be a `TupleType`
+    - splice its element types into the literal's `Elems`
+
+    A non-tuple spread operand is a typed error.
   - **Algorithm — object computed/numeric keys** (inferObject, infer_expr.go:660
     `objKeyName` fail path): a statically-constant string/numeric key resolves
     to a field name; a genuinely dynamic key (`{[k]: v}`) stays a typed error
     (full index-signature support rides M9 index types). Keep the last-wins
     dedup invariant.
-  - **Accept:** `[1, 2]` `<:` `[number, ...]` succeeds, `<:` `[number]` rejects;
-    a spread `[...pair, 3]` builds the spliced tuple; a constant numeric key
-    resolves, a dynamic key errors.
+  - **Accept:**
+    - `[1, 2]` `<:` `[number, ...]` succeeds, `<:` `[number]` rejects
+    - a spread `[...pair, 3]` builds the spliced tuple
+    - a constant numeric key resolves, a dynamic key errors
 
 - **A3 — Record/tuple/`mut`/lifetime type annotations** (~180).
   - **Files:** `solver/type_ann.go`, plus tests.
   - **Algorithm — extend `resolveTypeAnn`** (type_ann.go:21, today
-    primitives + `Promise<T>` only): add arms for object-type and tuple-type
-    annotations (building `RecordType`/`TupleType`, honoring a trailing `...`
-    ⇒ `Inexact: true`), and for the `mut`/lifetime annotation forms, which lower
-    to `RefType` (`mut T` ⇒ `RefType{Mut: true}`, `'a T` ⇒ `RefType{Mut: false,
-    Lt: …}`). **Ordering caveat:** `RefType` does not exist until C1, so A3
-    lands the record/tuple annotation arms now and gates the `mut`/lifetime arms
-    behind C1 (until then a `mut`/`'a` annotation keeps today's
-    `reportUnsupportedFeature` + recovery-var behavior). Track the gated arms as
-    a one-line follow-up in C1's checklist.
+    primitives + `Promise<T>` only):
+    - add arms for object-type and tuple-type annotations (building
+      `RecordType`/`TupleType`, honoring a trailing `...` ⇒ `Inexact: true`)
+    - add arms for the `mut`/lifetime annotation forms, which lower to `RefType`
+      (`mut T` ⇒ `RefType{Mut: true}`, `'a T` ⇒ `RefType{Mut: false, Lt: …}`)
+
+    **Ordering caveat:** `RefType` does not exist until C1, so A3 lands the
+    record/tuple annotation arms now and gates the `mut`/lifetime arms behind C1
+    (until then a `mut`/`'a` annotation keeps today's `reportUnsupportedFeature`
+    + recovery-var behavior). Track the gated arms as a one-line follow-up in
+    C1's checklist.
   - **Why first-ish:** every annotation-side acceptance test in Phase A/B/D
     (`var p: {x, y, ...} = …`, `fn f(p: mut {x: number}) …`) needs this; it is
     a leaf with no dependency on the constraint changes.
-  - **Accept:** `val r: {x: number, ...} = {x: 1, y: 2}` checks (inexact target
-    admits the extra field); `val r: {x: number} = {x: 1, y: 2}` rejects (exact
-    target); tuple annotations round-trip through the printer.
+  - **Accept:**
+    - `val r: {x: number, ...} = {x: 1, y: 2}` checks (inexact target admits the
+      extra field)
+    - `val r: {x: number} = {x: 1, y: 2}` rejects (exact target)
+    - tuple annotations round-trip through the printer
 
 ### Phase B — Usage-based inference refinement
 
@@ -593,9 +584,10 @@ these arms it must add.
   - **Algorithm:** when a param is marked `open`, B1's Policy-A close leaves its
     usage record `Inexact: true` (row-polymorphic) so callers may pass richer
     records. Everything else is unchanged.
-  - **Accept:** `fn dist(open p) { p.x; p.y }` renders an inexact `{x, y, ...}`
-    param; an un-`open` peer renders exact `{x, y}`; passing `{x, y, z}` to the
-    `open` one checks, to the closed one rejects.
+  - **Accept:**
+    - `fn dist(open p) { p.x; p.y }` renders an inexact `{x, y, ...}` param
+    - an un-`open` peer renders exact `{x, y}`
+    - passing `{x, y, z}` to the `open` one checks, to the closed one rejects
 
 - **B3 — `var` literal widening (authors `widen`)** (~150).
   - **Files:** `solver/constrain.go` or a new `solver/widen.go` (the helper),
@@ -613,9 +605,10 @@ these arms it must add.
     (infer_expr.go:532 note). Reassignment's RHS-vs-binding constrain
     (inferAssign, infer_expr.go:540s) now checks against the widened binding
     type.
-  - **Accept:** `var a = 5; a = 6` checks (binding is `number`);
-    `val a = 5; a = 6` still rejects (`CannotAssignToImmutableError`);
-    `var a = 5` with no reassignment still renders `number` (default-widen).
+  - **Accept:**
+    - `var a = 5; a = 6` checks (binding is `number`)
+    - `val a = 5; a = 6` still rejects (`CannotAssignToImmutableError`)
+    - `var a = 5` with no reassignment still renders `number` (default-widen)
 
 ### Phase C — Borrows & mutability (**the gate**)
 
@@ -623,20 +616,24 @@ these arms it must add.
   - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
     `solver/coalesce.go` (`equalType`), `solver/type_ann.go` (un-gate A3's
     `mut`/lifetime arms), plus a new `soltype/ref.go` for the helpers.
-  - **Structures:** add `RefType{Mut bool; Lt Lifetime; Inner RefInner}` and the
-    sealed `RefInner interface { Type; isRefInner() }` with
-    `isRefInner` on `RecordType`/`TupleType`/`TypeVarType` (and forward-declared
-    for `UnionType`/`IntersectionType`/`AliasType`/`ClassType`). `Lifetime` is a
-    placeholder interface here (`type Lifetime interface{ isLifetime() }` with no
-    concretes yet — D1 adds them); C1 only ever sets `Lt: nil`.
+  - **Structures:**
+    - add `RefType{Mut bool; Lt Lifetime; Inner RefInner}`
+    - the sealed `RefInner interface { Type; isRefInner() }`, with `isRefInner`
+      on `RecordType`/`TupleType`/`TypeVarType` (and forward-declared for
+      `UnionType`/`IntersectionType`/`AliasType`/`ClassType`)
+    - `Lifetime` is a placeholder interface here (`type Lifetime interface{
+      isLifetime() }` with no concretes yet — D1 adds them); C1 only ever sets
+      `Lt: nil`
   - **Structures — full type-set checklist (the standing rule):**
-    `isType()` on `*RefType`; `LevelOf` arm (`case *RefType: return
-    LevelOf(t.Inner)` — `Inner` is `RefInner` which embeds `Type`, so this
-    typechecks); `RefType.Accept` (see below); `printType` arm (`mut {…}`,
-    `mut Point`; immutable-borrow/lifetime forms render once D1 adds lifetime
-    printing — until then `Lt` is always nil); `equalType` arm
-    (`a.Mut == b.Mut && equalType(a.Inner, b.Inner)` — lifetime equality joins
-    in D1); `freeTypeVars` descends `Inner`.
+    - `isType()` on `*RefType`
+    - `LevelOf` arm (`case *RefType: return LevelOf(t.Inner)` — `Inner` is
+      `RefInner` which embeds `Type`, so this typechecks)
+    - `RefType.Accept` (see below)
+    - `printType` arm (`mut {…}`, `mut Point`; immutable-borrow/lifetime forms
+      render once D1 adds lifetime printing — until then `Lt` is always nil)
+    - `equalType` arm (`a.Mut == b.Mut && equalType(a.Inner, b.Inner)` — lifetime
+      equality joins in D1)
+    - `freeTypeVars` descends `Inner`
   - **Algorithm — `RefType.Accept`:** the inner is visited **once in the current
     polarity** (the read view); the `Mut` write view shares fresh vars via the
     transform's own cache (exactly the spike's `extrude` treatment of `Mut` at
@@ -644,34 +641,44 @@ these arms it must add.
     rebuild only if `Inner` changed; carry `Mut`/`Lt` through unchanged. The
     lifetime is **not** a `Type`, so `Accept` never walks it — only the
     lifetime-aware passes (D4) do.
-  - **Helpers:** `NewRef(mut, lt, inner) Type` (collapses the degenerate
-    `(false, nil)` cell to bare `inner`); `unwrapRef(t) (inner, mut, lt)`;
-    `carrierOf(t) Type` (peel any `RefType`); `borrowableType(t) bool` (content
-    invariant behind a `TypeVarType` inner). **No constrain rule yet** —
-    trivially green; tests assert `NewRef` collapses the degenerate cell, the
-    printer renders `mut {x: number}`, and `RefType` round-trips `Accept`.
+  - **Helpers:**
+    - `NewRef(mut, lt, inner) Type` (collapses the degenerate `(false, nil)` cell
+      to bare `inner`)
+    - `unwrapRef(t) (inner, mut, lt)`
+    - `carrierOf(t) Type` (peel any `RefType`)
+    - `borrowableType(t) bool` (content invariant behind a `TypeVarType` inner)
+  - **Accept:** no constrain rule yet, so trivially green:
+    - `NewRef` collapses the degenerate cell
+    - the printer renders `mut {x: number}`
+    - `RefType` round-trips `Accept`
 
 - **C2 — The `RefType` constrain rule** (~180). **← THE GATE.**
   - **Files:** `solver/constrain.go`, `solver/errors.go`, plus tests.
   - **Algorithm — the single rule** (new `case *soltype.RefType` in the
-    structural switch, per the sketch above): (1) mutability compatibility
-    (`!l.Mut && r.Mut` ⇒ `MutabilityMismatchError`); (2) inner variance —
-    covariant read view always, plus a contravariant write view **iff `r.Mut`**
-    (the read/write decomposition = invariance); (3) lifetime step written but
-    **inert while `Lt == nil`** (the `switch` over `l.Lt`/`r.Lt` is dead code
-    until D2). Plus the two cross-cases: `RefType <: bare` (peel `l.Inner`, but
-    an escape-error guard for `l.Lt != nil` that can't fire yet); `bare <:
-    RefType` (wrap the source as `&soltype.RefType{Mut: false, Lt: nil, Inner:
-    inner}` via a struct literal — **not** `NewRef`, which would collapse it and
-    recurse forever — and re-dispatch).
-  - **Errors:** `MutabilityMismatchError{LHS, RHS *soltype.RefType}`,
-    `BorrowEscapeError{LHS, RHS}` (the latter's firing path is inert until D2).
-  - **Accept (the gate):** `mut {x, y} <: mut {x}` **fails** (invariance — the
-    write view's contravariant `{x} <: {x, y}` is missing a field) while
-    immutable `{x, y} <: {x}` width-**succeeds** (inexact RHS); mut-decay
-    `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected. Full
-    messages. **Stop and reassess before any later phase if this does not encode
-    cleanly against the real visitor/journal.**
+    structural switch, per the sketch above):
+    - (1) mutability compatibility — `!l.Mut && r.Mut` ⇒
+      `MutabilityMismatchError`
+    - (2) inner variance — covariant read view always, plus a contravariant write
+      view **iff `r.Mut`** (the read/write decomposition = invariance)
+    - (3) lifetime step written but **inert while `Lt == nil`** (the `switch` over
+      `l.Lt`/`r.Lt` is dead code until D2)
+    - cross-case `RefType <: bare` — peel `l.Inner`, with an escape-error guard
+      for `l.Lt != nil` that can't fire yet
+    - cross-case `bare <: RefType` — wrap the source as `&soltype.RefType{Mut:
+      false, Lt: nil, Inner: inner}` via a struct literal (**not** `NewRef`, which
+      would collapse it and recurse forever) and re-dispatch
+  - **Errors:**
+    - `MutabilityMismatchError{LHS, RHS *soltype.RefType}`
+    - `BorrowEscapeError{LHS, RHS}` (the latter's firing path is inert until D2)
+  - **Accept (the gate):**
+    - `mut {x, y} <: mut {x}` **fails** (invariance — the write view's
+      contravariant `{x} <: {x, y}` is missing a field) while immutable
+      `{x, y} <: {x}` width-**succeeds** (inexact RHS)
+    - mut-decay `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected
+    - full messages
+
+    **Stop and reassess before any later phase if this does not encode cleanly
+    against the real visitor/journal.**
 
 - **C3 — Field-write inference + read-after-write** (~200).
   - **Files:** `solver/infer_expr.go` (the `inferAssign` member branch),
@@ -683,9 +690,14 @@ these arms it must add.
     receiver var's field so a later read returns it.
   - **Algorithm — replace the member-target stub** (infer_expr.go:494-500, today
     `reportUnsupportedFeature("assignment to a member or index")`): implement
-    `inferMemberAssign` per the sketch — infer receiver + RHS, `widen` the RHS,
-    constrain `recv <: RefType{Mut: true, Lt: nil, Inner: {field: widen(rhs),
-    Inexact: true}}`, record `written[recvID,field]`, return the stored value.
+    `inferMemberAssign` per the sketch:
+    - infer receiver + RHS
+    - `widen` the RHS
+    - constrain `recv <: RefType{Mut: true, Lt: nil, Inner: {field: widen(rhs),
+      Inexact: true}}`
+    - record `written[recvID,field]`
+    - return the stored value
+
     Keep the `*ast.IndexExpr` sub-case as `reportUnsupportedFeature` (array
     writes need Array types — note it for M7).
   - **Algorithm — read-after-write:** `inferMember` (infer_expr.go:687) consults
@@ -695,19 +707,23 @@ these arms it must add.
     `RefType{Mut: true, Inner: RecordType}` case so multiple writes merge into
     one mutable record (`mut {x} & mut {y}` ⇒ `mut {x, y}`) — the spike's
     `mergeObjects` handled `Mut`-wrapped objects the same way.
-  - **Accept:** `fn foo(obj) { obj.x = 5; obj.y = 10 }` ⇒ `(obj: mut {x: number,
-    y: number}) -> unit`; `fn foo(obj) { obj.x = 5; return obj.x }` ⇒ `... ->
-    number`.
+  - **Accept:**
+    - `fn foo(obj) { obj.x = 5; obj.y = 10 }` ⇒ `(obj: mut {x: number, y: number})
+      -> unit`
+    - `fn foo(obj) { obj.x = 5; return obj.x }` ⇒ `... -> number`
 
 ### Phase D — Lifetimes (second sort)
 
 - **D1 — Lifetime sort + probe extension** (~230).
   - **Files:** new `soltype/lifetime.go`, `solver/context.go`,
     `solver/constrain.go`, `solver/probe.go`, `soltype/print.go`.
-  - **Structures:** `LifetimeVar{ID int; LowerBounds, UpperBounds []Lifetime}`
-    and `StaticLifetime{}` (top of the outlives lattice), both implementing
-    `isLifetime()`. `Context` grows `lifetimeCounter int` (its own comment at
-    context.go:5 names this deferred field) and a `freshLifetime()` minter.
+  - **Structures:**
+    - `LifetimeVar{ID int; LowerBounds, UpperBounds []Lifetime}`, implementing
+      `isLifetime()`
+    - `StaticLifetime{}` (top of the outlives lattice), implementing
+      `isLifetime()`
+    - `Context` grows `lifetimeCounter int` (its own comment at context.go:5
+      names this deferred field) and a `freshLifetime()` minter
   - **Algorithm — `constrainLt`** (ported from `simplesub/lifetime.go:61`):
     mirrors `constrain` over the outlives lattice — a var on the left gains an
     upper bound, on the right a lower bound, var-to-var records both;
@@ -715,21 +731,24 @@ these arms it must add.
     seen-set terminates cycles. Bound appends go **only** through new
     `addLowerLtBound`/`addUpperLtBound` helpers that journal before appending —
     the same discipline as `addLowerBound`/`addUpperBound` (context.go:36).
-  - **Algorithm — probe extension (the careful part):** reintroduce the
-    `Bounded` interface with **exported** methods (`BoundLengths() (int, int)`,
-    `TruncateBounds(lo, hi int)`) on **both** `*soltype.TypeVarType` and
-    `*soltype.LifetimeVar` — the path `probe.go:45-52` prescribes for "a second
-    bounded type." Change `probeEntry.v` from `*soltype.TypeVarType` to
-    `Bounded`, and `Probe.touched`/`record` accordingly. Document the exported
-    `TruncateBounds` as speculation-internal. Verify a discarded overload trial
-    that touched a lifetime var rolls it back (probe_test.go pattern).
-  - **Structures — printer:** lifetime printing in `print.go` — a named param
-    lifetime renders `'a`, `'static` renders `'static`; the `RefType` print arm
-    (added in C1 with `Lt` always nil) now renders `mut 'a T` / `'a T` when
-    `Lt != nil`.
-  - **Accept:** `constrainLt` unit tests (outlives, transitivity, cycle
-    termination, `'static` absorption); a probe discard truncates an appended
-    lifetime bound.
+  - **Algorithm — probe extension (the careful part):**
+    - extend the probe with a parallel concrete journal for
+      `*soltype.LifetimeVar` — a second `probeEntry` kind with the same
+      length-snapshot + truncate-on-discard discipline as the
+      `*soltype.TypeVarType` path; the probe stays concrete, so soltype keeps no
+      exported speculation-only truncate verb
+    - add the lifetime sort to `Probe.touched`/`record` accordingly
+    - verify a discarded overload trial that touched a lifetime var rolls it back
+      (probe_test.go pattern)
+  - **Structures — printer:** lifetime printing in `print.go`:
+    - a named param lifetime renders `'a`
+    - `'static` renders `'static`
+    - the `RefType` print arm (added in C1 with `Lt` always nil) now renders
+      `mut 'a T` / `'a T` when `Lt != nil`
+  - **Accept:**
+    - `constrainLt` unit tests (outlives, transitivity, cycle termination,
+      `'static` absorption)
+    - a probe discard truncates an appended lifetime bound
 
 - **D2 — Activate the rule + borrow origination** (~160).
   - **Files:** `solver/constrain.go` (un-inert the C2 lifetime step),
@@ -738,10 +757,11 @@ these arms it must add.
   - **Structures:** add `paramLifetimes set.Set[int]` to the checker (the
     nameable-lifetime set, ported from `simplesub`).
   - **Algorithm — activate the `RefType` rule's step 3** (C2's inert `switch`):
-    covariant lifetime when both present (`constrainLt(r.Lt, l.Lt)`); owned
-    source into a borrow slot ok; borrow into an owned slot ⇒ `BorrowEscapeError`
-    (now live). The `RefType <: bare` escape guard (`l.Lt != nil`) also goes
-    live.
+    - covariant lifetime when both present (`constrainLt(r.Lt, l.Lt)`)
+    - owned source into a borrow slot ok
+    - borrow into an owned slot ⇒ `BorrowEscapeError` (now live)
+
+    The `RefType <: bare` escape guard (`l.Lt != nil`) also goes live.
   - **Algorithm — `attachParamLifetimes`** (per the sketch): a `RefType`-typed
     param with `Lt == nil` gets a fresh lifetime var, recorded in
     `paramLifetimes`. Called when binding function params.
@@ -749,9 +769,10 @@ these arms it must add.
     `Lt: nil` becomes `Lt: c.freshLifetime()` so a mut-borrow receiver of any
     lifetime is accepted (the fresh var imposes no lifetime obligation). Re-run
     C3's acceptance — owned receivers still check, borrowed receivers now check.
-  - **Accept:** `IdentityRefReturn` (`fn (p: mut {x: number}) { return p }`) ⇒
-    `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`; `FreshObjectReturn`
-    (returning a fresh `mut {x: 1}`) carries no lifetime.
+  - **Accept:**
+    - `IdentityRefReturn` (`fn (p: mut {x: number}) { return p }`) ⇒ `fn <'a>(p:
+      mut 'a {x: number}) -> mut 'a {x: number}`
+    - `FreshObjectReturn` (returning a fresh `mut {x: 1}`) carries no lifetime
 
 - **D3 — Multi-source lifetime joins + escape-to-`'static`** (~150).
   - **Files:** `solver/infer_stmt.go` / wherever the M3 return-point join lives,
@@ -765,18 +786,20 @@ these arms it must add.
   - **Algorithm — escape:** a value flowing into module/static storage (a
     top-level binding, a global write) constrains its lifetime `<: 'static`
     (`constrainLt(lt, &StaticLifetime{})`), which coalesces to `'static`.
-  - **Accept:** `ConditionalUnionReturn` (return one of two mut borrows) ⇒
-    `mut ('a | 'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`.
+  - **Accept:**
+    - `ConditionalUnionReturn` (return one of two mut borrows) ⇒ `mut ('a | 'b)
+      {x: number}`
+    - `EscapingRefIntoStatic` ⇒ `mut 'static`
 
 - **D4 — Display-time lifetime coalescing + elision** (~200).
   - **Files:** new lifetime-occurrence logic alongside `solver/simplify.go` /
     `solver/coalesce.go`, `soltype/print.go` (the `<'a>` quantifier).
-  - **Structures:** an `analyzeLts` occurrence pass (ported from
-    `simplesub/lifetime.go`) recording, per lifetime var, the polarities it
-    occurs in — built to mirror `simplify.go`'s `symOccVisitor` but over the
-    lifetime sort. A `ltKeep`/naming map keyed by lifetime-var ID, threaded into
-    the scheme coalescer the way `schemeSimplification` is threaded today
-    (coalesce.go:120).
+  - **Structures:**
+    - an `analyzeLts` occurrence pass (ported from `simplesub/lifetime.go`)
+      recording, per lifetime var, the polarities it occurs in — built to mirror
+      `simplify.go`'s `symOccVisitor` but over the lifetime sort
+    - a `ltKeep`/naming map keyed by lifetime-var ID, threaded into the scheme
+      coalescer the way `schemeSimplification` is threaded today (coalesce.go:120)
   - **Algorithm — naming:** only param-originated lifetimes are named (`'a`,
     `'b`, … via a base-26 `alphaName`, per the spike); a join var renders as the
     union of the param lifetimes it reaches; `'static` absorbs. The `<'a>`
@@ -794,10 +817,12 @@ these arms it must add.
   - **Algorithm — exactness passthrough:** the `RefType` coalescing arm carries
     the inner carrier's `Inexact` flag through untouched (spec §7.11 — `mut`/
     lifetime axes are orthogonal to exactness).
-  - **Accept:** property-level lifetimes (`{p: mut 'a {…}}`) and tuple-per-slot
-    lifetimes render; a connect-nothing param lifetime elides (mut ⇒ owned-mut,
-    immut ⇒ wrapper dropped); read-after-write field collapse with a lifetime
-    present.
+  - **Accept:**
+    - property-level lifetimes (`{p: mut 'a {…}}`) and tuple-per-slot lifetimes
+      render
+    - a connect-nothing param lifetime elides (mut ⇒ owned-mut, immut ⇒ wrapper
+      dropped)
+    - read-after-write field collapse with a lifetime present
 
 ### Phase E — Destructuring + `match`
 
@@ -806,12 +831,14 @@ these arms it must add.
     (`paramName`/pattern rendering), `solver/infer_decl.go` (`varName` →
     general pattern binding), `solver/infer_expr.go` (param patterns), plus a
     pattern-typing helper.
-  - **Structures:** add `TuplePat{Elems []Pat}`, `RecordPat{Fields
-    []*RecordPatField}`, and literal patterns as `Pat` concretes (soltype's
-    `Pat` interface was reserved for exactly this — type.go's `Pat` comment).
-    `print.go`'s `paramName` (print.go:278) gains arms for the new pattern
-    shapes; `varName` (infer_decl.go:131, today IdentPat-only) generalizes to
-    return the full set of bound names.
+  - **Structures:**
+    - add `TuplePat{Elems []Pat}`, `RecordPat{Fields []*RecordPatField}`, and
+      literal patterns as `Pat` concretes (soltype's `Pat` interface was reserved
+      for exactly this — type.go's `Pat` comment)
+    - `print.go`'s `paramName` (print.go:278) gains arms for the new pattern
+      shapes
+    - `varName` (infer_decl.go:131, today IdentPat-only) generalizes to return the
+      full set of bound names
   - **Algorithm — pattern typing:** a pattern dispatches through the
     **member-lookup constraint path**, not subtyping: a `RecordPat{x, y}`
     against a scrutinee `s` emits `constrain(s <: {x: βx, y: βy, Inexact:
@@ -822,9 +849,11 @@ these arms it must add.
     peel any `RefType` via `carrierOf` before matching (works on owned values
     before Phase D; borrowed scrutinees once D lands). Used uniformly by `val`
     destructuring, function-param destructuring, and (E2) `match` arms.
-  - **Accept:** `val {x, y} = p` binds `x`/`y` at their field types and rejects a
-    missing field; `val [a, b] = t` binds per slot and rejects wrong arity; a
-    destructured param `fn (({x, y})) { … }` types the same way.
+  - **Accept:**
+    - `val {x, y} = p` binds `x`/`y` at their field types and rejects a missing
+      field
+    - `val [a, b] = t` binds per slot and rejects wrong arity
+    - a destructured param `fn (({x, y})) { … }` types the same way
 
 - **E2 — The `match` expression** (~220).
   - **Files:** `solver/infer_expr.go` (the `match` walk), reusing the M3
@@ -839,9 +868,10 @@ these arms it must add.
     Constructor/enum patterns and enum-exhaustive `match` are M5; union-scrutinee
     exhaustiveness is M6 — E2 lays the form and the structural-pattern path they
     both extend.
-  - **Accept:** a `match` over structural patterns binds and type-checks each
-    arm; an exact-record scrutinee with a complete pattern set needs no
-    catch-all, an inexact one does (full error on the missing catch-all).
+  - **Accept:**
+    - a `match` over structural patterns binds and type-checks each arm
+    - an exact-record scrutinee with a complete pattern set needs no catch-all, an
+      inexact one does (full error on the missing catch-all)
 
 ### Phase F — Namespace member lookup (parallel track)
 
@@ -850,8 +880,10 @@ these arms it must add.
     `solver/scope.go` (optional thin `LookupValue`/`LookupNamespace` wrappers
     over the `Namespace` maps — **new** if added; today `Namespace` is
     fields-only, scope.go:61), `solver/errors.go`.
-  - **Structures:** `pathResult` sum (`Value | Namespace`); new errors
-    `UnknownNamespaceMemberError`, `DynamicNamespaceIndexError`.
+  - **Structures:**
+    - `pathResult` sum (`Value | Namespace`)
+    - new error `UnknownNamespaceMemberError`
+    - new error `DynamicNamespaceIndexError`
   - **Algorithm — `resolvePath`** (per the sketch): resolve an ident/member/
     index chain to `Value | Namespace`. Namespace lookup is a **direct,
     non-lexical** read of `ns.Values[name]` / `ns.Nested[name]` (no parent walk,
@@ -864,9 +896,11 @@ these arms it must add.
     `DynamicNamespaceIndexError`.
   - **Dependency:** only M2's `Namespace` structure — lands any time, parallel
     to every other phase.
-  - **Accept:** `Foo.bar` resolves to the member's type; `Foo["weird-name"]`
-    resolves a constant-keyed member; `f(Foo)` and `f(A.B)` reject
-    (`NamespaceUsedAsValueError`); `Foo[k]` rejects (`DynamicNamespaceIndexError`).
+  - **Accept:**
+    - `Foo.bar` resolves to the member's type
+    - `Foo["weird-name"]` resolves a constant-keyed member
+    - `f(Foo)` and `f(A.B)` reject (`NamespaceUsedAsValueError`)
+    - `Foo[k]` rejects (`DynamicNamespaceIndexError`)
 
 ### Phase G — Mutability-transition checking (port)
 
@@ -887,11 +921,13 @@ these arms it must add.
 
 - **G2 — Collapse the static-alias escape hatches** (~120).
   - **Files:** `solver/transitions.go`.
-  - **Algorithm:** drop the `HasStaticMutAlias` / `HasStaticImmAlias` bits; where
-    the old code consulted them, query the lifetime sort directly — a value
-    whose lifetime is constrained `<: 'static` (D3's escape output) is the
-    first-class signal the bits approximated. This is the one genuinely new
-    logic in the port; it depends on D3.
+  - **Algorithm:**
+    - drop the `HasStaticMutAlias` / `HasStaticImmAlias` bits
+    - where the old code consulted them, query the lifetime sort directly — a
+      value whose lifetime is constrained `<: 'static` (D3's escape output) is the
+      first-class signal the bits approximated
+
+    This is the one genuinely new logic in the port; it depends on D3.
   - **Accept:** the static-escape transition cases pass via lifetime queries
     rather than the dropped bits.
 
@@ -928,37 +964,62 @@ not old-checker output. Blame-span assertions follow the M2.5 pattern
 with per-field lifetimes). Each PR carries the acceptance set named above; the
 union is the milestone's M4 acceptance. No fixture harness yet (M8).
 
-## Risks / open questions
+## Risks
 
 - **The gate (C2)** remains the dominant risk, front-loaded with an explicit
   stop-and-reassess. The spike proved the algorithm; the residual risk is the
   production encoding (visitor, journal-gated bounds, blame spans).
-- **Probe × lifetimes (D1).** Reintroducing the `Bounded` interface touches M3's
-  speculation infrastructure used by overload resolution. Two constraints:
-  (a) it must use **exported** methods on the soltype types — the unexported
-  form is unsatisfiable across the package boundary, which is why `probe.go`
-  shipped the concrete-type journal instead (probe.go:45-52); (b) the "appends
-  only through journaling helpers" invariant must hold for the new sort from day
-  one, or a discarded overload trial could leak lifetime bounds. The exported
-  `TruncateBounds` is a public-surface footgun — document it speculation-internal.
+- **Probe × lifetimes (D1).** Extending the probe to a second bounded sort touches
+  M3's speculation infrastructure used by overload resolution. The "appends only
+  through journaling helpers" invariant must hold for the new sort from day one, or
+  a discarded overload trial could leak lifetime bounds. Keeping the probe concrete
+  — a parallel `LifetimeVar` journal rather than an abstraction over both sorts —
+  avoids exporting a speculation-only truncate verb on soltype's public surface.
 - **Elision branching on `Mut` (D4)**: the immutable-elide case **must** drop
   the wrapper or it reconstructs the forbidden degenerate cell; `NewRef`'s
   invariant (plus a printer assertion) is the backstop.
+- **`match` over borrowed scrutinees**: E2's structural exhaustiveness is
+  defined on the carrier; the `RefType` peel must not consult `Mut`/`Lt` for
+  completeness. Cheap to test once D-phase types exist; called out so E2
+  doesn't silently bake in owned-only assumptions.
+
+## Open questions
+
 - **Deferred overload resolution (#723).** M4's record types make the
   documented first-match fallback *observable* on object-typed arguments
   (today it only over-narrows function-typed ones). The real fix is scoped
   M4/M5; if object-arg overload tests start failing on arm choice rather than
   typing, that is #723, not a regression in these PRs.
+  - **Decision (deferred to M5).** Keep resolution out of M4's scope. The
+    fallback to declaration order fires because `moreSpecific`/`structuralSubtype`
+    (overload.go) ranks record-shaped args as a tie. The principled fix is to
+    rank record args by field-set subsumption and exactness — a record covering
+    more required fields, or the exact one, dominates, the object analogue of the
+    existing arity/exactness ranking for functions. Land that in M5, where
+    classes first produce multi-arm object overloads. For M4, pin the observable
+    cases with a `#723`-tagged test group so any later arm-choice change is
+    intentional rather than a silent regression.
 - **Rest-param element checking** (`FuncParam.Rest`'s "needs Array types and is
-  M4" note, #677 §4.2.3) — **needs an owner decision**: Array types are not
-  otherwise in M4's milestone scope. Recommendation: keep arity-only in M4 and
-  move element checking to wherever Array lands (M7 TypeRef ingestion),
-  updating the type.go comment.
+  M4" note, #677 §4.2.3) — Array types are not otherwise in M4's milestone scope.
+  - **Decision (deferred to M7).** Keep arity-only in M4 and move element checking
+    to wherever Array lands (M7 TypeRef ingestion), since the element type to
+    check against only exists once `Array<T>` resolves. Update the `FuncParam.Rest`
+    comment in type.go to read "M7," not "M4," so the gap is recorded as deferred
+    rather than in-scope-but-skipped. Trailing args stay unchecked until then — a
+    bounded, documented hole, acceptable because rest params are rare in M4
+    source.
 - **Function-arm Variation-B gap** (constrain.go's KNOWN GAP): unchecked extra
   positions against an inexact callback need the `_ <: unknown` (⊤) rule slated
   for M6. A3 does **not** add function annotations, so the gap stays
   unreachable through M4 — but if function annotations slip in, the ⊤ rule must
   come with them.
+  - **Decision (deferred to M6).** Leave the ⊤ rule for M6 — it touches every
+    constrain arm and isn't worth M4's risk. Make the gap fail loud rather than
+    stay merely unreachable: have the inexact-callback extra-position branch emit
+    an "unsupported until M6" error (via `reportUnsupportedFeature`) instead of
+    silently skipping the check, and add a test that a function annotation
+    carrying an inexact callback is rejected. That proves the path stays closed
+    through M4; M6 removes the guard when the ⊤ rule lands.
 - **`match` over borrowed scrutinees**: E2's structural exhaustiveness is
   defined on the carrier; the `RefType` peel must not consult `Mut`/`Lt` for
   completeness. Cheap to test once D-phase types exist; called out so E2

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -462,139 +462,458 @@ func isValueType(t soltype.Type) bool // from checker/check_transitions.go:189-2
 
 ## PR breakdown
 
-17 PRs across 7 phases, each ~120–250 non-test LoC, independently mergeable and
-green, each with table-driven tests asserting rendered types and **full** error
-messages. The gate (C2) sits 3rd on the critical path.
+17 PRs across 7 phases, each independently mergeable and green, each with
+table-driven tests asserting rendered types and **full** error messages. Every
+PR below names the concrete files touched, the data structures added/modified,
+the algorithm changes, and its acceptance set — enough to start implementation
+without further planning. The gate (C2) sits 3rd on the critical path.
+
+A standing rule for every PR that adds a `soltype` former or a second sort:
+**touch every site that switches over the type set.** The shipped checklist is
+`type.go` (the `isType` marker + `LevelOf` arm), `visitor.go` (the `Accept`
+method), `print.go` (`printType` + `typePrec` + `freeTypeVars`), and
+`solver/coalesce.go`'s `equalType`. Missing one is a latent panic
+(`printType`/`equalType` end in `panic("unhandled %T")`) or a silent wrong
+result (`LevelOf` defaulting to 0 — see its `IntersectionType` comment for why
+that corrupts `freshenAbove`). Each PR's "structures" list calls out which of
+these arms it must add.
 
 ### Phase A — Records & tuples completion (the M2 leftovers)
 
 - **A1 — `Inexact` flag + record exactness rules + the selection split**
-  (~200). Add `Inexact` to `RecordType`; rewrite the record constrain arm per
-  the sketch (one-way rule; new `InexactIntoExactError`/`ExtraPropertyError`);
-  flip `inferMember`'s requirement to `Inexact: true`; printer `...`. The M2
-  arm's "this is NOT the final semantics" comment is retired here.
-- **A2 — Tuple inexactness + tuple spread** (~150). `TupleType.Inexact`; the
-  `longer <: shorter`-vs-inexact arm (narrowing `TupleLengthMismatchError`'s
-  firing conditions per its own M4 note); tuple-typed spread in tuple literals
-  (the `infer_obj_test` "Tuple/array spread is M4" stub); the computed/numeric
-  object-key story (static-string keys resolve; dynamic keys get a typed
-  error, full support rides M9 index types).
-- **A3 — Record/tuple type annotations** (~180). Extend `resolveTypeAnn`:
-  object/tuple annotations incl. trailing `...`; `mut`/lifetime annotation
-  forms parse to `RefType` (consumed from C1 on — until then a `mut` annotation
-  reports unsupported, preserving today's behavior). Unblocks every
-  annotation-side acceptance test.
+  (~200).
+  - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
+    `solver/constrain.go`, `solver/infer_expr.go`, `solver/errors.go`,
+    `solver/coalesce.go`.
+  - **Structures:** add `Inexact bool` to `RecordType` (zero value = exact, the
+    `FuncType.Inexact` convention — every record M2 mints stays exact with no
+    construction churn). `visitor.go`'s `RecordType.Accept` must carry the flag
+    on rebuild: `out = &RecordType{Fields: fields, Inexact: cur.Inexact}` (today
+    line 123 drops it — a latent bug the new field exposes). `equalType`'s
+    `RecordType` arm gains `a.Inexact != b.Inexact` as a discriminator (mirrors
+    the `FuncType` arm's `a.Inexact != b.Inexact` at coalesce.go:315).
+    `print.go` appends a trailing `...` entry in the record case when `Inexact`
+    (mirroring `printFuncTail`'s `if t.Inexact { ps = append(ps, "...") }`).
+  - **Algorithm — the record constrain arm** (constrain.go:181, replacing the
+    "this is NOT the final semantics" body): keep the per-field covariant loop
+    (depth subtyping), then add the one-way exactness gate — when `!r.Inexact`,
+    reject `l.Inexact` (an `InexactIntoExactError`) and reject any field on `l`
+    absent from `r` (`ExtraPropertyError` per extra field). When `r.Inexact`,
+    the existing width-tolerant loop is complete and unchanged.
+  - **Algorithm — selection vs concrete:** flip `inferMember`'s synthesized
+    requirement (infer_expr.go:716) to `Inexact: true` so member access stays
+    "has at least this field," now expressed *as inexactness* rather than as an
+    unconditionally width-tolerant arm. This is the split the milestone calls
+    for: the same `RecordType <: RecordType` rule serves both selection (RHS
+    inexact) and concrete subtyping (RHS exact).
+  - **Errors:** new `InexactIntoExactError{LHS, RHS *soltype.RecordType}` and
+    `ExtraPropertyError{LHS, RHS *soltype.RecordType; Name string; prov; site}`
+    — same field/blame shape as `MissingPropertyError` (errors.go:97).
+  - **Accept:** exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds; inexact `<:`
+    exact and extra-member-on-exact reject (full messages); existing
+    member-access tests stay green (selection is now the inexact path).
+
+- **A2 — Tuple inexactness + tuple spread + computed-key story** (~170).
+  - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
+    `solver/constrain.go`, `solver/coalesce.go`, `solver/infer_expr.go`.
+  - **Structures:** add `Inexact bool` to `TupleType`; thread it through
+    `TupleType.Accept` (visitor.go:109 — `&TupleType{Elems: elems, Inexact:
+    cur.Inexact}`), `equalType`'s tuple arm, and `printType`'s tuple case (a
+    trailing `, ...`).
+  - **Algorithm — tuple constrain arm** (constrain.go:162): replace the strict
+    `len(l.Elems) != len(r.Elems)` reject with the exactness-aware rule — when
+    `r` is exact, lengths must match; when `r` is inexact, `len(l) >= len(r)`
+    and the shared prefix is covariant (the `longer <: shorter` case the arm's
+    own M4 comment promises). This *narrows* `TupleLengthMismatchError`'s firing
+    conditions (its errors.go:66 note anticipates this).
+  - **Algorithm — tuple spread:** in the tuple-literal walk, handle
+    `ast.ArraySpreadExpr` (today `reportUnsupported` → `ErrorType` slot, see
+    `infer_obj_test.go:31` "Tuple/array spread is M4"): infer the spread
+    operand, require it to be a `TupleType`, and splice its element types into
+    the literal's `Elems`. A non-tuple spread operand is a typed error.
+  - **Algorithm — object computed/numeric keys** (inferObject, infer_expr.go:660
+    `objKeyName` fail path): a statically-constant string/numeric key resolves
+    to a field name; a genuinely dynamic key (`{[k]: v}`) stays a typed error
+    (full index-signature support rides M9 index types). Keep the last-wins
+    dedup invariant.
+  - **Accept:** `[1, 2]` `<:` `[number, ...]` succeeds, `<:` `[number]` rejects;
+    a spread `[...pair, 3]` builds the spliced tuple; a constant numeric key
+    resolves, a dynamic key errors.
+
+- **A3 — Record/tuple/`mut`/lifetime type annotations** (~180).
+  - **Files:** `solver/type_ann.go`, plus tests.
+  - **Algorithm — extend `resolveTypeAnn`** (type_ann.go:21, today
+    primitives + `Promise<T>` only): add arms for object-type and tuple-type
+    annotations (building `RecordType`/`TupleType`, honoring a trailing `...`
+    ⇒ `Inexact: true`), and for the `mut`/lifetime annotation forms, which lower
+    to `RefType` (`mut T` ⇒ `RefType{Mut: true}`, `'a T` ⇒ `RefType{Mut: false,
+    Lt: …}`). **Ordering caveat:** `RefType` does not exist until C1, so A3
+    lands the record/tuple annotation arms now and gates the `mut`/lifetime arms
+    behind C1 (until then a `mut`/`'a` annotation keeps today's
+    `reportUnsupportedFeature` + recovery-var behavior). Track the gated arms as
+    a one-line follow-up in C1's checklist.
+  - **Why first-ish:** every annotation-side acceptance test in Phase A/B/D
+    (`var p: {x, y, ...} = …`, `fn f(p: mut {x: number}) …`) needs this; it is
+    a leaf with no dependency on the constraint changes.
+  - **Accept:** `val r: {x: number, ...} = {x: 1, y: 2}` checks (inexact target
+    admits the extra field); `val r: {x: number} = {x: 1, y: 2}` rejects (exact
+    target); tuple annotations round-trip through the printer.
 
 ### Phase B — Usage-based inference refinement
 
-- **B1 — Negative-position record merging + Policy-A closing** (~180). The
-  spike's `mergeObjects` brought to production coalesce: record upper bounds
-  in an intersection merge into one record (`{a: β} & {b: γ}` ⇒ `{a: β, b:
-  γ}`); the usage-collected shape **closes to exact** at display time (Policy
-  A, spec §8.1). Mut-record merging is added by C3.
-- **B2 — The `open` parameter marker** (~120). Parser marker + keep-inexact
-  flag on the closed shape. Spelling gated; semantics are what M4 proves.
-- **B3 — `var` literal widening** (~150). **Authors the `widen` helper**
-  (`func widen(t soltype.Type) soltype.Type`, ported from the spike — not yet in
-  the production solver; C3's field-write reuses it). The principled usage-based
-  form from the milestone: a `var`'s type is informed by all assignment sites
-  via `widen` + the same coalescing; `val` stays a literal singleton. Retires
-  PR8's documented `var a = 5; a = 6` failure.
+- **B1 — Negative-position record merging + Policy-A exact closing** (~190).
+  - **Files:** `solver/coalesce.go`, plus tests.
+  - **Background:** today `combine` (coalesce.go:254) builds a bare
+    `IntersectionType` of a negative variable's upper bounds. When two of those
+    bounds are member-access requirements on one receiver (`{a: β}` and
+    `{b: γ}`), the rendered type is the non-compact `{a: β} & {b: γ}` instead of
+    `{a: β, b: γ}`.
+  - **Algorithm — port the spike's `mergeObjects`** into the negative
+    (`Negative` polarity) path of `combine`: before wrapping parts in an
+    `IntersectionType`, fold all `RecordType` parts into one record (union the
+    field sets; a field appearing in several parts becomes the intersection of
+    its types). This is the production analogue of `simplesub/coalesce.go`'s
+    `mergeObjects`/`mergeObjectGroup`, rewritten over `soltype.RecordType`'s
+    slice fields and `Field(name)` lookup, using the existing `combine`/`dedup`
+    structure. Mut-record merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is
+    deferred to C3 once `RefType` exists.
+  - **Algorithm — Policy-A close:** the merged usage record closes to **exact**
+    (`Inexact: false`) at this display-time fold — the row is sealed once body
+    inference completes (spec §8.1). The per-access requirements stay inexact
+    (A1); only the *coalesced* result is exact. `open` (B2) is the opt-out.
+  - **Accept:** `fn (p) { p.a; p.b }` infers a param rendering `{a: …, b: …}`
+    (one exact record), not `{a: …} & {b: …}`.
+
+- **B2 — The `open` parameter marker** (~120).
+  - **Files:** parser hook (provisional keyword), `solver/infer_expr.go` (param
+    binding), `solver/coalesce.go`.
+  - **Structures:** carry an `open` bit from the parsed param to the coalescer —
+    cheapest form is a `set.Set[*soltype.TypeVarType]` of open param vars on the
+    checker, consulted in B1's close step.
+  - **Algorithm:** when a param is marked `open`, B1's Policy-A close leaves its
+    usage record `Inexact: true` (row-polymorphic) so callers may pass richer
+    records. Everything else is unchanged.
+  - **Accept:** `fn dist(open p) { p.x; p.y }` renders an inexact `{x, y, ...}`
+    param; an un-`open` peer renders exact `{x, y}`; passing `{x, y, z}` to the
+    `open` one checks, to the closed one rejects.
+
+- **B3 — `var` literal widening (authors `widen`)** (~150).
+  - **Files:** `solver/constrain.go` or a new `solver/widen.go` (the helper),
+    `solver/infer_decl.go`, plus tests.
+  - **Structures/helper:** author `func widen(t soltype.Type) soltype.Type`
+    (ported from `simplesub/constrain.go`): a `LitType` widens to its `PrimType`
+    (`5` ⇒ `number`, `"x"` ⇒ `string`, `true` ⇒ `boolean`); every other type
+    passes through. C3's field-write reuses it.
+  - **Algorithm:** in `inferVarDecl` (infer_decl.go:108), a `var` binding's
+    initializer type is widened before generalization, and — the principled
+    milestone form — informed by **all** assignment sites: collect the
+    initializer plus every later `a = e` RHS and coalesce their widened types
+    (the binding's type is the join). A `val` is left un-widened (a fixed
+    literal singleton). This retires PR8's documented `var a = 5; a = 6` failure
+    (infer_expr.go:532 note). Reassignment's RHS-vs-binding constrain
+    (inferAssign, infer_expr.go:540s) now checks against the widened binding
+    type.
+  - **Accept:** `var a = 5; a = 6` checks (binding is `number`);
+    `val a = 5; a = 6` still rejects (`CannotAssignToImmutableError`);
+    `var a = 5` with no reassignment still renders `number` (default-widen).
 
 ### Phase C — Borrows & mutability (**the gate**)
 
-- **C1 — `RefType` plumbing** (~220). The node, `RefInner` (PromiseType/
-  FuncType/prims excluded), `borrowableType`, `NewRef`, `unwrapRef`/
-  `carrierOf`; visitor `Accept` (read-view polarity, cache-shared);
-  `LevelOf`/`equalType`/`Print` arms. **No constrain rule yet** — trivially
-  green.
-- **C2 — The `RefType` constrain rule** (~180). **← THE GATE.** The single rule
-  per the sketch, lifetime steps inert; the two cross-cases (struct-literal
-  construction in `bare <: RefType` — *not* `NewRef`). Acceptance: `mut {x,y}
-  <: mut {x}` **fails** while `{x,y} <: {x}` width-succeeds (inexact);
-  mut-decay allowed, reverse rejected; full messages. **Stop and reassess
-  before any later phase if this does not encode cleanly.**
-- **C3 — Field-write inference + read-after-write** (~200). Replace
-  `inferAssign`'s member-branch stub per the sketch (`Lt: nil`); reuse B3's
-  `widen` on write; multi-write merge (mut-record case of B1's merge); the
-  `written`
-  read-after-write map on the checker. Acceptance: `fn foo(obj) { obj.x = 5;
-  obj.y = 10 }` ⇒ `(obj: mut {x: number, y: number}) -> unit`; write-then-read
-  ⇒ `number`.
+- **C1 — `RefType` plumbing** (~230).
+  - **Files:** `soltype/type.go`, `soltype/visitor.go`, `soltype/print.go`,
+    `solver/coalesce.go` (`equalType`), `solver/type_ann.go` (un-gate A3's
+    `mut`/lifetime arms), plus a new `soltype/ref.go` for the helpers.
+  - **Structures:** add `RefType{Mut bool; Lt Lifetime; Inner RefInner}` and the
+    sealed `RefInner interface { Type; isRefInner() }` with
+    `isRefInner` on `RecordType`/`TupleType`/`TypeVarType` (and forward-declared
+    for `UnionType`/`IntersectionType`/`AliasType`/`ClassType`). `Lifetime` is a
+    placeholder interface here (`type Lifetime interface{ isLifetime() }` with no
+    concretes yet — D1 adds them); C1 only ever sets `Lt: nil`.
+  - **Structures — full type-set checklist (the standing rule):**
+    `isType()` on `*RefType`; `LevelOf` arm (`case *RefType: return
+    LevelOf(t.Inner)` — `Inner` is `RefInner` which embeds `Type`, so this
+    typechecks); `RefType.Accept` (see below); `printType` arm (`mut {…}`,
+    `mut Point`; immutable-borrow/lifetime forms render once D1 adds lifetime
+    printing — until then `Lt` is always nil); `equalType` arm
+    (`a.Mut == b.Mut && equalType(a.Inner, b.Inner)` — lifetime equality joins
+    in D1); `freeTypeVars` descends `Inner`.
+  - **Algorithm — `RefType.Accept`:** the inner is visited **once in the current
+    polarity** (the read view); the `Mut` write view shares fresh vars via the
+    transform's own cache (exactly the spike's `extrude` treatment of `Mut` at
+    `simplesub/constrain.go:293`). Copy-on-write like the other formers:
+    rebuild only if `Inner` changed; carry `Mut`/`Lt` through unchanged. The
+    lifetime is **not** a `Type`, so `Accept` never walks it — only the
+    lifetime-aware passes (D4) do.
+  - **Helpers:** `NewRef(mut, lt, inner) Type` (collapses the degenerate
+    `(false, nil)` cell to bare `inner`); `unwrapRef(t) (inner, mut, lt)`;
+    `carrierOf(t) Type` (peel any `RefType`); `borrowableType(t) bool` (content
+    invariant behind a `TypeVarType` inner). **No constrain rule yet** —
+    trivially green; tests assert `NewRef` collapses the degenerate cell, the
+    printer renders `mut {x: number}`, and `RefType` round-trips `Accept`.
+
+- **C2 — The `RefType` constrain rule** (~180). **← THE GATE.**
+  - **Files:** `solver/constrain.go`, `solver/errors.go`, plus tests.
+  - **Algorithm — the single rule** (new `case *soltype.RefType` in the
+    structural switch, per the sketch above): (1) mutability compatibility
+    (`!l.Mut && r.Mut` ⇒ `MutabilityMismatchError`); (2) inner variance —
+    covariant read view always, plus a contravariant write view **iff `r.Mut`**
+    (the read/write decomposition = invariance); (3) lifetime step written but
+    **inert while `Lt == nil`** (the `switch` over `l.Lt`/`r.Lt` is dead code
+    until D2). Plus the two cross-cases: `RefType <: bare` (peel `l.Inner`, but
+    an escape-error guard for `l.Lt != nil` that can't fire yet); `bare <:
+    RefType` (wrap the source as `&soltype.RefType{Mut: false, Lt: nil, Inner:
+    inner}` via a struct literal — **not** `NewRef`, which would collapse it and
+    recurse forever — and re-dispatch).
+  - **Errors:** `MutabilityMismatchError{LHS, RHS *soltype.RefType}`,
+    `BorrowEscapeError{LHS, RHS}` (the latter's firing path is inert until D2).
+  - **Accept (the gate):** `mut {x, y} <: mut {x}` **fails** (invariance — the
+    write view's contravariant `{x} <: {x, y}` is missing a field) while
+    immutable `{x, y} <: {x}` width-**succeeds** (inexact RHS); mut-decay
+    `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected. Full
+    messages. **Stop and reassess before any later phase if this does not encode
+    cleanly against the real visitor/journal.**
+
+- **C3 — Field-write inference + read-after-write** (~200).
+  - **Files:** `solver/infer_expr.go` (the `inferAssign` member branch),
+    `solver/infer.go` (the `written` map on the checker), `solver/coalesce.go`
+    (mut-record merge), plus tests.
+  - **Structures:** add `written map[fieldKey]soltype.Type` to the checker
+    (`fieldKey struct{ recvID int; field string }`, ported from
+    `simplesub/constrain.go:14`); records the widened type stored into a
+    receiver var's field so a later read returns it.
+  - **Algorithm — replace the member-target stub** (infer_expr.go:494-500, today
+    `reportUnsupportedFeature("assignment to a member or index")`): implement
+    `inferMemberAssign` per the sketch — infer receiver + RHS, `widen` the RHS,
+    constrain `recv <: RefType{Mut: true, Lt: nil, Inner: {field: widen(rhs),
+    Inexact: true}}`, record `written[recvID,field]`, return the stored value.
+    Keep the `*ast.IndexExpr` sub-case as `reportUnsupportedFeature` (array
+    writes need Array types — note it for M7).
+  - **Algorithm — read-after-write:** `inferMember` (infer_expr.go:687) consults
+    `written` first: a read of a just-written field returns the recorded
+    concrete type instead of a fresh var, so `obj.x = 5; obj.x` is `number`.
+  - **Algorithm — mut-record merge:** extend B1's `mergeObjects` fold to the
+    `RefType{Mut: true, Inner: RecordType}` case so multiple writes merge into
+    one mutable record (`mut {x} & mut {y}` ⇒ `mut {x, y}`) — the spike's
+    `mergeObjects` handled `Mut`-wrapped objects the same way.
+  - **Accept:** `fn foo(obj) { obj.x = 5; obj.y = 10 }` ⇒ `(obj: mut {x: number,
+    y: number}) -> unit`; `fn foo(obj) { obj.x = 5; return obj.x }` ⇒ `... ->
+    number`.
 
 ### Phase D — Lifetimes (second sort)
 
-- **D1 — Lifetime sort + probe extension** (~220). `LifetimeVar`/
-  `StaticLifetime`; `constrainLt` with journal-gated appends
-  (`addLowerLtBound`/`addUpperLtBound`); extend the probe to the second sort by
-  reintroducing the `Bounded` interface with **exported** `BoundLengths`/
-  `TruncateBounds` on both soltype types (the path `probe.go:45-52` prescribes
-  for "a second bounded type" — *not* the rejected unexported form), so both
-  sorts roll back through one journal; lifetime printing.
-- **D2 — Activate the rule + borrow origination** (~160). Turn on step 3 and
-  the escape guards; `attachParamLifetimes`; **flip C3's write-requirement
-  lifetime from `nil` to a fresh var** and re-run C3's acceptance (borrowed
-  receivers now accepted). Acceptance: `IdentityRefReturn` ⇒ `fn <'a>(p: mut
-  'a {x: number}) -> mut 'a {x: number}`; `FreshObjectReturn` lifetime-free.
-- **D3 — Joins + escape** (~140). Multi-source returns union lifetimes via a
-  fresh join var (riding the M3 return-point join); escape to module/static
-  storage ⇒ `constrainLt(lt, 'static)`. Acceptance: `ConditionalUnionReturn` ⇒
-  `mut ('a | 'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`.
-- **D4 — Display-time coalescing + elision** (~200). `analyzeLts` occurrence
-  pass over scheme rendering; param-lifetime naming + `fn <'a>(…)` quantifier;
-  elision with the **mut elide-in-place vs immutable drop-the-wrapper**
-  branch; `RefType` passes the inner's `Inexact` through untouched (spec
-  §7.11). Property-level and tuple-per-slot lifetime acceptance.
+- **D1 — Lifetime sort + probe extension** (~230).
+  - **Files:** new `soltype/lifetime.go`, `solver/context.go`,
+    `solver/constrain.go`, `solver/probe.go`, `soltype/print.go`.
+  - **Structures:** `LifetimeVar{ID int; LowerBounds, UpperBounds []Lifetime}`
+    and `StaticLifetime{}` (top of the outlives lattice), both implementing
+    `isLifetime()`. `Context` grows `lifetimeCounter int` (its own comment at
+    context.go:5 names this deferred field) and a `freshLifetime()` minter.
+  - **Algorithm — `constrainLt`** (ported from `simplesub/lifetime.go:61`):
+    mirrors `constrain` over the outlives lattice — a var on the left gains an
+    upper bound, on the right a lower bound, var-to-var records both;
+    `'static` is top (`X <: 'static` always holds); a `(lhs, rhs)`-keyed
+    seen-set terminates cycles. Bound appends go **only** through new
+    `addLowerLtBound`/`addUpperLtBound` helpers that journal before appending —
+    the same discipline as `addLowerBound`/`addUpperBound` (context.go:36).
+  - **Algorithm — probe extension (the careful part):** reintroduce the
+    `Bounded` interface with **exported** methods (`BoundLengths() (int, int)`,
+    `TruncateBounds(lo, hi int)`) on **both** `*soltype.TypeVarType` and
+    `*soltype.LifetimeVar` — the path `probe.go:45-52` prescribes for "a second
+    bounded type." Change `probeEntry.v` from `*soltype.TypeVarType` to
+    `Bounded`, and `Probe.touched`/`record` accordingly. Document the exported
+    `TruncateBounds` as speculation-internal. Verify a discarded overload trial
+    that touched a lifetime var rolls it back (probe_test.go pattern).
+  - **Structures — printer:** lifetime printing in `print.go` — a named param
+    lifetime renders `'a`, `'static` renders `'static`; the `RefType` print arm
+    (added in C1 with `Lt` always nil) now renders `mut 'a T` / `'a T` when
+    `Lt != nil`.
+  - **Accept:** `constrainLt` unit tests (outlives, transitivity, cycle
+    termination, `'static` absorption); a probe discard truncates an appended
+    lifetime bound.
+
+- **D2 — Activate the rule + borrow origination** (~160).
+  - **Files:** `solver/constrain.go` (un-inert the C2 lifetime step),
+    `solver/infer_expr.go` (`attachParamLifetimes`), `solver/infer_expr.go`
+    (`inferMemberAssign` lifetime flip).
+  - **Structures:** add `paramLifetimes set.Set[int]` to the checker (the
+    nameable-lifetime set, ported from `simplesub`).
+  - **Algorithm — activate the `RefType` rule's step 3** (C2's inert `switch`):
+    covariant lifetime when both present (`constrainLt(r.Lt, l.Lt)`); owned
+    source into a borrow slot ok; borrow into an owned slot ⇒ `BorrowEscapeError`
+    (now live). The `RefType <: bare` escape guard (`l.Lt != nil`) also goes
+    live.
+  - **Algorithm — `attachParamLifetimes`** (per the sketch): a `RefType`-typed
+    param with `Lt == nil` gets a fresh lifetime var, recorded in
+    `paramLifetimes`. Called when binding function params.
+  - **Algorithm — flip C3's write requirement:** `inferMemberAssign`'s
+    `Lt: nil` becomes `Lt: c.freshLifetime()` so a mut-borrow receiver of any
+    lifetime is accepted (the fresh var imposes no lifetime obligation). Re-run
+    C3's acceptance — owned receivers still check, borrowed receivers now check.
+  - **Accept:** `IdentityRefReturn` (`fn (p: mut {x: number}) { return p }`) ⇒
+    `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`; `FreshObjectReturn`
+    (returning a fresh `mut {x: 1}`) carries no lifetime.
+
+- **D3 — Multi-source lifetime joins + escape-to-`'static`** (~150).
+  - **Files:** `solver/infer_stmt.go` / wherever the M3 return-point join lives,
+    `solver/infer_expr.go` (escape sites).
+  - **Algorithm — joins:** when the M3 return-point join (or an `if`/`match`
+    branch join) unifies two borrowed records with distinct lifetimes, mint a
+    fresh **join** lifetime var and `constrainLt` each source lifetime into it
+    (so it coalesces to `'a | 'b`). The join var is *not* a param lifetime —
+    only its reachable param-lifetime members are named (the spike's
+    `paramLifetimes`-vs-join distinction).
+  - **Algorithm — escape:** a value flowing into module/static storage (a
+    top-level binding, a global write) constrains its lifetime `<: 'static`
+    (`constrainLt(lt, &StaticLifetime{})`), which coalesces to `'static`.
+  - **Accept:** `ConditionalUnionReturn` (return one of two mut borrows) ⇒
+    `mut ('a | 'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`.
+
+- **D4 — Display-time lifetime coalescing + elision** (~200).
+  - **Files:** new lifetime-occurrence logic alongside `solver/simplify.go` /
+    `solver/coalesce.go`, `soltype/print.go` (the `<'a>` quantifier).
+  - **Structures:** an `analyzeLts` occurrence pass (ported from
+    `simplesub/lifetime.go`) recording, per lifetime var, the polarities it
+    occurs in — built to mirror `simplify.go`'s `symOccVisitor` but over the
+    lifetime sort. A `ltKeep`/naming map keyed by lifetime-var ID, threaded into
+    the scheme coalescer the way `schemeSimplification` is threaded today
+    (coalesce.go:120).
+  - **Algorithm — naming:** only param-originated lifetimes are named (`'a`,
+    `'b`, … via a base-26 `alphaName`, per the spike); a join var renders as the
+    union of the param lifetimes it reaches; `'static` absorbs. The `<'a>`
+    quantifier joins the existing `<T0, …>` prefix in `PrintAsSchemeWith`.
+  - **Algorithm — elision (the subtle branch):** a param lifetime occurring in
+    only one polarity (and not forced to `'static`) connects nothing and is
+    elided — the lifetime-sort analogue of single-polarity elimination. The
+    elision branches on `Mut`: a **mutable** borrow with an elided lifetime
+    becomes `RefType{Mut: true, Lt: nil}` (owned-mutable, well-formed); an
+    **immutable** borrow with an elided lifetime **must drop the `RefType`
+    wrapper entirely** (returning bare `Inner`), because `RefType{false, nil}` is
+    the forbidden degenerate cell `NewRef` rejects. The coalescer branches on
+    `Mut` at the elision site; the `NewRef` invariant (plus a printer assertion)
+    is the backstop.
+  - **Algorithm — exactness passthrough:** the `RefType` coalescing arm carries
+    the inner carrier's `Inexact` flag through untouched (spec §7.11 — `mut`/
+    lifetime axes are orthogonal to exactness).
+  - **Accept:** property-level lifetimes (`{p: mut 'a {…}}`) and tuple-per-slot
+    lifetimes render; a connect-nothing param lifetime elides (mut ⇒ owned-mut,
+    immut ⇒ wrapper dropped); read-after-write field collapse with a lifetime
+    present.
 
 ### Phase E — Destructuring + `match`
 
-- **E1 — Structural patterns** (~220). `TuplePat`/`RecordPat`/literal-pattern
-  `Pat` concretes (soltype's `Pat` reserved exactly this growth); binding
-  destructuring in `val` and params, dispatched through the member-lookup
-  constraint path (`constrain(scrutinee <: {x: β, …})`), not subtyping —
-  missing field / wrong arity reject. Patterns peel `RefType` via `carrierOf`
-  (works on owned values before Phase D completes).
-- **E2 — The `match` expression** (~220). The expression form over structural
-  patterns; arm binding + per-arm typing joined via the M3 return-point-join
-  machinery; exhaustiveness from exactness — an exact record/tuple scrutinee
-  with a complete pattern set needs no catch-all, an inexact one does.
-  Constructor/enum patterns are M5; union scrutinee exhaustiveness is M6.
+- **E1 — Structural patterns** (~220).
+  - **Files:** `soltype/type.go` (the `Pat` concretes), `soltype/print.go`
+    (`paramName`/pattern rendering), `solver/infer_decl.go` (`varName` →
+    general pattern binding), `solver/infer_expr.go` (param patterns), plus a
+    pattern-typing helper.
+  - **Structures:** add `TuplePat{Elems []Pat}`, `RecordPat{Fields
+    []*RecordPatField}`, and literal patterns as `Pat` concretes (soltype's
+    `Pat` interface was reserved for exactly this — type.go's `Pat` comment).
+    `print.go`'s `paramName` (print.go:278) gains arms for the new pattern
+    shapes; `varName` (infer_decl.go:131, today IdentPat-only) generalizes to
+    return the full set of bound names.
+  - **Algorithm — pattern typing:** a pattern dispatches through the
+    **member-lookup constraint path**, not subtyping: a `RecordPat{x, y}`
+    against a scrutinee `s` emits `constrain(s <: {x: βx, y: βy, Inexact:
+    true})` (the same inexact requirement `inferMember` uses) and binds `x`/`y`
+    to `βx`/`βy`; a `TuplePat[a, b]` emits `constrain(s <: [αa, αb])` (exact
+    length for an exact tuple pattern). A missing field / wrong arity surfaces
+    the existing `MissingPropertyError`/`TupleLengthMismatchError`. Patterns
+    peel any `RefType` via `carrierOf` before matching (works on owned values
+    before Phase D; borrowed scrutinees once D lands). Used uniformly by `val`
+    destructuring, function-param destructuring, and (E2) `match` arms.
+  - **Accept:** `val {x, y} = p` binds `x`/`y` at their field types and rejects a
+    missing field; `val [a, b] = t` binds per slot and rejects wrong arity; a
+    destructured param `fn (({x, y})) { … }` types the same way.
+
+- **E2 — The `match` expression** (~220).
+  - **Files:** `solver/infer_expr.go` (the `match` walk), reusing the M3
+    return-point-join machinery and E1's pattern typing.
+  - **Algorithm — arm typing:** infer the scrutinee once; for each arm, type its
+    pattern against the scrutinee (E1) in a child scope carrying the arm's
+    bindings, then infer the arm body; join the arm body types via the M3
+    return-point join (the same join D3 hooks lifetimes into).
+  - **Algorithm — exhaustiveness from exactness:** an **exact** record/tuple
+    scrutinee whose arms cover its shape needs no catch-all; an **inexact**
+    scrutinee requires a catch-all arm (a missing one is a typed error).
+    Constructor/enum patterns and enum-exhaustive `match` are M5; union-scrutinee
+    exhaustiveness is M6 — E2 lays the form and the structural-pattern path they
+    both extend.
+  - **Accept:** a `match` over structural patterns binds and type-checks each
+    arm; an exact-record scrutinee with a complete pattern set needs no
+    catch-all, an inexact one does (full error on the missing catch-all).
 
 ### Phase F — Namespace member lookup (parallel track)
 
-- **F1 — `resolvePath` + namespace access** (~180). Per the sketch: `Foo.bar`,
-  constant-keyed `Foo["x"]`; `NamespaceUsedAsValueError` moves off
-  `inferIdent` to the value-position consumer (its existing M4 note);
-  `UnknownNamespaceMemberError`, `DynamicNamespaceIndexError`. Depends only on
-  M2's `Namespace` — can land any time, parallel to every other phase.
+- **F1 — `resolvePath` + namespace access** (~180).
+  - **Files:** `solver/infer_expr.go` (new `resolvePath` + `pathResult`),
+    `solver/scope.go` (optional thin `LookupValue`/`LookupNamespace` wrappers
+    over the `Namespace` maps — **new** if added; today `Namespace` is
+    fields-only, scope.go:61), `solver/errors.go`.
+  - **Structures:** `pathResult` sum (`Value | Namespace`); new errors
+    `UnknownNamespaceMemberError`, `DynamicNamespaceIndexError`.
+  - **Algorithm — `resolvePath`** (per the sketch): resolve an ident/member/
+    index chain to `Value | Namespace`. Namespace lookup is a **direct,
+    non-lexical** read of `ns.Values[name]` / `ns.Nested[name]` (no parent walk,
+    unlike `Scope.GetValue`/`GetType`/`GetNamespace` which do walk parents). The
+    object/index position tolerates a namespace; every other value position
+    rejects one — so `NamespaceUsedAsValueError` moves **off** `inferIdent`
+    (infer_expr.go:50 note) to the value-position consumer, firing once for both
+    `f(Foo)` and partial chains `f(A.B)`. Index keys into a namespace must be
+    statically constant strings (`Foo["weird-name"]`); a dynamic `Foo[k]` is a
+    `DynamicNamespaceIndexError`.
+  - **Dependency:** only M2's `Namespace` structure — lands any time, parallel
+    to every other phase.
+  - **Accept:** `Foo.bar` resolves to the member's type; `Foo["weird-name"]`
+    resolves a constant-keyed member; `f(Foo)` and `f(A.B)` reject
+    (`NamespaceUsedAsValueError`); `Foo[k]` rejects (`DynamicNamespaceIndexError`).
 
 ### Phase G — Mutability-transition checking (port)
 
-- **G1 — Port liveness + predicates + wiring** (~220). `internal/liveness/`
-  verbatim; `isValueType`/`isMutableType` over `soltype`;
-  `checkMutabilityTransition` rule logic unchanged; `Liveness`/`Aliases` on
-  the solver context; old transition cases as intended-form tests.
-- **G2 — Collapse the static-alias escape hatches** (~120). Drop
-  `HasStaticMutAlias`/`HasStaticImmAlias`; query the lifetime sort
-  (`lt <: 'static`) directly. Depends on D3 — the one genuinely new logic in
-  the port.
+- **G1 — Port liveness + predicates + wiring** (~220).
+  - **Files:** new `solver/transitions.go`, `solver/context.go`, reusing
+    `internal/liveness/` and `internal/checker/liveness_prepass.go` verbatim.
+  - **Structures:** `solver.Context` (or the checker carrier) gains `Liveness
+    *liveness.Liveness` and `Aliases *liveness.AliasTracker`, populated by the
+    existing prepass (operates on the AST, not the checker's types).
+  - **Algorithm — two predicate ports:** reimplement `isValueType(t
+    soltype.Type) bool` and `isMutableType(t soltype.Type) bool`
+    (`check_transitions.go:189-217`) over `soltype` — `isMutableType` becomes
+    `if r, ok := t.(*soltype.RefType); ok { return r.Mut }; return false`.
+    `checkMutabilityTransition`'s Rule 1 / Rule 2 / Rule 3 logic is **unchanged**
+    (it talks only to `liveness.Liveness`/`liveness.AliasTracker`).
+  - **Accept:** the old checker's transition-checking cases reproduced as
+    intended-form tests pass through the ported checker.
+
+- **G2 — Collapse the static-alias escape hatches** (~120).
+  - **Files:** `solver/transitions.go`.
+  - **Algorithm:** drop the `HasStaticMutAlias` / `HasStaticImmAlias` bits; where
+    the old code consulted them, query the lifetime sort directly — a value
+    whose lifetime is constrained `<: 'static` (D3's escape output) is the
+    first-class signal the bits approximated. This is the one genuinely new
+    logic in the port; it depends on D3.
+  - **Accept:** the static-escape transition cases pass via lifetime queries
+    rather than the dropped bits.
 
 ### Dependency graph
 
 ```
 A1 → A2
-A1 → A3 ──────────────┐
-A1 → B1 → B2          │ (annotation-side acceptance tests)
-     B1 → B3          │
-A1 → C1 → C2(GATE) → C3 → D1 → D2 → D3 → D4 → G1 → G2
-A1 → E1 → E2   (independent of C/D; E1's RefType peel activates once C1 lands)
-F1             (independent; any time)
+A1 → A3 ───────────────────┐  (A3's mut/lifetime arms un-gated by C1)
+A1 → B1 → B2               │  (annotation-side acceptance tests)
+     B1 → B3               │
+     B1, B3 ───────────┐   │  (C3 reuses B1's mergeObjects fold + B3's widen)
+A1 → C1 → C2(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
+A1 → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
+F1             (independent; any time — only M2's Namespace)
 ```
 
 Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel
-tracks off A1; nothing downstream of the gate starts before C2 clears. Total
-≈ 3.0k non-test LoC across 17 PRs, with the single highest-risk change (C2)
-isolated to ~180 reviewable lines.
+tracks off A1; nothing downstream of the gate starts before C2 clears. B1's
+`mergeObjects` fold is reused by C3 (mut-record merge) and the `widen` helper
+authored in B3 is reused by C3, so land B before C3 even though B is otherwise
+independent of the gate. Total ≈ 3.0k non-test LoC across 17 PRs, with the
+single highest-risk change (C2) isolated to ~180 reviewable lines.
 
 ## Testing strategy
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -4,335 +4,403 @@ This is the implementation plan for **M4** as defined in
 [01-milestones.md](01-milestones.md) §"M4 — Core value types". It assumes M1
 (package skeleton + `soltype`), M2 (parser/resolver bridge), and M3 (functions,
 application, let-polymorphism, function exactness) have landed. It is grounded in
-the design in [02-design-notes.md](02-design-notes.md) (the `RefType` wrapper, the
-exactness flag, the `Probe` API, the provenance/`Info` side tables) and the
-lifetime lattice in [03-references.md](03-references.md).
+[02-design-notes.md](02-design-notes.md) (the `RefType` wrapper, the exactness
+flag, the `Probe` API, the `Info`/`Prov` side tables) and the lifetime lattice in
+[03-references.md](03-references.md).
+
+The type/function sketches below are **adapted from the proven spike**
+(`internal/simplesub/` — `types.go`, `constrain.go`, `lifetime.go`,
+`coalesce.go`) into production `soltype` shapes. The spike's separate `Mut`
+wrapper + `lt`-on-`Record` is **replaced** by the unified `RefType{mut, lt,
+inner}` per the settled design; names are provisional.
 
 ## Why M4 is "the big one"
 
 M4 promotes three spike milestones at once and they are **inseparable**:
+records/objects (spike M2 — the first borrowable value), `mut` (spike M3 — the
+highest-risk gate), and lifetimes (spike M4 — a second sort solved by the same
+`constrain`). Lifetimes ride on borrows, records are the first thing that can be
+borrowed, `mut` borrows are what first populate a lifetime. Exactness (the
+`exact` flag on `RecordType`/`TupleType`) also lands here, because the settled
+decision is to introduce the flag *with* each former, not retrofit it.
 
-- **records/objects** (spike M2) — the first *value* type that can be borrowed;
-- **`mut`** (spike M3) — invariant mutable references, encoded by the read/write
-  decomposition; the **highest-risk gate** of the whole migration;
-- **lifetimes** (spike M4) — a *second sort* solved by the same `constrain`
-  machinery, riding on the `RefType` wrapper.
+## Scope
 
-Lifetimes ride on borrows, records are the first thing that can be borrowed, and
-`mut` borrows are what first populate a lifetime. Trying to land any one of them
-without the others produces a representation you immediately have to rework, so
-the milestone is deliberately scoped as a cluster. Exactness (the `exact` flag on
-`RecordType`/`TupleType`) also lands here because, per the settled exactness
-decision, the flag is introduced *with* each former rather than retrofitted.
+In: owned `RecordType`/`TupleType` with the `exact` flag; the unified `RefType`
+borrow wrapper; usage-based inference (member reads → constraints); the single
+`RefType` constrain rule (mut invariance via read/write decomposition); field-write
+inference + read-after-write; lifetimes as a second sort; ported
+mutability-transition checking.
 
-The plan below decomposes the cluster into a strictly-ordered PR sequence that
-keeps `go test ./...` green at every step and **clears the highest-risk gate as
-early as the representation allows**.
+Out (later milestones): nominal classes (M5); union/intersection *annotations*
+(M6 — M2/M4 already produce them as coalescing *output*); type-level operators
+(M8); codegen and value-level `exact<T>(v)` (M9).
 
-## Scope (from the milestone definition)
+---
 
-In:
+## Key types and function sketches
 
-1. Owned `RecordType` / `TupleType` with the `exact` flag (default exact;
-   trailing `...` ⇒ inexact). Object/tuple **literals infer as exact**.
-2. The unified `RefType{mut, lt, inner}` borrow wrapper (per
-   [02-design-notes.md](02-design-notes.md) §"`soltype`"), with the `RefInner`
-   sealed marker and the `borrowableType` content predicate.
-3. **Usage-based inference**: member read `obj.bar` ⇒ `constrain(obj <:
-   RecordType{bar: β})`; field requirements accumulate as upper bounds and
-   coalesce (negative position) into a record/intersection. Replaces
-   `Open`/`Widenable`/`ArrayConstraint`. Usage-collected shape coalesces **exact**
-   by default (Policy A); the `open` parameter marker opts back into row
-   polymorphism.
-4. **The single `RefType` constrain rule**: mutability compatibility, `mut`-driven
-   inner invariance via read/write decomposition, covariant lifetime, mutability
-   decay, plus the two cross-cases (`bare <: RefType`, `RefType <: bare`).
-   Field-write inference (`obj.x = v` ⇒ `mut` record with a fresh lifetime) and
-   read-after-write field collapse.
-5. **Lifetimes as a second sort**: `LifetimeVar` (bound lists over the outlives
-   lattice, `'static` = top), `constrainLt`, lifetime coalescing + elision,
-   borrow origination at `RefType`-typed parameters, multi-source-return unioning,
-   escape ⇒ `<: 'static`.
-6. **Mutability-transition checking** ported from the old checker
-   (`internal/liveness/` verbatim + the two narrow predicates over `soltype`),
-   wired onto `solver.Context`.
+### Owned carriers + exactness (`soltype/type.go`)
 
-Out (deferred): nominal classes (M5), unions/intersections as *input annotations*
-(M6 — though M2/M4 already produce them as coalescing *output*), type-level
-operators (M8), codegen / value-level `exact<T>(v)` (M9).
+```go
+// RecordType is an owned structural object type. exact closes the type (no extra
+// members, no width subtyping); inexact (written `{... ...}`) permits width
+// subtyping. Owned — carries NO lifetime; a lifetime is a property of a borrow
+// and lives on the RefType wrapper.
+type RecordType struct {
+    fields map[string]Type
+    exact  bool
+}
 
-## Prerequisites and assumptions
-
-- `soltype` already has `TypeVarType` (bound lists + level), `PrimitiveType`,
-  `LiteralType`, `FunctionType`, `TupleType` scaffolding, `constrain`, extrusion,
-  let-polymorphism, simplification, and polarity-driven coalescing (M1–M3).
-- The `Info` side table and the `Prov` provenance side table exist (M1).
-- The `Probe` API (length-snapshot journal, design (A) in
-  [02-design-notes.md](02-design-notes.md)) exists; M4 does **not** need
-  speculation for its core path (bound-list monotonicity covers failed
-  constraints), but the field-write/read-after-write merge and any future
-  union-against-variable deferral should be probe-aware where they trial
-  constraints.
-- The constraint-generating AST walk (`infer.go`) handles `IdentExpr`,
-  `FuncExpr`, `CallExpr` (M2/M3). M4 adds `MemberExpr` (read + write),
-  `ObjectExpr`, `TupleExpr`, and conditional/branch joining.
-
-## Architecture / where the code lands
-
-Per the package layout in [02-design-notes.md](02-design-notes.md) (names
-provisional):
-
-```
-internal/solver/
-  soltype/
-    type.go        RecordType, TupleType (exact flag), RefType, RefInner marker
-    lifetime.go    LifetimeVar, StaticLifetime, LifetimeUnion (the second sort)
-    print.go       record / tuple / `mut 'a T` / `'a T` / exact `...` rendering
-  constrain.go     record & tuple structural+width rules (exact-aware);
-                   the single RefType rule; constrainLt; borrowableType
-  coalesce.go      negative-position record coalescing; lifetime join/meet;
-                   lifetime elision (mut elide-in-place vs immutable drop-wrapper)
-  simplify.go      occurrence analysis extended over record fields / Ref inner / lt
-  infer.go         MemberExpr read/write, ObjectExpr, TupleExpr, branch joining,
-                   attachParamLifetimes; field-write & read-after-write
-  transitions.go   ported checkMutabilityTransition over soltype (new in M4)
-  context.go       solver.Context gains Liveness / Aliases fields
+// TupleType gains the same flag (M1 left it as a stub). exact ⇒ fixed length;
+// inexact ⇒ length-flexible tail.
+type TupleType struct {
+    elems []Type
+    exact bool
+}
 ```
 
-`internal/liveness/` is reused **verbatim** (it operates on the name-resolved AST
-and has no `type_system` references — see the milestone note).
+### The borrow wrapper (`soltype/type.go`)
 
-## Sequencing rationale
+```go
+// RefType is the single wrapper for borrows and mutability (replaces the spike's
+// Mut + lt-on-carrier). See 02-design-notes.md §"soltype".
+//
+//   mut=false lt=nil  -> forbidden degenerate cell (smart ctor returns bare inner)
+//   mut=false lt='a   -> immutable borrow with lifetime 'a
+//   mut=true  lt=nil  -> owned mutable value
+//   mut=true  lt='a   -> mutable borrow with lifetime 'a
+type RefType struct {
+    mut   bool
+    lt    Lifetime  // nilable; see table above
+    inner RefInner  // narrower than Type — see marker below
+}
 
-The ordering is driven by two forces that mostly agree:
+// RefInner is the sealed set of types that may sit inside a RefType. Primitives,
+// literals, functions, and nested RefTypes are deliberately excluded.
+type RefInner interface {
+    Type
+    isRefInner()
+}
 
-1. **Dependency order.** A carrier must exist before it can be borrowed; the
-   `RefType` wrapper must exist before a lifetime can ride on it; transition
-   checking consumes the lifetime sort.
-2. **Risk order.** The milestone names the `RefType` rule's `mut`-driven inner
-   invariance as the **HIGHEST-RISK gate**: *"if it cannot be encoded cleanly
-   against the real AST, the whole migration is in question."* So it must be hit
-   as early as the dependency order permits, and nothing expensive (lifetimes,
-   transition port) should be built before it is cleared.
+func (*RecordType)  isRefInner() {}
+func (*TupleType)   isRefInner() {}
+func (*AliasType)   isRefInner() {}
+func (*TypeVarType) isRefInner() {} // mid-inference; checked at constrain time
+// + UnionType / IntersectionType once M6 lands; ClassType in M5.
 
-These agree: records (carrier) → usage-based reads (needed to produce non-trivial
-record shapes worth borrowing) → **`RefType` + `mut` gate** → lifetimes →
-transition checking. The gate lands third — right after the minimum needed to
-exercise it against the real AST.
+// NewRef enforces the wrapper invariant: the degenerate (immutable, no-lifetime)
+// cell collapses to the bare inner so no downstream *RefType type-switch ever
+// sees a borrow-shaped value that isn't a borrow.
+func NewRef(mut bool, lt Lifetime, inner RefInner) Type {
+    if !mut && lt == nil {
+        return inner
+    }
+    return &RefType{mut: mut, lt: lt, inner: inner}
+}
 
-De-risking note: the spike already proved the `mut`-invariance encoding in
-isolation (`internal/simplesub` M3, `mut {x,y} <: mut {x}` fails while immutable
-succeeds). PR 3 is therefore **re-validation against the production AST/`soltype`
-representation**, not novel research — but it is still the go/no-go gate, so its
-acceptance set is the spike's `mut` cases reproduced end-to-end from real source.
+// Peel helpers used everywhere a value is destructured (field access, etc.).
+func unwrapRef(t Type) (inner Type, mut bool, lt Lifetime)
+func carrierOf(t Type) Type // peel any RefType, return the inner carrier
 
-## PR breakdown
-
-Each PR is independently reviewable, lands behind no flag (the new checker is not
-yet wired into the compiler — that's M7), keeps `go test ./...` green, and ships
-its own table-driven tests asserting **rendered types** and **full error
-messages** (per CLAUDE.md). Sizes are rough.
-
-### PR 1 — Owned records & tuples + exactness + literal inference
-
-Representation and structural subtyping for the carriers, no borrows yet.
-
-- `RecordType{fields, exact}` and extend `TupleType` with `exact` (M1 stubbed
-  `TupleType`; this completes it). Smart constructors; printer support for
-  `{x: T, y: U}`, `[T, U]`, and the trailing `...` for inexact.
-- `constrain` structural cases:
-  - record `<:` record: per-field covariant; **width subtyping only in the
-    inexact `<:` inexact case**; exact `<:` exact requires the *same* field set;
-    exact `<:` inexact allowed; inexact `<:` exact rejected (the one-way rule
-    from [02-design-notes.md](02-design-notes.md) §"Exactness").
-  - tuple `<:` tuple: per-slot covariant; length rules mirror the exactness rule.
-- Inference (`infer.go`): `ObjectExpr` ⇒ `RecordType` (exact), `TupleExpr` ⇒
-  `TupleType` (exact), over inferred element types.
-- Coalescing: positive-position record/tuple recursion (fields are covariant).
-- **Tests**: object/tuple literal inference renders exact; exact `{x,y}` assignable
-  to inexact `{x,y,...}` but not the reverse; extra member on an exact target
-  rejected (full message); width subtyping works inexact-to-inexact.
-- **~Size**: medium. No `mut`, no lifetimes, no usage inference — deliberately the
-  smallest first slice so the carrier and exactness rule are reviewed alone.
-
-### PR 2 — Usage-based inference (member reads) + the `open` marker
-
-Turn member access into constraints; this is what makes record shapes worth
-borrowing in PR 3.
-
-- `infer.go` `MemberExpr` (value-typed receiver, read): `constrain(recv <:
-  RecordType{field: β})` with `β` fresh at the current level; record the field
-  type for the eventual read-after-write path (stubbed here, completed in PR 3).
-- Negative-position coalescing (`coalesce.go`): a variable's upper-bound record
-  requirements **merge into one record** (intersection of object bounds → single
-  record), coalescing as **exact** by default (Policy A — row closed once body
-  inference completes).
-- The `open` parameter marker (keyword provisional, e.g. `fn dist(open p) =>`):
-  keeps the usage-inferred param **inexact** so callers may pass richer records.
-  Lands here because this is the first milestone with record-typed params.
-- Namespace-qualified `MemberExpr` (`ns.foo`) routing is M2's concern; confirm the
-  value-typed-receiver path is correctly distinguished (see
-  [02-design-notes.md](02-design-notes.md) §"the constraint-generating AST walk").
-- **Tests**: `fn (p) => p.x + p.y` infers an (exact) `{x, y}`-shaped param; `open`
-  variant infers inexact `{x, y, ...}`; accessing a missing field on a known exact
-  record is rejected; the replacement of `Open`/`ArrayConstraint` behavior is
-  covered by re-expressing representative old-checker cases as intended-form table
-  tests.
-- **~Size**: medium.
-
-### PR 3 — `RefType` + `mut` (THE GATE)
-
-The single borrow wrapper and the one constrain rule. This clears the
-highest-risk gate.
-
-- `soltype`: `RefType{mut, lt, inner}` with `lt` left **nil** throughout this PR
-  (lifetimes arrive in PR 4); the `RefInner` sealed marker interface (only
-  `RecordType`/`TupleType`/`ClassType`(future)/`AliasType`/`UnionType`/
-  `IntersectionType`/`TypeVarType` qualify) and the `borrowableType` content
-  predicate. The `NewRef` smart constructor enforcing the degenerate-cell
-  invariant (`{false, nil}` ⇒ return bare `inner`). Helpers `unwrapRef` /
-  `carrierOf`. Printer: `mut Point`, and bare-inner pass-through for the
-  degenerate cell.
-- `constrain` — the **one** `RefType` rule (per
-  [02-design-notes.md](02-design-notes.md) §"The one `RefType` constrain rule"),
-  with lifetime steps written but inert while `lt == nil`:
-  1. mutability compatibility (`!l.mut && r.mut` ⇒ error);
-  2. inner variance — **bidirectional iff `r.mut`** (read view always +
-     contravariant write view when the target writes) = the read/write
-     decomposition that encodes invariance; covariant-only otherwise;
-  3. lifetime step (no-op here);
-  - plus `bare <: RefType` (wrap source as immutable/no-lt and re-dispatch) and
-    `RefType <: bare` (peel; escape-error guard becomes live in PR 4).
-- Field-write inference (`infer.go`): `obj.x = v` ⇒ `constrain(obj <: RefType{mut:
-  true, lt: nil, inner: RecordType{x: widen(v)}})` with literal widening; multiple
-  writes merge into one mutable record. Read-after-write: a read of a
-  just-written field returns the written type.
-- **Acceptance (the gate)**: reproduce the spike's `mut` cases from real source —
-  `mut {x,y} <: mut {x}` **fails** while immutable `{x,y} <: {x}` succeeds by
-  width subtyping; `fn foo(obj) { obj.x = 5; obj.y = 10 }` infers `(obj: mut {x:
-  number, y: number}) -> unit`; `fn foo(obj) { obj.x = 5; return obj.x }` infers
-  `(obj: mut {x: number}) -> number`; mut-borrow decay (`mut {x} <: {x}`) allowed,
-  the reverse rejected (full messages).
-- **Gate decision**: if the `mut`-driven invariance cannot be encoded cleanly here,
-  **stop and reassess** before PR 4/5 — that is the milestone's instruction.
-- **~Size**: medium-large. This is the conceptual core of M4.
-
-### PR 4 — Lifetimes as a second sort
-
-Populate the `lt` field that PR 3 left nil; activate the lifetime steps of the
-`RefType` rule.
-
-- `soltype/lifetime.go`: `LifetimeVar{lowerBounds, upperBounds}`,
-  `StaticLifetime` (top), and the single `LifetimeUnion` flow-set surface
-  representation (per [03-references.md](03-references.md) — one list, read as
-  join in positive position / meet in negative). `constrainLt` mirroring
-  `constrain` over the outlives lattice.
-- Activate `RefType` rule step 3 (covariant lifetime; the `RefType <: bare`
-  escape-error when `l.lt != nil`) and the `bare <: RefType` owned-satisfies-any
-  branch.
-- Borrow origination: `mut`/immutable `RefType`-typed parameters get a **fresh
-  lifetime** (`attachParamLifetimes` in `infer.go`); returning a borrow shares the
-  lifetime by value identity; multi-source returns **union** lifetimes via a fresh
-  join var; escape to module/static storage ⇒ `constrain(lt <: 'static)`.
-- Field-write target lifetime becomes a **fresh variable** (not nil) so the
-  receiver may be owned-mutable or a mut-borrow of any lifetime (per
-  [02-design-notes.md](02-design-notes.md) §"the constraint-generating AST walk",
-  assignment-to-member case).
-- Lifetime coalescing + **elision**, branching on `mut` at the elision site:
-  mutable borrow with elided lt ⇒ elide-in-place (`RefType{mut:true, lt:nil}`,
-  well-formed owned-mutable); **immutable** borrow with elided lt ⇒ **drop the
-  wrapper entirely** (else it becomes the forbidden degenerate cell).
-- **Acceptance**: the canonical lifetime cases from real source —
-  `IdentityRefReturn` ⇒ `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`;
-  `FreshObjectReturn` carries no lifetime; `ConditionalUnionReturn` ⇒ `mut ('a |
-  'b) {x: number}`; `EscapingRefIntoStatic` ⇒ `mut 'static`; property-level and
-  tuple-per-slot lifetimes; read-after-write field collapse with a lifetime
-  present. Plus: `RefType` neither tightens nor loosens the inner's exactness (the
-  inner carrier's `exact` flag passes through unchanged).
-- **~Size**: large. The second-sort machinery + elision branching is the bulk.
-
-### PR 5 — Mutability-transition checking (port)
-
-The flow-sensitive mutable↔immutable alias-creation check, ported with minimal
-adaptation (per the milestone's "reuses existing infrastructure" note).
-
-- Reuse `internal/liveness/` **verbatim** (`VarID`/`CFG`/`AliasTracker`/
-  `LivenessInfo`); reuse `liveness_prepass.go`.
-- Reimplement the two narrow predicates over `soltype`: `isValueType(t)` and
-  `isMutableType(t)` (the latter becomes `if r, ok := t.(*soltype.RefType); ok {
-  return r.mut }; return false`).
-- `checkMutabilityTransition`'s Rule 1 / Rule 2 / Rule 3 logic is **unchanged** —
-  it talks only to `liveness.Liveness`/`liveness.AliasTracker`.
-- `solver.Context` gains `Liveness` / `Aliases` fields, populated by the existing
-  prepass.
-- **Simplification**: collapse the `HasStaticMutAlias` / `HasStaticImmAlias`
-  escape-hatch bits — under the new checker the escape is first-class
-  (`lt <: 'static` is in the inference output), so the transition checker queries
-  the lifetime sort directly. This depends on PR 4, which is why it is last.
-- **Acceptance**: port the old checker's transition-checking fixtures/cases as
-  intended-form table tests; the static-escape cases pass via lifetime queries
-  rather than the dropped bits.
-- **~Size**: medium (mostly a port; the simplification is the only genuinely new
-  logic).
-
-## Sequencing summary
-
-```
-PR1 records+tuples+exactness ─► PR2 usage-based reads ─► PR3 RefType + mut  (GATE)
-                                                              │
-                                                              ▼
-                                              PR4 lifetimes (second sort)
-                                                              │
-                                                              ▼
-                                              PR5 transition checking (port)
+// borrowableType is the content invariant the RefInner marker can't express
+// (e.g. it rejects Union{RecordType, PrimitiveType}); descends collections.
+func borrowableType(t Type) bool
 ```
 
-- PR1 → PR2: usage inference needs the record carrier and its coalescing.
-- PR2 → PR3: the `mut` write path and read-after-write build on the member-access
-  path; non-trivial inferred record shapes make the gate's tests meaningful.
-- **PR3 is the gate** — do not start PR4/PR5 until it is cleared.
-- PR3 → PR4: lifetimes ride on the `RefType` wrapper PR3 introduces.
-- PR4 → PR5: the transition-check simplification (dropping the static-alias bits)
-  consumes the lifetime sort.
+### The lifetime sort (`soltype/lifetime.go`, faithful to spike)
 
-PR1 and the *test scaffolding* for PR2 can be drafted in parallel, but the merge
-order is strict. PR4 and PR5 cannot be meaningfully parallelized because PR5's
-simplification depends on PR4's escape-as-`'static` output.
+```go
+type Lifetime interface{ isLifetime() }
+
+type LifetimeVar struct {
+    id          int
+    lowerBounds []Lifetime
+    upperBounds []Lifetime
+}
+type StaticLifetime struct{} // top of the outlives lattice ('static)
+
+func (c *checker) freshLifetime() *LifetimeVar
+
+// constrainLt mirrors constrain over the outlives lattice: a var on the left
+// gains an upper bound, on the right a lower bound; var-to-var records both
+// directions. 'static is top, so X <: 'static always holds. Uses a seen-set
+// keyed on (lhs, rhs) for cycle termination.
+func (c *checker) constrainLt(lhs, rhs Lifetime)
+```
+
+### `constrain`: record + exactness (`constrain.go`)
+
+```go
+func (c *checker) constrainRecords(l, r *RecordType, seen seenSet) []error {
+    var errs []error
+    // every field r requires must exist in l, covariantly (depth subtyping)
+    for name, rt := range r.fields {
+        lt, ok := l.fields[name]
+        if !ok {
+            errs = append(errs, missingFieldError(name)) // full message asserted in tests
+            continue
+        }
+        errs = append(errs, c.constrain(lt, rt, seen)...)
+    }
+    // one-way exactness rule (02-design-notes §"Exactness"):
+    //   exact <: inexact            ok
+    //   exact <: exact              same member set (no extra in l)
+    //   inexact <: exact            rejected
+    //   inexact <: inexact          width subtyping (the loop above already allows extra)
+    if r.exact {
+        if !l.exact {
+            errs = append(errs, inexactIntoExactError(l, r))
+        }
+        for name := range l.fields {
+            if _, ok := r.fields[name]; !ok {
+                errs = append(errs, extraMemberError(name, r))
+            }
+        }
+    }
+    return errs
+}
+```
+
+### `constrain`: the single `RefType` rule — **THE GATE** (`constrain.go`)
+
+```go
+// Adapted from the spike's *Mut case (constrain.go:182-198), generalized to the
+// unified wrapper. The mut-driven bidirectional inner sweep is the read/write
+// decomposition that encodes invariance — the highest-risk gate.
+case *RefType: // l := lhs.(*RefType)
+    if r, ok := rhs.(*RefType); ok {
+        // 1. mutability compatibility — can't widen immutable to mutable.
+        if !l.mut && r.mut {
+            return []error{mutabilityError(l, r)}
+        }
+        // 2. inner variance — bidirectional iff the TARGET is mutable.
+        errs := c.constrain(l.inner, r.inner, seen) // read view (covariant)
+        if r.mut {
+            errs = append(errs, c.constrain(r.inner, l.inner, seen)...) // write view (contra)
+        }
+        // 3. lifetime — covariant when both present (inert until Phase D).
+        switch {
+        case l.lt != nil && r.lt != nil:
+            c.constrainLt(r.lt, l.lt)
+        case l.lt == nil && r.lt != nil: // owned source into borrow slot: ok
+        case l.lt != nil && r.lt == nil: // borrow into owned slot: escape
+            errs = append(errs, escapeError(l, r))
+        }
+        return errs
+    }
+    // RefType <: bare: only valid when l is an owned value (no lifetime).
+    if l.lt != nil {
+        return []error{escapeError(l, rhs)}
+    }
+    return c.constrain(l.inner, rhs, seen)
+// (bare <: RefType handled symmetrically: wrap source as NewRef(false,nil,_)
+//  and re-dispatch into the RefType<:RefType branch.)
+```
+
+### Usage-based inference + field write (`infer.go`)
+
+```go
+// MemberExpr read on a value-typed receiver: obj.field
+// The synthesized requirement is INEXACT ({field: β, ...}) — "recv must have AT
+// LEAST this field"; Policy-A coalescing closes the param to exact afterward.
+func (c *checker) inferMemberRead(recv Type, field string, n ast.Node) Type {
+    beta := c.freshVarAt(n, FieldAccess) // also writes Prov
+    req := &RecordType{fields: map[string]Type{field: beta}, exact: false}
+    c.constrain(recv, req, c.newSeen())
+    return beta
+}
+
+// Member write: obj.field = v  (constrain.go widen() reused)
+func (c *checker) inferFieldWrite(recv Type, field string, v Type, n ast.Node) {
+    lt := c.freshLifetime() // fresh: recv may be owned-mutable OR a mut-borrow of any lifetime
+    req := NewRef(true, lt, &RecordType{
+        fields: map[string]Type{field: widen(v)}, exact: false,
+    })
+    c.constrain(recv, req, c.newSeen())
+    c.recordWritten(recv, field, widen(v)) // read-after-write (spike's `written` map)
+}
+```
+
+### Borrow origination + lifetime coalescing/elision (`infer.go` / `coalesce.go`)
+
+```go
+// A RefType-typed parameter is a borrow without a lifetime yet: give it a fresh
+// one and record it as a "param lifetime" (only these are named in output).
+// Adapted from spike attachParamLifetimes (lifetime.go:260).
+func (c *checker) attachParamLifetimes(t Type) Type {
+    r, ok := t.(*RefType)
+    if !ok || r.lt != nil {
+        return t
+    }
+    lt := c.freshLifetime()
+    c.paramLifetimes.Add(lt.id)
+    return &RefType{mut: r.mut, lt: lt, inner: r.inner}
+}
+
+// Coalescing a RefType, with the mut-vs-immutable elision branch (the subtle one).
+func (c *checker) coalesceRef(t *RefType, pol Polarity, st *coalesceState) Type {
+    inner := c.coalesceInner(t.inner, pol, st) // inner invariance handled by constrain, not here
+    name := c.lifetimeName(t.lt, pol)          // "" when the lifetime is elidable
+    if name == "" {
+        if t.mut {
+            return NewRef(true, nil, inner.(RefInner)) // owned-mutable, well-formed
+        }
+        return inner // immutable + elided ⇒ MUST drop the wrapper (else degenerate cell)
+    }
+    return type_system.NewBorrowType(nil, inner, name, t.mut) // `mut 'a T` / `'a T`
+}
+```
+
+### Transition checking (`transitions.go` / `context.go`)
+
+```go
+// Two narrow predicates reimplemented over soltype (the rest of
+// internal/liveness ports verbatim).
+func isMutableType(t Type) bool {
+    if r, ok := t.(*RefType); ok {
+        return r.mut
+    }
+    return false
+}
+func isValueType(t Type) bool // ported from check_transitions.go:189-217
+
+// solver.Context gains the liveness fields the ported checker reads.
+type Context struct {
+    // ... existing M1–M3 fields (level, Probe, etc.)
+    Liveness *liveness.Liveness
+    Aliases  *liveness.AliasTracker
+}
+```
+
+---
+
+## Revised PR breakdown (finer than the first cut)
+
+The first draft of this plan used five PRs, two of them "large" (the `mut` gate
+and lifetimes lumped whole). For "the big one" that is too coarse to review
+well — the gate in particular deserves a PR where it is the *only* thing under
+review. The breakdown below is **13 PRs across 5 phases**, each independently
+mergeable, each keeping `go test ./...` green, each shipping its own
+table-driven tests (rendered types + **full** error messages, per CLAUDE.md).
+LoC figures are non-test estimates.
+
+### Phase A — Records & tuples (carrier + exactness)
+
+- **A1 — Representation + literal inference + coalescing + printer** (~250).
+  `RecordType`/`TupleType` with the `exact` flag; smart constructors; `ObjectExpr`
+  ⇒ exact record, `TupleExpr` ⇒ exact tuple; positive-position coalescing
+  (covariant fields/elems); printer for `{x: T}`, `[T, U]`, trailing `...`.
+  *Mergeable alone:* infers and renders literals; no subtyping needed to test.
+- **A2 — Structural + exactness subtyping** (~200). `constrainRecords` /
+  `constrainTuples` with the one-way exact/inexact rule (width subtyping only
+  inexact↔inexact; exact↔exact same-set; extra-member rejection). *Builds on A1;
+  first PR that accepts/rejects against annotations.*
+
+### Phase B — Usage-based inference
+
+- **B1 — Member-read usage inference + negative-position record coalescing**
+  (~250). `MemberExpr` read ⇒ `constrain(recv <: {field: β, ...})`; merge object
+  upper-bounds into one record at coalescing; close to **exact** (Policy A).
+  Replaces `Open`/`Widenable`/`ArrayConstraint` (re-express representative
+  old-checker cases as intended-form tests).
+- **B2 — The `open` parameter marker** (~120). Parser keyword (provisional) +
+  semantic flag that keeps a usage-inferred param **inexact**. *Small, isolated;
+  the surface syntax can be gated if the spelling is unsettled.*
+
+### Phase C — Borrows & mutability (**the gate**)
+
+- **C1 — `RefType` plumbing** (~200). The wrapper type, `RefInner` sealed marker,
+  `borrowableType`, `NewRef` smart constructor (degenerate-cell invariant),
+  `unwrapRef`/`carrierOf`, printer. **No constrain rule yet.** *Pure plumbing +
+  unit tests on the constructor/marker/printer; trivially green.*
+- **C2 — The `RefType` constrain rule** (~180). **← THE GATE.** The single rule:
+  mutability compatibility, mut-driven bidirectional inner sweep (read/write
+  decomposition), lifetime steps written but inert (`lt == nil`), and the two
+  cross-cases. *Scoped so the gate is the only thing under review.* Acceptance:
+  `mut {x,y} <: mut {x}` **fails** while immutable `{x,y} <: {x}` succeeds;
+  mut-borrow decay (`mut {x} <: {x}`) allowed, reverse rejected.
+  **If this can't be encoded cleanly against the real AST, stop and reassess
+  before Phase D/E** (the milestone's instruction).
+- **C3 — Field-write inference + read-after-write** (~180). `obj.x = v` ⇒ a `mut`
+  record requirement (lifetime nil for now); literal widening; multi-write merge;
+  read-after-write field collapse. Acceptance: `fn foo(obj){obj.x=5; obj.y=10}`
+  ⇒ `(obj: mut {x: number, y: number}) -> unit`; `{obj.x=5; return obj.x}` ⇒
+  `... -> number`.
+
+### Phase D — Lifetimes (second sort)
+
+- **D1 — Lifetime sort plumbing** (~220). `LifetimeVar`/`StaticLifetime`/
+  `LifetimeUnion`, `constrainLt`, printer. *Standalone second-sort machinery +
+  unit tests on `constrainLt` (outlives, transitivity, cycles, `'static` top).*
+- **D2 — Activate lifetimes in the `RefType` rule + borrow origination** (~150).
+  Turn on step 3 of the gate rule and the escape guards; `attachParamLifetimes`.
+  Acceptance: `IdentityRefReturn` ⇒ `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x:
+  number}`; `FreshObjectReturn` carries no lifetime.
+- **D3 — Multi-source unioning + escape-to-`'static`** (~140). Join branch
+  lifetimes via a fresh join var; escape ⇒ `constrain(lt <: 'static)`. Acceptance:
+  `ConditionalUnionReturn` ⇒ `mut ('a | 'b) {x}`; `EscapingRefIntoStatic` ⇒
+  `mut 'static`.
+- **D4 — Lifetime coalescing + elision** (~200). `analyzeLts` occurrence pass;
+  drop a param-only lifetime that connects nothing; the **mut elide-in-place vs
+  immutable drop-the-wrapper** branch (the subtle one — isolated on purpose).
+  Acceptance: property-level / tuple-per-slot lifetimes; `RefType` passes the
+  inner carrier's `exact` flag through unchanged.
+
+### Phase E — Mutability-transition checking (port)
+
+- **E1 — Port liveness + predicates + wiring** (~220). Reuse `internal/liveness/`
+  verbatim and `liveness_prepass.go`; reimplement `isValueType`/`isMutableType`
+  over `soltype`; `checkMutabilityTransition` logic unchanged; add `Liveness`/
+  `Aliases` to `Context`. Port the old transition fixtures as intended-form tests.
+- **E2 — Collapse the static-alias escape hatches** (~120). Drop
+  `HasStaticMutAlias`/`HasStaticImmAlias`; the transition checker queries the
+  lifetime sort (`lt <: 'static`) directly. *Depends on Phase D, hence last; the
+  only genuinely new logic in the port.*
+
+### Dependency graph
+
+```
+A1 → A2 → B1 → B2
+            └─→ C1 → C2(GATE) → C3 → D1 → D2 → D3 → D4 → E1 → E2
+```
+
+A1→A2 (subtyping needs the carrier); B1 needs A's coalescing; C2 needs C1's
+wrapper; C3/Phase D ride on the gate; E2 needs Phase D's escape-as-`'static`.
+A and the test scaffolding for B can be drafted in parallel, but merge order is
+strict. The gate (C2) is reached after only the minimum needed to exercise it
+against the real AST, and nothing expensive (lifetimes, the port) is built before
+it is cleared.
+
+Total ≈ 2.4k LoC non-test across 13 PRs — a realistic shape for "the big one,"
+with the single highest-risk change (C2) isolated to ~180 reviewable lines.
+
+---
 
 ## Testing strategy
 
-Following [02-design-notes.md](02-design-notes.md) §"Test coverage" and CLAUDE.md:
+Per [02-design-notes.md](02-design-notes.md) §"Test coverage" and CLAUDE.md:
+table-driven `*_test.go` keyed by name, with `expectedValues`/`expectedTypes`
+(rendered Escalier annotations) and `expectedError` (**full** message), authored
+against intended semantics — not copied from the old checker. Use inline snapshots
+for large type trees (nested borrowed records with per-field lifetimes). Each PR
+carries the acceptance set named in its section; the union is the milestone's M4
+criteria. No fixture-harness wiring yet (that's M7); M4 is validated entirely by
+the new package's own tests driven from real `.esc` source through the M2 bridge.
 
-- **Granular semantics** as table-driven `*_test.go` in the new checker package,
-  keyed by test name with `expectedValues` / `expectedTypes` (rendered Escalier
-  type-annotation strings) and `expectedError` (**full** message). Authored
-  against intended semantics, not copied from the old checker.
-- Where a type tree is large (e.g. nested borrowed records with per-field
-  lifetimes), render the subtree and use an inline snapshot rather than many
-  drill-down assertions.
-- Each PR carries the acceptance set named in its section above; the union of
-  those sets is the milestone's M4 acceptance criteria from
-  [01-milestones.md](01-milestones.md).
-- No fixture-harness wiring yet (that is M7); M4 validation is entirely the new
-  package's own tests driven from real `.esc` source through the M2 parser bridge.
+## Risks / open questions
 
-## Risks and open questions
-
-- **The gate (PR 3)** is the dominant risk; it is front-loaded and has an explicit
-  stop-and-reassess decision. The spike de-risked the *algorithm*; the residual
-  risk is encoding it cleanly against the production AST and `soltype`.
-- **Lifetime elision branching on `mut`** (PR 4) is the subtlest non-gate piece —
-  the immutable-borrow-must-drop-the-wrapper rule is easy to get wrong and
-  reintroduce the forbidden degenerate cell. The `NewRef` smart-constructor
-  assertion is the backstop; the coalescer must branch on `mut` at the elision
-  site.
-- **`open` keyword** is provisional (PR 2). If naming is unsettled, gate the
-  surface syntax behind the parser and keep the semantic flag; the inference
-  behavior is what M4 must prove, not the spelling.
-- **Probe usage**: M4's core path is monotone and needs no rollback, but the
-  field-write merge and any union-against-variable deferral should be written
-  probe-aware so M6/M8 speculation composes without rework.
-- **`exact`-by-default surface**: per the milestone, the exactness default for
-  usage-inferred shapes (Policy A) and the `open` opt-out are **not yet reflected
-  in `planning/exact-types/requirements.md`**. That spec section should be written
-  before PR 2 lands so the tests assert an agreed default.
+- **The gate (C2)** is the dominant risk and is front-loaded with an explicit
+  stop-and-reassess. The spike de-risked the *algorithm*; residual risk is
+  encoding it cleanly against the production AST/`soltype`.
+- **Elision branching on `mut` (D4)** is the subtlest non-gate piece — the
+  immutable-borrow-must-drop-the-wrapper rule, if missed, reintroduces the
+  forbidden degenerate cell. The `NewRef` assertion is the backstop.
+- **`open` keyword (B2)** is provisional; gate the spelling, keep the semantic
+  flag — the inference behavior is what M4 must prove.
+- **Probe usage**: M4's core path is monotone (no rollback needed for failed
+  constraints), but the field-write merge and any future union-against-variable
+  deferral should be written probe-aware so M6/M8 speculation composes.
+- **Exact-by-default spec**: the Policy-A default and the `open` opt-out are **not
+  yet in `planning/exact-types/requirements.md`** — that section should be written
+  before B1 lands so the tests assert an agreed default.


### PR DESCRIPTION
This adds the detailed implementation plan for M4 — the milestone that introduces core value types (records with exactness, lifetimes, mutability, and destructuring patterns).

## Summary

The M4 plan document (`planning/simple_sub/m4-implementation-plan.md`) is a comprehensive 1000+ line specification that breaks down the work into 17 independently mergeable PRs across 7 phases. It builds on M1–M3 (which have landed on main) and specifies the exact data structures, algorithms, error types, and acceptance tests needed to ship records with exactness flags, the unified `RefType` wrapper for borrows and mutability, lifetimes as a second constraint sort, field-write inference, destructuring patterns, the `match` expression, and namespace member lookup.

## Key sections

- **Ground truth (M1–M3 shipped):** Documents what actually landed in the codebase (package layout, `RecordType` structure, `Inexact` flag convention, probe discipline, visitor pattern, coalescing at display time, reassignment, error recovery, scope/namespace, type annotations, milestone renumbering).

- **Why M4 is "the big one":** Explains the inseparability of records, `mut`, and lifetimes, and identifies the `RefType` constrain rule as the highest-risk gate — nothing expensive starts before it clears.

- **Scope:** Lists what lands in M4 (exactness on records/tuples, usage-based inference refinement, `var` literal widening, the `RefType` wrapper and its single constrain rule, lifetimes, destructuring, `match`, namespace lookup, mutability-transition checking) and what defers (classes to M5, union/intersection rules to M6, etc.).

- **Key types and sketches:** Provides Go-like pseudocode for `RecordType.Inexact`, `TupleType.Inexact`, the `RefType{Mut, Lt, Inner}` wrapper, the sealed `RefInner` interface, the single constrain rule (the gate), lifetime sort (`LifetimeVar`, `StaticLifetime`), probe extension, field-write inference, display-time coalescing, and namespace lookup.

- **PR breakdown:** 17 PRs organized into phases:
  - **Phase A** (records & tuples completion): exactness flags, selection-vs-concrete split, tuple spread, type annotations.
  - **Phase B** (usage-based inference): negative-position record merging, Policy-A exact closing, `open` marker, `var` literal widening.
  - **Phase C** (borrows & mutability, **the gate**): `RefType` plumbing, the constrain rule, field-write inference, read-after-write.
  - **Phase D** (lifetimes): lifetime sort, probe extension, rule activation, borrow origination, joins, escape, display-time coalescing and elision.
  - **Phase E** (destructuring + `match`): structural patterns, the `match` expression with exactness-driven exhaustiveness.
  - **Phase F** (namespace lookup): `resolvePath`, member access, new errors.
  - **Phase G** (transition checking): port `internal/liveness/` and reimplement two predicates over `soltype`.

Each PR names the files touched, data structures added/modified, algorithm changes, and acceptance tests — enough to start implementation without further planning.

## Notable details

- The plan documents the standing rule: every new `soltype` former or second sort must touch `type.go` (`isType` + `LevelOf`), `visitor.go` (`Accept`), `print.go` (`printType` + `typePrec` + `freeTypeVars`), and `solver/coalesce.go` (`equalType`). Missing one causes latent panics or silent wrong results.

- The `RefType` constrain rule (C2, the gate) is written out in full pseudocode, including the read/write decomposition for invariance, lifetime steps (inert until D2), and cross-case wrapping/peeling.

- Lifetime elision branches on `Mut` — a subtle case where an immutable borrow with an elided lifetime must drop the `RefType` wrapper entirely (

https://claude.ai/code/session_01MvkQ4cK8oc3EeDfXvw68eL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified milestone scope and deferred several features to later phases.
  * Added a detailed M4 implementation plan outlining scope, phases, and acceptance criteria.
  * Tightened exactness rules: direct-literal excess property/element checking and its interaction with typed tails.
  * Specified rest-param element checking and typed variadic tuple behavior.
  * Introduced object- and tuple-spread type semantics and exactness threading.
  * Added contributor guidance to prefer concise, direct responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->