### PR TITLE
M4 A1: Object exactness and width-tolerance subtyping

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -30,8 +30,8 @@ func typePrec(t Type) int {
 	case *IntersectionType:
 		return precIntersection
 	default:
-		// PrimType, LitType, TupleType, RecordType, Void, NeverType, UnknownType —
-		// atoms (RecordType is brace-delimited, so it never needs parens). A
+		// PrimType, LitType, TupleType, ObjectType, Void, NeverType, UnknownType —
+		// atoms (ObjectType is brace-delimited, so it never needs parens). A
 		// raw TypeVarType (which appears only when printing an un-coalesced type,
 		// see printType) is also an atom (rendered as `t{ID}`), so it lands here.
 		return precAtom
@@ -144,9 +144,11 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, e := range t.Elems {
 				walk(e)
 			}
-		case *RecordType:
-			for _, f := range t.Fields {
-				walk(f.Type)
+		case *ObjectType:
+			for _, e := range t.Elems {
+				if p, ok := e.(*PropertyElem); ok {
+					walk(p.Type)
+				}
 			}
 		case *PromiseType:
 			walk(t.Inner)
@@ -217,12 +219,23 @@ func (p *namedPrinter) printType(t Type) string {
 			elems[i] = p.printType(e)
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
-	case *RecordType:
-		fields := make([]string, len(t.Fields))
-		for i, f := range t.Fields {
-			fields[i] = printRecordFieldName(f.Name) + ": " + p.printType(f.Type)
+	case *ObjectType:
+		elems := make([]string, 0, len(t.Elems)+1)
+		for _, e := range t.Elems {
+			prop, ok := e.(*PropertyElem)
+			if !ok {
+				continue
+			}
+			opt := ""
+			if prop.Optional {
+				opt = "?"
+			}
+			elems = append(elems, printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
 		}
-		return "{" + strings.Join(fields, ", ") + "}"
+		if t.Inexact {
+			elems = append(elems, "...")
+		}
+		return "{" + strings.Join(elems, ", ") + "}"
 	case *FuncType:
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
@@ -282,11 +295,11 @@ func paramName(p *FuncParam, i int) string {
 	return "arg" + strconv.Itoa(i)
 }
 
-// printRecordFieldName renders a record field name as Escalier surface syntax:
+// printObjectKeyName renders an object property name as Escalier surface syntax:
 // a bare label when the name is a valid identifier, otherwise a quoted string
 // key (e.g. "a-b", a key that came from a string-literal property). This keeps
-// the rendered record parseable; an unquoted "a-b" would corrupt the type.
-func printRecordFieldName(name string) string {
+// the rendered object parseable; an unquoted "a-b" would corrupt the type.
+func printObjectKeyName(name string) string {
 	if isIdent(name) {
 		return name
 	}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -146,9 +146,7 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *ObjectType:
 			for _, e := range t.Elems {
-				if p, ok := e.(*PropertyElem); ok {
-					walk(p.Type)
-				}
+				walk(AsProperty(e).Type)
 			}
 		case *PromiseType:
 			walk(t.Inner)
@@ -222,10 +220,7 @@ func (p *namedPrinter) printType(t Type) string {
 	case *ObjectType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
-			prop, ok := e.(*PropertyElem)
-			if !ok {
-				continue
-			}
+			prop := AsProperty(e)
 			opt := ""
 			if prop.Optional {
 				opt = "?"

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -259,6 +259,18 @@ func TestPrintScheme(t *testing.T) {
 		ty := &TupleType{Elems: []Type{a, a}}
 		require.Equal(t, "<T0> [T0, T0]", PrintAsScheme(ty))
 	})
+
+	t.Run("object property vars are named in property order", func(t *testing.T) {
+		a := &TypeVarType{ID: 1, Level: 1}
+		b := &TypeVarType{ID: 2, Level: 1}
+		// fn () -> {a: a, b: b}: freeTypeVars walks the return object's properties in
+		// order, so a names T0 (property a) and b names T1 (property b).
+		ty := &FuncType{Ret: &ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: a},
+			&PropertyElem{Name: "b", Type: b},
+		}}}
+		require.Equal(t, "fn <T0, T1>() -> {a: T0, b: T1}", PrintAsScheme(ty))
+	})
 }
 
 // PrintAsSchemeWith names ONLY the variables the predicate accepts as quantified

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -54,19 +54,36 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"empty tuple", &TupleType{}, "[]"},
 		{"pair tuple", &TupleType{Elems: []Type{numP(), strP()}}, "[number, string]"},
 
-		// Records.
-		{"empty record", &RecordType{}, "{}"},
+		// Objects.
+		{"empty object", &ObjectType{}, "{}"},
 		{
-			"two-field record",
-			&RecordType{Fields: []*RecordField{{Name: "a", Type: numP()}, {Name: "b", Type: strP()}}},
+			"two-property object",
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP()}, &PropertyElem{Name: "b", Type: strP()}}},
 			"{a: number, b: string}",
 		},
 		{
-			// A field name that isn't a valid identifier (e.g. from a string-literal
-			// key) is quoted so the rendered record stays parseable.
-			"non-identifier field name is quoted",
-			&RecordType{Fields: []*RecordField{{Name: "a-b", Type: numP()}}},
+			// A property name that isn't a valid identifier (e.g. from a string-literal
+			// key) is quoted so the rendered object stays parseable.
+			"non-identifier property name is quoted",
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a-b", Type: numP()}}},
 			`{"a-b": number}`,
+		},
+		{
+			// An inexact object renders a trailing `...`, mirroring inexact functions.
+			"inexact object renders trailing ...",
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP()}}, Inexact: true},
+			"{a: number, ...}",
+		},
+		{
+			"inexact empty object",
+			&ObjectType{Inexact: true},
+			"{...}",
+		},
+		{
+			// An optional property renders `x?: T`.
+			"optional property renders ?",
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP(), Optional: true}}},
+			"{a?: number}",
 		},
 
 		// Functions. A bare (exact) function renders with no trailing marker; an
@@ -165,11 +182,11 @@ func TestPrintNestedPrecedence(t *testing.T) {
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`[fn (x: number) -> string, boolean]`))
 	})
 
-	// A record is brace-delimited (an atom), so a record nested in a union needs
-	// no parens, and a function as a field value is delimited by the field's `:`.
-	t.Run("record in union", func(t *testing.T) {
+	// An object is brace-delimited (an atom), so an object nested in a union needs
+	// no parens, and a function as a property value is delimited by the property's `:`.
+	t.Run("object in union", func(t *testing.T) {
 		ty := &UnionType{Types: []Type{
-			&RecordType{Fields: []*RecordField{{Name: "f", Type: &FuncType{Ret: numP()}}}},
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "f", Type: &FuncType{Ret: numP()}}}},
 			strP(),
 		}}
 		snaps.MatchInlineSnapshot(t, Print(ty), snaps.Inline(`{f: fn () -> number} | string`))

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -178,6 +178,23 @@ func (o *ObjectType) Prop(name string) (*PropertyElem, bool) {
 	return nil, false
 }
 
+// AsProperty narrows an ObjTypeElem to its *PropertyElem. M4 ships PropertyElem
+// as the only ObjTypeElem kind, so any other element is a bug: a later member
+// kind (method/getter/setter in M5, index signature or object rest/spread in M9)
+// wired up without extending the call site that processes every element. It
+// panics rather than silently skipping, matching type_system's unknown-element
+// convention (print_type.go panics on an unhandled ObjTypeElem) and the M4 plan's
+// standing rule that a missed element kind must fail loudly, not vanish from
+// subtyping, equality, or rendering. Use it at sites that must visit EVERY
+// element; name lookups like Prop legitimately skip non-matching kinds instead.
+func AsProperty(e ObjTypeElem) *PropertyElem {
+	p, ok := e.(*PropertyElem)
+	if !ok {
+		panic(fmt.Sprintf("AsProperty: unhandled ObjTypeElem %T", e))
+	}
+	return p
+}
+
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
 // scope narrow: it is the one stdlib generic the milestone needs typed (Iterable/
@@ -256,9 +273,7 @@ func LevelOf(t Type) int {
 	case *ObjectType:
 		m := 0
 		for _, e := range t.Elems {
-			if p, ok := e.(*PropertyElem); ok {
-				m = max(m, LevelOf(p.Type))
-			}
+			m = max(m, LevelOf(AsProperty(e).Type))
 		}
 		return m
 	case *PromiseType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -130,32 +130,49 @@ type FuncType struct {
 // TupleType is a fixed-length tuple type.
 type TupleType struct{ Elems []Type }
 
-// RecordType is a record/object type with named value fields. M2 ships the
-// BASIC width-and-depth-subtyping form that record literals and field reads
-// need ({a: 5}, recv.a); the richer object system — optional fields, methods,
-// getters/setters, index signatures, spreads, `mut`, and usage-inference — is
-// M4. It mirrors the role of type_system.ObjectType but carries only named
-// value fields (no method/getter/setter/mapped elements yet), so it stays a
-// flat list of Name→Type fields. Subtyping matches fields by name (order is
-// irrelevant); the slice order is preserved only for stable rendering.
-type RecordType struct{ Fields []*RecordField }
-
-// RecordField is one named field of a RecordType.
-type RecordField struct {
-	Name string
-	Type Type
+// ObjectType is the structural object type — the carrier for object literals,
+// object/interface annotations, and (M5) class instance bodies, so one
+// structural-decomposition routine serves all three. It promotes M2's
+// RecordType{Fields} to an ordered element list. M4 ships only PropertyElem;
+// MethodElem/GetterElem/SetterElem arrive in M5, and IndexSigElem plus the
+// object rest/spread RestElem in M9, each a new ObjTypeElem arm.
+//
+// Inexact follows M3's FuncType convention: the zero value is exact, matching
+// Escalier's exact-by-default semantics, so every object M2 already mints —
+// literals, member-access requirements — is exact by default with no
+// construction-site churn. Only the parser's trailing `...` marker sets it.
+// Subtyping matches elements by name (order is irrelevant); the slice order is
+// preserved only for stable rendering.
+type ObjectType struct {
+	Elems   []ObjTypeElem // ordered, name-deduped (last wins); Prop(name) lookup
+	Inexact bool          // trailing `...` ⇒ true
 }
 
-// Field returns the type of the named field and whether it is present. Field
-// names are unique in a well-formed RecordType — the constraint solver dedups
-// duplicate keys (last value wins) when it builds a record from a literal — so
-// the first match is the field. The scan is linear because records are small;
-// it is the single canonical field lookup shared by constraining, structural
-// equality, and member access.
-func (r *RecordType) Field(name string) (Type, bool) {
-	for _, f := range r.Fields {
-		if f.Name == name {
-			return f.Type, true
+// ObjTypeElem is the sealed set of object members, mirroring type_system's
+// ObjTypeElem. M4 ships PropertyElem only; method/getter/setter members (M5),
+// index signatures and the object rest/spread (M9) add arms later.
+type ObjTypeElem interface{ isObjTypeElem() }
+
+// PropertyElem is one named value property of an ObjectType.
+type PropertyElem struct {
+	Name     string
+	Type     Type
+	Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
+}
+
+func (*PropertyElem) isObjTypeElem() {}
+
+// Prop returns the named property and whether it is present. Property names are
+// unique in a well-formed ObjectType — the constraint solver dedups duplicate
+// keys (last value wins) when it builds an object from a literal — so the first
+// match is the property. The scan is linear because objects are small; it is the
+// single canonical property lookup shared by constraining, structural equality,
+// and member access. M4's Elems are all PropertyElem; M5 widens the lookup to
+// method/getter/setter members.
+func (o *ObjectType) Prop(name string) (*PropertyElem, bool) {
+	for _, e := range o.Elems {
+		if p, ok := e.(*PropertyElem); ok && p.Name == name {
+			return p, true
 		}
 	}
 	return nil, false
@@ -209,7 +226,7 @@ func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
 func (*TupleType) isType()        {}
-func (*RecordType) isType()       {}
+func (*ObjectType) isType()       {}
 func (*PromiseType) isType()      {}
 func (*Void) isType()             {}
 func (*NeverType) isType()        {}
@@ -236,10 +253,12 @@ func LevelOf(t Type) int {
 			m = max(m, LevelOf(e))
 		}
 		return m
-	case *RecordType:
+	case *ObjectType:
 		m := 0
-		for _, f := range t.Fields {
-			m = max(m, LevelOf(f.Type))
+		for _, e := range t.Elems {
+			if p, ok := e.(*PropertyElem); ok {
+				m = max(m, LevelOf(p.Type))
+			}
 		}
 		return m
 	case *PromiseType:

--- a/internal/soltype/type_test.go
+++ b/internal/soltype/type_test.go
@@ -71,6 +71,36 @@ func TestLevelOf(t *testing.T) {
 			}},
 			want: 5,
 		},
+		{
+			// LevelOf must descend into ObjectType property types — its arm drives
+			// freshenAbove's level prune, and a wrong 0 would let a Level>0 object be
+			// shared and aliased across instantiations (the IntersectionType comment
+			// in LevelOf explains the same hazard).
+			name: "object: max over property types",
+			ty: &ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "a", Type: num},
+				&PropertyElem{Name: "b", Type: v2},
+				&PropertyElem{Name: "c", Type: v5},
+			}},
+			want: 5,
+		},
+		{
+			name: "object with concrete-only properties is level 0",
+			ty: &ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "a", Type: num},
+			}},
+			want: 0,
+		},
+		{
+			name: "nested function inside object",
+			ty: &ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "f", Type: &FuncType{
+					Params: []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: v5}},
+					Ret:    num,
+				}},
+			}},
+			want: 5,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -111,16 +111,16 @@ func (t *TupleType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *RecordType) Accept(v TypeVisitor, pol Polarity) Type {
+func (t *ObjectType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	fields, changed := acceptFields(cur.Fields, v, pol) // covariant
+	elems, changed := acceptObjElems(cur.Elems, v, pol) // covariant
 	out := cur
 	if changed {
-		out = &RecordType{Fields: fields}
+		out = &ObjectType{Elems: elems, Inexact: cur.Inexact}
 	}
 	return v.ExitType(out, pol)
 }
@@ -204,18 +204,24 @@ func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, b
 	return out, changed
 }
 
