### PR TITLE
liveness: add RenameFrom for a caller-supplied starting VarID

### DIFF
--- a/internal/liveness/rename.go
+++ b/internal/liveness/rename.go
@@ -63,11 +63,11 @@ type renamer struct {
 	varIDNames map[VarID]string
 }
 
-func newRenamer(outerBindings map[string]VarID) *renamer {
+func newRenamer(outerBindings map[string]VarID, firstID VarID) *renamer {
 	s := newScope(nil)
 	maps.Copy(s.bindings, outerBindings)
 	return &renamer{
-		nextID:     1, // local VarIDs start at 1
+		nextID:     firstID,
 		scope:      s,
 		varIDNames: make(map[VarID]string),
 	}
@@ -122,7 +122,19 @@ func (r *renamer) resolve(name string, span ast.Span) VarID {
 // After this function returns, the internal scope stack is discarded.
 // All downstream phases read VarIDs directly from AST nodes.
 func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, extraParamNames ...string) *RenameResult {
-	r := newRenamer(outerBindings)
+	return RenameFrom(params, body, outerBindings, 1, extraParamNames...)
+}
+
+// RenameFrom is Rename with an explicit starting id for the positive local VarIDs.
+// Plain Rename starts at 1, giving each body its own 1-based numbering. The solver
+// instead passes a module-wide running counter so VarIDs are unique across every
+// function body in a single inference run. A binding's VarID then names the same
+// variable in any frame, so feeding one body's id into another body's alias/liveness
+// tables can no longer collide with an unrelated local. firstID must be >= 1. The id 0
+// is the unset sentinel, and negative ids mark non-local bindings. The next free id is
+// firstID + the returned UniqueVarCount.
+func RenameFrom(params []*ast.Param, body ast.Block, outerBindings map[string]VarID, firstID VarID, extraParamNames ...string) *RenameResult {
+	r := newRenamer(outerBindings, firstID)
 
 	// Process function parameters — they are in scope for the entire body.
 	// Parameters share the root scope with outerBindings. This is fine because
@@ -146,7 +158,7 @@ func Rename(params []*ast.Param, body ast.Block, outerBindings map[string]VarID,
 	r.renameBlock(body)
 
 	return &RenameResult{
-		UniqueVarCount:   int(r.nextID) - 1, // count of local variables assigned
+		UniqueVarCount:   int(r.nextID) - int(firstID), // count of local variables assigned
 		VarIDNames:       r.varIDNames,
 		ExtraParamVarIDs: extraParamVarIDs,
 		Errors:           r.errors,

--- a/internal/liveness/rename_test.go
+++ b/internal/liveness/rename_test.go
@@ -58,6 +58,59 @@ func block(stmts ...ast.Stmt) ast.Block {
 	return ast.Block{Stmts: stmts, Span: span()}
 }
 
+// RenameFrom starts local numbering at firstID instead of 1, so a caller threading a
+// module-wide counter gets VarIDs unique across bodies. UniqueVarCount stays the count
+// of locals defined, independent of the starting id.
+func TestRenameFromStartsAtFirstID(t *testing.T) {
+	// val a = 1; val b = a  — two locals, started at id 10.
+	a := identPat("a")
+	b := identPat("b")
+	aRef := ident("a")
+	body := block(
+		valDecl(a, numLit(1)),
+		valDecl(b, aRef),
+	)
+
+	result := RenameFrom(nil, body, map[string]VarID{}, 10)
+
+	require.Empty(t, result.Errors)
+	require.Equal(t, 2, result.UniqueVarCount)  // count is start-independent
+	require.Equal(t, VarID(10), VarID(a.VarID)) // first local takes firstID
+	require.Equal(t, VarID(11), VarID(b.VarID)) // second is firstID+1
+	require.Equal(t, a.VarID, aRef.VarID)       // use resolves to binding
+	// Next free id = firstID + UniqueVarCount, so a following body starts at 12.
+	require.Equal(t, 12, 10+result.UniqueVarCount)
+}
+
+// Chaining RenameFrom across two bodies, with the second starting where the first left
+// off, gives every local a VarID unique across both bodies. That is the property that
+// lets a binding's VarID name the same variable in any frame.
+func TestRenameFromDisjointAcrossBodies(t *testing.T) {
+	// Body 1: val a = 1; val b = a
+	a := identPat("a")
+	b := identPat("b")
+	body1 := block(valDecl(a, numLit(1)), valDecl(b, ident("a")))
+
+	r1 := RenameFrom(nil, body1, map[string]VarID{}, 1)
+	require.Empty(t, r1.Errors)
+
+	// Body 2 starts at the next free id, so its locals cannot collide with body 1's.
+	c := identPat("c")
+	d := identPat("d")
+	body2 := block(valDecl(c, numLit(2)), valDecl(d, ident("c")))
+
+	r2 := RenameFrom(nil, body2, map[string]VarID{}, 1+VarID(r1.UniqueVarCount))
+	require.Empty(t, r2.Errors)
+
+	body1IDs := []int{a.VarID, b.VarID}
+	body2IDs := []int{c.VarID, d.VarID}
+	for _, id1 := range body1IDs {
+		for _, id2 := range body2IDs {
+			require.NotEqual(t, id1, id2, "VarIDs must be disjoint across bodies")
+		}
+	}
+}
+
 func TestSimpleBindingAndUse(t *testing.T) {
 	// val x = 1; print(x)
 	x := identPat("x")


### PR DESCRIPTION
Part 2/5 of splitting #750 into a reviewable stack.

`RenameFrom` is `Rename` with an explicit first id for the positive local VarIDs; `Rename` now delegates with `firstID=1`, so its per-body 1-based numbering is unchanged. A caller that wants VarIDs unique across several function bodies in one inference pass — so a binding's VarID names the same variable in any frame — threads a running counter through `RenameFrom` and advances it by the returned `UniqueVarCount`. The solver consumes this in part 5's transition machinery.

**Stack** (merge bottom-up): split-1-ast-walkers → **split-2-renamefrom (this PR)** → split-3-transition-machinery → split-4-wire-prepass → split-5-owned-mut-construction.

Base: `claude/split-1-ast-walkers`. Green: `internal/liveness` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Niass7yiLFrQHQZaYbP1A)_