### PR TITLE
Support namespace member access via dot and bracket notation

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -284,12 +284,35 @@ type UnknownIdentifierError struct {
 	Ident *ast.IdentExpr
 }
 
-// NamespaceUsedAsValueError fires when an identifier resolves to a namespace
-// rather than a value. Namespaces are a separate binding sort and never flow as
-// values; in M2 a namespace name in value position can only fail (qualified
-// member access — Foo.bar — is M4).
+// NamespaceUsedAsValueError fires when a path expression resolves to a namespace
+// in value position. Namespaces are a separate binding sort and never flow as
+// values. M4 moves the rejection off inferIdent to the value-position consumer
+// (demandValue): a namespace is legal in the object position of a member/index
+// chain, so this fires for both a bare `f(Foo)` and a partial chain `f(A.B)` where
+// the chain stops at a namespace. Node is the offending path expression (the blame
+// span); NS is the namespace it resolved to.
 type NamespaceUsedAsValueError struct {
-	Ident *ast.IdentExpr
+	Node ast.Expr
+	NS   *Namespace
+}
+
+// UnknownNamespaceMemberError fires when a namespace member access (Foo.bar or the
+// constant-keyed Foo["bar"]) names a member the namespace does not declare —
+// neither a value nor a nested namespace. Node is the member/index expression (the
+// blame span); NS is the namespace; Name is the absent member.
+type UnknownNamespaceMemberError struct {
+	Node ast.Expr
+	NS   *Namespace
+	Name string
+}
+
+// DynamicNamespaceIndexError fires when a namespace is indexed by a non-constant
+// key (Foo[k]). A namespace member is resolved statically, so an index into one
+// must be a constant string literal — Foo["bar"], the bracket form of Foo.bar.
+// Index is the offending index expression (the blame span); NS is the namespace.
+type DynamicNamespaceIndexError struct {
+	Index ast.Expr
+	NS    *Namespace
 }
 
 // UnsupportedNodeError is the M2-subset guard: an AST node whose KIND is outside
