### PR TITLE
Add destructuring patterns for function params and body-level bindings (M4 E1)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -457,6 +457,22 @@ func printPat(pat Pat) (string, bool) {
 			parts[i] = printObjectKeyName(f.Name) + ": " + s
 		}
 		return "{" + strings.Join(parts, ", ") + "}", true
+	case *ExtractorPat:
+		parts := make([]string, len(p.Args))
+		for i, a := range p.Args {
+			s, ok := printPat(a)
+			if !ok {
+				s = "_"
+			}
+			parts[i] = s
+		}
+		return p.Name + "(" + strings.Join(parts, ", ") + ")", true
+	case *InstancePat:
+		obj, ok := printPat(p.Object)
+		if !ok {
+			obj = "{}"
+		}
+		return p.ClassName + " " + obj, true
 	}
 	return "", false
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -444,8 +444,8 @@ func printPat(pat Pat) (string, bool) {
 	case *ObjectPat:
 		parts := make([]string, len(p.Fields))
 		for i, f := range p.Fields {
-			// A shorthand `{x}` is a field whose value is the IdentPat `x`; render it
-			// as the bare key. Any other sub-pattern renders `name: subpat`.
+			// A shorthand `{x}` is a field whose value is the IdentPat `x`, so render
+			// it as the bare key. Any other sub-pattern renders `name: subpat`.
 			if ip, ok := f.Value.(*IdentPat); ok && ip.Name == f.Name {
 				parts[i] = printObjectKeyName(f.Name)
 				continue

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -413,10 +413,52 @@ func (p *namedPrinter) printFuncTail(t *FuncType) string {
 // `?` marker is appended by printFuncTail, not here, so callers that only want
 // the bare name (none today) stay unaffected.
 func paramName(p *FuncParam, i int) string {
-	if pat, ok := p.Pattern.(*IdentPat); ok {
-		return pat.Name
+	if s, ok := printPat(p.Pattern); ok {
+		return s
 	}
 	return "arg" + strconv.Itoa(i)
+}
+
+// printPat renders a parameter pattern in Escalier surface syntax (M4 E1). A
+// pattern carries only sub-patterns and literal values, never a Type, so it
+// renders without the namedPrinter's type context. ok=false for a nil or unknown
+// pattern, so paramName falls back to a positional name.
+func printPat(pat Pat) (string, bool) {
+	switch p := pat.(type) {
+	case *IdentPat:
+		return p.Name, true
+	case *WildcardPat:
+		return "_", true
+	case *LitPat:
+		return printLit(p.Lit), true
+	case *TuplePat:
+		parts := make([]string, len(p.Elems))
+		for i, e := range p.Elems {
+			s, ok := printPat(e)
+			if !ok {
+				s = "_"
+			}
+			parts[i] = s
+		}
+		return "[" + strings.Join(parts, ", ") + "]", true
+	case *ObjectPat:
+		parts := make([]string, len(p.Fields))
+		for i, f := range p.Fields {
+			// A shorthand `{x}` is a field whose value is the IdentPat `x`; render it
+			// as the bare key. Any other sub-pattern renders `name: subpat`.
+			if ip, ok := f.Value.(*IdentPat); ok && ip.Name == f.Name {
+				parts[i] = printObjectKeyName(f.Name)
+				continue
+			}
+			s, ok := printPat(f.Value)
+			if !ok {
+				s = "_"
+			}
+			parts[i] = printObjectKeyName(f.Name) + ": " + s
+		}
+		return "{" + strings.Join(parts, ", ") + "}", true
+	}
+	return "", false
 }
 
 // printObjectKeyName renders an object property name as Escalier surface syntax:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -263,6 +263,62 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
 }
 
+// A destructuring parameter renders its pattern (M4 E1). Each Pat concrete in the
+// sealed set has a printPat arm, including the M5 constructor patterns
+// ExtractorPat and InstancePat, which are forward-declared members of the set.
+func TestPrintDestructuringParamPatterns(t *testing.T) {
+	tests := []struct {
+		name string
+		pat  Pat
+		want string
+	}{
+		{
+			name: "object shorthand and rename",
+			pat: &ObjectPat{Fields: []*ObjectPatField{
+				{Name: "x", Value: &IdentPat{Name: "x"}},
+				{Name: "y", Value: &IdentPat{Name: "b"}},
+			}},
+			want: "{x, y: b}",
+		},
+		{
+			name: "tuple with wildcard",
+			pat:  &TuplePat{Elems: []Pat{&IdentPat{Name: "a"}, &WildcardPat{}}},
+			want: "[a, _]",
+		},
+		{
+			name: "literal",
+			pat:  &LitPat{Lit: &NumLit{Value: 5}},
+			want: "5",
+		},
+		{
+			name: "nested object in tuple",
+			pat: &TuplePat{Elems: []Pat{
+				&ObjectPat{Fields: []*ObjectPatField{{Name: "x", Value: &IdentPat{Name: "x"}}}},
+			}},
+			want: "[{x}]",
+		},
+		{
+			name: "extractor",
+			pat:  &ExtractorPat{Name: "Some", Args: []Pat{&IdentPat{Name: "v"}}},
+			want: "Some(v)",
+		},
+		{
+			name: "instance",
+			pat: &InstancePat{ClassName: "Point", Object: &ObjectPat{Fields: []*ObjectPatField{
+				{Name: "x", Value: &IdentPat{Name: "x"}},
+				{Name: "y", Value: &IdentPat{Name: "y"}},
+			}}},
+			want: "Point {x, y}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := &FuncType{Params: []*FuncParam{{Pattern: tt.pat, Type: numP()}}, Ret: boolP()}
+			require.Equal(t, "fn ("+tt.want+": number) -> boolean", Print(fn))
+		})
+	}
+}
+
 // TestPrintScheme covers the M3 quantifier-prefix rendering: a generalized type's
 // free variables are collected into a <T0, T1, …> prefix (named by first
 // appearance in print order) and rendered under those names, while a variable-free

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -109,7 +109,7 @@ func (*IdentPat) isPat() {}
 
 // TuplePat is a tuple destructuring pattern (M4 E1). Its sub-patterns are
 // positional. It is carried on a destructured FuncParam.Pattern so the parameter
-// renders and round-trips; the solver's pattern-typing helper produces it.
+// renders and round-trips. The solver's pattern-typing helper produces it.
 type TuplePat struct{ Elems []Pat }
 
 func (*TuplePat) isPat() {}
@@ -127,8 +127,8 @@ type ObjectPatField struct {
 	Value Pat
 }
 
-// LitPat matches a literal value (M4 E1). It binds nothing; it is carried for
-// rendering and (E2) match-arm typing.
+// LitPat matches a literal value (M4 E1). It binds nothing. It is carried for
+// rendering and for E2's match-arm typing.
 type LitPat struct{ Lit Lit }
 
 func (*LitPat) isPat() {}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -138,6 +138,30 @@ type WildcardPat struct{}
 
 func (*WildcardPat) isPat() {}
 
+// ExtractorPat is a constructor/extractor pattern such as `Some(v)` or
+// `Point(x, y)`. The solver does not yet produce it; it is a forward-declared
+// member of the sealed set, the structural mirror of ast.ExtractorPat, and lands
+// with the constructor patterns in M5. Name is the qualified constructor name
+// rendered as a string, since soltype stays ast-free. Args are positional
+// sub-patterns.
+type ExtractorPat struct {
+	Name string
+	Args []Pat
+}
+
+func (*ExtractorPat) isPat() {}
+
+// InstancePat is a class-instance pattern such as `Point { x, y }`. Like
+// ExtractorPat it is forward-declared here, the mirror of ast.InstancePat, and
+// lands with classes in M5. ClassName is the qualified class name as a string;
+// Object is the field sub-pattern.
+type InstancePat struct {
+	ClassName string
+	Object    *ObjectPat
+}
+
+func (*InstancePat) isPat() {}
+
 // FuncParam mirrors type_system.FuncParam. Pattern is reachable only through Pat
 // concretes M1 defines (IdentPat). M3 (PR4) adds Optional: an `x?` parameter
 // lowers the function's `required` count (the accept-set lower bound) without

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -107,6 +107,37 @@ type IdentPat struct{ Name string }
 
 func (*IdentPat) isPat() {}
 
+// TuplePat is a tuple destructuring pattern (M4 E1). Its sub-patterns are
+// positional. It is carried on a destructured FuncParam.Pattern so the parameter
+// renders and round-trips; the solver's pattern-typing helper produces it.
+type TuplePat struct{ Elems []Pat }
+
+func (*TuplePat) isPat() {}
+
+// ObjectPat is an object destructuring pattern (M4 E1). Each field names a
+// property and binds its value through a sub-pattern. A bare `{x}` shorthand is
+// an ObjectPatField whose Value is an IdentPat of the same name.
+type ObjectPat struct{ Fields []*ObjectPatField }
+
+func (*ObjectPat) isPat() {}
+
+// ObjectPatField is one `name: subpat` entry of an ObjectPat.
+type ObjectPatField struct {
+	Name  string
+	Value Pat
+}
+
+// LitPat matches a literal value (M4 E1). It binds nothing; it is carried for
+// rendering and (E2) match-arm typing.
+type LitPat struct{ Lit Lit }
+
+func (*LitPat) isPat() {}
+
+// WildcardPat (`_`) matches anything and binds nothing (M4 E1).
+type WildcardPat struct{}
+
+func (*WildcardPat) isPat() {}
+
 // FuncParam mirrors type_system.FuncParam. Pattern is reachable only through Pat
 // concretes M1 defines (IdentPat). M3 (PR4) adds Optional: an `x?` parameter
 // lowers the function's `required` count (the accept-set lower bound) without

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -293,30 +293,38 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	}, true
 }
 
-// inferDestructureDecl types a body-level destructuring `val`/`var` (M4 E1):
-// `val {x, y} = p`, `val [a, b] = t`. It types the initializer through the shared
-// inferVarDeclInit core — so an annotation is honored and a `var` initializer is
-// widened — then binds the pattern's leaves against that type via bindPattern.
+// inferDestructureDecl types a body-level destructuring `val`/`var` such as
+// `val {x, y} = p` or `val [a, b] = t` (M4 E1). It types the initializer through
+// the shared inferVarDeclInit core, so an annotation is honored and a `var`
+// initializer is widened, then binds the pattern's leaves against that type via
+// bindPattern.
 //
 // The leaves are MONOMORPHIC projections of the initializer, not independently
-// generalized bindings: a destructured name reads a slot of the initializer, so
+// generalized bindings. A destructured name reads a slot of the initializer, so
 // it shares that slot's type rather than quantifying over it. Top-level
-// destructuring (`val {x, y} = p` at module scope) still defers — it needs the
-// SCC driver to bind several names from one decl — so this path is body-level
-// only; inferDeclDef reports a top-level destructuring decl as unsupported.
+// destructuring at module scope still defers. It needs the SCC driver to bind
+// several names from one decl, so this path is body-level only and inferDeclDef
+// reports a top-level destructuring decl as unsupported.
+//
+// After binding, the leaves are wired into the liveness machinery so a closure
+// capturing a leaf resolves its alias set and a mutability transition through it
+// is checked. This is the per-leaf analogue of the IdentPat path's VarID copy
+// plus trackAliasesForVarDecl.
 func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 	initType, ok := c.inferVarDeclInit(scope, lvl, d)
 	if !ok {
 		return
 	}
 	c.bindPattern(scope, lvl, d.Pattern, initType, nil)
+	c.trackDestructureLeaves(scope, d.Pattern)
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
 // ok=false for any other pattern shape. M2 binds IdentPat-only patterns,
-// mirroring M1's IdentPat-only FuncParam; body-level destructuring (`val [a, b] =
-// …`) is handled by inferDestructureDecl (M4 E1), top-level destructuring still
-// defers (it needs the SCC driver to bind several names from one decl).
+// mirroring M1's IdentPat-only FuncParam. Body-level destructuring such as
+// `val [a, b] = …` is handled by inferDestructureDecl (M4 E1). Top-level
+// destructuring still defers, since it needs the SCC driver to bind several names
+// from one decl.
 func varName(d *ast.VarDecl) (string, bool) {
 	if p, ok := d.Pattern.(*ast.IdentPat); ok {
 		return p.Name, true

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -293,10 +293,30 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	}, true
 }
 
+// inferDestructureDecl types a body-level destructuring `val`/`var` (M4 E1):
+// `val {x, y} = p`, `val [a, b] = t`. It types the initializer through the shared
+// inferVarDeclInit core — so an annotation is honored and a `var` initializer is
+// widened — then binds the pattern's leaves against that type via bindPattern.
+//
+// The leaves are MONOMORPHIC projections of the initializer, not independently
+// generalized bindings: a destructured name reads a slot of the initializer, so
+// it shares that slot's type rather than quantifying over it. Top-level
+// destructuring (`val {x, y} = p` at module scope) still defers — it needs the
+// SCC driver to bind several names from one decl — so this path is body-level
+// only; inferDeclDef reports a top-level destructuring decl as unsupported.
+func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
+	initType, ok := c.inferVarDeclInit(scope, lvl, d)
+	if !ok {
+		return
+	}
+	c.bindPattern(scope, lvl, d.Pattern, initType, nil)
+}
+
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
 // ok=false for any other pattern shape. M2 binds IdentPat-only patterns,
