### PR TITLE
docs(affine): add graph moves and Freeze/Thaw

### DIFF
--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -241,6 +241,8 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium |
+| 11 | Connected-component moves for graphs | 6, 7 | Large |
+| 12 | `Freeze`/`Thaw` deep mut↔immut utility types | 8, 11, M9 | Large |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -591,6 +593,64 @@ un-narrowed alias rejected by the pin.
 
 Acceptance: mutable narrowing works with the discriminant pinned for the arm.
 
+### PR 11 — Connected-component moves for graphs
+
+Goal: move a self-contained cyclic or acyclic graph out of a function — returned or
+stored — when no node is referenced from outside the graph. See "Moving a graph" in
+the requirements. This logically extends the move engine (PRs 5–7); it's numbered
+later only because its dependencies are 6 and 7.
+
+- Compute the connected component reachable from an escaping value through its
+  borrow edges, over the move/borrow state the engine already tracks on `funcCtx`
+  (PRs 5–7).
+- Establish the precondition that no node in the component is reachable from any
+  binding or store outside it, reusing the alias and liveness state and the
+  per-path tracking from PR 7.
+- When it holds, treat the escape as a component move: re-anchor the internal borrow
+  lifetimes to the destination region — unify the mutual lifetimes into the
+  destination rather than failing the borrow-escape check — and consume every local
+  binding in the component, so any later use of any of them is a use-after-move.
+- When it fails — some node is externally aliased — fall back to the ordinary
+  borrow-escape error or phase conflict.
+- Soundness rests on the GC keeping co-moved nodes alive and on there being no
+  external observer, so the phase rules are unchanged; this is the requirements'
+  "Moving a graph" argument.
+
+Tests: the cyclic `build()` returns `a` with both `a` and `b` consumed; an acyclic
+shared graph returned the same way; a graph where a node is also held by a retained
+binding is rejected.
+
+Acceptance: a self-contained graph, cyclic or acyclic, can be returned or stored;
+externally-aliased nodes still error.
+
+### PR 12 — `Freeze`/`Thaw` deep mut↔immut utility types
+
+Goal: the `Freeze<T>` and `Thaw<T>` utility types for deep mutability conversion. See
+"Freeze and Thaw" in the requirements. Depends on the mapped/conditional-type
+machinery (M9) and the freeze/thaw moves (PR 8).
+
+- Add the modifier-rewrite capability to mapped/conditional types: a type-level
+  operator that matches a `&mut`/`mut` reference and yields its immutable form, and
+  the inverse, analogous to TypeScript's `-readonly`/`+readonly` but on the
+  borrow/`mut` axis, applied recursively.
+- Define `Freeze<T>` and `Thaw<T>` as recursive mapped-plus-conditional types over
+  objects, arrays, tuples, and borrows, with the self-referential recursion resolved
+  by the existing recursion machinery, so `Freeze<Node>` is the recursive
+  `{ value: number, peers: Array<&Freeze<Node>> }`.
+- Wire soundness to the move, not the mapped type: assigning into `Freeze<T>` is the
+  mutable-to-immutable freeze move from PR 8, and `Thaw<T>` the immutable-to-mutable
+  move, each reusing that PR's preconditions — all mutable paths dead, or no live
+  immutable observer. There is no runtime transformation; the value is unchanged.
+- Compose with PR 11: a single-owner or component-moved graph freezes in one move,
+  because consuming the one binding kills every mutable path at once.
+
+Tests: `Freeze<Node>` renders as the deep-immutable recursive type; `Thaw<Freeze<Node>>`
+recovers `Node`; a component-owned graph frozen in one move; a write through a
+`Freeze<>` value rejected; the immutable-field over-thaw caveat asserted.
+
+Acceptance: `Freeze`/`Thaw` produce the deep types and are sound through the
+freeze/thaw moves, with no runtime cost.
+
 ---
 
 ## Deferred and out of scope
