### PR TITLE
Implement field writes and read-after-write for mutable objects (M4 C3)

### DIFF
--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -159,6 +159,13 @@ func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	// never sees a real Mut borrow — and Accept is shared with coalesce, which WANTS a
 	// single covariant visit, so the fix belongs in extrude/freshenAbove (not here)
 	// once borrows originate (D2) and the case becomes reachable and testable.
+	//
+	// The OCCURRENCE-analysis half of this invariance is already handled separately,
+	// not here: simplify.go's recordMutWriteView walks a Mut inner in the flipped
+	// polarity for the occurrence and co-occurrence visitors, so a var written through
+	// a mut field is retained as a type parameter rather than dropped (#737). That is a
+	// record-only pass, so it can add the write view without the double visit coalesce
+	// must avoid.
 	inner := cur.Inner.Accept(v, pol)
 	var out Type = cur
 	if inner != cur.Inner {

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -156,7 +156,7 @@ func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
 func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o?.a"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unsupported in M2: OptionalChain", "o?.a")
+	requireBlame(t, src, errs, "Unsupported: OptionalChain", "o?.a")
 }
 
 // --- Site-fallback fixtures ---
@@ -322,7 +322,7 @@ func TestUnsupportedAnnotationRecovers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "Unsupported in M2: TypeRefTypeAnn", errs[0].Message())
+			require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
 			require.Equal(t, tt.want, values)
 		})
 	}
@@ -340,6 +340,6 @@ func TestNilVarDeclPatternBlamesDeclWithoutPanic(t *testing.T) {
 		require.False(t, ok)
 	})
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: VarDecl", c.errs[0].Message())
+	require.Equal(t, "Unsupported: VarDecl", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span()) // derefs the decl node, not a nil pattern
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -330,8 +330,17 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 // parameter marker (B2) is the opt-out: when set, the folded object stays inexact
 // so the param is row-polymorphic and callers may pass objects with extra fields.
 //
-// Mut-object merging (`mut {x} & mut {y}` ⇒ `mut {x, y}`) is deferred to C3, once
-// the field-write path produces mut receivers.
+// Whole-object `mut` merge (M4 C3): the field-write path records a write `obj.x =
+// 5` as a MUTABLE inexact requirement `mut {x: number, ...}` on the receiver var,
+// alongside the bare inexact reads. When ANY write is present, every selection —
+// reads and writes alike — folds into ONE object wrapped in `mut`, following
+// internal/checker rather than the spike's per-field partition: `obj.x = 5; obj.y =
+// 10` ⇒ `mut {x, y}` and the mixed `val x = obj.bar; obj.baz = 5` ⇒
+// `mut {bar, baz}` — a single object, not `{bar} & mut {baz}`. With
+// no write the reads fold into a bare (immutable) object, the pre-C3 behavior. The
+// tradeoff: wrapping the whole object in `mut` makes read-only fields invariant
+// rather than covariant; for a generalized function this is invisible because each
+// read-only field is a fresh-per-call type parameter.
 //
 // This is NOT recursive: it folds the objects of ONE var's bound list and does not
 // descend into property types. Nesting (`p.a.b`) is reached by the callers' walks
@@ -341,54 +350,89 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 func foldUsageBounds(parts []soltype.Type, open bool) []soltype.Type {
 	var objs []*soltype.ObjectType
 	var others []soltype.Type
+	mut := false
 	for _, p := range parts {
 		if o, ok := p.(*soltype.ObjectType); ok && o.Inexact {
 			objs = append(objs, o)
 			continue
+		}
+		// A mutable inexact one-property requirement is a field write (C3). Its inner
+		// object joins the read requirements in the fold, and its presence makes the
+		// whole merged object `mut`.
+		if r, ok := p.(*soltype.RefType); ok && r.Mut {
+			if o, ok := r.Inner.(*soltype.ObjectType); ok && o.Inexact {
+				objs = append(objs, o)
+				mut = true
+				continue
+			}
 		}
 		others = append(others, p)
 	}
 	if len(objs) == 0 {
 		return parts // nothing to fold; leave the bound list as-is
 	}
-	return append([]soltype.Type{mergeObjectGroup(objs, open)}, others...)
+	mergedObj := mergeObjectGroup(objs, open)
+	merged := soltype.Type(mergedObj)
+	if mut {
+		// NewRef does not collapse a (true, nil) cell — an owned-mutable object — so
+		// the wrapper survives. mergeObjectGroup returns a *ObjectType, a RefInner.
+		merged = soltype.NewRef(true, nil, mergedObj)
+	}
+	return append([]soltype.Type{merged}, others...)
 }
 
 // mergeObjectGroup is the property-union step inside foldUsageBounds: it folds the
 // already-selected inexact objects into one object. The property sets are unioned