-// mirroring M1's IdentPat-only FuncParam; destructuring (`val [a, b] = …`)
-// arrives in M4 once tuple/record types exist (§3.2).
+// mirroring M1's IdentPat-only FuncParam; body-level destructuring (`val [a, b] =
+// …`) is handled by inferDestructureDecl (M4 E1), top-level destructuring still
+// defers (it needs the SCC driver to bind several names from one decl).
 func varName(d *ast.VarDecl) (string, bool) {
 	if p, ok := d.Pattern.(*ast.IdentPat); ok {
 		return p.Name, true

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -195,46 +195,52 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 				v.Open = true
 			}
 		}
-		name, ok := identPatName(p.Pattern)
-		var sources []provenance.Provenance
-		if !ok {
-			// Destructuring params (TuplePat/ObjectPat) need record/tuple types —
-			// they arrive in M4. M2 binds IdentPat only. A non-nil pattern blames
-			// itself (its own narrower span); a pattern-less param (not reachable
-			// from the real parser) blames the enclosing function, since Param.Span()
-			// dereferences the nil pattern — honoring M2's "never a panic" guarantee.
-			if p.Pattern != nil {
-				c.reportUnsupported(p.Pattern)
-			} else {
-				c.reportUnsupported(node)
-			}
-			name = fmt.Sprintf("arg%d", i)
-			// Leave sources empty: the synthetic arg%d name is not a real place, so
-			// there is nothing useful for go-to-definition or a related span to point at.
-		} else {
+		if name, ok := identPatName(p.Pattern); ok {
 			// The param's IdentPat IS its definition site, so record it as the binding's
 			// source — symmetric to a val/var/fn binding (inferVarDecl/module.go). This
 			// lets CannotAssignToImmutableError point "declared immutable here" at the
 			// parameter (see bindingDecl). p.Pattern is an ast.Node (*ast.Param is not).
-			sources = []provenance.Provenance{&ast.NodeProvenance{Node: p.Pattern}}
+			sources := []provenance.Provenance{&ast.NodeProvenance{Node: p.Pattern}}
 			if p.TypeAnn == nil {
 				// An un-annotated param's type is the fresh var minted here, so a
 				// param-type mismatch blames the param. An annotated param's blame
 				// instead rides on its annotation, recorded by resolveTypeAnn.
 				c.recordProv(pt, p.Pattern, ParamBinding)
 			}
+			// A parameter binding never generalizes — its var is fixed for the body — so
+			// it is a MonoScheme; instantiate returns pt unchanged at every use.
+			fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}, Sources: sources})
+			paramTypes[name] = pt
+			// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
+			// `required` count without dropping the param — carried onto the soltype so
+			// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
+			// in-body binding keeps the param's declared type (pt), NOT widened to
+			// `pt | undefined`, so a body that reads an omitted optional sees it at the
+			// narrower type. Widening needs undefined/unions (M6); M3 has neither.
+			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
+		} else if p.Pattern != nil {
+			// M4 E1: a destructuring parameter ({x, y}, [a, b]). bindPattern binds each
+			// leaf into the function scope against the param's type and returns the
+			// soltype mirror the printer renders. It also writes each leaf's type into
+			// paramTypes (keyed by leaf name) so the liveness pre-pass seeds the leaf's
+			// alias mutability. An un-annotated destructuring param mints a fresh var
+			// (pt) whose mismatch blame should point at the pattern.
+			if p.TypeAnn == nil {
+				c.recordProv(pt, p.Pattern, ParamBinding)
+			}
+			mirror := c.bindPattern(fnScope, lvl, p.Pattern, pt, paramTypes)
+			params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}
+		} else {
+			// A pattern-less param is not reachable from the real parser, which
+			// synthesizes a placeholder; blame the enclosing function rather than a nil
+			// Span(), honoring the "never a panic" guarantee. Bind a synthetic name so
+			// the param slot still types.
+			c.reportUnsupported(node)
+			name := fmt.Sprintf("arg%d", i)
+			fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
+			paramTypes[name] = pt
+			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 		}
-		// A parameter binding never generalizes — its var is fixed for the body — so
-		// it is a MonoScheme; instantiate returns pt unchanged at every use.
-		fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}, Sources: sources})
-		paramTypes[name] = pt
-		// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
-		// `required` count without dropping the param — carried onto the soltype so
-		// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
-		// in-body binding keeps the param's declared type (pt), NOT widened to
-		// `pt | undefined`, so a body that reads an omitted optional sees it at the
-		// narrower type. Widening needs undefined/unions (M6); M3 has neither.
-		params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 	}
 
 	var ret soltype.Type = &soltype.Void{}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -219,12 +219,12 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// narrower type. Widening needs undefined/unions (M6); M3 has neither.
 			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 		} else if p.Pattern != nil {
-			// M4 E1: a destructuring parameter ({x, y}, [a, b]). bindPattern binds each
-			// leaf into the function scope against the param's type and returns the
-			// soltype mirror the printer renders. It also writes each leaf's type into
-			// paramTypes (keyed by leaf name) so the liveness pre-pass seeds the leaf's
-			// alias mutability. An un-annotated destructuring param mints a fresh var
-			// (pt) whose mismatch blame should point at the pattern.
+			// M4 E1: a destructuring parameter such as `{x, y}` or `[a, b]`. bindPattern
+			// binds each leaf into the function scope against the param's type and returns
+			// the soltype mirror the printer renders. It also writes each leaf's type into
+			// paramTypes, keyed by leaf name, so the liveness pre-pass seeds the leaf's
+			// alias mutability. An un-annotated destructuring param mints a fresh var pt
+			// whose mismatch blame should point at the pattern.
 			if p.TypeAnn == nil {
 				c.recordProv(pt, p.Pattern, ParamBinding)
 			}
@@ -232,7 +232,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}
 		} else {
 			// A pattern-less param is not reachable from the real parser, which
-			// synthesizes a placeholder; blame the enclosing function rather than a nil
+			// synthesizes a placeholder. Blame the enclosing function rather than a nil
 			// Span(), honoring the "never a panic" guarantee. Bind a synthetic name so
 			// the param slot still types.
 			c.reportUnsupported(node)

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -152,7 +152,7 @@ func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 }
 
 // A destructuring parameter binds its leaves and renders its pattern (M4 E1). The
