### PR TITLE
Clarify level terminology: "above" → "inner", "down" → "out"

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -433,7 +433,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			}
 			return errs
 		}
-		// super lives at a higher level: extrude it down so it isn't wrongly
+		// super lives at an inner level: extrude it out so it isn't wrongly
 		// generalized at subVar's level.
 		return c.constrain(sub, c.extrude(super, soltype.Negative, subVar.Level, map[extrudeKey]*soltype.TypeVarType{}), seen)
 	}
@@ -496,11 +496,11 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 		// Maintain the level invariant: a bound's level must not exceed the var's, or
 		// the freshener/extruder level prune over the lifetime sort becomes unsound (M4
 		// D2.5). super sits in subVar's upper bounds, a negative-position slot, so when
-		// it outranks subVar extrude it down before recording, mirroring constrain's var
-		// arm. extrudeDownAsUpper reuses an existing down-extruded proxy of super if one
-		// is already a bound, so a repeated constraint does not mint a second proxy and
-		// defeat the ContainsLifetime dedup.
-		recSuper := c.extrudeDownAsUpper(super, subVar)
+		// it is inner to subVar extrude it out before recording, mirroring constrain's
+		// var arm. extrudeOuterAsUpper reuses an existing outer-extruded proxy of super
+		// if one is already a bound, so a repeated constraint does not mint a second
+		// proxy and defeat the ContainsLifetime dedup.
+		recSuper := c.extrudeOuterAsUpper(super, subVar)
 		if !soltype.ContainsLifetime(subVar.UpperBounds, recSuper) {
 			c.addUpperLtBound(subVar, recSuper)
 		}
@@ -510,9 +510,9 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 		}
 	}
 	if superIsVar {
-		// sub sits in superVar's lower bounds, a positive-position slot; extrude it down
+		// sub sits in superVar's lower bounds, a positive-position slot; extrude it out
 		// to superVar's level for the same invariant, reusing an existing proxy.
-		recSub := c.extrudeDownAsLower(sub, superVar)
+		recSub := c.extrudeOuterAsLower(sub, superVar)
 		if !soltype.ContainsLifetime(superVar.LowerBounds, recSub) {
 			c.addLowerLtBound(superVar, recSub)
 		}
@@ -523,15 +523,15 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	}
 }
 
-// extrudeDownAsUpper returns the lifetime to record as v's upper bound when
-// constraining v <: lt (M4 D2.5). lt is shared when it does not outrank v. When it
-// does, it is extruded down to v's level so v's bound never outranks v. A repeated
+// extrudeOuterAsUpper returns the lifetime to record as v's upper bound when
+// constraining v <: lt (M4 D2.5). lt is shared when it is not inner to v. When it
+// is, it is extruded out to v's level so v's bound is never inner to v. A repeated
 // constraint must not mint a fresh proxy each time, or the ContainsLifetime dedup —
 // which keys on identity — never matches and bounds accumulate. So an existing
-// down-extruded proxy of lt already among v's upper bounds is reused. This is
+// outer-extruded proxy of lt already among v's upper bounds is reused. This is
 // probe-safe: the scan reads v's current journal-managed bounds, so a proxy from a
 // discarded trial is already gone and a fresh one is minted.