-// and a property shared by several objects becomes the intersection of its types.
-// Property order is alphabetical for stable rendering. A property is optional in
-// the result only when it is optional in every object that carries it. The result
-// is exact (closed) unless `open`, in which case it stays inexact.
+// and a property shared by several objects becomes the intersection of its types,
+// after dropping structurally-equal duplicates — so two writes of the same widened
+// primitive (`obj.x = 5; obj.x = 10`, both `number`) give `x: number`, not the
+// redundant `x: number & number`, while two distinct requirements still intersect.
+// Property order is alphabetical for stable rendering. A property is optional in the
+// result only when it is optional in every object that carries it. The result is
+// exact (closed) unless `open`, in which case it stays inexact.
 //
 // This is NOT recursive: each property's type is copied through verbatim, never
 // descended into. Nesting is handled by the var-graph walks in sealUsageObjects,
 // coalesce, and coalesceScheme — see foldUsageBounds.
 func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType {
-	byName := map[string]*soltype.PropertyElem{}
+	types := map[string][]soltype.Type{}
+	allOptional := map[string]bool{}
 	var order []string
 	for _, o := range objs {
 		for _, elem := range o.Elems {
 			pe := soltype.AsProperty(elem)
-			if existing, dup := byName[pe.Name]; dup {
-				byName[pe.Name] = &soltype.PropertyElem{
-					Name:     pe.Name,
-					Type:     &soltype.IntersectionType{Types: []soltype.Type{existing.Type, pe.Type}},
-					Optional: existing.Optional && pe.Optional,
-				}
-			} else {
-				byName[pe.Name] = &soltype.PropertyElem{Name: pe.Name, Type: pe.Type, Optional: pe.Optional}
+			if _, seen := allOptional[pe.Name]; !seen {
 				order = append(order, pe.Name)
+				allOptional[pe.Name] = true
 			}
+			types[pe.Name] = appendDistinct(types[pe.Name], pe.Type)
+			allOptional[pe.Name] = allOptional[pe.Name] && pe.Optional
 		}
 	}
 	sort.Strings(order)
 	elems := make([]soltype.ObjTypeElem, len(order))
 	for i, name := range order {
-		elems[i] = byName[name]
+		ts := types[name]
+		ty := ts[0]
+		if len(ts) > 1 {
+			ty = &soltype.IntersectionType{Types: ts}
+		}
+		elems[i] = &soltype.PropertyElem{Name: name, Type: ty, Optional: allOptional[name]}
 	}
 	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
 	return &soltype.ObjectType{Elems: elems, Inexact: open}
+}
+
+// appendDistinct appends t to parts unless a structurally-equal type is already
+// present, so a property folded from several requirements with the same type does
+// not accumulate redundant intersection members (mergeObjectGroup).
+func appendDistinct(parts []soltype.Type, t soltype.Type) []soltype.Type {
+	for _, p := range parts {
+		if equalType(p, t) {
+			return parts
+		}
+	}
+	return append(parts, t)
 }
 
 // dedup removes structurally-equal parts, preserving first-occurrence order.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -352,19 +352,10 @@ func foldUsageBounds(parts []soltype.Type, open bool) []soltype.Type {
 	var others []soltype.Type
 	mut := false
 	for _, p := range parts {
-		if o, ok := p.(*soltype.ObjectType); ok && o.Inexact {
+		if o, isWrite, ok := usageObject(p); ok {
 			objs = append(objs, o)
+			mut = mut || isWrite
 			continue
-		}
-		// A mutable inexact one-property requirement is a field write (C3). Its inner
-		// object joins the read requirements in the fold, and its presence makes the
-		// whole merged object `mut`.
-		if r, ok := p.(*soltype.RefType); ok && r.Mut {
-			if o, ok := r.Inner.(*soltype.ObjectType); ok && o.Inexact {
-				objs = append(objs, o)
-				mut = true
-				continue
-			}
 		}
 		others = append(others, p)
 	}
@@ -381,6 +372,31 @@ func foldUsageBounds(parts []soltype.Type, open bool) []soltype.Type {
 	return append([]soltype.Type{merged}, others...)
 }
 
+// usageObject classifies a coalesced upper bound as a member-access requirement on
+// a receiver, the unit foldUsageBounds folds. It distinguishes the two requirement
+// shapes the inference walk mints:
+//   - a bare inexact object is a member READ — `obj.x` lowers to {x: β, ...}
+//     (valueProp); ok=true, write=false.
+//   - a `mut`-wrapped inexact object is a field WRITE — `obj.x = v` lowers to
+//     mut {x: widen(v), ...} (inferMemberAssign); ok=true, write=true.
+//
+// Everything else is not a usage requirement and returns ok=false: an EXACT object
+// is an already-closed shape (folding it would be wrong), an immutable borrow is not
+// a member requirement, and a non-object bound is unrelated. Centralizing the shape
+// test here keeps the two requirement forms named in one place rather than as inline
+// type-switches, so a future requirement shape is added here, not hunted for.
+func usageObject(t soltype.Type) (obj *soltype.ObjectType, write bool, ok bool) {
+	if o, isObj := t.(*soltype.ObjectType); isObj && o.Inexact {
+		return o, false, true
+	}
+	if inner, isMut, _ := soltype.UnwrapRef(t); isMut {
+		if o, isObj := inner.(*soltype.ObjectType); isObj && o.Inexact {
+			return o, true, true
+		}
+	}
+	return nil, false, false
+}
+
 // mergeObjectGroup is the property-union step inside foldUsageBounds: it folds the
 // already-selected inexact objects into one object. The property sets are unioned
 // and a property shared by several objects becomes the intersection of its types,
@@ -395,18 +411,19 @@ func foldUsageBounds(parts []soltype.Type, open bool) []soltype.Type {
 // descended into. Nesting is handled by the var-graph walks in sealUsageObjects,
 // coalesce, and coalesceScheme — see foldUsageBounds.
 func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType {
-	types := map[string][]soltype.Type{}
-	allOptional := map[string]bool{}
+	types := map[string][]soltype.Type{} // property name → its distinct types, in first-seen order
+	optional := map[string]bool{}        // property name → optional in every object seen so far
 	var order []string
 	for _, o := range objs {
 		for _, elem := range o.Elems {
 			pe := soltype.AsProperty(elem)
-			if _, seen := allOptional[pe.Name]; !seen {
+			if _, seen := types[pe.Name]; !seen {
 				order = append(order, pe.Name)
-				allOptional[pe.Name] = true
+				optional[pe.Name] = pe.Optional // first occurrence seeds the value
+			} else {
+				optional[pe.Name] = optional[pe.Name] && pe.Optional // optional iff optional in all
 			}
 			types[pe.Name] = appendDistinct(types[pe.Name], pe.Type)
-			allOptional[pe.Name] = allOptional[pe.Name] && pe.Optional
 		}
 	}
 	sort.Strings(order)
@@ -417,7 +434,7 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 		if len(ts) > 1 {
 			ty = &soltype.IntersectionType{Types: ts}
 		}
-		elems[i] = &soltype.PropertyElem{Name: name, Type: ty, Optional: allOptional[name]}
+		elems[i] = &soltype.PropertyElem{Name: name, Type: ty, Optional: optional[name]}
 	}
 	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
 	return &soltype.ObjectType{Elems: elems, Inexact: open}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -161,6 +161,75 @@ func TestCoalesceNegativeObjectMerge(t *testing.T) {
 	})
 }
 
+// TestCoalesceMutWriteFold pins the C3 whole-object mut merge: a field-write bound
+// (a mut-wrapped inexact object) folds with the receiver's reads into ONE object,
+// and the presence of any write wraps the merged object in `mut`. usageObject is the
+// classifier that routes both read and write requirements into the fold.
+func TestCoalesceMutWriteFold(t *testing.T) {
+	// A lone write requirement folds and the result is wrapped in mut.
+	t.Run("single write folds to a mut object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{mutRef(inexactObj(propElem("x", num())))}
+		got := coalesce(p, soltype.Negative)
+		want := mutRef(exactObj(propElem("x", num())))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	// A bare read and a mut write on the same receiver fold into ONE mut object —
+	// not `{x} & mut {y}` — because any write makes the whole merged object mut.
+	t.Run("read and write fold into one mut object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("x", num())),
+			mutRef(inexactObj(propElem("y", str()))),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := mutRef(exactObj(propElem("x", num()), propElem("y", str())))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	// With no write, reads fold into a bare (immutable) object — the pre-C3 behavior,
+	// confirming the mut wrap is gated on an actual write.
+	t.Run("reads only fold to a bare object", func(t *testing.T) {
+		c := &Context{}
+		p := c.freshVar(0)
+		p.UpperBounds = []soltype.Type{
+			inexactObj(propElem("x", num())),
+			inexactObj(propElem("y", str())),
+		}
+		got := coalesce(p, soltype.Negative)
+		want := exactObj(propElem("x", num()), propElem("y", str()))
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
+// TestUsageObject pins the requirement classifier directly: a bare inexact object is
+// a read, a mut-wrapped inexact object is a write, and an exact object, an immutable
+// borrow, or a non-object is not a usage requirement.
+func TestUsageObject(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        soltype.Type
+		wantOK    bool
+		wantWrite bool
+	}{
+		{"bare inexact object is a read", inexactObj(propElem("x", num())), true, false},
+		{"mut inexact object is a write", mutRef(inexactObj(propElem("x", num()))), true, true},
+		{"exact object is not a usage requirement", exactObj(propElem("x", num())), false, false},
+		{"mut exact object is not a usage requirement", mutRef(exactObj(propElem("x", num()))), false, false},
+		{"non-object is not a usage requirement", num(), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, write, ok := usageObject(tt.in)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantWrite, write)
+		})
+	}
+}
+
 // TestCoalesceOpenVarStaysInexact pins B2: an `open` parameter var's folded usage
 // object stays inexact (row-polymorphic) instead of closing to exact. The Open flag
 // on the var is the opt-out from B1's Policy-A close.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -307,6 +307,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//    number}` still rejects (x invariant: number <: 5 fails) and an EXACT
 			//    target still demands an identical field set (the read view rejects extras).
 			//
+			//    A literal-typed field like the `5` in `mut {x: 5}` only arises from an
+			//    ANNOTATION. A field WRITE never produces one: inferMemberAssign builds the
+			//    requirement with widen(source), so `obj.x = 5` lowers to `mut {x: number,
+			//    ...}`, not `mut {x: 5, ...}`. Writing through a mut receiver is itself a
+			//    mutation — a later write may store any number — so the stored literal widens
+			//    to its primitive before it becomes the field's type.
+			//
 			//    The write view gates on `sup.Mut`, which is load-bearing-equivalent to
 			//    `sub.Mut && sup.Mut`: the mutability check above already returned for
 			//    `!sub.Mut && sup.Mut`, so reaching here with sup.Mut implies sub.Mut.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -85,6 +85,35 @@ func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 	return c.constrain(sub, super, set.NewSet[constraintKey]())
 }
 
+// constrainWriteBack is the contravariant WRITE view of a mutable borrow's inner
+// (the RefType <: RefType rule, step 2). For each field the target object NAMES it
+// constrains target.field <: source.field, so combined with the covariant read view
+// that field is invariant. It ranges over the TARGET's fields only — not the whole
+// object — so an inexact target (a field write `obj.x = v` lowers to mut {x: v, ...})
+// pins its named fields without forcing the source down to exactly that field set.
+//
+// A field the target names but the source lacks is already reported by the read
+// view's MissingPropertyError, so it is skipped here to avoid a double report. When
+// the target is EXACT the read view has already forced the source to the same field
+// set, so this per-field pass is complete. Non-object inners — a TypeVarType
+// mid-inference, a tuple — fall back to a full contravariant constraint, the prior
+// whole-inner behavior.
+func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[constraintKey]) []SolverError {
+	targetObj, ok1 := target.(*soltype.ObjectType)
+	sourceObj, ok2 := source.(*soltype.ObjectType)
+	if !ok1 || !ok2 {
+		return c.constrain(target, source, seen)
+	}
+	var errs []SolverError
+	for _, elem := range targetObj.Elems {
+		p := soltype.AsProperty(elem)
+		if sp, ok := sourceObj.Prop(p.Name); ok {
+			errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)
+		}
+	}
+	return errs
+}
+
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]) []SolverError {
 	key := constraintKey{sub, super}
 	if seen.Contains(key) {
@@ -268,10 +297,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
 			}
 			// 2. Inner variance: the read view is always covariant; a mutable target
-			//    also takes a contravariant write view, and read + write together IS
-			//    invariance. So `mut {x, y} <: mut {x, ...}` rejects (the write view's
-			//    `{x, ...} <: {x, y}` is missing y), while `{x, y} <: {x, ...}` as bare
-			//    objects width-succeeds.
+			//    also takes a contravariant write view, and read + write together make
+			//    every field the target NAMES invariant. The write view is per-field over
+			//    the target's named fields (constrainWriteBack), not a whole-object
+			//    constraint, so an INEXACT target tolerates extra fields on the source
+			//    while still pinning its named fields. So `mut {x, y} <: mut {x, ...}`
+			//    SUCCEEDS — the inexact target names only x, which stays invariant, and y
+			//    is hidden, not writable through the target — while `mut {x: 5} <: mut {x:
+			//    number}` still rejects (x invariant: number <: 5 fails) and an EXACT
+			//    target still demands an identical field set (the read view rejects extras).
 			//
 			//    The write view gates on `sup.Mut`, which is load-bearing-equivalent to
 			//    `sub.Mut && sup.Mut`: the mutability check above already returned for
@@ -281,7 +315,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//    source.
 			errs := c.constrain(sub.Inner, sup.Inner, seen)
 			if sup.Mut {
-				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen)...)
+				errs = append(errs, c.constrainWriteBack(sup.Inner, sub.Inner, seen)...)
 			}
 			// 3. Lifetime outlives, covariant. Written now, INERT in C2 because Lt is
 			//    always nil until the lifetime sort lands (D1); constrainLt wires the

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -669,8 +669,8 @@ func TestConstrainRef(t *testing.T) {
 			super: mutRef(inexactObj(propElem("x", num()))),
 		},
 		{
-			// mut {x: 5, y} <: mut {x: number, ...}: width is still tolerated, but the
-			// named field x stays invariant — the write view number <: 5 fails. The
+			// mut {x: 5, y: number} <: mut {x: number, ...}: width is still tolerated, but
+			// the named field x stays invariant — the write view number <: 5 fails. The
 			// relaxation is width-only; it does not weaken depth invariance.
 			name:  "mut wider <: mut inexact still pins the named field's depth",
 			sub:   mutRef(exactObj(propElem("x", numLit(5)), propElem("y", num()))),

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -670,8 +670,14 @@ func TestConstrainRef(t *testing.T) {
 		},
 		{
 			// mut {x: 5, y: number} <: mut {x: number, ...}: width is still tolerated, but
-			// the named field x stays invariant — the write view number <: 5 fails. The
-			// relaxation is width-only; it does not weaken depth invariance.
+			// the named field x stays invariant because a mut reference checks it in BOTH
+			// directions:
+			//   - read view, covariant (sub <: super): 5 <: number, which holds.
+			//   - write view, contravariant (super <: sub): number <: 5, which fails. The
+			//     super lets a holder write any number into x, but the real field only
+			//     accepts 5.
+			// Invariance forces the two views together, so the named field's type must
+			// match. The relaxation is width-only; it does not weaken depth invariance.
 			name:  "mut wider <: mut inexact still pins the named field's depth",
 			sub:   mutRef(exactObj(propElem("x", numLit(5)), propElem("y", num()))),
 			super: mutRef(inexactObj(propElem("x", num()))),

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -658,16 +658,24 @@ func TestConstrainRef(t *testing.T) {
 			want:  []string{"cannot constrain number <: 5"},
 		},
 		{
-			// mut {x, y} <: mut {x, ...}: the read view width-succeeds (inexact super),
-			// but the write view {x, ...} <: {x, y} is missing y and is inexact-into-
-			// exact — the plan's headline invariance rejection.
-			name:  "mut wider <: mut inexact rejects on the write view",
+			// mut {x, y} <: mut {x, ...}: the read view width-succeeds (inexact super)
+			// and the write view is per-field over the target's NAMED fields (just x), so
+			// x stays invariant while the source's extra y is tolerated. The inexact
+			// target names only x, and y is not writable through it, so admitting the
+			// wider source is sound. This is what lets a field write `obj.x = v` — which
+			// lowers to mut {x, ...} — apply to a concretely-typed mutable receiver.
+			name:  "mut wider <: mut inexact: width tolerated, named field invariant",
 			sub:   mutRef(exactObj(propElem("x", num()), propElem("y", num()))),
 			super: mutRef(inexactObj(propElem("x", num()))),
-			want: []string{
-				"object is missing property: y",
-				"cannot constrain inexact object <: exact object",
-			},
+		},
+		{
+			// mut {x: 5, y} <: mut {x: number, ...}: width is still tolerated, but the
+			// named field x stays invariant — the write view number <: 5 fails. The
+			// relaxation is width-only; it does not weaken depth invariance.
+			name:  "mut wider <: mut inexact still pins the named field's depth",
+			sub:   mutRef(exactObj(propElem("x", numLit(5)), propElem("y", num()))),
+			super: mutRef(inexactObj(propElem("x", num()))),
+			want:  []string{"cannot constrain number <: 5"},
 		},
 		{
 			// The same two object inners as bare (immutable) values width-succeed: an

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -675,13 +675,13 @@ func (e *NotEnoughArgsError) Message() string {
 func (e *UnsupportedNodeError) Span() ast.Span      { return e.Node.Span() }
 func (e *UnsupportedNodeError) Related() []ast.Span { return nil }
 func (e *UnsupportedNodeError) Message() string {
-	return "Unsupported in M2: " + astKind(e.Node)
+	return "Unsupported: " + astKind(e.Node)
 }
 
 func (e *UnsupportedFeatureError) Span() ast.Span      { return e.Node.Span() }
 func (e *UnsupportedFeatureError) Related() []ast.Span { return nil }
 func (e *UnsupportedFeatureError) Message() string {
-	return "Unsupported in M2: " + e.Feature
+	return "Unsupported: " + e.Feature
 }
 
 func (e *BodyDeclNotAllowedError) Span() ast.Span      { return e.Decl.Span() }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -40,6 +40,24 @@ type checker struct {
 	// one. Off in production (a span bug must never crash the compiler); flipped on
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
+
+	// written records the widened type stored into a receiver variable's field by a
+	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
+	// the property name. A later read of the same field returns this concrete type
+	// instead of minting a fresh var, so `obj.x = 5; obj.x` is `number`
+	// (read-after-write). It is purely a precision win: write-after-read already
+	// works through ordinary bound accumulation. The receiver and read reference the
+	// same binding within one function body, so they share a var ID; distinct
+	// functions get distinct IDs from the fresh-var counter, so the map never
+	// collides across bodies.
+	written map[fieldKey]soltype.Type
+}
+
+// fieldKey identifies a written field by the receiver variable's ID and the
+// property name — the key into the checker's `written` map (M4 C3).
+type fieldKey struct {
+	recvID int
+	field  string
 }
 
 // funcCtx is the per-function inference context — pushed by inferFunc on entry to
@@ -84,7 +102,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
 // empty Prov side table.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}}
+	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, written: map[fieldKey]soltype.Type{}}
 }
 
 // freshAt allocates a fresh inference variable at the given level. Provenance for

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -40,21 +40,10 @@ type checker struct {
 	// one. Off in production (a span bug must never crash the compiler); flipped on
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
-
-	// written records the widened type stored into a receiver variable's field by a
-	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
-	// the property name. A later read of the same field returns this concrete type
-	// instead of minting a fresh var, so `obj.x = 5; obj.x` is `number`
-	// (read-after-write). It is purely a precision win: write-after-read already
-	// works through ordinary bound accumulation. The receiver and read reference the
-	// same binding within one function body, so they share a var ID; distinct
-	// functions get distinct IDs from the fresh-var counter, so the map never
-	// collides across bodies.
-	written map[fieldKey]soltype.Type
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the
-// property name — the key into the checker's `written` map (M4 C3).
+// property name — the key into a function body's `written` map (M4 C3).
 type fieldKey struct {
 	recvID int
 	field  string
@@ -76,6 +65,22 @@ type funcCtx struct {
 	async   bool
 	node    ast.Node
 	returns []soltype.Type
+
+	// written records the widened type stored into a receiver variable's field by a
+	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
+	// the property name. A later read of the same field returns this concrete type
+	// instead of minting a fresh var, so `obj.x = 5; obj.x` is `number`
+	// (read-after-write). It is purely a precision win: write-after-read already
+	// works through ordinary bound accumulation.
+	//
+	// It lives here, not on the checker, because read-after-write is an INTRA-BODY
+	// relation: scoping the cache to the function body it belongs to makes that
+	// correct by construction rather than relying on the global fresh-var counter to
+	// keep one body's receiver IDs from colliding with another's. Push/pop of funcCtx
+	// isolates it for free — a nested function gets its own map and the outer's is
+	// restored on exit. A field write at module top-level (c.fn == nil) simply gets
+	// no read-after-write precision, which is sound.
+	written map[fieldKey]soltype.Type
 }
 
 // pushFuncCtx enters the inference context for function `node` (async controls
@@ -86,7 +91,7 @@ type funcCtx struct {
 // than panicking, so there is no unwind to guard against.
 func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
 	saved := c.fn
-	c.fn = &funcCtx{async: async, node: node}
+	c.fn = &funcCtx{async: async, node: node, written: map[fieldKey]soltype.Type{}}
 	return saved
 }
 
@@ -102,7 +107,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
 // empty Prov side table.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, written: map[fieldKey]soltype.Type{}}
+	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}}
 }
 
 // freshAt allocates a fresh inference variable at the given level. Provenance for

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -224,7 +224,7 @@ func TestInferAssignMemberTargetImmutable(t *testing.T) {
 func TestInferAssignIndexTargetUnsupported(t *testing.T) {
 	src := "val xs = [1, 2]\nfn f() { xs[0] = 6 }"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unsupported in M2: assignment to a member or index", "xs[0]")
+	requireBlame(t, src, errs, "Unsupported: assignment to a member or index", "xs[0]")
 }
 
 // An immutable target with an independently-broken source reports BOTH errors — they
@@ -254,5 +254,5 @@ func TestInferAssignNilOperandDoesNotPanic(t *testing.T) {
 		}
 	})
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: BinaryExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: BinaryExpr", c.errs[0].Message())
 }

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -72,8 +72,8 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 }
 
 // A non-place target — a literal or a call — is an InvalidAssignmentTargetError that
