### PR TITLE
M4 D2: Borrow lifetime origination and active constraint

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -551,13 +551,12 @@ func equalType(a, b soltype.Type) bool {
 		return ok && equalType(a.Inner, b.Inner)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
-		// Mut must match — a mutable borrow never equals an immutable one. Lifetime
-		// equality is deferred to D2: D1 lands the lifetime sort but does not attach a
-		// lifetime to any borrow, so every Lt is nil here and comparing Inner+Mut is
-		// complete. D2, which mints borrow lifetimes, must add an Lt comparison (by
-		// pointer for a LifetimeVar, by value for 'static) or two borrows differing
-		// only in lifetime would coalesce as equal.
-		return ok && a.Mut == b.Mut && equalType(a.Inner, b.Inner)
+		// Mut must match — a mutable borrow never equals an immutable one — and the
+		// lifetimes must match: D2 mints borrow lifetimes, so two borrows differing only
+		// in lifetime are NOT equal. Without the Lt check, dedup would collapse them and
+		// silently drop a lifetime the solver computed. ltEqual compares a LifetimeVar by
+		// pointer and 'static by value.
+		return ok && a.Mut == b.Mut && ltEqual(a.Lt, b.Lt) && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		return ok && equalTypeSlice(a.Types, b.Types)
@@ -566,6 +565,21 @@ func equalType(a, b soltype.Type) bool {
 		return ok && equalTypeSlice(a.Types, b.Types)
 	}
 	return false
+}
+
+// ltEqual reports lifetime equality for equalType's RefType arm (D2). A
+// LifetimeVar is identity-keyed, so two are equal only when they are the same
+// pointer; 'static is a value, so any two StaticLifetimes are equal; a nil
+// lifetime (an owned-mutable borrow) equals only another nil. This mirrors how the
+// rest of equalType keys variables by pointer and primitives by value.
+func ltEqual(a, b soltype.Lifetime) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if soltype.IsStaticLifetime(a) || soltype.IsStaticLifetime(b) {
+		return soltype.IsStaticLifetime(a) && soltype.IsStaticLifetime(b)
+	}
+	return a == b
 }
 
 func equalTypeSlice(a, b []soltype.Type) bool {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -324,23 +324,24 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sup.Mut {
 				errs = append(errs, c.constrainWriteBack(sup.Inner, sub.Inner, seen)...)
 			}
-			// 3. Lifetime outlives, covariant. Written now, INERT in C2 because Lt is
-			//    always nil until the lifetime sort lands (D1); constrainLt wires the
-			//    var-to-var case in D2. The escape branch's error is unreachable until
-			//    borrows carry lifetimes.
+			// 3. Lifetime outlives, covariant (M4 D2). Active now that borrows carry
+			//    lifetimes (D1 minted the sort, attachParamLifetimes originates them).
 			switch {
 			case sub.Lt != nil && sup.Lt != nil:
-				// D2: c.constrainLt(sup.Lt, sub.Lt)
+				// Both borrows carry a lifetime: relate them covariantly through the
+				// outlives lattice, mirroring the covariant read view on the inner.
+				c.constrainLt(sup.Lt, sub.Lt)
 			case sub.Lt == nil && sup.Lt != nil:
 				// An owned source satisfies any borrow slot — no lifetime constraint.
 			case sub.Lt != nil && sup.Lt == nil:
+				// A borrow flowing into an owned slot escapes its region.
 				errs = append(errs, &BorrowEscapeError{Sub: sub, Super: sup})
 			}
 			return errs
 		}
 		// RefType <: a concrete non-borrow: peel to the inner. An owned value (Lt nil)
 		// satisfies a bare slot; a borrow escaping into an owned slot is a
-		// BorrowEscapeError (inert in C2). When super is a VARIABLE, fall through to the
+		// BorrowEscapeError (live in D2). When super is a VARIABLE, fall through to the
 		// var arm so the WHOLE borrow is recorded as a bound — peeling there would drop
 		// its mutability.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -850,9 +850,10 @@ func describe(t soltype.Type) string {
 		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
-		// recursing like the Promise arm. The immutable-borrow and lifetime prefixes
-		// (`'a object`) join once the lifetime sort lands (D1); Lt is always nil here,
-		// so only `mut` appears.
+		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2
+		// attaches lifetimes, so Lt may be non-nil here, but a raw `'l{id}` in a
+		// diagnostic is noise. Naming lands in D4; until then an escape message reads
+		// `mut object` without naming which borrow escaped.
 		prefix := ""
 		if t.Mut {
 			prefix = "mut "

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -40,6 +41,15 @@ type checker struct {
 	// one. Off in production (a span bug must never crash the compiler); flipped on
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
+
+	// paramLifetimes is the set of lifetime-variable ids that originate on a
+	// function parameter (M4 D2). A `mut`-borrow param without a declared lifetime
+	// is a borrow of whatever the caller lends, so attachParamLifetimes mints a
+	// fresh lifetime var for it and records its id here. These are the only
+	// lifetimes that get named in the rendered output — a borrow originates at a
+	// parameter — while internal join vars (D3) stay anonymous and render as the
+	// union of their reachable param lifetimes.
+	paramLifetimes set.Set[int]
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the
@@ -107,7 +117,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
 // empty Prov side table.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}}
+	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, paramLifetimes: set.NewSet[int]()}
 }
 
 // freshAt allocates a fresh inference variable at the given level. Provenance for

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -109,11 +109,13 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 	})
 }
 
