### PR TITLE
Add RefType constraint rule and borrow support (M4 C2)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -10,13 +10,14 @@ import (
 )
 
 // Precedence levels for type operators, matching the Escalier parser (and
-// type_system/print_type.go). Higher values bind more tightly. M1 carries only
-// the subset reachable from coalesced output — functions, unions, intersections,
-// and atoms; type_system's precPrefix (keyof/mut/...) has no M1 analogue yet.
+// type_system/print_type.go). Higher values bind more tightly. M4 adds precPrefix
+// for the `mut`/lifetime borrow prefix (RefType); type_system's other prefix forms
+// (keyof, ...T) land with their later milestones.
 const (
 	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
 	precUnion        = 3 // A | B
 	precIntersection = 4 // A & B
+	precPrefix       = 5 // mut T, 'a T — a borrow prefix binds looser than an atom
 	precAtom         = 6 // primary types, never need parens
 )
 
@@ -29,6 +30,8 @@ func typePrec(t Type) int {
 		return precUnion
 	case *IntersectionType:
 		return precIntersection
+	case *RefType:
+		return precPrefix
 	default:
 		// PrimType, LitType, TupleType, ObjectType, Void, NeverType, UnknownType —
 		// atoms (ObjectType is brace-delimited, so it never needs parens). A
@@ -150,6 +153,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *PromiseType:
 			walk(t.Inner)
+		case *RefType:
+			walk(t.Inner)
 		case *UnionType:
 			for _, m := range t.Types {
 				walk(m)
@@ -235,6 +240,16 @@ func (p *namedPrinter) printType(t Type) string {
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
+	case *RefType:
+		// `mut {x: number}`, `mut [number]`. The immutable-borrow and lifetime
+		// prefixes (`'a {…}`, `mut 'a {…}`) render once D1 adds the lifetime sort;
+		// Lt is always nil here, so only the `mut` prefix appears. The inner prints
+		// at precPrefix so a looser inner (a union/function) gets parenthesized.
+		prefix := ""
+		if t.Mut {
+			prefix = "mut "
+		}
+		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -284,6 +284,20 @@ func TestPrintScheme(t *testing.T) {
 		}}}
 		require.Equal(t, "fn <T0, T1>() -> {a: T0, b: T1}", PrintAsScheme(ty))
 	})
