### PR TITLE
Lower `&` borrow annotations to RefType

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -284,6 +284,30 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 	panic(fmt.Sprintf("printLifetime: unhandled %T", lt))
 }
 
+// borrowLifetimeName returns the lifetime to print after a borrow's leading `&`, or
+// "" when the lifetime is inferred and carries no load-bearing name. A LifetimeVar
+// renders its assigned quantifier name (`'a`) when ltNames carries one; an un-named
+// var is an inferred borrow that prints as a bare `&` with no lifetime, matching the
+// display rule that names a lifetime only when it is load-bearing. 'static and a
+// coalesced lifetime union are always shown. The `&` itself is emitted by the caller
+// whenever Lt is set, so a borrow is always distinguishable from an owned value.
+func (p *namedPrinter) borrowLifetimeName(lt Lifetime) string {
+	switch lt := lt.(type) {
+	case *LifetimeVar:
+		if p.ltNames != nil {
+			if name, ok := p.ltNames[lt]; ok {
+				return name
+			}
+		}
+		return ""
+	case *StaticLifetime:
+		return "'static"
+	case *LifetimeUnion:
+		return p.printLifetime(lt)
+	}
+	return ""
+}
+
 // printTypeMinPrec prints a child type, wrapping it in parentheses when its
 // precedence is below the required minimum — mirrors type_system's helper of the
 // same shape, so e.g. a function inside a union renders as