-// blames the target. A member or index target takes a separate path: it is a valid
-// place pending object/array types (M4), so it reports an UnsupportedFeatureError.
+// blames the target. A member target takes a separate path (a field write, C3) and an
+// index target another (unsupported pending Array types, M7).
 func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
 		src := "val a = 5\nfn g() { 5 = a }"
@@ -209,12 +209,22 @@ func TestInferAssignNamespaceTarget(t *testing.T) {
 	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
 }
 
-// A member target (obj.x = …) is a valid-but-deferred (M4) place, reported as an
-// unsupported feature — distinct from a fundamentally invalid target like `5 = a`.
-func TestInferAssignMemberTargetUnsupported(t *testing.T) {
+// A member target (obj.x = …) is a field write (M4 C3). Writing to a field of an
+// IMMUTABLE object — here `o` is `val`-bound, so its `{x: 5}` is immutable — is
+// rejected: the write requires `o <: mut {x: number, ...}`, and an immutable object
+// cannot fill the mutable slot (the C2 gate's mutability rule).
+func TestInferAssignMemberTargetImmutable(t *testing.T) {
 	src := "val o = {x: 5}\nfn f() { o.x = 6 }"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unsupported in M2: assignment to a member or index", "o.x")
+	requireBlame(t, src, errs, "cannot constrain immutable object <: mutable object", "o.x = 6")
+}
+
+// An INDEX target (xs[i] = …) still needs Array and index types (M7), so it stays
+// an unsupported feature — distinct from a member target, which C3 now types.
+func TestInferAssignIndexTargetUnsupported(t *testing.T) {
+	src := "val xs = [1, 2]\nfn f() { xs[0] = 6 }"
+	_, _, errs := inferSource(t, src)
+	requireBlame(t, src, errs, "Unsupported in M2: assignment to a member or index", "xs[0]")
 }
 
 // An immutable target with an independently-broken source reports BOTH errors — they

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -408,7 +408,7 @@ func TestInferPromiseUnsupportedInnerKeepsWrapper(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "Unsupported: BigintTypeAnn", errs[0].Message())
 	require.Equal(t, "fn (p: Promise<unknown>) -> 0", values["f"])
 }
 
