### PR TITLE
M4 D1: Add lifetime sort to constraint solver

### DIFF
--- a/internal/simplesub/coalesce.go
+++ b/internal/simplesub/coalesce.go
@@ -92,7 +92,7 @@ func alphaName(i int) string {
 // lifetime renders as its own name. A non-param (join) variable expands to the
 // set of param lifetimes reachable through its bounds — its lower bounds in
 // Positive position (a return uniting several borrows ⇒ `('a | 'b)`), its upper
-// bounds in Negative position. 'static (top) absorbs.
+// bounds in Negative position. 'static (bottom) absorbs.
 func (c *coalescer) coalesceLifetime(lt Lifetime, pol Polarity) type_system.Lifetime {
 	v, ok := lt.(*LifetimeVar)
 	if !ok {

--- a/internal/simplesub/doc.go
+++ b/internal/simplesub/doc.go
@@ -43,7 +43,7 @@
 //
 // M4 adds lifetimes as a SECOND SORT solved by the same constraint machinery
 // (see lifetime.go): a LifetimeVar carries lower/upper bounds over the
-// "outlives" lattice ('static = top), and constrainLt mirrors constrain. A `mut`
+// "outlives" lattice ('static = bottom), and constrainLt mirrors constrain. A `mut`
 // record parameter is a borrow, so it gets a fresh lifetime; returning it shares
 // that lifetime by value identity (`fn <'a>(p: mut 'a {x}) -> mut 'a {x}`);
 // returning one of several borrows unions their lifetimes via a fresh join

--- a/internal/simplesub/lifetime.go
+++ b/internal/simplesub/lifetime.go
@@ -7,8 +7,8 @@ import "github.com/escalier-lang/escalier/internal/set"
 // The M4 thesis: lifetime inference is not a separate multi-phase dataflow
 // analysis (as in the production infer_lifetime.go) but ordinary constraint
 // solving over a *second sort* of variable. A Lifetime is either a variable
-// (with lower/upper bounds, exactly like a type Variable) or 'static — the top
-// of the "outlives" lattice (it outlives everything).
+// (with lower/upper bounds, exactly like a type Variable) or 'static — the bottom
+// of the "outlives" lattice, since 'static outlives everything.
 //
 // Lifetimes ride on values: a borrowed record carries the lifetime of what it
 // was borrowed from. So lifetime relationships fall out of the same value flow
@@ -26,15 +26,17 @@ type Lifetime interface{ isLifetime() }
 // LifetimeVar is a lifetime inference variable. Like a type Variable it carries
 // lower/upper bounds and is coalesced polarity-dependently: positive position
 // (output) joins its lower bounds, negative position (input) meets its upper
-// bounds. 'static appearing as an upper bound drives a negative-position
-// variable to 'static.
+// bounds. 'static is the bottom of the order, so it absorbs a meet: a
+// negative-position variable with 'static among its upper bounds resolves to
+// 'static, regardless of any other upper bound.
 type LifetimeVar struct {
 	id          int
 	lowerBounds []Lifetime
 	upperBounds []Lifetime
 }
 
-// StaticLifetime is 'static, the top of the outlives lattice.
+// StaticLifetime is 'static, the bottom of the outlives lattice. It outlives every
+// lifetime.
 type StaticLifetime struct{}
 
 func (*LifetimeVar) isLifetime()    {}
@@ -57,7 +59,8 @@ func (in *Inferer) freshLifetime() *LifetimeVar {
 // var-to-var constraint records BOTH directions (lhs gains upper rhs, rhs gains
 // lower lhs) so each variable sees the full relationship at coalescing — the
 // type sort gets this from the separate symmetrize pass, but lifetimes are
-// recorded directly here. 'static is the top, so X <: 'static always holds.
+// recorded directly here. 'static is the bottom, so `'static <: X` always holds. The
+// reverse `X <: 'static` is the forcing escape constraint that pins X to 'static.
 func (in *Inferer) constrainLt(lhs, rhs Lifetime) {
 	in.constrainLtSeen(lhs, rhs, map[ltPair]bool{})
 }

--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -2,20 +2,24 @@ package soltype
 
 // Lifetime is the sort of borrow lifetimes — a second, non-Type sort threaded
 // through RefType.Lt. A Lifetime is either a variable carrying outlives bounds
-// (LifetimeVar) or 'static (StaticLifetime), the top of the outlives lattice.
+// (LifetimeVar) or 'static (StaticLifetime), the bottom of the outlives lattice.
 //
 // Lifetimes are solved by the same constraint machinery as types but live in
 // their own sort: a RefType's Lt is a Lifetime, never a Type, and the rewriting
 // visitor carries it through unchanged (only the lifetime-aware passes walk it).
 // The outlives relation `'a <: 'b` ("'a outlives, i.e. lives at least as long
-// as, 'b") is asserted by solver.constrainLt; 'static outlives everything.
+// as, 'b") is asserted by solver.constrainLt. 'static outlives everything, so it is
+// the bottom of this order: `'static <: X` holds for every X.
 type Lifetime interface{ isLifetime() }
 
 // LifetimeVar is a lifetime inference variable. Like a TypeVarType it carries
 // lower and upper bounds and is coalesced polarity-dependently: a positive
 // (output) occurrence joins its lower bounds, a negative (input) occurrence
-// meets its upper bounds. A 'static upper bound drives a negative-position
-// variable to 'static. Bound lists are extended ONLY through the solver's
+// meets its upper bounds. 'static is the bottom of the order, so it absorbs a meet:
+// a negative-position variable with 'static among its upper bounds resolves to
+// 'static, regardless of any other upper bound. That upper bound comes from a real
+// `v <: 'static` escape constraint, the one constraint that pins v to 'static. Bound
+// lists are extended ONLY through the solver's
 // addLowerLtBound/addUpperLtBound helpers, mirroring the type-sort discipline so
 // a discarded speculation trial truncates them back.
 type LifetimeVar struct {
@@ -24,8 +28,10 @@ type LifetimeVar struct {
 	UpperBounds []Lifetime
 }
 
-// StaticLifetime is 'static, the top of the outlives lattice: every lifetime
-// outlives at most 'static, so `X <: 'static` always holds.
+// StaticLifetime is 'static, the bottom of the outlives lattice: it outlives every
+// lifetime, so `'static <: X` always holds. The reverse, `X <: 'static`, holds only
+// for X = 'static, so asserting it forces X to 'static — the escape-to-static
+// constraint.
 type StaticLifetime struct{}
 
 // Static is the canonical 'static value. Prefer it over a fresh
@@ -47,7 +53,7 @@ func IsStaticLifetime(lt Lifetime) bool {
 // ContainsLifetime reports whether lt is already present in bounds, so a repeated
 // outlives constraint does not re-append a bound. A LifetimeVar matches by pointer
 // identity, but 'static matches by VALUE: every StaticLifetime denotes the one
-// lattice top, and origination sites mint a fresh &StaticLifetime{} per call, so
+// lattice bottom, and origination sites mint a fresh &StaticLifetime{} per call, so
 // pointer identity would wrongly treat two 'static values as distinct and let a
 // bound list accumulate duplicate 'static entries.
 func ContainsLifetime(bounds []Lifetime, lt Lifetime) bool {

--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -1,0 +1,49 @@
+package soltype
+
+// Lifetime is the sort of borrow lifetimes — a second, non-Type sort threaded
+// through RefType.Lt. A Lifetime is either a variable carrying outlives bounds
+// (LifetimeVar) or 'static (StaticLifetime), the top of the outlives lattice.
+//
+// Lifetimes are solved by the same constraint machinery as types but live in
+// their own sort: a RefType's Lt is a Lifetime, never a Type, and the rewriting
+// visitor carries it through unchanged (only the lifetime-aware passes walk it).
+// The outlives relation `'a <: 'b` ("'a outlives, i.e. lives at least as long
+// as, 'b") is asserted by solver.constrainLt; 'static outlives everything.
+type Lifetime interface{ isLifetime() }
+
+// LifetimeVar is a lifetime inference variable. Like a TypeVarType it carries
+// lower and upper bounds and is coalesced polarity-dependently: a positive
+// (output) occurrence joins its lower bounds, a negative (input) occurrence
+// meets its upper bounds. A 'static upper bound drives a negative-position
+// variable to 'static. Bound lists are extended ONLY through the solver's
+// addLowerLtBound/addUpperLtBound helpers, mirroring the type-sort discipline so
+// a discarded speculation trial truncates them back.
+type LifetimeVar struct {
+	ID          int
+	LowerBounds []Lifetime
+	UpperBounds []Lifetime
+}
+
+// StaticLifetime is 'static, the top of the outlives lattice: every lifetime
+// outlives at most 'static, so `X <: 'static` always holds.
+type StaticLifetime struct{}
+
+func (*LifetimeVar) isLifetime()    {}
+func (*StaticLifetime) isLifetime() {}
+
+// IsStaticLifetime reports whether lt is 'static.
+func IsStaticLifetime(lt Lifetime) bool {
+	_, ok := lt.(*StaticLifetime)
+	return ok
+}
+
+// ContainsLifetime reports whether lt is already present in bounds (by pointer
+// identity), so a repeated outlives constraint does not re-append a bound.
+func ContainsLifetime(bounds []Lifetime, lt Lifetime) bool {
+	for _, b := range bounds {
+		if b == lt {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -28,6 +28,13 @@ type LifetimeVar struct {
 // outlives at most 'static, so `X <: 'static` always holds.
 type StaticLifetime struct{}
 
+// Static is the canonical 'static value. Prefer it over a fresh
+// &StaticLifetime{} at every origination site (escape-to-static, annotations) so
+// all 'static share one pointer identity. ContainsLifetime dedups 'static by
+// value regardless, so a stray fresh instance is still correct — the singleton is
+// the cheap default, not a correctness crutch.
+var Static Lifetime = &StaticLifetime{}
+
 func (*LifetimeVar) isLifetime()    {}
 func (*StaticLifetime) isLifetime() {}
 
@@ -37,11 +44,19 @@ func IsStaticLifetime(lt Lifetime) bool {
 	return ok
 }
 
-// ContainsLifetime reports whether lt is already present in bounds (by pointer
-// identity), so a repeated outlives constraint does not re-append a bound.
+// ContainsLifetime reports whether lt is already present in bounds, so a repeated
+// outlives constraint does not re-append a bound. A LifetimeVar matches by pointer
+// identity, but 'static matches by VALUE: every StaticLifetime denotes the one
+// lattice top, and origination sites mint a fresh &StaticLifetime{} per call, so
+// pointer identity would wrongly treat two 'static values as distinct and let a
+// bound list accumulate duplicate 'static entries.
 func ContainsLifetime(bounds []Lifetime, lt Lifetime) bool {
+	ltStatic := IsStaticLifetime(lt)
 	for _, b := range bounds {
 		if b == lt {
+			return true
+		}
+		if ltStatic && IsStaticLifetime(b) {
 			return true
 		}
 	}

--- a/internal/soltype/lifetime_test.go
+++ b/internal/soltype/lifetime_test.go
@@ -8,7 +8,7 @@ import (
 
 // Test 4 — ContainsLifetime's two equality regimes: a LifetimeVar matches by
 // pointer identity, but 'static matches by VALUE because origination sites mint a
-// fresh &StaticLifetime{} per call and they all denote the one lattice top.
+// fresh &StaticLifetime{} per call and they all denote the one lattice bottom.
 func TestContainsLifetime(t *testing.T) {
 	a := &LifetimeVar{ID: 0}
 	b := &LifetimeVar{ID: 1}
@@ -32,7 +32,7 @@ func TestContainsLifetime(t *testing.T) {
 	require.False(t, ContainsLifetime(nil, a), "empty bounds contain nothing")
 }
 
-// IsStaticLifetime distinguishes the lattice top from a variable, including the
+// IsStaticLifetime distinguishes the lattice bottom from a variable, including the
 // canonical Static singleton.
 func TestIsStaticLifetime(t *testing.T) {
 	require.True(t, IsStaticLifetime(&StaticLifetime{}))

--- a/internal/soltype/lifetime_test.go
+++ b/internal/soltype/lifetime_test.go
@@ -1,0 +1,41 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test 4 — ContainsLifetime's two equality regimes: a LifetimeVar matches by
+// pointer identity, but 'static matches by VALUE because origination sites mint a
+// fresh &StaticLifetime{} per call and they all denote the one lattice top.
+func TestContainsLifetime(t *testing.T) {
+	a := &LifetimeVar{ID: 0}
+	b := &LifetimeVar{ID: 1}
+	static1 := &StaticLifetime{}
+	static2 := &StaticLifetime{}
+
+	// A LifetimeVar matches by pointer identity.
+	require.True(t, ContainsLifetime([]Lifetime{a, b}, a))
+	require.False(t, ContainsLifetime([]Lifetime{a}, b), "a different var does not match")
+	require.False(t, ContainsLifetime([]Lifetime{a}, &LifetimeVar{ID: 0}),
+		"vars match by pointer, not by ID — a distinct var with the same ID is a different lifetime")
+
+	// 'static matches by value: two distinct instances match, and the Static
+	// singleton matches a fresh instance either way round.
+	require.True(t, ContainsLifetime([]Lifetime{static1}, static2), "distinct 'static instances match by value")
+	require.True(t, ContainsLifetime([]Lifetime{Static}, &StaticLifetime{}), "the singleton matches a fresh 'static")
+	require.True(t, ContainsLifetime([]Lifetime{a, static1}, Static), "Static is found among mixed bounds")
+
+	// No false positives.
+	require.False(t, ContainsLifetime([]Lifetime{a, b}, static1), "'static does not match a var-only bound list")
+	require.False(t, ContainsLifetime(nil, a), "empty bounds contain nothing")
+}
+
+// IsStaticLifetime distinguishes the lattice top from a variable, including the
+// canonical Static singleton.
+func TestIsStaticLifetime(t *testing.T) {
+	require.True(t, IsStaticLifetime(&StaticLifetime{}))
+	require.True(t, IsStaticLifetime(Static))
+	require.False(t, IsStaticLifetime(&LifetimeVar{ID: 0}))
+}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -174,6 +174,30 @@ func freeTypeVars(t Type) []*TypeVarType {
 // `t{ID}`) and populated by PrintAsScheme (a retained variable renders as `T{i}`).
 type namedPrinter struct {
 	names map[*TypeVarType]string
+	// ltNames maps a retained lifetime variable to its surface name (`'a`, `'b`,
+	// …). It is nil for plain Print, where a lifetime var renders as the raw
+	// `'l{ID}` debug form; D4's display-time coalescing populates it so a
+	// param-originated lifetime renders under its quantified name.
+	ltNames map[*LifetimeVar]string
+}
+
+// printLifetime renders a lifetime in Escalier surface syntax: 'static for the
+// top of the lattice, a retained variable's assigned name (`'a`) when ltNames
+// carries one, else the raw `'l{ID}` debug form — the lifetime-sort twin of
+// printType's TypeVarType arm, which falls back to `t{ID}` for an un-named var.
+func (p *namedPrinter) printLifetime(lt Lifetime) string {
+	switch lt := lt.(type) {
+	case *StaticLifetime:
+		return "'static"
+	case *LifetimeVar:
+		if p.ltNames != nil {
+			if name, ok := p.ltNames[lt]; ok {
+				return name
+			}
+		}
+		return "'l" + strconv.Itoa(lt.ID)
+	}
+	panic(fmt.Sprintf("printLifetime: unhandled %T", lt))
 }
 
 // printTypeMinPrec prints a child type, wrapping it in parentheses when its
@@ -244,13 +268,16 @@ func (p *namedPrinter) printType(t Type) string {
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
-		// `mut {x: number}`, `mut [number]`. The immutable-borrow and lifetime
-		// prefixes (`'a {…}`, `mut 'a {…}`) render once D1 adds the lifetime sort;
-		// Lt is always nil here, so only the `mut` prefix appears. The inner prints
-		// at precPrefix so a looser inner (a union/function) gets parenthesized.
+		// A borrow prefix: `mut {x: number}` (owned-mutable), `'a {…}` (immutable
+		// borrow), `mut 'a {…}` (mutable borrow). The `mut` keyword leads, then the
+		// lifetime when present (Lt != nil). The inner prints at precPrefix so a
+		// looser inner (a union/function) gets parenthesized.
 		prefix := ""
 		if t.Mut {
 			prefix = "mut "
+		}
+		if t.Lt != nil {
+			prefix += p.printLifetime(t.Lt) + " "
 		}
 		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -182,7 +182,7 @@ type namedPrinter struct {
 }
 
 // printLifetime renders a lifetime in Escalier surface syntax: 'static for the
-// top of the lattice, a retained variable's assigned name (`'a`) when ltNames
+// bottom of the lattice, a retained variable's assigned name (`'a`) when ltNames
 // carries one, else the raw `'l{ID}` debug form — the lifetime-sort twin of
 // printType's TypeVarType arm, which falls back to `t{ID}` for an un-named var.
 func (p *namedPrinter) printLifetime(lt Lifetime) string {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -128,8 +128,9 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
 
-		// Borrows (M4). Lt is always nil in C1, so only the owned-mutable form
-		// renders; the inner object/tuple is brace/bracket-delimited, so no parens.
+		// Borrows (M4). The inner object/tuple is brace/bracket-delimited, so no
+		// parens. The owned-mutable form (Lt nil) and, with D1's lifetime sort, the
+		// borrow forms carrying a lifetime all render here.
 		{
 			"mut object",
 			&RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
@@ -139,6 +140,21 @@ func TestPrintRoundTrips(t *testing.T) {
 			"mut tuple",
 			&RefType{Mut: true, Inner: &TupleType{Elems: []Type{numP(), strP()}}},
 			"mut [number, string]",
+		},
+		{
+			"immutable borrow with lifetime var",
+			&RefType{Lt: &LifetimeVar{ID: 0}, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
+			"'l0 {x: number}",
+		},
+		{
+			"mutable borrow with lifetime var",
+			&RefType{Mut: true, Lt: &LifetimeVar{ID: 2}, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
+			"mut 'l2 {x: number}",
+		},
+		{
+			"borrow with static lifetime",
+			&RefType{Mut: true, Lt: &StaticLifetime{}, Inner: &TupleType{Elems: []Type{numP()}}},
+			"mut 'static [number]",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/soltype/ref.go
+++ b/internal/soltype/ref.go
@@ -1,12 +1,5 @@
 package soltype
 
-// Lifetime is the sort of borrow lifetimes — a second, non-Type sort threaded
-// through RefType.Lt. It is a placeholder in C1: it has no concretes yet, so Lt is
-// always nil and no RefType is borrowed. M4 D1 adds the concretes (LifetimeVar,
-// StaticLifetime) and the outlives lattice; until then a RefType carries the field
-// unused.
-type Lifetime interface{ isLifetime() }
-
 // NewRef wraps inner in a borrow, collapsing the degenerate immutable-no-lifetime
 // cell back to the bare inner so no *RefType ever names a value that isn't really a
 // borrow. A type-switch on *RefType can therefore assume the wrapper is meaningful.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -224,12 +224,14 @@ func AsProperty(e ObjTypeElem) *PropertyElem {
 //	Mut=true  Lt='a    mutable borrow
 //
 // The single RefType<:RefType constrain rule (M4 C2) reads Mut for inner variance
-// and Lt for the lifetime outlives check; until then a RefType only carries data.
-// Lt is always nil in C1 — the Lifetime sort and its constrain rule arrive in M4
-// D1/D2, so the immutable-borrow and lifetime forms above are reachable only then.
+// and Lt for the lifetime outlives check. M4 D1 lands the Lifetime sort (the
+// LifetimeVar/StaticLifetime concretes, freshLifetime, constrainLt, the probe
+// extension); D2 attaches a fresh lifetime to a borrowed parameter and activates
+// the rule's outlives step. Until D2 every minted RefType still carries Lt == nil,
+// so the immutable-borrow and lifetime forms above are only reached once D2 lands.
 type RefType struct {
 	Mut   bool
-	Lt    Lifetime // nilable; always nil until the lifetime sort lands (D1)
+	Lt    Lifetime // nilable; carries a lifetime once D2 attaches one to a borrow
 	Inner RefInner
 }
 

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -552,7 +552,11 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one. Lifetime
-		// equality joins in D1; Lt is always nil here.
+		// equality is deferred to D2: D1 lands the lifetime sort but does not attach a
+		// lifetime to any borrow, so every Lt is nil here and comparing Inner+Mut is
+		// complete. D2, which mints borrow lifetimes, must add an Lt comparison (by
+		// pointer for a LifetimeVar, by value for 'static) or two borrows differing
+		// only in lifetime would coalesce as equal.
 		return ok && a.Mut == b.Mut && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -465,18 +465,18 @@ type ltPair struct{ sub, super soltype.Lifetime }
 // rule is written and unit-tested now; the RefType constrain arm activates it in
 // D2 (its lifetime step is inert while every Lt is nil).
 func (c *Context) constrainLt(sub, super soltype.Lifetime) {
-	c.constrainLtSeen(sub, super, map[ltPair]bool{})
+	c.constrainLtSeen(sub, super, set.NewSet[ltPair]())
 }
 
-func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen map[ltPair]bool) {
+func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPair]) {
 	if sub == super {
 		return
 	}
 	key := ltPair{sub, super}
-	if seen[key] {
+	if seen.Contains(key) {
 		return
 	}
-	seen[key] = true
+	seen.Add(key)
 
 	subVar, subIsVar := sub.(*soltype.LifetimeVar)
 	superVar, superIsVar := super.(*soltype.LifetimeVar)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -455,7 +455,10 @@ type ltPair struct{ sub, super soltype.Lifetime }
 // bound, and a var-to-var constraint records BOTH directions so each variable
 // sees the full relationship at coalescing — the type sort gets symmetry from a
 // separate pass, but lifetimes record it directly here. 'static is the top of the
-// lattice, so `X <: 'static` always holds with no bound recorded.
+// lattice, so `X <: 'static` always holds: it is recorded as an upper bound (which
+// drives a negative-position variable to 'static at coalescing) and deduped by
+// value through ContainsLifetime, so repeating the constraint does not pile up
+// duplicate 'static bounds.
 //
 // Bound appends route through addLowerLtBound/addUpperLtBound so a speculation
 // trial journals them; the (sub, super)-keyed seen-set terminates cycles. The

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -454,11 +454,13 @@ type ltPair struct{ sub, super soltype.Lifetime }
 // variable on the left gains an upper bound, a variable on the right a lower
 // bound, and a var-to-var constraint records BOTH directions so each variable
 // sees the full relationship at coalescing — the type sort gets symmetry from a
-// separate pass, but lifetimes record it directly here. 'static is the top of the
-// lattice, so `X <: 'static` always holds: it is recorded as an upper bound (which
-// drives a negative-position variable to 'static at coalescing) and deduped by
-// value through ContainsLifetime, so repeating the constraint does not pile up
-// duplicate 'static bounds.
+// separate pass, but lifetimes record it directly here. 'static is the bottom of the
+// lattice: `'static <: X` always holds, while `X <: 'static` is the forcing escape
+// constraint, satisfiable only by X = 'static. The latter records 'static as X's
+// upper bound, and since 'static is the bottom it absorbs the meet at a
+// negative-position variable, so X coalesces to 'static regardless of any other upper
+// bound. The bound is deduped by value through ContainsLifetime, so repeating the
+// constraint does not pile up duplicate 'static bounds.
 //
 // Bound appends route through addLowerLtBound/addUpperLtBound so a speculation
 // trial journals them; the (sub, super)-keyed seen-set terminates cycles. The

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -443,6 +443,60 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
+// ltPair keys constrainLt's coinductive seen-set by (sub, super) lifetime
+// identity so a transitive cycle (`'a <: 'b`, `'b <: 'a`, or a longer chain back
+// to 'a) terminates: the same pair is never re-entered. Pointer equality on the
+// soltype lifetime concretes is the identity here, matching constraintKey.
+type ltPair struct{ sub, super soltype.Lifetime }
+
+// constrainLt asserts the outlives relation sub <: super between lifetimes,
+// mirroring constrain for the type sort. It is the M4 D1 lifetime-sort solver: a
+// variable on the left gains an upper bound, a variable on the right a lower
+// bound, and a var-to-var constraint records BOTH directions so each variable
+// sees the full relationship at coalescing — the type sort gets symmetry from a
+// separate pass, but lifetimes record it directly here. 'static is the top of the
+// lattice, so `X <: 'static` always holds with no bound recorded.
+//
+// Bound appends route through addLowerLtBound/addUpperLtBound so a speculation
+// trial journals them; the (sub, super)-keyed seen-set terminates cycles. The
+// rule is written and unit-tested now; the RefType constrain arm activates it in
+// D2 (its lifetime step is inert while every Lt is nil).
+func (c *Context) constrainLt(sub, super soltype.Lifetime) {
+	c.constrainLtSeen(sub, super, map[ltPair]bool{})
+}
+
+func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen map[ltPair]bool) {
+	if sub == super {
+		return
+	}
+	key := ltPair{sub, super}
+	if seen[key] {
+		return
+	}
+	seen[key] = true
+
+	subVar, subIsVar := sub.(*soltype.LifetimeVar)
+	superVar, superIsVar := super.(*soltype.LifetimeVar)
+	if subIsVar {
+		if !soltype.ContainsLifetime(subVar.UpperBounds, super) {
+			c.addUpperLtBound(subVar, super)
+		}
+		// Propagate to existing lower bounds: lb <: sub <: super.
+		for _, lb := range subVar.LowerBounds {
+			c.constrainLtSeen(lb, super, seen)
+		}
+	}
+	if superIsVar {
+		if !soltype.ContainsLifetime(superVar.LowerBounds, sub) {
+			c.addLowerLtBound(superVar, sub)
+		}
+		// Propagate to existing upper bounds: sub <: super <: ub.
+		for _, ub := range superVar.UpperBounds {
+			c.constrainLtSeen(sub, ub, seen)
+		}
+	}
+}
+
 // extrude copies t so that variables above lvl are replaced by fresh variables
 // at lvl, wired to the originals through the polarity-appropriate bound
 // direction. The cache is keyed by (var ID, polarity): a variable reached in

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -2,9 +2,9 @@ package solver
 
 import "github.com/escalier-lang/escalier/internal/soltype"
 
-// Context owns the engine's mutable counters. M1 carries ONLY varCounter; the
-// spike's lifetimeCounter / paramLifetimes / written fields are M4 (lifetimes
-// and records/mut), so M1's Context is correspondingly lean.
+// Context owns the engine's mutable counters. M1 carries ONLY varCounter; M4 D1
+// adds lifetimeCounter for the lifetime sort. The spike's paramLifetimes /
+// written fields live on the checker carrier (D2/C3), not here.
 //
 // M3 (PR5) adds the nullable probe pointer. The engine's bound-mutating core
 // (constrain/extrude) lives on *Context, so the speculation journal must live
@@ -22,6 +22,13 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 type Context struct {
 	varCounter int
 	probe      *Probe
+
+	// lifetimeCounter mints the next LifetimeVar id (M4 D1). Lifetimes are a
+	// SECOND bounded sort solved by the same machinery as types: a fresh lifetime
+	// gets the next id here, its bounds are extended only through
+	// addLowerLtBound/addUpperLtBound, and a speculation trial journals it under
+	// the same probe discipline as a TypeVarType.
+	lifetimeCounter int
 }
 
 // freshVar allocates a new inference variable at the given level, assigning it
@@ -30,6 +37,41 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	v := &soltype.TypeVarType{ID: c.varCounter, Level: level}
 	c.varCounter++
 	return v
+}
+
+// freshLifetime allocates a new lifetime variable, assigning it the next id in
+// sequence. Lifetimes carry no level — they are a flat sort over the outlives
+// lattice, not the let-generalization level hierarchy types ride.
+func (c *Context) freshLifetime() *soltype.LifetimeVar {
+	lv := &soltype.LifetimeVar{ID: c.lifetimeCounter}
+	c.lifetimeCounter++
+	return lv
+}
+
+// addLowerLtBound appends lt to v's lower bounds, journaling the mutation in the
+// active probe first so a discarded trial truncates it away. This (and
+// addUpperLtBound) is the ONLY sanctioned way to extend a lifetime bound list —
+// the second sort inherits the type sort's "appends only through journaling
+// helpers" invariant so an un-journaled append cannot survive a Discard.
+func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
+	c.recordLtMutation(v)
+	v.LowerBounds = append(v.LowerBounds, lt)
+}
+
+// addUpperLtBound is the upper-bound counterpart of addLowerLtBound.
+func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
+	c.recordLtMutation(v)
+	v.UpperBounds = append(v.UpperBounds, lt)
+}
+
+// recordLtMutation snapshots v's bound-list lengths in the active probe, if any,
+// BEFORE a bound append mutates v — the lifetime-sort twin of recordMutation. A
+// no-op when no probe is open; recordLt dedups per probe, so the first touch's
+// snapshot covers every later append to v under the same probe.
+func (c *Context) recordLtMutation(v *soltype.LifetimeVar) {
+	if c.probe != nil {
+		c.probe.recordLt(v)
+	}
 }
 
 // addLowerBound appends t to v's lower bounds, journaling the mutation in the

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 // A lifetime variable on the LEFT of an outlives constraint gains the right as an
-// upper bound; 'static on the right is the top of the lattice, so the constraint
-// holds with NO bound recorded.
+// upper bound. 'static is the top of the lattice, so `a <: 'static` always holds;
+// it is still recorded as a's upper bound, which is what drives a to 'static at
+// coalescing.
 func TestConstrainLtVarOutlivesStatic(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime()

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -168,3 +168,162 @@ func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
 	require.Empty(t, a.UpperBounds, "the parent discard reverts the committed child's lifetime bound")
 	require.Empty(t, b.LowerBounds)
 }
+
+// Test 1 — the lower-bound propagation branch. TestConstrainLtPropagatesTransitively
+// exercises propagation through the SUPER variable's upper bounds; this exercises the
+// distinct `subVar.LowerBounds` loop: with lb <: a already recorded, constraining
+// a <: super must propagate lb <: super through a's existing lower bound.
+func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
+	c := newChecker()
+	lb := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime()
+	super := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(lb, a)    // lb <: a ⇒ a gains lb as a lower bound
+	c.ctx.constrainLt(a, super) // a <: super ⇒ a's lower-bound loop propagates lb <: super
+
+	require.Contains(t, lb.UpperBounds, soltype.Lifetime(a), "lb gains a directly")
+	require.Contains(t, lb.UpperBounds, soltype.Lifetime(super), "lb gains super transitively through a's lower-bound propagation")
+	require.Contains(t, super.LowerBounds, soltype.Lifetime(lb), "super sees lb as a lower bound from the same propagation")
+}
+
+// Test 2 — a probe discard rolls back vars touched TRANSITIVELY, not just the ones
+// named at the constrainLt call site. With a <: b set pre-probe, a single
+// constrainLt(x, a) under the probe touches x, a, AND b (x <: a <: b), and the
+// discard must truncate every probe-era bound while leaving the pre-probe ones.
+func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, b) // pre-probe: a.upper=[b], b.lower=[a]
+	require.Len(t, a.UpperBounds, 1)
+	require.Len(t, b.LowerBounds, 1)
+
+	p := c.openProbe()
+	x := c.ctx.freshLifetime()
+	c.ctx.constrainLt(x, a) // x <: a, transitively recording x <: b; touches x, a, b
+	require.Contains(t, x.UpperBounds, soltype.Lifetime(a))
+	require.Contains(t, x.UpperBounds, soltype.Lifetime(b), "x gained b transitively under the probe")
+	require.Len(t, a.LowerBounds, 1, "a gained x as a probe-era lower bound")
+	require.Len(t, b.LowerBounds, 2, "b gained x transitively under the probe")
+
+	c.closeProbe(p, false) // discard
+
+	require.Empty(t, x.UpperBounds, "x was minted and constrained entirely under the probe")
+	require.Len(t, a.UpperBounds, 1, "a's pre-probe upper bound survives")
+	require.Empty(t, a.LowerBounds, "a's probe-era lower bound x is truncated")
+	require.Len(t, b.LowerBounds, 1, "b's transitive probe-era lower bound is truncated")
+	require.Equal(t, soltype.Lifetime(a), b.LowerBounds[0], "b's pre-probe lower bound survives")
+}
+
+// Test 3 — recordLt journals a lifetime var at most once per probe, even across
+// several appends to it, so the single snapshot truncates every later append on
+// discard. Mirrors the type sort's TestProbeRecordDedupsPerVariable. Each
+// constrainLt(a, …) also touches its super var, so the probe holds three entries
+// total; the point is that `a` appears in exactly one of them.
+func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+	d := c.ctx.freshLifetime()
+
+	p := c.openProbe()
+	c.ctx.constrainLt(a, b) // a.upper += b
+	c.ctx.constrainLt(a, d) // a.upper += d — a SECOND append to a
+	require.Len(t, a.UpperBounds, 2)
+
+	aEntries := 0
+	for _, e := range p.ltEntries {
+		if e.v == a {
+			aEntries++
+		}
+	}
+	require.Equal(t, 1, aEntries, "a is journaled exactly once despite two appends")
+
+	c.closeProbe(p, false) // discard
+	require.Empty(t, a.UpperBounds, "both speculative bounds on a are truncated via the single journal entry")
+}
+
+// Test 5 — a probe built directly as &Probe{} (bypassing newProbe) is safe for the
+// lifetime sort too: ltTouched is lazily created on first recordLt, so there is no
+// nil-map panic. Mirrors the type sort's TestProbeBareLiteralIsNilMapSafe.
+func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	c.ctx.probe = &Probe{} // deliberately skip newProbe
+	require.NotPanics(t, func() {
+		c.ctx.constrainLt(a, b) // appends bounds ⇒ recordLt(a), recordLt(b)
+	})
+	require.Len(t, a.UpperBounds, 1)
+
+	c.ctx.probe.Discard()
+	require.Empty(t, a.UpperBounds, "the bare-literal probe still rolls back the lifetime bound")
+	require.Empty(t, b.LowerBounds)
+}
+
+// Test 6a — a discarded child reverts only ITS OWN lifetime appends, leaving the
+// parent's journal and the var's parent-era bounds intact. Mirrors the type sort's
+// TestDiscardedChildLeavesParentJournalIntact.
+func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+	d := c.ctx.freshLifetime()
+
+	parent := c.openProbe()
+	c.ctx.constrainLt(a, b) // parent: a.upper=[b]
+	require.Len(t, a.UpperBounds, 1)
+
+	child := c.openProbe()
+	c.ctx.constrainLt(a, d) // child: a.upper=[b, d]
+	require.Len(t, a.UpperBounds, 2)
+	c.closeProbe(child, false) // child discards ⇒ back to [b]
+	require.Len(t, a.UpperBounds, 1, "the child discard reverts only the child's lifetime bound")
+	require.Equal(t, soltype.Lifetime(b), a.UpperBounds[0])
+
+	c.closeProbe(parent, false) // parent discards ⇒ back to empty
+	require.Empty(t, a.UpperBounds, "the parent discard reverts its own lifetime bound")
+}
+
+// Test 6b — when the parent has NOT touched a lifetime var the committed child did,
+// the child's snapshot is inherited so the parent discard reverts the child's bound
+// to the var's pre-child length. Mirrors TestCommittedChildInheritsUntouchedVarSnapshot.
+func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	parent := c.openProbe()
+	child := c.openProbe()
+	c.ctx.constrainLt(a, b) // only the child touches a and b
+	require.Len(t, a.UpperBounds, 1)
+	c.closeProbe(child, true) // commit: parent inherits a and b at snapshot 0
+
+	c.closeProbe(parent, false) // discard
+	require.Empty(t, a.UpperBounds, "the inherited child snapshot truncates a back to empty")
+	require.Empty(t, b.LowerBounds)
+}
+
+// Test 7 — re-constraining a lifetime bound already present journals nothing: the
+// ContainsLifetime guard skips the append, so no recordLt fires and a discard is a
+// clean no-op that leaves the pre-probe bound untouched. This verifies the
+// "no journal entry without an append" invariant for the lifetime sort.
+func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, b) // pre-probe: a.upper=[b], b.lower=[a]
+
+	p := c.openProbe()
+	c.ctx.constrainLt(a, b) // identical constraint: both bounds already present
+	require.Empty(t, p.ltEntries, "re-constraining a present bound journals nothing")
+	require.Len(t, a.UpperBounds, 1, "no duplicate bound is appended")
+
+	c.closeProbe(p, false) // discard is a clean no-op
+	require.Len(t, a.UpperBounds, 1, "the pre-probe bound is untouched by the no-op trial")
+	require.Equal(t, soltype.Lifetime(b), a.UpperBounds[0])
+}

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -1,0 +1,154 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A lifetime variable on the LEFT of an outlives constraint gains the right as an
+// upper bound; 'static on the right is the top of the lattice, so the constraint
+// holds with NO bound recorded.
+func TestConstrainLtVarOutlivesStatic(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	static := &soltype.StaticLifetime{}
+
+	c.ctx.constrainLt(a, static)
+
+	require.Equal(t, []soltype.Lifetime{static}, a.UpperBounds, "a <: 'static records 'static as a's upper bound")
+	require.Empty(t, a.LowerBounds)
+}
+
+// A var on the left gains an upper bound; a var on the right gains a lower bound.
+// A var-to-var constraint records BOTH directions so each variable sees the full
+// relationship at coalescing.
+func TestConstrainLtVarToVarRecordsBothDirections(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, b) // a outlives b
+
+	require.Equal(t, []soltype.Lifetime{b}, a.UpperBounds, "a gains b as an upper bound")
+	require.Empty(t, a.LowerBounds)
+	require.Equal(t, []soltype.Lifetime{a}, b.LowerBounds, "b gains a as a lower bound")
+	require.Empty(t, b.UpperBounds)
+}
+
+// Transitivity: with a <: b already recorded, constraining x <: a propagates
+// through a's existing upper bounds so x <: b is recorded too.
+func TestConstrainLtPropagatesTransitively(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+	x := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, b) // a <: b
+	c.ctx.constrainLt(x, a) // x <: a, which must propagate x <: b through a's uppers
+
+	require.Contains(t, x.UpperBounds, soltype.Lifetime(a), "x gains a directly")
+	require.Contains(t, x.UpperBounds, soltype.Lifetime(b), "x gains b transitively through a")
+}
+
+// A repeated outlives constraint does not re-append a bound already present.
+func TestConstrainLtDedupsBounds(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, b)
+	c.ctx.constrainLt(a, b) // identical constraint again
+
+	require.Len(t, a.UpperBounds, 1, "the duplicate upper bound is not re-appended")
+	require.Len(t, b.LowerBounds, 1, "the duplicate lower bound is not re-appended")
+}
+
+// A transitive cycle terminates: 'a <: 'b together with 'b <: 'a must not loop,
+// and each direction is recorded exactly once.
+func TestConstrainLtCycleTerminates(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	require.NotPanics(t, func() {
+		c.ctx.constrainLt(a, b)
+		c.ctx.constrainLt(b, a) // closes the cycle
+	})
+
+	require.Len(t, a.UpperBounds, 1)
+	require.Len(t, a.LowerBounds, 1)
+	require.Len(t, b.UpperBounds, 1)
+	require.Len(t, b.LowerBounds, 1)
+}
+
+// Constraining a lifetime against ITSELF is a no-op — neither a bound nor a loop.
+func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, a)
+
+	require.Empty(t, a.UpperBounds)
+	require.Empty(t, a.LowerBounds)
+}
+
+// A discarded probe truncates every lifetime bound the trial appended back to the
+// pre-probe length, exactly as it does for type-variable bounds — the second sort
+// rides the same journal discipline. Bounds added before the probe survive.
+func TestProbeDiscardRestoresLifetimeBounds(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	// Pre-probe bound on a, permanent.
+	c.ctx.constrainLt(a, b)
+	require.Len(t, a.UpperBounds, 1)
+
+	p := c.openProbe()
+	x := c.ctx.freshLifetime()
+	c.ctx.constrainLt(a, x) // a.UpperBounds: +1 ⇒ 2; x.LowerBounds: +1 ⇒ 1
+	require.Len(t, a.UpperBounds, 2)
+	require.Len(t, x.LowerBounds, 1)
+	require.Len(t, p.ltEntries, 2, "both touched lifetime vars are journaled")
+
+	c.closeProbe(p, false) // discard
+
+	require.Len(t, a.UpperBounds, 1, "the speculative upper bound on a is truncated away")
+	require.Equal(t, soltype.Lifetime(b), a.UpperBounds[0], "the pre-probe bound survives")
+	require.Empty(t, x.LowerBounds, "x's only bound was speculative")
+}
+
+// A committed lifetime-bound mutation survives — discard is what reverts, not the
+// journal's existence.
+func TestProbeCommitKeepsLifetimeBounds(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	p := c.openProbe()
+	c.ctx.constrainLt(a, b)
+	require.Len(t, a.UpperBounds, 1)
+	c.closeProbe(p, true) // commit
+
+	require.Len(t, a.UpperBounds, 1, "a committed probe makes the lifetime bound permanent")
+}
+
+// A committed child hands its lifetime-bound rollback obligation up to the parent,
+// so the parent's later discard still reverts the committed child's lifetime work.
+func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	parent := c.openProbe()
+	child := c.openProbe()
+	c.ctx.constrainLt(a, b) // child mutates a and b
+	require.Len(t, a.UpperBounds, 1)
+	c.closeProbe(child, true) // child commits — a/b become the parent's obligation
+
+	c.closeProbe(parent, false) // parent discards
+	require.Empty(t, a.UpperBounds, "the parent discard reverts the committed child's lifetime bound")
+	require.Empty(t, b.LowerBounds)
+}

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -8,9 +8,11 @@ import (
 )
 
 // A lifetime variable on the LEFT of an outlives constraint gains the right as an
-// upper bound. 'static is the top of the lattice, so `a <: 'static` always holds;
-// it is still recorded as a's upper bound, which is what drives a to 'static at
-// coalescing.
+// upper bound. 'static is the bottom of the lattice, so `'static <: a` is what always
+// holds; the reverse `a <: 'static` recorded here is the forcing escape constraint,
+// satisfiable only by a = 'static. Coalescing meets a negative-position variable's
+// upper bounds, and 'static is the bottom, so it absorbs that meet and a resolves to
+// 'static regardless of any other upper bound.
 func TestConstrainLtVarOutlivesStatic(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime()
@@ -53,7 +55,7 @@ func TestConstrainLtPropagatesTransitively(t *testing.T) {
 	require.Contains(t, x.UpperBounds, soltype.Lifetime(b), "x gains b transitively through a")
 }
 
-// Two DISTINCT 'static values denote the one lattice top, so constraining a
+// Two DISTINCT 'static values denote the one lattice bottom, so constraining a
 // variable against each in turn records a single 'static upper bound — dedup is by
 // value, not pointer. Origination sites mint a fresh &StaticLifetime{} per call, so
 // pointer-identity dedup would wrongly pile up duplicate 'static bounds.

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -52,6 +52,22 @@ func TestConstrainLtPropagatesTransitively(t *testing.T) {
 	require.Contains(t, x.UpperBounds, soltype.Lifetime(b), "x gains b transitively through a")
 }
 
+// Two DISTINCT 'static values denote the one lattice top, so constraining a
+// variable against each in turn records a single 'static upper bound — dedup is by
+// value, not pointer. Origination sites mint a fresh &StaticLifetime{} per call, so
+// pointer-identity dedup would wrongly pile up duplicate 'static bounds.
+func TestConstrainLtStaticDedupsByValue(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+
+	c.ctx.constrainLt(a, &soltype.StaticLifetime{})
+	c.ctx.constrainLt(a, &soltype.StaticLifetime{}) // a different 'static instance
+	c.ctx.constrainLt(a, soltype.Static)            // and the canonical singleton
+
+	require.Len(t, a.UpperBounds, 1, "all three 'static constraints collapse to one upper bound")
+	require.True(t, soltype.IsStaticLifetime(a.UpperBounds[0]))
+}
+
 // A repeated outlives constraint does not re-append a bound already present.
 func TestConstrainLtDedupsBounds(t *testing.T) {
 	c := newChecker()

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -42,14 +42,15 @@ import (
 // first consumer: each candidate overload is trialled under a probe and the
 // losers rolled back.
 //
-// M4 D1 adds a SECOND bounded sort, LifetimeVar. The probe stays concrete: rather
-// than abstract over "things with bound lists" (the plan's discarded `Bounded`
-// interface, which Go can't fit because the truncate methods would be unexported
-// on soltype types), it carries a PARALLEL journal — ltEntries / ltTouched /
-// recordLt — with the same length-snapshot + truncate-on-discard discipline as
-// the *TypeVarType path. The cost is two near-identical discard paths; the gain is
-// no speculation-only truncate verb on soltype's public surface and no
-// cross-package abstraction.
+// M4 D1 adds a SECOND bounded sort, LifetimeVar. The probe stays concrete instead
+// of abstracting over "things with bound lists". The plan's discarded `Bounded`
+// interface would have been that abstraction, but Go can't fit it because the
+// truncate methods would be unexported on soltype types. So the probe carries a
+// PARALLEL journal of its own: ltEntries, ltTouched, and recordLt. That journal
+// follows the same length-snapshot and truncate-on-discard discipline as the
+// *TypeVarType path. The cost is two near-identical discard paths. The gain is no
+// speculation-only truncate verb on soltype's public surface, and no cross-package
+// abstraction.
 type Probe struct {
 	entries   []probeEntry                  // one per touched type var, in first-touch order
 	touched   set.Set[*soltype.TypeVarType] // dedup: a type var is journaled at most once per probe

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -42,20 +42,22 @@ import (
 // first consumer: each candidate overload is trialled under a probe and the
 // losers rolled back.
 //
-// Deviation from the plan's sketch: the plan typed the journal over a `Bounded`
-// interface (boundLengths/truncateBounds) to abstract "things with bound lists".
-// Go can't add those (unexported) methods to soltype.TypeVarType from this
-// package, and M3 has exactly one bounded type, so the journal holds the concrete
-// *soltype.TypeVarType and truncates its exported bound fields directly — keeping
-// the speculation-only truncate out of soltype's public surface. If a second
-// bounded type appears, reintroduce the interface (with exported methods on the
-// soltype types) then.
+// M4 D1 adds a SECOND bounded sort, LifetimeVar. The probe stays concrete: rather
+// than abstract over "things with bound lists" (the plan's discarded `Bounded`
+// interface, which Go can't fit because the truncate methods would be unexported
+// on soltype types), it carries a PARALLEL journal — ltEntries / ltTouched /
+// recordLt — with the same length-snapshot + truncate-on-discard discipline as
+// the *TypeVarType path. The cost is two near-identical discard paths; the gain is
+// no speculation-only truncate verb on soltype's public surface and no
+// cross-package abstraction.
 type Probe struct {
-	entries  []probeEntry                  // one per touched variable, in first-touch order
-	touched  set.Set[*soltype.TypeVarType] // dedup: a var is journaled at most once per probe
-	cleanups []func()                      // Info / Prov rollback closures, registration order
-	parent   *Probe                        // enclosing probe (nil at top level)
-	done     bool                          // Commit/Discard are idempotent and mutually exclusive
+	entries   []probeEntry                  // one per touched type var, in first-touch order
+	touched   set.Set[*soltype.TypeVarType] // dedup: a type var is journaled at most once per probe
+	ltEntries []ltProbeEntry                // one per touched lifetime var, in first-touch order
+	ltTouched set.Set[*soltype.LifetimeVar] // dedup: a lifetime var is journaled at most once per probe
+	cleanups  []func()                      // Info / Prov rollback closures, registration order
+	parent    *Probe                        // enclosing probe (nil at top level)
+	done      bool                          // Commit/Discard are idempotent and mutually exclusive
 }
 
 // probeEntry snapshots one variable's bound-list lengths at the moment the probe
@@ -63,6 +65,15 @@ type Probe struct {
 // lengths, dropping exactly the bounds the trial appended.
 type probeEntry struct {
 	v         *soltype.TypeVarType
+	prevLower int
+	prevUpper int
+}
+
+// ltProbeEntry is probeEntry for the lifetime sort: it snapshots a LifetimeVar's
+// bound-list lengths at first touch so a discard truncates exactly the outlives
+// bounds the trial appended.
+type ltProbeEntry struct {
+	v         *soltype.LifetimeVar
 	prevLower int
 	prevUpper int
 }
@@ -100,6 +111,29 @@ func (p *Probe) record(v *soltype.TypeVarType) {
 	p.entries = append(p.entries, probeEntry{v: v, prevLower: len(v.LowerBounds), prevUpper: len(v.UpperBounds)})
 }
 
+// markLtTouched is markTouched for the lifetime sort: it dedups a LifetimeVar to
+// one journal entry per probe, lazily creating the set so a bare &Probe{} never
+// writes to a nil map.
+func (p *Probe) markLtTouched(v *soltype.LifetimeVar) bool {
+	if p.ltTouched == nil {
+		p.ltTouched = set.NewSet[*soltype.LifetimeVar]()
+	}
+	if p.ltTouched.Contains(v) {
+		return false
+	}
+	p.ltTouched.Add(v)
+	return true
+}
+
+// recordLt is record for the lifetime sort: it snapshots v's bound-list lengths
+// the first time this probe sees v, before the append that mutates it.
+func (p *Probe) recordLt(v *soltype.LifetimeVar) {
+	if !p.markLtTouched(v) {
+		return
+	}
+	p.ltEntries = append(p.ltEntries, ltProbeEntry{v: v, prevLower: len(v.LowerBounds), prevUpper: len(v.UpperBounds)})
+}
+
 // onRollback registers a closure to undo a side-table write (Info / Prov) made
 // under this probe. A discard runs the closures (see rollback); a commit hands
 // them to the parent (or drops them at top level).
@@ -127,6 +161,14 @@ func (p *Probe) rollback() {
 		e := p.entries[i]
 		if e.prevLower > len(e.v.LowerBounds) || e.prevUpper > len(e.v.UpperBounds) {
 			panic("probe.rollback: a journaled var's bounds were replaced or shortened, not appended — the append-only invariant is violated")
+		}
+		e.v.LowerBounds = e.v.LowerBounds[:e.prevLower]
+		e.v.UpperBounds = e.v.UpperBounds[:e.prevUpper]
+	}
+	for i := len(p.ltEntries) - 1; i >= 0; i-- {
+		e := p.ltEntries[i]
+		if e.prevLower > len(e.v.LowerBounds) || e.prevUpper > len(e.v.UpperBounds) {
+			panic("probe.rollback: a journaled lifetime var's bounds were replaced or shortened, not appended — the append-only invariant is violated")
 		}
 		e.v.LowerBounds = e.v.LowerBounds[:e.prevLower]
 		e.v.UpperBounds = e.v.UpperBounds[:e.prevUpper]
@@ -159,6 +201,7 @@ func (p *Probe) Commit() {
 	parent := p.parent
 	if parent == nil {
 		p.entries = nil
+		p.ltEntries = nil
 		p.cleanups = nil
 		return
 	}
@@ -169,8 +212,16 @@ func (p *Probe) Commit() {
 			parent.entries = append(parent.entries, e)
 		}
 	}
+	for _, e := range p.ltEntries {
+		// Same handoff for the lifetime sort: a lifetime var the parent hasn't
+		// journaled is inherited at the child's snapshot.
+		if parent.markLtTouched(e.v) {
+			parent.ltEntries = append(parent.ltEntries, e)
+		}
+	}
 	parent.cleanups = append(parent.cleanups, p.cleanups...)
 	p.entries = nil
+	p.ltEntries = nil
 	p.cleanups = nil
 }
 


### PR DESCRIPTION
Introduces the lifetime sort to the constraint solver, enabling inference and checking of borrow lifetimes. This is the first phase of lifetime support (M4 D1), landing the core machinery without yet attaching lifetimes to borrowed parameters (that arrives in D2).

**Key changes:**

- Add `Lifetime` interface with two concretes: `LifetimeVar` (an inference variable carrying outlives bounds) and `StaticLifetime` (the lattice top, representing unbounded lifetimes). Provide a canonical `Static` singleton and helper functions `IsStaticLifetime` and `ContainsLifetime` for deduplication by value.

- Implement `constrainLt(sub, super)` to assert the outlives relation between lifetimes. A variable on the left gains an upper bound, a variable on the right gains a lower bound. Var-to-var constraints record both directions so each variable sees the full relationship at coalescing. The rule terminates cycles via a `(sub, super)` keyed seen-set and propagates transitively through existing bounds.

- Extend the probe journal to track lifetime-variable mutations in parallel with type-variable mutations. Add `ltEntries` and `ltTouched` fields to `Probe`, along with `markLtTouched` and `recordLt` methods. A discarded probe truncates lifetime bounds back to their pre-probe lengths, mirroring the type-sort discipline.

- Add `freshLifetime`, `addLowerLtBound`, `addUpperLtBound`, and `recordLtMutation` to `Context`. Bound appends route through the add helpers so speculation trials journal them; `recordLtMutation` is a no-op when no probe is open.

- Update `RefType` printing to render the lifetime when present (e.g., `'a {x: number}` for an immutable borrow, `mut 'l2 {x: number}` for a mutable borrow with a lifetime variable).

- Add comprehensive unit tests covering constraint propagation, cycle termination, reflexivity, probe discard/commit semantics, and deduplication of 'static bounds.

The lifetime sort is now ready for use; the RefType constrain rule will activate it in D2 once lifetimes are attached to borrowed parameters.

https://claude.ai/code/session_019PVoG2cbTuVrnSuskbkVRZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lifetime “outlives” tracking for borrow/lifetime relationships.
  * Reference-type rendering now includes lifetime segments, including mapped retained lifetimes and `'static`.
  * Solver now propagates lifetime constraints and deduplicates consistent bounds.
* **Bug Fixes**
  * Improved speculative lifetime updates so trial rollbacks and commits behave correctly.
* **Tests**
  * Added extensive coverage for lifetime matching, printing, constraint propagation, cycle termination, and probe journaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->