@@ -352,16 +376,24 @@ func (p *namedPrinter) printType(t Type) string {
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
-		// A borrow prefix: `mut {x: number}` (owned-mutable), `'a {…}` (immutable
-		// borrow), `mut 'a {…}` (mutable borrow). The `mut` keyword leads, then the
-		// lifetime when present (Lt != nil). The inner prints at precPrefix so a
-		// looser inner (a union/function) gets parenthesized.
+		// Ownership and the borrow `&` split on Lt. An owned value (Lt nil) renders
+		// bare: `{x}` owned-immutable, which NewRef collapses so a surviving owned
+		// RefType is always `mut {x}` owned-mutable. A borrow (Lt set) leads with `&`,
+		// then the lifetime name when it is load-bearing, then `mut`:
+		//
+		//	&{x}        &mut {x}        &'a {x}        &'a mut {x}
+		//
+		// The inner prints at precPrefix so a looser inner (a union/function) gets
+		// parenthesized.
 		prefix := ""
-		if t.Mut {
-			prefix = "mut "
-		}
 		if t.Lt != nil {
-			prefix += p.printLifetime(t.Lt) + " "
+			prefix = "&"
+			if name := p.borrowLifetimeName(t.Lt); name != "" {
+				prefix += name + " "
+			}
+		}
+		if t.Mut {
+			prefix += "mut "
 		}
 		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -286,11 +286,11 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 
 // borrowLifetimeName returns the lifetime to print after a borrow's leading `&`, or
 // "" when the lifetime is inferred and carries no load-bearing name. A LifetimeVar
-// renders its assigned quantifier name (`'a`) when ltNames carries one; an un-named
-// var is an inferred borrow that prints as a bare `&` with no lifetime, matching the
-// display rule that names a lifetime only when it is load-bearing. 'static and a
-// coalesced lifetime union are always shown. The `&` itself is emitted by the caller
-// whenever Lt is set, so a borrow is always distinguishable from an owned value.
+// renders its assigned quantifier name `'a` when ltNames carries one. An un-named var
+// is an inferred borrow and prints as a bare `&` with no lifetime, matching the display
+// rule that names a lifetime only when it is load-bearing. 'static and a coalesced
+// lifetime union are always shown. The `&` itself is emitted by the caller whenever Lt
+// is set, so a borrow is always distinguishable from an owned value.
 func (p *namedPrinter) borrowLifetimeName(lt Lifetime) string {
 	switch lt := lt.(type) {
 	case *LifetimeVar:
@@ -376,15 +376,16 @@ func (p *namedPrinter) printType(t Type) string {
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
-		// Ownership and the borrow `&` split on Lt. An owned value (Lt nil) renders
-		// bare: `{x}` owned-immutable, which NewRef collapses so a surviving owned
-		// RefType is always `mut {x}` owned-mutable. A borrow (Lt set) leads with `&`,
-		// then the lifetime name when it is load-bearing, then `mut`:
+		// Ownership and the borrow `&` split on Lt. An owned value has Lt nil and
+		// renders bare. NewRef collapses the owned-immutable cell, so a surviving owned
+		// RefType is always owned-mutable and renders `mut {x}`. A borrow has Lt set and
+		// leads with `&`, then the lifetime name when it is load-bearing, then `mut`.
+		// The four forms are:
 		//
 		//	&{x}        &mut {x}        &'a {x}        &'a mut {x}
 		//
-		// The inner prints at precPrefix so a looser inner (a union/function) gets
-		// parenthesized.
+		// The inner prints at precPrefix so a looser inner such as a union or function
+		// gets parenthesized.
 		prefix := ""
 		if t.Lt != nil {
 			prefix = "&"

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -371,7 +371,7 @@ func TestPrintScheme(t *testing.T) {
 		lv := &LifetimeVar{ID: 0, Level: 1}
 		// fn (p: &'a mut {x: number}) -> &'a mut {x: number}: one borrow lifetime shared
 		// by the param and the return, so the scheme names it once and renders both in
-		// `&'a` notation — the mutable-borrow display form.
+		// the mutable-borrow `&'a mut` display form.
 		ref := &RefType{Mut: true, Lt: lv, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}}
 		ty := &FuncType{Params: []*FuncParam{identP("p", ref)}, Ret: ref}
 		require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", PrintAsScheme(ty))

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -128,33 +128,36 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
 
-		// Borrows (M4). The inner object/tuple is brace/bracket-delimited, so no
-		// parens. The owned-mutable form (Lt nil) and, with D1's lifetime sort, the
-		// borrow forms carrying a lifetime all render here.
+		// Borrows (M4). Ownership and the borrow `&` split on Lt. An owned value (Lt
+		// nil) renders bare — `mut {x}` owned-mutable — while a borrow (Lt set) leads
+		// with `&`. The inner object/tuple is brace/bracket-delimited, so no parens. An
+		// un-named LifetimeVar is an inferred borrow that prints as a bare `&` with no
+		// lifetime; a load-bearing lifetime is named by the scheme printer (covered in
+		// TestPrintScheme), and 'static is always shown.
 		{
-			"mut object",
+			"owned-mutable object renders bare mut, no borrow &",
 			&RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
 			"mut {x: number}",
 		},
 		{
-			"mut tuple",
+			"owned-mutable tuple renders bare mut, no borrow &",
 			&RefType{Mut: true, Inner: &TupleType{Elems: []Type{numP(), strP()}}},
 			"mut [number, string]",
 		},
 		{
-			"immutable borrow with lifetime var",
+			"immutable borrow with inferred lifetime renders bare &",
 			&RefType{Lt: &LifetimeVar{ID: 0}, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
-			"'l0 {x: number}",
+			"&{x: number}",
 		},
 		{
-			"mutable borrow with lifetime var",
+			"mutable borrow with inferred lifetime renders &mut",
 			&RefType{Mut: true, Lt: &LifetimeVar{ID: 2}, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
-			"mut 'l2 {x: number}",
+			"&mut {x: number}",
 		},
 		{
-			"borrow with static lifetime",
+			"borrow with static lifetime always shows 'static",
 			&RefType{Mut: true, Lt: &StaticLifetime{}, Inner: &TupleType{Elems: []Type{numP()}}},
-			"mut 'static [number]",
+			"&'static mut [number]",
 		},
 	}
 	for _, tt := range tests {
@@ -362,6 +365,23 @@ func TestPrintScheme(t *testing.T) {
 			&PropertyElem{Name: "b", Type: b},
 		}}}
 		require.Equal(t, "fn <T0, T1>() -> {a: T0, b: T1}", PrintAsScheme(ty))
+	})
+
+	t.Run("a load-bearing borrow lifetime is named in & notation", func(t *testing.T) {
+		lv := &LifetimeVar{ID: 0, Level: 1}
+		// fn (p: &'a mut {x: number}) -> &'a mut {x: number}: one borrow lifetime shared
+		// by the param and the return, so the scheme names it once and renders both in
+		// `&'a` notation — the mutable-borrow display form.
+		ref := &RefType{Mut: true, Lt: lv, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}}
+		ty := &FuncType{Params: []*FuncParam{identP("p", ref)}, Ret: ref}
+		require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", PrintAsScheme(ty))
+	})
+
+	t.Run("an immutable borrow lifetime is named after the &", func(t *testing.T) {
+		lv := &LifetimeVar{ID: 1, Level: 1}
+		ref := &RefType{Lt: lv, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}}
+		ty := &FuncType{Params: []*FuncParam{identP("p", ref)}, Ret: ref}
+		require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", PrintAsScheme(ty))
 	})
 
 	t.Run("a borrowed generic survives generalization", func(t *testing.T) {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -128,12 +128,12 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
 
-		// Borrows (M4). Ownership and the borrow `&` split on Lt. An owned value (Lt
-		// nil) renders bare — `mut {x}` owned-mutable — while a borrow (Lt set) leads
-		// with `&`. The inner object/tuple is brace/bracket-delimited, so no parens. An
-		// un-named LifetimeVar is an inferred borrow that prints as a bare `&` with no
-		// lifetime; a load-bearing lifetime is named by the scheme printer (covered in
-		// TestPrintScheme), and 'static is always shown.
+		// Borrows (M4). Ownership and the borrow `&` split on Lt. An owned value has Lt
+		// nil and renders bare, as owned-mutable `mut {x}`. A borrow has Lt set and leads
+		// with `&`. The inner object or tuple is brace- or bracket-delimited, so it needs
+		// no parens. An un-named LifetimeVar is an inferred borrow and prints as a bare
+		// `&` with no lifetime. A load-bearing lifetime is named by the scheme printer,
+		// which TestPrintScheme exercises. 'static is always shown.
 		{
 			"owned-mutable object renders bare mut, no borrow &",
 			&RefType{Mut: true, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}},
@@ -369,9 +369,8 @@ func TestPrintScheme(t *testing.T) {
 
 	t.Run("a load-bearing borrow lifetime is named in & notation", func(t *testing.T) {
 		lv := &LifetimeVar{ID: 0, Level: 1}
-		// fn (p: &'a mut {x: number}) -> &'a mut {x: number}: one borrow lifetime shared
-		// by the param and the return, so the scheme names it once and renders both in
-		// the mutable-borrow `&'a mut` display form.
+		// One borrow lifetime is shared by the param and the return, so the scheme names
+		// it once and renders both in the mutable-borrow `&'a mut {x: number}` form.
 		ref := &RefType{Mut: true, Lt: lv, Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}}
 		ty := &FuncType{Params: []*FuncParam{identP("p", ref)}, Ret: ref}
 		require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", PrintAsScheme(ty))

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -68,11 +68,11 @@ type checker struct {
 	// union of their reachable param lifetimes.
 	paramLifetimes set.Set[int]
 
-	// namedLifetimes resolves a written lifetime name (`'a`) to its lifetime
-	// variable so every `&'a` in one function shares one variable. inferFunc saves
-	// and clears it on entry and restores it on exit, so each function — including a
-	// nested one — has its own named-lifetime scope. A `&'a` outside any function
-	// resolves against the module-level map lazily allocated here.
+	// namedLifetimes resolves a written lifetime name `'a` to its lifetime variable so
+	// every `&'a` in one scope shares one variable. inferFunc saves and clears it on
+	// entry and restores it on exit, so each function has its own named-lifetime scope,
+	// nested functions included. inferComponent clears it per top-level binding for the
+	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
 }
 

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -67,6 +67,13 @@ type checker struct {
 	// parameter — while internal join vars (D3) stay anonymous and render as the
 	// union of their reachable param lifetimes.
 	paramLifetimes set.Set[int]
+
+	// namedLifetimes resolves a written lifetime name (`'a`) to its lifetime
+	// variable so every `&'a` in one function shares one variable. inferFunc saves
+	// and clears it on entry and restores it on exit, so each function — including a
+	// nested one — has its own named-lifetime scope. A `&'a` outside any function
+	// resolves against the module-level map lazily allocated here.
+	namedLifetimes map[string]*soltype.LifetimeVar
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -86,7 +86,7 @@ fn f(p: mut {x: number}) {
 }
 
 // Reading a field after writing it through an annotated `mut` borrow returns the
-// written field's type. The receiver is the concrete borrow `&'l0 mut {x: number}`,
+// written field's type. The receiver is a concrete mutable borrow `&mut {x: number}`,
 // so valueProp peels it via CarrierOf before emitting the read requirement — without
 // the peel this would trip the escape guard on the bare read requirement. Unlike the
 // usage-inferred read-after-write tests (which key off the `written` map on a

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -429,7 +429,7 @@ func TestInferNamedBorrowLifetimeShared(t *testing.T) {
 	require.Equal(t, "fn <'a>(p: &'a {x: number}, q: &'a {x: number}) -> &'a {x: number}", values["f"])
 }
 
-// A borrow of a value type has nothing to point at: `&number` wraps a primitive, which
+// A borrow of a value type has nothing to point at. `&number` wraps a primitive, which
 // is excluded from RefInner, so lowering reports it as an unsupported feature rather than
 // fabricating a borrow over a non-borrowable type.
 func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -20,7 +20,7 @@ import (
 func TestInferIdentityRefReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["f"])
 }
 
 // Returning a freshly-constructed owned object carries no borrow lifetime: the
@@ -38,7 +38,7 @@ func TestInferFreshObjectReturn(t *testing.T) {
 func TestInferDistinctParamLifetimes(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}, q: mut {y: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}, q: mut {y: number}) -> mut 'a {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}, q: mut {y: number}) -> &'a mut {x: number}", values["f"])
 }
 
 // Writing a field through an annotated `mut` borrow checks: the receiver carries a
@@ -86,7 +86,7 @@ fn f(p: mut {x: number}) {
 }
 
 // Reading a field after writing it through an annotated `mut` borrow returns the
-// written field's type. The receiver is the concrete borrow `mut 'l0 {x: number}`,
+// written field's type. The receiver is the concrete borrow `&'l0 mut {x: number}`,
 // so valueProp peels it via CarrierOf before emitting the read requirement — without
 // the peel this would trip the escape guard on the bare read requirement. Unlike the
 // usage-inferred read-after-write tests (which key off the `written` map on a
@@ -132,7 +132,7 @@ func TestInferConditionalUnionReturn(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
 		values["f"])
 }
 
@@ -152,7 +152,7 @@ func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {y: number}) -> mut 'a {x: number} | mut 'b {y: number}",
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {y: number}) -> &'a mut {x: number} | &'b mut {y: number}",
 		values["f"])
 }
 
