### PR TITLE
Implement var literal widening (M4 B3)

### DIFF
--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -27,6 +27,15 @@ type TypeVarType struct {
 	// bounds stays inexact (row-polymorphic) instead of closing to exact. It has
 	// no effect on constraint solving.
 	Open bool
+	// Widenable marks the binding var of an un-annotated `var` (M4 B3). Like Open
+	// it is read only at coalescing: a widenable var's coalesced value has its
+	// literals lowered to their primitives (`5` ⇒ number) in covariant position,
+	// so a mutable cell reads back as the primitive it may later hold. It has no
+	// effect on constraint solving. This stays sound while the only position that
+	// demands a literal super-type is the reassignment slot — itself a coalesced
+	// view — because no other site can observe the literal the graph still holds;
+	// literal type annotations (a second such site) are a later milestone.
+	Widenable bool
 }
 
 // BoundsAt returns the bounds relevant to a polarity: lowers in Positive

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -86,6 +86,14 @@ func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { 
 // `1 | 2`: widen passes a UnionType through, matching the reassignment rule that
 // rejects `a = 3` there. It is a no-op for a non-widenable var, in negative
 // position, or on a type carrying no literal (a function, a captured var).
+//
+// Both coalescers call it for parallelism with v.Open. The schemeCoalescer call
+// is the live one: a widenable var is always a binding var, which generalizes to
+// a PolyScheme and so renders through coalesceScheme. The plain coalescer call is
+// DEFENSIVE — no current path coalesces a widenable var outside a scheme — kept
+// so the flag is honored identically should one arise. TestWidenVar exercises the
+// helper logic directly to cover both. The helper has no test reaching the plain
+// coalescer through real source, by the same PolyScheme reasoning.
 func widenVar(v *soltype.TypeVarType, pol soltype.Polarity, t soltype.Type) soltype.Type {
 	if v.Widenable && pol == soltype.Positive {
 		return widen(t)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -74,10 +74,24 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	if len(bounds) == 0 {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: combine(pol, dedup(bounds), v.Open), SkipChildren: true}
+	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(bounds), v.Open)), SkipChildren: true}
 }
 
 func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// widenVar lowers a widenable `var` binding's coalesced value to its primitive
+// (M4 B3) when it is read in covariant (Positive) position — `var a = 5` ⇒
+// number, `var p = {x: 0}` ⇒ {x: number}. It runs AFTER combine, so a union of
+// literals from distinct branches (`var a = if c { 1 } else { 2 }`) is left as
+// `1 | 2`: widen passes a UnionType through, matching the reassignment rule that
+// rejects `a = 3` there. It is a no-op for a non-widenable var, in negative
+// position, or on a type carrying no literal (a function, a captured var).
+func widenVar(v *soltype.TypeVarType, pol soltype.Polarity, t soltype.Type) soltype.Type {
+	if v.Widenable && pol == soltype.Positive {
+		return widen(t)
+	}
+	return t
+}
 
 // occPolarity is the set of polarities a variable occurs in within a type — the
 // occurrence input single-polarity elimination needs to decide which variables a