-// acceptFields walks each field's type covariantly, copy-on-write like acceptParams.
-func acceptFields(fs []*RecordField, v TypeVisitor, pol Polarity) ([]*RecordField, bool) {
-	out := fs
+// acceptObjElems walks each property's type covariantly, copy-on-write like
+// acceptParams. M4's elements are all PropertyElem; later member kinds add their
+// own variance treatment here.
+func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeElem, bool) {
+	out := es
 	changed := false
-	for i, f := range fs {
-		ft := f.Type.Accept(v, pol)
-		if ft != f.Type {
+	for i, e := range es {
+		p, ok := e.(*PropertyElem)
+		if !ok {
+			continue
+		}
+		pt := p.Type.Accept(v, pol)
+		if pt != p.Type {
 			if !changed {
-				out = append([]*RecordField(nil), fs...)
+				out = append([]ObjTypeElem(nil), es...)
 				changed = true
 			}
-			out[i] = &RecordField{Name: f.Name, Type: ft}
+			out[i] = &PropertyElem{Name: p.Name, Type: pt, Optional: p.Optional}
 		}
 	}
 	return out, changed

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -211,10 +211,7 @@ func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeEle
 	out := es
 	changed := false
 	for i, e := range es {
-		p, ok := e.(*PropertyElem)
-		if !ok {
-			continue
-		}
+		p := AsProperty(e)
 		pt := p.Type.Accept(v, pol)
 		if pt != p.Type {
 			if !changed {

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -200,3 +200,35 @@ func TestAcceptDescendDifferentKindPanics(t *testing.T) {
 			"(set SkipChildren=true to replace with a different kind)",
 		func() { orig.Accept(v, Positive) })
 }
+
+// An Accept rewrite over an inexact ObjectType carries the Inexact flag onto the
+// rebuilt object. The old RecordType rebuild had no flag to carry; the M4
+// ObjectType.Accept must copy it (visitor.go), or a coalesce/extrude/freshenAbove
+// pass would silently turn an inexact object exact. This pins the property the A1
+// plan flagged as a latent bug the new field exposes.
+func TestAcceptObjectPreservesInexact(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	p0 := &PropertyElem{Name: "x", Type: a, Optional: true}
+	p1 := &PropertyElem{Name: "y", Type: num}
+	obj := &ObjectType{Elems: []ObjTypeElem{p0, p1}, Inexact: true}
+
+	got := obj.Accept(&replaceVar{target: a, repl: str}, Positive).(*ObjectType)
+
+	require.NotSame(t, obj, got, "a changed property forces a new object")
+	require.True(t, got.Inexact, "the rebuilt object keeps its Inexact marker")
+	gp0 := got.Elems[0].(*PropertyElem)
+	require.Same(t, str, gp0.Type, "the changed property took the replacement")
+	require.NotSame(t, p0, gp0, "the changed property is a fresh *PropertyElem")
+	require.True(t, gp0.Optional, "the changed property keeps its Optional marker")
+	require.Same(t, p1, got.Elems[1], "the unchanged property keeps its *PropertyElem pointer")
+}
+
+// An unchanged inexact ObjectType keeps its pointer (copy-on-write): a no-op
+// rewrite allocates nothing.
+func TestAcceptObjectIdentityPreservation(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: num}}, Inexact: true}
+	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive), "an unchanged ObjectType keeps its pointer")
+}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -239,13 +239,21 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 		}
 		require.Equal(t, site.Span(), e.Span())
 	})
+	t.Run("OptionalProperty", func(t *testing.T) {
+		e := &OptionalPropertyError{
+			LHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}, Optional: true}}},
+			RHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			Name: "b", prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
 }
 
 // checker.constrain stamps prov + the constraint node onto EVERY constraint-error
 // kind it forwards, so each error's Span() resolves to a real source span instead
-// of the zero span. The object-exactness errors (InexactIntoExactError,
-// ExtraPropertyError) were added in M4 A1; this pins that their switch arms exist
-// — a missing arm leaves prov/site nil and Span() degrades to 0:0. Exercised
+// of the zero span. The object errors (InexactIntoExactError, ExtraPropertyError,
+// OptionalPropertyError) were added in M4 A1; this pins that their switch arms
+// exist — a missing arm leaves prov/site nil and Span() degrades to 0:0. Exercised
 // directly through c.constrain because an exact-object sink is not reachable from
 // source until object annotations land (A3).
 func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
@@ -266,6 +274,17 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 		c.constrain(node, inexactObj(propElem("x", num())), exactObj(propElem("x", num())))
 		require.Len(t, c.errs, 1)
 		require.IsType(t, &InexactIntoExactError{}, c.errs[0])