-func (c *Context) extrudeDownAsUpper(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
+func (c *Context) extrudeOuterAsUpper(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
 	if soltype.LevelOfLifetime(lt) <= v.Level {
 		return lt
 	}
@@ -541,10 +541,10 @@ func (c *Context) extrudeDownAsUpper(lt soltype.Lifetime, v *soltype.LifetimeVar
 	return c.extrudeLt(lt, soltype.Negative, v.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
 }
 
-// extrudeDownAsLower is the lower-bound counterpart of extrudeDownAsUpper, for
-// constraining lt <: v: it reuses an existing down-extruded proxy of lt among v's
-// lower bounds, else extrudes lt down in positive position.
-func (c *Context) extrudeDownAsLower(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
+// extrudeOuterAsLower is the lower-bound counterpart of extrudeOuterAsUpper, for
+// constraining lt <: v: it reuses an existing outer-extruded proxy of lt among v's
+// lower bounds, else extrudes lt out in positive position.
+func (c *Context) extrudeOuterAsLower(lt soltype.Lifetime, v *soltype.LifetimeVar) soltype.Lifetime {
 	if soltype.LevelOfLifetime(lt) <= v.Level {
 		return lt
 	}
@@ -554,7 +554,7 @@ func (c *Context) extrudeDownAsLower(lt soltype.Lifetime, v *soltype.LifetimeVar
 	return c.extrudeLt(lt, soltype.Positive, v.Level, map[ltExtrudeKey]*soltype.LifetimeVar{})
 }
 
-// extrude copies t so that variables above lvl are replaced by fresh variables
+// extrude copies t so that variables inner to lvl are replaced by fresh variables
 // at lvl, wired to the originals through the polarity-appropriate bound
 // direction. The cache is keyed by (var ID, polarity): a variable reached in
 // both polarities during a single extrusion must yield two distinct fresh vars
@@ -567,14 +567,14 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 	return t.Accept(&extruder{c: c, lvl: lvl, cache: cache}, pol)
 }
 
-// extrudeLt copies a lifetime so a LifetimeVar above lvl is replaced by a fresh
+// extrudeLt copies a lifetime so a LifetimeVar inner to lvl is replaced by a fresh
 // lifetime at lvl, wired to the original through the polarity-appropriate outlives
 // bound (M4 D2.5) — the lifetime-sort twin of extrude's var node. The cache is
 // keyed by (var ID, polarity) for the same reason the type-var cache is. A
-// 'static, nil slot, or below-lvl lifetime extrudes to itself. Bound appends route
-// through the journaling helpers; mutating the ORIGINAL var's bound is the append a
-// Discard must truncate. The fresh var's appends are a harmless no-op, since a fresh
-// var is unreachable after a Discard.
+// 'static, nil slot, or lifetime at lvl or outside it extrudes to itself. Bound
+// appends route through the journaling helpers; mutating the ORIGINAL var's bound is
+// the append a Discard must truncate. The fresh var's appends are a harmless no-op,
+// since a fresh var is unreachable after a Discard.
 func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, cache map[ltExtrudeKey]*soltype.LifetimeVar) soltype.Lifetime {
 	lv, ok := lt.(*soltype.LifetimeVar)
 	if !ok || lv.Level <= lvl {
@@ -586,7 +586,7 @@ func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, 
 	}
 	nlv := c.freshLifetime(lvl)
 	cache[key] = nlv
-	// Remember which lifetime nlv is a down-extruded proxy of, so a repeated outlives
+	// Remember which lifetime nlv is an outer-extruded proxy of, so a repeated outlives
 	// constraint can reuse this proxy instead of minting a second one (constrainLt's
 	// findExtrudedLtBound dedup, M4 D2.5).
 	c.recordLtProxy(nlv, lv)
@@ -618,7 +618,7 @@ type extruder struct {
 }
 
 func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	// A subtree with no variable above lvl extrudes to itself (identity-shared).
+	// A subtree with no variable inner to lvl extrudes to itself (identity-shared).
 	if soltype.LevelOf(t) <= e.lvl {
 		return soltype.EnterResult{Type: t, SkipChildren: true}
 	}

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -30,7 +30,7 @@ type Context struct {
 	// the same probe discipline as a TypeVarType.
 	lifetimeCounter int
 
-	// ltProxyOrigin maps a down-extruded lifetime proxy to the lifetime it was
+	// ltProxyOrigin maps an outer-extruded lifetime proxy to the lifetime it was
 	// extruded from (M4 D2.5). constrainLt consults it through findLtProxy to reuse
 	// an existing proxy for a repeated cross-level outlives constraint, so the bound
 	// dedup is not defeated by minting a fresh proxy each time. It is metadata only
@@ -50,7 +50,7 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 
 // freshLifetime allocates a new lifetime variable at the given level, assigning it
 // the next id in sequence. Lifetimes now ride the same let-generalization level
-// hierarchy as types (M4 D2.5): a lifetime minted above its scheme's
+// hierarchy as types (M4 D2.5): a lifetime minted inside its scheme's
 // generalize-level is freshened per instantiation, so two uses of a
 // borrow-passing function never share one LifetimeVar.
 func (c *Context) freshLifetime(level int) *soltype.LifetimeVar {
@@ -75,7 +75,7 @@ func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
 	v.UpperBounds = append(v.UpperBounds, lt)
 }
 
-// recordLtProxy notes that proxy is a down-extruded copy of origin, so a later
+// recordLtProxy notes that proxy is an outer-extruded copy of origin, so a later
 // repeated outlives constraint can reuse the proxy rather than mint a new one (M4
 // D2.5). Lazily allocates the map.
 func (c *Context) recordLtProxy(proxy *soltype.LifetimeVar, origin soltype.Lifetime) {
@@ -85,7 +85,7 @@ func (c *Context) recordLtProxy(proxy *soltype.LifetimeVar, origin soltype.Lifet
 	c.ltProxyOrigin[proxy] = origin
 }
 
-// findLtProxy returns a lifetime among bounds that is a down-extruded proxy of
+// findLtProxy returns a lifetime among bounds that is an outer-extruded proxy of
 // origin, or nil if none. Identity-keyed: a proxy matches only when ltProxyOrigin
 // records it against the exact origin pointer. Scanning live bounds keeps it
 // probe-safe — a proxy a discarded trial removed from its bound list is not found.

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -279,9 +279,9 @@ func TestConstrainLtRecordsLowerLevelBoundDirectly(t *testing.T) {
 }
 
 // A repeated cross-level outlives constraint does NOT accumulate duplicate bounds.
-// Extrusion mints a down-extruded proxy of `high`; without proxy reuse the second
+// Extrusion mints an outer-extruded proxy of `high`; without proxy reuse the second
 // call would mint a second proxy and the identity-keyed ContainsLifetime dedup would
-// never match, so `low.UpperBounds` would grow to 2. extrudeDownAsUpper reuses the
+// never match, so `low.UpperBounds` would grow to 2. extrudeOuterAsUpper reuses the
 // first proxy, so the bound count stays 1 across repeats — the lifetime-sort
 // analogue of the same-level dedup, restored for the cross-level path.
 func TestConstrainLtCrossLevelDoesNotAccumulateDuplicates(t *testing.T) {
@@ -292,7 +292,7 @@ func TestConstrainLtCrossLevelDoesNotAccumulateDuplicates(t *testing.T) {
 	c.ctx.constrainLt(low, high)
 	upperAfterFirst := len(low.UpperBounds)
 	lowerAfterFirst := len(high.LowerBounds)
-	require.Equal(t, 1, upperAfterFirst, "low gains one down-extruded proxy of high as an upper bound")
+	require.Equal(t, 1, upperAfterFirst, "low gains one outer-extruded proxy of high as an upper bound")
 
 	c.ctx.constrainLt(low, high) // identical cross-level constraint again
 

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -128,7 +128,7 @@ type freshener struct {
 }
 
 func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
-	// Every variable inside t is at or below lim: nothing to freshen, SHARE the node
+	// Every variable inside t is at lim or outside it: nothing to freshen, SHARE the node
 	// (the original pointer flows through unchanged — Accept's identity preservation
 	// gives the same result for the structural arms too). Two consequences worth
 	// naming:
@@ -212,7 +212,7 @@ func (c *checker) freshenAll(t soltype.Type, lvl int) soltype.Type {
 		c:     c,
 		lvl:   lvl,
 		cache: map[*soltype.TypeVarType]*soltype.TypeVarType{},
-		// lim is below every lifetime level, so fresh replaces EVERY lifetime — the
+		// lim is outside every lifetime level, so fresh replaces EVERY lifetime — the
 		// lifetime-sort analogue of allFreshener's no-prune treatment of type vars.
 		lt: ltFreshener{ctx: c.ctx, lim: math.MinInt, lvl: lvl},
 	}, soltype.Positive)
@@ -272,10 +272,10 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // ltFreshener freshens lifetime variables for the rewriting visitors (M4 D2.5).
 // Accept never walks a RefType's lifetime, because a Lifetime is not a Type, so each
 // lifetime-aware visitor delegates here through refLifetimeResult. A LifetimeVar
-// above lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
+// inside lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
 // lvl and freshens its bounds, so each use gets its own lifetime and constraining
-// one site does not perturb another. A LifetimeVar at lim or below, 'static, and a
-// nil slot are shared. The freshener passes its own lim; allFreshener passes
+// one site does not perturb another. A LifetimeVar at lim or outside it, 'static,
+// and a nil slot are shared. The freshener passes its own lim; allFreshener passes
 // math.MinInt so every lifetime is freshened.
 //
 // The cache is allocated lazily, so a borrow-free rewrite pays no allocation. It is

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -108,7 +108,7 @@ breakdown, design rationale, and per-file sketches.
 **Accept:** unit tests for `constrain` (prim/function variance with exact
 arity — same-arity required, both fewer and more params rejected, parallel
 to the exact-tuple same-length rule; levels + extrusion with no
-higher-level var leakage into lower-level bound lists); coalescing
+inner-level var leakage into outer-level bound lists); coalescing
 (inline-to-bounds, empty-bound collapse to `never`/`unknown`, multi-bound
 union/intersection); printer round-trips for the M1 coalesced type set
 (prims, literals, tuples, multi-arg functions, `never`/`unknown`,

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1062,7 +1062,7 @@ these arms it must add.
     - **extruder:** the analogous `*RefType`/lifetime arm, wiring the fresh lifetime
       var to the original through the polarity-appropriate outlives bound, mirroring
       the type-var extrude.
-    - **`constrainLt`:** extrude a higher-level lifetime down before recording a bound,
+    - **`constrainLt`:** extrude an inner-level lifetime out before recording a bound,
       mirroring `constrain`'s `levelOf(rhs) <= lv.level` branch, so the lifetime-level
       invariant the freshener prune relies on is maintained.
   - **Accept (Option A):**


### PR DESCRIPTION
Rename level-related terminology throughout the solver to use more precise language. The type system uses a nesting hierarchy where "inner" (higher numeric level) and "outer" (lower numeric level) describe the relationship between scopes. Comments and function names previously used "above/below" and "down-extrude" which conflated numeric ordering with spatial direction.

Changes:
- Replace "above/below" with "inner/outside" when describing level relationships (e.g., "variables above lvl" → "variables inner to lvl")
- Rename `extrudeDownAsUpper` to `extrudeOuterAsUpper` and `extrudeDownAsLower` to `extrudeOuterAsLower`
- Update all related comments and docstrings to use consistent terminology
- Clarify that extrusion moves variables from inner scopes to outer scopes, not "down" but "out"

This improves clarity for readers unfamiliar with the codebase by using terminology that directly describes the scope nesting structure rather than relying on implicit numeric conventions.

https://claude.ai/code/session_01X8Y4wp1H6NYRM4qunSweKd