@@ -600,8 +660,11 @@ Acceptance: mutable narrowing works with the discriminant pinned for the arm.
 - **Cross-package moves.** Move behaviour at the boundary of imported, body-less
   declarations depends on declared lifetimes and is left to the library-import
   work, consistent with the requirements.
-- **Interior-mutability escape hatches.** A `Cell`-like wrapper for cyclic mutable
-  data is tracked separately under #618.
+- **Interior-mutability escape hatches.** Moving a self-contained graph (PR 11) and
+  `Freeze`/`Thaw` (PR 12) cover the cyclic and acyclic cases where the graph owns its
+  own nodes. What stays deferred is the case they do not: a mutable cyclic structure
+  whose nodes are referenced from outside the graph, with no single owner — a
+  `Cell`-like wrapper, tracked separately under #618.
 - **Diagnostic wording.** Each PR ships a working diagnostic; final wording and
   blame spans for use-after-move and move-on-escape are tuned as the engine
   settles.

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -47,8 +47,11 @@ PRs below add these.
 The move-engine work, PRs 1 through 8, builds only on this M4 substrate. The
 type-former PRs, 9 and 10, additionally depend on **M6** of
 [planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md), which lands
-union and intersection formers together with union-scrutinee narrowing. They are
-scheduled after M6, while PRs 1 through 8 can proceed once M4 is in place.
+union and intersection formers together with union-scrutinee narrowing. PR 11, the
+connected-component moves, is a further move-engine extension and stays on M4. PR 12,
+`Freeze`/`Thaw`, additionally depends on **M9**, the mapped and conditional type
+operators. So PRs 1 through 8 and 11 can proceed once M4 is in place, 9 and 10 wait
+on M6, and 12 waits on M9.
 
 ## Parsing borrows without a syntax mode
 

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -125,7 +125,10 @@ phases that never overlap:
 
 but the lifetime of an immutable borrow and the lifetime of a mutable borrow of
 the same value may never overlap. While any mutable borrow is live, no immutable
-borrow of that value may be live, and vice versa. That is exactly what preserves
+borrow of that value may be live, and vice versa. The owner's own write path counts
+as a mutable path here. In the mutable phase the owner may mutate the value alongside
+any number of live `&mut` borrows, and in the immutable phase nothing mutates it
+through the owner or a borrow. That is exactly what preserves
 the soundness invariant: an immutable borrow never coexists with a mutable path,
 so it never observes a mutation. Single-threaded execution is what makes the
 multiple-simultaneous-mutable-borrows case safe — there is no data race to
@@ -415,11 +418,11 @@ cannot separate.
 
 A value may hold borrows to other values — a graph of nodes wired together with
 `&mut` cross-edges, built from locals inside a function. Cyclic or acyclic, such a
-graph has no node that owns the others; the nodes own nothing and reference each
-other, and an external owner is what would normally hold them. The move precondition
-above forbids moving a value while a borrow points into it, so naively returning the
-graph's root would be rejected: its edges borrow sibling nodes that do not outlive
-the function.
+graph has no node that owns the others; each node owns only its own data and
+references the rest, and an external owner is what would normally hold the nodes. The
+move precondition above forbids moving a value while a borrow points into it, so
+naively returning the graph's root would be rejected, because its edges borrow
+sibling nodes that do not outlive the function.
 
 The refinement: when the graph's nodes are reachable **only through the graph
 itself** — no reference to any node exists outside the connected component — the
@@ -467,8 +470,8 @@ connected component.
 The freeze and thaw moves change mutability only at the level of the value moved; a
 nested `&mut` or `mut` field keeps its mutability, because Escalier is shallow by
 default — an immutable type may hold mutable fields. So moving a graph's root into an
-immutable binding does not freeze the graph: the `&mut` cross-edges and `mut` field
-types are part of the node type and stay mutable.
+immutable binding does not freeze the graph, because the `&mut` cross-edges and `mut`
+field types are part of the node type and stay mutable.
 
 To convert a whole structure between mutable and immutable, use the `Freeze<T>` and
 `Thaw<T>` utility types. `Freeze<T>` is a deep, recursive mapped type that rewrites
