### PR TITLE
M4 D3: Join borrows with distinct lifetimes and escape-to-static

### DIFF
--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -37,6 +37,27 @@ type LifetimeVar struct {
 	Level       int
 	LowerBounds []Lifetime
 	UpperBounds []Lifetime
+
+	// Join marks an internal lifetime minted at a multi-source join site — a return
+	// or branch that unites several borrows with distinct lifetimes (M4 D3). A join
+	// variable is NOT a borrow origin, so it is never named in the output; it
+	// renders as the union of the param lifetimes it reaches through its bounds,
+	// e.g. returning one of two borrows coalesces to `('a | 'b)`. A param lifetime
+	// (Join false), the default, originates at a borrow parameter and renders under
+	// its own name. The distinction governs coalesceLifetime: a param variable is
+	// kept whole, a join variable is expanded to its reachable members.
+	Join bool
+}
+
+// BoundsAt returns a lifetime variable's polarity-relevant bounds: lower bounds in
+// Positive position (an output joins its lower bounds), upper bounds in Negative
+// position (an input meets its upper bounds). The lifetime-sort twin of
+// TypeVarType.BoundsAt.
+func (v *LifetimeVar) BoundsAt(pol Polarity) []Lifetime {
+	if pol == Positive {
+		return v.LowerBounds
+	}
+	return v.UpperBounds
 }
 
 // StaticLifetime is 'static, the bottom of the outlives lattice: it outlives every
@@ -44,6 +65,18 @@ type LifetimeVar struct {
 // for X = 'static, so asserting it forces X to 'static — the escape-to-static
 // constraint.
 type StaticLifetime struct{}
+
+// LifetimeUnion is a coalescing-OUTPUT-only lifetime: the union of the param
+// lifetimes a join variable reaches, e.g. returning one of two borrows renders as
+// `('a | 'b)`. It never appears as a constraint input — constrainLt relates
+// LifetimeVars and 'static only — and is minted solely by coalesceLifetime when a
+// join variable expands to more than one member. A single-member expansion yields
+// the member directly, so a LifetimeUnion always carries at least two lifetimes.
+type LifetimeUnion struct {
+	Lifetimes []Lifetime
+}
+
+func (*LifetimeUnion) isLifetime() {}
 
 // Static is the canonical 'static value. Prefer it over a fresh
 // &StaticLifetime{} at every origination site (escape-to-static, annotations) so

--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -38,21 +38,22 @@ type LifetimeVar struct {
 	LowerBounds []Lifetime
 	UpperBounds []Lifetime
 
-	// Join marks an internal lifetime minted at a multi-source join site — a return
-	// or branch that unites several borrows with distinct lifetimes (M4 D3). A join
-	// variable is NOT a borrow origin, so it is never named in the output; it
-	// renders as the union of the param lifetimes it reaches through its bounds,
-	// e.g. returning one of two borrows coalesces to `('a | 'b)`. A param lifetime
-	// (Join false), the default, originates at a borrow parameter and renders under
-	// its own name. The distinction governs coalesceLifetime: a param variable is
-	// kept whole, a join variable is expanded to its reachable members.
+	// Join marks an internal lifetime minted at a multi-source join site (M4 D3).
+	// A join site is a return or branch that unites several borrows with distinct
+	// lifetimes. A join variable is NOT a borrow origin, so it is never named in
+	// the output. It renders as the union of the param lifetimes it reaches through
+	// its bounds, e.g. returning one of two borrows coalesces to `('a | 'b)`. The
+	// default is a param lifetime, Join false, which originates at a borrow
+	// parameter and renders under its own name. The distinction governs
+	// coalesceLifetime. A param variable is kept whole, a join variable is expanded
+	// to its reachable members.
 	Join bool
 }
 
-// BoundsAt returns a lifetime variable's polarity-relevant bounds: lower bounds in
-// Positive position (an output joins its lower bounds), upper bounds in Negative
-// position (an input meets its upper bounds). The lifetime-sort twin of
-// TypeVarType.BoundsAt.
+// BoundsAt returns a lifetime variable's polarity-relevant bounds. In Positive
+// position it returns the lower bounds, because an output joins its lower bounds.
+// In Negative position it returns the upper bounds, because an input meets its
+// upper bounds. This is the lifetime-sort twin of TypeVarType.BoundsAt.
 func (v *LifetimeVar) BoundsAt(pol Polarity) []Lifetime {
 	if pol == Positive {
 		return v.LowerBounds
@@ -66,10 +67,10 @@ func (v *LifetimeVar) BoundsAt(pol Polarity) []Lifetime {
 // constraint.
 type StaticLifetime struct{}
 
-// LifetimeUnion is a coalescing-OUTPUT-only lifetime: the union of the param
+// LifetimeUnion is a coalescing-output-only lifetime. It is the union of the param
 // lifetimes a join variable reaches, e.g. returning one of two borrows renders as
-// `('a | 'b)`. It never appears as a constraint input — constrainLt relates
-// LifetimeVars and 'static only — and is minted solely by coalesceLifetime when a
+// `('a | 'b)`. It never appears as a constraint input, since constrainLt relates
+// LifetimeVars and 'static only. It is minted solely by coalesceLifetime when a
 // join variable expands to more than one member. A single-member expansion yields
 // the member directly, so a LifetimeUnion always carries at least two lifetimes.
 type LifetimeUnion struct {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -197,9 +197,9 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 		}
 		return "'l" + strconv.Itoa(lt.ID)
 	case *LifetimeUnion:
-		// A join lifetime's coalesced face. It is the union of the param lifetimes
-		// it reaches, parenthesized so the `mut`/borrow prefix binds the whole union,
-		// giving `mut ('a | 'b) {…}` rather than `mut 'a | 'b {…}`.
+		// The union form a join lifetime coalesces to. It is the union of the param
+		// lifetimes it reaches, parenthesized so the `mut`/borrow prefix binds the
+		// whole union, giving `mut ('a | 'b) {…}` rather than `mut 'a | 'b {…}`.
 		parts := make([]string, len(lt.Lifetimes))
 		for i, m := range lt.Lifetimes {
 			parts[i] = p.printLifetime(m)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -197,9 +197,9 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 		}
 		return "'l" + strconv.Itoa(lt.ID)
 	case *LifetimeUnion:
-		// A join lifetime's coalesced face: the union of the param lifetimes it
-		// reaches, parenthesized so the `mut`/borrow prefix binds the whole union —
-		// `mut ('a | 'b) {…}`, not `mut 'a | 'b {…}`.
+		// A join lifetime's coalesced face. It is the union of the param lifetimes
+		// it reaches, parenthesized so the `mut`/borrow prefix binds the whole union,
+		// giving `mut ('a | 'b) {…}` rather than `mut 'a | 'b {…}`.
 		parts := make([]string, len(lt.Lifetimes))
 		for i, m := range lt.Lifetimes {
 			parts[i] = p.printLifetime(m)

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -196,6 +196,15 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 			}
 		}
 		return "'l" + strconv.Itoa(lt.ID)
+	case *LifetimeUnion:
+		// A join lifetime's coalesced face: the union of the param lifetimes it
+		// reaches, parenthesized so the `mut`/borrow prefix binds the whole union —
+		// `mut ('a | 'b) {…}`, not `mut 'a | 'b {…}`.
+		parts := make([]string, len(lt.Lifetimes))
+		for i, m := range lt.Lifetimes {
+			parts[i] = p.printLifetime(m)
+		}
+		return "(" + strings.Join(parts, " | ") + ")"
 	}
 	panic(fmt.Sprintf("printLifetime: unhandled %T", lt))
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -580,6 +580,7 @@ func equalType(a, b soltype.Type) bool {
 //   - A LifetimeUnion is the union form a join variable coalesces to in D3, such as
 //     'a | 'b. Two are equal when they hold the same members, pairwise equal in
 //     order. This lets two RefTypes carrying the same coalesced union dedup.
+//
 // This mirrors how the rest of equalType keys variables by pointer and primitives by
 // value.
 func ltEqual(a, b soltype.Lifetime) bool {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -77,7 +77,9 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(bounds), v.Open)), SkipChildren: true}
 }
 
-func (c *coalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return coalesceRefLifetime(t, pol)
+}
 
 // widenVar lowers a widenable `var` binding's coalesced value to its primitive
 // (M4 B3) when it is read in covariant (Positive) position — `var a = 5` ⇒
@@ -222,7 +224,9 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	return soltype.EnterResult{Type: widenVar(v, pol, combine(pol, dedup(parts), v.Open)), SkipChildren: true}
 }
 
-func (c *schemeCoalescer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return coalesceRefLifetime(t, pol)
+}
 
 // schemeType returns a scheme's coalesced DISPLAY type (variable-free except for
 // retained type parameters), the soltype handed to soltype.PrintAsScheme and
@@ -570,14 +574,28 @@ func equalType(a, b soltype.Type) bool {
 // ltEqual reports lifetime equality for equalType's RefType arm (D2). A
 // LifetimeVar is identity-keyed, so two are equal only when they are the same
 // pointer; 'static is a value, so any two StaticLifetimes are equal; a nil
-// lifetime (an owned-mutable borrow) equals only another nil. This mirrors how the
-// rest of equalType keys variables by pointer and primitives by value.
+// lifetime (an owned-mutable borrow) equals only another nil. A LifetimeUnion (a
+// join's coalesced face, D3) is compared structurally — equal iff its members are
+// pairwise equal in order — so two RefTypes with the same join face dedup. This
+// mirrors how the rest of equalType keys variables by pointer and primitives by value.
 func ltEqual(a, b soltype.Lifetime) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
 	if soltype.IsStaticLifetime(a) || soltype.IsStaticLifetime(b) {
 		return soltype.IsStaticLifetime(a) && soltype.IsStaticLifetime(b)
+	}
+	if ua, ok := a.(*soltype.LifetimeUnion); ok {
+		ub, ok := b.(*soltype.LifetimeUnion)
+		if !ok || len(ua.Lifetimes) != len(ub.Lifetimes) {
+			return false
+		}
+		for i := range ua.Lifetimes {
+			if !ltEqual(ua.Lifetimes[i], ub.Lifetimes[i]) {
+				return false
+			}
+		}
+		return true
 	}
 	return a == b
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -571,13 +571,17 @@ func equalType(a, b soltype.Type) bool {
 	return false
 }
 
-// ltEqual reports lifetime equality for equalType's RefType arm (D2). A
-// LifetimeVar is identity-keyed, so two are equal only when they are the same
-// pointer; 'static is a value, so any two StaticLifetimes are equal; a nil
-// lifetime (an owned-mutable borrow) equals only another nil. A LifetimeUnion (a
-// join's coalesced face, D3) is compared structurally — equal iff its members are
-// pairwise equal in order — so two RefTypes with the same join face dedup. This
-// mirrors how the rest of equalType keys variables by pointer and primitives by value.
+// ltEqual reports lifetime equality for equalType's RefType arm (D2). Each lifetime
+// form has its own equality rule:
+//   - A LifetimeVar is identity-keyed. Two are equal only when they are the same
+//     pointer.
+//   - 'static is a value, so any two StaticLifetimes are equal.
+//   - A nil lifetime is an owned-mutable borrow. It equals only another nil.
+//   - A LifetimeUnion is the union form a join variable coalesces to in D3, such as
+//     'a | 'b. Two are equal when they hold the same members, pairwise equal in
+//     order. This lets two RefTypes carrying the same coalesced union dedup.
+// This mirrors how the rest of equalType keys variables by pointer and primitives by
+// value.
 func ltEqual(a, b soltype.Lifetime) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -585,6 +585,7 @@ func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, 
 		return nlv
 	}
 	nlv := c.freshLifetime(lvl)