@@ -488,6 +511,8 @@ type CannotAssignToImmutableError struct {
 
 func (*UnknownIdentifierError) isSolverError()            {}
 func (*NamespaceUsedAsValueError) isSolverError()         {}
+func (*UnknownNamespaceMemberError) isSolverError()       {}
+func (*DynamicNamespaceIndexError) isSolverError()        {}
 func (*InvalidAssignmentTargetError) isSolverError()      {}
 func (*CannotAssignToImmutableError) isSolverError()      {}
 func (*TooManyArgsError) isSolverError()                  {}
@@ -510,10 +535,22 @@ func (e *UnknownIdentifierError) Message() string {
 	return "Unknown identifier: " + e.Ident.Name
 }
 
-func (e *NamespaceUsedAsValueError) Span() ast.Span      { return e.Ident.Span() }
+func (e *NamespaceUsedAsValueError) Span() ast.Span      { return e.Node.Span() }
 func (e *NamespaceUsedAsValueError) Related() []ast.Span { return nil }
 func (e *NamespaceUsedAsValueError) Message() string {
-	return "Namespace used as a value: " + e.Ident.Name
+	return "Namespace used as a value: " + e.NS.Name
+}
+
+func (e *UnknownNamespaceMemberError) Span() ast.Span      { return e.Node.Span() }
+func (e *UnknownNamespaceMemberError) Related() []ast.Span { return nil }
+func (e *UnknownNamespaceMemberError) Message() string {
+	return "Namespace " + e.NS.Name + " has no member: " + e.Name
+}
+
+func (e *DynamicNamespaceIndexError) Span() ast.Span      { return e.Index.Span() }
+func (e *DynamicNamespaceIndexError) Related() []ast.Span { return nil }
+func (e *DynamicNamespaceIndexError) Message() string {
+	return "Namespace " + e.NS.Name + " can only be indexed by a constant string"
 }
 
 func (e *InvalidAssignmentTargetError) Span() ast.Span      { return e.Target.Span() }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -200,6 +200,8 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 		return c.inferObject(scope, lvl, e)
 	case *ast.MemberExpr:
 		return c.inferMember(scope, lvl, e)
+	case *ast.IndexExpr:
+		return c.inferIndex(scope, lvl, e)
 	case *ast.AwaitExpr:
 		return c.inferAwait(scope, lvl, e)
 	case *ast.IfElseExpr:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -44,38 +44,94 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 // multi-FuncDecl names, so no overloaded binding is ever bound), so PR1 asserts
 // the single-scheme invariant rather than branching on it.
 //
-// A namespace name in value position can only fail in M2: there is no legal
-// namespace-member position yet (MemberExpr is value-only and there is no
-// IndexExpr), so raising NamespaceUsedAsValueError on any namespace name is
-// correct here. M4 moves that error to the value-position consumer once
-// qualified Foo.bar access lands.
+// A namespace name in value position is an error — namespaces are a separate
+// binding sort and never flow as values. M4 moves that rejection OFF inferIdent
+// to the value-position consumer (demandValue): a namespace is legal in the
+// OBJECT position of a member/index chain (Foo.bar, A.B.c), so resolvePath
+// surfaces it and only a consumer that needs a value rejects it. The error then
+// fires once for both `f(Foo)` and a partial chain `f(A.B)`.
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
-	// Any binding still in scope has at least one scheme: inferComponent pre-binds
-	// each group member to a fresh MonoScheme, and on failure deletes the binding
-	// (scope.removeValue) rather than leaving it with an empty Schemes slice. So the
-	// len > 0 check below should never fail in practice — but Schemes is a slice, not
-	// a guaranteed-non-empty field, so we guard it anyway: a malformed empty binding
-	// degrades to an unknown-identifier error here instead of panicking on Schemes[0].
-	//
-	// An overloaded name in VALUE position (PR6) — `val g = f`, or `f` passed as an
-	// argument — is the intersection of its arms (the one scoped lattice exception;
-	// see overloadIntersection and constrain's IntersectionType arm). A direct call
-	// `f(x)` never reaches here: inferCall intercepts the overloaded callee and routes
-	// it through resolveOverload before typing the callee as a value.
+	return c.demandValue(c.resolveIdentPath(scope, lvl, e), e)
+}
+
+// pathResult is the sum returned by resolvePath: a path expression resolves to
+// EITHER a value (its instantiated type, in value) OR a namespace (ns), or it
+// failed (err, with the diagnostic already reported, the caller should recover).
+// At most one of value/ns is set; err is set instead when resolution reported an
+// error. The value arm may itself hold the ErrorType recovery sentinel — that is a
+// value, not an err — so a malformed-but-already-reported leaf does not double-report.
+type pathResult struct {
+	value soltype.Type
+	ns    *Namespace
+	err   bool
+}
+
+// resolvePath resolves an ident / member / index chain to a value or a namespace
+// WITHOUT demanding either: the OBJECT position of a member/index tolerates a
+// namespace (so Foo.bar and A.B.c walk through), while demandValue — called by
+// every value-position consumer — rejects a namespace result. Any other
+// expression kind in path position is an ordinary value expression.
+func (c *checker) resolvePath(scope *Scope, lvl int, e ast.Expr) pathResult {
+	switch e := e.(type) {
+	case *ast.IdentExpr:
+		return c.resolveIdentPath(scope, lvl, e)
+	case *ast.MemberExpr:
+		return c.resolveMemberPath(scope, lvl, e)
+	case *ast.IndexExpr:
+		return c.resolveIndexPath(scope, lvl, e)
+	default:
+		return pathResult{value: c.inferExpr(scope, lvl, e)}
+	}
+}
+
+// demandValue collapses a pathResult for a value-position consumer: a namespace
+// result becomes a NamespaceUsedAsValueError blaming node, and an already-reported
+// failure recovers to the ErrorType sentinel.
+func (c *checker) demandValue(r pathResult, node ast.Expr) soltype.Type {
+	switch {
+	case r.err:
+		return &soltype.ErrorType{}
+	case r.ns != nil:
+		return c.report(&NamespaceUsedAsValueError{Node: node, NS: r.ns})
+	default:
+		return r.value
+	}
+}
+
+// resolveIdentPath looks a bare identifier up in the value sort first, then the
+// namespace sort, returning whichever it finds.
+//
+// Any binding still in scope has at least one scheme: inferComponent pre-binds
+// each group member to a fresh MonoScheme, and on failure deletes the binding
+// (scope.removeValue) rather than leaving it with an empty Schemes slice. So the
+// len > 0 check should never fail in practice — but Schemes is a slice, not a
+// guaranteed-non-empty field, so we guard it anyway: a malformed empty binding
+// degrades to an unknown-identifier error instead of panicking on Schemes[0].
+func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr) pathResult {
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
-		var t soltype.Type
-		if b.IsOverloaded() {
-			t = c.overloadIntersection(lvl, b)
-		} else {
-			t = c.instantiate(b.Schemes[0], lvl)
-		}
+		t := c.bindingValue(lvl, b)
 		c.recordType(e, t)
-		return t
+		return pathResult{value: t}
 	}