@@ -197,7 +211,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		// already leave parts=[rep]. Collapse to the polarity identity.
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
-	return soltype.EnterResult{Type: combine(pol, dedup(parts), v.Open), SkipChildren: true}
+	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(parts), v.Open)), SkipChildren: true}
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -17,9 +17,7 @@ import (
 // (or a top-level `val` initializer).
 
 // An annotated `var` reassignment type-checks when the source is a subtype of the
-// declared type, and reports a single CannotConstrainError otherwise. The `var` is
-// annotated because un-annotated `var` literal widening is M4 (see the literal case
-// below).
+// declared type, and reports a single CannotConstrainError otherwise.
 func TestInferAssignAnnotatedVar(t *testing.T) {
 	t.Run("matching type checks", func(t *testing.T) {
 		values, _, errs := inferSource(t, `
@@ -37,14 +35,13 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 	})
 }
 
-// An un-annotated `var a = 5` infers the literal type `5`, so reassigning a
-// DIFFERENT literal (`a = 6` ⇒ `6 <: 5`) does NOT check in M3 — `var` literal
-// widening is deferred to M4. This pins the interim behavior so the M4 change is
-// visible: when widening lands, this assignment will type-check.
-func TestInferAssignUnannotatedVarLiteralNotWidened(t *testing.T) {
-	src := "var a = 5\nfn f() { a = 6 }"
-	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "cannot constrain 6 <: 5", "6", "5")
+// An un-annotated `var a = 5` widens its binding to `number` (M4 B3), so
+// reassigning a DIFFERENT literal of the same primitive (`a = 6` ⇒ `6 <: number`)
+// checks. A `val` keeps the literal singleton (see TestInferAssignToValRejected).
+func TestInferAssignUnannotatedVarLiteralWidened(t *testing.T) {
+	values, _, errs := inferSource(t, "var a = 5\nfn f() { a = 6 }")
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["a"])
 }
 
 // Reassigning a `val` is rejected: only a `var` is reassignable. The error blames

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -100,10 +100,10 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// through the bound graph, so a read of the binding widens too
 		// (`var a = 5; val z = a` ⇒ z: number). A literal that arrives through a
 		// REFERENCE (`var y = x`) is a type variable here, which widen passes
-		// through unchanged; the binding var's Widenable flag widens that at
-		// coalesce time for display, the reassignment slot, and the binding's own
-		// rendered type. A `val` keeps its literal singleton — only a mutable cell
-		// widens, the new-checker form of the old checker's `Widenable` flag.
+		// through unchanged. The binding var's Widenable flag widens that at coalesce
+		// time. That covers display, the reassignment slot, and the binding's own
+		// rendered type. A `val` keeps its literal singleton; only a mutable cell
+		// widens.
 		initT = widen(initT)
 	}
 	return initT, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -94,13 +94,16 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 			initT = annT
 		}
 	case d.Kind == ast.VarKind:
-		// M4 B3: an un-annotated `var` binding widens its initializer's literal
-		// types to their primitives (recursively through objects/tuples/borrows),
-		// because a mutable cell may later hold a different value of the same
-		// primitive — `var a = 5; a = 6` checks once the binding is `number`. A
-		// `val` is left un-widened: it is a fixed singleton, so its inferred type
-		// keeps the literal. Widening is thus gated on mutability, the
-		// new-checker form of the old checker's `Widenable` type-var flag.
+		// M4 B3: eager-widen a DIRECT literal initializer to its primitive at the
+		// constraint level (`5` ⇒ number), recursively through objects/tuples. This
+		// is the constraint-level half of widening: the widened type propagates
+		// through the bound graph, so a read of the binding widens too
+		// (`var a = 5; val z = a` ⇒ z: number). A literal that arrives through a
+		// REFERENCE (`var y = x`) is a type variable here, which widen passes
+		// through unchanged; the binding var's Widenable flag widens that at
+		// coalesce time for display, the reassignment slot, and the binding's own
+		// rendered type. A `val` keeps its literal singleton — only a mutable cell
+		// widens, the new-checker form of the old checker's `Widenable` flag.
 		initT = widen(initT)
 	}
 	return initT, true
@@ -191,7 +194,27 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	if !ok {
 		return ValueBinding{}, false
 	}
-	scheme := c.generalize(initType, lvl)
+	bound := initType
+	// M4 B3: an un-annotated body-level `var` widens at coalesce time like its
+	// top-level peer. The top-level SCC path flags the binding var it already
+	// mints; a body-level binding has none — it generalizes the initializer
+	// directly — so wrap the initializer in a fresh widenable var (initType <: v)
+	// and generalize that. The flag rides v through coalescing, so the recorded
+	// display type, the reassignment slot, and any read of the binding all widen
+	// consistently. An annotated `var` adopts its annotation and needs no widening.
+	//
+	// Skip the wrap when the initializer recovered to the ErrorType sentinel: it
+	// absorbs in constrain, so `initType <: v` would leave v with no lower bound,
+	// coalescing to `never` and cascading a spurious error at every reassignment.
+	// Generalizing the ErrorType directly keeps the absorbing recovery binding.
+	_, isErr := initType.(*soltype.ErrorType)
+	if d.Kind == ast.VarKind && d.TypeAnn == nil && !isErr {
+		v := c.freshAt(lvl + 1)
+		v.Widenable = true
+		c.constrain(d.Init, initType, v)
+		bound = v
+	}
+	scheme := c.generalize(bound, lvl)
 	// The recorded display type retains any quantified type-parameter vars (it is
 	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
 	// plain soltype.Print — same contract as the top-level path (see module.go).

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -73,7 +73,8 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		return nil, false
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
-	if d.TypeAnn != nil {
+	switch {
+	case d.TypeAnn != nil:
 		// M2.5: constrain the initializer against the annotation (the one
 		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
 		// CannotConstrainError whose Sub (the "hi" literal) carries a
@@ -92,6 +93,15 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
+	case d.Kind == ast.VarKind:
+		// M4 B3: an un-annotated `var` binding widens its initializer's literal
+		// types to their primitives (recursively through objects/tuples/borrows),
+		// because a mutable cell may later hold a different value of the same
+		// primitive — `var a = 5; a = 6` checks once the binding is `number`. A
+		// `val` is left un-widened: it is a fixed singleton, so its inferred type
+		// keeps the literal. Widening is thus gated on mutability, the
+		// new-checker form of the old checker's `Widenable` type-var flag.
+		initT = widen(initT)
 	}
 	return initT, true
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -532,8 +532,8 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 // On success the source is constrained `<: target` (the binding's coalesced type),
 // the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
 // being stored must be a subtype of the slot. Reassigning an annotated `var a:
-// number = 5` with `a = 6` checks; an un-annotated `var a = 5` keeps the literal
-// type `5`, so `a = 6` does NOT check until `var` literal widening (M4).
+// number = 5` with `a = 6` checks; an un-annotated `var a = 5` now widens its
+// binding to `number` (M4 B3), so `a = 6` checks there too.
 //
 // The assignment EXPRESSION evaluates to the value just stored, so its type is the
 // target binding's slot type — `val b = (a = 6)` for `var a: number` yields
@@ -593,9 +593,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// fresh instantiation: instantiating a generalized binding yields a var carrying
 	// only its LOWER bounds (the read/covariant face), so `a = "x"` for `var a:
 	// number` would merely add another lower bound and wrongly succeed. The coalesced
-	// type is the concrete slot type — `number` for an annotated var, the literal `5`
-	// for an un-annotated one (so `a = 6` ⇒ `6 <: 5` does NOT check until M4 `var`
-	// literal widening).
+	// type is the concrete slot type — `number` for an annotated var, and (since M4
+	// B3) the widened `number` for an un-annotated `var a = 5`, so `a = 6` ⇒
+	// `6 <: number` checks.
 	//
 	// freshenAll copies the coalesced type so constraining the source cannot mutate
 	// type-parameter vars the coalesced form still shares with the binding

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -254,6 +254,13 @@ func (c *checker) inferComponent(
 				// a `val`/`fn` is not. A FuncDecl leaves kind at its ValKind zero value.
 				if isVarDecl {
 					b.kind = vd.Kind
+					// M4 B3: an un-annotated `var` widens at coalesce time, so its literal
+					// initializer reads back as the primitive (`var a = 5` ⇒ number) and a
+					// later reassignment of the same primitive checks. An annotated `var`
+					// adopts its annotation, which needs no widening.
+					if vd.Kind == ast.VarKind && vd.TypeAnn == nil {
+						b.v.Widenable = true
+					}
 				}
 				// PR6: when the primary decl is a function, record it as the first arm. If
 				// more FuncDecls follow under this name it becomes an overload set; otherwise

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -148,7 +148,8 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 		return soltype.EnterResult{Type: nv, SkipChildren: true}
 	}
 	nv := f.c.freshAt(f.lvl)
-	nv.Open = v.Open // carry the `open` param marker onto the instantiated copy
+	nv.Open = v.Open           // carry the `open` param marker onto the instantiated copy
+	nv.Widenable = v.Widenable // carry `var` widenability so a read of the binding widens too
 	f.cache[v] = nv
 	// Mint the FromInstantiation interior edge: the fresh var was copied from v.
 	// PR1 only records the edge; the multi-hop renderer that chases it back to an

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -148,8 +148,14 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 		return soltype.EnterResult{Type: nv, SkipChildren: true}
 	}
 	nv := f.c.freshAt(f.lvl)
-	nv.Open = v.Open           // carry the `open` param marker onto the instantiated copy
-	nv.Widenable = v.Widenable // carry `var` widenability so a read of the binding widens too
+	nv.Open = v.Open // carry the `open` param marker onto the instantiated copy
+	// Carry `var` widenability onto the copy, mirroring Open. DEFENSIVE: no current
+	// path observes it — a read of a widened binding gets the literal propagated
+	// concretely through the bound graph (constrain copies a var's concrete bounds
+	// along var↔var edges), routing around this freshened copy, so its flag never
+	// changes an outcome today. Kept parallel to Open so a future path that does
+	// coalesce a freshened binding var widens consistently. See TestFreshenCopiesWidenable.
+	nv.Widenable = v.Widenable
 	f.cache[v] = nv
 	// Mint the FromInstantiation interior edge: the fresh var was copied from v.
 	// PR1 only records the edge; the multi-hop renderer that chases it back to an

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -55,6 +55,14 @@ func widen(t soltype.Type) soltype.Type {
 			return soltype.NewRef(t.Mut, t.Lt, inner)
 		}
 		return t
+	case *soltype.TypeVarType:
+		// A variable carries bounds, not a value, so there is nothing concrete to
+		// widen here, and it must stay a variable: it is a node in the bound graph,
+		// and replacing it would sever the propagation that lets reads of the binding
+		// pick up the widened primitive. A literal that reaches the binding through a
+		// variable (`var y = x`) is widened later by widenVar at coalesce time, which
+		// runs after every variable has been inlined to its bounds.
+		return t
 	default:
 		return t
 	}

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -10,11 +10,17 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // and re-wrapped via NewRef. Every other type passes through unchanged.
 //
 // It is the new-checker analogue of internal/checker's widenLiteral /
-// widenObjectLiterals / widenTupleLiterals (unify.go). M4 B3 applies it to an
-// un-annotated `var` initializer before generalization, so `var a = 5; a = 6`
-// checks (the binding is `number`, not the singleton `5`) while a `val` keeps
-// its fixed literal. C3's field-write path reuses it: writing through a `mut`
-// receiver is itself a mutation, so the stored value widens too.
+// widenObjectLiterals / widenTupleLiterals (unify.go). M4 B3 calls it in two
+// places, both for an un-annotated `var`:
+//   - eagerly on a DIRECT literal initializer in inferVarDeclInit, widening at
+//     the constraint level so the widened type propagates through the bound graph
+//     to reads of the binding (`var a = 5; val z = a` ⇒ z: number); and
+//   - at coalesce time on a Widenable binding var (see widenVar in coalesce.go),
+//     which catches a literal that arrives through a REFERENCE (`var y = x`) and
+//     is still a variable when inferVarDeclInit runs.
+//
+// A `val` keeps its fixed literal. C3's field-write path reuses it: writing
+// through a `mut` receiver is itself a mutation, so the stored value widens too.
 func widen(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.LitType:

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -1,0 +1,55 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/soltype"
+
+// widen lowers literal types to their primitives, recursively through the
+// structural carriers, so a mutable cell can later hold a different value of the
+// same primitive. A number literal `5` widens to `number`, `"x"` to `string`,
+// `true` to `boolean`; an ObjectType/TupleType widens each property value /
+// element in place, preserving Inexact; a RefType is peeled, its inner widened,
+// and re-wrapped via NewRef. Every other type passes through unchanged.
+//
+// It is the new-checker analogue of internal/checker's widenLiteral /
+// widenObjectLiterals / widenTupleLiterals (unify.go). M4 B3 applies it to an
+// un-annotated `var` initializer before generalization, so `var a = 5; a = 6`
+// checks (the binding is `number`, not the singleton `5`) while a `val` keeps
+// its fixed literal. C3's field-write path reuses it: writing through a `mut`
+// receiver is itself a mutation, so the stored value widens too.
+func widen(t soltype.Type) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.LitType:
+		switch t.Lit.(type) {
+		case *soltype.NumLit:
+			return &soltype.PrimType{Prim: soltype.NumPrim}
+		case *soltype.StrLit:
+			return &soltype.PrimType{Prim: soltype.StrPrim}
+		case *soltype.BoolLit:
+			return &soltype.PrimType{Prim: soltype.BoolPrim}
+		default:
+			return t
+		}
+	case *soltype.ObjectType:
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: widen(p.Type), Optional: p.Optional}
+		}
+		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = widen(e)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.RefType:
+		// widening preserves RefInner-ness — ObjectType/TupleType widen to
+		// themselves and a TypeVarType passes through — so the assertion holds;
+		// fall back to the unwidened borrow if a future inner ever breaks it.
+		if inner, ok := widen(t.Inner).(soltype.RefInner); ok {
+			return soltype.NewRef(t.Mut, t.Lt, inner)
+		}
+		return t
+	default:
+		return t
+	}
+}

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -142,22 +142,54 @@ func TestWidenHelper(t *testing.T) {
 	})
 }
 