-// leaves below go unused, so each slot coalesces to `unknown`; the point is that
+// leaves below go unused, so each slot coalesces to `unknown`. The point is that
 // the param is accepted and rendered, not reported as unsupported.
 func TestInferFuncExprDestructuringParam(t *testing.T) {
 	c := newChecker()

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -151,18 +151,21 @@ func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-func TestInferFuncExprDestructuringParamUnsupported(t *testing.T) {
+// A destructuring parameter binds its leaves and renders its pattern (M4 E1). The
+// leaves below go unused, so each slot coalesces to `unknown`; the point is that
+// the param is accepted and rendered, not reported as unsupported.
+func TestInferFuncExprDestructuringParam(t *testing.T) {
 	c := newChecker()
-	// fn ([a, b]) { ... } — destructuring params are M4.
+	// fn ([a, b]) { 1 }
 	tuplePat := ast.NewTuplePat([]ast.Pat{
 		ast.NewIdentPat("a", false, nil, nil, testSpan()),
 		ast.NewIdentPat("b", false, nil, nil, testSpan()),
 	}, testSpan())
 	e := funcExpr([]*ast.Param{{Pattern: tuplePat}}, nil, block(exprStmt(numExpr(1))))
 
-	c.inferExpr(NewScope(), 0, e)
-	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported: TuplePat", c.errs[0].Message())
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "fn ([a, b]: [unknown, unknown]) -> void", render(got))
 }
 
 // A generic function (fn <T>() { ... }) is diagnosed rather than silently erased

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -123,3 +123,137 @@ func TestInferTuplePatternWildcard(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "fn (t: [number, string]) -> number", values["f"])
 }
