### PR TITLE
M4 D4: Display-time lifetime naming and elision

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -149,61 +149,52 @@ func lifetimeParamName(i int) string {
 }
 
 // freeLifetimeVars collects the LifetimeVars appearing in t in first-appearance
-// print order — the lifetime-sort twin of freeTypeVars. Lifetimes ride only on
-// RefType (its Lt slot, directly or as the members of a LifetimeUnion), so the walk
-// mirrors freeTypeVars but inspects each borrow's lifetime as it descends.
+// print order — the lifetime-sort twin of freeTypeVars. It rides the shared Accept
+// visitor rather than a hand-rolled walk, the same way simplify.go's varCollector
+// collects type vars. Lifetimes are not Types, so Accept never visits a Lt slot
+// itself; the collector reads it in EnterType when it reaches a RefType, before
+// Accept descends into the borrow's inner, which preserves print order — a borrow's
+// own lifetime precedes any lifetime nested in its inner.
 func freeLifetimeVars(t Type) []*LifetimeVar {
-	var out []*LifetimeVar
-	seen := set.NewSet[*LifetimeVar]()
-	addLt := func(lt Lifetime) {
-		switch lt := lt.(type) {
-		case *LifetimeVar:
-			if !seen.Contains(lt) {
-				seen.Add(lt)
-				out = append(out, lt)
-			}
-		case *LifetimeUnion:
-			for _, m := range lt.Lifetimes {
-				if mv, ok := m.(*LifetimeVar); ok && !seen.Contains(mv) {
-					seen.Add(mv)
-					out = append(out, mv)
-				}
+	c := &ltVarCollector{seen: set.NewSet[*LifetimeVar]()}
+	t.Accept(c, Positive)
+	return c.out
+}
+
+// ltVarCollector gathers LifetimeVars in Accept-traversal order. It rewrites nothing
+// — EnterType returns the default descend result and ExitType returns the node
+// unchanged — so Accept performs no allocation and the walk is a pure collection.
+type ltVarCollector struct {
+	out  []*LifetimeVar
+	seen set.Set[*LifetimeVar]
+}
+
+func (c *ltVarCollector) EnterType(t Type, _ Polarity) EnterResult {
+	if r, ok := t.(*RefType); ok {
+		c.add(r.Lt)
+	}
+	return EnterResult{}
+}
+
+func (c *ltVarCollector) ExitType(t Type, _ Polarity) Type { return t }
+
+// add records a borrow's lifetime: a LifetimeVar directly, or each LifetimeVar
+// member of a LifetimeUnion, deduped by identity.
+func (c *ltVarCollector) add(lt Lifetime) {
+	switch lt := lt.(type) {
+	case *LifetimeVar:
+		if !c.seen.Contains(lt) {
+			c.seen.Add(lt)
+			c.out = append(c.out, lt)
+		}
+	case *LifetimeUnion:
+		for _, m := range lt.Lifetimes {
+			if mv, ok := m.(*LifetimeVar); ok && !c.seen.Contains(mv) {
+				c.seen.Add(mv)
+				c.out = append(c.out, mv)
 			}
 		}
 	}
-	var walk func(Type)
-	walk = func(t Type) {
-		switch t := t.(type) {
-		case *FuncType:
-			for _, p := range t.Params {
-				walk(p.Type)
-			}
-			walk(t.Ret)
-		case *TupleType:
-			for _, e := range t.Elems {
-				walk(e)
-			}
-		case *ObjectType:
-			for _, e := range t.Elems {
-				walk(AsProperty(e).Type)
-			}
-		case *PromiseType:
-			walk(t.Inner)
-		case *RefType:
-			addLt(t.Lt)
-			walk(t.Inner)
-		case *UnionType:
-			for _, m := range t.Types {
-				walk(m)
-			}
-		case *IntersectionType:
-			for _, m := range t.Types {
-				walk(m)
-			}
-		}
-	}
-	walk(t)
-	return out
 }
 
 // freeTypeVars collects the TypeVarTypes appearing in t in first-appearance print

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -104,7 +104,7 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 		labels = append(labels, name)
 	}
 	// Borrow lifetimes left in the coalesced type by D4's coalesceLifetimes are all
-	// nameable param lifetimes — a connect-nothing one was already elided and a join
+	// nameable param lifetimes. A connect-nothing one was already elided, and a join
 	// expanded to a union of these. Name each 'a, 'b, … in first-appearance order and
 	// add it to the quantifier prefix after the type parameters.
 	ltNames := map[*LifetimeVar]string{}
@@ -134,7 +134,7 @@ func typeParamName(i int) string {
 }
 
 // lifetimeParamName is the surface name for the i-th quantified lifetime parameter:
-// 'a, 'b, …, 'z, 'aa, 'ab, … (Excel-style base-26), so a borrow renders as
+// 'a, 'b, …, 'z, 'aa, 'ab, … in Excel-style base-26, so a borrow renders as
 // `fn <'a>(p: mut 'a {x}) -> mut 'a {x}`.
 func lifetimeParamName(i int) string {
 	var b []byte
@@ -149,21 +149,21 @@ func lifetimeParamName(i int) string {
 }
 
 // freeLifetimeVars collects the LifetimeVars appearing in t in first-appearance
-// print order — the lifetime-sort twin of freeTypeVars. It rides the shared Accept
+// print order, the lifetime-sort twin of freeTypeVars. It rides the shared Accept
 // visitor rather than a hand-rolled walk, the same way simplify.go's varCollector
 // collects type vars. Lifetimes are not Types, so Accept never visits a Lt slot
-// itself; the collector reads it in EnterType when it reaches a RefType, before
-// Accept descends into the borrow's inner, which preserves print order — a borrow's
-// own lifetime precedes any lifetime nested in its inner.
+// itself. The collector reads it in EnterType when it reaches a RefType, before
+// Accept descends into the borrow's inner. That preserves print order, because a
+// borrow's own lifetime precedes any lifetime nested in its inner.
 func freeLifetimeVars(t Type) []*LifetimeVar {
 	c := &ltVarCollector{seen: set.NewSet[*LifetimeVar]()}
 	t.Accept(c, Positive)
 	return c.out
 }
 
-// ltVarCollector gathers LifetimeVars in Accept-traversal order. It rewrites nothing
-// — EnterType returns the default descend result and ExitType returns the node
-// unchanged — so Accept performs no allocation and the walk is a pure collection.
+// ltVarCollector gathers LifetimeVars in Accept-traversal order. It rewrites nothing.
+// EnterType returns the default descend result and ExitType returns the node
+// unchanged, so Accept performs no allocation and the walk is a pure collection.
 type ltVarCollector struct {
 	out  []*LifetimeVar
 	seen set.Set[*LifetimeVar]

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -103,13 +103,24 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 		names[v] = name
 		labels = append(labels, name)
 	}
-	if len(labels) == 0 {
+	// Borrow lifetimes left in the coalesced type by D4's coalesceLifetimes are all
+	// nameable param lifetimes — a connect-nothing one was already elided and a join
+	// expanded to a union of these. Name each 'a, 'b, … in first-appearance order and
+	// add it to the quantifier prefix after the type parameters.
+	ltNames := map[*LifetimeVar]string{}
+	var ltLabels []string
+	for _, lv := range freeLifetimeVars(t) {
+		name := lifetimeParamName(len(ltLabels))
+		ltNames[lv] = name
+		ltLabels = append(ltLabels, name)
+	}
+	if len(labels) == 0 && len(ltLabels) == 0 {
 		// No quantified parameters: render as a plain (possibly raw-var) type, which
 		// keeps a leaked variable visible as t{ID}.
 		return Print(t)
 	}
-	p := &namedPrinter{names: names}
-	prefix := "<" + strings.Join(labels, ", ") + ">"
+	p := &namedPrinter{names: names, ltNames: ltNames}
+	prefix := "<" + strings.Join(append(labels, ltLabels...), ", ") + ">"
 	if ft, ok := t.(*FuncType); ok {
 		return "fn " + prefix + p.printFuncTail(ft)
 	}
@@ -120,6 +131,79 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 // T1, …, matching the planned `fn <T0>(x: T0) -> T0` rendering.
 func typeParamName(i int) string {
 	return "T" + strconv.Itoa(i)
+}
+
+// lifetimeParamName is the surface name for the i-th quantified lifetime parameter:
+// 'a, 'b, …, 'z, 'aa, 'ab, … (Excel-style base-26), so a borrow renders as
+// `fn <'a>(p: mut 'a {x}) -> mut 'a {x}`.
+func lifetimeParamName(i int) string {
+	var b []byte
+	for {
+		b = append([]byte{byte('a' + i%26)}, b...)
+		i = i/26 - 1
+		if i < 0 {
+			break
+		}
+	}
+	return "'" + string(b)
+}
+
+// freeLifetimeVars collects the LifetimeVars appearing in t in first-appearance
+// print order — the lifetime-sort twin of freeTypeVars. Lifetimes ride only on
+// RefType (its Lt slot, directly or as the members of a LifetimeUnion), so the walk
+// mirrors freeTypeVars but inspects each borrow's lifetime as it descends.
+func freeLifetimeVars(t Type) []*LifetimeVar {
+	var out []*LifetimeVar
+	seen := set.NewSet[*LifetimeVar]()
+	addLt := func(lt Lifetime) {
+		switch lt := lt.(type) {
+		case *LifetimeVar:
+			if !seen.Contains(lt) {
+				seen.Add(lt)
+				out = append(out, lt)
+			}
+		case *LifetimeUnion:
+			for _, m := range lt.Lifetimes {
+				if mv, ok := m.(*LifetimeVar); ok && !seen.Contains(mv) {
+					seen.Add(mv)
+					out = append(out, mv)
+				}
+			}
+		}
+	}
+	var walk func(Type)
+	walk = func(t Type) {
+		switch t := t.(type) {
+		case *FuncType:
+			for _, p := range t.Params {
+				walk(p.Type)
+			}
+			walk(t.Ret)
+		case *TupleType:
+			for _, e := range t.Elems {
+				walk(e)
+			}
+		case *ObjectType:
+			for _, e := range t.Elems {
+				walk(AsProperty(e).Type)
+			}
+		case *PromiseType:
+			walk(t.Inner)
+		case *RefType:
+			addLt(t.Lt)
+			walk(t.Inner)
+		case *UnionType:
+			for _, m := range t.Types {
+				walk(m)
+			}
+		case *IntersectionType:
+			for _, m := range t.Types {
+				walk(m)
+			}
+		}
+	}
+	walk(t)
+	return out
 }
 
 // freeTypeVars collects the TypeVarTypes appearing in t in first-appearance print

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -31,7 +31,8 @@ import (
 // See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	return t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
+	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
+	return coalesceLifetimes(c) // D4: resolve borrow lifetimes to their display form
 }
 
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the
@@ -78,7 +79,9 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 }
 
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	return coalesceRefLifetime(t, pol)
+	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
+	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
+	return t
 }
 
 // widenVar lowers a widenable `var` binding's coalesced value to its primitive
@@ -143,11 +146,12 @@ type occKey struct {
 // its own polarities, so the check is exactly PR1's per-variable both-polarities
 // test.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
-	return t.Accept(&schemeCoalescer{
+	c := t.Accept(&schemeCoalescer{
 		simp:     simplifyScheme(t, genLevel),
 		genLevel: genLevel,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
+	return coalesceLifetimes(c) // D4: resolve borrow lifetimes to their display form
 }
 
 // schemeCoalescer is the soltype-visitor form of coalesceScheme. It has the same
@@ -225,7 +229,9 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 }
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	return coalesceRefLifetime(t, pol)
+	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
+	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
+	return t
 }
 
 // schemeType returns a scheme's coalesced DISPLAY type (variable-free except for

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -32,7 +32,7 @@ import (
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
-	return coalesceLifetimes(c) // D4: resolve borrow lifetimes to their display form
+	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the
@@ -151,7 +151,8 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 		genLevel: genLevel,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
-	return coalesceLifetimes(c) // D4: resolve borrow lifetimes to their display form
+	// A scheme display is always coalesced from the Positive root.
+	return coalesceLifetimes(c, soltype.Positive) // D4: resolve borrow lifetimes to their display form
 }
 
 // schemeCoalescer is the soltype-visitor form of coalesceScheme. It has the same

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -110,12 +110,12 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 }
 
 // A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function
-// parameter typed `mut {x: number}` originates a fresh borrow lifetime (D2) so it
-// renders `mut 'l0 {x: number}`, and a member read through it peels the borrow to
-// resolve the inner property. The lifetime is unused in the result, so D4's
-// display-time elision will later drop it and the render returns to `mut {…}`.
+// parameter typed `mut {x: number}` originates a fresh borrow lifetime (D2), and a
+// member read through it peels the borrow to resolve the inner property. The lifetime
+// is unused in the result — the body returns a number, not the borrow — so D4's
+// display-time elision drops it and the param renders as plain owned-mutable `mut {…}`.
 func TestInferMutObjectAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) -> number { return p.x }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
 }

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -112,7 +112,7 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 // A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function
 // parameter typed `mut {x: number}` originates a fresh borrow lifetime (D2), and a
 // member read through it peels the borrow to resolve the inner property. The lifetime
-// is unused in the result — the body returns a number, not the borrow — so D4's
+// is unused in the result, since the body returns a number, not the borrow, so D4's
 // display-time elision drops it and the param renders as plain owned-mutable `mut {…}`.
 func TestInferMutObjectAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) -> number { return p.x }`)

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -6,20 +6,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 D2: borrow origination + active lifetime step ---
+// --- M4 D2/D4: borrow origination + display-time lifetime naming and elision ---
 //
-// These assert the RAW `'l{id}` lifetime form. D4 adds display-time naming
-// (`'a`) and elision of param lifetimes that don't reach the output; until then a
-// param-originated lifetime renders under its mint id and is never dropped.
+// These assert the D4 display form: a param lifetime that reaches the output is
+// named ('a, 'b, …) and quantified in a leading <…> prefix, while a param lifetime
+// that connects nothing — it never reaches an output — is elided (a mut borrow
+// becomes owned-mutable, an immutable borrow drops the wrapper).
 
 // A `mut` param returned unchanged carries its originated lifetime to the result:
-// the same `'l0` appears on both the parameter and the return type, so the borrow
-// flows out at the lifetime it came in. This is the IdentityRefReturn acceptance —
-// D4 will render the shared lifetime as `fn <'a>(p: mut 'a {x}) -> mut 'a {x}`.
+// the same lifetime appears on both the parameter and the return type, so the
+// borrow flows out at the lifetime it came in. Occurring in both positions, it is
+// named `'a` and quantified — the IdentityRefReturn acceptance (M4 D4).
 func TestInferIdentityRefReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["f"])
 }
 
 // Returning a freshly-constructed owned object carries no borrow lifetime: the
@@ -31,21 +32,23 @@ func TestInferFreshObjectReturn(t *testing.T) {
 	require.Equal(t, "fn () -> {x: 5}", values["f"])
 }
 
-// Two `mut` params with distinct annotations originate independent lifetimes:
-// `'l0` on the first, `'l1` on the second.
+// Two `mut` params originate independent lifetimes, but only the returned one
+// reaches the output. `p` is returned, so its lifetime is named `'a`; `q` connects
+// nothing, so its borrow lifetime is elided to owned-mutable.
 func TestInferDistinctParamLifetimes(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}, q: mut {y: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}, q: mut 'l1 {y: number}) -> mut 'l0 {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: mut 'a {x: number}, q: mut {y: number}) -> mut 'a {x: number}", values["f"])
 }
 
 // Writing a field through an annotated `mut` borrow checks: the receiver carries a
-// borrow lifetime `'l0`, and the write requirement's fresh lifetime imposes no
-// obligation, so a borrowed receiver of any lifetime satisfies it.
+// borrow lifetime, and the write requirement's fresh lifetime imposes no obligation,
+// so a borrowed receiver of any lifetime satisfies it. The borrow never reaches the
+// output (the body returns void), so D4 elides its lifetime to owned-mutable.
 func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { p.x = 10 }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> void", values["f"])
+	require.Equal(t, "fn (p: mut {x: number}) -> void", values["f"])
 }
 
 // Passing a borrow into a function whose parameter is an OWNED (bare) object is the
@@ -79,7 +82,7 @@ fn f(p: mut {x: number}) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l1 {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
 }
 
 // Reading a field after writing it through an annotated `mut` borrow returns the
@@ -95,7 +98,7 @@ func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
 }
 
 // Writing a field of a NON-`mut` owned object is rejected: the write lowers to the
@@ -129,7 +132,7 @@ func TestInferConditionalUnionReturn(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut ('l0 | 'l1) {x: number}",
+		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
 		values["f"])
 }
 
@@ -149,7 +152,7 @@ func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {y: number}) -> mut 'l0 {x: number} | mut 'l1 {y: number}",
+		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {y: number}) -> mut 'a {x: number} | mut 'b {y: number}",
 		values["f"])
 }
 
@@ -171,7 +174,7 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}, r: mut 'l2 {x: number}) -> mut ('l0 | 'l1 | 'l2) {x: number}",
+		"fn <'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}, r: mut 'c {x: number}) -> mut ('a | 'b | 'c) {x: number}",
 		values["f"])
 }
 
@@ -179,10 +182,12 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 // A caller that passes two of its own borrows still sees a two-lifetime union, not a
 // single name. This is the only end-to-end exercise of the Join flag riding through
 // freshenAbove/extrude (D2.5). If the flag were dropped on the freshened join
-// lifetime, the instantiated return would coalesce to one `'l{id}` instead of a
-// union. `pick` generalizes to `mut ('l0 | 'l1) {…}`. Instantiating it inside `use`
-// freshens the join and its two members to use-level lifetimes, so `use` returns a
-// union of those.
+// lifetime, the instantiated return would coalesce to one lifetime instead of a
+// union. `pick` renders `mut ('a | 'b) {…}` over its two param lifetimes.
+// Instantiating it inside `use` freshens the join and its two members to use-level
+// lifetimes; D4's component-based expansion resolves those intermediaries back to
+// `use`'s own param lifetimes, so `use` renders the same clean `mut ('a | 'b) {…}`
+// over `a` and `b` rather than the raw freshened ids.
 func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {
 	src := `fn pick(p: mut {x: number}, q: mut {x: number}) {
   if true { return p } else { return q }
@@ -193,10 +198,10 @@ fn use(a: mut {x: number}, b: mut {x: number}) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}, q: mut 'l1 {x: number}) -> mut ('l0 | 'l1) {x: number}",
+		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
 		values["pick"])
 	require.Equal(t,
-		"fn (a: mut 'l3 {x: number}, b: mut 'l4 {x: number}) -> mut ('l5 | 'l7) {x: number}",
+		"fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
 		values["use"])
 }
 
@@ -242,7 +247,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number} | {x: 5}",
+		"fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number} | {x: 5}",
 		values["f"])
 }
 

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -8,15 +8,15 @@ import (
 
 // --- M4 D2/D4: borrow origination + display-time lifetime naming and elision ---
 //
-// These assert the D4 display form: a param lifetime that reaches the output is
-// named ('a, 'b, …) and quantified in a leading <…> prefix, while a param lifetime
-// that connects nothing — it never reaches an output — is elided (a mut borrow
-// becomes owned-mutable, an immutable borrow drops the wrapper).
+// These assert the D4 display form. A param lifetime that reaches the output is
+// named 'a, 'b, … and quantified in a leading <…> prefix. A param lifetime that
+// connects nothing, never reaching an output, is elided: a mut borrow becomes
+// owned-mutable, and an immutable borrow drops the wrapper.
 
 // A `mut` param returned unchanged carries its originated lifetime to the result:
 // the same lifetime appears on both the parameter and the return type, so the
 // borrow flows out at the lifetime it came in. Occurring in both positions, it is
-// named `'a` and quantified — the IdentityRefReturn acceptance (M4 D4).
+// named `'a` and quantified. This is the IdentityRefReturn acceptance (M4 D4).
 func TestInferIdentityRefReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
 	require.Empty(t, errs)
@@ -33,7 +33,7 @@ func TestInferFreshObjectReturn(t *testing.T) {
 }
 
 // Two `mut` params originate independent lifetimes, but only the returned one
-// reaches the output. `p` is returned, so its lifetime is named `'a`; `q` connects
+// reaches the output. `p` is returned, so its lifetime is named `'a`. `q` connects
 // nothing, so its borrow lifetime is elided to owned-mutable.
 func TestInferDistinctParamLifetimes(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}, q: mut {y: number}) { return p }`)
@@ -44,7 +44,7 @@ func TestInferDistinctParamLifetimes(t *testing.T) {
 // Writing a field through an annotated `mut` borrow checks: the receiver carries a
 // borrow lifetime, and the write requirement's fresh lifetime imposes no obligation,
 // so a borrowed receiver of any lifetime satisfies it. The borrow never reaches the
-// output (the body returns void), so D4 elides its lifetime to owned-mutable.
+// output, since the body returns void, so D4 elides its lifetime to owned-mutable.
 func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { p.x = 10 }`)
 	require.Empty(t, errs)
@@ -185,7 +185,7 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 // lifetime, the instantiated return would coalesce to one lifetime instead of a
 // union. `pick` renders `mut ('a | 'b) {…}` over its two param lifetimes.
 // Instantiating it inside `use` freshens the join and its two members to use-level
-// lifetimes; D4's component-based expansion resolves those intermediaries back to
+// lifetimes. D4's component-based expansion resolves those intermediaries back to
 // `use`'s own param lifetimes, so `use` renders the same clean `mut ('a | 'b) {…}`
 // over `a` and `b` rather than the raw freshened ids.
 func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -138,13 +138,13 @@ func TestInferMemberAssignVariableValueLinked(t *testing.T) {
 // declared fields. Before the per-field write view this reported spurious
 // "missing property: y" / "inexact <: exact" errors.
 //
-// The annotated `mut` param originates a borrow lifetime (D2), so it renders with
-// a raw `'l{id}` here; the lifetime is unused in the (void) result, so D4's
-// display-time elision will later drop it and the render returns to `mut {…}`.
+// The annotated `mut` param originates a borrow lifetime (D2), but it is unused in
+// the (void) result, so D4's display-time elision drops it and the param renders as
+// plain owned-mutable `mut {…}`.
 func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = 5 }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: mut 'l0 {x: number, y: string}) -> void", values["f"])
