### PR TITLE
Add move/affine semantics requirements and implementation plan

### DIFF
--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -167,18 +167,25 @@ needs a behavioural review and a test, not a compile fix. Sites to review:
   [internal/soltype/print.go](../../internal/soltype/print.go) — it already
   parenthesizes a looser inner, so `&(A | B)` renders correctly; add a snapshot.
 
-### Prefix `&` binds looser than `|` and `&`
+### Prefix `&` binds tight, like `mut`
 
-The requirements want `&A | B` to mean `&(A | B)`. The type-annotation parser gives
-intersection precedence 4 and union precedence 3, and prefix `mut` and lifetime are
-parsed inside `primaryTypeAnn`, so they bind tighter than both — `mut A | B` is
-`(mut A) | B`. Decision: prefix `&` is parsed at the top of `typeAnn`, above the
-precedence-climbing loop, wrapping the full following annotation. This gives it the
-loosest binding, so `&A | B` and `&mut A | B` wrap the whole union. It is the
-opposite placement from `mut`, which stays tight for the owned-mutable `mut A` form.
-In the printer the borrow-`&` prefix prints below `precUnion`, distinct from the
-`mut`/lifetime prefix which keep `precPrefix`. The borrow-mode flag gates this, so
+A leading `&` borrows the immediately following atom, not the whole annotation, so
+`&A | B` is `(&A) | B` and a borrow of the union is written with explicit
+parentheses, `&(A | B)`. This keeps `&` uniform with the prefixes that already
+exist: `mut` and the lifetime prefix are parsed inside `primaryTypeAnn` and bind
+tighter than intersection (precedence 4) and union (precedence 3), so `mut A | B` is
+`(mut A) | B`. Decision: prefix `&` is parsed in `primaryTypeAnn` alongside `mut`,
+consuming an optional lifetime and an optional `mut` and then the atom, so `&`,
+`&mut`, `&'a`, and `&'a mut` are tight prefixes on one atom. To borrow a union,
+intersection, or other compound, parenthesize it. In the printer the borrow-`&`
+prefix prints at `precPrefix`, the same level as `mut`/lifetime, so `&(A | B)`
+renders with the inner union parenthesized. The borrow-mode flag gates this, so
 legacy mode keeps `&` as infix intersection only.
+
+Disambiguation is by position, the standard prefix-versus-infix split: a `&` where
+an atom is expected is a borrow of that atom, and a `&` between two parsed types is
+intersection. Each string has one parse. A borrow as an intersection member needs no
+parentheses; only borrowing a compound does.
 
 ### Param-default flip is sequenced with the move engine
 
@@ -237,11 +244,11 @@ unaffected.
   [internal/ast/visitor.go](../../internal/ast/visitor.go). `MethodReceiver`
   ([internal/ast/class.go](../../internal/ast/class.go)) is the field template:
   it already carries `Mut bool` plus `Lifetime LifetimeAnnNode`.
-- Parse prefix `&`/`&mut`/`&'a`/`&'a mut` at the top of `typeAnn`, above the
-  precedence-climbing loop, gated on `BorrowSyntax`, so the borrow wraps the full
-  following annotation and `&A | B` is `&(A | B)`. See "Prefix `&` binds looser
-  than `|` and `&`" above. Reuse the existing `LifetimeAnn`/`LifetimeUnionAnn`
-  nodes for the lifetime slot.
+- Parse prefix `&`/`&mut`/`&'a`/`&'a mut` in `primaryTypeAnn` alongside the existing
+  `mut` and lifetime prefixes, gated on `BorrowSyntax`, so `&` binds tight to one
+  atom and `&A | B` is `(&A) | B`. A borrow of a union or intersection is written
+  `&(A | B)`. See "Prefix `&` binds tight, like `mut`" above. Reuse the existing
+  `LifetimeAnn`/`LifetimeUnionAnn` nodes for the lifetime slot.
 - Render `RefTypeAnn` in [internal/printer/printer.go](../../internal/printer/printer.go).
 - Defensive guard: replace the `panic` default in the old checker's
   `inferTypeAnn` ([internal/checker/infer_type_ann.go](../../internal/checker/infer_type_ann.go))

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -64,6 +64,146 @@ The fork inside the parser is small and local:
 Everything else — the `mut` prefix, `'a` prefixes on type refs, lifetime
 parameters, and `val mut` patterns — is already shared and stays common.
 
+## Architecture decisions for the high-risk areas
+
+These resolve the cross-cutting unknowns that several PRs depend on. They are the
+result of a spike into the flow-analysis, narrowing, type-representation, and
+grammar code, and should be read before starting PR 1.
+
+### Where the move analysis lives
+
+Move, use-after-move, conditional-move, and narrowing-scope checks are
+flow-sensitive, but solver inference is a single ordered pass over statements in
+source order, and a real CFG-based liveness analysis already exists. The decision
+is to **interleave the move checks into the existing ordered walk**, hook them at
+the same program-point granularity the mutability-transition checks already use,
+reuse the CFG and liveness, and build one new piece: a branch-merged per-binding
+*consumed* lattice.
+
+Reused as-is:
+
+- [internal/liveness](../../internal/liveness) builds a real CFG (`BuildCFG`) with
+  blocks and edges for if/else, match arms, loops, and try/catch, and runs
+  branch-merged backward liveness to a fixed point (`AnalyzeFunction`).
+  `BuildStmtToRef` plus `LivenessInfo.IsLiveAfter(StmtRef, VarID)` answer "is this
+  binding still live after point P," join-correct across branches. This is already
+  wired onto the solver's per-function `funcCtx`
+  ([internal/solver/infer.go](../../internal/solver/infer.go)) and consumed by the
+  transition checker.
+- The ordered walk exposes a program point via `c.fn.currentStmt` mapped through
+  `stmtToRef` to a `StmtRef`. The transition checks already interleave here, so the
+  move checks attach at the same points.
+
+Built new:
+
+- A per-binding consumed/moved lattice with joins at CFG merge blocks. Liveness is
+  branch-merged, but the existing `AliasTracker`
+  ([internal/liveness/alias.go](../../internal/liveness/alias.go)) is straight-line
+  accumulate with a conservative multi-set over-approximation and has no
+  per-program-point merge. Use-after-move needs "moved on some path" and "moved on
+  all paths" state that joins at if/else, match, and loop merge points. This is the
+  genuinely new analysis and the main cost of the move engine.
+
+Rejected: a standalone CFG post-pass after inference. It would duplicate the
+rename/VarID/StmtRef plumbing and re-derive types the ordered walk already holds on
+`funcCtx`, for no benefit, since the walk already provides program-point ordering.
+
+### Escape detection is generalized, not queried
+
+An earlier framing said move detection is a query over existing escape constraints.
+That is not true today and is corrected here. `constrainEscape`/`escapeVisitor`
+([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) force
+reachable borrow lifetimes to `'static`, but they run at exactly one site, the
+module-level global write. Returns, field and element stores, function arguments,
+and closure captures do not run escape. The query `borrowEscapedToStatic`
+([internal/solver/transitions.go](../../internal/solver/transitions.go)) also
+inspects only the top-level `RefType`, so a borrow nested in a field or reached
+through a usage-inferred type variable is missed, a known gap.
+
+Decision: the move engine **generalizes escape detection to every value-flow-out
+site** before any consume logic is written, and identifies consumption sites
+explicitly at returns, field and element stores, owned-parameter arguments, and
+escaping closure captures. The nested and type-variable escape gap is closed as
+part of this work, since a move that misses a nested escape is unsound. This is why
+the move engine is split across PR 5 (escape generalization and the consumed
+lattice) and PR 6 (the consume and use-after-move behaviour).
+
+### Narrowing does not exist yet in the solver
+
+The discriminant pin assumed narrowing infrastructure to build on; there is none.
+Neither `inferIfElse` nor `inferMatch`
+([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) refines the
+scrutinee inside a branch or arm. Match binds only the pattern's leaf projections
+through the member-lookup constraint path
+([internal/solver/pattern.go](../../internal/solver/pattern.go)), never a narrowed
+scrutinee. Decision: PR 10 splits. **PR 10a adds union narrowing** to the solver —
+discriminant and shape guards in conditionals and match arms that refine the
+scrutinee to a new per-arm binding, general type-system work that is independently
+useful. **PR 10b adds the affine layer** — a mutable narrowed binding `&mut A` with
+the discriminant pinned for the arm. The insertion points are `inferMatch` where
+the arm scope is built and the `LitPat` discriminant arm in `bindPatternWith`.
+
+### Unions as RefInner is a behavioural change, not a fan-out
+
+`RefType` is correctly not a `RefInner`
+([internal/soltype/type.go](../../internal/soltype/type.go)), so nested-borrow
+normalization is sound at the type level. Making `UnionType` and `IntersectionType`
+into `RefInner` is two new marker methods, and there is no name-exhaustive switch
+that forces a mechanical fan-out. The risk is the inverse: roughly seven
+`.(RefInner)` assertions silently start accepting unions and intersections, so each
+needs a behavioural review and a test, not a compile fix. Sites to review:
+
+- the `RefType <: RefType` rule and the `bare <: RefType` arm in
+  [internal/solver/constrain.go](../../internal/solver/constrain.go) — confirm
+  invariance handling for a `mut (A | B)` inner, and that a bare union satisfies
+  borrow-into.
+- [internal/solver/widen.go](../../internal/solver/widen.go) and
+  [internal/soltype/visitor.go](../../internal/soltype/visitor.go) — confirm a
+  widened or rewritten union inner stays a `RefInner`.
+- `resolveMutableTypeAnn` in
+  [internal/solver/type_ann.go](../../internal/solver/type_ann.go) — `mut (A | B)`
+  stops being rejected, which is the intended new surface.
+- the `RefType` print arm in
+  [internal/soltype/print.go](../../internal/soltype/print.go) — it already
+  parenthesizes a looser inner, so `&(A | B)` renders correctly; add a snapshot.
+
+### Prefix `&` binds looser than `|` and `&`
+
+The requirements want `&A | B` to mean `&(A | B)`. The type-annotation parser gives
+intersection precedence 4 and union precedence 3, and prefix `mut` and lifetime are
+parsed inside `primaryTypeAnn`, so they bind tighter than both — `mut A | B` is
+`(mut A) | B`. Decision: prefix `&` is parsed at the top of `typeAnn`, above the
+precedence-climbing loop, wrapping the full following annotation. This gives it the
+loosest binding, so `&A | B` and `&mut A | B` wrap the whole union. It is the
+opposite placement from `mut`, which stays tight for the owned-mutable `mut A` form.
+In the printer the borrow-`&` prefix prints below `precUnion`, distinct from the
+`mut`/lifetime prefix which keep `precPrefix`. The borrow-mode flag gates this, so
+legacy mode keeps `&` as infix intersection only.
+
+### Param-default flip is sequenced with the move engine
+
+PR 3 changes the parameter default from borrow-by-default — `attachParamLifetimes`
+mints a lifetime for every reference parameter today — to bare-is-owned. Two
+consequences. It churns existing solver snapshots that assert
+`fn <'a>(p: mut 'a {x}) -> ...`, which assume params borrow. And a bare owned
+parameter is consuming, but consuming has no enforcement until the move engine
+lands. Decision: land the `&`-parameter and auto-borrow behaviour in PR 3 and update
+the affected snapshots there, but defer making bare owned parameters actually
+consume to PR 6, where the consuming-argument check and its tests live. Between PR 3
+and PR 6 a bare owned parameter is owned in the type but not yet enforced as
+consumed.
+
+### Member-read borrows are scoped to rvalue reads of reference types
+
+Rule 4 wraps a member read in a receiver-bounded borrow. To avoid destabilising
+every member access, three limits apply. Only rvalue reads originate a borrow; an
+assignment target `obj.f = x` is not a borrow-producing read. A read whose result is
+a value type stays a value type, since primitives are excluded from `RefInner`, so
+the wrap is conditional on the field being reference-shaped. The receiver-bounded
+lifetime is elided in display when the read is consumed locally, so ordinary
+`obj.f` code shows no lifetime, and only an escaping member read shows the receiver
+lifetime. Chained access `a.b.c` composes the rule at each link.
+
 ---
 
 ## PR sequence
@@ -74,12 +214,13 @@ parameters, and `val mut` patterns — is already shared and stays common.
 | 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium |
 | 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium |
 | 4 | Member reads borrow the receiver | 3 | Medium |
-| 5 | Move engine core: consume-on-escape and use-after-move | 4 | Large |
-| 6 | Move at the remaining flow sites and conditional moves | 5 | Medium |
+| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large |
+| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large |
 | 7 | Partial moves and field-level ownership | 6 | Medium |
-| 8 | Immutable→mutable thaw move and borrow-phase framing | 5 | Medium |
+| 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3 | Medium |
-| 10 | Narrowing with pinned discriminant | 8, 9 | Medium |
+| 10a | Union narrowing in the solver (general type-system work) | 9 | Large |
+| 10b | Mutable narrowed binding with pinned discriminant | 8, 10a | Medium |
 
 ### PR 1 — Parser borrow mode, `&` grammar, `RefTypeAnn` node, printer
 
@@ -96,9 +237,11 @@ unaffected.
   [internal/ast/visitor.go](../../internal/ast/visitor.go). `MethodReceiver`
   ([internal/ast/class.go](../../internal/ast/class.go)) is the field template:
   it already carries `Mut bool` plus `Lifetime LifetimeAnnNode`.
-- Parse prefix `&`/`&mut`/`&'a`/`&'a mut` in `primaryTypeAnn`, gated on
-  `BorrowSyntax`. Reuse the existing `LifetimeAnn`/`LifetimeUnionAnn` nodes for
-  the lifetime slot.
+- Parse prefix `&`/`&mut`/`&'a`/`&'a mut` at the top of `typeAnn`, above the
+  precedence-climbing loop, gated on `BorrowSyntax`, so the borrow wraps the full
+  following annotation and `&A | B` is `&(A | B)`. See "Prefix `&` binds looser
+  than `|` and `&`" above. Reuse the existing `LifetimeAnn`/`LifetimeUnionAnn`
+  nodes for the lifetime slot.
 - Render `RefTypeAnn` in [internal/printer/printer.go](../../internal/printer/printer.go).
 - Defensive guard: replace the `panic` default in the old checker's
   `inferTypeAnn` ([internal/checker/infer_type_ann.go](../../internal/checker/infer_type_ann.go))
@@ -148,10 +291,14 @@ call sites auto-borrow.
 - Rule 3: with PR 2's lowering, a bare annotation is owned and a `&` annotation is
   a borrow in every position. Add tests pinning `val q: &{x} = p` as a borrow and
   `val q: {x} = p` as a move into an owned binding.
-- Rule 2: a `&` parameter is a borrow and a bare parameter is owned and consuming.
-  Adjust `attachParamLifetimes` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go))
-  so it mints a fresh lifetime only for `&` parameters, and leaves a bare
-  parameter owned. An unannotated parameter stays inferred.
+- Rule 2: a `&` parameter is a borrow and a bare parameter is owned. Adjust
+  `attachParamLifetimes` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go))
+  so it mints a fresh lifetime only for `&` parameters, and leaves a bare parameter
+  owned. An unannotated parameter stays inferred. The bare parameter is owned in the
+  type here, but is not yet enforced as *consuming* its argument; that enforcement
+  lands with the move engine in PR 6. See "Param-default flip is sequenced with the
+  move engine" above. This PR also migrates the existing param snapshots from the
+  borrow-by-default `mut 'a {x}` form to the new defaults.
 - Auto-borrow at call sites: passing an owned argument to a `&` or `&mut`
   parameter inserts the borrow implicitly. The `RefType <: RefType` rule in
   [internal/solver/constrain.go](../../internal/solver/constrain.go) already makes
@@ -183,52 +330,56 @@ carries the receiver lifetime; reading a `&`-typed field yields a flat borrow.
 
 Acceptance: member reads display and constrain as receiver-bounded borrows.
 
-### PR 5 — Move engine core: consume-on-escape and use-after-move
+### PR 5 — Move engine substrate: generalize escape detection, build the consumed lattice
 
-Goal: the central affine rule. When an owned value escapes its source binding's
-region, ownership moves, the source is consumed, and any later use is a
-use-after-move error.
+Goal: stand up the two pieces the move rule needs, with no use-after-move errors
+yet. See "Where the move analysis lives" and "Escape detection is generalized, not
+queried" above.
 
-- Add a consumption pass over owned bindings, keyed on the escape verdict already
-  computed by `constrainEscape`/`borrowEscapedToStatic`. A value escapes exactly
-  when its lifetime is forced to outlive its source region, so move detection is a
-  query over existing constraints rather than a new analysis. Build the
-  binding-liveness side on the infrastructure in
-  [internal/liveness](../../internal/liveness).
-- Cover the first flow sites: `val`/`var` binding, `return`, and the store into a
-  longer-lived or module-level binding. The global-write site
-  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) around the
-  `constrainEscape` call) stops dropping mutability and instead consumes the
-  source, per "Move subsumes the escape-site logic."
-- Add the `UseAfterMoveError`, reported against both the move site and the later
-  use.
+- Generalize escape detection beyond the single module-level write site. Run
+  `constrainEscape` at returns, field and element stores, owned-parameter
+  arguments, and escaping closure captures, and close the top-level-only gap in
+  `borrowEscapedToStatic` so a borrow nested in a field or reached through a
+  usage-inferred type variable is seen. Files:
+  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
+  [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go),
+  [internal/solver/transitions.go](../../internal/solver/transitions.go).
+- Build the branch-merged per-binding consumed lattice over the existing CFG. Add
+  "moved on some path" and "moved on all paths" state that joins at the CFG merge
+  blocks from [internal/liveness](../../internal/liveness), keyed by `VarID` and
+  queried at `StmtRef` granularity, alongside the existing liveness and alias state
+  on `funcCtx`. This is the genuinely new analysis.
 
-Tests: the motivating `leak` example now errors at `p.x = 5`; the freeze-by-return
-example; a plain `val q = storeGlobally(p); print(p.x)` use-after-move.
+Tests: unit tests that the consumed lattice merges correctly across if/else, match,
+and loops; tests that escape now fires at returns, stores, arguments, and captures.
 
-Acceptance: escape consumes the source; the use-after-move diagnostic names the
-move site and the use site.
+Acceptance: escape is detected at every value-flow-out site, and the consumed
+lattice reports correct per-path state. No user-facing errors yet.
 
-### PR 6 — Move at the remaining flow sites and conditional moves
+### PR 6 — Consume and use-after-move at every flow site, conditional moves
 
-Goal: extend the move rule to every flow site and make it path-sensitive.
+Goal: turn the PR 5 substrate into the affine rule. When an owned value escapes its
+source region, ownership moves, the source is consumed, and a later use is an error.
 
-- Field and element stores, function arguments to owned/consuming parameters,
-  closure captures by escaping closures, and reassignment that drops the previous
-  owner.
-- Conditional moves tracked per path: a value moved on one branch and untouched on
-  another is consumed only on the paths where the move occurs, and a later use is
-  an error only if some reaching path moved it.
+- Consume the source at each flow site: `val`/`var` binding, reassignment that drops
+  the previous owner, `return`, field and element stores, owned-parameter arguments,
+  and escaping closure captures. The global-write site stops dropping mutability and
+  instead consumes, per "Move subsumes the escape-site logic." This is also where a
+  bare owned parameter finally consumes its argument, the behaviour PR 3 deferred.
+- Conditional moves are path-sensitive through the consumed lattice: a value moved
+  on one branch and untouched on another is consumed only on the moving paths, and a
+  later use is an error only if some reaching path moved it.
+- Add `UseAfterMoveError`, reported against both the move site and the use site.
 - This subsumes the "no Copy bound" requirement: reusing an owned type-parameter