+
+	t.Run("a borrowed generic survives generalization", func(t *testing.T) {
+		a := &TypeVarType{ID: 1, Level: 1}
+		// fn (p: mut {x: a}) -> a: freeTypeVars must descend through the RefType
+		// wrapper into its inner object to find a, so the borrowed param and the
+		// return share the one type parameter T0. This is the realistic C3 shape — a
+		// field-write makes the receiver a `mut` object — surviving M3 generalization.
+		ty := &FuncType{
+			Params: []*FuncParam{identP("p", &RefType{Mut: true,
+				Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: a}}}})},
+			Ret: a,
+		}
+		require.Equal(t, "fn <T0>(p: mut {x: T0}) -> T0", PrintAsScheme(ty))
+	})
 }
 
 // PrintAsSchemeWith names ONLY the variables the predicate accepts as quantified

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -120,6 +120,19 @@ func TestPrintRoundTrips(t *testing.T) {
 		// Promises (M3).
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
+
+		// Borrows (M4). Lt is always nil in C1, so only the owned-mutable form
+		// renders; the inner object/tuple is brace/bracket-delimited, so no parens.
+		{
+			"mut object",
+			&RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
+			"mut {x: number}",
+		},
+		{
+			"mut tuple",
+			&RefType{Mut: true, Inner: &TupleType{Elems: []Type{numP(), strP()}}},
+			"mut [number, string]",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/soltype/ref.go
+++ b/internal/soltype/ref.go
@@ -1,0 +1,48 @@
+package soltype
+
+// Lifetime is the sort of borrow lifetimes — a second, non-Type sort threaded
+// through RefType.Lt. It is a placeholder in C1: it has no concretes yet, so Lt is
+// always nil and no RefType is borrowed. M4 D1 adds the concretes (LifetimeVar,
+// StaticLifetime) and the outlives lattice; until then a RefType carries the field
+// unused.
+type Lifetime interface{ isLifetime() }
+
+// NewRef wraps inner in a borrow, collapsing the degenerate immutable-no-lifetime
+// cell back to the bare inner so no *RefType ever names a value that isn't really a
+// borrow. A type-switch on *RefType can therefore assume the wrapper is meaningful.
+// Construct a &RefType literal directly when that cell must survive — the
+// bare<:RefType constrain arm (C2) does, to re-dispatch a source as an immutable
+// view without recursing forever.
+func NewRef(mut bool, lt Lifetime, inner RefInner) Type {
+	if !mut && lt == nil {
+		return inner
+	}
+	return &RefType{Mut: mut, Lt: lt, Inner: inner}
+}
+
+// UnwrapRef peels a RefType into its inner carrier, mutability, and lifetime,
+// returning (t, false, nil) when t is not a borrow.
+func UnwrapRef(t Type) (inner Type, mut bool, lt Lifetime) {
+	if r, ok := t.(*RefType); ok {
+		return r.Inner, r.Mut, r.Lt
+	}
+	return t, false, nil
+}
+
+// CarrierOf peels any RefType down to the value it wraps, returning t unchanged
+// when it is not a borrow. Member access and pattern matching look through a borrow
+// to its carrier.
+func CarrierOf(t Type) Type {
+	if r, ok := t.(*RefType); ok {
+		return r.Inner
+	}
+	return t
+}
+
+// BorrowableType reports whether t may sit inside a RefType — i.e. whether it is a
+// RefInner. A TypeVarType is borrowable mid-inference, with its content invariant
+// deferred to constrain time; PrimType / LitType / FuncType / PromiseType are not.
+func BorrowableType(t Type) bool {
+	_, ok := t.(RefInner)
+	return ok
+}

--- a/internal/soltype/ref_test.go
+++ b/internal/soltype/ref_test.go
@@ -1,0 +1,73 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// NewRef collapses the degenerate immutable-no-lifetime cell to the bare inner, and
+// keeps the wrapper for every meaningful borrow. Lt is always nil in C1, so the
+// only meaningful borrow constructible here is the owned-mutable one.
+func TestNewRef(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
+
+	t.Run("immutable no-lifetime collapses to bare inner", func(t *testing.T) {
+		require.Same(t, obj, NewRef(false, nil, obj))
+	})
+
+	t.Run("owned-mutable keeps the wrapper", func(t *testing.T) {
+		got := NewRef(true, nil, obj)
+		r, ok := got.(*RefType)
+		require.True(t, ok, "a mutable borrow stays a *RefType")
+		require.True(t, r.Mut)
+		require.Nil(t, r.Lt)
+		require.Same(t, obj, r.Inner)
+	})
+}
+
+func TestUnwrapRef(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
+
+	t.Run("peels a borrow into inner, mut, lt", func(t *testing.T) {
+		inner, mut, lt := UnwrapRef(&RefType{Mut: true, Inner: obj})
+		require.Same(t, obj, inner)
+		require.True(t, mut)
+		require.Nil(t, lt)
+	})
+
+	t.Run("a non-borrow returns itself, owned and immutable", func(t *testing.T) {
+		inner, mut, lt := UnwrapRef(obj)
+		require.Same(t, obj, inner)
+		require.False(t, mut)
+		require.Nil(t, lt)
+	})
+}
+
+func TestCarrierOf(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
+
+	require.Same(t, obj, CarrierOf(&RefType{Mut: true, Inner: obj}), "peels a borrow to its carrier")
+	require.Same(t, obj, CarrierOf(obj), "a non-borrow is its own carrier")
+}
+
+func TestBorrowableType(t *testing.T) {
+	tests := []struct {
+		name string
+		ty   Type
+		want bool
+	}{
+		{"object is borrowable", &ObjectType{}, true},
+		{"tuple is borrowable", &TupleType{}, true},
+		{"type variable is borrowable", &TypeVarType{ID: 1}, true},
+		{"primitive is not borrowable", &PrimType{Prim: NumPrim}, false},
+		{"literal is not borrowable", &LitType{Lit: &NumLit{Value: 5}}, false},
+		{"function is not borrowable", &FuncType{Ret: &PrimType{Prim: NumPrim}}, false},
+		{"promise is not borrowable", &PromiseType{Inner: &PrimType{Prim: NumPrim}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, BorrowableType(tt.ty))
+		})
+	}
+}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -195,6 +195,46 @@ func AsProperty(e ObjTypeElem) *PropertyElem {
 	return p
 }
 
+// RefType is the single wrapper for borrows and mutability. A bare value is owned
+// and immutable; wrapping it in a RefType marks it mutable, borrowed, or both:
+//
+//	Mut=false Lt=nil   forbidden degenerate cell — NewRef returns the bare Inner
+//	Mut=false Lt='a    immutable borrow
+//	Mut=true  Lt=nil   owned mutable
+//	Mut=true  Lt='a    mutable borrow
+//
+// The single RefType<:RefType constrain rule (M4 C2) reads Mut for inner variance
+// and Lt for the lifetime outlives check; until then a RefType only carries data.
+// Lt is always nil in C1 — the Lifetime sort and its constrain rule arrive in M4
+// D1/D2, so the immutable-borrow and lifetime forms above are reachable only then.
+type RefType struct {
+	Mut   bool
+	Lt    Lifetime // nilable; always nil until the lifetime sort lands (D1)
+	Inner RefInner
+}
+
+// RefInner is the sealed set of types that may sit inside a RefType. PrimType /
+// LitType / FuncType / PromiseType are deliberately excluded: a promise or function
+// reference is shared, not borrowed, and a `mut` primitive is a JS no-op. Excluding
+// PromiseType blocks borrowing the promise itself — there is no `mut Promise` or
+// `'a Promise`. It does NOT block the promise's payload from being a borrow:
+// `Promise<mut 'a Point>` is a PromiseType whose type argument is a RefType, which
+// is well-formed.
+//
+// M4 admits ObjectType / TupleType / TypeVarType. The TypeVarType arm covers a
+// borrow whose content is still an inference variable; the content invariant — that
+// it resolves to a borrowable type — is checked at constrain time. UnionType /
+// IntersectionType (M6 inputs), AliasType (M7), and ClassType (M5) add their
+// isRefInner arms with those milestones.
+type RefInner interface {
+	Type
+	isRefInner()
+}
+
+func (*ObjectType) isRefInner()  {}
+func (*TupleType) isRefInner()   {}
+func (*TypeVarType) isRefInner() {}
+
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
 // scope narrow: it is the one stdlib generic the milestone needs typed (Iterable/
@@ -244,6 +284,7 @@ func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
 func (*TupleType) isType()        {}
 func (*ObjectType) isType()       {}
+func (*RefType) isType()          {}
 func (*PromiseType) isType()      {}
 func (*Void) isType()             {}
 func (*NeverType) isType()        {}
@@ -277,6 +318,10 @@ func LevelOf(t Type) int {
 		}
 		return m
 	case *PromiseType:
+		return LevelOf(t.Inner)
+	case *RefType:
+		// Inner is a RefInner, which embeds Type; the borrow wrapper itself carries
+		// no variable, so the level is its content's.
 		return LevelOf(t.Inner)
 	// Union and Intersection recurse into their members for the same reason, but only
 	// the IntersectionType arm is load-bearing today. overloadIntersection (solver) is

--- a/internal/soltype/type_test.go
+++ b/internal/soltype/type_test.go
@@ -101,6 +101,19 @@ func TestLevelOf(t *testing.T) {
 			}},
 			want: 5,
 		},