@@ -423,7 +423,7 @@ func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "Unsupported: BigintTypeAnn", errs[0].Message())
 	require.Equal(t, "fn <T0>(p: Promise<T0>) -> Promise<T0>", values["f"])
 }
 
@@ -442,7 +442,7 @@ func TestInferPromiseLifetimeRejected(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "Unsupported in M2: lifetime annotation on Promise", errs[0].Message())
+			require.Equal(t, "Unsupported: lifetime annotation on Promise", errs[0].Message())
 		})
 	}
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -556,12 +556,15 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 
 	target, ok := e.Left.(*ast.IdentExpr)
 	if !ok {
-		// A member/index target (obj.x = …, xs[i] = …) is a structurally VALID place
-		// whose type rule needs record/array types — deferred to M4 — so report it as
-		// an unsupported feature, distinct from a fundamentally invalid target like
-		// `5 = x` or `f() = x`, which is an InvalidAssignmentTargetError.
-		switch e.Left.(type) {
-		case *ast.MemberExpr, *ast.IndexExpr:
+		// A member target (obj.x = …) is a field write: the receiver must accept a
+		// write to that field (M4 C3). An index target (xs[i] = …) still needs Array
+		// and index types (M7), so it stays unsupported, distinct from a fundamentally
+		// invalid target like `5 = x` or `f() = x`, which is an
+		// InvalidAssignmentTargetError.
+		switch left := e.Left.(type) {
+		case *ast.MemberExpr:
+			return c.inferMemberAssign(scope, lvl, e, left, sourceT)
+		case *ast.IndexExpr:
 			c.reportUnsupportedFeature(e.Left, "assignment to a member or index")
 		default:
 			c.report(&InvalidAssignmentTargetError{Target: e.Left})
@@ -623,6 +626,67 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	valueT := c.instantiate(b.Schemes[0], lvl)
 	c.recordType(e, valueT)
 	return valueT
+}
+
+// inferMemberAssign types a field write `recv.prop = source` (M4 C3). It extends
+// inferAssign's member-target branch: the receiver must ACCEPT a write to prop, so
+// the source is constrained against a mutable, inexact one-property requirement
+//
+//	recv <: mut {prop: widen(source), ...}
+//
+// The inexact requirement says "must accept a write to this field," not "is exactly
+// this shape." The mut wrapper makes the receiver a mutable cell, which the C3
+// coalesce fold collapses with the receiver's other selections into one `mut`
+// object. The stored value is WIDENED (5 ⇒ number) because writing through a `mut`
+// receiver is itself a mutation — a later write may store any number — mirroring
+// the `var`-binding widening (B3).
+//
+// C3 ships with Lt: nil: no borrows exist yet, so every receiver is owned. D2 flips
+// this to a fresh lifetime var so a borrowed receiver of any lifetime is accepted.
+//
+// When the receiver is a variable, the widened type is recorded in `written` so a
+// later read of the same field returns it (read-after-write; see valueProp). The
+// assignment evaluates to the value just stored, so its type is the widened source.
+func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m *ast.MemberExpr, source soltype.Type) soltype.Type {
+	voidT := soltype.Type(&soltype.Void{})
+	if m.OptChain {
+		// `recv?.prop = …` is not a meaningful assignment target; optional chaining is
+		// M6 regardless, so report the whole target as unsupported rather than typing it.
+		c.reportUnsupportedFeature(e.Left, "assignment to a member or index")
+		return voidT
+	}
+	if m.Prop == nil || m.Prop.Name == "" {
+		// A malformed `recv. = …`: the parser already reported the missing property
+		// name, so emit nothing further and recover to void.
+		return voidT
+	}
+	recv := c.inferExpr(scope, lvl, m.Object)
+	w := widen(source)
+	req := &soltype.RefType{
+		Mut: true,
+		Lt:  nil, // D2: c.freshLifetime()
+		Inner: &soltype.ObjectType{
+			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
+			Inexact: true, // "must accept a write to this field," not a full shape
+		},
+	}
+	c.constrain(e, recv, req)
+	c.recordWritten(recv, m.Prop.Name, w)
+	// The assignment evaluates to the value just stored. recordType overwrites the
+	// `void` recovery type inferAssign recorded on e before dispatching here.
+	c.recordType(e, w)
+	return w
+}
+
+// recordWritten remembers that field `name` of receiver `recv` was written with
+// type `t`, so a later read returns it (read-after-write; see valueProp). Only a
+// VARIABLE receiver has a stable ID to key on; a non-variable receiver — a literal
+// or another expression — cannot be read back through the same binding, so there is
+// nothing to record.
+func (c *checker) recordWritten(recv soltype.Type, name string, t soltype.Type) {
+	if v, ok := recv.(*soltype.TypeVarType); ok {
+		c.written[fieldKey{recvID: v.ID, field: name}] = t
+	}
 }
 
 // constrainAssign asserts `source <: target` for a reassignment. For a UNION target
@@ -852,6 +916,16 @@ func (c *checker) valueMember(lvl int, e *ast.MemberExpr, recv soltype.Type) pat
 // — so a missing-property read blames the property, not the receiver. name is the
 // property key being read.
 func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name string, recv soltype.Type) pathResult {
+	// Read-after-write (M4 C3): a read of a field just written to the same receiver
+	// var returns the recorded concrete type instead of minting a fresh var, so
+	// `obj.x = 5; obj.x` is `number`. The write already constrained the receiver to
+	// carry the field, so no additional requirement is needed here.
+	if v, ok := recv.(*soltype.TypeVarType); ok {
+		if t, found := c.written[fieldKey{recvID: v.ID, field: name}]; found {
+			c.recordType(blame, t)
+			return pathResult{value: t}
+		}
+	}
 	res := c.freshAt(lvl)
 	// The member-requirement record {prop: res} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner res var, so the record would be a dead

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -679,13 +679,17 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 }
 
 // recordWritten remembers that field `name` of receiver `recv` was written with