-// Widening fires only on a SYNTACTIC literal initializer. A `var` initialized
-// from a binding reference infers a type variable (not a bare literal), which
-// widen passes through, so the binding keeps the referenced literal type and a
-// later reassignment of a different value is rejected. This pins the known limit
-// of default-widen: it does not chase a literal that flows through a reference,
-// unlike the principled "join over all assignment sites" form (M4 plan B3).
-func TestInferVarWideningOnlyDirectLiteral(t *testing.T) {
-	t.Run("var from a val reference keeps the literal", func(t *testing.T) {
+// Widening reaches a literal that flows through a binding reference, not only a
+// syntactic literal initializer. `var y = x` (where x is a literal `val`) infers
+// y's initializer as a type variable, but the binding var's Widenable flag rides
+// through coalescing and lowers the inlined literal, so y widens to the primitive
+// and a later reassignment of the same primitive checks — the reference case
+// behaves like a direct literal.
+func TestInferVarWideningThroughReference(t *testing.T) {
+	t.Run("var from a val reference widens to the primitive", func(t *testing.T) {
 		values, _, errs := inferSource(t, "val x = 5\nvar y = x")
 		require.Empty(t, errs)
-		require.Equal(t, "5", values["y"])
+		require.Equal(t, "number", values["y"])
 	})
-	t.Run("reassigning the un-widened var is rejected", func(t *testing.T) {
-		src := "val x = 5\nvar y = x\nfn f() { y = 6 }"
-		_, _, errs := inferSource(t, src)
-		requireBlame(t, src, errs, "cannot constrain 6 <: 5", "6", "5")
+	t.Run("reassigning the widened var checks", func(t *testing.T) {
+		values, _, errs := inferSource(t, "val x = 5\nvar y = x\nfn f() { y = 6 }")
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["y"])
+	})
+	// Reference widening rides the Widenable flag at coalesce time (display, the
+	// reassignment slot, the binding's own type), but the literal still flows into
+	// the bound graph unwidened, so a read of the reference-widened var into a new
+	// binding keeps the precise literal: `val z = y` ⇒ z: 5. A direct literal
+	// widens at the constraint level instead, so ITS reads widen (see
+	// TestInferVarWideningPropagatesToReads). z: 5 is sound — z is an immutable
+	// snapshot of the value 5 — and this pins the narrow remaining corner.
+	t.Run("reading a reference-widened var keeps the literal", func(t *testing.T) {
+		values, _, errs := inferSource(t, "val x = 5\nvar y = x\nval z = y")
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["y"])
+		require.Equal(t, "5", values["z"])
+	})
+}
+
+// A read of a directly-widened `var` into another binding widens too: the eager
+// constraint-level widening of a direct literal propagates through the bound
+// graph, so `var a = 5; val z = a` ⇒ z: number, matching `a`'s own widened type
+// (unlike the reference corner above, where the literal reaches the reader
+// unwidened).
+func TestInferVarWideningPropagatesToReads(t *testing.T) {
+	t.Run("scalar read widens", func(t *testing.T) {
+		values, _, errs := inferSource(t, "var a = 5\nval z = a")
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["a"])
+		require.Equal(t, "number", values["z"])
+	})
+	t.Run("object read widens", func(t *testing.T) {
+		values, _, errs := inferSource(t, "var p = {x: 0}\nval q = p")
+		require.Empty(t, errs)
+		require.Equal(t, "{x: number}", values["q"])
 	})
 }
 

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,4 +80,92 @@ func TestInferVarWideningReassignment(t *testing.T) {
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, `cannot constrain "x" <: number`, `"x"`)
 	})
