### PR TITLE
PR 4: Member reads borrow the receiver at its lifetime

### DIFF
--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -494,6 +494,24 @@ func TestInferMemberReadFlatBorrowOfRefField(t *testing.T) {
 		values["f"])
 }
 
+// A `&mut` field falls through fieldReadBorrow's no-wrap branch, so the read
+// returns the field's mutable borrow at the field's own lifetime rather than
+// nesting under the receiver's. The TypeVar result var coalesces to the
+// concrete field type, and the function returns that `&mut` borrow at the
+// annotation-minted lifetime. Aliasing exclusivity on the surviving mut
+// borrow needs the move-engine work in PR 6, and PR 9 normalizes the
+// otherwise uninhabitable `&mut &mut` shape.
+func TestInferMemberReadOfMutBorrowField(t *testing.T) {
+	src := `fn f(p: {a: &mut {x: number}}) {
+  return p.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: {a: &'a mut {x: number}}) -> &'a mut {x: number}",
+		values["f"])
+}
+
 // A primitive field stays a value, since `PrimType` is not a `RefInner`. The
 // PR 4 wrap is skipped and the read returns the primitive directly. This is
 // the same shape pre-PR-4 returned. Pinning it here guards against the wrap

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -448,12 +448,11 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 
 // --- PR 4: member reads borrow the receiver ---
 
-// A member read whose result reaches the function output carries the receiver's
-// borrow lifetime through. The implicit read on `p.a` for `p: &mut {a: {...}}`
-// yields a borrow of the field at p's lifetime, so the rendered signature
-// names that lifetime on both the param and the return type. This is rule 4
-// of PR 4: the receiver's lifetime passes through to a reference-shaped field
-// read.
+// A member read whose result reaches the function output carries the
+// receiver's borrow lifetime through, the heart of PR 4 rule 4. The implicit
+// read on `p.a` for `p: &mut {a: {...}}` yields a borrow of the field at p's
+// lifetime, so the rendered signature names that lifetime on both the param
+// and the return type.
 func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	src := `fn f(p: &mut {a: {x: number}}) {
   return p.a
@@ -465,11 +464,10 @@ func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 		values["f"])
 }
 
-// A member read consumed locally — not flowing into the function output —
-// leaves the receiver lifetime free, so D4's display-time elision drops it
-// from the rendered signature. `obj.a` reads as a borrow inside the body, but
-// the binding `q` never escapes, so the param's borrow lifetime does not need
-// to be named.
+// A member read consumed inside the body leaves the receiver lifetime free,
+// so D4's display-time elision drops it from the rendered signature. `obj.a`
+// reads as a borrow inside the body, but the binding `q` never escapes, so
+// the param's borrow lifetime does not need to be named.
 func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
 	src := `fn f(p: &mut {a: {x: number}}) {
   val q = p.a
@@ -496,9 +494,9 @@ func TestInferMemberReadFlatBorrowOfRefField(t *testing.T) {
 		values["f"])
 }
 
-// A primitive field stays a value: `PrimType` is not a `RefInner`, so the
+// A primitive field stays a value, since `PrimType` is not a `RefInner`. The
 // PR 4 wrap is skipped and the read returns the primitive directly. This is
-// the same shape pre-PR-4 returned; pinning it here guards against the wrap
+// the same shape pre-PR-4 returned. Pinning it here guards against the wrap
 // firing on non-borrowable fields and tripping the bare<:RefType escape
 // guard when the field flows into a primitive sink.
 func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
@@ -512,7 +510,7 @@ func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
 
 // An explicit `&obj.f` shares the receiver-bounded lifetime of the implicit
 // read. PR 4 routes a `&`-of-MemberExpr through inferBorrowOfMember, which
-// produces a `&` borrow at the receiver lifetime — the same shape the
+// produces a `&` borrow at the receiver lifetime. This matches the shape the
 // implicit read produces, with no extra wrapping. Both the param and the
 // return render at the receiver's named lifetime.
 func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
@@ -529,9 +527,9 @@ func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
 // An explicit `&mut obj.g` mutably borrows the field at the receiver's
 // lifetime when the receiver supports a mutable view. The receiver is an
 // owned-mut object, so the mut requirement lowers via the RefType <: RefType
-// rule. Path-granular tracking — leaving a disjoint sibling such as `obj.a`
-// independently usable — is the partial-moves work in PR 7; this test pins
-// the typing rule only.
+// rule. The partial-moves work in PR 7 adds path-granular tracking that
+// leaves a disjoint sibling such as `obj.a` independently usable. This test
+// pins the typing rule only.
 func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
 	src := `fn f(obj: &mut {a: {x: number}, b: {y: number}}) {
   return &mut obj.b
@@ -558,16 +556,33 @@ func TestInferExplicitMutBorrowOfMemberOnImmutableRejected(t *testing.T) {
 	}, Messages(errs))
 }
 