-// type `t`, so a later read returns it (read-after-write; see valueProp). Only a
-// VARIABLE receiver has a stable ID to key on; a non-variable receiver — a literal
-// or another expression — cannot be read back through the same binding, so there is
-// nothing to record.
+// type `t`, so a later read in the same function body returns it (read-after-write;
+// see valueProp). Only a VARIABLE receiver has a stable ID to key on; a non-variable
+// receiver — a literal or another expression — cannot be read back through the same
+// binding, so there is nothing to record. The cache is per function body (c.fn): a
+// write at module top-level (c.fn == nil) records nothing, which is sound.
 func (c *checker) recordWritten(recv soltype.Type, name string, t soltype.Type) {
+	if c.fn == nil {
+		return
+	}
 	if v, ok := recv.(*soltype.TypeVarType); ok {
-		c.written[fieldKey{recvID: v.ID, field: name}] = t
+		c.fn.written[fieldKey{recvID: v.ID, field: name}] = t
 	}
 }
 
@@ -929,10 +933,12 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// this value therefore blames its constraint site rather than this `.prop`, the
 	// same graceful site fallback a Prov-less type takes everywhere (see
 	// TestBlameVoidSubjectFallsBackToCallSite).
-	if v, ok := recv.(*soltype.TypeVarType); ok {
-		if t, found := c.written[fieldKey{recvID: v.ID, field: name}]; found {
-			c.recordType(blame, t)
-			return pathResult{value: t}
+	if c.fn != nil {
+		if v, ok := recv.(*soltype.TypeVarType); ok {
+			if t, found := c.fn.written[fieldKey{recvID: v.ID, field: name}]; found {
+				c.recordType(blame, t)
+				return pathResult{value: t}
+			}
 		}
 	}
 	res := c.freshAt(lvl)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -920,6 +920,15 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// var returns the recorded concrete type instead of minting a fresh var, so
 	// `obj.x = 5; obj.x` is `number`. The write already constrained the receiver to
 	// carry the field, so no additional requirement is needed here.
+	//
+	// Provenance is deliberately NOT recorded on the returned type. Unlike the fresh
+	// `res` below, the recorded type is SHARED — it also sits in the `written` map, in
+	// the write's requirement, and is handed to every read of this field — so it is not
+	// the freshly-minted unique pointer recordProv requires (recording it would panic
+	// under debugProv and mis-blame the other aliases). A later constraint failure on
+	// this value therefore blames its constraint site rather than this `.prop`, the
+	// same graceful site fallback a Prov-less type takes everywhere (see
+	// TestBlameVoidSubjectFallsBackToCallSite).
 	if v, ok := recv.(*soltype.TypeVarType); ok {
 		if t, found := c.written[fieldKey{recvID: v.ID, field: name}]; found {
 			c.recordType(blame, t)

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -47,7 +47,7 @@ func TestInferLiteralUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: NullLit", c.errs[0].Message())
+	require.Equal(t, "Unsupported: NullLit", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
@@ -107,6 +107,6 @@ func TestInferExprUnsupportedNode(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: BinaryExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: BinaryExpr", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -135,7 +135,7 @@ func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 
 	ty, _ := c.inferFuncDecl(NewScope(), 0, d)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: BigintTypeAnn", c.errs[0].Message())
+	require.Equal(t, "Unsupported: BigintTypeAnn", c.errs[0].Message())
 	require.Equal(t, "fn () -> unknown", render(ty))
 }
 
@@ -162,7 +162,7 @@ func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
 
 	c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: TuplePat", c.errs[0].Message())
+	require.Equal(t, "Unsupported: TuplePat", c.errs[0].Message())
 }
 
 // A generic function (fn <T>() { ... }) is diagnosed rather than silently erased
@@ -176,7 +176,7 @@ func TestInferFuncExprGenericUnsupported(t *testing.T) {
 
 	c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: TypeParam", c.errs[0].Message())
+	require.Equal(t, "Unsupported: TypeParam", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -1,0 +1,70 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 C3: field-write inference + read-after-write ---
+//
+// A field write `recv.prop = source` extends inferAssign's member-target branch. It
+// constrains `recv <: mut {prop: widen(source), ...}` — a mutable, inexact
+// one-property requirement — and the C3 coalesce fold collapses every selection on
+// the receiver (reads and writes) into one `mut` object once any field is written.
+// The stored value is widened (5 ⇒ number) because writing through a `mut` receiver
+// is itself a mutation. These tests exercise the feature end to end through inferred
+// function signatures.
+
+// Two writes on an inferred param fold into a single `mut` object: each write
+// contributes a mutable one-property requirement, and the fold unions them and wraps
+// the whole object in `mut`.
+func TestInferMemberAssignTwoWrites(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.y = 10 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number, y: number}) -> void", values["foo"])
+}
+
+// Read-after-write: a read of a field just written to the same receiver returns the
+// recorded concrete (widened) type, not a fresh var, so `obj.x = 5; return obj.x` is
+// `number`. The receiver renders `mut {x: number}` from the single write.
+func TestInferMemberAssignReadAfterWrite(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj.x }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number}) -> number", values["foo"])
+}
+
+// A mixed read and write folds into ONE `mut` object rather than the spike's
+// `{bar: …} & mut {baz: …}` intersection: the presence of any write makes every
+// selection — the read-only `bar` included — fold into the mutable object. The
+// read-only field is unconstrained, so it renders `unknown`.
+func TestInferMemberAssignMixedReadWrite(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.bar\n obj.baz = 5 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {bar: unknown, baz: number}) -> void", values["foo"])
+}
+
+// A compound written value widens recursively via the shared widen (B3): writing
+// `{x: 0}` stores `{x: number}`, not the literal `{x: 0}`.
+func TestInferMemberAssignCompoundValueWidens(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.p = {x: 0} }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {p: {x: number}}) -> void", values["foo"])
+}
+
+// The assignment expression evaluates to the value just stored, so its type is the
+// widened source: `val r = (obj.x = 5)` ⇒ r: number, used inside a function so the
+// receiver is an inferable place.
+func TestInferMemberAssignValueIsStored(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { val r = (obj.x = 5)\n return r }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number}) -> number", values["foo"])
+}
+
+// Writing different literal values to the same field is the same widened primitive,
+// so the field stays `number` (no contradiction between `5` and `10`).
+func TestInferMemberAssignSameFieldTwice(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = 10 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number}) -> void", values["foo"])
+}

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -129,6 +129,36 @@ func TestInferMemberAssignVariableValueNotLinked(t *testing.T) {
 	require.Equal(t, "fn (obj: mut {x: unknown}, v: unknown) -> void", values["foo"])
 }
 
+// Writing one field of a concretely-typed (annotated) mut object checks: the field
+// write lowers to the inexact requirement `mut {x, ...}`, and the RefType rule's
+// per-field write view pins x invariantly while tolerating the object's other
+// declared fields. Before the per-field write view this reported spurious
+// "missing property: y" / "inexact <: exact" errors.
+func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
+	values, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = 5 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number, y: string}) -> void", values["f"])
+}
+
+// The named field stays invariant: storing a string into a number field of an
+// annotated mut object is rejected in both directions (the read view number <:
+// string and the write-back string <: number), so the relaxation is width-only.
+func TestInferMemberAssignAnnotatedMutWrongType(t *testing.T) {
+	_, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = \"bad\" }")
+	require.Equal(t, []string{
+		"cannot constrain number <: string",
+		"cannot constrain string <: number",
+	}, Messages(errs))
+}
+
+// Writing a field absent from an EXACT annotated mut object still errors: the read
+// view demands the object carry the written field.
+func TestInferMemberAssignAnnotatedMutMissingField(t *testing.T) {
+	src := "fn f(obj: mut {x: number}) { obj.z = 5 }"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{"object is missing property: z"}, Messages(errs))
+}
+
 // KNOWN GAP: two writes of INCOMPATIBLE types to one field produce an uninhabited
 // `number & string` rather than an error — each write is an independent upper bound
 // on the receiver var with no constraint relating them. Pinned so the gap is

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -68,3 +68,74 @@ func TestInferMemberAssignSameFieldTwice(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number}) -> void", values["foo"])
 }