-  value triggers a second move and a use-after-move error, with no extra
-  machinery. Add a test showing `fn dup<T>(x: T) -> [T, T]` fails and the `&T`
-  form succeeds.
+  value triggers a second move and a use-after-move error, with no extra machinery.
+  Add a test showing `fn dup<T>(x: T) -> [T, T]` fails and the `&T` form succeeds.
 
-Tests: a field store that escapes; an owned argument consumed by the callee; a
+Tests: the motivating `leak` example errors at `p.x = 5`; `val q = storeGlobally(p);
+print(p.x)`; a field store that escapes; an owned argument consumed by the callee; a
 capture by an escaping closure; an if/else where only one branch moves.
 
-Acceptance: all flow sites in the requirements move or borrow correctly, including
-per-branch behaviour.
+Acceptance: every flow site moves or borrows correctly, including per-branch
+behaviour, and use-after-move names both sites.
 
 ### PR 7 — Partial moves and field-level ownership
 
@@ -251,7 +402,7 @@ exclusivity.
 
 - Thaw: `val mut q = p` for an owned-immutable `p` moves `p` into a mutable
   binding and consumes it, so `q` is the sole owner and may be mutable. This is a
-  move variant on the binding site from PR 5.
+  move variant on the binding site from PR 6.
 - Reframe the residual exclusivity from Rules 1/2/3
   ([internal/solver/transitions.go](../../internal/solver/transitions.go)) as the
   borrow-phase rule: a mutable owned value is in either an immutable phase with any
@@ -272,10 +423,15 @@ Goal: the type-former interactions that do not involve narrowing.
 
 - Make `UnionType` and `IntersectionType` participate as `RefInner`
   ([internal/soltype/type.go](../../internal/soltype/type.go)) so `&(A | B)` is one
-  borrow over a union pointee.
+  borrow over a union pointee. This is two marker methods plus a behavioural review
+  of the `.(RefInner)` assertion sites listed under "Unions as RefInner is a
+  behavioural change, not a fan-out" above, each with a test.
 - Reject mixed-ownership unions and intersections: a type whose members disagree
   on ownership, such as `{x} | &{y}`, has no uniform verdict and is an error that
   asks the programmer to make ownership uniform first. No silent downgrade.
+  Detection sits at the join sites where a mixed union forms during inference, such
+  as if-branches or merges with different ownership, not at annotations, since the
+  wrapper is outer and an annotation cannot spell a mixed union.
 - Normalize nested borrows to depth one: collapse `& &` immutable layers to the
   inner borrow at the outer lifetime, and reject the uninhabitable `&mut &mut`
   form. With PR 4's copy-out of `&`-typed field reads, nesting only arises from
@@ -288,22 +444,42 @@ make-uniform message; `&&Point` normalized to `&Point`.
 Acceptance: unions borrow as a unit, mixed ownership is rejected, and nested
 borrows never exceed depth one.
 
-### PR 10 — Narrowing with pinned discriminant
+### PR 10a — Union narrowing in the solver
 
-Goal: narrowing a union produces a new borrow binding, and a mutable narrowed
-binding pins the discriminant.
+Goal: add the narrowing infrastructure the affine pin depends on, since the solver
+has none today. See "Narrowing does not exist yet in the solver" above. This is
+general type-system work, useful independently of affine semantics.
 
-- Narrowing introduces a fresh borrow of the scrutinee scoped to the narrowed
-  region; the original keeps its union type. An immutable narrowed binding sits in
-  the immutable phase and is sound with no extra rule.
+- In `inferIfElse` and `inferMatch`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), refine the
+  scrutinee inside a branch or arm based on a discriminant or shape guard, binding
+  the scrutinee to a narrowed type in the branch or arm scope rather than leaving it
+  at the un-narrowed union. The `match` arm scope is built where `bindPattern` is
+  called; the discriminant comparison is the `LitPat` arm in `bindPatternWith`
+  ([internal/solver/pattern.go](../../internal/solver/pattern.go)).
+- Narrowing introduces a fresh binding for the narrowed view; the original keeps its
+  union type.
+
+Tests: a discriminated union narrowed in a match arm and in an if guard; the
+narrowed binding has the variant type, the original keeps the union.
+
+Acceptance: conditionals and match arms narrow a union scrutinee.
+
+### PR 10b — Mutable narrowed binding with pinned discriminant
+
+Goal: the affine layer on PR 10a's narrowing.
+
+- The narrowed binding is a fresh borrow of the scrutinee scoped to the narrowed
+  region. An immutable narrowed binding sits in the immutable phase and is sound
+  with no extra rule.
 - A mutable narrowed binding `&mut A` is allowed, and while it is live the
-  discriminant the narrowing tested may not be written through any alias, though
-  the variant's other fields stay mutable. Implement the tag-pin as a scoped,
+  discriminant the narrowing tested may not be written through any alias, though the
+  variant's other fields stay mutable. Implement the tag-pin as a scoped,
   field-level write restriction layered on PR 7's field-level tracking and PR 8's
   phase framing.
 
-Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted and
-a write to the tag rejected for the arm.
+Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted and a
+write to the tag rejected for the arm.
 
 Acceptance: mutable narrowing works with the discriminant pinned for the arm.
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -44,6 +44,12 @@ What is missing: the `&` notation end to end, annotation-literal ownership, memb
 reads that borrow the receiver, and the whole move / use-after-move analysis. The
 PRs below add these.
 
+The move-engine work, PRs 1 through 8, builds only on this M4 substrate. The
+type-former PRs, 9 and 10, additionally depend on **M6** of
+[planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md), which lands
+union and intersection formers together with union-scrutinee narrowing. They are
+scheduled after M6, while PRs 1 through 8 can proceed once M4 is in place.
+
 ## Parsing borrows without a syntax mode
 
 There is no parser grammar mode. A prefix `&` is parsed as a borrow unconditionally,
@@ -134,20 +140,23 @@ part of this work, since a move that misses a nested escape is unsound. This is 
 the move engine is split across PR 5 (escape generalization and the consumed
 lattice) and PR 6 (the consume and use-after-move behaviour).
 
-### Narrowing does not exist yet in the solver
+### Narrowing comes from M6, not this plan
 
-The discriminant pin assumed narrowing infrastructure to build on; there is none.
-Neither `inferIfElse` nor `inferMatch`
+The discriminant pin needs union-scrutinee narrowing to build on, and the current
+solver has none — neither `inferIfElse` nor `inferMatch`
 ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) refines the
-scrutinee inside a branch or arm. Match binds only the pattern's leaf projections
-through the member-lookup constraint path
-([internal/solver/pattern.go](../../internal/solver/pattern.go)), never a narrowed
-scrutinee. Decision: PR 10 splits. **PR 10a adds union narrowing** to the solver —
-discriminant and shape guards in conditionals and match arms that refine the
-scrutinee to a new per-arm binding, general type-system work that is independently
-useful. **PR 10b adds the affine layer** — a mutable narrowed binding `&mut A` with
-the discriminant pinned for the arm. The insertion points are `inferMatch` where
-the arm scope is built and the `LitPat` discriminant arm in `bindPatternWith`.
+scrutinee inside a branch or arm, and match binds only the pattern's leaf
+projections through the member-lookup constraint path
+([internal/solver/pattern.go](../../internal/solver/pattern.go)). But narrowing is a
+planned deliverable of **M6** in
+[planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md), which adds
+union and intersection formers together with union-scrutinee narrowing to gate the
+read-until-narrowed-union write site, including the trickier non-discriminated form
+that narrows on a field's runtime type. Decision: the affine plan does not add
+narrowing. PR 10 adds only the affine layer — a mutable narrowed binding `&mut A`
+with the discriminant pinned for the arm — on top of M6's narrowing. The insertion
+points are `inferMatch` where the arm scope is built and the `LitPat` discriminant
+arm in `bindPatternWith`.
 
 ### Unions as RefInner is a behavioural change, not a fan-out
 
@@ -230,9 +239,8 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large |
 | 7 | Partial moves and field-level ownership | 6 | Medium |
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium |
-| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3 | Medium |
-| 10a | Union narrowing in the solver (general type-system work) | 9 | Large |
-| 10b | Mutable narrowed binding with pinned discriminant | 8, 10a | Medium |
+| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium |
+| 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -432,13 +440,16 @@ Acceptance: both transitions are moves, and exclusivity reads as the phase rule.
 
 ### PR 9 — Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization
 
-Goal: the type-former interactions that do not involve narrowing.
+Goal: the type-former interactions that do not involve narrowing, built on M6's
+union and intersection formers.
 
-- Make `UnionType` and `IntersectionType` participate as `RefInner`
+- Make M6's `UnionType` and `IntersectionType` participate as `RefInner`
   ([internal/soltype/type.go](../../internal/soltype/type.go)) so `&(A | B)` is one
-  borrow over a union pointee. This is two marker methods plus a behavioural review
-  of the `.(RefInner)` assertion sites listed under "Unions as RefInner is a
-  behavioural change, not a fan-out" above, each with a test.
+  borrow over a union pointee. M6 already introduces the formers and can carry
+  `mut` borrow members in a union, but does not make a union a valid borrow inner;
+  this is two marker methods plus a behavioural review of the `.(RefInner)`
+  assertion sites listed under "Unions as RefInner is a behavioural change, not a
+  fan-out" above, each with a test.
 - Reject mixed-ownership unions and intersections: a type whose members disagree
   on ownership, such as `{x} | &{y}`, has no uniform verdict and is an error that
   asks the programmer to make ownership uniform first. No silent downgrade.
@@ -457,39 +468,21 @@ make-uniform message; `&&Point` normalized to `&Point`.
 Acceptance: unions borrow as a unit, mixed ownership is rejected, and nested
 borrows never exceed depth one.
 
-### PR 10a — Union narrowing in the solver
+### PR 10 — Mutable narrowed binding with pinned discriminant
 
-Goal: add the narrowing infrastructure the affine pin depends on, since the solver
-has none today. See "Narrowing does not exist yet in the solver" above. This is
-general type-system work, useful independently of affine semantics.
+Goal: the affine layer on M6's union-scrutinee narrowing. See "Narrowing comes from
+M6, not this plan" above. This PR adds no narrowing of its own; it depends on M6
+having landed.
 
-- In `inferIfElse` and `inferMatch`
-  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), refine the
-  scrutinee inside a branch or arm based on a discriminant or shape guard, binding
-  the scrutinee to a narrowed type in the branch or arm scope rather than leaving it
-  at the un-narrowed union. The `match` arm scope is built where `bindPattern` is
-  called; the discriminant comparison is the `LitPat` arm in `bindPatternWith`
-  ([internal/solver/pattern.go](../../internal/solver/pattern.go)).
-- Narrowing introduces a fresh binding for the narrowed view; the original keeps its
-  union type.
-
-Tests: a discriminated union narrowed in a match arm and in an if guard; the
-narrowed binding has the variant type, the original keeps the union.
-
-Acceptance: conditionals and match arms narrow a union scrutinee.
-
-### PR 10b — Mutable narrowed binding with pinned discriminant
-
-Goal: the affine layer on PR 10a's narrowing.
-
-- The narrowed binding is a fresh borrow of the scrutinee scoped to the narrowed
-  region. An immutable narrowed binding sits in the immutable phase and is sound
-  with no extra rule.
+- The narrowed binding M6 produces is treated as a fresh borrow of the scrutinee
+  scoped to the narrowed region. An immutable narrowed binding sits in the immutable
+  phase and is sound with no extra rule.
 - A mutable narrowed binding `&mut A` is allowed, and while it is live the
   discriminant the narrowing tested may not be written through any alias, though the
   variant's other fields stay mutable. Implement the tag-pin as a scoped,
   field-level write restriction layered on PR 7's field-level tracking and PR 8's
