### PR TITLE
Add ECMA-262 builtin annotation extraction planning docs

### DIFF
--- a/planning/builtins/requirements.md
+++ b/planning/builtins/requirements.md
@@ -849,6 +849,24 @@ A one-time seeding tool. A Go binary that:
      one-directional (Escalier-side may be stricter than TS-side,
      not looser). Intended for CI on TS-version bumps.
 
+**Emitting inter-package imports.** After partitioning (step 4), a
+declaration in package P may reference a type owned by another
+pseudo-package Q — `std:intl`'s `DateTimeFormat` referencing `Date` from
+`std:date`, `std:async`'s `Promise` referencing `Iterable` from
+`std:iterator`. The converter emits the explicit imports FR6 requires:
+for each such cross-package reference it (a) adds an `import "std:Q"`
+(or `web:` / reserved `node:` scheme) at the top of P's `.esc` file,
+(b) qualifies the reference through the resulting binding per the binding
+shape (FR4 / FR5), and (c) resolves which package owns the referenced
+type via the same partition table that drove step 4. Imports are
+deduplicated per file. The resolver's pseudo-package cycle exemption
+(FR6) means a P↔Q reference cycle needs no special handling here. A
+referenced type absent from the partition table is the same
+unmapped-symbol error as step 4.
+
+**Type lowering — no `any`.** The emitted `.esc` never contains `any`;
+the converter rewrites every `.d.ts` `any` by position per FR17.
+
 **One-time seeding.** After the initial bootstrap commit, the
 pseudo-package `.esc` files are first-class Escalier source. Hand-edits add `throws`, lifetimes, and any
 structural refinements — written inline like `self` and `mut self`,
@@ -1092,6 +1110,47 @@ The implementation depends on:
 - A binding-shape preference per file (default `?local`; user-
   configurable). The quick-fix uses the file's existing convention
   if any of its imports already pick a flag.
+
+### FR17. Type-lowering policy (no `any`)
+
+The converter never emits `any`. TypeScript's `any` is both top and
+bottom and defeats soundness, so every `.d.ts` `any` is rewritten by the
+position it occurs in. This runs during the AST-to-AST conversion (FR10
+step 2), before mutability seeding and partitioning.
+
+- **`_` (the wildcard) in constraint positions**, where `any` means "no
+  constraint / matches anything":
+  - a type-parameter **bound** — `<T extends any>` → `<T extends _>`,
+    equivalent to an omitted bound;
+  - the **`extends` clause of a conditional type** — `X extends any ? A :
+    B` → `X extends _ ? A : B` — including nested wildcard positions such
+    as `T extends readonly any[] ? …` → `T extends readonly _[] ? …`.
+- **`unknown` (the sound top type) everywhere else.** It accepts any
+  value but forces narrowing before use, restoring the soundness `any`
+  bypassed. This covers function **parameters**, **property** types,
+  **type arguments** (`Array<any>` → `Array<unknown>`), array and tuple
+  **elements**, index signatures, `thisArg`, and callback shapes
+  (`(...args: any[]) => any` → `(...args: unknown[]) => unknown`).
+
+**Return-position `any` lowers to `unknown` but is flagged for curation.**
+It is sound, but it forces every caller to narrow, and a builtin that
+`.d.ts` types `any` in return position often has a precise type
+recoverable from the spec or JSDoc — `JSON.parse(): any` is honestly
+`unknown`, but many others are not. So the converter lowers it to
+`unknown` and records it in a review list, the same curation channel as
+`throws` and lifetimes, so a better type can replace it.
+
+**Default type arguments lower to `unknown`, not `_`.** `<T = any>` is a
+value default, not a bound, so it becomes `<T = unknown>`. The `_` rule
+applies only to the constraint (`extends`) slot, never the default (`=`)
+slot.
+
+**`Function` and `object` are out of scope for this rule.** They are
+TypeScript wide-types, not `any`, and need their own converter lowering
+policy — `Function` to a generic callable shape, `object` to a
+non-primitive bound. Until that policy is set they are an explicit
+converter TODO, not silently passed through and not collapsed to
+`unknown`.
 
 ## Non-functional requirements
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -32,7 +32,7 @@ Status legend: ✅ done, 🚧 partial, ⬜ not started.
 | 2   | Toolchain scoping                          | NFR        | ⬜      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment |
 | 3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ⬜      | §2         | `cfg.json` emitted for the full `std:*` surface, pinned spec, round-trips a schema check |
 | 4   | Go analysis: mutation + alias              | FR1–FR5    | ⬜      | §3         | `facts.json` produced from `cfg.json`; spot-checked methods classify correctly |
-| 5   | Keying and join                            | FR7        | ⬜      | §4         | Normalizer joins facts to converter declarations; unmatched on both sides reported |
+| 5   | Keying and join                            | FR7, FR15  | ⬜      | §4         | Normalizer joins facts to converter declarations; overload sets share algorithm-level facts and resolve the type-dependent parts per signature; unmatched on both sides reported |
 | 6   | Validation diff                            | FR9        | ⬜      | §5         | Receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
 | 7   | Integration as classification source       | FR8        | ⬜      | §6         | Converter ranks facts above name tiers; redundant `mutabilityOverrides` entries removed |
 | 8   | Parameter disposition + return-borrow outputs | FR12, FR4 | ⬜     | §7         | Per-parameter borrow/mutBorrow/escape from the store analysis; `escape` when a parameter is stored into the receiver (move vs lifetime-borrow spelled at curation); return-borrow seed documented |
@@ -449,7 +449,7 @@ soundness-bearing claim.
 
 Unclassified methods are listed.
 
-## §5. Keying and join (FR7)
+## §5. Keying and join (FR7, FR15)
 
 **Goal.** Join spec-keyed facts to the converter's class+method
 declarations.
@@ -546,6 +546,15 @@ entry. This is the gate that authorizes removing override entries in §7.
   heuristics.
 - Set receiver mutability from a classified fact; leave unclassified
   methods to the existing tiers.
+- Apply the FR5 defaults for what a `classified: false` record omits (its
+  effect fields are absent). Receiver mutability falls through to the name
+  tiers, defaulting to `&mut self`. For the curation-grade determinations
+  the converter writes a baseline and flags it for review rather than
+  trusting it — parameter mutation defaults to **`&mut`** (FR5's flipped
+  conservative default, not `&`), `escape` is written only where the
+  analysis found a store (never defaulted), and `throws`/`rejects` default
+  to empty (under-report). Only receiver mutability is auto-applied; the
+  rest are curation input, per "Applying the non-receiver facts" above.
 - Remove the `mutabilityOverrides` entries that §6 proved redundant for
   `std:*`. Keep entries the facts source does not cover, such as `web:*`
   classes, untouched.
@@ -647,7 +656,7 @@ and `Map.prototype.set` mark their stored parameters `escape`,
 `returns` → annotation mapping for the receiver-returning methods
 (`fill`, `sort`, `reverse`, `Map.set`).
 
-## §9. Throw-set extraction and coercion filter (FR10, FR11)
+## §9. Throw-set extraction, filter, and validation (FR10, FR11, FR13, FR14)
 
 **Goal.** Produce the `throws` candidate set for each method, reusing the
 §4 machinery with a throw transfer function and then pruning the
@@ -1036,7 +1045,9 @@ const (
     DispMutBorrow Disposition = "mutBorrow" // &mut: parameter object mutated in place (FR12)
     DispEscape    Disposition = "escape"    // stored into the receiver ⇒ must outlive it; spelled a
                                             // move or a lifetime-bounded borrow at curation (FR12)
-    // read-only borrow (&) is the default and is omitted from Params.
+    // A parameter the analysis PROVED read-only (&) is omitted from Params.
+    // That omission is distinct from the FR5 uncertain default (&mut): it
+    // means "shown read-only", and applies only to a classified method.
 )
 
 type ParamFact struct {
@@ -1080,8 +1091,10 @@ so the converter cannot mistake "unanalyzed" for "proven none"; it applies
 the FR5 defaults itself and falls the method through to the name
 heuristics. Such methods are also collected into a separate
 `unclassified` report alongside `facts.json` for auditing
-(FR5). A parameter absent from `Params` is a read-only borrow (`&`); the
-receiver-returning and fresh-returning alias kinds carry the return's
+(FR5). In a *classified* method's entry, a parameter absent from `Params`
+was proven read-only (`&`) — not to be confused with the FR5 `&mut`
+default the converter applies to an *unclassified* method's parameters.
+The receiver-returning and fresh-returning alias kinds carry the return's
 borrow lifetime per FR4.
 
 ## Appendix C. Canonical spec keys

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -607,10 +607,12 @@ the call:
   array it then returns; the arguments escape into the returned array).
 - `dest` origin is `Fresh` and does not escape → does **not** escape; the
   value enters an object `M` drops, so no escape.
-- `dest` origin is `Unknown` → cannot be proven to escape, so **not** an
-  escape; the parameter stays at the `borrow` default and the site is
-  listed for review (FR5 keeps the least-constraining choice, and this is
-  not treated as `Incomplete`).
+- `dest` origin is `Unknown` → cannot be proven to escape, so the
+  parameter is **not** marked `escape` and the site is listed for review.
+  FR5 gates `escape` on positive evidence of a store, so an unprovable
+  destination does not raise the disposition; this is the one axis FR5
+  does not default conservatively, and it is not treated as `Incomplete`.
+  The parameter's mutation axis is decided separately by `MutArgs`.
 
 Escape is **transitive** by the same fixpoint as FR2. Define, per abstract
 operation `G`, `StoreEdges(G) ⊆ {(k, m)}` meaning `G` stores its `k`-th

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -467,8 +467,21 @@ Unclassified methods are listed.
 
 ## §5. Keying and join (FR7, FR15)
 
-**Goal.** Join spec-keyed facts to the converter's class+method
-declarations.
+**Goal.** Join the two inputs the generated `.esc` is built from (FR7):
+
+- the **type declarations** from the pinned TypeScript `.d.ts` that ships
+  with TypeScript — the shapes the spec cannot supply: generics, parameter
+  and return types, typed overloads. This is the type source per FR7.
+- the **effect facts** in `facts.json`, produced by §4 / §8 / §9 from the
+  ECMA-262 spec — receiver mutability, parameter disposition, the
+  return-borrow seed, `throws`, and `rejects`.
+
+The `.d.ts` declarations are keyed by owner + member; the facts are keyed
+by canonical spec name (Appendix C). This phase is the **name-based match**
+between them, so each `.d.ts`-derived method element picks up its ECMA-262
+effects. The join is deliberately shape-blind — it carries no types — so it
+holds whether the type declarations come from `.d.ts` today or committed
+`.esc` later (FR7).
 
 **Work.**
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -152,7 +152,11 @@ analysis needs before committing to the toolchain.
   - promise rejection, a `Promise` combinator such as `Promise.all` or
     `Promise.race` — the CFG must let the analysis tell an
     `IfAbruptRejectPromise` / capability `[[Reject]]` site from a
-    synchronous `Throw` (§9.3).
+    synchronous `Throw` (§9.3);
+  - callback propagation, `Array.prototype.forEach` or `map` — the CFG must
+    let the analysis tell a `?`-guarded call whose callee is a **callback
+    parameter** (`? Call(callbackfn, …)`) from one whose callee is a
+    resolvable abstract operation, for the `throwsOf:param:k` rule (§9.1).
 
 **Gate.** For each method above, confirm the CFG exposes: the abstract-
 operation call nodes with their argument variables **including the
@@ -774,6 +778,8 @@ ThrowSites : map[FuncName] []ThrowSite  // provenance chains for §9.2 / §9.3
 type ThrowSite:
     Raised : Class(name)                 // a constructed error class (Throw a T exception)
            | Origin(Param(k) | Receiver) // a propagated value, resolved to a type at the join (FR13)
+           | CallbackThrows(Param(k))    // throwsOf:param:k — the method throws whatever the
+                                         // function-typed parameter k throws (FR13); throws polymorphism
            | Unknown                     // a propagated value that could not be traced
     Root : Direct(node)                  // raised here (domain check, coercion AO, or plain)
          | Propagated(callee, inner)     // via ? from `callee`'s own site `inner`
@@ -791,7 +797,11 @@ while worklist nonempty:
             Throws[F].add(raised)
             ThrowSites[F].append(ThrowSite{ Raised: raised, Root: Direct(node), Node: node })
         case Call where node.Guard == GuardQuestion:   // ? propagates the callee's throws
-            for s in ThrowSites[node.Callee]:          // carry the callee's OWN site, not just its name
+            if node.Callee is a function-typed Param(k):   // ? Call(callbackfn, …) → the callback's throws
+                raised = CallbackThrows(Param(k))          // throwsOf:param:k (FR13)
+                Throws[F].add(raised)
+                ThrowSites[F].append(ThrowSite{ Raised: raised, Root: Direct(node), Node: node })
+            else for s in ThrowSites[node.Callee]:         // resolvable AO: carry its OWN sites, by name
                 Throws[F].add(s.Raised)
                 ThrowSites[F].append(ThrowSite{ Raised: s.Raised,
                                                 Root: Propagated(node.Callee, s), Node: node })
@@ -808,6 +818,17 @@ constructor — so `Origin` sites are almost entirely a reject-channel
 phenomenon (§9.3). When `?`-propagated, the callee's `Param(k)` origin is
 re-mapped through the call's arguments to the caller's own formals, the
 same threading `precludedCoercion` (§9.2) does for coercion arguments.
+
+`CallbackThrows(Param(k))` covers the higher-order case — `?
+Call(callbackfn, …)` where the callee is a function-typed parameter, as in
+`Array.prototype.forEach`/`map`/`reduce`/`sort` — so the method throws
+whatever that callback throws (requirements FR13, "callback effects"). It
+needs the CFG to distinguish a `?`-guarded call whose callee is a formal
+parameter from one whose callee is a resolvable abstract operation — a
+**§1 spike / §3 serializer** question. At the FR7 join `throwsOf:param:k`
+becomes throws polymorphism (`<E>(cb: … throws E) … throws E`), a curation
+enrichment (§11) since `.d.ts` carries no throws to thread; unlike a value
+`Origin`, it names the parameter's *effect*, not its value.
 
 `ThrowSite.Root` threads the full chain back to the ultimate source
 rather than collapsing to the immediate callee: `Propagated` nests the