+
+// A written field and a read-only field that ESCAPES (is returned) fold into one
+// `mut` object: the written `x` is `number`, while the returned `y` becomes a real
+// type parameter rather than collapsing to `unknown`, because it occurs in an output
+// position. This is the key interplay between the C3 mut-merge and generalization.
+func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj.y }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(obj: mut {x: number, y: T0}) -> T0", values["foo"])
+}
+
+// Write-after-read on the SAME field needs no `written`-map support: the read mints
+// `T0` and constrains `obj <: {x: T0}`, the later write adds `obj <: mut {x: number}`,
+// and the two upper bounds merge so the field folds to `T0 & number`. The read's
+// value (returned `x`) stays `T0`. This pins the plan's claim that write-after-read
+// falls out of ordinary constraint accumulation, the reverse of read-after-write.
+func TestInferMemberAssignWriteAfterRead(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.x\n obj.x = 5\n return x }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
+}
+
+// A write through a nested receiver wraps only the INNER object in `mut`: `obj` is
+// read for `.p` but never written, so it stays immutable, while `obj.p` is the
+// mutable cell that field `x` is written through. The mut wrap is per-receiver.
+func TestInferMemberAssignNestedReceiver(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.p.x = 5 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: {p: mut {x: number}}) -> void", values["foo"])
+}
+
+// An `open` param's written object stays row-polymorphic: the C3 fold passes the
+// var's Open flag to mergeObjectGroup, so the merged `mut` object is inexact and
+// callers may pass an object with extra fields.
+func TestInferMemberAssignOpenParam(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(open obj) { obj.x = 5 }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number, ...}) -> void", values["foo"])
+}
+
+// A written receiver that ESCAPES (the whole object is returned) is not sealed: it
+// occurs in an output position, so the param keeps an open row and renders as the
+// written requirement intersected with the returned type parameter.
+func TestInferMemberAssignWrittenObjectEscapes(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(obj: mut {x: number} & T0) -> T0", values["foo"])
+}
+
+// KNOWN LIMITATION: writing a parameter's value into a field does NOT link their
+// types. Both `obj`'s field var and `v` occur only in negative position, so
+// single-polarity elimination inlines each to `unknown` independently rather than
+// sharing one type parameter — so this is `(obj: mut {x: unknown}, v: unknown)`, not
+// the tighter `fn <T0>(obj: mut {x: T0}, v: T0)`. Pinned so a future change that
+// connects them is a visible, intentional diff.
+func TestInferMemberAssignVariableValueNotLinked(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj, v) { obj.x = v }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: unknown}, v: unknown) -> void", values["foo"])
+}
+
+// KNOWN GAP: two writes of INCOMPATIBLE types to one field produce an uninhabited
+// `number & string` rather than an error — each write is an independent upper bound
+// on the receiver var with no constraint relating them. Pinned so the gap is
+// explicit; a future soundness pass over conflicting writes should surface an error
+// here and update this assertion.
+func TestInferMemberAssignConflictingWritesNoError(t *testing.T) {
+	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = \"hi\" }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {x: number & string}) -> void", values["foo"])
+}

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -167,6 +167,8 @@ func TestInferMemberAssignAnnotatedMutMissingField(t *testing.T) {
 // on the receiver var with no constraint relating them. Pinned so the gap is
 // explicit; a future soundness pass over conflicting writes should surface an error
 // here and update this assertion.
+// TODO(#738): report conflicting writes to one field instead of folding to an
+// uninhabited intersection.
 func TestInferMemberAssignConflictingWritesNoError(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = \"hi\" }")
 	require.Empty(t, errs)

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -36,12 +36,14 @@ func TestInferMemberAssignReadAfterWrite(t *testing.T) {
 
 // A mixed read and write folds into ONE `mut` object rather than the spike's
 // `{bar: …} & mut {baz: …}` intersection: the presence of any write makes every
-// selection — the read-only `bar` included — fold into the mutable object. The
-// read-only field is unconstrained, so it renders `unknown`.
+// selection — the read-only `bar` included — fold into the mutable object. Folding
+// `bar` into the `mut` object makes it invariant (#737), so its var occurs in both
+// polarities and is retained as a type parameter `T0` the caller picks, rather than
+// inlined to `unknown`. The written `baz` is the widened `number`.
 func TestInferMemberAssignMixedReadWrite(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.bar\n obj.baz = 5 }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: mut {bar: unknown, baz: number}) -> void", values["foo"])
+	require.Equal(t, "fn <T0>(obj: mut {bar: T0, baz: number}) -> void", values["foo"])
 }
 
 // A compound written value widens recursively via the shared widen (B3): writing
@@ -117,16 +119,17 @@ func TestInferMemberAssignWrittenObjectEscapes(t *testing.T) {
 	require.Equal(t, "fn <T0>(obj: mut {x: number} & T0) -> T0", values["foo"])
 }
 
-// KNOWN LIMITATION: writing a parameter's value into a field does NOT link their
-// types. Both `obj`'s field var and `v` occur only in negative position, so
-// single-polarity elimination inlines each to `unknown` independently rather than
-// sharing one type parameter — so this is `(obj: mut {x: unknown}, v: unknown)`, not
-// the tighter `fn <T0>(obj: mut {x: T0}, v: T0)`. Pinned so a future change that
-// connects them is a visible, intentional diff.
-func TestInferMemberAssignVariableValueNotLinked(t *testing.T) {
+// Writing a parameter's value into a field LINKS their types (#737). The write
+// `obj.x = v` makes the field's type the variable `v`, and because the field is
+// `mut` — hence invariant — `v` occurs in BOTH polarities, so single-polarity
+// elimination retains it as a shared type parameter instead of inlining each
+// occurrence to `unknown`. So `fn foo(obj, v) { obj.x = v }` infers the tighter
+// `fn <T0>(obj: mut {x: T0}, v: T0) -> void`. The mut-field invariance reaches the
+// occurrence analysis via recordMutWriteView (simplify.go).
+func TestInferMemberAssignVariableValueLinked(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj, v) { obj.x = v }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: mut {x: unknown}, v: unknown) -> void", values["foo"])
+	require.Equal(t, "fn <T0>(obj: mut {x: T0}, v: T0) -> void", values["foo"])
 }
 
 // Writing one field of a concretely-typed (annotated) mut object checks: the field

--- a/internal/solver/infer_namespace_test.go
+++ b/internal/solver/infer_namespace_test.go
@@ -150,5 +150,5 @@ func TestInferValueIndexUnsupported(t *testing.T) {
 	got := c.inferExpr(scope, 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: IndexExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: IndexExpr", c.errs[0].Message())
 }

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -40,7 +40,7 @@ func TestInferTupleSpreadUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, e)
 	require.Equal(t, "[error]", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: ArraySpreadExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: ArraySpreadExpr", c.errs[0].Message())
 }
 
 // --- ObjectExpr ---
@@ -99,7 +99,7 @@ func TestInferObjectShorthandUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, objExpr(shorthand))
 	require.Equal(t, "{}", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: PropertyExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: PropertyExpr", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
@@ -111,7 +111,7 @@ func TestInferObjectSpreadUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, objExpr(spread))
 	require.Equal(t, "{}", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: ObjSpreadExpr", c.errs[0].Message())
+	require.Equal(t, "Unsupported: ObjSpreadExpr", c.errs[0].Message())
 }
 
 // A computed key ({[k]: v}) carries no static field name — M4.
@@ -121,7 +121,7 @@ func TestInferObjectComputedKeyUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, objExpr(computed))
 	require.Equal(t, "{}", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: ComputedKey", c.errs[0].Message())
+	require.Equal(t, "Unsupported: ComputedKey", c.errs[0].Message())
 }
 
 // --- MemberExpr ---
@@ -160,7 +160,7 @@ func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, e)
 	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
+	require.Equal(t, "Unsupported: OptionalChain", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
@@ -174,7 +174,7 @@ func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
 
 	c.inferExpr(NewScope(), 0, e)
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported in M2: OptionalChain", c.errs[0].Message())
+	require.Equal(t, "Unsupported: OptionalChain", c.errs[0].Message())
 }
 
 // A malformed `recv.` (no valid property name) leaves Prop.Name empty; the

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -43,6 +43,6 @@ func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	// One error for the spread itself; `xs` is never walked (so no extra
 	// unknown-identifier), and the broken element does not cascade.
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: ArraySpreadExpr", errs[0].Message())
+	require.Equal(t, "Unsupported: ArraySpreadExpr", errs[0].Message())
 	require.Equal(t, "[error]", values["t"])
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -230,7 +230,7 @@ func TestInferModuleUnsupportedDecl(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TypeDecl", errs[0].Message())
+	require.Equal(t, "Unsupported: TypeDecl", errs[0].Message())
 	// M2.5: the error self-blames from the decl node.
 	require.Equal(t, src, spanText(src, errs[0].Span()))
 	// The unsupported decl must not leak a type binding.
@@ -276,7 +276,7 @@ func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
 	src := `val [a, b] = [1, 2]`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: TuplePat", errs[0].Message())
+	require.Equal(t, "Unsupported: TuplePat", errs[0].Message())
 	// M2.5: blame the offending pattern, not the whole decl.
 	require.Equal(t, "[a, b]", spanText(src, errs[0].Span()))
 	require.Empty(t, values)
@@ -459,7 +459,7 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported in M2: NamespaceDecl", errs[0].Message())
+	require.Equal(t, "Unsupported: NamespaceDecl", errs[0].Message())
 	require.Empty(t, values)
 	// The unsupported decl must not leak a type binding for the namespace.
 	require.NotContains(t, types, "Foo")

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -163,6 +163,28 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 	return slices.Concat(stored, mirrored)
 }
 
