### PR TITLE
Rename constraint operands from LHS/RHS to sub/super

### DIFF
--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -207,52 +207,52 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 
 	t.Run("FuncArity", func(t *testing.T) {
 		e := &FuncArityMismatchError{
-			LHS:  &soltype.FuncType{Params: make([]*soltype.FuncParam, 2)},
-			RHS:  &soltype.FuncType{Params: make([]*soltype.FuncParam, 1)},
-			prov: Prov{}, site: site,
+			Sub:   &soltype.FuncType{Params: make([]*soltype.FuncParam, 2)},
+			Super: &soltype.FuncType{Params: make([]*soltype.FuncParam, 1)},
+			prov:  Prov{}, site: site,
 		}
 		require.Equal(t, "cannot constrain function of arity 2 <: function of arity 1", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("TupleLength", func(t *testing.T) {
 		e := &TupleLengthMismatchError{
-			LHS:  &soltype.TupleType{Elems: []soltype.Type{num(), num()}},
-			RHS:  &soltype.TupleType{Elems: []soltype.Type{num()}},
-			prov: Prov{}, site: site,
+			Sub:   &soltype.TupleType{Elems: []soltype.Type{num(), num()}},
+			Super: &soltype.TupleType{Elems: []soltype.Type{num()}},
+			prov:  Prov{}, site: site,
 		}
 		require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 1", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("MissingProperty", func(t *testing.T) {
 		e := &MissingPropertyError{
-			LHS:  &soltype.ObjectType{},
-			RHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
-			Name: "b", prov: Prov{}, site: site,
+			Sub:   &soltype.ObjectType{},
+			Super: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			Name:  "b", prov: Prov{}, site: site,
 		}
 		require.Equal(t, "object is missing property: b", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("InexactIntoExact", func(t *testing.T) {
 		e := &InexactIntoExactError{
-			LHS: &soltype.ObjectType{Inexact: true}, RHS: &soltype.ObjectType{}, prov: Prov{}, site: site,
+			Sub: &soltype.ObjectType{Inexact: true}, Super: &soltype.ObjectType{}, prov: Prov{}, site: site,
 		}
 		require.Equal(t, "cannot constrain inexact object <: exact object", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("ExtraProperty", func(t *testing.T) {
 		e := &ExtraPropertyError{
-			LHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
-			RHS:  &soltype.ObjectType{},
-			Name: "b", prov: Prov{}, site: site,
+			Sub:   &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			Super: &soltype.ObjectType{},
+			Name:  "b", prov: Prov{}, site: site,
 		}
 		require.Equal(t, "object has extra property: b", e.Message())
 		require.Equal(t, site.Span(), e.Span())
 	})
 	t.Run("OptionalProperty", func(t *testing.T) {
 		e := &OptionalPropertyError{
-			LHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}, Optional: true}}},
-			RHS:  &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
-			Name: "b", prov: Prov{}, site: site,
+			Sub:   &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}, Optional: true}}},
+			Super: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{Name: "b", Type: &soltype.TypeVarType{ID: 9}}}},
+			Name:  "b", prov: Prov{}, site: site,
 		}
 		require.Equal(t, site.Span(), e.Span())
 	})

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -64,7 +64,7 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 // redundant cache entries, not infinite loops. M4's recursive types (aliases,
 // letrec) must preserve this property — see m1-implementation-plan §3.3
 // "Forward requirements for the named-ref node design".
-type constraintKey struct{ lhs, rhs soltype.Type }
+type constraintKey struct{ sub, super soltype.Type }
 
 // extrudeKey keys extrude's per-extrusion cache by both the origin variable's
 // ID and the polarity it was reached in, so the same variable copied in
@@ -74,14 +74,20 @@ type extrudeKey struct {
 	pol soltype.Polarity
 }
 
-// Constrain asserts lhs <: rhs, mutating bound lists. An empty result means
+// Constrain asserts sub <: super, mutating bound lists. An empty result means
 // success.
-func (c *Context) Constrain(lhs, rhs soltype.Type) []SolverError {
-	return c.constrain(lhs, rhs, set.NewSet[constraintKey]())
+//
+// Naming: sub is the subtype — the source value being checked; super is the
+// supertype — the target/expected type. Note this is the REVERSE of an
+// assignment's syntactic LHS/RHS: in `x = e`, the value `e` is sub and the target
+// `x` is super. The checker-level wrapper (checker.constrain) names these
+// source/target, which map to sub/super here.
+func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
+	return c.constrain(sub, super, set.NewSet[constraintKey]())
 }
 
