### PR TITLE
Extend lifetime variables to the let-generalization level hierarchy

### DIFF
--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -22,8 +22,19 @@ type Lifetime interface{ isLifetime() }
 // lists are extended ONLY through the solver's
 // addLowerLtBound/addUpperLtBound helpers, mirroring the type-sort discipline so
 // a discarded speculation trial truncates them back.
+//
+// Level brings the lifetime sort into the let-generalization hierarchy that
+// TypeVarType already rides (M4 D2.5). A lifetime minted onto a generalizable
+// parameter sits ABOVE its scheme's generalize-level, so instantiate freshens it
+// per use just as it does a type parameter, and two call sites of a
+// borrow-passing function never share one LifetimeVar's bounds. The MLsub level
+// invariant extends to this sort: a LifetimeVar's Level is >= the Level of every
+// lifetime in its bounds, maintained by constrainLt's level extrusion. LevelOf's
+// RefType arm reads it through LevelOfLifetime so the freshener/extruder prune
+// stays sound.
 type LifetimeVar struct {
 	ID          int
+	Level       int
 	LowerBounds []Lifetime
 	UpperBounds []Lifetime
 }
@@ -48,6 +59,18 @@ func (*StaticLifetime) isLifetime() {}
 func IsStaticLifetime(lt Lifetime) bool {
 	_, ok := lt.(*StaticLifetime)
 	return ok
+}
+
+// LevelOfLifetime is the lifetime-sort twin of LevelOf for a single Lifetime: a
+// LifetimeVar's own Level, and 0 for 'static or a nil slot (neither carries a
+// quantifiable variable). LevelOf's RefType arm folds this into the wrapper's
+// level so the freshener/extruder level prune accounts for a borrow's lifetime,
+// not just its inner.
+func LevelOfLifetime(lt Lifetime) int {
+	if lv, ok := lt.(*LifetimeVar); ok {
+		return lv.Level
+	}
+	return 0
 }
 
 // ContainsLifetime reports whether lt is already present in bounds, so a repeated

--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -62,10 +62,10 @@ func IsStaticLifetime(lt Lifetime) bool {
 }
 
 // LevelOfLifetime is the lifetime-sort twin of LevelOf for a single Lifetime: a