+		{
+			// A borrow carries no variable itself, so its level is its content's —
+			// the same hazard as the ObjectType arm: a wrong 0 would let a Level>0
+			// borrowed value be shared and aliased across instantiations.
+			name: "ref: level of its inner",
+			ty:   &RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: v5}}}},
+			want: 5,
+		},
+		{
+			name: "ref over a concrete inner is level 0",
+			ty:   &RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: num}}}},
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -152,13 +152,19 @@ func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	// lifetime is not a Type, so Accept never walks it; only the lifetime-aware
 	// passes (D4) do.
 	inner := cur.Inner.Accept(v, pol)
-	out := cur
+	var out Type = cur
 	if inner != cur.Inner {
-		ri, ok := inner.(RefInner)
-		if !ok {
-			panic(fmt.Sprintf("soltype.RefType.Accept: inner rewrote to non-RefInner %T", inner))
+		if ri, ok := inner.(RefInner); ok {
+			out = &RefType{Mut: cur.Mut, Lt: cur.Lt, Inner: ri}
+		} else {
+			// The inner rewrote to a non-borrowable type — e.g. coalescing a borrowed
+			// inference variable `mut β` whose β inlines to a union, never, or a
+			// primitive. A borrow of a non-RefInner is meaningless: a `mut number` is a
+			// JS no-op, exactly the degenerate case the RefInner set excludes. Peel the
+			// wrapper and yield the bare inner, mirroring NewRef's collapse of the
+			// (false, nil) cell.
+			out = inner
 		}
-		out = &RefType{Mut: cur.Mut, Lt: cur.Lt, Inner: ri}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -139,6 +139,30 @@ func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The inner is visited ONCE in the current polarity — the read view. When Mut,
+	// the inner is also a write view (the contravariant constrain step in C2), but
+	// the rewriting transforms visit it a single time and share fresh vars through
+	// their own cache, exactly as the spike's extrude treated a Mut inner. The
+	// lifetime is not a Type, so Accept never walks it; only the lifetime-aware
+	// passes (D4) do.
+	inner := cur.Inner.Accept(v, pol)
+	out := cur
+	if inner != cur.Inner {
+		ri, ok := inner.(RefInner)
+		if !ok {
+			panic(fmt.Sprintf("soltype.RefType.Accept: inner rewrote to non-RefInner %T", inner))
+		}
+		out = &RefType{Mut: cur.Mut, Lt: cur.Lt, Inner: ri}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -151,6 +151,14 @@ func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	// their own cache, exactly as the spike's extrude treated a Mut inner. The
 	// lifetime is not a Type, so Accept never walks it; only the lifetime-aware
 	// passes (D4) do.
+	//
+	// KNOWN GAP (D2): C2's constrain rule makes a Mut borrow's inner INVARIANT (it
+	// adds both a read and a write constraint), but this single covariant visit means
+	// extrude/freshenAbove wire an out-of-level inner var through only one bound
+	// direction. This is inert today — no inference path mints a RefType, so extrude
+	// never sees a real Mut borrow — and Accept is shared with coalesce, which WANTS a
+	// single covariant visit, so the fix belongs in extrude/freshenAbove (not here)
+	// once borrows originate (D2) and the case becomes reachable and testable.
 	inner := cur.Inner.Accept(v, pol)
 	var out Type = cur
 	if inner != cur.Inner {

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -232,3 +232,28 @@ func TestAcceptObjectIdentityPreservation(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: num}}, Inexact: true}
 	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive), "an unchanged ObjectType keeps its pointer")
 }