-  phase framing.
+  phase framing, hooked at the `inferMatch` arm scope and the `LitPat` discriminant
+  arm in `bindPatternWith`.
 
 Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted and a
 write to the tag rejected for the arm.

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1,0 +1,333 @@
+# Implementation plan: move / affine semantics
+
+This is the implementation plan for the requirements in
+[requirements.md](./requirements.md). It sequences the work into
+dependency-ordered pull requests, each sized to be reviewable on its own.
+
+## Scope and constraints
+
+- **New checker only.** All semantic work lands in the SimpleSub-based checker,
+  `internal/solver` and `internal/soltype`. The old HM-based checker in
+  `internal/checker` keeps its current behaviour and is not given affine
+  semantics. The new solver is invoked only from its own tests today via
+  `solver.InferModule` ([internal/solver/module.go](../../internal/solver/module.go)),
+  so the work rides in solver tests and never touches the fixture corpus, which
+  belongs to the old checker.
+- **Parser carries both grammars.** The parser is shared by both checkers through
+  one `ParseLibFiles` entry, and `&` already means intersection in type-annotation
+  position. To let the solver read the new `&`-borrow syntax while the old checker
+  keeps the existing grammar, the parser gains a syntax-mode flag. The solver's
+  parse path requests borrow mode; the old checker keeps the default. This is the
+  one cross-cutting change and is described next.
+
+## What the M4 substrate already provides
+
+These exist, are tested, and are built on rather than rebuilt:
+
+- `RefType{Mut, Lt, Inner}` and the four owned/borrowed quadrants —
+  [internal/soltype/type.go](../../internal/soltype/type.go), `NewRef`/`UnwrapRef`
+  in [internal/soltype/ref.go](../../internal/soltype/ref.go).
+- The lifetime sort `LifetimeVar`/`StaticLifetime`/`LifetimeUnion` —
+  [internal/soltype/lifetime.go](../../internal/soltype/lifetime.go).
+- `constrainLt` and the outlives lattice with level extrusion, plus the
+  `RefType <: RefType` rule where owned-into-borrow is free and borrow-into-owned
+  is a `BorrowEscapeError` — [internal/solver/constrain.go](../../internal/solver/constrain.go).
+- The mutability-transition checker, Rules 1/2/3, and the `'static`-escape query
+  `borrowEscapedToStatic` — [internal/solver/transitions.go](../../internal/solver/transitions.go).
+- Param borrow origination `attachParamLifetimes`, escape forcing via
+  `constrainEscape`/`escapeVisitor`, and join lifetimes `joinBorrows` —
+  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
+- `val mut p` binding patterns already parse, via `IdentPat.Mutable` —
+  [internal/ast/pattern.go](../../internal/ast/pattern.go).
+
+What is missing: the `&` notation end to end, annotation-literal ownership, member
+reads that borrow the receiver, and the whole move / use-after-move analysis. The
+PRs below add these.
+
+## The parser syntax-mode split
+
+A `SyntaxMode` value is added to the `Parser` struct
+([internal/parser/parser.go](../../internal/parser/parser.go)) with two values,
+`LegacySyntax` (default) and `BorrowSyntax`. It is threaded through `NewParser`,
+copied in `saveState`/`restoreState`, and exposed on a solver-facing parse entry.
+The fork inside the parser is small and local:
+
+- In `BorrowSyntax`, a prefix `&` in `primaryTypeAnn`
+  ([internal/parser/type_ann.go](../../internal/parser/type_ann.go)) parses a
+  borrow and produces the new `RefTypeAnn` node. Infix `&` stays intersection, so
+  `A & B` is unaffected and `&A` is a borrow; the two are distinguished by
+  position.
+- In `LegacySyntax`, `&` behaves exactly as today and `RefTypeAnn` is never
+  produced, so the old checker never encounters a node its translation switch
+  lacks.
+
+Everything else — the `mut` prefix, `'a` prefixes on type refs, lifetime
+parameters, and `val mut` patterns — is already shared and stays common.
+
+---
+
+## PR sequence
+
+| PR | Title | Depends on | Rough size |
+|----|-------|-----------|-----------|
+| 1 | Parser borrow mode, `&` grammar, `RefTypeAnn` node, printer | — | Medium |
+| 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium |
+| 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium |
+| 4 | Member reads borrow the receiver | 3 | Medium |
+| 5 | Move engine core: consume-on-escape and use-after-move | 4 | Large |
+| 6 | Move at the remaining flow sites and conditional moves | 5 | Medium |
+| 7 | Partial moves and field-level ownership | 6 | Medium |
+| 8 | Immutable→mutable thaw move and borrow-phase framing | 5 | Medium |
+| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3 | Medium |
+| 10 | Narrowing with pinned discriminant | 8, 9 | Medium |
+
+### PR 1 — Parser borrow mode, `&` grammar, `RefTypeAnn` node, printer
+
+Goal: the parser can read `&{x}`, `&mut {x}`, `&'a {x}`, and `&'a mut {x}` in
+borrow mode and round-trips them through the printer, with the old checker
+unaffected.
+
+- Add `SyntaxMode` to `Parser`; thread it through `NewParser`,
+  `saveState`/`restoreState`, and add a borrow-mode parse entry for the solver.
+- Add the `ast.RefTypeAnn{Mut bool, Lifetime LifetimeAnnNode, Inner TypeAnn}`
+  variant to the `TypeAnn` sum type
+  ([internal/ast/type_ann.go](../../internal/ast/type_ann.go)), add it to
+  `isTypeAnn()`, regenerate the AST via `gen_ast.go`, and update
+  [internal/ast/visitor.go](../../internal/ast/visitor.go). `MethodReceiver`
+  ([internal/ast/class.go](../../internal/ast/class.go)) is the field template:
+  it already carries `Mut bool` plus `Lifetime LifetimeAnnNode`.
+- Parse prefix `&`/`&mut`/`&'a`/`&'a mut` in `primaryTypeAnn`, gated on
+  `BorrowSyntax`. Reuse the existing `LifetimeAnn`/`LifetimeUnionAnn` nodes for
+  the lifetime slot.
+- Render `RefTypeAnn` in [internal/printer/printer.go](../../internal/printer/printer.go).
+- Defensive guard: replace the `panic` default in the old checker's
+  `inferTypeAnn` ([internal/checker/infer_type_ann.go](../../internal/checker/infer_type_ann.go))
+  with a clean "unsupported annotation" error returning `ErrorType`, so a stray
+  new node can never crash the CLI or LSP. The old checker still parses in legacy
+  mode and will not see `RefTypeAnn` in normal operation.
+
+Tests: parser tests for each borrow form in
+[internal/parser/type_ann_test.go](../../internal/parser/type_ann_test.go);
+printer round-trip; a legacy-mode test asserting `A & B` still parses as
+intersection and `&A` is not a borrow.
+
+Acceptance: borrow forms parse and print in borrow mode; the full existing parser
+and old-checker suites are green with no snapshot changes.
+
+### PR 2 — Solver lowering of `&`, soltype `&` rendering, snapshot migration
+
+Goal: the solver lowers `&`-annotations to `RefType` and renders every borrow in
+`&` notation, replacing the old `mut 'a {x}` display.
+
+- Add a `case *ast.RefTypeAnn` arm to `resolveTypeAnn`
+  ([internal/solver/type_ann.go](../../internal/solver/type_ann.go)) producing
+  `soltype.RefType{Mut, Lt, Inner}`. A `&` with no named lifetime mints a fresh
+  inferred `LifetimeVar`; `&'a` resolves the named lifetime, which closes the
+  currently-deferred named-lifetime path. A bare annotation stays owned:
+  `{x}` lowers to owned-immutable and `mut {x}` to owned-mutable, which the
+  existing `resolveMutableTypeAnn` already does.
+- Change the `RefType` arm of [internal/soltype/print.go](../../internal/soltype/print.go)
+  to render `&`, `&mut`, `&'a`, `&'a mut`, leaving owned as bare `{x}` / `mut {x}`.
+  Show the lifetime name only when it is load-bearing, per the display rules; the
+  `&` is always shown.
+- Migrate solver snapshots from `mut 'a {x}` to `&'a mut {x}` with `UPDATE_SNAPS`.
+  Watch [internal/solver/infer_borrow_lifetime_test.go](../../internal/solver/infer_borrow_lifetime_test.go)
+  and [internal/soltype/print_test.go](../../internal/soltype/print_test.go).
+
+Tests: lowering tests for each `&` form; print tests for owned vs borrowed and for
+elided vs named lifetimes.
+
+Acceptance: `&` round-trips annotation → soltype → display; no remaining
+`mut 'a {x}`-style borrow output.
+
+### PR 3 — Annotation-literal ownership, owned/borrow params, auto-borrow
+
+Goal: implement inference rules 2 and 3 — the annotation is read literally, and
+call sites auto-borrow.
+
+- Rule 3: with PR 2's lowering, a bare annotation is owned and a `&` annotation is
+  a borrow in every position. Add tests pinning `val q: &{x} = p` as a borrow and
+  `val q: {x} = p` as a move into an owned binding.
+- Rule 2: a `&` parameter is a borrow and a bare parameter is owned and consuming.
+  Adjust `attachParamLifetimes` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go))
+  so it mints a fresh lifetime only for `&` parameters, and leaves a bare
+  parameter owned. An unannotated parameter stays inferred.
+- Auto-borrow at call sites: passing an owned argument to a `&` or `&mut`
+  parameter inserts the borrow implicitly. The `RefType <: RefType` rule in
+  [internal/solver/constrain.go](../../internal/solver/constrain.go) already makes
+  owned-into-borrow free, so most of this falls out of argument constraining; add
+  the check that a `&mut` parameter requires an owned-mutable argument.
+
+Tests: owned vs borrow parameters; the consuming-parameter case; `foo(p)` rather
+than `foo(&p)`; the `&mut`-requires-mutable rejection.
+
+Acceptance: the rule-2 and rule-3 examples in the requirements check as written.
+
+### PR 4 — Member reads borrow the receiver
+
+Goal: implement inference rule 4.
+
+- Change `inferMember`/`resolveMemberPath`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) so reading
+  `obj.f` yields a borrow of the field bounded by the receiver, rather than
+  returning the property type directly. An owned receiver mints a fresh lifetime
+  bounded by its scope; a borrowed receiver passes its lifetime through. A read
+  consumed locally needs no displayed lifetime; one that escapes carries the
+  receiver's lifetime.
+- A field whose static type is itself a `&` borrow copies the borrow out rather
+  than nesting, since immutable borrows are freely duplicable. This keeps reads
+  from producing `&&` types and sets up PR 9's normalization.
+
+Tests: local member read with no displayed lifetime; an escaping member read that
+carries the receiver lifetime; reading a `&`-typed field yields a flat borrow.
+
+Acceptance: member reads display and constrain as receiver-bounded borrows.
+
+### PR 5 — Move engine core: consume-on-escape and use-after-move
+
+Goal: the central affine rule. When an owned value escapes its source binding's
+region, ownership moves, the source is consumed, and any later use is a
+use-after-move error.
+
+- Add a consumption pass over owned bindings, keyed on the escape verdict already
+  computed by `constrainEscape`/`borrowEscapedToStatic`. A value escapes exactly
+  when its lifetime is forced to outlive its source region, so move detection is a
+  query over existing constraints rather than a new analysis. Build the
+  binding-liveness side on the infrastructure in
+  [internal/liveness](../../internal/liveness).
+- Cover the first flow sites: `val`/`var` binding, `return`, and the store into a
+  longer-lived or module-level binding. The global-write site
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) around the
+  `constrainEscape` call) stops dropping mutability and instead consumes the
+  source, per "Move subsumes the escape-site logic."
+- Add the `UseAfterMoveError`, reported against both the move site and the later
+  use.
+
+Tests: the motivating `leak` example now errors at `p.x = 5`; the freeze-by-return
+example; a plain `val q = storeGlobally(p); print(p.x)` use-after-move.
+
+Acceptance: escape consumes the source; the use-after-move diagnostic names the
+move site and the use site.
+
+### PR 6 — Move at the remaining flow sites and conditional moves
+
+Goal: extend the move rule to every flow site and make it path-sensitive.
+
+- Field and element stores, function arguments to owned/consuming parameters,
+  closure captures by escaping closures, and reassignment that drops the previous
+  owner.
+- Conditional moves tracked per path: a value moved on one branch and untouched on
+  another is consumed only on the paths where the move occurs, and a later use is
+  an error only if some reaching path moved it.
+- This subsumes the "no Copy bound" requirement: reusing an owned type-parameter
+  value triggers a second move and a use-after-move error, with no extra
+  machinery. Add a test showing `fn dup<T>(x: T) -> [T, T]` fails and the `&T`
+  form succeeds.
+
+Tests: a field store that escapes; an owned argument consumed by the callee; a
+capture by an escaping closure; an if/else where only one branch moves.
+
+Acceptance: all flow sites in the requirements move or borrow correctly, including
+per-branch behaviour.
+
+### PR 7 — Partial moves and field-level ownership
+
+Goal: moving one field out consumes that field's slot, not the whole object.
+
+- Track consumption at field granularity. After a partial move the moved field may
+  not be read; sibling fields stay usable. A whole-object read after a partial
+  move errors only if it would expose a moved field.
+- The conservative floor, if field-granular tracking proves costly, is to consume
+  the whole object on any field move and record it as a precision limitation.
+
+Tests: the `pair.a` / `pair.b` partial-move example from the requirements.
+
+Acceptance: partial moves keep siblings live and reject reads of moved fields.
+
+### PR 8 — Immutable→mutable thaw move and borrow-phase framing
+
+Goal: the two ownership transitions, expressed as moves, plus the phase view of
+exclusivity.
+
+- Thaw: `val mut q = p` for an owned-immutable `p` moves `p` into a mutable
+  binding and consumes it, so `q` is the sole owner and may be mutable. This is a
+  move variant on the binding site from PR 5.
+- Reframe the residual exclusivity from Rules 1/2/3
+  ([internal/solver/transitions.go](../../internal/solver/transitions.go)) as the
+  borrow-phase rule: a mutable owned value is in either an immutable phase with any
+  number of `&` borrows or a mutable phase with any number of `&mut` borrows, and
+  the two never overlap. The existing liveness-driven mut/immut conflict check is
+  the mechanism; this PR aligns it to phases over lifetimes and keeps the freeze
+  (mut→immut) case it already handles.
+
+Tests: the thaw example with a use-after-move on the immutable source; the
+multiple-`&mut` example staying legal; an immutable borrow overlapping a `&mut`
+being rejected.
+
+Acceptance: both transitions are moves, and exclusivity reads as the phase rule.
+
+### PR 9 — Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization
+
+Goal: the type-former interactions that do not involve narrowing.
+
+- Make `UnionType` and `IntersectionType` participate as `RefInner`
+  ([internal/soltype/type.go](../../internal/soltype/type.go)) so `&(A | B)` is one
+  borrow over a union pointee.
+- Reject mixed-ownership unions and intersections: a type whose members disagree
+  on ownership, such as `{x} | &{y}`, has no uniform verdict and is an error that
+  asks the programmer to make ownership uniform first. No silent downgrade.
+- Normalize nested borrows to depth one: collapse `& &` immutable layers to the
+  inner borrow at the outer lifetime, and reject the uninhabitable `&mut &mut`
+  form. With PR 4's copy-out of `&`-typed field reads, nesting only arises from
+  generic substitution, so normalization is a local rule at lowering and
+  substitution.
+
+Tests: `&(A | B)` as a single borrow; a mixed-ownership union rejected with the
+make-uniform message; `&&Point` normalized to `&Point`.
+
+Acceptance: unions borrow as a unit, mixed ownership is rejected, and nested
+borrows never exceed depth one.
+
+### PR 10 — Narrowing with pinned discriminant
+
+Goal: narrowing a union produces a new borrow binding, and a mutable narrowed
+binding pins the discriminant.
+
+- Narrowing introduces a fresh borrow of the scrutinee scoped to the narrowed
+  region; the original keeps its union type. An immutable narrowed binding sits in
+  the immutable phase and is sound with no extra rule.
+- A mutable narrowed binding `&mut A` is allowed, and while it is live the
+  discriminant the narrowing tested may not be written through any alias, though
+  the variant's other fields stay mutable. Implement the tag-pin as a scoped,
+  field-level write restriction layered on PR 7's field-level tracking and PR 8's
+  phase framing.
+
+Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted and
+a write to the tag rejected for the arm.
+
+Acceptance: mutable narrowing works with the discriminant pinned for the arm.
+
+---
+
+## Deferred and out of scope
+
+- **Old checker affine semantics.** The HM checker keeps current behaviour; only
+  the non-panicking guard in PR 1 touches it.
+- **Cross-package moves.** Move behaviour at the boundary of imported, body-less
+  declarations depends on declared lifetimes and is left to the library-import
+  work, consistent with the requirements.
+- **Interior-mutability escape hatches.** A `Cell`-like wrapper for cyclic mutable
+  data is tracked separately under #618.
+- **Diagnostic wording.** Each PR ships a working diagnostic; final wording and
+  blame spans for use-after-move and move-on-escape are tuned as the engine
+  settles.
+
+## Testing approach
+
+Solver work is tested with inline Escalier source asserted against rendered
+`soltype` strings, the pattern in
+[internal/solver/infer_borrow_lifetime_test.go](../../internal/solver/infer_borrow_lifetime_test.go),
+with `snaps.MatchInlineSnapshot` for larger inferred types. Parser work is tested
+in [internal/parser](../../internal/parser). No fixture changes are expected, since
+fixtures exercise the old checker. After any change to checker or printer output,
+re-run with `UPDATE_SNAPS=true` so snapshots stay in sync.

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -561,15 +561,33 @@ having landed.
 - The narrowed binding M6 produces is treated as a fresh borrow of the scrutinee
   scoped to the narrowed region. An immutable narrowed binding sits in the immutable
   phase and is sound with no extra rule.
-- A mutable narrowed binding `&mut A` is allowed, and while it is live the
-  discriminant the narrowing tested may not be written through any alias, though the
-  variant's other fields stay mutable. Implement the tag-pin as a scoped,
-  field-level write restriction layered on PR 7's field-level tracking and PR 8's
-  phase framing, hooked at the `inferMatch` arm scope and the `LitPat` discriminant
-  arm in `bindPatternWith`.
+- A mutable narrowed binding `&mut A` is allowed. Through the binding itself the tag is
+  already unwritable, because M6 narrows it to a single literal: `a.tag = "b"` is a type
+  error since `"b"` is not assignable to `"a"`, with no extra rule, while the variant's
+  other fields stay mutable. The work this PR adds is the cross-alias case. While the
+  narrowed `&mut A` is live, the tag may not be written through any other alias of the
+  scrutinee, even one typed as the full union, since such a write would flip the variant
+  and invalidate the narrowed binding.
 
-Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted and a
-write to the tag rejected for the arm.
+  ```esc
+  val mut u: mut (A | B) = ...
+  val b = &mut u            // b: &mut (A | B) — not narrowed
+  match u {
+      a is A => {
+          a.x = 5           // OK — x is an ordinary field of the A variant
+          // a.tag = "b" is already a type error: "b" is not assignable to "a"
+          b.tag = "b"       // ERROR: the tag is pinned while a: &mut A is live
+      }
+  }
+  ```
+
+  Implement the pin as a scoped, field-level write restriction over the alias set,
+  layered on PR 7's field-level tracking and PR 8's phase framing, hooked at the
+  `inferMatch` arm scope and the `LitPat` discriminant arm in `bindPatternWith`.
+
+Tests: the `match u { a is A => { a.x = 5 } }` example, with `a.x = 5` accepted; a tag
+write through the narrowed binding rejected as a type error; a tag write through an
+un-narrowed alias rejected by the pin.
 
 Acceptance: mutable narrowing works with the discriminant pinned for the arm.
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -13,12 +13,12 @@ dependency-ordered pull requests, each sized to be reviewable on its own.
   `solver.InferModule` ([internal/solver/module.go](../../internal/solver/module.go)),
   so the work rides in solver tests and never touches the fixture corpus, which
   belongs to the old checker.
-- **Parser carries both grammars.** The parser is shared by both checkers through
-  one `ParseLibFiles` entry, and `&` already means intersection in type-annotation
-  position. To let the solver read the new `&`-borrow syntax while the old checker
-  keeps the existing grammar, the parser gains a syntax-mode flag. The solver's
-  parse path requests borrow mode; the old checker keeps the default. This is the
-  one cross-cutting change and is described next.
+- **Parser parses borrows unconditionally.** The parser is shared by both checkers
+  through one `ParseLibFiles` entry, and `&` already means intersection in
+  type-annotation position. Prefix `&` is position-disambiguated from infix `&`, so
+  the parser can read a prefix `&` as a borrow without a grammar mode: infix `&`
+  stays intersection and is unaffected. The old checker keeps working through a
+  graceful fallback rather than a parser flag, as described next.
 
 ## What the M4 substrate already provides
 
@@ -44,22 +44,28 @@ What is missing: the `&` notation end to end, annotation-literal ownership, memb
 reads that borrow the receiver, and the whole move / use-after-move analysis. The
 PRs below add these.
 
-## The parser syntax-mode split
+## Parsing borrows without a syntax mode
 
-A `SyntaxMode` value is added to the `Parser` struct
-([internal/parser/parser.go](../../internal/parser/parser.go)) with two values,
-`LegacySyntax` (default) and `BorrowSyntax`. It is threaded through `NewParser`,
-copied in `saveState`/`restoreState`, and exposed on a solver-facing parse entry.
-The fork inside the parser is small and local:
+There is no parser grammar mode. A prefix `&` is parsed as a borrow unconditionally,
+and the old checker is kept working by a graceful fallback at its translation layer.
+Three facts make this safe:
 
-- In `BorrowSyntax`, a prefix `&` in `primaryTypeAnn`
-  ([internal/parser/type_ann.go](../../internal/parser/type_ann.go)) parses a
-  borrow and produces the new `RefTypeAnn` node. Infix `&` stays intersection, so
-  `A & B` is unaffected and `&A` is a borrow; the two are distinguished by
-  position.
-- In `LegacySyntax`, `&` behaves exactly as today and `RefTypeAnn` is never
-  produced, so the old checker never encounters a node its translation switch
-  lacks.
+- **Infix `&` is untouched.** The only `&` form the existing corpus uses is infix
+  intersection — `A & B`, `keyof T & U`, `typeof x & U` — and a prefix `&` is
+  distinguished from it by position the way any Pratt parser separates prefix from
+  infix. A `&` where an atom is expected is a borrow; a `&` between two parsed types
+  is intersection.
+- **The only changed behaviour is unused.** The single thing a prefix-borrow
+  reinterpretation alters is the incidental leading-`&` skip at
+  [internal/parser/type_ann.go](../../internal/parser/type_ann.go) lines 51-52,
+  which mirrors the leading-`|` union sugar. No `.esc` fixture and no test string
+  starts a type annotation with `&`, so reinterpreting a leading `&` as a borrow
+  changes nothing in the corpus.
+- **The old checker degrades cleanly.** It only meets a `RefTypeAnn` if borrow
+  syntax appears in a file it parses, which does not happen for existing files. For
+  any stray case, the non-panicking fallback in PR 1 turns it into a clean
+  "borrows unsupported in the legacy checker" error rather than a crash, which is
+  better than a silent misparse.
 
 Everything else — the `mut` prefix, `'a` prefixes on type refs, lifetime
 parameters, and `val mut` patterns — is already shared and stays common.
@@ -179,8 +185,7 @@ consuming an optional lifetime and an optional `mut` and then the atom, so `&`,
 `&mut`, `&'a`, and `&'a mut` are tight prefixes on one atom. To borrow a union,
 intersection, or other compound, parenthesize it. In the printer the borrow-`&`
 prefix prints at `precPrefix`, the same level as `mut`/lifetime, so `&(A | B)`
-renders with the inner union parenthesized. The borrow-mode flag gates this, so
-legacy mode keeps `&` as infix intersection only.
+renders with the inner union parenthesized.
 
 Disambiguation is by position, the standard prefix-versus-infix split: a `&` where
 an atom is expected is a borrow of that atom, and a `&` between two parsed types is
@@ -217,7 +222,7 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 
 | PR | Title | Depends on | Rough size |
 |----|-------|-----------|-----------|
-| 1 | Parser borrow mode, `&` grammar, `RefTypeAnn` node, printer | — | Medium |
+| 1 | `&` grammar, `RefTypeAnn` node, printer | — | Medium |
 | 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium |
 | 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium |
 | 4 | Member reads borrow the receiver | 3 | Medium |
@@ -229,14 +234,11 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 10a | Union narrowing in the solver (general type-system work) | 9 | Large |
 | 10b | Mutable narrowed binding with pinned discriminant | 8, 10a | Medium |
 
-### PR 1 — Parser borrow mode, `&` grammar, `RefTypeAnn` node, printer
+### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
-Goal: the parser can read `&{x}`, `&mut {x}`, `&'a {x}`, and `&'a mut {x}` in
-borrow mode and round-trips them through the printer, with the old checker
-unaffected.
+Goal: the parser can read `&{x}`, `&mut {x}`, `&'a {x}`, and `&'a mut {x}` and
+round-trips them through the printer, with the old checker unaffected.
 
-- Add `SyntaxMode` to `Parser`; thread it through `NewParser`,
-  `saveState`/`restoreState`, and add a borrow-mode parse entry for the solver.
 - Add the `ast.RefTypeAnn{Mut bool, Lifetime LifetimeAnnNode, Inner TypeAnn}`
   variant to the `TypeAnn` sum type
   ([internal/ast/type_ann.go](../../internal/ast/type_ann.go)), add it to
@@ -245,24 +247,28 @@ unaffected.
   ([internal/ast/class.go](../../internal/ast/class.go)) is the field template:
   it already carries `Mut bool` plus `Lifetime LifetimeAnnNode`.
 - Parse prefix `&`/`&mut`/`&'a`/`&'a mut` in `primaryTypeAnn` alongside the existing
-  `mut` and lifetime prefixes, gated on `BorrowSyntax`, so `&` binds tight to one
-  atom and `&A | B` is `(&A) | B`. A borrow of a union or intersection is written
-  `&(A | B)`. See "Prefix `&` binds tight, like `mut`" above. Reuse the existing
-  `LifetimeAnn`/`LifetimeUnionAnn` nodes for the lifetime slot.
+  `mut` and lifetime prefixes, so `&` binds tight to one atom and `&A | B` is
+  `(&A) | B`. A borrow of a union or intersection is written `&(A | B)`. This
+  replaces the incidental leading-`&` skip. See "Prefix `&` binds tight, like `mut`"
+  above. Reuse the existing `LifetimeAnn`/`LifetimeUnionAnn` nodes for the lifetime
+  slot.
 - Render `RefTypeAnn` in [internal/printer/printer.go](../../internal/printer/printer.go).
-- Defensive guard: replace the `panic` default in the old checker's
-  `inferTypeAnn` ([internal/checker/infer_type_ann.go](../../internal/checker/infer_type_ann.go))
-  with a clean "unsupported annotation" error returning `ErrorType`, so a stray
-  new node can never crash the CLI or LSP. The old checker still parses in legacy
-  mode and will not see `RefTypeAnn` in normal operation.
+- Graceful fallback, which is the isolation mechanism in place of a parser mode:
+  replace the `panic` default in the old checker's `inferTypeAnn`
+  ([internal/checker/infer_type_ann.go](../../internal/checker/infer_type_ann.go))
+  with a clean "borrows unsupported in the legacy checker" error returning
+  `ErrorType`, so a `RefTypeAnn` can never crash the CLI or LSP. The old checker
+  does not see `RefTypeAnn` in normal operation, since existing files contain no
+  borrow syntax.
 
 Tests: parser tests for each borrow form in
 [internal/parser/type_ann_test.go](../../internal/parser/type_ann_test.go);