-// LifetimeVar's own Level, and 0 for 'static or a nil slot (neither carries a
-// quantifiable variable). LevelOf's RefType arm folds this into the wrapper's
-// level so the freshener/extruder level prune accounts for a borrow's lifetime,
-// not just its inner.
+// LifetimeVar's own Level, and 0 for 'static or a nil slot. Neither 'static nor a
+// nil slot carries a quantifiable variable. LevelOf's RefType arm folds this into
+// the wrapper's level so the freshener/extruder level prune accounts for a borrow's
+// lifetime, not just its inner.
 func LevelOfLifetime(lt Lifetime) int {
 	if lv, ok := lt.(*LifetimeVar); ok {
 		return lv.Level

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -342,9 +342,14 @@ func LevelOf(t Type) int {
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:
-		// Inner is a RefInner, which embeds Type; the borrow wrapper itself carries
-		// no variable, so the level is its content's.
-		return LevelOf(t.Inner)
+		// A borrow's level is the max of its inner content's and its lifetime's (M4
+		// D2.5). The lifetime is a SECOND quantifiable variable on the wrapper: a
+		// concrete-inner borrow whose lifetime var sits above a freshen/extrude limit
+		// must NOT be pruned and shared whole, or two instantiations would alias one
+		// LifetimeVar. Folding the lifetime level in here is the load-bearing change
+		// that makes the level prune descend into such a borrow to freshen its
+		// lifetime. LevelOfLifetime returns 0 for 'static and a nil slot.
+		return max(LevelOf(t.Inner), LevelOfLifetime(t.Lt))
 	// Union and Intersection recurse into their members for the same reason, but only
 	// the IntersectionType arm is load-bearing today. overloadIntersection (solver) is
 	// the ONE producer of a lattice node carrying LIVE inference variables that flows

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -495,12 +495,12 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	if subIsVar {
 		// Maintain the level invariant: a bound's level must not exceed the var's, or
 		// the freshener/extruder level prune over the lifetime sort becomes unsound (M4
-		// D2.5). super sits in subVar's upper bounds (a negative-position slot), so
-		// extrude it down before recording, mirroring constrain's var arm.
-		recSuper := super
-		if soltype.LevelOfLifetime(recSuper) > subVar.Level {
-			recSuper = c.extrudeLt(recSuper, soltype.Negative, subVar.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
-		}
+		// D2.5). super sits in subVar's upper bounds, a negative-position slot, so when
+		// it outranks subVar extrude it down before recording, mirroring constrain's var
+		// arm. extrudeDownAsUpper reuses an existing down-extruded proxy of super if one
+		// is already a bound, so a repeated constraint does not mint a second proxy and
+		// defeat the ContainsLifetime dedup.
+		recSuper := c.extrudeDownAsUpper(super, subVar)
 		if !soltype.ContainsLifetime(subVar.UpperBounds, recSuper) {
 			c.addUpperLtBound(subVar, recSuper)
 		}
@@ -510,12 +510,9 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 		}
 	}
 	if superIsVar {
-		// sub sits in superVar's lower bounds (a positive-position slot); extrude it
-		// down to superVar's level for the same invariant.
-		recSub := sub
-		if soltype.LevelOfLifetime(recSub) > superVar.Level {
-			recSub = c.extrudeLt(recSub, soltype.Positive, superVar.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
-		}
+		// sub sits in superVar's lower bounds, a positive-position slot; extrude it down
+		// to superVar's level for the same invariant, reusing an existing proxy.
+		recSub := c.extrudeDownAsLower(sub, superVar)
 		if !soltype.ContainsLifetime(superVar.LowerBounds, recSub) {
 			c.addLowerLtBound(superVar, recSub)
 		}
@@ -526,6 +523,37 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	}
 }
 
+// extrudeDownAsUpper returns the lifetime to record as v's upper bound when
+// constraining v <: lt (M4 D2.5). lt is shared when it does not outrank v. When it
+// does, it is extruded down to v's level so v's bound never outranks v. A repeated
+// constraint must not mint a fresh proxy each time, or the ContainsLifetime dedup —
+// which keys on identity — never matches and bounds accumulate. So an existing
+// down-extruded proxy of lt already among v's upper bounds is reused. This is
+// probe-safe: the scan reads v's current journal-managed bounds, so a proxy from a
+// discarded trial is already gone and a fresh one is minted.
+func (c *Context) extrudeDownAsUpper(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
+	if soltype.LevelOfLifetime(lt) <= v.Level {
+		return lt
+	}
+	if proxy := c.findLtProxy(v.UpperBounds, lt); proxy != nil {
+		return proxy
+	}
+	return c.extrudeLt(lt, soltype.Negative, v.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
+}
+
+// extrudeDownAsLower is the lower-bound counterpart of extrudeDownAsUpper, for
+// constraining lt <: v: it reuses an existing down-extruded proxy of lt among v's
+// lower bounds, else extrudes lt down in positive position.
+func (c *Context) extrudeDownAsLower(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
+	if soltype.LevelOfLifetime(lt) <= v.Level {
+		return lt
+	}
+	if proxy := c.findLtProxy(v.LowerBounds, lt); proxy != nil {
+		return proxy
+	}
+	return c.extrudeLt(lt, soltype.Positive, v.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
+}
+
 // extrude copies t so that variables above lvl are replaced by fresh variables
 // at lvl, wired to the originals through the polarity-appropriate bound
 // direction. The cache is keyed by (var ID, polarity): a variable reached in
@@ -534,12 +562,9 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 // cache). Keying by ID alone would reuse a Negative-polarity copy in Positive
 // position — skipping its covariant bounds — and vice versa.
 func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache map[extrudeKey]*soltype.TypeVarType) soltype.Type {
-	return t.Accept(&extruder{
-		c:       c,
-		lvl:     lvl,
-		cache:   cache,
-		ltCache: map[ltExtrudeKey]*soltype.LifetimeVar{},
-	}, pol)
+	// ltCache is left nil and lazily allocated on the first borrow encountered (see
+	// the RefType arm in EnterType), so a borrow-free extrusion pays no allocation.
+	return t.Accept(&extruder{c: c, lvl: lvl, cache: cache}, pol)
 }
 
 // extrudeLt copies a lifetime so a LifetimeVar above lvl is replaced by a fresh
@@ -548,8 +573,8 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 // keyed by (var ID, polarity) for the same reason the type-var cache is. A
 // 'static, nil slot, or below-lvl lifetime extrudes to itself. Bound appends route
 // through the journaling helpers; mutating the ORIGINAL var's bound is the append a
-// Discard must truncate, while the fresh var's appends are a harmless no-op (it is
-// unreachable after a Discard).
+// Discard must truncate. The fresh var's appends are a harmless no-op, since a fresh
+// var is unreachable after a Discard.
 func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, cache map[ltExtrudeKey]*soltype.LifetimeVar) soltype.Lifetime {
 	lv, ok := lt.(*soltype.LifetimeVar)
 	if !ok || lv.Level <= lvl {
@@ -561,6 +586,10 @@ func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, 
 	}
 	nlv := c.freshLifetime(lvl)
 	cache[key] = nlv
+	// Remember which lifetime nlv is a down-extruded proxy of, so a repeated outlives
+	// constraint can reuse this proxy instead of minting a second one (constrainLt's
+	// findExtrudedLtBound dedup, M4 D2.5).
+	c.recordLtProxy(nlv, lv)
 	if pol == soltype.Positive {
 		c.addUpperLtBound(lv, nlv)
 		for _, lb := range lv.LowerBounds {
@@ -595,14 +624,14 @@ func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Enter
 	}
 	if r, ok := t.(*soltype.RefType); ok {
 		// A borrow's lifetime is covariant on the wrapper and never walked by Accept, so
-		// extrude it here in the wrapper's polarity (M4 D2.5), then hand back a RefType
-		// carrying the fresh lifetime for the descend path to rebuild Inner around. When
-		// the lifetime needs no extrusion, fall through to the ordinary rebuild of Inner.
-		lt := e.c.extrudeLt(r.Lt, pol, e.lvl, e.ltCache)
-		if lt != r.Lt {
-			return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
+		// extrude it here in the wrapper's polarity (M4 D2.5). refLifetimeResult then
+		// hands back a RefType carrying the fresh lifetime for the descend path to
+		// rebuild Inner around, or signals an ordinary rebuild when no extrusion was
+		// needed. The cache is allocated on first use so a borrow-free pass pays nothing.
+		if e.ltCache == nil {
+			e.ltCache = map[ltExtrudeKey]*soltype.LifetimeVar{}
 		}
-		return soltype.EnterResult{}
+		return refLifetimeResult(r, e.c.extrudeLt(r.Lt, pol, e.lvl, e.ltCache))
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -74,6 +74,15 @@ type extrudeKey struct {
 	pol soltype.Polarity
 }
 
+// ltExtrudeKey is the lifetime-sort twin of extrudeKey (M4 D2.5): it keys the
+// lifetime extrusion cache by the origin LifetimeVar's ID and polarity, so a
+// lifetime reached in both polarities yields two fresh vars with opposite outlives
+// wiring, exactly as the type-var cache does.
+type ltExtrudeKey struct {
+	id  int
+	pol soltype.Polarity
+}
+
 // Constrain asserts sub <: super, mutating bound lists. An empty result means
 // success.
 //
@@ -484,21 +493,35 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	subVar, subIsVar := sub.(*soltype.LifetimeVar)
 	superVar, superIsVar := super.(*soltype.LifetimeVar)
 	if subIsVar {
-		if !soltype.ContainsLifetime(subVar.UpperBounds, super) {
-			c.addUpperLtBound(subVar, super)
+		// Maintain the level invariant: a bound's level must not exceed the var's, or
+		// the freshener/extruder level prune over the lifetime sort becomes unsound (M4
+		// D2.5). super sits in subVar's upper bounds (a negative-position slot), so
+		// extrude it down before recording, mirroring constrain's var arm.
+		recSuper := super
+		if soltype.LevelOfLifetime(recSuper) > subVar.Level {
+			recSuper = c.extrudeLt(recSuper, soltype.Negative, subVar.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
+		}
+		if !soltype.ContainsLifetime(subVar.UpperBounds, recSuper) {
+			c.addUpperLtBound(subVar, recSuper)
 		}
 		// Propagate to existing lower bounds: lb <: sub <: super.
 		for _, lb := range subVar.LowerBounds {
-			c.constrainLtSeen(lb, super, seen)
+			c.constrainLtSeen(lb, recSuper, seen)
 		}
 	}
 	if superIsVar {
-		if !soltype.ContainsLifetime(superVar.LowerBounds, sub) {
-			c.addLowerLtBound(superVar, sub)
+		// sub sits in superVar's lower bounds (a positive-position slot); extrude it
+		// down to superVar's level for the same invariant.
+		recSub := sub
+		if soltype.LevelOfLifetime(recSub) > superVar.Level {
+			recSub = c.extrudeLt(recSub, soltype.Positive, superVar.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
+		}
+		if !soltype.ContainsLifetime(superVar.LowerBounds, recSub) {
+			c.addLowerLtBound(superVar, recSub)
 		}
 		// Propagate to existing upper bounds: sub <: super <: ub.
 		for _, ub := range superVar.UpperBounds {
-			c.constrainLtSeen(sub, ub, seen)
+			c.constrainLtSeen(recSub, ub, seen)
 		}
 	}
 }
@@ -511,7 +534,45 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 // cache). Keying by ID alone would reuse a Negative-polarity copy in Positive
 // position — skipping its covariant bounds — and vice versa.
 func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache map[extrudeKey]*soltype.TypeVarType) soltype.Type {
-	return t.Accept(&extruder{c: c, lvl: lvl, cache: cache}, pol)
+	return t.Accept(&extruder{
+		c:       c,
+		lvl:     lvl,
+		cache:   cache,
+		ltCache: map[ltExtrudeKey]*soltype.LifetimeVar{},
+	}, pol)
+}
+
+// extrudeLt copies a lifetime so a LifetimeVar above lvl is replaced by a fresh
+// lifetime at lvl, wired to the original through the polarity-appropriate outlives
+// bound (M4 D2.5) — the lifetime-sort twin of extrude's var node. The cache is
+// keyed by (var ID, polarity) for the same reason the type-var cache is. A
+// 'static, nil slot, or below-lvl lifetime extrudes to itself. Bound appends route
+// through the journaling helpers; mutating the ORIGINAL var's bound is the append a
+// Discard must truncate, while the fresh var's appends are a harmless no-op (it is
+// unreachable after a Discard).
+func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, cache map[ltExtrudeKey]*soltype.LifetimeVar) soltype.Lifetime {
+	lv, ok := lt.(*soltype.LifetimeVar)
+	if !ok || lv.Level <= lvl {
+		return lt
+	}
+	key := ltExtrudeKey{id: lv.ID, pol: pol}
+	if nlv, ok := cache[key]; ok {
+		return nlv
+	}
+	nlv := c.freshLifetime(lvl)
+	cache[key] = nlv
+	if pol == soltype.Positive {
+		c.addUpperLtBound(lv, nlv)
+		for _, lb := range lv.LowerBounds {
+			c.addLowerLtBound(nlv, c.extrudeLt(lb, pol, lvl, cache))
+		}
+	} else {
+		c.addLowerLtBound(lv, nlv)
+		for _, ub := range lv.UpperBounds {
+			c.addUpperLtBound(nlv, c.extrudeLt(ub, pol, lvl, cache))
+		}
+	}
+	return nlv
 }
 
 // extruder is the soltype-visitor form of extrude. The structural arms and the
@@ -523,12 +584,25 @@ type extruder struct {
 	c     *Context
 	lvl   int
 	cache map[extrudeKey]*soltype.TypeVarType
+	// ltCache is the lifetime-sort twin of cache (M4 D2.5); see extrudeLt.
+	ltCache map[ltExtrudeKey]*soltype.LifetimeVar
 }
 
 func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	// A subtree with no variable above lvl extrudes to itself (identity-shared).
 	if soltype.LevelOf(t) <= e.lvl {
 		return soltype.EnterResult{Type: t, SkipChildren: true}
+	}
+	if r, ok := t.(*soltype.RefType); ok {
+		// A borrow's lifetime is covariant on the wrapper and never walked by Accept, so
+		// extrude it here in the wrapper's polarity (M4 D2.5), then hand back a RefType
+		// carrying the fresh lifetime for the descend path to rebuild Inner around. When
+		// the lifetime needs no extrusion, fall through to the ordinary rebuild of Inner.
+		lt := e.c.extrudeLt(r.Lt, pol, e.lvl, e.ltCache)
+		if lt != r.Lt {
+			return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
+		}
+		return soltype.EnterResult{}
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -29,6 +29,15 @@ type Context struct {
 	// addLowerLtBound/addUpperLtBound, and a speculation trial journals it under
 	// the same probe discipline as a TypeVarType.
 	lifetimeCounter int
+
+	// ltProxyOrigin maps a down-extruded lifetime proxy to the lifetime it was
+	// extruded from (M4 D2.5). constrainLt consults it through findLtProxy to reuse
+	// an existing proxy for a repeated cross-level outlives constraint, so the bound
+	// dedup is not defeated by minting a fresh proxy each time. It is metadata only
+	// and is never rolled back: a stale entry for a proxy that a discarded trial
+	// removed from its bound list is simply never matched, since findLtProxy scans
+	// only bounds currently present.
+	ltProxyOrigin map[*soltype.LifetimeVar]soltype.Lifetime
 }
 
 // freshVar allocates a new inference variable at the given level, assigning it
@@ -64,6 +73,29 @@ func (c *Context) addLowerLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
 func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
 	c.recordLtMutation(v)
 	v.UpperBounds = append(v.UpperBounds, lt)
+}
+
+// recordLtProxy notes that proxy is a down-extruded copy of origin, so a later
+// repeated outlives constraint can reuse the proxy rather than mint a new one (M4
+// D2.5). Lazily allocates the map.
+func (c *Context) recordLtProxy(proxy *soltype.LifetimeVar, origin soltype.Lifetime) {
+	if c.ltProxyOrigin == nil {
+		c.ltProxyOrigin = map[*soltype.LifetimeVar]soltype.Lifetime{}
+	}
+	c.ltProxyOrigin[proxy] = origin
+}
+
+// findLtProxy returns a lifetime among bounds that is a down-extruded proxy of
+// origin, or nil if none. Identity-keyed: a proxy matches only when ltProxyOrigin
+// records it against the exact origin pointer. Scanning live bounds keeps it
+// probe-safe — a proxy a discarded trial removed from its bound list is not found.
+func (c *Context) findLtProxy(bounds []soltype.Lifetime, origin soltype.Lifetime) soltype.Lifetime {
+	for _, b := range bounds {
+		if bv, ok := b.(*soltype.LifetimeVar); ok && c.ltProxyOrigin[bv] == origin {
+			return bv
+		}
+	}
+	return nil
 }
 
 // recordLtMutation snapshots v's bound-list lengths in the active probe, if any,

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -39,11 +39,13 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	return v
 }
 
-// freshLifetime allocates a new lifetime variable, assigning it the next id in
-// sequence. Lifetimes carry no level — they are a flat sort over the outlives
-// lattice, not the let-generalization level hierarchy types ride.
-func (c *Context) freshLifetime() *soltype.LifetimeVar {
-	lv := &soltype.LifetimeVar{ID: c.lifetimeCounter}
+// freshLifetime allocates a new lifetime variable at the given level, assigning it
+// the next id in sequence. Lifetimes now ride the same let-generalization level
+// hierarchy as types (M4 D2.5): a lifetime minted above its scheme's
+// generalize-level is freshened per instantiation, so two uses of a
+// borrow-passing function never share one LifetimeVar.
+func (c *Context) freshLifetime(level int) *soltype.LifetimeVar {
+	lv := &soltype.LifetimeVar{ID: c.lifetimeCounter, Level: level}
 	c.lifetimeCounter++
 	return lv
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -182,7 +182,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		pt := c.paramType(p, lvl)
 		// A `mut`-borrow param without a declared lifetime originates a fresh
 		// lifetime here (D2), so a returned borrow carries the param's lifetime.
-		pt = c.attachParamLifetimes(pt)
+		pt = c.attachParamLifetimes(pt, lvl)
 		// An `open` un-annotated param keeps its usage-inferred object inexact at
 		// display time (B2). The marker only makes sense for an inferred var; an
 		// annotated param's exactness is fixed by its annotation, and paramType
@@ -408,12 +408,15 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // (Prov is pointer-keyed). A new wrapper would drop that entry, so the "declared
 // mut here" related span on a borrow diagnostic would be lost. Mutating in place
 // also avoids an allocation per mut param.
-func (c *checker) attachParamLifetimes(t soltype.Type) soltype.Type {
+func (c *checker) attachParamLifetimes(t soltype.Type, lvl int) soltype.Type {
 	r, ok := t.(*soltype.RefType)
 	if !ok || r.Lt != nil {
 		return t
 	}
-	lt := c.ctx.freshLifetime()
+	// Mint the lifetime at the parameter's level — the same level as the param's
+	// inference var — so it sits above the function's generalize-level and is
+	// freshened per call (M4 D2.5), on par with a type parameter.
+	lt := c.ctx.freshLifetime(lvl)
 	c.paramLifetimes.Add(lt.ID)
 	r.Lt = lt
 	return r
@@ -699,7 +702,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		// gives the new variable an upper bound and constrains nothing back, so a
 		// mut-borrow receiver of ANY lifetime satisfies the write requirement. A
 		// nil slot lifetime would instead reject a borrow receiver as an escape.
-		Lt: c.ctx.freshLifetime(),
+		Lt: c.ctx.freshLifetime(lvl),
 		Inner: &soltype.ObjectType{
 			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
 			Inexact: true, // "must accept a write to this field," not a full shape

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -116,10 +116,10 @@ func TestFreshenSharesCapturedLifetime(t *testing.T) {
 	require.Same(t, soltype.Lifetime(captured), paramLt, "a captured lifetime (Level <= lim) is shared across instantiations")
 }
 
-// A freshened lifetime carries copies of the original's outlives bounds, and those
-// fresh-var bound writes are the sanctioned non-journaled append: a probe discard
-// rolls them back for free because the fresh var is unreachable afterward, so the
-// probe journals nothing for it and the original's bounds are untouched.
+// A freshened lifetime carries copies of the original's outlives bounds. Writing
+// those bounds onto the fresh var is the one sanctioned non-journaled append. Once a
+// probe is discarded the fresh var is unreachable, so there is nothing to roll back:
+// the probe journals nothing for it, and the original's bounds stay untouched.
 func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
 	c := newChecker()
 	lt := c.ctx.freshLifetime(1)
@@ -254,6 +254,28 @@ func TestConstrainLtMaintainsLevelInvariant(t *testing.T) {
 	require.True(t, ok)
 	require.LessOrEqual(t, recorded.Level, low.Level, "a recorded bound never outranks the variable's own level")
 	require.NotSame(t, high, recorded, "the higher-level bound is extruded to a fresh lower-level var")
+}
+
+// The mirror of TestConstrainLtMaintainsLevelInvariant: when the super sits below the
+// sub's level, it is recorded directly with no extrusion, so the recorded bound's
+// level is strictly BELOW the variable's own. This exercises the strict side of the
+// invariant — a bound may rank lower than its variable, only never higher.
+func TestConstrainLtRecordsLowerLevelBoundDirectly(t *testing.T) {
+	c := newChecker()
+	high := c.ctx.freshLifetime(2)
+	low := c.ctx.freshLifetime(0)
+
+	c.ctx.constrainLt(high, low) // high <: low; low does NOT outrank high's level
+
+	// low is below high's level, so it is recorded as-is with no extrusion. That gives
+	// high an upper bound ranking strictly below high itself. constrainLt also extrudes
+	// high down to seed low's lower bound, so high.UpperBounds additionally holds that
+	// self-proxy. Both bounds still satisfy the invariant, asserted by the loop.
+	require.Contains(t, high.UpperBounds, soltype.Lifetime(low), "a below-level super is recorded as-is, not extruded")
+	require.Less(t, low.Level, high.Level, "the directly-recorded bound ranks strictly below the variable's level")
+	for _, ub := range high.UpperBounds {
+		require.LessOrEqual(t, soltype.LevelOfLifetime(ub), high.Level, "no recorded bound outranks the variable's level")
+	}
 }
 
 // A repeated cross-level outlives constraint does NOT accumulate duplicate bounds.

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -256,13 +256,87 @@ func TestConstrainLtMaintainsLevelInvariant(t *testing.T) {
 	require.NotSame(t, high, recorded, "the higher-level bound is extruded to a fresh lower-level var")
 }
 
+// A repeated cross-level outlives constraint does NOT accumulate duplicate bounds.
+// Extrusion mints a down-extruded proxy of `high`; without proxy reuse the second
+// call would mint a second proxy and the identity-keyed ContainsLifetime dedup would
+// never match, so `low.UpperBounds` would grow to 2. extrudeDownAsUpper reuses the
+// first proxy, so the bound count stays 1 across repeats — the lifetime-sort
+// analogue of the same-level dedup, restored for the cross-level path.
+func TestConstrainLtCrossLevelDoesNotAccumulateDuplicates(t *testing.T) {
+	c := newChecker()
+	low := c.ctx.freshLifetime(0)
+	high := c.ctx.freshLifetime(2)
+
+	c.ctx.constrainLt(low, high)
+	upperAfterFirst := len(low.UpperBounds)
+	lowerAfterFirst := len(high.LowerBounds)
+	require.Equal(t, 1, upperAfterFirst, "low gains one down-extruded proxy of high as an upper bound")
+
+	c.ctx.constrainLt(low, high) // identical cross-level constraint again
+
+	require.Len(t, low.UpperBounds, upperAfterFirst, "the repeat reuses the proxy; no duplicate upper bound accrues")
+	require.Len(t, high.LowerBounds, lowerAfterFirst, "and no duplicate lower bound accrues on high")
+}
+
+// A discarded probe trial removes its extruded proxy from the bound list, so a later
+// real constraint mints a genuinely-wired fresh proxy rather than reusing the
+// rolled-back one. This guards the probe-safety of the proxy-reuse dedup: the reuse
+// scan reads live bounds, so a proxy whose wiring a Discard reverted is never found.
+func TestConstrainLtProxyReuseIsProbeSafe(t *testing.T) {
+	c := newChecker()
+	low := c.ctx.freshLifetime(0)
+	high := c.ctx.freshLifetime(2)
+
+	p := c.openProbe()
+	c.ctx.constrainLt(low, high)
+	require.Len(t, low.UpperBounds, 1)
+	c.closeProbe(p, false) // discard: low's proxy bound and the proxy's own wiring revert
+	require.Empty(t, low.UpperBounds, "the speculative cross-level bound is rolled back")
+
+	c.ctx.constrainLt(low, high) // real constraint after the discard
+	require.Len(t, low.UpperBounds, 1)
+	proxy := low.UpperBounds[0].(*soltype.LifetimeVar)
+	require.Contains(t, high.LowerBounds, soltype.Lifetime(proxy),
+		"the post-discard proxy is freshly wired to high, not a rolled-back orphan")
+}
+
+// freshenAll freshens a borrow's lifetime, not just its type vars. allFreshener has
+// no level prune, so EVERY quantifiable variable — including a RefType's lifetime —
+// is replaced. Without the arm a reassigned borrow-typed binding would keep its
+// scheme lifetime and the reassignment constraint would mutate it, contaminating
+// later uses. inferAssign relies on this isolation.
+func TestFreshenAllFreshensBorrowLifetime(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(3)
+	ref := mutObjAt(lt)
+
+	out := c.freshenAll(ref, 1)
+
+	outLt := out.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+	require.NotSame(t, lt, outLt, "freshenAll replaces the borrow's lifetime with a fresh one")
+}
+
+// freshenAll freshens a lifetime regardless of its level — even one at or below the
+// target level, which freshenAbove would share. This is the lifetime-sort analogue
+// of allFreshener's no-prune treatment of type vars (lim = math.MinInt).
+func TestFreshenAllFreshensLowLevelBorrowLifetime(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(0) // freshenAbove(lim=0) would share this; freshenAll must not
+	ref := mutObjAt(lt)
+
+	out := c.freshenAll(ref, 1)
+
+	outLt := out.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+	require.NotSame(t, lt, outLt, "freshenAll freshens even a level-0 lifetime")
+}
+
 // --- freshener fall-through: captured lifetime, quantified inner ---
 
 // A borrow with a CAPTURED lifetime (Level <= lim) but a QUANTIFIED inner type var
 // freshens the inner while sharing the lifetime. This exercises the RefType arm's
-// fall-through path — freshenLt returns the lifetime unchanged, so Accept rebuilds
-// Inner — which the all-concrete-inner cases never reach (they are pruned whole
-// before the arm runs).
+// fall-through path — ltFreshener.fresh returns the lifetime unchanged, so Accept
+// rebuilds Inner — which the all-concrete-inner cases never reach (they are pruned
+// whole before the arm runs).
 func TestFreshenSharesCapturedLifetimeWhileFreshateningInner(t *testing.T) {
 	c := newChecker()
 	captured := c.ctx.freshLifetime(0) // captured: shared across instantiations

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -1,0 +1,170 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 D2.5: lifetime-sort generalization (levels + per-instantiation freshening) ---
+//
+// A lifetime carried by a borrow now rides the same let-generalization level
+// hierarchy as a type variable: a lifetime minted above its scheme's
+// generalize-level is a quantified param lifetime, freshened per instantiation, so
+// two uses of a borrow-passing function never share one LifetimeVar's bounds.
+// These tests drive freshenAbove (the instantiation copy) directly, mirroring how
+// lifetime_test.go drives constrainLt directly.
+
+// mutObjAt builds `mut <lt> {x: number}` — a borrow carrying the given lifetime,
+// the minimal shape that exercises a RefType lifetime through the rewriters.
+func mutObjAt(lt soltype.Lifetime) *soltype.RefType {
+	return &soltype.RefType{
+		Mut: true,
+		Lt:  lt,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: num()},
+		}},
+	}
+}
+
+// identRefScheme is `fn(p: mut <lt> {x}) -> mut <lt> {x}` — the IdentityRefReturn
+// shape, with the SAME lifetime pointer on both the parameter and the return.
+func identRefScheme(lt soltype.Lifetime) *soltype.FuncType {
+	return &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Type: mutObjAt(lt)}},
+		Ret:    mutObjAt(lt),
+	}
+}
+
+// freshenLtOf pulls the (freshened) lifetimes off the param and return of a
+// freshened identRefScheme result.
+func freshenLtOf(t *testing.T, out soltype.Type) (paramLt, retLt soltype.Lifetime) {
+	t.Helper()
+	fn, ok := out.(*soltype.FuncType)
+	require.True(t, ok, "freshened scheme is still a FuncType")
+	paramLt = fn.Params[0].Type.(*soltype.RefType).Lt
+	retLt = fn.Ret.(*soltype.RefType).Lt
+	return paramLt, retLt
+}
+
+// A quantified param lifetime reached more than once in a single instantiation is
+// freshened ONCE: the param and the return share one fresh lifetime, distinct from
+// the scheme's original. Without the ltCache the two occurrences would freshen
+// independently and the returned borrow would no longer carry the parameter's
+// lifetime.
+func TestFreshenSharesParamLifetimeAcrossOccurrences(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(1) // above the generalize-level (lim = 0)
+	body := identRefScheme(lt)
+
+	out := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	paramLt, retLt := freshenLtOf(t, out)
+	require.Same(t, paramLt, retLt, "the param lifetime is shared across both occurrences in one instantiation")
+	require.NotSame(t, soltype.Lifetime(lt), paramLt, "and is a fresh copy, distinct from the scheme's original lifetime")
+}
+
+// Two instantiations of one scheme produce DISTINCT lifetime vars — the core
+// cross-site non-contamination property. Each call site gets its own cache, exactly
+// as instantiate allocates one per use.
+func TestFreshenTwoInstantiationsGetDistinctLifetimes(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(1)
+	body := identRefScheme(lt)
+
+	out1 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	out2 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	lt1, _ := freshenLtOf(t, out1)
+	lt2, _ := freshenLtOf(t, out2)
+	require.NotSame(t, lt1, lt2, "two call sites instantiate two distinct lifetime vars")
+}
+
+// Constraining one instantiation's lifetime does not perturb another's: the two
+// freshened lifetimes have independent bound lists. This is the contamination a
+// shared LifetimeVar would have caused — before D2.5 both call sites aliased the
+// scheme's one lifetime var, so a bound from one site leaked into the other.
+func TestFreshenInstantiationsAreNonContaminating(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(1)
+	body := identRefScheme(lt)
+
+	out1 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	out2 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	lt1, _ := freshenLtOf(t, out1)
+	lt2, _ := freshenLtOf(t, out2)
+
+	// Constrain the first site's lifetime to 'static; the second's must stay clean.
+	c.ctx.constrainLt(lt1, soltype.Static)
+
+	require.Len(t, lt1.(*soltype.LifetimeVar).UpperBounds, 1, "the constrained site records its own bound")
+	require.Empty(t, lt2.(*soltype.LifetimeVar).UpperBounds, "the other site is untouched")
+}
+
+// quantify-vs-keep: a lifetime captured from an outer scope (Level <= lim) is
+// SHARED, not freshened — the lifetime-sort analogue of a captured type variable.
+// Only lifetimes minted above the scheme's level are quantified.
+func TestFreshenSharesCapturedLifetime(t *testing.T) {
+	c := newChecker()
+	captured := c.ctx.freshLifetime(0) // at the generalize-level: not quantified
+	body := identRefScheme(captured)
+
+	out := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	paramLt, _ := freshenLtOf(t, out)
+	require.Same(t, soltype.Lifetime(captured), paramLt, "a captured lifetime (Level <= lim) is shared across instantiations")
+}
+
+// A freshened lifetime carries copies of the original's outlives bounds, and those
+// fresh-var bound writes are the sanctioned non-journaled append: a probe discard
+// rolls them back for free because the fresh var is unreachable afterward, so the
+// probe journals nothing for it and the original's bounds are untouched.
+func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(1)
+	// 'static is the lattice bottom — a level-free bound, so recording lt <: 'static
+	// does not trip the level-extrusion the var-to-var case would.
+	c.ctx.constrainLt(lt, soltype.Static) // lt.UpperBounds = ['static]
+	require.Len(t, lt.UpperBounds, 1)
+
+	p := c.openProbe()
+	out := c.freshenAbove(0, identRefScheme(lt), 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	paramLt, _ := freshenLtOf(t, out)
+	freshVar := paramLt.(*soltype.LifetimeVar)
+
+	require.NotSame(t, lt, freshVar, "the quantified lifetime is freshened")
+	require.Len(t, freshVar.UpperBounds, 1, "the fresh lifetime carries a copy of the original's outlives bound")
+	require.True(t, soltype.IsStaticLifetime(freshVar.UpperBounds[0]))
+	require.Empty(t, p.ltEntries, "the fresh var's bound write is non-journaled (it self-rolls-back)")
+
+	c.closeProbe(p, false) // discard
+	require.Len(t, lt.UpperBounds, 1, "the original scheme lifetime's bound is untouched by the discarded trial")
+}
+
+// Source-level regression: the D2 IdentityRefReturn acceptance still renders the
+// shared param lifetime on the generalized scheme. D2.5 freshens lifetimes at
+// instantiation, but the scheme body keeps its original param lifetime, so its
+// display is unchanged.
+func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}", values["f"])
+}
+
+// Source-level regression: a borrow-passing function called at two distinct sites
+// typechecks cleanly. Before D2.5 both calls shared the callee's one param
+// lifetime, linking the two borrows; freshening per instantiation keeps them
+// independent so neither call contaminates the other.
+func TestInferBorrowFnCalledAtTwoSites(t *testing.T) {
+	src := `fn use(o: mut {x: number}) -> number {
+  return o.x
+}
+fn f(a: mut {x: number}, b: mut {x: number}) {
+  val ra = use(a)
+  val rb = use(b)
+  return rb
+}`
+	_, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+}

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -168,3 +168,118 @@ fn f(a: mut {x: number}, b: mut {x: number}) {
 	_, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 }
+
+// --- extruder lifetime arm ---
+//
+// extrude copies a type so a variable above the target level is replaced by a
+// fresh var at that level, wired to the original. D2.5 extends it to the lifetime
+// sort: a borrow's lifetime above the level is extruded too. These drive extrude
+// directly, the first tests to do so.
+
+// A borrow whose lifetime outranks the extrusion level gets a fresh lifetime at
+// that level, and in Positive (covariant/output) polarity the original is wired
+// ABOVE the fresh var (original <: fresh), mirroring the type-var extrude's
+// addUpperBound.
+func TestExtrudeFreshensHigherLevelLifetimePositive(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(2) // above the extrusion target (lvl = 1)
+
+	out := c.ctx.extrude(mutObjAt(lt), soltype.Positive, 1, map[extrudeKey]*soltype.TypeVarType{})
+
+	outLt, ok := out.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+	require.True(t, ok)
+	require.NotSame(t, lt, outLt, "the higher-level lifetime is extruded to a fresh var")
+	require.Equal(t, 1, outLt.Level, "the fresh lifetime sits at the extrusion target level")
+	require.Contains(t, lt.UpperBounds, soltype.Lifetime(outLt),
+		"Positive polarity wires the fresh var as an upper bound of the original (orig <: fresh)")
+}
+
+// The contravariant counterpart: in Negative (input) polarity the fresh var is
+// wired BELOW the original (fresh <: original), mirroring the type-var extrude's
+// addLowerBound. A var reached in both polarities therefore yields two distinct
+// fresh vars with opposite wiring — the reason the cache is keyed by polarity.
+func TestExtrudeFreshensHigherLevelLifetimeNegative(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(2)
+
+	out := c.ctx.extrude(mutObjAt(lt), soltype.Negative, 1, map[extrudeKey]*soltype.TypeVarType{})
+
+	outLt := out.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+	require.Contains(t, lt.LowerBounds, soltype.Lifetime(outLt),
+		"Negative polarity wires the fresh var as a lower bound of the original (fresh <: orig)")
+}
+
+// A borrow whose lifetime is at or below the target level is extruded to itself:
+// the whole RefType is shared, since nothing in it outranks the level.
+func TestExtrudeSharesBelowLevelBorrow(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(1) // at the target level
+
+	out := c.ctx.extrude(mutObjAt(lt), soltype.Positive, 1, map[extrudeKey]*soltype.TypeVarType{})
+
+	require.Same(t, soltype.Lifetime(lt), out.(*soltype.RefType).Lt, "a below-level lifetime is shared, not extruded")
+	require.Empty(t, lt.UpperBounds, "and no extrusion bound is recorded on it")
+}
+
+// An extruded lifetime bound on the ORIGINAL var is journaled, so a discarded probe
+// trial truncates it back — the lifetime-sort twin of the type-var extrude's
+// journaled bound write. Without this a failed overload trial that extruded a borrow
+// lifetime would leak a bound.
+func TestExtrudeLifetimeBoundRolledBackOnDiscard(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(2)
+
+	p := c.openProbe()
+	c.ctx.extrude(mutObjAt(lt), soltype.Positive, 1, map[extrudeKey]*soltype.TypeVarType{})
+	require.Len(t, lt.UpperBounds, 1, "the extrusion records a bound on the original under the probe")
+
+	c.closeProbe(p, false) // discard
+	require.Empty(t, lt.UpperBounds, "the extruded lifetime bound is rolled back on discard")
+}
+
+// --- constrainLt level-extrusion ---
+
+// Recording a higher-level lifetime as the bound of a lower-level variable extrudes
+// it down first, so a variable's bound never outranks its own level — the invariant
+// the freshener/extruder level prune over the lifetime sort relies on.
+func TestConstrainLtMaintainsLevelInvariant(t *testing.T) {
+	c := newChecker()
+	low := c.ctx.freshLifetime(0)
+	high := c.ctx.freshLifetime(2)
+
+	c.ctx.constrainLt(low, high) // low <: high; high outranks low's level
+
+	require.Len(t, low.UpperBounds, 1)
+	recorded, ok := low.UpperBounds[0].(*soltype.LifetimeVar)
+	require.True(t, ok)
+	require.LessOrEqual(t, recorded.Level, low.Level, "a recorded bound never outranks the variable's own level")
+	require.NotSame(t, high, recorded, "the higher-level bound is extruded to a fresh lower-level var")
+}
+
+// --- freshener fall-through: captured lifetime, quantified inner ---
+
+// A borrow with a CAPTURED lifetime (Level <= lim) but a QUANTIFIED inner type var
+// freshens the inner while sharing the lifetime. This exercises the RefType arm's
+// fall-through path — freshenLt returns the lifetime unchanged, so Accept rebuilds
+// Inner — which the all-concrete-inner cases never reach (they are pruned whole
+// before the arm runs).
+func TestFreshenSharesCapturedLifetimeWhileFreshateningInner(t *testing.T) {
+	c := newChecker()
+	captured := c.ctx.freshLifetime(0) // captured: shared across instantiations
+	innerVar := c.freshAt(1)           // quantified inner type var: per-use fresh
+	ref := &soltype.RefType{
+		Mut: true,
+		Lt:  captured,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: innerVar},
+		}},
+	}
+
+	out := c.freshenAbove(0, ref, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	outRef := out.(*soltype.RefType)
+	require.True(t, outRef.Mut, "mutability is carried through")
+	require.Same(t, soltype.Lifetime(captured), outRef.Lt, "the captured lifetime is shared")
+	outInnerVar := outRef.Inner.(*soltype.ObjectType).Elems[0].(*soltype.PropertyElem).Type
+	require.NotSame(t, innerVar, outInnerVar, "the quantified inner type var is freshened")
+}

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -15,7 +15,7 @@ import (
 // 'static regardless of any other upper bound.
 func TestConstrainLtVarOutlivesStatic(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
 	static := &soltype.StaticLifetime{}
 
 	c.ctx.constrainLt(a, static)
@@ -29,8 +29,8 @@ func TestConstrainLtVarOutlivesStatic(t *testing.T) {
 // relationship at coalescing.
 func TestConstrainLtVarToVarRecordsBothDirections(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, b) // a outlives b
 
@@ -44,9 +44,9 @@ func TestConstrainLtVarToVarRecordsBothDirections(t *testing.T) {
 // through a's existing upper bounds so x <: b is recorded too.
 func TestConstrainLtPropagatesTransitively(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
-	x := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	x := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, b) // a <: b
 	c.ctx.constrainLt(x, a) // x <: a, which must propagate x <: b through a's uppers
@@ -61,7 +61,7 @@ func TestConstrainLtPropagatesTransitively(t *testing.T) {
 // pointer-identity dedup would wrongly pile up duplicate 'static bounds.
 func TestConstrainLtStaticDedupsByValue(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, &soltype.StaticLifetime{})
 	c.ctx.constrainLt(a, &soltype.StaticLifetime{}) // a different 'static instance
@@ -74,8 +74,8 @@ func TestConstrainLtStaticDedupsByValue(t *testing.T) {
 // A repeated outlives constraint does not re-append a bound already present.
 func TestConstrainLtDedupsBounds(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, b)
 	c.ctx.constrainLt(a, b) // identical constraint again
@@ -88,8 +88,8 @@ func TestConstrainLtDedupsBounds(t *testing.T) {
 // and each direction is recorded exactly once.
 func TestConstrainLtCycleTerminates(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	require.NotPanics(t, func() {
 		c.ctx.constrainLt(a, b)
@@ -105,7 +105,7 @@ func TestConstrainLtCycleTerminates(t *testing.T) {
 // Constraining a lifetime against ITSELF is a no-op — neither a bound nor a loop.
 func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, a)
 
@@ -118,15 +118,15 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 // rides the same journal discipline. Bounds added before the probe survive.
 func TestProbeDiscardRestoresLifetimeBounds(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	// Pre-probe bound on a, permanent.
 	c.ctx.constrainLt(a, b)
 	require.Len(t, a.UpperBounds, 1)
 
 	p := c.openProbe()
-	x := c.ctx.freshLifetime()
+	x := c.ctx.freshLifetime(0)
 	c.ctx.constrainLt(a, x) // a.UpperBounds: +1 ⇒ 2; x.LowerBounds: +1 ⇒ 1
 	require.Len(t, a.UpperBounds, 2)
 	require.Len(t, x.LowerBounds, 1)
@@ -143,8 +143,8 @@ func TestProbeDiscardRestoresLifetimeBounds(t *testing.T) {
 // journal's existence.
 func TestProbeCommitKeepsLifetimeBounds(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	p := c.openProbe()
 	c.ctx.constrainLt(a, b)
@@ -158,8 +158,8 @@ func TestProbeCommitKeepsLifetimeBounds(t *testing.T) {
 // so the parent's later discard still reverts the committed child's lifetime work.
 func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	parent := c.openProbe()
 	child := c.openProbe()
@@ -178,9 +178,9 @@ func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
 // a <: super must propagate lb <: super through a's existing lower bound.
 func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
 	c := newChecker()
-	lb := c.ctx.freshLifetime()
-	a := c.ctx.freshLifetime()
-	super := c.ctx.freshLifetime()
+	lb := c.ctx.freshLifetime(0)
+	a := c.ctx.freshLifetime(0)
+	super := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(lb, a)    // lb <: a ⇒ a gains lb as a lower bound
 	c.ctx.constrainLt(a, super) // a <: super ⇒ a's lower-bound loop propagates lb <: super
@@ -196,15 +196,15 @@ func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
 // discard must truncate every probe-era bound while leaving the pre-probe ones.
 func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, b) // pre-probe: a.upper=[b], b.lower=[a]
 	require.Len(t, a.UpperBounds, 1)
 	require.Len(t, b.LowerBounds, 1)
 
 	p := c.openProbe()
-	x := c.ctx.freshLifetime()
+	x := c.ctx.freshLifetime(0)
 	c.ctx.constrainLt(x, a) // x <: a, transitively recording x <: b; touches x, a, b
 	require.Contains(t, x.UpperBounds, soltype.Lifetime(a))
 	require.Contains(t, x.UpperBounds, soltype.Lifetime(b), "x gained b transitively under the probe")
@@ -227,9 +227,9 @@ func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
 // total; the point is that `a` appears in exactly one of them.
 func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
-	d := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	d := c.ctx.freshLifetime(0)
 
 	p := c.openProbe()
 	c.ctx.constrainLt(a, b) // a.upper += b
@@ -253,8 +253,8 @@ func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
 // nil-map panic. Mirrors the type sort's TestProbeBareLiteralIsNilMapSafe.
 func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	c.ctx.probe = &Probe{} // deliberately skip newProbe
 	require.NotPanics(t, func() {
@@ -272,9 +272,9 @@ func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
 // TestDiscardedChildLeavesParentJournalIntact.
 func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
-	d := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	d := c.ctx.freshLifetime(0)
 
 	parent := c.openProbe()
 	c.ctx.constrainLt(a, b) // parent: a.upper=[b]
@@ -296,8 +296,8 @@ func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
 // to the var's pre-child length. Mirrors TestCommittedChildInheritsUntouchedVarSnapshot.
 func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	parent := c.openProbe()
 	child := c.openProbe()
@@ -316,8 +316,8 @@ func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
 // "no journal entry without an append" invariant for the lifetime sort.
 func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	c.ctx.constrainLt(a, b) // pre-probe: a.upper=[b], b.lower=[a]
 
@@ -339,8 +339,8 @@ func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
 // failed overload trial that constrained two borrows would leak a lifetime bound.
 func TestProbeRollsBackLifetimeBoundFromRefArm(t *testing.T) {
 	c := newChecker()
-	a := c.ctx.freshLifetime()
-	b := c.ctx.freshLifetime()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
 
 	inner := func() *soltype.ObjectType {
 		return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"math"
+
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -99,11 +101,11 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 // those two it ignores polarity (it freshens uniformly, no variance flip).
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
 	return t.Accept(&freshener{
-		c:       c,
-		lim:     lim,
-		lvl:     lvl,
-		cache:   cache,
-		ltCache: map[*soltype.LifetimeVar]*soltype.LifetimeVar{},
+		c:     c,
+		lim:   lim,
+		lvl:   lvl,
+		cache: cache,
+		lt:    ltFreshener{ctx: c.ctx, lim: lim, lvl: lvl},
 	}, soltype.Positive)
 }
 
@@ -118,11 +120,11 @@ type freshener struct {
 	lim   int
 	lvl   int
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
-	// ltCache is the lifetime-sort twin of cache (M4 D2.5): a quantified param
-	// lifetime reached more than once in one instantiation yields a single fresh
-	// copy, so a borrow that flows to both a parameter and the return type keeps one
-	// shared lifetime across them.
-	ltCache map[*soltype.LifetimeVar]*soltype.LifetimeVar
+	// lt freshens a borrow's lifetime, the second quantifiable sort Accept does not
+	// walk (M4 D2.5). It shares the freshener's lim/lvl and lazily allocates its own
+	// cache, so a borrow that flows to both a parameter and the return type keeps one
+	// shared fresh lifetime across them.
+	lt ltFreshener
 }
 
 func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
@@ -154,16 +156,11 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	if r, ok := t.(*soltype.RefType); ok {
 		// A borrow's lifetime is not a Type, so Accept carries it through unchanged and
 		// neither the structural rebuild below nor the var arm would ever freshen it
-		// (M4 D2.5). Freshen it here when it is a quantified param lifetime
-		// (Level > lim), then hand back a RefType carrying the fresh lifetime so the
-		// descend path rebuilds Inner around it. When the lifetime is shared (captured,
-		// 'static, or nil), freshenLt returns it unchanged and we fall through to the
-		// ordinary structural rebuild of Inner.
-		lt := f.freshenLt(r.Lt)
-		if lt != r.Lt {
-			return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
-		}
-		return soltype.EnterResult{} // only Inner needs freshening: let Accept rebuild it
+		// (M4 D2.5). ltFreshener.fresh replaces a quantified param lifetime
+		// (Level > lim) and shares a captured, 'static, or nil one; refLifetimeResult
+		// then either hands back a RefType carrying the fresh lifetime or signals an
+		// ordinary descent so Accept rebuilds Inner.
+		return refLifetimeResult(r, f.lt.fresh(r.Lt))
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
@@ -211,7 +208,14 @@ func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { 
 // later use. Freshening first makes the constraint mutate throwaway copies instead.
 // A var-free input (the common annotated/literal case) is returned unchanged.
 func (c *checker) freshenAll(t soltype.Type, lvl int) soltype.Type {
-	return t.Accept(&allFreshener{c: c, lvl: lvl, cache: map[*soltype.TypeVarType]*soltype.TypeVarType{}}, soltype.Positive)
+	return t.Accept(&allFreshener{
+		c:     c,
+		lvl:   lvl,
+		cache: map[*soltype.TypeVarType]*soltype.TypeVarType{},
+		// lim is below every lifetime level, so fresh replaces EVERY lifetime — the
+		// lifetime-sort analogue of allFreshener's no-prune treatment of type vars.
+		lt: ltFreshener{ctx: c.ctx, lim: math.MinInt, lvl: lvl},
+	}, soltype.Positive)
 }
 
 // allFreshener is the soltype-visitor form of freshenAll: it replaces every var
@@ -222,9 +226,18 @@ type allFreshener struct {
 	c     *checker
 	lvl   int
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
+	// lt freshens a borrow's lifetime, which Accept does not walk (M4 D2.5). Without
+	// this arm a reassigned borrow-typed binding would keep its scheme's lifetime, so
+	// constraining the reassignment source would mutate the binding's own lifetime —
+	// the cross-use contamination freshenAll exists to prevent, here for the lifetime
+	// sort.
+	lt ltFreshener
 }
 
 func (f *allFreshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if r, ok := t.(*soltype.RefType); ok {
+		return refLifetimeResult(r, f.lt.fresh(r.Lt))
+	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
 		return soltype.EnterResult{} // structural / atom node: let Accept rebuild or descend
@@ -256,43 +269,71 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 	return out
 }
 
-// freshenLt is the lifetime-sort twin of the freshener's var arm (M4 D2.5). A
-// LifetimeVar at Level > lim is a quantified param lifetime: it is replaced by a
-// fresh lifetime at lvl, its bounds freshened too, so each instantiation gets its
-// own lifetime and constraining one call site does not perturb another. The cache
-// is populated BEFORE bounds are freshened so a cyclic bound referencing the
-// original resolves to the in-progress copy rather than looping. 'static, a nil
-// slot, and a captured lifetime (Level <= lim) are shared, never freshened.
+// ltFreshener freshens lifetime variables for the rewriting visitors (M4 D2.5).
+// Accept never walks a RefType's lifetime, because a Lifetime is not a Type, so each
+// lifetime-aware visitor delegates here through refLifetimeResult. A LifetimeVar
+// above lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
+// lvl and freshens its bounds, so each use gets its own lifetime and constraining
+// one site does not perturb another. A LifetimeVar at lim or below, 'static, and a
+// nil slot are shared. The freshener passes its own lim; allFreshener passes
+// math.MinInt so every lifetime is freshened.
 //
-// The fresh var's bounds are whole-slice assignments, intentionally NOT journaled
-// by the probe — the same sanctioned non-append the type-var path uses (a fresh
-// var is unreachable after a Discard, so it self-rolls-back).
-func (f *freshener) freshenLt(lt soltype.Lifetime) soltype.Lifetime {
+// The cache is allocated lazily, so a borrow-free rewrite pays no allocation. It is
+// populated BEFORE bounds are freshened, so a cyclic bound referencing the original
+// resolves to the in-progress copy rather than looping. The fresh var's bound
+// writes are whole-slice assignments, intentionally NOT journaled by the probe. A
+// fresh var is unreachable after a Discard, so it self-rolls-back, the same
+// sanctioned non-append the type-var paths use.
+type ltFreshener struct {
+	ctx   *Context
+	lim   int
+	lvl   int
+	cache map[*soltype.LifetimeVar]*soltype.LifetimeVar
+}
+
+func (lf *ltFreshener) fresh(lt soltype.Lifetime) soltype.Lifetime {
 	lv, ok := lt.(*soltype.LifetimeVar)
-	if !ok || lv.Level <= f.lim {
+	if !ok || lv.Level <= lf.lim {
 		return lt
 	}
-	if nlv, ok := f.ltCache[lv]; ok {
+	if lf.cache == nil {
+		lf.cache = map[*soltype.LifetimeVar]*soltype.LifetimeVar{}
+	}
+	if nlv, ok := lf.cache[lv]; ok {
 		return nlv
 	}
-	nlv := f.c.ctx.freshLifetime(f.lvl)
-	f.ltCache[lv] = nlv
-	nlv.LowerBounds = f.freshenLtBounds(lv.LowerBounds)
-	nlv.UpperBounds = f.freshenLtBounds(lv.UpperBounds)
+	nlv := lf.ctx.freshLifetime(lf.lvl)
+	lf.cache[lv] = nlv
+	nlv.LowerBounds = lf.freshBounds(lv.LowerBounds)
+	nlv.UpperBounds = lf.freshBounds(lv.UpperBounds)
 	return nlv
 }
 
-// freshenLtBounds freshens a lifetime var's bound list, preserving the
-// nil-for-empty shape — the lifetime-sort twin of freshenBounds.
-func (f *freshener) freshenLtBounds(bounds []soltype.Lifetime) []soltype.Lifetime {
+// freshBounds freshens a lifetime var's bound list, preserving the nil-for-empty
+// shape — the lifetime-sort twin of freshenBounds.
+func (lf *ltFreshener) freshBounds(bounds []soltype.Lifetime) []soltype.Lifetime {
 	if len(bounds) == 0 {
 		return nil
 	}
 	out := make([]soltype.Lifetime, len(bounds))
 	for i, b := range bounds {
-		out[i] = f.freshenLt(b)
+		out[i] = lf.fresh(b)
 	}
 	return out
+}
+
+// refLifetimeResult builds the EnterType result for a RefType whose lifetime a
+// visitor has transformed to lt. It is the single place every lifetime-aware
+// rewriting visitor handles a borrow's non-Type lifetime: when lt changed it hands
+// back a RefType carrying it so the descend path rebuilds Inner around the new
+// lifetime; otherwise it signals an ordinary descent so Accept rebuilds Inner with
+// the lifetime shared. Sharing this keeps freshener, allFreshener, and the extruder
+// from each re-deriving the rebuild-or-descend boilerplate.
+func refLifetimeResult(r *soltype.RefType, lt soltype.Lifetime) soltype.EnterResult {
+	if lt != r.Lt {
+		return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
+	}
+	return soltype.EnterResult{}
 }
 
 // freshenBounds freshens a var's bound list, preserving the nil-for-empty shape.

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -98,7 +98,13 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 // three onto a shared soltype rewriting visitor with no behavior change. Unlike
 // those two it ignores polarity (it freshens uniformly, no variance flip).
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
-	return t.Accept(&freshener{c: c, lim: lim, lvl: lvl, cache: cache}, soltype.Positive)
+	return t.Accept(&freshener{
+		c:       c,
+		lim:     lim,
+		lvl:     lvl,
+		cache:   cache,
+		ltCache: map[*soltype.LifetimeVar]*soltype.LifetimeVar{},
+	}, soltype.Positive)
 }
 
 // freshener is the soltype-visitor form of freshenAbove. The structural arms come
@@ -112,6 +118,11 @@ type freshener struct {
 	lim   int
 	lvl   int
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
+	// ltCache is the lifetime-sort twin of cache (M4 D2.5): a quantified param
+	// lifetime reached more than once in one instantiation yields a single fresh
+	// copy, so a borrow that flows to both a parameter and the return type keeps one
+	// shared lifetime across them.
+	ltCache map[*soltype.LifetimeVar]*soltype.LifetimeVar
 }
 
 func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
@@ -139,6 +150,20 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	//     instantiated node must account for the sharing.
 	if soltype.LevelOf(t) <= f.lim {
 		return soltype.EnterResult{Type: t, SkipChildren: true}
+	}
+	if r, ok := t.(*soltype.RefType); ok {
+		// A borrow's lifetime is not a Type, so Accept carries it through unchanged and
+		// neither the structural rebuild below nor the var arm would ever freshen it
+		// (M4 D2.5). Freshen it here when it is a quantified param lifetime
+		// (Level > lim), then hand back a RefType carrying the fresh lifetime so the
+		// descend path rebuilds Inner around it. When the lifetime is shared (captured,
+		// 'static, or nil), freshenLt returns it unchanged and we fall through to the
+		// ordinary structural rebuild of Inner.
+		lt := f.freshenLt(r.Lt)
+		if lt != r.Lt {
+			return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
+		}
+		return soltype.EnterResult{} // only Inner needs freshening: let Accept rebuild it
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
@@ -227,6 +252,45 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 	out := make([]soltype.Type, len(bounds))
 	for i, b := range bounds {
 		out[i] = b.Accept(f, soltype.Positive)
+	}
+	return out
+}
+
+// freshenLt is the lifetime-sort twin of the freshener's var arm (M4 D2.5). A
+// LifetimeVar at Level > lim is a quantified param lifetime: it is replaced by a
+// fresh lifetime at lvl, its bounds freshened too, so each instantiation gets its
+// own lifetime and constraining one call site does not perturb another. The cache
+// is populated BEFORE bounds are freshened so a cyclic bound referencing the
+// original resolves to the in-progress copy rather than looping. 'static, a nil
+// slot, and a captured lifetime (Level <= lim) are shared, never freshened.
+//
+// The fresh var's bounds are whole-slice assignments, intentionally NOT journaled
+// by the probe — the same sanctioned non-append the type-var path uses (a fresh
+// var is unreachable after a Discard, so it self-rolls-back).
+func (f *freshener) freshenLt(lt soltype.Lifetime) soltype.Lifetime {
+	lv, ok := lt.(*soltype.LifetimeVar)
+	if !ok || lv.Level <= f.lim {
+		return lt
+	}
+	if nlv, ok := f.ltCache[lv]; ok {
+		return nlv
+	}
+	nlv := f.c.ctx.freshLifetime(f.lvl)
+	f.ltCache[lv] = nlv
+	nlv.LowerBounds = f.freshenLtBounds(lv.LowerBounds)
+	nlv.UpperBounds = f.freshenLtBounds(lv.UpperBounds)
+	return nlv
+}
+
+// freshenLtBounds freshens a lifetime var's bound list, preserving the
+// nil-for-empty shape — the lifetime-sort twin of freshenBounds.
+func (f *freshener) freshenLtBounds(bounds []soltype.Lifetime) []soltype.Lifetime {
+	if len(bounds) == 0 {
+		return nil
+	}
+	out := make([]soltype.Lifetime, len(bounds))
+	for i, b := range bounds {
+		out[i] = f.freshenLt(b)
 	}
 	return out
 }


### PR DESCRIPTION
Lifetimes now ride the same level-based generalization hierarchy as type variables (M4 D2.5). A lifetime minted above its scheme's generalize-level is freshened per instantiation, so two call sites of a borrow-passing function never share one LifetimeVar's bounds.

Key changes:

- **LifetimeVar now carries a Level field** to track its position in the let-generalization hierarchy, enabling per-instantiation freshening just like type variables.

- **freshenAbove and freshenAll now freshen lifetimes** through a new ltFreshener visitor. A quantified lifetime (Level > lim) is replaced with a fresh copy at the target level, while captured lifetimes are shared. Bound lists are freshened too, so each instantiation gets independent constraints.

- **constrainLt maintains the level invariant** by extruding higher-level lifetimes down before recording them as bounds. This prevents a variable's bound from outranking its own level, keeping the freshener/extruder level prune sound.

- **extrudeLt implements lifetime extrusion** (the lifetime-sort twin of type-var extrude). A LifetimeVar above the target level is replaced by a fresh lifetime at that level, wired through the polarity-appropriate outlives bound. The cache is keyed by (var ID, polarity) so a lifetime reached in both polarities yields two distinct fresh vars with opposite wiring.

- **Proxy reuse prevents duplicate bounds** in cross-level constraints. extrudeDownAsUpper and extrudeDownAsLower reuse an existing down-extruded proxy of a lifetime among a variable's bounds, so repeated constraints don't accumulate duplicates. The reuse is probe-safe because the scan reads live bounds, and a proxy from a discarded trial is already gone.

- **RefType's lifetime is handled by rewriting visitors** through refLifetimeResult. Since Accept never walks a Lifetime (it's not a Type), each visitor (freshener, allFreshener, extruder) delegates lifetime transformation here, then either returns a RefType carrying the fresh lifetime or signals an ordinary descent to rebuild Inner.

- **LevelOf now accounts for borrow lifetimes** by returning the max of the inner content's level and the lifetime's level, so the freshener/extruder level prune correctly identifies borrows with quantified lifetimes.

- **attachParamLifetimes now receives the level** so freshly-minted parameter lifetimes are placed at the correct generalization level.

Comprehensive tests verify that instantiations get distinct lifetimes, constraining one site doesn't contaminate another, captured lifetimes are shared, bounds are copied and rolled back correctly under probes, and the level invariant is maintained across extrusion.

https://claude.ai/code/session_01HrQyHF1EadZpLNHMU2JGps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved lifetime-aware type inference and lifetime generalization by tracking lifetime levels more precisely for borrowed/ref types.
  * Enhanced lifetime subtyping constraint solving with level-consistent extrusion, caching, and deduplication to improve constraint resolution efficiency and consistency.
* **Tests**
  * Added extensive regression coverage for lifetime generalization, parameter lifetime freshening, constraint deduplication, probe safety, and level-extrusion invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->