@@ -538,7 +541,7 @@ that reaches a borrow of an internal node, not only a borrow of the root `g`, wh
 is the alias-set reasoning in "Relationship to the mutability-transition checker."
 
 Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable
-fields: it deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
+fields. It deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
 was fully mutable. And `Freeze<T>` is the deliberate opt-in to deep immutability; the
 default stays shallow, so a type is deeply immutable only where the program asks for
 it with `Freeze`.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -516,6 +516,27 @@ component: `g` is the only binding into the graph, so consuming it leaves no mut
 path. A scattered graph with many owning bindings would instead require all of them
 consumed.
 
+The "only binding" qualifier is load-bearing, and the checker holds the program to
+it by tracking aliases across the freeze. Extracting a borrow of a node before the
+freeze creates a second mutable path into the component, and the freeze is then
+rejected:
+
+```esc
+val g = build()
+val first = g.peers[0]          // first: &mut Node — a live mutable borrow into the component
+val frozen: Freeze<Node> = g    // ERROR: `first` is a live mutable path into the
+                                // component, so "every mutable path dead" fails
+first.value = 5                 // the later use that keeps `first` live across the freeze
+```
+
+The error lands on the freeze rather than on `first.value = 5`. Because `first` is
+live across the freeze, a mutable path into the structure is still outstanding when
+the freeze tries to make it immutable. Nothing dangles, since the garbage collector
+keeps the node alive; the freeze is refused because it would otherwise let `first`
+mutate a value an immutable view now depends on. Catching this needs alias tracking
+that reaches a borrow of an internal node, not only a borrow of the root `g`, which
+is the alias-set reasoning in "Relationship to the mutability-transition checker."
+
 Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable
 fields: it deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
 was fully mutable. And `Freeze<T>` is the deliberate opt-in to deep immutability; the

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -494,9 +494,26 @@ that no conflicting path survives.
 
 This pairs with the connected-component move. When a graph is owned as a single
 component — a returned component, or an arena whose one binding owns every node —
-consuming that binding kills every mutable path at once, so
-`val frozen: Freeze<Graph> = g` freezes the entire graph in one sound move. A
-scattered graph with many owning bindings would instead require all of them
+consuming that binding kills every mutable path at once, so the whole graph freezes
+in one sound move. Take the `build` function from the previous section, whose `Node`
+edges are `&mut` and so leave the returned graph mutable through them:
+
+```esc
+val g = build()                 // g: Node — the moved-out {a, b} component
+g.peers[0].value = 20           // OK — a node is mutated through a `&mut` edge, even
+                                // though g's own slots are immutable; this is the shallow gap
+
+val frozen: Freeze<Node> = g    // deep-freeze the whole component in one move; g consumed
+print(frozen.peers[0].value)    // OK — read
+// frozen.peers[0].value = 5    // ERROR: Freeze<Node> is deeply immutable; the edges are now `&`
+
+val mut h: Thaw<Freeze<Node>> = frozen   // thaw back to a mutable graph; recovers Node; frozen consumed
+h.peers[0].value = 7            // mutation allowed again
+```
+
+The freeze is a single sound move because `build` returned a self-contained
+component: `g` is the only binding into the graph, so consuming it leaves no mutable
+path. A scattered graph with many owning bindings would instead require all of them
 consumed.
 
 Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -411,6 +411,100 @@ checker cannot prove disjoint, such as a dynamic `arr[i]` versus `arr[j]`, falls
 a container-level borrow, the way the whole-object-consume fallback covers field moves it
 cannot separate.
 