+	nlv.Join = lv.Join // an extruded proxy keeps the origin's join-vs-param nature
 	cache[key] = nlv
 	// Remember which lifetime nlv is an outer-extruded proxy of, so a repeated outlives
 	// constraint can reuse this proxy instead of minting a second one (constrainLt's

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -59,6 +59,16 @@ func (c *Context) freshLifetime(level int) *soltype.LifetimeVar {
 	return lv
 }
 
+// freshJoinLifetime allocates a lifetime variable for a multi-source join site (a
+// return or branch uniting several borrows, M4 D3). It is identical to
+// freshLifetime but sets Join, so coalesceLifetime expands it to the union of the
+// param lifetimes it reaches rather than naming it as a borrow origin.
+func (c *Context) freshJoinLifetime(level int) *soltype.LifetimeVar {
+	lv := c.freshLifetime(level)
+	lv.Join = true
+	return lv
+}
+
 // addLowerLtBound appends lt to v's lower bounds, journaling the mutation in the
 // active probe first so a discarded trial truncates it away. This (and
 // addUpperLtBound) is the ONLY sanctioned way to extend a lifetime bound list —

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -59,10 +59,10 @@ func (c *Context) freshLifetime(level int) *soltype.LifetimeVar {
 	return lv
 }
 
-// freshJoinLifetime allocates a lifetime variable for a multi-source join site (a
-// return or branch uniting several borrows, M4 D3). It is identical to
-// freshLifetime but sets Join, so coalesceLifetime expands it to the union of the
-// param lifetimes it reaches rather than naming it as a borrow origin.
+// freshJoinLifetime allocates a lifetime variable for a multi-source join site
+// (M4 D3). A join site is a return or branch uniting several borrows. It is
+// identical to freshLifetime but sets Join, so coalesceLifetime expands it to the
+// union of the param lifetimes it reaches rather than naming it as a borrow origin.
 func (c *Context) freshJoinLifetime(level int) *soltype.LifetimeVar {
 	lv := c.freshLifetime(level)
 	lv.Join = true

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -113,11 +113,11 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 }
 
 // Returning one of two borrows with DISTINCT lifetimes joins them into a single
-// borrow whose lifetime is the union of theirs (M4 D3, the ConditionalUnionReturn
-// acceptance). The return-point join mints a fresh join lifetime bounded below by
-// 'l0 and 'l1, which coalesces to `('l0 | 'l1)` in the positive return position. The
-// param lifetimes 'l0/'l1 stay named on the borrows they originate; D4 renders them
-// `'a`/`'b` and the union `('a | 'b)`.
+// borrow whose lifetime is the union of theirs. This is the ConditionalUnionReturn
+// acceptance (M4 D3). The return-point join mints a fresh join lifetime bounded
+// below by 'l0 and 'l1, which coalesces to `('l0 | 'l1)` in the positive return
+// position. The param lifetimes 'l0/'l1 stay named on the borrows they originate.
+// D4 renders them `'a`/`'b` and the union `('a | 'b)`.
 func TestInferConditionalUnionReturn(t *testing.T) {
 	src := `fn f(p: mut {x: number}, q: mut {x: number}) {
   if true {
@@ -133,7 +133,7 @@ func TestInferConditionalUnionReturn(t *testing.T) {
 		values["f"])
 }
 
-// Returning borrows whose objects have DIFFERENT field sets does NOT join — a mut
+// Returning borrows whose objects have DIFFERENT field sets does NOT join. A mut
 // object's field set is invariant, so uniting `mut {x}` and `mut {y}` would invent a
 // writable field absent from one branch. joinBorrows rejects the mismatch and the
 // return falls back to the generic union, preserving both borrows with their own
@@ -153,7 +153,7 @@ func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
 		values["f"])
 }
 
-// A join over THREE borrows unites all their lifetimes: the fresh join lifetime is
+// A join over THREE borrows unites all their lifetimes. The fresh join lifetime is
 // bounded below by each, coalescing to `('l0 | 'l1 | 'l2)` in the return position.
 // This confirms the join generalizes past the two-branch case to an n-ary return set.
 func TestInferThreeWayBorrowJoin(t *testing.T) {
@@ -175,12 +175,12 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 		values["f"])
 }
 
-// A GENERALIZED joined-borrow function keeps its union face after instantiation: a
+// A GENERALIZED joined-borrow function keeps its union face after instantiation. A
 // caller that passes two of its own borrows still sees a two-lifetime union, not a
 // single name. This is the only end-to-end exercise of the Join flag riding through
-// freshenAbove/extrude (D2.5): if the flag were dropped on the freshened join
+// freshenAbove/extrude (D2.5). If the flag were dropped on the freshened join
 // lifetime, the instantiated return would coalesce to one `'l{id}` instead of a
-// union. `pick` generalizes to `mut ('l0 | 'l1) {…}`; instantiating it inside `use`
+// union. `pick` generalizes to `mut ('l0 | 'l1) {…}`. Instantiating it inside `use`
 // freshens the join and its two members to use-level lifetimes, so `use` returns a
 // union of those.
 func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {
@@ -200,7 +200,7 @@ fn use(a: mut {x: number}, b: mut {x: number}) {
 		values["use"])
 }
 
-// Joining borrows that share a field NAME but disagree on its TYPE is rejected: a mut
+// Joining borrows that share a field NAME but disagree on its TYPE is rejected. A mut
 // object's fields are observable in both directions, so the join pins each shared
 // field invariant, and `number` vs `string` for `x` fails that pin in both
 // directions. This locks in that the soundness constraint actually fires rather than
@@ -220,11 +220,11 @@ func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
 	}, Messages(errs))
 }
 
-// A return set mixing a borrow with an OWNED value does not join — joinBorrows
+// A return set mixing a borrow with an OWNED value does not join. joinBorrows
 // requires every input to be a mutable borrow carrying a lifetime, and an object
