### PR TITLE
solver: wire the liveness pre-pass and alias tracking into the walk (M4 G1)

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -178,6 +178,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
+	// paramTypes maps each bound parameter name to its soltype, consumed by the M4
+	// G1 liveness pre-pass to seed parameter alias mutability.
+	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
 		// A `mut`-borrow param without a declared lifetime originates a fresh
@@ -224,6 +227,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// A parameter binding never generalizes — its var is fixed for the body — so
 		// it is a MonoScheme; instantiate returns pt unchanged at every use.
 		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}, Sources: sources})
+		paramTypes[name] = pt
 		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
 		// `required` count without dropping the param — carried onto the soltype so
 		// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
@@ -240,6 +244,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node)
+		// M4 G1: run the liveness pre-pass before walking the body so mutability
+		// transitions are checked. It renames the body's variable nodes (writing the
+		// VarIDs DetermineAliasSource and the alias tracker read) and seeds the
+		// parameter alias sets onto c.fn. recordParamVarIDs then copies each param's
+		// freshly-assigned VarID onto its binding so a closure capturing the param
+		// resolves to its alias set.
+		c.runLivenessPrePass(fnScope, sig.Params, paramTypes, body)
+		recordParamVarIDs(fnScope, sig.Params)
 		// Walk the body for type-checking and to collect its ReturnStmts; the
 		// block's TAIL value is intentionally discarded. Unlike a value-position
 		// block, where the last expression IS the block's value, a function body's
@@ -691,6 +703,16 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	if e.Left == nil || e.Right == nil {
 		return c.reportUnsupported(e)
 	}
+	// M4 G1: snapshot the enclosing statement BEFORE walking the RHS. Reassignment
+	// transition checking needs this assignment's statement to find its CFG StmtRef,
+	// but walking an RHS that contains statements re-enters inferStmt and overwrites
+	// c.fn.currentStmt. A `b = if c { … } else { … }`, a match, or a block expression
+	// all do this. Capturing the statement here keeps the reassignment path on the
+	// right program point, the way the var-decl path threads its statement explicitly.
+	var assignStmt ast.Stmt
+	if c.fn != nil {
+		assignStmt = c.fn.currentStmt
+	}
 	sourceT := c.inferExpr(scope, lvl, e.Right)
 	// Record void on e up front as the recovery type: every error path below returns
 	// voidT without recording a type, so this guarantees the node is typed on failure.
@@ -758,6 +780,11 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
+	// M4 G1: track the alias this reassignment creates and check its mutability
+	// transition, but only when the constraint below succeeds — an ill-typed
+	// reassignment must not seed a false-positive transition error off types that
+	// never matched. assignErrsBefore captures the pre-constraint error count.
+	assignErrsBefore := len(c.errs)
 	if b.ModuleLevel {
 		// This is a global write, a store into module-level storage that lives for the
 		// program's whole run. Any borrow the value carries must outlive every borrow
@@ -782,6 +809,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		}
 	} else {
 		c.constrainAssign(e, sourceT, targetT)
+	}
+	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
+		c.trackAliasesForAssignment(target, e.Right, targetT, assignStmt)
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
@@ -842,8 +872,15 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 			Inexact: true, // "must accept a write to this field," not a full shape
 		},
 	}
+	errsBefore := len(c.errs)
 	c.constrain(e, recv, req)
 	c.recordWritten(recv, m.Prop.Name, w)