@@ -174,7 +174,7 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}, r: mut 'c {x: number}) -> mut ('a | 'b | 'c) {x: number}",
+		"fn <'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &('a | 'b | 'c) mut {x: number}",
 		values["f"])
 }
 
@@ -198,10 +198,10 @@ fn use(a: mut {x: number}, b: mut {x: number}) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
 		values["pick"])
 	require.Equal(t,
-		"fn <'a, 'b>(a: mut 'a {x: number}, b: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
+		"fn <'a, 'b>(a: &'a mut {x: number}, b: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
 		values["use"])
 }
 
@@ -212,7 +212,7 @@ fn use(a: mut {x: number}, b: mut {x: number}) {
 // silently unifying incompatible borrows (M4 D3).
 //
 // FUTURE (M6): this error is the conservative M4 default. M6 may relax it to a
-// read-until-narrowed union — `(mut 'a {x: number}) | (mut 'b {x: string})`, readable
+// read-until-narrowed union — `(&'a mut {x: number}) | (&'b mut {x: string})`, readable
 // always and writable only after narrowing — to match TypeScript. See 01-milestones.md
 // M6, "Permissive mut-borrow joins". When that lands, this test changes from asserting
 // an error to asserting the union.
@@ -247,7 +247,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number} | {x: 5}",
+		"fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number} | {x: 5}",
 		values["f"])
 }
 