-func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) []SolverError {
-	key := constraintKey{lhs, rhs}
+func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]) []SolverError {
+	key := constraintKey{sub, super}
 	if seen.Contains(key) {
 		return nil
 	}
@@ -95,160 +101,160 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 	// (and coalesce / extrude / freshenAbove never see it propagated through
 	// bounds). Unlike never (⊥) / unknown (⊤), which are coalesced-output only,
 	// ErrorType is a legal constrain input.
-	if _, ok := lhs.(*soltype.ErrorType); ok {
+	if _, ok := sub.(*soltype.ErrorType); ok {
 		return nil
 	}
-	if _, ok := rhs.(*soltype.ErrorType); ok {
+	if _, ok := super.(*soltype.ErrorType); ok {
 		return nil
 	}
 
 	// Structural cases first; fall through to the variable cases when a side
 	// that didn't match here is a TypeVarType.
-	switch l := lhs.(type) {
+	switch sub := sub.(type) {
 	case *soltype.PrimType:
-		if r, ok := rhs.(*soltype.PrimType); ok {
-			if r.Prim == l.Prim {
+		if sup, ok := super.(*soltype.PrimType); ok {
+			if sup.Prim == sub.Prim {
 				return nil
 			}
-			return []SolverError{&CannotConstrainError{LHS: l, RHS: r}}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
 	case *soltype.LitType:
-		if r, ok := rhs.(*soltype.LitType); ok {
-			if l.Equal(r) {
+		if sup, ok := super.(*soltype.LitType); ok {
+			if sub.Equal(sup) {
 				return nil
 			}
-			return []SolverError{&CannotConstrainError{LHS: l, RHS: r}}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
-		if r, ok := rhs.(*soltype.PrimType); ok {
-			if primOf(l.Lit) == r.Prim {
+		if sup, ok := super.(*soltype.PrimType); ok {
+			if primOf(sub.Lit) == sup.Prim {
 				return nil // a literal is a subtype of its primitive
 			}
-			return []SolverError{&CannotConstrainError{LHS: l, RHS: r}}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
 	case *soltype.FuncType:
-		if r, ok := rhs.(*soltype.FuncType); ok {
-			// Accept-set subtyping (#677 §4.2.1): read r as a callback slot. l <: r
-			// iff accept(l) ⊇ accept(r) — l must tolerate every argument count a
-			// holder of r may invoke it with. With accept(l) = [loL, hiL] and
-			// accept(r) = [loR, hiR]:
-			//   - loL <= loR — l must not DEMAND more args than r might supply, and
-			//   - hiL >= hiR — l must not REFUSE an arg count r might supply.
-			// The upper-bound clause is what exactness governs (an exact l caps hiL at
-			// len(l.Params), so it can't fill a wider/inexact slot); the lower-bound
+		if sup, ok := super.(*soltype.FuncType); ok {
+			// Accept-set subtyping (#677 §4.2.1): read super as a callback slot.
+			// sub <: super iff accept(sub) ⊇ accept(super) — sub must tolerate every
+			// argument count a holder of super may invoke it with. With
+			// accept(sub) = [loSub, hiSub] and accept(super) = [loSup, hiSup]:
+			//   - loSub <= loSup — sub must not DEMAND more args than super might supply,
+			//   - hiSub >= hiSup — sub must not REFUSE an arg count super might supply.
+			// The upper-bound clause is what exactness governs (an exact sub caps hiSub
+			// at len(sub.Params), so it can't fill a wider/inexact slot); the lower-bound
 			// clause is the `required` part (a typed-rest/optional lowers it). This
 			// subsumes M2's exact-same-arity rule: two EXACT functions have accept
 			// [r, n], so ⊇ forces equal upper bounds, i.e. the old same-arity check.
-			loL, hiL := acceptSet(l)
-			loR, hiR := acceptSet(r)
-			if loL > loR || hiL < hiR {
-				return []SolverError{&FuncArityMismatchError{LHS: l, RHS: r}}
+			loSub, hiSub := acceptSet(sub)
+			loSup, hiSup := acceptSet(sup)
+			if loSub > loSup || hiSub < hiSup {
+				return []SolverError{&FuncArityMismatchError{Sub: sub, Super: sup}}
 			}
 			// Shared positions are checked per-parameter (params contravariant,
-			// return covariant). When r is EXACT this is complete: r never supplies an
-			// argument beyond its declared params, and any extra param l declares there
-			// must be optional (the lo gate forced loL <= loR) and so is simply never
-			// passed.
+			// return covariant). When super is EXACT this is complete: super never
+			// supplies an argument beyond its declared params, and any extra param sub
+			// declares there must be optional (the lo gate forced loSub <= loSup) and so
+			// is simply never passed.
 			//
-			// KNOWN GAP (M4): when r is INEXACT and l declares MORE params than r, r's
-			// `...` tail may supply arbitrarily-typed args at l's extra positions, so
-			// soundness demands `unknown <: l.Params[i].Type` there — exact-types
-			// §4.2.1.2 "Variation B", the load-bearing rejection. That check needs the
-			// `_ <: unknown` (⊤) rule constrain lacks until M6, and an inexact function
-			// is unreachable from M3 source anyway (resolveTypeAnn resolves no function
-			// annotations), so the extra positions are left unchecked here for now. For
-			// every M3-reachable input (exact functions only) the shared loop is complete.
+			// KNOWN GAP (M4): when super is INEXACT and sub declares MORE params than
+			// super, super's `...` tail may supply arbitrarily-typed args at sub's extra
+			// positions, so soundness demands `unknown <: sub.Params[i].Type` there —
+			// exact-types §4.2.1.2 "Variation B", the load-bearing rejection. That check
+			// needs the `_ <: unknown` (⊤) rule constrain lacks until M6, and an inexact
+			// function is unreachable from M3 source anyway (resolveTypeAnn resolves no
+			// function annotations), so the extra positions are left unchecked here for
+			// now. For every M3-reachable input (exact functions only) the loop is complete.
 			var errs []SolverError
-			n := min(len(l.Params), len(r.Params))
+			n := min(len(sub.Params), len(sup.Params))
 			for i := 0; i < n; i++ {
-				errs = append(errs, c.constrain(r.Params[i].Type, l.Params[i].Type, seen)...) // contravariant
+				errs = append(errs, c.constrain(sup.Params[i].Type, sub.Params[i].Type, seen)...) // contravariant
 			}
-			return append(errs, c.constrain(l.Ret, r.Ret, seen)...) // covariant
+			return append(errs, c.constrain(sub.Ret, sup.Ret, seen)...) // covariant
 		}
 	case *soltype.TupleType:
-		if r, ok := rhs.(*soltype.TupleType); ok {
+		if sup, ok := super.(*soltype.TupleType); ok {
 			// Same length, element-wise covariant. M1's TupleType has no exact
 			// flag — same-length is the *exact <: exact* case applied
 			// implicitly; M4 adds the exact flag and the inexact arm.
-			if len(l.Elems) != len(r.Elems) {
-				return []SolverError{&TupleLengthMismatchError{LHS: l, RHS: r}}
+			if len(sub.Elems) != len(sup.Elems) {
+				return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
 			}
 			var errs []SolverError
-			for i := range l.Elems {
-				errs = append(errs, c.constrain(l.Elems[i], r.Elems[i], seen)...) // covariant
+			for i := range sub.Elems {
+				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen)...) // covariant
 			}
 			return errs
 		}
 	case *soltype.ObjectType:
-		if r, ok := rhs.(*soltype.ObjectType); ok {
+		if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
-			// conflated: member-access field SELECTION (the RHS is an inexact
+			// conflated: member-access field SELECTION (the super is an inexact
 			// "has at least this field" requirement minted by inferMember) and
 			// concrete object <: object SUBTYPING for object-typed params/annotations.
 			// The Inexact flag is the split — width tolerance IS inexactness.
 			//
-			// Depth first: every property the RHS requires must be present on the
-			// LHS, matched by name (Prop), and the shared property types are
+			// Depth first: every property the super requires must be present on the
+			// sub, matched by name (Prop), and the shared property types are
 			// covariant. PropertyElem.Optional makes presence part of the shape, so
 			// the loop is presence-aware before recursing on the property type:
-			//   - absent on the LHS: a MissingPropertyError only when the RHS
-			//     property is REQUIRED; an optional RHS property may be absent.
-			//   - present on both, optional on the LHS but required on the RHS: the
+			//   - absent on the sub: a MissingPropertyError only when the super
+			//     property is REQUIRED; an optional super property may be absent.
+			//   - present on both, optional on the sub but required on the super: the
 			//     source may omit it, so it cannot fill a required slot —
 			//     OptionalPropertyError, and skip the covariant type check (the
 			//     presence mismatch already rejects the constraint).
 			//   - otherwise (required<:required, required<:optional, optional<:
 			//     optional): covariant on the property type.
 			var errs []SolverError
-			for _, re := range r.Elems {
-				rp := soltype.AsProperty(re) // M4: every elem is a property
-				lp, ok := l.Prop(rp.Name)
+			for _, superElem := range sup.Elems {
+				superProp := soltype.AsProperty(superElem) // M4: every elem is a property
+				subProp, ok := sub.Prop(superProp.Name)
 				if !ok {
-					if !rp.Optional {
-						errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
+					if !superProp.Optional {
+						errs = append(errs, &MissingPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
 					}
 					continue
 				}
-				if lp.Optional && !rp.Optional {
-					errs = append(errs, &OptionalPropertyError{LHS: l, RHS: r, Name: rp.Name})
+				if subProp.Optional && !superProp.Optional {
+					errs = append(errs, &OptionalPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
 					continue
 				}
-				errs = append(errs, c.constrain(lp.Type, rp.Type, seen)...) // covariant
+				errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen)...) // covariant
 			}
 			// One-way exactness (02-design-notes §"Exactness"):
 			//   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
 			//   exact <: exact      same member set  inexact <: exact     rejected
-			// When the RHS is inexact, width tolerance is the complete rule and the
-			// depth loop above is all there is. When the RHS is exact, the LHS may
+			// When the super is inexact, width tolerance is the complete rule and the
+			// depth loop above is all there is. When the super is exact, the sub may
 			// carry no extra properties and may not itself be inexact.
-			if !r.Inexact {
-				if l.Inexact {
-					errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
+			if !sup.Inexact {
+				if sub.Inexact {
+					errs = append(errs, &InexactIntoExactError{Sub: sub, Super: sup})
 				}
-				for _, le := range l.Elems {
-					lp := soltype.AsProperty(le)
-					if _, ok := r.Prop(lp.Name); !ok {
-						errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lp.Name})
+				for _, subElem := range sub.Elems {
+					subProp := soltype.AsProperty(subElem)
+					if _, ok := sup.Prop(subProp.Name); !ok {
+						errs = append(errs, &ExtraPropertyError{Sub: sub, Super: sup, Name: subProp.Name})
 					}
 				}
 			}
 			return errs
 		}
 	case *soltype.PromiseType:
-		if r, ok := rhs.(*soltype.PromiseType); ok {
+		if sup, ok := super.(*soltype.PromiseType); ok {
 			// PromiseType is covariant in its Inner: Promise<L> <: Promise<R> iff
 			// L <: R. No auto-flatten — `await Promise<Promise<T>>` yields
 			// `Promise<T>` (Awaited<T> lands in M9). When the two sides are unrelated
 			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
 			// CannotConstrainError below, matching the function/tuple/record arms.
-			return c.constrain(l.Inner, r.Inner, seen)
+			return c.constrain(sub.Inner, sup.Inner, seen)
 		}
 	case *soltype.Void:
-		if _, ok := rhs.(*soltype.Void); ok {
+		if _, ok := super.(*soltype.Void); ok {
 			return nil
 		}
 	case *soltype.IntersectionType:
-		// Function-intersection LHS (PR6 scoped lattice exception): (A & B & …) <: rhs
-		// iff SOME member <: rhs. This is the ONE place the overload disjunction touches
+		// Function-intersection sub (PR6 scoped lattice exception): (A & B & …) <: super
+		// iff SOME member <: super. This is the ONE place the overload disjunction touches
 		// the lattice — reached only when an overloaded value (inferIdent synthesizes the
 		// arm intersection) flows into a constraint, e.g. a let-bound overload called
 		// through the binding (`g = f; g(x)`). The disjunction stays confined to the
@@ -260,16 +266,16 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		// intersection never reaches constrain as input (the design keeps these
 		// output-only), so this arm is overload-synthesis-only.
 		//
-		// Collapse only against a CONCRETE demand. If rhs is a variable — the overloaded
+		// Collapse only against a CONCRETE demand. If super is a variable — the overloaded
 		// value is flowing INTO a binding (`intersection <: b.v`) — don't collapse here.
 		// Fall through to the var arm below, which records the intersection WHOLE as a
 		// lower bound. Collapsing now would commit to one arm prematurely and discard the
 		// rest of the overload set. The collapse fires later instead, once that var is
 		// constrained against a concrete function demand (a call shape) and the whole
 		// intersection propagates to it.
-		if _, rhsIsVar := rhs.(*soltype.TypeVarType); !rhsIsVar && len(l.Types) > 0 {
-			funcs := make([]*soltype.FuncType, len(l.Types))
-			for i, m := range l.Types {
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
+			funcs := make([]*soltype.FuncType, len(sub.Types))
+			for i, m := range sub.Types {
 				funcs[i], _ = m.(*soltype.FuncType)
 			}
 			var lastErrs []SolverError
@@ -278,7 +284,7 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 				c.probe = p
 				// A cloned seen keeps each arm's coinductive cache independent, so a failed
 				// arm's entries can't wrongly short-circuit a later arm to success.
-				errs := c.constrain(l.Types[idx], rhs, seen.Clone())
+				errs := c.constrain(sub.Types[idx], super, seen.Clone())
 				c.probe = p.parent
 				if len(errs) == 0 {
 					p.Commit()
@@ -291,34 +297,34 @@ func (c *Context) constrain(lhs, rhs soltype.Type, seen set.Set[constraintKey]) 
 		}
 	}
 
-	// lhs is a variable: record rhs as an upper bound, propagate existing lowers.
-	if lv, ok := lhs.(*soltype.TypeVarType); ok {
-		if soltype.LevelOf(rhs) <= lv.Level {
-			c.addUpperBound(lv, rhs)
+	// sub is a variable: record super as an upper bound, propagate existing lowers.
+	if subVar, ok := sub.(*soltype.TypeVarType); ok {
+		if soltype.LevelOf(super) <= subVar.Level {
+			c.addUpperBound(subVar, super)
 			var errs []SolverError
-			for _, lb := range lv.LowerBounds {
-				errs = append(errs, c.constrain(lb, rhs, seen)...)
+			for _, lb := range subVar.LowerBounds {
+				errs = append(errs, c.constrain(lb, super, seen)...)
 			}
 			return errs
 		}
-		// rhs lives at a higher level: extrude it down so it isn't wrongly
-		// generalized at lv's level.
-		return c.constrain(lhs, c.extrude(rhs, soltype.Negative, lv.Level, map[extrudeKey]*soltype.TypeVarType{}), seen)
+		// super lives at a higher level: extrude it down so it isn't wrongly
+		// generalized at subVar's level.
+		return c.constrain(sub, c.extrude(super, soltype.Negative, subVar.Level, map[extrudeKey]*soltype.TypeVarType{}), seen)
 	}
-	// rhs is a variable: symmetric — record lhs as a lower bound, propagate uppers.
-	if rv, ok := rhs.(*soltype.TypeVarType); ok {
-		if soltype.LevelOf(lhs) <= rv.Level {
-			c.addLowerBound(rv, lhs)
+	// super is a variable: symmetric — record sub as a lower bound, propagate uppers.
+	if superVar, ok := super.(*soltype.TypeVarType); ok {
+		if soltype.LevelOf(sub) <= superVar.Level {
+			c.addLowerBound(superVar, sub)
 			var errs []SolverError
-			for _, ub := range rv.UpperBounds {
-				errs = append(errs, c.constrain(lhs, ub, seen)...)
+			for _, ub := range superVar.UpperBounds {
+				errs = append(errs, c.constrain(sub, ub, seen)...)
 			}
 			return errs
 		}
-		return c.constrain(c.extrude(lhs, soltype.Positive, rv.Level, map[extrudeKey]*soltype.TypeVarType{}), rhs, seen)
+		return c.constrain(c.extrude(sub, soltype.Positive, superVar.Level, map[extrudeKey]*soltype.TypeVarType{}), super, seen)
 	}
 
-	return []SolverError{&CannotConstrainError{LHS: lhs, RHS: rhs}}
+	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
 // extrude copies t so that variables above lvl are replaced by fresh variables

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -78,10 +78,9 @@ type extrudeKey struct {
 // success.
 //
 // Naming: sub is the subtype — the source value being checked; super is the
-// supertype — the target/expected type. Note this is the REVERSE of an
-// assignment's syntactic LHS/RHS: in `x = e`, the value `e` is sub and the target
-// `x` is super. The checker-level wrapper (checker.constrain) names these
-// source/target, which map to sub/super here.
+// supertype — the target/expected type. In `x = e`, the value `e` is sub and the
+// target `x` is the super. The checker-level wrapper (checker.constrain) names
+// these source/target, which map to sub/super here.
 func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 	return c.constrain(sub, super, set.NewSet[constraintKey]())
 }

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -53,10 +53,10 @@ func inexactFn(ret soltype.Type, params ...*soltype.FuncParam) *soltype.FuncType
 
 func TestConstrainPrim(t *testing.T) {
 	tests := []struct {
-		name string
-		lhs  soltype.Type
-		rhs  soltype.Type
-		want []string
+		name  string
+		sub   soltype.Type
+		super soltype.Type
+		want  []string
 	}{
 		{"number <: number", num(), num(), nil},
 		{"string <: string", str(), str(), nil},
@@ -66,7 +66,7 @@ func TestConstrainPrim(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Context{}
-			errs := c.Constrain(tt.lhs, tt.rhs)
+			errs := c.Constrain(tt.sub, tt.super)
 			require.Equal(t, tt.want, Messages(errs))
 		})
 	}
@@ -74,21 +74,21 @@ func TestConstrainPrim(t *testing.T) {
 
 func TestConstrainPrimMismatchStructure(t *testing.T) {
 	c := &Context{}
-	lhs, rhs := num(), str()
-	errs := c.Constrain(lhs, rhs)
+	sub, super := num(), str()
+	errs := c.Constrain(sub, super)
 	require.Len(t, errs, 1)
 	cc, ok := errs[0].(*CannotConstrainError)
 	require.True(t, ok)
-	require.Same(t, soltype.Type(lhs), cc.LHS)
-	require.Same(t, soltype.Type(rhs), cc.RHS)
+	require.Same(t, soltype.Type(sub), cc.Sub)
+	require.Same(t, soltype.Type(super), cc.Super)
 }
 
 func TestConstrainLiteral(t *testing.T) {
 	tests := []struct {
-		name string
-		lhs  soltype.Type
-		rhs  soltype.Type
-		want []string
+		name  string
+		sub   soltype.Type
+		super soltype.Type
+		want  []string
 	}{
 		{"5 <: number", numLit(5), num(), nil},
 		{`"hello" <: string`, strLit("hello"), str(), nil},
@@ -106,7 +106,7 @@ func TestConstrainLiteral(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Context{}
-			errs := c.Constrain(tt.lhs, tt.rhs)
+			errs := c.Constrain(tt.sub, tt.super)
 			require.Equal(t, tt.want, Messages(errs))
 		})
 	}
@@ -122,7 +122,7 @@ func TestConstrainFunctionVariance(t *testing.T) {
 	})
 
 	// Contravariant params: (number) -> number <: (5) -> number requires
-	// 5 <: number on the param (rhs param <: lhs param), which holds.
+	// 5 <: number on the param (super param <: sub param), which holds.
 	t.Run("contravariant params (ok)", func(t *testing.T) {
 		c := &Context{}
 		f1 := exactFn(num(), identParam("x", num()))
@@ -150,7 +150,7 @@ func TestConstrainFunctionVariance(t *testing.T) {
 
 // TestConstrainFunctionAcceptSet exercises the PR4 accept-set rule (#677 §4.2.1):
 // G <: F iff accept(G) ⊇ accept(F), with params contravariant and return covariant.
-// Read F (the RHS) as the callback slot.
+// Read F (the super) as the callback slot.
 func TestConstrainFunctionAcceptSet(t *testing.T) {
 	// Two EXACT functions relate by the old same-arity rule: accept is [n, n] on both
 	// sides, so ⊇ forces equal arity.
@@ -172,8 +172,8 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 		require.Equal(t, []string{"cannot constrain function of arity 1 <: function of arity 2"}, Messages(errs))
 		fa, ok := errs[0].(*FuncArityMismatchError)
 		require.True(t, ok)
-		require.Same(t, g, fa.LHS)
-		require.Same(t, f, fa.RHS)
+		require.Same(t, g, fa.Sub)
+		require.Same(t, f, fa.Super)
 	})
 
 	// The #677 callback matrix for an exact fn(x, y) slot: fn(x, y), fn(x, ...), and
@@ -338,8 +338,8 @@ func TestConstrainTuple(t *testing.T) {
 		require.Equal(t, []string{"cannot constrain tuple of length 2 <: tuple of length 1"}, Messages(errs))
 		tl, ok := errs[0].(*TupleLengthMismatchError)
 		require.True(t, ok)
-		require.Same(t, t1, tl.LHS)
-		require.Same(t, t2, tl.RHS)
+		require.Same(t, t1, tl.Sub)
+		require.Same(t, t2, tl.Super)
 	})
 }
 
@@ -359,7 +359,7 @@ func inexactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
 }
 
 // TestConstrainObject exercises the one-way object exactness rule (A1): width
-// tolerance is inexactness on the RHS, and an exact RHS fixes its member set.
+// tolerance is inexactness on the super, and an exact super fixes its member set.
 //
 // want is the expected rendered messages (nil for a clean constraint); check, when
 // set, runs extra structural assertions (the specific error type, the operand
@@ -369,63 +369,63 @@ func TestConstrainObject(t *testing.T) {
 		return &soltype.PropertyElem{Name: name, Type: ty, Optional: true}
 	}
 	tests := []struct {
-		name     string
-		lhs, rhs soltype.Type
-		want     []string
-		check    func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError)
+		name       string
+		sub, super soltype.Type
+		want       []string
+		check      func(t *testing.T, sub, super soltype.Type, errs []SolverError)
 	}{
 		{
 			// {x: 5} <: {x: number}
 			// Depth is covariant: checks 5 <: number on the shared property. Same
 			// member set on both sides, so the exact gate passes.
-			name: "exact same member set, covariant depth",
-			lhs:  exactObj(propElem("x", numLit(5))),
-			rhs:  exactObj(propElem("x", num())),
+			name:  "exact same member set, covariant depth",
+			sub:   exactObj(propElem("x", numLit(5))),
+			super: exactObj(propElem("x", num())),
 		},
 		{
 			// {x: number, y: number} <: {x: number, ...}
-			// Width is the inexact-target case: the LHS drops the extra y because the
-			// RHS only requires "has at least x".
-			name: "exact fills inexact (width)",
-			lhs:  exactObj(propElem("x", num()), propElem("y", num())),
-			rhs:  inexactObj(propElem("x", num())),
+			// Width is the inexact-target case: the sub drops the extra y because the
+			// super only requires "has at least x".
+			name:  "exact fills inexact (width)",
+			sub:   exactObj(propElem("x", num()), propElem("y", num())),
+			super: inexactObj(propElem("x", num())),
 		},
 		{
 			// {x: number, y: number, ...} <: {x: number, ...}
-			// Width again with an inexact source: an inexact LHS still satisfies an
-			// inexact RHS, dropping the extra y.
-			name: "inexact fills inexact (width)",
-			lhs:  inexactObj(propElem("x", num()), propElem("y", num())),
-			rhs:  inexactObj(propElem("x", num())),
+			// Width again with an inexact source: an inexact sub still satisfies an
+			// inexact super, dropping the extra y.
+			name:  "inexact fills inexact (width)",
+			sub:   inexactObj(propElem("x", num()), propElem("y", num())),
+			super: inexactObj(propElem("x", num())),
 		},
 		{
 			// {x: number} <: {y: number, ...}
-			// A required property the LHS lacks is a MissingPropertyError, regardless
-			// of the RHS's exactness.
-			name: "missing required property",
-			lhs:  exactObj(propElem("x", num())),
-			rhs:  inexactObj(propElem("y", num())),
-			want: []string{"object is missing property: y"},
-			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+			// A required property the sub lacks is a MissingPropertyError, regardless
+			// of the super's exactness.
+			name:  "missing required property",
+			sub:   exactObj(propElem("x", num())),
+			super: inexactObj(propElem("y", num())),
+			want:  []string{"object is missing property: y"},
+			check: func(t *testing.T, sub, super soltype.Type, errs []SolverError) {
 				mp, ok := errs[0].(*MissingPropertyError)
 				require.True(t, ok)
-				require.Same(t, lhs, mp.LHS)
-				require.Same(t, rhs, mp.RHS)
+				require.Same(t, sub, mp.Sub)
+				require.Same(t, super, mp.Super)
 			},
 		},
 		{
 			// {x: number, y: number} <: {x: number}
-			// An extra property on the LHS is rejected against an exact RHS, one error
+			// An extra property on the sub is rejected against an exact super, one error
 			// per extra property.
-			name: "extra property rejected by exact target",
-			lhs:  exactObj(propElem("x", num()), propElem("y", num())),
-			rhs:  exactObj(propElem("x", num())),
-			want: []string{"object has extra property: y"},
-			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+			name:  "extra property rejected by exact target",
+			sub:   exactObj(propElem("x", num()), propElem("y", num())),
+			super: exactObj(propElem("x", num())),
+			want:  []string{"object has extra property: y"},
+			check: func(t *testing.T, sub, super soltype.Type, errs []SolverError) {
 				ep, ok := errs[0].(*ExtraPropertyError)
 				require.True(t, ok)
-				require.Same(t, lhs, ep.LHS)
-				require.Same(t, rhs, ep.RHS)
+				require.Same(t, sub, ep.Sub)
+				require.Same(t, super, ep.Super)
 				require.Equal(t, "y", ep.Name)
 			},
 		},
@@ -433,78 +433,78 @@ func TestConstrainObject(t *testing.T) {
 			// {x: number, ...} <: {x: number}
 			// An inexact source cannot satisfy an exact target — the open `...` tail
 			// may carry properties the target does not declare.
-			name: "inexact rejected by exact target",
-			lhs:  inexactObj(propElem("x", num())),
-			rhs:  exactObj(propElem("x", num())),
-			want: []string{"cannot constrain inexact object <: exact object"},
-			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+			name:  "inexact rejected by exact target",
+			sub:   inexactObj(propElem("x", num())),
+			super: exactObj(propElem("x", num())),
+			want:  []string{"cannot constrain inexact object <: exact object"},
+			check: func(t *testing.T, sub, super soltype.Type, errs []SolverError) {
 				ie, ok := errs[0].(*InexactIntoExactError)
 				require.True(t, ok)
-				require.Same(t, lhs, ie.LHS)
-				require.Same(t, rhs, ie.RHS)
+				require.Same(t, sub, ie.Sub)
+				require.Same(t, super, ie.Super)
 			},
 		},
 		{
 			// {x: {a: number}} <: {x: {a: string}}
 			// Depth is recursive: a shared property whose types don't relate surfaces
 			// the inner failure, threaded through the path-scoped seen set.
-			name: "nested depth mismatch surfaces inner error",
-			lhs:  exactObj(propElem("x", exactObj(propElem("a", num())))),
-			rhs:  exactObj(propElem("x", exactObj(propElem("a", str())))),
-			want: []string{"cannot constrain number <: string"},
+			name:  "nested depth mismatch surfaces inner error",
+			sub:   exactObj(propElem("x", exactObj(propElem("a", num())))),
+			super: exactObj(propElem("x", exactObj(propElem("a", str())))),
+			want:  []string{"cannot constrain number <: string"},
 		},
 		{
 			// {x: {a: 5}} <: {x: {a: number}}
 			// Recursive depth that checks: the inner 5 <: number holds.
-			name: "nested depth covariant ok",
-			lhs:  exactObj(propElem("x", exactObj(propElem("a", numLit(5))))),
-			rhs:  exactObj(propElem("x", exactObj(propElem("a", num())))),
+			name:  "nested depth covariant ok",
+			sub:   exactObj(propElem("x", exactObj(propElem("a", numLit(5))))),
+			super: exactObj(propElem("x", exactObj(propElem("a", num())))),
 		},
 		{
 			// {a: number, b: number, c: number} <: {a: number}
 			// Every extra property on the source against an exact target fires its own
 			// ExtraPropertyError, in source-property order.
-			name: "multiple extra properties each report",
-			lhs:  exactObj(propElem("a", num()), propElem("b", num()), propElem("c", num())),
-			rhs:  exactObj(propElem("a", num())),
-			want: []string{"object has extra property: b", "object has extra property: c"},
+			name:  "multiple extra properties each report",
+			sub:   exactObj(propElem("a", num()), propElem("b", num()), propElem("c", num())),
+			super: exactObj(propElem("a", num())),
+			want:  []string{"object has extra property: b", "object has extra property: c"},
 		},
 		{
 			// {a: number, c: number} <: {a: number, b: number}
 			// A missing required property and an extra property both fire in one
-			// constraint: the RHS-required loop reports the missing one first, then the
-			// LHS-extra loop reports the extra.
-			name: "missing and extra combined against exact target",
-			lhs:  exactObj(propElem("a", num()), propElem("c", num())),
-			rhs:  exactObj(propElem("a", num()), propElem("b", num())),
-			want: []string{"object is missing property: b", "object has extra property: c"},
+			// constraint: the super-required loop reports the missing one first, then the
+			// sub-extra loop reports the extra.
+			name:  "missing and extra combined against exact target",
+			sub:   exactObj(propElem("a", num()), propElem("c", num())),
+			super: exactObj(propElem("a", num()), propElem("b", num())),
+			want:  []string{"object is missing property: b", "object has extra property: c"},
 		},
 		// Boundary member sets against the exactness gate.
 		{
 			// {} <: {a: number}
-			name: "empty exact missing required",
-			lhs:  exactObj(),
-			rhs:  exactObj(propElem("a", num())),
-			want: []string{"object is missing property: a"},
+			name:  "empty exact missing required",
+			sub:   exactObj(),
+			super: exactObj(propElem("a", num())),
+			want:  []string{"object is missing property: a"},
 		},
 		{
 			// {a: number} <: {}
-			name: "extra against empty exact",
-			lhs:  exactObj(propElem("a", num())),
-			rhs:  exactObj(),
-			want: []string{"object has extra property: a"},
+			name:  "extra against empty exact",
+			sub:   exactObj(propElem("a", num())),
+			super: exactObj(),
+			want:  []string{"object has extra property: a"},
 		},
 		{
 			// {} <: {}
-			name: "empty exact <: empty exact ok",
-			lhs:  exactObj(),
-			rhs:  exactObj(),
+			name:  "empty exact <: empty exact ok",
+			sub:   exactObj(),
+			super: exactObj(),
 		},
 		{
 			// {a: number} <: {...}
-			name: "exact fills empty inexact (width)",
-			lhs:  exactObj(propElem("a", num())),
-			rhs:  inexactObj(),
+			name:  "exact fills empty inexact (width)",
+			sub:   exactObj(propElem("a", num())),
+			super: inexactObj(),
 		},
 		// PropertyElem.Optional is part of the object shape, so subtyping is
 		// presence-aware: an optional target property may be absent on the source,
@@ -512,62 +512,62 @@ func TestConstrainObject(t *testing.T) {
 		// optional source property cannot fill a required target slot.
 		{
 			// {} <: {x?: number}: an optional target property may be absent.
-			name: "absent source satisfies optional target property",
-			lhs:  exactObj(),
-			rhs:  exactObj(optProp("x", num())),
+			name:  "absent source satisfies optional target property",
+			sub:   exactObj(),
+			super: exactObj(optProp("x", num())),
 		},
 		{
 			// {x?: number} <: {x: number}: the source may omit x, so it cannot fill a
 			// required slot.
-			name: "optional source rejected by required target",
-			lhs:  exactObj(optProp("x", num())),
-			rhs:  exactObj(propElem("x", num())),
-			want: []string{"object property is optional but required: x"},
-			check: func(t *testing.T, lhs, rhs soltype.Type, errs []SolverError) {
+			name:  "optional source rejected by required target",
+			sub:   exactObj(optProp("x", num())),
+			super: exactObj(propElem("x", num())),
+			want:  []string{"object property is optional but required: x"},
+			check: func(t *testing.T, sub, super soltype.Type, errs []SolverError) {
 				op, ok := errs[0].(*OptionalPropertyError)
 				require.True(t, ok)
-				require.Same(t, lhs, op.LHS)
-				require.Same(t, rhs, op.RHS)
+				require.Same(t, sub, op.Sub)
+				require.Same(t, super, op.Super)
 				require.Equal(t, "x", op.Name)
 			},
 		},
 		{
 			// {x: number} <: {x?: number}: a required property fills an optional slot.
-			name: "required source fills optional target property",
-			lhs:  exactObj(propElem("x", num())),
-			rhs:  exactObj(optProp("x", num())),
+			name:  "required source fills optional target property",
+			sub:   exactObj(propElem("x", num())),
+			super: exactObj(optProp("x", num())),
 		},
 		{
 			// {x?: number} <: {x?: number}: optional on both, types covariant.
-			name: "optional on both sides ok",
-			lhs:  exactObj(optProp("x", numLit(5))),
-			rhs:  exactObj(optProp("x", num())),
+			name:  "optional on both sides ok",
+			sub:   exactObj(optProp("x", numLit(5))),
+			super: exactObj(optProp("x", num())),
 		},
 		{
 			// An optional source property still recurses covariantly into an optional
 			// target property, so an incompatible type is caught.
-			name: "optional on both sides depth mismatch",
-			lhs:  exactObj(optProp("x", num())),
-			rhs:  exactObj(optProp("x", str())),
-			want: []string{"cannot constrain number <: string"},
+			name:  "optional on both sides depth mismatch",
+			sub:   exactObj(optProp("x", num())),
+			super: exactObj(optProp("x", str())),
+			want:  []string{"cannot constrain number <: string"},
 		},
 		{
 			// {a: 5} <: number
-			// A non-object RHS falls through the object arm to the generic
+			// A non-object super falls through the object arm to the generic
 			// CannotConstrainError, whose message renders the object via describe.
-			name: "object <: non-object renders via describe",
-			lhs:  exactObj(propElem("a", numLit(5))),
-			rhs:  num(),
-			want: []string{"cannot constrain object <: number"},
+			name:  "object <: non-object renders via describe",
+			sub:   exactObj(propElem("a", numLit(5))),
+			super: num(),
+			want:  []string{"cannot constrain object <: number"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Context{}
-			errs := c.Constrain(tt.lhs, tt.rhs)
+			errs := c.Constrain(tt.sub, tt.super)
 			require.Equal(t, tt.want, Messages(errs))
 			if tt.check != nil {
-				tt.check(t, tt.lhs, tt.rhs, errs)
+				tt.check(t, tt.sub, tt.super, errs)
 			}
 		})
 	}
@@ -662,7 +662,7 @@ func TestConstrainExtrusion(t *testing.T) {
 	low := c.freshVar(0)  // level 0
 	high := c.freshVar(1) // level 1
 
-	// low <: high. low (level 0) is the lhs variable; high (level 1) lives above
+	// low <: high. low (level 0) is the sub variable; high (level 1) lives above
 	// low's level, so it is extruded down to a fresh level-0 variable before
 	// being recorded as low's upper bound.
 	require.Empty(t, c.Constrain(low, high))

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -5,7 +5,7 @@
 //
 //   - fresh inference variables that carry lower/upper *bound lists* plus a level
 //     (for let-generalization in a later milestone),
-//   - a constrain(lhs <: rhs) primitive with a coinductive seen-cache, plus
+//   - a constrain(sub <: super) primitive with a coinductive seen-cache, plus
 //     level-aware extrusion, and
 //   - polarity-driven coalescing that inlines every variable to its bounds,
 //     returning a native soltype.Type.
@@ -68,5 +68,5 @@
 // fallback over-narrows the enclosing function, and the real fix rides with M4/M5
 // object-arg and method overloads (#723). M1 ships UnionType/IntersectionType *nodes*
 // for coalesced output; their general lattice rules in constrain remain deferred (PR6
-// adds only the function-intersection-LHS arm above).
+// adds only the function-intersection-sub arm above).
 package solver

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -28,20 +28,20 @@ type SolverError interface {
 	Related() []ast.Span // node-derived; empty unless the kind carries related nodes
 }
 
-// CannotConstrainError fires when a non-variable LHS/RHS pair fails to match:
+// CannotConstrainError fires when a non-variable sub/super pair fails to match:
 // prim/prim mismatch, lit/lit mismatch, lit/prim mismatch, and the generic
 // "no rule applies" fall-through at the end of constrain.
 //
-// LHS is the "actual" value, RHS the "expected"; blame follows LHS to its minting
+// Sub is the "actual" value, Super the "expected"; blame follows Sub to its minting
 // node (when that node lies inside the constraint site — the containment guard
 // that keeps identifier-flow blame on the use, not the definition, §3.8) and falls
 // back to site otherwise. This is the only constraint kind that keeps a site
 // fallback: its actual-value operand can legitimately resolve outside the
 // constraint (an ident's definition) or not at all (a Void result).
 type CannotConstrainError struct {
-	LHS, RHS soltype.Type
-	prov     NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
-	site     ast.Node     // M2.5: the constraint node n — the use, the fallback when LHS has no entry
+	Sub, Super soltype.Type
+	prov       NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
+	site       ast.Node     // M2.5: the constraint node n — the use, the fallback when Sub has no entry
 }
 
 // FuncArityMismatchError fires on FuncType <: FuncType when the two arities
@@ -50,88 +50,88 @@ type CannotConstrainError struct {
 // report param/return types too. M3 narrows the firing conditions when the
 // exactness flag adds the inexact fewer-params-is-subtype arm.
 //
-// The subject is the RHS call-shape (a fresh FuncType{args, res} minted per call,
+// The subject is the super call-shape (a fresh FuncType{args, res} minted per call,
 // recorded against the CallExpr), so Span() resolves precisely to the call;
-// Related() follows the LHS callee to a "defined here" span. site is the
+// Related() follows the sub callee to a "defined here" span. site is the
 // constraint node, used as a coarse fallback when neither operand resolves (e.g.
-// once M3 produces higher-order FuncArity errors whose RHS isn't a recorded
+// once M3 produces higher-order FuncArity errors whose super isn't a recorded
 // call-shape) so blame never degrades to the zero span.
 type FuncArityMismatchError struct {
-	LHS, RHS *soltype.FuncType
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback when no operand resolves
+	Sub, Super *soltype.FuncType
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback when no operand resolves
 }
 
 // TupleLengthMismatchError fires on TupleType <: TupleType with different
 // lengths (M1's exact-tuple case; M4 may narrow the firing conditions when the
 // inexact flag is added).
 //
-// The subject is the LHS tuple literal (recorded by inferTuple); Related() points
-// at the RHS expected-source. Not actually reachable in M2.5 — a tuple <: tuple
+// The subject is the sub tuple literal (recorded by inferTuple); Related() points
+// at the super expected-source. Not actually reachable in M2.5 — a tuple <: tuple
 // constraint needs a tuple sink (annotation/param) resolveTypeAnn does not yet
 // produce — so its blame is wired but exercised from M4. site is the constraint
 // node, the coarse fallback when neither tuple resolves (e.g. an M4 tuple
 // annotation whose elements aren't recorded) so blame never degrades to the zero
 // span.
 type TupleLengthMismatchError struct {
-	LHS, RHS *soltype.TupleType
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback when no operand resolves
+	Sub, Super *soltype.TupleType
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback when no operand resolves
 }
 
-// MissingPropertyError fires on ObjectType <: ObjectType when the RHS requires a
-// property the LHS lacks — the object analogue of FuncArityMismatchError /
+// MissingPropertyError fires on ObjectType <: ObjectType when the super requires a
+// property the sub lacks — the object analogue of FuncArityMismatchError /
 // TupleLengthMismatchError. It is the failure behind a field read on an object
 // without that property (recv.foo where recv has no foo): the walk constrains
 // recv <: {foo: fresh, ...}, and the absent property surfaces here. Holds both
 // objects plus the missing name so consumers can inspect what was required.
 //
-// The subject is the property's inner result var (RHS.Prop(Name)), minted by
+// The subject is the property's inner result var (Super.Prop(Name)), minted by
 // inferMember and recorded against the .prop identifier — so Span() blames the
 // member's prop (.foo), not the receiver. Name stays: the absent property name is
-// not recoverable from a single node (the RHS may require several properties).
+// not recoverable from a single node (the super may require several properties).
 // site is the constraint node, the coarse fallback when the property var has no
 // entry — reachable for a concrete object <: object requirement whose property
 // types are coalesced/annotation-minted (and therefore not recorded by
 // inferMember); for member access it never fires, but it keeps blame off the zero
 // span.
 type MissingPropertyError struct {
-	LHS, RHS *soltype.ObjectType
-	Name     string
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback when the property var has no entry
+	Sub, Super *soltype.ObjectType
+	Name       string
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback when the property var has no entry
 }
 
-// InexactIntoExactError fires on ObjectType <: ObjectType when the RHS is exact
-// but the LHS is inexact: an inexact source carries an open `...` tail of unknown
+// InexactIntoExactError fires on ObjectType <: ObjectType when the super is exact
+// but the sub is inexact: an inexact source carries an open `...` tail of unknown
 // properties, so it cannot satisfy an exact target that fixes its member set.
 type InexactIntoExactError struct {
-	LHS, RHS *soltype.ObjectType
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback
+	Sub, Super *soltype.ObjectType
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback
 }
 
-// ExtraPropertyError fires on ObjectType <: ObjectType when the RHS is exact and
-// the LHS carries a property the RHS does not declare — width is rejected against
+// ExtraPropertyError fires on ObjectType <: ObjectType when the super is exact and
+// the sub carries a property the super does not declare — width is rejected against
 // an exact target. One error fires per extra property, carrying its name.
 type ExtraPropertyError struct {
-	LHS, RHS *soltype.ObjectType
-	Name     string
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback
+	Sub, Super *soltype.ObjectType
+	Name       string
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback
 }
 
 // OptionalPropertyError fires on ObjectType <: ObjectType when a property is
-// optional on the LHS source but required on the RHS target: the source may omit
+// optional on the sub (source) but required on the super (target): the source may omit
 // the property, so it cannot satisfy a target that requires it present (the object
 // analogue of TypeScript's "Property 'x' is optional in type … but required in
 // type …"). The converse — a required source property filling an optional target
 // slot — is fine, so only this direction errors.
 type OptionalPropertyError struct {
-	LHS, RHS *soltype.ObjectType
-	Name     string
-	prov     NodeResolver // M2.5: type→node index (§3.5)
-	site     ast.Node     // M2.5: constraint node fallback
+	Sub, Super *soltype.ObjectType
+	Name       string
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback
 }
 
 func (*CannotConstrainError) isSolverError()     {}
@@ -145,20 +145,20 @@ func (*OptionalPropertyError) isSolverError()    {}
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
 
-func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.LHS, e.site) }
-func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.Sub, e.site) }
+func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *FuncArityMismatchError) Span() ast.Span {
-	// RHS call-shape → the CallExpr; degrade → the callee function; else the site.
-	return spanOfFirst(e.prov, e.site, e.RHS, e.LHS)
+	// super call-shape → the CallExpr; degrade → the callee function; else the site.
+	return spanOfFirst(e.prov, e.site, e.Super, e.Sub)
 }
-func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the fn
+func (e *FuncArityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.Sub) } // the fn
 
 func (e *TupleLengthMismatchError) Span() ast.Span {
-	// LHS tuple literal → degrade to the other tuple → else the site.
-	return spanOfFirst(e.prov, e.site, e.LHS, e.RHS)
+	// sub tuple literal → degrade to the other tuple → else the site.
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
 }
-func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+func (e *TupleLengthMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *MissingPropertyError) Span() ast.Span {
 	// The property's inner var → the .foo prop ident; degrade to the receiver;
@@ -166,42 +166,42 @@ func (e *MissingPropertyError) Span() ast.Span {
 	// access (which always records it); the receiver/site arms cover the concrete
 	// object <: object case where the property type may be unrecorded.
 	ops := make([]soltype.Type, 0, 2)
-	if p, ok := e.RHS.Prop(e.Name); ok {
+	if p, ok := e.Super.Prop(e.Name); ok {
 		ops = append(ops, p.Type)
 	}
-	ops = append(ops, e.LHS)
+	ops = append(ops, e.Sub)
 	return spanOfFirst(e.prov, e.site, ops...)
 }
-func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.LHS) } // the receiver
+func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Sub) } // the receiver
 
 func (e *InexactIntoExactError) Span() ast.Span {
-	return spanOfFirst(e.prov, e.site, e.LHS, e.RHS)
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
 }
-func (e *InexactIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+func (e *InexactIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *ExtraPropertyError) Span() ast.Span {
-	// The extra property lives on the LHS source; blame it, degrade to the RHS
-	// target, else the site.
+	// The extra property lives on the sub (source); blame it, degrade to the super
+	// (target), else the site.
 	ops := make([]soltype.Type, 0, 2)
-	if p, ok := e.LHS.Prop(e.Name); ok {
+	if p, ok := e.Sub.Prop(e.Name); ok {
 		ops = append(ops, p.Type)
 	}
-	ops = append(ops, e.LHS)
+	ops = append(ops, e.Sub)
 	return spanOfFirst(e.prov, e.site, ops...)
 }
-func (e *ExtraPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+func (e *ExtraPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *OptionalPropertyError) Span() ast.Span {
-	// The optional property lives on the LHS source; blame it, degrade to the RHS
-	// target, else the site (same shape as ExtraPropertyError).
+	// The optional property lives on the sub (source); blame it, degrade to the super
+	// (target), else the site (same shape as ExtraPropertyError).
 	ops := make([]soltype.Type, 0, 2)
-	if p, ok := e.LHS.Prop(e.Name); ok {
+	if p, ok := e.Sub.Prop(e.Name); ok {
 		ops = append(ops, p.Type)
 	}
-	ops = append(ops, e.LHS)
+	ops = append(ops, e.Sub)
 	return spanOfFirst(e.prov, e.site, ops...)
 }
-func (e *OptionalPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.RHS) }
+func (e *OptionalPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -459,13 +459,13 @@ type AsyncReturnNotPromiseError struct {
 // InvalidAssignmentTargetError fires when the left-hand side of an assignment
 // (`a = expr`) is not an assignable place. M3's only assignable target is an
 // IdentExpr resolving to a `var` binding; a literal, call, or any other non-place
-// LHS is rejected here. (A member target `obj.x = …` needs record types and lands
+// target is rejected here. (A member target `obj.x = …` needs record types and lands
 // in M4 — it is also reported here until then.)
 //
-// It is a BRIDGE error: born in inferAssign with the offending LHS node in hand,
-// so it self-blames (Span() is the LHS's own span); it carries no related node.
+// It is a BRIDGE error: born in inferAssign with the offending target node in hand,
+// so it self-blames (Span() is the target's own span); it carries no related node.
 type InvalidAssignmentTargetError struct {
-	Target ast.Expr // the non-place LHS (blame span)
+	Target ast.Expr // the non-place assignment target (blame span)
 }
 
 // CannotAssignToImmutableError fires when a reassignment (`a = expr`) targets a
@@ -658,17 +658,17 @@ func (e *AsyncReturnNotPromiseError) Message() string {
 }
 
 func (e *CannotConstrainError) Message() string {
-	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.LHS), describe(e.RHS))
+	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.Sub), describe(e.Super))
 }
 
 func (e *FuncArityMismatchError) Message() string {
 	return fmt.Sprintf("cannot constrain function of arity %d <: function of arity %d",
-		len(e.LHS.Params), len(e.RHS.Params))
+		len(e.Sub.Params), len(e.Super.Params))
 }
 
 func (e *TupleLengthMismatchError) Message() string {
 	return fmt.Sprintf("cannot constrain tuple of length %d <: tuple of length %d",
-		len(e.LHS.Elems), len(e.RHS.Elems))
+		len(e.Sub.Elems), len(e.Super.Elems))
 }
 
 func (e *MissingPropertyError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -459,8 +459,9 @@ type AsyncReturnNotPromiseError struct {
 // InvalidAssignmentTargetError fires when the left-hand side of an assignment
 // (`a = expr`) is not an assignable place. M3's only assignable target is an
 // IdentExpr resolving to a `var` binding; a literal, call, or any other non-place
-// target is rejected here. (A member target `obj.x = …` needs record types and lands
-// in M4 — it is also reported here until then.)
+// target is rejected here. A member or index target such as `obj.x = …` is instead
+// reported as an UnsupportedFeatureError: it is a valid place whose type rule needs
+// object/array types (M4), not a fundamentally invalid target.
 //
 // It is a BRIDGE error: born in inferAssign with the offending target node in hand,
 // so it self-blames (Span() is the target's own span); it carries no related node.

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -18,7 +18,7 @@ import (
 // not model cleanly. The shape matches both the simplesub spike's typeTerm and
 // the old checker's inferExpr. See m2-implementation-plan §3.2.
 type checker struct {
-	ctx  *Context      // M1: freshVar(level), Constrain(lhs, rhs) []SolverError
+	ctx  *Context      // M1: freshVar(level), Constrain(sub, super) []SolverError
 	info *Info         // M1: node → soltype.Type side table (unexported setType)
 	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only), the inverse of info
 	errs []SolverError // accumulated; mirrors the spike's []error threading
@@ -93,15 +93,20 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 	return c.ctx.freshVar(lvl)
 }
 
-// constrain asserts lhs <: rhs and, for each resulting constraint error, hands it
-// the provenance table and the constraint node n as a blame fallback, so its own
-// Span()/Related() can resolve per-operand blame through Prov on demand and fall
-// back to n's span (never the zero span) when an operand has no entry (§3.5). The
-// engine itself never touches Prov — the fields are assigned here, after Constrain
-// returns, so the hot loop stays off the table (the perf invariant, §3.9). Bridge
-// errors never flow through here; they self-blame from their own node.
-func (c *checker) constrain(n ast.Node, lhs, rhs soltype.Type) {
-	for _, e := range c.ctx.Constrain(lhs, rhs) {
+// constrain asserts source <: target and, for each resulting constraint error,
+// hands it the provenance table and the constraint node n as a blame fallback, so
+// its own Span()/Related() can resolve per-operand blame through Prov on demand and
+// fall back to n's span (never the zero span) when an operand has no entry (§3.5).
+// The engine itself never touches Prov — the fields are assigned here, after
+// Constrain returns, so the hot loop stays off the table (the perf invariant,
+// §3.9). Bridge errors never flow through here; they self-blame from their own node.
+//
+// source is the value being checked, target the expected type — these map to the
+// engine's sub/super (Context.Constrain). The data-flow names hold here because no
+// contravariant flip has happened yet; note the syntactic LHS of `x = e` is the
+// target, not the source.
+func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
+	for _, e := range c.ctx.Constrain(source, target) {
 		switch err := e.(type) {
 		case *CannotConstrainError:
 			err.prov, err.site = c.prov, n

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -103,8 +103,8 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 //
 // source is the value being checked, target the expected type — these map to the
 // engine's sub/super (Context.Constrain). The data-flow names hold here because no
-// contravariant flip has happened yet; note the syntactic LHS of `x = e` is the
-// target, not the source.
+// contravariant flip has happened yet: in `x = e`, `e` is the source and `x` is
+// the target.
 func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 	for _, e := range c.ctx.Constrain(source, target) {
 		switch err := e.(type) {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -93,18 +93,24 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 	return c.ctx.freshVar(lvl)
 }
 
-// constrain asserts source <: target and, for each resulting constraint error,
-// hands it the provenance table and the constraint node n as a blame fallback, so
-// its own Span()/Related() can resolve per-operand blame through Prov on demand and
-// fall back to n's span (never the zero span) when an operand has no entry (§3.5).
-// The engine itself never touches Prov — the fields are assigned here, after
-// Constrain returns, so the hot loop stays off the table (the perf invariant,
-// §3.9). Bridge errors never flow through here; they self-blame from their own node.
+// constrain asserts source <: target, then stamps blame onto each resulting error.
 //
-// source is the value being checked, target the expected type — these map to the
-// engine's sub/super (Context.Constrain). The data-flow names hold here because no
-// contravariant flip has happened yet: in `x = e`, `e` is the source and `x` is
-// the target.
+// The operands map onto the engine's sub/super names (Context.Constrain):
+//   - source is sub: the value being checked.
+//   - target is super: the expected type.
+//
+// These data-flow names hold here because no contravariant flip has happened yet.
+// In `x = e`, `e` is the source and `x` is the target.
+//
+// For each error Constrain returns:
+//  1. Assign the Prov table and the constraint node n to the error.
+//  2. The error's Span()/Related() then resolve per-operand blame through Prov on
+//     demand. When an operand has no Prov entry, blame falls back to n's span,
+//     never the zero span (§3.5).
+//
+// The engine never touches Prov. These fields are assigned after Constrain returns,
+// so the hot loop stays off the table. That is the perf invariant, §3.9. Bridge
+// errors never flow through here; they self-blame from their own node.
 func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 	for _, e := range c.ctx.Constrain(source, target) {
 		switch err := e.(type) {

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -75,7 +75,8 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 }
 
 // A non-place target — a literal or a call — is an InvalidAssignmentTargetError that
-// blames the target. (Member targets `obj.x = …` need record types and land in M4.)
+// blames the target. A member or index target takes a separate path: it is a valid
+// place pending object/array types (M4), so it reports an UnsupportedFeatureError.
 func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
 		src := "val a = 5\nfn g() { 5 = a }"

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -11,12 +11,12 @@ import (
 //
 // `a = expr` parses as an ast.BinaryExpr with Op == ast.Assign — the only binary
 // operator the M3 walk handles. The target must be a mutable (`var`) place; the
-// RHS must be a subtype of the binding's type; the assignment expression evaluates
+// source must be a subtype of the binding's type; the assignment expression evaluates
 // to the value just stored, so its type is the target's slot type. Reassignment
 // lives in expression position, so these tests exercise it inside a function body
 // (or a top-level `val` initializer).
 
-// An annotated `var` reassignment type-checks when the RHS is a subtype of the
+// An annotated `var` reassignment type-checks when the source is a subtype of the
 // declared type, and reports a single CannotConstrainError otherwise. The `var` is
 // annotated because un-annotated `var` literal widening is M4 (see the literal case
 // below).
@@ -74,8 +74,8 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 	})
 }
 
-// A non-place LHS — a literal or a call — is an InvalidAssignmentTargetError that
-// blames the LHS. (Member targets `obj.x = …` need record types and land in M4.)
+// A non-place target — a literal or a call — is an InvalidAssignmentTargetError that
+// blames the target. (Member targets `obj.x = …` need record types and land in M4.)
 func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
 		src := "val a = 5\nfn g() { 5 = a }"
@@ -126,7 +126,7 @@ func TestInferAssignUnknownTarget(t *testing.T) {
 }
 
 // Reassigning a POLYMORPHIC var must not corrupt the binding. inferAssign freshens
-// the binding's coalesced slot type before constraining, so the RHS flows into
+// the binding's coalesced slot type before constraining, so the source flows into
 // throwaway copies rather than the binding's retained type-parameter vars; `id`
 // keeps its generic type and a later `id("hello")` still type-checks.
 func TestInferAssignPolyVarNoCorruption(t *testing.T) {
@@ -154,7 +154,7 @@ func TestInferAssignTopLevelBrokenBindingNoCascade(t *testing.T) {
 	require.Equal(t, "error", values["a"]) // recovered as the sentinel, not never
 }
 
-// Reassigning a union-typed var applies the union-RHS rule: a member assigns, a
+// Reassigning a union-typed var applies the union-target rule: a member assigns, a
 // non-member is rejected once. (Union subtyping in general is M6; inferAssign trials
 // the members under a probe so a legal member assignment isn't wrongly rejected.)
 func TestInferAssignUnionTarget(t *testing.T) {
@@ -175,13 +175,13 @@ func TestInferAssignUnionTarget(t *testing.T) {
 	})
 }
 
-// KNOWN GAP (M6): assigning an inference-variable RHS into a union target
+// KNOWN GAP (M6): assigning an inference-variable source into a union target
 // over-narrows the variable. `a = x` for an un-annotated param `x` and `a: 1 | 2`
 // commits the first matching member (`x <: 1`), so `x` infers as `1` rather than
 // the sound `1 | 2`. This is INCOMPLETE, not unsound (the committed bound is always
 // stronger than required, so no invalid program is accepted), and it is not fixable
-// in constrainAssign — falling through to constrain(rhs, union) injects the
-// coalesced union node into rhs's bound list and panics the coalescer. The correct
+// in constrainAssign — falling through to constrain(source, union) injects the
+// coalesced union node into source's bound list and panics the coalescer. The correct
 // fix is M6's first-class union subtyping with inference variables. This pins the
 // interim behavior so the M6 change is visible: when it lands, `x` becomes `1 | 2`
 // and this assertion must be updated. See constrainAssign's KNOWN GAP note.
@@ -219,7 +219,7 @@ func TestInferAssignMemberTargetUnsupported(t *testing.T) {
 	requireBlame(t, src, errs, "Unsupported in M2: assignment to a member or index", "o.x")
 }
 
-// An immutable target with an independently-broken RHS reports BOTH errors — they
+// An immutable target with an independently-broken source reports BOTH errors — they
 // are two distinct problems, not a cascade (the immutable target never reaches
 // constrain). Pinned so the behavior is explicit.
 func TestInferAssignImmutableWithBadRHSReportsBoth(t *testing.T) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -76,11 +76,11 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	if d.TypeAnn != nil {
 		// M2.5: constrain the initializer against the annotation (the one
 		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
-		// CannotConstrainError whose LHS (the "hi" literal) carries a
+		// CannotConstrainError whose Sub (the "hi" literal) carries a
 		// LiteralInference origin — precise blame, with the annotation as the
 		// related node. The constraint node is the initializer, so even the
-		// fallback span is the RHS, not the whole decl; the binding then adopts the
-		// annotated type.
+		// fallback span is the initializer, not the whole decl; the binding then
+		// adopts the annotated type.
 		//
 		// Skip both the check and the adoption when the annotation is unsupported
 		// (ok=false): resolveTypeAnn already reported it and returned a `never`

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -20,7 +20,7 @@ import (
 // ok=false cases, each already reported:
 //   - VarDecl without an initializer → MissingInitializerError
 //   - VarDecl with a destructuring pattern → UnsupportedNodeError (initializer
-//     still walked first, so a malformed RHS surfaces its own errors)
+//     still walked first, so it surfaces its own errors)
 //   - any decl kind outside the M2 subset → UnsupportedNodeError
 func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
@@ -62,7 +62,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 // reported). Shared core of both binding paths; they differ only in WHEN they
 // coalesce: inferDeclDef (SCC driver) keeps it raw so inferComponent coalesces the
 // binding var once at completion, while inferVarDecl (body-level) coalesces it now.
-// Walks the initializer regardless so a malformed RHS still surfaces errors, and
+// Walks the initializer regardless so it still surfaces its own errors, and
 // binds nothing — the caller owns scope placement.
 //
 // A `val`/`var` with no initializer needs a type annotation (TypeAnn support lands
@@ -98,7 +98,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // inferVarDecl types a body-level `val`/`var` into a GENERALIZED ValueBinding —
 // the let-polymorphism rule (M3, PR1) that replaces M2's coalesce-at-binding
 // freeze. It infers the initializer one level deeper (lvl+1) and generalizes at
-// lvl: variables created in the RHS (level > lvl) become reusable type parameters,
+// lvl: variables created in the initializer (level > lvl) become reusable type parameters,
 // while variables captured from an enclosing scope (level <= lvl) stay shared — so
 // `fn (y) { val getY = fn () { y }; [getY(), getY()] }` keeps getY's captured `y`
 // instead of freezing it to `never`, the bug eager coalescing caused. A body-level

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -453,18 +453,18 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	return nil, false
 }
 
-// inferAssign types a reassignment `target = rhs` — the only BinaryExpr form the
-// M3 walk handles. The RHS is typed first (so its own errors surface regardless of
-// the target's validity), then the target is resolved and gated:
+// inferAssign types a reassignment `target = source` — the only BinaryExpr form the
+// M3 walk handles. The source value is typed first (so its own errors surface
+// regardless of the target's validity), then the target is resolved and gated:
 //
 //   - The target must be a place: an IdentExpr resolving to a value binding. A
-//     literal, call, member, or any other non-place LHS is an
+//     literal, call, member, or any other non-place target is an
 //     InvalidAssignmentTargetError (member targets `obj.x = …` need record types,
 //     M4). An ident that resolves to no binding is an UnknownIdentifierError.
 //   - The binding must be reassignable: only a `var` (Kind == VarKind) is. A `val`,
 //     function, parameter, or prelude binding is a CannotAssignToImmutableError.
 //
-// On success the RHS is constrained `<: target` (the binding's coalesced type),
+// On success the source is constrained `<: target` (the binding's coalesced type),
 // the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
 // being stored must be a subtype of the slot. Reassigning an annotated `var a:
 // number = 5` with `a = 6` checks; an un-annotated `var a = 5` keeps the literal
@@ -483,7 +483,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	if e.Left == nil || e.Right == nil {
 		return c.reportUnsupported(e)
 	}
-	rhs := c.inferExpr(scope, lvl, e.Right)
+	sourceT := c.inferExpr(scope, lvl, e.Right)
 	// Record void on e up front as the recovery type: every error path below returns
 	// voidT without recording a type, so this guarantees the node is typed on failure.
 	// The success path overwrites it with the stored value's type (see end of function).
@@ -523,7 +523,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		})
 		return voidT
 	}
-	// The RHS must be a subtype of the target binding's type. Use the binding's
+	// The source value must be a subtype of the target binding's type. Use the binding's
 	// COALESCED type (schemeType — what Info records and the printer renders), not a
 	// fresh instantiation: instantiating a generalized binding yields a var carrying
 	// only its LOWER bounds (the read/covariant face), so `a = "x"` for `var a:
@@ -532,14 +532,14 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// for an un-annotated one (so `a = 6` ⇒ `6 <: 5` does NOT check until M4 `var`
 	// literal widening).
 	//
-	// freshenAll copies the coalesced type so constraining the RHS cannot mutate
+	// freshenAll copies the coalesced type so constraining the source cannot mutate
 	// type-parameter vars the coalesced form still shares with the binding
 	// (coalesceScheme retains them by pointer): without the copy, reassigning a
 	// polymorphic var would poison it for every later use. A var-free coalesced type
 	// (the common annotated/literal case) freshens to itself.
 	//
 	// A probe can't do this: Discard would also roll back the constraint's real errors
-	// and the RHS's bound, while Commit would keep the binding poisoning — we need to
+	// and the source's bound, while Commit would keep the binding poisoning — we need to
 	// suppress one side effect, not the whole trial. freshenAll isolates just the var.
 	//
 	// b.Schemes[0]: a reassignable binding is always single-scheme — overload sets
@@ -547,7 +547,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
-	c.constrainAssign(e, rhs, targetT)
+	c.constrainAssign(e, sourceT, targetT)
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
 	// instantiate (the read face), NOT the coalesced write-face targetT: targetT is a
@@ -560,33 +560,33 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	return valueT
 }
 
-// constrainAssign asserts `rhs <: targetT` for a reassignment. For a UNION target it
-// applies the union-RHS rule — X <: (A | B) iff X <: A or X <: B — by trying each
-// member speculatively under a probe, committing the first that holds. constrain
-// itself has no UnionType-RHS rule until M6, so without this a legal assignment of a
+// constrainAssign asserts `source <: target` for a reassignment. For a UNION target
+// it applies the union-target rule — X <: (A | B) iff X <: A or X <: B — by trying
+// each member speculatively under a probe, committing the first that holds. constrain
+// itself has no UnionType-super rule until M6, so without this a legal assignment of a
 // union member (`var a = if c { 1 } else { 2 }; a = 1`) would be wrongly rejected.
 // A non-union target takes the ordinary single-constraint path.
 //
-// KNOWN GAP (M6): when `rhs` is (or contains) an inference variable, committing the
+// KNOWN GAP (M6): when `source` is (or contains) an inference variable, committing the
 // first matching member over-narrows it. `var a = 1 | 2; a = x` for an un-annotated
 // param `x` commits `x <: 1` and infers `x: 1` instead of the sound `x: 1 | 2`,
 // which can wrongly reject a later use of `x` that needs `2`. This is INCOMPLETE,
 // not unsound — the committed bound is always stronger than required, so no invalid
 // program is accepted. It is not fixable here: the obvious "don't commit, fall
-// through to constrain(rhs, targetT)" injects the COALESCED union node into rhs's
+// through to constrain(source, target)" injects the COALESCED union node into source's
 // bound list and panics the coalescer (coalesced output must never re-enter the
 // graph). A correct fix needs first-class union subtyping with inference variables
 // — M6's deferred union/intersection rules in constrain. Pinned by
 // TestInferAssignUnionTargetVarRHSOverNarrows.
-func (c *checker) constrainAssign(n ast.Node, rhs, targetT soltype.Type) {
-	union, ok := targetT.(*soltype.UnionType)
+func (c *checker) constrainAssign(n ast.Node, source, target soltype.Type) {
+	union, ok := target.(*soltype.UnionType)
 	if !ok {
-		c.constrain(n, rhs, targetT)
+		c.constrain(n, source, target)
 		return
 	}
 	for _, member := range union.Types {
 		p := c.openProbe()
-		errs := c.ctx.Constrain(rhs, member)
+		errs := c.ctx.Constrain(source, member)
 		c.closeProbe(p, len(errs) == 0) // commit the first member that holds; else roll back
 		if len(errs) == 0 {
 			return
@@ -594,7 +594,7 @@ func (c *checker) constrainAssign(n ast.Node, rhs, targetT soltype.Type) {
 	}
 	// No member matched: report once against the whole union (CannotConstrainError),
 	// blaming the assignment.
-	c.constrain(n, rhs, targetT)
+	c.constrain(n, source, target)
 }
 
 // bindingDecl returns the AST node of the binding's introducing declaration — the

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -224,7 +224,7 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 		require.Equal(t, "object is missing property: a", errs[0].Message())
 		// Blame the offending argument {b: 2} — the object that lacks the field — not
 		// the whole call. The requirement's field var is freshened on instantiation
-		// and carries no prov, so MissingPropertyError's blame degrades to the LHS
+		// and carries no prov, so MissingPropertyError's blame degrades to the Sub
 		// (the argument object literal), which inferObject did record.
 		require.Equal(t, "{b: 2}", spanText(src, errs[0].Span()))
 	})

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -190,7 +190,7 @@ func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
 
 // Value-position use (PR6 scoped lattice exception): a let-bound overloaded name is
 // the INTERSECTION of its arms, and calling THROUGH that binding resolves each call
-// via constrain's function-intersection-LHS arm — g(5) ⇒ number, g("hi") ⇒ string.
+// via constrain's function-intersection-sub arm — g(5) ⇒ number, g("hi") ⇒ string.
 func TestInferOverloadValuePosition(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return x }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -4,7 +4,7 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 
 // TypeScheme is a name's generalized type — the M3 replacement for M2's plain
 // soltype.Type binding. A MonoScheme is a value that does not generalize (a
-// parameter, a current-level RHS during inference, a body-level `val`, a prelude
+// parameter, a current-level initializer during inference, a body-level `val`, a prelude
 // operator); a PolyScheme carries a generalize-level so each use can be
 // instantiated with fresh variables (let-polymorphism). The IsAnnotated bit is
 // forward-looking metadata for PR6's overload-recursion gate — PR1 sets it false

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -170,7 +170,7 @@ func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { 
 // LevelOf prune would skip) — and freshens vars wherever they occur.
 //
 // inferAssign uses it on a binding's coalesced slot type: coalesceScheme RETAINS
-// type-parameter vars by pointer, so constraining the RHS against that type would
+// type-parameter vars by pointer, so constraining the source against that type would
 // mutate the binding's own vars and poison a reassigned polymorphic var for every
 // later use. Freshening first makes the constraint mutate throwaway copies instead.
 // A var-free input (the common annotated/literal case) is returned unchanged.

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -70,7 +70,7 @@ func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
 // LATENT TRAP for PR-3 (==/!= over unknown): the equality operators are seeded
 // with `unknown` (⊤) parameters, but M1's constrain has NO `T <: UnknownType`
 // rule — its switch handles prim/lit/func/tuple/void plus the two TypeVar arms,
-// and an UnknownType RHS falls through to CannotConstrainError. Nothing applies
+// and an UnknownType super falls through to CannotConstrainError. Nothing applies
 // the operators in PR-1 (BinaryExpr is still UnsupportedNodeError), so this is
 // inert today; but the moment the operator/call walk lands, `1 == 2` will
 // constrain `1 <: unknown` and fail with a spurious "cannot constrain 1 <:

--- a/internal/solver/probe_test.go
+++ b/internal/solver/probe_test.go
@@ -217,7 +217,7 @@ func TestProbeOutcomeIsIdempotent(t *testing.T) {
 	require.Empty(t, q.LowerBounds)
 }
 
-// Bounds appended by extrude (extrusion of a higher-level rhs down to lv's level)
+// Bounds appended by extrude (extrusion of a higher-level super down to subVar's level)
 // are journaled too: extrude mutates the ORIGINAL variable's bounds, and a
 // discard must truncate those back. Constraining a low-level var against a
 // higher-level var forces extrusion through the recorded append sites.

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -16,7 +16,7 @@ import (
 //
 // The assertion is intentionally loose: the test's real contract is that
 // inference TERMINATES (reaching the assertions at all proves that) and produces
-// a sane shape — a function returning a record bottoming out in `never`. The
+// a sane shape — a function returning an object bottoming out in `never`. The
 // exact unrolling depth (`{x: {x: never}}`) is a monomorphic-recursion artifact
 // that later coalesce/printer changes may legitimately alter; pinning it would
 // conflate "terminates" with "renders this exact shape".

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -71,7 +71,7 @@ breakdown, design rationale, and per-file sketches.
   multi-bound coalesced output. `Polarity` enum lives in `soltype` so
   `TypeVarType.BoundsAt(pol)` can take it without inverting the
   `soltype`/`solver` package boundary.
-- **The constraint engine** — `constrain(lhs <: rhs)` with the coinductive
+- **The constraint engine** — `constrain(sub <: super)` with the coinductive
   seen-cache (pointer-identity keying, sufficient for M1's non-recursive
   type set), the structural cases (`PrimType`/`LitType`/`FuncType`/
   `TupleType`/`Void`) for the M1 set, the variable cases (bound-append +
@@ -179,7 +179,7 @@ A focused infra milestone, **not** a language feature. See
 [m2.5-implementation-plan.md](m2.5-implementation-plan.md) for the full PR
 breakdown, the per-operand blame design, and the construction-site population
 table. M2 stamps the *umbrella*
-node's span on every constraint error — `constrain(n, lhs, rhs)` sets `n.Span()`
+node's span on every constraint error — `constrain(n, source, target)` sets `n.Span()`
 on each returned error ([internal/solver/infer.go](../../internal/solver/infer.go)
 `(*checker).constrain`), so a mismatch deep inside a large declaration blames the
 whole declaration. This milestone makes blame point at the **narrowest source of
@@ -202,7 +202,7 @@ once M3–M6 multiply them — so it lands *before* M3.
   field values, member-access result var. A single `prov[t] = FromAST{n, kind}`
   per site, via a node+kind-taking helper (design notes "Population discipline").
 - **Per-operand blame at the error path.** Each `SolverError` already carries
-  typed `LHS, RHS soltype.Type` references
+  typed `Sub, Super soltype.Type` references
   ([internal/solver/errors.go](../../internal/solver/errors.go)). Replace the
   single umbrella stamp with a lookup: map each failed operand to its narrowest
   `FromAST` span via `Prov` and stamp the **most specific contributing node**,
@@ -396,7 +396,7 @@ wrapper) are what first populate a lifetime. Land them together.
   richer than the field set the body touches. The `open` marker lands here
   (the first milestone where record-typed params exist).
 - **`var`-binding literal widening (reassignment ergonomics).** M3's PR8 ships
-  reassignment (`a = expr`) but constrains the RHS against the binding's type *as
+  reassignment (`a = expr`) but constrains the source against the binding's type *as
   inferred*, so an un-annotated `var a = 5; a = 6` rejects (`6 <: 5`) until a `var`
   binding **widens its literal initializer to the primitive** (`5` ⇒ `number`,
   `"x"` ⇒ `string`) — the binding-level analog of the `widen(v)` already applied to

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -187,7 +187,7 @@ func (o *ObjectType) Prop(name string) (*PropertyElem, bool)
 
 type TupleType struct {
     Elems   []Type
-    Inexact bool // `[A, B, ...]` ⇒ true: longer <: shorter becomes legal vs an inexact RHS
+    Inexact bool // `[A, B, ...]` ⇒ true: longer <: shorter becomes legal vs an inexact super
 }
 ```
 
@@ -199,28 +199,28 @@ width-tolerant:
 
 ```go
 case *soltype.ObjectType:
-    if r, ok := rhs.(*soltype.ObjectType); ok {
+    if sup, ok := super.(*soltype.ObjectType); ok {
         var errs []SolverError
-        for _, re := range r.Elems {                 // depth: members covariant
-            rp := re.(*soltype.PropertyElem)         // M4: every elem is a property
-            lp, ok := l.Prop(rp.Name)
+        for _, superElem := range sup.Elems {            // depth: members covariant
+            superProp := superElem.(*soltype.PropertyElem) // M4: every elem is a property
+            subProp, ok := sub.Prop(superProp.Name)
             if !ok {
-                errs = append(errs, &MissingPropertyError{LHS: l, RHS: r, Name: rp.Name})
+                errs = append(errs, &MissingPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
                 continue
             }
-            errs = append(errs, c.constrain(lp.Type, rp.Type, seen)...)
+            errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen)...)
         }
         // One-way exactness (02-design-notes §"Exactness"):
         //   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
         //   exact <: exact      same member set inexact <: exact     rejected
-        if !r.Inexact {
-            if l.Inexact {
-                errs = append(errs, &InexactIntoExactError{LHS: l, RHS: r})
+        if !sup.Inexact {
+            if sub.Inexact {
+                errs = append(errs, &InexactIntoExactError{Sub: sub, Super: sup})
             }
-            for _, le := range l.Elems {
-                lp := le.(*soltype.PropertyElem)
-                if _, ok := r.Prop(lp.Name); !ok {
-                    errs = append(errs, &ExtraPropertyError{LHS: l, RHS: r, Name: lp.Name})
+            for _, subElem := range sub.Elems {
+                subProp := subElem.(*soltype.PropertyElem)
+                if _, ok := sup.Prop(subProp.Name); !ok {
+                    errs = append(errs, &ExtraPropertyError{Sub: sub, Super: sup, Name: subProp.Name})
                 }
             }
         }
@@ -303,33 +303,33 @@ func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type
 // unified wrapper. Lifetime steps are written now, inert while Lt == nil (C2),
 // activated in D2.
 case *soltype.RefType:
-    if r, ok := rhs.(*soltype.RefType); ok {
+    if sup, ok := super.(*soltype.RefType); ok {
         // 1. mutability compatibility — can't widen immutable to mutable.
-        if !l.Mut && r.Mut {
-            return []SolverError{&MutabilityMismatchError{LHS: l, RHS: r}}
+        if !sub.Mut && sup.Mut {
+            return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
         }
         // 2. inner variance — bidirectional iff the TARGET writes (read/write
-        //    decomposition = invariance). Mut-decay (l.Mut && !r.Mut) falls
+        //    decomposition = invariance). Mut-decay (sub.Mut && !sup.Mut) falls
         //    through to the covariant-only read view.
-        errs := c.constrain(l.Inner, r.Inner, seen)
-        if r.Mut {
-            errs = append(errs, c.constrain(r.Inner, l.Inner, seen)...)
+        errs := c.constrain(sub.Inner, sup.Inner, seen)
+        if sup.Mut {
+            errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen)...)
         }
         // 3. lifetime — covariant when both present.
         switch {
-        case l.Lt != nil && r.Lt != nil:
-            c.constrainLt(r.Lt, l.Lt)
-        case l.Lt == nil && r.Lt != nil: // owned source satisfies any borrow slot
-        case l.Lt != nil && r.Lt == nil: // borrow into owned slot: escape
-            errs = append(errs, &BorrowEscapeError{LHS: l, RHS: r})
+        case sub.Lt != nil && sup.Lt != nil:
+            c.constrainLt(sup.Lt, sub.Lt)
+        case sub.Lt == nil && sup.Lt != nil: // owned source satisfies any borrow slot
+        case sub.Lt != nil && sup.Lt == nil: // borrow into owned slot: escape
+            errs = append(errs, &BorrowEscapeError{Sub: sub, Super: sup})
         }
         return errs
     }
     // RefType <: bare: legal only for an owned value (no lifetime); peel.
-    if l.Lt != nil {
-        return []SolverError{&BorrowEscapeError{LHS: l, RHS: rhs}}
+    if sub.Lt != nil {
+        return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
     }
-    return c.constrain(l.Inner, rhs, seen)
+    return c.constrain(sub.Inner, super, seen)
 ```
 
 ```go
@@ -337,9 +337,9 @@ case *soltype.RefType:
 // wrap the source as an immutable no-lifetime view and re-dispatch into the
 // RefType<:RefType branch. Construct the struct literal DIRECTLY — NewRef would
 // collapse (false, nil) back to the bare inner and recurse forever.
-if r, ok := rhs.(*soltype.RefType); ok {
-    if inner, ok := asRefInner(lhs); ok {
-        return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, r, seen)
+if sup, ok := super.(*soltype.RefType); ok {
+    if inner, ok := asRefInner(sub); ok {
+        return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, sup, seen)
     }
 }
 ```
@@ -365,10 +365,10 @@ type Context struct {
 
 // constrainLt mirrors constrain over the outlives lattice: var-left gains an
 // upper bound, var-right a lower bound, var-to-var records both; 'static is
-// top (X <: 'static always holds); (lhs, rhs)-keyed seen-set for cycles.
+// top (X <: 'static always holds); (sub, super)-keyed seen-set for cycles.
 // Bound appends go ONLY through addLowerLtBound/addUpperLtBound — the journal
 // invariant extends to the second sort:
-func (c *Context) constrainLt(lhs, rhs Lifetime)
+func (c *Context) constrainLt(sub, super Lifetime)
 func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 
@@ -404,8 +404,8 @@ func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime)
 // and re-runs C3's acceptance.
 func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m *ast.MemberExpr) soltype.Type {
     recv := c.inferExpr(scope, lvl, m.Object)
-    rhs := c.inferExpr(scope, lvl, e.Right)
-    w := widen(rhs) // 5 ⇒ number: a later write may store any number
+    source := c.inferExpr(scope, lvl, e.Right)
+    w := widen(source) // 5 ⇒ number: a later write may store any number
     req := &soltype.RefType{Mut: true, Lt: nil /* D2: c.freshLifetime() */,
         Inner: &soltype.ObjectType{
             Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
@@ -551,12 +551,12 @@ these arms it must add.
     requirement (infer_expr.go:716) to `Inexact: true` so member access stays
     "has at least this field," now expressed *as inexactness* rather than as an
     unconditionally width-tolerant arm. This is the split the milestone calls
-    for: the same `ObjectType <: ObjectType` rule serves both selection (RHS
-    inexact) and concrete subtyping (RHS exact).
+    for: the same `ObjectType <: ObjectType` rule serves both selection (super
+    inexact) and concrete subtyping (super exact).
   - **Errors:** new, same field/blame shape as `MissingPropertyError`
     (errors.go:97):
-    - `InexactIntoExactError{LHS, RHS *soltype.ObjectType}`
-    - `ExtraPropertyError{LHS, RHS *soltype.ObjectType; Name string; prov; site}`
+    - `InexactIntoExactError{Sub, Super *soltype.ObjectType}`
+    - `ExtraPropertyError{Sub, Super *soltype.ObjectType; Name string; prov; site}`
   - **Accept:**
     - exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds
     - inexact `<:` exact and extra-member-on-exact reject (full messages)
@@ -662,7 +662,7 @@ these arms it must add.
     direct-call extra-arg rule. It fires in the walk at literal-vs-annotation sites
     (annotated `val`/`var`, later call args and returns), not in the
     `ObjectType <: ObjectType` / tuple constrain arm. Reuse A1's `ExtraPropertyError`
-    for objects; add an analogous excess-element error for tuples. A non-literal RHS
+    for objects; add an analogous excess-element error for tuples. A non-literal source
     is unaffected — it takes ordinary width subtyping. M4 has only the untyped `...`
     tail; the typed-tail escape (an index signature that types the extras) rides M9,
     so until then an untyped-extras "bag" must use the variable escape hatch.
@@ -679,7 +679,7 @@ these arms it must add.
       ...} = v` (non-literal ⇒ width subtyping)
     - `val r: {x: number} = {x: 1, y: 2}` rejects (exact target, `ExtraPropertyError`)
     - tuple: `val t: [number, ...] = [1, 2, 3]` rejects (excess element on a
-      literal); the same RHS through a variable checks
+      literal); the same source through a variable checks
     - tuple annotations round-trip through the printer
 
 ### Phase B — Usage-based inference refinement
@@ -738,7 +738,7 @@ these arms it must add.
   - **Algorithm:** in `inferVarDecl` (infer_decl.go:108), a `var` binding's
     initializer type is widened before generalization, and — the principled
     milestone form — informed by **all** assignment sites: collect the
-    initializer plus every later `a = e` RHS and coalesce their widened types
+    initializer plus every later `a = e` source and coalesce their widened types
     (the binding's type is the join). **Widening is gated on mutability** — only
     a mutable cell widens, because only a mutable cell may later hold a different
     value of the same primitive. A `var` binding widens; a `val` is left
@@ -747,7 +747,7 @@ these arms it must add.
     new-checker form of the old checker's `Widenable` type-var flag, which gates
     `widenLiteral` to mutable bindings (unify.go:2260). This retires PR8's
     documented `var a = 5; a = 6` failure (infer_expr.go:532 note).
-    Reassignment's RHS-vs-binding constrain (inferAssign, infer_expr.go:540s) now
+    Reassignment's source-vs-binding constrain (inferAssign, infer_expr.go:540s) now
     checks against the widened binding type.
   - **Accept:**
     - `var a = 5; a = 6` checks (binding is `number`)
@@ -815,12 +815,12 @@ these arms it must add.
       false, Lt: nil, Inner: inner}` via a struct literal (**not** `NewRef`, which
       would collapse it and recurse forever) and re-dispatch
   - **Errors:**
-    - `MutabilityMismatchError{LHS, RHS *soltype.RefType}`
-    - `BorrowEscapeError{LHS, RHS}` (the latter's firing path is inert until D2)
+    - `MutabilityMismatchError{Sub, Super *soltype.RefType}`
+    - `BorrowEscapeError{Sub, Super}` (the latter's firing path is inert until D2)
   - **Accept (the gate):**
     - `mut {x, y} <: mut {x, ...}` **fails** (invariance — the write view's
       contravariant `{x, ...} <: {x, y}` is missing a field) while immutable
-      `{x, y} <: {x, ...}` width-**succeeds** (inexact RHS)
+      `{x, y} <: {x, ...}` width-**succeeds** (inexact super)
     - mut-decay `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected
     - full messages
 
@@ -838,9 +838,9 @@ these arms it must add.
   - **Algorithm — replace the member-target stub** (infer_expr.go:494-500, today
     `reportUnsupportedFeature("assignment to a member or index")`): implement
     `inferMemberAssign` per the sketch:
-    - infer receiver + RHS
-    - `widen` the RHS
-    - constrain `recv <: RefType{Mut: true, Lt: nil, Inner: {field: widen(rhs),
+    - infer receiver + source
+    - `widen` the source
+    - constrain `recv <: RefType{Mut: true, Lt: nil, Inner: {field: widen(source),
       Inexact: true}}`
     - record `written[recvID,field]`
     - return the stored value
@@ -852,7 +852,7 @@ these arms it must add.
     concrete type instead of a fresh var, so `obj.x = 5; obj.x` is `number`.
     **Write-after-read** needs no map support — it falls out of ordinary
     constraint accumulation: the earlier read emits `recv <: {x: β, ...}` and the
-    later write emits `recv <: mut {x: widen(rhs), ...}`, both upper-bound
+    later write emits `recv <: mut {x: widen(source), ...}`, both upper-bound
     constraints that merge, so the read's `β` picks up the field type through the
     bound graph. The `written` map is purely a read-after-write precision win
     (return the concrete stored type, not a coalesced var); the reverse order
@@ -908,7 +908,7 @@ these arms it must add.
   - **Algorithm — `constrainLt`** (ported from `simplesub/lifetime.go:61`):
     mirrors `constrain` over the outlives lattice — a var on the left gains an
     upper bound, on the right a lower bound, var-to-var records both;
-    `'static` is top (`X <: 'static` always holds); a `(lhs, rhs)`-keyed
+    `'static` is top (`X <: 'static` always holds); a `(sub, super)`-keyed
     seen-set terminates cycles. Bound appends go **only** through new
     `addLowerLtBound`/`addUpperLtBound` helpers that journal before appending —
     the same discipline as `addLowerBound`/`addUpperBound` (context.go:36).

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -201,11 +201,17 @@ width-tolerant:
 case *soltype.ObjectType:
     if sup, ok := super.(*soltype.ObjectType); ok {
         var errs []SolverError
-        for _, superElem := range sup.Elems {            // depth: members covariant
-            superProp := superElem.(*soltype.PropertyElem) // M4: every elem is a property
+        for _, superElem := range sup.Elems {              // depth: members covariant
+            superProp := soltype.AsProperty(superElem)     // M4: every elem is a property
             subProp, ok := sub.Prop(superProp.Name)
             if !ok {
-                errs = append(errs, &MissingPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
+                if !superProp.Optional {                   // an optional super prop may be absent
+                    errs = append(errs, &MissingPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
+                }
+                continue
+            }
+            if subProp.Optional && !superProp.Optional {   // optional source can't fill a required slot
+                errs = append(errs, &OptionalPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
                 continue
             }
             errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen)...)
@@ -218,7 +224,7 @@ case *soltype.ObjectType:
                 errs = append(errs, &InexactIntoExactError{Sub: sub, Super: sup})
             }
             for _, subElem := range sub.Elems {
-                subProp := subElem.(*soltype.PropertyElem)
+                subProp := soltype.AsProperty(subElem)
                 if _, ok := sup.Prop(subProp.Name); !ok {
                     errs = append(errs, &ExtraPropertyError{Sub: sub, Super: sup, Name: subProp.Name})
                 }
@@ -555,7 +561,7 @@ these arms it must add.
     inexact) and concrete subtyping (super exact).
   - **Errors:** new, same field/blame shape as `MissingPropertyError`
     (errors.go:97):
-    - `InexactIntoExactError{Sub, Super *soltype.ObjectType}`
+    - `InexactIntoExactError{Sub, Super *soltype.ObjectType; prov; site}`
     - `ExtraPropertyError{Sub, Super *soltype.ObjectType; Name string; prov; site}`
   - **Accept:**
     - exact `{x, y}` `<:` inexact `{x, y, ...}` succeeds


### PR DESCRIPTION
Rename the operands of the constraint relation throughout the codebase from `lhs`/`rhs` to `sub`/`super` to clarify the semantic meaning: `sub` is the subtype (source value being checked) and `super` is the supertype (target/expected type). This naming convention aligns with the checker-level wrapper which uses `source`/`target`, and makes the direction of the constraint relation explicit.

Key changes:

- Rename struct fields and function parameters in `constrain.go`, `errors.go`, and related constraint-handling code from `LHS`/`RHS` to `Sub`/`Super`
- Update all test files to use the new naming in test cases, assertions, and error checks
- Update documentation and comments throughout to reflect the new terminology, including the M4 implementation plan
- Rename `RecordType` to `ObjectType` and `RecordField` to `PropertyElem` in type definitions to align with M4 design (this is a companion change that clarifies the object/property model)
- Add `Inexact` flag to `ObjectType` and `Optional` flag to `PropertyElem` to support width tolerance in object subtyping
- Update visitor and coalesce logic to handle the new object type structure and preserve the `Inexact` flag through transformations

The renaming makes the constraint direction unambiguous: in `x = e`, the value `e` is `sub` and the target `x` is `super`, which is the reverse of syntactic LHS/RHS but matches the semantic direction of the subtyping relation.

https://claude.ai/code/session_01LCojZhvBeLroF5vNhVwsz3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional object properties and inexact (open) object types in type checking.

* **Bug Fixes**
  * Improved error reporting for object type constraint violations with dedicated messages for exactness mismatches and missing/extra properties.

* **Refactor**
  * Refactored internal type representation to better model object structures with property-level metadata and improved constraint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->