+	// M4 G1: when the written value aliases a variable, merge the receiver's and the
+	// source's alias sets so a later transition off either sees the shared value. Only
+	// when the write type-checked, so a rejected write does not record a bogus alias.
+	if c.fn != nil && len(c.errs) == errsBefore {
+		c.trackAliasesForPropAssignment(e.Left, e.Right)
+	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.
 	c.recordType(e, w)

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -45,6 +45,12 @@ func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) (soltype.Type,
 // and overwrites the name's slot in the current scope, so redeclaration rebinds
 // without constraining the old and new types together.
 func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
+	// M4 G1: record the enclosing statement so a reassignment in expression position
+	// can find its CFG StmtRef for transition checking. A no-op outside a function
+	// body (c.fn == nil), where no liveness analysis ran.
+	if c.fn != nil {
+		c.fn.currentStmt = s
+	}
 	switch s := s.(type) {
 	case *ast.ExprStmt:
 		return c.inferExpr(scope, lvl, s.Expr)
@@ -89,7 +95,17 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		// missing initializer itself and returns ok=false; bind only when it
 		// produced a type.
 		if b, ok := c.inferVarDecl(scope, lvl, vd); ok {
+			// M4 G1: carry the rename-assigned VarID onto the binding so a later
+			// closure capture resolves this body-level binding to its alias set, then
+			// track the alias the declaration creates and check its mutability
+			// transition. Both are no-ops outside a function body (c.fn == nil).
+			if ip, ok := vd.Pattern.(*ast.IdentPat); ok && ip.VarID > 0 {
+				b.VarID = ip.VarID
+			}
 			scope.defineValue(name, b) // overwrite ⇒ same-name redeclaration rebinds
+			if c.fn != nil {
+				c.trackAliasesForVarDecl(scope, vd, bindingType(b), s)
+			}
 		}
 		return &soltype.Void{}
 	default:

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -323,50 +323,31 @@ func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
 // mut→immutable (Rule 1) transition error from source, not just that it stays silent on
 // benign bodies.
 //
-// Before split-5 the only owned-mutable value is a `mut` parameter. Binding one into an
-// owned immutable slot is also a borrow escape, so a "does not live long enough"
-// lifetime error is reported alongside the transition error. Split-5 adds fresh-literal
-// owned-mutable construction, which removes the borrow escape and lets
-// TestMutabilityTransitionsFromSource assert the transition error in isolation. The two
-// arms below share the same alias and differ only in whether the mutable source stays
-// live, so the presence or absence of the transition error shows liveness — not the
-// lifetime check — is what gates it.
+// Before split-5 the only owned-mutable value is a `mut` parameter, so p (mut) is aliased
+// into immutable q and then mutated, leaving both live across the alias. Rule 1 fires.
+//
+// A second error rides along: binding the `mut` borrow into the owned slot `q` is a borrow
+// escape, so "does not live long enough" is reported too. That escape is a known divergence
+// from internal/checker, which accepts this binding — G3 removes it by reborrowing the
+// initializer instead of treating q as an owned slot. The clean dead-source variant, where
+// only the transition rule is in play, is covered without the escape by
+// TestMutabilityTransitionsFromSource (Rule1_SourceDead_OK) once split-5 supplies an owned
+// mutable value, and by TestCheckMutabilityTransition over constructed state. So this test
+// asserts only the live-source case and pins both messages, escape included.
 func TestTransitionWiringReportsRule1Error(t *testing.T) {
-	allMessages := func(errs []SolverError) []string {
-		msgs := make([]string, len(errs))
-		for i, e := range errs {
-			msgs[i] = e.Message()
+	_, _, errs := inferSource(t, `
+		fn test(p: mut {x: number}) {
+			val q: {x: number} = p
+			p.x = 5
+			q.x
 		}
-		return msgs
+	`)
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Message()
 	}
-
-	t.Run("source_live_reports_transition", func(t *testing.T) {
-		// p (mut) is aliased into immutable q and then mutated, so both are live across
-		// the alias. Rule 1 fires, accompanied by the borrow-escape lifetime error.
-		_, _, errs := inferSource(t, `
-			fn test(p: mut {x: number}) {
-				val q: {x: number} = p
-				p.x = 5
-				q.x
-			}
-		`)
-		require.ElementsMatch(t, []string{
-			"borrowed value mut object does not live long enough to satisfy object",
-			"cannot assign 'p' to immutable 'q': 'p' is still used mutably after this point",
-		}, allMessages(errs))
-	})
-
-	t.Run("source_dead_no_transition", func(t *testing.T) {
-		// The same alias, but p is never used after q is created, so the mutable source
-		// is dead and Rule 1 stays silent. Only the borrow-escape error remains.
-		_, _, errs := inferSource(t, `
-			fn test(p: mut {x: number}) {
-				val q: {x: number} = p
-				q.x
-			}
-		`)
-		require.ElementsMatch(t, []string{
-			"borrowed value mut object does not live long enough to satisfy object",
-		}, allMessages(errs))
-	})
+	require.ElementsMatch(t, []string{
+		"borrowed value mut object does not live long enough to satisfy object",
+		"cannot assign 'p' to immutable 'q': 'p' is still used mutably after this point",
+	}, msgs)
 }

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -317,3 +317,56 @@ func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestTransitionWiringReportsRule1Error is the error counterpart to
+// TestTransitionWiringNoSpuriousErrors: it proves the wired pre-pass reports a real
+// mut→immutable (Rule 1) transition error from source, not just that it stays silent on
+// benign bodies.
+//
+// Before split-5 the only owned-mutable value is a `mut` parameter. Binding one into an
+// owned immutable slot is also a borrow escape, so a "does not live long enough"
+// lifetime error is reported alongside the transition error. Split-5 adds fresh-literal
+// owned-mutable construction, which removes the borrow escape and lets
+// TestMutabilityTransitionsFromSource assert the transition error in isolation. The two
+// arms below share the same alias and differ only in whether the mutable source stays
+// live, so the presence or absence of the transition error shows liveness — not the
+// lifetime check — is what gates it.
+func TestTransitionWiringReportsRule1Error(t *testing.T) {
+	allMessages := func(errs []SolverError) []string {
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Message()
+		}
+		return msgs
+	}
+
+	t.Run("source_live_reports_transition", func(t *testing.T) {
+		// p (mut) is aliased into immutable q and then mutated, so both are live across
+		// the alias. Rule 1 fires, accompanied by the borrow-escape lifetime error.
+		_, _, errs := inferSource(t, `
+			fn test(p: mut {x: number}) {
+				val q: {x: number} = p
+				p.x = 5
+				q.x
+			}
+		`)
+		require.ElementsMatch(t, []string{
+			"borrowed value mut object does not live long enough to satisfy object",
+			"cannot assign 'p' to immutable 'q': 'p' is still used mutably after this point",
+		}, allMessages(errs))
+	})
+
+	t.Run("source_dead_no_transition", func(t *testing.T) {
+		// The same alias, but p is never used after q is created, so the mutable source
+		// is dead and Rule 1 stays silent. Only the borrow-escape error remains.
+		_, _, errs := inferSource(t, `
+			fn test(p: mut {x: number}) {
+				val q: {x: number} = p
+				q.x
+			}
+		`)
+		require.ElementsMatch(t, []string{
+			"borrowed value mut object does not live long enough to satisfy object",
+		}, allMessages(errs))
+	})
+}

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -251,3 +251,69 @@ func TestCollectOuterBindingsPreludeCache(t *testing.T) {
 	// the result.
 	require.Equal(t, first, c.collectOuterBindings(scope))
 }
+
+// TestTransitionReassignNestedRHS guards the currentStmt fix: a reassignment whose
+// RHS contains statements (`b = if cond { … } else { … }`) re-enters inferStmt while
+// walking the RHS, which overwrites c.fn.currentStmt. The reassignment transition path
+// must use the statement captured before the RHS walk, not the clobbered field, so it
+// resolves the correct CFG StmtRef. The body type-checks with no spurious error.
+func TestTransitionReassignNestedRHS(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test(cond: boolean) {
+			var b = 0
+			b = if cond { 1 } else { 2 }
+			b
+		}
+	`)
+	require.Empty(t, errs)
+}
+
+// TestTransitionWiringNoSpuriousErrors confirms the liveness pre-pass is wired into
+// function-body inference and that the alias-tracking paths run over real bodies
+// without inventing a transition error. Each case type-checks cleanly, so any
+// MutabilityTransitionError would be a wiring bug. The cases exercise the decl-alias
+// branches and parameter seeding end to end, which the constructed-state unit tests
+// above do not.
+func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
+	tests := map[string]string{
+		// Immutable owned objects aliased down a chain. No mutability, no transition.
+		"immutable_chain": `
+			fn test() {
+				val a = {x: 1}
+				val b = a
+				val c = b
+				c
+			}
+		`,
+		// Single-source decl alias: an immutable param aliased to a val exercises the
+		// AliasSourceVariable branch of trackAliasesForIdentPat.
+		"single_source_alias": `
+			fn test(q: {y: number}) {
+				val r = q
+				r
+			}
+		`,
+		// Multi-source decl alias: an if/else over two params makes the binding alias
+		// both, exercising the AliasSourceMultiple branch.
+		"multi_source_alias": `
+			fn test(cond: boolean, a: {x: number}, b: {x: number}) {
+				val c = if cond { a } else { b }
+				c
+			}
+		`,
+		// A mut and an immutable parameter are seeded into the alias tracker, and a
+		// field write through the mut param walks the prop-assignment path.
+		"params_seeded": `
+			fn test(p: mut {x: number}, q: {y: number}) {
+				p.x = 5
+				q.y
+			}
+		`,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Empty(t, errs)
+		})
+	}
+}


### PR DESCRIPTION
Part 4/5 of splitting #750 into a reviewable stack.

Turns the part-3 machinery on. `inferFunc` runs `runLivenessPrePass` before walking a body and records each parameter's VarID; `inferStmt` sets the enclosing statement and tracks the alias a body-level decl creates; `inferAssign` snapshots the enclosing statement *before* the RHS walk and tracks reassignment transitions; `inferMemberAssign` merges alias sets for a property write. Mutability transitions are now checked over real function bodies.

The wiring tests confirm the pass runs without inventing transition errors on benign bodies (decl-alias branches, parameter seeding) and that the `currentStmt` snapshot keeps a reassignment with a nested-statement RHS on the right CFG program point.

**Stack** (merge bottom-up): split-1 → split-2 → split-3 → **split-4-wire-prepass (this PR)** → split-5-owned-mut-construction.

Base: `claude/split-3-transition-machinery`. Green: `internal/solver` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Niass7yiLFrQHQZaYbP1A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mutation transition validation across reassignment and variable declaration scenarios.

---

**Note:** This release contains internal infrastructure improvements and testing enhancements with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->