@@ -255,7 +255,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 // the EscapingRefIntoStatic acceptance (M4 D3), now reachable from real source.
 // `cache` stores its borrow `p` into the module-level `var sink`, a global write. The
 // stored value outlives every borrow region, so p's lifetime is forced `<: 'static`
-// and the parameter renders `mut 'static {x: number}` rather than under a borrow
+// and the parameter renders `&'static mut {x: number}` rather than under a borrow
 // lifetime `'l{id}`. The store itself checks. A 'static borrow is owned-forever, so
 // it fills the owned slot instead of tripping BorrowEscapeError.
 func TestInferGlobalWriteEscapesBorrowToStatic(t *testing.T) {
@@ -266,7 +266,7 @@ fn cache(p: mut {x: number}) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t, "{x: number}", values["sink"])
-	require.Equal(t, "fn (p: mut 'static {x: number}) -> void", values["cache"])
+	require.Equal(t, "fn (p: &'static mut {x: number}) -> void", values["cache"])
 }
 
 // An ordinary global write of a NON-borrow value is unaffected by the escape rule.
@@ -311,7 +311,7 @@ func TestInferReborrowReturnedCarriesLifetime(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> 'a {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}", values["f"])
 }
 
 // A reborrow that escapes into an OWNED return slot still errors. The return annotation
@@ -368,7 +368,7 @@ func TestInferTupleReborrowReturnsLifetime(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a [number, number]) -> 'a [number, number]", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut [number, number]) -> &'a [number, number]", values["f"])
 }
 
 // This is the tuple twin of TestInferOwnedSourceNotReborrowed. An owned tuple source has
@@ -396,5 +396,43 @@ func TestInferInexactAnnotationReborrows(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number, y: number}) -> 'a {x: number, ...}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number, y: number}) -> &'a {x: number, ...}", values["f"])
+}
+
+// --- PR2: lowering `&` borrow annotations to RefType ---
+
+// A bare `&` parameter lowers to an immutable borrow with a fresh inferred lifetime.
+// Returned, the borrow carries that lifetime to the output, which is then load-bearing
+// and named `'a`, so the signature renders the borrow in `&'a` notation rather than the
+// old `'a {x}` form.
+func TestInferBorrowAnnImmutableParam(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &{x: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A `&mut` parameter lowers to a mutable borrow with a fresh inferred lifetime. This is
+// the same RefType the borrow-by-default `mut {x}` param produced, now written
+// explicitly, so it renders identically as `&'a mut {x}`.
+func TestInferBorrowAnnMutableParam(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["f"])
+}
+
+// A named `&'a` lifetime resolves to one lifetime variable shared by every occurrence in
+// the function, so two parameters annotated `&'a` borrow at the same lifetime. Returning
+// one makes that lifetime load-bearing, and the display names it `'a` on both params.
+func TestInferNamedBorrowLifetimeShared(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &'a {x: number}, q: &'a {x: number}) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}, q: &'a {x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A borrow of a value type has nothing to point at: `&number` wraps a primitive, which
+// is excluded from RefInner, so lowering reports it as an unsupported feature rather than
+// fabricating a borrow over a non-borrowable type.
+func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f(p: &number) -> number { return 0 }`)
+	require.Equal(t, []string{"Unsupported: borrow of a non-borrowable type"}, Messages(errs))
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -169,6 +169,13 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // without constraining anything. node supplies the span stamped onto a
 // return-annotation constraint failure.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
+	// Give this function its own named-lifetime scope so a `&'a` in its signature
+	// resolves consistently across its params and return, without sharing the name
+	// with an enclosing or sibling function. Restored on exit so a nested function
+	// does not clobber the outer scope's names.
+	savedNamedLts := c.namedLifetimes
+	c.namedLifetimes = map[string]*soltype.LifetimeVar{}
+	defer func() { c.namedLifetimes = savedNamedLts }()
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
 		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -172,9 +172,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// Give this function its own named-lifetime scope so a `&'a` in its signature
 	// resolves consistently across its params and return, without sharing the name
 	// with an enclosing or sibling function. Restored on exit so a nested function
-	// does not clobber the outer scope's names.
+	// does not clobber the outer scope's names. namedLifetime allocates the map on
+	// first use, so a body with no `&'a` annotation pays no allocation.
 	savedNamedLts := c.namedLifetimes