-// A usage-inferred receiver — an un-annotated param whose shape is inferred
-// from how it is used — keeps its pre-PR-4 read behaviour: the wrap fires
-// only off a concrete ObjectType carrier, so a TypeVar carrier returns the
-// field's result var directly. The param closes to its inferred object
-// shape, and the function returns the field's primitive type rather than a
-// borrow.
+// A usage-inferred receiver keeps its pre-PR-4 read behaviour. A
+// usage-inferred receiver is an un-annotated param whose shape the body's
+// uses determine. The wrap fires only off a concrete ObjectType carrier, so
+// a TypeVar carrier returns the field's result var directly. The param
+// closes to its inferred object shape, and the function returns the field's
+// primitive type rather than a borrow.
 func TestInferMemberReadInferredReceiverUnchanged(t *testing.T) {
 	src := `fn f(p) { return p.x }
 val r = f({x: 5})`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t, "5", values["r"])
+}
+
+// `&mut obj["foo"]` for a reference-shaped field matches the dot form. The
+// constant-string index access is the bracket form of dot access, so the
+// dispatch in inferBorrow routes it through inferBorrowOfMember and lifts
+// the receiver's borrow lifetime onto the mutable result. Without the
+// IndexExpr branch the operand types as an immutable wrap that the outer
+// `&mut` cannot upgrade.
+func TestInferExplicitMutBorrowOfConstIndexAcceptsMutReceiver(t *testing.T) {
+	src := `fn f(obj: &mut {a: {x: number}, b: {y: number}}) {
+  return &mut obj["b"]
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
+		values["f"])
 }

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -445,3 +445,129 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: &number) -> number { return 0 }`)
 	require.Equal(t, []string{"Unsupported: borrow of a non-borrowable type"}, Messages(errs))
 }
+
+// --- PR 4: member reads borrow the receiver ---
+
+// A member read whose result reaches the function output carries the receiver's
+// borrow lifetime through. The implicit read on `p.a` for `p: &mut {a: {...}}`
+// yields a borrow of the field at p's lifetime, so the rendered signature
+// names that lifetime on both the param and the return type. This is rule 4
+// of PR 4: the receiver's lifetime passes through to a reference-shaped field
+// read.
+func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
+	src := `fn f(p: &mut {a: {x: number}}) {
+  return p.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a mut {a: {x: number}}) -> &'a {x: number}",
+		values["f"])
+}
+
+// A member read consumed locally — not flowing into the function output —
+// leaves the receiver lifetime free, so D4's display-time elision drops it
+// from the rendered signature. `obj.a` reads as a borrow inside the body, but
+// the binding `q` never escapes, so the param's borrow lifetime does not need
+// to be named.
+func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
+	src := `fn f(p: &mut {a: {x: number}}) {
+  val q = p.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {a: {x: number}}) -> void", values["f"])
+}
+
+// A field whose static type is itself an immutable borrow reads through as
+// the same borrow rather than nesting under the receiver's lifetime. The
+// flat copy-out keeps reads of `&T` fields from producing `& &T` types,
+// setting up PR 9's nested-borrow normalization. Here `obj.a: &{x: number}`
+// reads back as a `&'a {x: number}` at the field's own annotation-minted
+// lifetime, not a depth-two borrow over the receiver.
+func TestInferMemberReadFlatBorrowOfRefField(t *testing.T) {
+	src := `fn f(obj: {a: &{x: number}}) {
+  return obj.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(obj: {a: &'a {x: number}}) -> &'a {x: number}",
+		values["f"])
+}
+
+// A primitive field stays a value: `PrimType` is not a `RefInner`, so the
+// PR 4 wrap is skipped and the read returns the primitive directly. This is
+// the same shape pre-PR-4 returned; pinning it here guards against the wrap
+// firing on non-borrowable fields and tripping the bare<:RefType escape
+// guard when the field flows into a primitive sink.
+func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
+	src := `fn f(p: &mut {x: number}) {
+  return p.x
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+}
+
+// An explicit `&obj.f` shares the receiver-bounded lifetime of the implicit
+// read. PR 4 routes a `&`-of-MemberExpr through inferBorrowOfMember, which
+// produces a `&` borrow at the receiver lifetime — the same shape the
+// implicit read produces, with no extra wrapping. Both the param and the
+// return render at the receiver's named lifetime.
+func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
+	src := `fn f(obj: &mut {a: {x: number}, b: {y: number}}) {
+  return &obj.b
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a {y: number}",
+		values["f"])
+}
+
+// An explicit `&mut obj.g` mutably borrows the field at the receiver's
+// lifetime when the receiver supports a mutable view. The receiver is an
+// owned-mut object, so the mut requirement lowers via the RefType <: RefType
+// rule. Path-granular tracking — leaving a disjoint sibling such as `obj.a`
+// independently usable — is the partial-moves work in PR 7; this test pins
+// the typing rule only.
+func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
+	src := `fn f(obj: &mut {a: {x: number}, b: {y: number}}) {
+  return &mut obj.b
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
+		values["f"])
+}
+
+// An explicit `&mut obj.f` on an immutable receiver is rejected: the mut
+// requirement lowers to `mut {f: T, ...}`, and an immutable receiver cannot
+// fill the mutable slot. This is the same mutability gate inferMemberAssign
+// imposes for a field write `obj.f = v`, surfacing here at the explicit mut
+// borrow.
+func TestInferExplicitMutBorrowOfMemberOnImmutableRejected(t *testing.T) {
+	src := `fn f(obj: &{a: {x: number}}) {
+  return &mut obj.a
+}`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"cannot constrain immutable object <: mutable object",
+	}, Messages(errs))
+}
+
+// A usage-inferred receiver — an un-annotated param whose shape is inferred
+// from how it is used — keeps its pre-PR-4 read behaviour: the wrap fires
+// only off a concrete ObjectType carrier, so a TypeVar carrier returns the
+// field's result var directly. The param closes to its inferred object
+// shape, and the function returns the field's primitive type rather than a
+// borrow.
+func TestInferMemberReadInferredReceiverUnchanged(t *testing.T) {
+	src := `fn f(p) { return p.x }
+val r = f({x: 5})`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["r"])
+}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -699,27 +699,26 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// both polarities.
 	chk := c.freshAt(lvl)
 	c.recordProv(chk, provNode, MemberAccess)