+## Moving a graph
+
+A value may hold borrows to other values — a graph of nodes wired together with
+`&mut` cross-edges, built from locals inside a function. Cyclic or acyclic, such a
+graph has no node that owns the others; the nodes own nothing and reference each
+other, and an external owner is what would normally hold them. The move precondition
+above forbids moving a value while a borrow points into it, so naively returning the
+graph's root would be rejected: its edges borrow sibling nodes that do not outlive
+the function.
+
+The refinement: when the graph's nodes are reachable **only through the graph
+itself** — no reference to any node exists outside the connected component — the
+whole component moves as a unit. Returning or storing the root co-moves every node
+in the component, re-anchors the internal borrows to the destination's region, and
+consumes every local binding in the component. A borrow internal to a component that
+moves as a unit is re-anchored, not orphaned. The unit of ownership becomes the
+connected component: the destination owns the whole reachable subgraph, and the
+`&mut` cross-edges are internal to it.
+
+```esc
+type Node = { value: number, peers: Array<&mut Node> }
+
+fn build() -> Node {
+    val mut a: Node = { value: 1, peers: [] }
+    val mut b: Node = { value: 2, peers: [] }
+    a.peers.push(b)            // a borrows b
+    b.peers.push(a)            // b borrows a — a cycle
+    return a                   // the whole {a, b} component moves out; a and b both consumed
+}
+```
+
+This is sound for two reasons. First, the runtime is garbage-collected, so a
+co-moved node stays alive as long as the destination keeps the component reachable;
+there is no dangling, which is the hazard the lifetime check guards against in a
+non-GC setting. Second, with no external reference to any node, every path to every
+node runs through the component, so extending the region to the destination adds no
+new observer — the phase rules keep governing mutation exactly as they did inside
+the function. The mutual internal lifetimes, which cannot nest, unify into the one
+destination region instead of failing.
+
+The precondition is **no external references to the component's nodes**. If any node
+is also reachable from outside the component — a parameter the caller retains, a
+separate binding, a longer-lived store — that outside reference pins the node's
+lifetime and ownership, the component move does not apply, and the ordinary
+borrow-escape error or a phase conflict stands. Acyclicity is not required: the
+mechanism handles trees, DAGs, and cyclic graphs alike, because reclamation is the
+collector's job and the re-anchoring unifies mutual lifetimes into one region. A
+component moves as a whole: a program may return or store the graph, or keep using
+its nodes locally, but not both. This is the single-binding move rule lifted to the
+connected component.
+
+## Freeze and Thaw
+
+The freeze and thaw moves change mutability only at the level of the value moved; a
+nested `&mut` or `mut` field keeps its mutability, because Escalier is shallow by
+default — an immutable type may hold mutable fields. So moving a graph's root into an
+immutable binding does not freeze the graph: the `&mut` cross-edges and `mut` field
+types are part of the node type and stay mutable.
+
+To convert a whole structure between mutable and immutable, use the `Freeze<T>` and
+`Thaw<T>` utility types. `Freeze<T>` is a deep, recursive mapped type that rewrites
+every reachable `&mut` to `&` and every `mut` container to its immutable form;
+`Thaw<T>` is the opposite direction. For the node type above:
+
+```esc
+type Freeze<Node>        // { value: number, peers: Array<&Freeze<Node>> }
+type Thaw<Freeze<Node>>  // { value: number, peers: Array<&mut Node> } — recovers Node
+```
+
+`Freeze<Node>` recurses into the peer references, so a frozen node's edges point at
+frozen nodes; the result is a recursive, self-referential type, resolved by the same
+machinery that resolves `Node`.
+
+The types are purely type-level and carry no runtime cost: the value is unchanged,
+the type is stricter or looser. Soundness comes from the move, not the mapped type.
+Assigning a value into `Freeze<T>` is the mutable-to-immutable freeze move — it
+consumes the source and requires every mutable path to the reachable structure to be
+dead. `Thaw<T>` is the immutable-to-mutable move and requires no live immutable
+observer. The mapped type names the deep target; the move supplies the guarantee
+that no conflicting path survives.
+
+This pairs with the connected-component move. When a graph is owned as a single
+component — a returned component, or an arena whose one binding owns every node —
+consuming that binding kills every mutable path at once, so
+`val frozen: Freeze<Graph> = g` freezes the entire graph in one sound move. A
+scattered graph with many owning bindings would instead require all of them
+consumed.
+
+Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable
+fields: it deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
+was fully mutable. And `Freeze<T>` is the deliberate opt-in to deep immutability; the
+default stays shallow, so a type is deeply immutable only where the program asks for
+it with `Freeze`.
+
 ## Why the invariant holds
 
 Move/affine semantics preserves the soundness invariant by eliminating, at the