-printer round-trip; a legacy-mode test asserting `A & B` still parses as
-intersection and `&A` is not a borrow.
+printer round-trip; a test asserting infix `A & B` still parses as intersection and
+`&A` parses as a borrow distinguished by position; `&(A | B)` borrows the union
+while `&A | B` is `(&A) | B`.
 
-Acceptance: borrow forms parse and print in borrow mode; the full existing parser
-and old-checker suites are green with no snapshot changes.
+Acceptance: borrow forms parse and print; the full existing parser and old-checker
+suites are green with no snapshot changes.
 
 ### PR 2 — Solver lowering of `&`, soltype `&` rendering, snapshot migration
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -310,8 +310,41 @@ Goal: implement inference rules 2 and 3 — the annotation is read literally, an
 call sites auto-borrow.
 
 - Rule 3: with PR 2's lowering, a bare annotation is owned and a `&` annotation is
-  a borrow in every position. Add tests pinning `val q: &{x} = p` as a borrow and
-  `val q: {x} = p` as a move into an owned binding.
+  a borrow in every position. The binding initializer makes the move-or-borrow and
+  mutability choice when `p` is an owned value:
+
+  | | move (owned `q`) | borrow |
+  |---|---|---|
+  | **immutable `q`** | `val q = p` | `val q = &p` |
+  | **mutable `q`** | `val mut q = p` | `val q = &mut p` |
+
+  A `&mut` borrow requires an owned-mutable `p`, and the `&` forms infer `q`'s borrow
+  type without repeating the pointee shape. The move forms establish owned bindings
+  here, with the consuming enforcement and use-after-move landing in PR 6, as with the
+  bare owned parameter.
+
+  Each quadrant also has an annotated spelling that restates the pointee shape instead
+  of inferring it:
+
+  | | move (owned `q`) | borrow |
+  |---|---|---|
+  | **immutable `q`** | `val q: {x} = p` | `val q: &{x} = p` |
+  | **mutable `q`** | `val q: mut {x} = p` | `val q: &mut {x} = p` |
+
+  Add tests pinning each form in both tables.
+- Borrow-expression syntax: `&p` and `&mut p` are the first `&` in expression position,
+  so they need new surface syntax, unlike the type-position `&` of PR 1. Add an
+  `ast.BorrowExpr{Mut bool, Arg Expr}` variant to the `Expr` sum type
+  ([internal/ast/expr.go](../../internal/ast/expr.go)), add it to `isExpr()`, regenerate
+  via `gen_ast.go`, and update [internal/ast/visitor.go](../../internal/ast/visitor.go).
+  The existing `UnaryExpr` is the precedent for a prefix operator. Parse prefix `&`/`&mut`
+  in the unary position of the expression parser and render it in
+  [internal/printer/printer.go](../../internal/printer/printer.go). In the solver, infer
+  `&p` to an immutable `RefType` borrow and `&mut p` to a mutable one, minting a fresh
+  inferred lifetime bounded by `p`'s region, the same `RefType` the annotated
+  `val q: &{x} = p` produces. Require `p` to be owned-mutable for `&mut p`. Prefix `&`
+  binds looser than the postfix `.` and `[]`, so `&obj.f` parses as `&(obj.f)`, a borrow
+  of the whole place path, not `(&obj).f`. Its field-granular semantics are in PR 4.
 - Rule 2: a `&` parameter is a borrow and a bare parameter is owned. Adjust
   `attachParamLifetimes` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go))
   so it mints a fresh lifetime only for `&` parameters, and leaves a bare parameter
@@ -327,7 +360,8 @@ call sites auto-borrow.
   the check that a `&mut` parameter requires an owned-mutable argument.
 
 Tests: owned vs borrow parameters; the consuming-parameter case; `foo(p)` rather
-than `foo(&p)`; the `&mut`-requires-mutable rejection.
+than `foo(&p)`; the `&mut`-requires-mutable rejection; `&p` and `&mut p` borrow
+expressions parse, print round-trip, and infer borrows.
 
 Acceptance: the rule-2 and rule-3 examples in the requirements check as written.
 
@@ -345,9 +379,16 @@ Goal: implement inference rule 4.
 - A field whose static type is itself a `&` borrow copies the borrow out rather
   than nesting, since immutable borrows are freely duplicable. This keeps reads
   from producing `&&` types and sets up PR 9's normalization.
+- An explicit `&obj.f` borrows the path `obj.f` at field granularity, with the same
+  receiver-bounded lifetime as the implicit member read, and locks only that field. A
+  disjoint sibling such as `obj.g` stays independently usable, including `&mut obj.g`.
+  This shares the path-granular tracking the partial-moves work introduces. A path the
+  checker cannot prove disjoint, such as `arr[i]` versus `arr[j]`, falls back to a
+  container-level borrow.
 
 Tests: local member read with no displayed lifetime; an escaping member read that
-carries the receiver lifetime; reading a `&`-typed field yields a flat borrow.
+carries the receiver lifetime; reading a `&`-typed field yields a flat borrow; an
+explicit `&obj.f` borrow locks only the field and leaves `&mut obj.g` legal.
 
 Acceptance: member reads display and constrain as receiver-bounded borrows.
 
@@ -370,6 +411,34 @@ queried" above.
   blocks from [internal/liveness](../../internal/liveness), keyed by `VarID` and
   queried at `StmtRef` granularity, alongside the existing liveness and alias state
   on `funcCtx`. This is the genuinely new analysis.
+
+The lattice the second bullet builds has three per-binding states, joined at every CFG
+merge:
+
+```text
+            MaybeMoved
+           /          \
+     NotMoved          Moved
+```
+
+- **NotMoved** — no reaching path has moved the binding, so a use is allowed.
+- **Moved** — every reaching path has moved it, so a use is an unconditional
+  use-after-move.
+- **MaybeMoved** — some but not all reaching paths moved it, so a use is a conditional
+  use-after-move.
+
+`NotMoved` and `Moved` are the agreeing states below the top. Joining two edges that
+disagree raises the result to `MaybeMoved`, which then absorbs everything:
+
+| ⊔ | NotMoved | Moved | MaybeMoved |
+|---|---|---|---|
+| **NotMoved** | NotMoved | MaybeMoved | MaybeMoved |
+| **Moved** | MaybeMoved | Moved | MaybeMoved |
+| **MaybeMoved** | MaybeMoved | MaybeMoved | MaybeMoved |
+
+The entry state for every binding is `NotMoved`, and a move site sets it to `Moved`.
+PR 6 reads the state at each use, passing `NotMoved` and rejecting `Moved` and
+`MaybeMoved`.
 
 Tests: unit tests that the consumed lattice merges correctly across if/else, match,
 and loops; tests that escape now fires at returns, stores, arguments, and captures.
@@ -424,13 +493,25 @@ exclusivity.
 - Thaw: `val mut q = p` for an owned-immutable `p` moves `p` into a mutable
   binding and consumes it, so `q` is the sole owner and may be mutable. This is a
   move variant on the binding site from PR 6.
+- Freeze: the mirror transition, `val q = p` for an owned-mutable `p`, moves `p` into
+  an immutable binding and consumes it, so no mutable alias survives. This already
+  falls out of the PR 6 move engine, since moving an owned value into an immutable
+  binding is an ordinary escape-move; PR 8 only confirms the phase reframing leaves it
+  intact.
+
+  ```esc
+  val mut p = {x: 0}    // owned-mutable
+  p.x = 42
+  val q = p             // freeze: move into an immutable binding; p consumed
+  q.x = 5               // ERROR: q is immutable
+  print(p.x)            // ERROR: use of `p` after it was moved into `q`
+  ```
 - Reframe the residual exclusivity from Rules 1/2/3
   ([internal/solver/transitions.go](../../internal/solver/transitions.go)) as the
   borrow-phase rule: a mutable owned value is in either an immutable phase with any
   number of `&` borrows or a mutable phase with any number of `&mut` borrows, and
   the two never overlap. The existing liveness-driven mut/immut conflict check is
-  the mechanism; this PR aligns it to phases over lifetimes and keeps the freeze
-  (mut→immut) case it already handles.
+  the mechanism; this PR aligns it to phases over lifetimes.
 
 Tests: the thaw example with a use-after-move on the immutable source; the
 multiple-`&mut` example staying legal; an immutable borrow overlapping a `&mut`
@@ -446,10 +527,13 @@ union and intersection formers.
 - Make M6's `UnionType` and `IntersectionType` participate as `RefInner`
   ([internal/soltype/type.go](../../internal/soltype/type.go)) so `&(A | B)` is one
   borrow over a union pointee. M6 already introduces the formers and can carry
-  `mut` borrow members in a union, but does not make a union a valid borrow inner;
-  this is two marker methods plus a behavioural review of the `.(RefInner)`
-  assertion sites listed under "Unions as RefInner is a behavioural change, not a
-  fan-out" above, each with a test.
+  `mut` borrow members in a union, but does not make a union a valid borrow inner.
+  The change itself is small, just two marker methods, but it quietly reaches further
+  than that. The roughly seven `.(RefInner)` type assertions in the codebase will now
+  also accept unions and intersections, with no compile error to point them out. Review
+  each of those sites to confirm its logic still behaves correctly for a union or
+  intersection inner, and add a test for each. The sites are listed earlier under
+  "Unions as `RefInner`".
 - Reject mixed-ownership unions and intersections: a type whose members disagree
   on ownership, such as `{x} | &{y}`, has no uniform verdict and is an error that
   asks the programmer to make ownership uniform first. No silent downgrade.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -136,18 +136,35 @@ through a parameter or a member read. The full set of rules:
    the caller as "pass a clone if you need to keep access." There is no separate
    ownership annotation.
 