+// recordMutWriteView reflects a `mut` borrow's INVARIANCE into a polarity-recording
+// visitor (#737). The C2 constrain rule makes every field a `mut` target names
+// invariant — it adds a covariant read view and a contravariant write view
+// (constrainWriteBack) — but RefType.Accept walks the inner only covariantly (the
+// read view; see visitor.go). So a variable that appears only inside a `mut` field,
+// such as the `v` in `fn (obj, v) { obj.x = v }`, would be seen in one polarity and
+// dropped by single-polarity elimination, severing the link between the field and
+// the value written into it.
+//
+// This adds the missing write view: for a `mut` borrow it walks the inner in the
+// FLIPPED polarity and returns true, signalling the caller to return the default
+// EnterResult so Accept still performs the covariant walk. The inner ends up
+// recorded in BOTH polarities, so such a variable is retained as a type parameter.
+// Shared by the occurrence and co-occurrence visitors so both agree.
+func recordMutWriteView(v soltype.TypeVisitor, t soltype.Type, pol soltype.Polarity) bool {
+	if rt, ok := t.(*soltype.RefType); ok && rt.Mut {
+		rt.Inner.Accept(v, pol.Flip())
+		return true
+	}
+	return false
+}
+
 // symOccVisitor records which polarities each variable occurs in. It walks the
 // symmetric bound graph through mirror.effectiveBounds, so a variable reached only
 // through a one-sided edge is still seen in that polarity.