-	if _, ok := scope.GetNamespace(e.Name); ok {
-		return c.report(&NamespaceUsedAsValueError{Ident: e})
+	if ns, ok := scope.GetNamespace(e.Name); ok {
+		return pathResult{ns: ns}
 	}
-	return c.report(&UnknownIdentifierError{Ident: e})
+	c.report(&UnknownIdentifierError{Ident: e})
+	return pathResult{err: true}
+}
+
+// bindingValue instantiates a value binding at lvl for value position. An
+// overloaded binding (PR6) — `val g = f`, or `f` passed as an argument — is the
+// intersection of its arms (the one scoped lattice exception; see
+// overloadIntersection and constrain's IntersectionType arm). An ordinary binding
+// instantiates its sole scheme, so each use gets fresh variables. A direct call
+// `f(x)` to an overloaded name never reaches here: inferCall intercepts the
+// overloaded callee and routes it through resolveOverload first.
+func (c *checker) bindingValue(lvl int, b ValueBinding) soltype.Type {
+	if b.IsOverloaded() {
+		return c.overloadIntersection(lvl, b)
+	}
+	return c.instantiate(b.Schemes[0], lvl)
 }
 
 // astKind returns a short surface name for any AST node — an expression,
@@ -508,8 +564,8 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// Not a value binding. Mirror inferIdent's value-position behavior: a name that
 		// resolves to a namespace reports NamespaceUsedAsValue; otherwise it is an
 		// unknown identifier.
-		if _, isNS := scope.GetNamespace(target.Name); isNS {
-			c.report(&NamespaceUsedAsValueError{Ident: target})
+		if ns, isNS := scope.GetNamespace(target.Name); isNS {
+			c.report(&NamespaceUsedAsValueError{Node: target, NS: ns})
 		} else {
 			c.report(&UnknownIdentifierError{Ident: target})
 		}
@@ -678,34 +734,38 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	return t
 }
 
-// inferMember types a field read (recv.prop). It types the receiver, allocates a
-// fresh result var, and constrains recv <: {prop: res, ...} — the basic form
-// from the plan's §3.2 table. The requirement is INEXACT: a member read asks
-// only that the receiver has AT LEAST this property, so width tolerance is
-// expressed as inexactness rather than as an unconditionally width-tolerant arm.
-//
-// This inexactness currently flows out to the inferred param type. A param used
-// only through member reads coalesces to its upper bound, so `fn (p) { p.foo }`
-// infers an inexact param `{foo: number, ...}`. M4 phase B PR B1 ("close
-// usage-inferred shapes to exact") will seal that coalesced result to exact via
-// the Policy-A close, rendering `{foo: number}`. The per-access requirement
-// minted here stays inexact; only the coalesced result is closed.
-//
-// The ObjectType <: ObjectType arm of constrain lowers res from the receiver's
-// matching property (so res coalesces to that property's type); a receiver
-// missing the property surfaces as a MissingPropertyError stamped with the
-// member's span. Optional chaining (recv?.prop) needs union/undefined handling
-// and is M6.
+// inferMember types a field read (recv.prop) in value position: it resolves the
+// member as a path and demands a value, so a property read returns its type while
+// a member that resolves to a namespace (A.B used as a value) is rejected.
+// Optional chaining (recv?.prop) needs union/undefined handling and is M6.
 func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