-	if e.Mut {
-		req := &soltype.RefType{
-			Mut: true,
-			Lt:  c.ctx.freshLifetime(lvl),
-			Inner: &soltype.ObjectType{
-				Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
-				Inexact: true,
-			},
-		}
-		c.constrain(e, recv, req)
-	} else {
-		c.constrain(e, recvCarrier, &soltype.ObjectType{
-			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
-			Inexact: true,
-		})
+	propSelection := soltype.ObjectType{
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
+		Inexact: true,
 	}
-	// The inner of the result borrow prefers a known concrete shape over the
-	// fresh check var. A read-after-write cache hit takes precedence. The
-	// receiver's annotation is the next fallback. The constrained check var
-	// stands in otherwise. A concrete inner makes the borrow render as a
-	// `RefType` rather than letting the co-occurrence pass peel the wrapper.
+	if e.Mut {
+		mutPropSelection := &soltype.RefType{
+			Mut:   true,
+			Lt:    c.ctx.freshLifetime(lvl),
+			Inner: &propSelection,
+		}
+		c.constrain(e, recv, mutPropSelection)
+	} else {
+		c.constrain(e, recvCarrier, &propSelection)
+	}
+	// Choose the inner so the borrow wrapper survives. The co-occurrence pass
+	// peels any borrow whose inner is the bare check var `chk`, so giving the
+	// result a concrete inner is what keeps it rendering as a `RefType`. Pick
+	// the most precise shape available: a read-after-write cache hit first,
+	// then the property type from the receiver's annotation, and `chk` itself
+	// only when neither is known.
 	var inner soltype.RefInner = chk
 	if cachedT != nil {
 		if ri, ok := cachedT.(soltype.RefInner); ok {
@@ -1064,6 +1063,13 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 // The write requirement carries a fresh lifetime (D2): a mut-borrow receiver of
 // any lifetime is accepted (the fresh var imposes no obligation), and an owned
 // receiver satisfies the borrow slot by the RefType rule.
+//
+// A write has no result borrow to construct, so it needs no counterpart to the
+// read path's fieldReadBorrow. That helper builds the value a read yields: a
+// reference-shaped field comes back as a fresh borrow bounded by the receiver.
+// Here the borrow exists only as the `mut` requirement above. The requirement
+// constrains the receiver and is then discarded. The assignment's own value is
+// the plain stored `w` recorded below.
 //
 // When the receiver is a variable, the widened type is recorded in `written` so a
 // later read of the same field returns it (read-after-write; see valueProp). The

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -555,18 +555,37 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // `val q = &p` and `val q = &mut p`. The move side establishes ownership only.
 // Consume and use-after-move enforcement lands in PR 6.
 func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.Type {
-	// PR 4: an explicit borrow of a member path takes the receiver-bounded
-	// lifetime of the implicit read at field granularity. Intercept the
-	// MemberExpr operand so a `&mut obj.f` can express a mutable view, which
-	// the ordinary inferBorrow path would reject as a mutability mismatch
-	// against the immutable wrap PR 4's fieldReadBorrow puts on `obj.f`.
-	if mem, ok := e.Arg.(*ast.MemberExpr); ok && !mem.OptChain && mem.Prop != nil && mem.Prop.Name != "" {
-		return c.inferBorrowOfMember(scope, lvl, e, mem)
+	// PR 4. An explicit borrow of a field path takes the receiver-bounded
+	// lifetime of the implicit read at field granularity. The dispatch covers
+	// both `MemberExpr` and the constant-string `IndexExpr` form, so
+	// `&mut obj["foo"]` behaves the same as `&mut obj.foo`. A `&mut` of a
+	// reference-shaped field has to go through this path. The ordinary borrow
+	// path would reject it as a mutability mismatch against the immutable
+	// wrap PR 4's `fieldReadBorrow` puts on an implicit read.
+	switch arg := e.Arg.(type) {
+	case *ast.MemberExpr:
+		if !arg.OptChain && arg.Prop != nil && arg.Prop.Name != "" {
+			return c.inferBorrowOfMember(scope, lvl, e, arg.Object, arg.Prop.Name, arg.Prop, arg)
+		}
+	case *ast.IndexExpr:
+		if !arg.OptChain {
+			if name, ok := constStringKey(arg.Index); ok {
+				return c.inferBorrowOfMember(scope, lvl, e, arg.Object, name, arg.Index, arg)
+			}
+		}
 	}
 	sub := c.inferExpr(scope, lvl, e.Arg)
-	// Absorb the ErrorType recovery sentinel: the operand already reported its
-	// own diagnostic, so the borrow must not cascade a second one. Record the
-	// sentinel against the BorrowExpr so downstream consumers see a typed node.
+	return c.wrapBorrow(e, lvl, sub)
+}
+
+// wrapBorrow wraps an already-typed operand in a `&` or `&mut` borrow, the
+// shared core of inferBorrow's main path and the namespace fallback in
+// inferBorrowOfMember. The operand's ErrorType recovery sentinel passes
+// through unchanged so a reported diagnostic does not cascade a second one.
+// A primitive, function, or promise reports the non-borrowable diagnostic and
+// builds the wrapper around a fresh inner var, keeping the surrounding
+// expression cascade-safe.
+func (c *checker) wrapBorrow(e *ast.BorrowExpr, lvl int, sub soltype.Type) soltype.Type {
 	if _, ok := sub.(*soltype.ErrorType); ok {
 		c.recordType(e, sub)
 		return sub
@@ -580,12 +599,10 @@ func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.
 		// ObjectType, TupleType, or TypeVarType — all valid borrow inners.
 		inner = s
 	default:
-		// A primitive, function, or promise is not a RefInner and has nothing to
-		// borrow. Report the diagnostic and build the wrapper around a fresh
-		// inner var so the surrounding expression stays cascade-safe. Skip the
-		// constrain step below. Routing `5 <: &T` through bare<:RefType would
-		// raise a second "cannot constrain" diagnostic on top of the single
-		// non-borrowable report.
+		// A primitive, function, or promise is not a RefInner and has nothing
+		// to borrow. Routing `5 <: &T` through bare<:RefType would raise a
+		// second "cannot constrain" diagnostic on top of the single
+		// non-borrowable report, so the constrain step is skipped.
 		c.reportUnsupportedFeature(e, "borrow of a non-borrowable type")
 		inner = c.freshAt(lvl)
 		constrainable = false
@@ -600,28 +617,52 @@ func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.
 	return target
 }
 
-// inferBorrowOfMember types `&obj.f` or `&mut obj.f` (PR 4 rule 4). It reads
-// `obj.f` as a borrow of the field bounded by the receiver, at the requested
-// mutability. An owned receiver mints a fresh lifetime here; a borrowed
-// receiver's lifetime passes through. A `&mut obj.f` requires the receiver to
-// support a mutable view of the field, expressed as a mutable inexact
-// requirement that the RefType <: RefType rule resolves against an owned-mut or
-// `&mut`-borrow receiver. A `&obj.f` reads the field through the ordinary
-// immutable selection. The receiver is inferred ONCE here rather than letting
-// inferExpr re-walk the MemberExpr through the PR 4 wrap in fieldReadBorrow,
-// which would produce an immutable borrow at the receiver lifetime that the
-// outer `&mut` could not upgrade.
+// inferBorrowOfMember types `&obj.f` and `&mut obj.f`, plus the constant-string
+// index form `&obj["foo"]` and `&mut obj["foo"]`, applying PR 4 rule 4. It
+// reads the field as a borrow bounded by the receiver at the requested
+// mutability. An owned receiver mints a fresh lifetime. A borrowed receiver's
+// lifetime passes through. A `&mut` borrow requires the receiver to support a
+// mutable view of the field, expressed as the same mutable inexact requirement
+// inferMemberAssign uses for `obj.f = v`. The receiver is resolved through
+// resolvePath rather than inferExpr so a namespace receiver walks through.
 //
-// Path-granular tracking — locking only the borrowed field while leaving a
-// disjoint sibling such as `obj.g` independently usable — is the partial-moves
-// work in PR 7. PR 4 ships only the typing rule.
-func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, mem *ast.MemberExpr) soltype.Type {
-	recv := c.inferExpr(scope, lvl, mem.Object)
-	// Absorb the ErrorType recovery sentinel from the receiver so the borrow
-	// does not cascade a second diagnostic. The MemberExpr and the BorrowExpr
-	// both adopt the sentinel as their recorded type.
+// A namespace receiver names a namespace value, not a field of a value object.
+// `&Foo.bar` for namespace `Foo` is the form that hits this case. There is no
+// receiver region to bound the borrow's lifetime. The namespace case resolves
+// the member through resolveNamespaceMember and falls through to wrapBorrow on
+// the resolved value, matching the pre-PR-4 path.
+//
+// Path-granular tracking that leaves a disjoint sibling such as `obj.g`
+// independently usable is the partial-moves work in PR 7. PR 4 ships only the
+// typing rule.
+//
+// The arguments name the parts of the field access uniformly across the two
+// shapes the dispatch in inferBorrow accepts. recvExpr is the receiver
+// expression. propName is the field name, taken from a dot identifier or a
+// constant-string index key. provNode is the AST node that owns blame for the
+// fresh check var's provenance, either the `.prop` identifier or the string
+// literal key. accessNode is the whole MemberExpr or IndexExpr, used for the
+// Info record on the inner access shape.
+func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, recvExpr ast.Expr, propName string, provNode ast.Node, accessNode ast.Expr) soltype.Type {
+	obj := c.resolvePath(scope, lvl, recvExpr)
+	if obj.err {
+		recovery := soltype.Type(&soltype.ErrorType{})
+		c.recordType(accessNode, recovery)
+		c.recordType(e, recovery)
+		return recovery
+	}
+	if obj.ns != nil {
+		// `Foo.bar` for a namespace `Foo` names a namespace value, not a field
+		// of a value receiver. resolveNamespaceMember records the resolved
+		// value's type on accessNode and reports an unknown name. The wrap
+		// then runs on the value with no receiver-bounded lifetime.
+		nsResult := c.resolveNamespaceMember(lvl, accessNode, obj.ns, propName)
+		sub := c.demandValue(nsResult, accessNode)
+		return c.wrapBorrow(e, lvl, sub)
+	}
+	recv := obj.value
 	if _, ok := recv.(*soltype.ErrorType); ok {
-		c.recordType(mem, recv)
+		c.recordType(accessNode, recv)
 		c.recordType(e, recv)
 		return recv
 	}
@@ -630,44 +671,62 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		recvLt = r.Lt
 	}
 	recvCarrier := soltype.CarrierOf(recv)
+	// Read-after-write cache. A usage-inferred receiver may carry a recorded
+	// write for this field. Take the cached value as the field's static shape
+	// so the explicit borrow uses the same precise type the implicit read
+	// would. The cache is keyed on a TypeVar receiver, matching the gate
+	// inferMemberAssign uses when it records a write.
+	var cachedT soltype.Type
+	if c.fn != nil {
+		if v, ok := recv.(*soltype.TypeVarType); ok {
+			if t, found := c.fn.written[fieldKey{recvID: v.ID, field: propName}]; found {
+				cachedT = t
+			}
+		}
+	}
 	// The constraint validates that the receiver supports the requested view
-	// of this field — a `&mut` lowers to the mutable inexact requirement
-	// inferMemberAssign uses for `obj.f = v`, a `&` to the ordinary immutable
-	// inexact read requirement. The requirement's fresh field var is consumed
-	// here for the check only; the borrow returned to the caller wires its
-	// Inner to the receiver's static property type when one is known, so the
-	// wrap survives coalescing. Routing the result through the fresh field var
-	// would let the co-occurrence pass widen a bi-polar inner — `mut`
+	// of this field. A `&mut` lowers to the mutable inexact requirement
+	// inferMemberAssign uses for `obj.f = v`. A `&` lowers to the ordinary
+	// immutable inexact read requirement. The requirement's fresh field var
+	// is consumed here for the check only. The borrow returned to the caller
+	// wires its Inner to the receiver's static property type when one is
+	// known, so the wrap survives coalescing.
+	//
+	// Routing the result through the fresh field var would let the
+	// co-occurrence pass widen it into a union node that is not a `RefInner`
+	// and peel the borrow wrapper away. The pass widens because `mut`
 	// constrainWriteBack pins the field invariant, so the same var occurs in
-	// both polarities — into a union node that is not a `RefInner` and peels
-	// the borrow wrapper away.
+	// both polarities.
 	chk := c.freshAt(lvl)
-	c.recordProv(chk, mem.Prop, MemberAccess)
+	c.recordProv(chk, provNode, MemberAccess)
 	if e.Mut {
 		req := &soltype.RefType{
 			Mut: true,
 			Lt:  c.ctx.freshLifetime(lvl),
 			Inner: &soltype.ObjectType{
-				Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: mem.Prop.Name, Type: chk}},
+				Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
 				Inexact: true,
 			},
 		}
 		c.constrain(e, recv, req)
 	} else {
 		c.constrain(e, recvCarrier, &soltype.ObjectType{
-			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: mem.Prop.Name, Type: chk}},
+			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
 			Inexact: true,
 		})
 	}