@@ -1131,7 +1152,11 @@ type Node struct {
     Kind      NodeKind `json:"kind"`
     Target    string   `json:"target,omitempty"`    // Let target, or Call result binding
     Source    *Expr    `json:"source,omitempty"`    // Let
-    Callee    string   `json:"callee,omitempty"`    // Call: abstract-operation name
+    Callee    string   `json:"callee,omitempty"`    // Call: the callee's name — an abstract-operation
+                                                    // name (resolvable in the CFG) OR a formal parameter
+                                                    // holding a function (a callback: `? Call(callbackfn,…)`).
+                                                    // The analysis tells them apart via the §4.2 origin map:
+                                                    // a callee bound to Param(k) drives CallbackThrows (§9.1).
     Args      []Expr   `json:"args,omitempty"`      // Call
     Guard     Guard    `json:"guard,omitempty"`     // Call: ? / ! / plain
     Object    *Expr    `json:"object,omitempty"`    // SlotWrite: the written object
@@ -1234,9 +1259,12 @@ standard error-class name the spec constructs (`TypeError`, `RangeError`,
 …); an **origin ref** for a value the spec propagates rather than
 constructs — `"param:k"` or `"receiver"` for a directly-forwarded value
 (`Promise.reject`'s argument, `throw <arg>`), or a combinator's element-`E`
-form (`Promise.all`/`race`/`any` forwarding their element promises' `E`),
-resolved to a type at the FR7 join; or the sentinel `"unknown"` for a
-propagated value the analysis can neither name nor trace. A `classified: false` entry carries no receiver,
+form (`Promise.all`/`race`/`any` forwarding their element promises' `E`);
+the **effect ref** `"throwsOf:param:k"` for a method that propagates a
+callback parameter's throws (`Array.prototype.forEach`/`map`/…), resolved
+at the FR7 join to throws polymorphism; or the sentinel `"unknown"` for a
+propagated value the analysis can neither name nor trace. All origin and
+effect refs resolve to types at the FR7 join. A `classified: false` entry carries no receiver,
 disposition, throw, or reject claim — those fields are absent, not empty —
 so the converter cannot mistake "unanalyzed" for "proven none"; it applies
 the FR5 defaults itself and falls the method through to the name

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -853,11 +853,32 @@ finished, unreviewed annotation" non-goal.
 
 **Work.**
 
-- Hand-curate a ground-truth `throws`/`rejects` sample over the
-  high-value methods (`JSON.parse`, `decodeURIComponent`,
-  `Number.prototype.toFixed`, `BigInt`, the `Promise` combinators, …),
-  applying the documented host-throws exclusion so stack-overflow
-  `RangeError` and OOM never appear in the ground truth.
+- Build the ground-truth sample so it is **independent of the spec
+  extraction**. A corpus a human reads out of the same ECMA-262 algorithm
+  the extractor reads would agree by construction — it would validate only
+  faithfulness, not correctness, and share the extractor's blind spots.
+  Seed it empirically instead:
+  - **Dynamic observation** in a real engine — V8 / Node, *not* engine262,
+    which is itself a spec mechanization and would reintroduce the shared
+    source. For each high-value method (`JSON.parse`, `decodeURIComponent`,
+    `Number.prototype.toFixed`, `BigInt`, the `Promise` combinators, …) run
+    an adversarial argument matrix (null/undefined, wrong types,
+    out-of-range values) and record the constructor of what it throws
+    (`try`/`catch`) or rejects with (`.then(null, …)`). This is
+    behavior-based ground truth; its coverage is input-dependent, so a
+    missed path surfaces as a *false positive* against the extractor
+    (triage: extend the fuzz inputs), never a silent gap.
+  - **Independent docs** (MDN, JSDoc) as a second cross-check — again not
+    the spec.
+  - **Hand-authored origin and combinator entries.** Dynamic observation
+    yields concrete error classes well but not the parametric forms, so the
+    `param:k` / `receiver` structure (visible only by varying the argument
+    across runs) and the combinator element-`E` / `AggregateError<E>` /
+    `never` forms are modeled into the corpus by hand.
+
+  Apply the documented host-throws exclusion throughout, so stack-overflow
+  `RangeError` and OOM are filtered from the observations and never enter
+  the ground truth. A human verifies and commits the result.
 - Diff the extracted sets against it and report two rates (FR14):
   - the **false-negative rate** — real throws the emitted set omits —
     measured in two layers: against the *raw* FR10 set (should be zero

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -54,13 +54,51 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 Within a section the sub-section PRs sequence per the "Depends on" column —
 `§4.1` reads the origin map, so `§4.2` lands first despite the numbering.
 
-**Dependency graph** (section-level; sub-section PRs sequence within per
-the table):
+**Dependency graph** (all PRs; edges are "must land before"):
 
-```
-§1 ── §2 ── §3 ── §4 ── §5 ── §6 ── §7 ──┬── §8 ─┐
-                                          ├── §9 ─┴── §11 (curation, per-package PRs)
-                                          └── §10 (maintenance)
+```mermaid
+flowchart TD
+    S1["§1 Feasibility spike"]
+    S2["§2 Toolchain scoping"]
+    S3["§3 CFG→JSON serializer"]
+    S42["§4.2 Origin map"]
+    S41["§4.1 Mutation-summary fixpoint"]
+    S43["§4.3 Method classification"]
+    S5["§5 Keying and join"]
+    S6["§6 Validation diff"]
+    S7["§7 Integration"]
+    S81["§8.1 Parameter disposition"]
+    S82["§8.2 Return-borrow seed"]
+    S91["§9.1 Throw-set fixpoint"]
+    S92["§9.2 Coercion filter"]
+    S93["§9.3 Throw/reject split, origins, combinators"]
+    S94["§9.4 Throws validation + auto-apply gate"]
+    S10["§10 Maintenance"]
+    S11["§11 Curation (per-package PRs)"]
+
+    S1 --> S2 --> S3
+    S3 --> S42
+    S3 --> S41
+    S42 --> S41
+    S41 --> S43
+    S42 --> S43
+    S43 --> S5 --> S6 --> S7
+    S41 --> S81
+    S7 --> S81
+    S43 --> S82
+    S42 --> S91
+    S91 --> S92
+    S5 --> S92
+    S91 --> S93
+    S92 --> S94
+    S93 --> S94
+    S7 --> S94
+    S7 --> S10
+    S81 --> S11
+    S82 --> S11
+    S93 --> S11
+    S94 --> S11
+    S7 --> S11
 ```
 
 §11 is a *content* PR series, not code: it fans out into a series of

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1,0 +1,1056 @@
+# ECMA-262-Derived Builtin Annotations: Implementation Plan
+
+This plan implements [requirements.md](requirements.md). Each phase
+lists the touch points and the gate that proves it done. The pipeline
+has three stages and the phases build them in dependency order:
+
+```
+ECMA-262 spec.html
+   │  (ESMeta: extract → compile → build-cfg, pinned via -extract:target)
+   ▼
+control-flow graph  ──(thin Scala serializer)──▶  cfg.json  [committed]
+   │
+   ▼ (Go: origin tagging + mutation fixpoint + alias detection)
+facts.json  [committed]
+   │
+   ▼ (Go: join + classification source)
+bootstrap converter  ──▶  std/*.esc
+```
+
+The language boundary is the committed `cfg.json`. Everything left of it
+is JVM/Scala and runs only on a spec bump. Everything right of it is Go
+and runs in the normal build. The Scala component is a serializer with
+no analysis; all Escalier-specific intelligence lives in the Go stages.
+
+## Implementation order and status
+
+Status legend: ✅ done, 🚧 partial, ⬜ not started.
+
+| §   | Phase                                      | FRs        | Status | Depends on | Gate |
+| --- | ------------------------------------------ | ---------- | ------ | ---------- | ---- |
+| 1   | Feasibility spike                          | FR1–FR4    | ⬜      | —          | ESMeta CFG for ~10 representative methods shows the call nodes, args, slot writes, and returns the analysis needs |
+| 2   | Toolchain scoping                          | NFR        | ⬜      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment |
+| 3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ⬜      | §2         | `cfg.json` emitted for the full `std:*` surface, pinned spec, round-trips a schema check |
+| 4   | Go analysis: mutation + alias              | FR1–FR5    | ⬜      | §3         | `facts.json` produced from `cfg.json`; spot-checked methods classify correctly |
+| 5   | Keying and join                            | FR7        | ⬜      | §4         | Normalizer joins facts to converter declarations; unmatched on both sides reported |
+| 6   | Validation diff                            | FR9        | ⬜      | §5         | Receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
+| 7   | Integration as classification source       | FR8        | ⬜      | §6         | Converter ranks facts above name tiers; redundant `mutabilityOverrides` entries removed |
+| 8   | Parameter disposition + return-borrow outputs | FR12, FR4 | ⬜     | §7         | Per-parameter borrow/mutBorrow/escape from the store analysis; `escape` when a parameter is stored into the receiver (move vs lifetime-borrow spelled at curation); return-borrow seed documented |
+| 9   | Throw + reject extraction, filter, validation | FR10, FR11, FR13, FR14 | ⬜ | §4, §7 | Sync throws and async rejections split by sink; coercion filter prunes type-guard `TypeError`s; `throws`/`rejects` land in `facts.json`; §9.4 measures the false-negative rate that gates auto-apply |
+| 10  | Maintenance workflow                       | NFR        | ⬜      | §7         | Spec-bump runbook; `--check`-style drift report in CI |
+
+**Dependency graph** (edges are "must land before"):
+
+```
+§1 ── §2 ── §3 ── §4 ── §5 ── §6 ── §7 ──┬── §8
+                                          ├── §9  (throws)
+                                          └── §10 (maintenance)
+```
+
+### Discovery phases may grow the plan
+
+§1 (spike) and §2 (toolchain scoping) are **discovery** phases: they
+answer open questions about ESMeta's control-flow graph and build, and
+their findings can add work to the later phases. The table above is the
+plan *assuming the spike confirms the happy path*. The concrete branches
+that would introduce new PRs:
+
+- **§1 → §3 serializer scope.** The escape analysis (§8.1) needs the CFG
+  to expose the *stored-value* operand of every write, and the reject
+  channel (§9.3) needs to distinguish an `IfAbruptRejectPromise` /
+  capability `[[Reject]]` site from a synchronous `Throw`. If ESMeta's IR
+  inlines these cleanly, §3 just serializes them. If it surfaces them as
+  opaque helpers, §3 grows a small hand-modeling layer for the fixed set
+  of promise-combinator steps, and §8/§9 narrow their claims — a new PR
+  each.
+- **§1 → fallback path.** If the CFG is missing a needed signal
+  wholesale, §3 becomes the pure-Go `spec.html` shallow parser (§3
+  alternatives), a materially larger §3 that also has to reconstruct the
+  call graph and the `?`/`!` guards itself.
+- **§2 → §3 integration shape.** ESMeta ships no library artifact, so
+  whether the serializer is an ESMeta **phase** invoked via `bin/esmeta`
+  or an external program depending on a `sbt publishLocal` build is a
+  §2 finding that fixes §3's entry point.
+- **Solver-side application (new, not yet a numbered phase).** §7
+  integrates the facts into the interop-layer `interop.Classify` and
+  removes the legacy `internal/checker/prelude.go` overrides. The active
+  checker's own builtin ingestion is milestone M7 in the solver
+  (`internal/solver`), not yet landed; wiring the facts into that
+  ingestion is a **dependent PR that cannot be written until M7 exists**,
+  tracked here as a known follow-on rather than a scheduled phase.
+- **Applying the non-receiver facts.** §7 auto-applies only receiver
+  mutability, the high-confidence determination. Parameter disposition
+  (§8), the return-borrow seed (§8.2), `throws` (§9), and `rejects` (§9.3)
+  are produced into `facts.json` but **consumed as curation input**, not
+  auto-written into the `.esc`. These are not permanently curation-grade,
+  though: `throws`/`rejects` have a defined graduation path — §9.4
+  measures the false-negative rate, and a measured zero flips them to
+  auto-apply (FR14). Whether disposition is confident enough to auto-apply
+  like receiver mutability is a similar open call to settle when §8 lands.
+- **`escape` spelling depends on external affine work.** §8 records the
+  `escape` disposition; curation spells it a `move` (owning container) or
+  a lifetime-bounded borrow (borrow-holding container), per requirements
+  FR12. The lifetime-borrow spelling needs the affine checker's
+  borrow-into-container tracking (`.push` of a borrow), which the
+  affine_semantics workstream
+  ([../affine_semantics/requirements.md](../affine_semantics/requirements.md))
+  defers to post-M7. That is **not this workstream's work** — until it
+  lands, curation applies only the `move` spelling, and the `escape` facts
+  for borrow-holding containers wait on it. Tracked here as an external
+  dependency, like the M7 solver-side application above.
+
+Re-scope the table once §1 and §2 report, splitting any of the above into
+their own rows before starting §4.
+
+## §1. Feasibility spike
+
+**Goal.** Confirm ESMeta's control-flow graph carries the structure the
+analysis needs before committing to the toolchain.
+
+**Work.**
+
+- Build ESMeta from source — clone `es-meta/esmeta`,
+  `git submodule update --init`, `sbt assembly` — and run
+  `extract → compile → build-cfg` against a pinned ECMA-262 revision.
+- Inspect the CFG for a representative set spanning every shape the
+  analysis must handle:
+  - direct receiver mutation, `Array.prototype.push`;
+  - receiver mutation that returns the receiver, `Array.prototype.fill`,
+    `Array.prototype.sort`;
+  - fresh allocation, no receiver mutation, `Array.prototype.slice`,
+    `Array.prototype.map`;
+  - internal-slot mutation, `Map.prototype.set`,
+    `Set.prototype.add`;
+  - transitive mutation through a helper abstract operation;
+  - immutable-primitive method, `String.prototype.replace`,
+    `String.prototype.charAt`;
+  - symbol-keyed method, `Array.prototype[Symbol.iterator]`;
+  - parameter stored into the receiver (escape), `Array.prototype.push`,
+    `Map.prototype.set`, `Reflect.set` — the CFG must expose the *stored
+    value* operand of a write, not only the written object (§8.1);
+  - promise rejection, a `Promise` combinator such as `Promise.all` or
+    `Promise.race` — the CFG must let the analysis tell an
+    `IfAbruptRejectPromise` / capability `[[Reject]]` site from a
+    synchronous `Throw` (§9.3).
+
+**Gate.** For each method above, confirm the CFG exposes: the abstract-
+operation call nodes with their argument variables **including the
+stored-value operand of writes**, the `Let` bindings and their origins,
+the internal-slot writes, the completion guards (`?`/`!`), the explicit
+`Throw` steps, the promise-rejection sites, and the return values. If any
+signal is missing, record it: a missing stored-value operand or reject
+site narrows §8/§9 scope and may need a hand-modeled combinator step (see
+§9.3); a broader gap falls back to the pure-Go `spec.html` shallow parser
+noted in §3 alternatives.
+
+**This spike can grow the plan.** §1 and §2 are discovery phases; their
+findings feed back into the later phases. See "Discovery phases may grow
+the plan" below.
+
+## §2. Toolchain scoping
+
+**Goal.** Make the JVM toolchain a maintainer-only dependency, absent
+from the normal Go build and CI.
+
+**Work.**
+
+- Add `tools/spec-extract/mise.toml` pinning `java` and `sbt` to **exact**
+  versions — e.g. `java = "temurin-21.0.5+11"` (satisfies ESMeta's JDK
+  17+) and `sbt = "1.10.7"`, never a floating `1.x` — and commit the
+  generated `mise.lock` so transitive tool resolution is reproducible. Do
+  **not** add these to the root `mise.toml`, which every contributor and
+  CI activates.
+- Vendor ESMeta as a git submodule under `tools/spec-extract/` so the
+  pinned ESMeta revision is reproducible alongside the pinned spec
+  revision. ESMeta has no published Maven artifact and no prebuilt JAR,
+  so source vendoring is the only stable option.
+
+**Gate.** A maintainer can `cd tools/spec-extract && mise install` and
+build ESMeta; a contributor building the compiler from the repo root
+never installs Java or sbt.
+
+## §3. Scala CFG→JSON serializer
+
+**Goal.** Give ESMeta's in-memory `esmeta.cfg.CFG` a committed JSON
+spelling. This is the only Scala we write, and it contains no analysis.
+
+**Work.**
+
+- Add a small Scala main in `tools/spec-extract/` that depends on the
+  vendored ESMeta build, runs `extract → compile → build-cfg` with
+  `-extract:target` set to a pinned ECMA-262 **commit** — a full SHA, not
+  a branch or a floating tag — and walks each `cfg.Func`.
+- Lower each ESMeta IR node to the flat, analysis-ready schema in
+  [Appendix A](#appendix-a-cfgjson-schema). The serializer's only job is
+  this lowering. It pattern-matches ESMeta IR instruction types onto the
+  `Node` and `Expr` variants and copies structure; it makes no
+  mutability or alias decision. The shape it must surface per function:
+  the formal parameters in order, with the receiver as index 0 for
+  builtin methods; every `Let` binding's target and source; every
+  abstract-operation call with its callee name, argument expressions,
+  and completion guard (`?` / `!` / plain, needed for the throw-set
+  fixpoint in §9); every internal-slot write with its object expression
+  and slot name; every explicit `Throw` step with its exception type;
+  every return with its value expression.
+- Write the result to `tools/spec-extract/cfg.json` and commit it. The
+  file is large; it is an intermediate regenerated only on a spec bump,
+  and committing it is what keeps the JVM out of the normal build.
+
+**Schema sketch** (full definitions in
+[Appendix A](#appendix-a-cfgjson-schema)):
+
+```go
+type CFG struct{ Funcs []Func }
+
+type Func struct {
+    Name   string   // "Array.prototype.push", "Array.from", or an AO name "Set"
+    Kind   FuncKind // BuiltinMethod | BuiltinStatic | AbstractOp | SyntaxDirected
+    Params []string // formals in order; index 0 is the receiver for BuiltinMethod
+    Nodes  []Node   // flattened, control-flow-edge order preserved
+}
+
+type Node struct {
+    Kind   NodeKind // Let | Call | SlotWrite | Return | Branch
+    Target string   // Let: bound name        | Call: optional result name
+    Source *Expr    // Let: bound expression
+    Callee string   // Call: abstract-operation name
+    Args   []Expr   // Call: argument expressions
+    Object *Expr    // SlotWrite: the object whose slot is written
+    Slot   string   // SlotWrite: e.g. "[[MapData]]"
+    Value  *Expr    // Return: returned expression
+}
+```
+
+**Alternative if §1 fails.** If the CFG does not carry the needed
+structure, fall back to a pure-Go shallow parser over the pinned
+`spec.html` using `golang.org/x/net/html`, exploiting ECMARKUP's
+structural markup — `aoid` attributes on `<emu-xref>` call nodes,
+`<var>` for variables, literal `.[[Slot]]` text. It emits the same
+[Appendix A](#appendix-a-cfgjson-schema) schema, so the Go stage is
+unchanged. The shallow parser drops the JVM entirely but must
+reconstruct the call graph itself and gives up accuracy on
+indirectly-phrased mutations. Keep the §1 CFG dump as a one-time oracle
+to validate the shallow parser's output.
+
+**Gate.** `cfg.json` covers the full `std:*` method surface and
+round-trips a schema validation. The schema is the contract the Go stage
+reads.
+
+## §4. Go analysis: mutation and alias
+
+**Goal.** Produce `facts.json` from `cfg.json` entirely in Go. The
+analysis has three passes: an inter-procedural mutation summary
+(§4.1), a per-function origin map (§4.2), and a per-method
+classification that combines them (§4.3).
+
+The unifying idea is that **the receiver is a distinct origin, not a
+parameter index**. Every function — builtin method, static, namespace
+function, or abstract operation — is analyzed for which of its declared
+parameter positions it mutates (`MutArgs`, 0-based with no offset), and a
+method's receiver mutation is tracked separately (`MutatesReceiver`).
+Receiver mutation means `&mut self`; parameter position `j` mutated means
+parameter `j` is `&mut`. Keeping the receiver out of the parameter index
+space is what makes static and namespace functions — whose parameter 0 is
+a real argument, not a receiver — fall out correctly.
+
+### §4.1. Mutation summary fixpoint (FR1, FR2, FR3)
+
+Compute `MutArgs(F) ⊆ {0..arity-1}`, the formal positions function `F`
+may mutate, directly or transitively. Seed it from the direct mutators
+and iterate to a fixpoint over the call graph.
+
+The receiver is tracked as its own origin, not as a formal index, so
+`MutArgs[F]` holds real 0-based parameter positions for every function
+kind — a method's declared parameters, a static/namespace function's
+arguments, an abstract operation's arguments — with no receiver offset to
+juggle. A method's receiver mutation is recorded separately in
+`MutatesReceiver`.
+
+```
+MutArgs        : map[FuncName] Set[int]  // mutated parameter positions (0-based, no receiver)
+MutatesReceiver: Set[FuncName]           // a method mutates its `this` value
+Unattributable : Set[FuncName]           // F mutates a value tied to no formal or receiver
+Incomplete     : Set[FuncName]           // analysis could not fully cover F (see below)
+
+// Seed: direct property/integrity mutators mutate their object argument (arg 0).
+seed = {
+    "Set":0, "CreateDataProperty":0, "CreateDataPropertyOrThrow":0,
+    "CreateMethodProperty":0, "DefinePropertyOrThrow":0,
+    "OrdinaryDefineOwnProperty":0, "DeletePropertyOrThrow":0,
+    "SetIntegrityLevel":0,
+}
+for ao, k in seed: MutArgs[ao].add(k)
+
+worklist = all funcs
+while worklist nonempty:
+    F = worklist.pop()
+    origin = OriginMap(F)               // §4.2, computed per function
+    before = snapshot(F)                // MutArgs, MutatesReceiver, Unattributable, Incomplete
+
+    for node in F.Nodes:
+        switch node.Kind:
+        case SlotWrite where node.Slot in BackingStoreSlots:   // FR3
+            attribute(F, origin, node.Object)
+        case Call:
+            if node.Callee not in AllFuncs: Incomplete.add(F)  // unresolved callee
+            else for k in MutArgs[node.Callee]:
+                attribute(F, origin, node.Args[k])
+        case Opaque: Incomplete.add(F)  // a step the serializer could not lower (§3)
+    // (a fresh-origin mutation is intentionally ignored: mutating a
+    //  value F allocated itself is not observable to F's callers.)
+
+    if changed(before, F): worklist.push(callers(F))
+
+// attribute: charge a mutated value expression to F's receiver or a formal.
+func attribute(F, origin, expr):
+    switch originOf(origin, expr):
+    case Receiver:   MutatesReceiver.add(F)   // only a BuiltinMethod has one
+    case Param(j):   MutArgs[F].add(j)        // real 0-based parameter position
+    case Fresh:      pass                     // not observable
+    case Unknown:    Unattributable.add(F)
+```
+
+`Incomplete` is distinct from `Unattributable`. `Unattributable` means
+the analysis saw a mutation it could not tie to a receiver or formal —
+it knows something escaped but not what. `Incomplete` means the analysis
+could not see the whole algorithm: an `Opaque` node the serializer could
+not lower (a prose step, §3), a `Call` to a callee absent from the CFG,
+or a mutation phrasing outside the FR1 vocabulary. Both force
+`classified: false` (§4.3), so FR5's heuristic fall-through handles the
+method rather than the analysis emitting a claim it cannot stand behind.
+
+`BackingStoreSlots` is the curated FR3 list: `[[MapData]]`,
+`[[SetData]]`, `[[ArrayBufferData]]`, `[[ArrayBufferByteLength]]`,
+`[[TypedArrayName]]`, `[[ViewedArrayBuffer]]`, `[[WeakRefTarget]]`, and
+others added as collection types enter the spec. Both the seed map and
+this list are reviewed Go constants — adding a mutator to the spec
+without listing it here produces a false non-mutating result, so they
+are deliberately explicit (FR1).
+
+### §4.2. Origin map (FR2, FR4)
+
+For each function, map every value name to its origin by a forward pass.
+Origins propagate only through **identity-preserving** operations; a
+property or slot *read* breaks the origin chain, because the value read
+out of a container is a different object from the container.
+
+```
+type Origin struct { Kind OriginKind; Index int }
+// OriginKind ∈ { Receiver, Param, Fresh, Unknown }
+// Receiver is a BuiltinMethod's `this` value; Param(i) is the i-th
+// declared parameter, 0-based, matching the fact's param index. The
+// receiver is never a Param, so there is no receiver offset.
+
+func OriginMap(F) map[string]Origin:
+    origin = {}
+    for i, p in F.Params: origin[p] = Param(i)       // declared params only; no receiver
+    for node in F.Nodes:
+        if node.Kind == Let:   origin[node.Target] = eval(F, node.Source)
+        if node.Kind == Call && node.Target != "":
+                               origin[node.Target] = evalCall(F, node)
+    return origin
+
+func eval(F, e Expr) Origin:
+    switch e.Kind:
+    case Var:   return origin[e.Var]
+    case This:  return Receiver if F.Kind == BuiltinMethod else Unknown
+                // only a prototype method has a `this` value to track; a
+                // static or namespace function's `this` is the constructor
+                // or namespace object, never a parameter.
+    case Call:  return evalCall(F, e)
+    case Alloc, Lit: return Fresh                     // fresh object / primitive
+    case Slot, Prop: return Unknown                   // a READ: origin chain breaks
+    default:    return Unknown
+
+func evalCall(F, c) Origin:
+    if c.Callee in Allocators:      return Fresh      // ArrayCreate, ArraySpeciesCreate,
+                                                      // OrdinaryObjectCreate, ...
+    if c.Callee in IdentityCoercions:                 // ToObject, RequireObjectCoercible
+        return eval(F, c.Args[0])                     // returns the same object identity
+    return Unknown                                    // Get, ToString, ToNumber, ... → read/fresh
+```
+
+`IdentityCoercions` is the key list for receiver tracking: `ToObject`
+and `RequireObjectCoercible` return the same object, so `O ← ?
+ToObject(this value)` keeps `O` at `Param(0)`. Coercions that build a
+new value — `ToString`, `ToNumber` — are *not* identity-preserving,
+which is exactly why every `String.prototype` method comes out
+non-mutating: the algorithm coerces `this` to a fresh string primitive
+and never writes back to `Param(0)`.
+
+**The analysis is deliberately path-insensitive.** It does not model
+control flow: `NodeBranch` is not interpreted, and the node list is
+walked as a flat sequence. Each name takes the join of every origin
+assigned to it anywhere in the function — equal origins stay, unequal
+collapse to `Unknown` — and `returnAlias` (§4.3) considers *every*
+`Return` node, not only the reachable ones. This over-approximates
+(a throw or return on a dead branch still counts), which is safe here:
+the mutation and throw sets only grow, over-approximating rather than
+missing an effect, and a method the analysis cannot fully resolve is left
+unclassified rather than guessed (FR5). ESMeta's CFG does carry
+block successors and branch conditions; if a later precision pass wants
+reachability or per-path joins, the serializer (§3) can emit that
+structure and this section becomes flow-sensitive. Until then the schema
+omits it (Appendix A) and the guarantees here are path-insensitive by
+construction, not by accident.
+
+### §4.3. Method classification (FR4, FR5)
+
+For each builtin method `M`, combine the summary and the origin map.
+Receiver mutability is just "is `M` in `MutatesReceiver`"; parameter
+dispositions and the reject set are computed by §8 and §9.3:
+
+```
+func classify(M) MethodFact:
+    fact.Receiver   = receiverKind(M)              // below
+    fact.Params     = paramDispositions(M)         // §8: escape / mutBorrow (borrow omitted)
+    fact.Returns    = returnAlias(M)               // below
+    fact.Throws     = filterThrows(M)              // §9.2
+    fact.Rejects    = rejectSet(M)                 // §9.3
+    // Soundness bias (FR5): a method the analysis could not fully cover
+    // OR could not fully attribute is unclassified.
+    fact.Classified = M not in Unattributable and M not in Incomplete
+    return fact
+
+func receiverKind(M):
+    if M.Kind != BuiltinMethod: return RecvNone    // static / namespace function: no receiver
+    return RecvMutBorrow if M in MutatesReceiver else RecvBorrow
+
+func returnAlias(M) AliasKind:
+    acc = Bottom
+    for node in M.Nodes where node.Kind == Return:
+        acc = join(acc, aliasOf(eval(M, node.Value)))
+    return acc
+// aliasOf: Receiver→Receiver; Param(j)→ParamJ; Fresh→FreshReturn; Unknown→UnknownReturn
+// join:    equal→same; FreshReturn⊔FreshReturn→FreshReturn;
+//          two distinct input origins→Union; anything⊔UnknownReturn→UnknownReturn
+```
+
+An `Unattributable` method has a mutation the analysis could not pin to
+a formal — a write through an `Unknown`-origin value, including deep
+mutation reached through a property read. It is emitted with
+`classified: false` and listed, so the converter falls it through to the
+name heuristics and the receiver defaults to `&mut self` (FR5). The
+return-alias axis tolerates `Unknown` without making the whole method
+unclassified, because it is the low-stakes lifetime seed, not a
+soundness-bearing claim.
+
+**Gate.** Spot-check the representative methods from §1:
+- `Array.prototype.push` — `Set(O,…)` on `Param(0)` ⇒ `receiver:
+  mutBorrow`, returns `len` ⇒ `fresh`.
+- `Array.prototype.fill` — `Set(O,…)`, `Return O` ⇒ `receiver:
+  mutBorrow`, `returns: receiver`.
+- `Array.prototype.slice` — writes only to an `ArraySpeciesCreate`
+  result `A` (Fresh), `Return A` ⇒ `receiver: borrow`, `fresh`.
+- `Map.prototype.set` — append to `M.[[MapData]]` (backing-store slot on
+  `Param(0)`), `Return M` ⇒ `receiver: mutBorrow`, `returns: receiver`.
+- every `String.prototype` method — `this` coerced to a fresh string,
+  never written ⇒ all `receiver: borrow`.
+
+Unclassified methods are listed.
+
+## §5. Keying and join (FR7)
+
+**Goal.** Join spec-keyed facts to the converter's class+method
+declarations.
+
+**Work.**
+
+- Implement the name normalizer that maps a spec key onto the
+  `(owner, member, sort)` triple the converter holds. `owner` is a dotted
+  path so namespace-nested constructors resolve; `sort` distinguishes an
+  instance method, a class static, and a namespace-level function:
+
+```
+func normalize(specKey string) (owner []string, member MemberKey, sort MemberSort):
+    // MemberSort ∈ { Instance, Static, NamespaceFunc }
+    // "Array.prototype.push"                   → (["Array"],     Str("push"),     Instance)
+    // "Array.prototype [ @@iterator ]"         → (["Array"],     Sym("iterator"), Instance)
+    // "get Map.prototype.size"                 → (["Map"],       Accessor("size"),Instance)  // never overwritten
+    // "Array.from"                             → (["Array"],     Str("from"),     Static)
+    // "Array [ @@species ]"                    → (["Array"],     Sym("species"),  Static)
+    // "Math.max"                               → (["Math"],      Str("max"),      NamespaceFunc)
+    // "Intl.getCanonicalLocales"               → (["Intl"],      Str("getCanonicalLocales"), NamespaceFunc)
+    // "Intl.DateTimeFormat.prototype.format"   → (["Intl","DateTimeFormat"], Str("format"),  Instance)
+    // "Intl.DateTimeFormat.supportedLocalesOf" → (["Intl","DateTimeFormat"], Str("supportedLocalesOf"), Static)
+```
+
+  The split rule: strip a trailing `.prototype.<member>` or
+  `[ @@symbol ]` to get an instance member; otherwise the last dotted
+  segment is the member and the leading segments are the owner. An owner
+  whose leading segment is a known namespace (`Intl`, `Math`, `Reflect`,
+  `JSON`, `Atomics`, `WebAssembly`) and that has no further constructor
+  segment yields `NamespaceFunc`; an owner ending in a constructor name
+  yields `Instance`/`Static`. The known-namespace set is a small reviewed
+  list, the same one FR7 enumerates.
+  `MemberKey` mirrors `soltype.ObjTypeKey` so symbol-keyed members join
+  by kind plus payload, matching how
+  [../../internal/interop/mutability.go](../../internal/interop/mutability.go)
+  already distinguishes string- from symbol-keyed names. A
+  `NamespaceFunc` carries `receiver: none`, so the join applies only its
+  `params`, `throws`, and `rejects`.
+- A spec algorithm maps to a single method element even when the
+  TypeScript side is an overload set (requirements FR15). The
+  algorithm-level facts — receiver mutability, return-alias, raw throw
+  provenance — apply to **all** signatures of the merged `MethodElem`,
+  the same iteration `applyMethodMutability` in
+  [../../internal/checker/prelude.go](../../internal/checker/prelude.go)
+  already does over `me.Signatures`. The type-dependent parts resolve per
+  signature: the coercion filter (§9.2) reads each overload's parameter
+  types, and a position-keyed parameter fact applies to a signature only
+  where that position exists, so `normalize` must align the spec
+  algorithm's parameter positions to each overload's arity.
+- Skip accessor members: spec getters/setters carry fixed mutability set
+  by the converter, so the normalizer tags them and the join refuses to
+  overwrite them, matching the `GetterElem`/`SetterElem` carve-out in
+  `applyMethodMutability`.
+- Wire the lookup into the bootstrap converter (`tools/dts_to_esc/`,
+  [../../internal/interop/dts_to_esc.go](../../internal/interop/dts_to_esc.go))
+  so a converted method element can resolve its fact.
+- Report names present on one side only, mirroring the converter's
+  unmapped-symbol fail-safe
+  ([../../internal/interop/partition.go](../../internal/interop/partition.go)).
+  A fact with no declaration and a declaration with no fact are both
+  informational, since the spec and the TS lib drift independently.
+
+**Gate.** Every `std:*` method the converter emits either resolves to a
+fact or is reported as unmatched; symbol-keyed and accessor members
+resolve correctly.
+
+## §6. Validation diff
+
+**Goal.** Prove the facts source before trusting it.
+
+**Work.**
+
+- Diff the receiver-mutability facts against the union of
+  `mutabilityOverrides`
+  ([../../internal/checker/prelude.go](../../internal/checker/prelude.go))
+  and `interop.ClassifyMethodByName`
+  ([../../internal/interop/mutability.go](../../internal/interop/mutability.go))
+  for the same methods.
+- Triage every disagreement: facts correct and override redundant, or
+  facts buggy and the §4 analysis fixed.
+
+**Gate.** A reviewed disagreement report with a disposition for each
+entry. This is the gate that authorizes removing override entries in §7.
+
+## §7. Integration as classification source
+
+**Goal.** Make the converter rank facts above the name tiers.
+
+**Work.**
+
+- Insert the facts lookup into `interop.Classify` at rung 2 (FR8):
+  after explicit author signals, before the `get*` prefix and name
+  heuristics.
+- Set receiver mutability from a classified fact; leave unclassified
+  methods to the existing tiers.
+- Remove the `mutabilityOverrides` entries that §6 proved redundant for
+  `std:*`. Keep entries the facts source does not cover, such as `web:*`
+  classes, untouched.
+
+**Gate.** Converter output for `std:*` matches the facts for every
+classified method; the removed override entries cause no regression in
+the converter and checker test suites.
+
+## §8. Parameter disposition and return-borrow outputs (FR12, FR4)
+
+**Goal.** Produce the per-parameter borrow/mutBorrow/escape disposition
+and surface the return-borrow lifetime seed.
+
+### §8.1. Parameter disposition (FR12)
+
+Two signals, both from the §4 machinery. Because the receiver is its own
+origin (§4.1), `MutArgs[M]` holds real 0-based parameter positions and no
+index offset is needed. A parameter object mutated in place is
+`mutBorrow`. A parameter *value* stored into a destination that outlives
+the call is `escape` — a new check over the same store nodes that reads
+the *stored value* operand (`Value` on a `SlotWrite`, or the value
+argument of `Set`/`CreateDataProperty`; Appendix A):
+
+```
+func paramDispositions(M) []ParamFact:
+    disp = {}
+    // mutBorrow: the parameter object itself is written in place (§4.1).
+    for j in MutArgs[M]: disp[j] = MutBorrow
+
+    // escape: a parameter value is stored into a destination that outlives
+    // the call. Escape outranks mutBorrow.
+    for (valueExpr, destExpr) in storeSites(M):  // Set(O,_,V) → (V, O);
+                                                 // "Append V to O.[[slot]]" → (V, O)
+        if originOf(M, valueExpr) is Param(j) and escapes(M, destExpr):
+            disp[j] = Escape
+    return [ {Index: j, Disposition: d} for j, d in disp ]   // direct 0-based index
+```
+
+The extractor records `escape` — the raw fact that the value is stored
+into the receiver and so must outlive it. It does **not** decide whether
+that is spelled a `move` (owned parameter, when the container owns its
+elements) or a lifetime-bounded borrow (`&'a T`, when the container's slot
+is itself a borrow); that depends on the container's element type and is
+settled at the FR7 join, per requirements FR12 and the ownership-model
+section. The default spelling is `move`, and it is the one the affine
+checker implements today; the lifetime-borrow spelling waits on external
+affine work, tracked in the dependency list under "Discovery phases may
+grow the plan."
+
+`escapes(M, dest)` decides whether a value written into `dest` outlives
+the call:
+
+- `dest` origin is `Receiver` or `Param` → **escapes**; the receiver and
+  every incoming argument outlive the call, so a value stored into one
+  escapes into it (`Array.prototype.push` into the receiver; `Reflect.set`
+  into its `target` parameter).
+- `dest` is returned by `M`, or transitively stored into something that
+  escapes → **escapes** (`Array.of` stores its arguments into a fresh
+  array it then returns; the arguments escape into the returned array).
+- `dest` origin is `Fresh` and does not escape → does **not** escape; the
+  value enters an object `M` drops, so no escape.
+- `dest` origin is `Unknown` → cannot be proven to escape, so **not** an
+  escape; the parameter stays at the `borrow` default and the site is
+  listed for review (FR5 keeps the least-constraining choice, and this is
+  not treated as `Incomplete`).
+
+Escape is **transitive** by the same fixpoint as FR2. Define, per abstract
+operation `G`, `StoreEdges(G) ⊆ {(k, m)}` meaning `G` stores its `k`-th
+argument into its `m`-th argument. Seed it from direct stores —
+`Set(args[m], _, args[k])` yields `(k, m)` — and propagate along the call
+graph: if `G` calls `H`, and `H` has edge `(k', m')`, and `G` passes its
+own formals at `H`'s positions `k'` and `m'`, then `G` gains that edge.
+A method then has an escape whenever it passes a parameter value at `k`
+and an escaping destination at `m`. Value-typed arguments are copied at
+runtime regardless (requirements ownership section), so the fact records
+`escape` without committing to a spelling.
+
+### §8.2. Return-borrow seed (FR4)
+
+Surface the `returns` alias kind to whoever curates the `&` and lifetime
+annotations in the hand-curated override layer (FR7), as review input
+rather than an automatic annotator — the annotations are re-applied when
+the `.esc` is generated, not hand-edited into it. The checker's lifetime
+inference and elision rules
+([../lifetimes/requirements.md](../lifetimes/requirements.md)) and the
+borrow model ([../affine_semantics/requirements.md](../affine_semantics/requirements.md))
+remain the mechanism; the facts only inform the curation. Document the
+mapping: `returns: receiver` ⇒ the return borrows the receiver
+(`-> &self` / `-> &mut self`); `returns: param` ⇒ the return borrows that
+parameter; `returns: fresh` ⇒ an owned return; `returns: union` ⇒ a
+lifetime union.
+
+**Gate.** Disposition present in `facts.json` — `Array.prototype.push`
+and `Map.prototype.set` mark their stored parameters `escape`,
+`Reflect.set` marks `target` `mutBorrow` and `value` `escape`,
+`Array.prototype.indexOf` leaves `searchElement` a borrow. A documented
+`returns` → annotation mapping for the receiver-returning methods
+(`fill`, `sort`, `reverse`, `Map.set`).
+
+## §9. Throw-set extraction and coercion filter (FR10, FR11)
+
+**Goal.** Produce the `throws` candidate set for each method, reusing the
+§4 machinery with a throw transfer function and then pruning the
+type-guard noise.
+
+### §9.1. Throw-set fixpoint (FR10)
+
+Compute `Throws(F) ⊆ ErrorType`, the exception types `F` can raise,
+directly or transitively. The structure is identical to the §4.1
+mutation-summary fixpoint: a worklist over the call graph, a per-call
+transfer, re-enqueue callers on change. The transfer differs and depends
+on each call's completion guard, which §3 now records on the `Node`.
+
+```
+Throws : map[FuncName] Set[ErrorType]   // {TypeError, RangeError, ...}
+ThrowSites : map[FuncName] []ThrowSite  // provenance chains for §9.2 / §9.3
+
+// A site preserves where the value ULTIMATELY came from, so a coercion
+// throw stays recognizable however many `?`-hops it propagates through.
+type ThrowSite:
+    Type : ErrorType
+    Root : Direct(node)                  // raised here (domain check, coercion AO, or plain)
+         | Propagated(callee, inner)     // via ? from `callee`'s own site `inner`
+    Node : node in F                     // the raising/propagating node; §9.3 reads it for the sink
+
+worklist = all funcs
+while worklist nonempty:
+    F = worklist.pop()
+    before = Throws[F].copy()
+    for node in F.Nodes:
+        switch node.Kind:
+        case Throw:                                 // explicit "Throw a T exception"
+            Throws[F].add(node.ErrorType)
+            ThrowSites[F].append(ThrowSite{ Type: node.ErrorType,
+                                            Root: Direct(node), Node: node })
+        case Call where node.Guard == GuardQuestion:   // ? propagates the callee's throws
+            for s in ThrowSites[node.Callee]:          // carry the callee's OWN site, not just its name
+                Throws[F].add(s.Type)
+                ThrowSites[F].append(ThrowSite{ Type: s.Type,
+                                                Root: Propagated(node.Callee, s), Node: node })
+        // GuardBang (! asserts no abrupt completion) and GuardPlain
+        // (result not completion-checked) contribute nothing.
+    if Throws[F] != before: worklist.push(callers(F))
+```
+
+`ThrowSite.Root` threads the full chain back to the ultimate source
+rather than collapsing to the immediate callee: `Propagated` nests the
+callee's own site, so a `TypeError` that a method inherits through three
+`?`-guarded calls still records that its origin is, say, a `ToNumber`
+coercion of the method's first argument. The §9.2 filter walks that chain
+to decide whether the throw is a coercion type-guard; §9.3 reads
+`ThrowSite.Node` to decide whether the site reaches the synchronous exit
+or a promise reject. There is no seed map as in §4.1; throws originate
+only at explicit `Throw` nodes and flow outward through `?`.
+
+### §9.2. Coercion filter (FR11)
+
+Prune throws whose provenance is a coercion of an already-typed receiver
+or parameter, because Escalier's static types make those paths
+unreachable.
+
+```
+CoercionAOs = { ToObject, RequireObjectCoercible,
+                ToString, ToNumber, ToNumeric, ToPrimitive }
+
+func filterThrows(M) []ErrorType:
+    kept = {}
+    for site in syncSites(M):                        // §9.3: sites reaching the synchronous exit
+        if site.Type == TypeError and precludedCoercion(M, site):
+            continue                                  // statically unreachable
+        kept.add(site.Type)
+    return sorted(kept)
+
+// precludedCoercion: the throw's Root bottoms out at a coercion AO whose
+// coerced value threads back to M's receiver, or to a parameter whose
+// DECLARED type already is the coercion's target type.
+func precludedCoercion(M, site) bool:
+    (ao, coerced) = rootCoercion(site.Root)          // unwrap Propagated(..) to the base Direct
+    if ao not in CoercionAOs: return false
+    place = threadBack(M, site.Root, coerced)        // map coerced value back to M's receiver/param
+    if place is Receiver:  return true               // receiver type is always statically known
+    if place is Param(j):  return targetTypeProven(M, j, ao)  // needs the joined signature type
+    return false
+```
+
+Receiver coercions are filtered unconditionally, because the receiver's
+type is always statically known. **Parameter coercions are filtered only
+when the joined declaration proves the parameter's type already is the
+coercion's target** — `ToNumber(p)` on a `p: number` cannot throw, but
+`ToNumber(p)` on a `p: unknown` can. That check needs the typed
+signature, which the shape-free facts do not carry (FR7), so the
+parameter branch of the filter **runs after the FR7 join** (or is fed the
+parameter types from it); the receiver branch can run earlier. A
+`RangeError`, `SyntaxError`, `URIError`, or a `TypeError` from an explicit
+domain check survives. Each filter decision is recorded for review, since
+FR11 is a heuristic. Channel assignment is **per throw site, not per
+error type**: `filterThrows` sees only the synchronous sites, `rejectSet`
+(§9.3) only the rejection sites, so the same error type can legitimately
+appear in both `throws` and `rejects` when raised on both a synchronous
+and an asynchronous path.
+
+**Gate.** Spot-check: `Number.prototype.toFixed` keeps `RangeError`
+(out-of-range `fractionDigits`) and drops the receiver-coercion
+`TypeError`; `decodeURIComponent` keeps `URIError`; `Array.prototype.push`
+keeps nothing. The dropped type-guard throws are listed in the review
+report.
+
+### §9.3. Synchronous throws versus asynchronous rejections (FR13)
+
+Split the raised set by which sink the value reaches. A synchronous
+`Throw` step feeds `throws` (§9.2); a rejection of the returned promise
+feeds `rejects` (the `Promise<T, E>` reject type). The two use the same
+fixpoint; they differ only in classifying the site:
+
+```
+func rejectSet(M) []ErrorType:
+    if not returnsPromise(M): return []          // no async channel (source below)
+    kept = {}
+    for site in rejectSites(M):                  // sites reaching the promise reject sink
+        if not (site.Type == TypeError and precludedCoercion(M, site)):
+            kept.add(site.Type)                  // same coercion filter as §9.2
+    return sorted(kept)
+
+// A method's throw sites PARTITION by which exit each reaches, so channel
+// assignment is per-site:
+//   rejectSites(M) — ThrowSite.Node flows into the created promise
+//     capability's [[Reject]]: a Call whose callee is `cap.[[Reject]]`,
+//     an IfAbruptRejectPromise step, or a Return of an already-rejected
+//     promise.
+//   syncSites(M)   — every other site: the value leaves M as a synchronous
+//     abrupt completion.
+// The two are disjoint and together cover ThrowSites[M], so each site
+// lands in exactly one channel; a single error TYPE may still appear in
+// both `throws` and `rejects` when raised on both a sync and an async path.
+
+// returnsPromise(M): read from the serialized CFG marker Func.Promise
+// (Appendix A), which the serializer sets when M's algorithm builds a
+// promise capability and returns its [[Promise]], or M is an async
+// function. It does NOT depend on a return TYPE, which the shape-free
+// facts lack. This subsumes generators and async generators (requirements
+// "Synchronous throws versus asynchronous rejections"): a generator's
+// %GeneratorPrototype%.next reaches the synchronous sink and a
+// promise-returning %AsyncGeneratorPrototype%.next sets Func.Promise and
+// reaches the reject sink, so both route through the same partition with
+// no special case.
+```
+
+Recognizing a rejection site needs the CFG to represent the promise
+capability and its `[[Reject]]` field access; whether ESMeta's CFG
+surfaces `IfAbruptRejectPromise` as an inlined reject or an opaque helper
+is a **§1 spike question** — if it is opaque, seed the classification by
+treating `IfAbruptRejectPromise(x, cap)` as a reject of `cap` with `x`'s
+type, the one hand-modeled combinator step.
+
+**Gate.** `Promise`-returning methods carry a `rejects` field distinct
+from `throws`; a synchronous validation `Throw` in a promise combinator
+lands in `throws` while an `IfAbruptRejectPromise` lands in `rejects`.
+Because concrete `std:*` domain rejections are rare (FR13), the honest
+expected outcome is that most `std:*` `rejects` sets are empty or a
+propagated generic, and that is recorded, not hidden.
+
+### §9.4. Throws validation and the auto-apply gate (FR14)
+
+The throws counterpart of §6's mutability diff. It decides, by
+measurement, whether throws stay a reviewed candidate set or graduate to
+auto-apply — so it is the phase that could later retire the "Throws as a
+finished, unreviewed annotation" non-goal.
+
+**Work.**
+
+- Hand-curate a ground-truth `throws`/`rejects` sample over the
+  high-value methods (`JSON.parse`, `decodeURIComponent`,
+  `Number.prototype.toFixed`, `BigInt`, the `Promise` combinators, …),
+  applying the documented host-throws exclusion so stack-overflow
+  `RangeError` and OOM never appear in the ground truth.
+- Diff the extracted sets against it and report two rates (FR14):
+  - the **false-negative rate** — real throws the emitted set omits —
+    measured in two layers: against the *raw* FR10 set (should be zero
+    when the CFG is faithful — isolates §9.1 soundness) and against the
+    *filtered* FR11 set (its false negatives are the coercion filter's
+    over-prunes);
+  - the **false-positive rate** — phantom throws — which costs only a
+    redundant handler and carries less weight.
+- Triage every filtered false negative: a genuine over-prune fixes the
+  §9.2 filter; a ground-truth error fixes the sample.
+
+**Gate.** A reviewed rate report. While the filtered false-negative rate
+is above zero, the converter treats `throws`/`rejects` as curation input
+(§7 does not auto-apply them). A measured filtered false-negative rate of
+zero on the sample is the evidence that authorizes flipping throws to
+auto-apply, mirroring how §6 authorizes trusting the mutability facts.
+
+## §10. Maintenance workflow
+
+**Goal.** Make spec-edition bumps a repeatable runbook.
+
+**Work.**
+
+- Document the bump: update the pinned `-extract:target`, rebuild
+  `cfg.json` under `tools/spec-extract/`, re-run the Go analysis, review
+  the `facts.json` diff, re-run the §6 validation.
+- Add a CI check that re-runs the Go analysis over the committed
+  `cfg.json` and fails if `facts.json` is stale, so the committed facts
+  cannot drift from the committed CFG without the JVM.
+- Add an informational drift report flagging spec methods that gained or
+  lost a mutating operation since the last bump.
+
+**Gate.** A bump runbook exists and a stale-facts CI check is green.
+
+---
+
+## Appendix A. `cfg.json` schema
+
+The serialized control-flow graph. This is the contract between the
+Scala serializer (§3) and the Go analysis (§4); it is the only shape
+either side agrees on. The schema is provisional pending the §1 spike,
+which confirms the ESMeta IR carries each field.
+
+```go
+type CFG struct {
+    SpecTarget string  `json:"specTarget"` // pinned ecma262 git ref (-extract:target)
+    Funcs      []Func  `json:"funcs"`
+}
+
+type FuncKind string
+const (
+    BuiltinMethod  FuncKind = "builtin-method"  // X.prototype.method; has a `this` value (ExprThis)
+    BuiltinStatic  FuncKind = "builtin-static"  // X.method; no receiver
+    AbstractOp     FuncKind = "abstract-op"     // Set, ToObject, ArrayCreate, ...
+    SyntaxDirected FuncKind = "syntax-directed" // evaluation semantics; mostly unused here
+)
+
+type Func struct {
+    Name    string   `json:"name"`    // canonical spec key (Appendix C) or AO name
+    Kind    FuncKind `json:"kind"`
+    Params  []string `json:"params"`  // DECLARED parameters, in order, 0-based. The receiver
+                                       // is NOT a parameter — a method's receiver is the `this`
+                                       // value, referenced via ExprThis, never Params[0].
+    Promise bool     `json:"promise"` // true when the algorithm builds a promise capability and
+                                       // returns its [[Promise]], or the function is async (§9.3)
+    Nodes   []Node   `json:"nodes"`   // CFG nodes in flat order; branches carry no analyzed data
+}
+
+type NodeKind string
+const (
+    NodeLet       NodeKind = "let"       // bind Target = Source
+    NodeCall      NodeKind = "call"      // optional Target = Callee(Args...)
+    NodeSlotWrite NodeKind = "slotwrite" // write Value into Object.Slot
+    NodeThrow     NodeKind = "throw"     // Throw a <ErrorType> exception
+    NodeReturn    NodeKind = "return"    // return Value
+    NodeBranch    NodeKind = "branch"    // control flow; carries no data we analyze
+    NodeOpaque    NodeKind = "opaque"    // a step the serializer could not lower ⇒ Incomplete (§4.1)
+)
+
+// Guard is the completion-record guard on a call, needed for the §9
+// throw-set fixpoint. ? propagates abrupt completions; ! asserts none.
+type Guard string
+const (
+    GuardQuestion Guard = "?"     // Let x be ? Foo(...)
+    GuardBang     Guard = "!"     // Let x be ! Foo(...)
+    GuardPlain    Guard = "plain" // result not completion-checked
+)
+
+type Node struct {
+    Kind      NodeKind `json:"kind"`
+    Target    string   `json:"target,omitempty"`    // Let target, or Call result binding
+    Source    *Expr    `json:"source,omitempty"`    // Let
+    Callee    string   `json:"callee,omitempty"`    // Call: abstract-operation name
+    Args      []Expr   `json:"args,omitempty"`      // Call
+    Guard     Guard    `json:"guard,omitempty"`     // Call: ? / ! / plain
+    Object    *Expr    `json:"object,omitempty"`    // SlotWrite: the written object
+    Slot      string   `json:"slot,omitempty"`      // SlotWrite, e.g. "[[MapData]]"
+    ErrorType string   `json:"errorType,omitempty"` // Throw: "TypeError", "RangeError", ...
+    Value     *Expr    `json:"value,omitempty"`     // Return: the returned expression;
+                                                    // SlotWrite: the stored value (needed by §8.1
+                                                    // escape detection — the V in "Append V to O.[[slot]]")
+}
+
+type ExprKind string
+const (
+    ExprVar  ExprKind = "var"  // a named value
+    ExprThis ExprKind = "this" // the this value
+    ExprLit  ExprKind = "lit"  // literal / primitive
+    ExprCall ExprKind = "call" // nested AO call, e.g. ToObject(x)
+    ExprSlot ExprKind = "slot" // READ of Object.Slot
+    ExprProp ExprKind = "prop" // READ via Get(Object, Key) etc.
+)
+
+type Expr struct {
+    Kind   ExprKind `json:"kind"`
+    Var    string   `json:"var,omitempty"`    // ExprVar
+    Callee string   `json:"callee,omitempty"` // ExprCall
+    Args   []Expr   `json:"args,omitempty"`   // ExprCall
+    Object *Expr    `json:"object,omitempty"` // ExprSlot / ExprProp
+    Slot   string   `json:"slot,omitempty"`   // ExprSlot
+}
+```
+
+The analysis never interprets `NodeBranch`, and the schema carries no
+block successors or branch conditions: the analysis is path-insensitive
+by construction (§4.2), joining every definition of a name regardless of
+control flow. A later precision pass that wanted reachability would add
+that structure here first. `ExprSlot` and `ExprProp` are *reads* and
+deliberately resolve to `Unknown` origin, so the origin chain breaks at a
+container access — this is what keeps deep mutation through reads from
+being mis-attributed to the receiver.
+
+## Appendix B. `facts.json` schema
+
+The committed output of §4, consumed by the converter (§7). Small,
+reviewable, keyed by canonical spec name.
+
+```go
+type Facts struct {
+    SpecTarget string               `json:"specTarget"` // echoes CFG.SpecTarget
+    Methods    map[string]MethodFact `json:"methods"`   // key: canonical spec name
+}
+
+type ReceiverKind string
+const (
+    RecvBorrow    ReceiverKind = "borrow"    // &self  (non-mutating method)
+    RecvMutBorrow ReceiverKind = "mutBorrow" // &mut self (mutating method)
+    RecvNone      ReceiverKind = "none"      // static / namespace function, no receiver
+)
+
+type Disposition string
+const (
+    DispMutBorrow Disposition = "mutBorrow" // &mut: parameter object mutated in place (FR12)
+    DispEscape    Disposition = "escape"    // stored into the receiver ⇒ must outlive it; spelled a
+                                            // move or a lifetime-bounded borrow at curation (FR12)
+    // read-only borrow (&) is the default and is omitted from Params.
+)
+
+type ParamFact struct {
+    Index       int         `json:"index"`
+    Disposition Disposition `json:"disposition"` // never "borrow": borrow params are omitted
+}
+
+type AliasKind string
+const (
+    AliasReceiver AliasKind = "receiver" // return borrows the receiver (&self / &mut self)
+    AliasParam    AliasKind = "param"    // return borrows ParamIndex
+    AliasFresh    AliasKind = "fresh"    // owned return: fresh / primitive values
+    AliasUnion    AliasKind = "union"    // returns borrow differing inputs (lifetime union)
+    AliasUnknown  AliasKind = "unknown"  // a return origin could not be resolved
+)
+
+// The effect fields are pointers/slices so they are ABSENT (JSON null or
+// omitted) when Classified is false — an unanalyzed method, distinct from
+// a proven-empty result which is Classified:true with empty effect fields.
+type MethodFact struct {
+    Classified bool          `json:"classified"`           // false ⇒ effect fields absent (FR5)
+    Receiver   *ReceiverKind `json:"receiver,omitempty"`   // borrow | mutBorrow | none (FR2)
+    Params     []ParamFact   `json:"params,omitempty"`     // only non-borrow parameters (FR12)
+    Returns    *AliasKind    `json:"returns,omitempty"`    // return-borrow lifetime seed (FR4)
+    ParamIndex int           `json:"paramIndex,omitempty"` // when Returns == "param"
+    Throws     []string      `json:"throws,omitempty"`     // sync throws post-filter (FR10, FR11)
+    Rejects    []string      `json:"rejects,omitempty"`    // async rejects → Promise<T,E>.Err (FR13)
+}
+```
+
+Each entry in `Throws` / `Rejects` is a standard error-class name
+(`TypeError`, `RangeError`, …) or the sentinel `"unknown"` for a
+propagated or arbitrary rejected value the spec does not construct
+(`Promise.reject`'s argument, combinator forwarding, `AggregateError`);
+requirements FR13. A `classified: false` entry carries no receiver,
+disposition, throw, or reject claim — those fields are absent, not empty —
+so the converter cannot mistake "unanalyzed" for "proven none"; it applies
+the FR5 defaults itself and falls the method through to the name
+heuristics. Such methods are also collected into a separate
+`unclassified` report alongside `facts.json` for auditing
+(FR5). A parameter absent from `Params` is a read-only borrow (`&`); the
+receiver-returning and fresh-returning alias kinds carry the return's
+borrow lifetime per FR4.
+
+## Appendix C. Canonical spec keys
+
+The shared key space between `cfg.json`, `facts.json`, and the §5
+normalizer.
+
+The host `X` is a dotted path, so a constructor nested in a namespace
+(`Intl.DateTimeFormat`) is just a longer `X`.
+
+| Form                          | Example                                  | Joins to                              |
+| ----------------------------- | ---------------------------------------- | ------------------------------------- |
+| `X.prototype.method`          | `Array.prototype.push`                   | instance method `push` on `X`         |
+| `X.method`                    | `Array.from`                             | static method `from` on `X`           |
+| `X.prototype [ @@symbol ]`    | `Array.prototype [ @@iterator ]`         | `[Symbol.iterator]` on `X`            |
+| `X [ @@symbol ]`              | `Array [ @@species ]`                    | static `[Symbol.species]` on `X`      |
+| `get X.prototype.accessor`    | `get Map.prototype.size`                 | getter `size` (not overwritten)       |
+| `set X.prototype.accessor`    | `set …`                                  | setter (not overwritten)              |
+| `Namespace.fn`                | `Math.max`, `Intl.getCanonicalLocales`   | namespace-level function (no receiver)|
+| `Namespace.Class.prototype.m` | `Intl.DateTimeFormat.prototype.format`   | instance method on a nested ctor      |
+| `Namespace.Class.method`      | `Intl.DateTimeFormat.supportedLocalesOf` | static method on a nested ctor        |
+
+Namespace-level functions carry `Kind: builtin-static` in `cfg.json`:
+like a class static they have no receiver, so the analysis treats index
+0 of their `Params` as the first real argument, not a `this` value. The
+§5 normalizer distinguishes a class static from a namespace function by
+the known-namespace owner list; the analysis itself does not need the
+distinction, because parameter mutation (`Reflect.set` writing its
+`target`) flows through the same formal-index machinery either way.
+
+Abstract operations referenced inside algorithms — `Set`, `ToObject`,
+`ArrayCreate`, and the like — appear in `cfg.json` as `Func`s with
+`Kind: abstract-op` keyed by their plain spec name. They feed the §4.1
+fixpoint but never appear in `facts.json`, which holds only builtin
+methods.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -54,7 +54,8 @@ sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
 Within a section the sub-section PRs sequence per the "Depends on" column —
 `§4.1` reads the origin map, so `§4.2` lands first despite the numbering.
 
-**Dependency graph** (all PRs; edges are "must land before"):
+**Dependency graph** (all PRs plus the external dependencies this plan
+names in other planning docs; edges are "must land before"):
 
 ```mermaid
 flowchart TD
@@ -99,7 +100,35 @@ flowchart TD
     S93 --> S11
     S94 --> S11
     S7 --> S11
+
+    subgraph external["External — other planning docs"]
+        EXT_CONV["builtins converter<br/>(planning/builtins FR10)"]
+        EXT_M75["M7.5 Library type resolution<br/>(planning/simple_sub)"]
+        EXT_AFFINE["container-method borrow tracking<br/>(planning/affine_semantics)"]
+    end
+    subgraph followons["Follow-ons — not numbered PRs"]
+        FO_SOLVER["Solver-side application"]
+        FO_ESCLB["escape lifetime-borrow spelling"]
+    end
+
+    EXT_CONV --> S5
+    EXT_CONV --> S7
+    EXT_M75 --> EXT_AFFINE
+    S7 --> FO_SOLVER
+    EXT_M75 --> FO_SOLVER
+    S11 --> FO_ESCLB
+    EXT_AFFINE --> FO_ESCLB
 ```
+
+The **external** group is work in other workstreams that this plan
+depends on: the builtins converter (planning/builtins FR10) that §5 and
+§7 wire into; M7.5 library-type resolution (planning/simple_sub); and the
+affine container-method borrow tracking (planning/affine_semantics),
+which is itself blocked on M7.5's `Array` ingestion. The **follow-ons**
+are ecma-262 work this plan names but does not number as PRs, because each
+waits on an external dependency: the solver-side application needs §7 and
+M7.5, and the `escape` lifetime-borrow spelling needs §11 and the affine
+work. Both are detailed in "Discovery phases may grow the plan" below.
 
 §11 is a *content* PR series, not code: it fans out into a series of
 per-package PRs and recurs as deltas on spec bumps. It is listed so the

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -1,8 +1,11 @@
 # ECMA-262-Derived Builtin Annotations: Implementation Plan
 
-This plan implements [requirements.md](requirements.md). Each phase
-lists the touch points and the gate that proves it done. The pipeline
-has three stages and the phases build them in dependency order:
+This plan implements [requirements.md](requirements.md). The whole
+ECMA-262 workstream is tracked by a **single milestone**; the table below
+breaks it into PRs. A section with numbered sub-sections lands as **one PR
+per sub-section** (§4.1, §4.2, …); a section without sub-sections is a
+single PR. Each PR lists its touch points and the gate that proves it
+done. The pipeline has three stages the PRs build in dependency order:
 
 ```
 ECMA-262 spec.html
@@ -22,25 +25,37 @@ is JVM/Scala and runs only on a spec bump. Everything right of it is Go
 and runs in the normal build. The Scala component is a serializer with
 no analysis; all Escalier-specific intelligence lives in the Go stages.
 
-## Implementation order and status
+## PRs
 
-Status legend: ✅ done, 🚧 partial, ⬜ not started.
+One milestone, the PRs below — each section is a PR, and a section with
+sub-sections is one PR per sub-section. Status legend: ✅ done, 🚧 partial,
+⬜ not started.
 
-| §   | Phase                                      | FRs        | Status | Depends on | Gate |
-| --- | ------------------------------------------ | ---------- | ------ | ---------- | ---- |
-| 1   | Feasibility spike                          | FR1–FR4    | ⬜      | —          | ESMeta CFG for ~10 representative methods shows the call nodes, args, slot writes, and returns the analysis needs |
-| 2   | Toolchain scoping                          | NFR        | ⬜      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment |
-| 3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ⬜      | §2         | `cfg.json` emitted for the full `std:*` surface, pinned spec, round-trips a schema check |
-| 4   | Go analysis: mutation + alias              | FR1–FR5    | ⬜      | §3         | `facts.json` produced from `cfg.json`; spot-checked methods classify correctly |
-| 5   | Keying and join                            | FR7, FR15  | ⬜      | §4         | Normalizer joins facts to converter declarations; overload sets share algorithm-level facts and resolve the type-dependent parts per signature; unmatched on both sides reported |
-| 6   | Validation diff                            | FR9        | ⬜      | §5         | Receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
-| 7   | Integration as classification source       | FR8        | ⬜      | §6         | Converter ranks facts above name tiers; redundant `mutabilityOverrides` entries removed |
-| 8   | Parameter disposition + return-borrow outputs | FR12, FR4 | ⬜     | §7         | Per-parameter borrow/mutBorrow/escape from the store analysis; `escape` when a parameter is stored into the receiver (move vs lifetime-borrow spelled at curation); return-borrow seed documented |
-| 9   | Throw + reject extraction, filter, validation | FR10, FR11, FR13, FR14 | ⬜ | §4, §7 | Sync throws and async rejections split by sink; coercion filter prunes type-guard `TypeError`s; `throws`/`rejects` land in `facts.json`; §9.4 measures the false-negative rate that gates auto-apply |
-| 10  | Maintenance workflow                       | NFR        | ⬜      | §7         | Spec-bump runbook; `--check`-style drift report in CI |
-| 11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | Override layer populated per pseudo-package by review; each candidate cross-checked against the §9.4 ground truth, disagreements triaged; fans out into per-package PRs |
+| PR   | Work                                       | FRs        | Status | Depends on | Gate |
+| ---- | ------------------------------------------ | ---------- | ------ | ---------- | ---- |
+| §1   | Feasibility spike                          | FR1–FR4    | ⬜      | —          | ESMeta CFG for ~10 representative methods (incl. escape, reject, callback) exposes the call nodes, args, stored-value operands, guards, `Throw`s, reject sites, and returns the analysis needs |
+| §2   | Toolchain scoping                          | NFR        | ⬜      | §1         | `tools/spec-extract/mise.toml` builds and runs ESMeta with no JVM in the root environment |
+| §3   | Scala CFG→JSON serializer                  | FR6 (cfg)  | ⬜      | §2         | `cfg.json` for the full `std:*` surface, pinned spec, round-trips a schema check |
+| §4.1 | Mutation-summary fixpoint                  | FR1–FR3    | ⬜      | §3, §4.2   | `MutArgs`/`MutatesReceiver` spot-checked — push/fill mutate the receiver, slice does not, Map.set via `[[MapData]]` |
+| §4.2 | Origin map                                 | FR2, FR4   | ⬜      | §3         | origins asserted for sample functions — `ToObject(this)`→Receiver, allocators→Fresh, reads→Unknown |
+| §4.3 | Method classification                      | FR4, FR5   | ⬜      | §4.1, §4.2 | facts.json core — receiver / returns / classified for the representative methods |
+| §5   | Keying and join                            | FR7, FR15  | ⬜      | §4.3       | normalizer joins facts to `.d.ts` declarations; overloads share algorithm-level facts, type-dependent parts per signature; unmatched reported |
+| §6   | Validation diff                            | FR9        | ⬜      | §5         | receiver facts diffed against `mutabilityOverrides` + heuristics; every disagreement triaged |
+| §7   | Integration as classification source       | FR8        | ⬜      | §6         | converter ranks facts above name tiers; the two application paths wired; redundant overrides removed |
+| §8.1 | Parameter disposition                      | FR12       | ⬜      | §4.1, §7   | push/Map.set `escape`, Reflect.set `mutBorrow`+`escape`, indexOf `borrow` in facts.json |
+| §8.2 | Return-borrow seed                         | FR4        | ⬜      | §4.3       | documented `returns` → `&`/lifetime annotation mapping (small) |
+| §9.1 | Throw-set fixpoint                          | FR10       | ⬜      | §4.2       | raw throw sets, `Raised` = class / origin / callback-effect / unknown |
+| §9.2 | Coercion filter                            | FR11       | ⬜      | §9.1, §5   | filtered throws — toFixed keeps RangeError, drops the receiver-coercion TypeError; param branch runs post-join |
+| §9.3 | Throw/reject split, parametric origins, combinators | FR10, FR13 | ⬜ | §9.1  | `rejects` distinct from `throws`; Promise.reject `param:0`, forEach `throwsOf:param:k`; combinators hand-modeled |
+| §9.4 | Throws validation + auto-apply gate        | FR14       | ⬜      | §9.1–§9.3, §7 | spec-independent (dynamically-observed) ground truth; false-negative rate report gates auto-apply |
+| §10  | Maintenance workflow                       | NFR        | ⬜      | §7         | spec-bump runbook; `--check`-style drift report in CI |
+| §11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | override layer populated per pseudo-package by review; fans out into per-package PRs |
 
-**Dependency graph** (edges are "must land before"):
+Within a section the sub-section PRs sequence per the "Depends on" column —
+`§4.1` reads the origin map, so `§4.2` lands first despite the numbering.
+
+**Dependency graph** (section-level; sub-section PRs sequence within per
+the table):
 
 ```
 §1 ── §2 ── §3 ── §4 ── §5 ── §6 ── §7 ──┬── §8 ─┐
@@ -48,8 +63,8 @@ Status legend: ✅ done, 🚧 partial, ⬜ not started.
                                           └── §10 (maintenance)
 ```
 
-§11 is a *content* phase, not a code phase: it fans out into a series of
-per-package PRs and recurs as deltas on spec bumps. It is numbered so the
+§11 is a *content* PR series, not code: it fans out into a series of
+per-package PRs and recurs as deltas on spec bumps. It is listed so the
 work is explicit and scheduled, but it is unlike §1–§10 in kind.
 
 ### Discovery phases may grow the plan

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -88,8 +88,12 @@ that would introduce new PRs:
 - **Applying the non-receiver facts.** §7 auto-applies only receiver
   mutability, the high-confidence determination. Parameter disposition
   (§8), the return-borrow seed (§8.2), `throws` (§9), and `rejects` (§9.3)
-  are produced into `facts.json` but **consumed as curation input**, not
-  auto-written into the `.esc`. These are not permanently curation-grade,
+  are produced into `facts.json` but reach the `.esc` **through the
+  hand-curated override layer**, not the trusted auto-apply path — a human
+  review sits between the fact and the committed annotation (see §7 "Two
+  application paths"; `throws`/`rejects` and the `&`/lifetime annotations
+  are added by the curator, disposition gets a provisional baseline the
+  curator corrects). These are not permanently curation-grade,
   though: `throws`/`rejects` have a defined graduation path — §9.4
   measures the false-negative rate, and a measured zero flips them to
   auto-apply (FR14). Whether disposition is confident enough to auto-apply
@@ -565,6 +569,46 @@ entry. This is the gate that authorizes removing override entries in §7.
 - Remove the `mutabilityOverrides` entries that §6 proved redundant for
   `std:*`. Keep entries the facts source does not cover, such as `web:*`
   classes, untouched.
+
+**Two application paths.** `facts.json` reaches the generated `.esc` two
+ways, and the split is per determination, not per method:
+
+```
+facts.json ─┬─ receiver mutability ──────────────────▶ generated .esc   (auto, trusted)
+            └─ disposition / return-borrow /
+               throws / rejects ──▶ review ──▶ override layer ──▶ generated .esc
+.d.ts ─── types ─────────────────────────────────────▶ generated .esc
+```
+
+- **Auto-applied (trusted).** Receiver mutability is read straight from a
+  classified fact and written into the `.esc` — no human in the loop. It
+  is the only determination §6 has validated (FR9) as trustworthy.
+- **Curation-grade (reviewed).** Parameter disposition, the return-borrow
+  seed, `throws`, and `rejects` reach the `.esc` only through a
+  **hand-curated override layer** — a committed data file keyed by
+  canonical spec name that a human populates by reviewing the
+  corresponding fields of `facts.json`, and that generation **re-applies
+  automatically** (per FR7, it is re-applied, not edited into the output).
+  A human is in the loop once per builtin, then only for deltas — new
+  methods, or a spec bump that surfaces new candidate throws; the
+  committed override layer means regeneration needs no manual step.
+
+**What "not auto-written" means, precisely** — it differs by determination:
+
+- `throws` / `rejects` and the `&` / lifetime annotations are **omitted**
+  from the generated `.esc` unless the override layer supplies them (an
+  absent `throws` clause is `never`), so the human genuinely *adds* them.
+- Parameter **disposition** is the exception: every parameter must carry a
+  disposition for the signature to be valid, so the converter writes a
+  **provisional baseline** — the analyzed disposition for a classified
+  method, the FR5 `&mut` default when uncertain — which the override
+  layer, if present, corrects. That is review-and-**correct**, not
+  author-from-scratch. So disposition is written but not trusted; the
+  other three are not written until curated.
+
+Once §9.4's FR14 gate measures a zero false-negative rate, `throws` /
+`rejects` graduate from the reviewed path to the auto-applied one for the
+covered subset.
 
 **Gate.** Converter output for `std:*` matches the facts for every
 classified method; the removed override entries cause no regression in

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -74,10 +74,17 @@ that would introduce new PRs:
 - **Solver-side application (new, not yet a numbered phase).** §7
   integrates the facts into the interop-layer `interop.Classify` and
   removes the legacy `internal/checker/prelude.go` overrides. The active
-  checker's own builtin ingestion is milestone M7 in the solver
-  (`internal/solver`), not yet landed; wiring the facts into that
-  ingestion is a **dependent PR that cannot be written until M7 exists**,
-  tracked here as a known follow-on rather than a scheduled phase.
+  checker's own builtin ingestion is milestone **M7.5 — Library type
+  resolution** in the solver (`internal/solver`), **not yet landed**: its
+  prelude still seeds stdlib types as opaque `unknown` placeholders
+  (`addStdlibTypePlaceholders`), pending real `.esc` ingestion. (The
+  underlying **M7 — Type aliases** milestone that M7.5 builds on has
+  largely landed — `soltype.AliasType` and scope-driven `TypeRef`
+  resolution exist — so M7 is the wrong milestone to name here; the
+  blocker is M7.5's ingestion, not the alias representation.) Wiring the
+  facts into that ingestion is a **dependent PR that cannot be written
+  until M7.5 lands**, tracked here as a known follow-on rather than a
+  scheduled phase.
 - **Applying the non-receiver facts.** §7 auto-applies only receiver
   mutability, the high-confidence determination. Parameter disposition
   (§8), the return-borrow seed (§8.2), `throws` (§9), and `rejects` (§9.3)
@@ -97,7 +104,7 @@ that would introduce new PRs:
   defers to post-M7. That is **not this workstream's work** — until it
   lands, curation applies only the `move` spelling, and the `escape` facts
   for borrow-holding containers wait on it. Tracked here as an external
-  dependency, like the M7 solver-side application above.
+  dependency, like the M7.5 solver-side application above.
 
 Re-scope the table once §1 and §2 report, splitting any of the above into
 their own rows before starting §4.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -38,14 +38,19 @@ Status legend: ✅ done, 🚧 partial, ⬜ not started.
 | 8   | Parameter disposition + return-borrow outputs | FR12, FR4 | ⬜     | §7         | Per-parameter borrow/mutBorrow/escape from the store analysis; `escape` when a parameter is stored into the receiver (move vs lifetime-borrow spelled at curation); return-borrow seed documented |
 | 9   | Throw + reject extraction, filter, validation | FR10, FR11, FR13, FR14 | ⬜ | §4, §7 | Sync throws and async rejections split by sink; coercion filter prunes type-guard `TypeError`s; `throws`/`rejects` land in `facts.json`; §9.4 measures the false-negative rate that gates auto-apply |
 | 10  | Maintenance workflow                       | NFR        | ⬜      | §7         | Spec-bump runbook; `--check`-style drift report in CI |
+| 11  | Curation of the override layer             | FR12, FR4, FR13, FR14 | ⬜ | §7, §8, §9 | Override layer populated per pseudo-package by review; each candidate cross-checked against the §9.4 ground truth, disagreements triaged; fans out into per-package PRs |
 
 **Dependency graph** (edges are "must land before"):
 
 ```
-§1 ── §2 ── §3 ── §4 ── §5 ── §6 ── §7 ──┬── §8
-                                          ├── §9  (throws)
+§1 ── §2 ── §3 ── §4 ── §5 ── §6 ── §7 ──┬── §8 ─┐
+                                          ├── §9 ─┴── §11 (curation, per-package PRs)
                                           └── §10 (maintenance)
 ```
+
+§11 is a *content* phase, not a code phase: it fans out into a series of
+per-package PRs and recurs as deltas on spec bumps. It is numbered so the
+work is explicit and scheduled, but it is unlike §1–§10 in kind.
 
 ### Discovery phases may grow the plan
 
@@ -605,8 +610,9 @@ facts.json ─┬─ receiver mutability ─────────────
   seed, `throws`, and `rejects` reach the `.esc` only through a
   **hand-curated override layer** — a committed data file keyed by
   canonical spec name that a human populates by reviewing the
-  corresponding fields of `facts.json`, and that generation **re-applies
-  automatically** (per FR7, it is re-applied, not edited into the output).
+  corresponding fields of `facts.json` (that is §11), and that generation
+  **re-applies automatically** (per FR7, it is re-applied, not edited into
+  the output).
   A human is in the loop once per builtin, then only for deltas — new
   methods, or a spec bump that surfaces new candidate throws; the
   committed override layer means regeneration needs no manual step.
@@ -991,14 +997,19 @@ auto-apply, mirroring how §6 authorizes trusting the mutability facts.
 
 **Gate.** A bump runbook exists and a stale-facts CI check is green.
 
-## Curation as a content workstream
+## §11. Curation of the override layer (FR12, FR4, FR13, FR14)
 
-The §1–§10 phases build the pipeline that *produces* `facts.json` and
-*applies* the override layer (§7). **Populating** that override layer —
-reviewing the curation-grade fields of `facts.json` and recording the
-accepted or corrected annotations — is a separate, ongoing content effort,
-not one of the numbered phases. It is data work, not code, and treating it
-as such keeps it reviewable.
+**Goal.** Populate the override layer (§7) with reviewed curation-grade
+annotations — parameter disposition, the return-borrow / lifetime seed,
+`throws`, and `rejects` — so the generated `.esc` carries trustworthy
+effects for everything the facts cannot auto-apply.
+
+This is a **content phase, not a code phase.** §1–§10 build the pipeline
+that *produces* `facts.json` and *applies* the override layer; §11
+*populates* it, by reviewing the curation-grade fields of `facts.json` and
+recording the accepted or corrected annotations. It is data work, and
+treating it as such — its own PRs, reviewed on their own terms — keeps it
+legible.
 
 **Sequencing.** Curation cannot begin until the facts exist (§4, §8, §9)
 and the override-layer path is wired (§7 plus the builtins converter that
@@ -1036,6 +1047,12 @@ correctness — the same circularity FR14's ground truth avoids by being
 observed rather than re-read from the spec. So the assistant proposes and
 explains; independent verification — a human, or the empirical corpus —
 approves the deltas.
+
+**Gate.** Each pseudo-package's curation PR commits the reviewed override
+entries; every candidate was cross-checked against the §9.4 ground truth
+with disagreements triaged; the package's generated `.esc` carries the
+reviewed annotations, not the raw facts. The phase is "done" per package,
+never globally — new methods and spec bumps reopen it as deltas (§10).
 
 ---
 

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -593,15 +593,23 @@ entry. This is the gate that authorizes removing override entries in §7.
   `std:*`. Keep entries the facts source does not cover, such as `web:*`
   classes, untouched.
 
-**Two application paths.** `facts.json` reaches the generated `.esc` two
-ways, and the split is per determination, not per method:
+**How a method's `.esc` is assembled.** Each generated method declaration
+is a **merge** of its type shape with its effects, combined per method —
+not three routes to pick among. The `.d.ts` types are *always* part of the
+merge, because `facts.json` is deliberately typeless (FR7) and carries no
+generics, parameter/return types, or overloads:
 
 ```
-facts.json ─┬─ receiver mutability ──────────────────▶ generated .esc   (auto, trusted)
-            └─ disposition / return-borrow /
-               throws / rejects ──▶ review ──▶ override layer ──▶ generated .esc
-.d.ts ─── types ─────────────────────────────────────▶ generated .esc
+per method, the .esc declaration = merge of
+  .d.ts       ── type shape: generics, parameter/return types, overloads   [always]
+  facts.json  ── receiver mutability                                       [auto, trusted]
+  facts.json  ── disposition / return-borrow / throws / rejects
+                   └─ review ─▶ override layer ─▶ merged in                 [curated]
 ```
+
+The `.d.ts` line is not a bypass — a method that *has* a fact never skips
+it. What differs is only how the two `facts.json` contributions reach the
+merge; that split is per determination, not per method:
 
 - **Auto-applied (trusted).** Receiver mutability is read straight from a
   classified fact and written into the `.esc` — no human in the loop. It
@@ -633,6 +641,17 @@ facts.json ─┬─ receiver mutability ─────────────
 Once §9.4's FR14 gate measures a zero false-negative rate, `throws` /
 `rejects` graduate from the reviewed path to the auto-applied one for the
 covered subset.
+
+**A method absent from `facts.json` falls back to types plus defaults.**
+When a `std:*` method has no fact — unclassified (§4.3) or unmatched by
+the join (§5) — its declaration is `.d.ts` types plus the FR5 defaults
+(`&mut self`, `&mut` parameters, empty `throws`/`rejects`), carrying no
+spec-derived effects. This is the degraded path, not a preferred one: FR5
+lists every unclassified method and §5 reports every unmatched
+declaration, precisely so these are visible gaps to close, not a silent
+route. (`web:*` / `node:*` methods have no `facts.json` entry by
+construction — out of ECMA-262 scope — and take the same
+types-plus-curation route until the WebIDL extractor lands.)
 
 **Gate.** Converter output for `std:*` matches the facts for every
 classified method; the removed override entries cause no regression in

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -655,20 +655,23 @@ type-guard noise.
 
 ### §9.1. Throw-set fixpoint (FR10)
 
-Compute `Throws(F) ⊆ ErrorType`, the exception types `F` can raise,
+Compute `Throws(F) ⊆ Raised`, the exceptions `F` can raise (a constructed
+error class, or a `Param(k)`/`Receiver` origin for a propagated value),
 directly or transitively. The structure is identical to the §4.1
 mutation-summary fixpoint: a worklist over the call graph, a per-call
 transfer, re-enqueue callers on change. The transfer differs and depends
 on each call's completion guard, which §3 now records on the `Node`.
 
 ```
-Throws : map[FuncName] Set[ErrorType]   // {TypeError, RangeError, ...}
+Throws : map[FuncName] Set[Raised]      // Class(TypeError), Origin(Param(k)), Unknown, ...
 ThrowSites : map[FuncName] []ThrowSite  // provenance chains for §9.2 / §9.3
 
 // A site preserves where the value ULTIMATELY came from, so a coercion
 // throw stays recognizable however many `?`-hops it propagates through.
 type ThrowSite:
-    Type : ErrorType
+    Raised : Class(name)                 // a constructed error class (Throw a T exception)
+           | Origin(Param(k) | Receiver) // a propagated value, resolved to a type at the join (FR13)
+           | Unknown                     // a propagated value that could not be traced
     Root : Direct(node)                  // raised here (domain check, coercion AO, or plain)
          | Propagated(callee, inner)     // via ? from `callee`'s own site `inner`
     Node : node in F                     // the raising/propagating node; §9.3 reads it for the sink
@@ -679,19 +682,29 @@ while worklist nonempty:
     before = Throws[F].copy()
     for node in F.Nodes:
         switch node.Kind:
-        case Throw:                                 // explicit "Throw a T exception"
-            Throws[F].add(node.ErrorType)
-            ThrowSites[F].append(ThrowSite{ Type: node.ErrorType,
-                                            Root: Direct(node), Node: node })
+        case Throw:
+            raised = node.ErrorType ? Class(node.ErrorType)   // "Throw a T exception" → class
+                                    : raisedOf(F, node.Value)  // "throw <value>" → origin (rare in std:*)
+            Throws[F].add(raised)
+            ThrowSites[F].append(ThrowSite{ Raised: raised, Root: Direct(node), Node: node })
         case Call where node.Guard == GuardQuestion:   // ? propagates the callee's throws
             for s in ThrowSites[node.Callee]:          // carry the callee's OWN site, not just its name
-                Throws[F].add(s.Type)
-                ThrowSites[F].append(ThrowSite{ Type: s.Type,
+                Throws[F].add(s.Raised)
+                ThrowSites[F].append(ThrowSite{ Raised: s.Raised,
                                                 Root: Propagated(node.Callee, s), Node: node })
         // GuardBang (! asserts no abrupt completion) and GuardPlain
         // (result not completion-checked) contribute nothing.
     if Throws[F] != before: worklist.push(callers(F))
 ```
+
+`raisedOf(F, expr)` is the §4.2 origin map read against a raised value: a
+`Param(k)` or `Receiver` origin becomes `Origin(...)` (the FR13 parametric
+form), anything else becomes `Unknown`. Named-class throws dominate the
+synchronous channel — ECMA-262 `Throw a *T* exception` steps always name a
+constructor — so `Origin` sites are almost entirely a reject-channel
+phenomenon (§9.3). When `?`-propagated, the callee's `Param(k)` origin is
+re-mapped through the call's arguments to the caller's own formals, the
+same threading `precludedCoercion` (§9.2) does for coercion arguments.
 
 `ThrowSite.Root` threads the full chain back to the ultimate source
 rather than collapsing to the immediate callee: `Propagated` nests the
@@ -713,12 +726,12 @@ unreachable.
 CoercionAOs = { ToObject, RequireObjectCoercible,
                 ToString, ToNumber, ToNumeric, ToPrimitive }
 
-func filterThrows(M) []ErrorType:
+func filterThrows(M) []Raised:
     kept = {}
     for site in syncSites(M):                        // §9.3: sites reaching the synchronous exit
-        if site.Type == TypeError and precludedCoercion(M, site):
+        if site.Raised == Class(TypeError) and precludedCoercion(M, site):
             continue                                  // statically unreachable
-        kept.add(site.Type)
+        kept.add(site.Raised)                         // a class name, an Origin, or Unknown
     return sorted(kept)
 
 // precludedCoercion: the throw's Root bottoms out at a coercion AO whose
@@ -763,25 +776,41 @@ feeds `rejects` (the `Promise<T, E>` reject type). The two use the same
 fixpoint; they differ only in classifying the site:
 
 ```
-func rejectSet(M) []ErrorType:
+func rejectSet(M) []Raised:
     if not returnsPromise(M): return []          // no async channel (source below)
+    if M in PromiseCombinators: return combinatorRejects(M)   // hand-modeled (below)
     kept = {}
-    for site in rejectSites(M):                  // sites reaching the promise reject sink
-        if not (site.Type == TypeError and precludedCoercion(M, site)):
-            kept.add(site.Type)                  // same coercion filter as §9.2
+    // (a) abrupt completions routed to the reject sink — IfAbruptRejectPromise,
+    //     or a throw value reaching [[Reject]]. These ARE ThrowSites.
+    for site in rejectSites(M):
+        if not (site.Raised == Class(TypeError) and precludedCoercion(M, site)):
+            kept.add(site.Raised)                // a class name, an Origin, or Unknown
+    // (b) direct rejections — Call(cap.[[Reject]], reason) whose reason is a
+    //     plain value, not an abrupt completion, as in Promise.reject(r).
+    //     These are NOT ThrowSites; scan them and record the reason's origin.
+    for node in directRejectCalls(M):            // Call(cap.[[Reject]], reason)
+        kept.add(raisedOf(M, node.reasonArg))    // Param(k)/Receiver → Origin; else Unknown
     return sorted(kept)
 
-// A method's throw sites PARTITION by which exit each reaches, so channel
+// combinatorRejects: the four Promise combinators forward their ELEMENT
+// promises' reject type, which arrives through the resolution machinery,
+// not a CFG-visible origin — so they are hand-modeled per FR13, keyed by
+// name, against the iterable parameter's element-promise E:
+//   Promise.all, Promise.race → [ ElementErrOf(iterableParam) ]  // union of elements' E
+//   Promise.any               → [ AggregateError over ElementErrOf(iterableParam) ]
+//   Promise.allSettled        → [ ]                              // never rejects from elements
+
+// A method's throw sites partition by which exit each reaches, so channel
 // assignment is per-site:
 //   rejectSites(M) — ThrowSite.Node flows into the created promise
-//     capability's [[Reject]]: a Call whose callee is `cap.[[Reject]]`,
-//     an IfAbruptRejectPromise step, or a Return of an already-rejected
-//     promise.
-//   syncSites(M)   — every other site: the value leaves M as a synchronous
-//     abrupt completion.
-// The two are disjoint and together cover ThrowSites[M], so each site
-// lands in exactly one channel; a single error TYPE may still appear in
-// both `throws` and `rejects` when raised on both a sync and an async path.
+//     capability's [[Reject]]: an IfAbruptRejectPromise step or a throw
+//     value routed there.
+//   syncSites(M)   — every other throw site: the value leaves M as a
+//     synchronous abrupt completion.
+// The two are disjoint and cover ThrowSites[M]; direct [[Reject]] calls
+// (source b) and the combinator model (above) add to `rejects` only. A
+// single error type may appear in both `throws` and `rejects` when raised
+// on both a sync and an async path.
 
 // returnsPromise(M): read from the serialized CFG marker Func.Promise
 // (Appendix A), which the serializer sets when M's algorithm builds a
@@ -796,18 +825,24 @@ func rejectSet(M) []ErrorType:
 ```
 
 Recognizing a rejection site needs the CFG to represent the promise
-capability and its `[[Reject]]` field access; whether ESMeta's CFG
-surfaces `IfAbruptRejectPromise` as an inlined reject or an opaque helper
-is a **§1 spike question** — if it is opaque, seed the classification by
-treating `IfAbruptRejectPromise(x, cap)` as a reject of `cap` with `x`'s
-type, the one hand-modeled combinator step.
+capability and its `[[Reject]]` field access, and — for the direct-reject
+source (b) — the argument passed to `[[Reject]]`, so `raisedOf` can read
+its origin. Whether ESMeta's CFG surfaces `IfAbruptRejectPromise` as an
+inlined reject or an opaque helper is a **§1 spike question**; if opaque,
+hand-model `IfAbruptRejectPromise(x, cap)` as a reject of `cap` with `x`'s
+raised value. The four combinators are hand-modeled unconditionally
+(`combinatorRejects`), and that model needs the CFG only to identify the
+iterable parameter whose element-promise `E` is forwarded, not to trace
+the value through the resolution machinery.
 
 **Gate.** `Promise`-returning methods carry a `rejects` field distinct
 from `throws`; a synchronous validation `Throw` in a promise combinator
-lands in `throws` while an `IfAbruptRejectPromise` lands in `rejects`.
-Because concrete `std:*` domain rejections are rare (FR13), the honest
-expected outcome is that most `std:*` `rejects` sets are empty or a
-propagated generic, and that is recorded, not hidden.
+lands in `throws` while an `IfAbruptRejectPromise` lands in `rejects`;
+`Promise.reject`'s argument is recorded as `param:0` (source b), and
+`Promise.all`/`race`/`any`/`allSettled` produce the hand-modeled
+element-`E` / `AggregateError` / `never` rejects. Because concrete `std:*`
+domain rejections are rare (FR13), most `std:*` `rejects` sets are empty
+or a forwarded element `E`, and that is recorded as an origin, not hidden.
 
 ### §9.4. Throws validation and the auto-apply gate (FR14)
 
@@ -920,10 +955,12 @@ type Node struct {
     Guard     Guard    `json:"guard,omitempty"`     // Call: ? / ! / plain
     Object    *Expr    `json:"object,omitempty"`    // SlotWrite: the written object
     Slot      string   `json:"slot,omitempty"`      // SlotWrite, e.g. "[[MapData]]"
-    ErrorType string   `json:"errorType,omitempty"` // Throw: "TypeError", "RangeError", ...
+    ErrorType string   `json:"errorType,omitempty"` // Throw of a constructed error: "TypeError", ...
     Value     *Expr    `json:"value,omitempty"`     // Return: the returned expression;
                                                     // SlotWrite: the stored value (needed by §8.1
-                                                    // escape detection — the V in "Append V to O.[[slot]]")
+                                                    // escape detection — the V in "Append V to O.[[slot]]");
+                                                    // Throw of a non-constructed value: the thrown expr,
+                                                    // whose origin §9.1 reads (rare in std:*)
 }
 
 type ExprKind string
@@ -1009,11 +1046,14 @@ type MethodFact struct {
 }
 ```
 
-Each entry in `Throws` / `Rejects` is a standard error-class name
-(`TypeError`, `RangeError`, …) or the sentinel `"unknown"` for a
-propagated or arbitrary rejected value the spec does not construct
-(`Promise.reject`'s argument, combinator forwarding, `AggregateError`);
-requirements FR13. A `classified: false` entry carries no receiver,
+Each entry in `Throws` / `Rejects` is one of (requirements FR13): a
+standard error-class name the spec constructs (`TypeError`, `RangeError`,
+…); an **origin ref** for a value the spec propagates rather than
+constructs — `"param:k"` or `"receiver"` for a directly-forwarded value
+(`Promise.reject`'s argument, `throw <arg>`), or a combinator's element-`E`
+form (`Promise.all`/`race`/`any` forwarding their element promises' `E`),
+resolved to a type at the FR7 join; or the sentinel `"unknown"` for a
+propagated value the analysis can neither name nor trace. A `classified: false` entry carries no receiver,
 disposition, throw, or reject claim — those fields are absent, not empty —
 so the converter cannot mistake "unanalyzed" for "proven none"; it applies
 the FR5 defaults itself and falls the method through to the name

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -101,14 +101,19 @@ that would introduce new PRs:
 - **`escape` spelling depends on external affine work.** §8 records the
   `escape` disposition; curation spells it a `move` (owning container) or
   a lifetime-bounded borrow (borrow-holding container), per requirements
-  FR12. The lifetime-borrow spelling needs the affine checker's
-  borrow-into-container tracking (`.push` of a borrow), which the
-  affine_semantics workstream
-  ([../affine_semantics/requirements.md](../affine_semantics/requirements.md))
-  defers to post-M7. That is **not this workstream's work** — until it
-  lands, curation applies only the `move` spelling, and the `escape` facts
-  for borrow-holding containers wait on it. Tracked here as an external
-  dependency, like the M7.5 solver-side application above.
+  FR12. The affine *core* — moves, use-after-move, borrows, escape forcing
+  — has landed, but the lifetime-borrow spelling needs one piece that has
+  not: **borrow tracking through container methods** (`.push` of a borrow,
+  `a.peers.push(&mut b)`), which the affine plan
+  ([../affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md))
+  lists as deferred and out of scope. It is blocked on two things: the
+  stdlib `Array` type and method surface (M7.5 ingestion, the same blocker
+  as the solver-side application above) and a container-method lifetime
+  annotation expressing "the argument-borrow is stored into the receiver."
+  That is **not this workstream's work** — until it lands, curation
+  applies only the `move` spelling, and the `escape` facts for
+  borrow-holding containers wait on it. Tracked here as an external
+  dependency.
 
 Re-scope the table once §1 and §2 report, splitting any of the above into
 their own rows before starting §4.

--- a/planning/ecma-262/implementation_plan.md
+++ b/planning/ecma-262/implementation_plan.md
@@ -991,6 +991,52 @@ auto-apply, mirroring how §6 authorizes trusting the mutability facts.
 
 **Gate.** A bump runbook exists and a stale-facts CI check is green.
 
+## Curation as a content workstream
+
+The §1–§10 phases build the pipeline that *produces* `facts.json` and
+*applies* the override layer (§7). **Populating** that override layer —
+reviewing the curation-grade fields of `facts.json` and recording the
+accepted or corrected annotations — is a separate, ongoing content effort,
+not one of the numbered phases. It is data work, not code, and treating it
+as such keeps it reviewable.
+
+**Sequencing.** Curation cannot begin until the facts exist (§4, §8, §9)
+and the override-layer path is wired (§7 plus the builtins converter that
+generates `.esc`). It is independent of the M7.5 solver-side application —
+the override layer can be populated against the converter's output before
+the active checker ingests it. Some curation-adjacent review is embedded
+earlier: §6 triages the receiver-mutability diff, and §9.4 builds the FR14
+ground-truth corpus.
+
+**PR shape.** Curation lands as its own PRs, separate from the infra
+phases and incremental — one per pseudo-package or batch (`std:array`,
+then `std:string`, …), each a self-contained diff against the override
+layer, plus the §9.4 ground-truth corpus PR. It is kept out of the infra
+PRs because a diff of hand-reviewed annotations reviews on different terms
+than a diff that changes the analyzer, and because the volume is large and
+recurs as deltas on spec bumps.
+
+**A shrinking surface.** Receiver mutability is already auto-applied (no
+curation). Once §9.4's FR14 gate measures a zero false-negative rate,
+`throws`/`rejects` graduate to auto-apply for the covered subset. So the
+curation surface contracts over time toward mostly disposition and
+lifetime annotations.
+
+**Where an assistant can and cannot stand in.** The labor is largely
+mechanical and an assistant (including Claude) can take much of it on:
+drafting override entries from the facts plus MDN/spec, triaging the FR11
+filter's false positives, cross-referencing each candidate against the
+FR14 ground truth and surfacing only the disagreements, batching per
+package, and — most valuably — running the §9.4 dynamic-observation
+harness, which is empirical and spec-independent and so free of the
+circularity below. What must **not** collapse onto the assistant is the
+trusted sign-off: an automated reviewer of automatically-extracted facts
+shares the extractor's blind spots, so it would validate faithfulness, not
+correctness — the same circularity FR14's ground truth avoids by being
+observed rather than re-read from the spec. So the assistant proposes and
+explains; independent verification — a human, or the empirical corpus —
+approves the deltas.
+
 ---
 
 ## Appendix A. `cfg.json` schema

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -1,0 +1,962 @@
+# ECMA-262-Derived Builtin Annotations: Requirements
+
+## Background
+
+The builtins workstream
+([../builtins/requirements.md](../builtins/requirements.md)) owns the
+JavaScript standard-library surface as first-class `.esc` files. Its
+bootstrap converter (FR10) translates the pinned TypeScript `.d.ts` set
+into Escalier declarations and seeds receiver mutability by running
+`interop.Classify` — the name-based tiers in
+[../../internal/interop/mutability.go](../../internal/interop/mutability.go).
+Those tiers are heuristics over method *names*: a `get*` prefix is
+non-mutating, a `set*`/`push`/`delete` prefix is mutating, and a
+hand-maintained exception table in
+[../../internal/checker/prelude.go](../../internal/checker/prelude.go)
+(`mutabilityOverrides`) patches the cases the names get wrong.
+
+Name heuristics are guesses. They misclassify methods whose names look
+mutating but are not — `String.prototype.replace` returns a fresh
+string, yet `replace` is a mutating-prefix, so it needs a hand override
+at `prelude.go`. They miss methods whose names carry no signal —
+`String.prototype.charAt`, `Object.prototype.propertyIsEnumerable`. And
+they cannot speak to non-receiver parameter mutability or to aliasing at
+all.
+
+ECMA-262 specifies each builtin as a numbered algorithm. Those
+algorithms state the ground truth the heuristics approximate: a method
+mutates a value exactly when its algorithm performs a mutating abstract
+operation on that value, and a method's return aliases an input exactly
+when the algorithm returns that input rather than a freshly allocated
+object. This workstream extracts those facts mechanically and feeds them
+to the converter as a higher-confidence classification source than the
+name heuristics.
+
+## Goals
+
+- Derive, per `std:*` builtin method, five facts from the ECMA-262
+  algorithm semantics:
+  1. whether the method mutates its receiver — the choice between a
+     `&self` and a `&mut self` borrow;
+  2. each non-receiver parameter's disposition — read-only borrow (`&`),
+     in-place mutable borrow (`&mut`), or escape when the parameter is
+     stored into the receiver and so must outlive it (spelled a move for
+     an owning container or a lifetime-bounded borrow otherwise);
+  3. whether its return value borrows the receiver or a parameter, as a
+     seed for the return's lifetime and `&` annotation;
+  4. which exception types the method can throw synchronously, as a
+     candidate set for the `throws` clause
+     (`soltype.FuncType.Throws`), pruned of the coercion throws the
+     type system already precludes;
+  5. which exception types a promise-returning method rejects with, as a
+     candidate for the reject type `E` of `Promise<T, E>`
+     (`soltype.PromiseType.Err`).
+- Emit those facts as a committed JSON artifact keyed by canonical spec
+  name, consumed by the bootstrap converter as a classification source
+  ranked above the name-based tiers.
+- Keep all Escalier-specific logic in Go. The only non-Go component is a
+  thin serializer that dumps ECMA-262's parsed control-flow graph to
+  JSON; it contains no analysis.
+- Make the extraction reproducible and version-pinned, re-run on
+  ECMA-262 edition bumps, mirroring how FR10 pins the TypeScript `.d.ts`
+  set.
+
+## Non-goals
+
+- **Web and Node builtins.** ECMA-262 covers only the JavaScript
+  language surface, the `std:*` packages. DOM and Web APIs are specified
+  in WebIDL, where `[Throws]`, `[NewObject]`, and `[SameObject]`
+  extended attributes are the analogous machine-readable signals; that
+  is a separate extractor for `web:*`. Node builtins have neither and
+  stay hand-authored.
+- **Throws as a finished, unreviewed annotation.** Emitting the throw
+  set is an in-scope deliverable (FR10, FR11), but it ships as a reviewed
+  candidate set, not a trusted final annotation. The review need is not
+  that the extraction is inaccurate — for a classified method FR10's
+  *raw* throw set is a sound, complete enumeration of what ECMA-262 models
+  the algorithm as throwing, and could ship unreviewed at the cost of
+  noise. Review guards the two things downstream of that, both properties
+  of the coercion filter (FR11):
+  - **The filter can under-report.** Making the raw set usable means
+    *narrowing* it — dropping coercion `TypeError`s — and narrowing is the
+    unsound direction: a dropped real throw yields a `throws` clause too
+    narrow, so a caller is not forced to handle an exception that can
+    occur. This is the opposite of receiver mutability, whose bias
+    over-constrains and so auto-applies safely (§FR5); the usable throw
+    set under-constrains.
+  - **The filter needs type information ECMA-262 does not carry.** Whether
+    a parameter coercion can throw depends on the parameter's declared
+    type, available only at the FR7 join, plus a judgment about which
+    coercions the types truly preclude.
+
+  Host and implementation-defined throws are **out of scope**, not a
+  review driver: stack-overflow `RangeError`, out-of-memory, and host
+  hooks can occur at essentially any call, so — like an effect system
+  declining to track OOM — the model does not enumerate them. This is a
+  policy exclusion (see Coverage and limitations), not a gap the spec
+  fails to fill, and it applies only to these pervasive host errors; a
+  `RangeError` from an explicit spec domain check, such as
+  `Number.prototype.toFixed`, is a tracked domain throw.
+
+  The claim is falsifiable and evidence-revisable: a measured
+  false-negative rate near zero from the FR14 validation would let throws
+  graduate to auto-apply. This refines the builtins workstream's
+  hand-curation plan rather than replacing it
+  ([../builtins/requirements.md](../builtins/requirements.md), FR10
+  "throws annotations are hand-curated for now"): the spec generates the
+  ~50 high-value entries instead of hand-curating them from scratch.
+- **Porting ESMeta.** We do not reimplement ECMA-262's algorithm-step
+  grammar. ESMeta already parses the spec into a control-flow graph; we
+  consume that graph and decline to recreate it.
+- **Runtime coupling.** Nothing here runs at compile time inside the
+  Escalier compiler. The extractor is an offline tool; its output is a
+  committed data file.
+- **Lifetime *generation* as a primary deliverable.** The alias facts
+  are a seed for hand-authored lifetime annotations, not a replacement
+  for the lifetime inference and elision rules already in the checker
+  ([../lifetimes/requirements.md](../lifetimes/requirements.md)). See
+  the confidence ranking below.
+
+## The determinations and their confidence
+
+The asks do not carry equal value, and the requirements reflect that
+ranking.
+
+1. **Receiver mutability — high confidence, high payoff.** The receiver
+   is always `this value`, usually bound via `O ← ? ToObject(this
+   value)`. Mutation of that value is explicit in the algorithm. This
+   determination retires the `mutabilityOverrides` table for `std:*`
+   types and corrects the misses and misclassifications the name
+   heuristics produce. It is the primary deliverable.
+
+2. **Parameter disposition — medium confidence.** The same analysis
+   aimed at parameter-origin values, sorting each parameter into borrow,
+   mutable borrow, or escape (FR12). In-place parameter mutation is rare
+   in ECMA-262, so `&mut` parameters are few; the escape case — a
+   parameter stored into the receiver, as in `Array.prototype.push` and
+   `Map.prototype.set` — is common and cleanly detectable from the same
+   store analysis. A `&mut` parameter requires a mutable argument at the
+   call site — an owned-mutable value or an existing `&mut` borrow, but
+   never an immutable one — so an over-eager `&mut` classification is more
+   disruptive than an over-eager escape; bias toward the read-only borrow
+   default and require positive spec evidence to raise a parameter to
+   `&mut` or escape.
+
+3. **Return aliasing — low confidence as a generator, useful as a
+   seed.** The algorithm reveals whether the return aliases an input:
+   `return O` / `return M` aliases the receiver; a return of a
+   freshly-allocated value from `ArrayCreate` / `OrdinaryObjectCreate` /
+   `ArraySpeciesCreate` does not. This maps onto the signals the
+   checker's lifetime inference already uses, and the elision rules
+   (lifetimes Phase 11) already cover the common return-self and
+   return-fresh cases without per-method data. The alias facts are a
+   secondary output of the same analysis, surfaced to a human editing
+   lifetime annotations, not an automatic annotator.
+
+4. **Thrown exceptions — medium confidence, curation-grade.** The
+   algorithm names the exception types it can raise, directly and
+   transitively through `?`-guarded calls. This is mechanically sound
+   but over-approximates: most methods coerce the receiver and arguments
+   up front, and those coercions can throw `TypeError` on a wrong
+   dynamic type that Escalier's static types already rule out. So the
+   raw throw set is dominated by type-guard noise. After the coercion
+   filter (FR11) the residue is the domain throws worth annotating —
+   `RangeError`, `URIError`, `SyntaxError`, and the non-coercion
+   `TypeError`s. The output is a curation candidate set, better than
+   hand-curating from scratch but not a finished annotation.
+
+## Relationship to Escalier's ownership and effect model
+
+Several Escalier features decide how a value flows through a call — who
+owns it, who may write it, how long a returned reference stays valid,
+and how a failure propagates. This section states what the facts
+determine for each of the features this workstream must respect, and
+what they deliberately leave to the typed source.
+
+### Two checkers; the active one is the target
+
+Escalier has two type-checker stacks. The **active** one is the
+SimpleSub rewrite in `internal/soltype` + `internal/solver`, extended
+with MLstruct — a Boolean algebra of structural types giving first-class
+unions, intersections, and negation — where the borrow/move model
+(`RefType`), the two-argument `Promise<T, E>`, and exactness live. That
+type algebra is directly relevant here: an extracted `throws` or
+`rejects` set is a union in it (`TypeError | RangeError`), and the
+negation is what expresses the `try`/`catch` residual the effect system
+already computes — the uncaught set is the caught types minus the handled
+ones (`caught & ~handled`). So the effect facts this workstream produces
+land in the MLstruct type lattice, not merely a flat list. The **legacy**
+stack is `internal/type_system` + `internal/checker`; it is being
+superseded and is not the integration target. Where earlier sections of this document cite legacy files
+(`internal/checker/prelude.go`, `internal/checker/unify_mut.go`), read
+them as naming the *concept*, not the final home — the facts apply to
+whichever checker owns builtin ingestion. Real stdlib ingestion into the
+solver is a later milestone (M7), so the concrete point where the facts
+are consumed tracks wherever the builtins workstream lands that
+ingestion. The interop-layer classifier `interop.Classify`
+([../../internal/interop/mutability.go](../../internal/interop/mutability.go))
+operates on `dts_parser` declarations and is checker-agnostic, so FR8's
+integration there holds across both.
+
+### Immutability by default, and how the facts serve it
+
+Escalier values are immutable by default; `mut` opts in
+([../../docs/08_mutability.md](../../docs/08_mutability.md)). But
+TypeScript `.d.ts` types default to *mutating* at the import boundary —
+`interop.Classify`'s tier 7 is "default mutating." The
+receiver-mutability facts exist precisely to recover the correct split,
+so an immutable Escalier value can call the many builtin methods that do
+not mutate. The facts are what make immutability-by-default usable
+against a mutable-by-default type source; they do not change the
+default, they inform it.
+
+### Receiver and parameters in the borrow/move model
+
+A method receiver is always **borrowed**, never consumed — calling a
+method does not take ownership of the object. So the receiver fact maps
+onto the borrow model directly: a non-mutating method borrows immutably
+(`&self`), a mutating one borrows mutably (`&mut self`). "Receiver
+mutability" (FR2) is the choice between those two.
+
+Parameters are richer, because the affine model
+([../affine_semantics/requirements.md](../affine_semantics/requirements.md))
+distinguishes three dispositions:
+
+- **borrow (`&`)** — the method only reads the parameter. The default.
+- **mutable borrow (`&mut`)** — the method writes the parameter object
+  in place, but the caller keeps it. `Reflect.set` writes its `target`.
+- **escape** — the method stores the parameter into the receiver, so it
+  outlives the call. `Array.prototype.push` and `Map.prototype.set` store
+  their arguments into the receiver's backing store; the argument escapes
+  into the array or map and its lifetime must be at least the receiver's.
+
+The escape is the fact the algorithm gives; how it is *spelled* in the
+signature is a separate, typed decision, and this is the important
+subtlety. Storing a value into the receiver forces the value to outlive
+the receiver, and there are two ways to guarantee that:
+
+- **move (owned parameter)** — when the container owns its elements
+  (`Array<T>`, `Map<K, V>`), storing transfers ownership into the
+  container, and that transfer *is* how the value's lifetime extends to
+  the container's; no lifetime is written and the caller gives the value
+  up. This is the default spelling.
+- **lifetime-bounded borrow (`&'a T`, no move)** — when the container's
+  slot is itself a borrow (`Array<&'a T>`), storing a reference transfers
+  no ownership; it only requires `'a` to outlive the container, and the
+  caller keeps the value.
+
+A move and a lifetime bound are two encodings of the same constraint
+"the value outlives the receiver." Which encoding applies depends on the
+container's element ownership — a property of the *typed* signature, not
+of the untyped algorithm — so it is the FR7 boundary again (see FR12).
+The affine checker today defaults to the owning/move model; borrow-into-
+container tracking (`.push` of a borrow) is deferred there, so `move` is
+the implemented spelling and the lifetime-borrow alternative is partly
+future work.
+
+The algorithm reveals only the escape, and it is the same store-detection
+as the mutation analysis (FR1–FR3) read against parameter-origin values:
+a parameter written into a receiver- or longer-lived-origin object
+escapes; a parameter mutated in place is a mutable borrow; a parameter
+only read is a borrow. See FR12.
+
+Value types — `number`, `string`, `boolean`, functions, promises — are
+never `RefType` and are copied, never moved. So a stored primitive is a
+copy at runtime even where the escape would otherwise be spelled a move;
+the checker resolves copy-versus-move-versus-borrow per instantiation.
+The fact records the escape; the typed source and the model handle the
+spelling.
+
+### Return values as borrows with lifetimes
+
+FR4's return-alias is the lifetime seed. In the borrow model a method
+that returns the receiver (`return O`) returns a borrow tied to the
+receiver's lifetime; a method returning a freshly-allocated value returns
+an owned value; a method returning a parameter returns a borrow threaded
+to that parameter's lifetime. The `receiver` / `param` / `fresh` /
+`union` alias kinds map onto return-borrows-receiver,
+return-borrows-parameter, return-owned-fresh, and a lifetime union.
+
+Three things the plain alias edge does **not** settle, so it seeds
+hand-authored `&` and lifetime annotations rather than auto-generating
+them:
+
+- **The returned receiver-borrow inherits the receiver's mutability.**
+  A method returns the receiver to be chained after mutating it —
+  `Array.prototype.fill`, `sort`, `reverse`, `Map.prototype.set` — and
+  each already took `&mut self`, so the return is `-> &mut Self`. That is
+  what keeps a fluent chain's mutability constant: every link takes
+  `&mut self` and hands back `&mut Self`, so `arr.fill(0).reverse()` stays
+  `mut` throughout. The rule is that the return-borrow carries the
+  receiver's mutability, not a fixed one. The harder case — a
+  *non-mutating* method that returns self and should preserve whatever
+  mutability the caller had — needs mutability polymorphism (a return
+  mutability abstracted over the receiver's), which the affine checker
+  does not express today. No ECMA-262 builtin hits it: every builtin that
+  returns `this` mutates, so `-> &mut Self` covers them all. The
+  polymorphic case is deferred to the affine_semantics workstream, out of
+  this workstream's scope.
+- **Whether a lifetime applies at all depends on the return type.** A
+  value-typed return has no lifetime — `String.prototype.charAt` returns a
+  fresh string value, `indexOf` a number — so the alias kind is moot
+  there. Only a reference-typed return carries a borrow/lifetime, and
+  reference-versus-value is the return **type**, which comes from the
+  typed source at the FR7 join, not from the shape-free fact.
+- **Elision already covers the common shapes.** Escalier's lifetime
+  elision infers the lifetime for return-self (`&self`/`&mut self` in,
+  borrow of self out) and needs none for return-fresh (owned). So FR4 adds
+  value only where elision gives up — a return that borrows a *non-receiver
+  parameter* (`param`) or mixes inputs (`union`) — and those are rare in
+  ECMA-262 (`Object.assign` returning its `target`; `Promise.resolve`
+  returning its argument or a fresh promise). Even there the concrete
+  annotation needs the typed signature (the borrow mutability, the union's
+  lifetime variables), so it is review input, not an auto-annotator.
+
+### Synchronous throws versus asynchronous rejections
+
+Escalier splits the exceptional exit into two channels
+(`internal/soltype/type.go`): `FuncType.Throws` for a synchronous
+`throws T` clause, and `PromiseType.Err` for the reject type `E` of a
+two-argument `Promise<T, E>`. An `async fn` has no `throws` clause; its
+body's failures populate `E`. The throw-set extraction routes
+accordingly: a synchronous `Throw` step becomes a `throws` candidate
+(FR10), while a rejection of the returned promise becomes a
+`Promise<T, E>` reject-type candidate (FR13). A promise-returning builtin
+can carry both — synchronous argument validation in `throws`, a rejection
+in `E`.
+
+**Generators and async generators fit the same split, observed one step
+later** — at the iterator protocol rather than at the call, because a
+generator's body does not run when the generator is created; it runs when
+the consumer drives it.
+
+- A **generator** (`Generator<T, R, N>`) surfaces its body's failures
+  **synchronously** at `.next()` / `.return()` / `.throw()`, so they land
+  in the `throws` clause of those methods — the same synchronous channel
+  as any other method.
+- An **async generator** (`AsyncGenerator<T, R, N>`) has `.next()` return
+  a `Promise<IteratorResult<T, R>, E>`, so its body's failures surface as
+  **rejections** of that per-`next` promise — the `E` channel, exactly as
+  for an `async fn`.
+
+The extraction needs no special case for either: FR13's routing keys on
+*which sink* a raised value reaches — a synchronous abrupt completion or a
+promise `[[Reject]]` — and a generator method's algorithm reaches the
+first while an async generator method's reaches the second. One practical
+limit: the generic `%GeneratorPrototype%.next` re-surfaces whatever the
+*generator body* threw, which is a type parameter of the generator
+instance, not a concrete set the per-method extractor can name; ECMA-262's
+own builtin iterators (`Array.prototype[Symbol.iterator]`,
+`Map.prototype.entries`, …) throw little, so this mostly bites user-defined
+generators, not the builtin surface.
+
+### Exactness is out of scope for the facts
+
+Object-type exactness — whether a type permits extra properties — is
+decided by the shape and its provenance, not by the algorithm. Escalier
+source objects are exact by default; types imported from TypeScript are
+inexact by default
+([../exact-types/requirements.md](../exact-types/requirements.md) §8–9),
+overridable per use with `Exact<T>`. Nothing in an ECMA-262 algorithm
+determines exactness, and the facts carry none. Exactness belongs to the
+typed source and the import boundary — the same FR7 boundary that owns
+the generic type shapes.
+
+## Functional requirements
+
+### FR1. Mutation vocabulary
+
+A value is *mutated* by an algorithm iff the algorithm performs one of a
+fixed set of mutating abstract operations on that value, directly or
+transitively:
+
+- property writes: `Set`, `CreateDataProperty`, `CreateDataPropertyOrThrow`,
+  `CreateMethodProperty`, `DefinePropertyOrThrow`,
+  `OrdinaryDefineOwnProperty`, `DeletePropertyOrThrow`;
+- integrity changes: `SetIntegrityLevel`;
+- internal-slot writes phrased as "Set *value*.[[Slot]] to …",
+  "Append … to *value*.[[List]]", or "Remove … from *value*.[[List]]".
+
+This vocabulary is the source of truth for the analysis and must be
+maintained against the spec edition the extractor is pinned to. Adding a
+new mutating abstract operation to the spec without adding it here
+produces a false non-mutating classification, so the vocabulary list is
+itself a reviewed artifact.
+
+### FR2. Origin tagging and transitive mutation
+
+The analysis tags each value in an algorithm with its origin:
+
+- `this value`, including `? ToObject(this value)` and other coercions
+  of it, is **receiver-origin**;
+- a named formal parameter is **parameter-origin**, tracked per
+  parameter index;
+- a value produced by an allocating abstract operation
+  (`ArrayCreate`, `OrdinaryObjectCreate`, `ArraySpeciesCreate`,
+  `OrdinaryObjectCreate`, constructor calls, and the like) is **fresh**.
+
+Origins propagate through `Let x be y` bindings. A method mutates an
+origin when a mutating operation from FR1 reaches a value of that
+origin.
+
+Mutation may be **transitive**: a method calls a helper abstract
+operation that itself performs the mutation. The analysis must compute,
+for every abstract operation, whether it mutates its k-th argument, as a
+fixpoint over the call graph seeded by the direct mutators in FR1. A
+per-method classification that ignored transitivity would miss any
+method that delegates its writes to a helper.
+
+### FR3. Internal-slot backing stores
+
+Some builtins mutate through internal slots rather than property
+operations — `Map.prototype.set` appends to `M.[[MapData]]`,
+`TypedArray.prototype.set` writes through `[[ArrayBufferData]]`. The
+analysis must recognize a curated list of slots that constitute an
+object's mutable backing store, including at least `[[MapData]]`,
+`[[SetData]]`, `[[ArrayBufferData]]`, `[[ArrayBufferByteLength]]`,
+`[[TypedArrayName]]`, `[[ViewedArrayBuffer]]`, and `[[WeakRefTarget]]`.
+A write to such a slot on a receiver- or parameter-origin value is a
+mutation of that value. The list is hand-curated and small; new slots
+are added as new collection types enter the spec.
+
+### FR4. Return-alias classification
+
+For each method the analysis records what its return statements alias:
+
+- `receiver` when every reachable return yields a receiver-origin value;
+- `param:<n>` when a return yields the n-th parameter;
+- `fresh` when returns yield only freshly-allocated or primitive values;
+- `union` when different reachable returns alias different inputs.
+
+This is the lifetime seed of the third determination. In the borrow
+model a `receiver` return is a borrow tied to the receiver's lifetime and
+**carrying the receiver's mutability** (`&mut Self` for the mutating
+self-returning builtins, which keeps fluent chains `mut`), a `param:<n>`
+return is a borrow tied to that parameter's lifetime, `fresh` is an owned
+return, and `union` is a lifetime union. It is recorded but not
+automatically converted into a `&`/lifetime annotation: the alias edge
+under-determines the annotation (return type reference-vs-value from the
+FR7 join, the borrow mutability, union lifetime variables), and elision
+already covers `receiver` and `fresh`, so FR4 mainly informs the rare
+`param`/`union` cases. See the ownership-model section above.
+
+### FR5. Soundness bias
+
+The bias is **conservative where a default is auto-applied and permissive
+where it is curation-grade** (reviewed before it reaches the `.esc`). That
+asymmetry is deliberate: only the receiver default ships unreviewed, so it
+is the one that must over-constrain; the rest are reviewed, so they can sit
+at the least-disruptive default while the fact is checked. Two of the four
+defaults below are therefore genuinely sound, and two are considered
+deviations.
+
+**Conservative defaults — over-constrain when uncertain:**
+
+- A method the analysis cannot classify — prose-only algorithm, host-
+  defined behavior, an unrecognized mutation phrasing — is emitted as
+  **unclassified**, not as a guess. Unclassified methods fall through to
+  the existing name heuristics and hand-curation in the converter.
+- Receiver mutability defaults to **mutating** (`&mut self`) when
+  unclassified, consistent with the interop core principle "default to
+  mutating"
+  ([../interop_mutability/requirements.md](../interop_mutability/requirements.md)).
+  This is the sound direction — an immutable Escalier value can never call
+  a method the analysis failed to prove non-mutating — and receiver
+  mutability is the only determination §7 auto-applies, so it must be
+  conservative.
+
+**Deviations toward ergonomics — under-constrain when uncertain:**
+
+- Parameter disposition defaults to **read-only borrow** (`&`) when
+  unclassified. This is *not* the sound direction: the conservative choice
+  would be `&mut` or escape, so a method that really does mutate or store a
+  parameter could not be handed an immutable or non-outliving argument. We
+  deviate because non-receiver parameter mutation and storage are rare in
+  ECMA-262 — the conservative default would be pervasively noisy for a
+  guarantee almost never needed — and because disposition is curation-grade
+  (§7 does not auto-apply it), so a wrong permissive default is caught at
+  review, not shipped. A `&mut` or escape classification also constrains
+  the call site more than a borrow — a `&mut` parameter demands a mutable
+  argument and refuses an immutable one, an escape makes the caller give
+  the value up or outlive the receiver — so `&` is the least-disruptive
+  place to sit while the fact is reviewed.
+- The asynchronous reject set (FR13), and the synchronous throw set under
+  the same logic (FR10), default toward **under-reporting**. Under-
+  reporting a throw or rejection is likewise the unsound direction — a
+  caller is not forced to handle an exception that can occur — and is
+  justified the same way: over-reporting the coercion noise would be
+  pervasive, and both sets are curation-grade, gated by the FR14
+  validation before they could ever auto-apply.
+
+These defaults are applied by the **converter**, not serialized as
+facts. A `classified: false` record omits its effect fields — `receiver`,
+`params`, `throws`, `rejects` are absent (or null) on the wire — so the
+format never conflates "the analysis proved this method borrows and
+throws nothing" with "the analysis could not tell." A proven-empty result
+is `classified: true` with empty effect fields; an unanalyzed method is
+`classified: false` with the effect fields absent. FR6 and Appendix B use
+this one contract.
+
+Every unclassified method is reported by name so the gap is visible and
+auditable rather than silent.
+
+### FR6. Output contract
+
+The extractor emits a committed JSON facts file keyed by canonical spec
+name. Each entry records the five determinations and the tier-relevant
+provenance. `receiver` is `borrow` (`&self`), `mutBorrow` (`&mut self`),
+or `none` (a static or namespace function with no receiver). `params`
+lists only the parameters whose disposition is not the default read-only
+borrow; each is `mutBorrow` (`&mut`) or `escape` (stored into the
+receiver, spelled at curation — see FR12).
+
+```json
+{
+  "Array.prototype.push":  { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"}], "returns": "fresh",    "throws": [], "rejects": [], "classified": true },
+  "Array.prototype.fill":  { "receiver": "mutBorrow", "params": [],                                    "returns": "receiver", "throws": [], "rejects": [], "classified": true },
+  "Array.prototype.slice": { "receiver": "borrow",    "params": [],                                    "returns": "fresh",    "throws": [], "rejects": [], "classified": true },
+  "Map.prototype.set":     { "receiver": "mutBorrow", "params": [{"index":0,"disposition":"escape"},{"index":1,"disposition":"escape"}], "returns": "receiver", "throws": [], "rejects": [], "classified": true },
+  "Number.prototype.toFixed": { "receiver": "borrow", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": true },
+
+  "Reflect.set":              { "receiver": "none", "params": [{"index":0,"disposition":"mutBorrow"},{"index":2,"disposition":"escape"}], "returns": "fresh", "throws": [], "rejects": [], "classified": true },
+  "Intl.getCanonicalLocales": { "receiver": "none", "params": [],                                    "returns": "fresh",    "throws": ["RangeError"], "rejects": [], "classified": true }
+}
+```
+
+- `receiver` maps a non-mutating method to `&self` and a mutating one to
+  `&mut self` (FR2). A method that stores an argument into the receiver
+  marks that parameter `escape`, because the argument outlives the call
+  inside the longer-lived receiver: `Array.prototype.push` stores its
+  element, `Map.prototype.set` stores both key and value (FR12). Whether
+  `escape` is spelled a move or a lifetime-bounded borrow is settled at
+  the FR7 join from the container's element type.
+- The `throws` array holds the synchronous domain exceptions that survive
+  the coercion filter (FR11). `Number.prototype.toFixed` throws
+  `RangeError` when `fractionDigits` is out of the 0–100 range — a domain
+  throw the type system cannot preclude — while the `TypeError` from
+  coercing a non-number receiver is filtered out.
+- The `rejects` array holds the asynchronous reject types for a
+  promise-returning method, the candidate for `Promise<T, E>`'s `E`
+  (FR13). It is empty for a non-promise method. For ECMA-262 `std:*` it
+  is usually empty or a propagated generic, because the core language has
+  few builtins with a concrete domain rejection; the channel matters more
+  for the future `web:*` extractor, where `fetch` and friends reject with
+  concrete types.
+
+The host portion of a key may be a **namespace-qualified dotted path**,
+not just a single class name. Three forms arise:
+
+- `Intl.DateTimeFormat.prototype.format` — a prototype method of
+  `DateTimeFormat`, a constructor nested in the `Intl` namespace. It has
+  a receiver, a `DateTimeFormat` instance, exactly like any other
+  prototype method.
+- `Intl.getCanonicalLocales`, `Math.max`, `JSON.parse` —
+  **namespace-level functions**. They have `receiver: none`, so the
+  signal of interest is `params`. `Intl.getCanonicalLocales` still
+  carries a domain `throws` (`RangeError` on a malformed language tag).
+- `Reflect.set`, `Reflect.defineProperty`, `Reflect.deleteProperty` —
+  namespace functions that touch a parameter: `Reflect.set` writes its
+  `target` in place (`mutBorrow`, index 0) and stores its `value` into
+  that target (`escape`, index 2). The analysis models every function
+  uniformly over parameter indices (FR2), so a namespace function with no
+  receiver still reports parameter dispositions through the same
+  machinery. `Reflect.set`'s optional fourth argument `receiver` (index 3)
+  is the `this` a triggered setter runs with; whether that setter writes
+  through it is conditional on the target property being an accessor and
+  unknowable statically, so index 3 is left **unresolved** — the `borrow`
+  default — rather than guessed. The analysis does not express conditional
+  dispositions.
+
+The key space therefore covers prototype methods
+(`X.prototype.method`), static methods (`X.method`), symbol-keyed
+methods, and namespace-qualified forms where `X` is a dotted path naming
+a namespace and optionally a nested constructor — all joined by FR7.
+`classified: false` marks the FR5 fall-through entries; their effect
+fields (`receiver`, `params`, `throws`, `rejects`) are absent, distinct
+from a proven-empty result (§FR5).
+
+### FR7. Keying and join to typed declarations
+
+**Why a join is needed at all.** ECMA-262 is untyped. It specifies
+algorithm semantics — what a method mutates, throws, and returns — but
+carries no static type information: no generics (`Array<T>`,
+`Map<K, V>`), no parameter or return types, no typed overloads.
+`Array.prototype.push` in the spec takes "a List of ECMAScript language
+values," not `(...items: T[]): number`. So the spec cannot be the source
+of the type signatures; it is the source only of the Escalier-specific
+semantics this workstream extracts. The facts file is therefore
+deliberately shape-free — keyed by spec name, carrying mutability,
+aliasing, and throws but no types — and must be joined to a separate
+source that holds the typed declarations. That typed source supplies the
+signatures; the facts supply the annotations layered on top.
+
+**The intended direction is to keep `.d.ts` as the type source and
+generate `.esc`, not to hand-author `.esc` signatures.** The type shapes
+come from the pinned TypeScript `.d.ts` — TypeScript's hand-curated
+generic signatures and JSDoc, maintained upstream and regenerated on a TS
+bump — and the effect annotations come from this workstream's ECMA-262
+facts, regenerated on a spec bump. A generated `.esc` builtin is the join
+of those two, plus a small hand-curated override layer for the
+curation-grade residue (reviewed throws and lifetimes) that is re-applied
+at generation rather than edited into the output. This keeps signatures
+out of hand-maintenance entirely, which is the whole point: hand-authored
+`.esc` signatures are the path to **avoid**, because they would drift from
+the upstream types and multiply the maintenance surface.
+
+Mechanically the ECMA-262 workstream stays agnostic to this decision: the
+join is purely name-based, so it targets whatever holds the typed
+declarations — the `.d.ts`-derived names at generation, or an `.esc` file
+if one existed — unchanged. The doc records the decision; it does not
+depend on it.
+
+**Cross-workstream alignment.** This preference diverges from the
+builtins workstream as written: its FR10
+([../builtins/requirements.md](../builtins/requirements.md)) treats the
+generated `.esc` files as hand-edited and "maintained as source going
+forward," with converter re-runs made additive-only so they never clobber
+those edits. Keeping `.esc` a pure generated artifact — with the human
+input confined to a re-applied override layer — drops that
+"don't-overwrite-my-edits" constraint and makes regeneration
+deterministic, but it is a change to the builtins workstream's
+maintenance model, not only to this join. Adopting it means updating
+builtins FR10 to match; tracked here as a cross-workstream dependency.
+
+A normalizer maps a spec key onto the typed declaration's owner and
+member and must handle:
+
+- symbol-keyed methods — `Symbol.iterator` in the spec maps to the
+  `[Symbol.iterator]` member the converter emits;
+- accessor properties — spec getters/setters map to the converter's
+  `get`/`set` elements, which carry fixed mutability and must not be
+  overwritten;
+- overload sets — one TypeScript overload set maps to a single spec
+  algorithm; the algorithm-level facts apply to every signature, while
+  the type-dependent parts resolve per overload (FR15);
+- namespace-qualified hosts — the host before `.prototype.` or the bare
+  member name may be a dotted path. The normalizer splits it: leading
+  segments naming a namespace (`Intl`, `Math`, `Reflect`, `JSON`,
+  `Atomics`, `WebAssembly`) route to the owning `std:*` package; a
+  trailing constructor segment (`Intl.DateTimeFormat`) routes to a class
+  in that package; a member with no constructor segment
+  (`Intl.getCanonicalLocales`, `Math.max`) is a namespace-level function
+  joined to a free function in the package. A namespace function has
+  `receiver: none`, so only its `params`, `throws`, and `rejects` apply.
+
+Names present on one side and absent from the other are reported,
+mirroring FR10's unmapped-symbol fail-safe in the builtins converter.
+A spec method with no converter declaration and a converter declaration
+with no spec fact are both informational, not fatal, because the spec
+and the TypeScript lib drift independently.
+
+### FR8. Integration as a classification source
+
+The converter consumes the facts file as a classification source ranked
+**above** the name-based tiers of `interop.Classify`. The resolution
+order becomes:
+
+1. explicit author signals already in `Classify` (getters/setters,
+   `this: Readonly<T>`, well-known symbols) — unchanged;
+2. **ECMA-262 facts** — new, this workstream;
+3. `get*` prefix rule — unchanged;
+4. name-based heuristics — unchanged, now a fall-through for methods the
+   facts file does not classify;
+5. default to mutating — unchanged.
+
+The facts source slots in at rung 2 so that explicit author intent still
+wins, but spec-derived ground truth overrides every name guess. The
+`mutabilityOverrides` table in `prelude.go` becomes redundant for every
+`std:*` method the facts file classifies; its entries are removed as the
+facts coverage is verified against them (FR9).
+
+### FR9. Validation against the current classification
+
+Before the facts source is trusted, the extractor's receiver-mutability
+output is diffed against the union of the current `mutabilityOverrides`
+table and the name-heuristic output for the same methods. Every
+disagreement is reviewed: either the facts source is correct and the
+hand override was a workaround now subsumed, or the facts source has a
+bug to fix. The diff is the gate that justifies deleting override
+entries.
+
+### FR10. Throw-set extraction
+
+For each builtin method the analysis computes the set of exception types
+the algorithm can raise, by the same inter-procedural fixpoint as the
+mutation summary (FR2) over the same control-flow graph, with a throw
+transfer function:
+
+- a `Throw a *T* exception` step contributes `T` to the function's throw
+  set, where `T` is one of `TypeError`, `RangeError`, `SyntaxError`,
+  `ReferenceError`, `URIError`, `AggregateError`;
+- a call guarded by `?` contributes the callee's entire throw set,
+  because `?` propagates any abrupt completion;
+- a call guarded by `!` contributes nothing, because `!` asserts the
+  operation never returns an abrupt completion;
+- a plain unguarded call whose result is not completion-checked
+  contributes nothing to the throw set on that path.
+
+The `?` / `!` / plain distinction is essential and must be carried from
+the spec into the control-flow graph. This is why throws extraction
+relies on ESMeta's completion-record modeling rather than the shallow
+`spec.html` fallback, which would have to recover the guards from markup
+itself. A method whose throw paths cannot be resolved is left out of the
+throw set and flagged, never guessed. The FR5 bias applied to throws is
+to under-report rather than over-report a throw the type system would
+force a caller to handle.
+
+### FR11. Coercion filter
+
+The raw throw set from FR10 over-approximates, because nearly every
+algorithm begins by coercing its receiver and arguments, and those
+coercions throw `TypeError` on a wrong dynamic type. Escalier's static
+types already preclude those paths, so the raw set is dominated by
+`TypeError`s a well-typed caller can never trigger.
+
+The filter discounts a throw when its origin is a coercion of an
+already-typed value:
+
+- `TypeError` raised inside `ToObject(this value)` or
+  `RequireObjectCoercible(this value)`. The receiver type is statically
+  known, so the null/undefined-receiver path is unreachable.
+- `TypeError` raised inside `ToString`, `ToNumber`, `ToNumeric`,
+  `ToPrimitive`, or `ToObject` applied to a parameter whose Escalier
+  type is already the coerced type.
+
+A throw survives the filter when it originates from an explicit domain
+check — an `If <condition>, throw a *RangeError*` over a value range, a
+`SyntaxError` from a parse step, a `URIError` from a decode step, or a
+`TypeError` not attributable to a receiver or parameter coercion. The
+surviving set is what FR6 records in `throws`. The filter is a heuristic
+over throw provenance, so its decisions are reported per method for
+review, consistent with the curation-grade confidence of this
+determination.
+
+The parameter types the filter reads come from the **typed source at the
+FR7 join**, not from the spec — the pinned TypeScript `.d.ts` that FR7
+keeps as the type source. That is why the parameter branch of the filter
+runs after the join — before it, the shape-free facts carry no types to
+consult, so the filter can only clear receiver coercions (whose type is
+always known) and must keep every parameter coercion. The filter's soundness therefore inherits the typed
+source's precision: a loose type (`any`, `unknown`) is safe — the filter
+keeps the coercion throw, only noisier — but a type that is wrong-but-
+tight could drop a throw that can occur, an unsoundness the FR14
+validation is built to catch. For this reason FR14's ground truth is
+curated independently of the `.d.ts`, not derived from it.
+
+### FR12. Parameter disposition
+
+For each non-receiver parameter the analysis assigns one of three
+dispositions in Escalier's affine model
+([../affine_semantics/requirements.md](../affine_semantics/requirements.md)):
+
+- **escape** — a parameter-origin value is stored into a receiver- or
+  otherwise longer-lived-origin object, through a property write or a
+  backing-store slot write (FR1, FR3). The value escapes into that
+  object, so its lifetime must be at least the receiver's.
+  `Array.prototype.push` stores its element into the receiver array;
+  `Map.prototype.set` stores key and value into `M.[[MapData]]`;
+  `Reflect.set` stores `value` into `target`.
+- **mutBorrow** (`&mut`) — a parameter-origin object is mutated in place
+  by a mutating operation from FR1 but is not stored anywhere, so the
+  caller keeps it. `Reflect.set` writes a property on its `target`.
+- **borrow** (`&`) — the parameter is only read. The default.
+
+**`escape` is the fact; `move` and a lifetime-bounded borrow are its two
+spellings.** The algorithm only tells us the value is stored into the
+receiver and therefore must outlive it. Whether the signature spells that
+as a `move` (an owned parameter, when the container owns its elements —
+`Array<T>`, `Map<K, V>`) or as a lifetime-bounded borrow (`&'a T` with
+`'a` at least the receiver's lifetime, when the container's slot is itself
+a borrow — `Array<&'a T>`) depends on the container's element ownership.
+That is a property of the *typed* signature, not of the untyped
+algorithm, so the choice is made at the FR7 join, not by the extractor.
+`escape` records the raw constraint; curation picks the spelling. The
+default is `move`, and the affine checker currently implements that
+spelling; borrow-into-container tracking is deferred there, so the
+lifetime-borrow spelling is partly future work.
+
+The disposition reuses the FR1–FR3 store analysis: it is the mutation
+detector run against parameter-origin values, plus a check of *where* the
+stored value came from. A parameter that is both mutated in place and has
+another value stored into it stays `mutBorrow` for its own object; the
+stored *value* parameter is what carries `escape`. Value-typed arguments
+— `number`, `string`, functions — are copied at runtime, never moved,
+even where an `escape` would otherwise be spelled a move; the checker
+resolves copy-versus-move-versus-borrow per instantiation (see the
+ownership-model section above), so the fact records `escape` without
+committing to a spelling.
+
+Disposition follows the FR5 default for an unclassified or uncertain
+parameter: `borrow`, the least constraining choice at the call site.
+As FR5 notes, this is a deliberate deviation from the soundness bias
+toward ergonomics, safe because disposition is curation-grade rather than
+auto-applied.
+
+### FR13. Asynchronous reject channel
+
+A promise-returning builtin fails in two distinguishable ways, and the
+analysis routes them to two different Escalier slots
+(`internal/soltype/type.go`):
+
+- a **synchronous** `Throw` step, executed before or outside the promise
+  machinery, is a `throws`-clause candidate (FR10);
+- an **asynchronous rejection** — the algorithm calling the created
+  promise capability's `[[Reject]]`, an `IfAbruptRejectPromise` step, or
+  returning an already-rejected promise — is a candidate for the reject
+  type `E` of `Promise<T, E>` (`soltype.PromiseType.Err`), recorded in
+  `rejects`.
+
+The two channels use the same throw-set fixpoint (FR10); they differ
+only in the sink a raised value flows to, mirroring how the checker
+treats `FuncType.Throws` and `PromiseType.Err` as twins. The same
+coercion filter (FR11) applies to the reject channel, since a rejection
+that merely propagates a receiver/parameter coercion `TypeError` is
+precluded by static typing just as a synchronous one is.
+
+**Thrown and rejected values are Escalier types, not only error names.**
+Both `throws` and `rejects` are Escalier types in the type system, and a
+promise may reject with any value, not just an `Error` subclass. But
+every ECMA-262 `Throw a *T* exception` step names one of the six standard
+error constructors, so an *extracted* synchronous throw is always an
+error-class name, and the string form is faithful there. The values the
+string form cannot name are the ones ECMA-262 propagates rather than
+constructs — `Promise.reject(x)` forwarding its argument, a combinator
+forwarding an element promise's `E`, `AggregateError`'s aggregated list.
+For those the fact records the sentinel `"unknown"` (the checker's top
+type) rather than a name, and the concrete reject type is filled from the
+typed signature at curation. So a value in `throws` or `rejects` is
+either a standard error-class name or `"unknown"`; FR13 is deliberately
+not restricted to error-only facts.
+
+For ECMA-262 `std:*` this channel is usually empty or a propagated
+generic: the core language's promise combinators reject by forwarding the
+element promises' own `E`, and their argument-validation failures are
+coercion type-guards the filter drops. Concrete domain rejections are a
+`web:*` concern — `fetch` rejecting with a network `TypeError`,
+`Response.prototype.json` rejecting with a `SyntaxError` — so FR13 is
+specified here for completeness and to fix the `throws`-versus-`rejects`
+split, but it delivers most of its value once the WebIDL extractor lands.
+
+### FR14. Throws validation and the auto-apply gate
+
+Whether the extracted `throws`/`rejects` are trustworthy without review is
+an empirical question, settled by measurement, not asserted. FR14 is the
+throws counterpart of FR9's mutability validation: diff the extracted
+throw sets against a hand-curated ground-truth sample of high-value
+methods and measure two rates.
+
+- **False-negative rate — the soundness metric.** Real throws that the
+  method can raise but the emitted set omits, almost always because the
+  FR11 coercion filter over-pruned. This is the rate that matters: a
+  false negative is an unsound `throws` clause. Measure it in two layers
+  so the blame is unambiguous:
+  - against the *raw* FR10 set (pre-filter), which should be zero when the
+    CFG is faithful — this isolates FR10 extraction soundness;
+  - against the *filtered* FR11 set, whose false negatives are exactly the
+    filter's over-prunes.
+- **False-positive rate — the ergonomics metric.** Phantom throws the
+  method cannot actually raise. These only cost callers a redundant
+  handler; they are not a soundness problem, so they carry less weight.
+
+The gate: while the filtered false-negative rate is above zero on the
+sample, throws remain a reviewed candidate set (the Non-goals entry
+stands). A measured filtered false-negative rate of zero on a
+representative sample is the evidence that would **graduate throws to
+auto-apply**, the same way FR9's diff authorizes trusting the mutability
+facts. Host and implementation-defined throws are excluded from the
+ground-truth sample by an explicit, documented policy so they do not
+register as false negatives against a spec-derived set that cannot
+contain them.
+
+### FR15. Overloaded methods
+
+ECMA-262 specifies **one algorithm per method**; it branches internally
+on the runtime type and count of its arguments. TypeScript, and the
+generated `.esc`, present that one runtime function as several typed
+**overload** signatures. FR7 keys the single spec algorithm to the
+method element; this requirement governs how the one algorithm's facts
+apply across that element's overloads.
+
+Because the overloads are typed views of a single runtime function, they
+**cannot differ in what the function actually does**. So the
+algorithm-level facts are shared by every overload and are extracted once:
+
+- receiver mutability (a call mutates the receiver or it does not,
+  regardless of which overload's types were used);
+- the return-alias kind (FR4);
+- the raw throw and reject provenance (FR10, FR13), before the
+  type-dependent filter.
+
+The per-parameter facts (FR12 disposition, FR2 mutation) are keyed by
+**parameter position**, not by overload, and apply to an overload only
+where it has that position. An overload with fewer parameters simply
+carries no fact for the missing indices — this is the `Reflect.set`
+three- versus four-argument case (the optional `receiver` at index 3
+exists only on the longer overload). The join (FR7) aligns the spec
+algorithm's parameter positions to each overload's positions and reports
+a mismatch it cannot align rather than applying a fact to the wrong slot.
+
+Two things legitimately **differ across overloads of the same method**,
+and both are type-dependent rather than algorithm-dependent, so the
+converter resolves them per overload at the FR7 join:
+
+- **The filtered `throws` / `rejects` set.** FR11's coercion filter
+  consults each overload's declared parameter types, so `ToNumber(p)` may
+  be precluded on an overload that types `p` as `number` and kept on one
+  that types it `unknown`. The same raw throw set can therefore filter to
+  different committed sets on different overloads.
+- **The `escape` spelling** (FR12). Whether a stored parameter is spelled
+  a move or a lifetime-bounded borrow depends on the container's element
+  type, which an overload fixes.
+
+The facts file stays **one entry per spec method** carrying the shared
+algorithm-level facts, the position-keyed parameter facts, and the throw
+provenance; the converter applies that single entry to each overload
+signature, completing the type-dependent parts against that overload's
+types and arity.
+
+## Non-functional requirements
+
+- **Pinned spec edition.** The extractor pins a specific ECMA-262
+  revision via ESMeta's `-extract:target` flag to an immutable **commit**
+  SHA of the `tc39/ecma262` repository. The flag also accepts a branch or
+  tag, but only a commit is reproducible, so the pin is a commit. The JVM
+  toolchain (`tools/spec-extract/`) is likewise pinned to exact `java`
+  and `sbt` versions with a committed `mise.lock`. Re-running on a
+  revision bump is the maintenance workflow, parallel to FR10's
+  TypeScript `.d.ts` pin.
+- **Go owns the analysis.** The mutation, transitivity, alias, and join
+  logic is Go. The JVM-dependent component is a thin serializer with no
+  analysis logic, run only on a spec bump (see implementation plan §3).
+- **Normal builds need no JVM.** The serialized control-flow graph is
+  committed, so the Go analysis and the converter run without Java or
+  sbt installed. Only regenerating the serialized graph on a spec bump
+  requires the JVM toolchain, scoped to `tools/spec-extract/` via a
+  per-directory `mise.toml`.
+- **Auditability.** Every classification carries its provenance, and
+  every unclassified method is listed, so a reviewer can see exactly
+  which methods the spec proved and which fell through to heuristics.
+
+## Coverage and limitations
+
+- ECMA-262 covers `std:*` only. `web:*` and `node:*` are out of scope.
+- **Host and implementation-defined throws are out of scope.** Errors
+  that can occur at essentially any call — stack-overflow `RangeError`,
+  out-of-memory, host-hook failures — are not enumerated in the spec and
+  are not tracked, the same way an effect system does not track OOM.
+  This exclusion is only for those pervasive host errors: a `RangeError`
+  raised by an explicit spec domain check (`Number.prototype.toFixed`
+  out of range, `Array(-1)`) is a tracked domain throw. The exclusion is
+  what keeps the throw sets ergonomic and removes a would-be permanent
+  blocker to the FR14 auto-apply gate.
+- A handful of algorithms are prose-only or host-defined and fall
+  through to the name heuristic per FR5.
+- Generic and array-like receivers operate on `O ← ? ToObject(this
+  value)`; the analysis treats `ToObject(this value)` as
+  receiver-origin so that a write to `O` is a write to the receiver.
+- Strings, numbers, booleans, bigints, and symbols are immutable
+  primitives. Every method on their wrapper classes is provably
+  non-mutating because the algorithm coerces to the primitive and builds
+  a fresh result. This is where the facts source most clearly beats the
+  name heuristics, which misclassify `String.prototype.replace` and miss
+  `String.prototype.charAt`.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -708,7 +708,11 @@ transfer function:
   (`throw <arg>`) instead contributes that value's **origin** — `param:k`
   or `receiver` — by the FR13 origin rule, resolved to a type at the join;
 - a call guarded by `?` contributes the callee's entire throw set,
-  because `?` propagates any abrupt completion;
+  because `?` propagates any abrupt completion; when the callee is a
+  **function-typed parameter** (a callback, e.g. `? Call(callbackfn, …)`)
+  it has no throw set in the CFG, so the call instead contributes
+  `throwsOf:param:k` — the callback's throws, resolved at the join to
+  throws polymorphism (FR13);
 - a call guarded by `!` contributes nothing, because `!` asserts the
   operation never returns an abrupt completion;
 - a plain unguarded call whose result is not completion-checked
@@ -874,13 +878,29 @@ type instead of collapsing to a bare `"unknown"`:
   - `Promise.allSettled` **never** rejects from element rejections — it
     captures each as `{status, value/reason}` data, so its element channel
     is `never`.
+- **Callback effects, parametric** — a method that `?`-calls a
+  function-typed parameter propagates *that callback's throws*, not a
+  value. `Array.prototype.forEach` / `map` / `filter` / `reduce` /
+  `sort` do `? Call(callbackfn, …)`, so the method throws whatever the
+  callback throws. The fact records `throwsOf:param:k` — an *effect*
+  origin naming the callback parameter, the higher-order analogue of the
+  value origins above. At curation this becomes **throws polymorphism**: a
+  type parameter `E` on the callback's throws, threaded to the method's own
+  throws — `map<U, E>(cb: (…) -> U throws E) -> [U] throws E`. A
+  non-throwing callback instantiates `E = never` (the method is
+  non-throwing at that call), a throwing one propagates its type — the
+  precise "may or may not throw" behavior, without the over-approximation
+  of `throws unknown` or the unsoundness of dropping it. `.d.ts` carries no
+  throws, so the throws-polymorphic signature is a curation enrichment
+  (§11) that the `throwsOf:param:k` fact makes mechanical.
 - **Unresolvable origin** — a propagated value the analysis can neither name
   nor trace falls back to the sentinel `"unknown"`, filled from the typed
   signature at curation.
 
 So a value in `throws` or `rejects` is a standard error-class name, an
-origin ref (`param:k`, `receiver`, or a combinator's element-`E` form), or
-`"unknown"`; FR13 is deliberately not restricted to error-only facts.
+origin ref (`param:k`, `receiver`, a combinator's element-`E` form, or the
+callback-effect `throwsOf:param:k`), or `"unknown"`; FR13 is deliberately
+not restricted to error-only facts.
 
 For ECMA-262 `std:*` the reject channel is usually empty or a forwarded
 element `E` (now recorded as an origin, above); argument-validation

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -193,9 +193,10 @@ superseded and is not the integration target. Where earlier sections of this doc
 (`internal/checker/prelude.go`, `internal/checker/unify_mut.go`), read
 them as naming the *concept*, not the final home — the facts apply to
 whichever checker owns builtin ingestion. Real stdlib ingestion into the
-solver is a later milestone (M7), so the concrete point where the facts
-are consumed tracks wherever the builtins workstream lands that
-ingestion. The interop-layer classifier `interop.Classify`
+solver is milestone M7.5 (Library type resolution), not yet landed — the
+solver prelude still seeds stdlib types as opaque placeholders — so the
+concrete point where the facts are consumed tracks wherever the builtins
+workstream lands that ingestion. The interop-layer classifier `interop.Classify`
 ([../../internal/interop/mutability.go](../../internal/interop/mutability.go))
 operates on `dts_parser` declarations and is checker-agnostic, so FR8's
 integration there holds across both.

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -544,18 +544,20 @@ showed this parameter is only read," whereas the FR5 default applies to an
   element, `Map.prototype.set` stores both key and value (FR12). Whether
   `escape` is spelled a move or a lifetime-bounded borrow is settled at
   the FR7 join from the container's element type.
-- The `throws` array holds the synchronous domain exceptions that survive
-  the coercion filter (FR11). `Number.prototype.toFixed` throws
-  `RangeError` when `fractionDigits` is out of the 0–100 range — a domain
-  throw the type system cannot preclude — while the `TypeError` from
-  coercing a non-number receiver is filtered out.
+- The `throws` array holds the synchronous exceptions that survive the
+  coercion filter (FR11). `Number.prototype.toFixed` throws `RangeError`
+  when `fractionDigits` is out of the 0–100 range — a domain throw the
+  type system cannot preclude — while the `TypeError` from coercing a
+  non-number receiver is filtered out. Each entry is a standard error-class
+  name, an origin ref (`param:k` / `receiver`), or `"unknown"` (FR13).
 - The `rejects` array holds the asynchronous reject types for a
   promise-returning method, the candidate for `Promise<T, E>`'s `E`
-  (FR13). It is empty for a non-promise method. For ECMA-262 `std:*` it
-  is usually empty or a propagated generic, because the core language has
-  few builtins with a concrete domain rejection; the channel matters more
-  for the future `web:*` extractor, where `fetch` and friends reject with
-  concrete types.
+  (FR13), in the same entry forms as `throws`. It is empty for a
+  non-promise method. For ECMA-262 `std:*` it is usually empty or a
+  forwarded element `E` (recorded as an origin), because the core language
+  has few builtins with a concrete domain rejection; the channel matters
+  more for the future `web:*` extractor, where `fetch` and friends reject
+  with concrete types.
 
 The host portion of a key may be a **namespace-qualified dotted path**,
 not just a single class name. Three forms arise:
@@ -699,9 +701,11 @@ the algorithm can raise, by the same inter-procedural fixpoint as the
 mutation summary (FR2) over the same control-flow graph, with a throw
 transfer function:
 
-- a `Throw a *T* exception` step contributes `T` to the function's throw
-  set, where `T` is one of `TypeError`, `RangeError`, `SyntaxError`,
-  `ReferenceError`, `URIError`, `AggregateError`;
+- a `Throw a *T* exception` step contributes the named error class `T`
+  (one of `TypeError`, `RangeError`, `SyntaxError`, `ReferenceError`,
+  `URIError`, `AggregateError`); a `throw` of a non-constructed value
+  (`throw <arg>`) instead contributes that value's **origin** — `param:k`
+  or `receiver` — by the FR13 origin rule, resolved to a type at the join;
 - a call guarded by `?` contributes the callee's entire throw set,
   because `?` propagates any abrupt completion;
 - a call guarded by `!` contributes nothing, because `!` asserts the
@@ -832,29 +836,57 @@ coercion filter (FR11) applies to the reject channel, since a rejection
 that merely propagates a receiver/parameter coercion `TypeError` is
 precluded by static typing just as a synchronous one is.
 
-**Thrown and rejected values are Escalier types, not only error names.**
-Both `throws` and `rejects` are Escalier types in the type system, and a
-promise may reject with any value, not just an `Error` subclass. But
-every ECMA-262 `Throw a *T* exception` step names one of the six standard
-error constructors, so an *extracted* synchronous throw is always an
-error-class name, and the string form is faithful there. The values the
-string form cannot name are the ones ECMA-262 propagates rather than
-constructs — `Promise.reject(x)` forwarding its argument, a combinator
-forwarding an element promise's `E`, `AggregateError`'s aggregated list.
-For those the fact records the sentinel `"unknown"` (the checker's top
-type) rather than a name, and the concrete reject type is filled from the
-typed signature at curation. So a value in `throws` or `rejects` is
-either a standard error-class name or `"unknown"`; FR13 is deliberately
-not restricted to error-only facts.
+**Thrown and rejected values are recorded by origin, not only by name.**
+Both `throws` and `rejects` are Escalier types, and a promise may reject
+with any value, not just an `Error` subclass. Every ECMA-262 `Throw a *T*
+exception` step names one of the six standard error constructors, so an
+extracted value the spec **constructs** is an error-class name and the
+string form is faithful. The values the string form cannot name are the
+ones ECMA-262 **propagates** rather than constructs — and for those the
+fact records the value's **origin**, so the FR7 join substitutes the real
+type instead of collapsing to a bare `"unknown"`:
 
-For ECMA-262 `std:*` this channel is usually empty or a propagated
-generic: the core language's promise combinators reject by forwarding the
-element promises' own `E`, and their argument-validation failures are
-coercion type-guards the filter drops. Concrete domain rejections are a
-`web:*` concern — `fetch` rejecting with a network `TypeError`,
-`Response.prototype.json` rejecting with a `SyntaxError` — so FR13 is
-specified here for completeness and to fix the `throws`-versus-`rejects`
-split, but it delivers most of its value once the WebIDL extractor lands.
+- **Direct propagation of a parameter or the receiver** — `Promise.reject(r)`
+  rejecting with its argument, or a synchronous `throw <arg>`. The raised
+  value's origin is `Param(k)` or `Receiver` by the same origin tagging
+  the mutation and disposition analyses use (FR2), applied to the
+  raised-value operand. The fact records `param:k` / `receiver`, and the
+  join resolves it to that formal's declared type — `Promise.reject<E>(reason:
+  E)` becomes `Promise<never, E>`. It is only as precise as that declared
+  type — `.d.ts` types `Promise.reject`'s `reason` as `any`, lowered to
+  `unknown` (FR17), so the immediate result is still `unknown` there — but
+  recording the origin makes the curation upgrade mechanical: generalize
+  the parameter to `E` and the reject follows automatically.
+- **Promise combinators, hand-modeled** — `Promise.all`, `Promise.race`,
+  `Promise.any`, and `Promise.allSettled` forward the reject type of their
+  *element* promises, but that value arrives through the promise-resolution
+  machinery, not a traceable origin, so origin tagging alone cannot see it.
+  Each is a hand-modeled rule (the same class of hand-modeling §9.3 uses
+  for `IfAbruptRejectPromise`):
+  - `Promise.all` and `Promise.race` reject with the **union of the element
+    promises' `E`** — `all<T, E>(Iterable<Promise<T, E>>) -> Promise<T[], E>`;
+  - `Promise.any` rejects with an **`AggregateError` aggregating the element
+    promises' `E`** — its `errors` list is `E[]`, a parameterized
+    `AggregateError<E>` if the surface is generalized;
+  - `Promise.allSettled` **never** rejects from element rejections — it
+    captures each as `{status, value/reason}` data, so its element channel
+    is `never`.
+- **Unresolvable origin** — a propagated value the analysis can neither name
+  nor trace falls back to the sentinel `"unknown"`, filled from the typed
+  signature at curation.
+
+So a value in `throws` or `rejects` is a standard error-class name, an
+origin ref (`param:k`, `receiver`, or a combinator's element-`E` form), or
+`"unknown"`; FR13 is deliberately not restricted to error-only facts.
+
+For ECMA-262 `std:*` the reject channel is usually empty or a forwarded
+element `E` (now recorded as an origin, above); argument-validation
+failures are coercion type-guards the filter drops. Concrete domain
+rejections are a `web:*` concern — `fetch` rejecting with a network
+`TypeError`, `Response.prototype.json` rejecting with a `SyntaxError` — so
+FR13 is specified here for completeness and to fix the
+`throws`-versus-`rejects` split, but it delivers most of its value once
+the WebIDL extractor lands.
 
 ### FR14. Throws validation and the auto-apply gate
 

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -854,7 +854,9 @@ type instead of collapsing to a bare `"unknown"`:
   join resolves it to that formal's declared type — `Promise.reject<E>(reason:
   E)` becomes `Promise<never, E>`. It is only as precise as that declared
   type — `.d.ts` types `Promise.reject`'s `reason` as `any`, lowered to
-  `unknown` (FR17), so the immediate result is still `unknown` there — but
+  `unknown` by the builtins converter's `any`-lowering policy
+  ([../builtins/requirements.md](../builtins/requirements.md) FR17), so
+  the immediate result is still `unknown` there — but
   recording the origin makes the curation upgrade mechanical: generalize
   the parameter to `E` and the reject follows automatically.
 - **Promise combinators, hand-modeled** — `Promise.all`, `Promise.race`,

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -893,8 +893,13 @@ the WebIDL extractor lands.
 Whether the extracted `throws`/`rejects` are trustworthy without review is
 an empirical question, settled by measurement, not asserted. FR14 is the
 throws counterpart of FR9's mutability validation: diff the extracted
-throw sets against a hand-curated ground-truth sample of high-value
-methods and measure two rates.
+throw sets against a ground-truth sample of high-value methods and measure
+two rates. The sample must be **independent of the spec extraction** — a
+corpus read out of the same algorithm would agree by construction, so it
+is seeded by dynamic observation in a real engine (fuzzing each method and
+recording what it throws or rejects with) rather than by re-reading the
+spec, with only the parametric and combinator entries hand-authored (the
+plan's §9.4 gives the mechanics).
 
 - **False-negative rate — the soundness metric.** Real throws that the
   method can raise but the emitted set omits, almost always because the

--- a/planning/ecma-262/requirements.md
+++ b/planning/ecma-262/requirements.md
@@ -131,16 +131,18 @@ ranking.
 
 2. **Parameter disposition — medium confidence.** The same analysis
    aimed at parameter-origin values, sorting each parameter into borrow,
-   mutable borrow, or escape (FR12). In-place parameter mutation is rare
-   in ECMA-262, so `&mut` parameters are few; the escape case — a
-   parameter stored into the receiver, as in `Array.prototype.push` and
-   `Map.prototype.set` — is common and cleanly detectable from the same
-   store analysis. A `&mut` parameter requires a mutable argument at the
-   call site — an owned-mutable value or an existing `&mut` borrow, but
-   never an immutable one — so an over-eager `&mut` classification is more
-   disruptive than an over-eager escape; bias toward the read-only borrow
-   default and require positive spec evidence to raise a parameter to
-   `&mut` or escape.
+   mutable borrow, or escape (FR12). Where the analysis positively proves a
+   parameter read-only it is `borrow`; where it proves in-place mutation it
+   is `&mut`; the escape case — a parameter stored into the receiver, as in
+   `Array.prototype.push` and `Map.prototype.set` — is common and cleanly
+   detectable from the same store analysis. When the mutation of a
+   parameter is *uncertain*, the default is `&mut`, the conservative
+   direction (FR5): marking a mutating parameter `&` would let an immutable
+   value be mutated at runtime, and the failure of an over-eager `&mut` is
+   loud and self-correcting rather than silently unsound. Escape is the one
+   axis not defaulted conservatively — it requires positive evidence of a
+   store — because assuming an uncertain parameter is consumed is
+   disproportionate.
 
 3. **Return aliasing — low confidence as a generator, useful as a
    seed.** The algorithm reveals whether the return aliases an input:
@@ -442,15 +444,18 @@ already covers `receiver` and `fresh`, so FR4 mainly informs the rare
 
 ### FR5. Soundness bias
 
-The bias is **conservative where a default is auto-applied and permissive
-where it is curation-grade** (reviewed before it reaches the `.esc`). That
-asymmetry is deliberate: only the receiver default ships unreviewed, so it
-is the one that must over-constrain; the rest are reviewed, so they can sit
-at the least-disruptive default while the fact is checked. Two of the four
-defaults below are therefore genuinely sound, and two are considered
-deviations.
+When the analysis has no signal, the default is **conservative — assume
+the effect** — so that a wrong default fails *loudly* rather than
+*silently*. A wrong conservative default (say, `&mut` on a read-only
+parameter) surfaces as call-site friction: a caller that cannot pass an
+immutable value asks for the type to be corrected, which drives the
+annotation toward accuracy. A wrong permissive default (say, `&` on a
+mutating parameter) fails silently as latent unsoundness that surfaces
+much later as a bug. Loud beats silent. There are exactly two documented
+exceptions, where the conservative direction is impractical rather than
+merely stricter.
 
-**Conservative defaults — over-constrain when uncertain:**
+**Conservative defaults — assume the effect when uncertain:**
 
 - A method the analysis cannot classify — prose-only algorithm, host-
   defined behavior, an unrecognized mutation phrasing — is emitted as
@@ -460,33 +465,38 @@ deviations.
   unclassified, consistent with the interop core principle "default to
   mutating"
   ([../interop_mutability/requirements.md](../interop_mutability/requirements.md)).
-  This is the sound direction — an immutable Escalier value can never call
-  a method the analysis failed to prove non-mutating — and receiver
-  mutability is the only determination §7 auto-applies, so it must be
-  conservative.
+  An immutable Escalier value can never call a method the analysis failed
+  to prove non-mutating.
+- Parameter mutability defaults to **mutable borrow** (`&mut`) when
+  uncertain — the same conservative direction as the receiver, and for the
+  same soundness reason: marking a mutating parameter `&` would let an
+  immutable value be passed and mutated at runtime. `&mut` refuses that by
+  demanding a mutable argument. The cost is real — most parameters are
+  read-only, so this default is wrong more often than right and imposes
+  friction across the un-analyzed surface (`web:*`, `node:*`, third-party,
+  any `.d.ts`-only method) where it, not a real signal, decides the
+  disposition — but the failure is loud and self-correcting, and it keeps
+  the policy uniformly conservative, matching the receiver.
 
-**Deviations toward ergonomics — under-constrain when uncertain:**
+**Documented exceptions — where the conservative direction is
+impractical:**
 
-- Parameter disposition defaults to **read-only borrow** (`&`) when
-  unclassified. This is *not* the sound direction: the conservative choice
-  would be `&mut` or escape, so a method that really does mutate or store a
-  parameter could not be handed an immutable or non-outliving argument. We
-  deviate because non-receiver parameter mutation and storage are rare in
-  ECMA-262 — the conservative default would be pervasively noisy for a
-  guarantee almost never needed — and because disposition is curation-grade
-  (§7 does not auto-apply it), so a wrong permissive default is caught at
-  review, not shipped. A `&mut` or escape classification also constrains
-  the call site more than a borrow — a `&mut` parameter demands a mutable
-  argument and refuses an immutable one, an escape makes the caller give
-  the value up or outlive the receiver — so `&` is the least-disruptive
-  place to sit while the fact is reviewed.
-- The asynchronous reject set (FR13), and the synchronous throw set under
-  the same logic (FR10), default toward **under-reporting**. Under-
-  reporting a throw or rejection is likewise the unsound direction — a
-  caller is not forced to handle an exception that can occur — and is
-  justified the same way: over-reporting the coercion noise would be
-  pervasive, and both sets are curation-grade, gated by the FR14
-  validation before they could ever auto-apply.
+- **The `escape` disposition is gated on positive evidence, not
+  defaulted.** Full conservatism would assume an uncertain parameter is
+  stored into the receiver and mark it `escape` (owned/consuming), but that
+  is disproportionate — it makes the caller give the value up entirely — so
+  `escape` requires the store analysis to actually find the parameter
+  written into a longer-lived place (FR12). This leaves a small residual
+  unsoundness on the escape axis for uncertain parameters, accepted
+  deliberately; the mutable-borrow default above still protects the more
+  common mutation case.
+- **The throw and reject sets default toward under-reporting.** The
+  conservative direction here would be to *over*-report — but that means
+  every `this`-touching method carries `throws TypeError` from its
+  receiver coercion, pervasive noise a parameter default does not produce.
+  So the throw set (FR10) and reject set (FR13) under-report instead,
+  accepting that this is the unsound direction, and both are curation-grade
+  and gated by the FR14 validation before they could ever auto-apply.
 
 These defaults are applied by the **converter**, not serialized as
 facts. A `classified: false` record omits its effect fields — `receiver`,
@@ -506,9 +516,13 @@ The extractor emits a committed JSON facts file keyed by canonical spec
 name. Each entry records the five determinations and the tier-relevant
 provenance. `receiver` is `borrow` (`&self`), `mutBorrow` (`&mut self`),
 or `none` (a static or namespace function with no receiver). `params`
-lists only the parameters whose disposition is not the default read-only
-borrow; each is `mutBorrow` (`&mut`) or `escape` (stored into the
-receiver, spelled at curation — see FR12).
+lists only the parameters the analysis found `mutBorrow` (`&mut`) or
+`escape` (stored into the receiver, spelled at curation — see FR12); a
+parameter omitted from a *classified* method's entry was proven read-only
+(`borrow`). That proven-read-only omission is distinct from the FR5
+uncertain default, which is `&mut`: the omission means "the analysis
+showed this parameter is only read," whereas the FR5 default applies to an
+*unclassified* method whose parameters are absent entirely.
 
 ```json
 {
@@ -773,7 +787,9 @@ algorithm, so the choice is made at the FR7 join, not by the extractor.
 `escape` records the raw constraint; curation picks the spelling. The
 default is `move`, and the affine checker currently implements that
 spelling; borrow-into-container tracking is deferred there, so the
-lifetime-borrow spelling is partly future work.
+lifetime-borrow spelling is partly future work — tracked as an external
+dependency in the implementation plan's "Discovery phases may grow the
+plan" list.
 
 The disposition reuses the FR1–FR3 store analysis: it is the mutation
 detector run against parameter-origin values, plus a check of *where* the
@@ -786,11 +802,14 @@ resolves copy-versus-move-versus-borrow per instantiation (see the
 ownership-model section above), so the fact records `escape` without
 committing to a spelling.
 
-Disposition follows the FR5 default for an unclassified or uncertain
-parameter: `borrow`, the least constraining choice at the call site.
-As FR5 notes, this is a deliberate deviation from the soundness bias
-toward ergonomics, safe because disposition is curation-grade rather than
-auto-applied.
+Disposition follows the FR5 defaults for an uncertain parameter: the
+mutation axis defaults to `&mut` (the conservative direction — a wrong
+`&mut` fails loudly at the call site and is corrected, where a wrong `&`
+would be silently unsound), while `escape` is gated on positive evidence
+of a store rather than defaulted, since assuming an uncertain parameter is
+consumed is disproportionate. Being curation-grade does not make a default
+safe; it only means a wrong default is *reviewed* before it ships, so the
+default still points the conservative way on the mutation axis.
 
 ### FR13. Asynchronous reject channel
 


### PR DESCRIPTION
Add requirements and implementation plan for extracting mutability and aliasing facts from ECMA-262 algorithm specifications.

This adds two planning documents under `planning/ecma-262/`:

- **requirements.md** — Specifies the three determinations (receiver mutability, parameter mutability, return aliasing) and nine functional/non-functional requirements. Establishes the confidence ranking (receiver mutability is high-confidence primary deliverable; parameter mutability is medium-confidence; return aliasing is low-confidence seed for hand-authored lifetime annotations). Defines the mutation vocabulary, origin tagging, internal-slot backing stores, and soundness bias toward unclassified fall-through.

- **implementation_plan.md** — Nine-phase roadmap with dependency graph and gates. Stages the pipeline as: ESMeta CFG extraction (Scala, JVM-only) → committed `cfg.json` (language boundary) → Go analysis (mutation fixpoint, origin tagging, alias classification) → `facts.json` → converter integration. Scopes the JVM to `tools/spec-extract/` via per-directory `mise.toml`. Includes detailed pseudocode for the three analysis passes (mutation summary fixpoint, origin map, method classification) and full schema definitions for `cfg.json` and `facts.json` in appendices.

The plan commits to using ESMeta's control-flow graph as the source of truth, with a fallback to a pure-Go shallow parser over `spec.html` if the CFG lacks needed structure. All Escalier-specific logic lives in Go; the Scala component is a thin serializer with no analysis.

https://claude.ai/code/session_01XR276FxA7i1ry5Z4iAkRpp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for an offline, edition-pinned ECMA-262 builtin analysis pipeline.
  * Documented extraction of receiver mutability, parameter disposition, return aliasing, synchronous throws, and asynchronous promise rejections.
  * Defined canonical naming and coverage for symbols, accessors, overloads, and namespace-qualified members.
  * Added guidance for conservative uncertainty handling, provenance, validation against existing annotations, maintenance checks, and reporting of unclassified methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->