+	require.Equal(t, "fn (obj: mut {x: number, y: string}) -> void", values["f"])
 }
 
 // The named field stays invariant: storing a string into a number field of an

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -139,7 +139,7 @@ func TestInferMemberAssignVariableValueLinked(t *testing.T) {
 // "missing property: y" / "inexact <: exact" errors.
 //
 // The annotated `mut` param originates a borrow lifetime (D2), but it is unused in
-// the (void) result, so D4's display-time elision drops it and the param renders as
+// the void result, so D4's display-time elision drops it and the param renders as
 // plain owned-mutable `mut {…}`.
 func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = 5 }")

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -89,6 +89,18 @@ type ltAnalysis struct {
 // the argument and parameter lifetimes it bridges. A component root is marked
 // positive when any structurally-positive lifetime falls in it; that is what keeps
 // a connected param lifetime from being elided.
+//
+// INVARIANT: this grouping is UNDIRECTED, so it conflates outlives direction. It is
+// correct only while two distinct param lifetimes share a component ONLY when they
+// genuinely co-flow — i.e. a join unites them, or one is borrowed from the other.
+// Every lifetime origin today obeys this: attachParamLifetimes mints an independent
+// var per parameter, and the only cross-links are joins (joinBorrows) and
+// instantiation copies (the freshener/extruder), both of which connect lifetimes
+// that really do flow together. A future origin that bound-links two independent
+// param borrows through a shared intermediary would break it: the two would be
+// unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing that case
+// needs directional reasoning (or first-class lifetime bounds), which the union
+// rendering deliberately does not yet model — see the join-expansion note above.
 func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 	uf := newUnionFind()
 	vars := map[int]*soltype.LifetimeVar{}

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -41,12 +41,19 @@ import (
 //     argument lifetime and the callee's freshened parameter lifetime, related only
 //     by a mix of upper and lower bounds, so reachability cannot be confined to one
 //     bound direction. A lifetime forced to 'static renders 'static and absorbs.
-func coalesceLifetimes(t soltype.Type) soltype.Type {
+//
+// coalesceLifetimes resolves the borrow lifetimes left raw by the structural
+// coalescers. pol is the root polarity the type was coalesced at, threaded through
+// so the occurrence walk and the rewrite classify lifetimes from the same root the
+// coalesced type was built from. Every caller coalesces a display type from the
+// Positive root today, so this is Positive in practice; threading it keeps the
+// lifetime analysis consistent with the coalescing polarity rather than assuming it.
+func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	occ := map[*soltype.LifetimeVar]occPolarity{}
-	t.Accept(&ltOccVisitor{occ: occ}, soltype.Positive)
+	t.Accept(&ltOccVisitor{occ: occ}, pol)
 
 	a := newLtAnalysis(occ)
-	return t.Accept(&ltRewriter{a: a}, soltype.Positive)
+	return t.Accept(&ltRewriter{a: a}, pol)
 }
 
 // ltOccVisitor records the polarities each lifetime variable occurs in

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -10,7 +10,7 @@ import (
 // Display-time lifetime coalescing (M4 D4). The structural coalescers (coalesce /
 // coalesceScheme) rebuild a type through the shared visitor, which carries every
 // RefType lifetime through unchanged because a Lifetime is not a Type. They leave
-// the RAW lifetime variables in place — a borrow parameter's originated lifetime, a
+// the RAW lifetime variables in place: a borrow parameter's originated lifetime, a
 // multi-source join variable, and any instantiation-freshened intermediary. This
 // pass runs once over the finished coalesced type and resolves those lifetimes to
 // their display form, the lifetime-sort analogue of how the var arms resolve a type
@@ -20,24 +20,24 @@ import (
 // connected-component grouping of the lifetime bound graph:
 //
 //  1. Naming. A borrow originates at a parameter, so a lifetime occurring in a
-//     NEGATIVE (input) position is a "param lifetime". It is the only kind named in
-//     the output. The printer assigns it 'a, 'b, … from the variables this pass
-//     leaves in the type.
+//     NEGATIVE position is a "param lifetime". It is the only kind named in the
+//     output. The printer assigns it 'a, 'b, … from the variables this pass leaves
+//     in the type.
 //
 //  2. Elision. A param lifetime whose borrow never reaches an output connects
-//     nothing — it occurs in no positive position and its bound-graph component
-//     holds no output lifetime — so it is dropped, the lifetime-sort analogue of
-//     single-polarity type-variable elimination. Dropping branches on Mut: a
-//     mutable borrow becomes owned-mutable (RefType{Mut: true, Lt: nil}); an
-//     immutable borrow drops the RefType wrapper entirely (its bare inner), because
-//     RefType{false, nil} is the forbidden degenerate cell NewRef rejects.
+//     nothing. It occurs in no positive position, and its bound-graph component
+//     holds no output lifetime, so it is dropped. This is the lifetime-sort analogue
+//     of single-polarity type-variable elimination. Dropping branches on Mut. A
+//     mutable borrow becomes owned-mutable, RefType{Mut: true, Lt: nil}. An
+//     immutable borrow drops the RefType wrapper entirely and returns its bare inner,
+//     because RefType{false, nil} is the forbidden degenerate cell NewRef rejects.
 //
-//  3. Join expansion. A non-param lifetime — a join variable minted at a return or
-//     branch, or a lifetime freshened when a borrow-passing function was
-//     instantiated — is not itself nameable. It expands to the union of the param
+//  3. Join expansion. A non-param lifetime is not itself nameable. It is either a
+//     join variable minted at a return or branch, or a lifetime freshened when a
+//     borrow-passing function was instantiated. It expands to the union of the param
 //     lifetimes it shares a bound-graph component with, so a return uniting two
 //     borrows coalesces to ('a | 'b). The expansion follows the UNDIRECTED bound
-//     graph: instantiation interposes intermediary variables between a call's
+//     graph. Instantiation interposes intermediary variables between a call's
 //     argument lifetime and the callee's freshened parameter lifetime, related only
 //     by a mix of upper and lower bounds, so reachability cannot be confined to one
 //     bound direction. A lifetime forced to 'static renders 'static and absorbs.
@@ -46,7 +46,7 @@ import (
 // coalescers. pol is the root polarity the type was coalesced at, threaded through
 // so the occurrence walk and the rewrite classify lifetimes from the same root the
 // coalesced type was built from. Every caller coalesces a display type from the
-// Positive root today, so this is Positive in practice; threading it keeps the
+// Positive root today, so this is Positive in practice. Threading it keeps the
 // lifetime analysis consistent with the coalescing polarity rather than assuming it.
 func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	occ := map[*soltype.LifetimeVar]occPolarity{}
@@ -57,8 +57,8 @@ func coalesceLifetimes(t soltype.Type, pol soltype.Polarity) soltype.Type {
 }
 
 // ltOccVisitor records the polarities each lifetime variable occurs in
-// structurally. A RefType lifetime is COVARIANT — it lives on the wrapper, not in
-// the inner — so it is recorded in the borrow's own polarity; the mut-driven write
+// structurally. A RefType lifetime is COVARIANT, since it lives on the wrapper, not
+// in the inner, so it is recorded in the borrow's own polarity. The mut-driven write
 // view that flips the inner never touches it.
 type ltOccVisitor struct {
 	occ map[*soltype.LifetimeVar]occPolarity
@@ -81,7 +81,7 @@ func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type
 
 // ltAnalysis is the precomputed input the rewriter reads: per-variable structural
 // occurrence, the connected-component grouping of the lifetime bound graph, and the
-// set of component roots that hold an output (positive) lifetime.
+// set of component roots that hold a positive output lifetime.
 type ltAnalysis struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
 	uf       *unionFind                   // components over lifetime bound edges
@@ -99,15 +99,15 @@ type ltAnalysis struct {
 //
 // INVARIANT: this grouping is UNDIRECTED, so it conflates outlives direction. It is
 // correct only while two distinct param lifetimes share a component ONLY when they
-// genuinely co-flow — i.e. a join unites them, or one is borrowed from the other.
-// Every lifetime origin today obeys this: attachParamLifetimes mints an independent
-// var per parameter, and the only cross-links are joins (joinBorrows) and
-// instantiation copies (the freshener/extruder), both of which connect lifetimes
-// that really do flow together. A future origin that bound-links two independent
-// param borrows through a shared intermediary would break it: the two would be
-// unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing that case
-// needs directional reasoning (or first-class lifetime bounds), which the union
-// rendering deliberately does not yet model — see the join-expansion note above.
+// genuinely co-flow, meaning a join unites them or one is borrowed from the other.
+// Every lifetime origin today obeys this. attachParamLifetimes mints an independent
+// var per parameter. The only cross-links are joins from joinBorrows and
+// instantiation copies from the freshener and extruder, both of which connect
+// lifetimes that really do flow together. A future origin that bound-links two
+// independent param borrows through a shared intermediary would break it. The two
+// would be unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing
+// that case needs directional reasoning, or first-class lifetime bounds, which the
+// union rendering deliberately does not yet model. See the join-expansion note above.
 func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 	uf := newUnionFind()
 	vars := map[int]*soltype.LifetimeVar{}
@@ -145,8 +145,8 @@ func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 	return &ltAnalysis{occ: occ, uf: uf, vars: vars, posRoots: posRoots}
 }
 
-// isParam reports whether v is a borrow-origin (param) lifetime: one occurring in a
-// negative position. Only param lifetimes are named.
+// isParam reports whether v is a param lifetime: one that originates at a borrow
+// parameter and so occurs in a negative position. Only param lifetimes are named.
 func (a *ltAnalysis) isParam(v *soltype.LifetimeVar) bool {
 	return a.occ[v]&occNeg != 0
 }
@@ -160,8 +160,8 @@ func (a *ltAnalysis) kept(v *soltype.LifetimeVar) bool {
 
 // componentParams returns the kept param lifetimes sharing v's component, sorted by
 // ID. Sorting yields a canonical union member order, so a join expanded here renders
-// the same ('a | 'b) regardless of bound-list order and ltEqual's positional member
-// compare stays order-insensitive (closes the order gap noted in coalesce.go).
+// the same ('a | 'b) regardless of bound-list order, and ltEqual's positional member
+// compare stays order-insensitive. This closes the order gap noted in coalesce.go.
 func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime {
 	root := a.uf.find(v.ID)
 	var ids []int
@@ -191,8 +191,8 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 		}
 		return nil, true // connect-nothing param: elide
 	}
-	// A non-param lifetime (join or instantiation intermediary) is not nameable; it
-	// expands to the union of the param lifetimes in its component.
+	// A non-param lifetime is a join variable or an instantiation intermediary. It is
+	// not nameable, so it expands to the union of the param lifetimes in its component.
 	members := a.componentParams(v)
 	switch len(members) {
 	case 0:
@@ -227,7 +227,7 @@ func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 	resolved, elide := r.a.resolveLt(lv)
 	if elide {
 		if rt.Mut {
-			// NewRef would collapse (true, nil) back to its inner; keep the
+			// NewRef would collapse (true, nil) back to its inner. Keep the
 			// owned-mutable wrapper by constructing it directly.
 			return &soltype.RefType{Mut: true, Lt: nil, Inner: rt.Inner}
 		}

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -27,10 +27,12 @@ import (
 //  2. Elision. A param lifetime whose borrow never reaches an output connects
 //     nothing. It occurs in no positive position, and its bound-graph component
 //     holds no output lifetime, so it is dropped. This is the lifetime-sort analogue
-//     of single-polarity type-variable elimination. Dropping branches on Mut. A
-//     mutable borrow becomes owned-mutable, RefType{Mut: true, Lt: nil}. An
-//     immutable borrow drops the RefType wrapper entirely and returns its bare inner,
-//     because RefType{false, nil} is the forbidden degenerate cell NewRef rejects.
+//     of single-polarity type-variable elimination. The drop branches on the
+//     borrow's Mut flag:
+//       - A mutable borrow becomes owned-mutable, RefType{Mut: true, Lt: nil}.
+//       - An immutable borrow drops the RefType wrapper entirely and returns its
+//         bare inner, because RefType{Mut: false, Lt: nil} is the forbidden
+//         degenerate cell NewRef rejects.
 //
 //  3. Join expansion. A non-param lifetime is not itself nameable. It is either a
 //     join variable minted at a return or branch, or a lifetime freshened when a
@@ -41,6 +43,11 @@ import (
 //     argument lifetime and the callee's freshened parameter lifetime, related only
 //     by a mix of upper and lower bounds, so reachability cannot be confined to one
 //     bound direction. A lifetime forced to 'static renders 'static and absorbs.
+//     FUTURE (M6.5, lifetime bounds): this undirected grouping is a D4
+//     approximation, sound only because independent param lifetimes never share a
+//     bound-graph component. M6.5 replaces it with directional reasoning over the
+//     LowerBounds/UpperBounds edges, rendering a join as precise where-clauses like
+//     `where 'a: 'c, 'b: 'c` rather than collapsing it to the union ('a | 'b).
 //
 // coalesceLifetimes resolves the borrow lifetimes left raw by the structural
 // coalescers. pol is the root polarity the type was coalesced at, threaded through
@@ -84,9 +91,9 @@ func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type
 // set of component roots that hold a positive output lifetime.
 type ltAnalysis struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
-	uf       *unionFind                   // components over lifetime bound edges
+	uf       *unionFind                   // components over lifetime bound edges; find(ID) is the component's representative ID
 	vars     map[int]*soltype.LifetimeVar // every lifetime var reachable, by ID
-	posRoots set.Set[int]                 // component roots reaching a positive occurrence
+	posRoots set.Set[int]                 // representative IDs (uf.find results) of components reaching a positive occurrence
 }
 
 // newLtAnalysis builds the bound-graph components from the structurally-occurring
@@ -107,7 +114,9 @@ type ltAnalysis struct {
 // independent param borrows through a shared intermediary would break it. The two
 // would be unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing
 // that case needs directional reasoning, or first-class lifetime bounds, which the
-// union rendering deliberately does not yet model. See the join-expansion note above.
+// union rendering deliberately does not yet model. M6.5 (lifetime bounds) is the
+// milestone that retires this undirected grouping, replacing it with directional
+// reasoning over the LowerBounds/UpperBounds edges. See the join-expansion note above.
 func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 	uf := newUnionFind()
 	vars := map[int]*soltype.LifetimeVar{}
@@ -138,6 +147,10 @@ func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 
 	posRoots := set.NewSet[int]()
 	for v, pols := range occ {
+		// pols is a bitset of the polarities v occurred in. `&occPos != 0` tests
+		// whether the positive flag is set, tolerating a co-set occNeg bit, so a
+		// both-polarity v still counts. A v that occurs positively reaches an output,
+		// so mark its component root positive — kept reads this to gate elision.
 		if pols&occPos != 0 {
 			posRoots.Add(uf.find(v.ID))
 		}
@@ -227,11 +240,13 @@ func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 	resolved, elide := r.a.resolveLt(lv)
 	if elide {
 		if rt.Mut {
-			// NewRef would collapse (true, nil) back to its inner. Keep the
-			// owned-mutable wrapper by constructing it directly.
+			// Drop the elided lifetime to owned-mutable. (true, nil) is a valid borrow
+			// cell — NewRef does NOT collapse it — so keep the wrapper. Only the
+			// immutable (false, nil) cell below is the degenerate one.
 			return &soltype.RefType{Mut: true, Lt: nil, Inner: rt.Inner}
 		}
-		// RefType{false, nil} is the forbidden degenerate cell — drop the wrapper.
+		// RefType{false, nil} is the forbidden degenerate cell NewRef collapses — drop
+		// the wrapper and return the bare inner.
 		return rt.Inner
 	}
 	return &soltype.RefType{Mut: rt.Mut, Lt: resolved, Inner: rt.Inner}

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -1,148 +1,221 @@
 package solver
 
 import (
+	"sort"
+
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// coalesceRefLifetime rewrites a coalesced RefType's lifetime to its display form
-// (M4 D3). The structural coalescers rebuild a RefType through the shared visitor,
-// which carries the lifetime through unchanged because a Lifetime is not a Type.
-// This runs in their ExitType to resolve that lifetime the way the var arms resolve
-// a type variable. A non-RefType, or a borrow with no lifetime, passes through
-// untouched. The RefType lifetime is covariant, so it coalesces in the borrow's own
-// polarity, pol. The mut-driven write view never touches it.
+// Display-time lifetime coalescing (M4 D4). The structural coalescers (coalesce /
+// coalesceScheme) rebuild a type through the shared visitor, which carries every
+// RefType lifetime through unchanged because a Lifetime is not a Type. They leave
+// the RAW lifetime variables in place — a borrow parameter's originated lifetime, a
+// multi-source join variable, and any instantiation-freshened intermediary. This
+// pass runs once over the finished coalesced type and resolves those lifetimes to
+// their display form, the lifetime-sort analogue of how the var arms resolve a type
+// variable.
 //
-// Naming and single-polarity elision of param lifetimes are deferred to D4. D3
-// resolves only the join-and-escape shape. A join variable expands to the union of
-// the param lifetimes it reaches, and any lifetime forced to 'static renders
-// 'static.
-func coalesceRefLifetime(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	r, ok := t.(*soltype.RefType)
-	if !ok || r.Lt == nil {
-		return t
-	}
-	lt := coalesceLifetime(r.Lt, pol)
-	if lt == r.Lt {
-		return r
-	}
-	return &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}
+// It has three jobs, all keyed off a single occurrence analysis plus a
+// connected-component grouping of the lifetime bound graph:
+//
+//  1. Naming. A borrow originates at a parameter, so a lifetime occurring in a
+//     NEGATIVE (input) position is a "param lifetime". It is the only kind named in
+//     the output. The printer assigns it 'a, 'b, … from the variables this pass
+//     leaves in the type.
+//
+//  2. Elision. A param lifetime whose borrow never reaches an output connects
+//     nothing — it occurs in no positive position and its bound-graph component
+//     holds no output lifetime — so it is dropped, the lifetime-sort analogue of
+//     single-polarity type-variable elimination. Dropping branches on Mut: a
+//     mutable borrow becomes owned-mutable (RefType{Mut: true, Lt: nil}); an
+//     immutable borrow drops the RefType wrapper entirely (its bare inner), because
+//     RefType{false, nil} is the forbidden degenerate cell NewRef rejects.
+//
+//  3. Join expansion. A non-param lifetime — a join variable minted at a return or
+//     branch, or a lifetime freshened when a borrow-passing function was
+//     instantiated — is not itself nameable. It expands to the union of the param
+//     lifetimes it shares a bound-graph component with, so a return uniting two
+//     borrows coalesces to ('a | 'b). The expansion follows the UNDIRECTED bound
+//     graph: instantiation interposes intermediary variables between a call's
+//     argument lifetime and the callee's freshened parameter lifetime, related only
+//     by a mix of upper and lower bounds, so reachability cannot be confined to one
+//     bound direction. A lifetime forced to 'static renders 'static and absorbs.
+func coalesceLifetimes(t soltype.Type) soltype.Type {
+	occ := map[*soltype.LifetimeVar]occPolarity{}
+	t.Accept(&ltOccVisitor{occ: occ}, soltype.Positive)
+
+	a := newLtAnalysis(occ)
+	return t.Accept(&ltRewriter{a: a}, soltype.Positive)
 }
 
-// coalesceLifetime resolves a single lifetime to its display form. A 'static
-// renders 'static and a nil lifetime stays nil. A lifetime variable resolves by
-// its origin:
-//
-//   - A param lifetime is a borrow origin. It is kept as itself. The printer renders
-//     it under its raw 'l{ID} debug name now and its quantified name in D4. A param
-//     forced to 'static is the exception: its borrow has escaped, so it renders
-//     'static.
-//   - A join lifetime is a multi-source return or branch with Join set. It expands
-//     to the union of the param lifetimes it reaches through its polarity-relevant
-//     bounds, so a return uniting two borrows coalesces to `('a | 'b)`. A reachable
-//     'static absorbs the whole union to 'static.
-func coalesceLifetime(lt soltype.Lifetime, pol soltype.Polarity) soltype.Lifetime {
-	v, ok := lt.(*soltype.LifetimeVar)
-	if !ok {
-		return lt // 'static, or a nil slot handled by the caller
-	}
-	// A param lifetime resolves by MEETING its upper bounds, but this lattice is
-	// degenerate, so that meet has only three outcomes and never builds a combined
-	// node:
-	//   1. meet('a, 'static) = 'static. 'static is the lattice bottom, so it absorbs
-	//      the meet. forcedToStatic detects the `v <: 'static` escape and returns
-	//      'static. This is the only outcome that changes the variable.
-	//   2. meet('a, 'a) = 'a. A duplicate bound is idempotent, so the variable keeps
-	//      its own name. ContainsLifetime already dedups bounds, so this never even
-	//      reaches a second copy.
-	//   3. meet('a, 'b), two distinct lifetimes, is NOT constructed. There is no
-	//      lifetime-intersection form to hold it. Only LifetimeUnion exists, and that
-	//      is the output-only join twin. So the variable keeps its own name and its
-	//      non-'static upper bounds do not appear in the result.
-	// Cases 2 and 3 both fall through to `return v`: a non-forced param renders under
-	// its own name regardless of its other upper bounds.
-	if !v.Join {
-		if forcedToStatic(v) {
-			return soltype.Static
-		}
-		return v
-	}
-	members, static := reachableParamLifetimes(v, pol, set.NewSet[*soltype.LifetimeVar]())
-	if static {
-		return soltype.Static
-	}
-	// reachableParamLifetimes can reach one param lifetime through two distinct
-	// nested joins, so its collected members may repeat one. Dedup before building
-	// the union so the rendered `('a | 'b)` lists each lifetime once and ltEqual's
-	// positional member comparison stays stable. Deduping here can also drop the
-	// count to one, which the switch then renders as a bare lifetime.
-	members = dedupLifetimes(members)
-	switch len(members) {
-	case 1:
-		return members[0]
-	case 0:
-		// Unreachable: joinBorrows gives every join at least one param lower bound, and
-		// a join whose members are all forced returns through the 'static branch above.
-		// Guard it so a degenerate empty union never reaches the printer as `()`. A
-		// memberless join carries no nameable lifetime, so it drops to nil, an
-		// owned-mutable borrow.
-		return nil
-	default:
-		return &soltype.LifetimeUnion{Lifetimes: members}
-	}
+// ltOccVisitor records the polarities each lifetime variable occurs in
+// structurally. A RefType lifetime is COVARIANT — it lives on the wrapper, not in
+// the inner — so it is recorded in the borrow's own polarity; the mut-driven write
+// view that flips the inner never touches it.
+type ltOccVisitor struct {
+	occ map[*soltype.LifetimeVar]occPolarity
 }
 
-// reachableParamLifetimes collects the param lifetimes a join variable reaches
-// through its polarity-relevant bounds — lower bounds in Positive position, upper
-// in Negative — following nested join variables transitively. It reports whether
-// 'static is reached, which absorbs the union. The seen-set keys by variable
-// identity so a cyclic bound graph terminates. A forced param member renders
-// 'static, which sets the static flag rather than adding the member.
-func reachableParamLifetimes(v *soltype.LifetimeVar, pol soltype.Polarity, seen set.Set[*soltype.LifetimeVar]) ([]soltype.Lifetime, bool) {
-	if seen.Contains(v) {
-		return nil, false
-	}
-	seen.Add(v)
-	var members []soltype.Lifetime
-	static := false
-	for _, b := range v.BoundsAt(pol) {
-		if soltype.IsStaticLifetime(b) {
-			static = true
-			continue
+func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if r, ok := t.(*soltype.RefType); ok {
+		if lv, ok := r.Lt.(*soltype.LifetimeVar); ok {
+			if pol == soltype.Positive {
+				v.occ[lv] |= occPos
+			} else {
+				v.occ[lv] |= occNeg
+			}
 		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// ltAnalysis is the precomputed input the rewriter reads: per-variable structural
+// occurrence, the connected-component grouping of the lifetime bound graph, and the
+// set of component roots that hold an output (positive) lifetime.
+type ltAnalysis struct {
+	occ      map[*soltype.LifetimeVar]occPolarity
+	uf       *unionFind                   // components over lifetime bound edges
+	vars     map[int]*soltype.LifetimeVar // every lifetime var reachable, by ID
+	posRoots set.Set[int]                 // component roots reaching a positive occurrence
+}
+
+// newLtAnalysis builds the bound-graph components from the structurally-occurring
+// lifetime variables. It walks each occurring variable's bounds transitively in
+// BOTH directions, unioning a variable with every lifetime variable it is bounded
+// by or bounds, so an instantiation intermediary ends up in the same component as
+// the argument and parameter lifetimes it bridges. A component root is marked
+// positive when any structurally-positive lifetime falls in it; that is what keeps
+// a connected param lifetime from being elided.
+func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
+	uf := newUnionFind()
+	vars := map[int]*soltype.LifetimeVar{}
+	var visit func(v *soltype.LifetimeVar)
+	visitBound := func(v *soltype.LifetimeVar, b soltype.Lifetime) {
 		bv, ok := b.(*soltype.LifetimeVar)
 		if !ok {
-			continue
+			return
 		}
-		if !bv.Join {
-			if forcedToStatic(bv) {
-				static = true
-				continue
-			}
-			members = append(members, bv)
-			continue
-		}
-		sub, subStatic := reachableParamLifetimes(bv, pol, seen)
-		members = append(members, sub...)
-		static = static || subStatic
+		uf.union(v.ID, bv.ID)
+		visit(bv)
 	}
-	return members, static
+	visit = func(v *soltype.LifetimeVar) {
+		if _, seen := vars[v.ID]; seen {
+			return
+		}
+		vars[v.ID] = v
+		for _, b := range v.LowerBounds {
+			visitBound(v, b)
+		}
+		for _, b := range v.UpperBounds {
+			visitBound(v, b)
+		}
+	}
+	for v := range occ {
+		visit(v)
+	}
+
+	posRoots := set.NewSet[int]()
+	for v, pols := range occ {
+		if pols&occPos != 0 {
+			posRoots.Add(uf.find(v.ID))
+		}
+	}
+	return &ltAnalysis{occ: occ, uf: uf, vars: vars, posRoots: posRoots}
 }
 
-// dedupLifetimes removes duplicate lifetimes, preserving first-occurrence order.
-// The members are identity-keyed LifetimeVars, the same key ltEqual uses, so
-// pointer equality is the right notion of "the same lifetime" here.
-func dedupLifetimes(lts []soltype.Lifetime) []soltype.Lifetime {
-	seen := set.NewSet[soltype.Lifetime]()
-	out := make([]soltype.Lifetime, 0, len(lts))
-	for _, lt := range lts {
-		if seen.Contains(lt) {
+// isParam reports whether v is a borrow-origin (param) lifetime: one occurring in a
+// negative position. Only param lifetimes are named.
+func (a *ltAnalysis) isParam(v *soltype.LifetimeVar) bool {
+	return a.occ[v]&occNeg != 0
+}
+
+// kept reports whether a param lifetime survives elision: its bound-graph component
+// reaches an output, so the borrow flows somewhere observable. A param occurring
+// only on its parameter, connected to no output, is elided.
+func (a *ltAnalysis) kept(v *soltype.LifetimeVar) bool {
+	return a.posRoots.Contains(a.uf.find(v.ID))
+}
+
+// componentParams returns the kept param lifetimes sharing v's component, sorted by
+// ID. Sorting yields a canonical union member order, so a join expanded here renders
+// the same ('a | 'b) regardless of bound-list order and ltEqual's positional member
+// compare stays order-insensitive (closes the order gap noted in coalesce.go).
+func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime {
+	root := a.uf.find(v.ID)
+	var ids []int
+	for id, lv := range a.vars {
+		if a.uf.find(id) != root || !a.isParam(lv) || !a.kept(lv) {
 			continue
 		}
-		seen.Add(lt)
-		out = append(out, lt)
+		ids = append(ids, id)
 	}
-	return out
+	sort.Ints(ids)
+	members := make([]soltype.Lifetime, len(ids))
+	for i, id := range ids {
+		members[i] = a.vars[id]
+	}
+	return members
+}
+
+// resolveLt maps a lifetime variable to its display form, or reports elide=true when
+// the borrow connects nothing and the wrapper should drop.
+func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, elide bool) {
+	if forcedToStatic(v) {
+		return soltype.Static, false
+	}
+	if a.isParam(v) {
+		if a.kept(v) {
+			return v, false // a named param renders under its own quantified name
+		}
+		return nil, true // connect-nothing param: elide
+	}
+	// A non-param lifetime (join or instantiation intermediary) is not nameable; it
+	// expands to the union of the param lifetimes in its component.
+	members := a.componentParams(v)
+	switch len(members) {
+	case 0:
+		return nil, true
+	case 1:
+		return members[0], false
+	default:
+		return &soltype.LifetimeUnion{Lifetimes: members}, false
+	}
+}
+
+// ltRewriter applies the analysis to a coalesced type, resolving each RefType's
+// lifetime and eliding the wrapper where the borrow connects nothing. It runs in
+// ExitType so a nested borrow is resolved before the borrow that contains it.
+type ltRewriter struct {
+	a *ltAnalysis
+}
+
+func (r *ltRewriter) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	return soltype.EnterResult{}
+}
+
+func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
+	rt, ok := t.(*soltype.RefType)
+	if !ok || rt.Lt == nil {
+		return t
+	}
+	lv, ok := rt.Lt.(*soltype.LifetimeVar)
+	if !ok {
+		return t // already a concrete display lifetime ('static)
+	}
+	resolved, elide := r.a.resolveLt(lv)
+	if elide {
+		if rt.Mut {
+			// NewRef would collapse (true, nil) back to its inner; keep the
+			// owned-mutable wrapper by constructing it directly.
+			return &soltype.RefType{Mut: true, Lt: nil, Inner: rt.Inner}
+		}
+		// RefType{false, nil} is the forbidden degenerate cell — drop the wrapper.
+		return rt.Inner
+	}
+	return &soltype.RefType{Mut: rt.Mut, Lt: resolved, Inner: rt.Inner}
 }
 
 // forcedToStatic reports whether a lifetime variable has 'static among its bounds,

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -144,7 +144,7 @@ func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
 
 // Source-level regression: the D2 IdentityRefReturn acceptance still renders the
 // shared param lifetime on the generalized scheme. D2.5 freshens lifetimes at
-// instantiation, but the scheme body keeps its original param lifetime; D4 names it
+// instantiation, but the scheme body keeps its original param lifetime. D4 names it
 // `'a` since it reaches both the parameter and the return.
 func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -144,12 +144,12 @@ func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
 
 // Source-level regression: the D2 IdentityRefReturn acceptance still renders the
 // shared param lifetime on the generalized scheme. D2.5 freshens lifetimes at
-// instantiation, but the scheme body keeps its original param lifetime, so its
-// display is unchanged.
+// instantiation, but the scheme body keeps its original param lifetime; D4 names it
+// `'a` since it reaches both the parameter and the return.
 func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut 'l0 {x: number}) -> mut 'l0 {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["f"])
 }
 
 // Source-level regression: a borrow-passing function called at two distinct sites

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -159,11 +159,38 @@ func TestEscapingNestedRefIntoStatic(t *testing.T) {
 	require.Equal(t, "{p: mut 'static {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
 }
 
+// mutPointRef is a `mut lt {x: number}` borrow — the carrier these lifetime tests
+// hang a join or escape off.
+func mutPointRef(lt soltype.Lifetime) *soltype.RefType {
+	return &soltype.RefType{
+		Mut: true,
+		Lt:  lt,
+		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+		}},
+	}
+}
+
+// borrowFn wraps a return type in a function whose parameters carry the given borrow
+// lifetimes. D4 names a lifetime only when it originates at a parameter (occurs in a
+// negative position), so a join's member lifetimes must appear on parameters to be
+// named or expanded — exactly how joinBorrows produces them from real source.
+func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType {
+	params := make([]*soltype.FuncParam, len(paramLts))
+	for i, lt := range paramLts {
+		params[i] = &soltype.FuncParam{
+			Pattern: &soltype.IdentPat{Name: string(rune('p' + i))},
+			Type:    mutPointRef(lt),
+		}
+	}
+	return &soltype.FuncType{Params: params, Ret: ret}
+}
+
 // Escaping a JOINED borrow forces every param lifetime the join reaches to outlive
-// 'static, so the whole `('l0 | 'l1)` union collapses to a single 'static. This is
-// the join↔escape interaction (M4 D3). constrainEscape constrains the join lifetime
+// 'static, so the whole `('a | 'b)` union collapses to a single 'static. This is the
+// join↔escape interaction (M4 D3). constrainEscape constrains the join lifetime
 // `<: 'static`, which propagates through its lower bounds to each member, and
-// coalesceLifetime then absorbs the union to 'static rather than expanding it.
+// coalesceLifetimes then absorbs the union to 'static rather than expanding it.
 func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)
@@ -172,28 +199,55 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	// The join is bounded below by each source lifetime, as joinBorrows wires it.
 	c.ctx.constrainLt(a, join)
 	c.ctx.constrainLt(b, join)
-	ref := &soltype.RefType{
-		Mut: true,
-		Lt:  join,
+	ret := mutPointRef(join)
+	fn := borrowFn(ret, a, b)
+
+	// Before escape the join expands to the union of its members.
+	require.Equal(t,
+		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+
+	c.constrainEscape(ret)
+
+	// Escape forces the join — and through its lower bounds each member — to 'static, so
+	// the entire signature collapses to 'static with no nameable lifetime left.
+	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
+	require.Equal(t,
+		"fn (p: mut 'static {x: number}, q: mut 'static {x: number}) -> mut 'static {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+}
+
+// D4 elision branches on Mut. A connect-nothing IMMUTABLE borrow — its lifetime
+// reaches no output — drops the RefType wrapper entirely, rendering as its bare
+// inner, because RefType{false, nil} is the forbidden degenerate cell NewRef
+// rejects. This contrasts with the mutable case, which becomes owned-mutable
+// (RefType{Mut: true, Lt: nil}); the FieldWrite acceptance covers that branch.
+func TestImmutableConnectNothingBorrowDropsWrapper(t *testing.T) {
+	c := newChecker()
+	lt := c.ctx.freshLifetime(0)
+	param := &soltype.RefType{
+		Mut: false,
+		Lt:  lt,
 		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
 			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
 		}},
 	}
+	// The borrow appears only on the parameter — the body returns a number, not the
+	// borrow — so its lifetime connects nothing and is elided.
+	fn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: param}},
+		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
+	}
 
-	// Before escape the join expands to the union of its members.
-	require.Equal(t, "mut ('l0 | 'l1) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
-
-	c.constrainEscape(ref)
-
-	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
-	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+	require.Equal(t, "fn (p: {x: number}) -> number", renderScheme(&MonoScheme{Ty: fn}))
 }
 
 // A nested join reaching one param lifetime through two distinct sub-joins lists
 // that lifetime once in the rendered union, not twice. The top join's lower bounds
-// are the two sub-joins, and both reach 'l0. So reachableParamLifetimes collects it
-// twice and coalesceLifetime dedups before building the LifetimeUnion. Without the
-// dedup this rendered `('l0 | 'l1 | 'l0 | 'l2)`.
+// are the two sub-joins, and both reach 'a. componentParams gathers the join's
+// component param lifetimes into an ID-keyed, sorted set, so a lifetime reached
+// through two sub-joins appears once. Without that dedup this rendered
+// `('a | 'b | 'a | 'c)`.
 func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)
@@ -204,19 +258,15 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	top := c.ctx.freshJoinLifetime(0)
 	c.ctx.constrainLt(a, j2)
 	c.ctx.constrainLt(b, j2)
-	c.ctx.constrainLt(a, j3) // 'l0 shared across both sub-joins
+	c.ctx.constrainLt(a, j3) // 'a shared across both sub-joins
 	c.ctx.constrainLt(d, j3)
 	c.ctx.constrainLt(j2, top)
 	c.ctx.constrainLt(j3, top)
-	ref := &soltype.RefType{
-		Mut: true,
-		Lt:  top,
-		Inner: &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
-		}},
-	}
+	fn := borrowFn(mutPointRef(top), a, b, d)
 
-	require.Equal(t, "mut ('l0 | 'l1 | 'l2) {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+	require.Equal(t,
+		"fn <'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}, r: mut 'c {x: number}) -> mut ('a | 'b | 'c) {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
 }
 
 // ltEqual compares a LifetimeUnion structurally. A LifetimeUnion is the union form a

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -159,7 +159,7 @@ func TestEscapingNestedRefIntoStatic(t *testing.T) {
 	require.Equal(t, "{p: mut 'static {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
 }
 
-// mutPointRef is a `mut lt {x: number}` borrow — the carrier these lifetime tests
+// mutPointRef is a `mut lt {x: number}` borrow, the carrier these lifetime tests
 // hang a join or escape off.
 func mutPointRef(lt soltype.Lifetime) *soltype.RefType {
 	return &soltype.RefType{
@@ -172,9 +172,10 @@ func mutPointRef(lt soltype.Lifetime) *soltype.RefType {
 }
 
 // borrowFn wraps a return type in a function whose parameters carry the given borrow
-// lifetimes. D4 names a lifetime only when it originates at a parameter (occurs in a
-// negative position), so a join's member lifetimes must appear on parameters to be
-// named or expanded — exactly how joinBorrows produces them from real source.
+// lifetimes. D4 names a lifetime only when it originates at a parameter, which means
+// it occurs in a negative position. So a join's member lifetimes must appear on
+// parameters to be named or expanded, exactly how joinBorrows produces them from
+// real source.
 func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(paramLts))
 	for i, lt := range paramLts {
@@ -209,19 +210,19 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 
 	c.constrainEscape(ret)
 
-	// Escape forces the join — and through its lower bounds each member — to 'static, so
-	// the entire signature collapses to 'static with no nameable lifetime left.
+	// Escape forces the join to 'static, propagating through its lower bounds to each
+	// member, so the entire signature collapses to 'static with no nameable lifetime left.
 	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
 	require.Equal(t,
 		"fn (p: mut 'static {x: number}, q: mut 'static {x: number}) -> mut 'static {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// D4 elision branches on Mut. A connect-nothing IMMUTABLE borrow — its lifetime
-// reaches no output — drops the RefType wrapper entirely, rendering as its bare
+// D4 elision branches on Mut. A connect-nothing IMMUTABLE borrow, whose lifetime
+// reaches no output, drops the RefType wrapper entirely and renders as its bare
 // inner, because RefType{false, nil} is the forbidden degenerate cell NewRef
-// rejects. This contrasts with the mutable case, which becomes owned-mutable
-// (RefType{Mut: true, Lt: nil}); the FieldWrite acceptance covers that branch.
+// rejects. This contrasts with the mutable case, which becomes owned-mutable,
+// RefType{Mut: true, Lt: nil}. The FieldWrite acceptance covers that branch.
 func TestImmutableConnectNothingBorrowDropsWrapper(t *testing.T) {
 	c := newChecker()
 	lt := c.ctx.freshLifetime(0)
@@ -232,8 +233,8 @@ func TestImmutableConnectNothingBorrowDropsWrapper(t *testing.T) {
 			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
 		}},
 	}
-	// The borrow appears only on the parameter — the body returns a number, not the
-	// borrow — so its lifetime connects nothing and is elided.
+	// The borrow appears only on the parameter, since the body returns a number, not
+	// the borrow, so its lifetime connects nothing and is elided.
 	fn := &soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: param}},
 		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -39,6 +39,7 @@ are recorded in
 - [M4 — Core value types: records + usage-based inference + `mut` + **lifetimes** + destructuring/`match`](#m4--core-value-types-records--usage-based-inference--mut--lifetimes--destructuringmatch)
 - [M5 — Nominal types (classes)](#m5--nominal-types-classes)
 - [M6 — Unions / intersections](#m6--unions--intersections)
+- [M6.5 — Lifetime bounds](#m65--lifetime-bounds)
 - [M7 — Library type resolution (`std:*` / `web:*` / `node:*`)](#m7--library-type-resolution-std--web--node)
 - [M8 — Second fixture harness + differential triage](#m8--second-fixture-harness--differential-triage)
 - [M9 — Type-level operators](#m9--type-level-operators)
@@ -863,6 +864,58 @@ inexact-union `match` does.
 
 ---
 
+## M6.5 — Lifetime bounds
+
+See [m6.5-implementation-plan.md](m6.5-implementation-plan.md) for the routes
+considered, the chosen route, and the sequencing rationale.
+
+A **lifetime bound** is a declared or rendered outlives relation between two named
+lifetimes in a signature — Rust's `'a: 'b`, read "`'a` outlives `'b`". Escalier's
+lifetimes are unrelated once named today; a bound lets a signature state how two of
+them relate. The constraint solver already builds the outlives graph —
+`constrainLt` records the edges in `LifetimeVar.LowerBounds`/`UpperBounds`, and M4
+D2.5 generalizes them per instantiation — so this milestone is about surfacing,
+declaring, and checking relations the solver already computes, not new inference.
+
+- **Render inferred bounds as where-clauses.** M4 D4 collapses a multi-source join
+  to the union `('a | 'b)`, the conservative stand-in for "one of these". The graph
+  underneath already carries `'a: 'c, 'b: 'c` for the join `'c`, so the precise form
+  `fn <'a, 'b, 'c>(…) -> mut 'c {…} where 'a: 'c, 'b: 'c` is a display upgrade, not
+  an inference change. Naming kept join lifetimes and a where-clause section in
+  `PrintAsSchemeWith` are the new rendering pieces.
+- **Declare bounds at no-body sites.** A site with no body to infer from must declare
+  its bounds — external and library signatures, abstract interface methods, and type
+  aliases over borrows. Add `where 'a: 'b` syntax to the AST and parser and lower it
+  into `constrainLt` during signature resolution, so a declared bound participates in
+  solving exactly like an inferred one.
+- **Check inferred against declared.** An annotated function's inferred bound set must
+  satisfy its declared one — subsumption over the lifetime sort, built on
+  `constrainLt`.
+- **Chosen route — a unified bound set.** `coalesceLifetimes` stops expanding and
+  eliding and instead computes one canonical, transitively-reduced bound set that
+  both the printer and the annotation resolver share. This is also where the
+  undirected connected-component grouping in `newLtAnalysis` — sound today only
+  because independent param lifetimes never share a bound-graph component, the
+  invariant that file documents — is replaced with directional reasoning. The cheaper
+  display-only and annotation-only routes are recorded in the plan as the alternatives
+  this supersedes.
+
+**Why it lands here.** It sits after M6 because M6 changes the join machinery
+directly — the permissive mut-borrow join and the canonical union member order — and
+the bound set is built on that settled representation. It sits with or just before M7
+because M7 library imports are the first site where declared bounds become
+mandatory, which is the first configuration where the unified model beats a
+display-only one. Earlier would be premature: nothing in M4 or M5 is blocked, since
+the D4 union rendering is sound and only less precise.
+
+**Accept:** a multi-source join renders `fn <'a, 'b, 'c>(p: mut 'a {…}, q: mut 'b
+{…}) -> mut 'c {…} where 'a: 'c, 'b: 'c` instead of the union; a `where`-annotated
+signature round-trips through the parser and printer; a body whose inferred bounds
+violate a declared `where` clause is rejected with the full outlives message; a
+redundant declared bound implied by transitivity is dropped from the rendered set.
+
+---
+
 ## M7 — Library type resolution (`std:*` / `web:*` / `node:*`)
 
 Port the standard-library type ingestion onto `soltype`. Today this is a
@@ -1288,6 +1341,13 @@ reduce through the M9 operator machinery.
   semantics (not old-checker output), and the second fixture harness's
   differential is a triage tool, not a parity gate. This is what lets
   intended improvements through instead of forcing old-checker parity.
+- M6.5 (lifetime bounds) is numbered `.5` for the same reason M2.5 is — to slot
+  between M6 and M7 without renumbering. It rides *after* M6 because M6 settles the
+  join machinery its canonical bound set is built on (the permissive mut-borrow join
+  and canonical union order), and *before/with* M7 because library imports are the
+  first no-body site where declared bounds become mandatory. It is deferred past M4,
+  even though M4 D4 already renders the union approximation, because that rendering is
+  sound and nothing in M4–M5 needs the precise bounded form.
 - M2.5 sits between M2 and M3 (rather than folding into M3 or deferring with the
   rest of `Prov`) because the `FromAST` discipline is "born-with-the-type" infra:
   threading one provenance line per construction site is cheap across M2's ~8

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -877,17 +877,22 @@ them relate. The constraint solver already builds the outlives graph —
 D2.5 generalizes them per instantiation — so this milestone is about surfacing,
 declaring, and checking relations the solver already computes, not new inference.
 
-- **Render inferred bounds as where-clauses.** M4 D4 collapses a multi-source join
+- **Bounds live in the lifetime and type-param list, not a `where` clause.** A
+  lifetime bound is attached in the `<…>` list as `<'a: 'b>`, mirroring how a
+  type-param bound is written `<T: U>`. One quantifier list carries both sorts and
+  their bounds, which keeps the surface consistent between type-param and lifetime
+  bounds and avoids a second bound-declaration grammar.
+- **Render inferred bounds in the param list.** M4 D4 collapses a multi-source join
   to the union `('a | 'b)`, the conservative stand-in for "one of these". The graph
   underneath already carries `'a: 'c, 'b: 'c` for the join `'c`, so the precise form
-  `fn <'a, 'b, 'c>(…) -> mut 'c {…} where 'a: 'c, 'b: 'c` is a display upgrade, not
-  an inference change. Naming kept join lifetimes and a where-clause section in
-  `PrintAsSchemeWith` are the new rendering pieces.
+  `fn <'a: 'c, 'b: 'c, 'c>(…) -> mut 'c {…}` is a display upgrade, not an inference
+  change. Naming kept join lifetimes and emitting their `'a: 'b` bounds in the
+  quantifier list `PrintAsSchemeWith` already builds are the new rendering pieces.
 - **Declare bounds at no-body sites.** A site with no body to infer from must declare
   its bounds — external and library signatures, abstract interface methods, and type
-  aliases over borrows. Add `where 'a: 'b` syntax to the AST and parser and lower it
-  into `constrainLt` during signature resolution, so a declared bound participates in
-  solving exactly like an inferred one.
+  aliases over borrows. Add in-list bound syntax `<'a, 'b: 'a>` to the AST and parser
+  and lower it into `constrainLt` during signature resolution, so a declared bound
+  participates in solving exactly like an inferred one.
 - **Check inferred against declared.** An annotated function's inferred bound set must
   satisfy its declared one — subsumption over the lifetime sort, built on
   `constrainLt`.
@@ -908,11 +913,11 @@ mandatory, which is the first configuration where the unified model beats a
 display-only one. Earlier would be premature: nothing in M4 or M5 is blocked, since
 the D4 union rendering is sound and only less precise.
 
-**Accept:** a multi-source join renders `fn <'a, 'b, 'c>(p: mut 'a {…}, q: mut 'b
-{…}) -> mut 'c {…} where 'a: 'c, 'b: 'c` instead of the union; a `where`-annotated
-signature round-trips through the parser and printer; a body whose inferred bounds
-violate a declared `where` clause is rejected with the full outlives message; a
-redundant declared bound implied by transitivity is dropped from the rendered set.
+**Accept:** a multi-source join renders `fn <'a: 'c, 'b: 'c, 'c>(p: mut 'a {…}, q:
+mut 'b {…}) -> mut 'c {…}` instead of the union; a signature with in-list bounds
+round-trips through the parser and printer; a body whose inferred bounds violate a
+declared bound is rejected with the full outlives message; a redundant declared bound
+implied by transitivity is dropped from the rendered set.
 
 ---
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1344,6 +1344,7 @@ these arms it must add.
 - A1 (#728)
 - A3 (#733)
 - B1+B2 (#732)
+- B3 (#733)
 - C1+C2 (#731)
 - C3 (#735)
 - D1 (#740)
@@ -1356,8 +1357,8 @@ these arms it must add.
 A1✓ → A2
 A1✓ → A3✓ ──────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
 A1✓ → B1✓ → B2✓                 │  (annotation-side acceptance tests)
-      B1✓ → B3                  │
-      B1✓, B3 ────────────┐     │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
+      B1✓ → B3✓                 │
+      B1✓, B3✓ ───────────┐     │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
 A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1✓ → D2✓ → D3✓ → D4✓ → G1 → G2
 A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
 F1✓             (independent; any time — only M2's Namespace)

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1346,6 +1346,11 @@ these arms it must add.
 - B1+B2 (#732)
 - C1+C2 (#731)
 - C3 (#735)
+- D1 (#740)
+- D2 (#744)
+- D2.5 (#745)
+- D3 (#748)
+- D4 (#749)
 - F1 (#730)
 
 A1✓ → A2
@@ -1353,7 +1358,7 @@ A1✓ → A3✓ ─────────────────────�
 A1✓ → B1✓ → B2✓                 │  (annotation-side acceptance tests)
       B1✓ → B3                  │
       B1✓, B3 ────────────┐     │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
-A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1 → D2 → D3 → D4 → G1 → G2
+A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1✓ → D2✓ → D3✓ → D4✓ → G1 → G2
 A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
 F1✓             (independent; any time — only M2's Namespace)
 ```

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -1,0 +1,214 @@
+# M6.5 implementation plan — Lifetime bounds
+
+This plan covers **M6.5 — Lifetime bounds** as listed in
+[01-milestones.md](01-milestones.md). It records the design routes considered, the
+chosen route, and the sequencing rationale. It is a routes-and-decision document,
+not yet a PR-by-PR breakdown. The PR breakdown is written once the route is
+committed and M6 has settled the join semantics this builds on.
+
+A **lifetime bound** is a declared or rendered outlives relation between two named
+lifetimes in a signature. Rust spells it `'a: 'b`, read "`'a` outlives `'b`".
+Escalier's lifetimes are unrelated once named today. A bound lets a signature state
+how two of them relate.
+
+## Background — the outlives graph already exists
+
+The constraint solver already builds the outlives relation. `constrainLt(sub, super)`
+records the edges in `LifetimeVar.LowerBounds` and `LifetimeVar.UpperBounds`
+([internal/soltype/lifetime.go](../../internal/soltype/lifetime.go)), and M4 D2.5
+already gives lifetimes a `Level` so the freshener copies those edges per
+instantiation. So the relations a body implies are inferred today. What is missing
+is surfacing them, declaring them at no-body sites, and checking one against the
+other.
+
+The work splits into three capability axes:
+
+1. **Render** an inferred bound as a where-clause instead of collapsing it to the
+   union `('a | 'b)` or eliding it, which is what M4 D4 does now.
+2. **Declare** a bound in source for a site that has no body to infer from, and
+   lower it into `constrainLt`.
+3. **Check** an inferred bound set against a declared one — subsumption over the
+   lifetime sort.
+
+## Inference vs annotation — the dividing line is the body
+
+The shape of the relation does not decide whether it needs an annotation. The
+presence of a body does. A bound is a fact about the solved graph, so any bound a
+body produces through its borrows, joins, and stores is inferred from `constrainLt`
+edges, then coalesced. A site with no body has nothing to watch, so its bounds must
+be declared.
+
+Four representative cases, with whether each is inferable from a concrete function:
+
+1. **Multi-source join.** Returning one of two borrows. The result lives only as
+   long as both inputs, so its lifetime is the shorter of the two.
+   ```
+   fn pick<'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut 'c {x: number}
+     where 'a: 'c, 'b: 'c
+   ```
+   **Fully inferred today.** `joinBorrows` mints the join lifetime and constrains
+   each source into it, so `'a: 'c, 'b: 'c` is the graph the solver already builds.
+   M4 D4 renders it as the union `('a | 'b)`, the conservative stand-in for "one of
+   these". Upgrading that to a bounded `'c` is a display change, not an inference
+   change.
+
+2. **Store a borrow inside a borrow.** Inserting a borrowed value into a borrowed
+   container. The inserted value must outlive the references the container holds.
+   ```
+   fn put<'a, 'v>(bag: mut 'a {items: ['v {…}]}, item: 'v {…})  where 'v: 'a
+   ```
+   **Inferred when the body performs the store**, via the same `constrainLt` the
+   borrow and escape rules already emit. The nested-container store path is not all
+   wired yet, since array writes are deferred to M7.
+
+3. **Object holding a borrow.** Returning a structure that carries a borrow.
+   ```
+   fn wrap<'a>(p: 'a {x: number}) -> {inner: 'a {x: number}}
+   ```
+   **Inferred.** Constructing `{inner: p}` carries `p`'s borrow into the literal, so
+   the object's lifetime is tied to `'a` by value flow, the same mechanism as
+   returning the borrow directly.
+
+4. **Abstract interface method.** An iterator yielding a borrow tied to itself.
+   ```
+   fn next<'a>(self: mut 'a Iter) -> 'a Item
+   ```
+   **Needs an annotation, but only because it is a no-body site.** The same
+   signature written as a concrete function with a body is inferred like the others.
+
+So the split is:
+
+- **Concrete functions** infer every shape, because each reduces to `constrainLt`
+  edges then coalesced. #1 is realized now. #2 and #3 are realized to the extent
+  their write and construct paths emit edges; some store paths wait on M7.
+- **No-body sites** require declaration. These are external and library signatures,
+  abstract interface methods, and type aliases over borrows. M5 classes surface a
+  soft pull through abstract methods. M7 library imports are the hard trigger,
+  because an imported borrow-relating function cannot be represented without its
+  declared bounds.
+
+A parameter still needs its `mut` or lifetime marker, or usage that makes it a
+borrow, so the solver knows it is a borrow at all. The relations between those
+lifetimes are inferred, not annotated.
+
+## Implementation routes
+
+### Route 1 — Display-first, inference-led
+
+Surface the graph already present. Change M4 D4 so a join lifetime is named and kept
+with its outlives edges rendered as a where-clause, instead of expanded to a union.
+Touches `internal/solver/lifetime_coalesce.go` for keeping and naming joins and
+pruning bounds, and `internal/soltype/print.go` for the where-clause section in
+`PrintAsSchemeWith`.
+
+- **Pros.** Smallest. Reuses the `constrainLt` graph and D2.5 generalization
+  wholesale. Makes the join rendering precise immediately. No new syntax to design.
+  Zero annotation burden for concrete functions.
+- **Cons.** Does nothing for no-body sites. Brings the where-clause machinery's hard
+  parts — which bounds to show, transitive reduction — without an annotation to
+  validate against. Risks noisy signatures if pruning is weak.
+
+### Route 2 — Annotation-first
+
+Add `where 'a: 'b` or Rust-style `<'a, 'b: 'a>` syntax, lower declared bounds into
+`constrainLt` during signature resolution, and check inferred against declared. Keep
+D4's union rendering for now. Touches `internal/ast`, `internal/parser`,
+`internal/solver/type_ann.go`, and a subsumption check.
+
+- **Pros.** Unblocks the cases inference cannot reach — interfaces and library
+  imports. The lowering reuses `constrainLt`, so the solver core barely changes.
+  Gives users explicit control.
+- **Cons.** More surface-area design. Does not improve inferred rendering, so a
+  declared bound can be one the renderer still collapses. An annotation then does not
+  round-trip, since parse then solve then render does not reproduce what was written.
+
+### Route 3 — Unified bound-set model (chosen)
+
+Make a canonical lifetime bound set the single representation both inference and
+annotation produce and consume. `coalesceLifetimes` stops expanding and eliding and
+instead computes a canonical, transitively-reduced bound set that both the printer
+and the annotation resolver share. This is also where the undirected-component
+heuristic in `newLtAnalysis` is replaced with directional reasoning, closing the
+invariant that file documents.
+
+- **Pros.** Principled and symmetric. Annotations round-trip. Closes the
+  undirected-grouping invariant. Sets up bounded quantifiers and future variance work
+  cleanly.
+- **Cons.** Largest. Touches the lifetime sort, coalescing, printer, parser, AST, and
+  `resolveTypeAnn` together, plus the directional analysis. Effectively its own
+  milestone. Highest risk.
+
+## None of the routes prevents inference
+
+A bound is computed by `constrainLt` regardless of how it is rendered or declared, so
+no route forecloses inference. The routes differ only in whether an inferred bound is
+surfaced and generalized. Route 1 surfaces it. Route 2 alone leaves it
+inferred-but-unrendered, which is incompleteness, not prevention. Route 3 is
+symmetric by construction.
+
+Two places could foreclose inference, and neither is one of these routes:
+
+1. **Monomorphic lifetimes — the M4 D2.5 Option B fallback.** Refusing to generalize
+   a scheme with free lifetime vars would block bounded-lifetime inference across
+   instantiations. D2.5 chose Option A, full generalization with per-use freshening,
+   so this door is open. Do not regress to Option B.
+2. **Route 1 built on the current undirected grouping has a ceiling, not a block.**
+   `coalesceLifetimes` discards outlives direction, so a display layered straight on
+   it can only emit unions, never directional `'a: 'b`. The directed information is
+   still on the vars, so this is not prevention, but rendering true bounds means
+   reading `LowerBounds`/`UpperBounds` directly rather than the undirected components.
+   That is the same directional analysis Route 3 needs.
+
+## Decision and sequencing
+
+**Route 3 is the chosen direction**, because its value is the symmetric
+infer-declare-render loop, and that loop is what no-body sites need. Inference alone
+is covered more cheaply by Route 1, so Route 3 pays off only once declaration also
+exists.
+
+Sequencing:
+
+- **After M6.** M6 changes the join machinery directly — it relaxes the incompatible
+  mut-borrow join to a read-until-narrowed union and adds canonical
+  union/intersection member order. Route 3's canonical bound set is built on that
+  join representation, so building it before M6 means reworking it afterward. The
+  dependency is M6 then M6.5.
+- **With or just before M7.** M7 library imports are the hard trigger, where declared
+  bounds become mandatory. That is the first configuration where both halves of the
+  loop exist at once, which is the only configuration where Route 3 beats Route 1.
+- **Earlier would be premature.** Nothing in M4 or M5 is blocked, since the D4 union
+  rendering is sound and only less precise. Committing to a unified bound-set
+  abstraction before M5, M6, and M7 have shown what they demand of it risks building
+  the wrong shape.
+
+**Cheap down payment, available any time.** When a real signature's `('a | 'b)`
+rendering first becomes confusing, do only Route 1's directional variant — read
+`LowerBounds`/`UpperBounds` off the vars instead of the undirected components, and
+render directional `'a: 'b`. That validates the directional analysis Route 3 depends
+on, retires the undirected-grouping invariant early, and is throwaway-free, since it
+is a strict subset of Route 3.
+
+## Hard parts shared by all routes
+
+- **Canonicalization and transitive reduction** of the bound set, so
+  `'a: 'b, 'b: 'c, 'a: 'c` renders as the two non-redundant edges. Needed for stable
+  output and for comparing schemes.
+- **Which bounds to keep** — the lifetime-sort analogue of the single-polarity
+  elimination and co-occurrence merging the type sort already does in
+  [internal/solver/simplify.go](../../internal/solver/simplify.go). A bound to an
+  elided or `'static`-forced lifetime should drop.
+- **Bound-set subsumption and equality.** `equalType`'s `RefType` arm, scheme dedup,
+  overload arms, and annotation-checking all need "does the inferred bound set imply
+  the declared one". `constrainLt` gives the primitive. The set-level comparison is
+  new.
+- **Coexistence with `LifetimeUnion`.** Decide whether bounds supersede the union
+  rendering M4 D4 produces or sit alongside it.
+
+## Relationship to M4 D4
+
+M4 D4 ([m4-implementation-plan.md](m4-implementation-plan.md) D4) ships the display
+pass this milestone extends. D4 renders a join as a union and elides connect-nothing
+lifetimes, using the undirected connected-component grouping documented in
+`newLtAnalysis`. M6.5 promotes that pass from "union approximation" to "directional
+bound set", and is the natural home for swapping the undirected grouping for the
+directional reasoning D4 deliberately deferred.

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -23,12 +23,19 @@ other.
 
 The work splits into three capability axes:
 
-1. **Render** an inferred bound as a where-clause instead of collapsing it to the
-   union `('a | 'b)` or eliding it, which is what M4 D4 does now.
+1. **Render** an inferred bound as an outlives bound attached in the lifetime and
+   type-param list, `<'a: 'c, …>`, instead of collapsing it to the union `('a | 'b)`
+   or eliding it. M4 D4 collapses or elides today.
 2. **Declare** a bound in source for a site that has no body to infer from, and
    lower it into `constrainLt`.
-3. **Check** an inferred bound set against a declared one — subsumption over the
-   lifetime sort.
+3. **Check** an inferred bound set against a declared one. This is subsumption over
+   the lifetime sort.
+
+A **bound lives in the param list, not a separate `where` clause.** Escalier attaches
+a type-param's bound in the `<…>` list as `<T: U>`, so a lifetime bound follows the
+same form, `<'a: 'b>`, read "`'a` outlives `'b`". One quantifier list carries both
+sorts and their bounds, which keeps the surface consistent between type-param bounds
+and lifetime bounds and avoids a second bound-declaration grammar.
 
 ## Inference vs annotation — the dividing line is the body
 
@@ -43,8 +50,7 @@ Four representative cases, with whether each is inferable from a concrete functi
 1. **Multi-source join.** Returning one of two borrows. The result lives only as
    long as both inputs, so its lifetime is the shorter of the two.
    ```
-   fn pick<'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut 'c {x: number}
-     where 'a: 'c, 'b: 'c
+   fn pick<'a: 'c, 'b: 'c, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut 'c {x: number}
    ```
    **Fully inferred today.** `joinBorrows` mints the join lifetime and constrains
    each source into it, so `'a: 'c, 'b: 'c` is the graph the solver already builds.
@@ -55,7 +61,7 @@ Four representative cases, with whether each is inferable from a concrete functi
 2. **Store a borrow inside a borrow.** Inserting a borrowed value into a borrowed
    container. The inserted value must outlive the references the container holds.
    ```
-   fn put<'a, 'v>(bag: mut 'a {items: ['v {…}]}, item: 'v {…})  where 'v: 'a
+   fn put<'a, 'v: 'a>(bag: mut 'a {items: ['v {…}]}, item: 'v {…})
    ```
    **Inferred when the body performs the store**, via the same `constrainLt` the
    borrow and escape rules already emit. The nested-container store path is not all
@@ -95,25 +101,26 @@ lifetimes are inferred, not annotated.
 
 ### Route 1 — Display-first, inference-led
 
-Surface the graph already present. Change M4 D4 so a join lifetime is named and kept
-with its outlives edges rendered as a where-clause, instead of expanded to a union.
-Touches `internal/solver/lifetime_coalesce.go` for keeping and naming joins and
-pruning bounds, and `internal/soltype/print.go` for the where-clause section in
-`PrintAsSchemeWith`.
+Surface the graph already present. Change M4 D4 so a join lifetime is named and kept,
+with its outlives edges rendered as bounds in the `<…>` list, instead of expanded to
+a union. Touches `internal/solver/lifetime_coalesce.go` for keeping and naming joins
+and pruning bounds, and `internal/soltype/print.go` for emitting the `'a: 'b` bounds
+in the quantifier list `PrintAsSchemeWith` already builds.
 
 - **Pros.** Smallest. Reuses the `constrainLt` graph and D2.5 generalization
-  wholesale. Makes the join rendering precise immediately. No new syntax to design.
-  Zero annotation burden for concrete functions.
-- **Cons.** Does nothing for no-body sites. Brings the where-clause machinery's hard
-  parts — which bounds to show, transitive reduction — without an annotation to
-  validate against. Risks noisy signatures if pruning is weak.
+  wholesale. Makes the join rendering precise immediately. Reuses the existing
+  quantifier list rather than adding a new clause. Zero annotation burden for
+  concrete functions.
+- **Cons.** Does nothing for no-body sites. Brings the bound-rendering hard parts,
+  which bounds to show and transitive reduction, without an annotation to validate
+  against. Risks noisy signatures if pruning is weak.
 
 ### Route 2 — Annotation-first
 
-Add `where 'a: 'b` or Rust-style `<'a, 'b: 'a>` syntax, lower declared bounds into
-`constrainLt` during signature resolution, and check inferred against declared. Keep
-D4's union rendering for now. Touches `internal/ast`, `internal/parser`,
-`internal/solver/type_ann.go`, and a subsumption check.
+Add in-list bound syntax `<'a, 'b: 'a>`, mirroring type-param bounds `<T: U>`, lower
+declared bounds into `constrainLt` during signature resolution, and check inferred
+against declared. Keep D4's union rendering for now. Touches `internal/ast`,
+`internal/parser`, `internal/solver/type_ann.go`, and a subsumption check.
 
 - **Pros.** Unblocks the cases inference cannot reach — interfaces and library
   imports. The lowering reuses `constrainLt`, so the solver core barely changes.


### PR DESCRIPTION
Implement the display pass that resolves borrow lifetimes to their final form, completing M4 D4. The constraint solver already builds the outlives graph through `constrainLt`, but leaves raw lifetime variables in place on RefTypes. This pass runs once over the finished coalesced type and resolves those lifetimes to their display form — the lifetime-sort analogue of how type-variable coalescing resolves type variables.

The pass has three jobs:

1. **Naming.** A borrow originates at a parameter, so a lifetime occurring in a negative (input) position is a "param lifetime". Only param lifetimes are named in the output; the printer assigns them 'a, 'b, … from the variables this pass leaves in the type.

2. **Elision.** A param lifetime whose borrow never reaches an output connects nothing — it occurs in no positive position and its bound-graph component holds no output lifetime — so it is dropped. For mutable borrows, this becomes owned-mutable (RefType{Mut: true, Lt: nil}); for immutable borrows, the RefType wrapper drops entirely since RefType{false, nil} is forbidden.

3. **Join expansion.** A non-param lifetime (a join variable or instantiation intermediary) is not itself nameable. It expands to the union of the param lifetimes it shares a bound-graph component with, so a return uniting two borrows coalesces to ('a | 'b). The expansion follows the undirected bound graph to handle instantiation intermediaries.

Key changes:

- Replace `coalesceRefLifetime` and `coalesceLifetime` with `coalesceLifetimes`, which performs a two-pass analysis: first collecting structural occurrence polarities of each lifetime variable, then computing connected components of the bound graph and resolving each lifetime based on its origin and reachability.
- Add `ltOccVisitor` to record which polarities each lifetime variable occurs in structurally. RefType lifetimes are covariant (they live on the wrapper, not the inner), so they are recorded in the borrow's own polarity.
- Add `ltAnalysis` to precompute the bound-graph components via union-find, track which component roots reach a positive occurrence, and provide query methods for param detection, elision, and component expansion.
- Add `ltRewriter` to apply the analysis to the coalesced type, resolving each RefType's lifetime and eliding the wrapper where appropriate.
- Update `PrintAsSchemeWith` to name and quantify kept param lifetimes in the output, using `freeLifetimeVars` to collect them in first-appearance order and `lifetimeParamName` to assign 'a, 'b, … names.
- Update tests to assert the D4 display form with named, quantified lifetimes and elided connect-nothing borrows, rather than raw 'l{id} forms.
- Add `m6.5-implementation-plan.md` documenting the design routes for lifetime bounds (the next milestone), the chosen unified bound-set approach, and sequencing rationale.

The undirected bound-graph grouping is sound today only because independent param lifetimes never share a component — the invariant documented in `newLtAnalysis`. This will be replaced with directional reasoning in M6.5 when bounds become a first-class rendered feature.

https://claude.ai/code/session_018pbzW3W4PcewQAAw7EMys5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Type inference now displays lifetime variables with readable names (e.g., `<'a, 'b>`) instead of internal identifiers.
  * Unnecessary lifetime annotations are automatically elided from mutable borrows in inferred types for cleaner signatures.
  * Generalized function signatures now properly quantify lifetime parameters alongside type parameters.

* **Documentation**
  * Added planning documentation for upcoming lifetime bounds feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->