+
+// A no-op rewrite over a RefType keeps its pointer all the way down (copy-on-write).
+func TestAcceptRefIdentityPreservation(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	ref := &RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: num}}}}
+	require.Same(t, ref, ref.Accept(identityVisitor{}, Positive), "an unchanged RefType keeps its pointer")
+}
+
+// Rewriting a variable inside a borrow rebuilds the RefType, carries the Mut marker
+// through, and keeps the result a well-formed RefInner inner.
+func TestAcceptRefCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	inner := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: a}}}
+	ref := &RefType{Mut: true, Inner: inner}
+
+	got := ref.Accept(&replaceVar{target: a, repl: str}, Positive).(*RefType)
+
+	require.NotSame(t, ref, got, "a changed inner forces a new RefType")
+	require.True(t, got.Mut, "the rebuilt RefType keeps its Mut marker")
+	require.Nil(t, got.Lt, "the lifetime carries through unchanged")
+	gotInner := got.Inner.(*ObjectType)
+	require.NotSame(t, inner, gotInner, "the changed inner is a fresh object")
+	require.Same(t, str, gotInner.Elems[0].(*PropertyElem).Type, "the variable took the replacement")
+}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -356,6 +356,11 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
 		return ok && equalType(a.Inner, b.Inner)
+	case *soltype.RefType:
+		b, ok := b.(*soltype.RefType)
+		// Mut must match — a mutable borrow never equals an immutable one. Lifetime
+		// equality joins in D1; Lt is always nil here.
+		return ok && a.Mut == b.Mut && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		return ok && equalTypeSlice(a.Types, b.Types)

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -141,6 +141,61 @@ func TestCoalesceBorrowedVarInnerPeels(t *testing.T) {
 	})
 }
 
+// TestCoalesceBorrowPreservesWrapper is the complement of TestCoalesceBorrowedVarInnerPeels:
+// when the borrow's inner stays a RefInner after coalescing (here the inner is an
+// OBJECT containing a variable, not a bare variable), the `mut` wrapper must SURVIVE.
+// `mut {x: β}` with β bounded by number coalesces to `mut {x: number}`, not a peeled
+// `{x: number}` — the realistic shape C3's field-write inference produces.
+func TestCoalesceBorrowPreservesWrapper(t *testing.T) {
+	c := &Context{}
+	v := c.freshVar(0)
+	v.UpperBounds = []soltype.Type{num()}
+	ref := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", v))}
+	got := coalesce(ref, soltype.Negative)
+	require.True(t, equalType(&soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}, got))
+}
+
+// equalType discriminates a borrow on its Mut flag and its inner, mirroring the
+// ObjectType arm's Inexact/Optional discriminators. This drives dedup in coalesce —
+// without the Mut check `mut {x}` and an immutable `{x}` view would collapse.
+func TestEqualTypeRef(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "same mut and inner",
+			a:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))},
+			b:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))},
+			want: true,
+		},
+		{
+			name: "Mut differs",
+			a:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))},
+			b:    &soltype.RefType{Mut: false, Inner: exactObj(propElem("x", num()))},
+			want: false,
+		},
+		{
+			name: "inner differs",
+			a:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))},
+			b:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", str()))},
+			want: false,
+		},
+		{
+			name: "ref is not its bare inner",
+			a:    &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))},
+			b:    exactObj(propElem("x", num())),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType on ObjectType must discriminate on the Inexact flag and on each
 // property's Optional marker (mirroring the FuncType arm's Inexact / param-Optional
 // checks), and must be order-independent. Without the Optional check (M4 A1 review

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -116,6 +116,31 @@ func TestCoalesceStructuralRecursion(t *testing.T) {
 	require.True(t, equalType(want, got))
 }
 
+// TestCoalesceBorrowedVarInnerPeels pins review finding 1: coalescing a borrow whose
+// inner is an inference variable inlines that variable to its bounds. RefInner admits
+// *TypeVarType, so `mut β` is well-formed mid-inference. When β inlines to a
+// non-borrowable type — a primitive bound, or never for empty bounds — the borrow
+// wrapper must PEEL to the bare inner rather than panic: a `mut number` is a JS
+// no-op, so the coalesced display is just the inner.
+func TestCoalesceBorrowedVarInnerPeels(t *testing.T) {
+	t.Run("inner var with a primitive bound peels to the primitive", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		a.LowerBounds = []soltype.Type{num()}
+		ref := &soltype.RefType{Mut: true, Inner: a}
+		got := coalesce(ref, soltype.Positive)
+		require.True(t, equalType(num(), got))
+	})
+
+	t.Run("inner var with empty bounds peels to never", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		ref := &soltype.RefType{Mut: true, Inner: a}
+		got := coalesce(ref, soltype.Positive)
+		require.IsType(t, &soltype.NeverType{}, got)
+	})
+}
+
 // equalType on ObjectType must discriminate on the Inexact flag and on each
 // property's Optional marker (mirroring the FuncType arm's Inexact / param-Optional
 // checks), and must be order-independent. Without the Optional check (M4 A1 review

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -263,6 +263,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//    invariance. So `mut {x, y} <: mut {x, ...}` rejects (the write view's
 			//    `{x, ...} <: {x, y}` is missing y), while `{x, y} <: {x, ...}` as bare
 			//    objects width-succeeds.
