### PR TITLE
M4 A3: object/tuple type annotations and construction-site excess check

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -207,12 +207,12 @@ func (*MappedTypeAnn) isObjTypeAnnElem()      {}
 func (*RestSpreadTypeAnn) isObjTypeAnnElem()  {}
 
 // No-op Doc/SetDoc impls for the variants that don't carry a JSDoc.
-func (*CallableTypeAnn) Doc() string       { return "" }
-func (*CallableTypeAnn) SetDoc(string)     {}
-func (*ConstructorTypeAnn) Doc() string    { return "" }
-func (*ConstructorTypeAnn) SetDoc(string)  {}
-func (*MappedTypeAnn) Doc() string         { return "" }
-func (*MappedTypeAnn) SetDoc(string)       {}
+func (*CallableTypeAnn) Doc() string      { return "" }
+func (*CallableTypeAnn) SetDoc(string)    {}
+func (*ConstructorTypeAnn) Doc() string   { return "" }
+func (*ConstructorTypeAnn) SetDoc(string) {}
+func (*MappedTypeAnn) Doc() string        { return "" }
+func (*MappedTypeAnn) SetDoc(string)      {}
 
 type CallableTypeAnn struct{ Fn *FuncTypeAnn }
 type ConstructorTypeAnn struct{ Fn *FuncTypeAnn }
@@ -223,9 +223,9 @@ type MethodTypeAnn struct {
 	doc      string
 }
 
-func (m *MethodTypeAnn) Span() Span { return m.Name.Span() }
-func (m *MethodTypeAnn) Doc() string         { return m.doc }
-func (m *MethodTypeAnn) SetDoc(doc string)   { m.doc = doc }
+func (m *MethodTypeAnn) Span() Span        { return m.Name.Span() }
+func (m *MethodTypeAnn) Doc() string       { return m.doc }
+func (m *MethodTypeAnn) SetDoc(doc string) { m.doc = doc }
 
 type GetterTypeAnn struct {
 	Name     ObjKey
@@ -234,9 +234,9 @@ type GetterTypeAnn struct {
 	doc      string
 }
 
-func (g *GetterTypeAnn) Span() Span { return g.Name.Span() }
-func (g *GetterTypeAnn) Doc() string         { return g.doc }
-func (g *GetterTypeAnn) SetDoc(doc string)   { g.doc = doc }
+func (g *GetterTypeAnn) Span() Span        { return g.Name.Span() }
+func (g *GetterTypeAnn) Doc() string       { return g.doc }
+func (g *GetterTypeAnn) SetDoc(doc string) { g.doc = doc }
 
 type SetterTypeAnn struct {
 	Name     ObjKey
@@ -245,9 +245,9 @@ type SetterTypeAnn struct {
 	doc      string
 }
 
-func (s *SetterTypeAnn) Span() Span { return s.Name.Span() }
-func (s *SetterTypeAnn) Doc() string         { return s.doc }
-func (s *SetterTypeAnn) SetDoc(doc string)   { s.doc = doc }
+func (s *SetterTypeAnn) Span() Span        { return s.Name.Span() }
+func (s *SetterTypeAnn) Doc() string       { return s.doc }
+func (s *SetterTypeAnn) SetDoc(doc string) { s.doc = doc }
 
 type MappedModifier string
 
@@ -268,9 +268,9 @@ type PropertyTypeAnn struct {
 	doc      string
 }
 
-func (p *PropertyTypeAnn) Span() Span { return p.Name.Span() }
-func (p *PropertyTypeAnn) Doc() string         { return p.doc }
-func (p *PropertyTypeAnn) SetDoc(doc string)   { p.doc = doc }
+func (p *PropertyTypeAnn) Span() Span        { return p.Name.Span() }
+func (p *PropertyTypeAnn) Doc() string       { return p.doc }
+func (p *PropertyTypeAnn) SetDoc(doc string) { p.doc = doc }
 
 type MappedTypeAnn struct {
 	TypeParam *IndexParamTypeAnn
@@ -313,6 +313,7 @@ func (t *RestSpreadTypeAnn) SetDoc(doc string) { t.doc = doc }
 
 type ObjectTypeAnn struct {
 	Elems        []ObjTypeAnnElem
+	Inexact      bool // trailing `...` marker: `{x: number, ...}` tolerates extra fields
 	span         Span
 	inferredType Type
 }
@@ -360,6 +361,7 @@ func (t *ObjectTypeAnn) Accept(v Visitor) {
 
 type TupleTypeAnn struct {
 	Elems        []TypeAnn
+	Inexact      bool // trailing `...` marker: `[number, ...]` tolerates extra elements
 	span         Span
 	inferredType Type
 }

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -1638,29 +1638,6 @@
 }
 ---
 
-[TestParseTypeAnnErrorHandling/RestSpreadMissingType - 1]
-&ast.TupleTypeAnn{
-    Elems: []ast.TypeAnn{
-        &ast.NumberTypeAnn{
-            span: 1:2-1:8,
-        },
-        &ast.ErrorTypeAnn{
-            span: 1:10-1:13,
-        },
-    },
-    span: 1:1-1:14,
-}
----
-
-[TestParseTypeAnnErrorHandling/RestSpreadMissingType - 2]
-[]*parser.Error{
-    &parser.Error{
-        Span: 1:10-1:13,
-        Message: "expected type annotation after '...'",
-    },
-}
----
-
 [TestParseTypeAnnNoErrors/UnionOfFunctions - 1]
 &ast.UnionTypeAnn{
     Types: []ast.TypeAnn{
@@ -1742,5 +1719,54 @@
         },
     },
     span: 1:2-1:55,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectInexact - 1]
+&ast.ObjectTypeAnn{
+    Elems: []ast.ObjTypeAnnElem{
+        &ast.PropertyTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "x",
+                span: 1:2-1:3,
+            },
+            Value: &ast.NumberTypeAnn{
+                span: 1:5-1:11,
+            },
+        },
+        &ast.PropertyTypeAnn{
+            Name: &ast.IdentExpr{
+                Name: "y",
+                span: 1:13-1:14,
+            },
+            Value: &ast.NumberTypeAnn{
+                span: 1:16-1:22,
+            },
+        },
+    },
+    Inexact: true,
+    span: 1:1-1:28,
+}
+---
+
+[TestParseTypeAnnNoErrors/TupleInexact - 1]
+&ast.TupleTypeAnn{
+    Elems: []ast.TypeAnn{
+        &ast.NumberTypeAnn{
+            span: 1:2-1:8,
+        },
+        &ast.StringTypeAnn{
+            span: 1:10-1:16,
+        },
+    },
+    Inexact: true,
+    span: 1:1-1:22,
+}
+---
+
+[TestParseTypeAnnNoErrors/ObjectInexactOnly - 1]
+&ast.ObjectTypeAnn{
+    Inexact: true,
+    span: 1:1-1:6,
 }
 ---

--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -51,6 +51,55 @@ func (p *Parser) parseFuncParams() (params []*ast.Param, inexact bool) {
 	}
 }
 