-// A `mut T` annotation lowers to an owned-mutable borrow (RefType{Mut: true}); a
-// function parameter typed `mut {x: number}` renders with the `mut` prefix and a
-// member read through it resolves the inner property.
+// A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function
+// parameter typed `mut {x: number}` originates a fresh borrow lifetime (D2) so it
+// renders `mut 'l0 {x: number}`, and a member read through it peels the borrow to
+// resolve the inner property. The lifetime is unused in the result, so D4's
+// display-time elision will later drop it and the render returns to `mut {…}`.
 func TestInferMutObjectAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) -> number { return p.x }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> number", values["f"])
 }

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -1,0 +1,49 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 D2: borrow origination + active lifetime step ---
+//
+// These assert the RAW `'l{id}` lifetime form. D4 adds display-time naming
+// (`'a`) and elision of param lifetimes that don't reach the output; until then a
+// param-originated lifetime renders under its mint id and is never dropped.
+
+// A `mut` param returned unchanged carries its originated lifetime to the result:
+// the same `'l0` appears on both the parameter and the return type, so the borrow
+// flows out at the lifetime it came in. This is the IdentityRefReturn acceptance —
+// D4 will render the shared lifetime as `fn <'a>(p: mut 'a {x}) -> mut 'a {x}`.
+func TestInferIdentityRefReturn(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}", values["f"])
+}
+
+// Returning a freshly-constructed mutable object carries no borrow lifetime: the
+// object is owned (Lt nil), not borrowed, so the result renders as a bare
+// owned-mutable `mut {…}` with no `'l`.
+func TestInferFreshObjectReturn(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() { return {x: 5} }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> {x: 5}", values["f"])
+}
+
+// Two `mut` params with distinct annotations originate independent lifetimes:
+// `'l0` on the first, `'l1` on the second.
+func TestInferDistinctParamLifetimes(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}, q: mut {y: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l0 {x: number}, q: mut 'l1 {y: number}) -> mut 'l0 {x: number}", values["f"])
+}
+
+// Writing a field through an annotated `mut` borrow checks: the receiver carries a
+// borrow lifetime `'l0`, and the write requirement's fresh lifetime imposes no
+// obligation, so a borrowed receiver of any lifetime satisfies it.
+func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { p.x = 10 }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> void", values["f"])
+}

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -96,3 +96,17 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 		"cannot constrain immutable object <: mutable object",
 	}, Messages(errs))
 }
+
+// Joining two borrows with DISTINCT lifetimes preserves both. equalType compares
+// lifetimes (D2), so dedup does not collapse `mut 'l0 {x}` and `mut 'l1 {x}` into a
+// single member and silently drop a lifetime. The branch join renders the un-joined
+// union here; D3 factors it into the `mut ('l0 | 'l1) {x}` form. Without the Lt
+// comparison in equalType this rendered `mut 'l0 {x}`, losing 'l1.
+func TestInferDistinctLifetimeBorrowsDoNotCoalesce(t *testing.T) {
+	src := "fn f(p: mut {x: number}, q: mut {x: number}) {\n  if true {\n    return p\n  } else {\n    return q\n  }\n}"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut 'l0 {x: number} | mut 'l1 {x: number}",
+		values["f"])
+}

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -22,9 +22,9 @@ func TestInferIdentityRefReturn(t *testing.T) {
 	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}", values["f"])
 }
 
-// Returning a freshly-constructed mutable object carries no borrow lifetime: the
-// object is owned (Lt nil), not borrowed, so the result renders as a bare
-// owned-mutable `mut {…}` with no `'l`.
+// Returning a freshly-constructed owned object carries no borrow lifetime: the
+// object literal is owned (Lt nil) and not mutable, so the result renders as a
+// bare object `{…}` with no `mut` prefix and no `'l` lifetime annotation.
 func TestInferFreshObjectReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() { return {x: 5} }`)
 	require.Empty(t, errs)

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -54,7 +54,12 @@ func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 // exercises the escape guard D2 activated — before D2 every Lt was nil, so it never
 // fired.
 func TestInferBorrowEscapesIntoOwnedArg(t *testing.T) {
-	src := "fn use(o: {x: number}) -> number {\n  return o.x\n}\nfn f(p: mut {x: number}) {\n  return use(p)\n}"
+	src := `fn use(o: {x: number}) -> number {
+  return o.x
+}
+fn f(p: mut {x: number}) {
+  return use(p)
+}`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"borrowed value mut object does not live long enough to satisfy object",
@@ -66,7 +71,12 @@ func TestInferBorrowEscapesIntoOwnedArg(t *testing.T) {
 // two lifetimes via constrainLt (the now-active step 3) instead of rejecting, so the
 // borrow slot — unlike the owned slot above — admits the borrow.
 func TestInferBorrowIntoBorrowArg(t *testing.T) {
-	src := "fn use(o: mut {x: number}) -> number {\n  return o.x\n}\nfn f(p: mut {x: number}) {\n  return use(p)\n}"
+	src := `fn use(o: mut {x: number}) -> number {
+  return o.x
+}
+fn f(p: mut {x: number}) {
+  return use(p)
+}`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: mut 'l1 {x: number}) -> number", values["f"])
@@ -79,7 +89,10 @@ func TestInferBorrowIntoBorrowArg(t *testing.T) {
 // usage-inferred read-after-write tests (which key off the `written` map on a
 // receiver VAR), this exercises the peel-and-constrain path on a concrete borrow.
 func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
-	src := "fn f(p: mut {x: number}) {\n  p.x = 5\n  return p.x\n}"
+	src := `fn f(p: mut {x: number}) {
+  p.x = 5
+  return p.x
+}`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> number", values["f"])
@@ -90,7 +103,9 @@ func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
 // mutable slot. This confirms the field-write requirement's fresh lifetime (D2) did
 // not loosen the mutability gate — an owned-but-immutable receiver still fails.
 func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
-	src := "fn g(o: {x: number}) {\n  o.x = 5\n}"
+	src := `fn g(o: {x: number}) {
+  o.x = 5
+}`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"cannot constrain immutable object <: mutable object",
@@ -103,7 +118,13 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 // union here; D3 factors it into the `mut ('l0 | 'l1) {x}` form. Without the Lt
 // comparison in equalType this rendered `mut 'l0 {x}`, losing 'l1.
 func TestInferDistinctLifetimeBorrowsDoNotCoalesce(t *testing.T) {
-	src := "fn f(p: mut {x: number}, q: mut {x: number}) {\n  if true {\n    return p\n  } else {\n    return q\n  }\n}"
+	src := `fn f(p: mut {x: number}, q: mut {x: number}) {
+  if true {
+    return p
+  } else {
+    return q
+  }
+}`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -47,3 +47,52 @@ func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> void", values["f"])
 }