-3. **Bare annotations in reference position reborrow (G3).** Binding a reference
-   into a bare object or tuple annotation lowers the annotation to an immutable
-   borrow with a fresh lifetime, not an owned slot. `val q: {x: number} = p` for
-   `p: mut {x: number}` makes `q` a local immutable view that borrows `p`; `p`
-   keeps ownership. G3 ships the reborrow only for bare, immutable annotations: a
-   `mut {x: number}` annotation lowers to an owned-mutable type and a
-   lifetime-qualified annotation names the borrow explicitly, neither rewritten by
-   G3. Under move/affine semantics the move-versus-borrow choice is escape-driven
-   and applies to every form, so a local `mut` binding of a reference is a mutable
-   reborrow that retains the source — the multiple-mutable-aliases case — and only
-   a binding that escapes moves. The bare/`mut` split decides the *mutability* of
-   the resulting view, not whether the source is moved.
+3. **Bare annotations fix shape and mutability; the lifetime is inferred.** A bare
+   object or tuple annotation constrains the value's shape and mutability and lets
+   the compiler infer the lifetime. This holds in every annotation position — a
+   `val`/`var` binding, a return type, a field, a parameter — not only `val`
+   bindings. A bare annotation never forces an owned slot. `val q: {x: number} = p`
+   for `p: mut {x: number}` makes `q` an immutable view that borrows `p` with an
+   inferred lifetime; `p` keeps ownership. The same holds in return position:
+
+   ```esc
+   fn f(p: mut {x: number}) -> {x: number} {
+       val q: {x: number} = p
+       return q
+   }
+   // inferred: fn <'a>(p: mut 'a {x: number}) -> 'a {x: number}
+   ```
+
+   The annotated function infers the same `-> 'a {x: number}` as the version with
+   the return type omitted, rather than rejecting the returned borrow against an
+   owned slot. This generalizes G3, which shipped the reborrow only for bare
+   immutable `val` annotations
+   ([#764](https://github.com/escalier-lang/escalier/pull/764)), to every
+   annotation position, so annotated and unannotated code agree. Whether the
+   source is moved or borrowed is the escape-driven decision, independent of the
+   annotation: a local `mut` binding of a reference is a mutable reborrow that
+   retains the source — the multiple-mutable-aliases case — and only a binding that
+   escapes moves. A `mut` annotation fixes mutable shape; a lifetime-qualified
+   annotation names the lifetime explicitly instead of inferring it. The bare/`mut`
+   split decides the *mutability* of the resulting view, not whether the source is
+   moved.
 
 4. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
    field for a lifetime bounded by the receiver, not a fresh owned value. A read
@@ -390,48 +407,54 @@ stays local borrows its captures. Repeated `await` of one promise returns the sa
 reference rather than a copy, so a borrowed payload awaited twice is ordinary
 aliasing, governed by exclusivity, not a second move.
 
-## Ownership visibility and ergonomics
+## Type display and annotations
 
-Ownership is inferred, and the lifetime that distinguishes an owned value from a
-borrow is elided from the canonical type. So the same printed type can be owned in
-one place and borrowed in another: a binding of type `{x: number}` is owned when
-it holds a fresh value and is a borrow when it reborrows another binding (G3).
-Nothing in the printed annotation says which. This document keeps that inference,
-because reborrowing is strictly more permissive than always moving and is what
-lets a program take a cheap immutable view of a value without giving up the
-mutable original.
+Ownership is inferred: whether a value is owned or borrowed follows from how it
+flows, not from the annotation. The lifetime is the part of the type that records
+this. The governing decision for how lifetimes appear:
 
-The risk is that a developer reads `{x: number}` as an owned object and is
-surprised when it behaves like a borrow. Two facts bound that risk:
+> A type annotation should match the inferred type. The displayed signature is
+> always a valid annotation, and writing it back produces the same type. The
+> compiler fills in a type the program did not write only at an explicit hole,
+> such as the `_` in `fn () -> _ throws _`.
 
-- The owned/borrow distinction is **observable only at a small, fixed set of
-  points**: the escape sites where a value must outlive its source — returns,
-  stores into longer-lived state, fields of an outliving object, escaping closure
-  captures — and the one local case where the source is mutated again after a
-  local immutable view of it has died. Everywhere else an owned value and a borrow
-  of the same type behave identically.
-- At every one of those points the divergence surfaces as a **compile-time
-  error**, never as silently different runtime behaviour. The failure mode is "the
-  compiler won't let me return this," answered by a diagnostic, not a latent bug.
+Two consequences follow.
 
-Because the distinction is invisible in the type but visible in behaviour, the
-ergonomic burden falls on diagnostics and on-demand display. The requirements:
+- **Load-bearing lifetimes are shown; connect-nothing lifetimes are elided.** A
+  lifetime that appears in a signature — one that connects an input to an output,
+  or escapes to `'static` — is part of the type and is rendered, so
+  `fn <'a>(p: mut 'a {x: number}) -> 'a {x: number}` displays its `'a`. A lifetime
+  that connects nothing is dropped at display time (D4), because the type genuinely
+  does not depend on it, and there owned and borrowed are indistinguishable.
+  Lifetimes are therefore shown exactly when they carry meaning and hidden exactly
+  when they do not, so the display is never misleading.
+- **A bare annotation is accepted and agrees with inference.** Because a bare
+  object or tuple annotation fixes shape and mutability and lets the compiler infer
+  the lifetime (inference rule 3), writing `{x: number}` produces the same type as
+  writing the full `'a {x: number}` or omitting the annotation entirely. Annotating
+  code never diverges from inferring it. This is what removes the
+  [#764](https://github.com/escalier-lang/escalier/pull/764) inconsistency, where a
+  bare return annotation forced an owned slot and errored while the same code with
+  the return type omitted inferred a lifetime.
 
-1. **Errors carry the ownership story.** When a borrow cannot escape, the message
-   names the borrow's source and explains the ownership relationship — for
-   example, "`q` borrows `p` and cannot outlive it; `p` is a local value" — and
-   suggests a concrete fix, such as returning the source directly or cloning. This
-   mirrors how the lifetime errors already explain an aliasing relationship that
-   is otherwise hidden.
-2. **Borrow-ness is discoverable on demand.** The canonical type display stays
-   elided and clean, rendering `{x: number}` for both owned and borrowed values.
-   LSP hover and a verbose `showLifetimes` mode reveal the inferred lifetime and
-   the borrow source, so a developer who wants to know whether a binding is owned
-   or borrowed can find out without every signature carrying lifetime noise.
+This stance is a deliberate reversal of an earlier draft that elided lifetimes from
+the canonical display and surfaced them only on hover. Matching annotations to
+inferred types matters more now that much code is written or transformed by LLMs: a
+tool can read the inferred signature and reproduce it verbatim as an annotation,
+and an annotated program type-checks to the same result as the inferred one. The
+remaining requirement on diagnostics:
 
-The aim is that a developer never has to reason about ownership to write ordinary
-local code, encounters the distinction only through an actionable error or a
-deliberate hover, and is never silently surprised by it at runtime.
+- **Errors carry the ownership story.** When a borrow cannot escape, the message
+  names the borrow's source and explains the ownership relationship — for example,
+  "`q` borrows `p` and cannot outlive it; `p` is a local value" — and suggests a
+  concrete fix, such as returning the source directly or cloning. A `showLifetimes`
+  verbose mode may additionally render every lifetime, including elided ones, for
+  diagnostic use.
+
+The aim is that the inferred type a developer sees is exactly the type they could
+write, ordinary local code needs no lifetime annotations because the elided
+lifetimes connect nothing, and the cases that do require a lifetime show it in the
+signature rather than hiding it behind a later error.
 
 ## Non-goals and deferred questions
 

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -215,6 +215,16 @@ set of rules:
    rule. A `mut` modifier still fixes mutable shape, and a lifetime-qualified `&'a`
    names the lifetime instead of inferring it.
 
+   A binding may also borrow with an explicit `&` on the initializer instead of an
+   annotation. `val q = &p` borrows `p` immutably and infers `q: &{x: number}`, and
+   `val q = &mut p` takes a mutable borrow, which requires `p` to be owned-mutable. This
+   is equivalent to the annotated form, but it does not repeat the pointee shape, so it
+   is the ergonomic way to force a borrow where inference would otherwise move. The
+   explicit `&` expression is a binding-site convenience. Call arguments still borrow
+   implicitly, `foo(p)` rather than `foo(&p)`, per the "Function argument" rule, because
+   the parameter's own `&` already states the borrow. A binding has no parameter
+   annotation to lean on, so the `&` on the initializer states the borrow there instead.
+
 4. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
    field for a lifetime bounded by the receiver, not a fresh owned value. A read
    that is immediately consumed locally needs no lifetime in the rendered type;
@@ -252,6 +262,12 @@ the transfer has one of three outcomes.
    meaning never tracked and never moved. It does not assert that a runtime
    duplicate is made. A promise's resolved payload is governed separately.
    Awaiting the promise borrows that payload under the ordinary borrow rules.
+
+   Immutable borrows are Copy as well. Copying one yields another immutable borrow of
+   the same value, and the source stays live, which is why a `&T` can be freely
+   duplicated. A mutable borrow is also non-consuming when bound, though as a
+   `&mut`-to-`&mut` reborrow under outcome 2 rather than a copy. The common rule is that
+   binding a borrow never consumes it. Only an owned value moves.
 
 2. **Borrow.** The destination takes a reference whose lifetime is bounded within
    the source binding's region. The source keeps ownership and stays usable. The
@@ -314,9 +330,32 @@ requiring every value to be consumed exactly once — is not a goal.
 Move/affine semantics applies the same copy/borrow/move decision uniformly. This
 section lists the sites and the outcome at each.
 
-- **`val` / `var` binding.** `val y = x` copies if `x` is a value type, borrows
-  if `y` is annotated `&` (a local view of `x`, immutable or `&mut`), and otherwise
-  moves `x` into `y`, consuming `x`.
+- **`val` / `var` binding.** The outcome depends on `x`. A value type is copied. A
+  borrow, `&T` or `&mut T`, is duplicated non-consumingly so the source stays live. An
+  immutable borrow is copied and a mutable borrow reborrowed, and the multiple-`&mut`
+  rule makes the mutable case sound. An owned value is moved into `y` and consumed,
+  unless `y` is annotated `&` or `&mut`, which borrows `x` and keeps it usable. So
+  binding a borrow never consumes it, and only owned values move.
+
+  ```esc
+  val p = Point(5, 10)
+  val q = &p             // q: &Point — immutable borrow of p
+  val r = q              // r: &Point — copies the borrow; q stays live
+  ```
+
+  ```esc
+  val mut p = Point(0, 0)
+  val q = &mut p         // q: &mut Point — mutable borrow of p
+  val r = q              // r: &mut Point — reborrows; q stays live (multiple &mut allowed)
+  ```
+
+  Mutability lives in a different place for the two, which is why `val r = q` preserves
+  a borrow's mutability while a plain `val` move of an owned value drops it. An owned
+  value's mutability belongs to the binding and defaults to immutable, so moving into a
+  plain `val` freezes it, and `val mut` keeps it mutable. A borrow's mutability belongs
+  to its `&`/`&mut` type and is inherited on copy. It can be narrowed by annotation, as
+  in `val r: &Point = q` downgrading a `&mut`, but never widened, since a view cannot
+  grant itself access the owner withheld.
 - **Reassignment.** `y = x` follows the same decision as a binding. A reassigned
   `var` that previously owned a value drops the old value and takes the new one.
 - **Field / element store.** `obj.f = x` and `t[i] = x` move `x` when `obj` or
@@ -358,6 +397,15 @@ moved field, and allowed if it only reaches live fields. The precision target is
 field-granular tracking; the conservative fallback, acceptable if field-granular
 tracking proves costly, is to consume the whole object on any field move and
 record that as a precision limitation.
+
+Place borrows share this path-granular tracking. `&obj.f` borrows the field `obj.f`
+rather than the whole receiver, so it locks only that path and leaves a disjoint sibling
+such as `obj.g` independently usable, including through `&mut obj.g`. Moves and borrows
+read the same per-path ownership state, so they compose, and a field may be borrowed
+while a disjoint field is moved. The same conservative fallback applies. A path the
+checker cannot prove disjoint, such as a dynamic `arr[i]` versus `arr[j]`, falls back to
+a container-level borrow, the way the whole-object-consume fallback covers field moves it
+cannot separate.
 
 ## Why the invariant holds
 

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -127,9 +127,14 @@ through a parameter or a member read. The full set of rules:
    without an explicit lifetime is a borrow of whatever the caller lends. The
    checker attaches a fresh lifetime variable to it, so inside the body the
    parameter is `'a {…}` or `mut 'a {…}`. The caller retains ownership; the callee
-   only borrows for the call. A parameter becomes a consuming, owned slot only
-   when it is annotated to take ownership or when the body lets it escape, which
-   forces the borrow's lifetime to `'static`.
+   only borrows for the call. A parameter is never owned in the `Lt`-nil sense a
+   local binding is — it is always reached across the call boundary, so it always
+   carries a lifetime. A parameter becomes *consuming* only when its lifetime is
+   `'static`, which the body forces by letting the parameter escape, or which a
+   signature states explicitly as `p: mut 'static {…}`. A consuming parameter
+   requires the caller to give up ownership; the lifetimes design phrases this to
+   the caller as "pass a clone if you need to keep access." There is no separate
+   ownership annotation.
 
 3. **Bare annotations in reference position reborrow (G3).** Binding a reference
    into a bare object or tuple annotation lowers the annotation to an immutable
@@ -436,6 +441,13 @@ deliberate hover, and is never silently surprised by it at runtime.
 - **Cross-package moves.** Move behaviour at the boundary of imported,
   body-less declarations depends on declared lifetimes and is deferred to the
   library-import work, consistent with the elision rules for lifetimes.
+- **Surface syntax for a consuming parameter.** A parameter is consuming when its
+  lifetime is `'static`. Today that is written by spelling the lifetime out,
+  `p: mut 'static {…}`, which is accurate but exposes a lifetime most code never
+  names. Whether to keep `'static` as the user-facing way to demand ownership, or
+  to add a dedicated keyword that reads as "consume this argument," is an unmade
+  design decision. It does not change behaviour — only how a caller-visible
+  ownership transfer is spelled.
 - **Diagnostics.** Exact wording and blame spans for use-after-move and
   move-on-escape errors are left to the implementation plan; they should name the
   move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -379,6 +379,49 @@ stays local borrows its captures. Repeated `await` of one promise returns the sa
 reference rather than a copy, so a borrowed payload awaited twice is ordinary
 aliasing, governed by exclusivity, not a second move.
 
+## Ownership visibility and ergonomics
+
+Ownership is inferred, and the lifetime that distinguishes an owned value from a
+borrow is elided from the canonical type. So the same printed type can be owned in
+one place and borrowed in another: a binding of type `{x: number}` is owned when
+it holds a fresh value and is a borrow when it reborrows another binding (G3).
+Nothing in the printed annotation says which. This document keeps that inference,
+because reborrowing is strictly more permissive than always moving and is what
+lets a program take a cheap immutable view of a value without giving up the
+mutable original.
+
+The risk is that a developer reads `{x: number}` as an owned object and is
+surprised when it behaves like a borrow. Two facts bound that risk:
+
+- The owned/borrow distinction is **observable only at a small, fixed set of
+  points**: the escape sites where a value must outlive its source — returns,
+  stores into longer-lived state, fields of an outliving object, escaping closure
+  captures — and the one local case where the source is mutated again after a
+  local immutable view of it has died. Everywhere else an owned value and a borrow
+  of the same type behave identically.
+- At every one of those points the divergence surfaces as a **compile-time
+  error**, never as silently different runtime behaviour. The failure mode is "the
+  compiler won't let me return this," answered by a diagnostic, not a latent bug.
+
+Because the distinction is invisible in the type but visible in behaviour, the
+ergonomic burden falls on diagnostics and on-demand display. The requirements:
+
+1. **Errors carry the ownership story.** When a borrow cannot escape, the message
+   names the borrow's source and explains the ownership relationship — for
+   example, "`q` borrows `p` and cannot outlive it; `p` is a local value" — and
+   suggests a concrete fix, such as returning the source directly or cloning. This
+   mirrors how the lifetime errors already explain an aliasing relationship that
+   is otherwise hidden.
+2. **Borrow-ness is discoverable on demand.** The canonical type display stays
+   elided and clean, rendering `{x: number}` for both owned and borrowed values.
+   LSP hover and a verbose `showLifetimes` mode reveal the inferred lifetime and
+   the borrow source, so a developer who wants to know whether a binding is owned
+   or borrowed can find out without every signature carrying lifetime noise.
+
+The aim is that a developer never has to reason about ownership to write ordinary
+local code, encounters the distinction only through an actionable error or a
+deliberate hover, and is never silently surprised by it at runtime.
+
 ## Non-goals and deferred questions
 
 - **Linearity / mandatory consumption.** Values need not be consumed; unused

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -554,6 +554,15 @@ multiple-input-borrows case. Within a single solved instantiation a variable has
 ownership. Owned and borrowed are different types, so an inference variable used as
 owned in one place and borrowed in another is a conflict, not a value that is both.
 
+There is no `Copy` bound. Generic code treats a type parameter as non-duplicable —
+the conservative affine assumption — because it cannot tell whether the argument is a
+value type. A body may therefore use a `T` value at most once, and a function that
+needs to reuse its argument takes it by `&T` and reads through the borrow. A function
+that genuinely duplicates an owned value, such as `fn dup<T>(x: T) -> (T, T)`, is not
+expressible generically; it must be written against a concrete value type or take a
+borrow. The bound is omitted deliberately: duplicating a type-parameter value is rare
+enough not to justify the constraint machinery, and borrowing covers the common case.
+
 ### Type aliases
 
 A shape alias is transparent. `type Point = {x: number, y: number}` names an owned
@@ -580,6 +589,23 @@ scope, and the phase rule already forbids any mutable borrow from changing the
 variant while it is live. A concurrent mutation can therefore never silently re-type
 a narrowed view.
 
+Narrowing a mutable value may yield a mutable narrowed binding, `&mut A`, so the
+variant's fields can be written. To keep that sound while several mutable borrows are
+live at once, the discriminant is **pinned** for the binding's scope: while a mutable
+narrowed `&mut A` is live, the tag the narrowing tested may not be written through any
+alias, though the variant's other fields stay mutable. Pinning matches the mental
+model — the narrowing already depends on the tag, so the tag is frozen for the arm —
+and it removes the only way a concurrent write could invalidate the narrowed type.
+
+```esc
+match u {              // u: mut (A | B)
+    a is A => {
+        a.x = 5        // OK — a is &mut A, and x is an ordinary field of the A variant
+        // a.tag = "b" is rejected — the discriminant is pinned for this arm
+    }
+}
+```
+
 `mut` and `&` sit identically on the wrapper but behave differently over a union,
 because mutation is invariant where an immutable borrow is covariant. An immutable
 borrow reads only, so `&(A | B)` factors by subtyping: `&A` is usable where
@@ -596,6 +622,15 @@ fn f(p: mut (A | B)) -> void {
     p = {tag: "b", y: 0}   // writes a value of type A | B; would corrupt storage typed mut A
 }
 ```
+
+A union or intersection must have uniform ownership. Because ownership is the outer
+wrapper, a type whose members disagree — an owned member beside a borrowed one, such
+as `{x: number} | &{y: number}` — has no single owned-or-borrowed verdict and is
+rejected. The programmer makes ownership uniform first: clone the borrowed member to
+own it, or borrow the owned member, so both sides agree before the union is formed.
+Auto-factoring the owned member down to a borrow is deliberately not done: when that
+member is a fresh temporary the resulting borrow lifetime is too short to be useful,
+and the silent downgrade would hide the problem rather than surface it.
 
 ### Nested borrows
 
@@ -632,9 +667,6 @@ policy choosing it.
   The wrapper is applied to the computed result, so a conditional type that selects
   between branches yields a pointee shape that a borrow then wraps.
 
-Open questions on type-former interactions are collected under "Non-goals and
-deferred questions."
-
 ## Non-goals and deferred questions
 
 - **Linearity / mandatory consumption.** Values need not be consumed; unused
@@ -649,20 +681,6 @@ deferred questions."
 - **Cross-package moves.** Move behaviour at the boundary of imported,
   body-less declarations depends on declared lifetimes and is deferred to the
   library-import work, consistent with the elision rules for lifetimes.
-- **A `Copy` bound for generics.** Without a value-type bound, generic code must
-  conservatively assume a type parameter *moves*, since it cannot tell whether the
-  argument is a value type. A `Copy`-like bound that marks a parameter as a value
-  type would let generic code pass it freely. Whether to add one is deferred.
-- **Mixed-ownership unions and intersections.** A union whose members carry
-  different ownership, such as `{x: number} | &{y: number}`, has no single owned-or-
-  borrowed verdict. The principled options are to factor a common wrapper or to
-  reject the type; which one is unsettled.
-- **Mutable narrowed bindings.** Whether narrowing may yield a mutable narrowed
-  binding — `&mut A`, so the variant's fields can be written — is open. If it can,
-  then because several mutable borrows may be live at once, that binding's soundness
-  needs the discriminant to stay stable for its scope: treat the tag as immutable
-  while narrowed, or make that one borrow exclusive. If narrowing yields only
-  immutable views, the question disappears.
 - **Diagnostics.** Exact wording and blame spans for use-after-move and
   move-on-escape errors are left to the implementation plan; they should name the
   move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -239,8 +239,18 @@ a separate analysis.
 At every site where a value flows from a source expression into a destination,
 the transfer has one of three outcomes.
 
-1. **Copy.** The source is a value type. It is duplicated; the source binding
-   stays fully usable. Primitives, functions, and promises always copy.
+1. **Copy.** The source is a value type, so the transfer never consumes it and
+   the source binding stays fully usable. What happens at runtime depends on the
+   kind of value. Primitives — `number`, `string`, and `boolean` — are
+   duplicated by value, so each binding holds an independent copy. Functions and
+   promises are reference objects that JavaScript cannot copy, so the transfer
+   shares the same object. They count as value types anyway, because the system
+   tracks no interior mutability for them. A function and a promise are immutable
+   to their holders, and freely aliasing an immutable reference can never let
+   another reference observe a mutation. "Copy" names the compile-time category,
+   meaning never tracked and never moved. It does not assert that a runtime
+   duplicate is made. A promise's resolved payload is governed separately.
+   Awaiting the promise borrows that payload under the ordinary borrow rules.
 
 2. **Borrow.** The destination takes a reference whose lifetime is bounded within
    the source binding's region. The source keeps ownership and stays usable. The
@@ -398,8 +408,8 @@ borrow is live, the mutable owner may not mutate.
 ```esc
 val p: mut {x: number} = {x: 0}
 val q: &{x: number} = p    // immutable borrow — q is a local view of p; p retained
-print(q.x)
 p.x = 5                    // ERROR: p mutated while immutable borrow q is live
+print(q.x)                 // q read here, so the borrow spans the mutation above
 ```
 
 The two mechanisms cover the two ways the invariant can be threatened. A value
@@ -558,10 +568,23 @@ There is no `Copy` bound. Generic code treats a type parameter as non-duplicable
 the conservative affine assumption — because it cannot tell whether the argument is a
 value type. A body may therefore use a `T` value at most once, and a function that
 needs to reuse its argument takes it by `&T` and reads through the borrow. A function
-that genuinely duplicates an owned value, such as `fn dup<T>(x: T) -> (T, T)`, is not
+that genuinely duplicates an owned value, such as `fn dup<T>(x: T) -> [T, T]`, is not
 expressible generically; it must be written against a concrete value type or take a
 borrow. The bound is omitted deliberately: duplicating a type-parameter value is rare
 enough not to justify the constraint machinery, and borrowing covers the common case.
+
+Writing the parameter as `&T` makes the function borrow-only, and that is what lets it
+duplicate the argument. In `fn dup<T>(x: &T) -> [&T, &T]` the parameter is a borrow, so
+`x` is a reference rather than an owned value. Copying a reference is not a move, so the
+body `return [x, x]` is allowed. It yields two immutable borrows of one value, both
+sharing the lent lifetime, which is sound because multiple immutable borrows may be live
+at once. Because `&T` is part of the signature, the function never takes ownership. It
+borrows for any `T`, whether the caller's value is owned or itself borrowed. This is the
+difference from the bare-`T` form above: the borrow is stated in the type, so the body's
+duplication is checked against a known-copyable reference rather than an unconstrained
+`T`. At the call the borrow is inserted implicitly. With an owned `x` you write `dup(x)`,
+not `dup(&x)`, since the parameter is declared `&` and owning a value subsumes lending
+it.
 
 ### Type aliases
 
@@ -571,6 +594,29 @@ a reference type is implicitly generic over the lifetime: each use of
 `type PointRef = &Point` gets a fresh inferred lifetime, the way lifetime elision
 works inside a Rust type alias. Write `&'a Point` directly to name the lifetime
 instead.
+
+Utility types extend this transparency to aliases that *compute* a shape rather than
+name a fixed one. TypeScript's `Partial<T>`, `Pick<T, K>`, `Record<K, V>`, and
+`ReturnType<T>` are generic aliases built on three foundations: conditional types,
+mapped types, and template literal types. The rule for `&` follows the wrapper's outer
+position and matches a plain alias. Strip the wrapper, evaluate the operator over the
+pointee shape, then re-wrap the result. `&Partial<T>` borrows the object that
+`Partial<T>` computes; it is not `Partial<&T>` with the borrow pushed inside the
+operands. The lifetime is solved over the whole computed shape and is fresh per use,
+exactly as a `&` alias is implicitly generic over its lifetime.
+
+The three foundations differ in whether `&` applies at all. Template literal types
+compute string-kind results, and strings are value types, so `&` never wraps them and
+the borrow question does not arise. Conditional and mapped types can compute an object
+or tuple shape, so the wrapper does apply. A conditional type wraps whichever branch
+shape it selects, and a mapped type wraps the object it builds. The per-property `readonly`
+modifier that a mapped type may toggle is a separate axis from the whole-value wrapper,
+and the two compose without conflict. A `readonly` field stays read-only however the
+object is held, even through an owned-mutable value or a `&mut` borrow. The whole-value
+mutability decides whether the value may be written or reassigned at all, while
+`readonly` independently forbids writes to that one field. A mapped type such as
+`Readonly<T>` therefore works inside the shape, marking fields read-only, and leaves the
+borrow wrapper untouched. No special reconciliation is needed.
 
 ### Unions and intersections
 
@@ -639,8 +685,9 @@ A nested borrow such as `&&Point` arises only from generic substitution — `&T`
 represents a borrow of a borrow. The JS compile target forces this rather than a
 policy choosing it.
 
-- **Immutable layers collapse.** Immutable borrows are Copy, and both layers compile
-  to the same bare object reference, so `&'a &'b Point` reduces to `&'a Point` — the
+- **Immutable layers collapse.** Immutable borrows are Copy. Here Copy duplicates the reference and never the
+  referenced data, so a duplicate is just another immutable alias to the same value.
+  Both layers compile to the same bare object reference, so `&'a &'b Point` reduces to `&'a Point` — the
   outer, shorter lifetime, with the standing constraint that `'b` outlives `'a`.
   Immutable `&` is idempotent.
 - **Mutable nesting is uninhabitable.** `&mut &mut Point` would have to mean "repoint
@@ -655,7 +702,7 @@ policy choosing it.
 
 ### Other formers
 
-- **Tuples and arrays** are `RefInner`. `&(A, B)` borrows the whole tuple, and
+- **Tuples and arrays** are `RefInner`. `&[A, B]` borrows the whole tuple, and
   element access borrows a piece for a lifetime bounded by the container. Partial
   moves apply at element granularity, as in the partial-moves section.
 - **Functions** are value types. They copy and are never wrapped in `RefType`. The

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -529,6 +529,91 @@ connect nothing, and the cases that do require a named lifetime show it in the
 signature rather than hiding it behind a later error. Borrows are always marked
 with `&`, but their lifetimes stay inferred until they become load-bearing.
 
+## Type-former interactions
+
+Ownership and lifetime live in the `RefType{Mut, Lt, Inner}` wrapper, which sits
+outside the shape. Type variables, aliases, unions, intersections, and tuples all
+describe the `Inner` shape, and the wrapper is a mostly-orthogonal layer applied on
+top. Borrowing therefore composes with the type formers: a borrow wraps whatever
+shape a former produces. The places where the composition is not fully orthogonal
+are described below.
+
+### Type variables
+
+A borrow applies outside a type parameter, never inside it. `&T`, `&mut T`, and
+`&'a T` wrap a `T`, and the lifetime is solved by the existing `constrainLt`
+machinery rather than baked into `T`. Because `&'a U` is itself an ordinary type, a
+type parameter can be instantiated with a borrow, and the lifetime rides along for
+free. Instantiating `fn id<T>(x: T) -> T` at a borrow yields `fn(&'a U) -> &'a U`
+with no separate lifetime parameter. This is a deliberate divergence from Rust,
+where lifetimes are a distinct kind that must be threaded explicitly.
+
+Explicit lifetime variables, a separate sort from type variables, are needed only to
+relate two borrows whose lifetimes elision cannot disambiguate — the
+multiple-input-borrows case. Within a single solved instantiation a variable has one
+ownership. Owned and borrowed are different types, so an inference variable used as
+owned in one place and borrowed in another is a conflict, not a value that is both.
+
+### Type aliases
+
+A shape alias is transparent. `type Point = {x: number, y: number}` names an owned
+shape, and `&Point` expands to `&{x: number, y: number}`. An alias that itself names
+a reference type is implicitly generic over the lifetime: each use of
+`type PointRef = &Point` gets a fresh inferred lifetime, the way lifetime elision
+works inside a Rust type alias. Write `&'a Point` directly to name the lifetime
+instead.
+
+### Unions and intersections
+
+The wrapper is outer and shared. `&(A | B)` is one borrow over a union pointee, with
+a single lifetime and mutability for the whole value, not `&A | &B` with independent
+lifetimes. A union is owned-or-borrowed and mutable-or-not as a unit; there is no
+per-member ownership. Move and borrow treat the union as a whole, so moving consumes
+it regardless of which variant it currently holds. Intersections compose the same
+way, with the wrapper outside `A & B`.
+
+Narrowing introduces a new binding, so it falls under the ordinary borrow and phase
+rules rather than a special narrowing rule. The narrowed binding is a fresh borrow of
+the scrutinee, scoped to the narrowed region, and the original keeps its `A | B`
+type. An immutable narrowed binding puts the value into the immutable phase for its
+scope, and the phase rule already forbids any mutable borrow from changing the
+variant while it is live. A concurrent mutation can therefore never silently re-type
+a narrowed view.
+
+`mut` and `&` sit identically on the wrapper but behave differently over a union,
+because mutation is invariant where an immutable borrow is covariant. An immutable
+borrow reads only, so `&(A | B)` factors by subtyping: `&A` is usable where
+`&(A | B)` is wanted, and `&A | &B <: &(A | B)`. A mutable wrapper can also write, so
+it is invariant: `mut A` and `mut (A | B)` are incomparable, and `mut (A | B)` does
+not factor. Passing a `mut A` where `mut (A | B)` is expected would let the callee
+write a `B` into `A`-typed storage:
+
+```esc
+type A = {tag: "a", x: number}
+type B = {tag: "b", y: number}
+
+fn f(p: mut (A | B)) -> void {
+    p = {tag: "b", y: 0}   // writes a value of type A | B; would corrupt storage typed mut A
+}
+```
+
+### Other formers
+
+- **Tuples and arrays** are `RefInner`. `&(A, B)` borrows the whole tuple, and
+  element access borrows a piece for a lifetime bounded by the container. Partial
+  moves apply at element granularity, as in the partial-moves section.
+- **Functions** are value types. They copy and are never wrapped in `RefType`. The
+  lifetimes inside a function signature elide or show by the display rules.
+- **Generic containers** such as `Array<T>` own their elements, so `arr[i]` yields a
+  `&T` bounded by the array's lifetime, and `&mut Array<T>` is a mutable borrow of
+  the container.
+- **Conditional and mapped types** compute a shape without reference to ownership.
+  The wrapper is applied to the computed result, so a conditional type that selects
+  between branches yields a pointee shape that a borrow then wraps.
+
+Open questions on type-former interactions are collected under "Non-goals and
+deferred questions."
+
 ## Non-goals and deferred questions
 
 - **Linearity / mandatory consumption.** Values need not be consumed; unused
@@ -543,6 +628,23 @@ with `&`, but their lifetimes stay inferred until they become load-bearing.
 - **Cross-package moves.** Move behaviour at the boundary of imported,
   body-less declarations depends on declared lifetimes and is deferred to the
   library-import work, consistent with the elision rules for lifetimes.
+- **A `Copy` bound for generics.** Without a value-type bound, generic code must
+  conservatively assume a type parameter *moves*, since it cannot tell whether the
+  argument is a value type. A `Copy`-like bound that marks a parameter as a value
+  type would let generic code pass it freely. Whether to add one is deferred.
+- **Nested borrows.** Instantiating `T` with a borrow under another `&` produces
+  `&&U`. Such nested borrows are meaningful but rare; whether to normalize them away
+  or carry them is unsettled.
+- **Mixed-ownership unions and intersections.** A union whose members carry
+  different ownership, such as `{x: number} | &{y: number}`, has no single owned-or-
+  borrowed verdict. The principled options are to factor a common wrapper or to
+  reject the type; which one is unsettled.
+- **Mutable narrowed bindings.** Whether narrowing may yield a mutable narrowed
+  binding — `&mut A`, so the variant's fields can be written — is open. If it can,
+  then because several mutable borrows may be live at once, that binding's soundness
+  needs the discriminant to stay stable for its scope: treat the tag as immutable
+  while narrowed, or make that one borrow exclusive. If narrowing yields only
+  immutable views, the question disappears.
 - **Diagnostics.** Exact wording and blame spans for use-after-move and
   move-on-escape errors are left to the implementation plan; they should name the
   move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -597,6 +597,27 @@ fn f(p: mut (A | B)) -> void {
 }
 ```
 
+### Nested borrows
+
+A nested borrow such as `&&Point` arises only from generic substitution — `&T` at
+`T = &Point` — and every nesting normalizes to depth at most one, so Escalier never
+represents a borrow of a borrow. The JS compile target forces this rather than a
+policy choosing it.
+
+- **Immutable layers collapse.** Immutable borrows are Copy, and both layers compile
+  to the same bare object reference, so `&'a &'b Point` reduces to `&'a Point` — the
+  outer, shorter lifetime, with the standing constraint that `'b` outlives `'a`.
+  Immutable `&` is idempotent.
+- **Mutable nesting is uninhabitable.** `&mut &mut Point` would have to mean "repoint
+  the inner borrow," which needs a storage cell holding the inner reference. A borrow
+  compiles to the bare object reference with no cell of its own, and JS offers no
+  lvalue-reference to a binding, so no such operation is expressible. Repointing a
+  borrow stored in a field is written by mutably borrowing the *container* — an
+  ordinary `&mut Holder` — never by forming `&mut &mut Point`. The only way to get a
+  real repointable cell is to box it by hand as a `{ value: ... }` object, which is a
+  normal owned value, not a borrow. So the mutable nested type has no inhabitant you
+  can produce, and rejecting it costs nothing.
+
 ### Other formers
 
 - **Tuples and arrays** are `RefInner`. `&(A, B)` borrows the whole tuple, and
@@ -632,9 +653,6 @@ deferred questions."
   conservatively assume a type parameter *moves*, since it cannot tell whether the
   argument is a value type. A `Copy`-like bound that marks a parameter as a value
   type would let generic code pass it freely. Whether to add one is deferred.
-- **Nested borrows.** Instantiating `T` with a borrow under another `&` produces
-  `&&U`. Such nested borrows are meaningful but rare; whether to normalize them away
-  or carry them is unsettled.
 - **Mixed-ownership unions and intersections.** A union whose members carry
   different ownership, such as `{x: number} | &{y: number}`, has no single owned-or-
   borrowed verdict. The principled options are to factor a common wrapper or to

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -154,9 +154,10 @@ set of rules:
 
    A `val mut` binding may also take ownership of an existing owned-immutable
    value by moving it. For an owned-immutable `p`, `val mut q = p` moves `p` into
-   the mutable binding `q` and consumes `p`. Because the move leaves `q` the sole
-   owner, it is sound for `q` to be mutable — no immutable reference to the value
-   survives the move. This is the mirror image of freezing: freezing moves an
+   the mutable binding `q` and consumes `p`. Like any move, it is rejected if `p`
+   has a live borrow. Given that, the move leaves `q` the sole owner, so it is sound
+   for `q` to be mutable, because no reference to the value survives to observe
+   `q`'s later mutations. This is the mirror image of freezing: freezing moves an
    owned-mutable value into an immutable binding, and this moves an owned-immutable
    value into a mutable one.
 
@@ -277,8 +278,11 @@ the transfer has one of three outcomes.
    `&` borrow that stays local.
 
 3. **Move.** Ownership transfers out of the source binding. The source binding is
-   **consumed**: any later use of it is a use-after-move error. This is the
-   outcome whenever the value **escapes** the source binding's region.
+   **consumed**: any later use of it is a use-after-move error. A move also requires
+   the source to have no live borrow at the move point. Moving a value that is
+   currently borrowed is rejected, because the move would consume storage the borrow
+   still points into. This is the outcome whenever the value **escapes** the source
+   binding's region.
 
 ### What counts as escape
 

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -140,8 +140,14 @@ through a parameter or a member read. The full set of rules:
    into a bare object or tuple annotation lowers the annotation to an immutable
    borrow with a fresh lifetime, not an owned slot. `val q: {x: number} = p` for
    `p: mut {x: number}` makes `q` a local immutable view that borrows `p`; `p`
-   keeps ownership. A `mut` or lifetime-qualified annotation is not reborrowed —
-   `mut {x: number}` stays an owned-mutable slot.
+   keeps ownership. G3 ships the reborrow only for bare, immutable annotations: a
+   `mut {x: number}` annotation lowers to an owned-mutable type and a
+   lifetime-qualified annotation names the borrow explicitly, neither rewritten by
+   G3. Under move/affine semantics the move-versus-borrow choice is escape-driven
+   and applies to every form, so a local `mut` binding of a reference is a mutable
+   reborrow that retains the source — the multiple-mutable-aliases case — and only
+   a binding that escapes moves. The bare/`mut` split decides the *mutability* of
+   the resulting view, not whether the source is moved.
 
 4. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
    field for a lifetime bounded by the receiver, not a fresh owned value. A read

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -1,0 +1,395 @@
+# Move / affine semantics for owned values
+
+## Status and scope
+
+This document specifies the behaviour we want from move/affine semantics in
+Escalier. It is the requirements portion of the RFC tracked at
+[#762](https://github.com/escalier-lang/escalier/issues/762), the use-after-move
+item of the broader sound borrow checker effort
+[#618](https://github.com/escalier-lang/escalier/issues/618).
+
+It assumes the M4 borrow and lifetime machinery has landed: the
+`RefType{Mut, Lt, Inner}` wrapper, the lifetime sort (`LifetimeVar`,
+`StaticLifetime`, `constrainLt`), borrow origination and escape-to-`'static`,
+and the liveness-based mutability-transition checker in
+[internal/solver/transitions.go](../../internal/solver/transitions.go). It also
+assumes **G3** is in place: a bare object or tuple annotation in reference
+position reborrows its initializer as a local immutable view rather than an owned
+slot. G3 is in review as [#764](https://github.com/escalier-lang/escalier/pull/764).
+
+This document describes target behaviour, not an implementation plan. The
+implementation plan is a separate doc.
+
+## Motivation
+
+Escalier is biased toward immutability and guarantees that an immutable reference
+never observes a mutation. Today that guarantee is enforced site by site. The
+mutability-transition checker has a Rule 1 for mutable-to-immutable bindings, a
+Rule 2 for immutable-to-mutable bindings, and ad-hoc mutability-dropping logic at
+global writes. Each new place a value can flow needs its own rule, and some flow
+paths slip through. The motivating gap from #762:
+
+```esc
+// module scope
+var sink: {x: number} = {x: 0}   // immutable global
+
+fn leak(p: mut {x: number}) -> void {
+    sink = p        // a mut borrow is stored into an immutable global
+    p.x = 5         // mutating through p now changes what `sink` reads
+}
+```
+
+Storing a mutable borrow into longer-lived immutable state, then mutating through
+the borrow, breaks the immutability guarantee. Patching this one site is not
+enough, because the same shape recurs at returns, field stores, and escaping
+function arguments.
+
+Move/affine semantics is the unifying fix. Instead of a separate rule per flow
+site, a single rule governs every site: when a value leaves the region its
+current binding owns, ownership **moves** out of that binding, the binding is
+**consumed**, and any later use of it is a compile-time use-after-move error.
+Because the move consumes the source, no conflicting path back to the value
+survives, and the per-site mutability-dropping logic is no longer needed.
+
+## The soundness invariant
+
+The one condition we must always preserve:
+
+> No immutable reference ever observes a mutation. If a value is reachable
+> through an immutable reference that is live at some point, then between the
+> creation of that reference and its last use, the value is not mutated through
+> any other path.
+
+Correctness comes first: this invariant must hold on every accepted program.
+Precision is the secondary goal: among the programs that preserve the invariant,
+we want to reject as few as possible. The two goals trade off only when we are
+unsure whether a program is safe; there we reject, and the precision sections
+below describe where we work to avoid being unsure.
+
+## Owned versus borrowed values
+
+Every object, tuple, and other reference-shaped value is, at each point in the
+program, either **owned** by a binding or **borrowed** from an owner. The
+distinction is carried in the type by the
+[`RefType`](../../internal/soltype/type.go) wrapper, whose lifetime field `Lt`
+decides ownership.
+
+- **Owned** — `Lt` is nil. The binding is the value's owner; the value's
+  lifetime is the binding's own region. Two flavours:
+  - **owned-immutable** — `RefType{Mut: false, Lt: nil}`, which `NewRef`
+    collapses to the bare inner type (`{x: number}`). The owner may read but not
+    mutate.
+  - **owned-mutable** — `RefType{Mut: true, Lt: nil}`, printed `mut {x: number}`.
+    The owner may read and mutate.
+- **Borrowed** — `Lt` is a lifetime. The value is a reference into storage owned
+  elsewhere, valid only for the lifetime `Lt`. Two flavours:
+  - **immutable borrow** — `RefType{Mut: false, Lt: 'a}`, printed `'a {x: number}`.
+    A read-only view for the duration of `'a`.
+  - **mutable borrow** — `RefType{Mut: true, Lt: 'a}`, printed `mut 'a {x: number}`.
+    A read-write view for the duration of `'a`.
+
+Primitives (`number`, `string`, `boolean`), functions, and promises are **value
+types**: they are never wrapped in a `RefType` and are excluded from `RefInner`.
+They carry no interior mutability worth tracking, so ownership and moves do not
+apply to them. They are freely duplicated.
+
+The four quadrants:
+
+| | owned (`Lt` nil) | borrowed (`Lt` = `'a`) |
+|---|---|---|
+| **immutable** (`Mut` false) | `{x: number}` | `'a {x: number}` |
+| **mutable** (`Mut` true) | `mut {x: number}` | `mut 'a {x: number}` |
+
+Ownership and mutability are orthogonal axes. Ownership decides who is
+responsible for the value and whether a transfer consumes the source. Mutability
+decides whether writes are allowed. Move/affine semantics governs the ownership
+axis; the mutability axis is governed by the existing exclusivity rule.
+
+## When owned versus borrowed is inferred
+
+The default is owned for freshly produced values and borrowed for values reached
+through a parameter or a member read. The full set of rules:
+
+1. **Literals are owned.** An object, tuple, or array literal produces a fresh
+   value the binding owns. `val p = {x: 0, y: 0}` makes `p` owned. Its mutability
+   follows the existing value-default rules: a plain object literal is
+   owned-immutable, and a `mut` annotation or a mutating method makes it
+   owned-mutable.
+
+2. **Constructor and fresh-value results are owned.** A class constructor or any
+   expression that builds a new value yields an owned value, mutable or immutable
+   per the class's default.
+
+3. **Function parameters are borrowed by default.** A reference-typed parameter
+   without an explicit lifetime is a borrow of whatever the caller lends. The
+   checker attaches a fresh lifetime variable to it, so inside the body the
+   parameter is `'a {…}` or `mut 'a {…}`. The caller retains ownership; the callee
+   only borrows for the call. A parameter becomes a consuming, owned slot only
+   when it is annotated to take ownership or when the body lets it escape, which
+   forces the borrow's lifetime to `'static`.
+
+4. **Bare annotations in reference position reborrow (G3).** Binding a reference
+   into a bare object or tuple annotation lowers the annotation to an immutable
+   borrow with a fresh lifetime, not an owned slot. `val q: {x: number} = p` for
+   `p: mut {x: number}` makes `q` a local immutable view that borrows `p`; `p`
+   keeps ownership. A `mut` or lifetime-qualified annotation is not reborrowed —
+   `mut {x: number}` stays an owned-mutable slot.
+
+5. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
+   field for a lifetime bounded by the receiver, not a fresh owned value. A read
+   that is immediately consumed locally needs no lifetime in the rendered type;
+   one that escapes carries the receiver's lifetime.
+
+6. **Escape forces ownership and lifetime.** A value that flows into storage
+   outliving its current binding — a module-level or other longer-lived binding,
+   a field of a longer-lived object, a return value, or an escaping closure
+   capture — has its lifetime constrained to outlive the destination. For a
+   value owned by a local binding, this is the trigger for a move, described
+   next. For a borrow, escape that the borrow's lifetime cannot satisfy is a
+   borrow-escape error.
+
+The principle behind these rules: **owned** is inferred when a binding is the sole
+producer or holder of a value, and **borrowed** is inferred when a binding reaches
+a value that something else owns. The lifetime machinery already in place
+computes which case applies; move semantics reads its verdict rather than running
+a separate analysis.
+
+## Move / affine semantics
+
+At every site where a value flows from a source expression into a destination,
+the transfer has one of three outcomes.
+
+1. **Copy.** The source is a value type. It is duplicated; the source binding
+   stays fully usable. Primitives, functions, and promises always copy.
+
+2. **Borrow.** The destination takes a reference whose lifetime is bounded within
+   the source binding's region. The source keeps ownership and stays usable. The
+   borrow is governed by the mutability-exclusivity rule for its lifetime. This
+   is the outcome for a read-only argument to a non-escaping parameter, a
+   `mut`-to-`mut` local reborrow, sharing an immutable value, and a G3 reborrow
+   that stays local.
+
+3. **Move.** Ownership transfers out of the source binding. The source binding is
+   **consumed**: any later use of it is a use-after-move error. This is the
+   outcome whenever the value **escapes** the source binding's region.
+
+### What counts as escape
+
+Escape is the single trigger for a move. A value escapes its current owner's
+region when it must outlive that region. Concretely, an owned value moves when it
+flows into:
+
+- a longer-lived binding — a module-level or other outer-scope binding;
+- a field or element of an object that outlives the source;
+- a `return` (the value outlives the call frame);
+- a function argument whose parameter the callee lets escape, which the callee's
+  inferred lifetime reports as `'static` or as a lifetime outliving the call;
+- a closure that itself escapes, capturing the value.
+
+A value does **not** escape — so the transfer is a borrow, and the source is
+retained — when it flows into a strictly shorter-lived destination: a read-only
+or non-escaping function argument, an inner-scope binding that dies first, or a
+local reborrow.
+
+The escape verdict is derived from the lifetime sort, not recomputed. A value
+escapes exactly when its lifetime is forced to outlive its source binding's
+scope, which in the constraint graph means the lifetime is pushed up to
+`'static` or to a lifetime that strictly outlives the local region. This is the
+same `constrainLt(... <: 'static)` machinery the escape rule already emits, so
+move detection is a query over existing constraints.
+
+### Use-after-move
+
+Once a binding is consumed by a move, using it again is an error. "Use" means
+reading it, mutating through it, calling a method on it, moving it again, or
+borrowing it. Each later use is reported against the move site and the use site.
+
+```esc
+val p = {x: 0}              // p owns a fresh value
+val q = storeGlobally(p)    // p escapes into global state — moved, p consumed
+print(p.x)                  // ERROR: use of `p` after it was moved into global state
+```
+
+### Affine, not linear
+
+Ownership is **affine**: a value may be consumed at most once, and a binding that
+is never moved is simply dropped at the end of its scope. There is no obligation
+to move or explicitly destroy a value, and no use-before-anything requirement.
+The JavaScript runtime is garbage-collected, so drops need no code. Linearity —
+requiring every value to be consumed exactly once — is not a goal.
+
+## Flow sites
+
+Move/affine semantics applies the same copy/borrow/move decision uniformly. This
+section lists the sites and the outcome at each.
+
+- **`val` / `var` binding.** `val y = x` copies if `x` is a value type, borrows
+  if `y` is a bounded local view of `x` (a G3 reborrow, or a `mut`-to-`mut`
+  reborrow), and moves if `y` outlives `x` or escapes.
+- **Reassignment.** `y = x` follows the same decision as a binding. A reassigned
+  `var` that previously owned a value drops the old value and takes the new one.
+- **Field / element store.** `obj.f = x` and `t[i] = x` move `x` when `obj` or
+  `t` outlives `x`. Storing into a longer-lived object is the canonical escape.
+- **`return`.** `return x` moves `x` out of the frame unless `x` is a value type
+  or a borrow whose lifetime already outlives the frame.
+- **Function argument.** Passing `x` to a parameter moves `x` when the callee's
+  signature lets that parameter escape, and borrows otherwise. A read-only or
+  non-escaping parameter borrows; the caller keeps `x`.
+- **Closure capture.** Capturing `x` in a closure that escapes moves `x` into the
+  closure. Capturing in a closure that stays local borrows.
+- **Destructuring.** Destructuring moves or borrows each extracted part following
+  the same rules; see partial moves below.
+- **`match` arms.** A pattern that binds a part of the scrutinee moves or borrows
+  that part per the arm's use, consistent with destructuring.
+
+## Partial moves and field-level ownership
+
+Moving one field of an owned object out does not consume the whole object; it
+consumes that field's slot. After a partial move, the moved field may not be
+read, but the other fields remain usable.
+
+```esc
+val pair = {a: makeWidget(), b: makeWidget()}
+storeGlobally(pair.a)      // moves pair.a out — pair.a consumed
+print(pair.b.id)           // OK: pair.b is untouched
+print(pair.a.id)           // ERROR: use of `pair.a` after it was moved
+```
+
+A read of the whole object after a partial move is an error if it would expose a
+moved field, and allowed if it only reaches live fields. The precision target is
+field-granular tracking; the conservative fallback, acceptable if field-granular
+tracking proves costly, is to consume the whole object on any field move and
+record that as a precision limitation.
+
+## Why the invariant holds
+
+Move/affine semantics preserves the soundness invariant by eliminating, at the
+moment of transfer, every path that could later mutate a value an immutable
+reference depends on.
+
+**Escaping into immutable state.** Revisiting the motivating gap: storing a value
+into the immutable global moves it. The source binding is consumed, so the
+mutation that followed is now a use-after-move error.
+
+```esc
+var sink: {x: number} = {x: 0}
+
+fn leak(p: mut {x: number}) -> void {
+    sink = p        // p escapes into 'static state — moved, p consumed
+    p.x = 5         // ERROR: use of `p` after it was moved into `sink`
+}
+```
+
+**Freezing a mutable value.** Building a value mutably and then exposing it
+immutably moves the mutable owner into the immutable binding when the immutable
+binding outlives the construction, leaving no mutable path.
+
+```esc
+fn build() -> {x: number} {
+    val tmp: mut {x: number} = {x: 0}
+    tmp.x = 42
+    return tmp       // tmp escapes the frame — moved into the return; no mutable alias survives
+}
+```
+
+**Local immutable view.** A G3 reborrow that stays local does not move; it
+borrows. The invariant is preserved instead by mutability exclusivity: while the
+immutable view is live, the mutable owner may not mutate.
+
+```esc
+val p: mut {x: number} = {x: 0}
+val q: {x: number} = p     // reborrow — q is a local immutable view of p; p retained
+print(q.x)
+p.x = 5                    // ERROR: p mutated while immutable view q is live
+```
+
+The two mechanisms cover the two ways the invariant can be threatened. A value
+that **escapes** is handled by a move that consumes the source. A value that
+stays **local** but is viewed both mutably and immutably is handled by exclusivity
+over the borrow's lifetime.
+
+## Precision
+
+Correctness requires rejecting unsafe programs; precision requires accepting safe
+ones. The behaviours below keep precision high.
+
+- **Value types never move.** Primitives, functions, and promises copy, so code
+  that passes numbers and strings around is never affected.
+- **Reads and non-escaping borrows do not consume.** Passing a value to a
+  function that only reads it, or binding a bounded local view, leaves the source
+  usable. Most application code is linear data flow and triggers no move at all.
+- **Multiple mutable borrows are allowed.** Escalier is not Rust. Several mutable
+  borrows of one value may be live at once. Move/affine semantics applies to
+  ownership transfer, not to mutable borrowing, so `mut`-to-`mut` aliasing stays
+  legal and does not consume the source.
+
+  ```esc
+  val a: mut {x: number} = {x: 1}
+  val b: mut {x: number} = a    // reborrow, not a move — a retained
+  b.x = 2
+  print(a.x)                    // OK — prints 2
+  ```
+- **Conditional moves track per-path.** A value moved on one branch and untouched
+  on another is consumed only on paths where the move occurs. A use after a
+  conditional move is an error only if some path that reaches it moved the value.
+- **Reborrows of mutable references at call boundaries.** Passing a mutable borrow
+  to a function that borrows it back for the call duration reborrows rather than
+  moves, so the caller regains full access after the call returns.
+
+## Relationship to the mutability-transition checker
+
+Move/affine semantics does not replace the whole transition checker; it takes over
+the escape dimension and lets the rest shrink.
+
+- **Move subsumes the escape-site logic.** Every place the current checker drops
+  mutability or special-cases a store into longer-lived state — global writes,
+  returns, escaping field stores, escaping arguments — is now a move. The ad-hoc
+  per-site mutability-dropping logic is removed in favour of the single move rule.
+- **Exclusivity is retained for local aliasing.** The case Escalier deliberately
+  permits — a value viewed locally through both mutable and immutable references
+  whose lifetimes overlap — is not an escape and is not a move. It stays governed
+  by a mutability-exclusivity rule: an immutable borrow and a mutable path to the
+  same value may not both be live and conflicting. This is the residual of Rules
+  1 and 2, now scoped to local, non-escaping aliasing, with the escape cases
+  handed to move semantics.
+- **Rule 3 is unchanged.** Multiple simultaneous mutable borrows remain allowed,
+  because mutable-to-mutable aliasing is a borrow, never a move.
+
+A consequence for alias tracking: a move consumes one binding, but if other live
+mutable aliases of the same value exist, consuming one binding alone does not kill
+them. The exclusivity rule, which reasons over the alias set rather than a single
+binding, covers that residual. Move semantics and alias-set exclusivity compose;
+neither alone is complete.
+
+## Interaction with the JavaScript runtime
+
+Escalier compiles to garbage-collected, single-threaded JavaScript. Move/affine
+semantics is a compile-time discipline only; it emits no runtime drops, refcounts,
+or copies. A move is the absence of generated code plus a compile-time mark that
+the source binding is dead.
+
+Closure capture is the one place the runtime model needs care. A captured variable
+is an implicit alias. A closure that escapes — stored, returned, or passed to a
+function that retains it — extends the captured value's region, so a capture by an
+escaping closure is a move of the captured value into the closure. A closure that
+stays local borrows its captures. Repeated `await` of one promise returns the same
+reference rather than a copy, so a borrowed payload awaited twice is ordinary
+aliasing, governed by exclusivity, not a second move.
+
+## Non-goals and deferred questions
+
+- **Linearity / mandatory consumption.** Values need not be consumed; unused
+  owned values are dropped. Out of scope.
+- **Interior-mutability escape hatches.** Patterns for cyclic mutable data that
+  outlive a single owner — a `Cell`-like wrapper — are noted in #618 as a separate
+  concern and are not specified here.
+- **Field-granular tracking depth.** Partial moves target field granularity. How
+  deep the tracking goes through nested objects and through dynamic index
+  expressions is an implementation-precision question for the plan, with the
+  whole-object-consume fallback as the conservative floor.
+- **Cross-package moves.** Move behaviour at the boundary of imported,
+  body-less declarations depends on declared lifetimes and is deferred to the
+  library-import work, consistent with the elision rules for lifetimes.
+- **Diagnostics.** Exact wording and blame spans for use-after-move and
+  move-on-escape errors are left to the implementation plan; they should name the
+  move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -12,10 +12,17 @@ It assumes the M4 borrow and lifetime machinery has landed: the
 `RefType{Mut, Lt, Inner}` wrapper, the lifetime sort (`LifetimeVar`,
 `StaticLifetime`, `constrainLt`), borrow origination and escape-to-`'static`,
 and the liveness-based mutability-transition checker in
-[internal/solver/transitions.go](../../internal/solver/transitions.go). It also
-assumes **G3** is in place: a bare object or tuple annotation in reference
-position reborrows its initializer as a local immutable view rather than an owned
-slot. G3 is in review as [#764](https://github.com/escalier-lang/escalier/pull/764).
+[internal/solver/transitions.go](../../internal/solver/transitions.go).
+
+Borrows are written with an explicit `&`, following Rust: `&{x: number}` and
+`&mut {x: number}` are immutable and mutable references whose lifetime is
+inferred, and `&'a {x: number}` and `&'a mut {x: number}` name the lifetime. A
+bare annotation is therefore always *owned*: `{x: number}` is owned-immutable and
+`mut {x: number}` is owned-mutable. This supersedes the earlier **G3** proposal
+([#764](https://github.com/escalier-lang/escalier/pull/764)), where a bare
+annotation in reference position implicitly reborrowed its initializer. With `&`
+the reborrow is spelled out, so a bare annotation no longer needs to mean anything
+other than ownership.
 
 This document describes target behaviour, not an implementation plan. The
 implementation plan is a separate doc.
@@ -34,13 +41,13 @@ paths slip through. The motivating gap from #762:
 var sink: {x: number} = {x: 0}   // immutable global
 
 fn leak(p: mut {x: number}) -> void {
-    sink = p        // a mut borrow is stored into an immutable global
-    p.x = 5         // mutating through p now changes what `sink` reads
+    sink = p        // an owned mutable value is stored into an immutable global
+    p.x = 5         // mutating it now changes what `sink` reads
 }
 ```
 
-Storing a mutable borrow into longer-lived immutable state, then mutating through
-the borrow, breaks the immutability guarantee. Patching this one site is not
+Storing a mutable value into longer-lived immutable state, then mutating it,
+breaks the immutability guarantee. Patching this one site is not
 enough, because the same shape recurs at returns, field stores, and escaping
 function arguments.
 
@@ -82,11 +89,14 @@ decides ownership.
   - **owned-mutable** — `RefType{Mut: true, Lt: nil}`, printed `mut {x: number}`.
     The owner may read and mutate.
 - **Borrowed** — `Lt` is a lifetime. The value is a reference into storage owned
-  elsewhere, valid only for the lifetime `Lt`. Two flavours:
-  - **immutable borrow** — `RefType{Mut: false, Lt: 'a}`, printed `'a {x: number}`.
-    A read-only view for the duration of `'a`.
-  - **mutable borrow** — `RefType{Mut: true, Lt: 'a}`, printed `mut 'a {x: number}`.
-    A read-write view for the duration of `'a`.
+  elsewhere, valid only for the lifetime `Lt`, and is written with a leading `&`.
+  Two flavours, each with an inferred or an explicitly named lifetime:
+  - **immutable borrow** — `RefType{Mut: false, Lt: 'a}`, printed `&{x: number}`
+    when the lifetime is inferred and `&'a {x: number}` when it is named. A
+    read-only view for the duration of `'a`.
+  - **mutable borrow** — `RefType{Mut: true, Lt: 'a}`, printed `&mut {x: number}`
+    when the lifetime is inferred and `&'a mut {x: number}` when it is named. A
+    read-write view for the duration of `'a`.
 
 Primitives (`number`, `string`, `boolean`), functions, and promises are **value
 types**: they are never wrapped in a `RefType` and are excluded from `RefInner`.
@@ -97,18 +107,37 @@ The four quadrants:
 
 | | owned (`Lt` nil) | borrowed (`Lt` = `'a`) |
 |---|---|---|
-| **immutable** (`Mut` false) | `{x: number}` | `'a {x: number}` |
-| **mutable** (`Mut` true) | `mut {x: number}` | `mut 'a {x: number}` |
+| **immutable** (`Mut` false) | `{x: number}` | `&{x: number}` / `&'a {x: number}` |
+| **mutable** (`Mut` true) | `mut {x: number}` | `&mut {x: number}` / `&'a mut {x: number}` |
 
 Ownership and mutability are orthogonal axes. Ownership decides who is
 responsible for the value and whether a transfer consumes the source. Mutability
 decides whether writes are allowed. Move/affine semantics governs the ownership
 axis; the mutability axis is governed by the existing exclusivity rule.
 
+### Borrows of a mutable owned value
+
+A mutable owned value may be borrowed many times over. Its borrows fall into two
+phases that never overlap:
+
+- multiple immutable borrows (`&{x: number}`) may be live at once, **or**
+- multiple mutable borrows (`&mut {x: number}`) may be live at once,
+
+but the lifetime of an immutable borrow and the lifetime of a mutable borrow of
+the same value may never overlap. While any mutable borrow is live, no immutable
+borrow of that value may be live, and vice versa. That is exactly what preserves
+the soundness invariant: an immutable borrow never coexists with a mutable path,
+so it never observes a mutation. Single-threaded execution is what makes the
+multiple-simultaneous-mutable-borrows case safe — there is no data race to
+exclude, and the invariant forbids only mixing the two kinds, not aliasing within
+one kind.
+
 ## When owned versus borrowed is inferred
 
-The default is owned for freshly produced values and borrowed for values reached
-through a parameter or a member read. The full set of rules:
+Freshly produced values are owned. A value is borrowed when an annotation marks it
+with `&`, when a member read reaches into a receiver, or when inference on an
+unannotated binding finds the value reaches storage something else owns. The full
+set of rules:
 
 1. **Freshly produced values are owned, and immutable by default.** An object,
    tuple, or array literal, a class constructor call, and any other expression
@@ -123,48 +152,68 @@ through a parameter or a member read. The full set of rules:
    object and tuple literals: `{x: 0}` is owned-immutable until a `mut` binding or
    annotation makes it owned-mutable.
 
-2. **Function parameters are borrowed by default.** A reference-typed parameter
-   without an explicit lifetime is a borrow of whatever the caller lends. The
-   checker attaches a fresh lifetime variable to it, so inside the body the
-   parameter is `'a {…}` or `mut 'a {…}`. The caller retains ownership; the callee
-   only borrows for the call. A parameter is never owned in the `Lt`-nil sense a
-   local binding is — it is always reached across the call boundary, so it always
-   carries a lifetime. A parameter becomes *consuming* only when its lifetime is
-   `'static`, which the body forces by letting the parameter escape, or which a
-   signature states explicitly as `p: mut 'static {…}`. A consuming parameter
-   requires the caller to give up ownership; the lifetimes design phrases this to
-   the caller as "pass a clone if you need to keep access." There is no separate
-   ownership annotation.
-
-3. **Bare annotations fix shape and mutability; the lifetime is inferred.** A bare
-   object or tuple annotation constrains the value's shape and mutability and lets
-   the compiler infer the lifetime. This holds in every annotation position — a
-   `val`/`var` binding, a return type, a field, a parameter — not only `val`
-   bindings. A bare annotation never forces an owned slot. `val q: {x: number} = p`
-   for `p: mut {x: number}` makes `q` an immutable view that borrows `p` with an
-   inferred lifetime; `p` keeps ownership. The same holds in return position:
+   A `val mut` binding may also take ownership of an existing owned-immutable
+   value by moving it. For an owned-immutable `p`, `val mut q = p` moves `p` into
+   the mutable binding `q` and consumes `p`. Because the move leaves `q` the sole
+   owner, it is sound for `q` to be mutable — no immutable reference to the value
+   survives the move. This is the mirror image of freezing: freezing moves an
+   owned-mutable value into an immutable binding, and this moves an owned-immutable
+   value into a mutable one.
 
    ```esc
-   fn f(p: mut {x: number}) -> {x: number} {
-       val q: {x: number} = p
-       return q
-   }
-   // inferred: fn <'a>(p: mut 'a {x: number}) -> 'a {x: number}
+   val p = Point(5, 10)       // owned-immutable
+   val mut q = Point(0, 0)    // owned-mutable, independent value
    ```
 
-   The annotated function infers the same `-> 'a {x: number}` as the version with
-   the return type omitted, rather than rejecting the returned borrow against an
-   owned slot. This generalizes G3, which shipped the reborrow only for bare
-   immutable `val` annotations
-   ([#764](https://github.com/escalier-lang/escalier/pull/764)), to every
-   annotation position, so annotated and unannotated code agree. Whether the
-   source is moved or borrowed is the escape-driven decision, independent of the
-   annotation: a local `mut` binding of a reference is a mutable reborrow that
-   retains the source — the multiple-mutable-aliases case — and only a binding that
-   escapes moves. A `mut` annotation fixes mutable shape; a lifetime-qualified
-   annotation names the lifetime explicitly instead of inferring it. The bare/`mut`
-   split decides the *mutability* of the resulting view, not whether the source is
-   moved.
+   ```esc
+   val p = Point(5, 10)       // owned-immutable
+   val mut q = p              // move: p into mutable q; p consumed
+   p.x                        // ERROR: use of `p` after it was moved into `q`
+   ```
+
+2. **A parameter is owned or borrowed according to its annotation.** A parameter
+   written with `&` is a borrow — `p: &{x: number}` or `p: &mut {x: number}` — and
+   the caller retains ownership, lending the value for the call. The lifetime is
+   inferred unless named with `&'a`. This is the common case: a function that only
+   reads or transiently uses its argument takes it by `&`, and the borrow keeps the
+   caller's value alive and usable after the call. A parameter written *without*
+   `&` is owned — `p: {x: number}` or `p: mut {x: number}` — and is *consuming*:
+   the signature declares an ownership transfer, so the caller gives the value up
+   at the call site. An unannotated parameter is inferred: the checker reads whether
+   the body lets the value escape and picks owned or borrowed accordingly. A
+   borrowing parameter no longer relies on an implicit lifetime — the `&` states the
+   borrow outright, and the lifetime appears only when it is load-bearing.
+
+3. **A bare annotation is owned; a `&` annotation borrows.** An annotation is read
+   literally. A bare object or tuple annotation fixes shape and mutability and
+   denotes an *owned* value — `{x: number}` owned-immutable, `mut {x: number}`
+   owned-mutable. To annotate a borrow, write `&`: `&{x: number}` and
+   `&mut {x: number}` leave the lifetime inferred, while `&'a {x: number}` and
+   `&'a mut {x: number}` name it. This holds in every annotation position — a
+   `val`/`var` binding, a return type, a field, a parameter.
+
+   So `val q: &{x: number} = p` makes `q` an immutable borrow of `p` with an
+   inferred lifetime, leaving `p` its owner; writing `val q: {x: number} = p`
+   instead *moves* `p` into the owned binding `q` and consumes `p`. Whether a value
+   is owned or borrowed is now visible in the annotation rather than inferred from
+   it. The same distinction works in return position, where a `&` return borrows
+   from a `&` parameter:
+
+   ```esc
+   fn f(p: &mut {x: number}) -> &{x: number} {
+       val q: &{x: number} = p    // downgrade the mutable borrow to an immutable one
+       return q
+   }
+   // inferred: fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}
+   ```
+
+   The lifetime `'a` threads the input borrow to the output borrow, so it is
+   load-bearing and shown. This replaces the implicit bare-annotation reborrow of
+   G3 ([#764](https://github.com/escalier-lang/escalier/pull/764)): the reborrow is
+   now spelled with `&`, and a bare annotation means ownership in every position,
+   so the inferred type and a written annotation agree without a special reborrow
+   rule. A `mut` modifier still fixes mutable shape, and a lifetime-qualified `&'a`
+   names the lifetime instead of inferring it.
 
 4. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
    field for a lifetime bounded by the receiver, not a fresh owned value. A read
@@ -196,9 +245,9 @@ the transfer has one of three outcomes.
 2. **Borrow.** The destination takes a reference whose lifetime is bounded within
    the source binding's region. The source keeps ownership and stays usable. The
    borrow is governed by the mutability-exclusivity rule for its lifetime. This
-   is the outcome for a read-only argument to a non-escaping parameter, a
-   `mut`-to-`mut` local reborrow, sharing an immutable value, and a G3 reborrow
-   that stays local.
+   is the outcome for a `&` parameter the callee does not let escape, a
+   `&mut`-to-`&mut` local reborrow, sharing an immutable value, and any explicit
+   `&` borrow that stays local.
 
 3. **Move.** Ownership transfers out of the source binding. The source binding is
    **consumed**: any later use of it is a use-after-move error. This is the
@@ -255,17 +304,18 @@ Move/affine semantics applies the same copy/borrow/move decision uniformly. This
 section lists the sites and the outcome at each.
 
 - **`val` / `var` binding.** `val y = x` copies if `x` is a value type, borrows
-  if `y` is a bounded local view of `x` (a G3 reborrow, or a `mut`-to-`mut`
-  reborrow), and moves if `y` outlives `x` or escapes.
+  if `y` is annotated `&` (a local view of `x`, immutable or `&mut`), and otherwise
+  moves `x` into `y`, consuming `x`.
 - **Reassignment.** `y = x` follows the same decision as a binding. A reassigned
   `var` that previously owned a value drops the old value and takes the new one.
 - **Field / element store.** `obj.f = x` and `t[i] = x` move `x` when `obj` or
   `t` outlives `x`. Storing into a longer-lived object is the canonical escape.
 - **`return`.** `return x` moves `x` out of the frame unless `x` is a value type
   or a borrow whose lifetime already outlives the frame.
-- **Function argument.** Passing `x` to a parameter moves `x` when the callee's
-  signature lets that parameter escape, and borrows otherwise. A read-only or
-  non-escaping parameter borrows; the caller keeps `x`.
+- **Function argument.** Passing `x` to a `&` parameter borrows; the caller keeps
+  `x`. Passing `x` to a bare owned parameter moves `x`; the caller gives it up. For
+  an unannotated parameter the outcome is inferred — a move when the callee lets the
+  value escape, a borrow otherwise.
 - **Closure capture.** Capturing `x` in a closure that escapes moves `x` into the
   closure. Capturing in a closure that stays local borrows.
 - **Destructuring.** Destructuring moves or borrows each extracted part following
@@ -323,15 +373,27 @@ fn build() -> {x: number} {
 }
 ```
 
-**Local immutable view.** A G3 reborrow that stays local does not move; it
-borrows. The invariant is preserved instead by mutability exclusivity: while the
-immutable view is live, the mutable owner may not mutate.
+**Thawing an immutable value.** The reverse transition is also a move. Moving an
+owned-immutable value into a `val mut` binding consumes the source, so the new
+binding is the sole owner and may safely mutate — no immutable reference to the
+value survives.
+
+```esc
+val p = {x: 0}             // owned-immutable
+val mut q = p              // move: p into mutable q; p consumed
+q.x = 5                    // OK — q is the sole owner
+print(p.x)                 // ERROR: use of `p` after it was moved into `q`
+```
+
+**Local immutable view.** A `&` borrow that stays local does not move; it borrows.
+The invariant is preserved instead by mutability exclusivity: while the immutable
+borrow is live, the mutable owner may not mutate.
 
 ```esc
 val p: mut {x: number} = {x: 0}
-val q: {x: number} = p     // reborrow — q is a local immutable view of p; p retained
+val q: &{x: number} = p    // immutable borrow — q is a local view of p; p retained
 print(q.x)
-p.x = 5                    // ERROR: p mutated while immutable view q is live
+p.x = 5                    // ERROR: p mutated while immutable borrow q is live
 ```
 
 The two mechanisms cover the two ways the invariant can be threatened. A value
@@ -349,16 +411,18 @@ ones. The behaviours below keep precision high.
 - **Reads and non-escaping borrows do not consume.** Passing a value to a
   function that only reads it, or binding a bounded local view, leaves the source
   usable. Most application code is linear data flow and triggers no move at all.
-- **Multiple mutable borrows are allowed.** Escalier is not Rust. Several mutable
-  borrows of one value may be live at once. Move/affine semantics applies to
-  ownership transfer, not to mutable borrowing, so `mut`-to-`mut` aliasing stays
-  legal and does not consume the source.
+- **Multiple borrows of one kind are allowed.** Escalier is not Rust. Several
+  mutable borrows of one value may be live at once, as may several immutable
+  borrows — but never a mutable and an immutable borrow at the same time, per
+  "Borrows of a mutable owned value." Move/affine semantics applies to ownership
+  transfer, not to borrowing, so `&mut`-to-`&mut` aliasing stays legal and does not
+  consume the source.
 
   ```esc
-  val a: mut {x: number} = {x: 1}
-  val b: mut {x: number} = a    // reborrow, not a move — a retained
+  val a: mut {x: number} = {x: 1}    // owned-mutable
+  val b: &mut {x: number} = a         // mutable borrow of a — a retained
   b.x = 2
-  print(a.x)                    // OK — prints 2
+  print(a.x)                          // OK — prints 2
   ```
 - **Conditional moves track per-path.** A value moved on one branch and untouched
   on another is consumed only on paths where the move occurs. A use after a
@@ -420,22 +484,24 @@ this. The governing decision for how lifetimes appear:
 
 Two consequences follow.
 
-- **Load-bearing lifetimes are shown; connect-nothing lifetimes are elided.** A
-  lifetime that appears in a signature — one that connects an input to an output,
-  or escapes to `'static` — is part of the type and is rendered, so
-  `fn <'a>(p: mut 'a {x: number}) -> 'a {x: number}` displays its `'a`. A lifetime
-  that connects nothing is dropped at display time (D4), because the type genuinely
-  does not depend on it, and there owned and borrowed are indistinguishable.
-  Lifetimes are therefore shown exactly when they carry meaning and hidden exactly
-  when they do not, so the display is never misleading.
-- **A bare annotation is accepted and agrees with inference.** Because a bare
-  object or tuple annotation fixes shape and mutability and lets the compiler infer
-  the lifetime (inference rule 3), writing `{x: number}` produces the same type as
-  writing the full `'a {x: number}` or omitting the annotation entirely. Annotating
-  code never diverges from inferring it. This is what removes the
+- **Load-bearing lifetime names are shown; connect-nothing names are elided, but
+  the `&` is never hidden.** A borrow always prints its `&`, so owned (`{x: number}`)
+  and borrowed (`&{x: number}`) are always distinguishable — the marker that earlier
+  drafts could only infer is now in the surface type. What the display elides is the
+  lifetime *name*. A lifetime that connects an input to an output or escapes to
+  `'static` is rendered, so `fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}`
+  shows its `'a`; a lifetime that connects nothing is dropped (D4), leaving the bare
+  `&{x: number}`. Names appear exactly when they carry meaning, while the borrow
+  marker itself is always present, so the display is never misleading.
+- **Annotations are read literally, and a written type round-trips.** A bare
+  annotation denotes an owned value and a `&` annotation a borrow (inference rule
+  3), so the displayed type is itself a valid annotation: writing it back produces
+  the same type, and no position silently reinterprets a bare annotation as a
+  borrow. This removes the
   [#764](https://github.com/escalier-lang/escalier/pull/764) inconsistency, where a
   bare return annotation forced an owned slot and errored while the same code with
-  the return type omitted inferred a lifetime.
+  the return type omitted inferred a lifetime. Now the omitted case infers a `&`
+  borrow and the explicit borrow is written `&`, so the two agree.
 
 This stance is a deliberate reversal of an earlier draft that elided lifetimes from
 the canonical display and surfaced them only on hover. Matching annotations to
@@ -452,9 +518,10 @@ remaining requirement on diagnostics:
   diagnostic use.
 
 The aim is that the inferred type a developer sees is exactly the type they could
-write, ordinary local code needs no lifetime annotations because the elided
-lifetimes connect nothing, and the cases that do require a lifetime show it in the
-signature rather than hiding it behind a later error.
+write, ordinary local code needs no lifetime *names* because the elided lifetimes
+connect nothing, and the cases that do require a named lifetime show it in the
+signature rather than hiding it behind a later error. Borrows are always marked
+with `&`, but their lifetimes stay inferred until they become load-bearing.
 
 ## Non-goals and deferred questions
 
@@ -470,13 +537,12 @@ signature rather than hiding it behind a later error.
 - **Cross-package moves.** Move behaviour at the boundary of imported,
   body-less declarations depends on declared lifetimes and is deferred to the
   library-import work, consistent with the elision rules for lifetimes.
-- **Surface syntax for a consuming parameter.** A parameter is consuming when its
-  lifetime is `'static`. Today that is written by spelling the lifetime out,
-  `p: mut 'static {…}`, which is accurate but exposes a lifetime most code never
-  names. Whether to keep `'static` as the user-facing way to demand ownership, or
-  to add a dedicated keyword that reads as "consume this argument," is an unmade
-  design decision. It does not change behaviour — only how a caller-visible
-  ownership transfer is spelled.
+- **Auto-borrow at call sites.** Passing an owned value to a `&` parameter is
+  sound without writing `&` at the call, since owning subsumes borrowing. Whether
+  the call site stays fully implicit, or a marker is required on mutable-borrow
+  calls so a `&mut` mutation is visible where it happens, is an open ergonomics
+  decision. It does not change which transfers are legal — only how a borrow is
+  spelled at the call.
 - **Diagnostics.** Exact wording and blame spans for use-after-move and
   move-on-escape errors are left to the implementation plan; they should name the
   move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -315,7 +315,13 @@ section lists the sites and the outcome at each.
 - **Function argument.** Passing `x` to a `&` parameter borrows; the caller keeps
   `x`. Passing `x` to a bare owned parameter moves `x`; the caller gives it up. For
   an unannotated parameter the outcome is inferred — a move when the callee lets the
-  value escape, a borrow otherwise.
+  value escape, a borrow otherwise. Both kinds of borrow are inserted implicitly at
+  the call: an owned argument passed to a `&` or `&mut` parameter is borrowed
+  without writing `&` or `&mut` — `foo(p)`, not `foo(&mut p)` — since owning a value
+  subsumes lending it. A `&mut` parameter requires the argument to be owned-mutable.
+  The compiler still inserts the borrow and checks it against the phase and
+  exclusivity rules, so the elision is purely syntactic and never changes which
+  calls are legal.
 - **Closure capture.** Capturing `x` in a closure that escapes moves `x` into the
   closure. Capturing in a closure that stays local borrows.
 - **Destructuring.** Destructuring moves or borrows each extracted part following
@@ -537,12 +543,6 @@ with `&`, but their lifetimes stay inferred until they become load-bearing.
 - **Cross-package moves.** Move behaviour at the boundary of imported,
   body-less declarations depends on declared lifetimes and is deferred to the
   library-import work, consistent with the elision rules for lifetimes.
-- **Auto-borrow at call sites.** Passing an owned value to a `&` parameter is
-  sound without writing `&` at the call, since owning subsumes borrowing. Whether
-  the call site stays fully implicit, or a marker is required on mutable-borrow
-  calls so a `&mut` mutation is visible where it happens, is an open ergonomics
-  decision. It does not change which transfers are legal — only how a borrow is
-  spelled at the call.
 - **Diagnostics.** Exact wording and blame spans for use-after-move and
   move-on-escape errors are left to the implementation plan; they should name the
   move site, the later use, and why the transfer was a move.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -110,17 +110,20 @@ axis; the mutability axis is governed by the existing exclusivity rule.
 The default is owned for freshly produced values and borrowed for values reached
 through a parameter or a member read. The full set of rules:
 
-1. **Literals are owned.** An object, tuple, or array literal produces a fresh
-   value the binding owns. `val p = {x: 0, y: 0}` makes `p` owned. Its mutability
-   follows the existing value-default rules: a plain object literal is
-   owned-immutable, and a `mut` annotation or a mutating method makes it
-   owned-mutable.
+1. **Freshly produced values are owned, and immutable by default.** An object,
+   tuple, or array literal, a class constructor call, and any other expression
+   that builds a new value all yield a value the binding owns. Escalier defaults
+   to immutability, so a fresh value is owned-immutable unless the program opts
+   into mutability. A class instance is immutable regardless of whether the class
+   has `mut self` methods — a bare `val p = Point(5, 10)` is `Point`, never
+   `mut Point`, per [#499](https://github.com/escalier-lang/escalier/issues/499)
+   and [TestDefaultMutabilityFromClass](../../internal/checker/tests/class_test.go).
+   The opt-in is at the binding pattern, `val mut p = Point(5, 10)`, or via a
+   `mut` annotation, `val obj: mut {x: number} = {x: 0}`. The same applies to
+   object and tuple literals: `{x: 0}` is owned-immutable until a `mut` binding or
+   annotation makes it owned-mutable.
 
-2. **Constructor and fresh-value results are owned.** A class constructor or any
-   expression that builds a new value yields an owned value, mutable or immutable
-   per the class's default.
-
-3. **Function parameters are borrowed by default.** A reference-typed parameter
+2. **Function parameters are borrowed by default.** A reference-typed parameter
    without an explicit lifetime is a borrow of whatever the caller lends. The
    checker attaches a fresh lifetime variable to it, so inside the body the
    parameter is `'a {…}` or `mut 'a {…}`. The caller retains ownership; the callee
@@ -128,19 +131,19 @@ through a parameter or a member read. The full set of rules:
    when it is annotated to take ownership or when the body lets it escape, which
    forces the borrow's lifetime to `'static`.
 
-4. **Bare annotations in reference position reborrow (G3).** Binding a reference
+3. **Bare annotations in reference position reborrow (G3).** Binding a reference
    into a bare object or tuple annotation lowers the annotation to an immutable
    borrow with a fresh lifetime, not an owned slot. `val q: {x: number} = p` for
    `p: mut {x: number}` makes `q` a local immutable view that borrows `p`; `p`
    keeps ownership. A `mut` or lifetime-qualified annotation is not reborrowed —
    `mut {x: number}` stays an owned-mutable slot.
 
-5. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
+4. **Member reads borrow the receiver.** Reading `obj.f` yields a borrow of the
    field for a lifetime bounded by the receiver, not a fresh owned value. A read
    that is immediately consumed locally needs no lifetime in the rendered type;
    one that escapes carries the receiver's lifetime.
 
-6. **Escape forces ownership and lifetime.** A value that flows into storage
+5. **Escape forces ownership and lifetime.** A value that flows into storage
    outliving its current binding — a module-level or other longer-lived binding,
    a field of a longer-lived object, a return value, or an escaping closure
    capture — has its lifetime constrained to outlive the destination. For a

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -228,11 +228,12 @@ set of rules:
    next. For a borrow, escape that the borrow's lifetime cannot satisfy is a
    borrow-escape error.
 
-The principle behind these rules: **owned** is inferred when a binding is the sole
-producer or holder of a value, and **borrowed** is inferred when a binding reaches
-a value that something else owns. The lifetime machinery already in place
-computes which case applies; move semantics reads its verdict rather than running
-a separate analysis.
+The principle behind these rules: when an annotation is present, its `&` or bare
+form decides owned versus borrowed directly. Otherwise **owned** is inferred when a
+binding is the sole producer or holder of a value, and **borrowed** is inferred when
+a binding reaches a value that something else owns. For the inferred case the
+lifetime machinery already in place computes which one applies, and move semantics
+reads its verdict rather than running a separate analysis.
 
 ## Move / affine semantics
 
@@ -489,9 +490,11 @@ aliasing, governed by exclusivity, not a second move.
 
 ## Type display and annotations
 
-Ownership is inferred: whether a value is owned or borrowed follows from how it
-flows, not from the annotation. The lifetime is the part of the type that records
-this. The governing decision for how lifetimes appear:
+Ownership is read from the annotation: a `&` marks a borrow and a bare type is
+owned, and inference fills in the verdict only for an unannotated value. The `&`
+marker is the part of the displayed type that records owned versus borrowed, and a
+lifetime name records the borrow's extent when it is load-bearing. The governing
+decision for how lifetimes appear:
 
 > A type annotation should match the inferred type. The displayed signature is
 > always a valid annotation, and writing it back produces the same type. The
@@ -506,7 +509,7 @@ Two consequences follow.
   drafts could only infer is now in the surface type. What the display elides is the
   lifetime *name*. A lifetime that connects an input to an output or escapes to
   `'static` is rendered, so `fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}`
-  shows its `'a`; a lifetime that connects nothing is dropped (D4), leaving the bare
+  shows its `'a`; a lifetime that connects nothing is dropped, leaving the bare
   `&{x: number}`. Names appear exactly when they carry meaning, while the borrow
   marker itself is always present, so the display is never misleading.
 - **Annotations are read literally, and a written type round-trips.** A bare
@@ -657,14 +660,15 @@ because mutation is invariant where an immutable borrow is covariant. An immutab
 borrow reads only, so `&(A | B)` factors by subtyping: `&A` is usable where
 `&(A | B)` is wanted, and `&A | &B <: &(A | B)`. A mutable wrapper can also write, so
 it is invariant: `mut A` and `mut (A | B)` are incomparable, and `mut (A | B)` does
-not factor. Passing a `mut A` where `mut (A | B)` is expected would let the callee
-write a `B` into `A`-typed storage:
+not factor. The corruption is observable only through a borrow, where the callee
+still aliases the caller's value: passing a `&mut A` where `&mut (A | B)` is expected
+would let the callee write a `B` into the caller's `A`-typed storage:
 
 ```esc
 type A = {tag: "a", x: number}
 type B = {tag: "b", y: number}
 
-fn f(p: mut (A | B)) -> void {
+fn f(p: &mut (A | B)) -> void {
     p = {tag: "b", y: 0}   // writes a value of type A | B; would corrupt storage typed mut A
 }
 ```


### PR DESCRIPTION
This adds two planning documents for move/affine semantics in Escalier, tracked in #762 as part of the broader sound borrow checker effort #618.

**requirements.md** specifies the target behaviour for move/affine semantics:
- Defines the soundness invariant: no immutable reference ever observes a mutation
- Establishes the four ownership/mutability quadrants (owned-immutable, owned-mutable, borrowed-immutable, borrowed-mutable) via the `RefType` wrapper
- Details when values are owned versus borrowed, including rules for fresh values, parameters, annotations, member reads, and escape
- Describes move semantics: when a value escapes its binding's region, ownership transfers and the source binding is consumed
- Specifies use-after-move errors and affine (not linear) semantics
- Lists all flow sites (bindings, returns, field stores, function arguments, closures, destructuring, match arms) and their copy/borrow/move outcomes
- Covers partial moves and field-level ownership tracking
- Explains how the invariant is preserved through moves and exclusivity rules
- Discusses precision goals and the relationship to the existing mutability-transition checker

**implementation_plan.md** sequences the work into ten dependency-ordered pull requests:
- Establishes scope (new checker only, shared parser) and what M4 substrate already provides
- Documents architecture decisions for high-risk areas: where move analysis lives (interleaved into ordered walk with new consumed lattice), escape detection (generalized to every flow site), narrowing (deferred to M6), unions as RefInner (behavioural review needed), prefix `&` binding (tight like `mut`), and param-default flip sequencing
- Provides detailed PR sequence from grammar and lowering through move engine substrate and consumption enforcement to partial moves, thaw moves, and mutable narrowed bindings
- Each PR includes goals, implementation steps, tests, and acceptance criteria

These documents establish the requirements and roadmap for implementing sound move semantics to close the gap where mutable values can escape into immutable state and later be mutated.

https://claude.ai/code/session_01QRtFcbx97cPbvFiq1cn1mK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added planning and requirements documentation for the affine semantics implementation roadmap, including proposed architecture and phased development approach for ownership and borrowing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->