+		require.Equal(t, node.Span(), c.errs[0].Span())
+	})
+
+	t.Run("OptionalPropertyError", func(t *testing.T) {
+		c := newChecker()
+		// {x?: number} <: {x: number}: an optional source cannot fill a required slot.
+		c.constrain(node,
+			exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true}),
+			exactObj(propElem("x", num())))
+		require.Len(t, c.errs, 1)
+		require.IsType(t, &OptionalPropertyError{}, c.errs[0])
 		require.Equal(t, node.Span(), c.errs[0].Span())
 	})
 }

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -89,8 +89,8 @@ func TestBlameCallTooFewArgs(t *testing.T) {
 // A missing-property read blames the member's prop (.foo), not the receiver, with
 // the receiver's definition as the related span. Like TestBlameCallArity, M2.5
 // resolved that related span only for an inline receiver (a named receiver was
-// coalesced to a fresh RecordType with no Prov entry); M3's generalize-and-share
-// instantiation keeps a VAR-FREE receiver's original record — here `{a: 5}` is
+// coalesced to a fresh ObjectType with no Prov entry); M3's generalize-and-share
+// instantiation keeps a VAR-FREE receiver's original object — here `{a: 5}` is
 // monomorphic, so it is shared unchanged through instantiation (recorded
 // ObjectField against the literal) — so the named receiver's related span now
 // resolves. A receiver whose value flowed through an instantiation that REBUILT it
@@ -219,8 +219,8 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 	})
 	t.Run("MissingProperty", func(t *testing.T) {
 		e := &MissingPropertyError{
-			LHS:  &soltype.RecordType{},
-			RHS:  &soltype.RecordType{Fields: []*soltype.RecordField{{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			LHS:  &soltype.ObjectType{},
+			RHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
 			Name: "b", prov: Prov{}, site: site,
 		}
 		require.Equal(t, site.Span(), e.Span())

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -225,6 +225,49 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 		}
 		require.Equal(t, site.Span(), e.Span())
 	})
+	t.Run("InexactIntoExact", func(t *testing.T) {
+		e := &InexactIntoExactError{
+			LHS: &soltype.ObjectType{Inexact: true}, RHS: &soltype.ObjectType{}, prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
+	t.Run("ExtraProperty", func(t *testing.T) {
+		e := &ExtraPropertyError{
+			LHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			RHS:  &soltype.ObjectType{},
+			Name: "b", prov: Prov{}, site: site,
+		}
+		require.Equal(t, site.Span(), e.Span())
+	})
+}
+
+// checker.constrain stamps prov + the constraint node onto EVERY constraint-error
+// kind it forwards, so each error's Span() resolves to a real source span instead
+// of the zero span. The object-exactness errors (InexactIntoExactError,
+// ExtraPropertyError) were added in M4 A1; this pins that their switch arms exist
+// — a missing arm leaves prov/site nil and Span() degrades to 0:0. Exercised
+// directly through c.constrain because an exact-object sink is not reachable from
+// source until object annotations land (A3).
+func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
+	node := ast.NewIdent("site", tspan(4, 2, 4, 6))
+
+	t.Run("ExtraPropertyError", func(t *testing.T) {
+		c := newChecker()
+		// exact {x, y} <: exact {x}: y is an extra property on the source.
+		c.constrain(node, exactObj(propElem("x", num()), propElem("y", num())), exactObj(propElem("x", num())))
+		require.Len(t, c.errs, 1)
+		require.IsType(t, &ExtraPropertyError{}, c.errs[0])
+		require.Equal(t, node.Span(), c.errs[0].Span())
+	})
+
+	t.Run("InexactIntoExactError", func(t *testing.T) {
+		c := newChecker()
+		// inexact {x, ...} <: exact {x}: an inexact source cannot fill an exact sink.
+		c.constrain(node, inexactObj(propElem("x", num())), exactObj(propElem("x", num())))
+		require.Len(t, c.errs, 1)
+		require.IsType(t, &InexactIntoExactError{}, c.errs[0])
+		require.Equal(t, node.Span(), c.errs[0].Span())
+	})
 }
 
 // --- M2.5 finding #1: unsupported-annotation recovery (no spurious `<: never`) ---

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -207,14 +207,20 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 
 	t.Run("FuncArity", func(t *testing.T) {
 		e := &FuncArityMismatchError{
-			LHS: &soltype.FuncType{}, RHS: &soltype.FuncType{}, prov: Prov{}, site: site,
+			LHS:  &soltype.FuncType{Params: make([]*soltype.FuncParam, 2)},
+			RHS:  &soltype.FuncType{Params: make([]*soltype.FuncParam, 1)},
+			prov: Prov{}, site: site,
 		}
+		require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("TupleLength", func(t *testing.T) {
 		e := &TupleLengthMismatchError{
-			LHS: &soltype.TupleType{}, RHS: &soltype.TupleType{}, prov: Prov{}, site: site,
+			LHS:  &soltype.TupleType{Elems: []soltype.Type{num(), num()}},
+			RHS:  &soltype.TupleType{Elems: []soltype.Type{num()}},
+			prov: Prov{}, site: site,
 		}
+		require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 1", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("MissingProperty", func(t *testing.T) {
@@ -223,12 +229,14 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 			RHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
 			Name: "b", prov: Prov{}, site: site,
 		}
+		require.Equal(t, "object is missing property: b", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("InexactIntoExact", func(t *testing.T) {
 		e := &InexactIntoExactError{
 			LHS: &soltype.ObjectType{Inexact: true}, RHS: &soltype.ObjectType{}, prov: Prov{}, site: site,
 		}
+		require.Equal(t, "cannot constrain inexact object <: exact object", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("ExtraProperty", func(t *testing.T) {
@@ -237,6 +245,7 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 			RHS:  &soltype.ObjectType{},
 			Name: "b", prov: Prov{}, site: site,
 		}
+		require.Equal(t, "object has extra property: b", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("OptionalProperty", func(t *testing.T) {
@@ -265,6 +274,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 		c.constrain(node, exactObj(propElem("x", num()), propElem("y", num())), exactObj(propElem("x", num())))
 		require.Len(t, c.errs, 1)
 		require.IsType(t, &ExtraPropertyError{}, c.errs[0])
+		require.Equal(t, "object has extra property: y", c.errs[0].Message())
 		require.Equal(t, node.Span(), c.errs[0].Span())
 	})
 
@@ -274,6 +284,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 		c.constrain(node, inexactObj(propElem("x", num())), exactObj(propElem("x", num())))
 		require.Len(t, c.errs, 1)
 		require.IsType(t, &InexactIntoExactError{}, c.errs[0])
+		require.Equal(t, "cannot constrain inexact object <: exact object", c.errs[0].Message())
 		require.Equal(t, node.Span(), c.errs[0].Span())
 	})
 

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -334,15 +334,17 @@ func equalType(a, b soltype.Type) bool {
 		return true
 	case *soltype.ObjectType:
 		b, ok := b.(*soltype.ObjectType)
+		// Inexact flags must be equal — an open object never equals a closed one.
+		// This mirrors the FuncType arm's a.Inexact discriminator.
 		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
-		// Objects are equal up to property order — match by name (ObjectType.Prop),
-		// not position. Well-formed objects have unique property names (the solver
-		// dedups on construction), so equal lengths plus every a-property matching a
-		// b-property by name, type, and optionality (and equal Inexact flags) is a
-		// full structural match. Inexact and Optional mirror the FuncType arm's
-		// a.Inexact / param-Optional discriminators.
+		// Objects are equal up to property order, so match each property by name
+		// via ObjectType.Prop rather than by position. The solver dedups property
+		// names on construction, so names are unique. Equal lengths plus every
+		// a-property matching a b-property by name, type, and optionality is then a
+		// full structural match. Optional mirrors the FuncType arm's param-Optional
+		// discriminator.
 		for _, ae := range a.Elems {
 			ap := soltype.AsProperty(ae)
 			bp, ok := b.Prop(ap.Name)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -340,15 +340,13 @@ func equalType(a, b soltype.Type) bool {
 		// Objects are equal up to property order — match by name (ObjectType.Prop),
 		// not position. Well-formed objects have unique property names (the solver
 		// dedups on construction), so equal lengths plus every a-property matching a
-		// b-property by name (and equal Inexact flags) is a full structural match.
-		// Inexact mirrors the FuncType arm's a.Inexact != b.Inexact discriminator.
+		// b-property by name, type, and optionality (and equal Inexact flags) is a
+		// full structural match. Inexact and Optional mirror the FuncType arm's
+		// a.Inexact / param-Optional discriminators.
 		for _, ae := range a.Elems {
-			ap, ok := ae.(*soltype.PropertyElem)
-			if !ok {
-				continue
-			}
+			ap := soltype.AsProperty(ae)
 			bp, ok := b.Prop(ap.Name)
-			if !ok || !equalType(ap.Type, bp.Type) {
+			if !ok || ap.Optional != bp.Optional || !equalType(ap.Type, bp.Type) {
 				return false
 			}
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -332,18 +332,23 @@ func equalType(a, b soltype.Type) bool {
 			}
 		}
 		return true
-	case *soltype.RecordType:
-		b, ok := b.(*soltype.RecordType)
-		if !ok || len(a.Fields) != len(b.Fields) {
+	case *soltype.ObjectType:
+		b, ok := b.(*soltype.ObjectType)
+		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
-		// Records are equal up to field order — match by name (RecordType.Field),
-		// not position. Well-formed records have unique field names (the solver
-		// dedups on construction), so equal lengths plus every a-field matching a
-		// b-field by name is a full structural match.
-		for _, f := range a.Fields {
-			bt, ok := b.Field(f.Name)
-			if !ok || !equalType(f.Type, bt) {
+		// Objects are equal up to property order — match by name (ObjectType.Prop),
+		// not position. Well-formed objects have unique property names (the solver
+		// dedups on construction), so equal lengths plus every a-property matching a
+		// b-property by name (and equal Inexact flags) is a full structural match.
+		// Inexact mirrors the FuncType arm's a.Inexact != b.Inexact discriminator.
+		for _, ae := range a.Elems {
+			ap, ok := ae.(*soltype.PropertyElem)
+			if !ok {
+				continue
+			}
+			bp, ok := b.Prop(ap.Name)
+			if !ok || !equalType(ap.Type, bp.Type) {
 				return false
 			}
 		}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -115,3 +115,55 @@ func TestCoalesceStructuralRecursion(t *testing.T) {
 	}
 	require.True(t, equalType(want, got))
 }
+
+// equalType on ObjectType must discriminate on the Inexact flag and on each
+// property's Optional marker (mirroring the FuncType arm's Inexact / param-Optional
+// checks), and must be order-independent. Without the Optional check (M4 A1 review
+// fix #2) {a: T} and {a?: T} would compare equal and coalesce/simplify would drop
+// optionality.
+func TestEqualTypeObject(t *testing.T) {
+	optProp := func(name string, ty soltype.Type) *soltype.PropertyElem {
+		return &soltype.PropertyElem{Name: name, Type: ty, Optional: true}
+	}
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "equal up to property order",
+			a:    exactObj(propElem("a", num()), propElem("b", str())),
+			b:    exactObj(propElem("b", str()), propElem("a", num())),
+			want: true,
+		},
+		{
+			name: "Inexact differs",
+			a:    exactObj(propElem("a", num())),
+			b:    inexactObj(propElem("a", num())),
+			want: false,
+		},
+		{
+			name: "Optional differs",
+			a:    exactObj(propElem("a", num())),
+			b:    exactObj(optProp("a", num())),
+			want: false,
+		},
+		{
+			name: "property type differs",
+			a:    exactObj(propElem("a", num())),
+			b:    exactObj(propElem("a", str())),
+			want: false,
+		},
+		{
+			name: "property set size differs",
+			a:    exactObj(propElem("a", num())),
+			b:    exactObj(propElem("a", num()), propElem("b", str())),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -188,13 +188,28 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			//
 			// Depth first: every property the RHS requires must be present on the
 			// LHS, matched by name (Prop), and the shared property types are
-			// covariant. A required property the LHS lacks is a MissingPropertyError.
+			// covariant. PropertyElem.Optional makes presence part of the shape, so
+			// the loop is presence-aware before recursing on the property type:
+			//   - absent on the LHS: a MissingPropertyError only when the RHS
+			//     property is REQUIRED; an optional RHS property may be absent.
+			//   - present on both, optional on the LHS but required on the RHS: the
+			//     source may omit it, so it cannot fill a required slot —
+			//     OptionalPropertyError, and skip the covariant type check (the
+			//     presence mismatch already rejects the constraint).
+			//   - otherwise (required<:required, required<:optional, optional<:
+			//     optional): covariant on the property type.
 			var errs []SolverError
 			for _, re := range r.Elems {
 				rp := soltype.AsProperty(re) // M4: every elem is a property
 				lp, ok := l.Prop(rp.Name)
 				if !ok {
-					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
+					if !rp.Optional {
+						errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
+					}
+					continue
+				}
+				if lp.Optional && !rp.Optional {
+					errs = append(errs, &OptionalPropertyError{LHS: l, RHS: r, Name: rp.Name})
 					continue
 				}
 				errs = append(errs, c.constrain(lp.Type, rp.Type, seen)...) // covariant

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -178,35 +178,49 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			}
 			return errs
 		}
-	case *soltype.RecordType:
-		if r, ok := rhs.(*soltype.RecordType); ok {
-			// M2 serves exactly one consumer through this arm: member-access field
-			// selection. inferMember lowers `recv.foo` to `constrain(recv, {foo:
-			// fresh})` (m2-implementation-plan.md §3.2), where the RHS lists only the
-			// field being read. That is a "has-field" REQUIREMENT, not a concrete
-			// record type, so the rule here is intentionally width-tolerant: every
-			// field the RHS requires must be present on the LHS (the LHS may carry
-			// MORE fields), and the shared fields are covariant (depth). Fields are
-			// matched by name (RecordType.Field), so source order is irrelevant.
+	case *soltype.ObjectType:
+		if r, ok := rhs.(*soltype.ObjectType); ok {
+			// One ObjectType <: ObjectType rule serves both uses the M2 arm
+			// conflated: member-access field SELECTION (the RHS is an inexact
+			// "has at least this field" requirement minted by inferMember) and
+			// concrete object <: object SUBTYPING for object-typed params/annotations.
+			// The Inexact flag is the split — width tolerance IS inexactness.
 			//
-			// This is NOT the final record-subtyping semantics. Escalier records are
-			// exact-by-default (01-milestones.md:278-282): exact <: exact requires the
-			// SAME field set (no width), and width is only the inexact <: inexact case
-			// behind the `...` flag. M4 differentiates the two uses the plan conflates
-			// here — the member-access field-selection requirement (width-tolerant,
-			// this arm) vs. concrete record <: record subtyping for record-typed
-			// params/annotations (exact, like the tuple same-length and function
-			// same-arity arms above). M2 has neither record annotations nor deep
-			// record params, so the exact path is unreachable and only this
-			// selection arm exists; `mut`-driven field invariance also lands in M4.
+			// Depth first: every property the RHS requires must be present on the
+			// LHS, matched by name (Prop), and the shared property types are
+			// covariant. A required property the LHS lacks is a MissingPropertyError.
 			var errs []SolverError
-			for _, rf := range r.Fields {
-				lt, ok := l.Field(rf.Name)
+			for _, re := range r.Elems {
+				rp, ok := re.(*soltype.PropertyElem) // M4: every elem is a property
 				if !ok {
-					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rf.Name})
 					continue
 				}
-				errs = append(errs, c.constrain(lt, rf.Type, seen)...) // covariant
+				lp, ok := l.Prop(rp.Name)
+				if !ok {
+					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
+					continue
+				}
+				errs = append(errs, c.constrain(lp.Type, rp.Type, seen)...) // covariant
+			}
+			// One-way exactness (02-design-notes §"Exactness"):
+			//   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
+			//   exact <: exact      same member set  inexact <: exact     rejected
+			// When the RHS is inexact, width tolerance is the complete rule and the
+			// depth loop above is all there is. When the RHS is exact, the LHS may
+			// carry no extra properties and may not itself be inexact.
+			if !r.Inexact {
+				if l.Inexact {
+					errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
+				}
+				for _, le := range l.Elems {
+					lp, ok := le.(*soltype.PropertyElem)
+					if !ok {
+						continue
+					}
+					if _, ok := r.Prop(lp.Name); !ok {
+						errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lp.Name})
+					}
+				}
 			}
 			return errs
 		}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -191,10 +191,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 			// covariant. A required property the LHS lacks is a MissingPropertyError.
 			var errs []SolverError
 			for _, re := range r.Elems {
-				rp, ok := re.(*soltype.PropertyElem) // M4: every elem is a property
-				if !ok {
-					continue
-				}
+				rp := soltype.AsProperty(re) // M4: every elem is a property
 				lp, ok := l.Prop(rp.Name)
 				if !ok {
 					errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
@@ -213,10 +210,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 					errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
 				}
 				for _, le := range l.Elems {
-					lp, ok := le.(*soltype.PropertyElem)
-					if !ok {
-						continue
-					}
+					lp := soltype.AsProperty(le)
 					if _, ok := r.Prop(lp.Name); !ok {
 						errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lp.Name})
 					}

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -343,6 +343,97 @@ func TestConstrainTuple(t *testing.T) {
 	})
 }
 
+// propElem builds a PropertyElem so the object accept-set tests read at a glance.
+func propElem(name string, t soltype.Type) *soltype.PropertyElem {
+	return &soltype.PropertyElem{Name: name, Type: t}
+}
+
+// exactObj / inexactObj build object types so the tests show which arm they
+// exercise. Exact is the zero value of Inexact, so exactObj sets no flag.
+func exactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
+	return &soltype.ObjectType{Elems: elems}
+}
+
+func inexactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
+	return &soltype.ObjectType{Elems: elems, Inexact: true}
+}
+
+// TestConstrainObject exercises the one-way object exactness rule (A1): width
+// tolerance is inexactness on the RHS, and an exact RHS fixes its member set.
+func TestConstrainObject(t *testing.T) {
+	// Depth is covariant: {x: 5} <: {x: number} checks 5 <: number on the shared
+	// property. Same member set on both sides, so the exact-target gate passes.
+	t.Run("exact same member set, covariant depth", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(
+			exactObj(propElem("x", numLit(5))),
+			exactObj(propElem("x", num())),
+		))
+	})
+
+	// Width is the inexact-target case: exact {x, y} <: inexact {x, ...} drops the
+	// extra y because the RHS only requires "has at least x".
+	t.Run("exact fills inexact (width)", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(
+			exactObj(propElem("x", num()), propElem("y", num())),
+			inexactObj(propElem("x", num())),
+		))
+	})
+
+	// inexact <: inexact is also width-tolerant.
+	t.Run("inexact fills inexact (width)", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(
+			inexactObj(propElem("x", num()), propElem("y", num())),
+			inexactObj(propElem("x", num())),
+		))
+	})
+
+	// A required property the LHS lacks is a MissingPropertyError, regardless of
+	// the RHS's exactness.
+	t.Run("missing required property", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("x", num()))
+		r := inexactObj(propElem("y", num()))
+		errs := c.Constrain(l, r)
+		require.Equal(t, []string{"object is missing property: y"}, Messages(errs))
+		mp, ok := errs[0].(*MissingPropertyError)
+		require.True(t, ok)
+		require.Same(t, l, mp.LHS)
+		require.Same(t, r, mp.RHS)
+	})
+
+	// An extra property on the LHS is rejected against an exact RHS, one error per
+	// extra property.
+	t.Run("extra property rejected by exact target", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("x", num()), propElem("y", num()))
+		r := exactObj(propElem("x", num()))
+		errs := c.Constrain(l, r)
+		require.Equal(t, []string{"object has extra property: y"}, Messages(errs))
+		ep, ok := errs[0].(*ExtraPropertyError)
+		require.True(t, ok)
+		require.Same(t, l, ep.LHS)
+		require.Same(t, r, ep.RHS)
+		require.Equal(t, "y", ep.Name)
+	})
+
+	// An inexact source cannot satisfy an exact target — the open `...` tail may
+	// carry properties the target does not declare.
+	t.Run("inexact rejected by exact target", func(t *testing.T) {
+		c := &Context{}
+		l := inexactObj(propElem("x", num()))
+		r := exactObj(propElem("x", num()))
+		errs := c.Constrain(l, r)
+		require.Equal(t, []string{"cannot constrain inexact object <: exact object"}, Messages(errs))
+		ie, ok := errs[0].(*InexactIntoExactError)
+		require.True(t, ok)
+		require.Same(t, l, ie.LHS)
+		require.Same(t, r, ie.RHS)
+	})
+}
+
 func TestConstrainVoid(t *testing.T) {
 	c := &Context{}
 	require.Empty(t, c.Constrain(&soltype.Void{}, &soltype.Void{}))

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -360,145 +360,173 @@ func inexactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
 
 // TestConstrainObject exercises the one-way object exactness rule (A1): width
 // tolerance is inexactness on the RHS, and an exact RHS fixes its member set.
+//
+// want is the expected rendered messages (nil for a clean constraint); check, when
+// set, runs extra structural assertions (the specific error type, the operand
+// pointers) that a message comparison can't express.
 func TestConstrainObject(t *testing.T) {
-	// Depth is covariant: {x: 5} <: {x: number} checks 5 <: number on the shared
-	// property. Same member set on both sides, so the exact-target gate passes.
-	t.Run("exact same member set, covariant depth", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, c.Constrain(
-			exactObj(propElem("x", numLit(5))),
-			exactObj(propElem("x", num())),
-		))
-	})
-
-	// Width is the inexact-target case: exact {x, y} <: inexact {x, ...} drops the
-	// extra y because the RHS only requires "has at least x".
-	t.Run("exact fills inexact (width)", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, c.Constrain(
-			exactObj(propElem("x", num()), propElem("y", num())),
-			inexactObj(propElem("x", num())),
-		))
-	})
-
-	// inexact <: inexact is also width-tolerant.
-	t.Run("inexact fills inexact (width)", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, c.Constrain(
-			inexactObj(propElem("x", num()), propElem("y", num())),
-			inexactObj(propElem("x", num())),
-		))
-	})
-
-	// A required property the LHS lacks is a MissingPropertyError, regardless of
-	// the RHS's exactness.
-	t.Run("missing required property", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("x", num()))
-		r := inexactObj(propElem("y", num()))
-		errs := c.Constrain(l, r)
-		require.Equal(t, []string{"object is missing property: y"}, Messages(errs))
-		mp, ok := errs[0].(*MissingPropertyError)
-		require.True(t, ok)
-		require.Same(t, l, mp.LHS)
-		require.Same(t, r, mp.RHS)
-	})
-
-	// An extra property on the LHS is rejected against an exact RHS, one error per
-	// extra property.
-	t.Run("extra property rejected by exact target", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("x", num()), propElem("y", num()))
-		r := exactObj(propElem("x", num()))
-		errs := c.Constrain(l, r)
-		require.Equal(t, []string{"object has extra property: y"}, Messages(errs))
-		ep, ok := errs[0].(*ExtraPropertyError)
-		require.True(t, ok)
-		require.Same(t, l, ep.LHS)
-		require.Same(t, r, ep.RHS)
-		require.Equal(t, "y", ep.Name)
-	})
-
-	// An inexact source cannot satisfy an exact target — the open `...` tail may
-	// carry properties the target does not declare.
-	t.Run("inexact rejected by exact target", func(t *testing.T) {
-		c := &Context{}
-		l := inexactObj(propElem("x", num()))
-		r := exactObj(propElem("x", num()))
-		errs := c.Constrain(l, r)
-		require.Equal(t, []string{"cannot constrain inexact object <: exact object"}, Messages(errs))
-		ie, ok := errs[0].(*InexactIntoExactError)
-		require.True(t, ok)
-		require.Same(t, l, ie.LHS)
-		require.Same(t, r, ie.RHS)
-	})
-
-	// Depth is recursive: a shared property whose types don't relate surfaces the
-	// inner failure, threaded through the path-scoped seen set.
-	t.Run("nested depth mismatch surfaces inner error", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("x", exactObj(propElem("a", num()))))
-		r := exactObj(propElem("x", exactObj(propElem("a", str()))))
-		require.Equal(t, []string{"cannot constrain number <: string"}, Messages(c.Constrain(l, r)))
-	})
-
-	t.Run("nested depth covariant ok", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("x", exactObj(propElem("a", numLit(5)))))
-		r := exactObj(propElem("x", exactObj(propElem("a", num()))))
-		require.Empty(t, c.Constrain(l, r))
-	})
-
-	// Every extra property on the source against an exact target fires its own
-	// ExtraPropertyError, in source-property order.
-	t.Run("multiple extra properties each report", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("a", num()), propElem("b", num()), propElem("c", num()))
-		r := exactObj(propElem("a", num()))
-		require.Equal(t,
-			[]string{"object has extra property: b", "object has extra property: c"},
-			Messages(c.Constrain(l, r)))
-	})
-
-	// A missing required property and an extra property both fire in one
-	// constraint: the RHS-required loop reports the missing one first, then the
-	// LHS-extra loop reports the extra.
-	t.Run("missing and extra combined against exact target", func(t *testing.T) {
-		c := &Context{}
-		l := exactObj(propElem("a", num()), propElem("c", num()))
-		r := exactObj(propElem("a", num()), propElem("b", num()))
-		require.Equal(t,
-			[]string{"object is missing property: b", "object has extra property: c"},
-			Messages(c.Constrain(l, r)))
-	})
-
-	// Boundary member sets against the exactness gate.
-	t.Run("empty exact missing required", func(t *testing.T) {
-		c := &Context{}
-		require.Equal(t, []string{"object is missing property: a"},
-			Messages(c.Constrain(exactObj(), exactObj(propElem("a", num())))))
-	})
-	t.Run("extra against empty exact", func(t *testing.T) {
-		c := &Context{}
-		require.Equal(t, []string{"object has extra property: a"},
-			Messages(c.Constrain(exactObj(propElem("a", num())), exactObj())))
-	})
-	t.Run("empty exact <: empty exact ok", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, c.Constrain(exactObj(), exactObj()))
-	})
-	t.Run("exact fills empty inexact (width)", func(t *testing.T) {
-		c := &Context{}
-		require.Empty(t, c.Constrain(exactObj(propElem("a", num())), inexactObj()))
-	})
-
-	// A non-object RHS falls through the object arm to the generic
-	// CannotConstrainError, whose message renders the object via describe ("object").
-	t.Run("object <: non-object renders via describe", func(t *testing.T) {
-		c := &Context{}
-		require.Equal(t, []string{"cannot constrain object <: number"},
-			Messages(c.Constrain(exactObj(propElem("a", numLit(5))), num())))
-	})
+	optProp := func(name string, ty soltype.Type) *soltype.PropertyElem {
+		return &soltype.PropertyElem{Name: name, Type: ty, Optional: true}
+	}
+	tests := []struct {
+		name     string
+		lhs, rhs soltype.Type
+		want     []string
+		check    func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError)
+	}{
+		{
+			// Depth is covariant: {x: 5} <: {x: number} checks 5 <: number on the
+			// shared property. Same member set on both sides, so the exact gate passes.
+			name: "exact same member set, covariant depth",
+			lhs:  exactObj(propElem("x", numLit(5))),
+			rhs:  exactObj(propElem("x", num())),
+		},
+		{
+			// Width is the inexact-target case: exact {x, y} <: inexact {x, ...} drops
+			// the extra y because the RHS only requires "has at least x".
+			name: "exact fills inexact (width)",
+			lhs:  exactObj(propElem("x", num()), propElem("y", num())),
+			rhs:  inexactObj(propElem("x", num())),
+		},
+		{
+			name: "inexact fills inexact (width)",
+			lhs:  inexactObj(propElem("x", num()), propElem("y", num())),
+			rhs:  inexactObj(propElem("x", num())),
+		},
+		{
+			// A required property the LHS lacks is a MissingPropertyError, regardless
+			// of the RHS's exactness.
+			name: "missing required property",
+			lhs:  exactObj(propElem("x", num())),
+			rhs:  inexactObj(propElem("y", num())),
+			want: []string{"object is missing property: y"},
+			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+				mp, ok := errs[0].(*MissingPropertyError)
+				require.True(t, ok)
+				require.Same(t, lhs, mp.LHS)
+				require.Same(t, rhs, mp.RHS)
+			},
+		},
+		{
+			// An extra property on the LHS is rejected against an exact RHS, one error
+			// per extra property.
+			name: "extra property rejected by exact target",
+			lhs:  exactObj(propElem("x", num()), propElem("y", num())),
+			rhs:  exactObj(propElem("x", num())),
+			want: []string{"object has extra property: y"},
+			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+				ep, ok := errs[0].(*ExtraPropertyError)
+				require.True(t, ok)
+				require.Same(t, lhs, ep.LHS)
+				require.Same(t, rhs, ep.RHS)
+				require.Equal(t, "y", ep.Name)
+			},
+		},
+		{
+			// An inexact source cannot satisfy an exact target — the open `...` tail
+			// may carry properties the target does not declare.
+			name: "inexact rejected by exact target",
+			lhs:  inexactObj(propElem("x", num())),
+			rhs:  exactObj(propElem("x", num())),
+			want: []string{"cannot constrain inexact object <: exact object"},
+			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+				ie, ok := errs[0].(*InexactIntoExactError)
+				require.True(t, ok)
+				require.Same(t, lhs, ie.LHS)
+				require.Same(t, rhs, ie.RHS)
+			},
+		},
+		{
+			// Depth is recursive: a shared property whose types don't relate surfaces
+			// the inner failure, threaded through the path-scoped seen set.
+			name: "nested depth mismatch surfaces inner error",
+			lhs:  exactObj(propElem("x", exactObj(propElem("a", num())))),
+			rhs:  exactObj(propElem("x", exactObj(propElem("a", str())))),
+			want: []string{"cannot constrain number <: string"},
+		},
+		{
+			name: "nested depth covariant ok",
+			lhs:  exactObj(propElem("x", exactObj(propElem("a", numLit(5))))),
+			rhs:  exactObj(propElem("x", exactObj(propElem("a", num())))),
+		},
+		{
+			// Every extra property on the source against an exact target fires its own
+			// ExtraPropertyError, in source-property order.
+			name: "multiple extra properties each report",
+			lhs:  exactObj(propElem("a", num()), propElem("b", num()), propElem("c", num())),
+			rhs:  exactObj(propElem("a", num())),
+			want: []string{"object has extra property: b", "object has extra property: c"},
+		},
+		{
+			// A missing required property and an extra property both fire in one
+			// constraint: the RHS-required loop reports the missing one first, then the
+			// LHS-extra loop reports the extra.
+			name: "missing and extra combined against exact target",
+			lhs:  exactObj(propElem("a", num()), propElem("c", num())),
+			rhs:  exactObj(propElem("a", num()), propElem("b", num())),
+			want: []string{"object is missing property: b", "object has extra property: c"},
+		},
+		// Boundary member sets against the exactness gate.
+		{
+			name: "empty exact missing required",
+			lhs:  exactObj(),
+			rhs:  exactObj(propElem("a", num())),
+			want: []string{"object is missing property: a"},
+		},
+		{
+			name: "extra against empty exact",
+			lhs:  exactObj(propElem("a", num())),
+			rhs:  exactObj(),
+			want: []string{"object has extra property: a"},
+		},
+		{
+			name: "empty exact <: empty exact ok",
+			lhs:  exactObj(),
+			rhs:  exactObj(),
+		},
+		{
+			name: "exact fills empty inexact (width)",
+			lhs:  exactObj(propElem("a", num())),
+			rhs:  inexactObj(),
+		},
+		// KNOWN LIMITATION (A1): the constrain arm treats every RHS property as
+		// required and ignores PropertyElem.Optional — optional-property subtyping is
+		// not modelled yet (no optional property is constructible from source until
+		// object annotations in A3). These two cases PIN today's behavior so the gap
+		// is visible and a future optional-subtyping change is forced to update them.
+		// With correct optional semantics, the first SUCCEEDS (an optional target
+		// property may be absent) and the second is REJECTED (an optional source
+		// property may be absent where the target requires it).
+		{
+			name: "optional target property treated as required (A1 limitation)",
+			lhs:  exactObj(),
+			rhs:  exactObj(optProp("x", num())),
+			want: []string{"object is missing property: x"},
+		},
+		{
+			name: "optional source into required target accepted (A1 limitation)",
+			lhs:  exactObj(optProp("x", num())),
+			rhs:  exactObj(propElem("x", num())),
+		},
+		{
+			// A non-object RHS falls through the object arm to the generic
+			// CannotConstrainError, whose message renders the object via describe.
+			name: "object <: non-object renders via describe",
+			lhs:  exactObj(propElem("a", numLit(5))),
+			rhs:  num(),
+			want: []string{"cannot constrain object <: number"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			errs := c.Constrain(tt.lhs, tt.rhs)
+			require.Equal(t, tt.want, Messages(errs))
+			if tt.check != nil {
+				tt.check(t, tt.lhs, tt.rhs, errs)
+			}
+		})
+	}
 }
 
 func TestConstrainVoid(t *testing.T) {

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -489,24 +489,50 @@ func TestConstrainObject(t *testing.T) {
 			lhs:  exactObj(propElem("a", num())),
 			rhs:  inexactObj(),
 		},
-		// KNOWN LIMITATION (A1): the constrain arm treats every RHS property as
-		// required and ignores PropertyElem.Optional — optional-property subtyping is
-		// not modelled yet (no optional property is constructible from source until
-		// object annotations in A3). These two cases PIN today's behavior so the gap
-		// is visible and a future optional-subtyping change is forced to update them.
-		// With correct optional semantics, the first SUCCEEDS (an optional target
-		// property may be absent) and the second is REJECTED (an optional source
-		// property may be absent where the target requires it).
+		// PropertyElem.Optional is part of the object shape, so subtyping is
+		// presence-aware: an optional target property may be absent on the source,
+		// and a required source property fills an optional target slot, but an
+		// optional source property cannot fill a required target slot.
 		{
-			name: "optional target property treated as required (A1 limitation)",
+			// {} <: {x?: number}: an optional target property may be absent.
+			name: "absent source satisfies optional target property",
 			lhs:  exactObj(),
 			rhs:  exactObj(optProp("x", num())),
-			want: []string{"object is missing property: x"},
 		},
 		{
-			name: "optional source into required target accepted (A1 limitation)",
+			// {x?: number} <: {x: number}: the source may omit x, so it cannot fill a
+			// required slot.
+			name: "optional source rejected by required target",
 			lhs:  exactObj(optProp("x", num())),
 			rhs:  exactObj(propElem("x", num())),
+			want: []string{"object property is optional but required: x"},
+			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+				op, ok := errs[0].(*OptionalPropertyError)
+				require.True(t, ok)
+				require.Same(t, lhs, op.LHS)
+				require.Same(t, rhs, op.RHS)
+				require.Equal(t, "x", op.Name)
+			},
+		},
+		{
+			// {x: number} <: {x?: number}: a required property fills an optional slot.
+			name: "required source fills optional target property",
+			lhs:  exactObj(propElem("x", num())),
+			rhs:  exactObj(optProp("x", num())),
+		},
+		{
+			// {x?: number} <: {x?: number}: optional on both, types covariant.
+			name: "optional on both sides ok",
+			lhs:  exactObj(optProp("x", numLit(5))),
+			rhs:  exactObj(optProp("x", num())),
+		},
+		{
+			// An optional source property still recurses covariantly into an optional
+			// target property, so an incompatible type is caught.
+			name: "optional on both sides depth mismatch",
+			lhs:  exactObj(optProp("x", num())),
+			rhs:  exactObj(optProp("x", str())),
+			want: []string{"cannot constrain number <: string"},
 		},
 		{
 			// A non-object RHS falls through the object arm to the generic

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -375,25 +375,31 @@ func TestConstrainObject(t *testing.T) {
 		check    func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError)
 	}{
 		{
-			// Depth is covariant: {x: 5} <: {x: number} checks 5 <: number on the
-			// shared property. Same member set on both sides, so the exact gate passes.
+			// {x: 5} <: {x: number}
+			// Depth is covariant: checks 5 <: number on the shared property. Same
+			// member set on both sides, so the exact gate passes.
 			name: "exact same member set, covariant depth",
 			lhs:  exactObj(propElem("x", numLit(5))),
 			rhs:  exactObj(propElem("x", num())),
 		},
 		{
-			// Width is the inexact-target case: exact {x, y} <: inexact {x, ...} drops
-			// the extra y because the RHS only requires "has at least x".
+			// {x: number, y: number} <: {x: number, ...}
+			// Width is the inexact-target case: the LHS drops the extra y because the
+			// RHS only requires "has at least x".
 			name: "exact fills inexact (width)",
 			lhs:  exactObj(propElem("x", num()), propElem("y", num())),
 			rhs:  inexactObj(propElem("x", num())),
 		},
 		{
+			// {x: number, y: number, ...} <: {x: number, ...}
+			// Width again with an inexact source: an inexact LHS still satisfies an
+			// inexact RHS, dropping the extra y.
 			name: "inexact fills inexact (width)",
 			lhs:  inexactObj(propElem("x", num()), propElem("y", num())),
 			rhs:  inexactObj(propElem("x", num())),
 		},
 		{
+			// {x: number} <: {y: number, ...}
 			// A required property the LHS lacks is a MissingPropertyError, regardless
 			// of the RHS's exactness.
 			name: "missing required property",
@@ -408,6 +414,7 @@ func TestConstrainObject(t *testing.T) {
 			},
 		},
 		{
+			// {x: number, y: number} <: {x: number}
 			// An extra property on the LHS is rejected against an exact RHS, one error
 			// per extra property.
 			name: "extra property rejected by exact target",
@@ -423,6 +430,7 @@ func TestConstrainObject(t *testing.T) {
 			},
 		},
 		{
+			// {x: number, ...} <: {x: number}
 			// An inexact source cannot satisfy an exact target — the open `...` tail
 			// may carry properties the target does not declare.
 			name: "inexact rejected by exact target",
@@ -437,6 +445,7 @@ func TestConstrainObject(t *testing.T) {
 			},
 		},
 		{
+			// {x: {a: number}} <: {x: {a: string}}
 			// Depth is recursive: a shared property whose types don't relate surfaces
 			// the inner failure, threaded through the path-scoped seen set.
 			name: "nested depth mismatch surfaces inner error",
@@ -445,11 +454,14 @@ func TestConstrainObject(t *testing.T) {
 			want: []string{"cannot constrain number <: string"},
 		},
 		{
+			// {x: {a: 5}} <: {x: {a: number}}
+			// Recursive depth that checks: the inner 5 <: number holds.
 			name: "nested depth covariant ok",
 			lhs:  exactObj(propElem("x", exactObj(propElem("a", numLit(5))))),
 			rhs:  exactObj(propElem("x", exactObj(propElem("a", num())))),
 		},
 		{
+			// {a: number, b: number, c: number} <: {a: number}
 			// Every extra property on the source against an exact target fires its own
 			// ExtraPropertyError, in source-property order.
 			name: "multiple extra properties each report",
@@ -458,6 +470,7 @@ func TestConstrainObject(t *testing.T) {
 			want: []string{"object has extra property: b", "object has extra property: c"},
 		},
 		{
+			// {a: number, c: number} <: {a: number, b: number}
 			// A missing required property and an extra property both fire in one
 			// constraint: the RHS-required loop reports the missing one first, then the
 			// LHS-extra loop reports the extra.
@@ -468,23 +481,27 @@ func TestConstrainObject(t *testing.T) {
 		},
 		// Boundary member sets against the exactness gate.
 		{
+			// {} <: {a: number}
 			name: "empty exact missing required",
 			lhs:  exactObj(),
 			rhs:  exactObj(propElem("a", num())),
 			want: []string{"object is missing property: a"},
 		},
 		{
+			// {a: number} <: {}
 			name: "extra against empty exact",
 			lhs:  exactObj(propElem("a", num())),
 			rhs:  exactObj(),
 			want: []string{"object has extra property: a"},
 		},
 		{
+			// {} <: {}
 			name: "empty exact <: empty exact ok",
 			lhs:  exactObj(),
 			rhs:  exactObj(),
 		},
 		{
+			// {a: number} <: {...}
 			name: "exact fills empty inexact (width)",
 			lhs:  exactObj(propElem("a", num())),
 			rhs:  inexactObj(),
@@ -535,6 +552,7 @@ func TestConstrainObject(t *testing.T) {
 			want: []string{"cannot constrain number <: string"},
 		},
 		{
+			// {a: 5} <: number
 			// A non-object RHS falls through the object arm to the generic
 			// CannotConstrainError, whose message renders the object via describe.
 			name: "object <: non-object renders via describe",

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -432,6 +432,73 @@ func TestConstrainObject(t *testing.T) {
 		require.Same(t, l, ie.LHS)
 		require.Same(t, r, ie.RHS)
 	})
+
+	// Depth is recursive: a shared property whose types don't relate surfaces the
+	// inner failure, threaded through the path-scoped seen set.
+	t.Run("nested depth mismatch surfaces inner error", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("x", exactObj(propElem("a", num()))))
+		r := exactObj(propElem("x", exactObj(propElem("a", str()))))
+		require.Equal(t, []string{"cannot constrain number <: string"}, Messages(c.Constrain(l, r)))
+	})
+
+	t.Run("nested depth covariant ok", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("x", exactObj(propElem("a", numLit(5)))))
+		r := exactObj(propElem("x", exactObj(propElem("a", num()))))
+		require.Empty(t, c.Constrain(l, r))
+	})
+
+	// Every extra property on the source against an exact target fires its own
+	// ExtraPropertyError, in source-property order.
+	t.Run("multiple extra properties each report", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("a", num()), propElem("b", num()), propElem("c", num()))
+		r := exactObj(propElem("a", num()))
+		require.Equal(t,
+			[]string{"object has extra property: b", "object has extra property: c"},
+			Messages(c.Constrain(l, r)))
+	})
+
+	// A missing required property and an extra property both fire in one
+	// constraint: the RHS-required loop reports the missing one first, then the
+	// LHS-extra loop reports the extra.
+	t.Run("missing and extra combined against exact target", func(t *testing.T) {
+		c := &Context{}
+		l := exactObj(propElem("a", num()), propElem("c", num()))
+		r := exactObj(propElem("a", num()), propElem("b", num()))
+		require.Equal(t,
+			[]string{"object is missing property: b", "object has extra property: c"},
+			Messages(c.Constrain(l, r)))
+	})
+
+	// Boundary member sets against the exactness gate.
+	t.Run("empty exact missing required", func(t *testing.T) {
+		c := &Context{}
+		require.Equal(t, []string{"object is missing property: a"},
+			Messages(c.Constrain(exactObj(), exactObj(propElem("a", num())))))
+	})
+	t.Run("extra against empty exact", func(t *testing.T) {
+		c := &Context{}
+		require.Equal(t, []string{"object has extra property: a"},
+			Messages(c.Constrain(exactObj(propElem("a", num())), exactObj())))
+	})
+	t.Run("empty exact <: empty exact ok", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(exactObj(), exactObj()))
+	})
+	t.Run("exact fills empty inexact (width)", func(t *testing.T) {
+		c := &Context{}
+		require.Empty(t, c.Constrain(exactObj(propElem("a", num())), inexactObj()))
+	})
+
+	// A non-object RHS falls through the object arm to the generic
+	// CannotConstrainError, whose message renders the object via describe ("object").
+	t.Run("object <: non-object renders via describe", func(t *testing.T) {
+		c := &Context{}
+		require.Equal(t, []string{"cannot constrain object <: number"},
+			Messages(c.Constrain(exactObj(propElem("a", numLit(5))), num())))
+	})
 }
 
 func TestConstrainVoid(t *testing.T) {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -79,32 +79,54 @@ type TupleLengthMismatchError struct {
 	site     ast.Node     // M2.5: constraint node fallback when no operand resolves
 }
 
-// MissingPropertyError fires on RecordType <: RecordType when the RHS requires a
-// field the LHS lacks — the record analogue of FuncArityMismatchError /
-// TupleLengthMismatchError. It is the failure behind a field read on a record
-// without that field (recv.foo where recv has no foo): the walk constrains
-// recv <: {foo: fresh}, and the absent field surfaces here. Holds both records
-// plus the missing name so consumers can inspect what was required.
+// MissingPropertyError fires on ObjectType <: ObjectType when the RHS requires a
+// property the LHS lacks — the object analogue of FuncArityMismatchError /
+// TupleLengthMismatchError. It is the failure behind a field read on an object
+// without that property (recv.foo where recv has no foo): the walk constrains
+// recv <: {foo: fresh, ...}, and the absent property surfaces here. Holds both
+// objects plus the missing name so consumers can inspect what was required.
 //
-// The subject is the field's inner result var (RHS.Field(Name)), minted by
+// The subject is the property's inner result var (RHS.Prop(Name)), minted by
 // inferMember and recorded against the .prop identifier — so Span() blames the
-// member's prop (.foo), not the receiver. Name stays: the absent field name is
-// not recoverable from a single node (the RHS may require several fields). site
-// is the constraint node, the coarse fallback when the field var has no entry —
-// reachable once M4 builds concrete record <: record requirements whose field
+// member's prop (.foo), not the receiver. Name stays: the absent property name is
+// not recoverable from a single node (the RHS may require several properties).
+// site is the constraint node, the coarse fallback when the property var has no
+// entry — reachable for a concrete object <: object requirement whose property
 // types are coalesced/annotation-minted (and therefore not recorded by
-// inferMember); until then it never fires, but it keeps blame off the zero span.
+// inferMember); for member access it never fires, but it keeps blame off the zero
+// span.
 type MissingPropertyError struct {
-	LHS, RHS *soltype.RecordType
+	LHS, RHS *soltype.ObjectType
 	Name     string
 	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback when the field var has no entry
+	site     ast.Node     // M2.5: constraint node fallback when the property var has no entry
+}
+
+// InexactIntoExactError fires on ObjectType <: ObjectType when the RHS is exact
+// but the LHS is inexact: an inexact source carries an open `...` tail of unknown
+// properties, so it cannot satisfy an exact target that fixes its member set.
+type InexactIntoExactError struct {
+	LHS, RHS *soltype.ObjectType
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback
+}
+
+// ExtraPropertyError fires on ObjectType <: ObjectType when the RHS is exact and
+// the LHS carries a property the RHS does not declare — width is rejected against
+// an exact target. One error fires per extra property, carrying its name.
+type ExtraPropertyError struct {
+	LHS, RHS *soltype.ObjectType
+	Name     string
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback
 }
 
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*MissingPropertyError) isSolverError()     {}
+func (*InexactIntoExactError) isSolverError()    {}
+func (*ExtraPropertyError) isSolverError()       {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -125,18 +147,35 @@ func (e *TupleLengthMismatchError) Span() ast.Span {
 func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
 func (e *MissingPropertyError) Span() ast.Span {
-	// The field's inner var → the .foo prop ident; degrade to the receiver; else
-	// the site. The field-var arm is the only one reachable in M2.5 (member
-	// access always records it); the receiver/site arms cover the M4 concrete
-	// record <: record case where the field type may be unrecorded.
+	// The property's inner var → the .foo prop ident; degrade to the receiver;
+	// else the site. The property-var arm is the only one reachable from member
+	// access (which always records it); the receiver/site arms cover the concrete
+	// object <: object case where the property type may be unrecorded.
 	ops := make([]soltype.Type, 0, 2)
-	if f, ok := e.RHS.Field(e.Name); ok {
-		ops = append(ops, f)
+	if p, ok := e.RHS.Prop(e.Name); ok {
+		ops = append(ops, p.Type)
 	}
 	ops = append(ops, e.LHS)
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the receiver
+
+func (e *InexactIntoExactError) Span() ast.Span {
+	return spanOfFirst(e.prov, e.site, e.LHS, e.RHS)
+}
+func (e *InexactIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *ExtraPropertyError) Span() ast.Span {
+	// The extra property lives on the LHS source; blame it, degrade to the RHS
+	// target, else the site.
+	ops := make([]soltype.Type, 0, 2)
+	if p, ok := e.LHS.Prop(e.Name); ok {
+		ops = append(ops, p.Type)
+	}
+	ops = append(ops, e.LHS)
+	return spanOfFirst(e.prov, e.site, ops...)
+}
+func (e *ExtraPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -610,6 +649,14 @@ func (e *MissingPropertyError) Message() string {
 	return "object is missing property: " + e.Name
 }
 
+func (e *InexactIntoExactError) Message() string {
+	return "cannot constrain inexact object <: exact object"
+}
+
+func (e *ExtraPropertyError) Message() string {
+	return "object has extra property: " + e.Name
+}
+
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,
 // function, number). Distinct from soltype.Print, which renders coalesced
 // output as user-facing Escalier syntax (see m1-implementation-plan §2.2). It
@@ -638,7 +685,7 @@ func describe(t soltype.Type) string {
 		return "function"
 	case *soltype.TupleType:
 		return "tuple"
-	case *soltype.RecordType:
+	case *soltype.ObjectType:
 		return "object"
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -121,12 +121,26 @@ type ExtraPropertyError struct {
 	site     ast.Node     // M2.5: constraint node fallback
 }
 
+// OptionalPropertyError fires on ObjectType <: ObjectType when a property is
+// optional on the LHS source but required on the RHS target: the source may omit
+// the property, so it cannot satisfy a target that requires it present (the object
+// analogue of TypeScript's "Property 'x' is optional in type … but required in
+// type …"). The converse — a required source property filling an optional target
+// slot — is fine, so only this direction errors.
+type OptionalPropertyError struct {
+	LHS, RHS *soltype.ObjectType
+	Name     string
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback
+}
+
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*ExtraPropertyError) isSolverError()       {}
+func (*OptionalPropertyError) isSolverError()    {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -176,6 +190,18 @@ func (e *ExtraPropertyError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *ExtraPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+
+func (e *OptionalPropertyError) Span() ast.Span {
+	// The optional property lives on the LHS source; blame it, degrade to the RHS
+	// target, else the site (same shape as ExtraPropertyError).
+	ops := make([]soltype.Type, 0, 2)
+	if p, ok := e.LHS.Prop(e.Name); ok {
+		ops = append(ops, p.Type)
+	}
+	ops = append(ops, e.LHS)
+	return spanOfFirst(e.prov, e.site, ops...)
+}
+func (e *OptionalPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -655,6 +681,10 @@ func (e *InexactIntoExactError) Message() string {
 
 func (e *ExtraPropertyError) Message() string {
 	return "object has extra property: " + e.Name
+}
+
+func (e *OptionalPropertyError) Message() string {
+	return "object property is optional but required: " + e.Name
 }
 
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -109,6 +109,10 @@ func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *MissingPropertyError:
 			err.prov, err.site = c.prov, n
+		case *InexactIntoExactError:
+			err.prov, err.site = c.prov, n
+		case *ExtraPropertyError:
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
 		}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -113,6 +113,8 @@ func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *ExtraPropertyError:
 			err.prov, err.site = c.prov, n
+		case *OptionalPropertyError:
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -683,6 +683,14 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 // from the plan's §3.2 table. The requirement is INEXACT: a member read asks
 // only that the receiver has AT LEAST this property, so width tolerance is
 // expressed as inexactness rather than as an unconditionally width-tolerant arm.
+//
+// This inexactness currently flows out to the inferred param type. A param used
+// only through member reads coalesces to its upper bound, so `fn (p) { p.foo }`
+// infers an inexact param `{foo: number, ...}`. M4 phase B PR B1 ("close
+// usage-inferred shapes to exact") will seal that coalesced result to exact via
+// the Policy-A close, rendering `{foo: number}`. The per-access requirement
+// minted here stays inexact; only the coalesced result is closed.
+//
 // The ObjectType <: ObjectType arm of constrain lowers res from the receiver's
 // matching property (so res coalesces to that property's type); a receiver
 // missing the property surfaces as a MissingPropertyError stamped with the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -628,23 +628,23 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 	return t
 }
 
-// inferObject types an object literal as a soltype.RecordType. M2 covers the
-// basic case only: a `name: value` property with a static (identifier or string)
-// key. The forms it does not cover each report an UnsupportedNodeError and are
-// skipped rather than panicking (the deeper object system is M4):
+// inferObject types an object literal as an exact soltype.ObjectType. M2 covers
+// the basic case only: a `name: value` property with a static (identifier or
+// string) key. The forms it does not cover each report an UnsupportedNodeError
+// and are skipped rather than panicking (the deeper object system is M4):
 //   - spreads ({...o}) and method/constructor elements,
 //   - computed ({[k]: v}) and numeric ({0: v}) keys,
 //   - shorthand ({x}, i.e. a property with no value).
 //
-// Usage-inference depth (e.g. inferring an open record from how a value is used)
-// is explicitly M4; M2 builds the closed record the literal spells out.
+// Usage-inference depth (e.g. inferring an open object from how a value is used)
+// is explicitly M4; M2 builds the closed object the literal spells out.
 //
 // Duplicate keys follow JavaScript semantics: the last value wins, keeping the
-// field at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
-// field names unique, the invariant RecordType.Field / equalType rely on.
+// property at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
+// property names unique, the invariant ObjectType.Prop / equalType rely on.
 func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
-	fields := make([]*soltype.RecordField, 0, len(e.Elems))
-	pos := make(map[string]int, len(e.Elems)) // field name → index in fields, for last-wins dedup
+	elems := make([]soltype.ObjTypeElem, 0, len(e.Elems))
+	pos := make(map[string]int, len(e.Elems)) // property name → index in elems, for last-wins dedup
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
@@ -659,31 +659,35 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
-			// Computed/numeric keys carry no static field name — M4. Blame the key
-			// itself (its own narrower span), not the whole property.
+			// Computed/numeric keys carry no static property name — M4. Blame the
+			// key itself (its own narrower span), not the whole property.
 			c.reportUnsupported(prop.Name)
 			continue
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
 		if i, dup := pos[name]; dup {
-			fields[i] = &soltype.RecordField{Name: name, Type: ft} // last value wins, first position kept
+			elems[i] = &soltype.PropertyElem{Name: name, Type: ft} // last value wins, first position kept
 			continue
 		}
-		pos[name] = len(fields)
-		fields = append(fields, &soltype.RecordField{Name: name, Type: ft})
+		pos[name] = len(elems)
+		elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft})
 	}
-	t := &soltype.RecordType{Fields: fields}
+	t := &soltype.ObjectType{Elems: elems}
 	c.recordType(e, t)
 	c.recordProv(t, e, ObjectField)
 	return t
 }
 
 // inferMember types a field read (recv.prop). It types the receiver, allocates a
-// fresh result var, and constrains recv <: {prop: res} — the basic form from the
-// plan's §3.2 table. The record <: record arm of constrain lowers res from the
-// receiver's matching field (so res coalesces to that field's type); a receiver
-// missing the field surfaces as a MissingPropertyError stamped with the member's
-// span. Optional chaining (recv?.prop) needs union/undefined handling and is M6.
+// fresh result var, and constrains recv <: {prop: res, ...} — the basic form
+// from the plan's §3.2 table. The requirement is INEXACT: a member read asks
+// only that the receiver has AT LEAST this property, so width tolerance is
+// expressed as inexactness rather than as an unconditionally width-tolerant arm.
+// The ObjectType <: ObjectType arm of constrain lowers res from the receiver's
+// matching property (so res coalesces to that property's type); a receiver
+// missing the property surfaces as a MissingPropertyError stamped with the
+// member's span. Optional chaining (recv?.prop) needs union/undefined handling
+// and is M6.
 func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
 	if e.OptChain {
 		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
@@ -713,7 +717,10 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 	// recorded — MissingPropertyError blames this inner res var, so the record
 	// would be a dead entry (§3.3).
 	c.recordProv(res, e.Prop, MemberAccess)
-	c.constrain(e, recv, &soltype.RecordType{Fields: []*soltype.RecordField{{Name: e.Prop.Name, Type: res}}})
+	c.constrain(e, recv, &soltype.ObjectType{
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: e.Prop.Name, Type: res}},
+		Inexact: true, // "has at least this property" — width tolerance is inexactness
+	})
 	c.recordType(e, res)
 	return res
 }

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -201,6 +201,11 @@ func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
 // tests only read a field off a literal receiver.
 func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 	t.Run("wider object is accepted", func(t *testing.T) {
+		// Today `p` is inferred INEXACT (`{a: number, ...}`), so a wider argument
+		// checks. M4 phase B PR B1 ("close usage-inferred shapes to exact") will
+		// seal `p` to exact `{a: number}`, after which this wider call REJECTS `b`
+		// as an extra property. PR B2's `open` marker (`fn f(open p)`) will restore
+		// the inexact, row-polymorphic form. Revisit this case when B1/B2 land.
 		src := `
 			fn f(p) { return p.a }
 			val r = f({a: 1, b: 2})

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -193,3 +193,29 @@ func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
 	require.Empty(t, c.errs) // no spurious MissingPropertyError
 	require.Same(t, got, c.info.TypeOf(e))
 }
+
+// Width tolerance through inference, not a literal: a function that reads a field
+// of its param synthesizes an inexact "has at least this field" requirement, so a
+// caller may pass a WIDER object. This exercises the selection-vs-concrete split
+// (A1) end-to-end through generalization and a call, where the existing member
+// tests only read a field off a literal receiver.
+func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
+	t.Run("wider object is accepted", func(t *testing.T) {
+		src := `
+			fn f(p) { return p.a }
+			val r = f({a: 1, b: 2})
+		`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+
+	t.Run("missing field is rejected at the call", func(t *testing.T) {
+		src := `
+			fn f(p) { return p.a }
+			val r = f({b: 2})
+		`
+		_, _, errs := inferSource(t, src)
+		require.Len(t, errs, 1)
+		require.Equal(t, "object is missing property: a", errs[0].Message())
+	})
+}

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -85,10 +85,10 @@ func TestInferObjectDuplicateKeyLastWins(t *testing.T) {
 	require.Empty(t, c.errs)
 	require.Equal(t, `{a: "x", b: 2}`, render(got))
 
-	rec, ok := got.(*soltype.RecordType)
+	obj, ok := got.(*soltype.ObjectType)
 	require.True(t, ok)
-	require.Len(t, rec.Fields, 2) // the duplicate `a` was collapsed, not appended
-	require.True(t, equalType(rec, rec), "equalType must be reflexive for a deduped record")
+	require.Len(t, obj.Elems, 2) // the duplicate `a` was collapsed, not appended
+	require.True(t, equalType(obj, obj), "equalType must be reflexive for a deduped object")
 }
 
 // Shorthand ({x}) is a property with no value — deferred to M4. It reports a

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -217,5 +217,10 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
 		require.Equal(t, "object is missing property: a", errs[0].Message())
+		// Blame the offending argument {b: 2} — the object that lacks the field — not
+		// the whole call. The requirement's field var is freshened on instantiation
+		// and carries no prov, so MissingPropertyError's blame degrades to the LHS
+		// (the argument object literal), which inferObject did record.
+		require.Equal(t, "{b: 2}", spanText(src, errs[0].Span()))
 	})
 }

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -49,20 +49,20 @@ func (FromInstantiation) isOrigin() {}
 type ASTOriginKind int
 
 const (
-	LiteralInference ASTOriginKind = iota // a LitType from inferLiteral
-	ParamBinding                          // a fresh param var from inferFunc
-	Application                           // a fresh call-result var from inferCall
-	TupleElem                             // a TupleType from inferTuple
-	ObjectField                           // a RecordType from inferObject
-	FuncInference                         // a FuncType from inferFunc (the function expr/decl)
-	CallShape                             // the synthesized FuncType{args,res} from inferCall (the CallExpr)
-	MemberAccess                          // a fresh member-result var from inferMember (recorded against the .prop ident)
-	AnnotationType                        // a fresh PrimType from resolveTypeAnn (number/string/boolean)
-	WildcardAnnotation                    // a fresh var from a `_` type annotation (resolveTypeAnn), the inner the surrounding annotation infers
-	AwaitResult                           // a fresh `await`-result var from inferAwait
-	PromiseWrap                           // a PromiseType minted by wrapping an async function's external return
-	ReturnJoin                            // a fresh return-join var from inferFunc (the union of every return point)
-	IfElseBranch                          // a fresh branch-join var from inferIfElse (the union of cons / alt)
+	LiteralInference   ASTOriginKind = iota // a LitType from inferLiteral
+	ParamBinding                            // a fresh param var from inferFunc
+	Application                             // a fresh call-result var from inferCall
+	TupleElem                               // a TupleType from inferTuple
+	ObjectField                             // an ObjectType from inferObject
+	FuncInference                           // a FuncType from inferFunc (the function expr/decl)
+	CallShape                               // the synthesized FuncType{args,res} from inferCall (the CallExpr)
+	MemberAccess                            // a fresh member-result var from inferMember (recorded against the .prop ident)
+	AnnotationType                          // a fresh PrimType from resolveTypeAnn (number/string/boolean)
+	WildcardAnnotation                      // a fresh var from a `_` type annotation (resolveTypeAnn), the inner the surrounding annotation infers
+	AwaitResult                             // a fresh `await`-result var from inferAwait
+	PromiseWrap                             // a PromiseType minted by wrapping an async function's external return
+	ReturnJoin                              // a fresh return-join var from inferFunc (the union of every return point)
+	IfElseBranch                            // a fresh branch-join var from inferIfElse (the union of cons / alt)
 )
 
 // NodeResolver resolves an operand type to the AST node that minted it. M2.5's

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A recursive function whose body is a record literal containing the recursive
-// call builds a cyclic var graph THROUGH a record field. coalesce's RecordType
+// A recursive function whose body is an object literal containing the recursive
+// call builds a cyclic var graph THROUGH an object property. coalesce's ObjectType
 // case must thread the path-scoped `seen` set (like the FuncType/TupleType cases)
 // or the cycle is never detected and coalescing never terminates.
 //

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -570,6 +570,15 @@ these arms it must add.
       cur.Inexact}`)
     - `equalType`'s tuple arm
     - `printType`'s tuple case (a trailing `, ...`)
+  - **Parser prerequisite (consumed by A3, not A2):** A2 adds `Inexact` to the
+    *soltype* `TupleType`, but the AST `TupleTypeAnn` has no `Inexact` field and
+    the parser rejects a bare trailing `...` in a tuple annotation
+    (`[number, ...]` → "expected type annotation after '...'"; `...T` parses only
+    as a `RestSpreadTypeAnn` element, which requires a following type). The same
+    is true of `ObjectTypeAnn` for A1's object `Inexact`. A2's own constrain/print
+    tests build `TupleType`/`ObjectType` values directly, so this does **not**
+    block A2 — it is a prerequisite for A3's `{x, ...}` / `[number, ...]`
+    annotation resolution. See A3's Parser prerequisite note.
   - **Algorithm — tuple constrain arm** (constrain.go:162): replace the strict
     `len(l.Elems) != len(r.Elems)` reject with the exactness-aware rule — when
     `r` is exact, lengths must match; when `r` is inexact, `len(l) >= len(r)`
@@ -609,7 +618,28 @@ these arms it must add.
     - a constant numeric key resolves, a dynamic key errors
 
 - **A3 — Object/tuple/`mut`/lifetime type annotations** (~180).
-  - **Files:** `solver/type_ann.go`, plus tests.
+  - **Files:** `internal/parser/type_ann.go` + `internal/ast/type_ann.go` (the
+    parser prerequisite below), `solver/type_ann.go`, plus tests.
+  - **Parser prerequisite (do this first).** `resolveTypeAnn` can only honor a
+    trailing `...` if the parser produces one, and today it does not. `ObjectTypeAnn`
+    and `TupleTypeAnn` (`internal/ast/type_ann.go`) carry **no `Inexact` field** —
+    only `FuncExpr`/`FuncTypeAnn` do — and a bare trailing `...` in an object or
+    tuple annotation is a **parse error** (`{x: number, ...}` and `[number, ...]`
+    both report "expected type annotation after '...'"); `...T` parses only as a
+    `RestSpreadTypeAnn` *element*, which requires a following type. So before the
+    `... ⇒ Inexact: true` arm and every `{x, ...}` / `[number, ...]` acceptance
+    test below, the parser must:
+    1. add `Inexact bool` to `ObjectTypeAnn` and `TupleTypeAnn`, and
+    2. recognize a bare trailing `...` before `}` / `]` as that marker instead of
+       erroring on a value-less rest-spread (the lookahead `parseFuncParams`
+       already uses for `fn(x, ...)` is the model).
+
+    The `mut`/lifetime annotation forms likewise need parser support before the
+    C1-gated arms land — confirm `mut {x}` and `'a T` parse (lifetime parsing
+    exists, see `internal/parser/lifetime_test.go`). This is parser-side work,
+    separate from and upstream of `resolveTypeAnn`; it does NOT touch the
+    A1 → C1 → C2 path to the gate, whose constrain-rule tests build `soltype`
+    values directly.
   - **Algorithm — extend `resolveTypeAnn`** (type_ann.go:21, today
     primitives + `Promise<T>` only):
     - add arms for object-type and tuple-type annotations (building


### PR DESCRIPTION
Replaces `RecordType` with `ObjectType`, a structural object type that carries an `Inexact` flag to express width tolerance through inexactness rather than an unconditionally width-tolerant constraint arm. Implements the one-way object exactness rule: exact objects require the same member set, inexact objects tolerate width on both sides, and an inexact source cannot satisfy an exact target.

**Key changes:**

- Rename `RecordType` to `ObjectType` and `RecordField` to `PropertyElem`, making `PropertyElem` a sealed `ObjTypeElem` interface to support future member kinds (methods, getters/setters in M5; index signatures and spreads in M9).
- Add `Inexact` flag to `ObjectType` (zero value is exact, matching Escalier's exact-by-default semantics). Object literals are exact by default; only the parser's trailing `...` marker sets it.
- Unify object subtyping into a single `ObjectType <: ObjectType` arm in `constrain` that handles both member-access field selection (inexact requirement) and concrete object subtyping (exact or inexact). Depth is covariant; width tolerance is expressed as inexactness on the RHS.
- Add two new error types: `InexactIntoExactError` (inexact source cannot fill exact target) and `ExtraPropertyError` (exact target rejects extra properties on source).
- Update `inferMember` to constrain `recv <: {prop: res, ...}` (inexact requirement) instead of the previous unconditionally width-tolerant form.
- Add `Prop(name)` lookup method to `ObjectType` (replaces `Field`) and `AsProperty` helper to narrow `ObjTypeElem` to `PropertyElem` with panic on unhandled element kinds.
- Update all call sites: constraint solver, error handling, type printing, visitor, coalescing, and tests.
- Add comprehensive test coverage in `TestConstrainObject` for covariance, width tolerance, missing properties, extra properties, and inexact-into-exact rejection.

The change preserves M2's member-access semantics (width-tolerant field selection) while laying groundwork for M4's object annotations and M5's richer object system.

https://claude.ai/code/session_01LCojZhvBeLroF5vNhVwsz3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a formal object type model with ordered properties, optional properties, and inexact object support; updated diagnostics to describe object-specific failures.

* **Bug Fixes**
  * Corrected structural equality, subtyping, and constraint handling for objects (property ordering, optionality, inexactness), reducing incorrect constraint and error reports.

* **Tests**
  * Expanded tests for object printing, traversal, equality, constraint semantics, and diagnostic/span attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->