-	c.namedLifetimes = map[string]*soltype.LifetimeVar{}
+	c.namedLifetimes = nil
 	defer func() { c.namedLifetimes = savedNamedLts }()
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -149,7 +149,7 @@ func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
 func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["f"])
 }
 
 // Source-level regression: a borrow-passing function called at two distinct sites

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -116,7 +116,7 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 // A borrowed value flowing into 'static storage has its lifetime forced to outlive
 // 'static. This is the EscapingRefIntoStatic acceptance (M4 D3). constrainEscape
 // constrains the borrow's lifetime `<: 'static`, so coalescing the borrow renders it
-// `mut 'static {x: number}` rather than under the param's own name. No Escalier
+// `&'static mut {x: number}` rather than under the param's own name. No Escalier
 // construct routes a borrow into static storage yet, since a borrow originates only
 // at a parameter, so this exercises the rule's mechanism directly.
 func TestEscapingRefIntoStatic(t *testing.T) {
@@ -133,10 +133,10 @@ func TestEscapingRefIntoStatic(t *testing.T) {
 	c.constrainEscape(ref)
 
 	require.Equal(t, []soltype.Lifetime{soltype.Static}, lt.UpperBounds)
-	require.Equal(t, "mut 'static {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
+	require.Equal(t, "&'static mut {x: number}", soltype.Print(coalesce(ref, soltype.Positive)))
 }
 
-// Escape reaches a borrow NESTED inside an object property. Storing `{p: mut 'a
+// Escape reaches a borrow NESTED inside an object property. Storing `{p: &'a mut
 // Point}` forces the inner borrow's lifetime to 'static too, since the whole value
 // escapes. constrainEscape walks the structural carriers, so the property's borrow
 // is constrained alongside any top-level one.
@@ -156,7 +156,7 @@ func TestEscapingNestedRefIntoStatic(t *testing.T) {
 	c.constrainEscape(stored)
 
 	require.Equal(t, []soltype.Lifetime{soltype.Static}, inner.UpperBounds)
-	require.Equal(t, "{p: mut 'static {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
+	require.Equal(t, "{p: &'static mut {x: number}}", soltype.Print(coalesce(stored, soltype.Positive)))
 }
 
 // mutPointRef is a `mut lt {x: number}` borrow, the carrier these lifetime tests
@@ -205,7 +205,7 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 
 	// Before escape the join expands to the union of its members.
 	require.Equal(t,
-		"fn <'a, 'b>(p: mut 'a {x: number}, q: mut 'b {x: number}) -> mut ('a | 'b) {x: number}",
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 
 	c.constrainEscape(ret)
@@ -214,7 +214,7 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	// member, so the entire signature collapses to 'static with no nameable lifetime left.
 	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
 	require.Equal(t,
-		"fn (p: mut 'static {x: number}, q: mut 'static {x: number}) -> mut 'static {x: number}",
+		"fn (p: &'static mut {x: number}, q: &'static mut {x: number}) -> &'static mut {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
@@ -266,7 +266,7 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	fn := borrowFn(mutPointRef(top), a, b, d)
 
 	require.Equal(t,
-		"fn <'a, 'b, 'c>(p: mut 'a {x: number}, q: mut 'b {x: number}, r: mut 'c {x: number}) -> mut ('a | 'b | 'c) {x: number}",
+		"fn <'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &('a | 'b | 'c) mut {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -207,6 +207,10 @@ func (c *checker) inferComponent(
 
 	// Phase 2: infer each declaration's definition and constrain it <: its var.
 	for _, key := range component {
+		// Each top-level binding is its own named-lifetime scope, mirroring inferFunc:
+		// two declarations that both write `&'a` get independent lifetimes rather than
+		// sharing one through a stale map. A function decl re-clears this inside inferFunc.
+		c.namedLifetimes = nil
 		b, isValue := bindings[key]
 		if !isValue {
 			continue // non-value keys handled below

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -207,8 +207,8 @@ func (c *checker) inferComponent(
 
 	// Phase 2: infer each declaration's definition and constrain it <: its var.
 	for _, key := range component {
-		// Each top-level binding is its own named-lifetime scope, mirroring inferFunc:
-		// two declarations that both write `&'a` get independent lifetimes rather than
+		// Each top-level binding is its own named-lifetime scope, mirroring inferFunc.
+		// Two declarations that both write `&'a` get independent lifetimes rather than
 		// sharing one through a stale map. A function decl re-clears this inside inferFunc.
 		c.namedLifetimes = nil
 		b, isValue := bindings[key]

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -233,7 +233,7 @@ func TestScriptBorrowLifetimeParity(t *testing.T) {
 
 	scriptValues, _, scriptErrs := inferScriptSource(t, src)
 	require.Empty(t, scriptErrs)
-	require.Equal(t, "fn <'a>(p: mut 'a {x: number}) -> mut 'a {x: number}", scriptValues["id"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", scriptValues["id"])
 
 	moduleValues, _, moduleErrs := inferSource(t, src)
 	require.Empty(t, moduleErrs)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -188,12 +188,12 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	return t, true
 }
 
-// borrowInner resolves the pointee of a `mut`/`&` annotation to a RefInner, the shared
-// inner-resolution step of resolveMutableTypeAnn and resolveRefTypeAnn. An unsupported
-// inner recovers to a fresh var, which IS a RefInner, so the wrapper is preserved and
-// the binding stays cascade-safe. ok=false means the inner resolved to a concrete
-// non-borrowable type (a primitive, function, or promise); the caller reports that with
-// a wrapper-specific message.
+// borrowInner resolves the pointee of a `mut` or `&` annotation to a RefInner, the
+// shared inner-resolution step of resolveMutableTypeAnn and resolveRefTypeAnn. An
+// unsupported inner recovers to a fresh var, which IS a RefInner, so the wrapper is
+// preserved and the binding stays cascade-safe. ok=false means the inner resolved to a
+// concrete non-borrowable type such as a primitive, function, or promise. The caller
+// reports that with a wrapper-specific message.
 func (c *checker) borrowInner(ta ast.TypeAnn, lvl int) (soltype.RefInner, bool) {
 	inner, ok := c.resolveTypeAnn(ta, lvl)
 	if !ok {
@@ -204,14 +204,14 @@ func (c *checker) borrowInner(ta ast.TypeAnn, lvl int) (soltype.RefInner, bool) 
 }
 
 // resolveRefTypeAnn lowers a borrow annotation `&T`, `&mut T`, `&'a T`, or `&'a mut T`
-// to a soltype.RefType{Mut, Lt, Inner}. The inner must be a RefInner; a borrow of a
-// value type, such as a primitive, has nothing to point at and is reported as an
+// to a soltype.RefType{Mut, Lt, Inner}. The inner must be a RefInner. A borrow of a
+// value type such as a primitive has nothing to point at and is reported as an
 // unsupported feature.
 //
-// resolveLifetimeAnn mints the lifetime: a bare `&` gets a fresh inferred lifetime, and
+// resolveLifetimeAnn mints the lifetime. A bare `&` gets a fresh inferred lifetime, and
 // `&'a` resolves the named lifetime to the variable that name denotes in the current
 // function. Display naming is decided structurally at coalesce time, so a borrow that
-// reaches an output renders under a quantified name like `&'a {x}` while one that
+// reaches an output renders under a quantified name like `&'a {x}`, while one that
 // connects nothing elides. Unlike resolveMutableTypeAnn, this arm always sets Lt, so the
 // result is a genuine borrow rather than an owned value.
 func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, bool) {
@@ -225,8 +225,8 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 }
 
 // resolveLifetimeAnn resolves the lifetime slot of a borrow annotation. A nil node is
-// an inferred borrow and mints a fresh lifetime; a named `'a` resolves to the variable
-// that name denotes; a `('a | 'b)` union resolves each member and joins them in a
+// an inferred borrow and mints a fresh lifetime. A named `'a` resolves to the variable
+// that name denotes. A `('a | 'b)` union resolves each member and joins them in a
 // LifetimeUnion.
 func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.Lifetime {
 	switch n := node.(type) {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -79,6 +79,8 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 		return c.resolveTupleTypeAnn(ta, lvl)
 	case *ast.MutableTypeAnn:
 		return c.resolveMutableTypeAnn(ta, lvl)
+	case *ast.RefTypeAnn:
+		return c.resolveRefTypeAnn(ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -191,6 +193,79 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	t := soltype.NewRef(true, nil, ri)
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// resolveRefTypeAnn lowers a borrow annotation — `&T`, `&mut T`, `&'a T`, `&'a mut T`
+// — to a soltype.RefType{Mut, Lt, Inner}. The inner must be a RefInner: a borrow of a
+// value type (a primitive, function, or promise) has nothing to point at and is
+// reported as an unsupported feature. An unsupported inner recovers to a fresh var,
+// which IS a RefInner, so the borrow wrapper is preserved and the binding stays
+// cascade-safe, mirroring resolveMutableTypeAnn.
+//
+// The lifetime is minted by resolveLifetimeAnn: a bare `&` gets a fresh inferred
+// LifetimeVar, while `&'a` resolves the named lifetime to the variable that name
+// denotes in the current function. Either is registered as a nameable param lifetime,
+// so a borrow that reaches an output renders under a quantified name (`&'a {x}`) and
+// one that connects nothing elides at display time. Unlike resolveMutableTypeAnn — the
+// bare-`mut` owned-mutable form, which leaves Lt nil — this arm always sets Lt, so the
+// result is a genuine borrow rather than an owned value.
+func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, bool) {
+	var ri soltype.RefInner
+	inner, ok := c.resolveTypeAnn(ta.Inner, lvl)
+	if !ok {
+		ri = c.freshAt(lvl) // a fresh var is a RefInner, so the borrow wrapper survives
+	} else if r, isRI := inner.(soltype.RefInner); isRI {
+		ri = r
+	} else {
+		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
+	}
+	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveLifetimeAnn resolves the lifetime slot of a borrow annotation. A nil node is
+// an inferred borrow and mints a fresh lifetime; a named `'a` resolves to the variable
+// that name denotes; a `('a | 'b)` union resolves each member and joins them in a
+// LifetimeUnion. Every variable is registered as a nameable param lifetime.
+func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.Lifetime {
+	switch n := node.(type) {
+	case *ast.LifetimeAnn:
+		return c.namedLifetime(n.Name, lvl)
+	case *ast.LifetimeUnionAnn:
+		members := make([]soltype.Lifetime, len(n.Lifetimes))
+		for i, m := range n.Lifetimes {
+			members[i] = c.namedLifetime(m.Name, lvl)
+		}
+		return &soltype.LifetimeUnion{Lifetimes: members}
+	default:
+		// A nil node (and any unexpected form) is an inferred borrow.
+		return c.freshParamLifetime(lvl)
+	}
+}
+
+// freshParamLifetime mints a fresh lifetime variable at lvl and records it as a
+// nameable param lifetime, so a load-bearing borrow renders under a quantified name.
+func (c *checker) freshParamLifetime(lvl int) *soltype.LifetimeVar {
+	lt := c.ctx.freshLifetime(lvl)
+	c.paramLifetimes.Add(lt.ID)
+	return lt
+}
+
+// namedLifetime resolves a written lifetime name to its variable, minting one on first
+// appearance so every `&'a` in one function shares a single lifetime. The map is reset
+// per function by inferFunc, so the same name in two functions denotes distinct
+// lifetimes.
+func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
+	if c.namedLifetimes == nil {
+		c.namedLifetimes = map[string]*soltype.LifetimeVar{}
+	}
+	if lt, ok := c.namedLifetimes[name]; ok {
+		return lt
+	}
+	lt := c.freshParamLifetime(lvl)
+	c.namedLifetimes[name] = lt
+	return lt
 }
 
 // annPrim mints a FRESH PrimType for an annotation and records it against the

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -177,16 +177,9 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 // `mut` over a non-borrowable inner (a primitive, function, promise — anything
 // outside RefInner) is a no-op in the value-types model: there is nothing to
 // borrow. It reports an unsupported feature rather than fabricating a borrow over
-// a type the wrapper cannot hold. An unsupported inner recovers to a fresh var,
-// which IS a RefInner, so the `mut` wrapper is preserved.
+// a type the wrapper cannot hold.
 func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltype.Type, bool) {
-	inner, ok := c.resolveTypeAnn(ta.Target, lvl)
-	if !ok {
-		t := soltype.NewRef(true, nil, c.freshAt(lvl))
-		c.recordProv(t, ta, AnnotationType)
-		return t, true
-	}
-	ri, ok := inner.(soltype.RefInner)
+	ri, ok := c.borrowInner(ta.Target, lvl)
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "mut on a non-borrowable type"), false
 	}
@@ -195,28 +188,35 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	return t, true
 }
 
-// resolveRefTypeAnn lowers a borrow annotation — `&T`, `&mut T`, `&'a T`, `&'a mut T`
-// — to a soltype.RefType{Mut, Lt, Inner}. The inner must be a RefInner: a borrow of a
-// value type (a primitive, function, or promise) has nothing to point at and is
-// reported as an unsupported feature. An unsupported inner recovers to a fresh var,
-// which IS a RefInner, so the borrow wrapper is preserved and the binding stays
-// cascade-safe, mirroring resolveMutableTypeAnn.
+// borrowInner resolves the pointee of a `mut`/`&` annotation to a RefInner, the shared
+// inner-resolution step of resolveMutableTypeAnn and resolveRefTypeAnn. An unsupported
+// inner recovers to a fresh var, which IS a RefInner, so the wrapper is preserved and
+// the binding stays cascade-safe. ok=false means the inner resolved to a concrete
+// non-borrowable type (a primitive, function, or promise); the caller reports that with
+// a wrapper-specific message.
+func (c *checker) borrowInner(ta ast.TypeAnn, lvl int) (soltype.RefInner, bool) {
+	inner, ok := c.resolveTypeAnn(ta, lvl)
+	if !ok {
+		return c.freshAt(lvl), true
+	}
+	ri, isRI := inner.(soltype.RefInner)
+	return ri, isRI
+}
+
+// resolveRefTypeAnn lowers a borrow annotation `&T`, `&mut T`, `&'a T`, or `&'a mut T`
+// to a soltype.RefType{Mut, Lt, Inner}. The inner must be a RefInner; a borrow of a
+// value type, such as a primitive, has nothing to point at and is reported as an
+// unsupported feature.
 //
-// The lifetime is minted by resolveLifetimeAnn: a bare `&` gets a fresh inferred
-// LifetimeVar, while `&'a` resolves the named lifetime to the variable that name
-// denotes in the current function. Either is registered as a nameable param lifetime,
-// so a borrow that reaches an output renders under a quantified name (`&'a {x}`) and
-// one that connects nothing elides at display time. Unlike resolveMutableTypeAnn — the
-// bare-`mut` owned-mutable form, which leaves Lt nil — this arm always sets Lt, so the
+// resolveLifetimeAnn mints the lifetime: a bare `&` gets a fresh inferred lifetime, and
+// `&'a` resolves the named lifetime to the variable that name denotes in the current
+// function. Display naming is decided structurally at coalesce time, so a borrow that
+// reaches an output renders under a quantified name like `&'a {x}` while one that
+// connects nothing elides. Unlike resolveMutableTypeAnn, this arm always sets Lt, so the
 // result is a genuine borrow rather than an owned value.
 func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, bool) {
-	var ri soltype.RefInner
-	inner, ok := c.resolveTypeAnn(ta.Inner, lvl)
+	ri, ok := c.borrowInner(ta.Inner, lvl)
 	if !ok {
-		ri = c.freshAt(lvl) // a fresh var is a RefInner, so the borrow wrapper survives
-	} else if r, isRI := inner.(soltype.RefInner); isRI {
-		ri = r
-	} else {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
 	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
@@ -227,7 +227,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 // resolveLifetimeAnn resolves the lifetime slot of a borrow annotation. A nil node is
 // an inferred borrow and mints a fresh lifetime; a named `'a` resolves to the variable
 // that name denotes; a `('a | 'b)` union resolves each member and joins them in a
-// LifetimeUnion. Every variable is registered as a nameable param lifetime.
+// LifetimeUnion.
 func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.Lifetime {
 	switch n := node.(type) {
 	case *ast.LifetimeAnn:
@@ -239,23 +239,15 @@ func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.
 		}
 		return &soltype.LifetimeUnion{Lifetimes: members}
 	default:
-		// A nil node (and any unexpected form) is an inferred borrow.
-		return c.freshParamLifetime(lvl)
+		// A nil node, or any unexpected form, is an inferred borrow with a fresh lifetime.
+		return c.ctx.freshLifetime(lvl)
 	}
-}
-
-// freshParamLifetime mints a fresh lifetime variable at lvl and records it as a
-// nameable param lifetime, so a load-bearing borrow renders under a quantified name.
-func (c *checker) freshParamLifetime(lvl int) *soltype.LifetimeVar {
-	lt := c.ctx.freshLifetime(lvl)
-	c.paramLifetimes.Add(lt.ID)
-	return lt
 }
 
 // namedLifetime resolves a written lifetime name to its variable, minting one on first
 // appearance so every `&'a` in one function shares a single lifetime. The map is reset
-// per function by inferFunc, so the same name in two functions denotes distinct
-// lifetimes.
+// per function by inferFunc and per top-level binding by inferComponent, so the same
+// name in two such scopes denotes distinct lifetimes.
 func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 	if c.namedLifetimes == nil {
 		c.namedLifetimes = map[string]*soltype.LifetimeVar{}
@@ -263,7 +255,7 @@ func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 	if lt, ok := c.namedLifetimes[name]; ok {
 		return lt
 	}
-	lt := c.freshParamLifetime(lvl)
+	lt := c.ctx.freshLifetime(lvl)
 	c.namedLifetimes[name] = lt
 	return lt
 }


### PR DESCRIPTION
Implement lowering of explicit borrow annotations (`&T`, `&mut T`, `&'a T`, `&'a mut T`) to `soltype.RefType`, completing the PR2 milestone for borrow-lifetime inference.

**Summary**

This change adds support for parsing and lowering borrow annotations in type positions. Previously, the type system only supported implicit borrow-by-default `mut {x}` syntax. Now users can write explicit `&` annotations with optional lifetime names and mutability, which lower to the same `RefType` representation used internally.

**Key changes**

- Add `resolveRefTypeAnn` to lower `&T` annotations to `RefType` with a lifetime slot, mirroring the structure of `resolveMutableTypeAnn` for owned-mutable values.
- Extract shared logic into `borrowInner` helper, used by both `resolveMutableTypeAnn` and `resolveRefTypeAnn` to resolve the pointee to a `RefInner` with consistent error handling.
- Add `resolveLifetimeAnn` to handle lifetime resolution: bare `&` gets a fresh inferred lifetime, `&'a` resolves to a named lifetime variable, and `&('a | 'b)` unions resolve each member.
- Add `namedLifetime` to maintain a per-function scope of named lifetime variables, so every `&'a` in one function shares a single `LifetimeVar`. The scope is saved and cleared on function entry and restored on exit, and cleared per top-level binding in `inferComponent`.
- Update `soltype.Print` to render borrows in `&` notation: `&{x}`, `&mut {x}`, `&'a {x}`, `&'a mut {x}`. Inferred lifetimes (unnamed `LifetimeVar`) print as bare `&`, while load-bearing lifetimes and `'static` are always shown.
- Update test expectations to reflect the new display format. Implicit `mut {x}` borrows now render as `&'a mut {x}` in signatures.
- Add four new tests covering bare `&`, `&mut`, named `&'a` lifetimes, and rejection of `&number` (borrow of non-borrowable type).

**Implementation notes**

The change preserves the existing cascade-safe recovery for unsupported inners: when `borrowInner` encounters an inference failure or non-`RefInner` type, it returns a fresh var (which is a `RefInner`) so the wrapper is preserved. For concrete non-borrowable types like primitives, the caller reports an unsupported-feature error with a wrapper-specific message.

Lifetime display is structural: an un-named `LifetimeVar` is an inferred borrow and prints as bare `&`, while a `LifetimeVar` with an assigned quantifier name (set by the scheme printer) renders as `&'a`. This matches the rule that a lifetime is named only when load-bearing.

https://claude.ai/code/session_01SWjacdHZ89Uyur9timitoi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reference/borrow annotations with explicit lifetime syntax (e.g., `&'a mut T`)
  
* **Improvements**
  * Enhanced lifetime tracking and isolation within function scopes to prevent unintended lifetime reuse across declarations
  * Updated reference display format for clearer and more consistent lifetime notation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->