+			//
+			//    The write view gates on `sup.Mut`, which is load-bearing-equivalent to
+			//    `sub.Mut && sup.Mut`: the mutability check above already returned for
+			//    `!sub.Mut && sup.Mut`, so reaching here with sup.Mut implies sub.Mut.
+			//    If that earlier gate is ever weakened, re-gate the write view explicitly
+			//    or it would impose a spurious contravariant constraint on an immutable
+			//    source.
 			errs := c.constrain(sub.Inner, sup.Inner, seen)
 			if sup.Mut {
 				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen)...)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -247,6 +247,51 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// CannotConstrainError below, matching the function/tuple/record arms.
 			return c.constrain(sub.Inner, sup.Inner, seen)
 		}
+	case *soltype.RefType:
+		// THE GATE (M4 C2): the single RefType <: RefType rule. The mut-driven inner
+		// invariance is the highest-risk encoding in the migration — see the M4 plan.
+		if sup, ok := super.(*soltype.RefType); ok {
+			// 1. Mutability compatibility: an immutable source cannot fill a mutable
+			//    slot (writing through the target would mutate a read-only borrow). The
+			//    reverse, mut-decay (mut sub, immutable super), is allowed and falls
+			//    through to the covariant read view below.
+			if !sub.Mut && sup.Mut {
+				return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
+			}
+			// 2. Inner variance: the read view is always covariant; a mutable target
+			//    also takes a contravariant write view, and read + write together IS
+			//    invariance. So `mut {x, y} <: mut {x, ...}` rejects (the write view's
+			//    `{x, ...} <: {x, y}` is missing y), while `{x, y} <: {x, ...}` as bare
+			//    objects width-succeeds.
+			errs := c.constrain(sub.Inner, sup.Inner, seen)
+			if sup.Mut {
+				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen)...)
+			}
+			// 3. Lifetime outlives, covariant. Written now, INERT in C2 because Lt is
+			//    always nil until the lifetime sort lands (D1); constrainLt wires the
+			//    var-to-var case in D2. The escape branch's error is unreachable until
+			//    borrows carry lifetimes.
+			switch {
+			case sub.Lt != nil && sup.Lt != nil:
+				// D2: c.constrainLt(sup.Lt, sub.Lt)
+			case sub.Lt == nil && sup.Lt != nil:
+				// An owned source satisfies any borrow slot — no lifetime constraint.
+			case sub.Lt != nil && sup.Lt == nil:
+				errs = append(errs, &BorrowEscapeError{Sub: sub, Super: sup})
+			}
+			return errs
+		}
+		// RefType <: a concrete non-borrow: peel to the inner. An owned value (Lt nil)
+		// satisfies a bare slot; a borrow escaping into an owned slot is a
+		// BorrowEscapeError (inert in C2). When super is a VARIABLE, fall through to the
+		// var arm so the WHOLE borrow is recorded as a bound — peeling there would drop
+		// its mutability.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if sub.Lt != nil {
+				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
+			}
+			return c.constrain(sub.Inner, super, seen)
+		}
 	case *soltype.Void:
 		if _, ok := super.(*soltype.Void); ok {
 			return nil
@@ -293,6 +338,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				lastErrs = errs
 			}
 			return lastErrs
+		}
+	}
+
+	// bare <: RefType: wrap a borrowable owned source as an immutable, no-lifetime
+	// view and re-dispatch into the RefType <: RefType branch above. Build the struct
+	// literal DIRECTLY — NewRef would collapse the (false, nil) cell back to the bare
+	// inner and recurse forever. A source that is not a RefInner (a primitive,
+	// function, promise) is not borrowable, so it falls through to CannotConstrainError
+	// naming the borrow. A variable source is excluded here so the subVar arm below
+	// records the borrow as an upper bound instead.
+	if sup, ok := super.(*soltype.RefType); ok {
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
+			if inner, ok := sub.(soltype.RefInner); ok {
+				return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, sup, seen)
+			}
 		}
 	}
 

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -348,6 +348,29 @@ func propElem(name string, t soltype.Type) *soltype.PropertyElem {
 	return &soltype.PropertyElem{Name: name, Type: t}
 }
 
+// mutRef / immutRef build borrow wrappers for the RefType constrain tests (C2).
+// Lt is always nil in C2 (the lifetime sort lands in D1), so only the owned-mutable
+// (mut) and the degenerate immutable-no-lifetime view are constructible — the latter
+// is what bare <: RefType mints internally to re-dispatch a borrowable source.
+func mutRef(inner soltype.RefInner) *soltype.RefType {
+	return &soltype.RefType{Mut: true, Inner: inner}
+}
+
+func immutRef(inner soltype.RefInner) *soltype.RefType {
+	return &soltype.RefType{Mut: false, Inner: inner}
+}
+
+// TestConstrainDescribesRefOperand pins review finding 2: describe must NAME a
+// RefType operand in a constraint failure, not render it as `?`. A non-borrowable
+// source (a primitive) against a mut-borrow target is not wrappable by the
+// bare <: RefType arm, so it falls through to CannotConstrainError carrying the
+// borrow as its Super — exactly the path describe was missing an arm for.
+func TestConstrainDescribesRefOperand(t *testing.T) {
+	c := &Context{}
+	errs := c.Constrain(num(), mutRef(exactObj(propElem("x", num()))))
+	require.Equal(t, []string{"cannot constrain number <: mut object"}, Messages(errs))
+}
+
 // exactObj / inexactObj build object types so the tests show which arm they
 // exercise. Exact is the zero value of Inexact, so exactObj sets no flag.
 func exactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