+
+// A leaf type annotation is enforced: annotating a field whose scrutinee type
+// conflicts is a constraint error, not a silently dropped annotation.
+func TestInferObjectPatternLeafTypeAnnConflict(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {x :: string} = p
+			return x
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain number <: string", errs[0].Message())
+}
+
+// A matching leaf type annotation checks and is adopted as the leaf's type.
+func TestInferObjectPatternLeafTypeAnnAdopted(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {x :: number} = p
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number}) -> number", values["f"])
+}
+
+// A field default makes the field optional, so destructuring an absent field
+// that carries a default binds the default's type instead of reporting a missing
+// property.
+func TestInferObjectPatternLeafDefault(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {z = 0} = p
+			return z
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number}) -> 0", values["f"])
+}
+
+// A trailing rest element relaxes the tuple requirement to an inexact prefix, so
+// the fixed slots bind without a spurious arity error. The rest element itself is
+// reported unsupported, since typed rest tuples are M9.
+func TestInferTuplePatternRestPrefix(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(t: [number, string, boolean]) {
+			val [a, ...rest] = t
+			return a
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported: RestPat", errs[0].Message())
+	require.Equal(t, "fn (t: [number, string, boolean]) -> number", values["f"])
+}
+
+// A closure capturing a destructured leaf resolves the leaf's binding. This
+// exercises the liveness wiring: the leaf's rename-assigned VarID is copied onto
+// its binding, so trackCapturedAliases finds it instead of skipping a VarID-0
+// binding.
+func TestInferDestructuredLeafClosureCapture(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {x} = p
+			val g = fn () { return x }
+			return g()
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number}) -> number", values["f"])
+}
+
+// A `var` tuple destructuring widens each leaf to its primitive, the B3 widening
+// applied through the initializer.
+func TestInferVarTupleDestructureWidens(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f() {
+			var [a, b] = [1, 2]
+			return [a, b]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> [number, number]", values["f"])
+}
+
+// A `var` object destructuring widens its leaf the same way.
+func TestInferVarObjectDestructureWidens(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f() {
+			var {x} = {x: 5}
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> number", values["f"])
+}
+
+// Destructuring a `mut` borrow scrutinee peels the borrow via CarrierOf and binds
+// the borrowed field values, just as a member read through the borrow would.
+func TestInferDestructureBorrowScrutinee(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: mut {x: number, y: string}) {
+			val {x, y} = p
+			return [x, y]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {x: number, y: string}) -> [number, string]", values["f"])
+}
+
+// A default is checked against an explicit leaf annotation: a default that the
+// annotation rejects is a constraint error.
+func TestInferObjectPatternLeafDefaultViolatesAnnotation(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {x :: number = "hi"} = p
+			return x
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+}
+
+// Patterns nest across kinds: an object pattern whose field is a tuple pattern
+// binds the inner slots at the nested element types.
+func TestInferObjectContainingTuplePattern(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(o: {pt: [number, string]}) {
+			val {pt: [a, b]} = o
+			return [b, a]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (o: {pt: [number, string]}) -> [string, number]", values["f"])
+}

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -1,0 +1,125 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M4 E1: structural destructuring patterns ---
+
+// An object pattern in a `val` binds each named field at its field type. The
+// function below reads the bound names back, so the inferred return shows the
+// binding worked.
+func TestInferValObjectPatternBinds(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number, y: string}) {
+			val {x, y} = p
+			return [x, y]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number, y: string}) -> [number, string]", values["f"])
+}
+
+// An object pattern may bind a SUBSET of the scrutinee's fields: the per-field
+// requirement is inexact ("has at least this field"), so the unmentioned `y` is
+// tolerated.
+func TestInferValObjectPatternPartial(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number, y: string}) {
+			val {x} = p
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number, y: string}) -> number", values["f"])
+}
+
+// Destructuring a field the scrutinee lacks is a MissingPropertyError, blamed at
+// the pattern field.
+func TestInferValObjectPatternMissingField(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number}) {
+			val {z} = p
+			return z
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: z", errs[0].Message())
+}
+
+// A tuple pattern binds per slot at the slot's element type. Reordering the bound
+// names in the result confirms each slot bound the right element.
+func TestInferValTuplePatternBinds(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn h(t: [number, string]) {
+			val [a, b] = t
+			return [b, a]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (t: [number, string]) -> [string, number]", values["h"])
+}
+
+// A tuple pattern is exact in arity: binding more (or fewer) slots than the
+// scrutinee has is a TupleLengthMismatchError.
+func TestInferValTuplePatternWrongArity(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn h(t: [number, string]) {
+			val [a, b, c] = t
+			return a
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 3", errs[0].Message())
+}
+
+// A destructuring parameter types like a `val` destructuring of the argument: the
+// leaves bind, and the parameter renders its pattern.
+func TestInferObjectPatternParam(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn g({x, y}: {x: number, y: string}) {
+			return [x, y]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn ({x, y}: {x: number, y: string}) -> [number, string]", values["g"])
+}
+
+// An UN-annotated destructuring parameter infers its shape from the leaves' uses
+// (usage-based inference), closing the coalesced object to exact (Policy A).
+func TestInferObjectPatternParamInferred(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn g({a, b}) {
+			return [a, b]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0, T1>({a, b}: {a: T0, b: T1}) -> [T0, T1]", values["g"])
+}
+
+// Patterns nest: an object pattern whose field is itself an object pattern binds
+// the inner leaves at the nested field types.
+func TestInferNestedObjectPattern(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {pt: {x: number, y: string}}) {
+			val {pt: {x, y}} = p
+			return [x, y]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {pt: {x: number, y: string}}) -> [number, string]", values["f"])
+}
+
+// A wildcard slot in a tuple pattern matches without binding a name.
+func TestInferTuplePatternWildcard(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(t: [number, string]) {
+			val [a, _] = t
+			return a
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (t: [number, string]) -> number", values["f"])
+}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -87,9 +87,9 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				c.reportUnsupported(vd)
 				return &soltype.Void{}
 			}
-			// M4 E1: a destructuring `val`/`var` ({x, y} = …, [a, b] = …). Type the
-			// initializer, then bind the pattern's leaves against it as monomorphic
-			// projections.
+			// M4 E1: a destructuring `val`/`var` such as `{x, y} = …` or `[a, b] = …`.
+			// Type the initializer, then bind the pattern's leaves against it as
+			// monomorphic projections.
 			c.inferDestructureDecl(scope, lvl, vd)
 			return &soltype.Void{}
 		}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -83,11 +83,14 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		if !named {
 			// A nil pattern (hand-built AST; the parser synthesizes a placeholder)
 			// blames the decl, mirroring inferFunc — never a nil-node Span() panic.
-			if vd.Pattern != nil {
-				c.reportUnsupported(vd.Pattern)
-			} else {
+			if vd.Pattern == nil {
 				c.reportUnsupported(vd)
+				return &soltype.Void{}
 			}
+			// M4 E1: a destructuring `val`/`var` ({x, y} = …, [a, b] = …). Type the
+			// initializer, then bind the pattern's leaves against it as monomorphic
+			// projections.
+			c.inferDestructureDecl(scope, lvl, vd)
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -268,9 +268,9 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Equal(t, map[string]string{"y": "error"}, values)
 }
 
-// A TOP-LEVEL destructuring pattern still defers (M4 E1 adds body-level and
+// A TOP-LEVEL destructuring pattern still defers. M4 E1 adds body-level and
 // function-param destructuring, but a module-scope `val [a, b] = …` needs the SCC
-// driver to bind several names from one decl); the binding reports
+// driver to bind several names from one decl. The binding reports
 // UnsupportedNodeError and introduces no value. The initializer `[1, 2]` is a
 // tuple expression, which PR-4 now infers, so the only remaining error is the
 // destructuring pattern on the binding side.

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -268,10 +268,12 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Equal(t, map[string]string{"y": "error"}, values)
 }
 
-// A destructuring pattern is IdentPat-only-gated in M2 (M4 adds tuple/record
-// binding); the binding reports UnsupportedNodeError and introduces no value.
-// The initializer `[1, 2]` is a tuple expression, which PR-4 now infers, so the
-// only remaining error is the destructuring pattern on the binding side.
+// A TOP-LEVEL destructuring pattern still defers (M4 E1 adds body-level and
+// function-param destructuring, but a module-scope `val [a, b] = …` needs the SCC
+// driver to bind several names from one decl); the binding reports
+// UnsupportedNodeError and introduces no value. The initializer `[1, 2]` is a
+// tuple expression, which PR-4 now infers, so the only remaining error is the
+// destructuring pattern on the binding side.
 func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
 	src := `val [a, b] = [1, 2]`
 	values, _, errs := inferSource(t, src)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -9,27 +9,29 @@ import (
 // identifier the pattern introduces into scope and returning the soltype.Pat
 // mirror used to render a destructured parameter (M4 E1). It is the
 // structural-pattern path shared by `val`/`var` destructuring and function-param
-// destructuring; E2's `match` arms reuse it too.
+// destructuring. E2's `match` arms reuse it too.
 //
-// A pattern dispatches through the member-lookup constraint path, NOT subtyping.
+// A pattern dispatches through the member-lookup constraint path, not subtyping.
 // An ObjectPat `{x, y}` against a scrutinee `s` emits `s <: {x: βx, ...}` and
-// `s <: {y: βy, ...}` — the same inexact, one-property requirement inferMember
-// mints for a field read — and binds x/y to βx/βy. Because each requirement is
-// inexact, a pattern may bind a SUBSET of the scrutinee's fields. A TuplePat
-// `[a, b]` emits `s <: [αa, αb]` (an EXACT tuple, so a wrong arity is rejected).
-// Only a field the scrutinee lacks, or a wrong tuple arity, is rejected,
-// surfacing MissingPropertyError / TupleLengthMismatchError. The scrutinee's
-// borrow wrapper is peeled first (CarrierOf), so a destructured borrow binds the
+// `s <: {y: βy, ...}`, then binds x/y to βx/βy. Each requirement is the inexact,
+// one-property requirement inferMember mints for a field read, so a pattern may
+// bind a SUBSET of the scrutinee's fields. A TuplePat `[a, b]` emits
+// `s <: [αa, αb]`, an exact tuple whose wrong arity is rejected. A trailing
+// `...rest` relaxes that to an inexact prefix requirement. Only a field the
+// scrutinee lacks, or a wrong tuple arity, is rejected, surfacing
+// MissingPropertyError or TupleLengthMismatchError. The scrutinee's borrow
+// wrapper is peeled first via CarrierOf, so a destructured borrow binds the
 // borrowed contents, just as a member read does.
 //
 // leafTypes, when non-nil, receives each leaf binding's type keyed by name. The
 // function-param path passes its paramTypes map so the liveness pre-pass can seed
-// each leaf's alias mutability; other callers pass nil.
+// each leaf's alias mutability. Other callers pass nil.
 func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
 	case *ast.IdentPat:
-		c.bindLeaf(scope, p.Name, scrutinee, p, leafTypes)
+		t := c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
+		c.bindLeaf(scope, p.Name, t, p, leafTypes)
 		return &soltype.IdentPat{Name: p.Name}
 
 	case *ast.WildcardPat:
@@ -43,28 +45,43 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			return &soltype.WildcardPat{}
 		}
 		// A literal pattern asserts the literal is an admissible value of the
-		// scrutinee, so the literal flows INTO the scrutinee: `5 <: number` checks.
-		// This is exact against a concrete scrutinee (a top-level `match` arm). For a
-		// NESTED slot the scrutinee here is the field's covariant result var, which
-		// carries no upper bound, so a kind mismatch like `{x: "hi"}` against `{x:
-		// number}` is not yet rejected — the refutable literal-pattern check lands
-		// with E2's `match`, which this path is laid out to extend. A literal pattern
-		// binds nothing.
+		// scrutinee, so the literal flows INTO the scrutinee. `5 <: number` checks.
+		// The check is exact against a concrete scrutinee such as a top-level `match`
+		// arm. For a NESTED slot the scrutinee here is the field's covariant result
+		// var, which carries no upper bound. So a kind mismatch like `{x: "hi"}`
+		// against `{x: number}` is not yet rejected. The refutable literal-pattern
+		// check lands with E2's `match`, which this path is laid out to extend. A
+		// literal pattern binds nothing.
 		c.constrain(p, lt, scrutinee)
 		c.recordType(p, lt)
 		return &soltype.LitPat{Lit: lt.Lit}
 
 	case *ast.TuplePat:
-		elemTypes := make([]soltype.Type, len(p.Elems))
-		for i := range p.Elems {
+		// A trailing `...rest` element makes the pattern match any tuple at least as
+		// long as the fixed prefix, so the requirement becomes an INEXACT tuple over
+		// the fixed elements. Without a rest the requirement stays exact and a wrong
+		// arity is a TupleLengthMismatchError. The rest element itself needs typed
+		// rest tuples, which arrive in M9, so it is reported unsupported and binds
+		// nothing.
+		fixed := make([]ast.Pat, 0, len(p.Elems))
+		inexact := false
+		for _, e := range p.Elems {
+			if _, isRest := e.(*ast.RestPat); isRest {
+				inexact = true
+				c.reportUnsupported(e)
+				continue
+			}
+			fixed = append(fixed, e)
+		}
+		elemTypes := make([]soltype.Type, len(fixed))
+		for i := range fixed {
 			elemTypes[i] = c.freshAt(lvl)
 		}
-		// scrutinee <: [α0, …, αn] — an EXACT tuple requirement, so a wrong arity is
-		// a TupleLengthMismatchError. Each αi lowers from the scrutinee's matching
-		// element, so a sub-pattern binds at that element's type.
-		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes})
-		subs := make([]soltype.Pat, len(p.Elems))
-		for i, e := range p.Elems {
+		// Each αi lowers from the scrutinee's matching element, so a sub-pattern binds
+		// at that element's type.
+		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes, Inexact: inexact})
+		subs := make([]soltype.Pat, len(fixed))
+		for i, e := range fixed {
 			subs[i] = c.bindPattern(scope, lvl, e, elemTypes[i], leafTypes)
 		}
 		c.recordType(p, scrutinee)
