### PR TITLE
Port mutability-transition checking to solver (M4 G1)

### DIFF
--- a/internal/ast/pattern.go
+++ b/internal/ast/pattern.go
@@ -21,7 +21,7 @@ func (*WildcardPat) isPat()  {}
 
 type IdentPat struct {
 	Name         string
-	VarID        int // set by the rename pass (liveness.VarID); 0 = unset
+	VarID        int     // set by the rename pass (liveness.VarID); 0 = unset
 	Mutable      bool    // `mut` prefix on the binding (e.g. `val mut x = …`)
 	TypeAnn      TypeAnn // optional
 	Default      Expr    // optional
@@ -69,8 +69,8 @@ func (p *ObjKeyValuePat) Accept(v Visitor) {
 
 type ObjShorthandPat struct {
 	Key     *Ident
-	VarID   int  // set by the rename pass (liveness.VarID); 0 = unset
-	Mutable bool // `mut` prefix on the shorthand binding (e.g. `{ mut x }`)
+	VarID   int     // set by the rename pass (liveness.VarID); 0 = unset
+	Mutable bool    // `mut` prefix on the shorthand binding (e.g. `{ mut x }`)
 	TypeAnn TypeAnn // optional
 	Default Expr    // optional
 	span    Span
@@ -262,4 +262,69 @@ func FindBindings(pat Pat) set.Set[string] {
 	pat.Accept(visitor)
 
 	return visitor.Bindings
+}
+
+// ForEachLeafBinding invokes fn for every identifier-binding leaf a pattern
+// introduces, recursing through destructuring patterns. varID is the leaf's VarID as
+// written on the AST node by the rename pass (0 when unset). Unlike FindBindings,
+// which yields only names and skips tuple/rest/key-value leaves, this exposes the
+// (name, varID) pair every leaf carries, so the checker's and solver's liveness
+// pre-passes share one walker instead of each keeping a copy.
+func ForEachLeafBinding(pat Pat, fn func(name string, varID int)) {
+	if pat == nil {
+		return
+	}
+	switch p := pat.(type) {
+	case *IdentPat:
+		fn(p.Name, p.VarID)
+	case *TuplePat:
+		for _, sub := range p.Elems {
+			ForEachLeafBinding(sub, fn)
+		}
+	case *ObjectPat:
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ObjKeyValuePat:
+				ForEachLeafBinding(e.Value, fn)
+			case *ObjShorthandPat:
+				if e.Key != nil {
+					fn(e.Key.Name, e.VarID)
+				}
+			case *ObjRestPat:
+				ForEachLeafBinding(e.Pattern, fn)
+			}
+		}
+	case *RestPat:
+		ForEachLeafBinding(p.Pattern, fn)
+	}
+}
+
+// CollectPatternBindingNames adds every identifier name a pattern introduces
+// (recursively) to into.
+func CollectPatternBindingNames(p Pat, into set.Set[string]) {
+	ForEachLeafBinding(p, func(name string, _ int) {
+		into.Add(name)
+	})
+}
+
+// RootObjectVarID walks a member/index expression chain (`a.b.c`, `a[b][c]`) to the
+// root object's VarID as written on the AST node, returning 0 when the root is not a
+// local variable. The result is the raw node VarID; liveness callers wrap it in
+// liveness.VarID.
+func RootObjectVarID(expr Expr) int {
+	for {
+		switch e := expr.(type) {
+		case *MemberExpr:
+			expr = e.Object
+		case *IndexExpr:
+			expr = e.Object
+		case *IdentExpr:
+			if e.VarID > 0 {
+				return e.VarID
+			}
+			return 0
+		default:
+			return 0
+		}
+	}
 }

--- a/internal/checker/check_transitions.go
+++ b/internal/checker/check_transitions.go
@@ -636,7 +636,7 @@ func (c *Checker) trackAliasesForPropAssignment(
 	rhs ast.Expr,
 ) {
 	// Find the root object variable of the member/index chain.
-	objVarID := rootObjectVarID(lhs)
+	objVarID := liveness.VarID(ast.RootObjectVarID(lhs))
 	if objVarID <= 0 {
 		return
 	}
@@ -653,27 +653,6 @@ func (c *Checker) trackAliasesForPropAssignment(
 		// No alias relationship to track.
 	default:
 		panic(fmt.Sprintf("trackAliasesForPropAssignment: unhandled alias source kind %d", source.RootKind()))
-	}
-}
-
-// rootObjectVarID iteratively walks a member/index expression chain
-// (e.g. a.b.c, a[b][c]) to find the root object's VarID.
-// Returns 0 if the root is not a local variable.
-func rootObjectVarID(expr ast.Expr) liveness.VarID {
-	for {
-		switch e := expr.(type) {
-		case *ast.MemberExpr:
-			expr = e.Object
-		case *ast.IndexExpr:
-			expr = e.Object
-		case *ast.IdentExpr:
-			if e.VarID > 0 {
-				return liveness.VarID(e.VarID)
-			}
-			return 0
-		default:
-			return 0
-		}
 	}
 }
 

--- a/internal/checker/infer_lifetime.go
+++ b/internal/checker/infer_lifetime.go
@@ -822,13 +822,13 @@ func (v *escapingRefsVisitor) EnterDecl(d ast.Decl) bool {
 
 // isEscapingLValue returns true if the given assignment-target expression's
 // root identifier (walking through MemberExpr/IndexExpr chains) is an
-// escape root: either a non-local binding (rootObjectVarID returns 0,
+// escape root: either a non-local binding (ast.RootObjectVarID returns 0,
 // meaning module-level / prelude / outer-scope) or a positive VarID that
 // the caller declared as a forced escape root (e.g. `self` in a
 // constructor body, where `self.<field> = expr` outlives the local frame
 // even though `self` itself is a local parameter).
 func (v *escapingRefsVisitor) isEscapingLValue(expr ast.Expr) bool {
-	root := rootObjectVarID(expr)
+	root := liveness.VarID(ast.RootObjectVarID(expr))
 	if root == 0 {
 		return true
 	}
@@ -1445,56 +1445,6 @@ func (v *fieldAssignVisitor) EnterDecl(d ast.Decl) bool {
 		return false
 	}
 	return true
-}
-
-// forEachLeafBinding invokes fn for every identifier-binding leaf
-// introduced by a pattern, walking through Tuple/Object/Rest containers.
-// Leaves are IdentPat (the pattern's own Name+VarID) and ObjShorthandPat
-// (the property's Key.Name plus the shorthand's own VarID). ObjRestPat,
-// RestPat, and ObjKeyValuePat are container-only; this helper recurses
-// through them.
-//
-// Note: walkPatternForLeaves cannot use this helper because it walks the
-// pattern in *lockstep with the parameter's type* (slicing tuple/object/
-// array sub-positions to compute each leaf's leafType) and intentionally
-// skips ObjRestPat (a freshly-assembled container has no
-// caller-provided lifetime). The two name-only walkers below share this
-// traversal; lifetime walking does not.
-func forEachLeafBinding(pat ast.Pat, fn func(name string, varID int)) {
-	if pat == nil {
-		return
-	}
-	switch p := pat.(type) {
-	case *ast.IdentPat:
-		fn(p.Name, p.VarID)
-	case *ast.TuplePat:
-		for _, sub := range p.Elems {
-			forEachLeafBinding(sub, fn)
-		}
-	case *ast.ObjectPat:
-		for _, elem := range p.Elems {
-			switch e := elem.(type) {
-			case *ast.ObjKeyValuePat:
-				forEachLeafBinding(e.Value, fn)
-			case *ast.ObjShorthandPat:
-				if e.Key != nil {
-					fn(e.Key.Name, e.VarID)
-				}
-			case *ast.ObjRestPat:
-				forEachLeafBinding(e.Pattern, fn)
-			}
-		}
-	case *ast.RestPat:
-		forEachLeafBinding(p.Pattern, fn)
-	}
-}
-
-// collectPatternBindingNames adds every identifier name introduced by a
-// pattern (recursively) to the provided set.
-func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
-	forEachLeafBinding(p, func(name string, _ int) {
-		into.Add(name)
-	})
 }
 
 // typeCarriesLifetime reports whether the given type can carry a lifetime.

--- a/internal/checker/liveness_prepass.go
+++ b/internal/checker/liveness_prepass.go
@@ -34,7 +34,7 @@ func (c *Checker) runLivenessPrePass(ctx *Context, astParams []*ast.Param, param
 	// IdentExpr.VarID resolves to.
 	astParamNames := set.NewSet[string]()
 	for _, p := range astParams {
-		collectPatternBindingNames(p.Pattern, astParamNames)
+		ast.CollectPatternBindingNames(p.Pattern, astParamNames)
 	}
 	var extraParamNames []string
 	for name := range paramBindings {
@@ -95,7 +95,7 @@ func seedParamLeafAliases(
 	aliases *liveness.AliasTracker,
 ) {
 	for _, param := range astParams {
-		forEachLeafBinding(param.Pattern, func(name string, varID int) {
+		ast.ForEachLeafBinding(param.Pattern, func(name string, varID int) {
 			if varID <= 0 {
 				return
 			}

--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -63,11 +63,11 @@ type renamer struct {
 	varIDNames map[VarID]string
 }
 
-func newRenamer(outerBindings map[string]VarID) *renamer {
+func newRenamer(outerBindings map[string]VarID, firstID VarID) *renamer {
 	s := newScope(nil)
 	maps.Copy(s.bindings, outerBindings)
 	return &renamer{
-		nextID:     1, // local VarIDs start at 1
+		nextID:     firstID,
 		scope:      s,
 		varIDNames: make(map[VarID]string),
 	}
@@ -122,7 +122,19 @@ func (r *renamer) resolve(name string, span ast.Span) VarID {
 // After this function returns, the internal scope stack is discarded.
 // All downstream phases read VarIDs directly from AST nodes.
 func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, extraParamNames ...string) *RenameResult {
-	r := newRenamer(outerBindings)
+	return RenameFrom(params, body, outerBindings, 1, extraParamNames...)
+}
+
+// RenameFrom is Rename with an explicit starting id for the positive local VarIDs.
+// Plain Rename starts at 1, giving each body its own 1-based numbering. The solver
+// instead passes a module-wide running counter so VarIDs are unique across every
+// function body in a single inference run: a binding's VarID then names the same
+// variable in any frame, so feeding one body's id into another body's alias/liveness
+// tables can no longer collide with an unrelated local. firstID must be >= 1 — 0 is
+// the "unset" sentinel and negative ids mark non-local (outer) bindings. The next
+// free id is firstID + the returned UniqueVarCount.
+func RenameFrom(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, firstID VarID, extraParamNames ...string) *RenameResult {
+	r := newRenamer(outerBindings, firstID)
 
 	// Process function parameters — they are in scope for the entire body.
 	// Parameters share the root scope with outerBindings. This is fine because
@@ -146,7 +158,7 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID,
 	r.renameBlock(body)
 
 	return &RenameResult{
-		UniqueVarCount:   int(r.nextID) - 1, // count of local variables assigned
+		UniqueVarCount:   int(r.nextID) - int(firstID), // count of local variables assigned
 		VarIDNames:       r.varIDNames,
 		ExtraParamVarIDs: extraParamVarIDs,
 		Errors:           r.errors,

--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -128,11 +128,11 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID,
 // RenameFrom is Rename with an explicit starting id for the positive local VarIDs.
 // Plain Rename starts at 1, giving each body its own 1-based numbering. The solver
 // instead passes a module-wide running counter so VarIDs are unique across every
-// function body in a single inference run: a binding's VarID then names the same
+// function body in a single inference run. A binding's VarID then names the same
 // variable in any frame, so feeding one body's id into another body's alias/liveness
-// tables can no longer collide with an unrelated local. firstID must be >= 1 — 0 is
-// the "unset" sentinel and negative ids mark non-local (outer) bindings. The next
-// free id is firstID + the returned UniqueVarCount.
+// tables can no longer collide with an unrelated local. firstID must be >= 1. The id 0
+// is the unset sentinel, and negative ids mark non-local bindings. The next free id is
+// firstID + the returned UniqueVarCount.
 func RenameFrom(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, firstID VarID, extraParamNames ...string) *RenameResult {
 	r := newRenamer(outerBindings, firstID)
 

--- a/internal/liveness/rename_test.go
+++ b/internal/liveness/rename_test.go
@@ -82,6 +82,35 @@ func TestRenameFromStartsAtFirstID(t *testing.T) {
 	require.Equal(t, 12, 10+result.UniqueVarCount)
 }
 
+// Chaining RenameFrom across two bodies, with the second starting where the first left
+// off, gives every local a VarID unique across both bodies. That is the property that
+// lets a binding's VarID name the same variable in any frame.
+func TestRenameFromDisjointAcrossBodies(t *testing.T) {
+	// Body 1: val a = 1; val b = a
+	a := identPat("a")
+	b := identPat("b")
+	body1 := block(valDecl(a, numLit(1)), valDecl(b, ident("a")))
+
+	r1 := RenameFrom(nil, body1, map[string]VarID{}, 1)
+	require.Empty(t, r1.Errors)
+
+	// Body 2 starts at the next free id, so its locals cannot collide with body 1's.
+	c := identPat("c")
+	d := identPat("d")
+	body2 := block(valDecl(c, numLit(2)), valDecl(d, ident("c")))
+
+	r2 := RenameFrom(nil, body2, map[string]VarID{}, 1+VarID(r1.UniqueVarCount))
+	require.Empty(t, r2.Errors)
+
+	body1IDs := []int{a.VarID, b.VarID}
+	body2IDs := []int{c.VarID, d.VarID}
+	for _, id1 := range body1IDs {
+		for _, id2 := range body2IDs {
+			require.NotEqual(t, id1, id2, "VarIDs must be disjoint across bodies")
+		}
+	}
+}
+
 func TestSimpleBindingAndUse(t *testing.T) {
 	// val x = 1; print(x)
 	x := identPat("x")

--- a/internal/liveness/rename_test.go
+++ b/internal/liveness/rename_test.go
@@ -58,6 +58,30 @@ func block(stmts ...ast.Stmt) ast.Block {
 	return ast.Block{Stmts: stmts, Span: span()}
 }
 
+// RenameFrom starts local numbering at firstID instead of 1, so a caller threading a
+// module-wide counter gets VarIDs unique across bodies. UniqueVarCount stays the count
+// of locals defined, independent of the starting id.
+func TestRenameFromStartsAtFirstID(t *testing.T) {
+	// val a = 1; val b = a  — two locals, started at id 10.
+	a := identPat("a")
+	b := identPat("b")
+	aRef := ident("a")
+	body := block(
+		valDecl(a, numLit(1)),
+		valDecl(b, aRef),
+	)
+
+	result := RenameFrom(nil, body, map[string]VarID{}, 10)
+
+	require.Empty(t, result.Errors)
+	require.Equal(t, 2, result.UniqueVarCount)  // count is start-independent
+	require.Equal(t, VarID(10), VarID(a.VarID)) // first local takes firstID
+	require.Equal(t, VarID(11), VarID(b.VarID)) // second is firstID+1
+	require.Equal(t, a.VarID, aRef.VarID)       // use resolves to binding
+	// Next free id = firstID + UniqueVarCount, so a following body starts at 12.
+	require.Equal(t, 12, 10+result.UniqueVarCount)
+}
+
 func TestSimpleBindingAndUse(t *testing.T) {
 	// val x = 1; print(x)
 	x := identPat("x")

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -91,6 +92,22 @@ type funcCtx struct {
 	// restored on exit. A field write at module top-level (c.fn == nil) simply gets
 	// no read-after-write precision, which is sound.
 	written map[fieldKey]soltype.Type
+
+	// liveness, aliases, stmtToRef, and varIDNames are the mutability-transition
+	// checking state for THIS function body (M4 G1), populated by runLivenessPrePass
+	// before the body is walked. They are the new-checker analogue of the old
+	// checker's Context.Liveness/Aliases/StmtToRef/VarIDNames. Scoping them to funcCtx
+	// gives a nested function its own liveness analysis for free — push/pop isolates
+	// them exactly like `written`. They stay nil at module top-level (c.fn == nil),
+	// where the transition checker is a no-op.
+	liveness   *liveness.LivenessInfo
+	aliases    *liveness.AliasTracker
+	stmtToRef  map[ast.Stmt]liveness.StmtRef
+	varIDNames map[liveness.VarID]string
+	// currentStmt is the enclosing statement currently being walked (M4 G1), set by
+	// inferStmt. A reassignment `a = e` lives in expression position, so the transition
+	// checker reads the enclosing statement from here to find its CFG StmtRef.
+	currentStmt ast.Stmt
 }
 
 // pushFuncCtx enters the inference context for function `node` (async controls

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -43,6 +43,15 @@ type checker struct {
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
 
+	// varIDCounter is the module-wide running allocator for liveness VarIDs (M4 G1).
+	// Each function body's pre-pass renames its locals starting from this counter and
+	// then advances it, so VarIDs are unique across every body in one inference run
+	// rather than restarting at 1 per body. That makes a binding's VarID name the same
+	// variable in any frame, so a stale or cross-frame id can never collide with an
+	// unrelated local in another body's alias/liveness tables. It starts at 1 (0 is the
+	// "unset" sentinel, negative ids mark non-local bindings).
+	varIDCounter int
+
 	// paramLifetimes is the set of lifetime-variable ids that originate on a
 	// function parameter (M4 D2). A `mut`-borrow param without a declared lifetime
 	// is a borrow of whatever the caller lends, so attachParamLifetimes mints a
@@ -134,7 +143,7 @@ func (c *checker) popFuncCtx(saved *funcCtx) []soltype.Type {
 // newChecker returns a checker with a fresh Context, an empty Info table, and an
 // empty Prov side table.
 func newChecker() *checker {
-	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, paramLifetimes: set.NewSet[int]()}
+	return &checker{ctx: &Context{}, info: NewInfo(), prov: Prov{}, paramLifetimes: set.NewSet[int](), varIDCounter: 1}
 }
 
 // freshAt allocates a fresh inference variable at the given level. Provenance for

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -52,6 +52,13 @@ type checker struct {
 	// "unset" sentinel, negative ids mark non-local bindings).
 	varIDCounter int
 
+	// preludeNames caches the immutable prelude root scope's sorted value names so the
+	// liveness pre-pass collects them once instead of re-walking and re-sorting the
+	// prelude for every function body (M4 G1). preludeNamesRoot is the scope the cache
+	// was computed for; collectOuterBindings recomputes if a different root appears.
+	preludeNames     []string
+	preludeNamesRoot *Scope
+
 	// paramLifetimes is the set of lifetime-variable ids that originate on a
 	// function parameter (M4 D2). A `mut`-borrow param without a declared lifetime
 	// is a borrow of whatever the caller lends, so attachParamLifetimes mints a

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -48,14 +48,14 @@ type checker struct {
 	// then advances it, so VarIDs are unique across every body in one inference run
 	// rather than restarting at 1 per body. That makes a binding's VarID name the same
 	// variable in any frame, so a stale or cross-frame id can never collide with an
-	// unrelated local in another body's alias/liveness tables. It starts at 1 (0 is the
-	// "unset" sentinel, negative ids mark non-local bindings).
+	// unrelated local in another body's alias/liveness tables. It starts at 1. The id 0
+	// is the unset sentinel, and negative ids mark non-local bindings.
 	varIDCounter int
 
 	// preludeNames caches the immutable prelude root scope's sorted value names so the
 	// liveness pre-pass collects them once instead of re-walking and re-sorting the
 	// prelude for every function body (M4 G1). preludeNamesRoot is the scope the cache
-	// was computed for; collectOuterBindings recomputes if a different root appears.
+	// was computed for. collectOuterBindings recomputes if a different root appears.
 	preludeNames     []string
 	preludeNamesRoot *Scope
 
@@ -113,9 +113,9 @@ type funcCtx struct {
 	// checking state for THIS function body (M4 G1), populated by runLivenessPrePass
 	// before the body is walked. They are the new-checker analogue of the old
 	// checker's Context.Liveness/Aliases/StmtToRef/VarIDNames. Scoping them to funcCtx
-	// gives a nested function its own liveness analysis for free — push/pop isolates
-	// them exactly like `written`. They stay nil at module top-level (c.fn == nil),
-	// where the transition checker is a no-op.
+	// gives a nested function its own liveness analysis for free. Push/pop isolates them
+	// exactly like `written`. They stay nil at module top-level (c.fn == nil), where the
+	// transition checker is a no-op.
 	liveness   *liveness.LivenessInfo
 	aliases    *liveness.AliasTracker
 	stmtToRef  map[ast.Stmt]liveness.StmtRef

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -85,10 +85,10 @@ func TestInferInexactTupleAnnotationVariableWidthSubtyping(t *testing.T) {
 }
 
 // The construction-site excess check looks THROUGH a `mut` borrow: an inexact
-// object/tuple wrapped in `mut` still rejects undeclared literal members, so the
-// rule is consistent whether or not the annotation is a borrow. The mutability
-// mismatch (an immutable literal into a mut slot) fires too — both are real,
-// independent problems — so the excess diagnostic must appear alongside it.
+// object/tuple wrapped in `mut` still rejects undeclared literal members, so the rule
+// is consistent whether or not the annotation is a borrow. The freshly constructed
+// literal is given the owned-mutable type without a mutability mismatch, since a fresh
+// value is uniquely owned, so the excess-member diagnostic is the only error.
 func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 	t.Run("object", func(t *testing.T) {
 		_, _, errs := inferSource(t, `val r: mut {x: number, ...} = {x: 1, y: 2}`)
@@ -96,7 +96,7 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 		for i, e := range errs {
 			msgs[i] = e.Message()
 		}
-		require.Contains(t, msgs, "object has extra property: y")
+		require.Equal(t, []string{"object has extra property: y"}, msgs)
 	})
 	t.Run("tuple", func(t *testing.T) {
 		_, _, errs := inferSource(t, `val t: mut [number, ...] = [1, 2, 3]`)
@@ -104,9 +104,41 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 		for i, e := range errs {
 			msgs[i] = e.Message()
 		}
-		require.Contains(t, msgs, "tuple has extra element at index 1")
-		require.Contains(t, msgs, "tuple has extra element at index 2")
+		require.ElementsMatch(t, []string{
+			"tuple has extra element at index 1",
+			"tuple has extra element at index 2",
+		}, msgs)
 	})
+}
+
+// A freshly constructed literal is uniquely owned, so it may be given an owned-mutable
+// annotation: `val items: mut {x} = {x: 1}` type-checks and the binding is mutable.
+// The upgrade recurses through nested literals and tuples.
+func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val items: mut {x: number} = {x: 1}`)
+		require.Empty(t, errs)
+		require.Equal(t, "mut {x: number}", values["items"])
+	})
+	t.Run("nested object", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
+		require.Empty(t, errs)
+		require.Equal(t, "mut {p: {x: number}}", values["w"])
+	})
+	t.Run("tuple", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val t: mut [number, number] = [1, 2]`)
+		require.Empty(t, errs)
+		require.Equal(t, "mut [number, number]", values["t"])
+	})
+}
+
+// The upgrade applies only to a freshly constructed value. A non-fresh source — here a
+// variable — still rejects an immutable→mutable assignment, because the variable could
+// alias a value held immutably elsewhere. That case waits on the lifetime/region work.
+func TestInferOwnedMutFromVariableRejected(t *testing.T) {
+	src := "fn f() {\n\tval cfg: {x: number} = {x: 1}\n\tval m: mut {x: number} = cfg\n\tm.x = 2\n}"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, "cannot constrain immutable object <: mutable object", errs[0].Message())
 }
 
 // A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -89,7 +89,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// error and adopting `never` would poison the binding. Keep the inferred
 		// initializer type instead (error recovery).
 		if annT, ok := c.resolveTypeAnn(d.TypeAnn, lvl); ok {
-			c.constrain(d.Init, initT, annT)
+			c.constrainInitAgainstAnnotation(d.Init, initT, annT)
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
@@ -107,6 +107,71 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		initT = widen(initT)
 	}
 	return initT, true
+}
+
+// constrainInitAgainstAnnotation constrains a `val`/`var` initializer against its
+// resolved annotation, with one refinement over a plain constrain: a freshly
+// constructed, unaliased initializer flowing into an OWNED-mutable annotation is
+// allowed to take that mutable type.
+//
+// The C2 gate rejects immutable <: mutable structurally, because writing through the
+// target would otherwise mutate a read-only value. But that is only unsound when a
+// live immutable alias to the source exists. A freshly constructed literal has none —
+// it is uniquely owned — so granting it the annotated mutable type is safe. This is
+// Rule 2 with an empty alias set, the construction case `val items: mut {x} = {x: 1}`.
+// The decision belongs at this value-flow site, which can see the source is fresh, not
+// in the liveness-blind constrain engine.
+//
+// The upgrade constrains the initializer's shape against the borrow's INNER, the
+// covariant read view, exactly as the non-mut path constrains against the annotation
+// directly. It does not relate two independent mutable references, so no write-view
+// invariance applies. It is gated on an owned-mutable annotation (Lt == nil): a borrow
+// annotation (`'a mut …`) is a reference into a caller's region, not an owned value, so
+// a fresh source flowing into it stays on the strict path. A non-fresh source — a
+// variable, a call, a member access — also stays strict; its Rule 2 safety depends on
+// liveness or the lifetime/region system (M4 G2), not on syntax.
+func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) {
+	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
+		c.constrain(init, initT, ref.Inner)
+		return
+	}
+	c.constrain(init, initT, annT)
+}
+
+// isFreshlyConstructed reports whether e is a syntactically fresh, unaliased value: a
+// literal, or an object/tuple literal whose every element is itself freshly
+// constructed. Such a value captures no reference to an existing binding, so it is
+// uniquely owned. It is deliberately conservative and identifier-free: any IdentExpr,
+// call, member access, or spread disqualifies the whole expression, because a captured
+// variable could alias a value held immutably elsewhere. Being identifier-free also
+// makes it sound without VarIDs, so it holds at module top level where the liveness
+// pre-pass has not run. A richer freshness judgment over provably-unique non-literal
+// expressions is the lifetime/region work (M4 G2).
+func isFreshlyConstructed(e ast.Expr) bool {
+	switch e := e.(type) {
+	case *ast.LiteralExpr:
+		return true
+	case *ast.TupleExpr:
+		for _, elem := range e.Elems {
+			if !isFreshlyConstructed(elem) {
+				return false
+			}
+		}
+		return true
+	case *ast.ObjectExpr:
+		for _, elem := range e.Elems {
+			prop, ok := elem.(*ast.PropertyExpr)
+			if !ok || prop.Value == nil {
+				return false
+			}
+			if !isFreshlyConstructed(prop.Value) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 // checkExcessLiteralMembers is the construction-site excess check (M4 A3): a

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -705,10 +705,10 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	}
 	// M4 G1: snapshot the enclosing statement BEFORE walking the RHS. Reassignment
 	// transition checking needs this assignment's statement to find its CFG StmtRef,
-	// but walking an RHS that contains statements (`b = if c { … } else { … }`, a
-	// match, a block expression) re-enters inferStmt and overwrites c.fn.currentStmt.
-	// Capturing it here keeps the reassignment path on the right program point, the
-	// way the var-decl path threads its statement explicitly.
+	// but walking an RHS that contains statements re-enters inferStmt and overwrites
+	// c.fn.currentStmt. A `b = if c { … } else { … }`, a match, or a block expression
+	// all do this. Capturing the statement here keeps the reassignment path on the
+	// right program point, the way the var-decl path threads its statement explicitly.
 	var assignStmt ast.Stmt
 	if c.fn != nil {
 		assignStmt = c.fn.currentStmt

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -178,6 +178,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
+	// paramTypes maps each bound parameter name to its soltype, consumed by the M4
+	// G1 liveness pre-pass to seed parameter alias mutability.
+	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
 		// A `mut`-borrow param without a declared lifetime originates a fresh
@@ -224,6 +227,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// A parameter binding never generalizes — its var is fixed for the body — so
 		// it is a MonoScheme; instantiate returns pt unchanged at every use.
 		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}, Sources: sources})
+		paramTypes[name] = pt
 		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
 		// `required` count without dropping the param — carried onto the soltype so
 		// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
@@ -240,6 +244,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node)
+		// M4 G1: run the liveness pre-pass before walking the body so mutability
+		// transitions are checked. It renames the body's variable nodes (writing the
+		// VarIDs DetermineAliasSource and the alias tracker read) and seeds the
+		// parameter alias sets onto c.fn. recordParamVarIDs then copies each param's
+		// freshly-assigned VarID onto its binding so a closure capturing the param
+		// resolves to its alias set.
+		c.runLivenessPrePass(fnScope, sig.Params, paramTypes, body)
+		recordParamVarIDs(fnScope, sig.Params)
 		// Walk the body for type-checking and to collect its ReturnStmts; the
 		// block's TAIL value is intentionally discarded. Unlike a value-position
 		// block, where the last expression IS the block's value, a function body's
@@ -758,6 +770,11 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
+	// M4 G1: track the alias this reassignment creates and check its mutability
+	// transition, but only when the constraint below succeeds — an ill-typed
+	// reassignment must not seed a false-positive transition error off types that
+	// never matched. assignErrsBefore captures the pre-constraint error count.
+	assignErrsBefore := len(c.errs)
 	if b.ModuleLevel {
 		// This is a global write, a store into module-level storage that lives for the
 		// program's whole run. Any borrow the value carries must outlive every borrow
@@ -782,6 +799,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		}
 	} else {
 		c.constrainAssign(e, sourceT, targetT)
+	}
+	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
+		c.trackAliasesForAssignment(target, e.Right, targetT)
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
@@ -842,8 +862,15 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 			Inexact: true, // "must accept a write to this field," not a full shape
 		},
 	}
+	errsBefore := len(c.errs)
 	c.constrain(e, recv, req)
 	c.recordWritten(recv, m.Prop.Name, w)
+	// M4 G1: when the written value aliases a variable, merge the receiver's and the
+	// source's alias sets so a later transition off either sees the shared value. Only
+	// when the write type-checked, so a rejected write does not record a bogus alias.
+	if c.fn != nil && len(c.errs) == errsBefore {
+		c.trackAliasesForPropAssignment(e.Left, e.Right)
+	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.
 	c.recordType(e, w)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -703,6 +703,16 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	if e.Left == nil || e.Right == nil {
 		return c.reportUnsupported(e)
 	}
+	// M4 G1: snapshot the enclosing statement BEFORE walking the RHS. Reassignment
+	// transition checking needs this assignment's statement to find its CFG StmtRef,
+	// but walking an RHS that contains statements (`b = if c { … } else { … }`, a
+	// match, a block expression) re-enters inferStmt and overwrites c.fn.currentStmt.
+	// Capturing it here keeps the reassignment path on the right program point, the
+	// way the var-decl path threads its statement explicitly.
+	var assignStmt ast.Stmt
+	if c.fn != nil {
+		assignStmt = c.fn.currentStmt
+	}
 	sourceT := c.inferExpr(scope, lvl, e.Right)
 	// Record void on e up front as the recovery type: every error path below returns
 	// voidT without recording a type, so this guarantees the node is typed on failure.
@@ -801,7 +811,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		c.constrainAssign(e, sourceT, targetT)
 	}
 	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
-		c.trackAliasesForAssignment(target, e.Right, targetT)
+		c.trackAliasesForAssignment(target, e.Right, targetT, assignStmt)
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -45,6 +45,12 @@ func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) (soltype.Type,
 // and overwrites the name's slot in the current scope, so redeclaration rebinds
 // without constraining the old and new types together.
 func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
+	// M4 G1: record the enclosing statement so a reassignment in expression position
+	// can find its CFG StmtRef for transition checking. A no-op outside a function
+	// body (c.fn == nil), where no liveness analysis ran.
+	if c.fn != nil {
+		c.fn.currentStmt = s
+	}
 	switch s := s.(type) {
 	case *ast.ExprStmt:
 		return c.inferExpr(scope, lvl, s.Expr)
@@ -89,7 +95,17 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		// missing initializer itself and returns ok=false; bind only when it
 		// produced a type.
 		if b, ok := c.inferVarDecl(scope, lvl, vd); ok {
+			// M4 G1: carry the rename-assigned VarID onto the binding so a later
+			// closure capture resolves this body-level binding to its alias set, then
+			// track the alias the declaration creates and check its mutability
+			// transition. Both are no-ops outside a function body (c.fn == nil).
+			if ip, ok := vd.Pattern.(*ast.IdentPat); ok && ip.VarID > 0 {
+				b.VarID = ip.VarID
+			}
 			scope.defineValue(name, b) // overwrite ⇒ same-name redeclaration rebinds
+			if c.fn != nil {
+				c.trackAliasesForVarDecl(scope, vd, bindingType(b), s)
+			}
 		}
 		return &soltype.Void{}
 	default:

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -36,6 +36,14 @@ type ValueBinding struct {
 	// WRITE: storing a value into module-level storage outlives every borrow region,
 	// so a borrowed value written there escapes to 'static (M4 D3).
 	ModuleLevel bool
+	// VarID is the liveness VarID assigned to this binding's name by the function
+	// body's rename pass (M4 G1), or 0 for a binding outside any liveness-analysed
+	// body (every top-level binding, and any binding minted before its enclosing
+	// body's prepass runs). The mutability-transition checker reads it to resolve a
+	// captured outer variable back to its alias set — the new-checker analogue of the
+	// old checker's type_system.Binding.VarID. It is metadata for transition checking
+	// only and never participates in type inference.
+	VarID int
 }
 
 // IsOverloaded reports whether this binding is an overload set. Consumers MUST

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -14,10 +14,10 @@ import (
 //
 // The transition checker is ported from the old checker (check_transitions.go), with
 // its two type predicates reimplemented over soltype. The old checker exercised it
-// through source like `val items: mut {x} = {x: 1}` followed by aliasing
-// (`val snapshot = items`). The new checker's borrow rules reject that shape outright
-// — a `mut` value is a borrow, and a borrow cannot be aliased into an owned local
-// (it would not live long enough) — so those exact programs no longer type-check, and
+// through source like `val items: mut {x} = {x: 1}` followed by aliasing such as
+// `val snapshot = items`. The new checker's borrow rules reject that shape outright. A
+// `mut` value is a borrow, and a borrow cannot be aliased into an owned local because
+// it would not live long enough. So those exact programs no longer type-check, and
 // their alias-transition scenarios are unreachable from source today. The ported Rule
 // 1 / Rule 2 / Rule 3 logic is therefore exercised directly here, reproducing the old
 // checker's cases at the level of the code that actually moved: the predicates, and
@@ -46,8 +46,8 @@ func TestIsValueType(t *testing.T) {
 	require.False(t, isValueType(&soltype.UnionType{}))
 	require.False(t, isValueType(objT()))
 	require.False(t, isValueType(&soltype.RefType{Mut: true, Inner: objT()}))
-	// An inference variable falls through to false (conservatively a reference), the
-	// no-Prune divergence from the old checker — see isValueType's doc.
+	// An inference variable falls through to false, conservatively a reference. This is
+	// the no-Prune divergence from the old checker; see isValueType's doc.
 	require.False(t, isValueType(&soltype.TypeVarType{ID: 0, Level: 0}))
 }
 
@@ -187,7 +187,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 
 	t.Run("TransitiveAlias_NamesLiveMutableAlias", func(t *testing.T) {
 		// p has a live mutable alias r and an immutable alias q being created. The
-		// conflict names r, the alias still holding mutable access — not p itself.
+		// conflict names r, the alias still holding mutable access, not p itself.
 		const (
 			p = liveness.VarID(1)
 			r = liveness.VarID(3)
@@ -248,17 +248,74 @@ func TestTransitionReassignNestedRHS(t *testing.T) {
 }
 
 // TestTransitionWiringNoSpuriousErrors confirms the liveness pre-pass is wired into
-// function-body inference and that aliasing immutable, owned values produces no
-// transition error: the pass runs, renames the body, tracks the aliases, and finds
-// nothing to report. This guards the wiring independently of any reachable error case.
+// function-body inference and that the alias-tracking paths run over real bodies
+// without inventing a transition error. Each case type-checks cleanly, so any
+// MutabilityTransitionError would be a wiring bug. The cases exercise the decl-alias
+// branches and parameter seeding end to end, which the constructed-state unit tests
+// above do not.
 func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn test() {
-			val a = {x: 1}
-			val b = a
-			val c = b
-			c
-		}
-	`)
-	require.Empty(t, errs)
+	tests := map[string]string{
+		// Immutable owned objects aliased down a chain. No mutability, no transition.
+		"immutable_chain": `
+			fn test() {
+				val a = {x: 1}
+				val b = a
+				val c = b
+				c
+			}
+		`,
+		// Single-source decl alias: an immutable param aliased to a val exercises the
+		// AliasSourceVariable branch of trackAliasesForIdentPat.
+		"single_source_alias": `
+			fn test(q: {y: number}) {
+				val r = q
+				r
+			}
+		`,
+		// Multi-source decl alias: an if/else over two params makes the binding alias
+		// both, exercising the AliasSourceMultiple branch.
+		"multi_source_alias": `
+			fn test(cond: boolean, a: {x: number}, b: {x: number}) {
+				val c = if cond { a } else { b }
+				c
+			}
+		`,
+		// A mut and an immutable parameter are seeded into the alias tracker, and a
+		// field write through the mut param walks the prop-assignment path.
+		"params_seeded": `
+			fn test(p: mut {x: number}, q: {y: number}) {
+				p.x = 5
+				q.y
+			}
+		`,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Empty(t, errs)
+		})
+	}
+}
+
+// TestCollectOuterBindingsPreludeCache covers the outer-binding collection that feeds
+// the rename pass: every reachable value name maps to a distinct negative id, the
+// prelude's operator names are included, and the prelude cache makes repeated calls
+// return the same result.
+func TestCollectOuterBindingsPreludeCache(t *testing.T) {
+	c := newChecker()
+	scope := sharedPrelude().Child()
+	scope.defineValue("myLocal", ValueBinding{})
+
+	first := c.collectOuterBindings(scope)
+
+	require.Contains(t, first, "myLocal")
+	require.Contains(t, first, "+") // a prelude operator name
+	for name, id := range first {
+		require.Negative(t, int(id), "outer binding %q must have a negative id", name)
+	}
+	require.Same(t, scope.parent, c.preludeNamesRoot) // prelude root was cached
+
+	// A second call returns an equal mapping, so the cached prelude names do not corrupt
+	// the result.
+	require.Equal(t, first, c.collectOuterBindings(scope))
 }

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -46,6 +46,28 @@ func TestIsValueType(t *testing.T) {
 	require.False(t, isValueType(&soltype.UnionType{}))
 	require.False(t, isValueType(objT()))
 	require.False(t, isValueType(&soltype.RefType{Mut: true, Inner: objT()}))
+	// An inference variable falls through to false (conservatively a reference), the
+	// no-Prune divergence from the old checker — see isValueType's doc.
+	require.False(t, isValueType(&soltype.TypeVarType{ID: 0, Level: 0}))
+}
+
+// TestIsSourceMutable locks the predicate that reads a source variable's recorded
+// mutability from the alias tracker: a seeded mutable value reports true, a seeded
+// immutable one reports false, and an unregistered source reports false.
+func TestIsSourceMutable(t *testing.T) {
+	const (
+		mutVar   = liveness.VarID(1)
+		immVar   = liveness.VarID(2)
+		unseeded = liveness.VarID(3)
+	)
+	a := liveness.NewAliasTracker()
+	a.NewValue(mutVar, liveness.AliasMutable)
+	a.NewValue(immVar, liveness.AliasImmutable)
+	c := transitionFixture(nil, a, set.NewSet[liveness.VarID]())
+
+	require.True(t, c.isSourceMutable(mutVar))
+	require.False(t, c.isSourceMutable(immVar))
+	require.False(t, c.isSourceMutable(unseeded))
 }
 
 // TestIsMutableType covers the predicate that distinguishes a mutable borrow from

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -1,0 +1,226 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 G1: mutability-transition checking ---
+//
+// The transition checker is ported from the old checker (check_transitions.go), with
+// its two type predicates reimplemented over soltype. The old checker exercised it
+// through source like `val items: mut {x} = {x: 1}` followed by aliasing
+// (`val snapshot = items`). The new checker's borrow rules reject that shape outright
+// — a `mut` value is a borrow, and a borrow cannot be aliased into an owned local
+// (it would not live long enough) — so those exact programs no longer type-check, and
+// their alias-transition scenarios are unreachable from source today. The ported Rule
+// 1 / Rule 2 / Rule 3 logic is therefore exercised directly here, reproducing the old
+// checker's cases at the level of the code that actually moved: the predicates, and
+// checkMutabilityTransition over a constructed alias/liveness state.
+
+func numT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.NumPrim} }
+func objT() *soltype.ObjectType {
+	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "x", Type: numT()},
+	}}
+}
+
+// TestIsValueType covers the value-vs-reference predicate that gates alias tracking:
+// primitives and literals (and unions of them) have copy semantics, so they are never
+// alias-tracked; objects and borrows are reference types.
+func TestIsValueType(t *testing.T) {
+	require.True(t, isValueType(numT()))
+	require.True(t, isValueType(&soltype.LitType{Lit: &soltype.NumLit{Value: 5}}))
+	require.True(t, isValueType(&soltype.UnionType{Types: []soltype.Type{
+		&soltype.LitType{Lit: &soltype.StrLit{Value: "on"}},
+		&soltype.LitType{Lit: &soltype.StrLit{Value: "off"}},
+	}}))
+	// A union with a non-value member is not a value type.
+	require.False(t, isValueType(&soltype.UnionType{Types: []soltype.Type{numT(), objT()}}))
+	// An empty union is not a value type (len == 0).
+	require.False(t, isValueType(&soltype.UnionType{}))
+	require.False(t, isValueType(objT()))
+	require.False(t, isValueType(&soltype.RefType{Mut: true, Inner: objT()}))
+}
+
+// TestIsMutableType covers the predicate that distinguishes a mutable borrow from
+// everything else: only a RefType with Mut set is mutable.
+func TestIsMutableType(t *testing.T) {
+	require.True(t, isMutableType(&soltype.RefType{Mut: true, Inner: objT()}))
+	require.False(t, isMutableType(&soltype.RefType{Mut: false, Inner: objT()}))
+	require.False(t, isMutableType(objT()))
+	require.False(t, isMutableType(numT()))
+}
+
+// transitionFixture builds a checker whose enclosing funcCtx carries a constructed
+// alias tracker plus a one-block liveness result in which exactly `live` is live after
+// the single statement position. assignRef below points at that position.
+func transitionFixture(
+	varNames map[liveness.VarID]string,
+	aliases *liveness.AliasTracker,
+	live set.Set[liveness.VarID],
+) *checker {
+	c := newChecker()
+	c.fn = &funcCtx{
+		liveness: &liveness.LivenessInfo{
+			LiveAfter: [][]set.Set[liveness.VarID]{{live}},
+		},
+		aliases:    aliases,
+		varIDNames: varNames,
+		written:    map[fieldKey]soltype.Type{},
+	}
+	return c
+}
+
+var transitionRef = liveness.StmtRef{BlockID: 0, StmtIdx: 0}
+
+// transitionSite is a placeholder blame node; the message under test does not read it.
+var transitionSite ast.Node = &ast.IdentExpr{}
+
+// transitionMessages renders every MutabilityTransitionError in c.errs, failing on any
+// other error kind.
+func transitionMessages(t *testing.T, c *checker) []string {
+	t.Helper()
+	var msgs []string
+	for _, e := range c.errs {
+		me, ok := e.(*MutabilityTransitionError)
+		require.True(t, ok, "unexpected non-transition error: %s", e.Message())
+		msgs = append(msgs, me.Message())
+	}
+	return msgs
+}
+
+// TestCheckMutabilityTransition reproduces the old checker's transition cases over the
+// ported Rule 1 / Rule 2 / Rule 3 logic.
+func TestCheckMutabilityTransition(t *testing.T) {
+	const (
+		items   = liveness.VarID(1)
+		snap    = liveness.VarID(2)
+		rAlias  = liveness.VarID(3)
+		config  = liveness.VarID(4)
+		mutConf = liveness.VarID(5)
+	)
+	names := map[liveness.VarID]string{
+		items: "items", snap: "snapshot", rAlias: "r", config: "config", mutConf: "mutableConfig",
+	}
+
+	t.Run("Rule1_MutToImmutable_SourceLive_Error", func(t *testing.T) {
+		// `val snapshot = items` where items is mut and still live afterwards.
+		a := liveness.NewAliasTracker()
+		a.NewValue(items, liveness.AliasMutable)
+		a.AddAlias(snap, items, liveness.AliasImmutable)
+		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{items, snap}))
+		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
+		require.Equal(t, []string{
+			"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
+		}, transitionMessages(t, c))
+	})
+
+	t.Run("Rule1_MutToImmutable_TargetDead_OK", func(t *testing.T) {
+		// snapshot is dead immediately after the transition, so there is no window.
+		a := liveness.NewAliasTracker()
+		a.NewValue(items, liveness.AliasMutable)
+		a.AddAlias(snap, items, liveness.AliasImmutable)
+		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{items}))
+		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
+		require.Empty(t, transitionMessages(t, c))
+	})
+
+	t.Run("Rule1_MutToImmutable_SourceDead_OK", func(t *testing.T) {
+		// items is dead after the transition; only the immutable snapshot survives.
+		a := liveness.NewAliasTracker()
+		a.NewValue(items, liveness.AliasMutable)
+		a.AddAlias(snap, items, liveness.AliasImmutable)
+		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{snap}))
+		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
+		require.Empty(t, transitionMessages(t, c))
+	})
+
+	t.Run("Rule2_ImmutableToMut_SourceLive_Error", func(t *testing.T) {
+		// `val mutableConfig = config` where config is immutable and still live.
+		a := liveness.NewAliasTracker()
+		a.NewValue(config, liveness.AliasImmutable)
+		a.AddAlias(mutConf, config, liveness.AliasMutable)
+		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{config, mutConf}))
+		c.checkMutabilityTransition(config, mutConf, "config", "mutableConfig", false, true, transitionRef, transitionSite)
+		require.Equal(t, []string{
+			"cannot assign 'config' to mutable 'mutableConfig': 'config' is still used immutably after this point",
+		}, transitionMessages(t, c))
+	})
+
+	t.Run("Rule3_MutToMut_NoTransition", func(t *testing.T) {
+		// Same mutability is not a transition, so nothing is checked.
+		a := liveness.NewAliasTracker()
+		a.NewValue(items, liveness.AliasMutable)
+		a.AddAlias(snap, items, liveness.AliasMutable)
+		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{items, snap}))
+		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, true, transitionRef, transitionSite)
+		require.Empty(t, transitionMessages(t, c))
+	})
+
+	t.Run("TransitiveAlias_NamesLiveMutableAlias", func(t *testing.T) {
+		// p has a live mutable alias r and an immutable alias q being created. The
+		// conflict names r, the alias still holding mutable access — not p itself.
+		const (
+			p = liveness.VarID(1)
+			r = liveness.VarID(3)
+			q = liveness.VarID(6)
+		)
+		nm := map[liveness.VarID]string{p: "p", r: "r", q: "q"}
+		a := liveness.NewAliasTracker()
+		a.NewValue(p, liveness.AliasMutable)
+		a.AddAlias(r, p, liveness.AliasMutable)
+		a.AddAlias(q, p, liveness.AliasImmutable)
+		// p itself is dead after the transition; r and q are live.
+		c := transitionFixture(nm, a, set.FromSlice([]liveness.VarID{r, q}))
+		c.checkMutabilityTransition(p, q, "p", "q", true, false, transitionRef, transitionSite)
+		require.Equal(t, []string{
+			"cannot assign 'p' to immutable 'q': 'r' still has mutable access to 'p' after this point",
+		}, transitionMessages(t, c))
+	})
+
+	t.Run("Conditional_SourceInMultipleSets_NoDuplicateConflicting", func(t *testing.T) {
+		// A source that belongs to two alias sets and is itself a live mutable alias is
+		// reported once, not once per set.
+		const (
+			a1 = liveness.VarID(1)
+			b1 = liveness.VarID(2)
+			cv = liveness.VarID(3)
+			fr = liveness.VarID(4)
+		)
+		nm := map[liveness.VarID]string{a1: "a", b1: "b", cv: "c", fr: "frozen"}
+		at := liveness.NewAliasTracker()
+		at.NewValue(a1, liveness.AliasMutable)
+		at.NewValue(b1, liveness.AliasMutable)
+		// c is mut and aliases both a and b (conditional), so it sits in two sets.
+		at.AddAlias(cv, a1, liveness.AliasMutable)
+		at.AddAlias(cv, b1, liveness.AliasMutable)
+		at.AddAlias(fr, cv, liveness.AliasImmutable)
+		c := transitionFixture(nm, at, set.FromSlice([]liveness.VarID{cv, fr}))
+		c.checkMutabilityTransition(cv, fr, "c", "frozen", true, false, transitionRef, transitionSite)
+		require.Equal(t, []string{
+			"cannot assign 'c' to immutable 'frozen': 'c' is still used mutably after this point",
+		}, transitionMessages(t, c))
+	})
+}
+
+// TestTransitionWiringNoSpuriousErrors confirms the liveness pre-pass is wired into
+// function-body inference and that aliasing immutable, owned values produces no
+// transition error: the pass runs, renames the body, tracks the aliases, and finds
+// nothing to report. This guards the wiring independently of any reachable error case.
+func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val a = {x: 1}
+			val b = a
+			val c = b
+			c
+		}
+	`)
+	require.Empty(t, errs)
+}

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -209,6 +209,22 @@ func TestCheckMutabilityTransition(t *testing.T) {
 	})
 }
 
+// TestTransitionReassignNestedRHS guards the currentStmt fix: a reassignment whose
+// RHS contains statements (`b = if cond { … } else { … }`) re-enters inferStmt while
+// walking the RHS, which overwrites c.fn.currentStmt. The reassignment transition path
+// must use the statement captured before the RHS walk, not the clobbered field, so it
+// resolves the correct CFG StmtRef. The body type-checks with no spurious error.
+func TestTransitionReassignNestedRHS(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test(cond: boolean) {
+			var b = 0
+			b = if cond { 1 } else { 2 }
+			b
+		}
+	`)
+	require.Empty(t, errs)
+}
+
 // TestTransitionWiringNoSpuriousErrors confirms the liveness pre-pass is wired into
 // function-body inference and that aliasing immutable, owned values produces no
 // transition error: the pass runs, renames the body, tracks the aliases, and finds

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -13,15 +13,20 @@ import (
 // --- M4 G1: mutability-transition checking ---
 //
 // The transition checker is ported from the old checker (check_transitions.go), with
-// its two type predicates reimplemented over soltype. The old checker exercised it
-// through source like `val items: mut {x} = {x: 1}` followed by aliasing such as
-// `val snapshot = items`. The new checker's borrow rules reject that shape outright. A
-// `mut` value is a borrow, and a borrow cannot be aliased into an owned local because
-// it would not live long enough. So those exact programs no longer type-check, and
-// their alias-transition scenarios are unreachable from source today. The ported Rule
-// 1 / Rule 2 / Rule 3 logic is therefore exercised directly here, reproducing the old
-// checker's cases at the level of the code that actually moved: the predicates, and
-// checkMutabilityTransition over a constructed alias/liveness state.
+// its two type predicates reimplemented over soltype.
+//
+// A freshly constructed literal can be given an owned-mutable type, so the
+// construction case `val items: mut {x} = {x: 1}` type-checks and the source-level
+// Rule 1 and Rule 3 scenarios are reachable. TestMutabilityTransitionsFromSource
+// exercises those end to end through inferSource.
+//
+// The rest stay at the unit level. Rule 2, an immutable→mut transition over a live
+// source, is rejected by the type system before the transition pass runs, so it never
+// produces a transition error from source. Other old-checker cases need features the
+// solver lacks: destructuring, enums and match, binary operators, unions, for-in
+// loops, and top-level statements. TestCheckMutabilityTransition exercises the ported
+// Rule 1 / Rule 2 / Rule 3 logic directly over a constructed alias/liveness state,
+// covering the rules independently of those gaps.
 
 func numT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.NumPrim} }
 func objT() *soltype.ObjectType {
@@ -104,12 +109,12 @@ var transitionRef = liveness.StmtRef{BlockID: 0, StmtIdx: 0}
 // transitionSite is a placeholder blame node; the message under test does not read it.
 var transitionSite ast.Node = &ast.IdentExpr{}
 
-// transitionMessages renders every MutabilityTransitionError in c.errs, failing on any
+// transitionMessages renders every MutabilityTransitionError in errs, failing on any
 // other error kind.
-func transitionMessages(t *testing.T, c *checker) []string {
+func transitionMessages(t *testing.T, errs []SolverError) []string {
 	t.Helper()
 	var msgs []string
-	for _, e := range c.errs {
+	for _, e := range errs {
 		me, ok := e.(*MutabilityTransitionError)
 		require.True(t, ok, "unexpected non-transition error: %s", e.Message())
 		msgs = append(msgs, me.Message())
@@ -140,7 +145,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
-		}, transitionMessages(t, c))
+		}, transitionMessages(t, c.errs))
 	})
 
 	t.Run("Rule1_MutToImmutable_TargetDead_OK", func(t *testing.T) {
@@ -150,7 +155,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		a.AddAlias(snap, items, liveness.AliasImmutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{items}))
 		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
-		require.Empty(t, transitionMessages(t, c))
+		require.Empty(t, transitionMessages(t, c.errs))
 	})
 
 	t.Run("Rule1_MutToImmutable_SourceDead_OK", func(t *testing.T) {
@@ -160,7 +165,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		a.AddAlias(snap, items, liveness.AliasImmutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{snap}))
 		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, false, transitionRef, transitionSite)
-		require.Empty(t, transitionMessages(t, c))
+		require.Empty(t, transitionMessages(t, c.errs))
 	})
 
 	t.Run("Rule2_ImmutableToMut_SourceLive_Error", func(t *testing.T) {
@@ -172,7 +177,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		c.checkMutabilityTransition(config, mutConf, "config", "mutableConfig", false, true, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'config' to mutable 'mutableConfig': 'config' is still used immutably after this point",
-		}, transitionMessages(t, c))
+		}, transitionMessages(t, c.errs))
 	})
 
 	t.Run("Rule3_MutToMut_NoTransition", func(t *testing.T) {
@@ -182,7 +187,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		a.AddAlias(snap, items, liveness.AliasMutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{items, snap}))
 		c.checkMutabilityTransition(items, snap, "items", "snapshot", true, true, transitionRef, transitionSite)
-		require.Empty(t, transitionMessages(t, c))
+		require.Empty(t, transitionMessages(t, c.errs))
 	})
 
 	t.Run("TransitiveAlias_NamesLiveMutableAlias", func(t *testing.T) {
@@ -203,7 +208,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		c.checkMutabilityTransition(p, q, "p", "q", true, false, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'p' to immutable 'q': 'r' still has mutable access to 'p' after this point",
-		}, transitionMessages(t, c))
+		}, transitionMessages(t, c.errs))
 	})
 
 	t.Run("Conditional_SourceInMultipleSets_NoDuplicateConflicting", func(t *testing.T) {
@@ -227,7 +232,7 @@ func TestCheckMutabilityTransition(t *testing.T) {
 		c.checkMutabilityTransition(cv, fr, "c", "frozen", true, false, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'c' to immutable 'frozen': 'c' is still used mutably after this point",
-		}, transitionMessages(t, c))
+		}, transitionMessages(t, c.errs))
 	})
 }
 
@@ -318,4 +323,89 @@ func TestCollectOuterBindingsPreludeCache(t *testing.T) {
 	// A second call returns an equal mapping, so the cached prelude names do not corrupt
 	// the result.
 	require.Equal(t, first, c.collectOuterBindings(scope))
+}
+
+// TestMutabilityTransitionsFromSource reproduces the old checker's transition cases at
+// the source level, now reachable because a fresh literal can be constructed into an
+// owned-mutable binding. Each case mints its mutable value with `val x: mut {…} = {…}`,
+// aliases it, and asserts the transition verdict. want is empty for the safe cases.
+func TestMutabilityTransitionsFromSource(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Rule 1 (mut→immutable): error when the mutable source is live after the alias.
+		"Rule1_SourceLive_Error": {
+			src: `
+				fn test() {
+					val items: mut {x: number} = {x: 1}
+					val snapshot: {x: number} = items
+					items.x = 2
+					snapshot
+				}
+			`,
+			want: []string{
+				"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
+			},
+		},
+		// Rule 1: safe when the mutable source is dead after the alias.
+		"Rule1_SourceDead_OK": {
+			src: `
+				fn test() {
+					val items: mut {x: number} = {x: 1}
+					items.x = 2
+					val snapshot: {x: number} = items
+					snapshot
+				}
+			`,
+		},
+		// Rule 3: two mutable aliases of the same value are always allowed.
+		"Rule3_MultipleMutableAliases_OK": {
+			src: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					b.x = 2
+					a.x
+				}
+			`,
+		},
+		// Chain aliasing through a mutable intermediate: the conflict names the live
+		// mutable alias, not the source itself.
+		"ChainAlias_TargetLive_Error": {
+			src: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: mut {x: number} = a
+					val c: {x: number} = b
+					a.x = 2
+					c
+				}
+			`,
+			want: []string{
+				"cannot assign 'b' to immutable 'c': 'a' still has mutable access to 'b' after this point",
+			},
+		},
+		// Conditional aliasing: c aliases both branches; a is live after the transition.
+		"Conditional_IfElse_Error": {
+			src: `
+				fn test(cond: boolean) {
+					val a: mut {x: number} = {x: 0}
+					val b: mut {x: number} = {x: 1}
+					val c: {x: number} = if cond { a } else { b }
+					a.x = 5
+					c
+				}
+			`,
+			want: []string{
+				"cannot assign 'a' to immutable 'c': 'a' is still used mutably after this point",
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, transitionMessages(t, errs))
+		})
+	}
 }

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -510,7 +510,12 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 		}
 	}
 
-	renameResult := liveness.Rename(astParams, *body, outerBindings, extraParamNames...)
+	// Allocate this body's local VarIDs from the module-wide counter so they are
+	// unique across every body in the run, then advance it past them. UniqueVarCount
+	// is the number of locals this body defined, so the next body starts just after.
+	firstID := liveness.VarID(c.varIDCounter)
+	renameResult := liveness.RenameFrom(astParams, *body, outerBindings, firstID, extraParamNames...)
+	c.varIDCounter += renameResult.UniqueVarCount
 
 	cfg := liveness.BuildCFG(*body)
 	livenessInfo := liveness.AnalyzeFunction(cfg)

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -1,0 +1,614 @@
+package solver
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Mutability-transition checking, ported from internal/checker/check_transitions.go
+// and internal/checker/liveness_prepass.go (M4 G1). The liveness/CFG/alias-tracking
+// machinery in internal/liveness is reused verbatim; only two pieces are
+// reimplemented over soltype rather than type_system:
+//
+//   - isValueType / isMutableType, the two type predicates the transition checker
+//     consults, and
+//   - the binding model: a captured variable's identity comes from
+//     ValueBinding.VarID and its mutability from the binding's coalesced soltype,
+//     not from a type_system.Binding.
+//
+// checkMutabilityTransition's Rule 1 / Rule 2 / Rule 3 logic is unchanged — it
+// talks only to liveness.LivenessInfo and liveness.AliasTracker. The whole pass
+// runs inside a function body, keyed off the per-body state on funcCtx (c.fn): at
+// module top-level c.fn is nil and every entry point below is a no-op.
+
+// staticConflictName is a sentinel placeholder used in
+// MutabilityTransitionError.ConflictingVars to represent a permanent alias from a
+// `'static` escape. The escape bits it stands for are populated only at `'static`
+// call sites, which M4 G1 does not yet mark, so it stays unset until G2 wires the
+// lifetime sort into the escape check. The message renders it specially rather than
+// printing the literal sentinel.
+const staticConflictName = "<static escape>"
+
+// MutabilityTransitionError is reported when a mutability transition
+// (mut→immutable or immutable→mut) is attempted while conflicting live aliases
+// exist. It is a liveness-derived diagnostic that self-blames from the
+// transition's node — the alias-creating declaration or reassignment — rather than
+// resolving an operand through the Prov table.
+type MutabilityTransitionError struct {
+	// SourceVar is the variable being aliased.
+	SourceVar string
+	// TargetVar is the variable being created/assigned.
+	TargetVar string
+	// ConflictingVars lists the names of live aliases that conflict.
+	ConflictingVars []string
+	// MutToImmutable is true for Rule 1 (mut→immutable), false for Rule 2 (immutable→mut).
+	MutToImmutable bool
+	// node is the transition site, used for blame (the decl or assignment).
+	node ast.Node
+}
+
+func (*MutabilityTransitionError) isSolverError()        {}
+func (e *MutabilityTransitionError) Span() ast.Span      { return e.node.Span() }
+func (e *MutabilityTransitionError) Related() []ast.Span { return nil }
+func (e *MutabilityTransitionError) Message() string {
+	// Render conflicts. The staticConflictName sentinel is rendered without quotes
+	// so the message reads naturally; everything else is a real identifier that gets
+	// single-quoted.
+	parts := make([]string, len(e.ConflictingVars))
+	for i, name := range e.ConflictingVars {
+		if name == staticConflictName {
+			parts[i] = "a `'static` escape"
+		} else {
+			parts[i] = "'" + name + "'"
+		}
+	}
+	vars := strings.Join(parts, ", ")
+	// When the conflicting variable is the source itself, the message is
+	// straightforward. When it's a different variable (an alias), clarify the
+	// relationship so the user understands the connection.
+	sameAsSource := len(e.ConflictingVars) == 1 && e.ConflictingVars[0] == e.SourceVar
+	if e.MutToImmutable {
+		if sameAsSource {
+			return fmt.Sprintf(
+				"cannot assign '%s' to immutable '%s': '%s' is still used mutably after this point",
+				e.SourceVar, e.TargetVar, e.SourceVar,
+			)
+		}
+		return fmt.Sprintf(
+			"cannot assign '%s' to immutable '%s': %s still has mutable access to '%s' after this point",
+			e.SourceVar, e.TargetVar, vars, e.SourceVar,
+		)
+	}
+	if sameAsSource {
+		return fmt.Sprintf(
+			"cannot assign '%s' to mutable '%s': '%s' is still used immutably after this point",
+			e.SourceVar, e.TargetVar, e.SourceVar,
+		)
+	}
+	return fmt.Sprintf(
+		"cannot assign '%s' to mutable '%s': %s still has immutable access to '%s' after this point",
+		e.SourceVar, e.TargetVar, vars, e.SourceVar,
+	)
+}
+
+// isValueType reports whether the type is a primitive or literal type (or a union
+// of such types). Value types have copy semantics — assigning them to another
+// variable creates an independent copy, so alias tracking is unnecessary. Ported
+// from check_transitions.go over soltype: there is no Prune step because the
+// coalesced display type the caller passes is already resolved.
+func isValueType(t soltype.Type) bool {
+	switch p := t.(type) {
+	case *soltype.PrimType, *soltype.LitType:
+		return true
+	case *soltype.UnionType:
+		for _, member := range p.Types {
+			if !isValueType(member) {
+				return false
+			}
+		}
+		return len(p.Types) > 0
+	}
+	return false
+}
+
+// isMutableType reports whether the type is a mutable borrow. In the new type
+// system mutability is carried by a RefType wrapper with Mut set, replacing the old
+// checker's MutType wrapper.
+func isMutableType(t soltype.Type) bool {
+	if r, ok := t.(*soltype.RefType); ok {
+		return r.Mut
+	}
+	return false
+}
+
+// aliasMutability maps a Go bool to the liveness alias-mutability enum.
+func aliasMutability(mut bool) liveness.AliasMutability {
+	if mut {
+		return liveness.AliasMutable
+	}
+	return liveness.AliasImmutable
+}
+
+// bindingType returns a binding's coalesced display type for the transition
+// checker's predicates, or nil for an empty (definition-less) binding.
+func bindingType(b ValueBinding) soltype.Type {
+	if len(b.Schemes) == 0 {
+		return nil
+	}
+	return schemeType(b.Schemes[0])
+}
+
+// checkMutabilityTransition verifies that a mutability transition is safe at the
+// given program point, reporting a MutabilityTransitionError when conflicting live
+// aliases exist. Ported verbatim from check_transitions.go — the Rule 1 / Rule 2 /
+// Rule 3 logic talks only to liveness state on c.fn.
+//
+// A transition is only dangerous when both sides are live simultaneously after the
+// transition point — a mutable alias could mutate the value while an immutable
+// alias assumes it is unchanged.
+//
+//	Rule 1 (mut → immutable): no live mutable aliases may exist after this point,
+//	  provided the target (immutable) alias is also live.
+//	Rule 2 (immutable → mut): no live immutable aliases may exist after this point,
+//	  provided the target (mutable) alias is also live.
+//	Rule 3: multiple mutable aliases are always allowed (mut → mut is not a transition).
+func (c *checker) checkMutabilityTransition(
+	sourceVarID liveness.VarID,
+	targetVarID liveness.VarID,
+	sourceVarName string,
+	targetVarName string,
+	sourceMut bool,
+	targetMut bool,
+	assignRef liveness.StmtRef,
+	node ast.Node,
+) {
+	fn := c.fn
+	// Same mutability — no transition (Rule 3 for mut→mut).
+	if sourceMut == targetMut {
+		return
+	}
+	if fn == nil || fn.liveness == nil || fn.aliases == nil {
+		return
+	}
+	// If the target alias is dead immediately after the transition, there is no
+	// window where both sides are live simultaneously, so it's safe.
+	if !fn.liveness.IsLiveAfter(assignRef, targetVarID) {
+		return
+	}
+
+	// The loop intentionally does NOT skip sourceVarID. The source variable is itself
+	// a member of the alias set, and if it is still live after the transition point,
+	// it IS a conflicting alias. A variable may belong to multiple alias sets
+	// (conditional aliasing), so deduplicate by collecting names into a set.
+	conflictingSet := make(map[string]struct{})
+	for _, aliasSet := range fn.aliases.GetAliasSets(sourceVarID) {
+		// A `'static` escape on the alias set represents a permanent outside
+		// reference — no liveness check is meaningful, so it always counts as a live
+		// alias of its escaped mutability. These bits are unset until G2 marks
+		// `'static` call sites.
+		if sourceMut && !targetMut && aliasSet.HasStaticMutAlias {
+			conflictingSet[staticConflictName] = struct{}{}
+		}
+		if !sourceMut && targetMut && aliasSet.HasStaticImmAlias {
+			conflictingSet[staticConflictName] = struct{}{}
+		}
+		for varID, aliasMut := range aliasSet.Members {
+			if !fn.liveness.IsLiveAfter(assignRef, varID) {
+				continue
+			}
+			if sourceMut && !targetMut {
+				// Rule 1: mut → immutable — error if any live mutable alias exists.
+				if aliasMut == liveness.AliasMutable {
+					conflictingSet[c.varIDToName(varID)] = struct{}{}
+				}
+			} else {
+				// Rule 2: immutable → mut — error if any live immutable alias exists.
+				if aliasMut == liveness.AliasImmutable {
+					conflictingSet[c.varIDToName(varID)] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(conflictingSet) == 0 {
+		return
+	}
+
+	conflicting := make([]string, 0, len(conflictingSet))
+	for name := range conflictingSet {
+		conflicting = append(conflicting, name)
+	}
+	sort.Strings(conflicting)
+
+	c.errs = append(c.errs, &MutabilityTransitionError{
+		SourceVar:       sourceVarName,
+		TargetVar:       targetVarName,
+		ConflictingVars: conflicting,
+		MutToImmutable:  sourceMut && !targetMut,
+		node:            node,
+	})
+}
+
+// trackAliasesForVarDecl updates the alias tracker and checks mutability
+// transitions for a body-level `val`/`var` declaration with an initializer. M4 G1
+// handles the IdentPat case (and closure capture when the initializer is a
+// FuncExpr); destructuring patterns are unsupported in the new checker until the
+// pattern PRs land, and a non-IdentPat decl produces no binding anyway.
+func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindingT soltype.Type, enclosingStmt ast.Stmt) {
+	if c.fn == nil || c.fn.aliases == nil || decl.Init == nil {
+		return
+	}
+	pat, ok := decl.Pattern.(*ast.IdentPat)
+	if !ok {
+		return
+	}
+	c.trackAliasesForIdentPat(pat, bindingT, decl.Init, enclosingStmt, decl)
+
+	// Closure-capture aliasing — when the initializer is a FuncExpr, add the closure
+	// variable to each captured variable's alias set. A read-only capture of a
+	// mutable variable is a mut→immut transition that must be checked against live
+	// mutable aliases.
+	if funcExpr, ok := decl.Init.(*ast.FuncExpr); ok && pat.VarID > 0 {
+		c.trackCapturedAliases(scope, funcExpr, liveness.VarID(pat.VarID), enclosingStmt, decl)
+	}
+}
+
+// trackAliasesForIdentPat handles alias tracking for a simple identifier pattern
+// binding (`val x = expr`).
+func (c *checker) trackAliasesForIdentPat(
+	identPat *ast.IdentPat,
+	bindingT soltype.Type,
+	init ast.Expr,
+	enclosingStmt ast.Stmt,
+	node ast.Node,
+) {
+	if identPat.VarID <= 0 {
+		return
+	}
+	targetVarID := liveness.VarID(identPat.VarID)
+	targetMut := isMutableType(bindingT)
+	aliasMut := aliasMutability(targetMut)
+
+	source := liveness.DetermineAliasSource(init)
+	switch source.RootKind() {
+	case liveness.AliasSourceVariable:
+		sourceVarID := source.UniqueVarIDs()[0]
+		c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
+		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
+			sourceMut := c.isSourceMutable(sourceVarID)
+			c.checkMutabilityTransition(
+				sourceVarID, targetVarID,
+				c.varIDToName(sourceVarID), identPat.Name,
+				sourceMut, targetMut, stmtRef, node,
+			)
+		}
+	case liveness.AliasSourceMultiple:
+		// Conditional aliasing: the target aliases all possible source variables.
+		for _, sourceVarID := range source.UniqueVarIDs() {
+			c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
+		}
+		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
+			for _, sourceVarID := range source.UniqueVarIDs() {
+				sourceMut := c.isSourceMutable(sourceVarID)
+				c.checkMutabilityTransition(
+					sourceVarID, targetVarID,
+					c.varIDToName(sourceVarID), identPat.Name,
+					sourceMut, targetMut, stmtRef, node,
+				)
+			}
+		}
+	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
+		c.fn.aliases.NewValue(targetVarID, aliasMut)
+	}
+}
+
+// trackCapturedAliases adds the closure variable to the alias sets of each captured
+// variable from the enclosing scope, and checks the mutability transition each
+// capture induces. The captured variable's identity (its VarID) and mutability come
+// from its ValueBinding, the new-checker analogue of type_system.Binding.
+func (c *checker) trackCapturedAliases(
+	scope *Scope,
+	funcExpr *ast.FuncExpr,
+	closureVarID liveness.VarID,
+	enclosingStmt ast.Stmt,
+	node ast.Node,
+) {
+	if c.fn.aliases == nil {
+		return
+	}
+	captures := liveness.AnalyzeCaptures(funcExpr)
+	for _, capture := range captures {
+		// Look up the captured variable's binding in the enclosing scope. The scope
+		// chain handles shadowing correctly — GetValue returns the innermost binding.
+		b, found := scope.GetValue(capture.Name)
+		if !found || b.VarID <= 0 {
+			continue
+		}
+		// Primitives and literals have value semantics — reassigning a captured
+		// primitive inside a closure can't affect other variables that copied the
+		// value, so alias tracking is unnecessary.
+		if isValueType(bindingType(b)) {
+			continue
+		}
+		enclosingVarID := liveness.VarID(b.VarID)
+		c.fn.aliases.AddAlias(closureVarID, enclosingVarID, aliasMutability(capture.IsMutable))
+
+		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
+			sourceMut := c.isSourceMutable(enclosingVarID)
+			c.checkMutabilityTransition(
+				enclosingVarID, closureVarID,
+				capture.Name, c.varIDToName(closureVarID),
+				sourceMut, capture.IsMutable, stmtRef, node,
+			)
+		}
+	}
+}
+
+// trackAliasesForAssignment updates the alias tracker and checks mutability
+// transitions for a variable reassignment (`b = expr`). Called only after the
+// assignment's source/target constraint succeeded, so the types it reads are sound.
+func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr, targetType soltype.Type) {
+	if c.fn == nil || c.fn.aliases == nil || target.VarID <= 0 {
+		return
+	}
+	targetVarID := liveness.VarID(target.VarID)
+	targetMut := isMutableType(targetType)
+	aliasMut := aliasMutability(targetMut)
+
+	source := liveness.DetermineAliasSource(rhs)
+	switch source.RootKind() {
+	case liveness.AliasSourceVariable:
+		sourceVarID := source.UniqueVarIDs()[0]
+		if stmtRef, hasRef := c.fn.stmtToRef[c.fn.currentStmt]; hasRef {
+			sourceMut := c.isSourceMutable(sourceVarID)
+			c.checkMutabilityTransition(
+				sourceVarID, targetVarID,
+				c.varIDToName(sourceVarID), target.Name,
+				sourceMut, targetMut, stmtRef, target,
+			)
+		}
+		c.fn.aliases.Reassign(targetVarID, &sourceVarID, aliasMut)
+	case liveness.AliasSourceMultiple:
+		// Conditional aliasing: reassign to all sources before checking transitions
+		// so alias state stays consistent regardless of whether errors are reported.
+		c.fn.aliases.ReassignMulti(targetVarID, source.UniqueVarIDs(), aliasMut)
+		if stmtRef, hasRef := c.fn.stmtToRef[c.fn.currentStmt]; hasRef {
+			for _, sourceVarID := range source.UniqueVarIDs() {
+				sourceMut := c.isSourceMutable(sourceVarID)
+				c.checkMutabilityTransition(
+					sourceVarID, targetVarID,
+					c.varIDToName(sourceVarID), target.Name,
+					sourceMut, targetMut, stmtRef, target,
+				)
+			}
+		}
+	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
+		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
+	}
+}
+
+// trackAliasesForPropAssignment handles alias tracking for property assignments
+// like `obj.prop = value`. When the RHS aliases a variable, the alias sets of the
+// object and the RHS source are merged.
+func (c *checker) trackAliasesForPropAssignment(lhs ast.Expr, rhs ast.Expr) {
+	if c.fn == nil || c.fn.aliases == nil {
+		return
+	}
+	objVarID := rootObjectVarID(lhs)
+	if objVarID <= 0 {
+		return
+	}
+	source := liveness.DetermineAliasSource(rhs)
+	switch source.RootKind() {
+	case liveness.AliasSourceVariable:
+		c.fn.aliases.MergeAliasSets(objVarID, source.UniqueVarIDs()[0])
+	case liveness.AliasSourceMultiple:
+		for _, srcID := range source.UniqueVarIDs() {
+			c.fn.aliases.MergeAliasSets(objVarID, srcID)
+		}
+	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
+		// No alias relationship to track.
+	}
+}
+
+// isSourceMutable checks whether a source variable is registered as mutable in its
+// alias sets. Returns true if the source holds a mutable reference.
+func (c *checker) isSourceMutable(sourceVarID liveness.VarID) bool {
+	for _, s := range c.fn.aliases.GetAliasSets(sourceVarID) {
+		if m, exists := s.Members[sourceVarID]; exists {
+			return m == liveness.AliasMutable
+		}
+	}
+	return false
+}
+
+// rootObjectVarID iteratively walks a member/index expression chain (`a.b.c`,
+// `a[b][c]`) to find the root object's VarID, returning 0 when the root is not a
+// local variable.
+func rootObjectVarID(expr ast.Expr) liveness.VarID {
+	for {
+		switch e := expr.(type) {
+		case *ast.MemberExpr:
+			expr = e.Object
+		case *ast.IndexExpr:
+			expr = e.Object
+		case *ast.IdentExpr:
+			if e.VarID > 0 {
+				return liveness.VarID(e.VarID)
+			}
+			return 0
+		default:
+			return 0
+		}
+	}
+}
+
+// varIDToName resolves a VarID back to a variable name for error messages, reading
+// the current body's rename-pass mapping.
+func (c *checker) varIDToName(id liveness.VarID) string {
+	if c.fn != nil && c.fn.varIDNames != nil {
+		if name, ok := c.fn.varIDNames[id]; ok {
+			return name
+		}
+	}
+	return fmt.Sprintf("var#%d", id)
+}
+
+// runLivenessPrePass runs name resolution, CFG construction, and liveness analysis
+// on the function body about to be walked, populating the transition-checking state
+// on c.fn. Ported from internal/checker/liveness_prepass.go: the rename pass writes
+// VarIDs directly onto the body's AST nodes, so DetermineAliasSource and the
+// IdentPat/IdentExpr reads downstream see them. paramTypes maps each parameter name
+// to its soltype, supplying the mutability the alias seeding records.
+//
+// Must be called after parameters are bound in scope (so outer-scope names resolve)
+// but before the body is walked.
+func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, paramTypes map[string]soltype.Type, body *ast.Block) {
+	// Build outer bindings from the scope chain. Every value binding accessible from
+	// the current scope gets a negative VarID so the rename pass can distinguish
+	// local from non-local variables.
+	outerBindings := collectOuterBindings(scope)
+
+	// Extra param names are bindings present as params but not in astParams (e.g. an
+	// implicit `self`). The new checker has no such params yet, so this is normally
+	// empty; the logic is kept for parity with the old prepass.
+	astParamNames := set.NewSet[string]()
+	for _, p := range astParams {
+		collectPatternBindingNames(p.Pattern, astParamNames)
+	}
+	var extraParamNames []string
+	for name := range paramTypes {
+		if !astParamNames.Contains(name) {
+			extraParamNames = append(extraParamNames, name)
+		}
+	}
+
+	renameResult := liveness.Rename(astParams, *body, outerBindings, extraParamNames...)
+
+	cfg := liveness.BuildCFG(*body)
+	livenessInfo := liveness.AnalyzeFunction(cfg)
+	stmtToRef := liveness.BuildStmtToRef(cfg)
+
+	// Initialize the alias tracker and seed parameters so aliases from parameters are
+	// tracked and mutability transitions involving them are detected.
+	aliases := liveness.NewAliasTracker()
+	seedParamLeafAliases(astParams, paramTypes, aliases)
+	for name, varID := range renameResult.ExtraParamVarIDs {
+		mut := liveness.AliasImmutable
+		if t, ok := paramTypes[name]; ok && isMutableType(t) {
+			mut = liveness.AliasMutable
+		}
+		aliases.NewValue(varID, mut)
+	}
+
+	c.fn.liveness = livenessInfo
+	c.fn.aliases = aliases
+	c.fn.stmtToRef = stmtToRef
+	c.fn.varIDNames = renameResult.VarIDNames
+}
+
+// seedParamLeafAliases walks each parameter pattern recursively and seeds the alias
+// tracker with one alias set per leaf binding, reading each leaf's mutability from
+// paramTypes so transitions involving the leaf are checked correctly.
+func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.Type, aliases *liveness.AliasTracker) {
+	for _, param := range astParams {
+		forEachLeafBinding(param.Pattern, func(name string, varID int) {
+			if varID <= 0 {
+				return
+			}
+			mut := liveness.AliasImmutable
+			if t, ok := paramTypes[name]; ok && isMutableType(t) {
+				mut = liveness.AliasMutable
+			}
+			aliases.NewValue(liveness.VarID(varID), mut)
+		})
+	}
+}
+
+// collectOuterBindings walks the scope chain and collects all value binding names,
+// assigning each a unique negative VarID. Names within each scope are sorted before
+// assignment so the resulting IDs are deterministic across runs (Go map iteration
+// order is randomized), keeping any VarID-capturing snapshots stable.
+func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
+	bindings := make(map[string]liveness.VarID)
+	nextID := liveness.VarID(-1)
+
+	for s := scope; s != nil; s = s.parent {
+		names := make([]string, 0, len(s.values))
+		for name := range s.values {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		for _, name := range names {
+			if _, exists := bindings[name]; !exists {
+				bindings[name] = nextID
+				nextID--
+			}
+		}
+	}
+
+	return bindings
+}
+
+// recordParamVarIDs copies each IdentPat parameter's rename-assigned VarID onto its
+// scope binding (M4 G1), so a closure that captures the parameter resolves it to its
+// alias set through trackCapturedAliases. Runs after the pre-pass, since the rename
+// is what assigns the VarIDs.
+func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
+	for _, p := range params {
+		ip, ok := p.Pattern.(*ast.IdentPat)
+		if !ok || ip.VarID <= 0 {
+			continue
+		}
+		if b, found := fnScope.GetValue(ip.Name); found {
+			b.VarID = ip.VarID
+			fnScope.defineValue(ip.Name, b)
+		}
+	}
+}
+
+// forEachLeafBinding invokes fn for every identifier name a pattern introduces,
+// recursing through destructuring patterns. Ported from internal/checker.
+func forEachLeafBinding(pat ast.Pat, fn func(name string, varID int)) {
+	if pat == nil {
+		return
+	}
+	switch p := pat.(type) {
+	case *ast.IdentPat:
+		fn(p.Name, p.VarID)
+	case *ast.TuplePat:
+		for _, sub := range p.Elems {
+			forEachLeafBinding(sub, fn)
+		}
+	case *ast.ObjectPat:
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				forEachLeafBinding(e.Value, fn)
+			case *ast.ObjShorthandPat:
+				if e.Key != nil {
+					fn(e.Key.Name, e.VarID)
+				}
+			case *ast.ObjRestPat:
+				forEachLeafBinding(e.Pattern, fn)
+			}
+		}
+	case *ast.RestPat:
+		forEachLeafBinding(p.Pattern, fn)
+	}
+}
+
+// collectPatternBindingNames adds every identifier name introduced by a pattern
+// (recursively) to the provided set.
+func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
+	forEachLeafBinding(p, func(name string, _ int) {
+		into.Add(name)
+	})
+}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -187,17 +187,17 @@ func (c *checker) checkMutabilityTransition(
 	// a member of the alias set, and if it is still live after the transition point,
 	// it IS a conflicting alias. A variable may belong to multiple alias sets
 	// (conditional aliasing), so deduplicate by collecting names into a set.
-	conflictingSet := make(map[string]struct{})
+	conflictingSet := set.NewSet[string]()
 	for _, aliasSet := range fn.aliases.GetAliasSets(sourceVarID) {
 		// A `'static` escape on the alias set represents a permanent outside
 		// reference — no liveness check is meaningful, so it always counts as a live
 		// alias of its escaped mutability. These bits are unset until G2 marks
 		// `'static` call sites.
 		if sourceMut && !targetMut && aliasSet.HasStaticMutAlias {
-			conflictingSet[staticConflictName] = struct{}{}
+			conflictingSet.Add(staticConflictName)
 		}
 		if !sourceMut && targetMut && aliasSet.HasStaticImmAlias {
-			conflictingSet[staticConflictName] = struct{}{}
+			conflictingSet.Add(staticConflictName)
 		}
 		for varID, aliasMut := range aliasSet.Members {
 			if !fn.liveness.IsLiveAfter(assignRef, varID) {
@@ -206,25 +206,22 @@ func (c *checker) checkMutabilityTransition(
 			if sourceMut && !targetMut {
 				// Rule 1: mut → immutable — error if any live mutable alias exists.
 				if aliasMut == liveness.AliasMutable {
-					conflictingSet[c.varIDToName(varID)] = struct{}{}
+					conflictingSet.Add(c.varIDToName(varID))
 				}
 			} else {
 				// Rule 2: immutable → mut — error if any live immutable alias exists.
 				if aliasMut == liveness.AliasImmutable {
-					conflictingSet[c.varIDToName(varID)] = struct{}{}
+					conflictingSet.Add(c.varIDToName(varID))
 				}
 			}
 		}
 	}
 
-	if len(conflictingSet) == 0 {
+	if conflictingSet.Len() == 0 {
 		return
 	}
 
-	conflicting := make([]string, 0, len(conflictingSet))
-	for name := range conflictingSet {
-		conflicting = append(conflicting, name)
-	}
+	conflicting := conflictingSet.ToSlice()
 	sort.Strings(conflicting)
 
 	c.errs = append(c.errs, &MutabilityTransitionError{
@@ -331,6 +328,21 @@ func (c *checker) trackCapturedAliases(
 		if !found || b.VarID <= 0 {
 			continue
 		}
+		// Cross-frame guard (M4 G1). A VarID is only meaningful within the frame whose
+		// rename pass assigned it — each function body restarts numbering at 1, and a
+		// binding stores the id of the body that DECLARED it. Track a capture only when
+		// its binding originated in THIS frame, i.e. the current body's rename assigned
+		// b.VarID to this name. A capture from an outer frame (a closure nested in
+		// another closure, reaching past its immediate enclosing function) carries an id
+		// from a different id-space; feeding it into this frame's AliasTracker /
+		// LivenessInfo would conflate it with an unrelated local and produce a silently
+		// wrong transition verdict. Skipping is sound — it misses that transition rather
+		// than inventing one. The real cross-frame fix rides G2's lifetime-escape bridge
+		// (see m4-implementation-plan G2). This is unreachable today: a captured mutable
+		// is a borrow, which cannot yet be aliased into a local.
+		if name, ok := c.fn.varIDNames[liveness.VarID(b.VarID)]; !ok || name != capture.Name {
+			continue
+		}
 		// Primitives and literals have value semantics — reassigning a captured
 		// primitive inside a closure can't affect other variables that copied the
 		// value, so alias tracking is unnecessary.
@@ -354,7 +366,15 @@ func (c *checker) trackCapturedAliases(
 // trackAliasesForAssignment updates the alias tracker and checks mutability
 // transitions for a variable reassignment (`b = expr`). Called only after the
 // assignment's source/target constraint succeeded, so the types it reads are sound.
-func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr, targetType soltype.Type) {
+//
+// enclosingStmt is the statement that contains the assignment, captured by
+// inferAssign BEFORE it walks the RHS. It must NOT be re-read from c.fn.currentStmt
+// here: walking an RHS that itself contains statements — `b = if c { … } else { … }`,
+// a match, a block expression — re-enters inferStmt and overwrites currentStmt with an
+// inner-branch statement, so by this point currentStmt no longer names the
+// assignment's statement. Reading it would resolve a valid-but-wrong CFG StmtRef and
+// run the liveness query at the wrong program point.
+func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr, targetType soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil || target.VarID <= 0 {
 		return
 	}
@@ -366,7 +386,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
 		sourceVarID := source.UniqueVarIDs()[0]
-		if stmtRef, hasRef := c.fn.stmtToRef[c.fn.currentStmt]; hasRef {
+		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
 			sourceMut := c.isSourceMutable(sourceVarID)
 			c.checkMutabilityTransition(
 				sourceVarID, targetVarID,
@@ -379,7 +399,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 		// Conditional aliasing: reassign to all sources before checking transitions
 		// so alias state stays consistent regardless of whether errors are reported.
 		c.fn.aliases.ReassignMulti(targetVarID, source.UniqueVarIDs(), aliasMut)
-		if stmtRef, hasRef := c.fn.stmtToRef[c.fn.currentStmt]; hasRef {
+		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
 			for _, sourceVarID := range source.UniqueVarIDs() {
 				sourceMut := c.isSourceMutable(sourceVarID)
 				c.checkMutabilityTransition(

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -590,12 +591,7 @@ func (c *checker) preludeOuterNames(root *Scope) []string {
 
 // sortedValueNames returns a scope's own value binding names in sorted order.
 func sortedValueNames(s *Scope) []string {
-	names := make([]string, 0, len(s.values))
-	for name := range s.values {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-	return names
+	return slices.Sorted(maps.Keys(s.values))
 }
 
 // recordParamVarIDs copies each IdentPat parameter's rename-assigned VarID onto its

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -14,8 +14,8 @@ import (
 
 // Mutability-transition checking, ported from internal/checker/check_transitions.go
 // and internal/checker/liveness_prepass.go (M4 G1). The liveness/CFG/alias-tracking
-// machinery in internal/liveness is reused verbatim; only two pieces are
-// reimplemented over soltype rather than type_system:
+// machinery in internal/liveness is reused verbatim. Only two pieces are reimplemented
+// over soltype rather than type_system:
 //
 //   - isValueType / isMutableType, the two type predicates the transition checker
 //     consults, and
@@ -23,10 +23,10 @@ import (
 //     ValueBinding.VarID and its mutability from the binding's coalesced soltype,
 //     not from a type_system.Binding.
 //
-// checkMutabilityTransition's Rule 1 / Rule 2 / Rule 3 logic is unchanged — it
-// talks only to liveness.LivenessInfo and liveness.AliasTracker. The whole pass
-// runs inside a function body, keyed off the per-body state on funcCtx (c.fn): at
-// module top-level c.fn is nil and every entry point below is a no-op.
+// checkMutabilityTransition's Rule 1 / Rule 2 / Rule 3 logic is unchanged. It talks
+// only to liveness.LivenessInfo and liveness.AliasTracker. The whole pass runs inside a
+// function body, keyed off the per-body state on funcCtx. At module top-level c.fn is
+// nil, so every entry point below is a no-op.
 
 // staticConflictName is a sentinel placeholder used in
 // MutabilityTransitionError.ConflictingVars to represent a permanent alias from a
@@ -36,10 +36,10 @@ import (
 // printing the literal sentinel.
 const staticConflictName = "<static escape>"
 
-// MutabilityTransitionError is reported when a mutability transition
-// (mut→immutable or immutable→mut) is attempted while conflicting live aliases
-// exist. It is a liveness-derived diagnostic that self-blames from the
-// transition's node — the alias-creating declaration or reassignment — rather than
+// MutabilityTransitionError is reported when a mutability transition is attempted
+// while conflicting live aliases exist. The transition is either mut→immutable or
+// immutable→mut. It is a liveness-derived diagnostic. It self-blames from the
+// transition's node, the alias-creating declaration or reassignment, rather than
 // resolving an operand through the Prov table.
 type MutabilityTransitionError struct {
 	// SourceVar is the variable being aliased.
@@ -48,7 +48,8 @@ type MutabilityTransitionError struct {
 	TargetVar string
 	// ConflictingVars lists the names of live aliases that conflict.
 	ConflictingVars []string
-	// MutToImmutable is true for Rule 1 (mut→immutable), false for Rule 2 (immutable→mut).
+	// MutToImmutable records the transition direction: true for Rule 1, the
+	// mut→immutable case, and false for Rule 2, the immutable→mut case.
 	MutToImmutable bool
 	// node is the transition site, used for blame (the decl or assignment).
 	node ast.Node
@@ -98,17 +99,17 @@ func (e *MutabilityTransitionError) Message() string {
 	)
 }
 
-// isValueType reports whether the type is a primitive or literal type (or a union of
-// such types). Value types have copy semantics — assigning them to another variable
+// isValueType reports whether the type is a primitive or literal type, or a union of
+// such types. Value types have copy semantics. Assigning one to another variable
 // creates an independent copy, so alias tracking is unnecessary.
 //
 // Ported from check_transitions.go, which first calls type_system.Prune. There is no
-// equivalent here: the only caller (trackCapturedAliases) passes a binding's coalesced
+// equivalent here. The only caller, trackCapturedAliases, passes a binding's coalesced
 // display type, which carries no inference-variable indirection to prune. If such a
-// type ever did surface as a bare *soltype.TypeVarType, it falls through to false —
-// classified as a reference and conservatively alias-tracked. That is sound: it can
-// only ADD a spurious alias edge, never drop a real transition, so a value-typed
-// binding mis-seen as a reference at worst over-reports, never under-reports.
+// type ever surfaced as a bare *soltype.TypeVarType, it falls through to false and is
+// classified as a reference, so it is conservatively alias-tracked. That is sound.
+// Mis-seeing a value type as a reference can only add a spurious alias edge, never
+// drop a real transition, so it over-reports rather than under-reports.
 func isValueType(t soltype.Type) bool {
 	switch p := t.(type) {
 	case *soltype.PrimType, *soltype.LitType:
@@ -153,11 +154,11 @@ func bindingType(b ValueBinding) soltype.Type {
 
 // checkMutabilityTransition verifies that a mutability transition is safe at the
 // given program point, reporting a MutabilityTransitionError when conflicting live
-// aliases exist. Ported verbatim from check_transitions.go — the Rule 1 / Rule 2 /
+// aliases exist. Ported verbatim from check_transitions.go. The Rule 1 / Rule 2 /
 // Rule 3 logic talks only to liveness state on c.fn.
 //
 // A transition is only dangerous when both sides are live simultaneously after the
-// transition point — a mutable alias could mutate the value while an immutable
+// transition point. A mutable alias could then mutate the value while an immutable
 // alias assumes it is unchanged.
 //
 //	Rule 1 (mut → immutable): no live mutable aliases may exist after this point,
@@ -195,10 +196,9 @@ func (c *checker) checkMutabilityTransition(
 	// (conditional aliasing), so deduplicate by collecting names into a set.
 	conflictingSet := set.NewSet[string]()
 	for _, aliasSet := range fn.aliases.GetAliasSets(sourceVarID) {
-		// A `'static` escape on the alias set represents a permanent outside
-		// reference — no liveness check is meaningful, so it always counts as a live
-		// alias of its escaped mutability. These bits are unset until G2 marks
-		// `'static` call sites.
+		// A `'static` escape on the alias set represents a permanent outside reference.
+		// No liveness check is meaningful, so it always counts as a live alias of its
+		// escaped mutability. These bits are unset until G2 marks `'static` call sites.
 		if sourceMut && !targetMut && aliasSet.HasStaticMutAlias {
 			conflictingSet.Add(staticConflictName)
 		}
@@ -239,11 +239,11 @@ func (c *checker) checkMutabilityTransition(
 	})
 }
 
-// trackAliasesForVarDecl updates the alias tracker and checks mutability
-// transitions for a body-level `val`/`var` declaration with an initializer. M4 G1
-// handles the IdentPat case (and closure capture when the initializer is a
-// FuncExpr); destructuring patterns are unsupported in the new checker until the
-// pattern PRs land, and a non-IdentPat decl produces no binding anyway.
+// trackAliasesForVarDecl records the alias a body-level `val`/`var` with an
+// initializer creates, then checks its mutability transition. It covers an IdentPat
+// binding. It also covers closure capture when the initializer is a FuncExpr.
+// Destructuring patterns are unsupported in the new checker until the pattern PRs
+// land, and a non-IdentPat decl produces no binding anyway.
 func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindingT soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil || decl.Init == nil {
 		return
@@ -254,7 +254,7 @@ func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindin
 	}
 	c.trackAliasesForIdentPat(pat, bindingT, decl.Init, enclosingStmt, decl)
 
-	// Closure-capture aliasing — when the initializer is a FuncExpr, add the closure
+	// Closure-capture aliasing. When the initializer is a FuncExpr, add the closure
 	// variable to each captured variable's alias set. A read-only capture of a
 	// mutable variable is a mut→immut transition that must be checked against live
 	// mutable aliases.
@@ -265,7 +265,7 @@ func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindin
 
 // checkTransitionsAgainst checks the mutability transition that aliasing each source
 // in sourceIDs to (targetVarID, targetName, targetMut) induces, at enclosingStmt's CFG
-// point. It is the shared core of the decl and reassignment paths — the single-source
+// point. It is the shared core of the decl and reassignment paths. The single-source
 // case is just the one-element instance of this loop, so neither path open-codes its
 // own copy. A no-op when the statement has no StmtRef.
 func (c *checker) checkTransitionsAgainst(
@@ -289,8 +289,8 @@ func (c *checker) checkTransitionsAgainst(
 	}
 }
 
-// trackAliasesForIdentPat handles alias tracking for a simple identifier pattern
-// binding (`val x = expr`).
+// trackAliasesForIdentPat records the alias a simple identifier binding `val x = expr`
+// creates and checks its mutability transition.
 func (c *checker) trackAliasesForIdentPat(
 	identPat *ast.IdentPat,
 	bindingT soltype.Type,
@@ -308,8 +308,9 @@ func (c *checker) trackAliasesForIdentPat(
 	source := liveness.DetermineAliasSource(init)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-		// The target aliases every source — one variable, or several under conditional
-		// aliasing. Add each alias edge, then check the transition against each source.
+		// The target aliases every source, whether one variable or several under
+		// conditional aliasing. Add each alias edge, then check the transition against
+		// each source.
 		sourceIDs := source.UniqueVarIDs()
 		for _, sourceVarID := range sourceIDs {
 			c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
@@ -322,8 +323,8 @@ func (c *checker) trackAliasesForIdentPat(
 
 // trackCapturedAliases adds the closure variable to the alias sets of each captured
 // variable from the enclosing scope, and checks the mutability transition each
-// capture induces. The captured variable's identity (its VarID) and mutability come
-// from its ValueBinding, the new-checker analogue of type_system.Binding.
+// capture induces. The captured variable's VarID and mutability both come from its
+// ValueBinding, the new-checker analogue of type_system.Binding.
 func (c *checker) trackCapturedAliases(
 	scope *Scope,
 	funcExpr *ast.FuncExpr,
@@ -336,28 +337,29 @@ func (c *checker) trackCapturedAliases(
 	}
 	captures := liveness.AnalyzeCaptures(funcExpr)
 	for _, capture := range captures {
-		// Look up the captured variable's binding in the enclosing scope. The scope
-		// chain handles shadowing correctly — GetValue returns the innermost binding.
+		// Look up the captured variable's binding in the enclosing scope. GetValue
+		// walks the scope chain and returns the innermost binding, so shadowing
+		// resolves to the name in scope at the capture site.
 		b, found := scope.GetValue(capture.Name)
 		if !found || b.VarID <= 0 {
 			continue
 		}
-		// Cross-frame guard (M4 G1). A VarID is only meaningful within the frame whose
-		// rename pass assigned it — each function body restarts numbering at 1, and a
-		// binding stores the id of the body that DECLARED it. Track a capture only when
-		// its binding originated in THIS frame, i.e. the current body's rename assigned
-		// b.VarID to this name. A capture from an outer frame (a closure nested in
-		// another closure, reaching past its immediate enclosing function) carries an id
-		// from a different id-space; feeding it into this frame's AliasTracker /
-		// LivenessInfo would conflate it with an unrelated local and produce a silently
-		// wrong transition verdict. Skipping is sound — it misses that transition rather
-		// than inventing one. The real cross-frame fix rides G2's lifetime-escape bridge
-		// (see m4-implementation-plan G2). This is unreachable today: a captured mutable
-		// is a borrow, which cannot yet be aliased into a local.
+		// Cross-frame guard (M4 G1). A binding stores the VarID of the body that
+		// declared it. Module-wide numbering keeps those ids distinct across bodies, so
+		// they no longer collide, but a captured variable from an outer frame still does
+		// not appear in THIS frame's varIDNames or liveness tables. Track a capture only
+		// when its binding originated in this frame. That holds exactly when the current
+		// body's rename assigned b.VarID to this name. A capture from an outer frame
+		// reaches past its immediate enclosing function, so its liveness lives in another
+		// body's tables and cannot be queried here. Skipping is sound. It misses that
+		// transition rather than inventing one. The real cross-frame fix rides G2's
+		// lifetime-escape bridge; see the G2 note in m4-implementation-plan. This is
+		// unreachable today because a captured mutable is a borrow, which cannot yet be
+		// aliased into a local.
 		if name, ok := c.fn.varIDNames[liveness.VarID(b.VarID)]; !ok || name != capture.Name {
 			continue
 		}
-		// Primitives and literals have value semantics — reassigning a captured
+		// Primitives and literals have value semantics. Reassigning a captured
 		// primitive inside a closure can't affect other variables that copied the
 		// value, so alias tracking is unnecessary.
 		if isValueType(bindingType(b)) {
@@ -381,11 +383,12 @@ func (c *checker) trackCapturedAliases(
 //
 // enclosingStmt is the statement that contains the assignment, captured by
 // inferAssign BEFORE it walks the RHS. It must NOT be re-read from c.fn.currentStmt
-// here: walking an RHS that itself contains statements — `b = if c { … } else { … }`,
-// a match, a block expression — re-enters inferStmt and overwrites currentStmt with an
-// inner-branch statement, so by this point currentStmt no longer names the
-// assignment's statement. Reading it would resolve a valid-but-wrong CFG StmtRef and
-// run the liveness query at the wrong program point.
+// here. Walking an RHS that itself contains statements re-enters inferStmt and
+// overwrites currentStmt with an inner-branch statement, so by this point currentStmt
+// no longer names the assignment's statement. A `b = if c { … } else { … }`, a match,
+// or a block expression all trigger this. Reading the clobbered currentStmt would
+// resolve a valid-but-wrong CFG StmtRef and run the liveness query at the wrong
+// program point.
 func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr, targetType soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil || target.VarID <= 0 {
 		return
@@ -397,7 +400,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	source := liveness.DetermineAliasSource(rhs)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
-		// Check the transition BEFORE reassigning: the single-source reassign rewires
+		// Check the transition before reassigning. The single-source reassign rewires
 		// the target's membership, so checking first reads the pre-reassign alias state.
 		sourceVarID := source.UniqueVarIDs()[0]
 		c.checkTransitionsAgainst([]liveness.VarID{sourceVarID}, targetVarID, target.Name, targetMut, enclosingStmt, target)
@@ -413,9 +416,9 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	}
 }
 
-// trackAliasesForPropAssignment handles alias tracking for property assignments
-// like `obj.prop = value`. When the RHS aliases a variable, the alias sets of the
-// object and the RHS source are merged.
+// trackAliasesForPropAssignment merges alias sets for a property assignment
+// `obj.prop = value`. When the RHS aliases a variable, the object's alias set and the
+// RHS source's alias set are merged.
 func (c *checker) trackAliasesForPropAssignment(lhs ast.Expr, rhs ast.Expr) {
 	if c.fn == nil || c.fn.aliases == nil {
 		return
@@ -438,10 +441,10 @@ func (c *checker) trackAliasesForPropAssignment(lhs ast.Expr, rhs ast.Expr) {
 }
 
 // isSourceMutable checks whether a source variable is registered as mutable in its
-// alias sets. Returns true if the source holds a mutable reference, and false when the
-// source is absent from the tracker — every decl/param seeds its source first
-// (NewValue/AddAlias), so an unregistered source means "no mutable alias on record,"
-// which conservatively reads as immutable.
+// alias sets. It returns true if the source holds a mutable reference, and false when
+// the source is absent from the tracker. Every decl and param seeds its source first
+// through NewValue or AddAlias, so an unregistered source means no mutable alias is on
+// record, which conservatively reads as immutable.
 func (c *checker) isSourceMutable(sourceVarID liveness.VarID) bool {
 	for _, s := range c.fn.aliases.GetAliasSets(sourceVarID) {
 		if m, exists := s.Members[sourceVarID]; exists {
@@ -464,10 +467,10 @@ func (c *checker) varIDToName(id liveness.VarID) string {
 
 // runLivenessPrePass runs name resolution, CFG construction, and liveness analysis
 // on the function body about to be walked, populating the transition-checking state
-// on c.fn. Ported from internal/checker/liveness_prepass.go: the rename pass writes
+// on c.fn. Ported from internal/checker/liveness_prepass.go. The rename pass writes
 // VarIDs directly onto the body's AST nodes, so DetermineAliasSource and the
-// IdentPat/IdentExpr reads downstream see them. paramTypes maps each parameter name
-// to its soltype, supplying the mutability the alias seeding records.
+// downstream IdentPat/IdentExpr reads see them. paramTypes maps each parameter name to
+// its soltype, the mutability the alias seeding records.
 //
 // Must be called after parameters are bound in scope (so outer-scope names resolve)
 // but before the body is walked.
@@ -478,9 +481,9 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	outerBindings := c.collectOuterBindings(scope)
 
 	// Extra param names are bindings present in paramTypes but not introduced by an
-	// astParams pattern — the implicit `self` of a method. M4 has no methods, so this
-	// is inert today and extraParamNames stays empty; the seam is kept for M5, which
-	// adds classes and the `self` receiver. The one exception is an unsupported
+	// astParams pattern, such as the implicit `self` of a method. M4 has no methods, so
+	// this is inert today and extraParamNames stays empty. The seam is kept for M5,
+	// which adds classes and the `self` receiver. The one exception is an unsupported
 	// destructuring param, whose synthetic `arg%d` name lands here harmlessly.
 	astParamNames := set.NewSet[string]()
 	for _, p := range astParams {
@@ -545,12 +548,12 @@ func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.
 // reference from a local. Names within each scope are sorted before assignment so the
 // ids are deterministic across runs (Go map iteration order is randomized).
 //
-// The root of every chain is the shared, immutable prelude, which this re-walks and
-// re-sorts on every function body's pre-pass. preludeOuterNames memoizes the prelude's
-// sorted names so only the mutable scopes above it are re-collected each time — the
-// old checker left this re-walk as a TODO(Phase 15.1). The module scope above the
-// prelude is NOT cached: it grows as later SCC components bind, so a cached snapshot
-// would be stale for a body inferred after it.
+// The root of every chain is the shared, immutable prelude, which this would re-walk
+// and re-sort on every function body's pre-pass. preludeOuterNames memoizes the
+// prelude's sorted names so only the mutable scopes above it are re-collected each
+// time. The old checker left this re-walk as a TODO(Phase 15.1). The module scope
+// above the prelude is NOT cached. It grows as later SCC components bind, so a cached
+// snapshot would be stale for a body inferred after it.
 func (c *checker) collectOuterBindings(scope *Scope) map[string]liveness.VarID {
 	bindings := make(map[string]liveness.VarID)
 	nextID := liveness.VarID(-1)

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -98,11 +98,17 @@ func (e *MutabilityTransitionError) Message() string {
 	)
 }
 
-// isValueType reports whether the type is a primitive or literal type (or a union
-// of such types). Value types have copy semantics — assigning them to another
-// variable creates an independent copy, so alias tracking is unnecessary. Ported
-// from check_transitions.go over soltype: there is no Prune step because the
-// coalesced display type the caller passes is already resolved.
+// isValueType reports whether the type is a primitive or literal type (or a union of
+// such types). Value types have copy semantics — assigning them to another variable
+// creates an independent copy, so alias tracking is unnecessary.
+//
+// Ported from check_transitions.go, which first calls type_system.Prune. There is no
+// equivalent here: the only caller (trackCapturedAliases) passes a binding's coalesced
+// display type, which carries no inference-variable indirection to prune. If such a
+// type ever did surface as a bare *soltype.TypeVarType, it falls through to false —
+// classified as a reference and conservatively alias-tracked. That is sound: it can
+// only ADD a spurious alias edge, never drop a real transition, so a value-typed
+// binding mis-seen as a reference at worst over-reports, never under-reports.
 func isValueType(t soltype.Type) bool {
 	switch p := t.(type) {
 	case *soltype.PrimType, *soltype.LitType:
@@ -257,6 +263,32 @@ func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindin
 	}
 }
 
+// checkTransitionsAgainst checks the mutability transition that aliasing each source
+// in sourceIDs to (targetVarID, targetName, targetMut) induces, at enclosingStmt's CFG
+// point. It is the shared core of the decl and reassignment paths — the single-source
+// case is just the one-element instance of this loop, so neither path open-codes its
+// own copy. A no-op when the statement has no StmtRef.
+func (c *checker) checkTransitionsAgainst(
+	sourceIDs []liveness.VarID,
+	targetVarID liveness.VarID,
+	targetName string,
+	targetMut bool,
+	enclosingStmt ast.Stmt,
+	node ast.Node,
+) {
+	stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]
+	if !hasRef {
+		return
+	}
+	for _, sourceVarID := range sourceIDs {
+		c.checkMutabilityTransition(
+			sourceVarID, targetVarID,
+			c.varIDToName(sourceVarID), targetName,
+			c.isSourceMutable(sourceVarID), targetMut, stmtRef, node,
+		)
+	}
+}
+
 // trackAliasesForIdentPat handles alias tracking for a simple identifier pattern
 // binding (`val x = expr`).
 func (c *checker) trackAliasesForIdentPat(
@@ -275,32 +307,14 @@ func (c *checker) trackAliasesForIdentPat(
 
 	source := liveness.DetermineAliasSource(init)
 	switch source.RootKind() {
-	case liveness.AliasSourceVariable:
-		sourceVarID := source.UniqueVarIDs()[0]
-		c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
-		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
-			sourceMut := c.isSourceMutable(sourceVarID)
-			c.checkMutabilityTransition(
-				sourceVarID, targetVarID,
-				c.varIDToName(sourceVarID), identPat.Name,
-				sourceMut, targetMut, stmtRef, node,
-			)
-		}
-	case liveness.AliasSourceMultiple:
-		// Conditional aliasing: the target aliases all possible source variables.
-		for _, sourceVarID := range source.UniqueVarIDs() {
+	case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
+		// The target aliases every source — one variable, or several under conditional
+		// aliasing. Add each alias edge, then check the transition against each source.
+		sourceIDs := source.UniqueVarIDs()
+		for _, sourceVarID := range sourceIDs {
 			c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 		}
-		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
-			for _, sourceVarID := range source.UniqueVarIDs() {
-				sourceMut := c.isSourceMutable(sourceVarID)
-				c.checkMutabilityTransition(
-					sourceVarID, targetVarID,
-					c.varIDToName(sourceVarID), identPat.Name,
-					sourceMut, targetMut, stmtRef, node,
-				)
-			}
-		}
+		c.checkTransitionsAgainst(sourceIDs, targetVarID, identPat.Name, targetMut, enclosingStmt, node)
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		c.fn.aliases.NewValue(targetVarID, aliasMut)
 	}
@@ -351,15 +365,13 @@ func (c *checker) trackCapturedAliases(
 		}
 		enclosingVarID := liveness.VarID(b.VarID)
 		c.fn.aliases.AddAlias(closureVarID, enclosingVarID, aliasMutability(capture.IsMutable))
-
-		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
-			sourceMut := c.isSourceMutable(enclosingVarID)
-			c.checkMutabilityTransition(
-				enclosingVarID, closureVarID,
-				capture.Name, c.varIDToName(closureVarID),
-				sourceMut, capture.IsMutable, stmtRef, node,
-			)
-		}
+		// The capture creates a (closure ← enclosing var) alias; check the transition it
+		// induces. The cross-frame guard above guarantees enclosingVarID resolves in this
+		// frame, so the helper's varIDToName(enclosingVarID) is capture.Name.
+		c.checkTransitionsAgainst(
+			[]liveness.VarID{enclosingVarID}, closureVarID,
+			c.varIDToName(closureVarID), capture.IsMutable, enclosingStmt, node,
+		)
 	}
 }
 
@@ -385,30 +397,17 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	source := liveness.DetermineAliasSource(rhs)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
+		// Check the transition BEFORE reassigning: the single-source reassign rewires
+		// the target's membership, so checking first reads the pre-reassign alias state.
 		sourceVarID := source.UniqueVarIDs()[0]
-		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
-			sourceMut := c.isSourceMutable(sourceVarID)
-			c.checkMutabilityTransition(
-				sourceVarID, targetVarID,
-				c.varIDToName(sourceVarID), target.Name,
-				sourceMut, targetMut, stmtRef, target,
-			)
-		}
+		c.checkTransitionsAgainst([]liveness.VarID{sourceVarID}, targetVarID, target.Name, targetMut, enclosingStmt, target)
 		c.fn.aliases.Reassign(targetVarID, &sourceVarID, aliasMut)
 	case liveness.AliasSourceMultiple:
-		// Conditional aliasing: reassign to all sources before checking transitions
-		// so alias state stays consistent regardless of whether errors are reported.
-		c.fn.aliases.ReassignMulti(targetVarID, source.UniqueVarIDs(), aliasMut)
-		if stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]; hasRef {
-			for _, sourceVarID := range source.UniqueVarIDs() {
-				sourceMut := c.isSourceMutable(sourceVarID)
-				c.checkMutabilityTransition(
-					sourceVarID, targetVarID,
-					c.varIDToName(sourceVarID), target.Name,
-					sourceMut, targetMut, stmtRef, target,
-				)
-			}
-		}
+		// Conditional aliasing: reassign to all sources BEFORE checking transitions so
+		// alias state stays consistent regardless of whether errors are reported.
+		sourceIDs := source.UniqueVarIDs()
+		c.fn.aliases.ReassignMulti(targetVarID, sourceIDs, aliasMut)
+		c.checkTransitionsAgainst(sourceIDs, targetVarID, target.Name, targetMut, enclosingStmt, target)
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
 	}
@@ -421,7 +420,7 @@ func (c *checker) trackAliasesForPropAssignment(lhs ast.Expr, rhs ast.Expr) {
 	if c.fn == nil || c.fn.aliases == nil {
 		return
 	}
-	objVarID := rootObjectVarID(lhs)
+	objVarID := liveness.VarID(ast.RootObjectVarID(lhs))
 	if objVarID <= 0 {
 		return
 	}
@@ -439,7 +438,10 @@ func (c *checker) trackAliasesForPropAssignment(lhs ast.Expr, rhs ast.Expr) {
 }
 
 // isSourceMutable checks whether a source variable is registered as mutable in its
-// alias sets. Returns true if the source holds a mutable reference.
+// alias sets. Returns true if the source holds a mutable reference, and false when the
+// source is absent from the tracker — every decl/param seeds its source first
+// (NewValue/AddAlias), so an unregistered source means "no mutable alias on record,"
+// which conservatively reads as immutable.
 func (c *checker) isSourceMutable(sourceVarID liveness.VarID) bool {
 	for _, s := range c.fn.aliases.GetAliasSets(sourceVarID) {
 		if m, exists := s.Members[sourceVarID]; exists {
@@ -447,27 +449,6 @@ func (c *checker) isSourceMutable(sourceVarID liveness.VarID) bool {
 		}
 	}
 	return false
-}
-
-// rootObjectVarID iteratively walks a member/index expression chain (`a.b.c`,
-// `a[b][c]`) to find the root object's VarID, returning 0 when the root is not a
-// local variable.
-func rootObjectVarID(expr ast.Expr) liveness.VarID {
-	for {
-		switch e := expr.(type) {
-		case *ast.MemberExpr:
-			expr = e.Object
-		case *ast.IndexExpr:
-			expr = e.Object
-		case *ast.IdentExpr:
-			if e.VarID > 0 {
-				return liveness.VarID(e.VarID)
-			}
-			return 0
-		default:
-			return 0
-		}
-	}
 }
 
 // varIDToName resolves a VarID back to a variable name for error messages, reading
@@ -494,16 +475,18 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	// Build outer bindings from the scope chain. Every value binding accessible from
 	// the current scope gets a negative VarID so the rename pass can distinguish
 	// local from non-local variables.
-	outerBindings := collectOuterBindings(scope)
+	outerBindings := c.collectOuterBindings(scope)
 
-	// Extra param names are bindings present as params but not in astParams (e.g. an
-	// implicit `self`). The new checker has no such params yet, so this is normally
-	// empty; the logic is kept for parity with the old prepass.
+	// Extra param names are bindings present in paramTypes but not introduced by an
+	// astParams pattern — the implicit `self` of a method. M4 has no methods, so this
+	// is inert today and extraParamNames stays empty; the seam is kept for M5, which
+	// adds classes and the `self` receiver. The one exception is an unsupported
+	// destructuring param, whose synthetic `arg%d` name lands here harmlessly.
 	astParamNames := set.NewSet[string]()
 	for _, p := range astParams {
-		collectPatternBindingNames(p.Pattern, astParamNames)
+		ast.CollectPatternBindingNames(p.Pattern, astParamNames)
 	}
-	var extraParamNames []string
+	var extraParamNames []string // M5: populated once methods introduce `self`
 	for name := range paramTypes {
 		if !astParamNames.Contains(name) {
 			extraParamNames = append(extraParamNames, name)
@@ -544,7 +527,7 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 // paramTypes so transitions involving the leaf are checked correctly.
 func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.Type, aliases *liveness.AliasTracker) {
 	for _, param := range astParams {
-		forEachLeafBinding(param.Pattern, func(name string, varID int) {
+		ast.ForEachLeafBinding(param.Pattern, func(name string, varID int) {
 			if varID <= 0 {
 				return
 			}
@@ -558,19 +541,20 @@ func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.
 }
 
 // collectOuterBindings walks the scope chain and collects all value binding names,
-// assigning each a unique negative VarID. Names within each scope are sorted before
-// assignment so the resulting IDs are deterministic across runs (Go map iteration
-// order is randomized), keeping any VarID-capturing snapshots stable.
-func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
+// assigning each a unique negative VarID so the rename pass can tell a non-local
+// reference from a local. Names within each scope are sorted before assignment so the
+// ids are deterministic across runs (Go map iteration order is randomized).
+//
+// The root of every chain is the shared, immutable prelude, which this re-walks and
+// re-sorts on every function body's pre-pass. preludeOuterNames memoizes the prelude's
+// sorted names so only the mutable scopes above it are re-collected each time — the
+// old checker left this re-walk as a TODO(Phase 15.1). The module scope above the
+// prelude is NOT cached: it grows as later SCC components bind, so a cached snapshot
+// would be stale for a body inferred after it.
+func (c *checker) collectOuterBindings(scope *Scope) map[string]liveness.VarID {
 	bindings := make(map[string]liveness.VarID)
 	nextID := liveness.VarID(-1)
-
-	for s := scope; s != nil; s = s.parent {
-		names := make([]string, 0, len(s.values))
-		for name := range s.values {
-			names = append(names, name)
-		}
-		slices.Sort(names)
+	add := func(names []string) {
 		for _, name := range names {
 			if _, exists := bindings[name]; !exists {
 				bindings[name] = nextID
@@ -579,7 +563,36 @@ func collectOuterBindings(scope *Scope) map[string]liveness.VarID {
 		}
 	}
 
+	for s := scope; s != nil; s = s.parent {
+		if s.parent == nil {
+			add(c.preludeOuterNames(s)) // immutable prelude root: collected once, reused
+		} else {
+			add(sortedValueNames(s))
+		}
+	}
+
 	return bindings
+}
+
+// preludeOuterNames returns the prelude root scope's sorted value names, computing
+// them once per root and caching the result on the checker. The prelude is built once
+// and never mutated during a run, so the cache is always fresh.
+func (c *checker) preludeOuterNames(root *Scope) []string {
+	if c.preludeNamesRoot != root {
+		c.preludeNames = sortedValueNames(root)
+		c.preludeNamesRoot = root
+	}
+	return c.preludeNames
+}
+
+// sortedValueNames returns a scope's own value binding names in sorted order.
+func sortedValueNames(s *Scope) []string {
+	names := make([]string, 0, len(s.values))
+	for name := range s.values {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
 }
 
 // recordParamVarIDs copies each IdentPat parameter's rename-assigned VarID onto its
@@ -597,43 +610,4 @@ func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
 			fnScope.defineValue(ip.Name, b)
 		}
 	}
-}
-
-// forEachLeafBinding invokes fn for every identifier name a pattern introduces,
-// recursing through destructuring patterns. Ported from internal/checker.
-func forEachLeafBinding(pat ast.Pat, fn func(name string, varID int)) {
-	if pat == nil {
-		return
-	}
-	switch p := pat.(type) {
-	case *ast.IdentPat:
-		fn(p.Name, p.VarID)
-	case *ast.TuplePat:
-		for _, sub := range p.Elems {
-			forEachLeafBinding(sub, fn)
-		}
-	case *ast.ObjectPat:
-		for _, elem := range p.Elems {
-			switch e := elem.(type) {
-			case *ast.ObjKeyValuePat:
-				forEachLeafBinding(e.Value, fn)
-			case *ast.ObjShorthandPat:
-				if e.Key != nil {
-					fn(e.Key.Name, e.VarID)
-				}
-			case *ast.ObjRestPat:
-				forEachLeafBinding(e.Pattern, fn)
-			}
-		}
-	case *ast.RestPat:
-		forEachLeafBinding(p.Pattern, fn)
-	}
-}
-
-// collectPatternBindingNames adds every identifier name introduced by a pattern
-// (recursively) to the provided set.
-func collectPatternBindingNames(p ast.Pat, into set.Set[string]) {
-	forEachLeafBinding(p, func(name string, _ int) {
-		into.Add(name)
-	})
 }

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1364,6 +1364,25 @@ these arms it must add.
     global-write escape above, so the two share G2's `VarID` ↔ `soltype`-borrow bridge.
     When G2 lands, the capture guard can relax to defer cross-frame cases to the
     lifetime escape instead of skipping them.
+  - **Carried into G2 — immutable→mutable upgrade for a non-fresh source.** The C2 gate
+    rejects `immutable <: mutable` structurally, but the upgrade is sound whenever the
+    source has no live immutable alias. This is Rule 2 with an empty alias set. G1's
+    construction path already takes the trivial case: `constrainInitAgainstAnnotation`
+    upgrades a freshly constructed, unaliased literal flowing into an owned-mutable
+    annotation, so `val items: mut {x} = {x: 1}` type-checks and the source-level Rule 1
+    and Rule 3 scenarios become reachable. `isFreshlyConstructed` is deliberately
+    syntactic and identifier-free, so it is sound without VarIDs and at module top
+    level, but it covers only literals.
+    G2 should generalize this to a non-fresh source — a variable, a call, a member
+    access — by resolving the source's owning region rather than its syntax: the upgrade
+    is admitted when that region carries no live immutable borrow, the same question the
+    `VarID` ↔ `soltype`-borrow bridge answers for escape and cross-frame captures. So a
+    dead immutable variable (`val cfg = …; val m: mut … = cfg` with `cfg` dead after) can
+    be moved to `mut`, which today still reports the structural mismatch. The three
+    consumers — escape-to-`'static`, cross-frame capture, and this immutable→mut move —
+    all reduce to "does this value's region have a conflicting outstanding borrow here?"
+    and share one mechanism. The narrow walk-level upgrade stays as the fast path for
+    fresh construction; the region query is the general case layered behind it.
 
 ### Dependency graph
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1364,25 +1364,44 @@ these arms it must add.
     global-write escape above, so the two share G2's `VarID` ↔ `soltype`-borrow bridge.
     When G2 lands, the capture guard can relax to defer cross-frame cases to the
     lifetime escape instead of skipping them.
-  - **Carried into G2 — immutable→mutable upgrade for a non-fresh source.** The C2 gate
-    rejects `immutable <: mutable` structurally, but the upgrade is sound whenever the
-    source has no live immutable alias. This is Rule 2 with an empty alias set. G1's
-    construction path already takes the trivial case: `constrainInitAgainstAnnotation`
-    upgrades a freshly constructed, unaliased literal flowing into an owned-mutable
-    annotation, so `val items: mut {x} = {x: 1}` type-checks and the source-level Rule 1
-    and Rule 3 scenarios become reachable. `isFreshlyConstructed` is deliberately
-    syntactic and identifier-free, so it is sound without VarIDs and at module top
-    level, but it covers only literals.
-    G2 should generalize this to a non-fresh source — a variable, a call, a member
-    access — by resolving the source's owning region rather than its syntax: the upgrade
-    is admitted when that region carries no live immutable borrow, the same question the
-    `VarID` ↔ `soltype`-borrow bridge answers for escape and cross-frame captures. So a
-    dead immutable variable (`val cfg = …; val m: mut … = cfg` with `cfg` dead after) can
-    be moved to `mut`, which today still reports the structural mismatch. The three
-    consumers — escape-to-`'static`, cross-frame capture, and this immutable→mut move —
-    all reduce to "does this value's region have a conflicting outstanding borrow here?"
-    and share one mechanism. The narrow walk-level upgrade stays as the fast path for
-    fresh construction; the region query is the general case layered behind it.
+  - **Carried into G2 — immutable→mutable upgrade, at every value-flow site.** The C2
+    gate rejects `immutable <: mutable` structurally, but the upgrade is sound whenever
+    the source has no live immutable alias. This is Rule 2 with an empty alias set. G1
+    ships the narrow start; G2 generalizes it along two orthogonal axes.
+
+    *Sites — where the upgrade is checked.* G1 wires it at ONE site, the annotated
+    `val`/`var` initializer in `constrainInitAgainstAnnotation`. The same decision applies
+    wherever a value flows into a `mut` slot:
+    1. a reassignment `x = e` into a `mut` binding (`inferAssign`);
+    2. a call argument against a `mut` parameter (`inferCall`);
+    3. a `return e` against a `mut` return annotation (`inferFunc` / `asyncReturn`);
+    4. a field write `obj.f = e` where `obj.f` is `mut` (`inferMemberAssign`).
+
+    Today a fresh literal type-checks into a `mut` declaration but not into a `mut`
+    parameter, return, or field, an inconsistency a caller hits the moment they write
+    `f({x: 1})` for `fn f(p: mut {x: number})`. G2 should lift the decision into one
+    shared helper consulted at every site, rather than repeating the `inferVarDeclInit`
+    special case four more times. The helper needs the source EXPRESSION, for the
+    syntactic freshness check, alongside the source type, exactly as
+    `constrainInitAgainstAnnotation` takes both `init` and `initT`. The return site has a
+    wrinkle: several `return`s join into one type, so the check keys on each branch's
+    return expression, not the joined result.
+
+    *Sources — which sources qualify.* G1's `isFreshlyConstructed` is deliberately
+    syntactic and identifier-free, so it is sound without VarIDs and at module top level,
+    but it covers only literals. G2 should admit a non-fresh source — a variable, a call,
+    a member access — by resolving the source's owning region rather than its syntax. The
+    upgrade holds when that region carries no live immutable borrow, the same question the
+    `VarID` ↔ `soltype`-borrow bridge answers for escape and cross-frame captures. A dead
+    immutable variable (`val cfg = …; val m: mut … = cfg` with `cfg` dead after) can then
+    be moved to `mut`, which today still reports the structural mismatch.
+
+    The two axes compose: every site consults the one upgrade helper, and the helper
+    decides via the syntactic fast path or the region query. The three region consumers —
+    escape-to-`'static`, cross-frame capture, and this immutable→mut move — all reduce to
+    "does this value's region have a conflicting outstanding borrow here?" and share one
+    mechanism. The walk-level fresh-literal check stays as the fast path; the region query
+    is the general case layered behind it.
 
 ### Dependency graph
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1336,6 +1336,30 @@ these arms it must add.
     slot. That avoids both the C2-gate change and an ad-hoc variable-bound walk D3
     declined to add. D3 left the boundary documented in `constrainEscape` and the
     `inferAssign` global-write branch.
+  - **Carried over from G1 — cross-frame captured-mutability via lifetime escape.**
+    G1's `trackCapturedAliases` keys alias/liveness on a liveness `VarID`, but a
+    `VarID` is only meaningful within one function body's rename pass — each body
+    restarts numbering at 1. A binding stores the `VarID` of the body that DECLARED it,
+    so when a closure captures a variable declared in a frame ABOVE its enclosing
+    function, that outer-frame id is fed into the enclosing frame's `AliasTracker` /
+    `LivenessInfo`, where the same number names a different variable. The result is a
+    silently wrong transition verdict, not a crash — `IsLiveAfter` is a set membership
+    test, so a foreign id returns the wrong boolean. It is dormant today because a
+    captured mutable is a borrow that cannot yet be aliased into a local, so no
+    cross-frame transition is reachable. G1 ships a conservative guard: skip a capture
+    whose binding did not originate in the current frame, which is sound (it misses such
+    a transition rather than inventing one). G2 should supply the real fix from the
+    same bridge it already builds: a captured outer mutable is a borrow whose lifetime
+    escapes INTO the closure, so the transition is enforced by the lifetime sort — the
+    captured borrow's escape constraint and its `RefType.Mut` — rather than by
+    extending the per-frame `VarID` machinery across frames. This is the same
+    "resolve borrows through the constraint graph, not the syntactic id-space"
+    principle as the global-write escape above, so the two share G2's
+    `VarID` ↔ `soltype`-borrow bridge. Per-frame alternatives (global module-wide
+    `VarID`s, or `(frame, VarID)` keys with an owner-frame liveness query) would fix
+    the id collision but still cannot answer cross-frame liveness, so they are a
+    correctness floor at best — the lifetime-escape route is the one that actually
+    models "the closure keeps the captured value live."
 
 ### Dependency graph
 

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1337,29 +1337,33 @@ these arms it must add.
     declined to add. D3 left the boundary documented in `constrainEscape` and the
     `inferAssign` global-write branch.
   - **Carried over from G1 — cross-frame captured-mutability via lifetime escape.**
-    G1's `trackCapturedAliases` keys alias/liveness on a liveness `VarID`, but a
-    `VarID` is only meaningful within one function body's rename pass — each body
-    restarts numbering at 1. A binding stores the `VarID` of the body that DECLARED it,
-    so when a closure captures a variable declared in a frame ABOVE its enclosing
-    function, that outer-frame id is fed into the enclosing frame's `AliasTracker` /
-    `LivenessInfo`, where the same number names a different variable. The result is a
-    silently wrong transition verdict, not a crash — `IsLiveAfter` is a set membership
+    G1's `trackCapturedAliases` keys alias/liveness on a liveness `VarID`. A binding
+    stores the `VarID` of the body that DECLARED it, so when a closure captures a
+    variable declared in a frame ABOVE its enclosing function, that outer-frame id is
+    fed into the enclosing frame's `AliasTracker` / `LivenessInfo`. The result would be
+    a silently wrong transition verdict, not a crash — `IsLiveAfter` is a set membership
     test, so a foreign id returns the wrong boolean. It is dormant today because a
     captured mutable is a borrow that cannot yet be aliased into a local, so no
-    cross-frame transition is reachable. G1 ships a conservative guard: skip a capture
-    whose binding did not originate in the current frame, which is sound (it misses such
-    a transition rather than inventing one). G2 should supply the real fix from the
+    cross-frame transition is reachable. G1 ships two defensive measures already:
+    1. **Module-wide unique `VarID`s.** `liveness.RenameFrom` numbers each body's
+       locals from a checker-level running counter instead of restarting at 1, so a
+       `VarID` names the same variable in any frame and a foreign id can never collide
+       with an unrelated local. This makes the system SOUND on its own — a foreign id
+       is simply absent from the current frame's tables.
+    2. **A conservative capture guard.** `trackCapturedAliases` skips a capture whose
+       binding did not originate in the current frame, so a cross-frame capture is not
+       tracked at all rather than mis-tracked.
+    Both are a correctness FLOOR, not the full answer: even with unique ids, an outer
+    variable's id is not in the inner frame's `LiveAfter` set, so cross-frame liveness
+    reads as "dead" and the transition is missed. G2 supplies the real fix from the
     same bridge it already builds: a captured outer mutable is a borrow whose lifetime
     escapes INTO the closure, so the transition is enforced by the lifetime sort — the
-    captured borrow's escape constraint and its `RefType.Mut` — rather than by
-    extending the per-frame `VarID` machinery across frames. This is the same
-    "resolve borrows through the constraint graph, not the syntactic id-space"
-    principle as the global-write escape above, so the two share G2's
-    `VarID` ↔ `soltype`-borrow bridge. Per-frame alternatives (global module-wide
-    `VarID`s, or `(frame, VarID)` keys with an owner-frame liveness query) would fix
-    the id collision but still cannot answer cross-frame liveness, so they are a
-    correctness floor at best — the lifetime-escape route is the one that actually
-    models "the closure keeps the captured value live."
+    captured borrow's escape constraint and its `RefType.Mut` — rather than by extending
+    the per-frame `VarID` machinery across frames. This is the same "resolve borrows
+    through the constraint graph, not the syntactic id-space" principle as the
+    global-write escape above, so the two share G2's `VarID` ↔ `soltype`-borrow bridge.
+    When G2 lands, the capture guard can relax to defer cross-frame cases to the
+    lifetime escape instead of skipping them.
 
 ### Dependency graph
 


### PR DESCRIPTION
Ports the mutability-transition checker from `internal/checker` to `internal/solver`, implementing M4 G1 of the implementation plan. The transition checker enforces that a variable cannot change mutability (mut→immutable or immutable→mut) while conflicting live aliases exist.

## Key changes

- **New file `internal/solver/transitions.go`**: Complete port of transition-checking logic from `internal/checker/check_transitions.go` and `internal/checker/liveness_prepass.go`, reimplemented over `soltype` instead of `type_system`. Includes `MutabilityTransitionError` diagnostic, the three transition rules (Rule 1: mut→immutable, Rule 2: immutable→mut, Rule 3: mut→mut is safe), and alias-tracking for variable declarations, reassignments, and closure captures.

- **New file `internal/solver/transition_test.go`**: Unit tests covering the type predicates (`isValueType`, `isMutableType`), the transition-checking logic over constructed alias/liveness state, and end-to-end wiring tests that verify no spurious errors are reported on real function bodies.

- **`internal/solver/infer_expr.go`**: Wire the liveness pre-pass into function-body inference. Collect parameter types into a map and call `runLivenessPrePass` before walking the body, populating liveness/CFG/alias state on `c.fn`. This enables transition checking during body inference.

- **`internal/solver/infer_stmt.go`**: Record the enclosing statement in `c.fn.currentStmt` before walking an RHS, so reassignment transition checking can resolve the correct CFG `StmtRef` even when the RHS contains nested statements that re-enter `inferStmt`.

- **`internal/solver/infer.go`**: Add module-wide `varIDCounter` and `preludeNames` cache to `checker`. The counter allocates VarIDs uniquely across all function bodies in one inference run, so a binding's VarID names the same variable in any frame. The cache avoids re-walking and re-sorting the prelude for every body.

- **`internal/solver/scope.go`**: Add `VarID` field to `ValueBinding` to store the liveness VarID assigned by the rename pass, enabling the transition checker to look up a captured variable's mutability.

- **`internal/ast/pattern.go`**: Extract pattern-walking helpers `ForEachLeafBinding` and `CollectPatternBindingNames` from `internal/checker/infer_lifetime.go`, and add `RootObjectVarID` to walk member/index chains to the root object's VarID. These are shared by both checker and solver liveness pre-passes.

- **`internal/liveness/rename.go`**: Generalize `Rename` to `RenameFrom(firstID)` so callers can thread a module-wide counter and get VarIDs unique across bodies.

- **`internal/liveness/rename_test.go`**: Add tests for `RenameFrom` starting at a custom ID and chaining across bodies.

- **`internal/checker/check_transitions.go`**: Update to use `ast.RootObjectVarID` instead of the local `rootObjectVarID` helper, which is now in `ast/pattern.go`.

- **`internal/checker/infer_lifetime.go`**: Update to use `ast.RootObjectVarID` and remove the now-shared `forEachLeafBinding` helper.

- **`internal/checker/liveness_prepass.go`**: Update to use `ast.CollectPatternBindingNames`.

- **`planning/simple_sub/m4-implementation-plan.md`**: Document the cross-frame captured-mutability limitation and defensive measures in G1.

## Implementation notes

The port reuses the liveness/CFG/alias-tracking machinery from `internal/liveness` verbatim. Only two pieces are reimplemented over `soltype`: the type predicates (`isValueType`, `isMutableType`) and the binding model (a captured variable's identity comes from `ValueBinding.VarID` and its mutability from the binding's co

https://claude.ai/code/session_015Niass7yiLFrQHQZaYbP1A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mutability transition checking to validate variable reassignments and property mutations, preventing incompatible modifications that could violate type safety constraints.

* **Tests**
  * Added comprehensive unit tests for mutability transition validation, liveness analysis, and pattern binding traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->