-	// Inner of the result borrow: prefer the receiver's static property type
-	// so the borrow renders as a concrete `RefType` rather than a co-occurring
-	// var. A receiver without a concrete property type — a usage-inferred
-	// TypeVar carrier or a missing property the constraint above will already
-	// have reported — falls back to the fresh check var, matching the existing
-	// immutable selection's shape.
+	// The inner of the result borrow prefers a known concrete shape over the
+	// fresh check var. A read-after-write cache hit takes precedence. The
+	// receiver's annotation is the next fallback. The constrained check var
+	// stands in otherwise. A concrete inner makes the borrow render as a
+	// `RefType` rather than letting the co-occurrence pass peel the wrapper.
 	var inner soltype.RefInner = chk
-	if obj, ok := recvCarrier.(*soltype.ObjectType); ok {
-		if prop, ok := obj.Prop(mem.Prop.Name); ok {
+	if cachedT != nil {
+		if ri, ok := cachedT.(soltype.RefInner); ok {
+			inner = ri
+		}
+	} else if recvObj, ok := recvCarrier.(*soltype.ObjectType); ok {
+		if prop, ok := recvObj.Prop(propName); ok {
 			if ri, ok := prop.Type.(soltype.RefInner); ok {
 				inner = ri
 			}
@@ -679,7 +738,11 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	}
 	target := &soltype.RefType{Mut: e.Mut, Lt: lt, Inner: inner}
 	c.recordProv(target, e, BorrowExprOrigin)
-	c.recordType(mem, target)
+	// Record on the access node the shape an implicit read would produce.
+	// fieldReadBorrow makes the same wrap decision valueProp uses, so hover
+	// on the inner `obj.f` reads the same whether it stands alone or under
+	// `&obj.f` or `&mut obj.f`.
+	c.recordType(accessNode, c.fieldReadBorrow(chk, recvCarrier, propName, recvLt, lvl))
 	c.recordType(e, target)
 	return target
 }
@@ -1346,11 +1409,11 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
-	// A borrowed receiver passes its lifetime through to the read; an owned
+	// A borrowed receiver passes its lifetime through to the read. An owned
 	// receiver originates a fresh lifetime at the read site. PR 4 rule 4 makes
 	// a member read on a reference-shaped field yield a borrow bounded by the
 	// receiver, rather than the bare field value. Capture the receiver's
-	// lifetime BEFORE peeling the borrow wrapper so the wrap site has it.
+	// lifetime before peeling the borrow wrapper so the wrap site has it.
 	var recvLt soltype.Lifetime
 	if r, ok := recv.(*soltype.RefType); ok {
 		recvLt = r.Lt
@@ -1376,18 +1439,20 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	return pathResult{value: out}
 }
 
-// fieldReadBorrow applies PR 4 rule 4: a member read yields a borrow of the
+// fieldReadBorrow applies PR 4 rule 4. A member read yields a borrow of the
 // field bounded by the receiver when the field is reference-shaped. An owned
-// receiver mints a fresh lifetime here; a borrowed receiver's lifetime passes
-// through via recvLt. The wrap is conditional on the field's static shape, read
-// off a concrete receiver carrier — a primitive or function field stays a
-// value, since PrimType and FuncType are excluded from RefInner. A field whose
-// static type is itself an immutable borrow copies the borrow out flat rather
-// than nesting, setting up PR 9's nested-borrow normalization. When the
-// receiver's shape is not statically known — a usage-inferred TypeVar carrier
-// or an index path with no concrete property — the existing `res` var is
-// returned unchanged, so the inferred-receiver paths keep their pre-PR-4
-// behaviour and only annotated reference shapes pick up the new borrow.
+// receiver mints a fresh lifetime here. A borrowed receiver's lifetime passes
+// through via recvLt. The wrap reads the field's static shape off a concrete
+// receiver carrier. A primitive or function field stays a value, since
+// PrimType and FuncType are excluded from RefInner. A field whose static type
+// is itself an immutable borrow copies the borrow out flat rather than
+// nesting, setting up PR 9's nested-borrow normalization.
+//
+// A receiver whose shape is not statically known returns the existing `res`
+// var unchanged. A usage-inferred TypeVar carrier and an index path with no
+// concrete property both fall into this branch. The inferred-receiver paths
+// keep their pre-PR-4 behaviour, so only annotated reference shapes pick up
+// the new borrow.
 func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.Type, name string, recvLt soltype.Lifetime, lvl int) soltype.Type {
 	obj, ok := recvCarrier.(*soltype.ObjectType)
 	if !ok {
@@ -1403,8 +1468,8 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.
 			// Flat copy-out of an immutable borrow field. Immutable borrows are
 			// freely duplicable, so the read hands back the field's borrow at
 			// its own lifetime rather than nesting under the receiver's. A
-			// `&mut` field falls through to the no-wrap branch — aliasing a
-			// mutable borrow needs the move-engine work in PR 6 — and PR 9
+			// `&mut` field falls through to the no-wrap branch. Aliasing a
+			// mutable borrow needs the move-engine work in PR 6, and PR 9
 			// retires the depth-two `&mut &mut` shape entirely.
 			return ft
 		}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -555,6 +555,14 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // `val q = &p` and `val q = &mut p`. The move side establishes ownership only.
 // Consume and use-after-move enforcement lands in PR 6.
 func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.Type {
+	// PR 4: an explicit borrow of a member path takes the receiver-bounded
+	// lifetime of the implicit read at field granularity. Intercept the
+	// MemberExpr operand so a `&mut obj.f` can express a mutable view, which
+	// the ordinary inferBorrow path would reject as a mutability mismatch
+	// against the immutable wrap PR 4's fieldReadBorrow puts on `obj.f`.
+	if mem, ok := e.Arg.(*ast.MemberExpr); ok && !mem.OptChain && mem.Prop != nil && mem.Prop.Name != "" {
+		return c.inferBorrowOfMember(scope, lvl, e, mem)
+	}
 	sub := c.inferExpr(scope, lvl, e.Arg)
 	// Absorb the ErrorType recovery sentinel: the operand already reported its
 	// own diagnostic, so the borrow must not cascade a second one. Record the
@@ -588,6 +596,90 @@ func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.
 	if constrainable {
 		c.constrain(e, sub, target)
 	}
+	c.recordType(e, target)
+	return target
+}
+
+// inferBorrowOfMember types `&obj.f` or `&mut obj.f` (PR 4 rule 4). It reads
+// `obj.f` as a borrow of the field bounded by the receiver, at the requested
+// mutability. An owned receiver mints a fresh lifetime here; a borrowed
+// receiver's lifetime passes through. A `&mut obj.f` requires the receiver to
+// support a mutable view of the field, expressed as a mutable inexact
+// requirement that the RefType <: RefType rule resolves against an owned-mut or
+// `&mut`-borrow receiver. A `&obj.f` reads the field through the ordinary
+// immutable selection. The receiver is inferred ONCE here rather than letting
+// inferExpr re-walk the MemberExpr through the PR 4 wrap in fieldReadBorrow,
+// which would produce an immutable borrow at the receiver lifetime that the
+// outer `&mut` could not upgrade.
+//
+// Path-granular tracking — locking only the borrowed field while leaving a
+// disjoint sibling such as `obj.g` independently usable — is the partial-moves
+// work in PR 7. PR 4 ships only the typing rule.
+func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, mem *ast.MemberExpr) soltype.Type {
+	recv := c.inferExpr(scope, lvl, mem.Object)
+	// Absorb the ErrorType recovery sentinel from the receiver so the borrow
+	// does not cascade a second diagnostic. The MemberExpr and the BorrowExpr
+	// both adopt the sentinel as their recorded type.
+	if _, ok := recv.(*soltype.ErrorType); ok {
+		c.recordType(mem, recv)
+		c.recordType(e, recv)
+		return recv
+	}
+	var recvLt soltype.Lifetime
+	if r, ok := recv.(*soltype.RefType); ok {
+		recvLt = r.Lt
+	}
+	recvCarrier := soltype.CarrierOf(recv)
+	// The constraint validates that the receiver supports the requested view
+	// of this field — a `&mut` lowers to the mutable inexact requirement
+	// inferMemberAssign uses for `obj.f = v`, a `&` to the ordinary immutable
+	// inexact read requirement. The requirement's fresh field var is consumed
+	// here for the check only; the borrow returned to the caller wires its
+	// Inner to the receiver's static property type when one is known, so the
+	// wrap survives coalescing. Routing the result through the fresh field var
+	// would let the co-occurrence pass widen a bi-polar inner — `mut`
+	// constrainWriteBack pins the field invariant, so the same var occurs in
+	// both polarities — into a union node that is not a `RefInner` and peels
+	// the borrow wrapper away.
+	chk := c.freshAt(lvl)
+	c.recordProv(chk, mem.Prop, MemberAccess)
+	if e.Mut {
+		req := &soltype.RefType{
+			Mut: true,
+			Lt:  c.ctx.freshLifetime(lvl),
+			Inner: &soltype.ObjectType{
+				Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: mem.Prop.Name, Type: chk}},
+				Inexact: true,
+			},
+		}
+		c.constrain(e, recv, req)
+	} else {
+		c.constrain(e, recvCarrier, &soltype.ObjectType{
+			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: mem.Prop.Name, Type: chk}},
+			Inexact: true,
+		})
+	}
+	// Inner of the result borrow: prefer the receiver's static property type
+	// so the borrow renders as a concrete `RefType` rather than a co-occurring
+	// var. A receiver without a concrete property type — a usage-inferred
+	// TypeVar carrier or a missing property the constraint above will already
+	// have reported — falls back to the fresh check var, matching the existing
+	// immutable selection's shape.
+	var inner soltype.RefInner = chk
+	if obj, ok := recvCarrier.(*soltype.ObjectType); ok {
+		if prop, ok := obj.Prop(mem.Prop.Name); ok {
+			if ri, ok := prop.Type.(soltype.RefInner); ok {
+				inner = ri
+			}
+		}
+	}
+	lt := recvLt
+	if lt == nil {
+		lt = c.ctx.freshLifetime(lvl)
+	}
+	target := &soltype.RefType{Mut: e.Mut, Lt: lt, Inner: inner}
+	c.recordProv(target, e, BorrowExprOrigin)
+	c.recordType(mem, target)
 	c.recordType(e, target)
 	return target
 }