@@ -774,9 +868,12 @@ policy choosing it.
 
 - **Linearity / mandatory consumption.** Values need not be consumed; unused
   owned values are dropped. Out of scope.
-- **Interior-mutability escape hatches.** Patterns for cyclic mutable data that
-  outlive a single owner — a `Cell`-like wrapper — are noted in #618 as a separate
-  concern and are not specified here.
+- **Interior-mutability escape hatches.** Moving a self-contained cyclic or acyclic
+  graph is specified above under "Moving a graph," and `Freeze`/`Thaw` convert such a
+  graph between mutable and immutable. What remains out of scope is the case those do
+  not cover: a mutable cyclic structure whose nodes are referenced from outside the
+  graph, with no single owner — a `Cell`-like wrapper, noted in #618 as a separate
+  concern.
 - **Field-granular tracking depth.** Partial moves target field granularity. How
   deep the tracking goes through nested objects and through dynamic index
   expressions is an implementation-precision question for the plan, with the


### PR DESCRIPTION
Follow-up to the move/affine semantics docs landed in #767. Specifies two capabilities that came out of the cyclic/acyclic graph discussion, as a doc-only change to `planning/affine_semantics/`.

## Connected-component moves

A self-contained cyclic or acyclic graph can be moved out of a function — returned or stored — when **no node is referenced from outside the connected component**. The whole component co-moves as a unit: internal `&mut` cross-edges are re-anchored to the destination region (their mutual lifetimes unify there instead of failing to nest), and every local binding in the component is consumed.

It's sound for two reasons: the GC keeps co-moved nodes alive as long as the destination keeps them reachable (no dangling), and with no external reference every path to every node runs through the component, so extending the region adds no new observer and the phase rules are unchanged. Acyclicity is not required — trees, DAGs, and cyclic graphs alike. If any node is externally aliased, the component move doesn't apply and the ordinary borrow-escape error or phase conflict stands.

## `Freeze<T>` / `Thaw<T>`

Deep, recursive mapped types that rewrite the `&mut`/`mut` modifier to convert a whole structure between mutable and immutable, e.g. `Freeze<Node>` is the recursive `{ value: number, peers: Array<&Freeze<Node>> }`. They are purely type-level with **no runtime cost**; soundness comes from the freeze/thaw moves (all mutable paths dead, or no live immutable observer), not from the mapped type. They pair with single-owner / component-moved graphs so the whole graph freezes in one move. Caveats noted: `Thaw` over-thaws genuinely-immutable fields, and `Freeze` is the deliberate opt-in to deep immutability while the default stays shallow.

## Changes

- **requirements.md** — new "Moving a graph" and "Freeze and Thaw" sections; the interior-mutability non-goal narrowed to the genuinely-deferred case (externally-referenced, ownerless mutable cycles → the `Cell` hatch in #618).
- **implementation_plan.md** — **PR 11** (connected-component moves, deps PRs 6/7) and **PR 12** (`Freeze`/`Thaw`, deps PR 8 + PR 11 + the mapped/conditional types in M9); the deferred interior-mutability entry narrowed to match.

Doc-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRtFcbx97cPbvFiq1cn1mK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRtFcbx97cPbvFiq1cn1mK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the planning documentation with a new “moving a graph” requirement, defining when connected-component co-moves are allowed for values containing mutually-referencing owned nodes, including the gating conditions.
  * Added “Freeze” and “Thaw” deep, recursive type utilities to the requirements, clarifying behavior, opt-in semantics, and soundness expectations.
  * Refined the non-goals section by narrowing the deferred interior-mutability escape hatch description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->