### PR TITLE
Add borrow type annotation syntax (&, &mut, &'a)

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -37,6 +37,7 @@ func (*IntrinsicTypeAnn) isTypeAnn()    {}
 func (*ImportTypeAnn) isTypeAnn()       {}
 func (*MatchTypeAnn) isTypeAnn()        {}
 func (*MutableTypeAnn) isTypeAnn()      {}
+func (*RefTypeAnn) isTypeAnn()          {}
 func (*ErrorTypeAnn) isTypeAnn()        {}
 func (*RestSpreadTypeAnn) isTypeAnn()   {}
 
@@ -681,6 +682,33 @@ func NewMutableTypeAnn(target TypeAnn, span Span) *MutableTypeAnn {
 func (t *MutableTypeAnn) Accept(v Visitor) {
 	if v.EnterTypeAnn(t) {
 		t.Target.Accept(v)
+	}
+	v.ExitTypeAnn(t)
+}
+
+// RefTypeAnn is a borrow annotation written with a prefix `&`:
+//
+//	&{x}         → RefTypeAnn{Mut: false}
+//	&mut {x}     → RefTypeAnn{Mut: true}
+//	&'a {x}      → RefTypeAnn{Mut: false, Lifetime: 'a}
+//	&'a mut {x}  → RefTypeAnn{Mut: true,  Lifetime: 'a}
+//
+// The prefix `&` binds tight to a single atom, so `&A | B` is `(&A) | B`;
+// a borrow of a compound is written with explicit parens, `&(A | B)`.
+type RefTypeAnn struct {
+	Mut          bool
+	Lifetime     LifetimeAnnNode // optional
+	Inner        TypeAnn
+	span         Span
+	inferredType Type
+}
+
+func NewBorrowTypeAnn(mut bool, lifetime LifetimeAnnNode, inner TypeAnn, span Span) *RefTypeAnn {
+	return &RefTypeAnn{Mut: mut, Lifetime: lifetime, Inner: inner, span: span, inferredType: nil}
+}
+func (t *RefTypeAnn) Accept(v Visitor) {
+	if v.EnterTypeAnn(t) {
+		t.Inner.Accept(v)
 	}
 	v.ExitTypeAnn(t)
 }

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -693,8 +693,8 @@ func (t *MutableTypeAnn) Accept(v Visitor) {
 //	&'a {x}      → RefTypeAnn{Mut: false, Lifetime: 'a}
 //	&'a mut {x}  → RefTypeAnn{Mut: true,  Lifetime: 'a}
 //
-// The prefix `&` binds tight to a single atom, so `&A | B` is `(&A) | B`;
-// a borrow of a compound is written with explicit parens, `&(A | B)`.
+// The prefix `&` binds tight to a single atom, so `&A | B` is `(&A) | B`.
+// A borrow of a compound is written with explicit parens, `&(A | B)`.
 type RefTypeAnn struct {
 	Mut          bool
 	Lifetime     LifetimeAnnNode // optional

--- a/internal/ast/type_ann_gen.go
+++ b/internal/ast/type_ann_gen.go
@@ -118,6 +118,10 @@ func (node *MutableTypeAnn) Span() Span             { return node.span }
 func (node *MutableTypeAnn) InferredType() Type     { return node.inferredType }
 func (node *MutableTypeAnn) SetInferredType(t Type) { node.inferredType = t }
 
+func (node *RefTypeAnn) Span() Span             { return node.span }
+func (node *RefTypeAnn) InferredType() Type     { return node.inferredType }
+func (node *RefTypeAnn) SetInferredType(t Type) { node.inferredType = t }
+
 func (node *ErrorTypeAnn) Span() Span             { return node.span }
 func (node *ErrorTypeAnn) InferredType() Type     { return node.inferredType }
 func (node *ErrorTypeAnn) SetInferredType(t Type) { node.inferredType = t }

--- a/internal/checker/error.go
+++ b/internal/checker/error.go
@@ -36,6 +36,7 @@ func (e CannotUnifyTypesError) isError()                    {}
 func (e UnknownIdentifierError) isError()                   {}
 func (e UnknownOperatorError) isError()                     {}
 func (e UnknownTypeError) isError()                         {}
+func (e BorrowUnsupportedError) isError()                   {}
 func (e CalleeIsNotCallableError) isError()                 {}
 func (e InvalidNumberOfArgumentsError) isError()            {}
 func (e NoMatchingOverloadError) isError()                  {}
@@ -98,6 +99,7 @@ func (e CannotUnifyTypesError) IsWarning() bool                    { return fals
 func (e UnknownIdentifierError) IsWarning() bool                   { return false }
 func (e UnknownOperatorError) IsWarning() bool                     { return false }
 func (e UnknownTypeError) IsWarning() bool                         { return false }
+func (e BorrowUnsupportedError) IsWarning() bool                   { return false }
 func (e CalleeIsNotCallableError) IsWarning() bool                 { return false }
 func (e InvalidNumberOfArgumentsError) IsWarning() bool            { return false }
 func (e NoMatchingOverloadError) IsWarning() bool                  { return false }
@@ -431,6 +433,17 @@ func (e UnknownTypeError) Span() ast.Span {
 }
 func (e UnknownTypeError) Message() string {
 	return "Unknown type: " + e.TypeName
+}
+
+type BorrowUnsupportedError struct {
+	span ast.Span
+}
+
+func (e BorrowUnsupportedError) Span() ast.Span {
+	return e.span
+}
+func (e BorrowUnsupportedError) Message() string {
+	return "borrows are unsupported in the legacy checker"
 }
 
 type CalleeIsNotCallableError struct {

--- a/internal/checker/infer_type_ann.go
+++ b/internal/checker/infer_type_ann.go
@@ -230,6 +230,14 @@ func (c *Checker) inferTypeAnn(
 		targetType, targetErrors := c.inferTypeAnn(ctx, typeAnn.Target)
 		errors = slices.Concat(errors, targetErrors)
 		t = type_system.NewMutType(provenance, targetType)
+	case *ast.RefTypeAnn:
+		// Borrow annotations carry affine/move semantics that only the
+		// SimpleSub-based checker implements. The legacy HM checker never
+		// meets one in normal operation, since no existing source uses
+		// borrow syntax. Report cleanly rather than panicking on the
+		// default arm so a stray `&T` can't crash the CLI or LSP.
+		errors = append(errors, &BorrowUnsupportedError{span: typeAnn.Span()})
+		t = type_system.NewErrorType(provenance)
 	case *ast.TemplateLitTypeAnn:
 		types := make([]type_system.Type, len(typeAnn.TypeAnns))
 		quasis := make([]*type_system.Quasi, len(typeAnn.Quasis))

--- a/internal/parser/__snapshots__/type_ann_test.snap
+++ b/internal/parser/__snapshots__/type_ann_test.snap
@@ -1770,3 +1770,203 @@
     span: 1:1-1:6,
 }
 ---
+
+[TestParseTypeAnnNoErrors/BorrowLifetimeMutType - 1]
+&ast.RefTypeAnn{
+    Mut: true,
+    Lifetime: &ast.LifetimeAnn{
+        Name: "a",
+        span: 1:2-1:4,
+    },
+    Inner: &ast.ObjectTypeAnn{
+        Elems: []ast.ObjTypeAnnElem{
+            &ast.PropertyTypeAnn{
+                Name: &ast.IdentExpr{
+                    Name: "x",
+                    span: 1:10-1:11,
+                },
+                Value: &ast.NumberTypeAnn{
+                    span: 1:13-1:19,
+                },
+            },
+        },
+        span: 1:9-1:20,
+    },
+    span: 1:1-1:20,
+}
+---
+
+[TestParseTypeAnnNoErrors/InfixIntersectionStillParses - 1]
+&ast.IntersectionTypeAnn{
+    Types: []ast.TypeAnn{
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "A",
+                span: 1:1-1:2,
+            },
+            span: 1:1-1:2,
+        },
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "B",
+                span: 1:5-1:6,
+            },
+            span: 1:5-1:6,
+        },
+    },
+    span: 1:1-1:6,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowAsIntersectionMember - 1]
+&ast.IntersectionTypeAnn{
+    Types: []ast.TypeAnn{
+        &ast.RefTypeAnn{
+            Inner: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "A",
+                    span: 1:2-1:3,
+                },
+                span: 1:2-1:3,
+            },
+            span: 1:1-1:3,
+        },
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "B",
+                span: 1:6-1:7,
+            },
+            span: 1:6-1:7,
+        },
+    },
+    span: 1:1-1:7,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowBindsTighterThanUnion - 1]
+&ast.UnionTypeAnn{
+    Types: []ast.TypeAnn{
+        &ast.RefTypeAnn{
+            Inner: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "A",
+                    span: 1:2-1:3,
+                },
+                span: 1:2-1:3,
+            },
+            span: 1:1-1:3,
+        },
+        &ast.TypeRefTypeAnn{
+            Name: &ast.Ident{
+                Name: "B",
+                span: 1:6-1:7,
+            },
+            span: 1:6-1:7,
+        },
+    },
+    span: 1:1-1:7,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowMutType - 1]
+&ast.RefTypeAnn{
+    Mut: true,
+    Inner: &ast.ObjectTypeAnn{
+        Elems: []ast.ObjTypeAnnElem{
+            &ast.PropertyTypeAnn{
+                Name: &ast.IdentExpr{
+                    Name: "x",
+                    span: 1:7-1:8,
+                },
+                Value: &ast.NumberTypeAnn{
+                    span: 1:10-1:16,
+                },
+            },
+        },
+        span: 1:6-1:17,
+    },
+    span: 1:1-1:17,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowTypeRef - 1]
+&ast.RefTypeAnn{
+    Inner: &ast.TypeRefTypeAnn{
+        Name: &ast.Ident{
+            Name: "Point",
+            span: 1:2-1:7,
+        },
+        span: 1:2-1:7,
+    },
+    span: 1:1-1:7,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowLifetimeType - 1]
+&ast.RefTypeAnn{
+    Lifetime: &ast.LifetimeAnn{
+        Name: "a",
+        span: 1:2-1:4,
+    },
+    Inner: &ast.ObjectTypeAnn{
+        Elems: []ast.ObjTypeAnnElem{
+            &ast.PropertyTypeAnn{
+                Name: &ast.IdentExpr{
+                    Name: "x",
+                    span: 1:6-1:7,
+                },
+                Value: &ast.NumberTypeAnn{
+                    span: 1:9-1:15,
+                },
+            },
+        },
+        span: 1:5-1:16,
+    },
+    span: 1:1-1:16,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowOfUnion - 1]
+&ast.RefTypeAnn{
+    Inner: &ast.UnionTypeAnn{
+        Types: []ast.TypeAnn{
+            &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "A",
+                    span: 1:3-1:4,
+                },
+                span: 1:3-1:4,
+            },
+            &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "B",
+                    span: 1:7-1:8,
+                },
+                span: 1:7-1:8,
+            },
+        },
+        span: 1:3-1:8,
+    },
+    span: 1:1-1:8,
+}
+---
+
+[TestParseTypeAnnNoErrors/BorrowType - 1]
+&ast.RefTypeAnn{
+    Inner: &ast.ObjectTypeAnn{
+        Elems: []ast.ObjTypeAnnElem{
+            &ast.PropertyTypeAnn{
+                Name: &ast.IdentExpr{
+                    Name: "x",
+                    span: 1:3-1:4,
+                },
+                Value: &ast.NumberTypeAnn{
+                    span: 1:6-1:12,
+                },
+            },
+        },
+        span: 1:2-1:13,
+    },
+    span: 1:1-1:13,
+}
+---

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -48,10 +48,9 @@ func (p *Parser) typeAnn() ast.TypeAnn {
 	switch token.Type {
 	case Pipe:
 		p.lexer.consume() // skip leading '|'
-	case Ampersand:
-		p.lexer.consume() // skip leading '&'
 	default:
-		// Nothing to skip, continue parsing
+		// A leading '&' is no longer skipped as intersection sugar: in
+		// primary position it is a prefix borrow (see primaryTypeAnn).
 	}
 
 	primary := p.primaryTypeAnn()
@@ -179,8 +178,31 @@ loop:
 
 func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 	token := p.lexer.peek()
-	isMut := false
 
+	// Prefix borrow: `&`, `&mut`, `&'a`, `&'a mut`. The `&` binds tight to a
+	// single atom, so `&A | B` parses as `(&A) | B`; a borrow of a compound is
+	// written with explicit parens, `&(A | B)`. The optional lifetime precedes
+	// an optional `mut`, mirroring the `&'a mut` receiver form on methods.
+	if token.Type == Ampersand {
+		p.lexer.consume() // consume '&'
+		lifetime := p.parseOptLifetimeAnn()
+		isMut := false
+		if p.lexer.peek().Type == Mut {
+			p.lexer.consume() // consume 'mut'
+			isMut = true
+		}
+		inner := p.primaryTypeAnn()
+		if inner == nil {
+			next := p.lexer.peek()
+			p.reportError(ast.MergeSpans(token.Span, next.Span),
+				"expected a type annotation after '&'")
+			inner = ast.NewErrorTypeAnn(token.Span)
+		}
+		span := ast.MergeSpans(token.Span, inner.Span())
+		return ast.NewBorrowTypeAnn(isMut, lifetime, inner, span)
+	}
+
+	isMut := false
 	if token.Type == Mut {
 		p.lexer.consume() // consume 'mut'
 		token = p.lexer.peek()
@@ -192,41 +214,8 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 	//   ('a | 'b) Point  → LifetimeUnionAnn{...}
 	// We attach the lifetime to the resulting TypeRefTypeAnn after parsing
 	// the inner type.
-	var lifetime ast.LifetimeAnnNode
-	// nolint: exhaustive
-	switch token.Type {
-	case Lifetime:
-		p.lexer.consume()
-		lifetime = ast.NewLifetimeAnn(token.Value, token.Span)
-		token = p.lexer.peek()
-	case OpenParen:
-		// Try to parse a lifetime union: ( 'a | 'b | ... ) followed by a type.
-		// If the parens don't enclose a lifetime list, restore and fall through
-		// to the regular parenthesized-type-annotation path below.
-		saved := p.saveState()
-		open := p.lexer.next() // consume '('
-		if p.lexer.peek().Type != Lifetime {
-			p.restoreState(saved)
-			break
-		}
-		lifetimes := parseDelimSeq(p, CloseParen, Pipe, func() *ast.LifetimeAnn {
-			lt := p.lexer.peek()
-			if lt.Type != Lifetime {
-				return nil
-			}
-			p.lexer.consume()
-			return ast.NewLifetimeAnn(lt.Value, lt.Span)
-		})
-		closeTok := p.lexer.peek()
-		if closeTok.Type != CloseParen {
-			p.restoreState(saved)
-			break
-		}
-		p.lexer.consume()
-		lifetime = ast.NewLifetimeUnionAnn(lifetimes,
-			ast.MergeSpans(open.Span, closeTok.Span))
-		token = p.lexer.peek()
-	}
+	lifetime := p.parseOptLifetimeAnn()
+	token = p.lexer.peek()
 
 	var typeAnn ast.TypeAnn
 
@@ -1011,6 +1000,47 @@ func (p *Parser) parseTypeRef(firstToken *Token) *ast.TypeRefTypeAnn {
 		return ref
 	}
 	return ast.NewRefTypeAnn(qualIdent, []ast.TypeAnn{}, getQualIdentSpan(qualIdent))
+}
+
+// parseOptLifetimeAnn parses an optional leading lifetime annotation that
+// precedes an inner type — a single `'a` or a union `('a | 'b)`. It returns
+// nil and consumes nothing when the next tokens are not a lifetime, so an
+// `(` that opens a parenthesized type rather than a lifetime union falls
+// through to the regular type-annotation path. Used both for the `'a Point`
+// prefix on a type reference and for the lifetime slot of a prefix borrow.
+func (p *Parser) parseOptLifetimeAnn() ast.LifetimeAnnNode {
+	token := p.lexer.peek()
+	// nolint: exhaustive
+	switch token.Type {
+	case Lifetime:
+		p.lexer.consume()
+		return ast.NewLifetimeAnn(token.Value, token.Span)
+	case OpenParen:
+		saved := p.saveState()
+		open := p.lexer.next() // consume '('
+		if p.lexer.peek().Type != Lifetime {
+			p.restoreState(saved)
+			return nil
+		}
+		lifetimes := parseDelimSeq(p, CloseParen, Pipe, func() *ast.LifetimeAnn {
+			lt := p.lexer.peek()
+			if lt.Type != Lifetime {
+				return nil
+			}
+			p.lexer.consume()
+			return ast.NewLifetimeAnn(lt.Value, lt.Span)
+		})
+		closeTok := p.lexer.peek()
+		if closeTok.Type != CloseParen {
+			p.restoreState(saved)
+			return nil
+		}
+		p.lexer.consume()
+		return ast.NewLifetimeUnionAnn(lifetimes,
+			ast.MergeSpans(open.Span, closeTok.Span))
+	default:
+		return nil
+	}
 }
 
 // tryParseLifetimeArg attempts to parse a bare lifetime argument (`'a` or

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -49,7 +49,7 @@ func (p *Parser) typeAnn() ast.TypeAnn {
 	case Pipe:
 		p.lexer.consume() // skip leading '|'
 	default:
-		// A leading '&' is no longer skipped as intersection sugar: in
+		// A leading '&' is no longer skipped as intersection sugar. In
 		// primary position it is a prefix borrow (see primaryTypeAnn).
 	}
 
@@ -180,7 +180,7 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 	token := p.lexer.peek()
 
 	// Prefix borrow: `&`, `&mut`, `&'a`, `&'a mut`. The `&` binds tight to a
-	// single atom, so `&A | B` parses as `(&A) | B`; a borrow of a compound is
+	// single atom, so `&A | B` parses as `(&A) | B`. A borrow of a compound is
 	// written with explicit parens, `&(A | B)`. The optional lifetime precedes
 	// an optional `mut`, mirroring the `&'a mut` receiver form on methods.
 	if token.Type == Ampersand {
@@ -1003,8 +1003,9 @@ func (p *Parser) parseTypeRef(firstToken *Token) *ast.TypeRefTypeAnn {
 }
 
 // parseOptLifetimeAnn parses an optional leading lifetime annotation that
-// precedes an inner type — a single `'a` or a union `('a | 'b)`. It returns
-// nil and consumes nothing when the next tokens are not a lifetime, so an
+// precedes an inner type. The annotation is a single `'a` or a union
+// `('a | 'b)`. It returns nil and consumes nothing when the next tokens are
+// not a lifetime, so an
 // `(` that opens a parenthesized type rather than a lifetime union falls
 // through to the regular type-annotation path. Used both for the `'a Point`
 // prefix on a type reference and for the lifetime slot of a prefix borrow.

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -194,9 +194,9 @@ func (p *Parser) primaryTypeAnn() ast.TypeAnn {
 		inner := p.primaryTypeAnn()
 		if inner == nil {
 			next := p.lexer.peek()
-			p.reportError(ast.MergeSpans(token.Span, next.Span),
-				"expected a type annotation after '&'")
-			inner = ast.NewErrorTypeAnn(token.Span)
+			errSpan := ast.MergeSpans(token.Span, next.Span)
+			p.reportError(errSpan, "expected a type annotation after '&'")
+			inner = ast.NewErrorTypeAnn(errSpan)
 		}
 		span := ast.MergeSpans(token.Span, inner.Span())
 		return ast.NewBorrowTypeAnn(isMut, lifetime, inner, span)

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -103,7 +103,7 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 			input: "&(A | B)", // borrow of the whole union
 		},
 		"BorrowAsIntersectionMember": {
-			input: "&A & B", // (&A) & B — no parens needed
+			input: "&A & B", // (&A) & B, no parens needed
 		},
 		"InfixIntersectionStillParses": {
 			input: "A & B", // infix '&' stays intersection

--- a/internal/parser/type_ann_test.go
+++ b/internal/parser/type_ann_test.go
@@ -81,6 +81,33 @@ func TestParseTypeAnnNoErrors(t *testing.T) {
 		"MutableUnionType": {
 			input: "mut number | string",
 		},
+		"BorrowType": {
+			input: "&{x: number}",
+		},
+		"BorrowMutType": {
+			input: "&mut {x: number}",
+		},
+		"BorrowLifetimeType": {
+			input: "&'a {x: number}",
+		},
+		"BorrowLifetimeMutType": {
+			input: "&'a mut {x: number}",
+		},
+		"BorrowTypeRef": {
+			input: "&Point",
+		},
+		"BorrowBindsTighterThanUnion": {
+			input: "&A | B", // parses as (&A) | B
+		},
+		"BorrowOfUnion": {
+			input: "&(A | B)", // borrow of the whole union
+		},
+		"BorrowAsIntersectionMember": {
+			input: "&A & B", // (&A) & B — no parens needed
+		},
+		"InfixIntersectionStillParses": {
+			input: "A & B", // infix '&' stays intersection
+		},
 		"ConditionalType": {
 			input: "if A : B { C } else { D }",
 		},

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -961,11 +961,7 @@ func (p *Printer) printTypeCastExpr(expr *ast.TypeCastExpr) {
 	p.printExpr(expr.Expr)
 	p.writeString(":")
 	// Wrap union/intersection types in parentheses for clarity
-	needsParens := false
-	switch expr.TypeAnn.(type) {
-	case *ast.UnionTypeAnn, *ast.IntersectionTypeAnn:
-		needsParens = true
-	}
+	needsParens := needsTypeAnnParens(expr.TypeAnn)
 	if needsParens {
 		p.writeString("(")
 	}
@@ -1447,17 +1443,26 @@ func (p *Printer) printRefTypeAnn(typ *ast.RefTypeAnn) {
 	if typ.Mut {
 		p.writeString("mut ")
 	}
-	needsParens := false
-	switch typ.Inner.(type) {
-	case *ast.UnionTypeAnn, *ast.IntersectionTypeAnn:
-		needsParens = true
-	}
+	needsParens := needsTypeAnnParens(typ.Inner)
 	if needsParens {
 		p.writeString("(")
 	}
 	p.printTypeAnn(typ.Inner)
 	if needsParens {
 		p.writeString(")")
+	}
+}
+
+// needsTypeAnnParens reports whether a type annotation must be parenthesized
+// when it appears as the operand of a tighter-binding prefix such as a borrow
+// `&` or a type cast. Union and intersection bind looser than those prefixes,
+// so they are the cases that need wrapping.
+func needsTypeAnnParens(typ ast.TypeAnn) bool {
+	switch typ.(type) {
+	case *ast.UnionTypeAnn, *ast.IntersectionTypeAnn:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1443,13 +1443,29 @@ func (p *Printer) printRefTypeAnn(typ *ast.RefTypeAnn) {
 	if typ.Mut {
 		p.writeString("mut ")
 	}
-	needsParens := needsTypeAnnParens(typ.Inner)
+	needsParens := borrowInnerNeedsParens(typ.Inner)
 	if needsParens {
 		p.writeString("(")
 	}
 	p.printTypeAnn(typ.Inner)
 	if needsParens {
 		p.writeString(")")
+	}
+}
+
+// borrowInnerNeedsParens reports whether the inner of a prefix borrow must be
+// parenthesized to round-trip. A borrow prints as `& [lifetime] [mut] Inner`,
+// so an Inner whose own leading token would re-associate into the borrow needs
+// wrapping. A `mut A` inner would otherwise print as `&mut A` and re-parse as a
+// mutable borrow of `A`. A nested borrow `&A` would print as `&&A`, which the
+// lexer reads as a single `&&` token. Union and intersection bind looser than
+// the prefix `&`, the same reason needsTypeAnnParens already gives.
+func borrowInnerNeedsParens(typ ast.TypeAnn) bool {
+	switch typ.(type) {
+	case *ast.MutableTypeAnn, *ast.RefTypeAnn:
+		return true
+	default:
+		return needsTypeAnnParens(typ)
 	}
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1231,6 +1231,8 @@ func (p *Printer) printTypeAnn(typ ast.TypeAnn) {
 	case *ast.MutableTypeAnn:
 		p.writeString("mut ")
 		p.printTypeAnn(t.Target)
+	case *ast.RefTypeAnn:
+		p.printRefTypeAnn(t)
 	case *ast.ErrorTypeAnn:
 		// Skip error recovery nodes
 	case *ast.RestSpreadTypeAnn:
@@ -1429,6 +1431,53 @@ func (p *Printer) printTypeRefTypeAnn(typ *ast.TypeRefTypeAnn) {
 			}
 		}
 		p.writeString(">")
+	}
+}
+
+// printRefTypeAnn renders a prefix borrow: `&`, `&mut`, `&'a`, `&'a mut`.
+// The `&` binds tighter than union and intersection, so a union or
+// intersection inner is parenthesized to keep `&(A | B)` distinct from the
+// `(&A) | B` that an unparenthesized `&A | B` denotes.
+func (p *Printer) printRefTypeAnn(typ *ast.RefTypeAnn) {
+	p.writeString("&")
+	if typ.Lifetime != nil {
+		p.printLifetimeAnn(typ.Lifetime)
+		p.writeString(" ")
+	}
+	if typ.Mut {
+		p.writeString("mut ")
+	}
+	needsParens := false
+	switch typ.Inner.(type) {
+	case *ast.UnionTypeAnn, *ast.IntersectionTypeAnn:
+		needsParens = true
+	}
+	if needsParens {
+		p.writeString("(")
+	}
+	p.printTypeAnn(typ.Inner)
+	if needsParens {
+		p.writeString(")")
+	}
+}
+
+// printLifetimeAnn renders a lifetime annotation node: a single lifetime
+// `'a` or a union `('a | 'b)`.
+func (p *Printer) printLifetimeAnn(lt ast.LifetimeAnnNode) {
+	switch lt := lt.(type) {
+	case *ast.LifetimeAnn:
+		p.writeString("'")
+		p.writeString(lt.Name)
+	case *ast.LifetimeUnionAnn:
+		p.writeString("(")
+		for i, l := range lt.Lifetimes {
+			p.writeString("'")
+			p.writeString(l.Name)
+			if i < len(lt.Lifetimes)-1 {
+				p.writeString(" | ")
+			}
+		}
+		p.writeString(")")
 	}
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -716,6 +716,36 @@ func TestPrintTypeAnnotations(t *testing.T) {
 	}
 }
 
+func TestPrintBorrowTypeAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"borrow", "&Point", "&Point"},
+		{"borrow mut", "&mut Point", "&mut Point"},
+		{"borrow lifetime", "&'a Point", "&'a Point"},
+		{"borrow lifetime mut", "&'a mut Point", "&'a mut Point"},
+		{"borrow of union parenthesized", "&(A | B)", "&(A | B)"},
+		{"borrow binds tighter than union", "&A | B", "&A | B"},
+		{"borrow as intersection member", "&A & B", "&A & B"},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typeAnn := parseTypeAnn(t, tt.input)
+			result, err := Print(typeAnn, opts)
+			if err != nil {
+				t.Fatalf("Print error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected:\n%s\nGot:\n%s", tt.expected, result)
+			}
+		})
+	}
+}
+
 func TestPrintScript(t *testing.T) {
 	input := `val x = 5
 val y = 10

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
 )
 
 func parseScript(t *testing.T, input string) *ast.Script {
@@ -729,6 +730,12 @@ func TestPrintBorrowTypeAnnotations(t *testing.T) {
 		{"borrow of union parenthesized", "&(A | B)", "&(A | B)"},
 		{"borrow binds tighter than union", "&A | B", "&A | B"},
 		{"borrow as intersection member", "&A & B", "&A & B"},
+		// A prefix-mut or nested-borrow inner must keep its parens, else
+		// `&(mut A)` would print as `&mut A` and `&(&A)` as `&&A`, both of
+		// which re-parse to a different annotation.
+		{"borrow of mut inner keeps parens", "&(mut A)", "&(mut A)"},
+		{"borrow of mut inner with lifetime", "&'a (mut A)", "&'a (mut A)"},
+		{"nested borrow keeps parens", "&(&A)", "&(&A)"},
 	}
 
 	opts := DefaultOptions()
@@ -736,12 +743,8 @@ func TestPrintBorrowTypeAnnotations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			typeAnn := parseTypeAnn(t, tt.input)
 			result, err := Print(typeAnn, opts)
-			if err != nil {
-				t.Fatalf("Print error: %v", err)
-			}
-			if result != tt.expected {
-				t.Errorf("Expected:\n%s\nGot:\n%s", tt.expected, result)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/test_util/test_util.go
+++ b/internal/test_util/test_util.go
@@ -172,6 +172,12 @@ func typeAnnToType(typeAnn ast.TypeAnn) Type {
 		// declaration that wraps it (e.g. `type Uppercase = intrinsic`).
 		// Audit test skips IntrinsicType for round-trip.
 		return &IntrinsicType{Name: ""}
+	case *ast.RefTypeAnn:
+		// The legacy type system has no borrow/ref representation; borrows
+		// are modeled only by the SimpleSub-based checker. Feeding a borrow
+		// annotation here is a test mistake — fail with a clear cause rather
+		// than the generic default below.
+		panic("typeAnnToType: borrow annotations are unsupported in the legacy test helper")
 	default:
 		panic(fmt.Sprintf("ConvertTypeAnnToType: unsupported type annotation: %T", typeAnn))
 	}

--- a/internal/test_util/test_util.go
+++ b/internal/test_util/test_util.go
@@ -173,9 +173,9 @@ func typeAnnToType(typeAnn ast.TypeAnn) Type {
 		// Audit test skips IntrinsicType for round-trip.
 		return &IntrinsicType{Name: ""}
 	case *ast.RefTypeAnn:
-		// The legacy type system has no borrow/ref representation; borrows
+		// The legacy type system has no borrow/ref representation. Borrows
 		// are modeled only by the SimpleSub-based checker. Feeding a borrow
-		// annotation here is a test mistake — fail with a clear cause rather
+		// annotation here is a test mistake. Fail with a clear cause rather
 		// than the generic default below.
 		panic("typeAnnToType: borrow annotations are unsupported in the legacy test helper")
 	default:


### PR DESCRIPTION
Adds support for parsing and printing borrow type annotations with the prefix `&` operator, mirroring the borrow syntax used in method receivers.

**Summary**

Borrow annotations can now be written as `&T`, `&mut T`, `&'a T`, or `&'a mut T`. The `&` prefix binds tightly to a single type atom, so `&A | B` parses as `(&A) | B`. Borrowing a compound type requires explicit parentheses: `&(A | B)`.

**Changes**

- **Parser** (`internal/parser/type_ann.go`): Moved borrow parsing from the top-level `typeAnn()` function to `primaryTypeAnn()` so it binds tighter than union and intersection. Extracted lifetime parsing into a new `parseOptLifetimeAnn()` helper used by both borrow and type-reference prefixes.

- **AST** (`internal/ast/type_ann.go`): Added `RefTypeAnn` node to represent borrows with optional `Mut` flag and `Lifetime` annotation.

- **Printer** (`internal/printer/printer.go`): Added `printRefTypeAnn()` to render borrow syntax, with automatic parenthesization of union and intersection inner types. Extracted `needsTypeAnnParens()` helper and added `printLifetimeAnn()` for lifetime rendering.

- **Type checker** (`internal/checker/infer_type_ann.go`): Borrow annotations are reported as unsupported in the legacy HM checker (they are only implemented in the SimpleSub-based checker). Added `BorrowUnsupportedError` to `internal/checker/error.go`.

- **Tests**: Added parser tests covering borrow syntax variants and operator precedence. Added printer round-trip tests. Updated test utilities to reject borrow annotations in the legacy type system.

**Implementation notes**

The lifetime slot in a borrow (`&'a mut T`) mirrors the receiver form on methods. Lifetime parsing reuses the same logic as type-reference prefixes, supporting both single lifetimes (`'a`) and unions (`('a | 'b)`). The borrow operator is now context-sensitive: at the start of a type annotation it is a prefix borrow, while in infix position it remains the intersection operator.

https://claude.ai/code/session_01KHLLggQnd4VM4oQdVcMsme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parsing and printing support for borrow/reference type annotations, including mutable borrows (`&mut T`) and lifetime-qualified references (`&'a T`)

* **Bug Fixes**
  * Compiler now emits a proper error message for unsupported borrow syntax instead of crashing

* **Tests**
  * Added test coverage for parsing and printing borrow type annotations with various syntax combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->