+}
+
+// widen's structural arms are exercised directly here because no M4 source can
+// yet produce a borrow-typed or inexact var initializer — C3's field-write path
+// is the first consumer of the RefType arm, and inexactness only reaches a var
+// binding through annotations (which take the annotation, not widening). These
+// pin the helper's full contract — literal lowering, recursive object/tuple
+// descent preserving Inexact, RefType peel/re-wrap preserving Mut, and
+// passthrough of already-widened or still-variable types — that C3 relies on.
+func TestWidenHelper(t *testing.T) {
+	numLit := &soltype.LitType{Lit: &soltype.NumLit{Value: 5}}
+	objLit := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "x", Type: &soltype.LitType{Lit: &soltype.NumLit{Value: 5}}},
+	}}
+
+	tests := []struct {
+		name string
+		in   soltype.Type
+		want string
+	}{
+		{"number literal", numLit, "number"},
+		{"string literal", &soltype.LitType{Lit: &soltype.StrLit{Value: "x"}}, "string"},
+		{"bool literal", &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}, "boolean"},
+		{
+			name: "inexact object preserves the tail",
+			in: &soltype.ObjectType{Inexact: true, Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: "x", Type: &soltype.LitType{Lit: &soltype.NumLit{Value: 5}}},
+			}},
+			want: "{x: number, ...}",
+		},
+		{
+			name: "inexact tuple preserves the tail",
+			in: &soltype.TupleType{Inexact: true, Elems: []soltype.Type{
+				&soltype.LitType{Lit: &soltype.NumLit{Value: 1}},
+			}},
+			want: "[number, ...]",
+		},
+		{
+			name: "mut borrow widens inner and keeps Mut",
+			in:   &soltype.RefType{Mut: true, Inner: objLit},
+			want: "mut {x: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(widen(tt.in)))
+		})
+	}
+
+	// A type with no literal to lower passes through by identity — widen neither
+	// rebuilds nor mutates it. A PrimType is already widened; a TypeVarType is
+	// left for the solver (widen never follows its bounds).
+	t.Run("already-primitive passes through unchanged", func(t *testing.T) {
+		prim := &soltype.PrimType{Prim: soltype.NumPrim}
+		require.Same(t, prim, widen(prim))
+	})
+	t.Run("type variable passes through unchanged", func(t *testing.T) {
+		tv := &soltype.TypeVarType{ID: 1}
+		require.Same(t, tv, widen(tv))
+	})
+}
+
+// Widening fires only on a SYNTACTIC literal initializer. A `var` initialized
+// from a binding reference infers a type variable (not a bare literal), which
+// widen passes through, so the binding keeps the referenced literal type and a
+// later reassignment of a different value is rejected. This pins the known limit
+// of default-widen: it does not chase a literal that flows through a reference,
+// unlike the principled "join over all assignment sites" form (M4 plan B3).
+func TestInferVarWideningOnlyDirectLiteral(t *testing.T) {
+	t.Run("var from a val reference keeps the literal", func(t *testing.T) {
+		values, _, errs := inferSource(t, "val x = 5\nvar y = x")
+		require.Empty(t, errs)
+		require.Equal(t, "5", values["y"])
+	})
+	t.Run("reassigning the un-widened var is rejected", func(t *testing.T) {
+		src := "val x = 5\nvar y = x\nfn f() { y = 6 }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs, "cannot constrain 6 <: 5", "6", "5")
+	})
+}
+
+// A body-level `var` widens through the inferVarDecl path (distinct from the
+// top-level inferDeclDef/SCC path the other tests exercise), so reassigning it
+// inside the same function checks and the binding reads back as the primitive.
+func TestInferVarWideningBodyLevel(t *testing.T) {
+	values, _, errs := inferSource(t, "fn f() { var a = 5\n  a = 6\n  return a }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> number", values["f"])
 }

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -1,0 +1,82 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// M4 B3: an un-annotated `var` binding widens its initializer's literal types to
+// their primitives, recursively through objects and tuples, so a mutable cell can
+// later hold a different value of the same primitive. A `val` is a fixed
+// singleton and keeps its literal type. These exercise the rendered binding type
+// end-to-end through the real parser pipeline.
+func TestInferVarLiteralWidening(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "scalar var widens to its primitive",
+			src:  `var a = 5`,
+			want: map[string]string{"a": "number"},
+		},
+		{
+			name: "string and bool vars widen",
+			src: `
+				var s = "hi"
+				var b = true
+			`,
+			want: map[string]string{"s": "string", "b": "boolean"},
+		},
+		{
+			name: "val keeps its literal singleton",
+			src:  `val a = 5`,
+			want: map[string]string{"a": "5"},
+		},
+		{
+			name: "object var widens each property",
+			src:  `var p = {x: 0, y: 0}`,
+			want: map[string]string{"p": "{x: number, y: number}"},
+		},
+		{
+			name: "tuple var widens each element",
+			src:  `var t = [1, 2]`,
+			want: map[string]string{"t": "[number, number]"},
+		},
+		{
+			name: "nesting widens through",
+			src:  `var n = {p: {x: 0}}`,
+			want: map[string]string{"n": "{p: {x: number}}"},
+		},
+		{
+			name: "object val keeps its literals",
+			src:  `val p = {x: 0, y: 0}`,
+			want: map[string]string{"p": "{x: 0, y: 0}"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values)
+		})
+	}
+}
+
+// A widened `var` accepts a reassignment of a different value of the same
+// primitive, while a value of a different primitive is still rejected — the
+// binding is the widened primitive, not `any`.
+func TestInferVarWideningReassignment(t *testing.T) {
+	t.Run("same-primitive reassignment checks", func(t *testing.T) {
+		values, _, errs := inferSource(t, "var a = 5\nfn f() { a = 6 }")
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["a"])
+	})
+	t.Run("different-primitive reassignment rejected", func(t *testing.T) {
+		src := "var a = 5\nfn f() { a = \"x\" }"
+		_, _, errs := inferSource(t, src)
+		requireBlame(t, src, errs, `cannot constrain "x" <: number`, `"x"`)
+	})
+}

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -122,6 +122,13 @@ func TestWidenHelper(t *testing.T) {
 			in:   &soltype.RefType{Mut: true, Inner: objLit},
 			want: "mut {x: number}",
 		},