@@ -1254,24 +1346,79 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
+	// A borrowed receiver passes its lifetime through to the read; an owned
+	// receiver originates a fresh lifetime at the read site. PR 4 rule 4 makes
+	// a member read on a reference-shaped field yield a borrow bounded by the
+	// receiver, rather than the bare field value. Capture the receiver's
+	// lifetime BEFORE peeling the borrow wrapper so the wrap site has it.
+	var recvLt soltype.Lifetime
+	if r, ok := recv.(*soltype.RefType); ok {
+		recvLt = r.Lt
+	}
 	// Strip the borrow wrapper before building the field-read requirement (D2):
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
 	//     the field's value, not the borrow.
 	//   - It keeps the requirement off the RefType, so the RefType<:bare escape
 	//     guard fires only when the borrow flows into an owned slot, not on a read.
 	//   - A non-borrow receiver is returned unchanged, leaving plain vars untouched.
-	recv = soltype.CarrierOf(recv)
+	recvCarrier := soltype.CarrierOf(recv)
 	res := c.freshAt(lvl)
 	// The member-requirement record {prop: res} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner res var, so the record would be a dead
 	// entry (§3.3).
 	c.recordProv(res, provNode, MemberAccess)
-	c.constrain(blame, recv, &soltype.ObjectType{
+	c.constrain(blame, recvCarrier, &soltype.ObjectType{
 		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: res}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
-	c.recordType(blame, res)
-	return pathResult{value: res}
+	out := c.fieldReadBorrow(res, recvCarrier, name, recvLt, lvl)
+	c.recordType(blame, out)
+	return pathResult{value: out}
+}
+
+// fieldReadBorrow applies PR 4 rule 4: a member read yields a borrow of the
+// field bounded by the receiver when the field is reference-shaped. An owned
+// receiver mints a fresh lifetime here; a borrowed receiver's lifetime passes
+// through via recvLt. The wrap is conditional on the field's static shape, read
+// off a concrete receiver carrier — a primitive or function field stays a
+// value, since PrimType and FuncType are excluded from RefInner. A field whose
+// static type is itself an immutable borrow copies the borrow out flat rather
+// than nesting, setting up PR 9's nested-borrow normalization. When the
+// receiver's shape is not statically known — a usage-inferred TypeVar carrier
+// or an index path with no concrete property — the existing `res` var is
+// returned unchanged, so the inferred-receiver paths keep their pre-PR-4
+// behaviour and only annotated reference shapes pick up the new borrow.
+func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.Type, name string, recvLt soltype.Lifetime, lvl int) soltype.Type {
+	obj, ok := recvCarrier.(*soltype.ObjectType)
+	if !ok {
+		return res
+	}
+	prop, ok := obj.Prop(name)
+	if !ok {
+		return res
+	}
+	switch ft := prop.Type.(type) {
+	case *soltype.RefType:
+		if !ft.Mut {
+			// Flat copy-out of an immutable borrow field. Immutable borrows are
+			// freely duplicable, so the read hands back the field's borrow at
+			// its own lifetime rather than nesting under the receiver's. A
+			// `&mut` field falls through to the no-wrap branch — aliasing a
+			// mutable borrow needs the move-engine work in PR 6 — and PR 9
+			// retires the depth-two `&mut &mut` shape entirely.
+			return ft
+		}
+		return res
+	case *soltype.ObjectType, *soltype.TupleType:
+		_ = ft
+		lt := recvLt
+		if lt == nil {
+			lt = c.ctx.freshLifetime(lvl)
+		}
+		return &soltype.RefType{Mut: false, Lt: lt, Inner: res}
+	default:
+		return res
+	}
 }
 
 // resolveIndexPath resolves `obj[index]`. A namespace object is indexed by a

--- a/internal/solver/infer_namespace_test.go
+++ b/internal/solver/infer_namespace_test.go
@@ -152,3 +152,30 @@ func TestInferValueIndexUnsupported(t *testing.T) {
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported: IndexExpr", c.errs[0].Message())
 }
+
+// `&Foo.bar` where `Foo` is a namespace and `bar` is a borrowable value
+// resolves through the namespace path and borrows the resolved value. The
+// receiver-bounded path in inferBorrowOfMember bails to wrapBorrow when the
+// receiver is a namespace, since a namespace has no value region to bound the
+// borrow's lifetime. Pre-fix this case errored with NamespaceUsedAsValueError
+// because the intercept routed the receiver through inferExpr, which rejects
+// a namespace in value position.
+func TestInferBorrowOfNamespaceMember(t *testing.T) {
+	c := newChecker()
+	scope := NewScope()
+	objT := &soltype.ObjectType{
+		Elems: []soltype.ObjTypeElem{&soltype.PropertyElem{
+			Name: "x",
+			Type: &soltype.PrimType{Prim: soltype.NumPrim},
+		}},
+	}
+	scope.defineNamespace("Foo", &Namespace{
+		Name:   "Foo",
+		Values: map[string]ValueBinding{"bar": {Schemes: []TypeScheme{monoScheme(objT)}}},
+	})
+
+	e := ast.NewBorrow(false, memberExpr(identExpr("Foo"), "bar"), testSpan())
+	got := c.inferExpr(scope, 0, e)
+	require.Empty(t, c.errs)
+	require.Equal(t, "&{x: number}", soltype.Print(got))
+}


### PR DESCRIPTION
Implements PR 4 rule 4, which makes member field reads yield borrows bounded by the receiver's lifetime rather than bare field values. This enables proper lifetime tracking when fields escape through function returns and sets up nested-borrow normalization in PR 9.

**Key changes:**

- Split borrow wrapping into `wrapBorrow` helper so both explicit borrows and member reads can apply the same borrow logic consistently.

- Added `inferBorrowOfMember` to handle explicit `&obj.f` and `&mut obj.f` syntax (including constant-string index form `&obj["foo"]`). Routes through receiver-bounded lifetime logic rather than the generic borrow path. Handles namespace receivers by falling back to `wrapBorrow` on the resolved value.

- Added `fieldReadBorrow` to apply the member-read borrow rule. When a field's static type is reference-shaped, the read yields a borrow at the receiver's lifetime. Immutable borrow fields copy out flat (no nesting) to avoid depth-two `&mut &mut` shapes. Primitive and function fields stay values since they're not `RefInner` types. Usage-inferred receivers (TypeVar carriers) skip the wrap to preserve pre-PR-4 behavior.

- Updated `valueProp` to call `fieldReadBorrow` on implicit member reads, capturing the receiver's lifetime before stripping the borrow wrapper.

- Added comprehensive test coverage for member-read lifetime propagation, explicit borrows of members, mutability constraints on `&mut` member borrows, and the constant-string index form.

The implementation preserves backward compatibility for usage-inferred receivers and correctly handles the interaction between receiver mutability and field access.

https://claude.ai/code/session_01V5nZQQn5U4ppabRWnU9hui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved borrow inference for member access (`obj.field` and `obj["key"]`) when using explicit `&` and `&mut`, with more accurate lifetime propagation.
  * Correct handling for borrowed reference fields (flattening) and clearer lifetime elision when values are only used within the function body.
  * Borrowing namespace members now resolves correctly for `&Namespace.member`.
* **Tests**
  * Added/expanded coverage for member-read borrow lifetimes, explicit `&`/`&mut` acceptance and rejection rules, indexed-member behavior, and namespace-member borrowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->