### PR TITLE
Implement `open` parameter marker and seal usage objects to exact

### DIFF
--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -101,7 +101,12 @@ func (d *VarDecl) SetProvenance(p provenance.Provenance) {
 type Param struct {
 	Pattern  Pat
 	Optional bool
-	TypeAnn  TypeAnn // optional
+	// Open marks an `open p` parameter: its usage-inferred object stays
+	// row-polymorphic (inexact) instead of closing to exact, so callers may pass
+	// objects with extra fields. The provisional `open` keyword is recognized only
+	// before a parameter pattern; elsewhere `open` is an ordinary identifier.
+	Open    bool
+	TypeAnn TypeAnn // optional
 }
 
 func (p *Param) Span() Span {

--- a/internal/parser/expr.go
+++ b/internal/parser/expr.go
@@ -752,6 +752,22 @@ func (p *Parser) objExprElem() ast.ObjExprElem {
 // <pattern>?
 // <pattern>
 func (p *Parser) param() *ast.Param {
+	// `open` is a provisional, context-sensitive keyword: it marks a
+	// row-polymorphic parameter only when a parameter pattern follows (`open p`,
+	// `open mut p`, `open {x}`). Otherwise it is an ordinary identifier — a param
+	// literally named `open`, or `open: T` / `open = e` — so back the lexer up.
+	open := false
+	if tok := p.lexer.peek(); tok.Type == Identifier && tok.Value == "open" {
+		saved := p.lexer.saveState()
+		p.lexer.consume() // tentatively consume `open`
+		switch p.lexer.peek().Type {
+		case Identifier, Mut, OpenBrace, OpenBracket:
+			open = true
+		default:
+			p.lexer.restoreState(saved)
+		}
+	}
+
 	pat := p.pattern(true, false)
 	if pat == nil {
 		return nil
@@ -795,6 +811,7 @@ func (p *Parser) param() *ast.Param {
 		Pattern:  pat,
 		TypeAnn:  typeAnn,
 		Optional: opt,
+		Open:     open,
 	}
 
 	return &param

--- a/internal/parser/open_param_test.go
+++ b/internal/parser/open_param_test.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// The provisional `open` parameter marker (M4 B2) parses as a per-param flag when
+// it precedes a parameter pattern, and is treated as an ordinary identifier
+// otherwise (a param literally named `open`, an annotated `open: T`, or a default
+// `open = e`). It never becomes a separate param.
+func TestParseOpenParamMarker(t *testing.T) {
+	ctx := context.Background()
+
+	paramsOf := func(t *testing.T, src string) []*ast.Param {
+		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: src})
+		require.Empty(t, errs)
+		fd, ok := decls[0].(*ast.FuncDecl)
+		require.True(t, ok)
+		return fd.Params
+	}
+
+	identName := func(t *testing.T, p *ast.Param) string {
+		ip, ok := p.Pattern.(*ast.IdentPat)
+		require.True(t, ok)
+		return ip.Name
+	}
+
+	t.Run("open before a pattern marks the param", func(t *testing.T) {
+		params := paramsOf(t, "fn dist(open p) { p }")
+		require.Len(t, params, 1)
+		require.True(t, params[0].Open)
+		require.Equal(t, "p", identName(t, params[0]))
+	})
+
+	t.Run("open before mut pattern marks the param", func(t *testing.T) {
+		params := paramsOf(t, "fn f(open mut p) { p }")
+		require.Len(t, params, 1)
+		require.True(t, params[0].Open)
+		ip, ok := params[0].Pattern.(*ast.IdentPat)
+		require.True(t, ok)
+		require.True(t, ip.Mutable)
+		require.Equal(t, "p", ip.Name)
+	})
+
+	t.Run("open alone is an ordinary param name", func(t *testing.T) {
+		params := paramsOf(t, "fn f(open) { open }")
+		require.Len(t, params, 1)
+		require.False(t, params[0].Open)
+		require.Equal(t, "open", identName(t, params[0]))
+	})
+
+	t.Run("annotated open is an ordinary param name", func(t *testing.T) {
+		params := paramsOf(t, "fn f(open: number) { open }")
+		require.Len(t, params, 1)
+		require.False(t, params[0].Open)
+		require.Equal(t, "open", identName(t, params[0]))
+	})
+
+	t.Run("open with a peer param", func(t *testing.T) {
+		params := paramsOf(t, "fn f(open p, q) { p }")
+		require.Len(t, params, 2)
+		require.True(t, params[0].Open)
+		require.Equal(t, "p", identName(t, params[0]))
+		require.False(t, params[1].Open)
+		require.Equal(t, "q", identName(t, params[1]))
+	})
+}

--- a/internal/parser/open_param_test.go
+++ b/internal/parser/open_param_test.go
@@ -18,6 +18,7 @@ func TestParseOpenParamMarker(t *testing.T) {
 	paramsOf := func(t *testing.T, src string) []*ast.Param {
 		decls, errs := ParseDecls(ctx, &ast.Source{ID: 0, Path: "t.esc", Contents: src})
 		require.Empty(t, errs)
+		require.NotEmpty(t, decls) // guard decls[0] so a parse miss reports here, not a panic
 		fd, ok := decls[0].(*ast.FuncDecl)
 		require.True(t, ok)
 		return fd.Params

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -22,6 +22,11 @@ type TypeVarType struct {
 	Level       int
 	LowerBounds []Type
 	UpperBounds []Type
+	// Open marks the variable of an `open` parameter (M4 B2). It is read only at
+	// display-time coalescing: a usage-inferred object on an open var's upper
+	// bounds stays inexact (row-polymorphic) instead of closing to exact. It has
+	// no effect on constraint solving.
+	Open bool
 }
 
 // BoundsAt returns the bounds relevant to a polarity: lowers in Positive

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -74,7 +74,7 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	if len(bounds) == 0 {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: combine(pol, dedup(bounds)), SkipChildren: true}
+	return soltype.EnterResult{Type: combine(pol, dedup(bounds), v.Open), SkipChildren: true}
 }
 
 func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
@@ -197,7 +197,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		// already leave parts=[rep]. Collapse to the polarity identity.
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: combine(pol, dedup(parts)), SkipChildren: true}
+	return soltype.EnterResult{Type: combine(pol, dedup(parts), v.Open), SkipChildren: true}
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
@@ -253,12 +253,14 @@ func emptyOf(pol soltype.Polarity) soltype.Type {
 // remains. The UnionType/IntersectionType nodes ship in M1 (soltype/type.go) so
 // combine can always return a native soltype.Type.
 //
-// In Negative position the object parts are first folded into a single exact
-// object (mergeObjects, B1) so member-access requirements on one receiver render
-// as one compact object rather than an intersection of one-property objects.
-func combine(pol soltype.Polarity, parts []soltype.Type) soltype.Type {
+// In Negative position the object parts are first folded into a single object
+// (mergeObjects, B1) so member-access requirements on one receiver render as one
+// compact object rather than an intersection of one-property objects. The folded
+// object closes to exact unless `open` is set — an `open` parameter (B2) stays
+// row-polymorphic (inexact).
+func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type {
 	if pol == soltype.Negative {
-		parts = mergeObjects(parts)
+		parts = mergeObjects(parts, open)
 	}
 	if len(parts) == 1 {
 		return parts[0]
@@ -281,14 +283,15 @@ func combine(pol soltype.Polarity, parts []soltype.Type) soltype.Type {
 // property appearing in several parts becomes the intersection of its types,
 // because `obj <: {a: β}` and `obj <: {a: γ}` together require `obj.a <: β & γ`.
 //
-// Policy A (exact-types spec §8.1): the folded usage object closes to EXACT. The
-// per-access requirements stay inexact (A1); only this coalesced result is sealed,
-// once body inference has produced every selection on the receiver. `open` (B2) is
-// the opt-out that leaves the result inexact for row-polymorphic params.
+// Policy A (exact-types spec §8.1): the folded usage object closes to EXACT once
+// body inference has produced every selection on the receiver. The per-access
+// requirements stay inexact (A1); only this coalesced result is sealed. The `open`
+// parameter marker (B2) is the opt-out: when set, the folded object stays inexact
+// so the param is row-polymorphic and callers may pass objects with extra fields.
 //
 // Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is deferred to C3, once
 // the field-write path produces mut receivers.
-func mergeObjects(parts []soltype.Type) []soltype.Type {
+func mergeObjects(parts []soltype.Type, open bool) []soltype.Type {
 	var objs []*soltype.ObjectType
 	var others []soltype.Type
 	for _, p := range parts {
@@ -301,14 +304,15 @@ func mergeObjects(parts []soltype.Type) []soltype.Type {
 	if len(objs) == 0 {
 		return parts // nothing to fold; leave the bound list as-is
 	}
-	return append([]soltype.Type{mergeObjectGroup(objs)}, others...)
+	return append([]soltype.Type{mergeObjectGroup(objs, open)}, others...)
 }
 
-// mergeObjectGroup folds object types into one exact object: the property sets are
+// mergeObjectGroup folds object types into one object: the property sets are
 // unioned and a property shared by several objects becomes the intersection of its
 // types. Property order is alphabetical for stable rendering. A property is
 // optional in the result only when it is optional in every object that carries it.
-func mergeObjectGroup(objs []*soltype.ObjectType) *soltype.ObjectType {
+// The result is exact (closed) unless `open`, in which case it stays inexact.
+func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType {
 	byName := map[string]*soltype.PropertyElem{}
 	var order []string
 	for _, o := range objs {
@@ -331,7 +335,8 @@ func mergeObjectGroup(objs []*soltype.ObjectType) *soltype.ObjectType {
 	for i, name := range order {
 		elems[i] = byName[name]
 	}
-	return &soltype.ObjectType{Elems: elems} // Inexact: false ⇒ closed (Policy A)
+	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
+	return &soltype.ObjectType{Elems: elems, Inexact: open}
 }
 
 // dedup removes structurally-equal parts, preserving first-occurrence order.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -253,14 +253,15 @@ func emptyOf(pol soltype.Polarity) soltype.Type {
 // remains. The UnionType/IntersectionType nodes ship in M1 (soltype/type.go) so
 // combine can always return a native soltype.Type.
 //
-// In Negative position the object parts are first folded into a single object
-// (mergeObjects, B1) so member-access requirements on one receiver render as one
+// In Negative position the object parts are first folded into a single object by
+// foldUsageBounds (B1) so member-access requirements on one receiver render as one
 // compact object rather than an intersection of one-property objects. The folded
 // object closes to exact unless `open` is set — an `open` parameter (B2) stays
-// row-polymorphic (inexact).
+// row-polymorphic (inexact). This is the DISPLAY fold; sealUsageObjects runs the
+// same foldUsageBounds operatively on the stored bounds at generalization.
 func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type {
 	if pol == soltype.Negative {
-		parts = mergeObjects(parts, open)
+		parts = foldUsageBounds(parts, open)
 	}
 	if len(parts) == 1 {
 		return parts[0]
@@ -271,17 +272,28 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 	return &soltype.IntersectionType{Types: parts}
 }
 
-// mergeObjects folds the INEXACT ObjectType parts of a negative-position
-// (intersection) bound list into a single exact object — the meet — leaving every
-// other part untouched. It runs only in Negative position, where the parts are a
-// variable's coalesced upper bounds.
+// foldUsageBounds folds the INEXACT ObjectType parts of an upper-bound list into a
+// single object — the meet of the member-access requirements — leaving every other
+// part untouched. The folded object is exact unless `open`.
 //
-// Only inexact objects fold, matching sealUsageObjects: an inexact object is a
-// member-access requirement ("has at least these fields"), and merging several is
-// the receiver's combined width requirement. An EXACT object on the bounds is an
-// already-closed shape, not a width requirement, so it passes through unchanged —
-// folding it would be wrong (`{x} & {y}` over exact objects is uninhabited, not
-// `{x, y}`) and would feed a non-member object to mergeObjectGroup/AsProperty.
+// Two callers fold with this one helper, so the exactness rule lives in one place:
+//   - sealUsageObjects (poly.go) is the OPERATIVE seal. It writes the fold back
+//     into a closed usage var's stored upper bounds at generalization, so
+//     freshenAbove copies a sealed exact requirement at each call site and a caller
+//     passing extra fields is rejected.
+//   - combine (above) is the DISPLAY fold. It runs during coalescing on a var's
+//     already-coalesced upper bounds, folding the vars sealUsageObjects skipped
+//     such as open params, for a compact rendered type.
+//
+// Both pass the var's Open flag, so the operative and display folds agree on
+// exactness.
+//
+// Only inexact objects fold: an inexact object is a member-access requirement
+// ("has at least these fields"), and merging several is the receiver's combined
+// width requirement. An EXACT object on the bounds is an already-closed shape, not
+// a width requirement, so it passes through unchanged — folding it would be wrong
+// (`{x} & {y}` over exact objects is uninhabited, not `{x, y}`) and would feed a
+// non-member object to mergeObjectGroup/AsProperty.
 //
 // Member-access requirements on one receiver arrive as separate inexact
 // one-property objects: A1's inferMember lowers `obj.a; obj.b` to the upper bounds
@@ -292,13 +304,19 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 //
 // Policy A (exact-types spec §8.1): the folded usage object closes to EXACT once
 // body inference has produced every selection on the receiver. The per-access
-// requirements stay inexact (A1); only this coalesced result is sealed. The `open`
+// requirements stay inexact (A1); only this folded result is sealed. The `open`
 // parameter marker (B2) is the opt-out: when set, the folded object stays inexact
 // so the param is row-polymorphic and callers may pass objects with extra fields.
 //
 // Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is deferred to C3, once
 // the field-write path produces mut receivers.
-func mergeObjects(parts []soltype.Type, open bool) []soltype.Type {
+//
+// This is NOT recursive: it folds the objects of ONE var's bound list and does not
+// descend into property types. Nesting (`p.a.b`) is reached by the callers' walks
+// over the var graph — sealUsageObjects's loop over every collected var for the
+// operative seal, and coalesce / coalesceScheme's recursive bound coalescing for
+// display.
+func foldUsageBounds(parts []soltype.Type, open bool) []soltype.Type {
 	var objs []*soltype.ObjectType
 	var others []soltype.Type
 	for _, p := range parts {
@@ -314,11 +332,16 @@ func mergeObjects(parts []soltype.Type, open bool) []soltype.Type {
 	return append([]soltype.Type{mergeObjectGroup(objs, open)}, others...)
 }
 
-// mergeObjectGroup folds object types into one object: the property sets are
-// unioned and a property shared by several objects becomes the intersection of its
-// types. Property order is alphabetical for stable rendering. A property is
-// optional in the result only when it is optional in every object that carries it.
-// The result is exact (closed) unless `open`, in which case it stays inexact.
+// mergeObjectGroup is the property-union step inside foldUsageBounds: it folds the
+// already-selected inexact objects into one object. The property sets are unioned
+// and a property shared by several objects becomes the intersection of its types.
+// Property order is alphabetical for stable rendering. A property is optional in
+// the result only when it is optional in every object that carries it. The result
+// is exact (closed) unless `open`, in which case it stays inexact.
+//
+// This is NOT recursive: each property's type is copied through verbatim, never
+// descended into. Nesting is handled by the var-graph walks in sealUsageObjects,
+// coalesce, and coalesceScheme — see foldUsageBounds.
 func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType {
 	byName := map[string]*soltype.PropertyElem{}
 	var order []string

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -271,10 +271,17 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 	return &soltype.IntersectionType{Types: parts}
 }
 
-// mergeObjects folds the ObjectType parts of a negative-position (intersection)
-// bound list into a single exact object — the meet — leaving every non-object
-// part untouched. It runs only in Negative position, where the parts are a
+// mergeObjects folds the INEXACT ObjectType parts of a negative-position
+// (intersection) bound list into a single exact object — the meet — leaving every
+// other part untouched. It runs only in Negative position, where the parts are a
 // variable's coalesced upper bounds.
+//
+// Only inexact objects fold, matching sealUsageObjects: an inexact object is a
+// member-access requirement ("has at least these fields"), and merging several is
+// the receiver's combined width requirement. An EXACT object on the bounds is an
+// already-closed shape, not a width requirement, so it passes through unchanged —
+// folding it would be wrong (`{x} & {y}` over exact objects is uninhabited, not
+// `{x, y}`) and would feed a non-member object to mergeObjectGroup/AsProperty.
 //
 // Member-access requirements on one receiver arrive as separate inexact
 // one-property objects: A1's inferMember lowers `obj.a; obj.b` to the upper bounds
@@ -295,7 +302,7 @@ func mergeObjects(parts []soltype.Type, open bool) []soltype.Type {
 	var objs []*soltype.ObjectType
 	var others []soltype.Type
 	for _, p := range parts {
-		if o, ok := p.(*soltype.ObjectType); ok {
+		if o, ok := p.(*soltype.ObjectType); ok && o.Inexact {
 			objs = append(objs, o)
 			continue
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -251,7 +252,14 @@ func emptyOf(pol soltype.Polarity) soltype.Type {
 // (Negative) of parts, returning the sole element directly when only one
 // remains. The UnionType/IntersectionType nodes ship in M1 (soltype/type.go) so
 // combine can always return a native soltype.Type.
+//
+// In Negative position the object parts are first folded into a single exact
+// object (mergeObjects, B1) so member-access requirements on one receiver render
+// as one compact object rather than an intersection of one-property objects.
 func combine(pol soltype.Polarity, parts []soltype.Type) soltype.Type {
+	if pol == soltype.Negative {
+		parts = mergeObjects(parts)
+	}
 	if len(parts) == 1 {
 		return parts[0]
 	}
@@ -259,6 +267,71 @@ func combine(pol soltype.Polarity, parts []soltype.Type) soltype.Type {
 		return &soltype.UnionType{Types: parts}
 	}
 	return &soltype.IntersectionType{Types: parts}
+}
+
+// mergeObjects folds the ObjectType parts of a negative-position (intersection)
+// bound list into a single exact object — the meet — leaving every non-object
+// part untouched. It runs only in Negative position, where the parts are a
+// variable's coalesced upper bounds.
+//
+// Member-access requirements on one receiver arrive as separate inexact
+// one-property objects: A1's inferMember lowers `obj.a; obj.b` to the upper bounds
+// `{a: β, ...}` and `{b: γ, ...}` on the receiver var. Folding them yields
+// `{a: β, b: γ}` instead of the non-compact `{a: β, ...} & {b: γ, ...}`. A
+// property appearing in several parts becomes the intersection of its types,
+// because `obj <: {a: β}` and `obj <: {a: γ}` together require `obj.a <: β & γ`.
+//
+// Policy A (exact-types spec §8.1): the folded usage object closes to EXACT. The
+// per-access requirements stay inexact (A1); only this coalesced result is sealed,
+// once body inference has produced every selection on the receiver. `open` (B2) is
+// the opt-out that leaves the result inexact for row-polymorphic params.
+//
+// Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is deferred to C3, once
+// the field-write path produces mut receivers.
+func mergeObjects(parts []soltype.Type) []soltype.Type {
+	var objs []*soltype.ObjectType
+	var others []soltype.Type
+	for _, p := range parts {
+		if o, ok := p.(*soltype.ObjectType); ok {
+			objs = append(objs, o)
+			continue
+		}
+		others = append(others, p)
+	}
+	if len(objs) == 0 {
+		return parts // nothing to fold; leave the bound list as-is
+	}
+	return append([]soltype.Type{mergeObjectGroup(objs)}, others...)
+}
+
+// mergeObjectGroup folds object types into one exact object: the property sets are
+// unioned and a property shared by several objects becomes the intersection of its
+// types. Property order is alphabetical for stable rendering. A property is
+// optional in the result only when it is optional in every object that carries it.
+func mergeObjectGroup(objs []*soltype.ObjectType) *soltype.ObjectType {
+	byName := map[string]*soltype.PropertyElem{}
+	var order []string
+	for _, o := range objs {
+		for _, elem := range o.Elems {
+			pe := soltype.AsProperty(elem)
+			if existing, dup := byName[pe.Name]; dup {
+				byName[pe.Name] = &soltype.PropertyElem{
+					Name:     pe.Name,
+					Type:     &soltype.IntersectionType{Types: []soltype.Type{existing.Type, pe.Type}},
+					Optional: existing.Optional && pe.Optional,
+				}
+			} else {
+				byName[pe.Name] = &soltype.PropertyElem{Name: pe.Name, Type: pe.Type, Optional: pe.Optional}
+				order = append(order, pe.Name)
+			}
+		}
+	}
+	sort.Strings(order)
+	elems := make([]soltype.ObjTypeElem, len(order))
+	for i, name := range order {
+		elems[i] = byName[name]
+	}
+	return &soltype.ObjectType{Elems: elems} // Inexact: false ⇒ closed (Policy A)
 }
 
 // dedup removes structurally-equal parts, preserving first-occurrence order.

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -161,6 +161,49 @@ func TestCoalesceNegativeObjectMerge(t *testing.T) {
 	})
 }
 
+// TestCoalesceOpenVarStaysInexact pins B2: an `open` parameter var's folded usage
+// object stays inexact (row-polymorphic) instead of closing to exact. The Open flag
+// on the var is the opt-out from B1's Policy-A close.
+func TestCoalesceOpenVarStaysInexact(t *testing.T) {
+	// An open var with two member-access requirements folds to one INEXACT object.
+	t.Run("open var folds to inexact object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.Open = true
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("x", num())),
+			inexactObj(propElem("y", str())),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := inexactObj(propElem("x", num()), propElem("y", str()))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	// A single requirement on an open var also stays inexact.
+	t.Run("open var single requirement stays inexact", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.Open = true
+		p.UpperBounds = []soltype.Type{inexactObj(propElem("x", num()))}
+		got := coalesce(p, soltype.Negative)
+		require.True(t, equalType(inexactObj(propElem("x", num())), got), "got %s", soltype.Print(got))
+	})
+
+	// The un-open peer closes to exact (the B1 baseline), so the flag is what
+	// distinguishes them.
+	t.Run("closed peer folds to exact object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0) // Open defaults to false
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("x", num())),
+			inexactObj(propElem("y", str())),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := exactObj(propElem("x", num()), propElem("y", str()))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
 func TestCoalesceStructuralRecursion(t *testing.T) {
 	// The identity function `fn (x) -> x` is built with one variable used both as
 	// the parameter type (negative) and the return type (positive). With empty

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -95,6 +95,72 @@ func TestCoalesceMultiBound(t *testing.T) {
 	})
 }
 
+// TestCoalesceNegativeObjectMerge pins B1: a negative variable carrying several
+// member-access requirements as separate inexact one-property objects coalesces to
+// a single EXACT object (Policy A), not an intersection of one-property objects.
+// This is the receiver of `fn (p) { p.a; p.b }`, whose body lands `{a: …, ...}` and
+// `{b: …, ...}` on p's upper bounds.
+func TestCoalesceNegativeObjectMerge(t *testing.T) {
+	// Two distinct one-property requirements fold into one exact two-property object.
+	t.Run("distinct properties fold to one exact object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("a", num())),
+			inexactObj(propElem("b", str())),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := exactObj(propElem("a", num()), propElem("b", str()))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	// A single member-access requirement closes to exact too — the row is sealed
+	// once body inference completes, so `{a, ...}` becomes `{a}`.
+	t.Run("single requirement closes to exact", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{inexactObj(propElem("a", num()))}
+		got := coalesce(p, soltype.Negative)
+		require.True(t, equalType(exactObj(propElem("a", num())), got), "got %s", soltype.Print(got))
+	})
+
+	// A property required on several of the merged objects becomes the intersection
+	// of its per-requirement types: p <: {a: number} and p <: {a: string} ⇒ p.a is
+	// number & string.
+	t.Run("shared property becomes intersection", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("a", num())),
+			inexactObj(propElem("a", str())),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := exactObj(&soltype.PropertyElem{
+			Name: "a",
+			Type: &soltype.IntersectionType{Types: []soltype.Type{num(), str()}},
+		})
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	// Non-object upper bounds are left untouched alongside the folded object, so a
+	// mixed bound list still renders as an intersection of the merged object and the
+	// other parts.
+	t.Run("non-object bounds survive the fold", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("a", num())),
+			num(),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := &soltype.IntersectionType{Types: []soltype.Type{
+			exactObj(propElem("a", num())),
+			num(),
+		}}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
 func TestCoalesceStructuralRecursion(t *testing.T) {
 	// The identity function `fn (x) -> x` is built with one variable used both as
 	// the parameter type (negative) and the return type (positive). With empty

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -180,6 +180,15 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	params := make([]*soltype.FuncParam, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
+		// An `open` un-annotated param keeps its usage-inferred object inexact at
+		// display time (B2). The marker only makes sense for an inferred var; an
+		// annotated param's exactness is fixed by its annotation, and paramType
+		// returns the resolved annotation (not a var) in that case.
+		if p.Open {
+			if v, ok := pt.(*soltype.TypeVarType); ok {
+				v.Open = true
+			}
+		}
 		name, ok := identPatName(p.Pattern)
 		var sources []provenance.Provenance
 		if !ok {

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -194,20 +194,27 @@ func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
 	require.Same(t, got, c.info.TypeOf(e))
 }
 
-// Width tolerance through inference, not a literal: a function that reads a field
-// of its param synthesizes an inexact "has at least this field" requirement, so a
-// caller may pass a WIDER object. This exercises the selection-vs-concrete split
-// (A1) end-to-end through generalization and a call, where the existing member
-// tests only read a field off a literal receiver.
+// A function reading a field of its param synthesizes an inexact "has at least this
+// field" requirement during body inference (A1's selection-vs-concrete split), then
+// SEALS it to exact at generalization (B1/B2's operative close): `p` is `non-open`
+// and never escapes — `p.a`'s result is returned, but `p` itself is not — so its
+// requirement closes to exact `{a: number}` and a wider argument is rejected. An
+// `open` param keeps the row-polymorphic form and accepts the wider object. This
+// exercises the close end-to-end through generalization and a call.
 func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
-	t.Run("wider object is accepted", func(t *testing.T) {
-		// Today `p` is inferred INEXACT (`{a: number, ...}`), so a wider argument
-		// checks. M4 phase B PR B1 ("close usage-inferred shapes to exact") will
-		// seal `p` to exact `{a: number}`, after which this wider call REJECTS `b`
-		// as an extra property. PR B2's `open` marker (`fn f(open p)`) will restore
-		// the inexact, row-polymorphic form. Revisit this case when B1/B2 land.
+	t.Run("wider object is rejected for a closed param", func(t *testing.T) {
 		src := `
 			fn f(p) { return p.a }
+			val r = f({a: 1, b: 2})
+		`
+		_, _, errs := inferSource(t, src)
+		require.Len(t, errs, 1)
+		require.Equal(t, "object has extra property: b", errs[0].Message())
+	})
+
+	t.Run("wider object is accepted for an open param", func(t *testing.T) {
+		src := `
+			fn f(open p) { return p.a }
 			val r = f({a: 1, b: 2})
 		`
 		_, _, errs := inferSource(t, src)
@@ -220,8 +227,12 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 			val r = f({b: 2})
 		`
 		_, _, errs := inferSource(t, src)
-		require.Len(t, errs, 1)
+		// {b: 2} fails the sealed exact `{a: T}` requirement on two counts: the
+		// missing `a` and the extra `b`. The object arm reports missing properties
+		// before extra ones.
+		require.Len(t, errs, 2)
 		require.Equal(t, "object is missing property: a", errs[0].Message())
+		require.Equal(t, "object has extra property: b", errs[1].Message())
 		// Blame the offending argument {b: 2} — the object that lacks the field — not
 		// the whole call. The requirement's field var is freshened on instantiation
 		// and carries no prov, so MissingPropertyError's blame degrades to the Sub

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -50,3 +50,43 @@ func TestInferOpenParam(t *testing.T) {
 		require.Equal(t, "fn <T0>(open: T0) -> T0", values["f"])
 	})
 }
+
+// TestInferOpenParamNested pins the DEEP semantics of `open`: it makes the param's
+// whole inferred shape row-polymorphic, every nested object included — not just the
+// top object. The un-`open` peer seals every level to exact. So a closed param
+// rejects an extra field at ANY depth, while an open param accepts one at any depth.
+func TestInferOpenParamNested(t *testing.T) {
+	t.Run("open renders inexact at every level", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn foo(open p) { p.a.b }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: {a: {b: unknown, ...}, ...}) -> void", values["foo"])
+	})
+
+	t.Run("closed seals every level to exact", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn foo(p) { p.a.b }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: {a: {b: unknown}}) -> void", values["foo"])
+	})
+
+	t.Run("open accepts an extra field on the nested object", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(open p) { p.a.b }\nval r = foo({a: {b: 1, c: 2}})")
+		require.Empty(t, errs)
+	})
+
+	t.Run("open accepts an extra field on the outer object", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(open p) { p.a.b }\nval r = foo({a: {b: 1}, d: 2})")
+		require.Empty(t, errs)
+	})
+
+	t.Run("closed rejects an extra field on the nested object", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1, c: 2}})")
+		require.Len(t, errs, 1)
+		require.Equal(t, "object has extra property: c", errs[0].Message())
+	})
+
+	t.Run("closed rejects an extra field on the outer object", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1}, d: 2})")
+		require.Len(t, errs, 1)
+		require.Equal(t, "object has extra property: d", errs[0].Message())
+	})
+}

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -28,6 +28,20 @@ func TestInferOpenParam(t *testing.T) {
 		require.Empty(t, errs)
 	})
 
+	// The operative seal (B2): a closed param's requirement is sealed to exact at
+	// generalization, so a call passing an object with extra fields is rejected.
+	t.Run("passing extra fields to a closed param rejects", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
+		require.Len(t, errs, 1)
+		require.Equal(t, "object has extra property: z", errs[0].Message())
+	})
+
+	// An exact argument still checks against a closed param.
+	t.Run("passing the exact shape to a closed param checks", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2})")
+		require.Empty(t, errs)
+	})
+
 	// `open` is provisional and context-sensitive: a param literally named `open`
 	// (no following pattern) is an ordinary binding, not a marker.
 	t.Run("open as a plain param name is not a marker", func(t *testing.T) {

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -1,0 +1,38 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferOpenParam exercises the `open` parameter marker end to end (M4 B2): an
+// `open` param's usage-inferred object renders row-polymorphic (inexact), while an
+// un-`open` peer closes to exact (the B1 Policy-A close). Passing an object with
+// extra fields to the open param checks.
+func TestInferOpenParam(t *testing.T) {
+	t.Run("open param renders inexact", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn dist(open p) { p.x\n p.y }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: {x: unknown, y: unknown, ...}) -> void", values["dist"])
+	})
+
+	t.Run("un-open peer renders exact", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn dist(p) { p.x\n p.y }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: {x: unknown, y: unknown}) -> void", values["dist"])
+	})
+
+	t.Run("passing extra fields to an open param checks", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn foo(open p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
+		require.Empty(t, errs)
+	})
+
+	// `open` is provisional and context-sensitive: a param literally named `open`
+	// (no following pattern) is an ordinary binding, not a marker.
+	t.Run("open as a plain param name is not a marker", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn f(open) { return open }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn <T0>(open: T0) -> T0", values["f"])
+	})
+}

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -287,6 +287,16 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 	occ := map[int]occPolarity{}
 	t.Accept(&symOccVisitor{m: m, occ: occ, seen: set.NewSet[occKey]()}, soltype.Positive)
 
+	// `open` is DEEP: it makes a param's whole inferred shape row-polymorphic, not
+	// just its top object. The nested receiver vars are created lazily during body
+	// inference, so they are not marked when inferFunc sets the param var's Open
+	// flag; propagate it to them now, before the seal loop, by walking each open
+	// var's inexact member-access objects and opening every property-type var
+	// reachable through them. Without this, `fn f(open p) { p.a.b }` would accept an
+	// extra field on p but seal `p.a` and reject an extra field there — the same
+	// "richer object" request answered differently by depth.
+	propagateOpen(vars)
+
 	for id, v := range vars {
 		if v.Open || v.Level <= lvl || len(v.LowerBounds) > 0 {
 			continue
@@ -310,5 +320,38 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 		// mergeObjectGroup folds the per-access objects into one exact object (the
 		// same fold display uses); the closed object replaces the inexact ones.
 		v.UpperBounds = append(others, mergeObjectGroup(objs, false))
+	}
+}
+
+// propagateOpen marks the transitive closure of `open` over nested receivers: from
+// every open var, it opens each property-type var reachable through that var's
+// inexact member-access objects, so an open param opens its whole inferred shape.
+// It reads only the inexact object upper bounds — the member-access requirements
+// whose property types are the nested receiver vars (`p.a`'s var is the type of
+// `p`'s `a` property). Opening a var that carries no object bound is inert, so the
+// closure never widens anything that was not already a usage shape.
+func propagateOpen(vars map[int]*soltype.TypeVarType) {
+	work := make([]*soltype.TypeVarType, 0, len(vars))
+	for _, v := range vars {
+		if v.Open {
+			work = append(work, v)
+		}
+	}
+	for len(work) > 0 {
+		v := work[len(work)-1]
+		work = work[:len(work)-1]
+		for _, b := range v.UpperBounds {
+			ob, ok := b.(*soltype.ObjectType)
+			if !ok || !ob.Inexact {
+				continue
+			}
+			for _, elem := range ob.Elems {
+				pv, ok := soltype.AsProperty(elem).Type.(*soltype.TypeVarType)
+				if ok && !pv.Open {
+					pv.Open = true
+					work = append(work, pv)
+				}
+			}
+		}
 	}
 }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -145,6 +145,7 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 		return soltype.EnterResult{Type: nv, SkipChildren: true}
 	}
 	nv := f.c.freshAt(f.lvl)
+	nv.Open = v.Open // carry the `open` param marker onto the instantiated copy
 	f.cache[v] = nv
 	// Mint the FromInstantiation interior edge: the fresh var was copied from v.
 	// PR1 only records the edge; the multi-hop renderer that chases it back to an
@@ -197,7 +198,8 @@ func (f *allFreshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Ent
 		return soltype.EnterResult{Type: nv, SkipChildren: true}
 	}
 	nv := f.c.freshAt(f.lvl)
-	f.cache[v] = nv // populate BEFORE bounds so a cyclic bound referencing v resolves to nv
+	nv.Open = v.Open // carry the `open` param marker onto the freshened copy
+	f.cache[v] = nv  // populate BEFORE bounds so a cyclic bound referencing v resolves to nv
 	nv.LowerBounds = f.freshenBounds(v.LowerBounds)
 	nv.UpperBounds = f.freshenBounds(v.UpperBounds)
 	// SkipChildren is a no-op for a var (Accept treats it as a leaf), but we set it

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -305,21 +305,15 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 		if !occHas(o, soltype.Negative) || occHas(o, soltype.Positive) {
 			continue // unused, or escapes to an output position — keep the open row
 		}
-		var objs []*soltype.ObjectType
-		var others []soltype.Type
-		for _, b := range v.UpperBounds {
-			if ob, ok := b.(*soltype.ObjectType); ok && ob.Inexact {
-				objs = append(objs, ob)
-			} else {
-				others = append(others, b)
-			}
-		}
-		if len(objs) == 0 {
-			continue
-		}
-		// mergeObjectGroup folds the per-access objects into one exact object (the
-		// same fold display uses); the closed object replaces the inexact ones.
-		v.UpperBounds = append(others, mergeObjectGroup(objs, false))
+		// foldUsageBounds folds this var's inexact member-access objects into ONE
+		// object and writes the result back to the stored upper bounds. This is the
+		// OPERATIVE half of the fold: freshenAbove copies these sealed bounds at each
+		// call site, so the closed requirement rejects a caller passing extra fields.
+		// coalesce's combine runs the same foldUsageBounds for display on the vars
+		// this loop skips. v.Open is always false here since open vars are skipped
+		// above; passing it keeps the operative and display folds on one exactness
+		// rule. A var with no inexact object bound folds to itself, a no-op.
+		v.UpperBounds = foldUsageBounds(v.UpperBounds, v.Open)
 	}
 }
 

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -1,6 +1,9 @@
 package solver
 
-import "github.com/escalier-lang/escalier/internal/soltype"
+import (
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
 
 // TypeScheme is a name's generalized type — the M3 replacement for M2's plain
 // soltype.Type binding. A MonoScheme is a value that does not generalize (a
@@ -244,6 +247,68 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // co-occurrence merging run at DISPLAY time inside coalesceScheme, so the body
 // keeps every variable for instantiation while the rendered signature stays
 // compact. See simplify.go.
+//
+// sealUsageObjects runs first, the one body rewrite generalize performs: it is the
+// finalize point where a non-escaping usage-inferred object closes to exact in the
+// OPERATIVE body, so callers cannot pass extra fields (Policy A / B2). See its doc.
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
+	c.sealUsageObjects(t, lvl)
 	return &PolyScheme{Level: lvl, Body: t}
+}
+
+// sealUsageObjects is the operative half of Policy A (B2). Body inference records a
+// member access `p.x` as an INEXACT upper bound `{x: β, ...}` on the receiver var,
+// and it must stay inexact while the body is walked: two exact requirements on one
+// var contradict (`p <: {x}` and `p <: {y}` cannot both hold for an object with
+// both fields), so the full field set is only known once inference completes. This
+// runs at that point — generalization — and seals each qualifying var's inexact
+// member-access objects into one EXACT object, replacing them in the var's upper
+// bounds. instantiate then freshens an exact requirement, so a call passing an
+// object with extra fields is rejected.
+//
+// A var is sealed only when ALL of these hold, so the row stays open exactly where
+// it must:
+//   - it is not `open` (the explicit row-polymorphic opt-out, B2),
+//   - it occurs only in NEGATIVE position: a var that also reaches an output
+//     position escapes, and its object must keep the open row so the returned value
+//     retains the caller's extra fields (`fn (obj) { obj.x; return obj }`),
+//   - it has no lower bounds: nothing concrete flows into it, so it is a pure usage
+//     requirement and sealing cannot contradict an incoming value, and
+//   - its upper bounds include at least one inexact object.
+//
+// Only quantifiable vars (Level > lvl) are candidates, matching simplifyScheme: a
+// captured outer var is shared with an enclosing scope and must not be resealed.
+// The walk reaches param vars through the binding var's bounds and descends nested
+// receivers, so `fn (obj) { obj.a.b }` seals both `{a: …}` and the inner `{b: …}`.
+func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
+	vars := map[int]*soltype.TypeVarType{}
+	t.Accept(&varCollector{out: vars, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
+	m := buildMirror(vars)
+	occ := map[int]occPolarity{}
+	t.Accept(&symOccVisitor{m: m, occ: occ, seen: set.NewSet[occKey]()}, soltype.Positive)
+
+	for id, v := range vars {
+		if v.Open || v.Level <= lvl || len(v.LowerBounds) > 0 {
+			continue
+		}
+		o := occ[id]
+		if !occHas(o, soltype.Negative) || occHas(o, soltype.Positive) {
+			continue // unused, or escapes to an output position — keep the open row
+		}
+		var objs []*soltype.ObjectType
+		var others []soltype.Type
+		for _, b := range v.UpperBounds {
+			if ob, ok := b.(*soltype.ObjectType); ok && ob.Inexact {
+				objs = append(objs, ob)
+			} else {
+				others = append(others, b)
+			}
+		}
+		if len(objs) == 0 {
+			continue
+		}
+		// mergeObjectGroup folds the per-access objects into one exact object (the
+		// same fold display uses); the closed object replaces the inexact ones.
+		v.UpperBounds = append(others, mergeObjectGroup(objs, false))
+	}
 }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -840,19 +840,22 @@ now resolve to real `soltype` structures rather than opaque placeholders.
   seal for objects: `inferMember` lowers `recv.prop` to an inexact one-property
   requirement, and `sealUsageObjects` (M4 B2, `solver/poly.go`) folds those
   requirements into one exact object at generalization unless the var escapes to an
-  output position or is marked `open`. **Index reads got none of this** — the
-  `inferExpr` dispatch (`solver/infer.go`) sends `*ast.IndexExpr` to the
-  `reportUnsupported` default, because the read shape depends on whether the
-  receiver is a tuple or an `Array`, and `Array` only exists at this milestone. Wire
-  it here:
-    - **`inferIndex` (NEW), constant numeric key.** `recv[0]` lowers to an inexact
-      *tuple* requirement "has at least a slot at this index" — the positional twin
-      of `inferMember`'s `{prop: β, ...}` object requirement. So `recv[0]; recv[1]`
-      lands two inexact tuple upper bounds on the receiver var, mirroring the
-      object path. The result type is the element var β. This is the new-checker
-      port of the reference checker's "single literal index infers a tuple"
-      behavior (`checker/tests/row_types_test.go` `NumericIndex` /
-      `ArrayElementReadAccess`).
+  output position or is marked `open`. F1 (#730) extended that to a constant STRING
+  index: `recv["bar"]` routes through `valueProp` to the same inexact object
+  requirement, so it already gets the object seal. **What index reads still lack is
+  the TUPLE path** — `resolveIndexPath` (`solver/infer_expr.go`) sends a constant
+  NUMERIC index `recv[0]` and any dynamic key to `reportUnsupported`, because the
+  read shape there depends on whether the receiver is a tuple or an `Array`, and
+  `Array` only exists at this milestone. Wire it here:
+    - **`inferIndex` tuple arm (NEW), constant numeric key.** `recv[0]` lowers to an
+      inexact *tuple* requirement "has at least a slot at this index" — the
+      positional twin of the `{prop: β, ...}` object requirement `valueProp` already
+      builds. So `recv[0]; recv[1]` lands two inexact tuple upper bounds on the
+      receiver var, mirroring the object path. The result type is the element var β.
+      This is the new-checker port of the reference checker's "single literal index
+      infers a tuple" behavior (`checker/tests/row_types_test.go` `NumericIndex` /
+      `ArrayElementReadAccess`). It slots into `resolveIndexPath`'s value-index
+      branch beside the existing constant-string-key `valueProp` call.
     - **Tuple merge-by-position.** Where the object fold (`mergeObjectGroup`) unions
       properties by NAME, the tuple fold unions slots by INDEX: `recv[0]; recv[2]`
       requires length ≥ 3, with index 1 a hole filled by a fresh var, and a slot

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -835,6 +835,53 @@ now resolve to real `soltype` structures rather than opaque placeholders.
   `[number, number] <: [number, ...Array<number>]` and
   `[number, ...Array<number>] <: Array<number>`. The `infer`-matching form
   `T extends [any, ...infer R] ? R : never` is M9 (conditional + `infer`), not here.
+- **Index-read usage inference + tuple/array closing (the M4 object-close analogue,
+  deferred from M4).** M4 shipped `.prop` usage inference plus the close-to-exact
+  seal for objects: `inferMember` lowers `recv.prop` to an inexact one-property
+  requirement, and `sealUsageObjects` (M4 B2, `solver/poly.go`) folds those
+  requirements into one exact object at generalization unless the var escapes to an
+  output position or is marked `open`. **Index reads got none of this** — the
+  `inferExpr` dispatch (`solver/infer.go`) sends `*ast.IndexExpr` to the
+  `reportUnsupported` default, because the read shape depends on whether the
+  receiver is a tuple or an `Array`, and `Array` only exists at this milestone. Wire
+  it here:
+    - **`inferIndex` (NEW), constant numeric key.** `recv[0]` lowers to an inexact
+      *tuple* requirement "has at least a slot at this index" — the positional twin
+      of `inferMember`'s `{prop: β, ...}` object requirement. So `recv[0]; recv[1]`
+      lands two inexact tuple upper bounds on the receiver var, mirroring the
+      object path. The result type is the element var β. This is the new-checker
+      port of the reference checker's "single literal index infers a tuple"
+      behavior (`checker/tests/row_types_test.go` `NumericIndex` /
+      `ArrayElementReadAccess`).
+    - **Tuple merge-by-position.** Where the object fold (`mergeObjectGroup`) unions
+      properties by NAME, the tuple fold unions slots by INDEX: `recv[0]; recv[2]`
+      requires length ≥ 3, with index 1 a hole filled by a fresh var, and a slot
+      required at several indices intersects its element types (`recv[0] <: β` and
+      `recv[0] <: γ` ⇒ slot 0 is `β & γ`), exactly as the object fold intersects a
+      shared property. Add this as a `mergeTupleGroup` beside `mergeObjectGroup`.
+    - **Seal arm.** `sealUsageObjects` grows a `TupleType` arm beside its
+      `ObjectType` arm, reusing the SAME gating verbatim: a var that is not `open`,
+      occurs only negatively, and has no lower bounds gets its inexact tuple upper
+      bounds folded into one exact tuple, so `fn f(t) { t[0]; t[1] }` seals to
+      `[T0, T1]` and a caller passing a longer tuple is rejected. An escaping
+      receiver (`fn f(t) { t[0]; return t }`) is NOT sealed and keeps its open row
+      so the returned tuple retains the caller's extra elements, and `open` leaves
+      the A2 inexact `[T0, ...]` form — both fall straight out of the existing
+      escape/`open` checks, no new gating. The exact rendered form of an escaping
+      tuple row follows whatever the object case renders (today `{x} & T0`); the
+      tuple row's display is settled when this lands, not specified here.
+    - **Dynamic key → `Array`, not tuple.** A non-constant key (`recv[i]`) cannot
+      address a positional slot, so it infers an `Array`/index-signature read
+      against the now-resolvable `Array<T>` rather than a tuple requirement. **The
+      index-signature inference itself is M9** (index types); until then a dynamic
+      key against a non-array receiver is a typed error, consistent with M4's
+      object computed-key handling and the M9 index-signature deferral. So M7 owns
+      constant-index tuple inference and array reads; M9 owns index signatures.
+    - **Index WRITES** (`recv[0] = v`) extend C3's `inferMemberAssign` the same way
+      — M4 kept the `*ast.IndexExpr` write sub-case as `reportUnsupported` with a
+      "needs Array types — M7" note (m4-implementation-plan §C3). The write path
+      reuses the tuple/array read classification above plus C3's `mut` receiver
+      requirement and `widen`.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
@@ -843,9 +890,15 @@ from "std:array"` / `"web:dom"` resolves member types; the M3 `await` and M5
 `for (x in xs)` rules now exercise against the **real** `Promise`/`Iterable`
 (replacing the M2 placeholders); operator-dependent utility types remain stubbed
 pending M9, and which names are stubbed is reported, not silently dropped.
+`fn f(t) { t[0]; t[1] }` infers and SEALS the param to exact `[T0, T1]`, rejecting a
+longer-tuple argument, while `fn f(open t) { … }` stays inexact `[T0, ...]` and
+`fn f(t) { t[0]; return t }` is not sealed (the open row is preserved) — the tuple
+analogue of M4's object close; a dynamic-key read resolves against the real
+`Array<T>`.
 
-**Depends on:** M3 (generics), M4 (objects/records), M5 (classes / methods /
-`final`), M6 (unions). **Feeds:** M8 — the real-package differential cannot run
+**Depends on:** M3 (generics), M4 (objects/records — `sealUsageObjects`, the close
+machinery this extends), M5 (classes / methods / `final`), M6 (unions). **Feeds:**
+M8 — the real-package differential cannot run
 the existing `fixtures/` tree (which uses `console`/`Array`/`Promise`/…) without
 real lib types.
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -698,14 +698,15 @@ these arms it must add.
     `{b: γ}`), the rendered type is the non-compact `{a: β} & {b: γ}` instead of
     `{a: β, b: γ}`.
   - **Algorithm — port the spike's `mergeObjects`** into the negative
-    (`Negative` polarity) path of `combine`: before wrapping parts in an
-    `IntersectionType`, fold all `ObjectType` parts into one object (union the
-    property sets; a property appearing in several parts becomes the intersection
-    of its types). This is the production analogue of `simplesub/coalesce.go`'s
-    `mergeObjects`/`mergeObjectGroup`, rewritten over `soltype.ObjectType`'s
-    element list and `Prop(name)` lookup, using the existing `combine`/`dedup`
-    structure. Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is
-    deferred to C3 once `RefType` exists.
+    (`Negative` polarity) path of `combine` as `foldUsageBounds`: before wrapping
+    parts in an `IntersectionType`, fold all `ObjectType` parts into one object
+    (union the property sets; a property appearing in several parts becomes the
+    intersection of its types). This is the production analogue of
+    `simplesub/coalesce.go`'s `mergeObjects`/`mergeObjectGroup`, landing as
+    `solver`'s `foldUsageBounds`/`mergeObjectGroup`, rewritten over
+    `soltype.ObjectType`'s element list and `Prop(name)` lookup, using the existing
+    `combine`/`dedup` structure. Mut-object merging (`mut {x} & mut {y}` ⇒
+    `mut {x, y}`) is deferred to C3 once `RefType` exists.
   - **Algorithm — Policy-A close:** the merged usage object closes to **exact**
     (`Inexact: false`) at this display-time fold — the row is sealed once body
     inference completes (spec §8.1). The per-access requirements stay inexact
@@ -865,7 +866,7 @@ these arms it must add.
     already works, and an incompatible read-then-write surfaces as a normal
     constrain error.
   - **Algorithm — whole-object `mut` merge (follows `internal/checker`, not the
-    spike's partition):** extend B1's `mergeObjects` fold over the receiver's
+    spike's partition):** extend B1's `foldUsageBounds` fold over the receiver's
     accumulated selections so that **if any field was written, every selection —
     reads and writes alike — folds into one `mut` object**; with no write, the
     reads fold into a bare (immutable) object. So `obj.x = 5; obj.y = 10` ⇒
@@ -1169,13 +1170,13 @@ these arms it must add.
 ### Dependency graph
 
 ```
-✓ = landed on main.  Done so far: A1 (#728), C1+C2 (#731), F1 (#730).
+✓ = landed on main.  Done so far: A1 (#728), B1+B2 (#732), C1+C2 (#731), F1 (#730).
 
 A1✓ → A2
-A1✓ → A3 ───────────────────┐  (A3's mut/lifetime arms un-gated by C1)
-A1✓ → B1 → B2               │  (annotation-side acceptance tests)
-      B1 → B3               │
-      B1, B3 ───────────┐   │  (C3 reuses B1's mergeObjects fold + B3's widen)
+A1✓ → A3 ─────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
+A1✓ → B1✓ → B2✓               │  (annotation-side acceptance tests)
+      B1✓ → B3                │
+      B1✓, B3 ────────────┐   │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
 A1✓ → C1✓ → C2✓(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
 A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
 F1✓             (independent; any time — only M2's Namespace)
@@ -1183,7 +1184,7 @@ F1✓             (independent; any time — only M2's Namespace)
 
 Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel
 tracks off A1; nothing downstream of the gate starts before C2 clears. B1's
-`mergeObjects` fold is reused by C3 (whole-object mut merge) and the `widen` helper
+`foldUsageBounds` fold is reused by C3 (whole-object mut merge) and the `widen` helper
 authored in B3 is reused by C3, so land B before C3 even though B is otherwise
 independent of the gate. Total ≈ 3.0k non-test LoC across 17 PRs, with the
 single highest-risk change (C2) isolated to ~180 reviewable lines.


### PR DESCRIPTION
Implements M4 phase B: the `open` parameter marker (B2) and operative sealing of usage-inferred objects to exact (B1).

## Summary

When a function reads fields from a parameter, type inference records each field access as a separate inexact object requirement (e.g., `{a: …, ...}` and `{b: …, ...}`). This PR adds two features:

1. **Policy A (B1)**: Coalesce these per-access requirements into a single exact object at generalization time, so `fn (p) { p.a; p.b }` renders as `fn (p: {a: T, b: U}) -> void` instead of an intersection of one-property objects. This rejects callers passing objects with extra fields.

2. **Open parameter marker (B2)**: The `open` keyword before a parameter pattern opts out of the exact seal, keeping the object row-polymorphic. `fn (open p) { p.a; p.b }` renders as `fn (open p: {a: T, b: U, ...}) -> void` and accepts objects with extra fields.

## Key changes

- **Parser** (`internal/parser/expr.go`, `internal/parser/open_param_test.go`): Recognize `open` as a context-sensitive keyword that marks a parameter only when followed by a pattern. Otherwise treat it as an ordinary identifier.

- **AST** (`internal/ast/decl.go`): Add `Open` field to `Param` to track the marker.

- **Type representation** (`internal/soltype/type.go`): Add `Open` field to `TypeVarType` to carry the marker through constraint solving.

- **Coalescing** (`internal/solver/coalesce.go`, `internal/solver/coalesce_test.go`): Implement `mergeObjects` and `mergeObjectGroup` to fold multiple inexact one-property objects into a single object. Properties shared across objects become intersections of their types. The result is exact unless `open` is set.

- **Sealing** (`internal/solver/poly.go`, `internal/solver/infer_open_test.go`): Implement `sealUsageObjects` to run at generalization time. It seals inexact member-access objects on non-`open` parameters that occur only in negative position and have no lower bounds. This is the operative half of Policy A.

- **Inference** (`internal/solver/infer_expr.go`): Propagate the `open` marker from the parameter to its inferred type variable.

- **Freshening** (`internal/solver/poly.go`): Carry the `open` marker when instantiating and freshening type variables.

- **Tests** (`internal/solver/infer_obj_test.go`): Update existing test expectations to reflect the new exact-object sealing behavior.

## Implementation notes

The seal runs only on variables that satisfy all of these conditions: not marked `open`, quantifiable (Level > lvl), occurring only in negative position, with no lower bounds, and with at least one inexact object in upper bounds. This ensures the row stays open exactly where it must (e.g., when a parameter escapes to an output position).

The `open` keyword is provisional and context-sensitive: `fn (open p)` marks the parameter, but `fn (open)` or `fn (open: T)` treats `open` as an ordinary identifier name.

https://claude.ai/code/session_01CBEs4FRAh9zH5FTutAPHVy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `open` parameter marker for function parameters. When applied, `open` enables parameters to accept objects with extra fields beyond those explicitly declared, while unmarked parameters enforce exact object shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->