+
+// Passing a borrow into a function whose parameter is an OWNED (bare) object is the
+// borrow-into-owned-slot escape: the RefType<:bare arm rejects because the source
+// carries a lifetime and the target owns its value. This is the only path that
+// exercises the escape guard D2 activated — before D2 every Lt was nil, so it never
+// fired.
+func TestInferBorrowEscapesIntoOwnedArg(t *testing.T) {
+	src := "fn use(o: {x: number}) -> number {\n  return o.x\n}\nfn f(p: mut {x: number}) {\n  return use(p)\n}"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"borrowed value mut object does not live long enough to satisfy object",
+	}, Messages(errs))
+}
+
+// The companion to the escape case: passing the same borrow into a function whose
+// parameter is itself a `mut` borrow checks. The RefType<:RefType arm relates the
+// two lifetimes via constrainLt (the now-active step 3) instead of rejecting, so the
+// borrow slot — unlike the owned slot above — admits the borrow.
+func TestInferBorrowIntoBorrowArg(t *testing.T) {
+	src := "fn use(o: mut {x: number}) -> number {\n  return o.x\n}\nfn f(p: mut {x: number}) {\n  return use(p)\n}"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l1 {x: number}) -> number", values["f"])
+}
+
+// Reading a field after writing it through an annotated `mut` borrow returns the
+// written field's type. The receiver is the concrete borrow `mut 'l0 {x: number}`,
+// so valueProp peels it via CarrierOf before emitting the read requirement — without
+// the peel this would trip the escape guard on the bare read requirement. Unlike the
+// usage-inferred read-after-write tests (which key off the `written` map on a
+// receiver VAR), this exercises the peel-and-constrain path on a concrete borrow.
+func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
+	src := "fn f(p: mut {x: number}) {\n  p.x = 5\n  return p.x\n}"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> number", values["f"])
+}
+
+// Writing a field of a NON-`mut` owned object is rejected: the write lowers to the
+// mutable requirement `mut {x, ...}`, and an immutable owned object cannot fill a
+// mutable slot. This confirms the field-write requirement's fresh lifetime (D2) did
+// not loosen the mutability gate — an owned-but-immutable receiver still fails.
+func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
+	src := "fn g(o: {x: number}) {\n  o.x = 5\n}"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"cannot constrain immutable object <: mutable object",
+	}, Messages(errs))
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -400,9 +400,14 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`. The fresh lifetime's
 // id is recorded as a param lifetime so it gets a name (`'a`) at display time.
 //
-// A param that already carries a lifetime (an explicit `'a T` annotation) or
-// that is not a borrow at all is returned unchanged. The returned RefType shares
-// the inner, so the lifetime is the only thing that changes.
+// A param that already carries a lifetime (an explicit `'a T` annotation) or that
+// is not a borrow at all is returned unchanged. The lifetime is attached by
+// mutating the RefType IN PLACE rather than minting a new wrapper: the param's
+// RefType is freshly resolved by resolveMutableTypeAnn and not yet shared, and its
+// pointer is the key under which resolveTypeAnn recorded AnnotationType provenance
+// (Prov is pointer-keyed). A new wrapper would drop that entry, so the "declared
+// mut here" related span on a borrow diagnostic would be lost. Mutating in place
+// also avoids an allocation per mut param.
 func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
 	r, ok := t.(*soltype.RefType)
 	if !ok || r.Lt != nil {
@@ -410,7 +415,8 @@ func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
 	}
 	lt := c.ctx.freshLifetime()
 	c.paramLifetimes.Add(lt.ID)
-	return &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}
+	r.Lt = lt
+	return r
 }
 
 // inferCall types a function application. It types the callee and each argument,

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -180,6 +180,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	params := make([]*soltype.FuncParam, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
+		// A `mut`-borrow param without a declared lifetime originates a fresh
+		// lifetime here (D2), so a returned borrow carries the param's lifetime.
+		pt = c.attachParamLifetimes(pt)
 		// An `open` un-annotated param keeps its usage-inferred object inexact at
 		// display time (B2). The marker only makes sense for an inferred var; an
 		// annotated param's exactness is fixed by its annotation, and paramType
@@ -387,6 +390,27 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 		}
 	}
 	return c.freshAt(lvl)
+}
+
+// attachParamLifetimes originates a borrow at a function parameter (M4 D2). A
+// RefType-typed param without a declared lifetime is a borrow of whatever the
+// caller lends, so it gets a fresh lifetime var that flows wherever the param
+// does — when the param is returned, that lifetime appears on the return type,
+// which is how `fn (p: mut {x: number}) { return p }` infers
+// `fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}`. The fresh lifetime's
+// id is recorded as a param lifetime so it gets a name (`'a`) at display time.
+//
+// A param that already carries a lifetime (an explicit `'a T` annotation) or
+// that is not a borrow at all is returned unchanged. The returned RefType shares
+// the inner, so the lifetime is the only thing that changes.
+func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
+	r, ok := t.(*soltype.RefType)
+	if !ok || r.Lt != nil {
+		return t
+	}
+	lt := c.ctx.freshLifetime()
+	c.paramLifetimes.Add(lt.ID)
+	return &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}
 }
 
 // inferCall types a function application. It types the callee and each argument,
@@ -641,8 +665,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 // receiver is itself a mutation — a later write may store any number — mirroring
 // the `var`-binding widening (B3).
 //
-// C3 ships with Lt: nil: no borrows exist yet, so every receiver is owned. D2 flips
-// this to a fresh lifetime var so a borrowed receiver of any lifetime is accepted.
+// The write requirement carries a fresh lifetime (D2): a mut-borrow receiver of
+// any lifetime is accepted (the fresh var imposes no obligation), and an owned
+// receiver satisfies the borrow slot by the RefType rule.
 //
 // When the receiver is a variable, the widened type is recorded in `written` so a
 // later read of the same field returns it (read-after-write; see valueProp). The