-// literal is owned (not a RefType). The all-borrows gate falls back to the generic
-// union, so the result keeps the borrow's lifetime alongside the owned literal (M4
-// D3).
+// literal is owned rather than a RefType. The all-borrows gate falls back to the
+// generic union, so the result keeps the borrow's lifetime alongside the owned
+// literal (M4 D3).
 func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 	src := `fn f(p: mut {x: number}) {
   if true {
@@ -240,13 +240,13 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 		values["f"])
 }
 
-// A borrowed parameter written into module-level storage escapes to 'static (M4 D3,
-// the EscapingRefIntoStatic acceptance — now reachable from real source). `cache`
-// stores its borrow `p` into the module-level `var sink`, a GLOBAL WRITE: the value
-// outlives every borrow region, so p's lifetime is forced `<: 'static` and the
-// parameter renders `mut 'static {x: number}` rather than under a borrow lifetime
-// `'l{id}`. The store itself checks — a 'static borrow is owned-forever, so it fills
-// the owned slot instead of tripping BorrowEscapeError.
+// A borrowed parameter written into module-level storage escapes to 'static. This is
+// the EscapingRefIntoStatic acceptance (M4 D3), now reachable from real source.
+// `cache` stores its borrow `p` into the module-level `var sink`, a global write. The
+// stored value outlives every borrow region, so p's lifetime is forced `<: 'static`
+// and the parameter renders `mut 'static {x: number}` rather than under a borrow
+// lifetime `'l{id}`. The store itself checks. A 'static borrow is owned-forever, so
+// it fills the owned slot instead of tripping BorrowEscapeError.
 func TestInferGlobalWriteEscapesBorrowToStatic(t *testing.T) {
 	src := `var sink = {x: 0}
 fn cache(p: mut {x: number}) {
@@ -258,7 +258,7 @@ fn cache(p: mut {x: number}) {
 	require.Equal(t, "fn (p: mut 'static {x: number}) -> void", values["cache"])
 }
 
-// An ordinary global write of a NON-borrow value is unaffected by the escape rule:
+// An ordinary global write of a NON-borrow value is unaffected by the escape rule.
 // constrainEscape is a no-op on a non-borrow source and CarrierOf is the identity, so
 // `bump` reassigning the module-level `var n` checks exactly as before, with no
 // lifetime machinery engaged.

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -112,12 +112,13 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 	}, Messages(errs))
 }
 
-// Joining two borrows with DISTINCT lifetimes preserves both. equalType compares
-// lifetimes (D2), so dedup does not collapse `mut 'l0 {x}` and `mut 'l1 {x}` into a
-// single member and silently drop a lifetime. The branch join renders the un-joined
-// union here; D3 factors it into the `mut ('l0 | 'l1) {x}` form. Without the Lt
-// comparison in equalType this rendered `mut 'l0 {x}`, losing 'l1.
-func TestInferDistinctLifetimeBorrowsDoNotCoalesce(t *testing.T) {
+// Returning one of two borrows with DISTINCT lifetimes joins them into a single
+// borrow whose lifetime is the union of theirs (M4 D3, the ConditionalUnionReturn
+// acceptance). The return-point join mints a fresh join lifetime bounded below by
+// 'l0 and 'l1, which coalesces to `('l0 | 'l1)` in the positive return position. The
+// param lifetimes 'l0/'l1 stay named on the borrows they originate; D4 renders them
+// `'a`/`'b` and the union `('a | 'b)`.
+func TestInferConditionalUnionReturn(t *testing.T) {
 	src := `fn f(p: mut {x: number}, q: mut {x: number}) {
   if true {
     return p
@@ -128,6 +129,48 @@ func TestInferDistinctLifetimeBorrowsDoNotCoalesce(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut 'l0 {x: number} | mut 'l1 {x: number}",
+		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut ('l0 | 'l1) {x: number}",
+		values["f"])
+}
+
+// Returning borrows whose objects have DIFFERENT field sets does NOT join — a mut
+// object's field set is invariant, so uniting `mut {x}` and `mut {y}` would invent a
+// writable field absent from one branch. joinBorrows rejects the mismatch and the
+// return falls back to the generic union, preserving both borrows with their own
+// lifetimes (M4 D3).
+func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
+	src := `fn f(p: mut {x: number}, q: mut {y: number}) {
+  if true {
+    return p
+  } else {
+    return q
+  }
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {y: number}) -> mut 'l0 {x: number} | mut 'l1 {y: number}",
+		values["f"])
+}
+
+// A join over THREE borrows unites all their lifetimes: the fresh join lifetime is
+// bounded below by each, coalescing to `('l0 | 'l1 | 'l2)` in the return position.
+// This confirms the join generalizes past the two-branch case to an n-ary return set.
+func TestInferThreeWayBorrowJoin(t *testing.T) {
+	src := `fn f(p: mut {x: number}, q: mut {x: number}, r: mut {x: number}) {
+  if true {
+    return p
+  } else {
+    if true {
+      return q
+    } else {
+      return r
+    }
+  }
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}, r: mut 'l2 {x: number}) -> mut ('l0 | 'l1 | 'l2) {x: number}",
 		values["f"])
 }

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -175,8 +175,8 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 		values["f"])
 }
 
-// A GENERALIZED joined-borrow function keeps its union face after instantiation. A
-// caller that passes two of its own borrows still sees a two-lifetime union, not a
+// A GENERALIZED joined-borrow function keeps its lifetime union after instantiation.
+// A caller that passes two of its own borrows still sees a two-lifetime union, not a
 // single name. This is the only end-to-end exercise of the Join flag riding through
 // freshenAbove/extrude (D2.5). If the flag were dropped on the freshened join
 // lifetime, the instantiated return would coalesce to one `'l{id}` instead of a
@@ -205,6 +205,12 @@ fn use(a: mut {x: number}, b: mut {x: number}) {
 // field invariant, and `number` vs `string` for `x` fails that pin in both
 // directions. This locks in that the soundness constraint actually fires rather than
 // silently unifying incompatible borrows (M4 D3).
+//
+// FUTURE (M6): this error is the conservative M4 default. M6 may relax it to a
+// read-until-narrowed union — `(mut 'a {x: number}) | (mut 'b {x: string})`, readable
+// always and writable only after narrowing — to match TypeScript. See 01-milestones.md
+// M6, "Permissive mut-borrow joins". When that lands, this test changes from asserting
+// an error to asserting the union.
 func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
 	src := `fn f(p: mut {x: number}, q: mut {x: string}) {
   if true {

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -239,3 +239,36 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 		"fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number} | {x: 5}",
 		values["f"])
 }
+
+// A borrowed parameter written into module-level storage escapes to 'static (M4 D3,
+// the EscapingRefIntoStatic acceptance — now reachable from real source). `cache`
+// stores its borrow `p` into the module-level `var sink`, a GLOBAL WRITE: the value
+// outlives every borrow region, so p's lifetime is forced `<: 'static` and the
+// parameter renders `mut 'static {x: number}` rather than under a borrow lifetime
+// `'l{id}`. The store itself checks — a 'static borrow is owned-forever, so it fills
+// the owned slot instead of tripping BorrowEscapeError.
+func TestInferGlobalWriteEscapesBorrowToStatic(t *testing.T) {
+	src := `var sink = {x: 0}
+fn cache(p: mut {x: number}) {
+  sink = p
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "{x: number}", values["sink"])
+	require.Equal(t, "fn (p: mut 'static {x: number}) -> void", values["cache"])
+}
+
+// An ordinary global write of a NON-borrow value is unaffected by the escape rule:
+// constrainEscape is a no-op on a non-borrow source and CarrierOf is the identity, so
+// `bump` reassigning the module-level `var n` checks exactly as before, with no
+// lifetime machinery engaged.
+func TestInferGlobalWriteNonBorrowUnaffected(t *testing.T) {
+	src := `var n = 0
+fn bump() {
+  n = 5
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["n"])
+	require.Equal(t, "fn () -> void", values["bump"])
+}

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -174,3 +174,68 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}, r: mut 'l2 {x: number}) -> mut ('l0 | 'l1 | 'l2) {x: number}",
 		values["f"])
 }
+
+// A GENERALIZED joined-borrow function keeps its union face after instantiation: a
+// caller that passes two of its own borrows still sees a two-lifetime union, not a
+// single name. This is the only end-to-end exercise of the Join flag riding through
+// freshenAbove/extrude (D2.5): if the flag were dropped on the freshened join
+// lifetime, the instantiated return would coalesce to one `'l{id}` instead of a
+// union. `pick` generalizes to `mut ('l0 | 'l1) {…}`; instantiating it inside `use`
+// freshens the join and its two members to use-level lifetimes, so `use` returns a
+// union of those.
+func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {
+	src := `fn pick(p: mut {x: number}, q: mut {x: number}) {
+  if true { return p } else { return q }
+}
+fn use(a: mut {x: number}, b: mut {x: number}) {
+  return pick(a, b)
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut ('l0 | 'l1) {x: number}",
+		values["pick"])
+	require.Equal(t,
+		"fn (a: mut 'l3 {x: number}, b: mut 'l4 {x: number}) -> mut ('l5 | 'l7) {x: number}",
+		values["use"])
+}
+
+// Joining borrows that share a field NAME but disagree on its TYPE is rejected: a mut
+// object's fields are observable in both directions, so the join pins each shared
+// field invariant, and `number` vs `string` for `x` fails that pin in both
+// directions. This locks in that the soundness constraint actually fires rather than
+// silently unifying incompatible borrows (M4 D3).
+func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
+	src := `fn f(p: mut {x: number}, q: mut {x: string}) {
+  if true {
+    return p
+  } else {
+    return q
+  }
+}`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"cannot constrain number <: string",
+		"cannot constrain string <: number",
+	}, Messages(errs))
+}
+
+// A return set mixing a borrow with an OWNED value does not join — joinBorrows
+// requires every input to be a mutable borrow carrying a lifetime, and an object
+// literal is owned (not a RefType). The all-borrows gate falls back to the generic
+// union, so the result keeps the borrow's lifetime alongside the owned literal (M4
+// D3).
+func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
+	src := `fn f(p: mut {x: number}) {
+  if true {
+    return p
+  } else {
+    return {x: 5}
+  }
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number} | {x: 5}",
+		values["f"])
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -751,7 +751,24 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
-	c.constrainAssign(e, sourceT, targetT)
+	if b.ModuleLevel {
+		// A GLOBAL WRITE: the value is now reachable from module-level storage for the
+		// program's lifetime, so any borrow it carries must outlive every borrow region
+		// — it escapes to 'static (M4 D3). constrainEscape forces each of the source's
+		// borrow lifetimes `<: 'static`, which is why `var sink = {…}; fn(p: mut {…}) {
+		// sink = p }` reports p as `mut 'static {…}`.
+		//
+		// The value-compatibility check then runs against the source's CARRIER, not the
+		// borrow itself: a borrow forced to 'static is owned-forever, so it satisfies the
+		// owned slot — comparing the whole borrow would instead trip the
+		// borrow-into-owned BorrowEscapeError (the rule that rejects a NON-escaping
+		// borrow). CarrierOf is the identity on a non-borrow source, so an ordinary
+		// global write like `n = 5` is unaffected.
+		c.constrainEscape(sourceT)
+		c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
+	} else {
+		c.constrainAssign(e, sourceT, targetT)
+	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
 	// instantiate (the read face), NOT the coalesced write-face targetT: targetT is a

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -383,35 +383,41 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 }
 
 // constrainEscape constrains every borrow lifetime reachable in t to outlive
-// 'static (M4 D3) — the rule for a value flowing into module-level or otherwise
-// 'static storage. A borrow that escapes its borrow region must live forever, so
-// each lifetime variable v gains the upper bound 'static (`v <: 'static`), which
-// coalesceLifetime then resolves to 'static. It walks the structural carriers a
-// borrow can nest in — the RefType inner, object properties, tuple elements — so a
-// stored `{p: mut 'a Point}` escapes its inner borrow too.
+// 'static (M4 D3). It is the rule for a value flowing into module-level or otherwise
+// 'static storage. A borrow that escapes its region must live forever, so each
+// lifetime variable v gains the upper bound 'static. coalesceLifetime then resolves
+// such a forced lifetime to 'static.
 //