@@ -175,6 +197,9 @@ type symOccVisitor struct {
 }
 
 func (o *symOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if recordMutWriteView(o, t, pol) {
+		return soltype.EnterResult{} // let Accept do the covariant read-view walk
+	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
 		return soltype.EnterResult{} // structural / atom node: let Accept descend
@@ -231,6 +256,9 @@ type coOccVisitor struct {
 }
 
 func (c *coOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if recordMutWriteView(c, t, pol) {
+		return soltype.EnterResult{} // let Accept do the covariant read-view walk
+	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
 		return soltype.EnterResult{} // structural / atom node: let Accept descend

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -177,6 +177,18 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 // EnterResult so Accept still performs the covariant walk. The inner ends up
 // recorded in BOTH polarities, so such a variable is retained as a type parameter.
 // Shared by the occurrence and co-occurrence visitors so both agree.
+//
+// The flipped descent is safe to run inline for two reasons:
+//   - It is a fixed structural property of the `mut` constructor, not a fact derived
+//     from the constraint graph. A mut borrow's inner is invariant no matter what
+//     bounds exist.
+//   - It is stateless. It records occurrences through the normal variable-recording
+//     path and mutates no stored bound lists, so it touches nothing coalesce or
+//     extrude reads.
+//
+// This is the contrast with the reverse var↔var bound edges, which buildMirror keeps
+// in a separate derived view precisely because writing them back to the bound lists
+// would corrupt those passes.
 func recordMutWriteView(v soltype.TypeVisitor, t soltype.Type, pol soltype.Polarity) bool {
 	if rt, ok := t.(*soltype.RefType); ok && rt.Mut {
 		rt.Inner.Accept(v, pol.Flip())
@@ -188,6 +200,15 @@ func recordMutWriteView(v soltype.TypeVisitor, t soltype.Type, pol soltype.Polar
 // symOccVisitor records which polarities each variable occurs in. It walks the
 // symmetric bound graph through mirror.effectiveBounds, so a variable reached only
 // through a one-sided edge is still seen in that polarity.
+//
+// It does not reconstruct those reverse var↔var edges itself. buildMirror derives
+// them once into a separate view, and this visitor only reads that view. Two reasons
+// keep the reconstruction out of here:
+//   - The same reverse-edge graph is also consumed by coOccVisitor and gatherGroup,
+//     so building it once and sharing it avoids duplicating the work.
+//   - The reverse edges must stay off the canonical bound lists, because coalesce and
+//     extrude read those lists and an extra edge would pull a spurious variable into a
+//     rendered union or intersection.
 //
 // The (var, pol) seen-set keeps a cyclic graph terminating.
 type symOccVisitor struct {

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -409,9 +409,13 @@ wrapper) are what first populate a lifetime. Land them together.
   narrowing use should be allowed to reclaim the literal.
 - **`Ref` constrain rule** (single rule for the unified borrow wrapper): inner
   variance is bidirectional iff `r.mut` (read/write decomposition: covariant
-  read + contravariant write when the target writes), covariant otherwise;
-  lifetime is covariant when both sides have one; mutability decay (`Ref{mut:
-  true} <: Ref{mut: false}`) is allowed, the reverse rejects. Plus inferring
+  read + contravariant write when the target writes), covariant otherwise. The
+  write view is **per named field**, ranging over the target's fields only, so an
+  inexact mutable target pins its named fields invariantly but stays width-tolerant
+  (`mut {x, y} <: mut {x, ...}` holds) — which is what lets a field write's inexact
+  `mut {field, ...}` requirement apply to a concretely-typed receiver. Lifetime is
+  covariant when both sides have one; mutability decay (`Ref{mut: true} <: Ref{mut:
+  false}`) is allowed, the reverse rejects. Plus inferring
   mutability from field writes (`obj.x = v` ⇒ `Ref{mut: true, lt: freshLt,
   inner: Record{x: widen(v)}}`, with literal widening and merging; the
   lifetime is a fresh variable so the constraint accepts both owned-mutable

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -415,11 +415,17 @@ wrapper) are what first populate a lifetime. Land them together.
   (`mut {x, y} <: mut {x, ...}` holds) — which is what lets a field write's inexact
   `mut {field, ...}` requirement apply to a concretely-typed receiver. Lifetime is
   covariant when both sides have one; mutability decay (`Ref{mut: true} <: Ref{mut:
-  false}`) is allowed, the reverse rejects. Plus inferring
-  mutability from field writes (`obj.x = v` ⇒ `Ref{mut: true, lt: freshLt,
-  inner: Record{x: widen(v)}}`, with literal widening and merging; the
-  lifetime is a fresh variable so the constraint accepts both owned-mutable
-  and mut-borrowed receivers). (Spike M3 + extension.)
+  false}`) is allowed, the reverse rejects.
+- **Mutability inference from field writes** (M4): `obj.x = v` constrains the
+  receiver against the inexact requirement `Ref{mut: true, lt: nil, inner:
+  Record{x: widen(v)}}`, with literal widening and merging of a receiver's
+  selections into one `mut` object. The lifetime is `nil`, so M4 supports only
+  owned-mutable receivers. (Spike M3 + extension.)
+- **Lifetime origination on field writes** (D2, **not** M4): the write
+  requirement's lifetime becomes a fresh variable rather than `nil`, so the
+  constraint also accepts a mut-borrowed receiver of any lifetime. This depends on
+  the lifetime sort and borrow origination, which land in D2 — until then a borrowed
+  receiver is not yet supported.
 - **Lifetimes as a second sort**: `LifetimeVar` with lower/upper bounds over the
   outlives lattice (`'static` = top), `constrainLt`, lifetime coalescing +
   elision (a parameter-only lifetime that connects nothing is dropped). Borrows

--- a/planning/simple_sub/02-design-notes.md
+++ b/planning/simple_sub/02-design-notes.md
@@ -424,13 +424,16 @@ case RefType <: RefType:
         return mutabilityError
     }
 
-    // 2. Inner variance — bidirectional iff the *target* is mutable
-    //    (read view always; write view only when the target writes).
+    // 2. Inner variance — covariant read view always; when the *target* is
+    //    mutable, a contravariant write view PER NAMED FIELD makes each field the
+    //    target names invariant. The write view ranges over the target's fields
+    //    only (constrainWriteBack), so an inexact target tolerates extra fields on
+    //    the source while pinning its named fields — `mut {x, y} <: mut {x, ...}`
+    //    holds (x invariant, y hidden and not writable through the target), while
+    //    `mut {x: Cat} <: mut {x: Animal}` still fails (x is invariant).
+    constrain(l.inner, r.inner, seen)        // read view (covariant)
     if r.mut {
-        constrain(l.inner, r.inner, seen)
-        constrain(r.inner, l.inner, seen)
-    } else {
-        constrain(l.inner, r.inner, seen)
+        constrainWriteBack(r.inner, l.inner, seen) // write view (per named field)
     }
 
     // 3. Lifetime — covariant when both present.

--- a/planning/simple_sub/03-references.md
+++ b/planning/simple_sub/03-references.md
@@ -156,7 +156,13 @@ mutability flag and the (nilable) lifetime around a borrowed value (see
 `Ref` is **invariant in its inner type when the wrapper is mutable**, encoded
 via the read/write decomposition (covariant read view + contravariant write
 view); invariance is not native to a co/contravariant lattice, so it is the
-one place we deliberately step outside the clean lattice structure.
+one place we deliberately step outside the clean lattice structure. The write
+view is **per named field**: it pins the fields the target names invariantly but
+ranges over those fields only, so an **inexact** mutable target stays
+width-tolerant (`mut {x, y} <: mut {x, ...}` holds — `x` is invariant, `y` is
+hidden and not writable through the target). This is what lets a field write,
+which lowers to an inexact `mut {field, ...}` requirement, apply to a
+concretely-typed mutable receiver.
 **Lifetimes themselves are always covariant**: a `Ref`'s lifetime field is
 constrained once in the subtype direction (longer-lived can stand in for
 shorter-lived), regardless of whether the wrapper is mutable. Because the

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -314,12 +314,16 @@ case *soltype.RefType:
         if !sub.Mut && sup.Mut {
             return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
         }
-        // 2. inner variance — bidirectional iff the TARGET writes (read/write
-        //    decomposition = invariance). Mut-decay (sub.Mut && !sup.Mut) falls
-        //    through to the covariant-only read view.
+        // 2. inner variance — covariant read view always; when the TARGET writes,
+        //    a contravariant write view PER NAMED FIELD makes each field the target
+        //    names invariant (read/write decomposition = invariance). The write view
+        //    ranges over the target's fields only (constrainWriteBack), not the whole
+        //    object, so an INEXACT target tolerates extra fields on the source while
+        //    pinning its named fields. Mut-decay (sub.Mut && !sup.Mut) falls through to
+        //    the covariant-only read view.
         errs := c.constrain(sub.Inner, sup.Inner, seen)
         if sup.Mut {
-            errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen)...)
+            errs = append(errs, c.constrainWriteBack(sup.Inner, sub.Inner, seen)...)
         }
         // 3. lifetime — covariant when both present.
         switch {
@@ -813,7 +817,10 @@ these arms it must add.
     - (1) mutability compatibility — `!l.Mut && r.Mut` ⇒
       `MutabilityMismatchError`
     - (2) inner variance — covariant read view always, plus a contravariant write
-      view **iff `r.Mut`** (the read/write decomposition = invariance)
+      view **iff `r.Mut`** (the read/write decomposition = invariance). The write
+      view is **per named field** (`constrainWriteBack`), ranging over the target's
+      fields only, so an inexact target pins its named fields invariantly while
+      tolerating extra fields on the source (see Accept and C3)
     - (3) lifetime step written but **inert while `Lt == nil`** (the `switch` over
       `l.Lt`/`r.Lt` is dead code until D2)
     - cross-case `RefType <: bare` — peel `l.Inner`, with an escape-error guard
@@ -825,9 +832,15 @@ these arms it must add.
     - `MutabilityMismatchError{Sub, Super *soltype.RefType}`
     - `BorrowEscapeError{Sub, Super}` (the latter's firing path is inert until D2)
   - **Accept (the gate):**
-    - `mut {x, y} <: mut {x, ...}` **fails** (invariance — the write view's
-      contravariant `{x, ...} <: {x, y}` is missing a field) while immutable
-      `{x, y} <: {x, ...}` width-**succeeds** (inexact super)
+    - `mut {x, y} <: mut {x, ...}` **succeeds** — the inexact target names only `x`,
+      which the per-field write view pins invariantly, while the source's extra `y`
+      is tolerated (it is hidden, not writable through the target). This width
+      relaxation is sound and is what lets a field write `obj.x = v` — which lowers to
+      the inexact requirement `mut {x, ...}` — apply to a concretely-typed mutable
+      receiver. Immutable `{x, y} <: {x, ...}` also width-**succeeds** (inexact super)
+    - depth invariance is preserved: `mut {x: 5} <: mut {x: number}` **fails**
+      (`number <: 5` on the write view), and an EXACT target still demands an
+      identical field set (the read view rejects extras)
     - mut-decay `mut {x} <: {x}` allowed, the reverse `{x} <: mut {x}` rejected
     - full messages
 
@@ -899,6 +912,11 @@ these arms it must add.
     - a compound written value widens recursively via the shared `widen` (B3): in
       `fn foo(obj) { obj.p = {x: 0} }`, `obj`'s `p` field is `{x: number}`, not
       `{x: 0}`
+    - a write to a **concretely-typed** mutable receiver checks via C2's per-field
+      write view: `fn f(obj: mut {x: number, y: string}) { obj.x = 5 }` is accepted
+      (the inexact write requirement `mut {x, ...}` pins `x` invariantly and tolerates
+      the declared `y`), while `obj.x = "bad"` rejects on `x`'s invariance and a write
+      to a field absent from an exact `mut` object reports a missing property
 
 ### Phase D — Lifetimes (second sort)
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1193,14 +1193,15 @@ these arms it must add.
 - A3 (#733)
 - B1+B2 (#732)
 - C1+C2 (#731)
+- C3 (#735)
 - F1 (#730)
 
 A1✓ → A2
-A1✓ → A3✓ ─────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
-A1✓ → B1✓ → B2✓                │  (annotation-side acceptance tests)
-      B1✓ → B3                 │
-      B1✓, B3 ────────────┐    │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
-A1✓ → C1✓ → C2✓(GATE) →  C3 → D1 → D2 → D3 → D4 → G1 → G2
+A1✓ → A3✓ ──────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
+A1✓ → B1✓ → B2✓                 │  (annotation-side acceptance tests)
+      B1✓ → B3                  │
+      B1✓, B3 ────────────┐     │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
+A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1 → D2 → D3 → D4 → G1 → G2
 A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
 F1✓             (independent; any time — only M2's Namespace)
 ```


### PR DESCRIPTION
Adds support for field-write assignments (`obj.x = value`) and read-after-write semantics for inferred function parameters. This implements the M4 C3 milestone: field writes constrain the receiver to a mutable, inexact one-property requirement, and the coalesce fold merges all selections on a receiver into a single `mut` object when any write is present.

## Key changes

- **Field-write inference** (`inferMemberAssign`): A field write `recv.prop = source` now constrains the receiver to `recv <: mut {prop: widen(source), ...}`. The inexact requirement signals "must accept a write to this field" rather than a full shape. The stored value is widened (e.g., `5` becomes `number`) because writing through a mutable receiver is itself a mutation.

- **Read-after-write tracking** (`written` map): When a field is written to a variable receiver, the widened type is recorded. A later read of the same field returns the concrete type instead of minting a fresh type variable, so `obj.x = 5; obj.x` infers as `number`.

- **Whole-object `mut` merge** (`foldUsageBounds`, `usageObject`): The coalesce fold now distinguishes bare inexact objects (reads) from `mut`-wrapped inexact objects (writes). When any write is present, all selections on a receiver fold into one object wrapped in `mut`, rather than keeping reads and writes separate. This simplifies the inferred type and makes read-only fields invariant (a necessary trade-off for soundness with mutable receivers).

- **Per-field write-back constraint** (`constrainWriteBack`): The `RefType <: RefType` rule now applies the contravariant write view per named field only, not the whole object. This allows an inexact mutable target (e.g., `mut {x: number, ...}` from a field write) to accept a wider source with extra fields, while still pinning the named fields invariantly. This is what enables writing to a field of a concretely-typed mutable receiver without spurious "missing property" errors.

- **Test coverage**: Added 14 end-to-end tests in `infer_member_assign_test.go` covering two writes, read-after-write, mixed read/write, compound values, nested receivers, open parameters, escaping objects, annotated mutable objects, and known limitations (variable values not linked, conflicting writes not yet detected).

## Notable details

- The `written` map is keyed by receiver variable ID and field name, so it never collides across function bodies.
- Lifetime is set to `nil` (owned mutable) in C3; D2 will introduce fresh lifetime variables for borrowed receivers.
- The per-field write-back constraint is the key to accepting `mut {x, y} <: mut {x, ...}` (width tolerated, named field invariant) while still rejecting `mut {x: Cat} <: mut {x: Animal}` (depth invariance preserved).

https://claude.ai/code/session_012PWdKvxMzP2Mk4kwxPcGJS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for member assignment: you can now assign values to object fields with comprehensive type checking.
  * Implemented read-after-write type refinement for mutable objects.

* **Tests**
  * Added extensive test coverage for member assignment scenarios, including field mutations, read-after-write behavior, and type constraints.

* **Documentation**
  * Updated design documentation clarifying mutable reference type constraints and field-scoped type precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->