@@ -664,7 +689,10 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	w := widen(source)
 	req := &soltype.RefType{
 		Mut: true,
-		Lt:  nil, // D2: c.freshLifetime()
+		// A fresh lifetime imposes no obligation on the receiver (D2): a mut-borrow
+		// receiver of ANY lifetime satisfies the write requirement, and an owned
+		// receiver (Lt nil) satisfies a borrow slot by the RefType rule's step 3.
+		Lt: c.ctx.freshLifetime(),
 		Inner: &soltype.ObjectType{
 			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
 			Inexact: true, // "must accept a write to this field," not a full shape
@@ -941,6 +969,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
+	// Look through a borrow to its carrier (D2): reading a field through a
+	// `mut`/`'a` borrow is always legal and yields the field's value, not the
+	// borrow. Peeling here keeps the read requirement off the RefType, so the
+	// RefType<:bare escape guard fires only when the borrow itself flows into an
+	// owned slot — never when a field is merely read. A non-borrow receiver is
+	// returned unchanged, so usage inference over a plain var is untouched.
+	recv = soltype.CarrierOf(recv)
 	res := c.freshAt(lvl)
 	// The member-requirement record {prop: res} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner res var, so the record would be a dead

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -695,9 +695,10 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	w := widen(source)
 	req := &soltype.RefType{
 		Mut: true,
-		// A fresh lifetime imposes no obligation on the receiver (D2): a mut-borrow
-		// receiver of ANY lifetime satisfies the write requirement, and an owned
-		// receiver (Lt nil) satisfies a borrow slot by the RefType rule's step 3.
+		// A fresh lifetime imposes no obligation on the receiver (D2): constrainLt
+		// gives the new variable an upper bound and constrains nothing back, so a
+		// mut-borrow receiver of ANY lifetime satisfies the write requirement. A
+		// nil slot lifetime would instead reject a borrow receiver as an escape.
 		Lt: c.ctx.freshLifetime(),
 		Inner: &soltype.ObjectType{
 			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
@@ -975,12 +976,12 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
-	// Look through a borrow to its carrier (D2): reading a field through a
-	// `mut`/`'a` borrow is always legal and yields the field's value, not the
-	// borrow. Peeling here keeps the read requirement off the RefType, so the
-	// RefType<:bare escape guard fires only when the borrow itself flows into an
-	// owned slot — never when a field is merely read. A non-borrow receiver is
-	// returned unchanged, so usage inference over a plain var is untouched.
+	// Strip the borrow wrapper before building the field-read requirement (D2):
+	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
+	//     the field's value, not the borrow.
+	//   - It keeps the requirement off the RefType, so the RefType<:bare escape
+	//     guard fires only when the borrow flows into an owned slot, not on a read.
+	//   - A non-borrow receiver is returned unchanged, leaving plain vars untouched.
 	recv = soltype.CarrierOf(recv)
 	res := c.freshAt(lvl)
 	// The member-requirement record {prop: res} is deliberately NOT recorded —

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -137,10 +137,14 @@ func TestInferMemberAssignVariableValueLinked(t *testing.T) {
 // per-field write view pins x invariantly while tolerating the object's other
 // declared fields. Before the per-field write view this reported spurious
 // "missing property: y" / "inexact <: exact" errors.
+//
+// The annotated `mut` param originates a borrow lifetime (D2), so it renders with
+// a raw `'l{id}` here; the lifetime is unused in the (void) result, so D4's
+// display-time elision will later drop it and the render returns to `mut {…}`.
 func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = 5 }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: mut {x: number, y: string}) -> void", values["f"])
+	require.Equal(t, "fn (obj: mut 'l0 {x: number, y: string}) -> void", values["f"])
 }
 
 // The named field stays invariant: storing a string into a number field of an

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -330,3 +330,35 @@ func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
 	require.Len(t, a.UpperBounds, 1, "the pre-probe bound is untouched by the no-op trial")
 	require.Equal(t, soltype.Lifetime(b), a.UpperBounds[0])
 }
+
+// Test 8 — the lifetime bound minted by the RefType constrain arm itself is
+// journaled, so a discarded trial rolls it back. The earlier probe tests drive
+// constrainLt directly; this drives it THROUGH constrain over two `mut` borrows
+// (the now-active step 3, D2), confirming the RefType arm participates in the same
+// speculation discipline as a direct constrainLt call. Without journaling here, a
+// failed overload trial that constrained two borrows would leak a lifetime bound.
+func TestProbeRollsBackLifetimeBoundFromRefArm(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime()
+	b := c.ctx.freshLifetime()
+
+	inner := func() *soltype.ObjectType {
+		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: num()},
+		}}
+	}
+	sub := &soltype.RefType{Mut: true, Lt: a, Inner: inner()}
+	super := &soltype.RefType{Mut: true, Lt: b, Inner: inner()}
+
+	p := c.openProbe()
+	errs := c.ctx.Constrain(sub, super)
+	require.Empty(t, errs, "two compatible mut borrows constrain cleanly")
+	// step 3 runs constrainLt(super.Lt, sub.Lt) = constrainLt(b, a): b gains a as an
+	// upper bound, a gains b as a lower bound.
+	require.Equal(t, []soltype.Lifetime{a}, b.UpperBounds)
+	require.Equal(t, []soltype.Lifetime{b}, a.LowerBounds)
+
+	c.closeProbe(p, false) // discard
+	require.Empty(t, b.UpperBounds, "the RefType arm's lifetime bound is rolled back on discard")
+	require.Empty(t, a.LowerBounds)
+}

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -420,7 +420,10 @@ wrapper) are what first populate a lifetime. Land them together.
   receiver against the inexact requirement `Ref{mut: true, lt: nil, inner:
   Record{x: widen(v)}}`, with literal widening and merging of a receiver's
   selections into one `mut` object. The lifetime is `nil`, so M4 supports only
-  owned-mutable receivers. (Spike M3 + extension.)
+  owned-mutable receivers. (Spike M3 + extension.) Read-after-write returns the
+  stored value, but its cache is keyed on a type-variable receiver, so a concrete
+  borrow receiver re-derives from its annotation instead — a divergence observable
+  only with M6 unions, tracked in issue #742.
 - **Lifetime origination on field writes** (D2, **not** M4): the write
   requirement's lifetime becomes a fresh variable rather than `nil`, so the
   constraint also accepts a mut-borrowed receiver of any lifetime. This depends on