+	return c.demandValue(c.resolveMemberPath(scope, lvl, e), e)
+}
+
+// inferIndex types `obj[index]` in value position — today only namespace index
+// access (Foo["bar"]); value indexing is M7.
+func (c *checker) inferIndex(scope *Scope, lvl int, e *ast.IndexExpr) soltype.Type {
+	return c.demandValue(c.resolveIndexPath(scope, lvl, e), e)
+}
+
+// resolveMemberPath resolves `obj.prop`. It first resolves the object as a path —
+// so a namespace object (Foo.bar, A.B.c) walks through as a non-lexical member
+// lookup — and otherwise types the object as an ordinary value receiver and reads
+// the property structurally.
+func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pathResult {
 	if e.OptChain {
 		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
 		// up front and do NOT descend into the receiver, so a single diagnostic
 		// stands for the construct instead of cascading the receiver's errors. The
 		// MemberExpr kind is supported — it is the optional-chain feature that is
 		// not — so this is an UnsupportedFeatureError blaming the member.
-		return c.reportUnsupportedFeature(e, "OptionalChain")
+		c.reportUnsupportedFeature(e, "OptionalChain")
+		return pathResult{err: true}
 	}
-	recv := c.inferExpr(scope, lvl, e.Object)
+	obj := c.resolvePath(scope, lvl, e.Object)
+	if obj.err {
+		return pathResult{err: true}
+	}
 	if e.Prop == nil || e.Prop.Name == "" {
 		// A malformed `recv.` with no valid property name: the parser already
 		// reported the missing identifier, so constraining recv <: {"": res} here
@@ -716,8 +776,31 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 		// already emitted the diagnostic here (via the parser), so no extra error.
 		t := soltype.Type(&soltype.ErrorType{})
 		c.recordType(e, t)
-		return t
+		return pathResult{value: t}
 	}
+	if obj.ns != nil {
+		return c.resolveNamespaceMember(lvl, e, obj.ns, e.Prop.Name)
+	}
+	return c.valueMember(lvl, e, obj.value)
+}
+
+// valueMember reads property prop off a value receiver: it allocates a fresh
+// result var and constrains recv <: {prop: res, ...} — the basic form from the
+// plan's §3.2 table. The requirement is INEXACT: a member read asks only that the
+// receiver has AT LEAST this property, so width tolerance is expressed as
+// inexactness rather than as an unconditionally width-tolerant arm.
+//
+// This inexactness currently flows out to the inferred param type. A param used
+// only through member reads coalesces to its upper bound, so `fn (p) { p.foo }`
+// infers an inexact param `{foo: number, ...}`. M4 phase B PR B1 ("close
+// usage-inferred shapes to exact") will seal that coalesced result to exact via
+// the Policy-A close, rendering `{foo: number}`. The per-access requirement minted
+// here stays inexact; only the coalesced result is closed.
+//
+// The ObjectType <: ObjectType arm of constrain lowers res from the receiver's
+// matching property (so res coalesces to that property's type); a receiver missing
+// the property surfaces as a MissingPropertyError stamped with the member's span.
+func (c *checker) valueMember(lvl int, e *ast.MemberExpr, recv soltype.Type) pathResult {
 	res := c.freshAt(lvl)
 	// Record the fresh result var against the .prop IDENTIFIER (not the whole
 	// MemberExpr), so a missing-property read blames the property (.foo), not the
@@ -730,7 +813,67 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
 	c.recordType(e, res)
-	return res
+	return pathResult{value: res}
+}
+
+// resolveIndexPath resolves `obj[index]`. A namespace object is indexed by a
+// constant string key — Foo["bar"] is the bracket form of Foo.bar — while a
+// dynamic key (Foo[k]) is rejected. A value object indexed is array/index-type
+// territory (M7), so it stays unsupported here.
+func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) pathResult {
+	if e.OptChain {
+		c.reportUnsupportedFeature(e, "OptionalChain")
+		return pathResult{err: true}
+	}
+	obj := c.resolvePath(scope, lvl, e.Object)
+	if obj.err {
+		return pathResult{err: true}
+	}
+	if obj.ns != nil {
+		name, ok := constStringKey(e.Index)
+		if !ok {
+			c.report(&DynamicNamespaceIndexError{Index: e, NS: obj.ns})
+			return pathResult{err: true}
+		}
+		return c.resolveNamespaceMember(lvl, e, obj.ns, name)
+	}
+	// Indexing a value (array element / index-signature read) needs Array and index
+	// types, which land in M7; until then the index form over a value is outside the
+	// supported subset.
+	c.reportUnsupported(e)
+	return pathResult{err: true}
+}
+
+// resolveNamespaceMember looks name up in ns directly and non-lexically — a
+// namespace member resolution reads the namespace's OWN maps, never walking a
+// parent scope (unlike Scope.GetValue/GetType/GetNamespace). A nested namespace is
+// returned as a namespace so a longer chain keeps walking; a value member is
+// instantiated and recorded against node; an absent name is an
+// UnknownNamespaceMemberError. node is the member/index expression, for blame and
+// the Info record.
+func (c *checker) resolveNamespaceMember(lvl int, node ast.Expr, ns *Namespace, name string) pathResult {
+	if nested, ok := ns.Nested[name]; ok {
+		return pathResult{ns: nested}
+	}
+	if b, ok := ns.Values[name]; ok && len(b.Schemes) > 0 {
+		t := c.bindingValue(lvl, b)
+		c.recordType(node, t)
+		return pathResult{value: t}
+	}
+	c.report(&UnknownNamespaceMemberError{Node: node, NS: ns, Name: name})
+	return pathResult{err: true}
+}
+
+// constStringKey reads a statically-constant string index key. Only a string
+// literal qualifies — Foo["bar"]; a numeric, identifier, or otherwise dynamic key
+// returns false so the caller can reject it.
+func constStringKey(e ast.Expr) (string, bool) {
+	if lit, ok := e.(*ast.LiteralExpr); ok {
+		if s, ok := lit.Lit.(*ast.StrLit); ok {
+			return s.Value, true
+		}
+	}
+	return "", false
 }
 
 // objKeyName reads the static field name of an object-literal key. M2 records

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -742,8 +742,9 @@ func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.
 	return c.demandValue(c.resolveMemberPath(scope, lvl, e), e)
 }
 