@@ -75,16 +92,21 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		for _, elem := range p.Elems {
 			switch e := elem.(type) {
 			case *ast.ObjShorthandPat:
+				// A default makes the field optional. `{x = 0}` binds even when x is
+				// absent, so the requirement must not demand it.
 				beta := c.freshAt(lvl)
-				c.constrain(e, scrutinee, propReq(e.Key.Name, beta))
-				c.bindLeaf(scope, e.Key.Name, beta, e, leafTypes)
+				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, e.Default != nil))
+				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
+				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
 					Value: &soltype.IdentPat{Name: e.Key.Name},
 				})
 			case *ast.ObjKeyValuePat:
+				// A default on the value sub-pattern, as in `{x: a = 0}`, likewise makes
+				// the field optional.
 				beta := c.freshAt(lvl)
-				c.constrain(e, scrutinee, propReq(e.Key.Name, beta))
+				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, patternDefaultsField(e.Value)))
 				sub := c.bindPattern(scope, lvl, e.Value, beta, leafTypes)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			default:
@@ -96,11 +118,41 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		return &soltype.ObjectPat{Fields: fields}
 
 	default:
-		// ExtractorPat / InstancePat (constructor patterns) are M5; a bare RestPat is
-		// only meaningful inside a tuple/object. Report and bind nothing.
+		// ExtractorPat and InstancePat are the constructor patterns; they are M5. A
+		// bare RestPat is only meaningful inside a tuple or object. Report and bind
+		// nothing.
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
+}
+
+// applyLeafExtras resolves a destructured leaf's optional type annotation
+// (`{x :: T}`, `[a :: T]`) and default value (`{x = d}`, `[a = d]`) against its
+// slot type, returning the type to bind. An annotation constrains the slot to
+// satisfy it and is then adopted as the leaf's type, mirroring how an annotated
+// `val` adopts its annotation. A default is required to satisfy that bound type
+// and flows into it, so a leaf bound from an absent-but-defaulted field reads the
+// default's type rather than `never`.
+func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot soltype.Type, typeAnn ast.TypeAnn, def ast.Expr) soltype.Type {
+	bound := slot
+	if typeAnn != nil {
+		if annT, ok := c.resolveTypeAnn(typeAnn, lvl); ok {
+			c.constrain(node, slot, annT)
+			bound = annT
+		}
+	}
+	if def != nil {
+		defT := c.inferExpr(scope, lvl, def)
+		c.constrain(def, defT, bound)
+	}
+	return bound
+}
+
+// patternDefaultsField reports whether a destructured field's value sub-pattern
+// carries a default (`{x: a = 0}`), which makes the field optional.
+func patternDefaultsField(p ast.Pat) bool {
+	ip, ok := p.(*ast.IdentPat)
+	return ok && ip.Default != nil
 }
 
 // bindLeaf binds one identifier leaf to t in scope as a monomorphic projection of