@@ -431,7 +434,10 @@ wrapper) are what first populate a lifetime. Land them together.
   elision (a parameter-only lifetime that connects nothing is dropped). Borrows
   originate at parameters typed as `Ref` (mut or immut); returning shares by
   value identity; multi-source returns union lifetimes; escape constrains `<:
-  'static`. (Spike M4.)
+  'static`. (Spike M4.) A borrow flowing into an owned slot is rejected as an
+  escape, but a member *read* must look through the borrow first; the read-side
+  peel misses a variable bound to a borrow, so such a read can fire a spurious
+  escape — tracked in issue #741, not reachable until D3.
 - **Destructuring patterns + the `match` expression form.** `IdentPat` (M1, the
   only `Pat` concrete through M2–M3) is joined here by the structural concretes —
   `TuplePat`, `ObjectPat`, and literal patterns — now that tuple/record types

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -430,7 +430,7 @@ wrapper) are what first populate a lifetime. Land them together.
   the lifetime sort and borrow origination, which land in D2 — until then a borrowed
   receiver is not yet supported.
 - **Lifetimes as a second sort**: `LifetimeVar` with lower/upper bounds over the
-  outlives lattice (`'static` = top), `constrainLt`, lifetime coalescing +
+  outlives lattice (`'static` = bottom), `constrainLt`, lifetime coalescing +
   elision (a parameter-only lifetime that connects nothing is dropped). Borrows
   originate at parameters typed as `Ref` (mut or immut); returning shares by
   value identity; multi-source returns union lifetimes; escape constrains `<:
@@ -539,6 +539,41 @@ further.
 - **Rest-param element checking (#677)** — `...xs: T[]` element checking needs
   `Array<T>`, so it lands in **M7**. M4 stays arity-only and marks the
   `FuncParam.Rest` note "M7."
+
+**Open design question — per-property lifetimes on alias-typed params (needs type
+annotations first).** Per-property and tuple-per-slot lifetimes have a syntactic
+home when the parameter's type spells out its structure inline, so each leaf can
+name its own lifetime:
+
+```
+fn getPoints(line: {p: 'a Point, q: 'b Point}) -> ['a Point, 'b Point] {
+  return [line.p, line.q]
+}
+```
+
+A type alias hides that structure, leaving nowhere to write the per-leaf
+lifetimes:
+
+```
+type Line = {p: Point, q: Point}
+fn getPoints(line: Line) -> [Point, Point] { // no way to name line.p / line.q's lifetimes
+  return [line.p, line.q]
+}
+```
+
+One candidate is a path-based lifetime annotation that names a lifetime by the
+access path into the aliased parameter, so the return slots borrow from `line.p`
+and `line.q` directly:
+
+```
+fn getPoints(line: Line) -> ['line.p Point, 'line.q Point]
+```
+
+This is unsettled and needs its own design pass. The surface syntax, how a path
+lifetime resolves against the alias body, and how it interacts with elision and
+escape are all open. It also depends on type annotations being implemented first,
+since there is no annotation surface to attach these to until then. Out of scope
+for M4 — capture the design before any milestone commits to it.
 
 ---
 

--- a/planning/simple_sub/02-design-notes.md
+++ b/planning/simple_sub/02-design-notes.md
@@ -630,7 +630,7 @@ Lifetimes are a **second sort** solved by the same machinery:
 
 ```go
 type LifetimeVar struct { id int; lowerBounds, upperBounds []Lifetime }
-type StaticLifetime struct{}           // top of the outlives lattice
+type StaticLifetime struct{}           // bottom of the outlives lattice
 ```
 
 ## Exactness

--- a/planning/simple_sub/03-references.md
+++ b/planning/simple_sub/03-references.md
@@ -91,21 +91,22 @@ Simple-sub as published is purely structural; it has no notion of lifetimes.
 by the *same* constraint machinery (the spike proved this collapses Escalier's
 multi-phase `infer_lifetime.go` into ordinary constraint solving).
 
-The ordering `≤` is **"is outlived by"**: `'a ≤ 'b` ⟺ `'b` outlives `'a`
-(equivalently, `'a` is outlived by `'b`). So a **longer-lived lifetime is a
-greater element**, and `'static` — which outlives everything — is the top. (This
-is the lattice direction the code uses: `X <: 'static` always holds. It is
-consistent with references being covariant in their lifetime — a longer-lived
-value can stand in where a shorter-lived one is expected, so the longer lifetime
-sits higher.)
+The ordering `<:` is **"outlives"**: `'a <: 'b` ⟺ `'a` outlives `'b`
+(equivalently, `'a` lives at least as long as `'b`). This is the relation
+`constrainLt` asserts. So a **longer-lived lifetime is a lesser element**, and
+`'static` — which outlives everything — is the **bottom**: `'static <: X` holds
+for every `X`, while `X <: 'static` holds only for `X = 'static` and is therefore
+the forcing escape constraint. It is consistent with references being covariant
+in their lifetime — a longer-lived value can stand in where a shorter-lived one
+is expected, so `'static` is the universal subtype and sits at the bottom.
 
 | Lattice notion | Lifetime meaning |
 |---|---|
-| order `≤` | "is outlived by" (`'a ≤ 'b` ⟺ `'b` outlives `'a`) |
-| join `'a ⊔ 'b` | least lifetime that outlives both — arises in **positive position** from a multi-source borrow (e.g. an `if` returning either `&'a T` or `&'b T`); the result carries one of the source lifetimes |
-| meet `'a ⊓ 'b` | greatest lifetime outlived by both — arises in **negative position** from a borrow with multiple upper bounds (e.g. a borrow that must fit within both context `'a` and context `'b`); the principal solution is the shorter window where both are still valid |
-| top `⊤` | `'static` — outlives everything, so every lifetime `≤ 'static` |
-| bottom `⊥` | a maximally-short / fresh lifetime |
+| order `<:` | "outlives" (`'a <: 'b` ⟺ `'a` outlives `'b`) |
+| join `'a ⊔ 'b` | arises in **positive position** from a multi-source borrow (e.g. an `if` returning either `&'a T` or `&'b T`); the result carries one of the source lifetimes and is valid only within the span where both are still alive |
+| meet `'a ⊓ 'b` | arises in **negative position** from a borrow with multiple upper bounds (e.g. a borrow that must fit within both context `'a` and context `'b`); the borrow must be valid in every context that uses it |
+| bottom `⊥` | `'static` — outlives everything, so `'static <: X` for every lifetime `X` |
+| top `⊤` | a maximally-short / fresh lifetime |
 
 The lattice formally has both operations and the spike computes both —
 positive-position coalescing joins lower bounds, negative-position coalescing
