### PR TITLE
Add script inference entry point with linear scoping

### DIFF
--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -1,0 +1,60 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+)
+
+// InferScript infers a script — a source file whose top-level statements run in
+// source order with function-body semantics, the bin/ counterpart to a library
+// module. It returns the populated script Scope (a child of the prelude, so
+// operators and the stdlib-type placeholders resolve through the parent), the Info
+// side table, and any SolverErrors.
+//
+// A module and a script differ in how their top-level declarations relate.
+// InferModule dependency-orders mutually-visible top-level declarations through the
+// dep graph. A script is instead one straight-line body: its bindings are linear,
+// and each statement sees only the ones before it, exactly as inside a function. So
+// liveness, alias tracking, and the `mut` transition rules — which a module skips at
+// top level because c.fn is nil there, making every transition entry point a no-op —
+// all apply to a script's top-level statements.
+//
+// It mirrors the old checker's InferScript in internal/checker/infer_script.go:
+//
+//  1. wrap the script's statements in an ast.Block;
+//  2. push a fresh funcCtx so c.fn is non-nil and the transition checker is live;
+//  3. run runLivenessPrePass over that block to rename the body's variable nodes and
+//     seed the alias/liveness tables;
+//  4. walk the statements in source order through inferStmt.
+//
+// M4 shipped every building block this uses — the pre-pass, the per-body funcCtx, the
+// alias tracker, and the transition checker. The only new code is this entry point
+// that runs them over a script body. There is no new inference.
+//
+// The funcCtx carries no async flag, so a top-level `await` reports against the
+// script node, matching a non-async function body. inferStmt routes a top-level
+// `return` into the funcCtx's returns list, which the script never joins, so the
+// return is accepted and discarded — the same no-op the old checker's inferStmt
+// applies to a script-level return.
+func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
+	c := newChecker()
+	scope := sharedPrelude().Child()
+
+	// A script's statements form one linear body, so give them the same per-body
+	// context a function body gets. pushFuncCtx makes c.fn non-nil — the transition
+	// checker keys off it, and runLivenessPrePass writes its liveness/alias state onto
+	// it — and the prelude child is the outer scope the pre-pass resolves names
+	// against. There is no enclosing function to restore, so the returned previous
+	// context is discarded.
+	scriptBody := &ast.Block{Stmts: script.Stmts, Span: script.Span()}
+	c.pushFuncCtx(false, script)
+	c.runLivenessPrePass(scope, nil, nil, scriptBody)
+
+	// Walk at level 0, the script body's own level: inferVarDecl types each
+	// initializer one level deeper and generalizes back to 0, so a top-level binding
+	// is a generalized local exactly like one in a function body walked at its level.
+	for _, stmt := range script.Stmts {
+		c.inferStmt(scope, 0, stmt)
+	}
+
+	return scope, c.info, c.errs
+}

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -4,19 +4,19 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 )
 
-// InferScript infers a script — a source file whose top-level statements run in
-// source order with function-body semantics, the bin/ counterpart to a library
-// module. It returns the populated script Scope (a child of the prelude, so
-// operators and the stdlib-type placeholders resolve through the parent), the Info
-// side table, and any SolverErrors.
+// InferScript infers a script. A script is a source file whose top-level statements
+// run in source order with function-body semantics, the bin/ counterpart to a
+// library module. It returns the populated script Scope, the Info side table, and any
+// SolverErrors. The returned scope is a child of the prelude, so operators and the
+// stdlib-type placeholders resolve through the parent.
 //
-// A module and a script differ in how their top-level declarations relate.
-// InferModule dependency-orders mutually-visible top-level declarations through the
-// dep graph. A script is instead one straight-line body: its bindings are linear,
-// and each statement sees only the ones before it, exactly as inside a function. So
-// liveness, alias tracking, and the `mut` transition rules — which a module skips at
-// top level because c.fn is nil there, making every transition entry point a no-op —
-// all apply to a script's top-level statements.
+// A module and a script differ in how their top-level declarations relate. InferModule
+// dependency-orders mutually-visible top-level declarations through the dep graph. A
+// script is instead one straight-line body. Its bindings are linear, and each
+// statement sees only the ones before it, exactly as inside a function. So liveness,
+// alias tracking, and the `mut` transition rules all apply to a script's top-level
+// statements. A module skips those at top level: there c.fn is nil, which makes every
+// transition entry point a no-op.
 //
 // It mirrors the old checker's InferScript in internal/checker/infer_script.go:
 //