+// parseDelimSeqInexact parses a separator-delimited sequence up to (but not
+// consuming) the terminator, additionally recognizing a bare trailing `...` before
+// the terminator as an inexact marker — the object/tuple type-annotation analogue
+// of parseFuncParams' `fn(a, ...)`. A `...` immediately before the terminator
+// returns inexact=true; anything else after `...` (a rest-spread element `...T`) is
+// left for parserCombinator to parse, so the lexer is restored before falling
+// through. Comma handling matches parseDelimSeq, including a tolerated trailing
+// comma (the top-of-loop terminator check exits after the separator is consumed).
+func parseDelimSeqInexact[T any](
+	p *Parser,
+	terminator TokenType,
+	separator TokenType,
+	parserCombinator func() T,
+) (items []T, inexact bool) {
+	items = []T{}
+	for {
+		select {
+		case <-p.ctx.Done():
+			return items, inexact
+		default:
+		}
+
+		tok := p.lexer.peek()
+		if tok.Type == terminator || tok.Type == EndOfFile {
+			return items, inexact
+		}
+
+		if tok.Type == DotDotDot {
+			saved := p.lexer.saveState()
+			p.lexer.consume() // tentatively consume '...'
+			if p.lexer.peek().Type == terminator {
+				return items, true
+			}
+			p.lexer.restoreState(saved)
+		}
+
+		item := parserCombinator()
+		if any(item) == nil {
+			return items, inexact
+		}
+		items = append(items, item)
+
+		if p.lexer.peek().Type != separator {
+			return items, inexact
+		}
+		p.lexer.consume() // consume separator
+	}
+}
+
 func parseDelimSeq[T any](
 	p *Parser,
 	terminator TokenType,

--- a/internal/parser/combinators.go
+++ b/internal/parser/combinators.go
@@ -65,6 +65,43 @@ func parseDelimSeqInexact[T any](
 	separator TokenType,
 	parserCombinator func() T,
 ) (items []T, inexact bool) {
+	return parseDelimSeqHelper(p, terminator, separator, true, parserCombinator)
+}
+
+func parseDelimSeq[T any](
+	p *Parser,
+	terminator TokenType,
+	separator TokenType,
+	// TODO: update this to return `nil` instead of `optional.None` when there
+	// is no item
+	parserCombinator func() T,
+) []T {
+	items, _ := parseDelimSeqHelper(p, terminator, separator, false, parserCombinator)
+	return items
+}
+
+// parseDelimSeqHelper is the shared loop behind parseDelimSeq and
+// parseDelimSeqInexact. It parses a separator-delimited sequence up to (but not
+// consuming) the terminator, tolerating a trailing separator before the terminator.
+//
+// When recognizeInexact is set, a bare `...` immediately before the terminator is
+// consumed and returned as inexact=true; anything else after `...` is a rest-spread
+// element left for parserCombinator, so the lexer is restored before falling
+// through. When recognizeInexact is false the `...` is left untouched and inexact is
+// always false.
+//
+// recognizeInexact also selects the EOF behavior, the one other point the two forms
+// differ. The inexact form stops cleanly at EOF. The plain form instead runs
+// parserCombinator at EOF so it reports the expected-item / expected-terminator
+// error at the truncation point — e.g. `foo(a,` yields a trailing ErrorExpr and an
+// "Expected an expression" diagnostic.
+func parseDelimSeqHelper[T any](
+	p *Parser,
+	terminator TokenType,
+	separator TokenType,
+	recognizeInexact bool,
+	parserCombinator func() T,
+) (items []T, inexact bool) {
 	items = []T{}
 	for {
 		select {
@@ -74,11 +111,16 @@ func parseDelimSeqInexact[T any](
 		}
 
 		tok := p.lexer.peek()
-		if tok.Type == terminator || tok.Type == EndOfFile {
+		if tok.Type == terminator {
+			return items, inexact
+		}
+		// Only the inexact form treats EOF as a clean stop; the plain form falls
+		// through to parserCombinator so it reports the truncation error.
+		if tok.Type == EndOfFile && recognizeInexact {
 			return items, inexact
 		}
 
-		if tok.Type == DotDotDot {
+		if recognizeInexact && tok.Type == DotDotDot {
 			saved := p.lexer.saveState()
 			p.lexer.consume() // tentatively consume '...'
 			if p.lexer.peek().Type == terminator {
@@ -97,60 +139,5 @@ func parseDelimSeqInexact[T any](
 			return items, inexact
 		}
 		p.lexer.consume() // consume separator
-	}
-}
-
-func parseDelimSeq[T any](
-	p *Parser,
-	terminator TokenType,
-	separator TokenType,
-	// TODO: update this to return `nil` instead of `optional.None` when there
-	// is no item
-	parserCombinator func() T,
-) []T {
-	items := []T{}
-
-	// Empty sequence
-	token := p.lexer.peek()
-	if token.Type == terminator {
-		return items
-	}
-
-	item := parserCombinator()
-	if any(item) == nil {
-		return items
-	}
-	items = append(items, item)
-
-	for {
-		// Check if context has been cancelled (timeout or cancellation)
-		select {
-		case <-p.ctx.Done():
-			// Return what we have so far when context is done
-			return items
-		default:
-			// continue
-		}
-
-		token = p.lexer.peek()
-		if token.Type == EndOfFile {
-			// If we hit EOF before finding terminator, return what we have
-			return items
-		} else if token.Type == separator {
-			p.lexer.consume() // consume separator
-
-			token = p.lexer.peek()
-			if token.Type == terminator {
-				return items
-			}
-
-			item := parserCombinator()
-			if interface{}(item) == nil {
-				return items
-			}
-			items = append(items, item)
-		} else {
-			return items
-		}
 	}
 }

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -420,14 +420,18 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			typeAnn = ast.NewTypeOfTypeAnn(qualIdent, qualIdent.Span())
 		case OpenBracket: // tuple type
 			p.lexer.consume()
-			elemTypes := parseDelimSeq(p, CloseBracket, Comma, p.typeAnn)
+			elemTypes, tupleInexact := p.parseTupleTypeElems()
 			end := p.expect(CloseBracket, AlwaysConsume)
-			typeAnn = ast.NewTupleTypeAnn(elemTypes, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
+			tupleAnn := ast.NewTupleTypeAnn(elemTypes, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
+			tupleAnn.Inexact = tupleInexact
+			typeAnn = tupleAnn
 		case OpenBrace: // object type
 			p.lexer.consume() // consume '{'
-			elems := parseDelimSeq(p, CloseBrace, Comma, p.objTypeAnnElem)
+			elems, objInexact := p.parseObjectTypeElems()
 			end := p.expect(CloseBrace, AlwaysConsume)
-			typeAnn = ast.NewObjectTypeAnn(elems, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
+			objAnn := ast.NewObjectTypeAnn(elems, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
+			objAnn.Inexact = objInexact
+			typeAnn = objAnn
 		case Identifier:
 			p.lexer.consume()
 			typeAnn = p.parseTypeRef(token)
@@ -717,6 +721,89 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 	}
 
 	return nil
+}
+
+// parseTupleTypeElems parses the element list of a tuple type annotation up to the
+// closing `]`, reporting whether a bare trailing `...` marked the tuple inexact.
+// The `...` lookahead mirrors parseFuncParams: a `...` immediately before `]` is
+// the inexact marker, while `...T` is a rest-spread element that p.typeAnn parses.
+func (p *Parser) parseTupleTypeElems() (elems []ast.TypeAnn, inexact bool) {
+	elems = []ast.TypeAnn{}
+	for {
+		select {
+		case <-p.ctx.Done():
+			return elems, inexact
+		default:
+		}
+
+		tok := p.lexer.peek()
+		if tok.Type == CloseBracket || tok.Type == EndOfFile {
+			return elems, inexact
+		}
+
+		// A bare `...` (the next token after it is the closing bracket) marks the
+		// tuple inexact. Anything else after `...` is a rest-spread element (`...T`),
+		// which p.typeAnn parses, so back the lexer up and fall through.
+		if tok.Type == DotDotDot {
+			saved := p.lexer.saveState()
+			p.lexer.consume() // tentatively consume '...'
+			if p.lexer.peek().Type == CloseBracket {
+				return elems, true
+			}
+			p.lexer.restoreState(saved)
+		}
+
+		elem := p.typeAnn()
+		if elem == nil {
+			return elems, inexact
+		}
+		elems = append(elems, elem)
+
+		if p.lexer.peek().Type != Comma {
+			return elems, inexact
+		}
+		p.lexer.consume() // consume separator
+	}
+}
+
+// parseObjectTypeElems parses the member list of an object type annotation up to
+// the closing `}`, reporting whether a bare trailing `...` marked the object
+// inexact. Same `...` lookahead as parseTupleTypeElems: `...` before `}` is the
+// inexact marker, `...T` is a rest-spread member that objTypeAnnElem parses.
+func (p *Parser) parseObjectTypeElems() (elems []ast.ObjTypeAnnElem, inexact bool) {
+	elems = []ast.ObjTypeAnnElem{}
+	for {
+		select {
+		case <-p.ctx.Done():
+			return elems, inexact
+		default:
+		}
+
+		tok := p.lexer.peek()
+		if tok.Type == CloseBrace || tok.Type == EndOfFile {
+			return elems, inexact
+		}
+
+		if tok.Type == DotDotDot {
+			saved := p.lexer.saveState()
+			p.lexer.consume() // tentatively consume '...'
+			if p.lexer.peek().Type == CloseBrace {
+				return elems, true
+			}
+			p.lexer.restoreState(saved)
+		}
+
+		elem := p.objTypeAnnElem()
+		if elem == nil {
+			return elems, inexact
+		}
+		elems = append(elems, elem)
+
+		if p.lexer.peek().Type != Comma {
+			return elems, inexact
+		}
+		p.lexer.consume() // consume separator
+	}
 }
 
 // objTypeAnnElem parses a single member of an object type annotation

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -420,14 +420,14 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 			typeAnn = ast.NewTypeOfTypeAnn(qualIdent, qualIdent.Span())
 		case OpenBracket: // tuple type
 			p.lexer.consume()
-			elemTypes, tupleInexact := p.parseTupleTypeElems()
+			elemTypes, tupleInexact := parseDelimSeqInexact(p, CloseBracket, Comma, p.typeAnn)
 			end := p.expect(CloseBracket, AlwaysConsume)
 			tupleAnn := ast.NewTupleTypeAnn(elemTypes, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
 			tupleAnn.Inexact = tupleInexact
 			typeAnn = tupleAnn
 		case OpenBrace: // object type
 			p.lexer.consume() // consume '{'
-			elems, objInexact := p.parseObjectTypeElems()
+			elems, objInexact := parseDelimSeqInexact(p, CloseBrace, Comma, p.objTypeAnnElem)
 			end := p.expect(CloseBrace, AlwaysConsume)
 			objAnn := ast.NewObjectTypeAnn(elems, ast.NewSpan(token.Span.Start, end, p.lexer.source.ID))
 			objAnn.Inexact = objInexact
@@ -721,89 +721,6 @@ func (p *Parser) tryParseMappedType() *ast.MappedTypeAnn {
 	}
 
 	return nil
-}
-
-// parseTupleTypeElems parses the element list of a tuple type annotation up to the
-// closing `]`, reporting whether a bare trailing `...` marked the tuple inexact.
-// The `...` lookahead mirrors parseFuncParams: a `...` immediately before `]` is
-// the inexact marker, while `...T` is a rest-spread element that p.typeAnn parses.
-func (p *Parser) parseTupleTypeElems() (elems []ast.TypeAnn, inexact bool) {
-	elems = []ast.TypeAnn{}
-	for {
-		select {
-		case <-p.ctx.Done():
-			return elems, inexact
-		default:
-		}
-
-		tok := p.lexer.peek()
-		if tok.Type == CloseBracket || tok.Type == EndOfFile {
-			return elems, inexact
-		}
-
-		// A bare `...` (the next token after it is the closing bracket) marks the
-		// tuple inexact. Anything else after `...` is a rest-spread element (`...T`),
-		// which p.typeAnn parses, so back the lexer up and fall through.
-		if tok.Type == DotDotDot {
-			saved := p.lexer.saveState()
-			p.lexer.consume() // tentatively consume '...'
-			if p.lexer.peek().Type == CloseBracket {
-				return elems, true
-			}
-			p.lexer.restoreState(saved)
-		}
-
-		elem := p.typeAnn()
-		if elem == nil {
-			return elems, inexact
-		}
-		elems = append(elems, elem)
-
-		if p.lexer.peek().Type != Comma {
-			return elems, inexact
-		}
-		p.lexer.consume() // consume separator
-	}
-}
-
-// parseObjectTypeElems parses the member list of an object type annotation up to
-// the closing `}`, reporting whether a bare trailing `...` marked the object
-// inexact. Same `...` lookahead as parseTupleTypeElems: `...` before `}` is the
-// inexact marker, `...T` is a rest-spread member that objTypeAnnElem parses.
-func (p *Parser) parseObjectTypeElems() (elems []ast.ObjTypeAnnElem, inexact bool) {
-	elems = []ast.ObjTypeAnnElem{}
-	for {
-		select {
-		case <-p.ctx.Done():
-			return elems, inexact
-		default:
-		}
-
-		tok := p.lexer.peek()
-		if tok.Type == CloseBrace || tok.Type == EndOfFile {
-			return elems, inexact
-		}
-
-		if tok.Type == DotDotDot {
-			saved := p.lexer.saveState()
-			p.lexer.consume() // tentatively consume '...'
-			if p.lexer.peek().Type == CloseBrace {
-				return elems, true
-			}
-			p.lexer.restoreState(saved)
-		}
-
-		elem := p.objTypeAnnElem()
-		if elem == nil {
-			return elems, inexact
-		}
-		elems = append(elems, elem)
-
-		if p.lexer.peek().Type != Comma {
-			return elems, inexact
-		}
-		p.lexer.consume() // consume separator
-	}
 }
 
 // objTypeAnnElem parses a single member of an object type annotation

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -180,6 +180,15 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"TupleWithRestSpreadArray": {
 			input: "[number, ...Array<string>]",
 		},
+		"TupleInexact": {
+			input: "[number, string, ...]",
+		},
+		"ObjectInexact": {
+			input: "{x: number, y: number, ...}",
+		},
+		"ObjectInexactOnly": {
+			input: "{...}",
+		},
 		"UnionOfFunctions": {
 			input: "(fn (x: number) -> string) | (fn (x: string) -> number)",
 		},
@@ -232,9 +241,6 @@ func TestParseTypeAnnErrorHandling(t *testing.T) {
 		},
 		"ConditionalTypeMissingThen": {
 			input: "if A : B { } else { D }",
-		},
-		"RestSpreadMissingType": {
-			input: "[number, ...]",
 		},
 	}
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1243,7 +1243,11 @@ func (p *Printer) printTypeAnn(typ ast.TypeAnn) {
 
 func (p *Printer) printObjectTypeAnn(typ *ast.ObjectTypeAnn) {
 	if len(typ.Elems) == 0 {
-		p.writeString("{}")
+		if typ.Inexact {
+			p.writeString("{...}")
+		} else {
+			p.writeString("{}")
+		}
 		return
 	}
 
@@ -1253,9 +1257,13 @@ func (p *Printer) printObjectTypeAnn(typ *ast.ObjectTypeAnn) {
 
 	for i, elem := range typ.Elems {
 		p.printObjTypeAnnElem(elem)
-		if i < len(typ.Elems)-1 {
+		if i < len(typ.Elems)-1 || typ.Inexact {
 			p.writeString(",")
 		}
+		p.newline()
+	}
+	if typ.Inexact {
+		p.writeString("...")
 		p.newline()
 	}
 
@@ -1382,6 +1390,12 @@ func (p *Printer) printTupleTypeAnn(typ *ast.TupleTypeAnn) {
 		if i < len(typ.Elems)-1 {
 			p.writeString(", ")
 		}
+	}
+	if typ.Inexact {
+		if len(typ.Elems) > 0 {
+			p.writeString(", ")
+		}
+		p.writeString("...")
 	}
 	p.writeString("]")
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -61,6 +61,63 @@ func parseTypeAnn(t *testing.T, input string) ast.TypeAnn {
 
 // The trailing `...` inexact marker round-trips through the printer on function
 // declarations, expressions, and type annotations (#677 §4.1).
+// TestPrintInexactObjectAndTupleAnnotations covers the trailing `...` marker on
+// object and tuple type annotations (M4 A3) round-tripping through the printer.
+func TestPrintInexactObjectAndTupleAnnotations(t *testing.T) {
+	opts := DefaultOptions()
+
+	tupleTests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"inexact tuple", "[number, string, ...]", "[number, string, ...]"},
+		{"inexact unary tuple", "[number, ...]", "[number, ...]"},
+		{"exact tuple unchanged", "[number, string]", "[number, string]"},
+	}
+	for _, tt := range tupleTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Print(parseTypeAnn(t, tt.input), opts)
+			if err != nil {
+				t.Fatalf("Print error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+
+	// The object printer is multiline, so assert the `...` marker appears (an exact
+	// object must not grow one).
+	t.Run("inexact object has trailing ...", func(t *testing.T) {
+		result, err := Print(parseTypeAnn(t, "{x: number, ...}"), opts)
+		if err != nil {
+			t.Fatalf("Print error: %v", err)
+		}
+		if !strings.Contains(result, "...") {
+			t.Errorf("Expected an inexact marker in %q", result)
+		}
+	})
+	t.Run("exact object has no ...", func(t *testing.T) {
+		result, err := Print(parseTypeAnn(t, "{x: number}"), opts)
+		if err != nil {
+			t.Fatalf("Print error: %v", err)
+		}
+		if strings.Contains(result, "...") {
+			t.Errorf("Did not expect an inexact marker in %q", result)
+		}
+	})
+	t.Run("inexact-only object round-trips", func(t *testing.T) {
+		result, err := Print(parseTypeAnn(t, "{...}"), opts)
+		if err != nil {
+			t.Fatalf("Print error: %v", err)
+		}
+		if result != "{...}" {
+			t.Errorf("Expected %q, got %q", "{...}", result)
+		}
+	})
+}
+
 func TestPrintInexactFunctions(t *testing.T) {
 	opts := DefaultOptions()
 

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -217,9 +217,12 @@ func (p *namedPrinter) printType(t Type) string {
 	case *Void:
 		return "void"
 	case *TupleType:
-		elems := make([]string, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = p.printType(e)
+		elems := make([]string, 0, len(t.Elems)+1)
+		for _, e := range t.Elems {
+			elems = append(elems, p.printType(e))
+		}
+		if t.Inexact {
+			elems = append(elems, "...")
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
 	case *ObjectType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -53,6 +53,13 @@ func TestPrintRoundTrips(t *testing.T) {
 		// Tuples.
 		{"empty tuple", &TupleType{}, "[]"},
 		{"pair tuple", &TupleType{Elems: []Type{numP(), strP()}}, "[number, string]"},
+		{
+			// An inexact tuple renders a trailing `...`, mirroring inexact objects.
+			"inexact tuple renders trailing ...",
+			&TupleType{Elems: []Type{numP()}, Inexact: true},
+			"[number, ...]",
+		},
+		{"inexact empty tuple", &TupleType{Inexact: true}, "[...]"},
 
 		// Objects.
 		{"empty object", &ObjectType{}, "{}"},

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -132,8 +132,14 @@ type FuncType struct {
 	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 }
 
-// TupleType is a fixed-length tuple type.
-type TupleType struct{ Elems []Type }
+// TupleType is a tuple type. Inexact follows the ObjectType/FuncType convention:
+// the zero value is exact, so a tuple is fixed-length by default and only the
+// parser's trailing `...` marker sets it. An inexact tuple (`[A, ...]`) accepts a
+// longer tuple as a subtype, matching the shared prefix element-wise.
+type TupleType struct {
+	Elems   []Type
+	Inexact bool // trailing `...` ⇒ true
+}
 
 // ObjectType is the structural object type — the carrier for object literals,
 // object/interface annotations, and (M5) class instance bodies, so one

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -106,7 +106,7 @@ func (t *TupleType) Accept(v TypeVisitor, pol Polarity) Type {
 	elems, changed := acceptTypes(cur.Elems, v, pol) // covariant
 	out := cur
 	if changed {
-		out = &TupleType{Elems: elems}
+		out = &TupleType{Elems: elems, Inexact: cur.Inexact}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -431,7 +431,9 @@ func equalType(a, b soltype.Type) bool {
 		return equalType(a.Ret, b.Ret)
 	case *soltype.TupleType:
 		b, ok := b.(*soltype.TupleType)
-		if !ok || len(a.Elems) != len(b.Elems) {
+		// Inexact flags must be equal — an open tuple never equals a closed one,
+		// mirroring the ObjectType/FuncType arms' Inexact discriminator.
+		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
 		for i := range a.Elems {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -184,6 +184,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
 			}
 			var errs []SolverError
+			// Range over sup.Elems, not sub.Elems: an inexact super (`[A, ...]`) lets
+			// the sub be longer, so sup is the shorter side. This walks the shared
+			// prefix and keeps sup.Elems[i] in bounds.
 			for i := range sup.Elems {
 				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen)...) // covariant
 			}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -171,14 +171,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.TupleType:
 		if sup, ok := super.(*soltype.TupleType); ok {
-			// Same length, element-wise covariant. M1's TupleType has no exact
-			// flag — same-length is the *exact <: exact* case applied
-			// implicitly; M4 adds the exact flag and the inexact arm.
-			if len(sub.Elems) != len(sup.Elems) {
+			// Element-wise covariant over the shared prefix. Length tolerance follows
+			// the super's exactness: an exact super (`[A, B]`) fixes its length, while
+			// an inexact super (`[A, ...]`) only requires the sub to be at least as
+			// long — the longer <: shorter case the `...` tail permits. This mirrors
+			// the ObjectType width rule (inexact super = width-tolerant).
+			if sup.Inexact {
+				if len(sub.Elems) < len(sup.Elems) {
+					return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
+				}
+			} else if len(sub.Elems) != len(sup.Elems) {
 				return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
 			}
 			var errs []SolverError
-			for i := range sub.Elems {
+			for i := range sup.Elems {
 				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen)...) // covariant
 			}
 			return errs

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -341,6 +341,44 @@ func TestConstrainTuple(t *testing.T) {
 		require.Same(t, t1, tl.Sub)
 		require.Same(t, t2, tl.Super)
 	})
+
+	// [number, string, boolean] <: [number, ...]: a longer tuple satisfies an
+	// inexact super, matching the shared prefix element-wise (the A2 width arm).
+	t.Run("longer fills inexact (width)", func(t *testing.T) {
+		c := &Context{}
+		t1 := &soltype.TupleType{Elems: []soltype.Type{num(), str(), boolT()}}
+		t2 := &soltype.TupleType{Elems: []soltype.Type{num()}, Inexact: true}
+		require.Empty(t, c.Constrain(t1, t2))
+	})
+
+	// [5] <: [number, ...]: same length against an inexact super still checks; the
+	// prefix is covariant (5 <: number).
+	t.Run("equal length fills inexact covariant", func(t *testing.T) {
+		c := &Context{}
+		t1 := &soltype.TupleType{Elems: []soltype.Type{numLit(5)}}
+		t2 := &soltype.TupleType{Elems: []soltype.Type{num()}, Inexact: true}
+		require.Empty(t, c.Constrain(t1, t2))
+	})
+
+	// [number] <: [number, string, ...]: too SHORT for the inexact super's declared
+	// prefix is still a length mismatch — inexactness widens only on the long side.
+	t.Run("shorter than inexact prefix rejects", func(t *testing.T) {
+		c := &Context{}
+		t1 := &soltype.TupleType{Elems: []soltype.Type{num()}}
+		t2 := &soltype.TupleType{Elems: []soltype.Type{num(), str()}, Inexact: true}
+		errs := c.Constrain(t1, t2)
+		require.Equal(t, []string{"cannot constrain tuple of length 1 <: tuple of length 2"}, Messages(errs))
+		require.IsType(t, &TupleLengthMismatchError{}, errs[0])
+	})
+
+	// The shared prefix stays covariant against an inexact super: a prefix mismatch
+	// surfaces the inner failure rather than being masked by width tolerance.
+	t.Run("inexact prefix mismatch surfaces", func(t *testing.T) {
+		c := &Context{}
+		t1 := &soltype.TupleType{Elems: []soltype.Type{num(), num()}}
+		t2 := &soltype.TupleType{Elems: []soltype.Type{str()}, Inexact: true}
+		require.Equal(t, []string{"cannot constrain number <: string"}, Messages(c.Constrain(t1, t2)))
+	})
 }
 
 // propElem builds a PropertyElem so the object accept-set tests read at a glance.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -121,6 +121,21 @@ type ExtraPropertyError struct {
 	site       ast.Node     // M2.5: constraint node fallback
 }
 
+// ExtraElementError is the tuple analogue of ExtraPropertyError, fired by the
+// construction-site excess check (A3): a tuple LITERAL checked against a tuple
+// annotation may not carry elements beyond the target's declared set, even when
+// the target is inexact (`[number, ...]`). It is the parallel of the direct-call
+// extra-arg lint: an inexact tail tolerates extra elements from a non-literal
+// source through width subtyping, but a literal spells out its elements, so an
+// extra one is a construction error. One error fires per excess element, carrying
+// its index. It is reported from the walk, not from the tuple constrain arm.
+type ExtraElementError struct {
+	Sub, Super *soltype.TupleType
+	Index      int
+	prov       NodeResolver // M2.5: type→node index (§3.5)
+	site       ast.Node     // M2.5: the excess element node fallback
+}
+
 // OptionalPropertyError fires on ObjectType <: ObjectType when a property is
 // optional on the sub (source) but required on the super (target): the source may omit
 // the property, so it cannot satisfy a target that requires it present (the object
@@ -169,6 +184,7 @@ func (*TupleLengthMismatchError) isSolverError() {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*ExtraPropertyError) isSolverError()       {}
+func (*ExtraElementError) isSolverError()        {}
 func (*OptionalPropertyError) isSolverError()    {}
 func (*MutabilityMismatchError) isSolverError()  {}
 func (*BorrowEscapeError) isSolverError()        {}
@@ -221,6 +237,17 @@ func (e *ExtraPropertyError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *ExtraPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *ExtraElementError) Span() ast.Span {
+	// The excess element lives on the sub (source) at Index; blame it, degrade to
+	// the super (target), else the site.
+	ops := make([]soltype.Type, 0, 2)
+	if e.Index >= 0 && e.Index < len(e.Sub.Elems) {
+		ops = append(ops, e.Sub.Elems[e.Index])
+	}
+	return spanOfFirst(e.prov, e.site, ops...)
+}
+func (e *ExtraElementError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *OptionalPropertyError) Span() ast.Span {
 	// The optional property lives on the sub (source); blame it, degrade to the super
@@ -764,6 +791,10 @@ func (e *InexactIntoExactError) Message() string {
 
 func (e *ExtraPropertyError) Message() string {
 	return "object has extra property: " + e.Name
+}
+
+func (e *ExtraElementError) Message() string {
+	return "tuple has extra element at index " + strconv.Itoa(e.Index)
 }
 
 func (e *OptionalPropertyError) Message() string {

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -84,6 +84,31 @@ func TestInferInexactTupleAnnotationVariableWidthSubtyping(t *testing.T) {
 	require.Empty(t, errs)
 }
 
+// The construction-site excess check looks THROUGH a `mut` borrow: an inexact
+// object/tuple wrapped in `mut` still rejects undeclared literal members, so the
+// rule is consistent whether or not the annotation is a borrow. The mutability
+// mismatch (an immutable literal into a mut slot) fires too — both are real,
+// independent problems — so the excess diagnostic must appear alongside it.
+func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		_, _, errs := inferSource(t, `val r: mut {x: number, ...} = {x: 1, y: 2}`)
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Message()
+		}
+		require.Contains(t, msgs, "object has extra property: y")
+	})
+	t.Run("tuple", func(t *testing.T) {
+		_, _, errs := inferSource(t, `val t: mut [number, ...] = [1, 2, 3]`)
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Message()
+		}
+		require.Contains(t, msgs, "tuple has extra element at index 1")
+		require.Contains(t, msgs, "tuple has extra element at index 2")
+	})
+}
+
 // A `mut T` annotation lowers to an owned-mutable borrow (RefType{Mut: true}); a
 // function parameter typed `mut {x: number}` renders with the `mut` prefix and a
 // member read through it resolves the inner property.

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -1,0 +1,94 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 A3: object / tuple / mut type annotations + the construction-site
+// excess-member check (exact-types §§2.2.4, 3.2.4) ---
+
+// An object annotation resolves to an ObjectType and an annotated binding adopts
+// it, so the rendered binding type is the annotation, trailing `...` and all.
+func TestInferObjectAnnotationAdopted(t *testing.T) {
+	values, _, errs := inferSource(t, `val r: {x: number, y: number} = {x: 1, y: 2}`)
+	require.Empty(t, errs)
+	require.Equal(t, "{x: number, y: number}", values["r"])
+}
+
+// An inexact object annotation renders its `...` tail and accepts a literal whose
+// fields are all declared — the tail simply goes unused.
+func TestInferInexactObjectAnnotationDeclaredFields(t *testing.T) {
+	values, _, errs := inferSource(t, `val r: {x: number, y: number, ...} = {x: 1, y: 2}`)
+	require.Empty(t, errs)
+	require.Equal(t, "{x: number, y: number, ...}", values["r"])
+}
+
+// A literal carrying a field the inexact target does not declare is rejected — the
+// construction-site excess check fires even though the target is inexact (parallel
+// to the direct-call extra-arg rejection, exact-types §2.2.4).
+func TestInferInexactObjectAnnotationRejectsExcessLiteralField(t *testing.T) {
+	_, _, errs := inferSource(t, `val r: {x: number, ...} = {x: 1, y: 2}`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &ExtraPropertyError{}, errs[0])
+	require.Equal(t, "object has extra property: y", errs[0].Message())
+}
+
+// The variable escape hatch: a NON-literal source against an inexact target takes
+// ordinary width subtyping, so the extra field is dropped instead of rejected.
+func TestInferInexactObjectAnnotationVariableWidthSubtyping(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		val v = {x: 1, y: 2}
+		val r: {x: number, ...} = v
+	`)
+	require.Empty(t, errs)
+}
+
+// An EXACT object annotation rejects an extra field through the ordinary object
+// constrain arm (one ExtraPropertyError, not doubled by the excess check, which
+// only fires for an inexact target).
+func TestInferExactObjectAnnotationRejectsExtraField(t *testing.T) {
+	_, _, errs := inferSource(t, `val r: {x: number} = {x: 1, y: 2}`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &ExtraPropertyError{}, errs[0])
+	require.Equal(t, "object has extra property: y", errs[0].Message())
+}
+
+// A tuple annotation resolves to a TupleType and an annotated binding adopts it.
+func TestInferTupleAnnotationAdopted(t *testing.T) {
+	values, _, errs := inferSource(t, `val t: [number, string] = [1, "a"]`)
+	require.Empty(t, errs)
+	require.Equal(t, "[number, string]", values["t"])
+}
+
+// An inexact tuple annotation renders its `...` tail and rejects excess elements on
+// a literal source — one ExtraElementError per excess element.
+func TestInferInexactTupleAnnotationRejectsExcessLiteralElements(t *testing.T) {
+	values, _, errs := inferSource(t, `val t: [number, ...] = [1, 2, 3]`)
+	require.Len(t, errs, 2)
+	require.IsType(t, &ExtraElementError{}, errs[0])
+	require.Equal(t, "tuple has extra element at index 1", errs[0].Message())
+	require.Equal(t, "tuple has extra element at index 2", errs[1].Message())
+	// The binding still adopts the inexact annotation (error recovery).
+	require.Equal(t, "[number, ...]", values["t"])
+}
+
+// The tuple variable escape hatch: a non-literal source against an inexact tuple
+// target takes width subtyping (longer <: shorter through the inexact tail).
+func TestInferInexactTupleAnnotationVariableWidthSubtyping(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		val v = [1, 2, 3]
+		val t: [number, ...] = v
+	`)
+	require.Empty(t, errs)
+}
+
+// A `mut T` annotation lowers to an owned-mutable borrow (RefType{Mut: true}); a
+// function parameter typed `mut {x: number}` renders with the `mut` prefix and a
+// member read through it resolves the inner property.
+func TestInferMutObjectAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) -> number { return p.x }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -89,10 +89,70 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// initializer type instead (error recovery).
 		if annT, ok := c.resolveTypeAnn(d.TypeAnn, lvl); ok {
 			c.constrain(d.Init, initT, annT)
+			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
 	}
 	return initT, true
+}
+
+// checkExcessLiteralMembers is the construction-site excess check (M4 A3): a
+// syntactic object/tuple LITERAL checked against an object/tuple annotation may
+// not carry members the target does not declare, EVEN when the target is inexact
+// (`{x, ...}` / `[number, ...]`). It is the construction-site twin of the
+// direct-call extra-arg rule: a non-literal source takes ordinary width
+// subtyping (an inexact target admits extras), but a literal spells out its
+// members, so an undeclared one is a construction error.
+//
+// It fires only for an INEXACT target. An exact target already rejects extras
+// through the ordinary ObjectType/TupleType constrain arm (ExtraPropertyError /
+// TupleLengthMismatchError run by the c.constrain call above), so checking it here
+// too would double-report. The errors reuse A1's ExtraPropertyError for objects
+// and the parallel ExtraElementError for tuples, wired with the same Prov table /
+// site as the constraint path so blame resolves to the offending member.
+func (c *checker) checkExcessLiteralMembers(e ast.Expr, sub, annT soltype.Type) {
+	switch ann := annT.(type) {
+	case *soltype.ObjectType:
+		if !ann.Inexact {
+			return
+		}
+		obj, isLit := e.(*ast.ObjectExpr)
+		subObj, isObj := sub.(*soltype.ObjectType)
+		if !isLit || !isObj {
+			return
+		}
+		for _, elem := range obj.Elems {
+			prop, ok := elem.(*ast.PropertyExpr)
+			if !ok || prop.Value == nil {
+				continue
+			}
+			name, ok := objKeyName(prop.Name)
+			if !ok {
+				continue
+			}
+			if _, declared := ann.Prop(name); declared {
+				continue
+			}
+			err := &ExtraPropertyError{Sub: subObj, Super: ann, Name: name}
+			err.prov, err.site = c.prov, prop
+			c.errs = append(c.errs, err)
+		}
+	case *soltype.TupleType:
+		if !ann.Inexact {
+			return
+		}
+		tup, isLit := e.(*ast.TupleExpr)
+		subTup, isTup := sub.(*soltype.TupleType)
+		if !isLit || !isTup {
+			return
+		}
+		// Elements beyond the target's declared prefix are excess on the literal.
+		for i := len(ann.Elems); i < len(tup.Elems) && i < len(subTup.Elems); i++ {
+			err := &ExtraElementError{Sub: subTup, Super: ann, Index: i}
+			err.prov, err.site = c.prov, tup.Elems[i]
+			c.errs = append(c.errs, err)
+		}
+	}
 }
 
 // inferVarDecl types a body-level `val`/`var` into a GENERALIZED ValueBinding —

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -104,14 +104,25 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // subtyping (an inexact target admits extras), but a literal spells out its
 // members, so an undeclared one is a construction error.
 //
+// SCOPE (M4 A3): it is wired here, at annotated `val`/`var` bindings, only. The
+// twin sites the rule will eventually cover — literal call arguments and return
+// positions checked against an inexact annotation — defer to the milestone work
+// that adds annotated call/return checking; until then a literal flowing into an
+// inexact target through those paths takes ordinary width subtyping.
+//
 // It fires only for an INEXACT target. An exact target already rejects extras
 // through the ordinary ObjectType/TupleType constrain arm (ExtraPropertyError /
 // TupleLengthMismatchError run by the c.constrain call above), so checking it here
 // too would double-report. The errors reuse A1's ExtraPropertyError for objects
 // and the parallel ExtraElementError for tuples, wired with the same Prov table /
 // site as the constraint path so blame resolves to the offending member.
+//
+// A `mut T` annotation resolves to a RefType wrapping the object/tuple, so peel
+// the borrow first: the excess rule is about the literal's SHAPE versus the
+// target's declared members, which is independent of the borrow's mutability. The
+// literal source itself is never a borrow, so only the annotation needs peeling.
 func (c *checker) checkExcessLiteralMembers(e ast.Expr, sub, annT soltype.Type) {
-	switch ann := annT.(type) {
+	switch ann := soltype.CarrierOf(annT).(type) {
 	case *soltype.ObjectType:
 		if !ann.Inexact {
 			return

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -708,8 +708,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 // property at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
 // property names unique, the invariant ObjectType.Prop / equalType rely on.
 func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
-	elems := make([]soltype.ObjTypeElem, 0, len(e.Elems))
-	pos := make(map[string]int, len(e.Elems)) // property name → index in elems, for last-wins dedup
+	b := newObjElemBuilder(len(e.Elems))
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
@@ -730,17 +729,40 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 			continue
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
-		if i, dup := pos[name]; dup {
-			elems[i] = &soltype.PropertyElem{Name: name, Type: ft} // last value wins, first position kept
-			continue
-		}
-		pos[name] = len(elems)
-		elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft})
+		b.add(name, ft, false) // a literal property is never optional
 	}
-	t := &soltype.ObjectType{Elems: elems}
+	t := &soltype.ObjectType{Elems: b.elems}
 	c.recordType(e, t)
 	c.recordProv(t, e, ObjectField)
 	return t
+}
+
+// objElemBuilder accumulates object PropertyElems under JavaScript's last-wins,
+// first-position dedup: a repeated key updates the value in place at the key's
+// original position, so property names stay unique — the invariant ObjectType.Prop
+// and equalType rely on ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). Shared by inferObject
+// (object literals) and resolveObjectTypeAnn (object type annotations) so the dedup
+// rule lives in one place.
+type objElemBuilder struct {
+	elems []soltype.ObjTypeElem
+	pos   map[string]int // property name → index in elems
+}
+
+func newObjElemBuilder(capacity int) *objElemBuilder {
+	return &objElemBuilder{
+		elems: make([]soltype.ObjTypeElem, 0, capacity),
+		pos:   make(map[string]int, capacity),
+	}
+}
+
+func (b *objElemBuilder) add(name string, t soltype.Type, optional bool) {
+	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional}
+	if i, dup := b.pos[name]; dup {
+		b.elems[i] = pe // last value wins, first position kept
+		return
+	}
+	b.pos[name] = len(b.elems)
+	b.elems = append(b.elems, pe)
 }
 
 // inferMember types a field read (recv.prop) in value position: it resolves the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -743,6 +743,11 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 // and equalType rely on ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). Shared by inferObject
 // (object literals) and resolveObjectTypeAnn (object type annotations) so the dedup
 // rule lives in one place.
+//
+// It is NOT recursive: it accumulates the direct properties of ONE object level.
+// Each property's type arrives already built — inferObject computes it with
+// inferExpr, resolveObjectTypeAnn with resolveTypeAnn — so a nested object is built
+// by that caller's recursion before add stores it.
 type objElemBuilder struct {
 	elems []soltype.ObjTypeElem
 	pos   map[string]int // property name → index in elems

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -73,6 +73,12 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 			return t, true
 		}
 		return c.reportUnsupported(ta), false
+	case *ast.ObjectTypeAnn:
+		return c.resolveObjectTypeAnn(ta, lvl)
+	case *ast.TupleTypeAnn:
+		return c.resolveTupleTypeAnn(ta, lvl)
+	case *ast.MutableTypeAnn:
+		return c.resolveMutableTypeAnn(ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -86,6 +92,115 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	default:
 		return c.reportUnsupported(ta), false
 	}
+}
+
+// resolveObjectTypeAnn lowers an object type annotation to a soltype.ObjectType,
+// honoring the trailing `...` inexact marker. M4 ships PropertyElem only: a
+// `name: T` / `name?: T` property resolves to a PropertyElem; method/getter/setter
+// members (M5), mapped/index signatures and the object rest/spread (M9) are not
+// part of M4's object and report an unsupported feature, with the object still
+// built from the properties that do resolve. Duplicate keys follow the
+// last-wins-first-position dedup inferObject uses, keeping property names unique.
+//
+// A property whose value annotation is itself unsupported recovers that value to a
+// fresh var and keeps the object shape — cascade-safe, mirroring the Promise<bad>
+// recovery — so the binding still checks structurally. The arm therefore always
+// returns ok=true: any unsupported sub-part has already reported its own error.
+func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
+	elems := make([]soltype.ObjTypeElem, 0, len(ta.Elems))
+	pos := make(map[string]int, len(ta.Elems)) // property name → index, for last-wins dedup
+	unsupported := false
+	for _, elem := range ta.Elems {
+		prop, ok := elem.(*ast.PropertyTypeAnn)
+		if !ok {
+			unsupported = true
+			continue
+		}
+		name, ok := objKeyName(prop.Name)
+		if !ok {
+			c.reportUnsupported(prop.Name)
+			continue
+		}
+		var ft soltype.Type
+		switch {
+		case prop.Value == nil:
+			ft = c.freshAt(lvl)
+		default:
+			if t, ok := c.resolveTypeAnn(prop.Value, lvl); ok {
+				ft = t
+			} else {
+				ft = c.freshAt(lvl)
+			}
+		}
+		pe := &soltype.PropertyElem{Name: name, Type: ft, Optional: prop.Optional}
+		if i, dup := pos[name]; dup {
+			elems[i] = pe // last value wins, first position kept
+			continue
+		}
+		pos[name] = len(elems)
+		elems = append(elems, pe)
+	}
+	if unsupported {
+		c.reportUnsupportedFeature(ta, "object type member other than a property")
+	}
+	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType,
+// honoring the trailing `...` inexact marker. A rest-spread / variadic element
+// (`[...P]`, `[number, ...Array<number>]`) defers with its type-level feature
+// (M9 / M7) and reports unsupported; the bare trailing `...` inexact marker is
+// carried on ta.Inexact, not as an element. An element whose annotation is
+// unsupported recovers to a fresh var so the tuple keeps its arity.
+func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
+	elems := make([]soltype.Type, 0, len(ta.Elems))
+	unsupported := false
+	for _, el := range ta.Elems {
+		if _, isRest := el.(*ast.RestSpreadTypeAnn); isRest {
+			unsupported = true
+			continue
+		}
+		if t, ok := c.resolveTypeAnn(el, lvl); ok {
+			elems = append(elems, t)
+		} else {
+			elems = append(elems, c.freshAt(lvl))
+		}
+	}
+	if unsupported {
+		c.reportUnsupportedFeature(ta, "tuple spread or variadic element")
+	}
+	t := &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveMutableTypeAnn lowers a `mut T` annotation to an owned-mutable borrow,
+// RefType{Mut: true, Lt: nil, Inner: T} (the C1 RefType wrapper). The lifetime
+// borrow forms (`'a T`, `mut 'a T`) still defer: a named lifetime needs the
+// lifetime sort (D1), and the parser already rejects a lifetime before a non-
+// reference inner, so only the no-lifetime `mut` form reaches here.
+//
+// `mut` over a non-borrowable inner (a primitive, function, promise — anything
+// outside RefInner) is a no-op in the value-types model: there is nothing to
+// borrow. It reports an unsupported feature rather than fabricating a borrow over
+// a type the wrapper cannot hold. An unsupported inner recovers to a fresh var,
+// which IS a RefInner, so the `mut` wrapper is preserved.
+func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltype.Type, bool) {
+	inner, ok := c.resolveTypeAnn(ta.Target, lvl)
+	if !ok {
+		t := soltype.NewRef(true, nil, c.freshAt(lvl))
+		c.recordProv(t, ta, AnnotationType)
+		return t, true
+	}
+	ri, ok := inner.(soltype.RefInner)
+	if !ok {
+		return c.reportUnsupportedFeature(ta, "mut on a non-borrowable type"), false
+	}
+	t := soltype.NewRef(true, nil, ri)
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
 }
 
 // annPrim mints a FRESH PrimType for an annotation and records it against the

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -107,8 +107,7 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 // recovery — so the binding still checks structurally. The arm therefore always
 // returns ok=true: any unsupported sub-part has already reported its own error.
 func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
-	elems := make([]soltype.ObjTypeElem, 0, len(ta.Elems))
-	pos := make(map[string]int, len(ta.Elems)) // property name → index, for last-wins dedup
+	b := newObjElemBuilder(len(ta.Elems))
 	unsupported := false
 	for _, elem := range ta.Elems {
 		prop, ok := elem.(*ast.PropertyTypeAnn)
@@ -121,29 +120,20 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 			c.reportUnsupported(prop.Name)
 			continue
 		}
-		var ft soltype.Type
-		switch {
-		case prop.Value == nil:
-			ft = c.freshAt(lvl)
-		default:
+		// A missing or unsupported value annotation recovers to a fresh var, keeping
+		// the object shape cascade-safe — mirroring the Promise<bad> recovery.
+		var ft soltype.Type = c.freshAt(lvl)
+		if prop.Value != nil {
 			if t, ok := c.resolveTypeAnn(prop.Value, lvl); ok {
 				ft = t
-			} else {
-				ft = c.freshAt(lvl)
 			}
 		}
-		pe := &soltype.PropertyElem{Name: name, Type: ft, Optional: prop.Optional}
-		if i, dup := pos[name]; dup {
-			elems[i] = pe // last value wins, first position kept
-			continue
-		}
-		pos[name] = len(elems)
-		elems = append(elems, pe)
+		b.add(name, ft, prop.Optional)
 	}
 	if unsupported {
 		c.reportUnsupportedFeature(ta, "object type member other than a property")
 	}
-	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
+	t := &soltype.ObjectType{Elems: b.elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1170,13 +1170,18 @@ these arms it must add.
 ### Dependency graph
 
 ```
-✓ = landed on main.  Done so far: A1 (#728), B1+B2 (#732), C1+C2 (#731), F1 (#730).
+✓ = landed on main.  Done so far:
+- A1 (#728)
+- A3 (#733)
+- B1+B2 (#732)
+- C1+C2 (#731)
+- F1 (#730)
 
 A1✓ → A2
-A1✓ → A3 ─────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
-A1✓ → B1✓ → B2✓               │  (annotation-side acceptance tests)
-      B1✓ → B3                │
-      B1✓, B3 ────────────┐   │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
+A1✓ → A3✓ ─────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
+A1✓ → B1✓ → B2✓                │  (annotation-side acceptance tests)
+      B1✓ → B3                 │
+      B1✓, B3 ────────────┐    │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
 A1✓ → C1✓ → C2✓(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
 A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
 F1✓             (independent; any time — only M2's Namespace)


### PR DESCRIPTION
Adds support for object and tuple type annotations in M4, along with the construction-site excess-member check that rejects undeclared fields in literals even when the target annotation is inexact.

## Summary

This change implements three related features for M4 A3:

1. **Object type annotations** (`{x: number, y: number}` and `{x: number, ...}`) resolve to `ObjectType` with support for the inexact marker.
2. **Tuple type annotations** (`[number, string]` and `[number, ...]`) resolve to `TupleType` with support for the inexact marker.
3. **Mutable type annotations** (`mut T`) lower to owned-mutable borrows (`RefType{Mut: true}`).
4. **Construction-site excess check** rejects object/tuple literals that carry undeclared members when checked against an annotation, even if the annotation is inexact. Non-literal sources take ordinary width subtyping instead.

## Key changes

- **Parser** (`internal/parser/`): Added `parseDelimSeqInexact` combinator to recognize trailing `...` in object and tuple type annotations. Updated `type_ann.go` to parse `ObjectTypeAnn`, `TupleTypeAnn`, and `MutableTypeAnn` with their inexact flags.

- **Type resolution** (`internal/solver/type_ann.go`): Implemented `resolveObjectTypeAnn`, `resolveTupleTypeAnn`, and `resolveMutableTypeAnn` to lower annotations to solver types. Object and tuple annotations recover unsupported sub-parts to fresh variables for cascade safety.

- **Excess check** (`internal/solver/infer_decl.go`): Added `checkExcessLiteralMembers` that fires after constraint checking for annotated bindings. It inspects the literal source and reports `ExtraPropertyError` (objects) or `ExtraElementError` (tuples) for undeclared members. The check looks through `mut` borrows to inspect the inner shape.

- **Tuple width subtyping** (`internal/solver/constrain.go`): Updated tuple constraint to allow longer tuples to satisfy inexact supers by matching the shared prefix element-wise, mirroring the object width rule.

- **Error types** (`internal/solver/errors.go`): Added `ExtraElementError` as the tuple analogue of `ExtraPropertyError`, carrying the excess element's index.

- **Printer support** (`internal/printer/`): Updated object and tuple type annotation printing to render the trailing `...` marker. Empty inexact objects print as `{...}`.

- **Type representation** (`internal/soltype/`): Added `Inexact` flag to `TupleType` (mirroring `ObjectType` and `FuncType`). Updated print and visitor to handle the flag.

- **Tests** (`internal/solver/infer_ann_test.go`): Comprehensive test suite covering annotation adoption, inexact width tolerance for non-literals, excess-member rejection for literals, and `mut` annotation behavior.

## Implementation notes

The excess check is wired only at annotated `val`/`var` bindings in M4. Twin sites (literal call arguments and return positions) defer to future milestone work. The check respects the distinction between literals and variables: a literal spells out its members explicitly, so an undeclared one is a construction error; a variable takes ordinary width subtyping through the constraint path.

Object and tuple type annotations share deduplication logic via the new `objElemBuilder` helper, which implements JavaScript's last-wins, first-position rule for repeated keys.

https://claude.ai/code/session_016XyUg7DraWyAob4Pg2veF5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inexact tuple and object type annotations using a trailing `...` marker, including `{...}` / `[T, ...]`, with correct variable-width subtyping behavior.

* **Improvements**
  * Improved formatting for inexact tuples/objects so printed types preserve `...` accurately (including `{...}` for empty inexact objects).
  * Enhanced solver diagnostics for construction-site excess members/elements when checking inexact targets against literal sources.

* **Tests**
  * Expanded coverage for parsing, printing, and solver behavior of inexact tuple/object annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->