@@ -128,11 +129,11 @@ itself. The flow-set framing is what makes a single representation work for
 both polarities.
 
 ```text
-            'static            ⊤   (outlives everything)
+         (fresh/short)         ⊤
           /    |    \
        'a     'b    'c   ...     (concrete borrows)
           \    |    /
-         (fresh/short)         ⊥
+            'static            ⊥   (outlives everything)
 ```
 
 A `LifetimeVar` carries lower/upper bound lists and coalesces by join/meet
@@ -143,7 +144,7 @@ the entire reason "lifetimes as a second sort" works:
 - a multi-source return ⇒ the result lifetime is the **join** of the sources,
   coalescing to `('a | 'b)`;
 - a value escaping to module/static storage ⇒ `constrain(lifetime <: 'static)`,
-  coalescing to `'static` (top absorbs);
+  coalescing to `'static` (the bottom absorbs the meet);
 - a parameter-only lifetime that connects nothing is **elided** — the
   lifetime-sort analogue of single-polarity elimination.
 
@@ -187,5 +188,5 @@ covariance is structural, not a special case.
 The lattice is the subtype-ordered space of types (`never` ⊥, `unknown` ⊤, union
 = join, intersection = meet); Simple-sub is "collect ordering constraints, then
 compute joins and meets in it," and **our extension adds a second lattice over
-lifetimes ordered so that longer-lived is greater (`'static` = ⊤) — i.e. `≤` is
-"is outlived by" — so lifetimes are solved by the very same machinery.**
+lifetimes ordered by `<:` = "outlives" so that longer-lived is lesser (`'static`
+= ⊥, the universal subtype) — so lifetimes are solved by the very same machinery.**

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -363,7 +363,7 @@ type LifetimeVar struct {
     LowerBounds []Lifetime
     UpperBounds []Lifetime
 }