-// inferIndex types `obj[index]` in value position — today only namespace index
-// access (Foo["bar"]); value indexing is M7.
+// inferIndex types `obj[index]` in value position — namespace index access
+// (Foo["bar"]) and the constant-string bracket form of property access
+// (obj["foo-bar"]); dynamic value indexing is M7.
 func (c *checker) inferIndex(scope *Scope, lvl int, e *ast.IndexExpr) soltype.Type {
 	return c.demandValue(c.resolveIndexPath(scope, lvl, e), e)
 }
@@ -801,25 +802,40 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 // matching property (so res coalesces to that property's type); a receiver missing
 // the property surfaces as a MissingPropertyError stamped with the member's span.
 func (c *checker) valueMember(lvl int, e *ast.MemberExpr, recv soltype.Type) pathResult {
-	res := c.freshAt(lvl)
 	// Record the fresh result var against the .prop IDENTIFIER (not the whole
 	// MemberExpr), so a missing-property read blames the property (.foo), not the
-	// receiver. The member-requirement record {prop: res} is deliberately NOT
-	// recorded — MissingPropertyError blames this inner res var, so the record
-	// would be a dead entry (§3.3).
-	c.recordProv(res, e.Prop, MemberAccess)
-	c.constrain(e, recv, &soltype.ObjectType{
-		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: e.Prop.Name, Type: res}},
+	// receiver.
+	return c.valueProp(lvl, e, e.Prop, e.Prop.Name, recv)
+}
+
+// valueProp is the shared core of property access off a value receiver, used by
+// both dot access (obj.prop) and constant-string index access (obj["foo-bar"]).
+// blame is the node a constraint failure points at — the whole access expression;
+// provNode is the node the fresh result var's provenance is recorded against —
+// the property identifier for dot access, the string-literal key for index access
+// — so a missing-property read blames the property, not the receiver. name is the
+// property key being read.
+func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name string, recv soltype.Type) pathResult {
+	res := c.freshAt(lvl)
+	// The member-requirement record {prop: res} is deliberately NOT recorded —
+	// MissingPropertyError blames this inner res var, so the record would be a dead
+	// entry (§3.3).
+	c.recordProv(res, provNode, MemberAccess)
+	c.constrain(blame, recv, &soltype.ObjectType{
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: res}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
-	c.recordType(e, res)
+	c.recordType(blame, res)
 	return pathResult{value: res}
 }
 
 // resolveIndexPath resolves `obj[index]`. A namespace object is indexed by a
 // constant string key — Foo["bar"] is the bracket form of Foo.bar — while a
-// dynamic key (Foo[k]) is rejected. A value object indexed is array/index-type
-// territory (M7), so it stays unsupported here.
+// dynamic key (Foo[k]) is rejected. A value object indexed by a constant string
+// key is the bracket form of property access — obj["foo-bar"] reads the same
+// property as obj.foo would, and lets the source name a property whose key is not
+// a valid identifier. A dynamic key over a value (array element / index-signature
+// read) needs Array and index types from M7, so it stays unsupported here.
 func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) pathResult {
 	if e.OptChain {
 		c.reportUnsupportedFeature(e, "OptionalChain")
@@ -837,9 +853,12 @@ func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) path
 		}
 		return c.resolveNamespaceMember(lvl, e, obj.ns, name)
 	}