+		{
+			name: "object property keeps its optional flag while widening",
+			in: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: "x", Type: &soltype.LitType{Lit: &soltype.NumLit{Value: 5}}, Optional: true},
+			}},
+			want: "{x?: number}",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -197,7 +204,77 @@ func TestInferVarWideningPropagatesToReads(t *testing.T) {
 // top-level inferDeclDef/SCC path the other tests exercise), so reassigning it
 // inside the same function checks and the binding reads back as the primitive.
 func TestInferVarWideningBodyLevel(t *testing.T) {
-	values, _, errs := inferSource(t, "fn f() { var a = 5\n  a = 6\n  return a }")
-	require.Empty(t, errs)
-	require.Equal(t, "fn () -> number", values["f"])
+	t.Run("direct literal widens and reassigns", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn f() { var a = 5\n  a = 6\n  return a }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> number", values["f"])
+	})
+	// A body-level `var` initialized from a REFERENCE widens via the wrapper var's
+	// Widenable flag, so the reassignment slot is the primitive and `y = 6` checks
+	// — the body-level twin of TestInferVarWideningThroughReference.
+	t.Run("reference widens and reassigns", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn f() { val x = 5\n  var y = x\n  y = 6 }")
+		require.Empty(t, errs)
+	})
+}
+
+// Widening through a reference reaches the structural carriers, not only scalars:
+// `val o = {x: 0}; var p = o` widens p to {x: number}, and the tuple form to
+// [number, number]. This exercises the Widenable flag driving widen's RECURSION
+// at coalesce time, distinct from the eager direct-literal path that widens
+// `var p = {x: 0}` at the constraint level.
+func TestInferVarWideningReferenceStructural(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		values, _, errs := inferSource(t, "val o = {x: 0}\nvar p = o")
+		require.Empty(t, errs)
+		require.Equal(t, "{x: number}", values["p"])
+	})
+	t.Run("tuple", func(t *testing.T) {
+		values, _, errs := inferSource(t, "val o = [1, 2]\nvar p = o")
+		require.Empty(t, errs)
+		require.Equal(t, "[number, number]", values["p"])
+	})
+}
+
+// widenVar is the shared helper both coalescers call. It is unit-tested directly
+// because the plain-coalescer call site is unreachable through real source (a
+// widenable var is always a binding var, which renders through coalesceScheme),
+// and because the negative-polarity no-op cannot arise for a binding var either.
+// It widens only a widenable var read in covariant (Positive) position.
+func TestWidenVar(t *testing.T) {
+	lit := func() soltype.Type { return &soltype.LitType{Lit: &soltype.NumLit{Value: 5}} }
+	widenable := &soltype.TypeVarType{ID: 1, Widenable: true}
+	plain := &soltype.TypeVarType{ID: 2}
+	tests := []struct {
+		name string
+		v    *soltype.TypeVarType
+		pol  soltype.Polarity
+		want string
+	}{
+		{"widenable positive widens", widenable, soltype.Positive, "number"},
+		{"widenable negative is a no-op", widenable, soltype.Negative, "5"},
+		{"non-widenable positive is a no-op", plain, soltype.Positive, "5"},
+		{"non-widenable negative is a no-op", plain, soltype.Negative, "5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, soltype.Print(widenVar(tt.v, tt.pol, lit())))
+		})
+	}
+}
+
+// The freshener copies the Widenable flag onto an instantiated binding var. This
+// behavior is currently unreachable from source — a read of a widened binding
+// gets the literal propagated concretely, routing around the freshened copy — so
+// it is pinned here directly as the defensive contract that keeps Widenable
+// parallel to Open. See the freshener note in poly.go.
+func TestFreshenCopiesWidenable(t *testing.T) {
+	c := newChecker()
+	v := c.freshAt(1)
+	v.Widenable = true
+	out := c.freshenAbove(0, v, 0, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	nv, ok := out.(*soltype.TypeVarType)
+	require.True(t, ok)
+	require.NotSame(t, v, nv) // a fresh copy, not the original
+	require.True(t, nv.Widenable)
 }


### PR DESCRIPTION
Un-annotated `var` bindings now widen their initializer's literal types to primitives, allowing reassignment of different values of the same primitive type. A `val` keeps its literal singleton type unchanged.

**Changes:**

- Add `widen()` function that recursively lowers literal types (`5` → `number`, `"x"` → `string`, `true` → `boolean`) through structural types (objects, tuples, borrows) while leaving other types unchanged.
- Apply widening to un-annotated `var` initializers in `inferVarDeclInit()` before generalization, gated on mutability so `val` bindings remain unwidened.
- Update assignment checking comments to reflect that un-annotated `var a = 5` now has binding type `number` rather than the literal `5`, so `a = 6` type-checks.
- Add comprehensive test suite covering scalar, string, boolean, object, tuple, and nested literal widening for both `var` and `val`, plus reassignment validation.

**Implementation notes:**

The widening function mirrors the old checker's `widenLiteral` / `widenObjectLiterals` / `widenTupleLiterals` behavior. RefType widening preserves the borrow wrapper and asserts the inner type remains a valid RefInner. Widening is applied only to un-annotated `var` declarations, not `val`, making the binding type the concrete slot type for assignment checking.

https://claude.ai/code/session_01CFDoKAprQ1vhbnhpViwu69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved type inference for variable declarations without explicit type annotations
  * Variables initialized with literal values now widen to their primitive types
  * Enhanced reassignment type checking to reflect updated type inference behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->