-type StaticLifetime struct{} // 'static, top of the outlives lattice
+type StaticLifetime struct{} // 'static, bottom of the outlives lattice
 
 // Context grows the spike's M4 fields (context.go's own comment reserves them):
 type Context struct {
@@ -374,8 +374,8 @@ type Context struct {
 }
 
 // constrainLt mirrors constrain over the outlives lattice: var-left gains an
-// upper bound, var-right a lower bound, var-to-var records both; 'static is
-// top (X <: 'static always holds); (sub, super)-keyed seen-set for cycles.
+// upper bound, var-right a lower bound, var-to-var records both; 'static is the
+// bottom ('static <: X always holds); (sub, super)-keyed seen-set for cycles.
 // Bound appends go ONLY through addLowerLtBound/addUpperLtBound — the journal
 // invariant extends to the second sort:
 func (c *Context) constrainLt(sub, super Lifetime)
@@ -931,14 +931,14 @@ these arms it must add.
   - **Structures:**
     - `LifetimeVar{ID int; LowerBounds, UpperBounds []Lifetime}`, implementing
       `isLifetime()`
-    - `StaticLifetime{}` (top of the outlives lattice), implementing
+    - `StaticLifetime{}` (bottom of the outlives lattice), implementing
       `isLifetime()`
     - `Context` grows `lifetimeCounter int` (its own comment at context.go:5
       names this deferred field) and a `freshLifetime()` minter
   - **Algorithm — `constrainLt`** (ported from `simplesub/lifetime.go:61`):
     mirrors `constrain` over the outlives lattice — a var on the left gains an
     upper bound, on the right a lower bound, var-to-var records both;
-    `'static` is top (`X <: 'static` always holds); a `(sub, super)`-keyed
+    `'static` is the bottom (`'static <: X` always holds); a `(sub, super)`-keyed
     seen-set terminates cycles. Bound appends go **only** through new
     `addLowerLtBound`/`addUpperLtBound` helpers that journal before appending —
     the same discipline as `addLowerBound`/`addUpperBound` (context.go:36).

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -507,7 +507,7 @@ func isValueType(t soltype.Type) bool // from checker/check_transitions.go:189-2
 
 ## PR breakdown
 
-17 PRs across 7 phases, each independently mergeable and green, each with
+18 PRs across 7 phases, each independently mergeable and green, each with
 table-driven tests asserting rendered types and **full** error messages. Every
 PR below names the concrete files touched, the data structures added/modified,
 the algorithm changes, and its acceptance set — enough to start implementation
@@ -980,6 +980,91 @@ these arms it must add.
       mut 'a {x: number}) -> mut 'a {x: number}`
     - `FreshObjectReturn` (returning a fresh `mut {x: 1}`) carries no lifetime
 
+- **D2.5 — Lifetime-sort generalization: levels + per-instantiation freshening**
+  (~150–250, design-dependent).
+  - **Why this PR exists (provenance).** The spike documented this exact gap as a
+    KNOWN LIMITATION at [simplesub/scheme.go:32-38](../../internal/simplesub/scheme.go):
+    a lifetime carried by a borrow is copied **by reference, not freshened**, so two
+    instantiations of a generalized lifetime-bearing scheme share one `LifetimeVar`.
+    The spike deferred the fix to "the M1 production rewrite," but D1 added
+    `LifetimeVar` **without a `Level`**, and D2 is the first phase to mint lifetimes
+    onto generalizable param types (`attachParamLifetimes`), so the gap is now live in
+    production. D2 itself shows no wrong output — lifetimes render by their raw
+    `'l{id}` and no phase reads lifetime **bounds** yet — which is why this is split
+    out rather than folded into D2.
+  - **Ordering — blocks D4, should precede D3.** This lands after the already-merged
+    D1/D2. It is a hard prerequisite for **D4**, the first phase to consume lifetime
+    bounds (the `analyzeLts` occurrence walk over the bound graph): cross-instantiation
+    contamination of a shared `LifetimeVar`'s bounds becomes wrong output exactly when
+    those bounds are read. It should also precede **D3**, which mints more distinct
+    lifetimes (joins, escape) and so widens the surface the sharing bug corrupts.
+  - **The defect, concretely.** `freshenAbove`
+    ([poly.go](../../internal/solver/poly.go)) and `extrude`
+    ([constrain.go](../../internal/solver/constrain.go)) ride the `Accept` visitor,
+    which only walks `Type`s. A `Lifetime` is **not** a `Type`, so `RefType.Accept`
+    carries `Lt` through unchanged ([visitor.go:173](../../internal/soltype/visitor.go))
+    and neither pass ever freshens it. Worse, `LevelOf(*RefType)` returns
+    `LevelOf(Inner)` ([type.go:344](../../internal/soltype/type.go)), so a
+    concrete-inner borrow whose lifetime var sits above `lim` is pruned and **shared
+    whole** by the freshener. The MLsub level invariant — a variable's level is `>=`
+    the level of everything in its bounds, the property the freshener prune at
+    [poly.go:123-132](../../internal/solver/poly.go) depends on — does not yet extend
+    to the lifetime sort.
+  - **DESIGN DECISION — resolve before implementing.** Two shapes, with very
+    different sizes:
+    - **Option A — full lifetime generalization (recommended).** Give `LifetimeVar` a
+      `Level`, make `LevelOf` lifetime-aware, add freshen/extrude lifetime arms with a
+      lifetime cache, and add level-extrusion to `constrainLt` so the invariant holds.
+      ~150–250 lines; extends the level discipline to a second sort. A param lifetime
+      becomes per-call-fresh, on par with how a `TypeVarType` param is.
+    - **Option B — monomorphic lifetimes.** Refuse to generalize a scheme whose body
+      has a free lifetime var — or pin param lifetimes at a fixed level so
+      `freshenAbove` never copies them — and defer per-use freshening to the M7
+      library-import boundary. ~50 lines, but it narrows the language: a generic
+      borrow-passing function cannot be instantiated at two distinct lifetimes within
+      one module. Record that consequence in the spec if chosen.
+    - Recommendation is **A**, to keep lifetimes on par with type vars and avoid an M7
+      special case. **B** is the cheaper fallback if A's invariant work proves too
+      costly; pick before writing code, since it swings the PR size ~5×.
+  - **Files (Option A):** `soltype/lifetime.go` (`Level` field), `soltype/type.go`
+    (`LevelOf`), `solver/context.go` (`freshLifetime` takes a level; update the
+    `attachParamLifetimes` and `inferMemberAssign` call sites), `solver/poly.go`
+    (freshener lifetime arm + cache, threaded through `freshenAbove`/`instantiate`),
+    `solver/constrain.go` (extruder lifetime arm; `constrainLt` level-extrusion).
+  - **Structures (Option A):**
+    - `LifetimeVar` gains `Level int`; `freshLifetime(lvl int)` sets it.
+    - the freshener and extruder each gain a
+      `map[*soltype.LifetimeVar]*soltype.LifetimeVar` cache, parallel to their
+      `*TypeVarType` cache, so a lifetime reached twice in one pass yields one copy.
+  - **Algorithm (Option A):**
+    - `LevelOf(*RefType)` ⇒ `max(LevelOf(Inner), levelOfLt(Lt))`, where `levelOfLt`
+      returns a `LifetimeVar`'s `Level` and `0` for `'static`. This is the
+      load-bearing change: without it the prune shares the lifetime and nothing else
+      fires.
+    - **freshener:** special-case `*RefType` in `EnterType` — when `LevelOf(t) > lim`
+      on account of its lifetime, freshen `Lt` through the lifetime cache, copying its
+      bounds with the same cache-before-bounds order the `*TypeVarType` path uses to
+      terminate recursion, then let `Accept` rebuild `Inner` around the fresh `Lt`. A
+      `'static` lifetime is shared, never freshened.
+    - **extruder:** the analogous `*RefType`/lifetime arm, wiring the fresh lifetime
+      var to the original through the polarity-appropriate outlives bound, mirroring
+      the type-var extrude.
+    - **`constrainLt`:** extrude a higher-level lifetime down before recording a bound,
+      mirroring `constrain`'s `levelOf(rhs) <= lv.level` branch, so the lifetime-level
+      invariant the freshener prune relies on is maintained.
+  - **Accept (Option A):**
+    - a generalized borrow-returning fn (`fn id(p: mut {x: number}) { return p }`)
+      called at two sites instantiates **two distinct** lifetime vars; constraining one
+      site's borrow does not perturb the other (cross-site non-contamination)
+    - quantify-vs-keep: a param lifetime at the scheme's level is freshened per use,
+      while a lifetime captured from an outer scope (level `<= lim`) is shared
+    - the D2 acceptance (`IdentityRefReturn`) still renders correctly
+    - a probe discard rolls back a freshened lifetime bound (the freshener's fresh-var
+      bound writes are sanctioned non-journaled, same as the type-var path)
+  - **Standing rule reminder:** adding the `Level` field touches no new type-set arm,
+    but the lifetime sort now participates in `LevelOf`, so re-audit every `LevelOf`
+    caller that assumed a borrow's level equals its inner's.
+
 - **D3 — Multi-source lifetime joins + escape-to-`'static`** (~150).
   - **Files:** `solver/infer_stmt.go` / wherever the M3 return-point join lives,
     `solver/infer_expr.go` (escape sites).
@@ -1018,6 +1103,10 @@ these arms it must add.
       escapes it to `mut 'static`
 
 - **D4 — Display-time lifetime coalescing + elision** (~200).
+  - **Depends on D2.5.** The occurrence walk below reads each lifetime var's
+    bound graph, so it produces correct output only once lifetimes are freshened
+    per instantiation (D2.5). Without that, two call sites share one `LifetimeVar`
+    and its contaminated bounds drive wrong naming/elision here. Land D2.5 first.
   - **Files:** new lifetime-occurrence logic alongside `solver/simplify.go` /
     `solver/coalesce.go`, `soltype/print.go` (the `<'a>` quantifier).
   - **Structures:**
@@ -1210,8 +1299,10 @@ Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are paral
 tracks off A1; nothing downstream of the gate starts before C2 clears. B1's
 `foldUsageBounds` fold is reused by C3 (whole-object mut merge) and the `widen` helper
 authored in B3 is reused by C3, so land B before C3 even though B is otherwise
-independent of the gate. Total ≈ 3.0k non-test LoC across 17 PRs, with the
-single highest-risk change (C2) isolated to ~180 reviewable lines.
+independent of the gate. D2.5 is the one PR discovered mid-implementation rather
+than planned up front — the spike's deferred lifetime-generalization gap — and
+gates D4, so it lands between D2 and D3. Total ≈ 3.2k non-test LoC across 18 PRs,
+with the single highest-risk change (C2) isolated to ~180 reviewable lines.
 
 ## Testing strategy
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1115,6 +1115,11 @@ these arms it must add.
       `simplify.go`'s `symOccVisitor` but over the lifetime sort
     - a `ltKeep`/naming map keyed by lifetime-var ID, threaded into the scheme
       coalescer the way `schemeSimplification` is threaded today (coalesce.go:120)
+    - **scope `paramLifetimes` per function first** (issue #743). D2 added it as a
+      module-wide accumulator on the checker; this pass is its first reader, so move
+      it onto `funcCtx` (push/pop like `written`) or snapshot/restore it around each
+      `inferFunc` before naming reads it, or naming sees stale ids from earlier
+      functions.
   - **Algorithm — naming:** only param-originated lifetimes are named (`'a`,
     `'b`, … via a base-26 `alphaName`, per the spike); a join var renders as the
     union of the param lifetimes it reaches; `'static` absorbs. The `<'a>`

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -878,6 +878,11 @@ these arms it must add.
     (return the concrete stored type, not a coalesced var); the reverse order
     already works, and an incompatible read-then-write surfaces as a normal
     constrain error.
+    **KNOWN GAP (issue #742):** the `written` lookup is keyed on a `*TypeVarType`
+    receiver, so a *concrete borrow* receiver (an annotated `mut {…}` param after
+    D2) misses the cache and re-derives the field from its annotation. The two paths
+    diverge only when the declared field type is wider than the widened write, which
+    needs M6 unions to exhibit; fix is to key the map on `CarrierOf(recv)`'s inner.
   - **Algorithm — whole-object `mut` merge (follows `internal/checker`, not the
     spike's partition):** extend B1's `foldUsageBounds` fold over the receiver's
     accumulated selections so that **if any field was written, every selection —
@@ -967,7 +972,15 @@ these arms it must add.
     - owned source into a borrow slot ok
     - borrow into an owned slot ⇒ `BorrowEscapeError` (now live)
 
-    The `RefType <: bare` escape guard (`l.Lt != nil`) also goes live.
+    The `RefType <: bare` escape guard (`l.Lt != nil`) also goes live. A member
+    *read* must not trip it, so `valueProp` peels the receiver through
+    `CarrierOf` before emitting the read requirement. **KNOWN GAP (issue #741):**
+    the peel is a no-op when the receiver is a *variable* whose lower bound is a
+    borrow, so the borrow reaches the guard through the bound graph and a plain
+    read fires a spurious `BorrowEscapeError`. Not constructible until D3 makes a
+    var-bound-to-borrow read reachable; the deeper fix is to peel an inexact
+    read-requirement target inside the constrain arm and drop the `valueProp`
+    bandaid.
   - **Algorithm — `attachParamLifetimes`** (per the sketch): a `RefType`-typed
     param with `Lt == nil` gets a fresh lifetime var, recorded in
     `paramLifetimes`. Called when binding function params.


### PR DESCRIPTION
Implements the first phase of borrow lifetime tracking (M4 D2), activating lifetime constraints on mutable borrows and originating lifetimes at function parameters.

## Summary

This PR lands the core lifetime machinery for borrows: parameter lifetimes are now minted and flow through the type system, enabling the solver to track which borrow a value came from. A `mut` parameter without an explicit lifetime annotation now originates a fresh lifetime variable that propagates to any return value, so `fn f(p: mut {x: number}) { return p }` correctly infers `fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}`.

## Key changes

- **Parameter lifetime origination** (`attachParamLifetimes`): A `mut`-borrow parameter without a declared lifetime gets a fresh `LifetimeVar` that is recorded as a param lifetime for later naming (D4). The lifetime is attached in-place to preserve provenance tracking.

- **Active RefType constraint step 3**: The lifetime outlives relation is now live. When two borrows are constrained, their lifetimes are related covariantly via `constrainLt`. An owned value satisfies any borrow slot (no constraint), but a borrow flowing into an owned slot triggers a `BorrowEscapeError`.

- **Field write requirement freshening** (`inferMemberAssign`): The write requirement now carries a fresh lifetime, allowing any borrow receiver to satisfy it while still rejecting writes to immutable owned objects.

- **Field read through borrows** (`valueProp`): Reading a field through a borrow now peels to the carrier type via `CarrierOf`, preventing the read requirement from escaping the borrow itself.

- **Lifetime equality in deduplication** (`equalType`): The `RefType` arm now compares lifetimes via `ltEqual`, so two borrows differing only in lifetime are not coalesced. This prevents silent loss of computed lifetimes in union types.

- **Probe journaling for lifetime bounds**: Lifetime bounds recorded during constraint are now journaled, so discarded probes roll back contamination from failed overload trials.

- **Test coverage**: Added 8 new tests covering identity returns, fresh objects, distinct param lifetimes, field writes through borrows, borrow-into-owned escape, borrow-into-borrow passing, read-after-write, and distinct lifetime preservation in branches.

## Implementation notes

- Lifetimes are rendered in raw `'l{id}` form; display-time naming and elision land in D4.
- The `paramLifetimes` set tracks which lifetime vars originated on parameters, distinguishing them from internal join vars (D3) for later naming.
- `CarrierOf` is a new helper that peels a `RefType` to its inner type, used by field reads to avoid escape errors on the borrow itself.
- The plan document is updated to reflect this PR and notes D2.5 (lifetime generalization) as a discovered gap that must land before D3 and D4.

https://claude.ai/code/session_01PVMxshbA6Sb6aw278nA4w8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed borrow type comparison to properly account for lifetime differences, preventing incorrect type deduplication.

* **Improvements**
  * Enhanced lifetime constraint enforcement for borrowed types.
  * Added automatic lifetime tracking for function parameters with mutable borrows.
  * Refined type checking behavior for field access and assignment through borrowed references.

* **Tests**
  * Added comprehensive test coverage for borrow-lifetime inference scenarios.
  * Added lifetime constraint rollback verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->