@@ -116,10 +168,11 @@ func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.N
 
 // propReq builds the inexact one-property requirement `{name: t, ...}` — "the
 // receiver has at least this field" — the same shape inferMember's valueProp
-// mints for a field read.
-func propReq(name string, t soltype.Type) *soltype.ObjectType {
+// mints for a field read. optional marks the property `name?: t` so an absent
+// field is tolerated, which a destructuring default relies on.
+func propReq(name string, t soltype.Type, optional bool) *soltype.ObjectType {
 	return &soltype.ObjectType{
-		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: t}},
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: t, Optional: optional}},
 		Inexact: true,
 	}
 }

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -1,0 +1,139 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// bindPattern types an ast.Pat against a scrutinee type, binding every leaf
+// identifier the pattern introduces into scope and returning the soltype.Pat
+// mirror used to render a destructured parameter (M4 E1). It is the
+// structural-pattern path shared by `val`/`var` destructuring and function-param
+// destructuring; E2's `match` arms reuse it too.
+//
+// A pattern dispatches through the member-lookup constraint path, NOT subtyping.
+// An ObjectPat `{x, y}` against a scrutinee `s` emits `s <: {x: βx, ...}` and
+// `s <: {y: βy, ...}` — the same inexact, one-property requirement inferMember
+// mints for a field read — and binds x/y to βx/βy. Because each requirement is
+// inexact, a pattern may bind a SUBSET of the scrutinee's fields. A TuplePat
+// `[a, b]` emits `s <: [αa, αb]` (an EXACT tuple, so a wrong arity is rejected).
+// Only a field the scrutinee lacks, or a wrong tuple arity, is rejected,
+// surfacing MissingPropertyError / TupleLengthMismatchError. The scrutinee's
+// borrow wrapper is peeled first (CarrierOf), so a destructured borrow binds the
+// borrowed contents, just as a member read does.
+//
+// leafTypes, when non-nil, receives each leaf binding's type keyed by name. The
+// function-param path passes its paramTypes map so the liveness pre-pass can seed
+// each leaf's alias mutability; other callers pass nil.
+func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type) soltype.Pat {
+	scrutinee = soltype.CarrierOf(scrutinee)
+	switch p := pat.(type) {
+	case *ast.IdentPat:
+		c.bindLeaf(scope, p.Name, scrutinee, p, leafTypes)
+		return &soltype.IdentPat{Name: p.Name}
+
+	case *ast.WildcardPat:
+		c.recordType(p, scrutinee)
+		return &soltype.WildcardPat{}
+
+	case *ast.LitPat:
+		lt, ok := c.litTypeOf(p.Lit)
+		if !ok {
+			c.reportUnsupported(p.Lit)
+			return &soltype.WildcardPat{}
+		}
+		// A literal pattern asserts the literal is an admissible value of the
+		// scrutinee, so the literal flows INTO the scrutinee: `5 <: number` checks.
+		// This is exact against a concrete scrutinee (a top-level `match` arm). For a
+		// NESTED slot the scrutinee here is the field's covariant result var, which
+		// carries no upper bound, so a kind mismatch like `{x: "hi"}` against `{x:
+		// number}` is not yet rejected — the refutable literal-pattern check lands
+		// with E2's `match`, which this path is laid out to extend. A literal pattern
+		// binds nothing.
+		c.constrain(p, lt, scrutinee)
+		c.recordType(p, lt)
+		return &soltype.LitPat{Lit: lt.Lit}
+
+	case *ast.TuplePat:
+		elemTypes := make([]soltype.Type, len(p.Elems))
+		for i := range p.Elems {
+			elemTypes[i] = c.freshAt(lvl)
+		}
+		// scrutinee <: [α0, …, αn] — an EXACT tuple requirement, so a wrong arity is
+		// a TupleLengthMismatchError. Each αi lowers from the scrutinee's matching
+		// element, so a sub-pattern binds at that element's type.
+		c.constrain(p, scrutinee, &soltype.TupleType{Elems: elemTypes})
+		subs := make([]soltype.Pat, len(p.Elems))
+		for i, e := range p.Elems {
+			subs[i] = c.bindPattern(scope, lvl, e, elemTypes[i], leafTypes)
+		}
+		c.recordType(p, scrutinee)
+		return &soltype.TuplePat{Elems: subs}
+
+	case *ast.ObjectPat:
+		fields := make([]*soltype.ObjectPatField, 0, len(p.Elems))
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjShorthandPat:
+				beta := c.freshAt(lvl)
+				c.constrain(e, scrutinee, propReq(e.Key.Name, beta))
+				c.bindLeaf(scope, e.Key.Name, beta, e, leafTypes)
+				fields = append(fields, &soltype.ObjectPatField{
+					Name:  e.Key.Name,
+					Value: &soltype.IdentPat{Name: e.Key.Name},
+				})
+			case *ast.ObjKeyValuePat:
+				beta := c.freshAt(lvl)
+				c.constrain(e, scrutinee, propReq(e.Key.Name, beta))
+				sub := c.bindPattern(scope, lvl, e.Value, beta, leafTypes)
+				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
+			default:
+				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
+				c.reportUnsupported(elem)
+			}
+		}
+		c.recordType(p, scrutinee)
+		return &soltype.ObjectPat{Fields: fields}
+
+	default:
+		// ExtractorPat / InstancePat (constructor patterns) are M5; a bare RestPat is
+		// only meaningful inside a tuple/object. Report and bind nothing.
+		c.reportUnsupported(pat)
+		return &soltype.WildcardPat{}
+	}
+}
+
+// bindLeaf binds one identifier leaf to t in scope as a monomorphic projection of
+// the scrutinee, records its type, and (when leafTypes is non-nil) reports the
+// leaf's type by name for the liveness pre-pass.
+func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type) {
+	scope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
+	c.recordType(node, t)
+	if leafTypes != nil {
+		leafTypes[name] = t
+	}
+}
+
+// propReq builds the inexact one-property requirement `{name: t, ...}` — "the
+// receiver has at least this field" — the same shape inferMember's valueProp
+// mints for a field read.
+func propReq(name string, t soltype.Type) *soltype.ObjectType {
+	return &soltype.ObjectType{
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: t}},
+		Inexact: true,
+	}
+}
+
+// litTypeOf lowers an ast literal to its soltype LitType, mirroring inferLiteral.
+// ok=false for a literal kind outside the M-subset (the caller reports it).
+func (c *checker) litTypeOf(lit ast.Lit) (*soltype.LitType, bool) {
+	switch l := lit.(type) {
+	case *ast.NumLit:
+		return &soltype.LitType{Lit: &soltype.NumLit{Value: l.Value}}, true
+	case *ast.StrLit:
+		return &soltype.LitType{Lit: &soltype.StrLit{Value: l.Value}}, true
+	case *ast.BoolLit:
+		return &soltype.LitType{Lit: &soltype.BoolLit{Value: l.Value}}, true
+	}
+	return nil, false
+}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -518,15 +518,16 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 // tracker with one alias set per leaf binding, reading each leaf's mutability from
 // paramTypes so transitions involving the leaf are checked correctly.
 //