@@ -571,6 +594,123 @@ func TestConstrainObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConstrainRef exercises the single RefType <: RefType rule — THE GATE (C2).
+// The headline property is mut-driven inner invariance: a mutable target takes both
+// a covariant read view and a contravariant write view, so the inner is invariant.
+func TestConstrainRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		sub, super soltype.Type
+		want       []string
+		check      func(t *testing.T, sub, super soltype.Type, errs []SolverError)
+	}{
+		{
+			// mut {x} <: mut {x}: identical inner satisfies both the read and write
+			// view, so invariance holds.
+			name:  "mut <: mut, identical inner",
+			sub:   mutRef(exactObj(propElem("x", num()))),
+			super: mutRef(exactObj(propElem("x", num()))),
+		},
+		{
+			// mut {x: 5} <: mut {x: number}: the read view 5 <: number holds, but the
+			// write view requires number <: 5, which fails — invariance in one message.
+			name:  "mut inner is invariant: literal depth rejected on the write view",
+			sub:   mutRef(exactObj(propElem("x", numLit(5)))),
+			super: mutRef(exactObj(propElem("x", num()))),
+			want:  []string{"cannot constrain number <: 5"},
+		},
+		{
+			// mut {x, y} <: mut {x, ...}: the read view width-succeeds (inexact super),
+			// but the write view {x, ...} <: {x, y} is missing y and is inexact-into-
+			// exact — the plan's headline invariance rejection.
+			name:  "mut wider <: mut inexact rejects on the write view",
+			sub:   mutRef(exactObj(propElem("x", num()), propElem("y", num()))),
+			super: mutRef(inexactObj(propElem("x", num()))),
+			want: []string{
+				"object is missing property: y",
+				"cannot constrain inexact object <: exact object",
+			},
+		},
+		{
+			// The same two object inners as bare (immutable) values width-succeed: an
+			// immutable borrow is covariant, so the missing-on-write-view problem never
+			// arises. This is the contrast the plan draws against the mut case above.
+			name:  "immutable width succeeds where mut invariance rejects",
+			sub:   exactObj(propElem("x", num()), propElem("y", num())),
+			super: inexactObj(propElem("x", num())),
+		},
+		{
+			// mut {x} <: {x}: mut-decay. A mutable source satisfies a bare (owned,
+			// immutable) target; the borrow peels and the inner is checked covariantly.
+			name:  "mut-decay: mut <: bare allowed",
+			sub:   mutRef(exactObj(propElem("x", num()))),
+			super: exactObj(propElem("x", num())),
+		},
+		{
+			// {x} <: mut {x}: the reverse is rejected. The bare source is wrapped as an
+			// immutable view, and an immutable source cannot fill a mutable slot.
+			name:  "bare <: mut rejected (mutability)",
+			sub:   exactObj(propElem("x", num())),
+			super: mutRef(exactObj(propElem("x", num()))),
+			want:  []string{"cannot constrain immutable object <: mutable object"},
+			check: func(t *testing.T, sub, super soltype.Type, errs []SolverError) {
+				mm, ok := errs[0].(*MutabilityMismatchError)
+				require.True(t, ok)
+				// The sub is the wrapped immutable view; its inner is the bare source.
+				require.Same(t, sub, mm.Sub.Inner)
+				require.Same(t, super, soltype.Type(mm.Super))
+			},
+		},
+		{
+			// mut {x} <: number: an owned borrow peels and the inner object is checked
+			// against the non-object super, falling through to CannotConstrainError.
+			name:  "mut <: non-borrow peels to the inner",
+			sub:   mutRef(exactObj(propElem("x", num()))),
+			super: num(),
+			want:  []string{"cannot constrain object <: number"},
+		},
+		{
+			// number <: mut {x}: a non-borrowable source cannot be wrapped, so it falls
+			// through to CannotConstrainError naming the borrow (review finding 2).
+			name:  "non-borrowable source <: borrow names the borrow",
+			sub:   num(),
+			super: mutRef(exactObj(propElem("x", num()))),
+			want:  []string{"cannot constrain number <: mut object"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			errs := c.Constrain(tt.sub, tt.super)
+			require.Equal(t, tt.want, Messages(errs))
+			if tt.check != nil {
+				tt.check(t, tt.sub, tt.super, errs)
+			}
+		})
+	}
+}
+
+// A borrow on either side of a constraint against a type VARIABLE records the WHOLE
+// borrow as a bound (peeling would drop its mutability), so the variable coalesces
+// back to the borrow. This pins the var-arm fall-through both directions.
+func TestConstrainRefAgainstVar(t *testing.T) {
+	t.Run("RefType <: var records the borrow as a lower bound", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		ref := mutRef(exactObj(propElem("x", num())))
+		require.Empty(t, c.Constrain(ref, a))
+		require.True(t, equalType(ref, coalesce(a, soltype.Positive)))
+	})
+
+	t.Run("var <: RefType records the borrow as an upper bound", func(t *testing.T) {
+		c := &Context{}
+		a := c.freshVar(0)
+		ref := mutRef(exactObj(propElem("x", num())))
+		require.Empty(t, c.Constrain(a, ref))
+		require.True(t, equalType(ref, coalesce(a, soltype.Negative)))
+	})
 }
 
 func TestConstrainVoid(t *testing.T) {

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -713,6 +713,23 @@ func TestConstrainRefAgainstVar(t *testing.T) {
 	})
 }
 