-// No current Escalier construct routes a borrow into 'static storage: a borrow
-// originates only at a parameter, and no syntax stores one module-level yet. So this
-// has no source-reachable call site — it lands as the rule's mechanism, covered by a
-// direct test, ready for the first escape site (a module-level binding or global
-// write) to call it.
+// inferAssign calls this on the source of a GLOBAL WRITE, a store into a
+// module-level binding. The walk rides the shared soltype visitor through
+// escapeVisitor, so it reaches a borrow in any structural position without a
+// hand-maintained type switch.
+//
+// One boundary: the visitor treats a TypeVarType as a leaf, so a borrow reachable
+// only through a usage-inferred variable is not forced here. That is the same place
+// the global-write CarrierOf peel stops, and the deeper handling rides M4 G2.
 func (c *checker) constrainEscape(t soltype.Type) {
-	switch t := t.(type) {
-	case *soltype.RefType:
-		if lt, ok := t.Lt.(*soltype.LifetimeVar); ok {
-			c.ctx.constrainLt(lt, soltype.Static)
-		}
-		c.constrainEscape(t.Inner)
-	case *soltype.ObjectType:
-		for _, e := range t.Elems {
-			c.constrainEscape(soltype.AsProperty(e).Type)
-		}
-	case *soltype.TupleType:
-		for _, e := range t.Elems {
-			c.constrainEscape(e)
+	t.Accept(escapeVisitor{c: c}, soltype.Positive)
+}
+
+// escapeVisitor forces every borrow lifetime it reaches to outlive 'static. It
+// rewrites nothing: EnterType records the constraint and returns an ordinary descent,
+// so the shared rewriting visitor carries it through a RefType inner, object
+// property, tuple element, union member, function parameter or return, and promise
+// payload alike. The 'static bound is monotonic, so visiting a borrow in any polarity
+// is sound.
+type escapeVisitor struct{ c *checker }
+
+func (v escapeVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if r, ok := t.(*soltype.RefType); ok {
+		if lt, ok := r.Lt.(*soltype.LifetimeVar); ok {
+			v.c.ctx.constrainLt(lt, soltype.Static)
 		}
 	}
+	return soltype.EnterResult{}
 }
+
+func (escapeVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // sameObjectKeys reports whether two objects carry exactly the same set of property
 // names — the join's precondition, since a mut object's field set is invariant.
@@ -752,20 +758,27 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
 	if b.ModuleLevel {
-		// A GLOBAL WRITE: the value is now reachable from module-level storage for the
-		// program's lifetime, so any borrow it carries must outlive every borrow region
-		// — it escapes to 'static (M4 D3). constrainEscape forces each of the source's
-		// borrow lifetimes `<: 'static`, which is why `var sink = {…}; fn(p: mut {…}) {
-		// sink = p }` reports p as `mut 'static {…}`.
+		// This is a global write, a store into module-level storage that lives for the
+		// program's whole run. Any borrow the value carries must outlive every borrow
+		// region, so it escapes to 'static (M4 D3).
 		//
-		// The value-compatibility check then runs against the source's CARRIER, not the
-		// borrow itself: a borrow forced to 'static is owned-forever, so it satisfies the
-		// owned slot — comparing the whole borrow would instead trip the
-		// borrow-into-owned BorrowEscapeError (the rule that rejects a NON-escaping
-		// borrow). CarrierOf is the identity on a non-borrow source, so an ordinary
-		// global write like `n = 5` is unaffected.
-		c.constrainEscape(sourceT)
+		// The value-compatibility check runs against the source's CARRIER, not the
+		// borrow itself. A borrow forced to 'static is owned-forever, so it satisfies an
+		// owned slot. Comparing the whole borrow would instead trip the
+		// borrow-into-owned BorrowEscapeError, the rule that rejects a borrow which does
+		// NOT escape. CarrierOf is the identity on a non-borrow source, so an ordinary
+		// global write such as `n = 5` is unaffected. The peel only looks through a
+		// top-level borrow and drops the source's mutability check; the fuller treatment
+		// of an escaped borrow's mutability rides M4 G2.
+		//
+		// Escape runs only when the compatibility check passes, so a rejected store does
+		// not leave the source's lifetime forced to 'static. So `var sink = {…}; fn(p:
+		// mut {…}) { sink = p }` reports p as `mut 'static {…}`.
+		errsBefore := len(c.errs)
 		c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
+		if len(c.errs) == errsBefore {
+			c.constrainEscape(sourceT)
+		}
 	} else {
 		c.constrainAssign(e, sourceT, targetT)
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -315,6 +315,14 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 	case 1:
 		return collected[0]
 	default:
+		// M4 D3: several returns of borrowed objects that differ only in lifetime join
+		// into one borrow whose lifetime unites theirs, so `if c { return p } else {
+		// return q }` over two `mut` params is `mut ('a | 'b) {…}` rather than the
+		// un-joined `mut 'a {…} | mut 'b {…}`. A mixed or non-borrow set falls through to
+		// the generic union below.
+		if joined, ok := c.joinBorrows(node, lvl, collected); ok {
+			return joined
+		}
 		joinVar := c.freshAt(lvl)
 		c.recordProv(joinVar, node, ReturnJoin)
 		for _, rt := range collected {
@@ -322,6 +330,101 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		}
 		return joinVar
 	}
+}
+
+// joinBorrows synthesizes the join of several borrowed objects that differ only in
+// lifetime (M4 D3). It applies only when EVERY input is a mutable borrow of an
+// object, all sharing the same field-name set with each carrying a lifetime. The
+// result is one mutable borrow whose lifetime is a fresh JOIN variable bounded below
+// by each input's lifetime — so a positive-position result coalesces to `('a | 'b)`
+// — with the shared fields constrained invariant across the inputs. A mut object's
+// fields are observable in both directions, so a sound join pins them equal; uniting
+// differing field sets is rejected (ok=false) because it would invent writable fields
+// absent from one input.
+//
+// ok=false leaves the caller on its generic union path. A usage-inferred borrow is a
+// type variable here, not a concrete RefType, so it falls through to ok=false —
+// matching the spike, which joins only concrete mut records.
+func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
+	refs := make([]*soltype.RefType, len(types))
+	objs := make([]*soltype.ObjectType, len(types))
+	for i, t := range types {
+		r, ok := t.(*soltype.RefType)
+		if !ok || !r.Mut || r.Lt == nil {
+			return nil, false
+		}
+		obj, ok := r.Inner.(*soltype.ObjectType)
+		if !ok {
+			return nil, false
+		}
+		if i > 0 && !sameObjectKeys(objs[0], obj) {
+			return nil, false
+		}
+		refs[i] = r
+		objs[i] = obj
+	}
+
+	joinLt := c.ctx.freshJoinLifetime(lvl)
+	for _, r := range refs {
+		c.ctx.constrainLt(r.Lt, joinLt)
+	}
+	// Pin each shared field invariant across the inputs: a mut object's fields are
+	// read AND written through the join, so the join is sound only when they agree.
+	for _, e := range objs[0].Elems {
+		name := soltype.AsProperty(e).Name
+		first, _ := objs[0].Prop(name)
+		for _, obj := range objs[1:] {
+			other, _ := obj.Prop(name)
+			c.constrain(node, first.Type, other.Type)
+			c.constrain(node, other.Type, first.Type)
+		}
+	}
+	return &soltype.RefType{Mut: true, Lt: joinLt, Inner: objs[0]}, true
+}
+
+// constrainEscape constrains every borrow lifetime reachable in t to outlive
+// 'static (M4 D3) — the rule for a value flowing into module-level or otherwise
+// 'static storage. A borrow that escapes its borrow region must live forever, so
+// each lifetime variable v gains the upper bound 'static (`v <: 'static`), which
+// coalesceLifetime then resolves to 'static. It walks the structural carriers a
+// borrow can nest in — the RefType inner, object properties, tuple elements — so a
+// stored `{p: mut 'a Point}` escapes its inner borrow too.
+//
+// No current Escalier construct routes a borrow into 'static storage: a borrow
+// originates only at a parameter, and no syntax stores one module-level yet. So this
+// has no source-reachable call site — it lands as the rule's mechanism, covered by a
+// direct test, ready for the first escape site (a module-level binding or global
+// write) to call it.
+func (c *checker) constrainEscape(t soltype.Type) {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if lt, ok := t.Lt.(*soltype.LifetimeVar); ok {
+			c.ctx.constrainLt(lt, soltype.Static)
+		}
+		c.constrainEscape(t.Inner)
+	case *soltype.ObjectType:
+		for _, e := range t.Elems {
+			c.constrainEscape(soltype.AsProperty(e).Type)
+		}
+	case *soltype.TupleType:
+		for _, e := range t.Elems {
+			c.constrainEscape(e)
+		}
+	}
+}
+
+// sameObjectKeys reports whether two objects carry exactly the same set of property
+// names — the join's precondition, since a mut object's field set is invariant.
+func sameObjectKeys(a, b *soltype.ObjectType) bool {
+	if len(a.Elems) != len(b.Elems) {
+		return false
+	}
+	for _, e := range a.Elems {
+		if _, ok := b.Prop(soltype.AsProperty(e).Name); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // asyncReturn computes an `async fn`'s external return type, which always faces

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -316,7 +316,7 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		return collected[0]
 	default:
 		// M4 D3: several returns of borrowed objects that differ only in lifetime join
-		// into one borrow whose lifetime unites theirs, so `if c { return p } else {
+		// into one borrow whose lifetime unites theirs. So `if c { return p } else {
 		// return q }` over two `mut` params is `mut ('a | 'b) {…}` rather than the
 		// un-joined `mut 'a {…} | mut 'b {…}`. A mixed or non-borrow set falls through to
 		// the generic union below.
@@ -336,15 +336,15 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 // lifetime (M4 D3). It applies only when EVERY input is a mutable borrow of an
 // object, all sharing the same field-name set with each carrying a lifetime. The
 // result is one mutable borrow whose lifetime is a fresh JOIN variable bounded below
-// by each input's lifetime — so a positive-position result coalesces to `('a | 'b)`
-// — with the shared fields constrained invariant across the inputs. A mut object's
-// fields are observable in both directions, so a sound join pins them equal; uniting
-// differing field sets is rejected (ok=false) because it would invent writable fields
+// by each input's lifetime, so a positive-position result coalesces to `('a | 'b)`.
+// The shared fields are constrained invariant across the inputs. A mut object's
+// fields are observable in both directions, so a sound join pins them equal. Uniting
+// differing field sets returns ok=false, because it would invent writable fields
 // absent from one input.
 //
 // ok=false leaves the caller on its generic union path. A usage-inferred borrow is a
-// type variable here, not a concrete RefType, so it falls through to ok=false —
-// matching the spike, which joins only concrete mut records.
+// type variable here, not a concrete RefType, so it returns ok=false. This matches
+// the spike, which joins only concrete mut records.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
 	refs := make([]*soltype.RefType, len(types))
 	objs := make([]*soltype.ObjectType, len(types))
@@ -393,15 +393,16 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 // escapeVisitor, so it reaches a borrow in any structural position without a
 // hand-maintained type switch.
 //
-// One boundary: the visitor treats a TypeVarType as a leaf, so a borrow reachable
-// only through a usage-inferred variable is not forced here. That is the same place
-// the global-write CarrierOf peel stops, and the deeper handling rides M4 G2.
+// There is one boundary. The visitor treats a TypeVarType as a leaf, so a borrow
+// reachable only through a usage-inferred variable is not forced here. That is the
+// same place the global-write CarrierOf peel stops, and the deeper handling rides
+// M4 G2.
 func (c *checker) constrainEscape(t soltype.Type) {
 	t.Accept(escapeVisitor{c: c}, soltype.Positive)
 }
 
 // escapeVisitor forces every borrow lifetime it reaches to outlive 'static. It
-// rewrites nothing: EnterType records the constraint and returns an ordinary descent,
+// rewrites nothing. EnterType records the constraint and returns an ordinary descent,
 // so the shared rewriting visitor carries it through a RefType inner, object
 // property, tuple element, union member, function parameter or return, and promise
 // payload alike. The 'static bound is monotonic, so visiting a borrow in any polarity
@@ -768,7 +769,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// borrow-into-owned BorrowEscapeError, the rule that rejects a borrow which does
 		// NOT escape. CarrierOf is the identity on a non-borrow source, so an ordinary
 		// global write such as `n = 5` is unaffected. The peel only looks through a
-		// top-level borrow and drops the source's mutability check; the fuller treatment
+		// top-level borrow and drops the source's mutability check. The fuller treatment
 		// of an escaped borrow's mutability rides M4 G2.
 		//
 		// Escape runs only when the compatibility check passes, so a rejected store does

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -7,14 +7,14 @@ import (
 
 // coalesceRefLifetime rewrites a coalesced RefType's lifetime to its display form
 // (M4 D3). The structural coalescers rebuild a RefType through the shared visitor,
-// which carries the lifetime through unchanged because a Lifetime is not a Type; this
-// runs in their ExitType to resolve that lifetime the way the var arms resolve a
-// type variable. A non-RefType, or a borrow with no lifetime, passes through
-// untouched. The RefType lifetime is covariant — the mut-driven write view never
-// touches it — so it coalesces in the borrow's own polarity, pol.
+// which carries the lifetime through unchanged because a Lifetime is not a Type.
+// This runs in their ExitType to resolve that lifetime the way the var arms resolve
+// a type variable. A non-RefType, or a borrow with no lifetime, passes through
+// untouched. The RefType lifetime is covariant, so it coalesces in the borrow's own
+// polarity, pol. The mut-driven write view never touches it.
 //
-// Naming and single-polarity elision of param lifetimes are deferred to D4; D3
-// resolves only the join-and-escape shape: a join variable expands to the union of
+// Naming and single-polarity elision of param lifetimes are deferred to D4. D3
+// resolves only the join-and-escape shape. A join variable expands to the union of
 // the param lifetimes it reaches, and any lifetime forced to 'static renders
 // 'static.
 func coalesceRefLifetime(t soltype.Type, pol soltype.Polarity) soltype.Type {
@@ -33,14 +33,14 @@ func coalesceRefLifetime(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // renders 'static and a nil lifetime stays nil. A lifetime variable resolves by
 // its origin:
 //
-//   - A param lifetime (a borrow origin) is kept as itself. The printer renders it
-//     under its raw 'l{ID} debug name now and its quantified name in D4. A param
+//   - A param lifetime is a borrow origin. It is kept as itself. The printer renders
+//     it under its raw 'l{ID} debug name now and its quantified name in D4. A param
 //     forced to 'static is the exception: its borrow has escaped, so it renders
 //     'static.
-//   - A join lifetime (a multi-source return/branch, Join set) expands to the union
-//     of the param lifetimes it reaches through its polarity-relevant bounds, so a
-//     return uniting two borrows coalesces to `('a | 'b)`. A reachable 'static
-//     absorbs the whole union to 'static.
+//   - A join lifetime is a multi-source return or branch with Join set. It expands
+//     to the union of the param lifetimes it reaches through its polarity-relevant
+//     bounds, so a return uniting two borrows coalesces to `('a | 'b)`. A reachable
+//     'static absorbs the whole union to 'static.
 func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetime {
 	v, ok := lt.(*soltype.LifetimeVar)
 	if !ok {
@@ -56,8 +56,8 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 	//      its own name. ContainsLifetime already dedups bounds, so this never even
 	//      reaches a second copy.
 	//   3. meet('a, 'b), two distinct lifetimes, is NOT constructed. There is no
-	//      lifetime-intersection form to hold it — only LifetimeUnion exists, and that
-	//      is the output-only join twin — so the variable keeps its own name and its
+	//      lifetime-intersection form to hold it. Only LifetimeUnion exists, and that
+	//      is the output-only join twin. So the variable keeps its own name and its
 	//      non-'static upper bounds do not appear in the result.
 	// Cases 2 and 3 both fall through to `return v`: a non-forced param renders under
 	// its own name regardless of its other upper bounds.

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -50,7 +50,7 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 	// degenerate, so that meet has only three outcomes and never builds a combined
 	// node:
 	//   1. meet('a, 'static) = 'static. 'static is the lattice bottom, so it absorbs
-	//      the meet. lifetimeForced detects the `v <: 'static` escape and returns
+	//      the meet. forcedToStatic detects the `v <: 'static` escape and returns
 	//      'static. This is the only outcome that changes the variable.
 	//   2. meet('a, 'a) = 'a. A duplicate bound is idempotent, so the variable keeps
 	//      its own name. ContainsLifetime already dedups bounds, so this never even
@@ -62,7 +62,7 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 	// Cases 2 and 3 both fall through to `return v`: a non-forced param renders under
 	// its own name regardless of its other upper bounds.
 	if !v.Join {
-		if lifetimeForced(v) {
+		if forcedToStatic(v) {
 			return soltype.Static
 		}
 		return v
@@ -115,7 +115,7 @@ func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen 
 			continue
 		}
 		if !bv.Join {
-			if lifetimeForced(bv) {
+			if forcedToStatic(bv) {
 				static = true
 				continue
 			}
@@ -145,11 +145,11 @@ func dedupLifetimes(lts []soltype.Lifetime) []soltype.Lifetime {
 	return out
 }
 
-// lifetimeForced reports whether a lifetime variable has 'static among its bounds,
+// forcedToStatic reports whether a lifetime variable has 'static among its bounds,
 // in which case it coalesces to 'static — the escape-to-static outcome. Both bound
 // directions are checked: the escape constraint `v <: 'static` adds 'static as an
 // upper bound, while a lower-bound 'static can arise from a join member.
-func lifetimeForced(v *soltype.LifetimeVar) bool {
+func forcedToStatic(v *soltype.LifetimeVar) bool {
 	return soltype.ContainsLifetime(v.LowerBounds, soltype.Static) ||
 		soltype.ContainsLifetime(v.UpperBounds, soltype.Static)
 }

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -46,6 +46,21 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 	if !ok {
 		return lt // 'static, or a nil slot handled by the caller
 	}
+	// A param lifetime resolves by MEETING its upper bounds, but this lattice is
+	// degenerate, so that meet has only three outcomes and never builds a combined
+	// node:
+	//   1. meet('a, 'static) = 'static. 'static is the lattice bottom, so it absorbs
+	//      the meet. lifetimeForced detects the `v <: 'static` escape and returns
+	//      'static. This is the only outcome that changes the variable.
+	//   2. meet('a, 'a) = 'a. A duplicate bound is idempotent, so the variable keeps
+	//      its own name. ContainsLifetime already dedups bounds, so this never even
+	//      reaches a second copy.
+	//   3. meet('a, 'b), two distinct lifetimes, is NOT constructed. There is no
+	//      lifetime-intersection form to hold it — only LifetimeUnion exists, and that
+	//      is the output-only join twin — so the variable keeps its own name and its
+	//      non-'static upper bounds do not appear in the result.
+	// Cases 2 and 3 both fall through to `return v`: a non-forced param renders under
+	// its own name regardless of its other upper bounds.
 	if !v.Join {
 		if lifetimeForced(v) {
 			return soltype.Static

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -1,0 +1,111 @@
+package solver
+
+import "github.com/escalier-lang/escalier/internal/soltype"
+
+// coalesceRefLifetime rewrites a coalesced RefType's lifetime to its display form
+// (M4 D3). The structural coalescers rebuild a RefType through the shared visitor,
+// which carries the lifetime through unchanged because a Lifetime is not a Type; this
+// runs in their ExitType to resolve that lifetime the way the var arms resolve a
+// type variable. A non-RefType, or a borrow with no lifetime, passes through
+// untouched. The RefType lifetime is covariant — the mut-driven write view never
+// touches it — so it coalesces in the borrow's own polarity, pol.
+//
+// Naming and single-polarity elision of param lifetimes are deferred to D4; D3
+// resolves only the join-and-escape shape: a join variable expands to the union of
+// the param lifetimes it reaches, and any lifetime forced to 'static renders
+// 'static.
+func coalesceRefLifetime(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	r, ok := t.(*soltype.RefType)
+	if !ok || r.Lt == nil {
+		return t
+	}
+	lt := coalesceLifetime(r.Lt, pol)
+	if lt == r.Lt {
+		return r
+	}
+	return &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}
+}
+
+// coalesceLifetime resolves a single lifetime to its display form. A 'static
+// renders 'static and a nil lifetime stays nil. A lifetime variable resolves by
+// its origin:
+//
+//   - A param lifetime (a borrow origin) is kept as itself — the printer renders it
+//     under its raw 'l{ID} debug name now, its quantified name in D4 — unless it is
+//     forced to 'static, in which case its borrow escapes and it renders 'static.
+//   - A join lifetime (a multi-source return/branch, Join set) expands to the union
+//     of the param lifetimes it reaches through its polarity-relevant bounds, so a
+//     return uniting two borrows coalesces to `('a | 'b)`. A reachable 'static
+//     absorbs the whole union to 'static.
+func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetime {
+	v, ok := lt.(*soltype.LifetimeVar)
+	if !ok {
+		return lt // 'static, or a nil slot handled by the caller
+	}
+	if !v.Join {
+		if lifetimeForced(v) {
+			return soltype.Static
+		}
+		return v
+	}
+	members, static := reachableParamLifetimes(v, pol, map[*soltype.LifetimeVar]bool{})
+	if static {
+		return soltype.Static
+	}
+	switch len(members) {
+	case 0:
+		// A join reaching no param lifetime carries no nameable lifetime — drop it,
+		// yielding an owned-mutable borrow (the wrapper's lifetime goes nil).
+		return nil
+	case 1:
+		return members[0]
+	default:
+		return &soltype.LifetimeUnion{Lifetimes: members}
+	}
+}
+
+// reachableParamLifetimes collects the param lifetimes a join variable reaches
+// through its polarity-relevant bounds — lower bounds in Positive position, upper
+// in Negative — following nested join variables transitively. It reports whether
+// 'static is reached, which absorbs the union. The seen-set keys by variable
+// identity so a cyclic bound graph terminates. A forced param member renders
+// 'static, which sets the static flag rather than adding the member.
+func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen map[*soltype.LifetimeVar]bool) ([]soltype.Lifetime, bool) {
+	if seen[v] {
+		return nil, false
+	}
+	seen[v] = true
+	var members []soltype.Lifetime
+	static := false
+	for _, b := range v.BoundsAt(pol) {
+		if soltype.IsStaticLifetime(b) {
+			static = true
+			continue
+		}
+		bv, ok := b.(*soltype.LifetimeVar)
+		if !ok {
+			continue
+		}
+		if !bv.Join {
+			if lifetimeForced(bv) {
+				static = true
+				continue
+			}
+			members = append(members, bv)
+			continue
+		}
+		sub, subStatic := reachableParamLifetimes(bv, pol, seen)
+		members = append(members, sub...)
+		static = static || subStatic
+	}
+	return members, static
+}
+
+// lifetimeForced reports whether a lifetime variable has 'static among its bounds,
+// in which case it coalesces to 'static — the escape-to-static outcome. Both bound
+// directions are checked: the escape constraint `v <: 'static` adds 'static as an
+// upper bound, while a lower-bound 'static can arise from a join member.
+func lifetimeForced(v *soltype.LifetimeVar) bool {
+	return soltype.ContainsLifetime(v.LowerBounds, soltype.Static) ||
+		soltype.ContainsLifetime(v.UpperBounds, soltype.Static)
+}

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -1,6 +1,9 @@
 package solver
 
-import "github.com/escalier-lang/escalier/internal/soltype"
+import (
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
 
 // coalesceRefLifetime rewrites a coalesced RefType's lifetime to its display form
 // (M4 D3). The structural coalescers rebuild a RefType through the shared visitor,
@@ -30,9 +33,10 @@ func coalesceRefLifetime(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // renders 'static and a nil lifetime stays nil. A lifetime variable resolves by
 // its origin:
 //
-//   - A param lifetime (a borrow origin) is kept as itself — the printer renders it
-//     under its raw 'l{ID} debug name now, its quantified name in D4 — unless it is
-//     forced to 'static, in which case its borrow escapes and it renders 'static.
+//   - A param lifetime (a borrow origin) is kept as itself. The printer renders it
+//     under its raw 'l{ID} debug name now and its quantified name in D4. A param
+//     forced to 'static is the exception: its borrow has escaped, so it renders
+//     'static.
 //   - A join lifetime (a multi-source return/branch, Join set) expands to the union
 //     of the param lifetimes it reaches through its polarity-relevant bounds, so a
 //     return uniting two borrows coalesces to `('a | 'b)`. A reachable 'static
@@ -48,17 +52,20 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 		}
 		return v
 	}
-	members, static := reachableParamLifetimes(v, pol, map[*soltype.LifetimeVar]bool{})
+	members, static := reachableParamLifetimes(v, pol, set.NewSet[*soltype.LifetimeVar]())
 	if static {
 		return soltype.Static
 	}
 	switch len(members) {
-	case 0:
-		// A join reaching no param lifetime carries no nameable lifetime — drop it,
-		// yielding an owned-mutable borrow (the wrapper's lifetime goes nil).
-		return nil
 	case 1:
 		return members[0]
+	case 0:
+		// Unreachable: joinBorrows gives every join at least one param lower bound, and
+		// a join whose members are all forced returns through the 'static branch above.
+		// Guard it so a degenerate empty union never reaches the printer as `()`. A
+		// memberless join carries no nameable lifetime, so it drops to nil, an
+		// owned-mutable borrow.
+		return nil
 	default:
 		return &soltype.LifetimeUnion{Lifetimes: members}
 	}
@@ -70,11 +77,11 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 // 'static is reached, which absorbs the union. The seen-set keys by variable
 // identity so a cyclic bound graph terminates. A forced param member renders
 // 'static, which sets the static flag rather than adding the member.
-func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen map[*soltype.LifetimeVar]bool) ([]soltype.Lifetime, bool) {
-	if seen[v] {
+func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen set.Set[*soltype.LifetimeVar]) ([]soltype.Lifetime, bool) {
+	if seen.Contains(v) {
 		return nil, false
 	}
-	seen[v] = true
+	seen.Add(v)
 	var members []soltype.Lifetime
 	static := false
 	for _, b := range v.BoundsAt(pol) {

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -56,6 +56,12 @@ func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetim
 	if static {
 		return soltype.Static
 	}
+	// reachableParamLifetimes can reach one param lifetime through two distinct
+	// nested joins, so its collected members may repeat one. Dedup before building
+	// the union so the rendered `('a | 'b)` lists each lifetime once and ltEqual's
+	// positional member comparison stays stable. Deduping here can also drop the
+	// count to one, which the switch then renders as a bare lifetime.
+	members = dedupLifetimes(members)
 	switch len(members) {
 	case 1:
 		return members[0]
@@ -106,6 +112,22 @@ func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen 
 		static = static || subStatic
 	}
 	return members, static
+}
+
+// dedupLifetimes removes duplicate lifetimes, preserving first-occurrence order.
+// The members are identity-keyed LifetimeVars, the same key ltEqual uses, so
+// pointer equality is the right notion of "the same lifetime" here.
+func dedupLifetimes(lts []soltype.Lifetime) []soltype.Lifetime {
+	seen := set.NewSet[soltype.Lifetime]()
+	out := make([]soltype.Lifetime, 0, len(lts))
+	for _, lt := range lts {
+		if seen.Contains(lt) {
+			continue
+		}
+		seen.Add(lt)
+		out = append(out, lt)
+	}
+	return out
 }
 
 // lifetimeForced reports whether a lifetime variable has 'static among its bounds,

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -159,6 +159,36 @@ func TestEscapingNestedRefIntoStatic(t *testing.T) {
 	require.Equal(t, "{p: mut 'static {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
 }
 
+// Escaping a JOINED borrow forces every param lifetime the join reaches to outlive
+// 'static, so the whole `('l0 | 'l1)` union collapses to a single 'static (M4 D3, the
+// join↔escape interaction). constrainEscape constrains the join lifetime `<:
+// 'static`, which propagates through its lower bounds to each member, and
+// coalesceLifetime then absorbs the union to 'static rather than expanding it.
+func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	join := c.ctx.freshJoinLifetime(0)
+	// The join is bounded below by each source lifetime, as joinBorrows wires it.
+	c.ctx.constrainLt(a, join)
+	c.ctx.constrainLt(b, join)
+	ref := &soltype.RefType{
+		Mut: true,
+		Lt:  join,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+		}},
+	}
+
+	// Before escape the join expands to the union of its members.
+	require.Equal(t, "mut ('l0 | 'l1) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+
+	c.constrainEscape(ref)
+
+	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
+	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+}
+
 // A discarded probe truncates every lifetime bound the trial appended back to the
 // pre-probe length, exactly as it does for type-variable bounds — the second sort
 // rides the same journal discipline. Bounds added before the probe survive.

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -114,11 +114,11 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 }
 
 // A borrowed value flowing into 'static storage has its lifetime forced to outlive
-// 'static (M4 D3, the EscapingRefIntoStatic acceptance). constrainEscape constrains
-// the borrow's lifetime `<: 'static`, so coalescing the borrow renders it `mut
-// 'static {x: number}` rather than under the param's own name. No Escalier construct
-// routes a borrow into static storage yet — a borrow originates only at a parameter
-// — so this exercises the rule's mechanism directly.
+// 'static. This is the EscapingRefIntoStatic acceptance (M4 D3). constrainEscape
+// constrains the borrow's lifetime `<: 'static`, so coalescing the borrow renders it
+// `mut 'static {x: number}` rather than under the param's own name. No Escalier
+// construct routes a borrow into static storage yet, since a borrow originates only
+// at a parameter, so this exercises the rule's mechanism directly.
 func TestEscapingRefIntoStatic(t *testing.T) {
 	c := newChecker()
 	lt := c.ctx.freshLifetime(0)
@@ -136,7 +136,7 @@ func TestEscapingRefIntoStatic(t *testing.T) {
 	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
-// Escape reaches a borrow NESTED inside an object property: storing `{p: mut 'a
+// Escape reaches a borrow NESTED inside an object property. Storing `{p: mut 'a
 // Point}` forces the inner borrow's lifetime to 'static too, since the whole value
 // escapes. constrainEscape walks the structural carriers, so the property's borrow
 // is constrained alongside any top-level one.
@@ -160,9 +160,9 @@ func TestEscapingNestedRefIntoStatic(t *testing.T) {
 }
 
 // Escaping a JOINED borrow forces every param lifetime the join reaches to outlive
-// 'static, so the whole `('l0 | 'l1)` union collapses to a single 'static (M4 D3, the
-// join↔escape interaction). constrainEscape constrains the join lifetime `<:
-// 'static`, which propagates through its lower bounds to each member, and
+// 'static, so the whole `('l0 | 'l1)` union collapses to a single 'static. This is
+// the join↔escape interaction (M4 D3). constrainEscape constrains the join lifetime
+// `<: 'static`, which propagates through its lower bounds to each member, and
 // coalesceLifetime then absorbs the union to 'static rather than expanding it.
 func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	c := newChecker()
@@ -191,7 +191,7 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 
 // A nested join reaching one param lifetime through two distinct sub-joins lists
 // that lifetime once in the rendered union, not twice. The top join's lower bounds
-// are the two sub-joins; both reach 'l0, so reachableParamLifetimes collects it
+// are the two sub-joins, and both reach 'l0. So reachableParamLifetimes collects it
 // twice and coalesceLifetime dedups before building the LifetimeUnion. Without the
 // dedup this rendered `('l0 | 'l1 | 'l0 | 'l2)`.
 func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
@@ -219,11 +219,12 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	require.Equal(t, "mut ('l0 | 'l1 | 'l2) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
-// ltEqual compares a LifetimeUnion (a join's coalesced face) structurally — equal
-// iff its members are pairwise equal in order — so two RefTypes with the same join
-// face dedup during coalescing. A LifetimeVar member keys by identity and 'static by
-// value, inherited from the recursive call. This branch has no source-reachable
-// trigger yet (two identical joined borrows in one union), so it is checked directly.
+// ltEqual compares a LifetimeUnion structurally. A LifetimeUnion is a join's
+// coalesced face. Two unions are equal iff their members are pairwise equal in order,
+// so two RefTypes with the same join face dedup during coalescing. A LifetimeVar
+// member keys by identity and 'static by value, inherited from the recursive call.
+// This branch has no source-reachable trigger yet, which would be two identical
+// joined borrows in one union, so it is checked directly.
 func TestLtEqualLifetimeUnion(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -113,6 +113,52 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 	require.Empty(t, a.LowerBounds)
 }
 
+// A borrowed value flowing into 'static storage has its lifetime forced to outlive
+// 'static (M4 D3, the EscapingRefIntoStatic acceptance). constrainEscape constrains
+// the borrow's lifetime `<: 'static`, so coalescing the borrow renders it `mut
+// 'static {x: number}` rather than under the param's own name. No Escalier construct
+// routes a borrow into static storage yet — a borrow originates only at a parameter
+// — so this exercises the rule's mechanism directly.
+func TestEscapingRefIntoStatic(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(0)
+	ref := &soltype.RefType{
+		Mut: true,
+		Lt:  lt,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+		}},
+	}
+
+	c.constrainEscape(ref)
+
+	require.Equal(t, []soltype.Lifetime{soltype.Static}, lt.UpperBounds)
+	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+}
+
+// Escape reaches a borrow NESTED inside an object property: storing `{p: mut 'a
+// Point}` forces the inner borrow's lifetime to 'static too, since the whole value
+// escapes. constrainEscape walks the structural carriers, so the property's borrow
+// is constrained alongside any top-level one.
+func TestEscapingNestedRefIntoStatic(t *testing.T) {
+	c := newChecker()
+	inner := c.ctx.freshLifetime(0)
+	stored := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "p", Type: &soltype.RefType{
+			Mut: true,
+			Lt:  inner,
+			Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+				&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+			}},
+		}},
+	}}
+
+	c.constrainEscape(stored)
+
+	require.Equal(t, []soltype.Lifetime{soltype.Static}, inner.UpperBounds)
+	require.Equal(t, "{p: mut 'static {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
+}
+
 // A discarded probe truncates every lifetime bound the trial appended back to the
 // pre-probe length, exactly as it does for type-variable bounds — the second sort
 // rides the same journal discipline. Bounds added before the probe survive.

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -219,10 +219,11 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	require.Equal(t, "mut ('l0 | 'l1 | 'l2) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
-// ltEqual compares a LifetimeUnion structurally. A LifetimeUnion is a join's
-// coalesced face. Two unions are equal iff their members are pairwise equal in order,
-// so two RefTypes with the same join face dedup during coalescing. A LifetimeVar
-// member keys by identity and 'static by value, inherited from the recursive call.
+// ltEqual compares a LifetimeUnion structurally. A LifetimeUnion is the union form a
+// join variable coalesces to. Two unions are equal iff their members are pairwise
+// equal in order, so two RefTypes with the same coalesced union dedup during
+// coalescing. A LifetimeVar member keys by identity and 'static by value, inherited
+// from the recursive call.
 // This branch has no source-reachable trigger yet, which would be two identical
 // joined borrows in one union, so it is checked directly.
 func TestLtEqualLifetimeUnion(t *testing.T) {

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -189,6 +189,36 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
+// A nested join reaching one param lifetime through two distinct sub-joins lists
+// that lifetime once in the rendered union, not twice. The top join's lower bounds
+// are the two sub-joins; both reach 'l0, so reachableParamLifetimes collects it
+// twice and coalesceLifetime dedups before building the LifetimeUnion. Without the
+// dedup this rendered `('l0 | 'l1 | 'l0 | 'l2)`.
+func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	d := c.ctx.freshLifetime(0)
+	j2 := c.ctx.freshJoinLifetime(0)
+	j3 := c.ctx.freshJoinLifetime(0)
+	top := c.ctx.freshJoinLifetime(0)
+	c.ctx.constrainLt(a, j2)
+	c.ctx.constrainLt(b, j2)
+	c.ctx.constrainLt(a, j3) // 'l0 shared across both sub-joins
+	c.ctx.constrainLt(d, j3)
+	c.ctx.constrainLt(j2, top)
+	c.ctx.constrainLt(j3, top)
+	ref := &soltype.RefType{
+		Mut: true,
+		Lt:  top,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+		}},
+	}
+
+	require.Equal(t, "mut ('l0 | 'l1 | 'l2) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+}
+
 // ltEqual compares a LifetimeUnion (a join's coalesced face) structurally — equal
 // iff its members are pairwise equal in order — so two RefTypes with the same join
 // face dedup during coalescing. A LifetimeVar member keys by identity and 'static by

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -189,6 +189,27 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
+// ltEqual compares a LifetimeUnion (a join's coalesced face) structurally — equal
+// iff its members are pairwise equal in order — so two RefTypes with the same join
+// face dedup during coalescing. A LifetimeVar member keys by identity and 'static by
+// value, inherited from the recursive call. This branch has no source-reachable
+// trigger yet (two identical joined borrows in one union), so it is checked directly.
+func TestLtEqualLifetimeUnion(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+
+	ab1 := &soltype.LifetimeUnion{Lifetimes: []soltype.Lifetime{a, b}}
+	ab2 := &soltype.LifetimeUnion{Lifetimes: []soltype.Lifetime{a, b}}
+	ba := &soltype.LifetimeUnion{Lifetimes: []soltype.Lifetime{b, a}}
+	a1 := &soltype.LifetimeUnion{Lifetimes: []soltype.Lifetime{a}}
+
+	require.True(t, ltEqual(ab1, ab2), "same members in the same order are equal")
+	require.False(t, ltEqual(ab1, ba), "order matters: member i must match member i")
+	require.False(t, ltEqual(ab1, a1), "differing member counts are unequal")
+	require.False(t, ltEqual(ab1, a), "a union and a bare variable are unequal")
+}
+
 // A discarded probe truncates every lifetime bound the trial appended back to the
 // pre-probe length, exactly as it does for type-variable bounds — the second sort
 // rides the same journal discipline. Bounds added before the probe survive.

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -376,7 +376,7 @@ func (c *checker) inferComponent(
 					c.recordType(arm.decl.Name, schemeType(sc))
 				}
 			}
-			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: srcs})
+			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: srcs, ModuleLevel: true})
 			continue
 		}
 		// Generalize the binding var at the component's level (was: coalesce to a
@@ -398,7 +398,7 @@ func (c *checker) inferComponent(
 		} else {
 			scheme = c.generalize(b.v, lvl)
 		}
-		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Kind: b.kind})
+		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Kind: b.kind, ModuleLevel: true})
 		// Record the binding's final (coalesced) DISPLAY type in Info on the name
 		// node, so it is queryable even for a `val` in a recursive group (where
 		// coalescing at definition time would have frozen it to `never`). A VarDecl

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -303,6 +303,7 @@ func (lf *ltFreshener) fresh(lt soltype.Lifetime) soltype.Lifetime {
 		return nlv
 	}
 	nlv := lf.ctx.freshLifetime(lf.lvl)