@@ -24,37 +24,40 @@ import (
 //  2. push a fresh funcCtx so c.fn is non-nil and the transition checker is live;
 //  3. run runLivenessPrePass over that block to rename the body's variable nodes and
 //     seed the alias/liveness tables;
-//  4. walk the statements in source order through inferStmt.
+//  4. walk the block in source order through inferBlock.
 //
-// M4 shipped every building block this uses — the pre-pass, the per-body funcCtx, the
+// M4 shipped every building block this uses: the pre-pass, the per-body funcCtx, the
 // alias tracker, and the transition checker. The only new code is this entry point
 // that runs them over a script body. There is no new inference.
 //
-// The funcCtx carries no async flag, so a top-level `await` reports against the
-// script node, matching a non-async function body. inferStmt routes a top-level
-// `return` into the funcCtx's returns list, which the script never joins, so the
-// return is accepted and discarded — the same no-op the old checker's inferStmt
-// applies to a script-level return.
+// The pushed funcCtx carries no async flag and a nil node. A top-level `await` is
+// rejected the same way it is at module top level, with no enclosing function to mark
+// `async`, since a script has none. inferStmt routes a top-level `return` into the
+// funcCtx's returns list, which the script never joins, so the return is accepted and
+// discarded — the same no-op the old checker's inferStmt applies to a script-level
+// return.
 func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
 
 	// A script's statements form one linear body, so give them the same per-body
-	// context a function body gets. pushFuncCtx makes c.fn non-nil — the transition
-	// checker keys off it, and runLivenessPrePass writes its liveness/alias state onto
-	// it — and the prelude child is the outer scope the pre-pass resolves names
-	// against. There is no enclosing function to restore, so the returned previous
-	// context is discarded.
+	// context a function body gets. pushFuncCtx makes c.fn non-nil, which the
+	// transition checker keys off and which runLivenessPrePass writes its
+	// liveness/alias state onto. The node is nil because a script has no enclosing
+	// function. The prelude child is the outer scope the pre-pass resolves names
+	// against. There is no enclosing context to restore, so the returned previous one
+	// is discarded.
 	scriptBody := &ast.Block{Stmts: script.Stmts, Span: script.Span()}
-	c.pushFuncCtx(false, script)
+	c.pushFuncCtx(false, nil)
 	c.runLivenessPrePass(scope, nil, nil, scriptBody)
 
-	// Walk at level 0, the script body's own level: inferVarDecl types each
-	// initializer one level deeper and generalizes back to 0, so a top-level binding
-	// is a generalized local exactly like one in a function body walked at its level.
-	for _, stmt := range script.Stmts {
-		c.inferStmt(scope, 0, stmt)
-	}
+	// Walk the body through inferBlock, the same source-order statement walker a
+	// function body uses, at level 0. inferVarDecl types each initializer one level
+	// deeper and generalizes back to 0, so a top-level binding is a generalized local
+	// exactly like one in a function body walked at its level. inferBlock's tail value
+	// and divergence flag are discarded, just as inferFunc discards them: a script,
+	// like a function body, produces no value from its last statement.
+	c.inferBlock(scope, 0, scriptBody)
 
 	return scope, c.info, c.errs
 }

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -15,8 +15,8 @@ import (
 // script is instead one straight-line body. Its bindings are linear, and each
 // statement sees only the ones before it, exactly as inside a function. So liveness,
 // alias tracking, and the `mut` transition rules all apply to a script's top-level
-// statements. A module skips those at top level: there c.fn is nil, which makes every
-// transition entry point a no-op.
+// statements. A module skips those at top level, where c.fn is nil and every
+// transition entry point is a no-op.
 //
 // It mirrors the old checker's InferScript in internal/checker/infer_script.go:
 //
@@ -31,22 +31,21 @@ import (
 // that runs them over a script body. There is no new inference.
 //
 // The pushed funcCtx carries no async flag and a nil node. A top-level `await` is
-// rejected the same way it is at module top level, with no enclosing function to mark
-// `async`, since a script has none. inferStmt routes a top-level `return` into the
-// funcCtx's returns list, which the script never joins, so the return is accepted and
-// discarded — the same no-op the old checker's inferStmt applies to a script-level
-// return.
+// rejected the same way it is at module top level. There is no enclosing function to
+// mark `async`, because a script has none. inferStmt routes a top-level `return` into
+// the funcCtx's returns list. The script never joins that list, so the return is
+// accepted and discarded. The old checker's inferStmt applies the same no-op to a
+// script-level return.
 func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
 
 	// A script's statements form one linear body, so give them the same per-body
-	// context a function body gets. pushFuncCtx makes c.fn non-nil, which the
-	// transition checker keys off and which runLivenessPrePass writes its
-	// liveness/alias state onto. The node is nil because a script has no enclosing
-	// function. The prelude child is the outer scope the pre-pass resolves names
-	// against. There is no enclosing context to restore, so the returned previous one
-	// is discarded.
+	// context a function body gets. pushFuncCtx makes c.fn non-nil. The transition
+	// checker keys off c.fn, and runLivenessPrePass writes its liveness and alias state
+	// onto it. The node is nil because a script has no enclosing function. The prelude
+	// child is the outer scope the pre-pass resolves names against. There is no
+	// enclosing context to restore, so the returned previous one is discarded.
 	scriptBody := &ast.Block{Stmts: script.Stmts, Span: script.Span()}
 	c.pushFuncCtx(false, nil)
 	c.runLivenessPrePass(scope, nil, nil, scriptBody)
@@ -55,7 +54,7 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// function body uses, at level 0. inferVarDecl types each initializer one level
 	// deeper and generalizes back to 0, so a top-level binding is a generalized local
 	// exactly like one in a function body walked at its level. inferBlock's tail value
-	// and divergence flag are discarded, just as inferFunc discards them: a script,
+	// and divergence flag are discarded, just as inferFunc discards them. A script,
 	// like a function body, produces no value from its last statement.
 	c.inferBlock(scope, 0, scriptBody)
 

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -165,6 +165,29 @@ func TestScriptEmpty(t *testing.T) {
 	require.Empty(t, values)
 }
 
+// TestScriptRedeclaration checks that a script allows a name to be redeclared, the
+// function-body rule rather than the module rule. inferStmt overwrites the name's slot
+// on a body-level `val`/`var`, so a second declaration rebinds without constraining
+// the old and new types together. A later reference sees the new type. The identical
+// source as a module is rejected, because the dep-graph driver reports a duplicate
+// top-level declaration.
+func TestScriptRedeclaration(t *testing.T) {
+	src := `
+		val x = 5
+		val x = "hi"
+		val y = x
+	`
+	values, _, scriptErrs := inferScriptSource(t, src)
+	require.Empty(t, scriptErrs)
+	require.Equal(t, `"hi"`, values["x"])
+	require.Equal(t, `"hi"`, values["y"])
+
+	// The same source is a duplicate-declaration error as a module.
+	_, _, moduleErrs := inferSource(t, src)
+	require.Len(t, moduleErrs, 1)
+	require.Equal(t, "Duplicate declaration: x", moduleErrs[0].Message())
+}
+
 // TestScriptReassignTransition exercises the reassignment transition path
 // (inferAssign), distinct from the declaration-aliasing path the other parity cases
 // drive. inferAssign reads the enclosing statement from c.fn.currentStmt to find its

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -134,20 +134,97 @@ func TestScriptTransitionParity(t *testing.T) {
 	}
 }
 
+// TestScriptLinearScoping pins the defining difference between a script and a
+// module: a script's top-level statements are a linear body, so a binding sees only
+// the ones before it. The same source that forward-references a later binding is an
+// "Unknown identifier" error as a script but type-checks as a module, where
+// BuildDepGraph orders declarations by dependency rather than source position.
+func TestScriptLinearScoping(t *testing.T) {
+	src := `
+		val y = x
+		val x = 5
+	`
+	_, _, scriptErrs := inferScriptSource(t, src)
+	require.Len(t, scriptErrs, 1)
+	require.Equal(t, "Unknown identifier: x", scriptErrs[0].Message())
+
+	// The identical source is well-formed as a module: the dep graph types `val x`
+	// before the `val y` that refers to it.
+	_, _, moduleErrs := inferSource(t, src)
+	require.Empty(t, moduleErrs)
+}
+
+// TestScriptEmpty checks that a script with no statements infers cleanly. The
+// liveness pre-pass over an empty block and the empty statement walk must not panic
+// or invent diagnostics.
+func TestScriptEmpty(t *testing.T) {
+	values, _, errs := inferScriptSource(t, "")
+	require.Empty(t, errs)
+	require.Empty(t, values)
+}
+
+// TestScriptReassignTransition exercises the reassignment transition path
+// (inferAssign), distinct from the declaration-aliasing path the other parity cases
+// drive. inferAssign reads the enclosing statement from c.fn.currentStmt to find its
+// CFG StmtRef, which only exists because InferScript installs a funcCtx and runs the
+// liveness pre-pass over the script body. Reassigning a live mutable owned value into
+// an immutable binding is a Rule 1 transition; mutating it before the reassignment
+// makes it dead and the transition stays silent.
+func TestScriptReassignTransition(t *testing.T) {
+	t.Run("source_live_error", func(t *testing.T) {
+		_, _, errs := inferScriptSource(t, `
+			var snap: {x: number} = {x: 0}
+			val items: mut {x: number} = {x: 1}
+			snap = items
+			items.x = 2
+			snap
+		`)
+		require.Equal(t, []string{
+			"cannot assign 'items' to immutable 'snap': 'items' is still used mutably after this point",
+		}, transitionMessages(t, errs))
+	})
+
+	t.Run("source_dead_ok", func(t *testing.T) {
+		_, _, errs := inferScriptSource(t, `
+			var snap: {x: number} = {x: 0}
+			val items: mut {x: number} = {x: 1}
+			items.x = 2
+			snap = items
+			snap
+		`)
+		require.Empty(t, transitionMessages(t, errs))
+	})
+}
+
 // TestScriptBorrowLifetimeParity checks that the lifetime origination/escape
 // machinery runs over a script body too. A function expression with a `mut` borrow
-// parameter, bound to a top-level `val`, originates a fresh lifetime on its
-// parameter and threads it through the return — the `'a` in the rendered type is the
-// evidence the borrow lifetime was inferred, not skipped. The same statement wrapped
-// in a function body produces the identical (empty) error list.
+// parameter, bound to a top-level `val`, originates a fresh lifetime on its parameter
+// and threads it through the return. The `'a` in the rendered type is the evidence the
+// borrow lifetime was inferred, not skipped. The identical source as a module binds
+// the same `id`, and the two rendered types must match: the script entry point and the
+// module entry point thread the borrow lifetime the same way.
 func TestScriptBorrowLifetimeParity(t *testing.T) {
-	stmts := `
-		val id = fn (p: mut {x: number}) { return p }
-	`
-	values, _, scriptErrs := inferScriptSource(t, stmts)
-	require.Empty(t, scriptErrs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["id"])
+	const src = `val id = fn (p: mut {x: number}) { return p }`
 
-	_, _, fnErrs := inferSource(t, "fn test() {"+stmts+"\n}")
-	require.Empty(t, transitionMessages(t, fnErrs))
+	scriptValues, _, scriptErrs := inferScriptSource(t, src)
+	require.Empty(t, scriptErrs)
+	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", scriptValues["id"])
+
+	moduleValues, _, moduleErrs := inferSource(t, src)
+	require.Empty(t, moduleErrs)
+	require.Equal(t, scriptValues["id"], moduleValues["id"])
+}
+
+// TestScriptAwaitOutsideAsync pins the top-level `await` diagnostic. A script has no
+// enclosing function to mark `async`, so the error carries no related span, matching a
+// module top-level await rather than pointing Related() at the whole script. This
+// guards InferScript passing a nil funcCtx node.
+func TestScriptAwaitOutsideAsync(t *testing.T) {
+	_, _, errs := inferScriptSource(t, `
+		val x = 5
+		val y = await x
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+	require.Empty(t, errs[0].Related())
 }

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -1,0 +1,153 @@
+package solver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// parseScript parses a single in-memory .esc source as a SCRIPT — top-level
+// statements that run in source order with function-body semantics — and returns
+// the AST. It is the script counterpart to parseModule, parsing through
+// ParseScript rather than the library-module assembly ParseLibFiles drives.
+func parseScript(t *testing.T, src string) *ast.Script {
+	t.Helper()
+	source := &ast.Source{ID: 0, Path: "input.esc", Contents: src}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	p := parser.NewParser(ctx, source)
+	script, parseErrors := p.ParseScript()
+	require.Empty(t, parseErrors, "expected no parse errors")
+	return script
+}
+
+// inferScriptSource parses src as a script, runs InferScript, and renders the
+// top-level value/type bindings off the script scope's own maps (not the prelude
+// parent). It is the script counterpart to inferSource. A script's top-level
+// bindings are linear locals, so this is how their generalized types are inspected.
+func inferScriptSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
+	t.Helper()
+	scope, _, errs := InferScript(parseScript(t, src))
+	values = make(map[string]string, len(scope.values))
+	for name, b := range scope.values {
+		values[name] = renderScheme(b.Schemes[0])
+	}
+	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
+	return values, types, errs
+}
+
+// TestInferScriptSourceOrder checks the core of the script entry point: top-level
+// statements infer in source order, each binding seeing only the ones before it,
+// exactly as inside a function body and unlike a module's dependency-ordered decls.
+func TestInferScriptSourceOrder(t *testing.T) {
+	values, _, errs := inferScriptSource(t, `
+		val x = 5
+		val y = x
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.Equal(t, "5", values["y"])
+}
+
+// TestScriptTransitionParity is the milestone's central claim: a `mut`→immutable
+// transition at script top level is checked identically to the same statements
+// wrapped in a function body. Each case runs through InferScript directly and,
+// indented into `fn test() { … }`, through InferModule. The two error lists must
+// match each other and the expected verdict — the proof that a script's top-level
+// body runs the same liveness/alias/transition machinery a function body does.
+func TestScriptTransitionParity(t *testing.T) {
+	tests := map[string]struct {
+		// stmts are valid both at script top level and inside a function body, so the
+		// same text drives both entry points.
+		stmts string
+		want  []string
+	}{
+		// Rule 1 (mut→immutable): error when the mutable source is live after the alias.
+		// This is the Accept example — a top-level `val items: mut {…}` aliased to an
+		// immutable binding and then used mutably reports the Rule 1 transition error.
+		"Rule1_SourceLive_Error": {
+			stmts: `
+				val items: mut {x: number} = {x: 1}
+				val snapshot: {x: number} = items
+				items.x = 2
+				snapshot
+			`,
+			want: []string{
+				"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
+			},
+		},
+		// Rule 1: safe when the mutable source is dead after the alias.
+		"Rule1_SourceDead_OK": {
+			stmts: `
+				val items: mut {x: number} = {x: 1}
+				items.x = 2
+				val snapshot: {x: number} = items
+				snapshot
+			`,
+		},
+		// Rule 3: two mutable aliases of the same value are always allowed.
+		"Rule3_MultipleMutableAliases_OK": {
+			stmts: `
+				val a: mut {x: number} = {x: 1}
+				val b: mut {x: number} = a
+				b.x = 2
+				a.x
+			`,
+		},
+		// Chain aliasing through a mutable intermediate: the conflict names the live
+		// mutable alias, not the source itself.
+		"ChainAlias_TargetLive_Error": {
+			stmts: `
+				val a: mut {x: number} = {x: 1}
+				val b: mut {x: number} = a
+				val c: {x: number} = b
+				a.x = 2
+				c
+			`,
+			want: []string{
+				"cannot assign 'b' to immutable 'c': 'a' still has mutable access to 'b' after this point",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, scriptErrs := inferScriptSource(t, tt.stmts)
+			scriptMsgs := transitionMessages(t, scriptErrs)
+
+			_, _, fnErrs := inferSource(t, "fn test() {"+tt.stmts+"\n}")
+			fnMsgs := transitionMessages(t, fnErrs)
+
+			if len(tt.want) == 0 {
+				require.Empty(t, scriptMsgs)
+				require.Empty(t, fnMsgs)
+				return
+			}
+			require.ElementsMatch(t, tt.want, scriptMsgs)
+			require.ElementsMatch(t, tt.want, fnMsgs, "script and function-wrapped forms must report the same transition errors")
+		})
+	}
+}
+
+// TestScriptBorrowLifetimeParity checks that the lifetime origination/escape
+// machinery runs over a script body too. A function expression with a `mut` borrow
+// parameter, bound to a top-level `val`, originates a fresh lifetime on its
+// parameter and threads it through the return — the `'a` in the rendered type is the
+// evidence the borrow lifetime was inferred, not skipped. The same statement wrapped
+// in a function body produces the identical (empty) error list.
+func TestScriptBorrowLifetimeParity(t *testing.T) {
+	stmts := `
+		val id = fn (p: mut {x: number}) { return p }
+	`
+	values, _, scriptErrs := inferScriptSource(t, stmts)
+	require.Empty(t, scriptErrs)
+	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["id"])
+
+	_, _, fnErrs := inferSource(t, "fn test() {"+stmts+"\n}")
+	require.Empty(t, transitionMessages(t, fnErrs))
+}

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// parseScript parses a single in-memory .esc source as a SCRIPT — top-level
-// statements that run in source order with function-body semantics — and returns
-// the AST. It is the script counterpart to parseModule, parsing through
+// parseScript parses a single in-memory .esc source as a script and returns the AST.
+// A script is top-level statements that run in source order with function-body
+// semantics. parseScript is the script counterpart to parseModule, parsing through
 // ParseScript rather than the library-module assembly ParseLibFiles drives.
 func parseScript(t *testing.T, src string) *ast.Script {
 	t.Helper()
@@ -27,8 +27,8 @@ func parseScript(t *testing.T, src string) *ast.Script {
 }
 
 // inferScriptSource parses src as a script, runs InferScript, and renders the
-// top-level value/type bindings off the script scope's own maps (not the prelude
-// parent). It is the script counterpart to inferSource. A script's top-level
+// top-level value and type bindings off the script scope's own maps rather than the
+// prelude parent. It is the script counterpart to inferSource. A script's top-level
 // bindings are linear locals, so this is how their generalized types are inspected.
 func inferScriptSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
 	t.Helper()
@@ -56,10 +56,11 @@ func TestInferScriptSourceOrder(t *testing.T) {
 
 // TestScriptTransitionParity is the milestone's central claim: a `mut`→immutable
 // transition at script top level is checked identically to the same statements
-// wrapped in a function body. Each case runs through InferScript directly and,
-// indented into `fn test() { … }`, through InferModule. The two error lists must
-// match each other and the expected verdict — the proof that a script's top-level
-// body runs the same liveness/alias/transition machinery a function body does.
+// wrapped in a function body. Each case runs through InferScript directly, then again
+// through InferModule after being indented into `fn test() { … }`. The two error lists
+// must match each other and the expected verdict. That match proves a script's
+// top-level body runs the same liveness, alias, and transition machinery a function
+// body does.
 func TestScriptTransitionParity(t *testing.T) {
 	tests := map[string]struct {
 		// stmts are valid both at script top level and inside a function body, so the
@@ -67,9 +68,10 @@ func TestScriptTransitionParity(t *testing.T) {
 		stmts string
 		want  []string
 	}{
-		// Rule 1 (mut→immutable): error when the mutable source is live after the alias.
-		// This is the Accept example — a top-level `val items: mut {…}` aliased to an
-		// immutable binding and then used mutably reports the Rule 1 transition error.
+		// Rule 1, the mut→immutable case, errors when the mutable source is live after
+		// the alias. This is the Accept example. A top-level `val items: mut {…}` aliased
+		// to an immutable binding and then used mutably reports the Rule 1 transition
+		// error.
 		"Rule1_SourceLive_Error": {
 			stmts: `
 				val items: mut {x: number} = {x: 1}
@@ -148,7 +150,7 @@ func TestScriptLinearScoping(t *testing.T) {
 	require.Len(t, scriptErrs, 1)
 	require.Equal(t, "Unknown identifier: x", scriptErrs[0].Message())
 
-	// The identical source is well-formed as a module: the dep graph types `val x`
+	// The identical source is well-formed as a module. The dep graph types `val x`
 	// before the `val y` that refers to it.
 	_, _, moduleErrs := inferSource(t, src)
 	require.Empty(t, moduleErrs)
@@ -168,8 +170,8 @@ func TestScriptEmpty(t *testing.T) {
 // drive. inferAssign reads the enclosing statement from c.fn.currentStmt to find its
 // CFG StmtRef, which only exists because InferScript installs a funcCtx and runs the
 // liveness pre-pass over the script body. Reassigning a live mutable owned value into
-// an immutable binding is a Rule 1 transition; mutating it before the reassignment
-// makes it dead and the transition stays silent.
+// an immutable binding is a Rule 1 transition. Mutating it before the reassignment
+// makes it dead, and the transition stays silent.
 func TestScriptReassignTransition(t *testing.T) {
 	t.Run("source_live_error", func(t *testing.T) {
 		_, _, errs := inferScriptSource(t, `
@@ -201,7 +203,7 @@ func TestScriptReassignTransition(t *testing.T) {
 // parameter, bound to a top-level `val`, originates a fresh lifetime on its parameter
 // and threads it through the return. The `'a` in the rendered type is the evidence the
 // borrow lifetime was inferred, not skipped. The identical source as a module binds
-// the same `id`, and the two rendered types must match: the script entry point and the
+// the same `id`, and the two rendered types must match. The script entry point and the
 // module entry point thread the borrow lifetime the same way.
 func TestScriptBorrowLifetimeParity(t *testing.T) {
 	const src = `val id = fn (p: mut {x: number}) { return p }`
@@ -216,9 +218,9 @@ func TestScriptBorrowLifetimeParity(t *testing.T) {
 }
 
 // TestScriptAwaitOutsideAsync pins the top-level `await` diagnostic. A script has no
-// enclosing function to mark `async`, so the error carries no related span, matching a
-// module top-level await rather than pointing Related() at the whole script. This
-// guards InferScript passing a nil funcCtx node.
+// enclosing function to mark `async`, so the error carries no related span. That
+// matches a module top-level await, rather than pointing Related() at the whole
+// script. This guards InferScript passing a nil funcCtx node.
 func TestScriptAwaitOutsideAsync(t *testing.T) {
 	_, _, errs := inferScriptSource(t, `
 		val x = 5


### PR DESCRIPTION
Adds `InferScript`, a new type inference entry point for scripts. Scripts are source files whose top-level statements run in source order with function-body semantics, unlike modules where declarations are dependency-ordered.

Key changes:

- **New `InferScript` function** wraps a script's statements in a block, installs a function context to enable liveness and alias tracking, runs the liveness pre-pass, and walks statements in source order through `inferBlock`. This mirrors the old checker's script handling and reuses existing M4 machinery (pre-pass, per-body context, alias tracker, transition checker).

- **Linear scoping for scripts** ensures each statement sees only bindings before it, unlike modules where the dependency graph reorders declarations. Forward references are rejected as "Unknown identifier" errors.

- **Transition checking at script top level** applies `mut`→immutable transition rules to script statements, just as they apply inside function bodies. The pre-pass seeds liveness and alias state on the function context.

- **Comprehensive test suite** validates script behavior through eight test cases covering source-order inference, transition parity with function bodies, linear scoping differences from modules, empty scripts, reassignment transitions, borrow lifetime handling, and top-level `await` diagnostics.

The implementation adds no new inference logic, only the entry point that orchestrates existing components to handle scripts as linear bodies rather than dependency-ordered declarations.

https://claude.ai/code/session_01U2KkrxPvS78ouhRaZxKHBs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type inference and analysis capabilities for scripts with source-order scoping and liveness checking.
  * Added support for script-specific error handling, including detection of top-level operations.

* **Tests**
  * Added comprehensive test suite validating script type checking and semantic behavior against module equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->