+// TestConstrainRefInnerInvariantViaBounds is the gate's load-bearing property: a
+// variable INSIDE a mutable inner is invariant, pinned from BOTH directions through
+// the ordinary bound machinery with no special journaling. `mut {x: β} <: mut {x:
+// number}` adds number as β's upper bound (the covariant read view) AND as its lower
+// bound (the contravariant write view), so β coalesces to number in either polarity.
+// This is what "encodes cleanly against the journal" means for the gate.
+func TestConstrainRefInnerInvariantViaBounds(t *testing.T) {
+	c := &Context{}
+	b := c.freshVar(0)
+	require.Empty(t, c.Constrain(
+		mutRef(exactObj(propElem("x", b))),
+		mutRef(exactObj(propElem("x", num()))),
+	))
+	require.True(t, equalType(num(), coalesce(b, soltype.Positive)), "lower bound (write view)")
+	require.True(t, equalType(num(), coalesce(b, soltype.Negative)), "upper bound (read view)")
+}
+
 func TestConstrainVoid(t *testing.T) {
 	c := &Context{}
 	require.Empty(t, c.Constrain(&soltype.Void{}, &soltype.Void{}))

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -348,16 +348,14 @@ func propElem(name string, t soltype.Type) *soltype.PropertyElem {
 	return &soltype.PropertyElem{Name: name, Type: t}
 }
 
-// mutRef / immutRef build borrow wrappers for the RefType constrain tests (C2).
-// Lt is always nil in C2 (the lifetime sort lands in D1), so only the owned-mutable
-// (mut) and the degenerate immutable-no-lifetime view are constructible — the latter
-// is what bare <: RefType mints internally to re-dispatch a borrowable source.
+// mutRef builds an owned-mutable borrow for the RefType constrain tests (C2). Lt is
+// always nil in C2 — the lifetime sort lands in D1 — so the owned-mutable wrapper is
+// the only meaningful borrow constructible here. A real immutable borrow needs a
+// lifetime (`Mut: false, Lt: 'a`), so its helper arrives in D2; the bare <: RefType
+// arm mints the degenerate `Mut: false, Lt: nil` view internally with a struct
+// literal, not through a helper.
 func mutRef(inner soltype.RefInner) *soltype.RefType {
 	return &soltype.RefType{Mut: true, Inner: inner}
-}
-
-func immutRef(inner soltype.RefInner) *soltype.RefType {
-	return &soltype.RefType{Mut: false, Inner: inner}
 }
 
 // TestConstrainDescribesRefOperand pins review finding 2: describe must NAME a

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -151,6 +151,11 @@ type MutabilityMismatchError struct {
 // supertype or a RefType super with no lifetime. The firing path is INERT in C2 —
 // every RefType carries Lt == nil until the lifetime sort lands (D1) and borrows
 // originate (D2) — so the struct is wired now and exercised from D2.
+//
+// It is intentionally UNTESTED until then, and currently unconstructible: soltype.Lifetime
+// has no concrete implementors, so no non-nil Lt exists to drive any firing branch.
+// The Message format and the describe-the-whole-borrow choice are first observed in
+// D2; coverage of Message/Span/Related is deferred to that PR.
 type BorrowEscapeError struct {
 	Sub   *soltype.RefType
 	Super soltype.Type

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -134,6 +134,30 @@ type OptionalPropertyError struct {
 	site       ast.Node     // M2.5: constraint node fallback
 }
 
+// MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
+// borrow but the super is mutable: writing through the mutable target would mutate a
+// value the source only lent out as read-only, so an immutable reference cannot fill
+// a mutable slot. The reverse — a mutable source decaying to an immutable target — is
+// fine, so only this direction errors. It also fires for `{x} <: mut {x}`, where the
+// bare source is wrapped as an immutable view before re-dispatch.
+type MutabilityMismatchError struct {
+	Sub, Super *soltype.RefType
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: constraint node fallback
+}
+
+// BorrowEscapeError fires when a borrow outlives the slot it flows into: a borrowed
+// value (Lt != nil) constrained against an owned slot (Lt == nil), either a bare
+// supertype or a RefType super with no lifetime. The firing path is INERT in C2 —
+// every RefType carries Lt == nil until the lifetime sort lands (D1) and borrows
+// originate (D2) — so the struct is wired now and exercised from D2.
+type BorrowEscapeError struct {
+	Sub   *soltype.RefType
+	Super soltype.Type
+	prov  NodeResolver // M2.5: type→node index (§3.5)
+	site  ast.Node     // M2.5: constraint node fallback
+}
+
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
@@ -141,6 +165,8 @@ func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*ExtraPropertyError) isSolverError()       {}
 func (*OptionalPropertyError) isSolverError()    {}
+func (*MutabilityMismatchError) isSolverError()  {}
+func (*BorrowEscapeError) isSolverError()        {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -202,6 +228,20 @@ func (e *OptionalPropertyError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *OptionalPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *MutabilityMismatchError) Span() ast.Span {
+	// The immutable source borrow is the actual value; blame it, degrade to the
+	// mutable target, else the site.
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
+}
+func (e *MutabilityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *BorrowEscapeError) Span() ast.Span {
+	// The escaping borrow is the subject; blame it, degrade to the slot it escaped
+	// into, else the site.
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
+}
+func (e *BorrowEscapeError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -688,6 +728,16 @@ func (e *OptionalPropertyError) Message() string {
 	return "object property is optional but required: " + e.Name
 }
 
+func (e *MutabilityMismatchError) Message() string {
+	return fmt.Sprintf("cannot constrain immutable %s <: mutable %s",
+		describe(e.Sub.Inner), describe(e.Super.Inner))
+}
+
+func (e *BorrowEscapeError) Message() string {
+	return fmt.Sprintf("borrowed value %s does not live long enough to satisfy %s",
+		describe(e.Sub), describe(e.Super))
+}
+
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,
 // function, number). Distinct from soltype.Print, which renders coalesced
 // output as user-facing Escalier syntax (see m1-implementation-plan §2.2). It
@@ -725,6 +775,16 @@ func describe(t soltype.Type) string {
 		// and informative (`Promise<number>`), whereas a function/tuple/record would
 		// be verbose spelled out, so those stay nominal.
 		return "Promise<" + describe(t.Inner) + ">"
+	case *soltype.RefType:
+		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
+		// recursing like the Promise arm. The immutable-borrow and lifetime prefixes
+		// (`'a object`) join once the lifetime sort lands (D1); Lt is always nil here,
+		// so only `mut` appears.
+		prefix := ""
+		if t.Mut {
+			prefix = "mut "
+		}
+		return prefix + describe(t.Inner)
 	case *soltype.Void:
 		return "void"
 	case *soltype.NeverType:

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -128,6 +128,10 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
+		case *MutabilityMismatchError:
+			err.prov, err.site = c.prov, n
+		case *BorrowEscapeError:
+			err.prov, err.site = c.prov, n
 		}
 		c.errs = append(c.errs, e)
 	}


### PR DESCRIPTION
Implements the single RefType <: RefType constraint rule (THE GATE, M4 C2), which gates all borrow-related type checking. This adds mutable borrow support and the mut-driven inner invariance property that is central to the borrow system.

## Key changes

- **New type: RefType** (`internal/soltype/type.go`, `internal/soltype/ref.go`). A wrapper for borrows and mutability with fields `Mut`, `Lt` (lifetime, always nil in C1), and `Inner` (a RefInner). The degenerate immutable-no-lifetime cell collapses to the bare inner via `NewRef`, so every *RefType in the system represents a meaningful borrow. Helper functions `UnwrapRef`, `CarrierOf`, and `BorrowableType` provide standard operations.

- **RefInner sealed set** (`internal/soltype/type.go`). ObjectType, TupleType, and TypeVarType are borrowable; PrimType, LitType, FuncType, and PromiseType are not. This prevents meaningless constructs like `mut number`.

- **RefType <: RefType rule** (`internal/solver/constrain.go`). The headline property is mut-driven inner invariance: a mutable target takes both a covariant read view and a contravariant write view, so the inner is invariant. An immutable source cannot fill a mutable slot (MutabilityMismatchError). Owned values (Lt nil) satisfy bare slots; borrowed values escaping into owned slots error (BorrowEscapeError, inert in C2). Variables record the whole borrow as a bound, not the peeled inner.

- **bare <: RefType wrapping** (`internal/solver/constrain.go`). A borrowable owned source wraps as an immutable view and re-dispatches into the RefType rule. Non-borrowable sources (primitives, functions) fall through to CannotConstrainError naming the borrow (review finding 2).

- **Error types** (`internal/solver/errors.go`). MutabilityMismatchError for immutable <: mutable violations. BorrowEscapeError for borrowed values escaping into owned slots (wired now, inert until D1/D2 add Lifetime concretes). Both render with `describe` support for RefType.

- **Type system integration**. RefType integrates into `LevelOf` (level is the inner's), the visitor pattern (Accept walks the inner once covariant, peels non-RefInner results), and printing (renders as `mut {x: number}` etc.). Snapshot tests cover roundtrip printing and scheme generalization of borrowed generics.

- **Comprehensive test coverage** (`internal/solver/constrain_test.go`, `internal/solver/coalesce_test.go`, `internal/soltype/ref_test.go`). Tests pin the invariance property, mut-decay, mutability mismatch, variable bounds, and the peeling behavior when a borrowed variable inlines to a non-borrowable type.

## Implementation notes

The mut-driven invariance is encoded cleanly against the journal: a variable inside a mutable inner is invariant because the RefType rule adds both a read constraint (covariant) and a write constraint (contravariant) through the ordinary bound machinery, with no special journaling. This is load-bearing for the design.

Lt is always nil in C1, so immutable-borrow and lifetime forms are unreachable. The lifetime outlives check and the BorrowEscapeError firing path are wired now and exercised from D1/D2.

https://claude.ai/code/session_01KXgyZZgkH6v2FeShiHukSg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reference type support with mutability and lifetime tracking to the type system.
  * Implemented borrow escape detection to report when borrowed values outlive their scope.
  * Extended type constraint rules to enforce mutable and immutable reference compatibility.

* **Improvements**
  * Enhanced type printing to properly display borrowed and mutable type references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->