### PR TITLE
Implement tuple spread and numeric object keys

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -178,9 +178,23 @@ type BorrowEscapeError struct {
 	site  ast.Node     // M2.5: constraint node fallback
 }
 
+// SpreadNotTupleError fires when a tuple-literal spread element ([...xs]) has an
+// operand that does not infer to a tuple. M4 handles only the concrete-literal
+// splice: the operand's element types are copied into the literal in order, so it
+// must be a TupleType. A spread of any other type (e.g. an Array, which is M7)
+// cannot be spliced statically. The type-level cousins — a tuple-spread type over
+// an abstract operand ([...P, x]) and a typed variadic tail
+// ([number, ...Array<number>]) — defer to M9/M7. Spread is the offending spread
+// element (the blame span); Operand is the type it inferred to.
+type SpreadNotTupleError struct {
+	Spread  *ast.ArraySpreadExpr
+	Operand soltype.Type
+}
+
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
+func (*SpreadNotTupleError) isSolverError()      {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*ExtraPropertyError) isSolverError()       {}
@@ -800,6 +814,12 @@ func (e *FuncArityMismatchError) Message() string {
 func (e *TupleLengthMismatchError) Message() string {
 	return fmt.Sprintf("cannot constrain tuple of length %d <: tuple of length %d",
 		len(e.Sub.Elems), len(e.Super.Elems))
+}
+
+func (e *SpreadNotTupleError) Span() ast.Span      { return e.Spread.Span() }
+func (e *SpreadNotTupleError) Related() []ast.Span { return nil }
+func (e *SpreadNotTupleError) Message() string {
+	return "cannot spread " + describe(e.Operand) + " into a tuple"
 }
 
 func (e *MissingPropertyError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -181,11 +181,11 @@ type BorrowEscapeError struct {
 // SpreadNotTupleError fires when a tuple-literal spread element ([...xs]) has an
 // operand that does not infer to a tuple. M4 handles only the concrete-literal
 // splice: the operand's element types are copied into the literal in order, so it
-// must be a TupleType. A spread of any other type (e.g. an Array, which is M7)
-// cannot be spliced statically. The type-level cousins — a tuple-spread type over
-// an abstract operand ([...P, x]) and a typed variadic tail
-// ([number, ...Array<number>]) — defer to M9/M7. Spread is the offending spread
-// element (the blame span); Operand is the type it inferred to.
+// must be a TupleType. A spread of any other type, such as an Array (M7), cannot
+// be spliced statically. Two type-level cousins defer to M7/M9: a tuple-spread
+// type over an abstract operand [...P, x], and a typed variadic tail
+// [number, ...Array<number>]. Spread is the offending spread element and carries
+// the blame span. Operand is the type it inferred to.
 type SpreadNotTupleError struct {
 	Spread  *ast.ArraySpreadExpr
 	Operand soltype.Type
@@ -194,10 +194,10 @@ type SpreadNotTupleError struct {
 // InexactTupleSpreadError fires when a tuple-literal spread element ([...xs]) has an
 // operand that infers to an INEXACT tuple ([number, ...]). An inexact tuple has
 // unknown length, so an element written after the spread lands at an unknown
-// position and the result tuple's shape cannot be pinned. M4 splices concrete
-// (exact) tuples only; the variadic-tail forms ([number, ...Array<number>]) defer
-// to M7/M9. Spread is the offending spread element (the blame span); Operand is the
-// inexact tuple it inferred to.
+// position and the result tuple's shape cannot be pinned. M4 splices exact tuples
+// only. The variadic-tail forms such as [number, ...Array<number>] defer to M7/M9.
+// Spread is the offending spread element and carries the blame span. Operand is
+// the inexact tuple it inferred to.
 type InexactTupleSpreadError struct {
 	Spread  *ast.ArraySpreadExpr
 	Operand *soltype.TupleType

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -191,10 +191,23 @@ type SpreadNotTupleError struct {
 	Operand soltype.Type
 }
 
+// InexactTupleSpreadError fires when a tuple-literal spread element ([...xs]) has an
+// operand that infers to an INEXACT tuple ([number, ...]). An inexact tuple has
+// unknown length, so an element written after the spread lands at an unknown
+// position and the result tuple's shape cannot be pinned. M4 splices concrete
+// (exact) tuples only; the variadic-tail forms ([number, ...Array<number>]) defer
+// to M7/M9. Spread is the offending spread element (the blame span); Operand is the
+// inexact tuple it inferred to.
+type InexactTupleSpreadError struct {
+	Spread  *ast.ArraySpreadExpr
+	Operand *soltype.TupleType
+}
+
 func (*CannotConstrainError) isSolverError()     {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*SpreadNotTupleError) isSolverError()      {}
+func (*InexactTupleSpreadError) isSolverError()  {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*ExtraPropertyError) isSolverError()       {}
@@ -820,6 +833,12 @@ func (e *SpreadNotTupleError) Span() ast.Span      { return e.Spread.Span() }
 func (e *SpreadNotTupleError) Related() []ast.Span { return nil }
 func (e *SpreadNotTupleError) Message() string {
 	return "cannot spread " + describe(e.Operand) + " into a tuple"
+}
+
+func (e *InexactTupleSpreadError) Span() ast.Span      { return e.Spread.Span() }
+func (e *InexactTupleSpreadError) Related() []ast.Span { return nil }
+func (e *InexactTupleSpreadError) Message() string {
+	return "cannot spread an inexact tuple into a tuple"
 }
 
 func (e *MissingPropertyError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -192,12 +192,13 @@ type SpreadNotTupleError struct {
 }
 
 // InexactTupleSpreadError fires when a tuple-literal spread element ([...xs]) has an
-// operand that infers to an INEXACT tuple ([number, ...]). An inexact tuple has
-// unknown length, so an element written after the spread lands at an unknown
-// position and the result tuple's shape cannot be pinned. M4 splices exact tuples
-// only. The variadic-tail forms such as [number, ...Array<number>] defer to M7/M9.
-// Spread is the offending spread element and carries the blame span. Operand is
-// the inexact tuple it inferred to.
+// operand that infers to an INEXACT tuple ([number, ...]) and is not the last
+// element of the literal. An inexact tuple has unknown length, so an element written
+// after the spread would land at an unknown position and the result tuple's shape
+// could not be pinned. A trailing inexact spread is allowed and makes the whole
+// result inexact. The variadic-tail forms such as [number, ...Array<number>] defer
+// to M7/M9. Spread is the offending spread element and carries the blame span.
+// Operand is the inexact tuple it inferred to.
 type InexactTupleSpreadError struct {
 	Spread  *ast.ArraySpreadExpr
 	Operand *soltype.TupleType
@@ -838,7 +839,7 @@ func (e *SpreadNotTupleError) Message() string {
 func (e *InexactTupleSpreadError) Span() ast.Span      { return e.Spread.Span() }
 func (e *InexactTupleSpreadError) Related() []ast.Span { return nil }
 func (e *InexactTupleSpreadError) Message() string {
-	return "cannot spread an inexact tuple into a tuple"
+	return "cannot spread an inexact tuple except as the last element"
 }
 
 func (e *MissingPropertyError) Message() string {

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -17,6 +17,15 @@ func TestInferObjectAnnotationAdopted(t *testing.T) {
 	require.Equal(t, "{x: number, y: number}", values["r"])
 }
 
+// A numeric key resolves in an object annotation just as it does in a literal,
+// since both go through objKeyName. {0: number} names the field "0", which a {0: 5}
+// literal satisfies.
+func TestInferObjectAnnotationNumericKey(t *testing.T) {
+	values, _, errs := inferSource(t, `val o: {0: number} = {0: 5}`)
+	require.Empty(t, errs)
+	require.Equal(t, `{"0": number}`, values["o"])
+}
+
 // An inexact object annotation renders its `...` tail and accepts a literal whose
 // fields are all declared — the tail simply goes unused.
 func TestInferInexactObjectAnnotationDeclaredFields(t *testing.T) {
@@ -81,7 +90,7 @@ func TestInferInexactTupleAnnotationRejectsExcessLiteralElements(t *testing.T) {
 func TestInferInexactTupleAnnotationExcessThroughSpread(t *testing.T) {
 	src := `val t: [number, ...] = [...[5, 6], 7]`
 	values, _, errs := inferSource(t, src)
-	// Inferred [5, 6, 7] against [number]: indices 1 and 2 are excess — two errors.
+	// Inferred [5, 6, 7] against [number]: indices 1 and 2 are excess, so two errors.
 	require.Len(t, errs, 2)
 	require.IsType(t, &ExtraElementError{}, errs[0])
 	require.Equal(t, "tuple has extra element at index 1", errs[0].Message())

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -74,6 +74,25 @@ func TestInferInexactTupleAnnotationRejectsExcessLiteralElements(t *testing.T) {
 	require.Equal(t, "[number, ...]", values["t"])
 }
 
+// The excess check counts and blames by the INFERRED tuple's index, so a literal
+// with a spread reports each spliced excess element with precise per-element blame.
+// Before the fix the loop indexed the AST tuple and the inferred tuple by the same
+// counter, so a spread mis-blamed and under-reported the excess.
+func TestInferInexactTupleAnnotationExcessThroughSpread(t *testing.T) {
+	src := `val t: [number, ...] = [...[5, 6], 7]`
+	values, _, errs := inferSource(t, src)
+	// Inferred [5, 6, 7] against [number]: indices 1 and 2 are excess — two errors.
+	require.Len(t, errs, 2)
+	require.IsType(t, &ExtraElementError{}, errs[0])
+	require.Equal(t, "tuple has extra element at index 1", errs[0].Message())
+	require.Equal(t, "tuple has extra element at index 2", errs[1].Message())
+	// Per-element blame resolves through prov to each spliced element's own node:
+	// index 1 is the spread's `6`, index 2 is the trailing `7`.
+	require.Equal(t, "6", spanText(src, errs[0].Span()))
+	require.Equal(t, "7", spanText(src, errs[1].Span()))
+	require.Equal(t, "[number, ...]", values["t"])
+}
+
 // The tuple variable escape hatch: a non-literal source against an inexact tuple
 // target takes width subtyping (longer <: shorter through the inexact tail).
 func TestInferInexactTupleAnnotationVariableWidthSubtyping(t *testing.T) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -243,10 +243,10 @@ func (c *checker) checkExcessLiteralMembers(e ast.Expr, sub, annT soltype.Type) 
 		// A spread element ([...xs]) splices a variable number of inferred elements
 		// into the literal, so an AST element position no longer lines up with the
 		// inferred tuple's. Index ranges over the INFERRED tuple, which
-		// ExtraElementError.Index and .Sub both refer to; Span() resolves each
+		// ExtraElementError.Index and .Sub both refer to. Span() resolves each
 		// element's own origin node through prov, so per-element blame stays precise.
-		// The site is only a fallback: the AST element at i when the literal has no
-		// spread (positions match), else the whole literal.
+		// The site is only a fallback. It is the AST element at i when the literal has
+		// no spread, since positions then match, and the whole literal otherwise.
 		hasSpread := false
 		for _, el := range tup.Elems {
 			if _, ok := el.(*ast.ArraySpreadExpr); ok {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -240,10 +240,28 @@ func (c *checker) checkExcessLiteralMembers(e ast.Expr, sub, annT soltype.Type) 
 		if !isLit || !isTup {
 			return
 		}
+		// A spread element ([...xs]) splices a variable number of inferred elements
+		// into the literal, so an AST element position no longer lines up with the
+		// inferred tuple's. Index ranges over the INFERRED tuple, which
+		// ExtraElementError.Index and .Sub both refer to; Span() resolves each
+		// element's own origin node through prov, so per-element blame stays precise.
+		// The site is only a fallback: the AST element at i when the literal has no
+		// spread (positions match), else the whole literal.
+		hasSpread := false
+		for _, el := range tup.Elems {
+			if _, ok := el.(*ast.ArraySpreadExpr); ok {
+				hasSpread = true
+				break
+			}
+		}
 		// Elements beyond the target's declared prefix are excess on the literal.
-		for i := len(ann.Elems); i < len(tup.Elems) && i < len(subTup.Elems); i++ {
+		for i := len(ann.Elems); i < len(subTup.Elems); i++ {
 			err := &ExtraElementError{Sub: subTup, Super: ann, Index: i}
-			err.prov, err.site = c.prov, tup.Elems[i]
+			if !hasSpread && i < len(tup.Elems) {
+				err.prov, err.site = c.prov, tup.Elems[i]
+			} else {
+				err.prov, err.site = c.prov, tup
+			}
 			c.errs = append(c.errs, err)
 		}
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -984,16 +984,16 @@ func bindingDecl(b ValueBinding) ast.Node {
 // inferTuple types a tuple literal as a soltype.TupleType of its element types
 // and records it in Info. Elements are typed left-to-right in the current scope.
 //
-// A spread element ([...xs]) splices the operand's element types into the literal
-// (so [...pair, 3] over pair: [number, string] builds [number, string, number]).
-// M4 handles only this concrete-literal splice: the operand must infer to an EXACT
-// TupleType. An inexact operand ([number, ...]) has unknown length, so a later
-// element lands at an unknown position and the result's shape can't be pinned — it
-// is an InexactTupleSpreadError. A spread of any other type is a
-// SpreadNotTupleError; a spread whose operand already errored is absorbed silently,
-// so the recovery sentinel does not cascade a second diagnostic. The type-level
-// cousins — a tuple-spread type over an abstract operand ([...P, x]) and a typed
-// variadic tail ([number, ...Array<number>]) — defer to M9/M7.
+// A spread element ([...xs]) splices the operand's element types into the literal.
+// For example, [...pair, 3] over pair: [number, string] builds
+// [number, string, number]. M4 handles only this concrete-literal splice: the
+// operand must infer to an EXACT TupleType. An inexact operand ([number, ...]) has
+// unknown length, so a later element lands at an unknown position and the result's
+// shape can't be pinned, which is an InexactTupleSpreadError. A spread of any other
+// type is a SpreadNotTupleError. A spread whose operand already errored is absorbed
+// silently, so the recovery sentinel does not cascade a second diagnostic. Two
+// type-level cousins defer to M7/M9: a tuple-spread type over an abstract operand
+// [...P, x], and a typed variadic tail [number, ...Array<number>].
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
 	elems := make([]soltype.Type, 0, len(e.Elems))
 	for _, el := range e.Elems {
@@ -1023,16 +1023,17 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 }
 
 // inferObject types an object literal as an exact soltype.ObjectType. A property
-// with a static key — an identifier label, a string-literal key, or a numeric key
-// ({0: v}) — folds into the object. The forms it does not cover each report an
-// UnsupportedNodeError and are skipped rather than panicking:
+// with a static key folds into the object. A static key is an identifier label, a
+// string-literal key, or a numeric key like {0: v}. The forms it does not cover
+// each report an UnsupportedNodeError and are skipped rather than panicking:
 //   - spreads ({...o}), deferred to M9 with object rest/spread,
 //   - method/constructor elements, which arrive with classes in M5,
 //   - computed keys ({[k]: v}), which need M9 index signatures,
-//   - shorthand ({x}, i.e. a property with no value).
+//   - shorthand ({x}, a property with no value).
 //
-// Usage-inference depth (e.g. inferring an open object from how a value is used)
-// builds on this elsewhere; here the closed object the literal spells out is built.
+// Usage-inference depth builds on this elsewhere, for example inferring an open
+// object from how a value is used. Here the closed object the literal spells out is
+// built.
 //
 // Duplicate keys follow JavaScript semantics: the last value wins, keeping the
 // property at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
@@ -1042,8 +1043,9 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
-			// ObjSpreadExpr is M9 (object rest/spread); CallableExpr (method) and
-			// ConstructorExpr arrive with classes in M5.
+			// ObjSpreadExpr is object rest/spread, which is M9. The method and
+			// constructor elements CallableExpr and ConstructorExpr arrive with
+			// classes in M5.
 			c.reportUnsupported(elem)
 			continue
 		}
@@ -1054,8 +1056,9 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
-			// A computed key ({[k]: v}) carries no static property name — M9. Blame
-			// the key itself (its own narrower span), not the whole property.
+			// A computed key ({[k]: v}) carries no static property name, so it is M9.
+			// Blame the key itself, which has its own narrower span, not the whole
+			// property.
 			c.reportUnsupported(prop.Name)
 			continue
 		}
@@ -1292,10 +1295,10 @@ func constStringKey(e ast.Expr) (string, bool) {
 
 // objKeyName reads the static field name of an object-literal key. Object field
 // names are strings, so an identifier label, a string-literal key, or a numeric
-// key all map to a field: a numeric key is coerced to its string form the way
+// key all map to a field. A numeric key is coerced to its string form the way
 // JavaScript does, so {0: v} names the field "0". A computed key ({[k]: v}) carries
-// no static name and returns false so the caller can raise a structured error;
-// full index-signature support rides M9.
+// no static name and returns false so the caller can raise a structured error.
+// Full index-signature support rides M9.
 func objKeyName(k ast.ObjKey) (string, bool) {
 	switch k := k.(type) {
 	case *ast.IdentExpr:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -987,16 +987,19 @@ func bindingDecl(b ValueBinding) ast.Node {
 // A spread element ([...xs]) splices the operand's element types into the literal.
 // For example, [...pair, 3] over pair: [number, string] builds
 // [number, string, number]. M4 handles only this concrete-literal splice: the
-// operand must infer to an EXACT TupleType. An inexact operand ([number, ...]) has
-// unknown length, so a later element lands at an unknown position and the result's
-// shape can't be pinned, which is an InexactTupleSpreadError. A spread of any other
-// type is a SpreadNotTupleError. A spread whose operand already errored is absorbed
-// silently, so the recovery sentinel does not cascade a second diagnostic. Two
-// type-level cousins defer to M7/M9: a tuple-spread type over an abstract operand
-// [...P, x], and a typed variadic tail [number, ...Array<number>].
+// operand must infer to a TupleType. An inexact operand ([number, ...]) has unknown
+// length, so it may only be spread as the last element. There its known prefix
+// extends the literal and its unknown tail makes the result inexact too. An inexact
+// operand anywhere else would put a later element at an unknown position, which is an
+// InexactTupleSpreadError. A spread of any other type is a SpreadNotTupleError. A
+// spread whose operand already errored is absorbed silently, so the recovery
+// sentinel does not cascade a second diagnostic. Two type-level cousins defer to
+// M7/M9: a tuple-spread type over an abstract operand [...P, x], and a typed
+// variadic tail [number, ...Array<number>].
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
 	elems := make([]soltype.Type, 0, len(e.Elems))
-	for _, el := range e.Elems {
+	inexact := false
+	for i, el := range e.Elems {
 		spread, ok := el.(*ast.ArraySpreadExpr)
 		if !ok {
 			elems = append(elems, c.inferExpr(scope, lvl, el))
@@ -1004,11 +1007,14 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 		}
 		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
 		case *soltype.TupleType:
-			if op.Inexact {
+			if op.Inexact && i != len(e.Elems)-1 {
 				c.report(&InexactTupleSpreadError{Spread: spread, Operand: op})
 				continue
 			}
 			elems = append(elems, op.Elems...)
+			if op.Inexact {
+				inexact = true // a trailing inexact spread carries through
+			}
 		case *soltype.ErrorType:
 			// The operand already reported its own failure; absorb it rather than
 			// layering a SpreadNotTupleError on the recovery sentinel.
@@ -1016,7 +1022,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 			c.report(&SpreadNotTupleError{Spread: spread, Operand: op})
 		}
 	}
-	t := &soltype.TupleType{Elems: elems}
+	t := &soltype.TupleType{Elems: elems, Inexact: inexact}
 	c.recordType(e, t)
 	c.recordProv(t, e, TupleElem)
 	return t

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -982,13 +983,32 @@ func bindingDecl(b ValueBinding) ast.Node {
 
 // inferTuple types a tuple literal as a soltype.TupleType of its element types
 // and records it in Info. Elements are typed left-to-right in the current scope.
-// A spread element ([...xs]) is an ArraySpreadExpr, which is not in the M2 walk,
-// so inferExpr reports it as unsupported and contributes a never placeholder in
-// its slot — the tuple is still built (error already accumulated), never a panic.
+//
+// A spread element ([...xs]) splices the operand's element types into the literal
+// (so [...pair, 3] over pair: [number, string] builds [number, string, number]).
+// M4 handles only this concrete-literal splice: the operand must infer to a
+// TupleType. A spread of any other type is a SpreadNotTupleError; a spread whose
+// operand already errored is absorbed silently, so the recovery sentinel does not
+// cascade a second diagnostic. The type-level cousins — a tuple-spread type over
+// an abstract operand ([...P, x]) and a typed variadic tail
+// ([number, ...Array<number>]) — defer to M9/M7.
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
-	elems := make([]soltype.Type, len(e.Elems))
-	for i, el := range e.Elems {
-		elems[i] = c.inferExpr(scope, lvl, el)
+	elems := make([]soltype.Type, 0, len(e.Elems))
+	for _, el := range e.Elems {
+		spread, ok := el.(*ast.ArraySpreadExpr)
+		if !ok {
+			elems = append(elems, c.inferExpr(scope, lvl, el))
+			continue
+		}
+		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
+		case *soltype.TupleType:
+			elems = append(elems, op.Elems...)
+		case *soltype.ErrorType:
+			// The operand already reported its own failure; absorb it rather than
+			// layering a SpreadNotTupleError on the recovery sentinel.
+		default:
+			c.report(&SpreadNotTupleError{Spread: spread, Operand: op})
+		}
 	}
 	t := &soltype.TupleType{Elems: elems}
 	c.recordType(e, t)
@@ -996,16 +1016,17 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 	return t
 }
 
-// inferObject types an object literal as an exact soltype.ObjectType. M2 covers
-// the basic case only: a `name: value` property with a static (identifier or
-// string) key. The forms it does not cover each report an UnsupportedNodeError
-// and are skipped rather than panicking (the deeper object system is M4):
-//   - spreads ({...o}) and method/constructor elements,
-//   - computed ({[k]: v}) and numeric ({0: v}) keys,
+// inferObject types an object literal as an exact soltype.ObjectType. A property
+// with a static key — an identifier label, a string-literal key, or a numeric key
+// ({0: v}) — folds into the object. The forms it does not cover each report an
+// UnsupportedNodeError and are skipped rather than panicking:
+//   - spreads ({...o}), deferred to M9 with object rest/spread,
+//   - method/constructor elements, which arrive with classes in M5,
+//   - computed keys ({[k]: v}), which need M9 index signatures,
 //   - shorthand ({x}, i.e. a property with no value).
 //
 // Usage-inference depth (e.g. inferring an open object from how a value is used)
-// is explicitly M4; M2 builds the closed object the literal spells out.
+// builds on this elsewhere; here the closed object the literal spells out is built.
 //
 // Duplicate keys follow JavaScript semantics: the last value wins, keeping the
 // property at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
@@ -1015,19 +1036,20 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
-			// ObjSpreadExpr, CallableExpr (method), ConstructorExpr — all M4.
+			// ObjSpreadExpr is M9 (object rest/spread); CallableExpr (method) and
+			// ConstructorExpr arrive with classes in M5.
 			c.reportUnsupported(elem)
 			continue
 		}
 		if prop.Value == nil {
-			// Shorthand ({x}) needs the ident's binding folded in as the value — M4.
+			// Shorthand ({x}) needs the ident's binding folded in as the value.
 			c.reportUnsupported(prop)
 			continue
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
-			// Computed/numeric keys carry no static property name — M4. Blame the
-			// key itself (its own narrower span), not the whole property.
+			// A computed key ({[k]: v}) carries no static property name — M9. Blame
+			// the key itself (its own narrower span), not the whole property.
 			c.reportUnsupported(prop.Name)
 			continue
 		}
@@ -1262,16 +1284,20 @@ func constStringKey(e ast.Expr) (string, bool) {
 	return "", false
 }
 
-// objKeyName reads the static field name of an object-literal key. M2 records
-// have string field names, so an identifier label or a string-literal key maps
-// to a field; numeric and computed keys do not (they need M4's wider object
-// system) and return false so the caller can raise a structured error.
+// objKeyName reads the static field name of an object-literal key. Object field
+// names are strings, so an identifier label, a string-literal key, or a numeric
+// key all map to a field: a numeric key is coerced to its string form the way
+// JavaScript does, so {0: v} names the field "0". A computed key ({[k]: v}) carries
+// no static name and returns false so the caller can raise a structured error;
+// full index-signature support rides M9.
 func objKeyName(k ast.ObjKey) (string, bool) {
 	switch k := k.(type) {
 	case *ast.IdentExpr:
 		return k.Name, true
 	case *ast.StrLit:
 		return k.Value, true
+	case *ast.NumLit:
+		return strconv.FormatFloat(k.Value, 'f', -1, 64), true
 	default:
 		return "", false
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -986,12 +986,14 @@ func bindingDecl(b ValueBinding) ast.Node {
 //
 // A spread element ([...xs]) splices the operand's element types into the literal
 // (so [...pair, 3] over pair: [number, string] builds [number, string, number]).
-// M4 handles only this concrete-literal splice: the operand must infer to a
-// TupleType. A spread of any other type is a SpreadNotTupleError; a spread whose
-// operand already errored is absorbed silently, so the recovery sentinel does not
-// cascade a second diagnostic. The type-level cousins — a tuple-spread type over
-// an abstract operand ([...P, x]) and a typed variadic tail
-// ([number, ...Array<number>]) — defer to M9/M7.
+// M4 handles only this concrete-literal splice: the operand must infer to an EXACT
+// TupleType. An inexact operand ([number, ...]) has unknown length, so a later
+// element lands at an unknown position and the result's shape can't be pinned — it
+// is an InexactTupleSpreadError. A spread of any other type is a
+// SpreadNotTupleError; a spread whose operand already errored is absorbed silently,
+// so the recovery sentinel does not cascade a second diagnostic. The type-level
+// cousins — a tuple-spread type over an abstract operand ([...P, x]) and a typed
+// variadic tail ([number, ...Array<number>]) — defer to M9/M7.
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
 	elems := make([]soltype.Type, 0, len(e.Elems))
 	for _, el := range e.Elems {
@@ -1002,6 +1004,10 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 		}
 		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
 		case *soltype.TupleType:
+			if op.Inexact {
+				c.report(&InexactTupleSpreadError{Spread: spread, Operand: op})
+				continue
+			}
 			elems = append(elems, op.Elems...)
 		case *soltype.ErrorType:
 			// The operand already reported its own failure; absorb it rather than

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -65,16 +65,33 @@ func TestInferTupleSpreadNonTuple(t *testing.T) {
 	require.Equal(t, "cannot spread 5 into a tuple", c.errs[0].Message())
 }
 
-// Spreading an inexact tuple is rejected: an inexact operand ([number, ...]) has
-// unknown length, so an element after the spread lands at an unknown position and
-// the result's shape can't be pinned. M4 splices exact tuples only.
-func TestInferTupleSpreadInexact(t *testing.T) {
+// Spreading an inexact tuple before another element is rejected: the inexact
+// operand ([number, ...]) has unknown length, so the trailing 1 would land at an
+// unknown position.
+func TestInferTupleSpreadInexactNotLast(t *testing.T) {
 	// fn f(z: [number, ...]) { return [...z, 1] }
 	_, _, errs := inferSource(t, `
 		fn f(z: [number, ...]) { return [...z, 1] }
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot spread an inexact tuple into a tuple", errs[0].Message())
+	require.Equal(t, "cannot spread an inexact tuple except as the last element", errs[0].Message())
+}
+
+// A trailing inexact spread is sound: the operand's known prefix extends the
+// literal and its unknown tail becomes the literal's tail, so the result is itself
+// an inexact tuple. [...z] over z: [number, ...] yields [number, ...], and a leading
+// element keeps its place: [a, ...z] yields [typeof a, number, ...].
+func TestInferTupleSpreadInexactLast(t *testing.T) {
+	t.Run("spread alone", func(t *testing.T) {
+		vals, _, errs := inferSource(t, `fn f(z: [number, ...]) { return [...z] }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (z: [number, ...]) -> [number, ...]", vals["f"])
+	})
+	t.Run("element before a trailing spread", func(t *testing.T) {
+		vals, _, errs := inferSource(t, `fn f(z: [number, ...]) { return ["hi", ...z] }`)
+		require.Empty(t, errs)
+		require.Equal(t, `fn (z: [number, ...]) -> ["hi", number, ...]`, vals["f"])
+	})
 }
 
 // A spread whose operand already errored is absorbed: walking the unbound `a`

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -53,6 +53,26 @@ func TestInferTupleSpreadMiddle(t *testing.T) {
 	require.Equal(t, "[1, 2, 3, 4]", render(got))
 }
 
+// Spreading multiple exact tuples concatenates them into one exact tuple whose
+// length is the sum of the operand lengths. The result stays exact, since every
+// operand has a known length, so the assertion checks the Inexact flag and the
+// element count directly rather than relying on the rendered form.
+func TestInferTupleSpreadMultipleExact(t *testing.T) {
+	c := newChecker()
+	// [...[1, 2], ...[3, 4]]
+	a := tupleExpr(numExpr(1), numExpr(2))
+	b := tupleExpr(numExpr(3), numExpr(4))
+	e := tupleExpr(ast.NewArraySpread(a, testSpan()), ast.NewArraySpread(b, testSpan()))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "[1, 2, 3, 4]", render(got))
+
+	tup, ok := got.(*soltype.TupleType)
+	require.True(t, ok)
+	require.False(t, tup.Inexact) // every operand had a known length
+	require.Len(t, tup.Elems, 4)  // 2 + 2 spliced elements
+}
+
 // Spreading a non-tuple value is a typed error: M4 splices concrete tuple
 // literals only, so the operand must infer to a tuple.
 func TestInferTupleSpreadNonTuple(t *testing.T) {

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -28,19 +28,41 @@ func TestInferTupleEmpty(t *testing.T) {
 	require.Equal(t, "[]", render(got))
 }
 
-// A spread element ([...a]) is an ArraySpreadExpr, which the M2 walk does not
-// cover; inferExpr reports it as unsupported and drops the error-recovery
-// placeholder (PR8) into the tuple slot, so the tuple still builds (no panic) and
-// the spread's value `a` is never walked — so no cascading unknown-identifier
-// error. Tuple/array spread is M4.
-func TestInferTupleSpreadUnsupported(t *testing.T) {
+// A spread element ([...pair]) splices the operand tuple's element types into the
+// literal: [...pair, 3] over pair: [number, string] builds [number, string, 3].
+func TestInferTupleSpread(t *testing.T) {
+	c := newChecker()
+	// [...[1, "hi"], 3]
+	pair := tupleExpr(numExpr(1), strExpr("hi"))
+	e := tupleExpr(ast.NewArraySpread(pair, testSpan()), numExpr(3))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, `[1, "hi", 3]`, render(got))
+}
+
+// Spreading a non-tuple value is a typed error: M4 splices concrete tuple
+// literals only, so the operand must infer to a tuple.
+func TestInferTupleSpreadNonTuple(t *testing.T) {
+	c := newChecker()
+	// [...5]
+	e := tupleExpr(ast.NewArraySpread(numExpr(5), testSpan()))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Equal(t, "[]", render(got)) // the bad spread contributes no elements
+	require.Len(t, c.errs, 1)
+	require.Equal(t, "cannot spread 5 into a tuple", c.errs[0].Message())
+}
+
+// A spread whose operand already errored is absorbed: walking the unbound `a`
+// reports a single unknown-identifier error, and the spread does not layer a
+// SpreadNotTupleError on the recovery sentinel.
+func TestInferTupleSpreadErrorOperandAbsorbs(t *testing.T) {
 	c := newChecker()
 	// [...a]
 	e := tupleExpr(ast.NewArraySpread(identExpr("a"), testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
-	require.Equal(t, "[error]", render(got))
+	require.Equal(t, "[]", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported: ArraySpreadExpr", c.errs[0].Message())
+	require.Equal(t, "Unknown identifier: a", c.errs[0].Message())
 }
 
 // --- ObjectExpr ---
@@ -71,6 +93,18 @@ func TestInferObjectStringKey(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, objExpr(strKey))
 	require.Empty(t, c.errs)
 	require.Equal(t, "{a: 5}", render(got))
+}
+
+// A numeric key resolves to a static field name: JavaScript coerces it to its
+// string form, so {0: 5} names the field "0". The field name is not a valid
+// identifier, so it renders as a quoted key.
+func TestInferObjectNumericKey(t *testing.T) {
+	c := newChecker()
+	// {0: 5}
+	numKey := ast.NewProperty(ast.NewNumber(0, testSpan()), false, false, numExpr(5), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(numKey))
+	require.Empty(t, c.errs)
+	require.Equal(t, `{"0": 5}`, render(got))
 }
 
 // Duplicate keys follow JS last-wins semantics: the later value replaces the

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -52,6 +52,18 @@ func TestInferTupleSpreadNonTuple(t *testing.T) {
 	require.Equal(t, "cannot spread 5 into a tuple", c.errs[0].Message())
 }
 
+// Spreading an inexact tuple is rejected: an inexact operand ([number, ...]) has
+// unknown length, so an element after the spread lands at an unknown position and
+// the result's shape can't be pinned. M4 splices exact tuples only.
+func TestInferTupleSpreadInexact(t *testing.T) {
+	// fn f(z: [number, ...]) { return [...z, 1] }
+	_, _, errs := inferSource(t, `
+		fn f(z: [number, ...]) { return [...z, 1] }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot spread an inexact tuple into a tuple", errs[0].Message())
+}
+
 // A spread whose operand already errored is absorbed: walking the unbound `a`
 // reports a single unknown-identifier error, and the spread does not layer a
 // SpreadNotTupleError on the recovery sentinel.

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -40,6 +40,19 @@ func TestInferTupleSpread(t *testing.T) {
 	require.Equal(t, `[1, "hi", 3]`, render(got))
 }
 
+// A spread in the middle of a literal keeps element order: the elements before
+// the spread, then the splice, then the elements after. [1, ...[2, 3], 4] builds
+// [1, 2, 3, 4].
+func TestInferTupleSpreadMiddle(t *testing.T) {
+	c := newChecker()
+	// [1, ...[2, 3], 4]
+	mid := tupleExpr(numExpr(2), numExpr(3))
+	e := tupleExpr(numExpr(1), ast.NewArraySpread(mid, testSpan()), numExpr(4))
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "[1, 2, 3, 4]", render(got))
+}
+
 // Spreading a non-tuple value is a typed error: M4 splices concrete tuple
 // literals only, so the operand must infer to a tuple.
 func TestInferTupleSpreadNonTuple(t *testing.T) {
@@ -117,6 +130,24 @@ func TestInferObjectNumericKey(t *testing.T) {
 	got := c.inferExpr(NewScope(), 0, objExpr(numKey))
 	require.Empty(t, c.errs)
 	require.Equal(t, `{"0": 5}`, render(got))
+}
+
+// A numeric key and a string key that coerce to the same name are the same field
+// under JavaScript semantics: {0: 1, "0": 2} is a single field "0". Last-wins
+// dedup then collapses them to {"0": 2}, so the resolved name, not the syntactic
+// key kind, decides identity.
+func TestInferObjectNumericStringKeyCollision(t *testing.T) {
+	c := newChecker()
+	// {0: 1, "0": 2}
+	numKey := ast.NewProperty(ast.NewNumber(0, testSpan()), false, false, numExpr(1), testSpan())
+	strKey := ast.NewProperty(ast.NewString("0", testSpan()), false, false, numExpr(2), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(numKey, strKey))
+	require.Empty(t, c.errs)
+	require.Equal(t, `{"0": 2}`, render(got))
+
+	obj, ok := got.(*soltype.ObjectType)
+	require.True(t, ok)
+	require.Len(t, obj.Elems, 1) // the two keys collapsed to one field
 }
 
 // Duplicate keys follow JS last-wins semantics: the later value replaces the

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -33,9 +33,9 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 	require.Equal(t, "fn () -> number", values["f"])
 }
 
-// An unsupported expression (here an object spread, deferred to M9) recovers to the
-// ErrorType sentinel and flows on without cascading: the only error is the
-// unsupported-node one, and the surrounding object still builds.
+// An unsupported expression recovers to the ErrorType sentinel and flows on without
+// cascading. Here the unsupported expression is an object spread, which is M9. The
+// only error is the unsupported-node one, and the surrounding object still builds.
 func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val o = {...xs}

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -33,16 +33,16 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 	require.Equal(t, "fn () -> number", values["f"])
 }
 
-// An unsupported expression (here an array spread, an M4 construct) recovers to the
+// An unsupported expression (here an object spread, deferred to M9) recovers to the
 // ErrorType sentinel and flows on without cascading: the only error is the
-// unsupported-node one, and the surrounding tuple still builds.
+// unsupported-node one, and the surrounding object still builds.
 func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		val t = [...xs]
+		val o = {...xs}
 	`)
 	// One error for the spread itself; `xs` is never walked (so no extra
 	// unknown-identifier), and the broken element does not cascade.
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: ArraySpreadExpr", errs[0].Message())
-	require.Equal(t, "[error]", values["t"])
+	require.Equal(t, "Unsupported: ObjSpreadExpr", errs[0].Message())
+	require.Equal(t, "{}", values["o"])
 }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -354,6 +354,15 @@ checker:
 
 ## M4 — Core value types: records + usage-based inference + `mut` + **lifetimes** + destructuring/`match`
 
+**Status: landed** (PRs #728–#765; see
+[m4-implementation-plan.md](m4-implementation-plan.md) §"Dependency graph" — all
+phases A–G complete). The `ObjectType`/`TupleType` exactness flag and subtyping
+rules, usage-based inference with the `open` marker, `var` literal widening, the
+unified `RefType{mut, lt, inner}` borrow wrapper and its constrain rule,
+field-write mutability inference, the lifetime sort with origination/escape/elision,
+destructuring patterns and the `match` expression, namespace member lookup, and the
+ported mutability-transition checks all shipped.
+
 The big one. These are inseparable: lifetimes ride on borrows, records are the
 first value type that can be borrowed, and `mut` borrows (via the `Ref`
 wrapper) are what first populate a lifetime. Land them together.

--- a/planning/simple_sub/m4-implementation-plan.md
+++ b/planning/simple_sub/m4-implementation-plan.md
@@ -1510,29 +1510,24 @@ these arms it must add.
 ### Dependency graph
 
 ```
-✓ = landed on main.  Done so far:
-- A1 (#728)
+✓ = landed.  All M4 PRs are complete:
+- A1 (#728), A2 (#765)
 - A3 (#733)
-- B1+B2 (#732)
-- B3 (#733)
-- C1+C2 (#731)
-- C3 (#735)
-- D1 (#740)
-- D2 (#744)
-- D2.5 (#745)
-- D3 (#748)
-- D4 (#749)
-- G1 (#753, #754, #755; ast/liveness prereqs #751, #752)
+- B1+B2 (#732), B3 (#734)
+- C1+C2 (#731), C3 (#735)
+- D1 (#740), D2 (#744), D2.5 (#745), D3 (#748), D4 (#749)
+- E1 (#758), E2 (#761), E3 (#763)
 - F1 (#730)
+- G1 (#753, #754, #755; ast/liveness prereqs #751, #752), G2 (#759), G3 (#764)
 
-A1✓ → A2
+A1✓ → A2✓
 A1✓ → A3✓ ──────────────────────┐  (A3's mut/lifetime arms un-gated by C1)
 A1✓ → B1✓ → B2✓                 │  (annotation-side acceptance tests)
       B1✓ → B3✓                 │
       B1✓, B3✓ ───────────┐     │  (C3 reuses B1's foldUsageBounds fold + B3's widen)
-A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1✓ → D2✓ → D3✓ → D4✓ → G1✓ → G2 → G3
-A1✓ → E1 → E2   (independent of C/D; E1's RefType peel via carrierOf needs C1)
-F1✓             (independent; any time — only M2's Namespace)
+A1✓ → C1✓ → C2✓(GATE) →  C3✓ → D1✓ → D2✓ → D2.5✓ → D3✓ → D4✓ → G1✓ → G2✓ → G3✓
+A1✓ → E1✓ → E2✓ → E3✓   (independent of C/D; E1's RefType peel via carrierOf needs C1)
+F1✓                     (independent; any time — only M2's Namespace)
 ```
 
 Critical path to the gate: **A1 → C1 → C2** — three PRs. B, E, F are parallel


### PR DESCRIPTION
Implement support for tuple-literal spread elements and numeric object keys in M4.

**Summary**

This change adds two related features to the type checker:

1. **Tuple spread elements** (`[...xs]`) now splice the operand's element types into the literal. For example, `[...pair, 3]` over `pair: [number, string]` builds `[number, string, 3]`. The operand must infer to an exact tuple; spreading an inexact tuple or non-tuple type reports a structured error. A spread whose operand already errored is absorbed silently to avoid cascading diagnostics.

2. **Numeric object keys** (`{0: v}`) now resolve to static field names by coercing to their string form, matching JavaScript semantics. The field `{0: 5}` names `"0"`, and `{0: 1, "0": 2}` collapses to a single field `{"0": 2}` under last-wins dedup.

**Key changes**

- `inferTuple` now detects `ArraySpreadExpr` elements and splices exact tuple operands into the literal. Inexact tuples and non-tuples report `InexactTupleSpreadError` and `SpreadNotTupleError` respectively. Error operands are absorbed without cascading.

- `objKeyName` now handles numeric keys via `strconv.FormatFloat`, coercing them to strings the way JavaScript does.

- Two new error types added: `SpreadNotTupleError` (spread operand is not a tuple) and `InexactTupleSpreadError` (spread operand is an inexact tuple).

- `checkExcessLiteralMembers` now accounts for spreads when indexing the inferred tuple, since AST positions no longer line up with inferred positions when spreads are present. Per-element blame is preserved through provenance.

**Tests**

New test cases cover tuple spreads at the start, middle, and end of literals; spreading non-tuples and inexact tuples; error operand absorption; numeric keys in literals and annotations; and numeric-string key collisions. An existing test for unsupported spreads was updated to reflect the new behavior.

https://claude.ai/code/session_012FVQKFnTTuRSE9kv472ENB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for spreading tuple element types inside tuple literals (including middle and multiple exact spreads).
  * Added numeric literal property keys in object literals, including JavaScript-like stringification and last-wins deduplication.
* **Bug Fixes**
  * Improved type-checking and diagnostics for tuple spreads: non-tuple operands and inexact tuple spreads in non-trailing positions now report clearer, dedicated errors; operand errors are absorbed to avoid duplicates.
  * Refined excess-position error blame when tuple literals include spreads.
  * Updated recovery for unsupported object spread to prevent cascading diagnostics.
* **Tests**
  * Expanded tuple spread, inexact spread, numeric key, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->