-	// Indexing a value (array element / index-signature read) needs Array and index
-	// types, which land in M7; until then the index form over a value is outside the
-	// supported subset.
+	if name, ok := constStringKey(e.Index); ok {
+		return c.valueProp(lvl, e, e.Index, name, obj.value)
+	}
+	// A dynamic key over a value (array element / index-signature read) needs Array
+	// and index types, which land in M7; until then it is outside the supported
+	// subset.
 	c.reportUnsupported(e)
 	return pathResult{err: true}
 }

--- a/internal/solver/infer_namespace_test.go
+++ b/internal/solver/infer_namespace_test.go
@@ -1,0 +1,154 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// F1: namespace member lookup (resolvePath). Namespaces never enter scope via real
+// source yet (namespace declarations are unsupported in M3), so these tests
+// hand-build the Namespace structure and feed path expressions straight into the
+// walk — the same construction as TestInferIdentNamespaceUsedAsValue.
+
+func numScheme() []TypeScheme {
+	return []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}
+}
+
+func strScheme() []TypeScheme {
+	return []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.StrPrim})}
+}
+
+// Foo.bar resolves to the member's type.
+func TestInferNamespaceMember(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{
+		Name:   "Foo",
+		Values: map[string]ValueBinding{"bar": {Schemes: numScheme()}},
+	})
+
+	e := memberExpr(identExpr("Foo"), "bar")
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", soltype.Print(got))
+	require.Equal(t, got, c.info.TypeOf(e))
+}
+
+// Foo["bar"] resolves a constant-keyed member — the bracket form of Foo.bar.
+func TestInferNamespaceConstantIndex(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{
+		Name:   "Foo",
+		Values: map[string]ValueBinding{"bar": {Schemes: strScheme()}},
+	})
+
+	e := ast.NewIndex(identExpr("Foo"), strExpr("bar"), false, testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "string", soltype.Print(got))
+	require.Equal(t, got, c.info.TypeOf(e))
+}
+
+// A.B.c walks through a nested namespace to the member's type.
+func TestInferNestedNamespaceMember(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	inner := &Namespace{
+		Name:   "A.B",
+		Values: map[string]ValueBinding{"c": {Schemes: numScheme()}},
+	}
+	scope.defineNamespace("A", &Namespace{
+		Name:   "A",
+		Nested: map[string]*Namespace{"B": inner},
+	})
+
+	e := memberExpr(memberExpr(identExpr("A"), "B"), "c")
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "number", soltype.Print(got))
+}
+
+// f(Foo) — a bare namespace name in value position is rejected.
+func TestInferNamespaceAsValue(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{Name: "Foo"})
+
+	got := c.inferExpr(scope, 0, identExpr("Foo"))
+	require.IsType(t, &soltype.ErrorType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// f(A.B) — a partial chain stopping at a nested namespace is rejected once, with
+// the nested namespace's qualified name.
+func TestInferNestedNamespaceAsValue(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	inner := &Namespace{Name: "A.B"}
+	scope.defineNamespace("A", &Namespace{
+		Name:   "A",
+		Nested: map[string]*Namespace{"B": inner},
+	})
+
+	e := memberExpr(identExpr("A"), "B")
+	got := c.inferExpr(scope, 0, e)
+	require.IsType(t, &soltype.ErrorType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace used as a value: A.B", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// Foo.nope — an absent member is an UnknownNamespaceMemberError.
+func TestInferNamespaceUnknownMember(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineNamespace("Foo", &Namespace{
+		Name:   "Foo",
+		Values: map[string]ValueBinding{"bar": {Schemes: numScheme()}},
+	})
+
+	e := memberExpr(identExpr("Foo"), "nope")
+	got := c.inferExpr(scope, 0, e)
+	require.IsType(t, &soltype.ErrorType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace Foo has no member: nope", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// Foo[k] — a dynamic (non-constant) index into a namespace is rejected.
+func TestInferNamespaceDynamicIndex(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("k", ValueBinding{Schemes: strScheme()})
+	scope.defineNamespace("Foo", &Namespace{
+		Name:   "Foo",
+		Values: map[string]ValueBinding{"bar": {Schemes: numScheme()}},
+	})
+
+	e := ast.NewIndex(identExpr("Foo"), identExpr("k"), false, testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.IsType(t, &soltype.ErrorType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Namespace Foo can only be indexed by a constant string", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// An index into a value (array element / index-signature read) is M7, still
+// outside the supported subset — the namespace path doesn't accidentally accept it.
+func TestInferValueIndexUnsupported(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	scope.defineValue("o", ValueBinding{Schemes: numScheme()})
+
+	e := ast.NewIndex(identExpr("o"), numExpr(0), false, testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.IsType(t, &soltype.ErrorType{}, got)
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "Unsupported in M2: IndexExpr", c.errs[0].Message())
+}

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -229,3 +229,48 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 		require.Equal(t, "{b: 2}", spanText(src, errs[0].Span()))
 	})
 }
+
+// --- IndexExpr (value receiver, constant string key) ---
+
+// obj["foo-bar"] is the bracket form of property access: a constant string key
+// reads the same property a dot access would, and lets the source name a key that
+// is not a valid identifier. The receiver here is a value, not a namespace.
+func TestInferIndexValueConstStringKey(t *testing.T) {
+	c := newChecker()
+	// {"foo-bar": 5, b: "hi"}["foo-bar"]
+	fooBar := ast.NewProperty(ast.NewString("foo-bar", testSpan()), false, false, numExpr(5), testSpan())
+	recv := objExpr(fooBar, prop("b", strExpr("hi")))
+	e := ast.NewIndex(recv, strExpr("foo-bar"), false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "5", render(got))
+	require.Same(t, got, c.info.TypeOf(e))
+}
+
+// Reading a constant string key the receiver lacks fails with a
+// MissingPropertyError, the same as the dot form — the index path shares
+// valueProp's blame.
+func TestInferIndexValueMissingProperty(t *testing.T) {
+	c := newChecker()
+	// {a: 5}["foo-bar"]
+	e := ast.NewIndex(objExpr(prop("a", numExpr(5))), strExpr("foo-bar"), false, testSpan())
+
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Equal(t, "never", render(got)) // the fresh result var picks up no lower bound
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "object is missing property: foo-bar", c.errs[0].Message())
+	require.Equal(t, testSpan(), c.errs[0].Span())
+}
+
+// End-to-end through the parser: `obj["foo-bar"]` parses to an IndexExpr and
+// reads the property whose key is not a valid identifier.
+func TestInferIndexValueConstStringKeySource(t *testing.T) {
+	src := `
+		val obj = {"foo-bar": 5}
+		val x = obj["foo-bar"]
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+}

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1169,14 +1169,16 @@ these arms it must add.
 ### Dependency graph
 
 ```
-A1 → A2
-A1 → A3 ───────────────────┐  (A3's mut/lifetime arms un-gated by C1)
-A1 → B1 → B2               │  (annotation-side acceptance tests)
-     B1 → B3               │
-     B1, B3 ───────────┐   │  (C3 reuses B1's mergeObjects fold + B3's widen)
-A1 → C1 → C2(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
-A1 → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
-F1             (independent; any time — only M2's Namespace)
+✓ = landed on main.  Done so far: A1 (#728), C1+C2 (#731), F1 (#730).
+
+A1✓ → A2
+A1✓ → A3 ───────────────────┐  (A3's mut/lifetime arms un-gated by C1)
+A1✓ → B1 → B2               │  (annotation-side acceptance tests)
+      B1 → B3               │
+      B1, B3 ───────────┐   │  (C3 reuses B1's mergeObjects fold + B3's widen)
+A1✓ → C1✓ → C2✓(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
+A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
+F1✓             (independent; any time — only M2's Namespace)
 ```
 
 Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel


### PR DESCRIPTION
This change implements path resolution for namespace member access, allowing expressions like `Foo.bar` and `Foo["bar"]` to resolve to namespace members while rejecting bare namespace names in value position.

**Key changes:**

- Refactored identifier and member resolution into a path-resolution layer (`resolvePath`, `resolveIdentPath`, `resolveMemberPath`, `resolveIndexPath`) that returns a `pathResult` sum type distinguishing between value results, namespace results, and errors.
- Introduced `demandValue` to centralize the rejection of namespace results in value position, so both `f(Foo)` and partial chains like `f(A.B)` report a single `NamespaceUsedAsValueError` with the namespace's qualified name.
- Added `resolveNamespaceMember` to perform non-lexical member lookup in a namespace's own maps, supporting both nested namespaces (which continue the chain) and value members (which are instantiated and recorded).
- Implemented constant-string-key indexing for namespaces via `constStringKey`, rejecting dynamic keys with `DynamicNamespaceIndexError`.
- Extracted `bindingValue` to handle instantiation of value bindings (overloaded or ordinary) in a reusable way.
- Added three new error types: `UnknownNamespaceMemberError` (absent member), `DynamicNamespaceIndexError` (non-constant namespace index), and updated `NamespaceUsedAsValueError` to carry the namespace and blame the path expression rather than just the identifier.
- Added comprehensive test coverage in `infer_namespace_test.go` for member access, nested namespaces, dynamic indexing, and error cases.

The change preserves the existing value-position behavior for identifiers and members while enabling namespace chains to walk through intermediate namespaces without error, deferring the value-position rejection to the consumer.

https://claude.ai/code/session_01UBWx4vW8RCiBUP9jksaaC4