+	nlv.Join = lv.Join // a freshened copy keeps the origin's join-vs-param nature
 	lf.cache[lv] = nlv
 	nlv.LowerBounds = lf.freshBounds(lv.LowerBounds)
 	nlv.UpperBounds = lf.freshBounds(lv.UpperBounds)

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -31,7 +31,7 @@ type ValueBinding struct {
 	Kind ast.VariableKind
 	// ModuleLevel marks a top-level binding — one defined directly in the module
 	// scope, as opposed to a function parameter or body-local `val`/`var`. It is set
-	// only by inferComponent's phase-3 definitions (the module's SCC bindings) and
+	// only by inferComponent's phase-3 definitions, the module's SCC bindings, and
 	// left false for every nested binding. inferAssign reads it to recognise a GLOBAL
 	// WRITE: storing a value into module-level storage outlives every borrow region,
 	// so a borrowed value written there escapes to 'static (M4 D3).

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -29,6 +29,13 @@ type ValueBinding struct {
 	// SEPARATE from type-level mutability (`mut`-field / aliasing / lifetime
 	// transitions, M4), which is a property of the TYPE, not of this binding.
 	Kind ast.VariableKind
+	// ModuleLevel marks a top-level binding — one defined directly in the module
+	// scope, as opposed to a function parameter or body-local `val`/`var`. It is set
+	// only by inferComponent's phase-3 definitions (the module's SCC bindings) and
+	// left false for every nested binding. inferAssign reads it to recognise a GLOBAL
+	// WRITE: storing a value into module-level storage outlives every borrow region,
+	// so a borrowed value written there escapes to 'static (M4 D3).
+	ModuleLevel bool
 }
 
 // IsOverloaded reports whether this binding is an overload set. Consumers MUST

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -803,6 +803,20 @@ recursive references (cf. `infer_module.go:431-872` and the discussion in
   reported. (In M3 this is an invariant freebie — `ErrorType` is short-circuited out
   of every bound list, so it never reaches a former; M6 must keep it true once
   formers can be built directly.)
+- **Canonical union/intersection member order — closes the `equalType` order gap.**
+  `equalType` compares `UnionType`/`IntersectionType` members positionally
+  (`equalTypeSlice`), so two unions over the same members in a different order
+  compare unequal even though both formers are commutative — a latent dedup gap.
+  It is masked today only because pre-M6 unions arise from coalescing **output** in
+  a deterministic construction order. Once unions are real formers built from
+  annotations and constraint inputs, that determinism is gone, so member order must
+  be canonicalized at construction. This needs a stable total order over arbitrary
+  types — there is no cheap key as there is for the lifetime sort — so fold it into
+  the "Former simplification" normalization above, running dedup, lattice
+  identities, and canonical ordering as one pass. The lifetime-sort twin —
+  `ltEqual` over `LifetimeUnion` — is closed earlier and more cheaply in M4 D4 by
+  sorting members on `LifetimeVar.ID` (see m4-implementation-plan.md D4, "canonical
+  union member order").
 - **The `_ <: unknown` (⊤) subtyping rule — closes M4's Variation-B gap
   (deferred from M4).** With `unknown` a real former here, add the rule that makes
   it the top of the lattice (everything is a subtype of `unknown`). M4 left a
@@ -812,6 +826,33 @@ recursive references (cf. `infer_module.go:431-872` and the discussion in
   path closed — A3 adds no function annotations and the extra-position branch
   fails loud via `reportUnsupportedFeature` — so the gap is unreachable until this
   rule lands and that guard is removed.
+- **Permissive mut-borrow joins — degrade an incompatible join to a
+  read-until-narrowed union, matching TypeScript.** M4 D3's `joinBorrows` rejects a
+  return set of mutable borrows whose shared fields disagree on TYPE. Joining
+  `mut {x: number}` and `mut {x: string}` pins `x` invariant in both directions and
+  reports `number <: string` / `string <: number`, asserted by
+  `TestInferIncompatibleBorrowJoinErrors`. That error is the conservative default M4
+  could represent. The intended M6 behavior is more permissive: produce the
+  type-level union `(mut 'a {x: number}) | (mut 'b {x: string})` instead. That union
+  is readable — `.x` yields `number | string` through the covariant read view — and
+  a write through `.x` is allowed only after the static type narrows to one branch,
+  which re-establishes the field's write type. This is sound by the same rule
+  TypeScript uses: an un-narrowed union of mutable objects is read-only at its
+  conflicting fields and writable once narrowed.
+  - **Why it lands here, not in M4.** It needs two M6 pieces. First, union types as
+    first-class OUTPUTS that can carry `mut` `RefType` members — M4's join only
+    builds a single-carrier lifetime-union `mut ('a | 'b) {x}`, never a union of two
+    distinct borrows. Second, union-scrutinee narrowing to gate the write site.
+    Until both exist the union is unrepresentable or permanently read-only.
+  - **The hard case is non-discriminated narrowing.** These branches differ only in
+    the TYPE of `x`, with no discriminant tag, so re-enabling writes needs narrowing
+    by a field's runtime type such as `typeof r.x === "number"`, not tag-based
+    narrowing. That is the trickiest narrowing form, so this exact shape narrows
+    last.
+  - **Scope.** This relaxes D3's all-mut-borrows reconcile-or-error contract to
+    reconcile-or-union. The compatible case still joins to one carrier with a union
+    lifetime as today; only the incompatible case changes from error to union.
+    Revisit the D3 join policy once M6 union outputs and narrowing land.
 
 **Accept:** `number | string` annotation accepts `number`/rejects `boolean`;
 intersection annotation satisfied by a value at both member types; both

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1291,32 +1291,32 @@ these arms it must add.
     into inference ad hoc.
   - **Accept:** the static-escape transition cases pass via lifetime queries
     rather than the dropped bits.
-  - **Carried over from D3 — finish the global-write escape (issue: revisit at G2).**
+  - **Carried over from D3 — finish the global-write escape.** Revisit this at G2.
     D3 shipped the escape-to-`'static` rule and wired it to the one global-write site
-    it could: `inferAssign`'s store into a module-level binding. That wiring is
-    deliberately shallow and G2 should complete it, since G2 is already designing the
+    it could reach, `inferAssign`'s store into a module-level binding. That wiring is
+    deliberately shallow, and G2 should complete it, since G2 is already designing the
     liveness-`VarID` ↔ `soltype`-borrow bridge the full fix needs. Two gaps remain:
     1. **Escape only engages a structurally-borrowed source.** `constrainEscape` rides
-       the `soltype` visitor, which treats a `TypeVarType` as a leaf, so a borrow that
-       reaches module storage only through a usage-inferred variable — `sink = if c { p
-       } else { … }`, where the source is the if-join var, not a `RefType` — is never
-       forced `<: 'static`. A bare `sink = p` works because `p`'s static type is already
-       a `RefType`.
+       the `soltype` visitor, which treats a `TypeVarType` as a leaf. So a borrow that
+       reaches module storage only through a usage-inferred variable is never forced
+       `<: 'static`. Take `sink = if c { p } else { … }`, where the source is the
+       if-join variable, not a `RefType`. A bare `sink = p` works because `p`'s static
+       type is already a `RefType`.
     2. **The value-compatibility check trips `BorrowEscapeError` for those same
        sources.** The global-write branch compares `CarrierOf(sourceT)` against the
        slot so a forced-`'static` borrow fills an owned slot instead of being rejected.
        `CarrierOf` peels only a top-level `RefType`, so a borrow buried in a variable or
        union still reaches the owned slot as a non-escaping borrow and is rejected. So
-       `sink = p` checks but `sink = if c { p } else { … }` errors — an inconsistency.
-       The peel also drops the source's mutability check, which is the mutability
-       half this PR already owns (Rule 1/Rule 2 above).
+       `sink = p` checks but `sink = if c { p } else { … }` errors, an inconsistency.
+       The peel also drops the source's mutability check, the mutability half this PR
+       already owns in Rule 1 and Rule 2 above.
 
-    The clean fix is the same seam G2 builds: resolve a value's borrows through the
+    The clean fix is the same seam G2 builds. Resolve a value's borrows through the
     constraint graph rather than its syntactic type, so escape forces every reachable
     borrow lifetime and the compat check admits a forced-`'static` borrow into an owned
-    slot — instead of the C2-gate change or an ad-hoc variable-bound walk D3 declined to
-    add. D3 left the boundary documented in `constrainEscape` and the `inferAssign`
-    global-write branch.
+    slot. That avoids both the C2-gate change and an ad-hoc variable-bound walk D3
+    declined to add. D3 left the boundary documented in `constrainEscape` and the
+    `inferAssign` global-write branch.
 
 ### Dependency graph
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1086,7 +1086,12 @@ these arms it must add.
     fresh **join** lifetime var and `constrainLt` each source lifetime into it
     (so it coalesces to `'a | 'b`). The join var is *not* a param lifetime —
     only its reachable param-lifetime members are named (the spike's
-    `paramLifetimes`-vs-join distinction).
+    `paramLifetimes`-vs-join distinction). This unifies a SINGLE carrier object, so
+    two borrows whose shared fields disagree on type fail the invariant field pin and
+    error (`TestInferIncompatibleBorrowJoinErrors`). That reconcile-or-error contract
+    is the conservative M4 default; M6 may relax the incompatible case to a
+    read-until-narrowed union to match TypeScript (see 01-milestones.md M6,
+    "Permissive mut-borrow joins").
   - **Algorithm — escape:** a value flowing into module/static storage (a
     top-level binding, a global write) constrains its lifetime `<: 'static`
     (`constrainLt(lt, &StaticLifetime{})`), which coalesces to `'static`.
@@ -1137,6 +1142,18 @@ these arms it must add.
     `'b`, … via a base-26 `alphaName`, per the spike); a join var renders as the
     union of the param lifetimes it reaches; `'static` absorbs. The `<'a>`
     quantifier joins the existing `<T0, …>` prefix in `PrintAsSchemeWith`.
+  - **Algorithm — canonical union member order (closes the `ltEqual` order gap):**
+    sort a join's reached param lifetimes by `LifetimeVar.ID` before building the
+    `LifetimeUnion`, so the rendered `'a | 'b` is deterministic and `ltEqual`'s
+    positional member compare (`coalesce.go`) becomes order-insensitive with no set
+    comparison. `coalesceLifetime` today builds the union in bound-list order, so two
+    separately-built unions over the same lifetimes can differ in order, and
+    `equalType` then treats the two borrows as distinct — a latent dedup gap. It is
+    not reachable from current source but is cheap to close while the union is
+    rendered here. Members are always param `LifetimeVar`s with stable IDs, so the
+    sort is total. The type-sort twin — positional `UnionType`/`IntersectionType`
+    comparison in `equalType` — needs a canonical order over arbitrary types and
+    rides M6 (see 01-milestones.md M6, "Canonical union/intersection member order").
   - **Algorithm — elision (the subtle branch):** a param lifetime occurring in
     only one polarity (and not forced to `'static`) connects nothing and is
     elided — the lifetime-sort analogue of single-polarity elimination. The
@@ -1156,6 +1173,8 @@ these arms it must add.
     - a connect-nothing param lifetime elides (mut ⇒ owned-mut, immut ⇒ wrapper
       dropped)
     - read-after-write field collapse with a lifetime present
+    - a `LifetimeUnion` built from the same param lifetimes in any order renders
+      identically and `ltEqual`-compares equal
 
 ### Phase E — Destructuring + `match`
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1291,6 +1291,32 @@ these arms it must add.
     into inference ad hoc.
   - **Accept:** the static-escape transition cases pass via lifetime queries
     rather than the dropped bits.
+  - **Carried over from D3 — finish the global-write escape (issue: revisit at G2).**
+    D3 shipped the escape-to-`'static` rule and wired it to the one global-write site
+    it could: `inferAssign`'s store into a module-level binding. That wiring is
+    deliberately shallow and G2 should complete it, since G2 is already designing the
+    liveness-`VarID` ↔ `soltype`-borrow bridge the full fix needs. Two gaps remain:
+    1. **Escape only engages a structurally-borrowed source.** `constrainEscape` rides
+       the `soltype` visitor, which treats a `TypeVarType` as a leaf, so a borrow that
+       reaches module storage only through a usage-inferred variable — `sink = if c { p
+       } else { … }`, where the source is the if-join var, not a `RefType` — is never
+       forced `<: 'static`. A bare `sink = p` works because `p`'s static type is already
+       a `RefType`.
+    2. **The value-compatibility check trips `BorrowEscapeError` for those same
+       sources.** The global-write branch compares `CarrierOf(sourceT)` against the
+       slot so a forced-`'static` borrow fills an owned slot instead of being rejected.
+       `CarrierOf` peels only a top-level `RefType`, so a borrow buried in a variable or
+       union still reaches the owned slot as a non-escaping borrow and is rejected. So
+       `sink = p` checks but `sink = if c { p } else { … }` errors — an inconsistency.
+       The peel also drops the source's mutability check, which is the mutability
+       half this PR already owns (Rule 1/Rule 2 above).
+
+    The clean fix is the same seam G2 builds: resolve a value's borrows through the
+    constraint graph rather than its syntactic type, so escape forces every reachable
+    borrow lifetime and the compat check admits a forced-`'static` borrow into an owned
+    slot — instead of the C2-gate change or an ad-hoc variable-bound walk D3 declined to
+    add. D3 left the boundary documented in `constrainEscape` and the `inferAssign`
+    global-write branch.
 
 ### Dependency graph
 


### PR DESCRIPTION
Implements the join-borrow and escape-to-static rules from M4 D3, enabling sound handling of multiple borrows in return positions and borrows that flow into module-level storage.

## Summary

When a function returns one of several borrowed objects that differ only in lifetime, the return type now joins them into a single borrow whose lifetime is the union of the originating lifetimes. For example, `if c { return p } else { return q }` over two `mut` parameters now infers `mut ('l0 | 'l1) {x: number}` instead of the un-joined union `mut 'l0 {x: number} | mut 'l1 {x: number}`.

Additionally, when a borrowed value flows into module-level storage (a global write), its lifetime is forced to outlive `'static`, rendering it as `mut 'static {…}` rather than under a borrow lifetime. This prevents a borrow from escaping its region.

## Key changes

- **joinBorrows** synthesizes the join of several mutable borrows that share the same field set. It creates a fresh join lifetime bounded below by each input's lifetime, constrains shared fields invariant across inputs, and returns a single borrow. Falls back to generic union if inputs differ in field set, mutability, or include non-borrows.

- **constrainEscape** and **escapeVisitor** force every borrow lifetime reachable in a value to outlive `'static` when the value is stored in module-level bindings. The visitor walks structural carriers (object properties, tuple elements, union members, etc.) to reach nested borrows.

- **coalesceRefLifetime** and **coalesceLifetime** resolve borrow lifetimes to their display form. Join variables expand to the union of reachable param lifetimes; param variables forced to `'static` render as `'static`; otherwise param variables render under their own name.

- **LifetimeUnion** represents a coalesced join lifetime as the union of its member lifetimes, printed as `('a | 'b | …)`.

- **LifetimeVar.Join** flag distinguishes join lifetimes (internal, multi-source) from param lifetimes (borrow origins). Coalescing expands join variables but preserves param variables.

- **freshJoinLifetime** allocates a lifetime variable for multi-source join sites with the Join flag set.

- **inferAssign** now detects global writes (module-level bindings) and applies escape constraints to the source before the compatibility check. The check compares the source's carrier (the owned value after peeling a top-level borrow) so a forced-`'static` borrow fills an owned slot instead of being rejected.

- **sameObjectKeys** validates that two objects carry the same set of property names, the precondition for joining since a mut object's field set is invariant.

## Tests

Added comprehensive test coverage for join behavior, escape-to-static, and their interactions:
- Joining distinct-lifetime borrows into a union
- Rejecting joins when field sets or field types mismatch
- Three-way and n-ary joins
- Instantiated generalized joined-borrow functions
- Escaping borrows into static storage (top-level and nested)
- Escaping joined borrows collapsing to `'static`
- Global writes of non-borrow values remaining unaffected

https://claude.ai/code/session_01M9BaqNpskcZ4sMEwPZkDai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime coalescing and structural comparisons for borrowed references, including consistent, stable equality/rendering for unioned lifetimes.
  * Better handling of join-origin lifetimes to keep coalescing and display behavior aligned.
  * Fixed escape-to-`'static` behavior for module-level assignments involving borrowed values.
  * Enhanced conditional return inference for mutable borrows, using specialized joins when safe and cleanly falling back to lifetime unions otherwise.
* **Tests**
  * Expanded conditional return, multi-branch join, incompatibility, nested union deduplication, and `'static` escape coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->