-// TODO(destructuring params): paramTypes is keyed by the top-level parameter name, not
-// by leaf name, so the lookup below only resolves an IdentPat parameter, where the leaf
-// IS the parameter. For a destructuring param like `{a, b}: {a: mut T, b: U}` there is
-// no paramTypes["a"]/["b"] entry, so every leaf falls back to AliasImmutable and a
-// `mut` leaf is mis-seeded. This is unreachable today because inferFunc reports a
-// destructuring param as unsupported. When destructuring params land, either populate
-// paramTypes per leaf (the old checker's inferPattern did this) or derive each leaf's
-// type by walking the pattern against the param's structural type, rather than the
-// flat name lookup here.
+// paramTypes is keyed by leaf name: an IdentPat parameter contributes the parameter
+// itself, and a destructuring param (M4 E1) contributes one entry per leaf via
+// bindPattern. So the lookup below resolves every leaf.
+//
+// KNOWN LIMITATION: a destructured leaf's type is a fresh inference variable at
+// pre-pass time, before constraints are coalesced, so isMutableType sees a bare var
+// rather than a RefType and a `mut` leaf still seeds AliasImmutable. Seeding a
+// destructured `mut` leaf accurately needs the leaf's resolved type, which is not
+// available until after the body walk — deferred with the rest of the destructuring
+// mutability work.
 func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.Type, aliases *liveness.AliasTracker) {
 	for _, param := range astParams {
 		ast.ForEachLeafBinding(param.Pattern, func(name string, varID int) {

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -518,16 +518,16 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 // tracker with one alias set per leaf binding, reading each leaf's mutability from
 // paramTypes so transitions involving the leaf are checked correctly.
 //
-// paramTypes is keyed by leaf name: an IdentPat parameter contributes the parameter
+// paramTypes is keyed by leaf name. An IdentPat parameter contributes the parameter
 // itself, and a destructuring param (M4 E1) contributes one entry per leaf via
-// bindPattern. So the lookup below resolves every leaf.
+// bindPattern, so the lookup below resolves every leaf.
 //
 // KNOWN LIMITATION: a destructured leaf's type is a fresh inference variable at
 // pre-pass time, before constraints are coalesced, so isMutableType sees a bare var
 // rather than a RefType and a `mut` leaf still seeds AliasImmutable. Seeding a
 // destructured `mut` leaf accurately needs the leaf's resolved type, which is not
-// available until after the body walk — deferred with the rest of the destructuring
-// mutability work.
+// available until after the body walk. This is deferred with the rest of the
+// destructuring mutability work.
 func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.Type, aliases *liveness.AliasTracker) {
 	for _, param := range astParams {
 		ast.ForEachLeafBinding(param.Pattern, func(name string, varID int) {
@@ -598,19 +598,52 @@ func sortedValueNames(s *Scope) []string {
 	return names
 }
 
-// recordParamVarIDs copies each IdentPat parameter's rename-assigned VarID onto its
-// scope binding (M4 G1), so a closure that captures the parameter resolves it to its
-// alias set through trackCapturedAliases. Runs after the pre-pass, since the rename
-// is what assigns the VarIDs.
+// recordParamVarIDs copies each parameter leaf's rename-assigned VarID onto its
+// scope binding (M4 G1), so a closure that captures the parameter resolves it to
+// its alias set through trackCapturedAliases. It walks every leaf, so a
+// destructuring parameter's leaves (M4 E1) are covered alongside a plain IdentPat
+// parameter. Runs after the pre-pass, since the rename is what assigns the VarIDs.
 func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
 	for _, p := range params {
-		ip, ok := p.Pattern.(*ast.IdentPat)
-		if !ok || ip.VarID <= 0 {
-			continue
-		}
-		if b, found := fnScope.GetValue(ip.Name); found {
-			b.VarID = ip.VarID
-			fnScope.defineValue(ip.Name, b)
-		}
+		ast.ForEachLeafBinding(p.Pattern, func(name string, varID int) {
+			if varID <= 0 {
+				return
+			}
+			if b, found := fnScope.GetValue(name); found {
+				b.VarID = varID
+				fnScope.defineValue(name, b)
+			}
+		})
 	}
+}
+
+// trackDestructureLeaves wires a body-level destructuring `val`/`var`'s leaves
+// (M4 E1) into the liveness machinery, the IdentPat path's per-leaf analogue. For
+// each leaf it copies the rename-assigned VarID onto the binding — so a closure
+// capturing the leaf resolves its alias set — and registers the leaf as a tracked
+// value carrying its mutability, so a later mutation or reassignment through it is
+// checked. A no-op outside a function body.
+//
+// Unlike trackAliasesForVarDecl it does not add an alias edge from each leaf to
+// the initializer. A destructured leaf reads a PROJECTION of the initializer. For
+// example `x` from `val {x} = p` is `p.x`, not `p`. That projection is not a
+// variable the liveness graph names, so the leaf is registered as its own value.
+// A leaf whose resolved type is a `mut` borrow still seeds AliasImmutable here,
+// since the leaf's type is an unresolved inference variable at this point. That
+// timing gap is the destructuring-mutability work deferred with the rest.
+func (c *checker) trackDestructureLeaves(scope *Scope, pat ast.Pat) {
+	ast.ForEachLeafBinding(pat, func(name string, varID int) {
+		if varID <= 0 {
+			return
+		}
+		b, found := scope.GetValue(name)
+		if !found {
+			return
+		}
+		b.VarID = varID
+		scope.defineValue(name, b)
+		if c.fn != nil && c.fn.aliases != nil {
+			c.fn.aliases.NewValue(liveness.VarID(varID), aliasMutability(isMutableType(bindingType(b))))
+		}
+	})
 }

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -507,7 +507,7 @@ func isValueType(t soltype.Type) bool // from checker/check_transitions.go:189-2
 
 ## PR breakdown
 
-18 PRs across 7 phases, each independently mergeable and green, each with
+19 PRs across 7 phases, each independently mergeable and green, each with
 table-driven tests asserting rendered types and **full** error messages. Every
 PR below names the concrete files touched, the data structures added/modified,
 the algorithm changes, and its acceptance set — enough to start implementation
@@ -1231,6 +1231,69 @@ these arms it must add.
     - a `match` over structural patterns binds and type-checks each arm
     - an exact-object scrutinee with a complete pattern set needs no catch-all, an
       inexact one does (full error on the missing catch-all)
+
+- **E3 — Top-level destructuring binding** (~180).
+  - **Background:** E1 shipped destructuring for body-level `val`/`var` and
+    function params, but a MODULE-scope `val {x, y} = p` / `val [a, b] = t` still
+    reports `UnsupportedNodeError` and binds nothing. The reason is the SCC driver,
+    not the pattern machinery: `inferComponent`/`inferDeclDef`
+    ([module.go](../../internal/solver/module.go),
+    [infer_decl.go](../../internal/solver/infer_decl.go)) are built
+    **one-decl-to-one-binding-var**, while a destructuring decl produces SEVERAL
+    binding names from one declaration. E3 teaches the driver that fan-out. It
+    retires E1's body-level-only deferral and the
+    `TestInferModuleDestructuringPatternUnsupported` regression test.
+  - **Files:** `solver/module.go` (the SCC driver's phase 2/3),
+    `solver/infer_decl.go` (`inferDeclDef`'s destructuring arm),
+    `solver/pattern.go` (factor a leaf-placement callback out of `bindPattern`).
+    **No dep_graph change:** `ModuleBindingVisitor.EnterDecl` already registers a
+    `VarDecl` under one `ValueBindingKey` per bound name via
+    `ast.FindBindings(d.Pattern)` ([dep_graph.go:183](../../internal/dep_graph/dep_graph.go)),
+    so `val [a, b] = …` already lands under keys `a` and `b`, both pointing at the
+    same decl. Phase 1 therefore already mints a binding var per leaf, and phase 2's
+    `handled` set already dedups the multi-key decl to a single inference.
+  - **Structures:**
+    - factor `bindPattern`'s leaf placement behind an emit callback —
+      `bindPatternWith(scope, lvl, pat, scrutinee, emit func(name string, t
+      soltype.Type))` — so the leaf-placement STRATEGY is pluggable. Body-level
+      (E1) keeps `emit = scope.defineValue(name, monoScheme(t))`; top-level passes
+      an emit that constrains each leaf type into its pre-bound binding var
+      (`constrain(t, bindings[ValueBindingKey(name)].v)`) instead of defining a
+      fresh monoScheme that would shadow the generalization-pending var.
+    - the per-decl driver result grows from a single `(type, prov, ok)` to a
+      per-leaf set, so `inferDeclDef` can hand each leaf's type to the matching
+      binding var. Keep the single-binding shape as the one-leaf case.
+  - **Algorithm — fan one decl across its keys:**
+    - in phase 2, on a destructuring `VarDecl` (reached under its first key, the
+      rest skipped by `handled`), type the initializer ONCE through
+      `inferVarDeclInit` — so an annotation is honored and a `var` initializer is
+      widened, exactly as the body-level path does — then run the pattern against
+      that type with the constrain-into-var emit, lowering each leaf's projected
+      type into `bindings[leafKey].v`
+    - phase 3 generalizes each leaf key's var **independently**, the existing
+      per-key `generalize` path — no new generalization logic, each leaf is its own
+      scheme
+    - record each leaf's display type on its pattern leaf node for Info /
+      go-to-definition (the per-leaf analogue of the `recordType(d.Pattern,
+      display)` a single-name `VarDecl` does at module.go:415)
+  - **Edge cases (each reuses an existing mechanism):**
+    - **recursion:** a destructuring binding inside a recursive SCC resolves
+      through the phase-1 pre-bound leaf vars, so `val {f} = mk()` where `mk`
+      references `f` type-checks, same as a single recursive `val`
+    - **error recovery:** a destructuring whose initializer recovered to the
+      `ErrorType` sentinel leaves every leaf var unbound; recover EACH leaf as the
+      error sentinel (the `b.recovered && len(b.v.LowerBounds) == 0` guard at
+      module.go:396), so no leaf cascades `<: never`
+    - **`var` widening** flows from `inferVarDeclInit` as above, so
+      `var [a, b] = [1, 2]` binds `a`/`b` at `number`
+  - **Accept:**
+    - `val [a, b] = [1, 2]` at module scope binds `a: 1`, `b: 2`; `var [a, b] =
+      [1, 2]` binds both at `number`
+    - `val {x, y} = p` at module scope, with `p` another top-level binding, binds
+      `x`/`y` at their field types and a missing field / wrong arity still errors
+    - a recursive group through a destructured binding type-checks
+    - the former `TestInferModuleDestructuringPatternUnsupported` becomes a
+      binding test asserting the rendered leaf types
 
 ### Phase F — Namespace member lookup (parallel track)
 


### PR DESCRIPTION
Implement structural destructuring patterns for function parameters and body-level `val`/`var` declarations. This adds support for tuple and object patterns that bind multiple names from a single structured value.

## Changes

- **Pattern typing** (`pattern.go`): New `bindPattern` helper types destructuring patterns against a scrutinee type. It dispatches through member-lookup constraints rather than subtyping, allowing patterns to bind a subset of object fields while enforcing exact tuple arity. Patterns nest recursively and support optional leaf type annotations and defaults.

- **Function parameters** (`infer_expr.go`): Destructuring parameters like `fn f({x, y}: T)` or `fn f([a, b]: T)` now bind their leaves into the function scope via `bindPattern`. Un-annotated destructuring params infer their shape from leaf usage. The parameter renders its pattern in the function signature.

- **Body-level destructuring** (`infer_decl.go`, `infer_stmt.go`): New `inferDestructureDecl` handles `val`/`var` destructuring at function scope. Leaves are monomorphic projections of the initializer, not independently generalized. Top-level destructuring still defers (needs SCC driver support).

- **Liveness integration** (`transitions.go`): Extended `recordParamVarIDs` to walk all parameter leaves, not just IdentPat. New `trackDestructureLeaves` wires body-level destructuring leaves into the alias tracker so closures capturing them resolve correctly and mutations are checked.

- **Pattern rendering** (`soltype/type.go`, `soltype/print.go`): Added `TuplePat`, `ObjectPat`, `LitPat`, and `WildcardPat` types to mirror AST patterns. New `printPat` renders patterns in surface syntax for function signatures.

- **Tests** (`infer_pattern_test.go`, `infer_func_test.go`, `infer_test.go`): Comprehensive test coverage for pattern binding, nesting, defaults, type annotations, and closure capture. Updated existing tests to reflect that destructuring params are now supported.

## Implementation notes

- Patterns constrain via member lookup (`propReq` for objects, exact/inexact tuple requirements), not subtyping, so object patterns tolerate extra fields while tuple patterns enforce arity.
- Leaf type annotations are checked and adopted; defaults are checked against the bound type.
- A trailing `...rest` in tuple patterns relaxes the requirement to an inexact prefix; the rest element itself is reported unsupported (M9 feature).
- Destructured leaves' mutability seeding is deferred due to timing (leaves are unresolved inference variables at pre-pass time); this is noted as a known limitation.

https://claude.ai/code/session_011yjJ51xACfT4gjMupGUM9G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for destructuring patterns in function parameters, enabling tuple and object destructuring syntax.
  * Enhanced variable declaration destructuring with improved type constraints and inference.
  * Improved function parameter name rendering to display pattern structure instead of synthetic names.

* **Tests**
  * Added comprehensive test suite for destructuring pattern type inference, constraint checking, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->