### PR TITLE
Support top-level destructuring patterns (M4 E3)

### DIFF
--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -17,7 +17,7 @@ import (
 // would read a recursive peer's still-empty binding var and freeze the binding to
 // `never` — the bug behind splitting this out of inferVarDecl.
 //
-// A top-level destructuring VarDecl never reaches here: inferComponent intercepts
+// A top-level destructuring VarDecl never reaches here. inferComponent intercepts
 // each of its leaf keys via destructureDecl and binds them through
 // bindModuleDestructureLeaf (M4 E3). The destructuring arm below is a defensive
 // guard for a hand-built AST that bypasses that path.

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -17,6 +17,11 @@ import (
 // would read a recursive peer's still-empty binding var and freeze the binding to
 // `never` — the bug behind splitting this out of inferVarDecl.
 //
+// A top-level destructuring VarDecl never reaches here: inferComponent intercepts
+// each of its leaf keys via destructureDecl and binds them through
+// bindModuleDestructureLeaf (M4 E3). The destructuring arm below is a defensive
+// guard for a hand-built AST that bypasses that path.
+//
 // ok=false cases, each already reported:
 //   - VarDecl without an initializer → MissingInitializerError
 //   - VarDecl with a destructuring pattern → UnsupportedNodeError (initializer

--- a/internal/solver/infer_module_destructure_test.go
+++ b/internal/solver/infer_module_destructure_test.go
@@ -43,8 +43,8 @@ func TestInferModuleObjectDestructuring(t *testing.T) {
 }
 
 // A partial object destructuring binds only the named fields and tolerates the
-// rest, since the pattern requirement is inexact (the same width-tolerant member
-// requirement a field read mints).
+// rest, since the pattern requirement is inexact. That requirement is the same
+// width-tolerant member requirement a field read mints.
 func TestInferModuleObjectDestructuringPartial(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val p = {x: 5, y: 10}
@@ -83,6 +83,63 @@ func TestInferModuleDestructuringErrorRecovery(t *testing.T) {
 	require.Equal(t, "Unknown identifier: nope", errs[0].Message())
 	require.Equal(t, "error", values["x"])
 	require.Equal(t, "error", values["y"])
+}
+
+// A nested pattern binds only its leaf identifiers. The leaf name the pattern walk
+// collects must match the name dep_graph registered the key under, since a nested
+// leaf is reached through the recursive bindPatternWith descent. `x` binds. The
+// intermediate `p` is not a binding.
+func TestInferModuleNestedObjectDestructuring(t *testing.T) {
+	values, _, errs := inferSource(t, `val {p: {x}} = {p: {x: 5}}`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.NotContains(t, values, "p")
+}
+
+// A nested tuple pattern binds each leaf through the same recursive descent. `a`
+// binds at the inner element, `b` at the outer.
+func TestInferModuleNestedTupleDestructuring(t *testing.T) {
+	values, _, errs := inferSource(t, `val [[a], b] = [[1], 2]`)
+	require.Empty(t, errs)
+	require.Equal(t, "1", values["a"])
+	require.Equal(t, "2", values["b"])
+}
+
+// A destructured leaf is a real top-level binding another declaration can resolve.
+// `z` reads `x`, so the two land in separate components and the driver must have
+// bound `x` in scope before `z`'s component runs.
+func TestInferModuleDestructuredLeafForwardReference(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val {x} = {x: 5}
+		val z = x
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.Equal(t, "5", values["z"])
+}
+
+// Phase 3 generalizes each leaf key independently, so a destructured leaf bound to
+// a polymorphic function generalizes to its own scheme and instantiates fresh at
+// each call site. That is full let-polymorphism, not a shared monomorphic projection.
+func TestInferModuleDestructuredLeafGeneralizes(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val {id} = {id: fn (x) { return x }}
+		val a = id(1)
+		val b = id("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0>(x: T0) -> T0", values["id"])
+	require.Equal(t, "1", values["a"])
+	require.Equal(t, `"hi"`, values["b"])
+}
+
+// An un-annotated `var` object destructuring widens each leaf to its primitive, the
+// object twin of the tuple case (M4 B3), so a later reassignment of the same
+// primitive checks.
+func TestInferModuleObjectDestructuringVarWidens(t *testing.T) {
+	values, _, errs := inferSource(t, `var {x} = {x: 5}`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["x"])
 }
 
 // A genuinely recursive group threaded through a destructured binding resolves

--- a/internal/solver/infer_module_destructure_test.go
+++ b/internal/solver/infer_module_destructure_test.go
@@ -1,0 +1,101 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// M4 E3: a top-level destructuring `val [a, b] = …` binds SEVERAL names from one
+// decl. The SCC driver fans the decl across its leaf binding keys, types the
+// initializer once, and lowers each leaf's projected type into its pre-bound var.
+// This replaces the former TestInferModuleDestructuringPatternUnsupported, which
+// asserted the binding deferred with an UnsupportedNodeError.
+func TestInferModuleTupleDestructuring(t *testing.T) {
+	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
+	require.Empty(t, errs)
+	require.Equal(t, "1", values["a"])
+	require.Equal(t, "2", values["b"])
+}
+
+// A top-level `var` destructuring widens each leaf to its primitive, the
+// constraint-level widening inferVarDeclInit applies to a direct literal
+// initializer (M4 B3), so the leaves read back as `number` rather than the
+// literal singletons.
+func TestInferModuleTupleDestructuringVarWidens(t *testing.T) {
+	values, _, errs := inferSource(t, `var [a, b] = [1, 2]`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["a"])
+	require.Equal(t, "number", values["b"])
+}
+
+// An object destructuring at module scope binds each leaf at its field type. The
+// scrutinee is another top-level binding, so this also exercises the dep-graph
+// ordering: `p` is inferred before the destructuring decl that reads it.
+func TestInferModuleObjectDestructuring(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val p = {x: 5, y: 10}
+		val {x, y} = p
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.Equal(t, "10", values["y"])
+}
+
+// A partial object destructuring binds only the named fields and tolerates the
+// rest, since the pattern requirement is inexact (the same width-tolerant member
+// requirement a field read mints).
+func TestInferModuleObjectDestructuringPartial(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		val p = {x: 5, y: 10}
+		val {x} = p
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.NotContains(t, values, "y")
+}
+
+// A field the scrutinee lacks is still rejected, surfacing MissingPropertyError —
+// the binding side is the same constraint path body-level destructuring uses.
+func TestInferModuleObjectDestructuringMissingField(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		val p = {x: 5}
+		val {x, z} = p
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: z", errs[0].Message())
+}
+
+// A wrong tuple arity is rejected with a TupleLengthMismatchError.
+func TestInferModuleTupleDestructuringWrongArity(t *testing.T) {
+	_, _, errs := inferSource(t, `val [a, b, c] = [1, 2]`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 3", errs[0].Message())
+}
+
+// A destructuring whose initializer recovered to the ErrorType sentinel recovers
+// EACH leaf AS the sentinel rather than freezing it to `never`, so a single
+// unknown-identifier diagnostic is reported and no leaf cascades `<: never`
+// downstream.
+func TestInferModuleDestructuringErrorRecovery(t *testing.T) {
+	values, _, errs := inferSource(t, `val {x, y} = nope`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: nope", errs[0].Message())
+	require.Equal(t, "error", values["x"])
+	require.Equal(t, "error", values["y"])
+}
+
+// A genuinely recursive group threaded through a destructured binding resolves
+// through the phase-1 pre-bound leaf vars: `f` calls `g`, and `g` is destructured
+// from a record whose field is `f`, so `f` and `g` form one strongly connected
+// component. The leaf binding var `g` is visible while `f`'s body is inferred, the
+// same way a single recursive `val` resolves through its var.
+func TestInferModuleDestructuringRecursiveGroup(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f() { return g() }
+		val {g} = {g: f}
+	`)
+	require.Empty(t, errs)
+	require.Contains(t, values, "f")
+	require.Contains(t, values, "g")
+}

--- a/internal/solver/infer_module_destructure_test.go
+++ b/internal/solver/infer_module_destructure_test.go
@@ -11,148 +11,172 @@ import (
 // initializer once, and lowers each leaf's projected type into its pre-bound var.
 // This replaces the former TestInferModuleDestructuringPatternUnsupported, which
 // asserted the binding deferred with an UnsupportedNodeError.
-func TestInferModuleTupleDestructuring(t *testing.T) {
-	values, _, errs := inferSource(t, `val [a, b] = [1, 2]`)
-	require.Empty(t, errs)
-	require.Equal(t, "1", values["a"])
-	require.Equal(t, "2", values["b"])
-}
+//
+// Each case lists the names that must bind to a given rendered type (values), the
+// names that must NOT bind (absent), and the full error messages expected in order
+// (errs). A success case leaves errs empty.
+func TestInferModuleDestructuring(t *testing.T) {
+	type testCase struct {
+		name   string
+		src    string
+		values map[string]string
+		absent []string
+		errs   []string
+	}
 
-// A top-level `var` destructuring widens each leaf to its primitive, the
-// constraint-level widening inferVarDeclInit applies to a direct literal
-// initializer (M4 B3), so the leaves read back as `number` rather than the
-// literal singletons.
-func TestInferModuleTupleDestructuringVarWidens(t *testing.T) {
-	values, _, errs := inferSource(t, `var [a, b] = [1, 2]`)
-	require.Empty(t, errs)
-	require.Equal(t, "number", values["a"])
-	require.Equal(t, "number", values["b"])
-}
+	cases := []testCase{
+		{
+			// A tuple destructuring binds each leaf at its element type.
+			name:   "tuple",
+			src:    `val [a, b] = [1, 2]`,
+			values: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			// A `var` tuple destructuring widens each leaf to its primitive, the
+			// constraint-level widening inferVarDeclInit applies to a direct literal
+			// initializer (M4 B3), so the leaves read back as `number`.
+			name:   "tuple var widens",
+			src:    `var [a, b] = [1, 2]`,
+			values: map[string]string{"a": "number", "b": "number"},
+		},
+		{
+			// An object destructuring binds each leaf at its field type. The scrutinee
+			// is another top-level binding, so this also exercises the dep-graph
+			// ordering: `p` is inferred before the destructuring decl that reads it.
+			name: "object",
+			src: `
+				val p = {x: 5, y: 10}
+				val {x, y} = p
+			`,
+			values: map[string]string{"x": "5", "y": "10"},
+		},
+		{
+			// A partial object destructuring binds only the named fields and tolerates
+			// the rest, since the pattern requirement is inexact. That requirement is
+			// the same width-tolerant member requirement a field read mints.
+			name: "object partial",
+			src: `
+				val p = {x: 5, y: 10}
+				val {x} = p
+			`,
+			values: map[string]string{"x": "5"},
+			absent: []string{"y"},
+		},
+		{
+			// A nested pattern binds only its leaf identifiers. The leaf name the
+			// pattern walk collects must match the name dep_graph registered the key
+			// under, since a nested leaf is reached through the recursive
+			// bindPatternWith descent. `x` binds. The intermediate `p` is not a binding.
+			name:   "nested object",
+			src:    `val {p: {x}} = {p: {x: 5}}`,
+			values: map[string]string{"x": "5"},
+			absent: []string{"p"},
+		},
+		{
+			// A nested tuple pattern binds each leaf through the same recursive descent.
+			// `a` binds at the inner element, `b` at the outer.
+			name:   "nested tuple",
+			src:    `val [[a], b] = [[1], 2]`,
+			values: map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			// A destructured leaf is a real top-level binding another declaration can
+			// resolve. `z` reads `x`, so the two land in separate components and the
+			// driver must have bound `x` in scope before `z`'s component runs.
+			name: "forward reference to a leaf",
+			src: `
+				val {x} = {x: 5}
+				val z = x
+			`,
+			values: map[string]string{"x": "5", "z": "5"},
+		},
+		{
+			// Phase 3 generalizes each leaf key independently, so a destructured leaf
+			// bound to a polymorphic function generalizes to its own scheme and
+			// instantiates fresh at each call site. That is full let-polymorphism, not a
+			// shared monomorphic projection.
+			name: "leaf generalizes",
+			src: `
+				val {id} = {id: fn (x) { return x }}
+				val a = id(1)
+				val b = id("hi")
+			`,
+			values: map[string]string{"id": "fn <T0>(x: T0) -> T0", "a": "1", "b": `"hi"`},
+		},
+		{
+			// An un-annotated `var` object destructuring widens each leaf to its
+			// primitive, the object twin of the tuple case (M4 B3), so a later
+			// reassignment of the same primitive checks.
+			name:   "object var widens",
+			src:    `var {x} = {x: 5}`,
+			values: map[string]string{"x": "number"},
+		},
+		{
+			// A genuinely recursive group threaded through a destructured binding
+			// resolves through the phase-1 pre-bound leaf vars: `f` calls `g`, and `g`
+			// is destructured from a record whose field is `f`, so `f` and `g` form one
+			// strongly connected component. The leaf binding var `g` is visible while
+			// `f`'s body is inferred, the same way a single recursive `val` resolves.
+			name: "recursive group",
+			src: `
+				fn f() { return g() }
+				val {g} = {g: f}
+			`,
+			values: map[string]string{"f": "fn () -> never", "g": "fn () -> never"},
+		},
+		{
+			// A field the scrutinee lacks is rejected, surfacing MissingPropertyError —
+			// the binding side is the same constraint path body-level destructuring uses.
+			name: "missing field",
+			src: `
+				val p = {x: 5}
+				val {x, z} = p
+			`,
+			errs: []string{"object is missing property: z"},
+		},
+		{
+			// A wrong tuple arity is rejected with a TupleLengthMismatchError.
+			name: "tuple wrong arity",
+			src:  `val [a, b, c] = [1, 2]`,
+			errs: []string{"cannot constrain tuple of length 2 <: tuple of length 3"},
+		},
+		{
+			// An initializer that recovered to the ErrorType sentinel recovers EACH leaf
+			// AS the sentinel rather than freezing it to `never`, so a single
+			// unknown-identifier diagnostic is reported and no leaf cascades `<: never`.
+			name:   "error recovery",
+			src:    `val {x, y} = nope`,
+			values: map[string]string{"x": "error", "y": "error"},
+			errs:   []string{"Unknown identifier: nope"},
+		},
+		{
+			// A destructured leaf colliding with another top-level binding of the same
+			// name is a duplicate declaration, not an unsupported pattern. The first
+			// binding is kept, the non-colliding leaf `y` still binds, and the collision
+			// reports cleanly.
+			name: "leaf name collides with another decl",
+			src: `
+				val {x, y} = {x: 1, y: 2}
+				val x = 5
+			`,
+			values: map[string]string{"x": "1", "y": "2"},
+			errs:   []string{"Duplicate declaration: x"},
+		},
+	}
 
-// An object destructuring at module scope binds each leaf at its field type. The
-// scrutinee is another top-level binding, so this also exercises the dep-graph
-// ordering: `p` is inferred before the destructuring decl that reads it.
-func TestInferModuleObjectDestructuring(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		val p = {x: 5, y: 10}
-		val {x, y} = p
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "5", values["x"])
-	require.Equal(t, "10", values["y"])
-}
-
-// A partial object destructuring binds only the named fields and tolerates the
-// rest, since the pattern requirement is inexact. That requirement is the same
-// width-tolerant member requirement a field read mints.
-func TestInferModuleObjectDestructuringPartial(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		val p = {x: 5, y: 10}
-		val {x} = p
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "5", values["x"])
-	require.NotContains(t, values, "y")
-}
-
-// A field the scrutinee lacks is still rejected, surfacing MissingPropertyError —
-// the binding side is the same constraint path body-level destructuring uses.
-func TestInferModuleObjectDestructuringMissingField(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		val p = {x: 5}
-		val {x, z} = p
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "object is missing property: z", errs[0].Message())
-}
-
-// A wrong tuple arity is rejected with a TupleLengthMismatchError.
-func TestInferModuleTupleDestructuringWrongArity(t *testing.T) {
-	_, _, errs := inferSource(t, `val [a, b, c] = [1, 2]`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 3", errs[0].Message())
-}
-
-// A destructuring whose initializer recovered to the ErrorType sentinel recovers
-// EACH leaf AS the sentinel rather than freezing it to `never`, so a single
-// unknown-identifier diagnostic is reported and no leaf cascades `<: never`
-// downstream.
-func TestInferModuleDestructuringErrorRecovery(t *testing.T) {
-	values, _, errs := inferSource(t, `val {x, y} = nope`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: nope", errs[0].Message())
-	require.Equal(t, "error", values["x"])
-	require.Equal(t, "error", values["y"])
-}
-
-// A nested pattern binds only its leaf identifiers. The leaf name the pattern walk
-// collects must match the name dep_graph registered the key under, since a nested
-// leaf is reached through the recursive bindPatternWith descent. `x` binds. The
-// intermediate `p` is not a binding.
-func TestInferModuleNestedObjectDestructuring(t *testing.T) {
-	values, _, errs := inferSource(t, `val {p: {x}} = {p: {x: 5}}`)
-	require.Empty(t, errs)
-	require.Equal(t, "5", values["x"])
-	require.NotContains(t, values, "p")
-}
-
-// A nested tuple pattern binds each leaf through the same recursive descent. `a`
-// binds at the inner element, `b` at the outer.
-func TestInferModuleNestedTupleDestructuring(t *testing.T) {
-	values, _, errs := inferSource(t, `val [[a], b] = [[1], 2]`)
-	require.Empty(t, errs)
-	require.Equal(t, "1", values["a"])
-	require.Equal(t, "2", values["b"])
-}
-
-// A destructured leaf is a real top-level binding another declaration can resolve.
-// `z` reads `x`, so the two land in separate components and the driver must have
-// bound `x` in scope before `z`'s component runs.
-func TestInferModuleDestructuredLeafForwardReference(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		val {x} = {x: 5}
-		val z = x
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "5", values["x"])
-	require.Equal(t, "5", values["z"])
-}
-
-// Phase 3 generalizes each leaf key independently, so a destructured leaf bound to
-// a polymorphic function generalizes to its own scheme and instantiates fresh at
-// each call site. That is full let-polymorphism, not a shared monomorphic projection.
-func TestInferModuleDestructuredLeafGeneralizes(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		val {id} = {id: fn (x) { return x }}
-		val a = id(1)
-		val b = id("hi")
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(x: T0) -> T0", values["id"])
-	require.Equal(t, "1", values["a"])
-	require.Equal(t, `"hi"`, values["b"])
-}
-
-// An un-annotated `var` object destructuring widens each leaf to its primitive, the
-// object twin of the tuple case (M4 B3), so a later reassignment of the same
-// primitive checks.
-func TestInferModuleObjectDestructuringVarWidens(t *testing.T) {
-	values, _, errs := inferSource(t, `var {x} = {x: 5}`)
-	require.Empty(t, errs)
-	require.Equal(t, "number", values["x"])
-}
-
-// A genuinely recursive group threaded through a destructured binding resolves
-// through the phase-1 pre-bound leaf vars: `f` calls `g`, and `g` is destructured
-// from a record whose field is `f`, so `f` and `g` form one strongly connected
-// component. The leaf binding var `g` is visible while `f`'s body is inferred, the
-// same way a single recursive `val` resolves through its var.
-func TestInferModuleDestructuringRecursiveGroup(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		fn f() { return g() }
-		val {g} = {g: f}
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn () -> never", values["f"])
-	require.Equal(t, "fn () -> never", values["g"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Len(t, errs, len(tc.errs))
+			for i := range tc.errs {
+				require.Equal(t, tc.errs[i], errs[i].Message())
+			}
+			for name, want := range tc.values {
+				require.Equal(t, want, values[name], "value of %s", name)
+			}
+			for _, name := range tc.absent {
+				require.NotContains(t, values, name)
+			}
+		})
+	}
 }

--- a/internal/solver/infer_module_destructure_test.go
+++ b/internal/solver/infer_module_destructure_test.go
@@ -96,6 +96,6 @@ func TestInferModuleDestructuringRecursiveGroup(t *testing.T) {
 		val {g} = {g: f}
 	`)
 	require.Empty(t, errs)
-	require.Contains(t, values, "f")
-	require.Contains(t, values, "g")
+	require.Equal(t, "fn () -> never", values["f"])
+	require.Equal(t, "fn () -> never", values["g"])
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -268,22 +268,6 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Equal(t, map[string]string{"y": "error"}, values)
 }
 
-// A TOP-LEVEL destructuring pattern still defers. M4 E1 adds body-level and
-// function-param destructuring, but a module-scope `val [a, b] = …` needs the SCC
-// driver to bind several names from one decl. The binding reports
-// UnsupportedNodeError and introduces no value. The initializer `[1, 2]` is a
-// tuple expression, which PR-4 now infers, so the only remaining error is the
-// destructuring pattern on the binding side.
-func TestInferModuleDestructuringPatternUnsupported(t *testing.T) {
-	src := `val [a, b] = [1, 2]`
-	values, _, errs := inferSource(t, src)
-	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: TuplePat", errs[0].Message())
-	// M2.5: blame the offending pattern, not the whole decl.
-	require.Equal(t, "[a, b]", spanText(src, errs[0].Span()))
-	require.Empty(t, values)
-}
-
 // A duplicate top-level `val` is a redeclaration error (unlike FuncDecl
 // overloads); the first binding is kept and the second reports cleanly.
 func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -224,19 +224,21 @@ func (c *checker) inferComponent(
 			}
 			continue
 		}
-		// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …` fans
-		// one decl across one leaf key per bound name, each its own component. This
-		// key is one such leaf, so type the decl's pattern once, memoized in the
-		// destructured map, and lower THIS leaf's projected type into its binding var.
-		if vd := destructureDecl(g, key); vd != nil {
-			c.bindModuleDestructureLeaf(scope, inner, vd, g, key, b, handled, destructured)
-			continue
-		}
 		for _, d := range g.GetDecls(key) {
+			// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …`
+			// registers one decl under one leaf key per bound name. Bind it per key it
+			// appears under, before the handled-dedup that gates ordinary decls, so a
+			// destructuring decl sharing a name with another decl still binds its other
+			// leaves and the collision reports as a duplicate rather than as an
+			// unsupported pattern.
+			if vd := asDestructureDecl(d); vd != nil {
+				c.bindModuleDestructureLeaf(scope, inner, vd, g, key, b, handled, destructured)
+				continue
+			}
 			if handled.Contains(d) {
-				// Already inferred under another binding key. The only M2 decl that
-				// registers under several keys is a destructuring `val [a, b] = …`,
-				// which is handled by the E3 leaf path above and never reaches here.
+				// Already inferred under another key this decl registers under, e.g. a
+				// class contributing both a value and a type key. Skipping avoids
+				// re-inferring and re-reporting it.
 				continue
 			}
 			handled.Add(d)
@@ -468,20 +470,14 @@ type destructureLeaf struct {
 	node ast.Node
 }
 
-// destructureDecl returns the destructuring VarDecl bound to key, or nil when key is
-// not a destructuring leaf. A destructuring decl is a top-level `val`/`var` whose
-// pattern is not a plain IdentPat. dep_graph registers such a decl under one value
-// key per bound name, each its own decl-of-one, so a leaf key has exactly that one
-// VarDecl.
-func destructureDecl(g *dep_graph.DepGraph, key dep_graph.BindingKey) *ast.VarDecl {
-	if key.Kind() != dep_graph.DepKindValue {
-		return nil
-	}
-	decls := g.GetDecls(key)
-	if len(decls) != 1 {
-		return nil // an overload set or merge is never a destructuring leaf
-	}
-	vd, ok := decls[0].(*ast.VarDecl)
+// asDestructureDecl returns d as a destructuring VarDecl, a top-level `val`/`var`
+// whose pattern is not a plain IdentPat, or nil when d is not one. dep_graph
+// registers such a decl under one value key per bound name, and phase 2 binds each
+// leaf under the key it appears. Detecting it per decl rather than per key lets a
+// destructuring decl that shares a key with another decl bind its leaves and report
+// the collision as a duplicate.
+func asDestructureDecl(d ast.Decl) *ast.VarDecl {
+	vd, ok := d.(*ast.VarDecl)
 	if !ok || vd.Pattern == nil {
 		return nil
 	}
@@ -511,6 +507,13 @@ func (c *checker) bindModuleDestructureLeaf(
 		// The pattern bound no leaf for this name, because destructurePattern already
 		// reported a field the scrutinee lacks or a wrong tuple arity. Leave the leaf
 		// unbound. Phase 3 removes it.
+		return
+	}
+	if b.bound {
+		// Another declaration already bound this name. A destructured leaf is neither
+		// an overload arm nor a merge, so the collision is a duplicate declaration.
+		// Keep the first binding and blame the destructuring decl.
+		c.report(&DuplicateDeclarationError{Decl: d, Previous: b.primary, Name: key.Name()})
 		return
 	}
 	c.constrain(d, leaf.t, b.v)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -93,13 +93,14 @@ type componentBinding struct {
 	// 3 to recover a VarDecl's Pattern (or a single FuncDecl's Name) for Info
 	// recording, and (via isVarDecl) to tell an overload arm from a duplicate.
 	primary ast.Decl
-	// patLeaf is the pattern leaf node a top-level destructuring binding fans this
-	// key onto, for example the `a` IdentPat of `val [a, b] = …` (M4 E3). It is
-	// non-nil only for a destructured leaf. Phase 3 records the generalized display
-	// type on this leaf node rather than on the whole decl pattern, which several
-	// leaf keys share.
-	patLeaf ast.Node
-	bound   bool // a definition was inferred and constrained
+	// infoNode is the AST node phase 3 records the binding's generalized display type
+	// on, for Info and go-to-definition. It is the binding's own name-bearing node: a
+	// VarDecl's pattern, a FuncDecl's name, or — for a top-level destructuring — the
+	// individual pattern leaf this key binds, e.g. the `a` IdentPat of `val [a, b] = …`
+	// (M4 E3). A destructuring records per leaf rather than on the whole decl pattern,
+	// which its sibling leaf keys share.
+	infoNode ast.Node
+	bound    bool // a definition was inferred and constrained
 	// isVarDecl reports whether the primary decl is a VarDecl, i.e. a `val` or a `var`
 	// rather than a function. It is NOT the `var`-vs-`val` distinction — that is kind.
 	isVarDecl bool
@@ -270,6 +271,14 @@ func (c *checker) inferComponent(
 				b.bound = true
 				vd, isVarDecl := d.(*ast.VarDecl)
 				b.isVarDecl = isVarDecl
+				// Record where phase 3 stamps the display type: a `val`/`var` on its
+				// pattern, a `fn` on its name. A destructuring leaf overrides this with its
+				// own leaf node in bindModuleDestructureLeaf.
+				if isVarDecl {
+					b.infoNode = vd.Pattern
+				} else if isFunc {
+					b.infoNode = fd.Name
+				}
 				// PR8: carry the decl's kind so phase 3 can gate reassignment — a top-level
 				// `var` is reassignable (e.g. from a function body that closes over it);
 				// a `val`/`fn` is not. A FuncDecl leaves kind at its ValKind zero value.
@@ -420,38 +429,32 @@ func (c *checker) inferComponent(
 			scheme = c.generalize(b.v, lvl)
 		}
 		scope.defineValue(key.Name(), ValueBinding{Schemes: []TypeScheme{scheme}, Sources: b.sources, Kind: b.kind, ModuleLevel: true})
-		// Record the binding's final (coalesced) DISPLAY type in Info on the name
-		// node, so it is queryable even for a `val` in a recursive group (where
-		// coalescing at definition time would have frozen it to `never`). A VarDecl
-		// records on its pattern, a FuncDecl on its name, so a top-level `fn` is
-		// queryable through Info exactly like a `val`.
+		// Record the binding's final (coalesced) DISPLAY type in Info on infoNode, so
+		// it is queryable even for a `val` in a recursive group (where coalescing at
+		// definition time would have frozen it to `never`). infoNode is the binding's
+		// name-bearing node — a VarDecl's pattern, a FuncDecl's name, or a destructuring
+		// leaf — so a top-level `fn` is queryable through Info exactly like a `val`.
 		//
 		// NOTE: for a GENERALIZED binding this display type RETAINS its quantified
 		// type-parameter variables (it is not var-free), so consumers must render it
 		// with soltype.PrintAsScheme — plain soltype.Print renders those vars as the
 		// raw `t{ID}` debug form. (renderScheme is the canonical renderer.)
 		display := schemeType(scheme)
-		if b.patLeaf != nil {
-			// M4 E3: a destructured leaf records on its own pattern leaf node, not on
-			// the whole decl pattern that its sibling leaf keys share.
-			c.recordType(b.patLeaf, display)
-		} else {
-			switch d := b.primary.(type) {
-			case *ast.VarDecl:
-				c.recordType(d.Pattern, display)
-			case *ast.FuncDecl:
-				if d.Name != nil {
-					c.recordType(d.Name, display)
-				}
-			}
+		if b.infoNode != nil {
+			c.recordType(b.infoNode, display)
 		}
 	}
 }
 
 // moduleDestructure memoizes a top-level destructuring decl's typed pattern (M4
-// E3). dep_graph fans one `val {x, y} = …` across one component per bound name. The
-// initializer is typed and the pattern bound once, on the first leaf key reached.
-// Each leaf component then constrains its own projected type into its binding var.
+// E3). dep_graph fans one `val {x, y} = …` across one component per bound name, so
+// every leaf key points at the same decl. The pattern must be typed and bound only
+// ONCE — typing the initializer or re-binding the pattern per leaf would re-report
+// its errors and duplicate work — so the first leaf key whose component is processed
+// in topological order types it and stores the result here, keyed by the decl. Every
+// later leaf key reuses this memo and only constrains its own projected type into its
+// binding var. There is nothing special about which leaf is "first"; the memo just
+// makes whichever one runs first the single typing site.
 //
 // leaves maps each bound name to that projection plus its pattern leaf node. ok is
 // false when the decl had no initializer, in which case MissingInitializerError was
@@ -518,7 +521,7 @@ func (c *checker) bindModuleDestructureLeaf(
 	}
 	c.constrain(d, leaf.t, b.v)
 	b.primary = d
-	b.patLeaf = leaf.node
+	b.infoNode = leaf.node
 	b.isVarDecl = true
 	b.kind = d.Kind
 	b.bound = true

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -52,8 +52,13 @@ func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 // graph did not model.
 func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph) {
 	handled := set.NewSet[ast.Decl]()
+	// M4 E3: dep_graph fans one top-level destructuring `val {x, y} = …` across one
+	// SCC component per leaf key, so its initializer is typed and its pattern bound
+	// ONCE — memoized here on the first leaf reached — and each leaf component then
+	// constrains its own projected type into its binding var.
+	destructured := map[*ast.VarDecl]*moduleDestructure{}
 	for _, component := range g.Components {
-		c.inferComponent(scope, lvl, module, g, component, handled)
+		c.inferComponent(scope, lvl, module, g, component, handled, destructured)
 	}
 	// Reconcile against the source: BuildDepGraph only produces binding keys for
 	// the decl kinds it models, so a kind it does not descend into — e.g. a
@@ -88,6 +93,11 @@ type componentBinding struct {
 	// 3 to recover a VarDecl's Pattern (or a single FuncDecl's Name) for Info
 	// recording, and (via isVarDecl) to tell an overload arm from a duplicate.
 	primary ast.Decl
+	// patLeaf is the pattern leaf node a top-level destructuring binding fans this
+	// key onto (M4 E3) — e.g. the `a` IdentPat of `val [a, b] = …`. Non-nil only for
+	// a destructured leaf; phase 3 records the generalized display type on this leaf
+	// node rather than on the whole decl pattern, which several leaf keys share.
+	patLeaf ast.Node
 	bound   bool // a definition was inferred and constrained
 	// isVarDecl reports whether the primary decl is a VarDecl, i.e. a `val` or a `var`
 	// rather than a function. It is NOT the `var`-vs-`val` distinction — that is kind.
@@ -136,6 +146,7 @@ type componentBinding struct {
 func (c *checker) inferComponent(
 	scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph,
 	component []dep_graph.BindingKey, handled set.Set[ast.Decl],
+	destructured map[*ast.VarDecl]*moduleDestructure,
 ) {
 	inner := lvl + 1
 
@@ -212,12 +223,19 @@ func (c *checker) inferComponent(
 			}
 			continue
 		}
+		// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …` fans
+		// one decl across one leaf key per bound name, each its own component. This
+		// key is one such leaf: type the decl's pattern once (memoized in
+		// destructured) and lower THIS leaf's projected type into its binding var.
+		if vd := destructureDecl(g, key); vd != nil {
+			c.bindModuleDestructureLeaf(scope, inner, vd, g, key, b, handled, destructured)
+			continue
+		}
 		for _, d := range g.GetDecls(key) {
 			if handled.Contains(d) {
 				// Already inferred under another binding key. The only M2 decl that
 				// registers under several keys is a destructuring `val [a, b] = …`,
-				// which is unsupported and produces no binding either way; skipping
-				// the re-inference avoids reporting its errors once per name.
+				// which is handled by the E3 leaf path above and never reaches here.
 				continue
 			}
 			handled.Add(d)
@@ -410,15 +428,149 @@ func (c *checker) inferComponent(
 		// with soltype.PrintAsScheme — plain soltype.Print renders those vars as the
 		// raw `t{ID}` debug form. (renderScheme is the canonical renderer.)
 		display := schemeType(scheme)
-		switch d := b.primary.(type) {
-		case *ast.VarDecl:
-			c.recordType(d.Pattern, display)
-		case *ast.FuncDecl:
-			if d.Name != nil {
-				c.recordType(d.Name, display)
+		if b.patLeaf != nil {
+			// M4 E3: a destructured leaf records on its own pattern leaf node, not on
+			// the whole decl pattern that its sibling leaf keys share.
+			c.recordType(b.patLeaf, display)
+		} else {
+			switch d := b.primary.(type) {
+			case *ast.VarDecl:
+				c.recordType(d.Pattern, display)
+			case *ast.FuncDecl:
+				if d.Name != nil {
+					c.recordType(d.Name, display)
+				}
 			}
 		}
 	}
+}
+
+// moduleDestructure memoizes a top-level destructuring decl's typed pattern (M4
+// E3). dep_graph fans one `val {x, y} = …` across one component per bound name, so
+// the initializer is typed and the pattern bound ONCE — on the first leaf key
+// reached — and each leaf component then constrains its own projected type into its
+// binding var. leaves maps each bound name to that projection plus its pattern leaf
+// node; ok is false when the decl had no initializer (MissingInitializerError
+// already reported); recovered marks an initializer that fell back to the ErrorType
+// sentinel, so each leaf recovers AS the sentinel rather than freezing to `never`.
+type moduleDestructure struct {
+	leaves    map[string]destructureLeaf
+	recovered bool
+	ok        bool
+}
+
+// destructureLeaf is one bound leaf of a memoized destructuring pattern: its
+// projected type and the pattern leaf node it was bound from.
+type destructureLeaf struct {
+	t    soltype.Type
+	node ast.Node
+}
+
+// destructureDecl returns the destructuring VarDecl bound to key — a top-level
+// `val`/`var` whose pattern is not a plain IdentPat — or nil when key is not such a
+// leaf. dep_graph registers a destructuring decl under one value key per bound
+// name, each its own decl-of-one, so a leaf key has exactly that one VarDecl.
+func destructureDecl(g *dep_graph.DepGraph, key dep_graph.BindingKey) *ast.VarDecl {
+	if key.Kind() != dep_graph.DepKindValue {
+		return nil
+	}
+	decls := g.GetDecls(key)
+	if len(decls) != 1 {
+		return nil // an overload set or merge is never a destructuring leaf
+	}
+	vd, ok := decls[0].(*ast.VarDecl)
+	if !ok || vd.Pattern == nil {
+		return nil
+	}
+	if _, named := varName(vd); named {
+		return nil // a plain IdentPat `val x = …` takes the ordinary path
+	}
+	return vd
+}
+
+// bindModuleDestructureLeaf binds one leaf of a top-level destructuring decl into
+// its pre-bound binding var (M4 E3). The decl's pattern is typed once via
+// destructurePattern and memoized; this call looks up THIS key's projected leaf
+// type and constrains it into b.v, so phase 3 generalizes the leaf independently.
+// `key` is this leaf's binding key; its bound name is the key name minus the decl's
+// namespace prefix, matching the name dep_graph registered the leaf under.
+func (c *checker) bindModuleDestructureLeaf(
+	scope *Scope, lvl int, d *ast.VarDecl, g *dep_graph.DepGraph,
+	key dep_graph.BindingKey, b *componentBinding, handled set.Set[ast.Decl],
+	destructured map[*ast.VarDecl]*moduleDestructure,
+) {
+	md := c.destructurePattern(scope, lvl, d, handled, destructured)
+	if !md.ok {
+		return // no initializer; leaf stays unbound and is removed in phase 3
+	}
+	leaf, found := md.leaves[leafName(g, key)]
+	if !found {
+		// The pattern bound no leaf for this name — a field the scrutinee lacks or a
+		// wrong tuple arity already reported by destructurePattern. Leave the leaf
+		// unbound; phase 3 removes it.
+		return
+	}
+	c.constrain(d, leaf.t, b.v)
+	b.primary = d
+	b.patLeaf = leaf.node
+	b.isVarDecl = true
+	b.kind = d.Kind
+	b.bound = true
+	b.sources = append(b.sources, &ast.NodeProvenance{Node: d})
+	if md.recovered {
+		b.recovered = true
+	}
+	// M4 B3: an un-annotated `var` leaf widens at coalesce time, so a literal it
+	// binds reads back as the primitive and a later reassignment of the same
+	// primitive checks. An annotated `var` adopts its annotation, which needs no
+	// widening; a `val` leaf is a fixed singleton.
+	if d.Kind == ast.VarKind && d.TypeAnn == nil {
+		b.v.Widenable = true
+	}
+}
+
+// destructurePattern types a top-level destructuring decl's initializer and binds
+// its pattern ONCE, memoizing the per-leaf projected types so each leaf component
+// reuses them (M4 E3). The initializer flows through the shared inferVarDeclInit
+// core, so an annotation is honored and a `var` initializer is widened, exactly as
+// the body-level path does. The pattern is bound with a collecting emit that
+// records each leaf's projection without defining it in scope — phase 1 already
+// pre-bound each leaf name as its binding var, and phase 3 redefines it generalized.
+// The decl is added to handled so the reconciliation pass does not report it as an
+// unmodeled top-level declaration.
+func (c *checker) destructurePattern(
+	scope *Scope, lvl int, d *ast.VarDecl, handled set.Set[ast.Decl],
+	destructured map[*ast.VarDecl]*moduleDestructure,
+) *moduleDestructure {
+	if md, done := destructured[d]; done {
+		return md
+	}
+	handled.Add(d)
+	md := &moduleDestructure{leaves: map[string]destructureLeaf{}}
+	destructured[d] = md
+	initType, ok := c.inferVarDeclInit(scope, lvl, d)
+	if !ok {
+		return md // MissingInitializerError already reported; md.ok stays false
+	}
+	md.ok = true
+	_, md.recovered = initType.(*soltype.ErrorType)
+	emit := func(_ *Scope, name string, t soltype.Type, node ast.Node) {
+		md.leaves[name] = destructureLeaf{t: t, node: node}
+	}
+	c.bindPatternWith(scope, lvl, d.Pattern, initType, nil, emit)
+	return md
+}
+
+// leafName returns a destructuring leaf key's bound name: the key's qualified name
+// with the decl's namespace prefix stripped, the inverse of dep_graph's
+// ModuleBindingVisitor.qualifyName. A leaf bound under namespace `A.B` as `x` has
+// key name `A.B.x`, so stripping `A.B.` recovers the pattern leaf name `x`.
+func leafName(g *dep_graph.DepGraph, key dep_graph.BindingKey) string {
+	name := key.Name()
+	if ns := g.GetNamespace(key); ns != "" {
+		return name[len(ns)+1:]
+	}
+	return name
 }
 
 // checkOverloadAnnotations enforces the PR6 recursion gate. It returns the set of

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -53,8 +53,8 @@ func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph) {
 	handled := set.NewSet[ast.Decl]()
 	// M4 E3: dep_graph fans one top-level destructuring `val {x, y} = …` across one
-	// SCC component per leaf key, so its initializer is typed and its pattern bound
-	// ONCE — memoized here on the first leaf reached — and each leaf component then
+	// SCC component per leaf key. Its initializer is typed and its pattern bound
+	// once, memoized here on the first leaf reached. Each leaf component then
 	// constrains its own projected type into its binding var.
 	destructured := map[*ast.VarDecl]*moduleDestructure{}
 	for _, component := range g.Components {
@@ -94,9 +94,10 @@ type componentBinding struct {
 	// recording, and (via isVarDecl) to tell an overload arm from a duplicate.
 	primary ast.Decl
 	// patLeaf is the pattern leaf node a top-level destructuring binding fans this
-	// key onto (M4 E3) — e.g. the `a` IdentPat of `val [a, b] = …`. Non-nil only for
-	// a destructured leaf; phase 3 records the generalized display type on this leaf
-	// node rather than on the whole decl pattern, which several leaf keys share.
+	// key onto, for example the `a` IdentPat of `val [a, b] = …` (M4 E3). It is
+	// non-nil only for a destructured leaf. Phase 3 records the generalized display
+	// type on this leaf node rather than on the whole decl pattern, which several
+	// leaf keys share.
 	patLeaf ast.Node
 	bound   bool // a definition was inferred and constrained
 	// isVarDecl reports whether the primary decl is a VarDecl, i.e. a `val` or a `var`
@@ -225,8 +226,8 @@ func (c *checker) inferComponent(
 		}
 		// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …` fans
 		// one decl across one leaf key per bound name, each its own component. This
-		// key is one such leaf: type the decl's pattern once (memoized in
-		// destructured) and lower THIS leaf's projected type into its binding var.
+		// key is one such leaf, so type the decl's pattern once, memoized in the
+		// destructured map, and lower THIS leaf's projected type into its binding var.
 		if vd := destructureDecl(g, key); vd != nil {
 			c.bindModuleDestructureLeaf(scope, inner, vd, g, key, b, handled, destructured)
 			continue
@@ -446,12 +447,13 @@ func (c *checker) inferComponent(
 }
 
 // moduleDestructure memoizes a top-level destructuring decl's typed pattern (M4
-// E3). dep_graph fans one `val {x, y} = …` across one component per bound name, so
-// the initializer is typed and the pattern bound ONCE — on the first leaf key
-// reached — and each leaf component then constrains its own projected type into its
-// binding var. leaves maps each bound name to that projection plus its pattern leaf
-// node; ok is false when the decl had no initializer (MissingInitializerError
-// already reported); recovered marks an initializer that fell back to the ErrorType
+// E3). dep_graph fans one `val {x, y} = …` across one component per bound name. The
+// initializer is typed and the pattern bound once, on the first leaf key reached.
+// Each leaf component then constrains its own projected type into its binding var.
+//
+// leaves maps each bound name to that projection plus its pattern leaf node. ok is
+// false when the decl had no initializer, in which case MissingInitializerError was
+// already reported. recovered marks an initializer that fell back to the ErrorType
 // sentinel, so each leaf recovers AS the sentinel rather than freezing to `never`.
 type moduleDestructure struct {
 	leaves    map[string]destructureLeaf
@@ -466,10 +468,11 @@ type destructureLeaf struct {
 	node ast.Node
 }
 
-// destructureDecl returns the destructuring VarDecl bound to key — a top-level
-// `val`/`var` whose pattern is not a plain IdentPat — or nil when key is not such a
-// leaf. dep_graph registers a destructuring decl under one value key per bound
-// name, each its own decl-of-one, so a leaf key has exactly that one VarDecl.
+// destructureDecl returns the destructuring VarDecl bound to key, or nil when key is
+// not a destructuring leaf. A destructuring decl is a top-level `val`/`var` whose
+// pattern is not a plain IdentPat. dep_graph registers such a decl under one value
+// key per bound name, each its own decl-of-one, so a leaf key has exactly that one
+// VarDecl.
 func destructureDecl(g *dep_graph.DepGraph, key dep_graph.BindingKey) *ast.VarDecl {
 	if key.Kind() != dep_graph.DepKindValue {
 		return nil
@@ -489,11 +492,11 @@ func destructureDecl(g *dep_graph.DepGraph, key dep_graph.BindingKey) *ast.VarDe
 }
 
 // bindModuleDestructureLeaf binds one leaf of a top-level destructuring decl into
-// its pre-bound binding var (M4 E3). The decl's pattern is typed once via
-// destructurePattern and memoized; this call looks up THIS key's projected leaf
-// type and constrains it into b.v, so phase 3 generalizes the leaf independently.
-// `key` is this leaf's binding key; its bound name is the key name minus the decl's
-// namespace prefix, matching the name dep_graph registered the leaf under.
+// its pre-bound binding var (M4 E3). destructurePattern types the decl's pattern
+// once and memoizes it. This call looks up THIS key's projected leaf type and
+// constrains it into b.v, so phase 3 generalizes the leaf independently. `key` is
+// this leaf's binding key. Its bound name is the key name minus the decl's namespace
+// prefix, matching the name dep_graph registered the leaf under.
 func (c *checker) bindModuleDestructureLeaf(
 	scope *Scope, lvl int, d *ast.VarDecl, g *dep_graph.DepGraph,
 	key dep_graph.BindingKey, b *componentBinding, handled set.Set[ast.Decl],
@@ -501,13 +504,13 @@ func (c *checker) bindModuleDestructureLeaf(
 ) {
 	md := c.destructurePattern(scope, lvl, d, handled, destructured)
 	if !md.ok {
-		return // no initializer; leaf stays unbound and is removed in phase 3
+		return // no initializer, so the leaf stays unbound and is removed in phase 3
 	}
 	leaf, found := md.leaves[leafName(g, key)]
 	if !found {
-		// The pattern bound no leaf for this name — a field the scrutinee lacks or a
-		// wrong tuple arity already reported by destructurePattern. Leave the leaf
-		// unbound; phase 3 removes it.
+		// The pattern bound no leaf for this name, because destructurePattern already
+		// reported a field the scrutinee lacks or a wrong tuple arity. Leave the leaf
+		// unbound. Phase 3 removes it.
 		return
 	}
 	c.constrain(d, leaf.t, b.v)
@@ -523,7 +526,7 @@ func (c *checker) bindModuleDestructureLeaf(
 	// M4 B3: an un-annotated `var` leaf widens at coalesce time, so a literal it
 	// binds reads back as the primitive and a later reassignment of the same
 	// primitive checks. An annotated `var` adopts its annotation, which needs no
-	// widening; a `val` leaf is a fixed singleton.
+	// widening. A `val` leaf is a fixed singleton.
 	if d.Kind == ast.VarKind && d.TypeAnn == nil {
 		b.v.Widenable = true
 	}
@@ -533,11 +536,11 @@ func (c *checker) bindModuleDestructureLeaf(
 // its pattern ONCE, memoizing the per-leaf projected types so each leaf component
 // reuses them (M4 E3). The initializer flows through the shared inferVarDeclInit
 // core, so an annotation is honored and a `var` initializer is widened, exactly as
-// the body-level path does. The pattern is bound with a collecting emit that
-// records each leaf's projection without defining it in scope — phase 1 already
-// pre-bound each leaf name as its binding var, and phase 3 redefines it generalized.
-// The decl is added to handled so the reconciliation pass does not report it as an
-// unmodeled top-level declaration.
+// the body-level path does. The pattern is bound with a collecting emit that records
+// each leaf's projection without defining it in scope. Phase 1 already pre-bound
+// each leaf name as its binding var, and phase 3 redefines it generalized. The decl
+// is added to handled so the reconciliation pass does not report it as an unmodeled
+// top-level declaration.
 func (c *checker) destructurePattern(
 	scope *Scope, lvl int, d *ast.VarDecl, handled set.Set[ast.Decl],
 	destructured map[*ast.VarDecl]*moduleDestructure,
@@ -550,7 +553,7 @@ func (c *checker) destructurePattern(
 	destructured[d] = md
 	initType, ok := c.inferVarDeclInit(scope, lvl, d)
 	if !ok {
-		return md // MissingInitializerError already reported; md.ok stays false
+		return md // MissingInitializerError already reported, so md.ok stays false
 	}
 	md.ok = true
 	_, md.recovered = initType.(*soltype.ErrorType)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -36,9 +36,9 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 }
 
 // leafEmit places one bound leaf: it receives the leaf's name, its projected type,
-// and its pattern node. defineLeafMono defines a fresh monomorphic binding in
-// scope (body-level / function-param); the top-level driver passes an emit that
-// constrains the leaf's type into a pre-bound binding var instead (M4 E3).
+// and its pattern node. defineLeafMono defines a fresh monomorphic binding in scope
+// for the body-level and function-param paths. The top-level driver passes an emit
+// that constrains the leaf's type into a pre-bound binding var instead (M4 E3).
 type leafEmit func(scope *Scope, name string, t soltype.Type, node ast.Node)
 
 // defineLeafMono is the default leaf-placement strategy: it defines the leaf as a
@@ -49,8 +49,8 @@ func defineLeafMono(scope *Scope, name string, t soltype.Type, _ ast.Node) {
 }
 
 // bindPatternWith is bindPattern parameterized by the leaf-placement strategy. See
-// bindPattern for the pattern-typing contract; emit decides where each bound leaf
-// lands.
+// bindPattern for the pattern-typing contract. The emit decides where each bound
+// leaf lands.
 func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
@@ -202,11 +202,11 @@ func patternDefaultsField(p ast.Pat) bool {
 	return ok && ip.Default != nil
 }
 
-// bindLeaf places one identifier leaf bound to t via emit, records its type, and
-// (when leafTypes is non-nil) reports the leaf's type by name for the liveness
-// pre-pass. The default emit (defineLeafMono) defines a monomorphic projection of
-// the scrutinee in scope; the top-level driver's emit constrains t into a
-// pre-bound binding var instead.
+// bindLeaf places one identifier leaf bound to t via emit and records its type. When
+// leafTypes is non-nil it also reports the leaf's type by name for the liveness
+// pre-pass. The default emit, defineLeafMono, defines a monomorphic projection of the
+// scrutinee in scope. The top-level driver's emit constrains t into a pre-bound
+// binding var instead.
 func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type, emit leafEmit) {
 	emit(scope, name, t, node)
 	c.recordType(node, t)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -26,12 +26,37 @@ import (
 // leafTypes, when non-nil, receives each leaf binding's type keyed by name. The
 // function-param path passes its paramTypes map so the liveness pre-pass can seed
 // each leaf's alias mutability. Other callers pass nil.
+//
+// bindPattern places each leaf as a monomorphic binding in scope, the body-level
+// and function-param strategy. The top-level driver needs the leaves constrained
+// into pre-bound binding vars instead, so it calls bindPatternWith with its own
+// emit (M4 E3).
 func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type) soltype.Pat {
+	return c.bindPatternWith(scope, lvl, pat, scrutinee, leafTypes, defineLeafMono)
+}
+
+// leafEmit places one bound leaf: it receives the leaf's name, its projected type,
+// and its pattern node. defineLeafMono defines a fresh monomorphic binding in
+// scope (body-level / function-param); the top-level driver passes an emit that
+// constrains the leaf's type into a pre-bound binding var instead (M4 E3).
+type leafEmit func(scope *Scope, name string, t soltype.Type, node ast.Node)
+
+// defineLeafMono is the default leaf-placement strategy: it defines the leaf as a
+// monomorphic projection of the scrutinee. Used by every body-level and
+// function-param destructuring path.
+func defineLeafMono(scope *Scope, name string, t soltype.Type, _ ast.Node) {
+	scope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
+}
+
+// bindPatternWith is bindPattern parameterized by the leaf-placement strategy. See
+// bindPattern for the pattern-typing contract; emit decides where each bound leaf
+// lands.
+func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
 	case *ast.IdentPat:
 		t := c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
-		c.bindLeaf(scope, p.Name, t, p, leafTypes)
+		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit)
 		return &soltype.IdentPat{Name: p.Name}
 
 	case *ast.WildcardPat:
@@ -94,7 +119,7 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		}
 		subs := make([]soltype.Pat, len(fixed))
 		for i, e := range fixed {
-			subs[i] = c.bindPattern(scope, lvl, e, elemTypes[i], leafTypes)
+			subs[i] = c.bindPatternWith(scope, lvl, e, elemTypes[i], leafTypes, emit)
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
@@ -109,7 +134,7 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				beta := c.freshAt(lvl)
 				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, e.Default != nil))
 				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
-				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes)
+				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
 					Value: &soltype.IdentPat{Name: e.Key.Name},
@@ -129,7 +154,7 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 						c.constrain(e, beta, prop.Type)
 					}
 				}
-				sub := c.bindPattern(scope, lvl, e.Value, beta, leafTypes)
+				sub := c.bindPatternWith(scope, lvl, e.Value, beta, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			default:
 				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
@@ -177,11 +202,13 @@ func patternDefaultsField(p ast.Pat) bool {
 	return ok && ip.Default != nil
 }
 
-// bindLeaf binds one identifier leaf to t in scope as a monomorphic projection of
-// the scrutinee, records its type, and (when leafTypes is non-nil) reports the
-// leaf's type by name for the liveness pre-pass.
-func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type) {
-	scope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
+// bindLeaf places one identifier leaf bound to t via emit, records its type, and
+// (when leafTypes is non-nil) reports the leaf's type by name for the liveness
+// pre-pass. The default emit (defineLeafMono) defines a monomorphic projection of
+// the scrutinee in scope; the top-level driver's emit constrains t into a
+// pre-bound binding var instead.
+func (c *checker) bindLeaf(scope *Scope, name string, t soltype.Type, node ast.Node, leafTypes map[string]soltype.Type, emit leafEmit) {
+	emit(scope, name, t, node)
 	c.recordType(node, t)
 	if leafTypes != nil {
 		leafTypes[name] = t


### PR DESCRIPTION
Enable type inference for top-level destructuring declarations like `val [a, b] = [1, 2]` and `val {x, y} = obj`. Previously these patterns reported an UnsupportedNodeError.

The SCC driver now handles destructuring by fanning one declaration across multiple binding keys (one per bound name). Each leaf key is processed as its own component, with the initializer typed once and memoized. Each leaf then constrains its projected type into its pre-bound binding variable, allowing phase 3 to generalize each leaf independently.

Key changes:

- Add `destructurePattern` to type a destructuring decl's initializer once and bind its pattern, memoizing per-leaf projected types
- Add `bindModuleDestructureLeaf` to constrain each leaf's projected type into its pre-bound binding var
- Parameterize `bindPattern` with a `leafEmit` callback via new `bindPatternWith`, allowing the top-level driver to place leaves in pre-bound vars instead of defining them in scope
- Track destructured leaves in `componentBinding.patLeaf` so phase 3 records generalized types on individual leaf nodes rather than the whole pattern
- Add comprehensive test coverage for tuple and object destructuring, nested patterns, error recovery, and recursive groups

An un-annotated `var` destructuring widens each leaf to its primitive (M4 B3), matching the body-level behavior. Destructured leaves are real bindings visible to other declarations, enabling forward references and recursive groups.

https://claude.ai/code/session_01A5ZWGWETaT39aKZrGZucep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for module-level destructuring patterns, including tuple and object destructuring syntax for more flexible top-level variable binding.

* **Tests**
  * Added comprehensive test coverage for module-scope destructuring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->