### PR TITLE
M6 PR1: Add lattice normalization smart constructors

### DIFF
--- a/internal/codegen/builder.go
+++ b/internal/codegen/builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/printer"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -95,7 +96,7 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 	// below, we'll encounter this declaration three times. We track processed
 	// declarations to ensure we only emit the code once, on the first binding key
 	// we encounter.
-	processedDecls := make(map[ast.Decl]bool)
+	processedDecls := set.NewSet[ast.Decl]()
 
 	// Iterate over components in topological order
 	for _, component := range depGraph.Components {
@@ -147,8 +148,8 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 
 			// Build the declaration only once
 			// (VarDecls with pattern destructuring appear under multiple binding keys)
-			if !processedDecls[decl] {
-				processedDecls[decl] = true
+			if !processedDecls.Contains(decl) {
+				processedDecls.Add(decl)
 				stmts = slices.Concat(stmts, b.buildDeclWithNamespace(decl, nsName))
 			}
 
@@ -237,7 +238,7 @@ func (b *Builder) BuildTopLevelDecls(depGraph *dep_graph.DepGraph) *Module {
 // for all namespaces in the dependency graph
 func (b *Builder) buildNamespaceStatements(depGraph *dep_graph.DepGraph) []Stmt {
 	// Track which namespace segments have been defined to avoid redefinition
-	definedNamespaces := make(map[string]bool)
+	definedNamespaces := set.NewSet[string]()
 	var stmts []Stmt
 
 	// For each namespace, generate the hierarchy of statements
@@ -632,7 +633,7 @@ func (b *Builder) BuildScript(mod *ast.Script) *Module {
 
 // buildNamespaceHierarchy generates statements to create a namespace hierarchy
 // For "foo.bar.baz", it generates: const foo = {}; foo.bar = {}; foo.bar.baz = {};
-func (b *Builder) buildNamespaceHierarchy(namespace string, definedNamespaces map[string]bool) []Stmt {
+func (b *Builder) buildNamespaceHierarchy(namespace string, definedNamespaces set.Set[string]) []Stmt {
 	if namespace == "" {
 		return []Stmt{}
 	}
@@ -645,10 +646,10 @@ func (b *Builder) buildNamespaceHierarchy(namespace string, definedNamespaces ma
 		currentNS := strings.Join(parts[:i], ".")
 
 		// Skip if this namespace level has already been defined
-		if definedNamespaces[currentNS] {
+		if definedNamespaces.Contains(currentNS) {
 			continue
 		}
-		definedNamespaces[currentNS] = true
+		definedNamespaces.Add(currentNS)
 
 		if i == 1 {
 			// First level: const foo = {};

--- a/internal/codegen/builder_test.go
+++ b/internal/codegen/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -156,7 +157,7 @@ very.deep.nested.namespace.structure = {};`,
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			builder := &Builder{tempId: 0, depGraph: nil}
-			definedNamespaces := make(map[string]bool)
+			definedNamespaces := set.NewSet[string]()
 			stmts := builder.buildNamespaceHierarchy(test.namespace, definedNamespaces)
 
 			// Use the printer to generate the output
@@ -175,7 +176,7 @@ very.deep.nested.namespace.structure = {};`,
 
 func TestBuildNamespaceHierarchy_AvoidRedefinition(t *testing.T) {
 	builder := &Builder{tempId: 0, depGraph: nil}
-	definedNamespaces := make(map[string]bool)
+	definedNamespaces := set.NewSet[string]()
 
 	// First call should generate all statements
 	stmts1 := builder.buildNamespaceHierarchy("foo.bar.baz", definedNamespaces)

--- a/internal/codegen/dts.go
+++ b/internal/codegen/dts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/set"
 	type_sys "github.com/escalier-lang/escalier/internal/type_system"
 )
 
@@ -43,7 +44,7 @@ func (b *Builder) BuildDefinitions(
 
 	// Track which declarations we've already processed to avoid duplicates
 	// (enums and classes have both type and value bindings pointing to the same decl)
-	processedDecls := make(map[ast.Decl]bool)
+	processedDecls := set.NewSet[ast.Decl]()
 
 	for _, namespace := range namespaceNames {
 		bindingKeys := namespaceGroups[namespace]
@@ -59,10 +60,10 @@ func (b *Builder) BuildDefinitions(
 				// For multiple declarations (overloads, interface merging), process all of them
 				for _, decl := range decls {
 					// Skip if we've already processed this declaration
-					if processedDecls[decl] {
+					if processedDecls.Contains(decl) {
 						continue
 					}
-					processedDecls[decl] = true
+					processedDecls.Add(decl)
 
 					declStmts := b.buildDeclStmt(decl, moduleNS, true)
 					if len(declStmts) != 0 {
@@ -89,10 +90,10 @@ func (b *Builder) BuildDefinitions(
 				// For multiple declarations (overloads, interface merging), process all of them
 				for _, decl := range decls {
 					// Skip if we've already processed this declaration
-					if processedDecls[decl] {
+					if processedDecls.Contains(decl) {
 						continue
 					}
-					processedDecls[decl] = true
+					processedDecls.Add(decl)
 
 					declStmts := b.buildDeclStmt(decl, nestedNS, false)
 					if len(declStmts) != 0 {

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -841,7 +841,7 @@ func (g *DepGraph) FindStronglyConnectedComponents(threshold int) [][]BindingKey
 	stack := make([]BindingKey, 0)
 	indices := make(map[BindingKey]int)
 	lowlinks := make(map[BindingKey]int)
-	onStack := make(map[BindingKey]bool)
+	onStack := set.NewSet[BindingKey]()
 	sccs := make([][]BindingKey, 0)
 
 	var strongConnect func(BindingKey)
@@ -850,7 +850,7 @@ func (g *DepGraph) FindStronglyConnectedComponents(threshold int) [][]BindingKey
 		lowlinks[v] = index
 		index++
 		stack = append(stack, v)
-		onStack[v] = true
+		onStack.Add(v)
 
 		// Consider successors of v
 		deps := g.GetDeps(v)
@@ -863,7 +863,7 @@ func (g *DepGraph) FindStronglyConnectedComponents(threshold int) [][]BindingKey
 				if lowlinks[w] < lowlinks[v] {
 					lowlinks[v] = lowlinks[w]
 				}
-			} else if onStack[w] {
+			} else if onStack.Contains(w) {
 				// Successor w is in stack and hence in the current SCC
 				if indices[w] < lowlinks[v] {
 					lowlinks[v] = indices[w]
@@ -877,7 +877,7 @@ func (g *DepGraph) FindStronglyConnectedComponents(threshold int) [][]BindingKey
 			for {
 				w := stack[len(stack)-1]
 				stack = stack[:len(stack)-1]
-				onStack[w] = false
+				onStack.Remove(w)
 				scc = append(scc, w)
 				if w == v {
 					break

--- a/internal/interop/twin_rewrite.go
+++ b/internal/interop/twin_rewrite.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 )
 
 // rewriteReadonlyTwinRefs walks every TypeAnn slot reachable from the
@@ -33,10 +34,10 @@ func rewriteReadonlyTwinRefs(mod *StandaloneModule, twins []readonlyTwin) {
 		return
 	}
 	readonlyToMutable := make(map[string]string, len(twins))
-	mutableSet := make(map[string]struct{}, len(twins))
+	mutableSet := set.NewSet[string]()
 	for _, t := range twins {
 		readonlyToMutable[t.readonlyName] = t.mutableName
-		mutableSet[t.mutableName] = struct{}{}
+		mutableSet.Add(t.mutableName)
 	}
 	rw := &twinRewriter{readonlyToMutable: readonlyToMutable, mutable: mutableSet}
 	mod.Module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
@@ -49,7 +50,7 @@ func rewriteReadonlyTwinRefs(mod *StandaloneModule, twins []readonlyTwin) {
 
 type twinRewriter struct {
 	readonlyToMutable map[string]string
-	mutable           map[string]struct{}
+	mutable           set.Set[string]
 }
 
 // rewriteDecl dispatches over every Decl variant. The default panics
@@ -184,7 +185,7 @@ func (r *twinRewriter) renameTypeRefInPlace(ref *ast.TypeRefTypeAnn) {
 		id.Name = mutableName
 		return
 	}
-	if _, ok := r.mutable[id.Name]; ok {
+	if r.mutable.Contains(id.Name) {
 		panic(fmt.Sprintf("twinRewriter.renameTypeRefInPlace: mutable twin %q appears in an Extends/Implements slot, which cannot carry a `mut` wrapper — the readonly-twin rewrite assumed no class or interface in the pinned TS lib extends a mutable twin directly", id.Name))
 	}
 }
@@ -208,7 +209,7 @@ func (r *twinRewriter) rewrite(t ast.TypeAnn) ast.TypeAnn {
 			id.Name = mutableName
 			return tt
 		}
-		if _, ok := r.mutable[id.Name]; ok {
+		if r.mutable.Contains(id.Name) {
 			return ast.NewMutableTypeAnn(tt, tt.Span())
 		}
 		return tt

--- a/internal/liveness/alias.go
+++ b/internal/liveness/alias.go
@@ -1,6 +1,10 @@
 package liveness
 
-import "slices"
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
 
 // AliasMutability tracks whether a variable holds a mutable or immutable
 // reference within an alias set.
@@ -206,15 +210,15 @@ func (a *AliasTracker) MergeAliasSets(v1 VarID, v2 VarID) {
 			// Update VarToSets: replace setID with targetID, deduplicating
 			// to avoid accumulating multiple entries for the same set when
 			// a member already belongs to targetID (e.g. from a prior merge).
-			seen := make(map[SetID]bool)
+			seen := set.NewSet[SetID]()
 			newSets := make([]SetID, 0, len(a.VarToSets[member]))
 			for _, sid := range a.VarToSets[member] {
 				id := sid
 				if id == setID {
 					id = targetID
 				}
-				if !seen[id] {
-					seen[id] = true
+				if !seen.Contains(id) {
+					seen.Add(id)
 					newSets = append(newSets, id)
 				}
 			}

--- a/internal/liveness/alias_test.go
+++ b/internal/liveness/alias_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,10 +155,10 @@ func TestMergeAliasSetsNoDuplicateSetIDs(t *testing.T) {
 	// y already belonged to targetID before the merge, so the replacement
 	// of z's setID with targetID must not create a duplicate entry.
 	for v, setIDs := range tracker.VarToSets {
-		seen := make(map[SetID]bool)
+		seen := set.NewSet[SetID]()
 		for _, id := range setIDs {
-			require.False(t, seen[id], "VarToSets[%d] contains duplicate SetID %d", v, id)
-			seen[id] = true
+			require.False(t, seen.Contains(id), "VarToSets[%d] contains duplicate SetID %d", v, id)
+			seen.Add(id)
 		}
 	}
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -398,9 +398,9 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:
-		// M6 PR1: an inexact union renders a trailing `...` entry — `A | B | ...` —
-		// mirroring the inexact tuple/object/function rendering so the flag round-trips
-		// to surface syntax.
+		// An inexact union renders a trailing `...` entry, so a union typed
+		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
+		// object, and function arms render their flag the same way.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
 			parts = append(parts, p.printTypeMinPrec(m, precUnion))

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -348,6 +348,8 @@ func (p *namedPrinter) printType(t Type) string {
 		return "error"
 	case *Void:
 		return "void"
+	case *NullType:
+		return "null"
 	case *TupleType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -398,9 +398,15 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:
-		parts := make([]string, len(t.Types))
-		for i, m := range t.Types {
-			parts[i] = p.printTypeMinPrec(m, precUnion)
+		// M6 PR1: an inexact union renders a trailing `...` entry — `A | B | ...` —
+		// mirroring the inexact tuple/object/function rendering so the flag round-trips
+		// to surface syntax.
+		parts := make([]string, 0, len(t.Types)+1)
+		for _, m := range t.Types {
+			parts = append(parts, p.printTypeMinPrec(m, precUnion))
+		}
+		if t.Inexact {
+			parts = append(parts, "...")
 		}
 		return strings.Join(parts, " | ")
 	case *IntersectionType:

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -122,6 +122,8 @@ func TestPrintRoundTrips(t *testing.T) {
 		// Unions and intersections.
 		{"union pair", &UnionType{Types: []Type{numP(), strP()}}, "number | string"},
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
+		// M6 PR1: an inexact union renders a trailing `...` entry.
+		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 
 		// Promises (M3).

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -124,6 +124,8 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
 		// An inexact union renders a trailing `...` entry.
 		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
+		// NullType renders as `null`. It is a distinct atomic kind from Void.
+		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 
 		// Promises (M3).

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -122,7 +122,7 @@ func TestPrintRoundTrips(t *testing.T) {
 		// Unions and intersections.
 		{"union pair", &UnionType{Types: []Type{numP(), strP()}}, "number | string"},
 		{"union triple", &UnionType{Types: []Type{numP(), strP(), boolP()}}, "number | string | boolean"},
-		// M6 PR1: an inexact union renders a trailing `...` entry.
+		// An inexact union renders a trailing `...` entry.
 		{"inexact union", &UnionType{Types: []Type{numP(), strP()}, Inexact: true}, "number | string | ..."},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -342,15 +342,17 @@ type UnknownType struct{}
 // legal `constrain` inputs (M6 PR2), writable annotations (M6 PR2), and the
 // subjects of a normalization pass (M6 PR1).
 //
-// UnionType.Inexact (M6 PR1) flags whether the union is open. A bare `A | B` is
-// EXACT — its inhabitants are exactly A ∪ B. An `A | B | ...` written with a
-// trailing `...` is INEXACT — at least these, with an unknown-typed tail. The
-// flag is Inexact (not Exact) so the zero value is exact, matching the
-// ObjectType / TupleType / FuncType convention. IntersectionType carries no
-// exactness flag: exactness is a property of the result, not the meet.
+// UnionType.Inexact flags whether the union is open. A bare `A | B` is
+// exact, so its inhabitants are exactly A ∪ B. An `A | B | ...` written with
+// a trailing `...` is inexact: at least these, with an unknown-typed tail.
+// The flag is Inexact rather than Exact so the zero value is exact, matching
+// the ObjectType, TupleType, and FuncType convention. IntersectionType
+// carries no exactness flag, since exactness is a property of the result
+// rather than the meet. The flag and the smart constructors land with M6 PR1.
 type UnionType struct {
-	Types   []Type
-	Inexact bool // M6 PR1: trailing `...` ⇒ true; bare `A | B` ⇒ false (the exact zero value)
+	Types []Type
+	// Inexact tracks the trailing `...` marker. The zero value is exact.
+	Inexact bool
 }
 type IntersectionType struct{ Types []Type }
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -327,6 +327,13 @@ type PromiseType struct{ Inner Type }
 // Void is the result type of a statement block with no value.
 type Void struct{}
 
+// NullType is the type whose only inhabitant is the `null` literal. It
+// mirrors TypeScript's `null` type and sits alongside Void as a distinct
+// atomic kind. The canonical comparator sorts both kinds last so a union
+// such as `T | null | void` consistently renders with the data members
+// first.
+type NullType struct{}
+
 // NeverType (⊥) and UnknownType (⊤) are the bottom/top of the subtype lattice —
 // the coalesced output of an empty-bounds single-polarity variable (positive ⇒
 // never, negative ⇒ unknown). The spike emits these via type_system; M1 carries
@@ -377,6 +384,7 @@ func (*ObjectType) isType()       {}
 func (*RefType) isType()          {}
 func (*PromiseType) isType()      {}
 func (*Void) isType()             {}
+func (*NullType) isType()         {}
 func (*NeverType) isType()        {}
 func (*UnknownType) isType()      {}
 func (*UnionType) isType()        {}
@@ -435,8 +443,8 @@ func LevelOf(t Type) int {
 	case *IntersectionType:
 		return maxMemberLevel(t.Types)
 	default:
-		// PrimType, LitType, Void, NeverType, UnknownType, ErrorType: childless leaves
-		// (ErrorType is a sentinel, level 0).
+		// PrimType, LitType, Void, NullType, NeverType, UnknownType, ErrorType:
+		// childless leaves. ErrorType is a sentinel at level 0.
 		return 0
 	}
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -338,9 +338,20 @@ type UnknownType struct{}
 // single-polarity variables (positive ⇒ union of lowers, negative ⇒ intersection
 // of uppers). The spike emits these via type_system.NewUnionType /
 // NewIntersectionType; M1 carries them natively so coalescing returns
-// soltype.Type in every case. Their *subtyping rules* in constrain are M6 —
-// these nodes appear only as coalesced output in M1, never as constrain inputs.
-type UnionType struct{ Types []Type }
+// soltype.Type in every case. M6 promotes them to first-class lattice members:
+// legal `constrain` inputs (M6 PR2), writable annotations (M6 PR2), and the
+// subjects of a normalization pass (M6 PR1).
+//
+// UnionType.Inexact (M6 PR1) flags whether the union is open. A bare `A | B` is
+// EXACT — its inhabitants are exactly A ∪ B. An `A | B | ...` written with a
+// trailing `...` is INEXACT — at least these, with an unknown-typed tail. The
+// flag is Inexact (not Exact) so the zero value is exact, matching the
+// ObjectType / TupleType / FuncType convention. IntersectionType carries no
+// exactness flag: exactness is a property of the result, not the meet.
+type UnionType struct {
+	Types   []Type
+	Inexact bool // M6 PR1: trailing `...` ⇒ true; bare `A | B` ⇒ false (the exact zero value)
+}
 type IntersectionType struct{ Types []Type }
 
 // ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -193,7 +193,7 @@ func (t *UnionType) Accept(v TypeVisitor, pol Polarity) Type {
 	types, changed := acceptTypes(cur.Types, v, pol)
 	out := cur
 	if changed {
-		out = &UnionType{Types: types}
+		out = &UnionType{Types: types, Inexact: cur.Inexact}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -268,3 +268,33 @@ func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeEle
 	}
 	return out, changed
 }
+
+// HasTypeVar reports whether t contains any TypeVarType in its structure.
+// It drives the shared TypeVisitor so every kind that participates in Accept
+// participates here, with no parallel switch to keep in sync as new kinds land.
+// The visitor sets found on the first TypeVarType it sees and returns
+// SkipChildren so the walk short-circuits.
+func HasTypeVar(t Type) bool {
+	s := &typeVarSeeker{}
+	t.Accept(s, Positive)
+	return s.found
+}
+
+// typeVarSeeker is the read-only TypeVisitor that backs HasTypeVar. It rewrites
+// nothing. EnterType returns SkipChildren once it has seen a TypeVarType so
+// later sibling subtrees are not walked.
+type typeVarSeeker struct{ found bool }
+
+func (s *typeVarSeeker) EnterType(t Type, _ Polarity) EnterResult {
+	if s.found {
+		return EnterResult{SkipChildren: true}
+	}
+	if _, ok := t.(*TypeVarType); ok {
+		s.found = true
+		return EnterResult{SkipChildren: true}
+	}
+	return EnterResult{}
+}
+
+func (s *typeVarSeeker) ExitType(t Type, _ Polarity) Type { return t }
+

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -78,6 +78,7 @@ func (t *TypeVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLe
 func (t *PrimType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 func (t *LitType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *Void) Accept(v TypeVisitor, pol Polarity) Type        { return acceptLeaf(t, v, pol) }
+func (t *NullType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -225,10 +225,10 @@ func TestAcceptObjectPreservesInexact(t *testing.T) {
 	require.Same(t, p1, got.Elems[1], "the unchanged property keeps its *PropertyElem pointer")
 }
 
-// M6 PR1: UnionType.Accept threads the Inexact flag through a rewrite. Without
-// the fix at visitor.go's UnionType arm, every coalesce / extrude / freshenAbove
-// pass would silently drop the flag — load-bearing, not cosmetic, since those
-// passes run on every type the solver touches.
+// UnionType.Accept threads the Inexact flag through a rewrite. Without the
+// fix at visitor.go's UnionType arm, every coalesce, extrude, and
+// freshenAbove pass would silently drop the flag. The fix is load-bearing,
+// not cosmetic: those passes run on every type the solver touches.
 func TestAcceptUnionPreservesInexact(t *testing.T) {
 	a := &TypeVarType{ID: 1}
 	num := &PrimType{Prim: NumPrim}

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -225,6 +225,32 @@ func TestAcceptObjectPreservesInexact(t *testing.T) {
 	require.Same(t, p1, got.Elems[1], "the unchanged property keeps its *PropertyElem pointer")
 }
 
+// M6 PR1: UnionType.Accept threads the Inexact flag through a rewrite. Without
+// the fix at visitor.go's UnionType arm, every coalesce / extrude / freshenAbove
+// pass would silently drop the flag — load-bearing, not cosmetic, since those
+// passes run on every type the solver touches.
+func TestAcceptUnionPreservesInexact(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	u := &UnionType{Types: []Type{a, num}, Inexact: true}
+
+	got := u.Accept(&replaceVar{target: a, repl: str}, Positive).(*UnionType)
+
+	require.NotSame(t, u, got, "a changed member forces a new union")
+	require.True(t, got.Inexact, "the rebuilt union keeps its Inexact marker")
+	require.Same(t, str, got.Types[0], "the changed member took the replacement")
+	require.Same(t, num, got.Types[1], "the unchanged member keeps its pointer")
+}
+
+// An unchanged inexact UnionType keeps its pointer (copy-on-write).
+func TestAcceptUnionIdentityPreservation(t *testing.T) {
+	num := &PrimType{Prim: NumPrim}
+	str := &PrimType{Prim: StrPrim}
+	u := &UnionType{Types: []Type{num, str}, Inexact: true}
+	require.Same(t, u, u.Accept(identityVisitor{}, Positive), "an unchanged UnionType keeps its pointer")
+}
+
 // An unchanged inexact ObjectType keeps its pointer (copy-on-write): a no-op
 // rewrite allocates nothing.
 func TestAcceptObjectIdentityPreservation(t *testing.T) {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -508,6 +508,9 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.Void:
 		_, ok := b.(*soltype.Void)
 		return ok
+	case *soltype.NullType:
+		_, ok := b.(*soltype.NullType)
+		return ok
 	case *soltype.NeverType:
 		_, ok := b.(*soltype.NeverType)
 		return ok

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -297,14 +297,14 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 		parts = foldUsageBounds(parts, open)
 	}
 	// Route through the M6 PR1 smart constructors so the coalesced output is
-	// flattened, deduped, lattice-identity-pruned, and canonically ordered. The
-	// Context is nil here: members are already coalesced and concrete, so the
-	// core normalization is enough — subsumption is reserved for the
-	// Context-bearing mint sites (PR2 resolveTypeAnn, PR6 joinBorrows). The
-	// single-member collapse is handled by the constructor.
+	// flattened, deduped, lattice-identity-pruned, and canonically ordered.
+	// The Context is nil here. Members are already coalesced and concrete, so
+	// the core normalization is enough. Subsumption is reserved for the
+	// Context-bearing mint sites resolveTypeAnn in PR2 and joinBorrows in PR6.
+	// The single-member collapse is handled by the constructor.
 	//
-	// Coalesced unions are EXACT by default — an inferred shape is closed unless
-	// PR4 thread of an inexact source flag says otherwise (M6 plan PR4).
+	// Coalesced unions are exact by default. An inferred shape is closed
+	// unless PR4 threads an inexact source flag through to here.
 	if pol == soltype.Positive {
 		return newUnion(nil, parts, false)
 	}
@@ -446,10 +446,10 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 	sort.Strings(order)
 	elems := make([]soltype.ObjTypeElem, len(order))
 	for i, name := range order {
-		// Route the per-property intersection through newIntersection so a shared
-		// property's type is normalized like every other lattice mint (M6 PR1).
-		// Context is nil — the per-property folded types are already coalesced,
-		// so the core normalization is enough.
+		// Route the per-property intersection through newIntersection so a
+		// shared property's type is normalized like every other lattice mint.
+		// Context is nil because the per-property folded types are already
+		// coalesced, so the core normalization is enough.
 		elems[i] = &soltype.PropertyElem{Name: name, Type: newIntersection(nil, types[name]), Optional: optional[name]}
 	}
 	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
@@ -575,10 +575,11 @@ func equalType(a, b soltype.Type) bool {
 		return ok && a.Mut == b.Mut && ltEqual(a.Lt, b.Lt) && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
-		// Inexact flags must match — an open union never equals a closed one. With
-		// canonical member order imposed at construction (M6 PR1 newUnion), the
-		// positional equalTypeSlice is order-stable, so two unions over the same
-		// member set are now equal whatever order their members were minted in.
+		// Inexact flags must match, since an open union never equals a closed
+		// one. The M6 PR1 newUnion imposes canonical member order at
+		// construction, so the positional equalTypeSlice is order-stable and
+		// two unions over the same member set are now equal whatever order
+		// their members were minted in.
 		return ok && a.Inexact == b.Inexact && equalTypeSlice(a.Types, b.Types)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -296,13 +296,19 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 	if pol == soltype.Negative {
 		parts = foldUsageBounds(parts, open)
 	}
-	if len(parts) == 1 {
-		return parts[0]
-	}
+	// Route through the M6 PR1 smart constructors so the coalesced output is
+	// flattened, deduped, lattice-identity-pruned, and canonically ordered. The
+	// Context is nil here: members are already coalesced and concrete, so the
+	// core normalization is enough — subsumption is reserved for the
+	// Context-bearing mint sites (PR2 resolveTypeAnn, PR6 joinBorrows). The
+	// single-member collapse is handled by the constructor.
+	//
+	// Coalesced unions are EXACT by default — an inferred shape is closed unless
+	// PR4 thread of an inexact source flag says otherwise (M6 plan PR4).
 	if pol == soltype.Positive {
-		return &soltype.UnionType{Types: parts}
+		return newUnion(nil, parts, false)
 	}
-	return &soltype.IntersectionType{Types: parts}
+	return newIntersection(nil, parts)
 }
 
 // foldUsageBounds folds the INEXACT ObjectType parts of an upper-bound list into a
@@ -440,12 +446,11 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 	sort.Strings(order)
 	elems := make([]soltype.ObjTypeElem, len(order))
 	for i, name := range order {
-		ts := types[name]
-		ty := ts[0]
-		if len(ts) > 1 {
-			ty = &soltype.IntersectionType{Types: ts}
-		}
-		elems[i] = &soltype.PropertyElem{Name: name, Type: ty, Optional: optional[name]}
+		// Route the per-property intersection through newIntersection so a shared
+		// property's type is normalized like every other lattice mint (M6 PR1).
+		// Context is nil — the per-property folded types are already coalesced,
+		// so the core normalization is enough.
+		elems[i] = &soltype.PropertyElem{Name: name, Type: newIntersection(nil, types[name]), Optional: optional[name]}
 	}
 	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
 	return &soltype.ObjectType{Elems: elems, Inexact: open}
@@ -570,7 +575,11 @@ func equalType(a, b soltype.Type) bool {
 		return ok && a.Mut == b.Mut && ltEqual(a.Lt, b.Lt) && equalType(a.Inner, b.Inner)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
-		return ok && equalTypeSlice(a.Types, b.Types)
+		// Inexact flags must match — an open union never equals a closed one. With
+		// canonical member order imposed at construction (M6 PR1 newUnion), the
+		// positional equalTypeSlice is order-stable, so two unions over the same
+		// member set are now equal whatever order their members were minted in.
+		return ok && a.Inexact == b.Inexact && equalTypeSlice(a.Types, b.Types)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
 		return ok && equalTypeSlice(a.Types, b.Types)

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -153,9 +153,11 @@ func TestCoalesceNegativeObjectMerge(t *testing.T) {
 			num(),
 		}
 		got := coalesce(p, soltype.Negative)
+		// Members are in canonical order (M6 PR1): PrimType ranks before
+		// ObjectType, so `number & {a: number}`.
 		want := &soltype.IntersectionType{Types: []soltype.Type{
-			exactObj(propElem("a", num())),
 			num(),
+			exactObj(propElem("a", num())),
 		}}
 		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
 	})

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -209,22 +209,32 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.TupleType:
 		if sup, ok := super.(*soltype.TupleType); ok {
-			// Element-wise covariant over the shared prefix. Length tolerance follows
-			// the super's exactness: an exact super (`[A, B]`) fixes its length, while
-			// an inexact super (`[A, ...]`) only requires the sub to be at least as
-			// long — the longer <: shorter case the `...` tail permits. This mirrors
-			// the ObjectType width rule (inexact super = width-tolerant).
+			// Element-wise covariant over the shared prefix. Length tolerance
+			// follows the super's exactness. An exact super such as `[A, B]`
+			// fixes its length. An inexact super such as `[A, ...]` only
+			// requires the sub to be at least as long, the longer <: shorter
+			// case the `...` tail permits. The ObjectType width rule has the
+			// same shape: an inexact super is width-tolerant.
 			if sup.Inexact {
 				if len(sub.Elems) < len(sup.Elems) {
 					return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
 				}
-			} else if len(sub.Elems) != len(sup.Elems) {
-				return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
+			} else {
+				if len(sub.Elems) != len(sup.Elems) {
+					return []SolverError{&TupleLengthMismatchError{Sub: sub, Super: sup}}
+				}
+				// An exact super pins its length. An inexact sub whose
+				// declared elements happen to match is still rejected, since
+				// the open tail could carry extra trailing elements at
+				// runtime. Mirrors the ObjectType InexactIntoExactError rule.
+				if sub.Inexact {
+					return []SolverError{&InexactTupleIntoExactError{Sub: sub, Super: sup}}
+				}
 			}
 			var errs []SolverError
-			// Range over sup.Elems, not sub.Elems: an inexact super (`[A, ...]`) lets
-			// the sub be longer, so sup is the shorter side. This walks the shared
-			// prefix and keeps sup.Elems[i] in bounds.
+			// Range over sup.Elems, not sub.Elems: an inexact super such as
+			// `[A, ...]` lets the sub be longer, so sup is the shorter side.
+			// This walks the shared prefix and keeps sup.Elems[i] in bounds.
 			for i := range sup.Elems {
 				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen)...) // covariant
 			}

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -360,6 +360,22 @@ func TestConstrainTuple(t *testing.T) {
 		require.Empty(t, c.Constrain(t1, t2))
 	})
 
+	// [number, ...] <: [number]: an inexact source carries an open tail of
+	// trailing elements, so it cannot satisfy an exact target whose length
+	// is fixed, even when the declared prefixes match. The error mirrors
+	// the ObjectType InexactIntoExactError.
+	t.Run("inexact into exact rejects", func(t *testing.T) {
+		c := &Context{}
+		t1 := &soltype.TupleType{Elems: []soltype.Type{num()}, Inexact: true}
+		t2 := &soltype.TupleType{Elems: []soltype.Type{num()}}
+		errs := c.Constrain(t1, t2)
+		require.Equal(t, []string{"cannot constrain inexact tuple <: exact tuple"}, Messages(errs))
+		ie, ok := errs[0].(*InexactTupleIntoExactError)
+		require.True(t, ok)
+		require.Same(t, t1, ie.Sub)
+		require.Same(t, t2, ie.Super)
+	})
+
 	// [number] <: [number, string, ...]: too SHORT for the inexact super's declared
 	// prefix is still a length mismatch — inexactness widens only on the long side.
 	t.Run("shorter than inexact prefix rejects", func(t *testing.T) {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -929,7 +929,13 @@ func describe(t soltype.Type) string {
 	case *soltype.ErrorType:
 		return "error"
 	case *soltype.UnionType:
-		return joinDescribe(t.Types, " | ")
+		s := joinDescribe(t.Types, " | ")
+		if t.Inexact {
+			// An inexact union has an open tail. Append the marker so a
+			// diagnostic naming the union matches the printer's surface form.
+			return s + " | ..."
+		}
+		return s
 	case *soltype.IntersectionType:
 		return joinDescribe(t.Types, " & ")
 	case *soltype.TypeVarType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -922,6 +922,8 @@ func describe(t soltype.Type) string {
 		return prefix + describe(t.Inner)
 	case *soltype.Void:
 		return "void"
+	case *soltype.NullType:
+		return "null"
 	case *soltype.NeverType:
 		return "never"
 	case *soltype.UnknownType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -111,6 +111,16 @@ type InexactIntoExactError struct {
 	site       ast.Node     // M2.5: constraint node fallback
 }
 
+// InexactTupleIntoExactError is the tuple twin of InexactIntoExactError. An
+// inexact tuple `[T, ...]` carries an open tail of unknown trailing elements,
+// so it cannot satisfy an exact tuple target `[T]` whose length is fixed,
+// even when the declared element prefixes match.
+type InexactTupleIntoExactError struct {
+	Sub, Super *soltype.TupleType
+	prov       NodeResolver
+	site       ast.Node
+}
+
 // ExtraPropertyError fires on ObjectType <: ObjectType when the super is exact and
 // the sub carries a property the super does not declare — width is rejected against
 // an exact target. One error fires per extra property, carrying its name.
@@ -211,6 +221,7 @@ func (*SpreadNotTupleError) isSolverError()      {}
 func (*InexactTupleSpreadError) isSolverError()  {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
+func (*InexactTupleIntoExactError) isSolverError() {}
 func (*ExtraPropertyError) isSolverError()       {}
 func (*ExtraElementError) isSolverError()        {}
 func (*OptionalPropertyError) isSolverError()    {}
@@ -248,6 +259,11 @@ func (e *MissingPropertyError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *MissingPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Sub) } // the receiver
+
+func (e *InexactTupleIntoExactError) Span() ast.Span {
+	return spanOf(e.prov, e.Sub, e.site)
+}
+func (e *InexactTupleIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *InexactIntoExactError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
@@ -848,6 +864,10 @@ func (e *MissingPropertyError) Message() string {
 
 func (e *InexactIntoExactError) Message() string {
 	return "cannot constrain inexact object <: exact object"
+}
+
+func (e *InexactTupleIntoExactError) Message() string {
+	return "cannot constrain inexact tuple <: exact tuple"
 }
 
 func (e *ExtraPropertyError) Message() string {

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -195,6 +195,8 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *InexactIntoExactError:
 			err.prov, err.site = c.prov, n
+		case *InexactTupleIntoExactError:
+			err.prov, err.site = c.prov, n
 		case *ExtraPropertyError:
 			err.prov, err.site = c.prov, n
 		case *OptionalPropertyError:

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -293,8 +293,8 @@ func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 }
 
 // An if without an else folds in void from the missing alt, so
-// `return if c { 5 }` returns `void | 5`. Void ranks before LitType in M6
-// PR1's canonical order.
+// `return if c { 5 }` returns `5 | void`. Void sorts last in M6 PR1's
+// canonical order, so the data member 5 leads.
 func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {
@@ -302,7 +302,7 @@ func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> void | 5`, values["pick"])
+	require.Equal(t, `fn (c: boolean) -> 5 | void`, values["pick"])
 }
 
 // The if's condition must be boolean; a string condition is rejected.

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -224,9 +224,9 @@ func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// The two return points coalesce into a union; the renderer orders by
-	// first-occurrence in the join var's lower-bound list (declaration order).
-	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["h"])
+	// The two return points coalesce into a union, canonicalized to print-string
+	// order by M6 PR1's newUnion: `"x"` sorts before `1` within the LitType kind.
+	require.Equal(t, `fn (c: boolean) -> "x" | 1`, values["h"])
 }
 
 // An early return inside one branch plus a fall-through return: both return
@@ -262,7 +262,7 @@ func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
 }
 
 // `async fn` joined with multiple returns wraps the join in Promise<…>. The
-// external return is Promise<1 | "x">.
+// external return is Promise<"x" | 1> (members in canonical order, M6 PR1).
 func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn f(c: boolean) {
@@ -271,7 +271,7 @@ func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> Promise<1 | "x">`, values["f"])
+	require.Equal(t, `fn (c: boolean) -> Promise<"x" | 1>`, values["f"])
 }
 
 // --- IfElseExpr value ---
@@ -287,11 +287,11 @@ func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["pick"])
+	require.Equal(t, `fn (c: boolean) -> "x" | 1`, values["pick"])
 }
 
 // An if WITHOUT else folds in void from the missing alt — `return if c { 5 }`
-// returns `5 | void`.
+// returns `void | 5` (Void ranks before LitType in canonical order, M6 PR1).
 func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {
@@ -299,7 +299,7 @@ func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> 5 | void`, values["pick"])
+	require.Equal(t, `fn (c: boolean) -> void | 5`, values["pick"])
 }
 
 // The if's condition must be boolean; a string condition is rejected.

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -224,9 +224,10 @@ func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// The two return points coalesce into a union, canonicalized to print-string
-	// order by M6 PR1's newUnion: `"x"` sorts before `1` within the LitType kind.
-	require.Equal(t, `fn (c: boolean) -> "x" | 1`, values["h"])
+	// The two return points coalesce into a union, canonicalized by M6 PR1's
+	// newUnion. NumLit sorts before StrLit within the LitType kind, so 1
+	// comes before "x".
+	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["h"])
 }
 
 // An early return inside one branch plus a fall-through return: both return
@@ -261,8 +262,9 @@ func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
 	require.Contains(t, errs[0].Message(), "number")
 }
 
-// `async fn` joined with multiple returns wraps the join in Promise<…>. The
-// external return is Promise<"x" | 1> (members in canonical order, M6 PR1).
+// An `async fn` joined with multiple returns wraps the join in Promise. The
+// external return is Promise<1 | "x">. Members are in canonical order under
+// M6 PR1.
 func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn f(c: boolean) {
@@ -271,7 +273,7 @@ func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> Promise<"x" | 1>`, values["f"])
+	require.Equal(t, `fn (c: boolean) -> Promise<1 | "x">`, values["f"])
 }
 
 // --- IfElseExpr value ---
@@ -287,11 +289,12 @@ func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, `fn (c: boolean) -> "x" | 1`, values["pick"])
+	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["pick"])
 }
 
-// An if WITHOUT else folds in void from the missing alt — `return if c { 5 }`
-// returns `void | 5` (Void ranks before LitType in canonical order, M6 PR1).
+// An if without an else folds in void from the missing alt, so
+// `return if c { 5 }` returns `void | 5`. Void ranks before LitType in M6
+// PR1's canonical order.
 func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1002,6 +1002,12 @@ func (c *checker) constrainAssign(n ast.Node, source, target soltype.Type) {
 			return
 		}
 	}
+	if union.Inexact {
+		// An inexact union target has an open tail of unknown type, so a
+		// value that does not match any named member still satisfies the
+		// tail. Skip the failure report. The tail accepts everything.
+		return
+	}
 	// No member matched: report once against the whole union (CannotConstrainError),
 	// blaming the assignment.
 	c.constrain(n, source, target)

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -89,7 +89,7 @@ func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
 func TestInferMemberAssignWriteAfterRead(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.x\n obj.x = 5\n return x }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
+	require.Equal(t, "fn <T0>(obj: mut {x: number & T0}) -> T0", values["foo"])
 }
 
 // A write through a nested receiver wraps only the INNER object in `mut`: `obj` is
@@ -116,7 +116,7 @@ func TestInferMemberAssignOpenParam(t *testing.T) {
 func TestInferMemberAssignWrittenObjectEscapes(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(obj: mut {x: number} & T0) -> T0", values["foo"])
+	require.Equal(t, "fn <T0>(obj: T0 & mut {x: number}) -> T0", values["foo"])
 }
 
 // Writing a parameter's value into a field LINKS their types (#737). The write

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -89,7 +89,7 @@ func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
 func TestInferMemberAssignWriteAfterRead(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.x\n obj.x = 5\n return x }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(obj: mut {x: number & T0}) -> T0", values["foo"])
+	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
 }
 
 // A write through a nested receiver wraps only the INNER object in `mut`: `obj` is

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -276,7 +276,7 @@ func TestInferMatchParamUsageObject(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(p: {x: T0, y: unknown}) -> T0 | 0", values["f"])
+	require.Equal(t, "fn <T0>(p: {x: T0, y: unknown}) -> 0 | T0", values["f"])
 }
 
 // The same usage inference applies through a tuple pattern: the scrutinee infers a
@@ -437,7 +437,7 @@ func TestInferMatchNestedRightLiteralOK(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: {x: number}) -> 1 | 0", values["f"])
+	require.Equal(t, "fn (p: {x: number}) -> 0 | 1", values["f"])
 }
 
 // A name a match arm binds is local to that arm. Referencing it in the arm body

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -276,7 +276,7 @@ func TestInferMatchParamUsageObject(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <T0>(p: {x: T0, y: unknown}) -> 0 | T0", values["f"])
+	require.Equal(t, "fn <T0>(p: {x: T0, y: unknown}) -> T0 | 0", values["f"])
 }
 
 // The same usage inference applies through a tuple pattern: the scrutinee infers a

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -258,25 +258,31 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	for i, p := range parts {
 		hasVar[i] = soltype.HasTypeVar(p)
 	}
-	keep := make([]bool, len(parts))
-	for i := range keep {
-		keep[i] = true
-	}
+	dropped := set.NewSet[int]()
 	for i, a := range parts {
-		if !keep[i] || hasVar[i] {
+		if dropped.Contains(i) || hasVar[i] {
 			continue
 		}
 		for j, b := range parts {
-			if i == j || !keep[j] || hasVar[j] {
+			if i == j || dropped.Contains(j) || hasVar[j] {
 				continue
 			}
 			if drops(c, a, b) {
-				keep[i] = false
+				dropped.Add(i)
 				break
 			}
 		}
 	}
-	return compactKept(parts, keep)
+	if dropped.Len() == 0 {
+		return parts
+	}
+	out := make([]soltype.Type, 0, len(parts)-dropped.Len())
+	for i, p := range parts {
+		if !dropped.Contains(i) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // unionDrops returns true when union member m should be dropped because the
@@ -291,23 +297,6 @@ func unionDrops(c *Context, m, sibling soltype.Type) bool {
 // one to discard.
 func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 	return subtypeUnderProbe(c, sibling, m)
-}
-
-// compactKept returns the elements of parts whose keep flag is set, reusing
-// parts when every entry is kept.
-func compactKept(parts []soltype.Type, keep []bool) []soltype.Type {
-	for _, k := range keep {
-		if !k {
-			out := make([]soltype.Type, 0, len(parts))
-			for i, p := range parts {
-				if keep[i] {
-					out = append(out, p)
-				}
-			}
-			return out
-		}
-	}
-	return parts
 }
 
 // subtypeUnderProbe trials sub <: super under a discard-only probe and

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -567,10 +567,12 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 }
 
 // typeKindOrder ranks a soltype concrete kind for compareType. The lattice
-// bounds and the error sentinel come first, then the structural kinds, then
-// the lattice forms, and finally NullType and Void so a union renders its
-// data members before its absence markers. NullType precedes Void by
-// convention, so `T | null | void` is the canonical render.
+// bounds and the error sentinel come first, then TypeVarType so quantified
+// parameters lead in a rendered union, then primitives and literals, then
+// the remaining structural kinds, then the lattice forms, and finally
+// NullType and Void. A union renders its parameters and data members
+// before its absence markers. NullType precedes Void by convention, so
+// `T0 | number | null | void` is the canonical render.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:
@@ -579,11 +581,11 @@ func typeKindOrder(t soltype.Type) int {
 		return 1
 	case *soltype.ErrorType:
 		return 2
-	case *soltype.PrimType:
-		return 3
-	case *soltype.LitType:
-		return 4
 	case *soltype.TypeVarType:
+		return 3
+	case *soltype.PrimType:
+		return 4
+	case *soltype.LitType:
 		return 5
 	case *soltype.RefType:
 		return 6

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -1,0 +1,366 @@
+package solver
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// newUnion / newIntersection are the M6 PR1 smart constructors — the SINGLE
+// mint path for UnionType and IntersectionType. They run the normalization the
+// M6 plan enumerates in one pass, so every later milestone that mints a lattice
+// node — combine's coalesced output, mergeObjectGroup's shared-property meet,
+// PR2's annotation input, PR6's permissive borrow join — produces well-formed,
+// canonical, deduplicated lattice nodes without re-spelling the rules.
+//
+// The normalization splits into a Context-free CORE — flatten, lattice
+// identities, ErrorType elision, dedup, canonical order, collapse — and a
+// Context-gated subsumed-member elimination step. The core is what every mint
+// site needs; subsumption runs ONLY when a Context is supplied, because the
+// subtype test it relies on calls c.constrain under a probe. combine and
+// mergeObjectGroup pass a nil Context (their members are already coalesced, so
+// dedup + identities tighten them enough). resolveTypeAnn (PR2) and
+// joinBorrows (PR6) pass their checker's Context so an annotation or borrow
+// union is fully subsumed.
+//
+// Canonical member order is imposed at construction so equalType stays
+// positional and cheap: two unions over the same member set hold them in the
+// same order, so the existing equalTypeSlice already returns true. The order
+// is also what lets rendering be deterministic (string | number and number |
+// string render identically), and what makes a canonicalized type usable as a
+// stable key for caching.
+func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
+	// 1. Flatten nested same-kind members and detect tail-inexactness: a nested
+	//    UnionType is spliced in, and an inexact member contributes to the
+	//    result's inexactness (an inexact tail anywhere makes the whole union
+	//    inexact).
+	flat := make([]soltype.Type, 0, len(parts))
+	for _, p := range parts {
+		if u, ok := p.(*soltype.UnionType); ok {
+			flat = append(flat, u.Types...)
+			if u.Inexact {
+				inexact = true
+			}
+			continue
+		}
+		flat = append(flat, p)
+	}
+
+	// 2. Lattice identity drop: never (⊥) is the identity of |, so drop it.
+	// 3. ErrorType elision: drop ErrorType (the join identity / absorbing sentinel)
+	//    unless it ends up the sole survivor below.
+	pruned := make([]soltype.Type, 0, len(flat))
+	hadError := false
+	for _, p := range flat {
+		if _, isNever := p.(*soltype.NeverType); isNever {
+			continue
+		}
+		if _, isError := p.(*soltype.ErrorType); isError {
+			hadError = true
+			continue
+		}
+		pruned = append(pruned, p)
+	}
+
+	// 4. Structural dedup via equalType — order-preserving.
+	pruned = dedup(pruned)
+
+	// 5. Subsumed-member elimination (Context-gated, optional). Drop a member
+	//    that is a subtype of another member, since the wider one already
+	//    covers it. Concrete-gated: skip when either side carries a free type
+	//    variable, to avoid speculatively pinning a var mid-walk.
+	if c != nil {
+		pruned = subsumeUnionMembers(c, pruned)
+	}
+
+	// 6. Canonical order, so member order is construction-order-independent.
+	sortTypes(pruned)
+
+	// 7. Collapse.
+	if len(pruned) == 0 {
+		if hadError {
+			return &soltype.ErrorType{}
+		}
+		// Empty union ⇒ never (⊥, the identity of |). An inexact-but-empty union
+		// is still ⊥; the inexactness flag has no carrier without members. If a
+		// future caller needs an "inexact never" — i.e. a tail of unknown alone —
+		// it can express that as unknown explicitly.
+		return &soltype.NeverType{}
+	}
+	if len(pruned) == 1 && !inexact {
+		// A single exact-union member collapses to that member. An inexact
+		// single-member union keeps its wrapper, since the `... | T` tail makes
+		// it strictly weaker than the bare T.
+		return pruned[0]
+	}
+	return &soltype.UnionType{Types: pruned, Inexact: inexact}
+}
+
+// newIntersection is the meet twin of newUnion. An IntersectionType carries no
+// exactness flag (M6 plan: "intersection has no exact/inexact variant —
+// exactness is a property of its result, not the meet"), so the API is one
+// argument shorter.
+func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
+	// 1. Flatten nested intersections.
+	flat := make([]soltype.Type, 0, len(parts))
+	for _, p := range parts {
+		if i, ok := p.(*soltype.IntersectionType); ok {
+			flat = append(flat, i.Types...)
+			continue
+		}
+		flat = append(flat, p)
+	}
+
+	// 2. Lattice identity drop: unknown (⊤) is the identity of &, so drop it.
+	// 3. ErrorType elision: drop ErrorType unless it ends up the sole survivor.
+	pruned := make([]soltype.Type, 0, len(flat))
+	hadError := false
+	for _, p := range flat {
+		if _, isUnknown := p.(*soltype.UnknownType); isUnknown {
+			continue
+		}
+		if _, isError := p.(*soltype.ErrorType); isError {
+			hadError = true
+			continue
+		}
+		pruned = append(pruned, p)
+	}
+
+	// 4. Structural dedup.
+	pruned = dedup(pruned)
+
+	// 5. Subsumed-member elimination, Context-gated. Drop an intersection
+	//    member that is a SUPERTYPE of another, since the more specific
+	//    sibling already implies it.
+	if c != nil {
+		pruned = subsumeIntersectionMembers(c, pruned)
+	}
+
+	// 6. Canonical order.
+	sortTypes(pruned)
+
+	// 7. Collapse.
+	if len(pruned) == 0 {
+		if hadError {
+			return &soltype.ErrorType{}
+		}
+		// Empty intersection ⇒ unknown (⊤, the identity of &).
+		return &soltype.UnknownType{}
+	}
+	if len(pruned) == 1 {
+		return pruned[0]
+	}
+	return &soltype.IntersectionType{Types: pruned}
+}
+
+// subsumeUnionMembers drops a union member that is a subtype of another member.
+// Concrete-gated: a member that still carries a free type variable is left
+// alone, since trialling subtype against an inference variable would
+// speculatively pin it.
+//
+// The check uses a discard-only probe so a successful trial leaves no bound
+// mutation behind. With c.constrain returning the trial's errors directly
+// rather than routing through c.errs, the probe just needs to roll back bound
+// appends — newProbe + Discard is enough.
+func subsumeUnionMembers(c *Context, parts []soltype.Type) []soltype.Type {
+	if len(parts) < 2 {
+		return parts
+	}
+	keep := make([]bool, len(parts))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i, a := range parts {
+		if !keep[i] || hasTypeVar(a) {
+			continue
+		}
+		for j, b := range parts {
+			if i == j || !keep[j] || hasTypeVar(b) {
+				continue
+			}
+			// a is subsumed if a <: b for some other kept member b.
+			if subtypeUnderProbe(c, a, b) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+	return filterKept(parts, keep)
+}
+
+// subsumeIntersectionMembers drops an intersection member that is a supertype
+// of another. The dropped member is the wider one — the narrower sibling
+// already constrains the value below it. Symmetric to subsumeUnionMembers.
+func subsumeIntersectionMembers(c *Context, parts []soltype.Type) []soltype.Type {
+	if len(parts) < 2 {
+		return parts
+	}
+	keep := make([]bool, len(parts))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i, a := range parts {
+		if !keep[i] || hasTypeVar(a) {
+			continue
+		}
+		for j, b := range parts {
+			if i == j || !keep[j] || hasTypeVar(b) {
+				continue
+			}
+			// a is subsumed if b <: a for some other kept member b (a is the wider).
+			if subtypeUnderProbe(c, b, a) {
+				keep[i] = false
+				break
+			}
+		}
+	}
+	return filterKept(parts, keep)
+}
+
+func filterKept(parts []soltype.Type, keep []bool) []soltype.Type {
+	out := make([]soltype.Type, 0, len(parts))
+	for i, p := range parts {
+		if keep[i] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// subtypeUnderProbe trials sub <: super under a discard-only probe and reports
+// whether the trial succeeded. A successful trial means subsumption holds; the
+// probe is always Discarded so the bound mutations it would otherwise leave
+// behind never become visible. Used by the M6 PR1 subsumption pass.
+func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
+	p := newProbe(c.probe)
+	c.probe = p
+	errs := c.constrain(sub, super, set.NewSet[constraintKey]())
+	c.probe = p.parent
+	p.Discard()
+	return len(errs) == 0
+}
+
+// hasTypeVar reports whether t contains any TypeVarType, anywhere in its
+// structure. Subsumption checks gate on this: a member with a free var would
+// trial constrain against an unresolved variable and could pin it
+// speculatively, which is the failure mode the M6 plan calls out.
+func hasTypeVar(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.TypeVarType:
+		return true
+	case *soltype.FuncType:
+		for _, p := range t.Params {
+			if hasTypeVar(p.Type) {
+				return true
+			}
+		}
+		return hasTypeVar(t.Ret)
+	case *soltype.TupleType:
+		for _, e := range t.Elems {
+			if hasTypeVar(e) {
+				return true
+			}
+		}
+		return false
+	case *soltype.ObjectType:
+		for _, e := range t.Elems {
+			if hasTypeVar(soltype.AsProperty(e).Type) {
+				return true
+			}
+		}
+		return false
+	case *soltype.PromiseType:
+		return hasTypeVar(t.Inner)
+	case *soltype.RefType:
+		return hasTypeVar(t.Inner)
+	case *soltype.UnionType:
+		for _, m := range t.Types {
+			if hasTypeVar(m) {
+				return true
+			}
+		}
+		return false
+	case *soltype.IntersectionType:
+		for _, m := range t.Types {
+			if hasTypeVar(m) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// sortTypes orders parts in place under compareType. Stable so that members
+// already in canonical order across passes keep their pointer order, which
+// keeps the rebuild identity-preserving when possible.
+func sortTypes(parts []soltype.Type) {
+	sort.SliceStable(parts, func(i, j int) bool {
+		return compareType(parts[i], parts[j]) < 0
+	})
+}
+
+// compareType is the deterministic total order canonical member order is built
+// on. It is consistent with equalType: two equalType-equal types compare equal.
+// The ordering ranks by a concrete-kind tag first, then tie-breaks by the
+// rendered Print string within a kind. The string fallback is a pragmatic
+// choice — the M6 plan flags it as such — and couples the canonical order to
+// the printer, but it bottoms out deterministically and produces a stable order
+// for every shape M1–M4 mints.
+func compareType(a, b soltype.Type) int {
+	if equalType(a, b) {
+		return 0
+	}
+	ka, kb := typeKindOrder(a), typeKindOrder(b)
+	if ka != kb {
+		if ka < kb {
+			return -1
+		}
+		return 1
+	}
+	// Same kind, structurally distinct: fall back to the printer for a stable
+	// total order. Two equalType-equal types are already filtered above.
+	return strings.Compare(soltype.Print(a), soltype.Print(b))
+}
+
+// typeKindOrder ranks a soltype concrete kind for compareType. Lattice atoms
+// come first (never, unknown, error, void), then primitives and literals, then
+// the structural kinds, and the lattice forms (UnionType / IntersectionType)
+// last so a nested lattice node always sorts after its concrete siblings —
+// useful while M6 still allows residual lattice nodes after dedup but before
+// flatten finishes (it shouldn't, but the order keeps the result legible).
+func typeKindOrder(t soltype.Type) int {
+	switch t.(type) {
+	case *soltype.NeverType:
+		return 0
+	case *soltype.UnknownType:
+		return 1
+	case *soltype.ErrorType:
+		return 2
+	case *soltype.Void:
+		return 3
+	case *soltype.PrimType:
+		return 4
+	case *soltype.LitType:
+		return 5
+	case *soltype.TypeVarType:
+		return 6
+	case *soltype.RefType:
+		return 7
+	case *soltype.TupleType:
+		return 8
+	case *soltype.ObjectType:
+		return 9
+	case *soltype.PromiseType:
+		return 10
+	case *soltype.FuncType:
+		return 11
+	case *soltype.UnionType:
+		return 12
+	case *soltype.IntersectionType:
+		return 13
+	}
+	return 14
+}

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -53,41 +53,66 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 }
 
 // flattenUnion splices nested UnionType members into the outer member list
-// and carries an inner inexact flag out to the caller. An inexact nested
-// member makes the outer union inexact, since `... | (A | ...)` collapses to
-// `A | ...`. When no member nests, the input slice is reused, so the common
-// case pays no allocation.
+// and carries an inner inexact flag out to the caller. The splice is
+// recursive, so a UnionType whose members include another UnionType is fully
+// unwrapped in one pass. An inexact nested member at any depth makes the
+// outer union inexact, since `... | (A | ...)` collapses to `A | ...`. When
+// no member nests, the input slice is reused, so the common case pays no
+// allocation.
+//
+// Recursion matters when a caller hands flatten an unnormalized member, such
+// as a raw `&UnionType{Types: [...]}` constructed in a test or rebuilt by a
+// visitor that bypasses newUnion. The smart constructor's own output is
+// always flat, so a chain of normal newUnion calls would never trigger the
+// recursive case, but the recursion keeps the flatness invariant true for
+// every input.
 func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
 	if !anyUnion(parts) {
 		return parts, inexact
 	}
 	flat := make([]soltype.Type, 0, len(parts))
-	for _, p := range parts {
-		if u, ok := p.(*soltype.UnionType); ok {
-			flat = append(flat, u.Types...)
-			if u.Inexact {
-				inexact = true
-			}
-			continue
+	var splice func(p soltype.Type)
+	splice = func(p soltype.Type) {
+		u, ok := p.(*soltype.UnionType)
+		if !ok {
+			flat = append(flat, p)
+			return
 		}
-		flat = append(flat, p)
+		if u.Inexact {
+			inexact = true
+		}
+		for _, m := range u.Types {
+			splice(m)
+		}
+	}
+	for _, p := range parts {
+		splice(p)
 	}
 	return flat, inexact
 }
 
-// flattenIntersection is the meet twin of flattenUnion. There is no exactness
-// flag to carry.
+// flattenIntersection is the meet twin of flattenUnion. The splice is
+// recursive for the same reason: a raw or visitor-rebuilt IntersectionType
+// whose members include another IntersectionType is fully unwrapped in one
+// pass. There is no exactness flag to carry.
 func flattenIntersection(parts []soltype.Type) []soltype.Type {
 	if !anyIntersection(parts) {
 		return parts
 	}
 	flat := make([]soltype.Type, 0, len(parts))
-	for _, p := range parts {
-		if i, ok := p.(*soltype.IntersectionType); ok {
-			flat = append(flat, i.Types...)
-			continue
+	var splice func(p soltype.Type)
+	splice = func(p soltype.Type) {
+		i, ok := p.(*soltype.IntersectionType)
+		if !ok {
+			flat = append(flat, p)
+			return
 		}
-		flat = append(flat, p)
+		for _, m := range i.Types {
+			splice(m)
+		}
+	}
+	for _, p := range parts {
+		splice(p)
 	}
 	return flat
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -2,40 +2,65 @@ package solver
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// newUnion / newIntersection are the M6 PR1 smart constructors — the SINGLE
-// mint path for UnionType and IntersectionType. They run the normalization the
-// M6 plan enumerates in one pass, so every later milestone that mints a lattice
-// node — combine's coalesced output, mergeObjectGroup's shared-property meet,
-// PR2's annotation input, PR6's permissive borrow join — produces well-formed,
-// canonical, deduplicated lattice nodes without re-spelling the rules.
+// newUnion and newIntersection are the M6 PR1 smart constructors. They are
+// the single mint path for UnionType and IntersectionType. Every site that
+// builds a lattice node routes through them, so coalesced output, the
+// shared-property meet in mergeObjectGroup, PR2's annotation input, and PR6's
+// permissive borrow join all produce well-formed, canonical, deduplicated
+// lattice nodes without re-spelling the rules.
 //
-// The normalization splits into a Context-free CORE — flatten, lattice
-// identities, ErrorType elision, dedup, canonical order, collapse — and a
-// Context-gated subsumed-member elimination step. The core is what every mint
-// site needs; subsumption runs ONLY when a Context is supplied, because the
-// subtype test it relies on calls c.constrain under a probe. combine and
-// mergeObjectGroup pass a nil Context (their members are already coalesced, so
-// dedup + identities tighten them enough). resolveTypeAnn (PR2) and
-// joinBorrows (PR6) pass their checker's Context so an annotation or borrow
-// union is fully subsumed.
+// Normalization splits into a Context-free core and a Context-gated
+// subsumed-member elimination step. The core covers flatten, lattice
+// identities, ErrorType elision, dedup, canonical order, and collapse. Every
+// caller needs it. Subsumption runs only when the caller passes a Context,
+// because the subtype test it uses calls c.constrain under a probe. combine
+// and mergeObjectGroup pass nil. resolveTypeAnn from PR2 and joinBorrows from
+// PR6 pass their checker's Context.
 //
-// Canonical member order is imposed at construction so equalType stays
-// positional and cheap: two unions over the same member set hold them in the
-// same order, so the existing equalTypeSlice already returns true. The order
-// is also what lets rendering be deterministic (string | number and number |
-// string render identically), and what makes a canonicalized type usable as a
-// stable key for caching.
+// Canonical member order keeps equalType positional and cheap. Two unions
+// over the same members hold them in the same order, so equalTypeSlice
+// already returns true. Canonical order also makes rendering deterministic,
+// so `number | string` and `string | number` print identically, and it lets
+// the canonical type serve as a stable key for caching.
 func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
-	// 1. Flatten nested same-kind members and detect tail-inexactness: a nested
-	//    UnionType is spliced in, and an inexact member contributes to the
-	//    result's inexactness (an inexact tail anywhere makes the whole union
-	//    inexact).
+	flat, inexact := flattenUnion(parts, inexact)
+	pruned, hadError := pruneUnion(flat)
+	pruned = dedup(pruned)
+	if c != nil {
+		pruned = subsumeMembers(c, pruned, unionDrops)
+	}
+	sortTypes(pruned)
+	return collapseUnion(pruned, inexact, hadError)
+}
+
+// newIntersection is the meet twin of newUnion. An IntersectionType carries
+// no exactness flag, since exactness is a property of the result rather than
+// the meet, so the API is one argument shorter.
+func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
+	flat := flattenIntersection(parts)
+	pruned, hadError := pruneIntersection(flat)
+	pruned = dedup(pruned)
+	if c != nil {
+		pruned = subsumeMembers(c, pruned, intersectionDrops)
+	}
+	sortTypes(pruned)
+	return collapseIntersection(pruned, hadError)
+}
+
+// flattenUnion splices nested UnionType members into the outer member list
+// and carries an inner inexact flag out to the caller. An inexact nested
+// member makes the outer union inexact, since `... | (A | ...)` collapses to
+// `A | ...`. When no member nests, the input slice is reused, so the common
+// case pays no allocation.
+func flattenUnion(parts []soltype.Type, inexact bool) ([]soltype.Type, bool) {
+	if !anyUnion(parts) {
+		return parts, inexact
+	}
 	flat := make([]soltype.Type, 0, len(parts))
 	for _, p := range parts {
 		if u, ok := p.(*soltype.UnionType); ok {
@@ -47,63 +72,15 @@ func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
 		}
 		flat = append(flat, p)
 	}
-
-	// 2. Lattice identity drop: never (⊥) is the identity of |, so drop it.
-	// 3. ErrorType elision: drop ErrorType (the join identity / absorbing sentinel)
-	//    unless it ends up the sole survivor below.
-	pruned := make([]soltype.Type, 0, len(flat))
-	hadError := false
-	for _, p := range flat {
-		if _, isNever := p.(*soltype.NeverType); isNever {
-			continue
-		}
-		if _, isError := p.(*soltype.ErrorType); isError {
-			hadError = true
-			continue
-		}
-		pruned = append(pruned, p)
-	}
-
-	// 4. Structural dedup via equalType — order-preserving.
-	pruned = dedup(pruned)
-
-	// 5. Subsumed-member elimination (Context-gated, optional). Drop a member
-	//    that is a subtype of another member, since the wider one already
-	//    covers it. Concrete-gated: skip when either side carries a free type
-	//    variable, to avoid speculatively pinning a var mid-walk.
-	if c != nil {
-		pruned = subsumeUnionMembers(c, pruned)
-	}
-
-	// 6. Canonical order, so member order is construction-order-independent.
-	sortTypes(pruned)
-
-	// 7. Collapse.
-	if len(pruned) == 0 {
-		if hadError {
-			return &soltype.ErrorType{}
-		}
-		// Empty union ⇒ never (⊥, the identity of |). An inexact-but-empty union
-		// is still ⊥; the inexactness flag has no carrier without members. If a
-		// future caller needs an "inexact never" — i.e. a tail of unknown alone —
-		// it can express that as unknown explicitly.
-		return &soltype.NeverType{}
-	}
-	if len(pruned) == 1 && !inexact {
-		// A single exact-union member collapses to that member. An inexact
-		// single-member union keeps its wrapper, since the `... | T` tail makes
-		// it strictly weaker than the bare T.
-		return pruned[0]
-	}
-	return &soltype.UnionType{Types: pruned, Inexact: inexact}
+	return flat, inexact
 }
 
-// newIntersection is the meet twin of newUnion. An IntersectionType carries no
-// exactness flag (M6 plan: "intersection has no exact/inexact variant —
-// exactness is a property of its result, not the meet"), so the API is one
-// argument shorter.
-func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
-	// 1. Flatten nested intersections.
+// flattenIntersection is the meet twin of flattenUnion. There is no exactness
+// flag to carry.
+func flattenIntersection(parts []soltype.Type) []soltype.Type {
+	if !anyIntersection(parts) {
+		return parts
+	}
 	flat := make([]soltype.Type, 0, len(parts))
 	for _, p := range parts {
 		if i, ok := p.(*soltype.IntersectionType); ok {
@@ -112,41 +89,116 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 		}
 		flat = append(flat, p)
 	}
+	return flat
+}
 
-	// 2. Lattice identity drop: unknown (⊤) is the identity of &, so drop it.
-	// 3. ErrorType elision: drop ErrorType unless it ends up the sole survivor.
-	pruned := make([]soltype.Type, 0, len(flat))
+func anyUnion(parts []soltype.Type) bool {
+	for _, p := range parts {
+		if _, ok := p.(*soltype.UnionType); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func anyIntersection(parts []soltype.Type) bool {
+	for _, p := range parts {
+		if _, ok := p.(*soltype.IntersectionType); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// pruneUnion drops the union's lattice identity never, which is ⊥, and
+// elides ErrorType. ErrorType is the join identity and the absorbing recovery
+// sentinel. It is dropped unless every other member was also dropped, in
+// which case the collapse step keeps a single ErrorType as the sole
+// survivor. The hadError return signals that case to the collapse step.
+//
+// Reuses the input slice when nothing was dropped.
+func pruneUnion(parts []soltype.Type) ([]soltype.Type, bool) {
 	hadError := false
-	for _, p := range flat {
-		if _, isUnknown := p.(*soltype.UnknownType); isUnknown {
-			continue
+	drop := func(p soltype.Type) bool {
+		if _, isNever := p.(*soltype.NeverType); isNever {
+			return true
 		}
 		if _, isError := p.(*soltype.ErrorType); isError {
 			hadError = true
-			continue
+			return true
 		}
-		pruned = append(pruned, p)
+		return false
 	}
+	return filterDropped(parts, drop), hadError
+}
 
-	// 4. Structural dedup.
-	pruned = dedup(pruned)
-
-	// 5. Subsumed-member elimination, Context-gated. Drop an intersection
-	//    member that is a SUPERTYPE of another, since the more specific
-	//    sibling already implies it.
-	if c != nil {
-		pruned = subsumeIntersectionMembers(c, pruned)
+// pruneIntersection is the meet twin of pruneUnion. It drops unknown, the
+// identity of &, and elides ErrorType under the same sole-survivor rule.
+func pruneIntersection(parts []soltype.Type) ([]soltype.Type, bool) {
+	hadError := false
+	drop := func(p soltype.Type) bool {
+		if _, isUnknown := p.(*soltype.UnknownType); isUnknown {
+			return true
+		}
+		if _, isError := p.(*soltype.ErrorType); isError {
+			hadError = true
+			return true
+		}
+		return false
 	}
+	return filterDropped(parts, drop), hadError
+}
 
-	// 6. Canonical order.
-	sortTypes(pruned)
+// filterDropped returns parts with every element the drop callback flagged
+// removed, preserving order. It reuses the input slice when nothing was
+// dropped, so the common case pays no allocation.
+func filterDropped(parts []soltype.Type, drop func(soltype.Type) bool) []soltype.Type {
+	firstDrop := -1
+	for i, p := range parts {
+		if drop(p) {
+			firstDrop = i
+			break
+		}
+	}
+	if firstDrop < 0 {
+		return parts
+	}
+	out := make([]soltype.Type, 0, len(parts)-1)
+	out = append(out, parts[:firstDrop]...)
+	for _, p := range parts[firstDrop+1:] {
+		if !drop(p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
-	// 7. Collapse.
+func collapseUnion(pruned []soltype.Type, inexact, hadError bool) soltype.Type {
 	if len(pruned) == 0 {
 		if hadError {
 			return &soltype.ErrorType{}
 		}
-		// Empty intersection ⇒ unknown (⊤, the identity of &).
+		// Empty union ⇒ never, the identity of |. An inexact-but-empty union is
+		// still never, since the inexactness flag has no carrier without
+		// members. A caller that needs a union whose only content is the open
+		// tail should write unknown directly.
+		return &soltype.NeverType{}
+	}
+	if len(pruned) == 1 && !inexact {
+		// A single exact-union member collapses to that member. An inexact
+		// single-member union keeps its wrapper, since the `... | T` tail
+		// makes it strictly weaker than the bare T.
+		return pruned[0]
+	}
+	return &soltype.UnionType{Types: pruned, Inexact: inexact}
+}
+
+func collapseIntersection(pruned []soltype.Type, hadError bool) soltype.Type {
+	if len(pruned) == 0 {
+		if hadError {
+			return &soltype.ErrorType{}
+		}
+		// Empty intersection ⇒ unknown, the identity of &.
 		return &soltype.UnknownType{}
 	}
 	if len(pruned) == 1 {
@@ -155,84 +207,93 @@ func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 	return &soltype.IntersectionType{Types: pruned}
 }
 
-// subsumeUnionMembers drops a union member that is a subtype of another member.
-// Concrete-gated: a member that still carries a free type variable is left
-// alone, since trialling subtype against an inference variable would
-// speculatively pin it.
+// subsumeMembers drops every member m for which drops(m, sibling) returns
+// true for some kept sibling. The drops callback names the direction of the
+// subtype check. A union drops m when m <: sibling, since the sibling is
+// wider. An intersection drops m when sibling <: m, since the sibling is
+// narrower and already constrains the value below m.
 //
-// The check uses a discard-only probe so a successful trial leaves no bound
-// mutation behind. With c.constrain returning the trial's errors directly
-// rather than routing through c.errs, the probe just needs to roll back bound
-// appends — newProbe + Discard is enough.
-func subsumeUnionMembers(c *Context, parts []soltype.Type) []soltype.Type {
+// The pass is concrete-gated. A member that still carries a free type
+// variable is left alone, since trialling subtype against an inference
+// variable could pin it speculatively. The trial uses a discard-only probe
+// so a successful trial leaves no bound mutation behind.
+//
+// When two members mutually subsume, the survivor must be deterministic. The
+// pass pre-sorts the input by compareType, so the iteration order is
+// canonical and newUnion([A, B]) and newUnion([B, A]) drop the same member
+// when A and B subsume each other but differ structurally. That is the
+// canonicalization contract the M6 plan asserts.
+func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, sibling soltype.Type) bool) []soltype.Type {
 	if len(parts) < 2 {
 		return parts
 	}
-	keep := make([]bool, len(parts))
-	for i := range keep {
-		keep[i] = true
-	}
-	for i, a := range parts {
-		if !keep[i] || hasTypeVar(a) {
-			continue
-		}
-		for j, b := range parts {
-			if i == j || !keep[j] || hasTypeVar(b) {
-				continue
-			}
-			// a is subsumed if a <: b for some other kept member b.
-			if subtypeUnderProbe(c, a, b) {
-				keep[i] = false
-				break
-			}
-		}
-	}
-	return filterKept(parts, keep)
-}
-
-// subsumeIntersectionMembers drops an intersection member that is a supertype
-// of another. The dropped member is the wider one — the narrower sibling
-// already constrains the value below it. Symmetric to subsumeUnionMembers.
-func subsumeIntersectionMembers(c *Context, parts []soltype.Type) []soltype.Type {
-	if len(parts) < 2 {
-		return parts
-	}
-	keep := make([]bool, len(parts))
-	for i := range keep {
-		keep[i] = true
-	}
-	for i, a := range parts {
-		if !keep[i] || hasTypeVar(a) {
-			continue
-		}
-		for j, b := range parts {
-			if i == j || !keep[j] || hasTypeVar(b) {
-				continue
-			}
-			// a is subsumed if b <: a for some other kept member b (a is the wider).
-			if subtypeUnderProbe(c, b, a) {
-				keep[i] = false
-				break
-			}
-		}
-	}
-	return filterKept(parts, keep)
-}
-
-func filterKept(parts []soltype.Type, keep []bool) []soltype.Type {
-	out := make([]soltype.Type, 0, len(parts))
+	parts = append([]soltype.Type(nil), parts...)
+	sortTypes(parts)
+	hasVar := make([]bool, len(parts))
 	for i, p := range parts {
-		if keep[i] {
-			out = append(out, p)
+		hasVar[i] = soltype.HasTypeVar(p)
+	}
+	keep := make([]bool, len(parts))
+	for i := range keep {
+		keep[i] = true
+	}
+	for i, a := range parts {
+		if !keep[i] || hasVar[i] {
+			continue
+		}
+		for j, b := range parts {
+			if i == j || !keep[j] || hasVar[j] {
+				continue
+			}
+			if drops(c, a, b) {
+				keep[i] = false
+				break
+			}
 		}
 	}
-	return out
+	return compactKept(parts, keep)
 }
 
-// subtypeUnderProbe trials sub <: super under a discard-only probe and reports
-// whether the trial succeeded. A successful trial means subsumption holds; the
-// probe is always Discarded so the bound mutations it would otherwise leave
-// behind never become visible. Used by the M6 PR1 subsumption pass.
+// unionDrops returns true when union member m should be dropped because the
+// sibling subsumes it. The check is m <: sibling.
+func unionDrops(c *Context, m, sibling soltype.Type) bool {
+	return subtypeUnderProbe(c, m, sibling)
+}
+
+// intersectionDrops returns true when intersection member m should be
+// dropped because the sibling subsumes it from below. The check is sibling
+// <: m. The sibling is narrower, so it already implies m, and m is the wider
+// one to discard.
+func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
+	return subtypeUnderProbe(c, sibling, m)
+}
+
+// compactKept returns the elements of parts whose keep flag is set, reusing
+// parts when every entry is kept.
+func compactKept(parts []soltype.Type, keep []bool) []soltype.Type {
+	for _, k := range keep {
+		if !k {
+			out := make([]soltype.Type, 0, len(parts))
+			for i, p := range parts {
+				if keep[i] {
+					out = append(out, p)
+				}
+			}
+			return out
+		}
+	}
+	return parts
+}
+
+// subtypeUnderProbe trials sub <: super under a discard-only probe and
+// reports whether the trial succeeded. A successful trial means subsumption
+// holds. The probe is always Discarded so the bound mutations it would
+// otherwise leave behind never become visible.
+//
+// The probe push/pop runs directly on *Context. openProbe and closeProbe are
+// the checker-level path and additionally snapshot c.errs, which subsumption
+// does not need. (*Context).constrain returns its errors through the return
+// value and never appends to checker state.
 func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
 	p := newProbe(c.probe)
 	c.probe = p
@@ -242,95 +303,273 @@ func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
 	return len(errs) == 0
 }
 
-// hasTypeVar reports whether t contains any TypeVarType, anywhere in its
-// structure. Subsumption checks gate on this: a member with a free var would
-// trial constrain against an unresolved variable and could pin it
-// speculatively, which is the failure mode the M6 plan calls out.
-func hasTypeVar(t soltype.Type) bool {
-	switch t := t.(type) {
-	case *soltype.TypeVarType:
-		return true
-	case *soltype.FuncType:
-		for _, p := range t.Params {
-			if hasTypeVar(p.Type) {
-				return true
-			}
-		}
-		return hasTypeVar(t.Ret)
-	case *soltype.TupleType:
-		for _, e := range t.Elems {
-			if hasTypeVar(e) {
-				return true
-			}
-		}
-		return false
-	case *soltype.ObjectType:
-		for _, e := range t.Elems {
-			if hasTypeVar(soltype.AsProperty(e).Type) {
-				return true
-			}
-		}
-		return false
-	case *soltype.PromiseType:
-		return hasTypeVar(t.Inner)
-	case *soltype.RefType:
-		return hasTypeVar(t.Inner)
-	case *soltype.UnionType:
-		for _, m := range t.Types {
-			if hasTypeVar(m) {
-				return true
-			}
-		}
-		return false
-	case *soltype.IntersectionType:
-		for _, m := range t.Types {
-			if hasTypeVar(m) {
-				return true
-			}
-		}
-		return false
-	}
-	return false
-}
-
-// sortTypes orders parts in place under compareType. Stable so that members
-// already in canonical order across passes keep their pointer order, which
-// keeps the rebuild identity-preserving when possible.
+// sortTypes orders parts in place under compareType. The sort is stable so a
+// list already in canonical order keeps its pointer order across passes,
+// which keeps a downstream rebuild identity-preserving when possible.
 func sortTypes(parts []soltype.Type) {
 	sort.SliceStable(parts, func(i, j int) bool {
 		return compareType(parts[i], parts[j]) < 0
 	})
 }
 
-// compareType is the deterministic total order canonical member order is built
-// on. It is consistent with equalType: two equalType-equal types compare equal.
-// The ordering ranks by a concrete-kind tag first, then tie-breaks by the
-// rendered Print string within a kind. The string fallback is a pragmatic
-// choice — the M6 plan flags it as such — and couples the canonical order to
-// the printer, but it bottoms out deterministically and produces a stable order
-// for every shape M1–M4 mints.
+// compareType is the deterministic total order canonical member order is
+// built on. It is consistent with equalType: two equalType-equal types
+// compare equal. The ordering ranks by a concrete-kind tag and tie-breaks
+// structurally, so distinct types that print identically still compare
+// strictly. Two RefTypes whose only difference is a pair of distinct unnamed
+// LifetimeVars is the case that motivates avoiding a printer-string
+// tie-break: under top-level Print they render the same string but they are
+// not equalType-equal, and a string fallback would call them equal. The
+// comparator never calls the printer.
 func compareType(a, b soltype.Type) int {
 	if equalType(a, b) {
 		return 0
 	}
 	ka, kb := typeKindOrder(a), typeKindOrder(b)
 	if ka != kb {
-		if ka < kb {
-			return -1
+		return ka - kb
+	}
+	return compareSameKind(a, b)
+}
+
+// compareSameKind is the per-kind structural tie-breaker. The payload-free
+// kinds NeverType, UnknownType, ErrorType, and Void cannot reach this
+// function, because equalType already returned true for any two of them above.
+// The remaining kinds compare by their fields in declaration order, with
+// nested types recursing through compareType.
+func compareSameKind(a, b soltype.Type) int {
+	switch a := a.(type) {
+	case *soltype.PrimType:
+		b := b.(*soltype.PrimType)
+		return int(a.Prim) - int(b.Prim)
+	case *soltype.LitType:
+		return compareLit(a.Lit, b.(*soltype.LitType).Lit)
+	case *soltype.TypeVarType:
+		b := b.(*soltype.TypeVarType)
+		return a.ID - b.ID
+	case *soltype.RefType:
+		b := b.(*soltype.RefType)
+		if a.Mut != b.Mut {
+			return boolOrder(a.Mut) - boolOrder(b.Mut)
 		}
+		if c := compareLifetime(a.Lt, b.Lt); c != 0 {
+			return c
+		}
+		return compareType(a.Inner, b.Inner)
+	case *soltype.TupleType:
+		b := b.(*soltype.TupleType)
+		if a.Inexact != b.Inexact {
+			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		if c := len(a.Elems) - len(b.Elems); c != 0 {
+			return c
+		}
+		return compareTypeSlice(a.Elems, b.Elems)
+	case *soltype.ObjectType:
+		b := b.(*soltype.ObjectType)
+		if a.Inexact != b.Inexact {
+			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		return compareObjectFields(a, b)
+	case *soltype.PromiseType:
+		return compareType(a.Inner, b.(*soltype.PromiseType).Inner)
+	case *soltype.FuncType:
+		b := b.(*soltype.FuncType)
+		if a.Inexact != b.Inexact {
+			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		if c := len(a.Params) - len(b.Params); c != 0 {
+			return c
+		}
+		for i := range a.Params {
+			if c := compareFuncParam(a.Params[i], b.Params[i]); c != 0 {
+				return c
+			}
+		}
+		return compareType(a.Ret, b.Ret)
+	case *soltype.UnionType:
+		b := b.(*soltype.UnionType)
+		if a.Inexact != b.Inexact {
+			return boolOrder(a.Inexact) - boolOrder(b.Inexact)
+		}
+		if c := len(a.Types) - len(b.Types); c != 0 {
+			return c
+		}
+		return compareTypeSlice(a.Types, b.Types)
+	case *soltype.IntersectionType:
+		b := b.(*soltype.IntersectionType)
+		if c := len(a.Types) - len(b.Types); c != 0 {
+			return c
+		}
+		return compareTypeSlice(a.Types, b.Types)
+	}
+	return 0
+}
+
+func compareTypeSlice(a, b []soltype.Type) int {
+	for i := range a {
+		if c := compareType(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+// compareFuncParam orders parameters by surface marker first. Rest comes
+// first, then Optional, then the parameter type. Pattern is intentionally
+// ignored, since an inferred or unnamed pattern would otherwise discriminate
+// two type-equal parameters.
+func compareFuncParam(a, b *soltype.FuncParam) int {
+	if a.Rest != b.Rest {
+		return boolOrder(a.Rest) - boolOrder(b.Rest)
+	}
+	if a.Optional != b.Optional {
+		return boolOrder(a.Optional) - boolOrder(b.Optional)
+	}
+	return compareType(a.Type, b.Type)
+}
+
+// compareObjectFields orders two objects by property name, then by each
+// property's optional flag and type. Property order in the slice is
+// presentation only, so the comparator walks both objects in name-sorted
+// order.
+func compareObjectFields(a, b *soltype.ObjectType) int {
+	if c := len(a.Elems) - len(b.Elems); c != 0 {
+		return c
+	}
+	an := sortedPropertyNames(a)
+	bn := sortedPropertyNames(b)
+	for i := range an {
+		if c := stringCompare(an[i], bn[i]); c != 0 {
+			return c
+		}
+		ap, _ := a.Prop(an[i])
+		bp, _ := b.Prop(bn[i])
+		if ap.Optional != bp.Optional {
+			return boolOrder(ap.Optional) - boolOrder(bp.Optional)
+		}
+		if c := compareType(ap.Type, bp.Type); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func sortedPropertyNames(o *soltype.ObjectType) []string {
+	names := make([]string, len(o.Elems))
+	for i, e := range o.Elems {
+		names[i] = soltype.AsProperty(e).Name
+	}
+	sort.Strings(names)
+	return names
+}
+
+func stringCompare(a, b string) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
 		return 1
 	}
-	// Same kind, structurally distinct: fall back to the printer for a stable
-	// total order. Two equalType-equal types are already filtered above.
-	return strings.Compare(soltype.Print(a), soltype.Print(b))
+	return 0
+}
+
+func boolOrder(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// compareLit orders literal values within the LitType kind. NumLit comes
+// first, then StrLit, then BoolLit; within a sort, values compare by their
+// own ordering.
+func compareLit(a, b soltype.Lit) int {
+	ka, kb := litKindOrder(a), litKindOrder(b)
+	if ka != kb {
+		return ka - kb
+	}
+	switch a := a.(type) {
+	case *soltype.NumLit:
+		b := b.(*soltype.NumLit)
+		switch {
+		case a.Value < b.Value:
+			return -1
+		case a.Value > b.Value:
+			return 1
+		}
+		return 0
+	case *soltype.StrLit:
+		return stringCompare(a.Value, b.(*soltype.StrLit).Value)
+	case *soltype.BoolLit:
+		b := b.(*soltype.BoolLit)
+		return boolOrder(a.Value) - boolOrder(b.Value)
+	}
+	return 0
+}
+
+func litKindOrder(l soltype.Lit) int {
+	switch l.(type) {
+	case *soltype.NumLit:
+		return 0
+	case *soltype.StrLit:
+		return 1
+	case *soltype.BoolLit:
+		return 2
+	}
+	return 3
+}
+
+// compareLifetime orders the lifetime forms a RefType.Lt can take. A nil
+// slot, which marks an owned value, sorts first. Then 'static. Then
+// LifetimeVar, ordered by ID. Then LifetimeUnion, ordered by length first
+// and members second.
+func compareLifetime(a, b soltype.Lifetime) int {
+	ka, kb := lifetimeKindOrder(a), lifetimeKindOrder(b)
+	if ka != kb {
+		return ka - kb
+	}
+	switch a := a.(type) {
+	case nil:
+		return 0
+	case *soltype.StaticLifetime:
+		return 0
+	case *soltype.LifetimeVar:
+		b := b.(*soltype.LifetimeVar)
+		return a.ID - b.ID
+	case *soltype.LifetimeUnion:
+		b := b.(*soltype.LifetimeUnion)
+		if c := len(a.Lifetimes) - len(b.Lifetimes); c != 0 {
+			return c
+		}
+		for i := range a.Lifetimes {
+			if c := compareLifetime(a.Lifetimes[i], b.Lifetimes[i]); c != 0 {
+				return c
+			}
+		}
+		return 0
+	}
+	return 0
+}
+
+func lifetimeKindOrder(lt soltype.Lifetime) int {
+	switch lt.(type) {
+	case nil:
+		return 0
+	case *soltype.StaticLifetime:
+		return 1
+	case *soltype.LifetimeVar:
+		return 2
+	case *soltype.LifetimeUnion:
+		return 3
+	}
+	return 4
 }
 
 // typeKindOrder ranks a soltype concrete kind for compareType. Lattice atoms
-// come first (never, unknown, error, void), then primitives and literals, then
-// the structural kinds, and the lattice forms (UnionType / IntersectionType)
-// last so a nested lattice node always sorts after its concrete siblings —
-// useful while M6 still allows residual lattice nodes after dedup but before
-// flatten finishes (it shouldn't, but the order keeps the result legible).
+// come first, then primitives and literals, then the structural kinds. The
+// lattice forms come last so a residual nested UnionType or IntersectionType
+// sorts after its concrete siblings.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -566,10 +566,11 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 	return 4
 }
 
-// typeKindOrder ranks a soltype concrete kind for compareType. Lattice atoms
-// come first, then primitives and literals, then the structural kinds. The
-// lattice forms come last so a residual nested UnionType or IntersectionType
-// sorts after its concrete siblings.
+// typeKindOrder ranks a soltype concrete kind for compareType. The lattice
+// bounds and the error sentinel come first, then the structural kinds, then
+// the lattice forms, and finally NullType and Void so a union renders its
+// data members before its absence markers. NullType precedes Void by
+// convention, so `T | null | void` is the canonical render.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:
@@ -578,28 +579,30 @@ func typeKindOrder(t soltype.Type) int {
 		return 1
 	case *soltype.ErrorType:
 		return 2
-	case *soltype.Void:
-		return 3
 	case *soltype.PrimType:
-		return 4
+		return 3
 	case *soltype.LitType:
-		return 5
+		return 4
 	case *soltype.TypeVarType:
-		return 6
+		return 5
 	case *soltype.RefType:
-		return 7
+		return 6
 	case *soltype.TupleType:
-		return 8
+		return 7
 	case *soltype.ObjectType:
-		return 9
+		return 8
 	case *soltype.PromiseType:
-		return 10
+		return 9
 	case *soltype.FuncType:
-		return 11
+		return 10
 	case *soltype.UnionType:
-		return 12
+		return 11
 	case *soltype.IntersectionType:
+		return 12
+	case *soltype.NullType:
 		return 13
+	case *soltype.Void:
+		return 14
 	}
-	return 14
+	return 15
 }

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -42,6 +42,29 @@ func TestNewUnionNormalization(t *testing.T) {
 			want:    &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true},
 		},
 		{
+			name: "doubly-nested union splices fully",
+			// ((number | string) | boolean) collapses to number | string | boolean.
+			// The recursive splice walks the inner UnionType the outer member
+			// holds rather than stopping at one level.
+			parts: []soltype.Type{&soltype.UnionType{Types: []soltype.Type{
+				&soltype.UnionType{Types: []soltype.Type{num(), str()}},
+				boolT(),
+			}}},
+			want: &soltype.UnionType{Types: []soltype.Type{num(), str(), boolT()}},
+		},
+		{
+			name: "inexact propagates from a deeply nested member",
+			// number | ((string | ...)) — the inexact tail lives two levels
+			// down and still makes the outer union inexact.
+			parts: []soltype.Type{
+				num(),
+				&soltype.UnionType{Types: []soltype.Type{
+					&soltype.UnionType{Types: []soltype.Type{str()}, Inexact: true},
+				}},
+			},
+			want: &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true},
+		},
+		{
 			name:  "never drops from union",
 			parts: []soltype.Type{num(), &soltype.NeverType{}},
 			want:  num(),
@@ -107,6 +130,24 @@ func TestNewIntersectionNormalization(t *testing.T) {
 			name:  "nested intersection splices in, canonical order",
 			parts: []soltype.Type{&soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num()))}}, exactObj(propElem("b", str()))},
 			want:  &soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num())), exactObj(propElem("b", str()))}},
+		},
+		{
+			name: "doubly-nested intersection splices fully",
+			// (({a} & {b}) & number) collapses to number & {a} & {b}. The
+			// recursive splice walks the inner IntersectionType the outer
+			// member holds.
+			parts: []soltype.Type{&soltype.IntersectionType{Types: []soltype.Type{
+				&soltype.IntersectionType{Types: []soltype.Type{
+					exactObj(propElem("a", num())),
+					exactObj(propElem("b", str())),
+				}},
+				num(),
+			}}},
+			want: &soltype.IntersectionType{Types: []soltype.Type{
+				num(),
+				exactObj(propElem("a", num())),
+				exactObj(propElem("b", str())),
+			}},
 		},
 		{
 			name:  "unknown drops from intersection",

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -7,130 +7,159 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewUnionFlatten exercises step 1 of newUnion's normalization: a nested
-// UnionType is spliced into the outer union, and an inexact member contributes
-// to the result's inexactness.
-func TestNewUnionFlatten(t *testing.T) {
-	t.Run("nested union splices in", func(t *testing.T) {
-		// (number | string) | boolean ⇒ boolean | number | string (canonical print
-		// order within the PrimType kind: alphabetical).
-		got := newUnion(nil, []soltype.Type{
-			&soltype.UnionType{Types: []soltype.Type{num(), str()}},
-			boolT(),
-		}, false)
-		want := &soltype.UnionType{Types: []soltype.Type{boolT(), num(), str()}}
-		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("inexact nested member makes outer inexact", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{
-			&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true},
-			str(),
-		}, false)
-		want := &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true}
-		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
-	})
+// inexactTuple builds the tail-tolerant tuple form `[…, ...]`. The mutual-
+// subsumption canonicalization tests read at a glance which arm they
+// exercise.
+func inexactTuple(elems ...soltype.Type) *soltype.TupleType {
+	return &soltype.TupleType{Elems: elems, Inexact: true}
 }
 
-// TestNewIntersectionFlatten is the meet twin of TestNewUnionFlatten.
-func TestNewIntersectionFlatten(t *testing.T) {
-	// (number & {a}) & {b} ⇒ number & {a} & {b}, canonical order.
-	got := newIntersection(nil, []soltype.Type{
-		&soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num()))}},
-		exactObj(propElem("b", str())),
-	})
-	want := &soltype.IntersectionType{Types: []soltype.Type{
-		num(),
-		exactObj(propElem("a", num())),
-		exactObj(propElem("b", str())),
-	}}
-	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+func exactTuple(elems ...soltype.Type) *soltype.TupleType {
+	return &soltype.TupleType{Elems: elems}
 }
 
-// TestNewUnionLatticeIdentity covers step 2: never (⊥) drops out of a union.
-func TestNewUnionLatticeIdentity(t *testing.T) {
-	t.Run("never drops from union", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{num(), &soltype.NeverType{}}, false)
-		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("all-never collapses to never", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{&soltype.NeverType{}, &soltype.NeverType{}}, false)
-		require.IsType(t, &soltype.NeverType{}, got)
-	})
+// TestNewUnionNormalization is the table-driven sweep over newUnion's
+// Context-free steps. Each row exercises one of flatten, lattice identities,
+// ErrorType elision, dedup, canonical order, or collapse.
+func TestNewUnionNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		parts   []soltype.Type
+		inexact bool
+		want    soltype.Type
+	}{
+		{
+			name:  "nested union splices in, canonical order",
+			parts: []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num(), str()}}, boolT()},
+			// PrimType members sort by the Prim enum order NumPrim, StrPrim,
+			// BoolPrim.
+			want: &soltype.UnionType{Types: []soltype.Type{num(), str(), boolT()}},
+		},
+		{
+			name:    "inexact nested member makes outer inexact",
+			parts:   []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}, str()},
+			inexact: false,
+			want:    &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true},
+		},
+		{
+			name:  "never drops from union",
+			parts: []soltype.Type{num(), &soltype.NeverType{}},
+			want:  num(),
+		},
+		{
+			name:  "all-never collapses to never",
+			parts: []soltype.Type{&soltype.NeverType{}, &soltype.NeverType{}},
+			want:  &soltype.NeverType{},
+		},
+		{
+			name:  "error drops from union with other members",
+			parts: []soltype.Type{num(), &soltype.ErrorType{}},
+			want:  num(),
+		},
+		{
+			name:  "error retained as sole member",
+			parts: []soltype.Type{&soltype.ErrorType{}},
+			want:  &soltype.ErrorType{},
+		},
+		{
+			name:  "error retained when other members are all lattice identities",
+			parts: []soltype.Type{&soltype.ErrorType{}, &soltype.NeverType{}},
+			want:  &soltype.ErrorType{},
+		},
+		{
+			name:  "structural dedup",
+			parts: []soltype.Type{num(), num(), str()},
+			want:  &soltype.UnionType{Types: []soltype.Type{num(), str()}},
+		},
+		{
+			name:  "empty union collapses to never",
+			parts: nil,
+			want:  &soltype.NeverType{},
+		},
+		{
+			name:  "single exact member collapses to that member",
+			parts: []soltype.Type{num()},
+			want:  num(),
+		},
+		{
+			name:    "inexact single member keeps the wrapper",
+			parts:   []soltype.Type{num()},
+			inexact: true,
+			want:    &soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newUnion(nil, tt.parts, tt.inexact)
+			require.True(t, equalType(tt.want, got), "want %s, got %s", soltype.Print(tt.want), soltype.Print(got))
+		})
+	}
 }
 
-// TestNewIntersectionLatticeIdentity covers step 2 on the meet side: unknown
-// (⊤) drops out of an intersection.
-func TestNewIntersectionLatticeIdentity(t *testing.T) {
-	t.Run("unknown drops from intersection", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{num(), &soltype.UnknownType{}})
-		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("all-unknown collapses to unknown", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{&soltype.UnknownType{}, &soltype.UnknownType{}})
-		require.IsType(t, &soltype.UnknownType{}, got)
-	})
-}
-
-// TestNewUnionErrorElision covers step 3: ErrorType drops from both forms,
-// unless it ends up the SOLE survivor.
-func TestNewUnionErrorElision(t *testing.T) {
-	t.Run("error drops from union with other members", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{num(), &soltype.ErrorType{}}, false)
-		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("error retained as sole member", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{&soltype.ErrorType{}}, false)
-		require.IsType(t, &soltype.ErrorType{}, got)
-	})
-
-	t.Run("error retained when other members are all lattice identities", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{&soltype.ErrorType{}, &soltype.NeverType{}}, false)
-		require.IsType(t, &soltype.ErrorType{}, got)
-	})
-}
-
-func TestNewIntersectionErrorElision(t *testing.T) {
-	t.Run("error drops from intersection with other members", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{num(), &soltype.ErrorType{}})
-		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("error retained as sole member", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{&soltype.ErrorType{}})
-		require.IsType(t, &soltype.ErrorType{}, got)
-	})
-
-	t.Run("error retained when other members are all lattice identities", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{&soltype.ErrorType{}, &soltype.UnknownType{}})
-		require.IsType(t, &soltype.ErrorType{}, got)
-	})
-}
-
-// TestNewUnionDedup covers step 4: structurally-equal members collapse.
-func TestNewUnionDedup(t *testing.T) {
-	t.Run("union dedup", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{num(), num(), str()}, false)
-		// Canonical order falls back to print string within the PrimType kind:
-		// "number" < "string", so num() before str().
-		want := &soltype.UnionType{Types: []soltype.Type{num(), str()}}
-		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
-	})
-
-	t.Run("intersection dedup", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{num(), str(), num()})
-		want := &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}
-		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
-	})
+// TestNewIntersectionNormalization is the meet twin of TestNewUnionNormalization.
+func TestNewIntersectionNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  soltype.Type
+	}{
+		{
+			name:  "nested intersection splices in, canonical order",
+			parts: []soltype.Type{&soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num()))}}, exactObj(propElem("b", str()))},
+			want:  &soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num())), exactObj(propElem("b", str()))}},
+		},
+		{
+			name:  "unknown drops from intersection",
+			parts: []soltype.Type{num(), &soltype.UnknownType{}},
+			want:  num(),
+		},
+		{
+			name:  "all-unknown collapses to unknown",
+			parts: []soltype.Type{&soltype.UnknownType{}, &soltype.UnknownType{}},
+			want:  &soltype.UnknownType{},
+		},
+		{
+			name:  "error drops from intersection with other members",
+			parts: []soltype.Type{num(), &soltype.ErrorType{}},
+			want:  num(),
+		},
+		{
+			name:  "error retained as sole member",
+			parts: []soltype.Type{&soltype.ErrorType{}},
+			want:  &soltype.ErrorType{},
+		},
+		{
+			name:  "error retained when other members are all lattice identities",
+			parts: []soltype.Type{&soltype.ErrorType{}, &soltype.UnknownType{}},
+			want:  &soltype.ErrorType{},
+		},
+		{
+			name:  "structural dedup",
+			parts: []soltype.Type{num(), str(), num()},
+			want:  &soltype.IntersectionType{Types: []soltype.Type{num(), str()}},
+		},
+		{
+			name:  "empty intersection collapses to unknown",
+			parts: nil,
+			want:  &soltype.UnknownType{},
+		},
+		{
+			name:  "single member collapses to that member",
+			parts: []soltype.Type{num()},
+			want:  num(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newIntersection(nil, tt.parts)
+			require.True(t, equalType(tt.want, got), "want %s, got %s", soltype.Print(tt.want), soltype.Print(got))
+		})
+	}
 }
 
 // TestNewUnionCanonicalOrder is the M6 PR1 gate against speculative-pinning
-// drift: a union of a member list and of its shuffle render identically and
-// equalType-match. The canonical order makes equalTypeSlice correct without a
-// rewrite.
+// drift. A union of a member list and of its shuffle must render identically
+// and compare equalType-equal.
 func TestNewUnionCanonicalOrder(t *testing.T) {
 	a := newUnion(nil, []soltype.Type{num(), str()}, false)
 	b := newUnion(nil, []soltype.Type{str(), num()}, false)
@@ -145,59 +174,26 @@ func TestNewIntersectionCanonicalOrder(t *testing.T) {
 	require.Equal(t, soltype.Print(a), soltype.Print(b))
 }
 
-// TestNewUnionCollapse covers step 7: an empty union ⇒ never, a single member ⇒
-// that member, an empty intersection ⇒ unknown.
-func TestNewUnionCollapse(t *testing.T) {
-	t.Run("empty union ⇒ never", func(t *testing.T) {
-		got := newUnion(nil, nil, false)
-		require.IsType(t, &soltype.NeverType{}, got)
-	})
-
-	t.Run("single member ⇒ member directly", func(t *testing.T) {
-		got := newUnion(nil, []soltype.Type{num()}, false)
-		require.True(t, equalType(num(), got))
-	})
-
-	t.Run("empty intersection ⇒ unknown", func(t *testing.T) {
-		got := newIntersection(nil, nil)
-		require.IsType(t, &soltype.UnknownType{}, got)
-	})
-
-	t.Run("single intersection member ⇒ member directly", func(t *testing.T) {
-		got := newIntersection(nil, []soltype.Type{num()})
-		require.True(t, equalType(num(), got))
-	})
-
-	t.Run("inexact single-member union keeps the wrapper", func(t *testing.T) {
-		// A `... | T` tail makes the union strictly weaker than the bare T, so
-		// the inexact single-member union does NOT collapse.
-		got := newUnion(nil, []soltype.Type{num()}, true)
-		want := &soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}
-		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
-	})
-}
-
 // TestNewUnionInexactPrintRoundTrip pins the printer's trailing `...` rendering
 // for an inexact union, so the flag round-trips to surface syntax.
 func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
 	u := newUnion(nil, []soltype.Type{num(), str()}, true)
-	// Canonical order: number < string (alphabetical print fallback within the
-	// PrimType kind).
 	require.Equal(t, "number | string | ...", soltype.Print(u))
 }
 
-// TestNewUnionSubsumeWithContext covers step 5: when a Context is supplied, a
-// member that is a subtype of another member is dropped. `number | 1` ⇒ `number`.
+// TestNewUnionSubsumeWithContext covers the Context-gated subsumption step.
+// A member that is a subtype of another member is dropped, so `number | 1`
+// reduces to `number`.
 func TestNewUnionSubsumeWithContext(t *testing.T) {
 	c := &Context{}
 	got := newUnion(c, []soltype.Type{num(), numLit(1)}, false)
 	require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
 }
 
-// TestNewIntersectionSubsumeWithContext is the meet twin: an intersection
-// member that is a SUPERTYPE of another is dropped. Width subtyping holds on
-// inexact objects (the wider object is a subtype of the narrower), so
-// `{x, ...} & {x, y, ...}` ⇒ `{x, y, ...}`.
+// TestNewIntersectionSubsumeWithContext is the meet twin. An intersection
+// member that is a supertype of another is dropped. Width subtyping on
+// inexact objects makes the wider object a subtype of the narrower one, so
+// `{x, ...} & {x, y, ...}` reduces to `{x, y, ...}`.
 func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 	c := &Context{}
 	got := newIntersection(c, []soltype.Type{
@@ -208,16 +204,45 @@ func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
 }
 
-// TestNewUnionNoSubsumeWithoutContext is the negative case: without a Context,
-// the constructor leaves non-equal subsumable members in place. This is the
-// `combine` posture — a coalesced output is dedup'd and lattice-pruned but not
-// subsumed, since subsumption needs a Context to run constrain under a probe.
-// PR8 closes this gap at the finalization boundaries.
+// TestSubsumeMutualPicksCanonicalSurvivor pins the M6 PR1 canonicalization
+// fix. When two members mutually subsume but are not equalType-equal, the
+// survivor must be deterministic across input shuffles. The tuple constrain
+// rule admits `[T] <: [T, ...]` and `[T, ...] <: [T]` at equal length, so
+// the two tuples are mutual subtypes, but their Inexact flags distinguish
+// them structurally. Without the pre-sort, [A, B] and [B, A] would drop
+// different members. With it, both produce the same survivor.
+func TestSubsumeMutualPicksCanonicalSurvivor(t *testing.T) {
+	c := &Context{}
+	exact := exactTuple(num())
+	inexact := inexactTuple(num())
+	t.Run("union forward order", func(t *testing.T) {
+		got := newUnion(c, []soltype.Type{exact, inexact}, false)
+		require.IsType(t, &soltype.TupleType{}, got)
+	})
+	t.Run("union reverse order", func(t *testing.T) {
+		forward := newUnion(c, []soltype.Type{exact, inexact}, false)
+		reverse := newUnion(c, []soltype.Type{inexact, exact}, false)
+		require.True(t, equalType(forward, reverse), "forward %s, reverse %s", soltype.Print(forward), soltype.Print(reverse))
+	})
+	t.Run("intersection forward order", func(t *testing.T) {
+		got := newIntersection(c, []soltype.Type{exact, inexact})
+		require.IsType(t, &soltype.TupleType{}, got)
+	})
+	t.Run("intersection reverse order", func(t *testing.T) {
+		forward := newIntersection(c, []soltype.Type{exact, inexact})
+		reverse := newIntersection(c, []soltype.Type{inexact, exact})
+		require.True(t, equalType(forward, reverse), "forward %s, reverse %s", soltype.Print(forward), soltype.Print(reverse))
+	})
+}
+
+// TestNewUnionNoSubsumeWithoutContext is the negative case. Without a
+// Context, the constructor leaves non-equal subsumable members in place.
+// This is the `combine` posture, where coalesced output is deduped and
+// lattice-pruned but not subsumed. PR8 closes this gap at the finalization
+// boundaries.
 func TestNewUnionNoSubsumeWithoutContext(t *testing.T) {
 	got := newUnion(nil, []soltype.Type{num(), numLit(1)}, false)
-	// Both members survive; canonical order is numLit(1) before num() by kind
-	// (LitType ranks before PrimType is false — actually PrimType=4 < LitType=5,
-	// so num() first).
+	// PrimType ranks before LitType in the kind table, so num leads.
 	want := &soltype.UnionType{Types: []soltype.Type{num(), numLit(1)}}
 	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
 }
@@ -227,7 +252,6 @@ func TestNewIntersectionNoSubsumeWithoutContext(t *testing.T) {
 		inexactObj(propElem("x", num())),
 		inexactObj(propElem("x", num()), propElem("y", str())),
 	})
-	// Both members survive — the wider `{x, ...}` is not dropped without a Context.
 	require.IsType(t, &soltype.IntersectionType{}, got)
 	it := got.(*soltype.IntersectionType)
 	require.Len(t, it.Types, 2)
@@ -235,20 +259,19 @@ func TestNewIntersectionNoSubsumeWithoutContext(t *testing.T) {
 
 // TestNewUnionSubsumptionSkipsVar pins the concrete gate: a member that still
 // carries a free type variable is left alone, even with a Context, to avoid
-// speculatively pinning that variable mid-walk. Both members survive.
+// speculatively pinning that variable mid-walk.
 func TestNewUnionSubsumptionSkipsVar(t *testing.T) {
 	c := &Context{}
 	v := c.freshVar(0)
 	got := newUnion(c, []soltype.Type{num(), v}, false)
-	// number | T (a free var), neither member is dropped.
 	require.IsType(t, &soltype.UnionType{}, got)
 	u := got.(*soltype.UnionType)
 	require.Len(t, u.Types, 2)
 }
 
-// TestCompareTypeConsistentWithEqual pins compareType's consistency contract:
-// two equalType-equal types compare equal. Without this canonicalization would
-// be unstable and dedup unreliable.
+// TestCompareTypeConsistentWithEqual pins compareType's consistency
+// contract. Two equalType-equal types must compare equal. Without that,
+// canonicalization would be unstable and dedup unreliable.
 func TestCompareTypeConsistentWithEqual(t *testing.T) {
 	tests := []struct {
 		name string
@@ -271,11 +294,26 @@ func TestCompareTypeConsistentWithEqual(t *testing.T) {
 // TestCompareTypeKindOrder pins the kind ranking that orders dissimilar
 // members so a union of mixed kinds renders deterministically.
 func TestCompareTypeKindOrder(t *testing.T) {
-	// PrimType (4) ranks before LitType (5) ranks before TypeVarType (6).
 	c := &Context{}
 	v := c.freshVar(0)
 	require.Less(t, compareType(num(), numLit(1)), 0, "PrimType < LitType")
 	require.Less(t, compareType(numLit(1), v), 0, "LitType < TypeVarType")
 	require.Less(t, compareType(&soltype.NeverType{}, num()), 0, "NeverType < PrimType")
 	require.Less(t, compareType(&soltype.UnknownType{}, num()), 0, "UnknownType < PrimType")
+}
+
+// TestCompareTypeDistinctRefsWithUnnamedLifetimes pins the structural
+// comparator fix for borrows. Two RefTypes that differ only in distinct,
+// unnamed LifetimeVars print identically when the top-level Print supplies
+// no name map, so a Print-based tie-break would collapse them. The
+// structural comparator orders them by LifetimeVar.ID and keeps them
+// strictly distinct.
+func TestCompareTypeDistinctRefsWithUnnamedLifetimes(t *testing.T) {
+	c := &Context{}
+	lt1 := c.freshLifetime(0)
+	lt2 := c.freshLifetime(0)
+	r1 := &soltype.RefType{Mut: true, Lt: lt1, Inner: exactObj(propElem("x", num()))}
+	r2 := &soltype.RefType{Mut: true, Lt: lt2, Inner: exactObj(propElem("x", num()))}
+	require.False(t, equalType(r1, r2), "precondition: distinct LifetimeVars are not equalType")
+	require.NotEqual(t, 0, compareType(r1, r2), "distinct unnamed-lifetime borrows must compare unequal")
 }

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -233,31 +233,40 @@ func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 
 // TestSubsumeMutualPicksCanonicalSurvivor pins the M6 PR1 canonicalization
 // fix. When two members mutually subsume but are not equalType-equal, the
-// survivor must be deterministic across input shuffles. The tuple constrain
-// rule admits `[T] <: [T, ...]` and `[T, ...] <: [T]` at equal length, so
-// the two tuples are mutual subtypes, but their Inexact flags distinguish
-// them structurally. Without the pre-sort, [A, B] and [B, A] would drop
-// different members. With it, both produce the same survivor.
+// survivor must be deterministic across input shuffles.
+//
+// Function callback subtyping is the case that triggers mutual subsumption
+// today. A typed-rest function `(...xs: T[]) -> R` and an inexact
+// zero-param function `(...) -> R` are not equalType, since they differ in
+// Inexact and in declared param count, but they share an accept-set of
+// [0, ∞) and the same return, so each is a subtype of the other under the
+// callback rule. Without the pre-sort, the loop would drop whichever was
+// reached first as `i`, and a shuffled input would drop the other. With
+// the pre-sort, both input orders pick the same survivor.
+//
+// parseType cannot author FuncTypeAnn yet, so the test builds the two
+// functions directly.
 func TestSubsumeMutualPicksCanonicalSurvivor(t *testing.T) {
 	c := &Context{}
-	exact := parseType(t, "[number]")
-	inexact := parseType(t, "[number, ...]")
-	t.Run("union forward order", func(t *testing.T) {
-		got := newUnion(c, []soltype.Type{exact, inexact}, false)
-		require.IsType(t, &soltype.TupleType{}, got)
-	})
-	t.Run("union reverse order", func(t *testing.T) {
-		forward := newUnion(c, []soltype.Type{exact, inexact}, false)
-		reverse := newUnion(c, []soltype.Type{inexact, exact}, false)
+	restFn := &soltype.FuncType{
+		Params: []*soltype.FuncParam{
+			{Pattern: &soltype.IdentPat{Name: "xs"}, Type: &soltype.UnknownType{}, Rest: true},
+		},
+		Ret: num(),
+	}
+	inexactFn := &soltype.FuncType{Ret: num(), Inexact: true}
+	require.False(t, equalType(restFn, inexactFn), "precondition: structurally distinct")
+	require.Empty(t, c.Constrain(restFn, inexactFn), "precondition: restFn <: inexactFn")
+	require.Empty(t, c.Constrain(inexactFn, restFn), "precondition: inexactFn <: restFn")
+
+	t.Run("union order-independent", func(t *testing.T) {
+		forward := newUnion(c, []soltype.Type{restFn, inexactFn}, false)
+		reverse := newUnion(c, []soltype.Type{inexactFn, restFn}, false)
 		require.True(t, equalType(forward, reverse), "forward %s, reverse %s", soltype.Print(forward), soltype.Print(reverse))
 	})
-	t.Run("intersection forward order", func(t *testing.T) {
-		got := newIntersection(c, []soltype.Type{exact, inexact})
-		require.IsType(t, &soltype.TupleType{}, got)
-	})
-	t.Run("intersection reverse order", func(t *testing.T) {
-		forward := newIntersection(c, []soltype.Type{exact, inexact})
-		reverse := newIntersection(c, []soltype.Type{inexact, exact})
+	t.Run("intersection order-independent", func(t *testing.T) {
+		forward := newIntersection(c, []soltype.Type{restFn, inexactFn})
+		reverse := newIntersection(c, []soltype.Type{inexactFn, restFn})
 		require.True(t, equalType(forward, reverse), "forward %s, reverse %s", soltype.Print(forward), soltype.Print(reverse))
 	})
 }

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// inexactTuple builds the tail-tolerant tuple form `[…, ...]`. The mutual-
-// subsumption canonicalization tests read at a glance which arm they
-// exercise.
-func inexactTuple(elems ...soltype.Type) *soltype.TupleType {
-	return &soltype.TupleType{Elems: elems, Inexact: true}
-}
-
-func exactTuple(elems ...soltype.Type) *soltype.TupleType {
-	return &soltype.TupleType{Elems: elems}
-}
-
 // TestNewUnionNormalization is the table-driven sweep over newUnion's
 // Context-free steps. Each row exercises one of flatten, lattice identities,
 // ErrorType elision, dedup, canonical order, or collapse.
@@ -30,54 +19,59 @@ func TestNewUnionNormalization(t *testing.T) {
 	}{
 		{
 			name:  "nested union splices in, canonical order",
-			parts: []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num(), str()}}, boolT()},
+			parts: []soltype.Type{parseType(t, "number | string"), parseType(t, "boolean")},
 			// PrimType members sort by the Prim enum order NumPrim, StrPrim,
 			// BoolPrim.
-			want: &soltype.UnionType{Types: []soltype.Type{num(), str(), boolT()}},
+			want: parseType(t, "number | string | boolean"),
 		},
 		{
-			name:    "inexact nested member makes outer inexact",
-			parts:   []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}, str()},
+			name: "inexact nested member makes outer inexact",
+			// A nested inexact UnionType carries the inexact flag out to the
+			// outer mint. parseType cannot author an inexact union literal
+			// today (PR4 lands the surface marker), so the nested member is
+			// built from a parsed exact union with Inexact flipped.
+			parts:   []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}, parseType(t, "string")},
 			inexact: false,
-			want:    &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true},
+			want:    &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true},
 		},
 		{
 			name: "doubly-nested union splices fully",
-			// ((number | string) | boolean) collapses to number | string | boolean.
-			// The recursive splice walks the inner UnionType the outer member
-			// holds rather than stopping at one level.
+			// `((number | string) | boolean)` collapses to
+			// `number | string | boolean`. The recursive splice walks the
+			// inner UnionType the outer member holds rather than stopping at
+			// one level.
 			parts: []soltype.Type{&soltype.UnionType{Types: []soltype.Type{
-				&soltype.UnionType{Types: []soltype.Type{num(), str()}},
-				boolT(),
+				parseType(t, "number | string"),
+				parseType(t, "boolean"),
 			}}},
-			want: &soltype.UnionType{Types: []soltype.Type{num(), str(), boolT()}},
+			want: parseType(t, "number | string | boolean"),
 		},
 		{
 			name: "inexact propagates from a deeply nested member",
-			// number | ((string | ...)) — the inexact tail lives two levels
+			// `number | ((string | ...))` — the inexact tail lives two levels
 			// down and still makes the outer union inexact.
 			parts: []soltype.Type{
-				num(),
+				parseType(t, "number"),
 				&soltype.UnionType{Types: []soltype.Type{
-					&soltype.UnionType{Types: []soltype.Type{str()}, Inexact: true},
+					&soltype.UnionType{Types: parseTypes(t, "string"), Inexact: true},
 				}},
 			},
-			want: &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true},
+			want: &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true},
 		},
 		{
 			name:  "never drops from union",
-			parts: []soltype.Type{num(), &soltype.NeverType{}},
-			want:  num(),
+			parts: parseTypes(t, "number", "never"),
+			want:  parseType(t, "number"),
 		},
 		{
 			name:  "all-never collapses to never",
-			parts: []soltype.Type{&soltype.NeverType{}, &soltype.NeverType{}},
-			want:  &soltype.NeverType{},
+			parts: parseTypes(t, "never", "never"),
+			want:  parseType(t, "never"),
 		},
 		{
 			name:  "error drops from union with other members",
-			parts: []soltype.Type{num(), &soltype.ErrorType{}},
-			want:  num(),
+			parts: []soltype.Type{parseType(t, "number"), &soltype.ErrorType{}},
+			want:  parseType(t, "number"),
 		},
 		{
 			name:  "error retained as sole member",
@@ -86,29 +80,29 @@ func TestNewUnionNormalization(t *testing.T) {
 		},
 		{
 			name:  "error retained when other members are all lattice identities",
-			parts: []soltype.Type{&soltype.ErrorType{}, &soltype.NeverType{}},
+			parts: []soltype.Type{&soltype.ErrorType{}, parseType(t, "never")},
 			want:  &soltype.ErrorType{},
 		},
 		{
 			name:  "structural dedup",
-			parts: []soltype.Type{num(), num(), str()},
-			want:  &soltype.UnionType{Types: []soltype.Type{num(), str()}},
+			parts: parseTypes(t, "number", "number", "string"),
+			want:  parseType(t, "number | string"),
 		},
 		{
 			name:  "empty union collapses to never",
 			parts: nil,
-			want:  &soltype.NeverType{},
+			want:  parseType(t, "never"),
 		},
 		{
 			name:  "single exact member collapses to that member",
-			parts: []soltype.Type{num()},
-			want:  num(),
+			parts: parseTypes(t, "number"),
+			want:  parseType(t, "number"),
 		},
 		{
 			name:    "inexact single member keeps the wrapper",
-			parts:   []soltype.Type{num()},
+			parts:   parseTypes(t, "number"),
 			inexact: true,
-			want:    &soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true},
+			want:    &soltype.UnionType{Types: parseTypes(t, "number"), Inexact: true},
 		},
 	}
 	for _, tt := range tests {
@@ -128,41 +122,34 @@ func TestNewIntersectionNormalization(t *testing.T) {
 	}{
 		{
 			name:  "nested intersection splices in, canonical order",
-			parts: []soltype.Type{&soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num()))}}, exactObj(propElem("b", str()))},
-			want:  &soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num())), exactObj(propElem("b", str()))}},
+			parts: []soltype.Type{parseType(t, "number & {a: number}"), parseType(t, "{b: string}")},
+			want:  parseType(t, "number & {a: number} & {b: string}"),
 		},
 		{
 			name: "doubly-nested intersection splices fully",
-			// (({a} & {b}) & number) collapses to number & {a} & {b}. The
-			// recursive splice walks the inner IntersectionType the outer
-			// member holds.
+			// `(({a} & {b}) & number)` collapses to `number & {a} & {b}`.
+			// The recursive splice walks the inner IntersectionType the
+			// outer member holds.
 			parts: []soltype.Type{&soltype.IntersectionType{Types: []soltype.Type{
-				&soltype.IntersectionType{Types: []soltype.Type{
-					exactObj(propElem("a", num())),
-					exactObj(propElem("b", str())),
-				}},
-				num(),
+				parseType(t, "{a: number} & {b: string}"),
+				parseType(t, "number"),
 			}}},
-			want: &soltype.IntersectionType{Types: []soltype.Type{
-				num(),
-				exactObj(propElem("a", num())),
-				exactObj(propElem("b", str())),
-			}},
+			want: parseType(t, "number & {a: number} & {b: string}"),
 		},
 		{
 			name:  "unknown drops from intersection",
-			parts: []soltype.Type{num(), &soltype.UnknownType{}},
-			want:  num(),
+			parts: parseTypes(t, "number", "unknown"),
+			want:  parseType(t, "number"),
 		},
 		{
 			name:  "all-unknown collapses to unknown",
-			parts: []soltype.Type{&soltype.UnknownType{}, &soltype.UnknownType{}},
-			want:  &soltype.UnknownType{},
+			parts: parseTypes(t, "unknown", "unknown"),
+			want:  parseType(t, "unknown"),
 		},
 		{
 			name:  "error drops from intersection with other members",
-			parts: []soltype.Type{num(), &soltype.ErrorType{}},
-			want:  num(),
+			parts: []soltype.Type{parseType(t, "number"), &soltype.ErrorType{}},
+			want:  parseType(t, "number"),
 		},
 		{
 			name:  "error retained as sole member",
@@ -171,23 +158,23 @@ func TestNewIntersectionNormalization(t *testing.T) {
 		},
 		{
 			name:  "error retained when other members are all lattice identities",
-			parts: []soltype.Type{&soltype.ErrorType{}, &soltype.UnknownType{}},
+			parts: []soltype.Type{&soltype.ErrorType{}, parseType(t, "unknown")},
 			want:  &soltype.ErrorType{},
 		},
 		{
 			name:  "structural dedup",
-			parts: []soltype.Type{num(), str(), num()},
-			want:  &soltype.IntersectionType{Types: []soltype.Type{num(), str()}},
+			parts: parseTypes(t, "number", "string", "number"),
+			want:  parseType(t, "number & string"),
 		},
 		{
 			name:  "empty intersection collapses to unknown",
 			parts: nil,
-			want:  &soltype.UnknownType{},
+			want:  parseType(t, "unknown"),
 		},
 		{
 			name:  "single member collapses to that member",
-			parts: []soltype.Type{num()},
-			want:  num(),
+			parts: parseTypes(t, "number"),
+			want:  parseType(t, "number"),
 		},
 	}
 	for _, tt := range tests {
@@ -202,15 +189,15 @@ func TestNewIntersectionNormalization(t *testing.T) {
 // drift. A union of a member list and of its shuffle must render identically
 // and compare equalType-equal.
 func TestNewUnionCanonicalOrder(t *testing.T) {
-	a := newUnion(nil, []soltype.Type{num(), str()}, false)
-	b := newUnion(nil, []soltype.Type{str(), num()}, false)
+	a := newUnion(nil, parseTypes(t, "number", "string"), false)
+	b := newUnion(nil, parseTypes(t, "string", "number"), false)
 	require.True(t, equalType(a, b), "expected canonical order to equate both shuffles")
 	require.Equal(t, soltype.Print(a), soltype.Print(b))
 }
 
 func TestNewIntersectionCanonicalOrder(t *testing.T) {
-	a := newIntersection(nil, []soltype.Type{num(), str()})
-	b := newIntersection(nil, []soltype.Type{str(), num()})
+	a := newIntersection(nil, parseTypes(t, "number", "string"))
+	b := newIntersection(nil, parseTypes(t, "string", "number"))
 	require.True(t, equalType(a, b), "expected canonical order to equate both shuffles")
 	require.Equal(t, soltype.Print(a), soltype.Print(b))
 }
@@ -218,7 +205,7 @@ func TestNewIntersectionCanonicalOrder(t *testing.T) {
 // TestNewUnionInexactPrintRoundTrip pins the printer's trailing `...` rendering
 // for an inexact union, so the flag round-trips to surface syntax.
 func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
-	u := newUnion(nil, []soltype.Type{num(), str()}, true)
+	u := newUnion(nil, parseTypes(t, "number", "string"), true)
 	require.Equal(t, "number | string | ...", soltype.Print(u))
 }
 
@@ -227,8 +214,8 @@ func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
 // reduces to `number`.
 func TestNewUnionSubsumeWithContext(t *testing.T) {
 	c := &Context{}
-	got := newUnion(c, []soltype.Type{num(), numLit(1)}, false)
-	require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+	got := newUnion(c, parseTypes(t, "number", "1"), false)
+	require.True(t, equalType(parseType(t, "number"), got), "got %s", soltype.Print(got))
 }
 
 // TestNewIntersectionSubsumeWithContext is the meet twin. An intersection
@@ -237,12 +224,11 @@ func TestNewUnionSubsumeWithContext(t *testing.T) {
 // `{x, ...} & {x, y, ...}` reduces to `{x, y, ...}`.
 func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 	c := &Context{}
-	got := newIntersection(c, []soltype.Type{
-		inexactObj(propElem("x", num())),
-		inexactObj(propElem("x", num()), propElem("y", str())),
-	})
-	want := inexactObj(propElem("x", num()), propElem("y", str()))
-	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	got := newIntersection(c, parseTypes(t,
+		"{x: number, ...}",
+		"{x: number, y: string, ...}",
+	))
+	require.True(t, equalType(parseType(t, "{x: number, y: string, ...}"), got), "got %s", soltype.Print(got))
 }
 
 // TestSubsumeMutualPicksCanonicalSurvivor pins the M6 PR1 canonicalization
@@ -254,8 +240,8 @@ func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 // different members. With it, both produce the same survivor.
 func TestSubsumeMutualPicksCanonicalSurvivor(t *testing.T) {
 	c := &Context{}
-	exact := exactTuple(num())
-	inexact := inexactTuple(num())
+	exact := parseType(t, "[number]")
+	inexact := parseType(t, "[number, ...]")
 	t.Run("union forward order", func(t *testing.T) {
 		got := newUnion(c, []soltype.Type{exact, inexact}, false)
 		require.IsType(t, &soltype.TupleType{}, got)
@@ -282,17 +268,14 @@ func TestSubsumeMutualPicksCanonicalSurvivor(t *testing.T) {
 // lattice-pruned but not subsumed. PR8 closes this gap at the finalization
 // boundaries.
 func TestNewUnionNoSubsumeWithoutContext(t *testing.T) {
-	got := newUnion(nil, []soltype.Type{num(), numLit(1)}, false)
-	// PrimType ranks before LitType in the kind table, so num leads.
-	want := &soltype.UnionType{Types: []soltype.Type{num(), numLit(1)}}
+	got := newUnion(nil, parseTypes(t, "number", "1"), false)
+	// PrimType ranks before LitType in the kind table, so number leads.
+	want := parseType(t, "number | 1")
 	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
 }
 
 func TestNewIntersectionNoSubsumeWithoutContext(t *testing.T) {
-	got := newIntersection(nil, []soltype.Type{
-		inexactObj(propElem("x", num())),
-		inexactObj(propElem("x", num()), propElem("y", str())),
-	})
+	got := newIntersection(nil, parseTypes(t, "{x: number, ...}", "{x: number, y: string, ...}"))
 	require.IsType(t, &soltype.IntersectionType{}, got)
 	it := got.(*soltype.IntersectionType)
 	require.Len(t, it.Types, 2)
@@ -300,14 +283,54 @@ func TestNewIntersectionNoSubsumeWithoutContext(t *testing.T) {
 
 // TestNewUnionSubsumptionSkipsVar pins the concrete gate: a member that still
 // carries a free type variable is left alone, even with a Context, to avoid
-// speculatively pinning that variable mid-walk.
+// speculatively pinning that variable mid-walk. The free var has no surface
+// form parseType can produce, so the test builds it directly.
 func TestNewUnionSubsumptionSkipsVar(t *testing.T) {
 	c := &Context{}
 	v := c.freshVar(0)
-	got := newUnion(c, []soltype.Type{num(), v}, false)
+	got := newUnion(c, []soltype.Type{parseType(t, "number"), v}, false)
 	require.IsType(t, &soltype.UnionType{}, got)
 	u := got.(*soltype.UnionType)
 	require.Len(t, u.Types, 2)
+}
+
+// TestVoidAndNullSortLast pins the convention that the absence markers
+// NullType and Void appear after data members in canonical order, with
+// NullType before Void. A mixed union such as `number | null | void`
+// surfaces the data first and the absence markers last.
+func TestVoidAndNullSortLast(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		{
+			name:  "void sorts after a data member",
+			parts: parseTypes(t, "void", "number"),
+			want:  "number | void",
+		},
+		{
+			name:  "null sorts after a data member",
+			parts: parseTypes(t, "null", "number"),
+			want:  "number | null",
+		},
+		{
+			name:  "null sorts before void",
+			parts: parseTypes(t, "void", "null", "number"),
+			want:  "number | null | void",
+		},
+		{
+			name:  "null before void independent of input order",
+			parts: parseTypes(t, "void", "null"),
+			want:  "null | void",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newUnion(nil, tt.parts, false)
+			require.Equal(t, tt.want, soltype.Print(got))
+		})
+	}
 }
 
 // TestCompareTypeConsistentWithEqual pins compareType's consistency
@@ -318,11 +341,13 @@ func TestCompareTypeConsistentWithEqual(t *testing.T) {
 		name string
 		a, b soltype.Type
 	}{
-		{"primitives", num(), num()},
-		{"literals", numLit(5), numLit(5)},
-		{"never", &soltype.NeverType{}, &soltype.NeverType{}},
-		{"unknown", &soltype.UnknownType{}, &soltype.UnknownType{}},
-		{"objects equal up to order", exactObj(propElem("a", num()), propElem("b", str())), exactObj(propElem("b", str()), propElem("a", num()))},
+		{"primitives", parseType(t, "number"), parseType(t, "number")},
+		{"literals", parseType(t, "5"), parseType(t, "5")},
+		{"never", parseType(t, "never"), parseType(t, "never")},
+		{"unknown", parseType(t, "unknown"), parseType(t, "unknown")},
+		// equalType treats objects as equal up to property order; the
+		// comparator must agree.
+		{"objects equal up to order", parseType(t, "{a: number, b: string}"), parseType(t, "{b: string, a: number}")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -339,49 +364,10 @@ func TestCompareTypeConsistentWithEqual(t *testing.T) {
 func TestCompareTypeKindOrder(t *testing.T) {
 	c := &Context{}
 	v := c.freshVar(0)
-	require.Less(t, compareType(v, num()), 0, "TypeVarType < PrimType")
-	require.Less(t, compareType(num(), numLit(1)), 0, "PrimType < LitType")
-	require.Less(t, compareType(&soltype.NeverType{}, v), 0, "NeverType < TypeVarType")
-	require.Less(t, compareType(&soltype.UnknownType{}, v), 0, "UnknownType < TypeVarType")
-}
-
-// TestVoidAndNullSortLast pins the convention that the absence markers
-// NullType and Void appear after data members in canonical order, with
-// NullType before Void. A mixed union such as `number | null | void`
-// surfaces the data first and the absence markers last.
-func TestVoidAndNullSortLast(t *testing.T) {
-	tests := []struct {
-		name  string
-		parts []soltype.Type
-		want  string
-	}{
-		{
-			name:  "void sorts after a data member",
-			parts: []soltype.Type{&soltype.Void{}, num()},
-			want:  "number | void",
-		},
-		{
-			name:  "null sorts after a data member",
-			parts: []soltype.Type{&soltype.NullType{}, num()},
-			want:  "number | null",
-		},
-		{
-			name:  "null sorts before void",
-			parts: []soltype.Type{&soltype.Void{}, &soltype.NullType{}, num()},
-			want:  "number | null | void",
-		},
-		{
-			name:  "null before void independent of input order",
-			parts: []soltype.Type{&soltype.Void{}, &soltype.NullType{}},
-			want:  "null | void",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := newUnion(nil, tt.parts, false)
-			require.Equal(t, tt.want, soltype.Print(got))
-		})
-	}
+	require.Less(t, compareType(v, parseType(t, "number")), 0, "TypeVarType < PrimType")
+	require.Less(t, compareType(parseType(t, "number"), parseType(t, "1")), 0, "PrimType < LitType")
+	require.Less(t, compareType(parseType(t, "never"), v), 0, "NeverType < TypeVarType")
+	require.Less(t, compareType(parseType(t, "unknown"), v), 0, "UnknownType < TypeVarType")
 }
 
 // TestCompareTypeDistinctRefsWithUnnamedLifetimes pins the structural
@@ -389,7 +375,8 @@ func TestVoidAndNullSortLast(t *testing.T) {
 // unnamed LifetimeVars print identically when the top-level Print supplies
 // no name map, so a Print-based tie-break would collapse them. The
 // structural comparator orders them by LifetimeVar.ID and keeps them
-// strictly distinct.
+// strictly distinct. The parseType helper does not author borrows with
+// LifetimeVars, so the test builds the RefTypes directly.
 func TestCompareTypeDistinctRefsWithUnnamedLifetimes(t *testing.T) {
 	c := &Context{}
 	lt1 := c.freshLifetime(0)

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -1,0 +1,281 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewUnionFlatten exercises step 1 of newUnion's normalization: a nested
+// UnionType is spliced into the outer union, and an inexact member contributes
+// to the result's inexactness.
+func TestNewUnionFlatten(t *testing.T) {
+	t.Run("nested union splices in", func(t *testing.T) {
+		// (number | string) | boolean ⇒ boolean | number | string (canonical print
+		// order within the PrimType kind: alphabetical).
+		got := newUnion(nil, []soltype.Type{
+			&soltype.UnionType{Types: []soltype.Type{num(), str()}},
+			boolT(),
+		}, false)
+		want := &soltype.UnionType{Types: []soltype.Type{boolT(), num(), str()}}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("inexact nested member makes outer inexact", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{
+			&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true},
+			str(),
+		}, false)
+		want := &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
+// TestNewIntersectionFlatten is the meet twin of TestNewUnionFlatten.
+func TestNewIntersectionFlatten(t *testing.T) {
+	// (number & {a}) & {b} ⇒ number & {a} & {b}, canonical order.
+	got := newIntersection(nil, []soltype.Type{
+		&soltype.IntersectionType{Types: []soltype.Type{num(), exactObj(propElem("a", num()))}},
+		exactObj(propElem("b", str())),
+	})
+	want := &soltype.IntersectionType{Types: []soltype.Type{
+		num(),
+		exactObj(propElem("a", num())),
+		exactObj(propElem("b", str())),
+	}}
+	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+}
+
+// TestNewUnionLatticeIdentity covers step 2: never (⊥) drops out of a union.
+func TestNewUnionLatticeIdentity(t *testing.T) {
+	t.Run("never drops from union", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{num(), &soltype.NeverType{}}, false)
+		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("all-never collapses to never", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{&soltype.NeverType{}, &soltype.NeverType{}}, false)
+		require.IsType(t, &soltype.NeverType{}, got)
+	})
+}
+
+// TestNewIntersectionLatticeIdentity covers step 2 on the meet side: unknown
+// (⊤) drops out of an intersection.
+func TestNewIntersectionLatticeIdentity(t *testing.T) {
+	t.Run("unknown drops from intersection", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{num(), &soltype.UnknownType{}})
+		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("all-unknown collapses to unknown", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{&soltype.UnknownType{}, &soltype.UnknownType{}})
+		require.IsType(t, &soltype.UnknownType{}, got)
+	})
+}
+
+// TestNewUnionErrorElision covers step 3: ErrorType drops from both forms,
+// unless it ends up the SOLE survivor.
+func TestNewUnionErrorElision(t *testing.T) {
+	t.Run("error drops from union with other members", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{num(), &soltype.ErrorType{}}, false)
+		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("error retained as sole member", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{&soltype.ErrorType{}}, false)
+		require.IsType(t, &soltype.ErrorType{}, got)
+	})
+
+	t.Run("error retained when other members are all lattice identities", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{&soltype.ErrorType{}, &soltype.NeverType{}}, false)
+		require.IsType(t, &soltype.ErrorType{}, got)
+	})
+}
+
+func TestNewIntersectionErrorElision(t *testing.T) {
+	t.Run("error drops from intersection with other members", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{num(), &soltype.ErrorType{}})
+		require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("error retained as sole member", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{&soltype.ErrorType{}})
+		require.IsType(t, &soltype.ErrorType{}, got)
+	})
+
+	t.Run("error retained when other members are all lattice identities", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{&soltype.ErrorType{}, &soltype.UnknownType{}})
+		require.IsType(t, &soltype.ErrorType{}, got)
+	})
+}
+
+// TestNewUnionDedup covers step 4: structurally-equal members collapse.
+func TestNewUnionDedup(t *testing.T) {
+	t.Run("union dedup", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{num(), num(), str()}, false)
+		// Canonical order falls back to print string within the PrimType kind:
+		// "number" < "string", so num() before str().
+		want := &soltype.UnionType{Types: []soltype.Type{num(), str()}}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+
+	t.Run("intersection dedup", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{num(), str(), num()})
+		want := &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
+// TestNewUnionCanonicalOrder is the M6 PR1 gate against speculative-pinning
+// drift: a union of a member list and of its shuffle render identically and
+// equalType-match. The canonical order makes equalTypeSlice correct without a
+// rewrite.
+func TestNewUnionCanonicalOrder(t *testing.T) {
+	a := newUnion(nil, []soltype.Type{num(), str()}, false)
+	b := newUnion(nil, []soltype.Type{str(), num()}, false)
+	require.True(t, equalType(a, b), "expected canonical order to equate both shuffles")
+	require.Equal(t, soltype.Print(a), soltype.Print(b))
+}
+
+func TestNewIntersectionCanonicalOrder(t *testing.T) {
+	a := newIntersection(nil, []soltype.Type{num(), str()})
+	b := newIntersection(nil, []soltype.Type{str(), num()})
+	require.True(t, equalType(a, b), "expected canonical order to equate both shuffles")
+	require.Equal(t, soltype.Print(a), soltype.Print(b))
+}
+
+// TestNewUnionCollapse covers step 7: an empty union ⇒ never, a single member ⇒
+// that member, an empty intersection ⇒ unknown.
+func TestNewUnionCollapse(t *testing.T) {
+	t.Run("empty union ⇒ never", func(t *testing.T) {
+		got := newUnion(nil, nil, false)
+		require.IsType(t, &soltype.NeverType{}, got)
+	})
+
+	t.Run("single member ⇒ member directly", func(t *testing.T) {
+		got := newUnion(nil, []soltype.Type{num()}, false)
+		require.True(t, equalType(num(), got))
+	})
+
+	t.Run("empty intersection ⇒ unknown", func(t *testing.T) {
+		got := newIntersection(nil, nil)
+		require.IsType(t, &soltype.UnknownType{}, got)
+	})
+
+	t.Run("single intersection member ⇒ member directly", func(t *testing.T) {
+		got := newIntersection(nil, []soltype.Type{num()})
+		require.True(t, equalType(num(), got))
+	})
+
+	t.Run("inexact single-member union keeps the wrapper", func(t *testing.T) {
+		// A `... | T` tail makes the union strictly weaker than the bare T, so
+		// the inexact single-member union does NOT collapse.
+		got := newUnion(nil, []soltype.Type{num()}, true)
+		want := &soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}
+		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+	})
+}
+
+// TestNewUnionInexactPrintRoundTrip pins the printer's trailing `...` rendering
+// for an inexact union, so the flag round-trips to surface syntax.
+func TestNewUnionInexactPrintRoundTrip(t *testing.T) {
+	u := newUnion(nil, []soltype.Type{num(), str()}, true)
+	// Canonical order: number < string (alphabetical print fallback within the
+	// PrimType kind).
+	require.Equal(t, "number | string | ...", soltype.Print(u))
+}
+
+// TestNewUnionSubsumeWithContext covers step 5: when a Context is supplied, a
+// member that is a subtype of another member is dropped. `number | 1` ⇒ `number`.
+func TestNewUnionSubsumeWithContext(t *testing.T) {
+	c := &Context{}
+	got := newUnion(c, []soltype.Type{num(), numLit(1)}, false)
+	require.True(t, equalType(num(), got), "got %s", soltype.Print(got))
+}
+
+// TestNewIntersectionSubsumeWithContext is the meet twin: an intersection
+// member that is a SUPERTYPE of another is dropped. Width subtyping holds on
+// inexact objects (the wider object is a subtype of the narrower), so
+// `{x, ...} & {x, y, ...}` ⇒ `{x, y, ...}`.
+func TestNewIntersectionSubsumeWithContext(t *testing.T) {
+	c := &Context{}
+	got := newIntersection(c, []soltype.Type{
+		inexactObj(propElem("x", num())),
+		inexactObj(propElem("x", num()), propElem("y", str())),
+	})
+	want := inexactObj(propElem("x", num()), propElem("y", str()))
+	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+}
+
+// TestNewUnionNoSubsumeWithoutContext is the negative case: without a Context,
+// the constructor leaves non-equal subsumable members in place. This is the
+// `combine` posture — a coalesced output is dedup'd and lattice-pruned but not
+// subsumed, since subsumption needs a Context to run constrain under a probe.
+// PR8 closes this gap at the finalization boundaries.
+func TestNewUnionNoSubsumeWithoutContext(t *testing.T) {
+	got := newUnion(nil, []soltype.Type{num(), numLit(1)}, false)
+	// Both members survive; canonical order is numLit(1) before num() by kind
+	// (LitType ranks before PrimType is false — actually PrimType=4 < LitType=5,
+	// so num() first).
+	want := &soltype.UnionType{Types: []soltype.Type{num(), numLit(1)}}
+	require.True(t, equalType(want, got), "got %s", soltype.Print(got))
+}
+
+func TestNewIntersectionNoSubsumeWithoutContext(t *testing.T) {
+	got := newIntersection(nil, []soltype.Type{
+		inexactObj(propElem("x", num())),
+		inexactObj(propElem("x", num()), propElem("y", str())),
+	})
+	// Both members survive — the wider `{x, ...}` is not dropped without a Context.
+	require.IsType(t, &soltype.IntersectionType{}, got)
+	it := got.(*soltype.IntersectionType)
+	require.Len(t, it.Types, 2)
+}
+
+// TestNewUnionSubsumptionSkipsVar pins the concrete gate: a member that still
+// carries a free type variable is left alone, even with a Context, to avoid
+// speculatively pinning that variable mid-walk. Both members survive.
+func TestNewUnionSubsumptionSkipsVar(t *testing.T) {
+	c := &Context{}
+	v := c.freshVar(0)
+	got := newUnion(c, []soltype.Type{num(), v}, false)
+	// number | T (a free var), neither member is dropped.
+	require.IsType(t, &soltype.UnionType{}, got)
+	u := got.(*soltype.UnionType)
+	require.Len(t, u.Types, 2)
+}
+
+// TestCompareTypeConsistentWithEqual pins compareType's consistency contract:
+// two equalType-equal types compare equal. Without this canonicalization would
+// be unstable and dedup unreliable.
+func TestCompareTypeConsistentWithEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b soltype.Type
+	}{
+		{"primitives", num(), num()},
+		{"literals", numLit(5), numLit(5)},
+		{"never", &soltype.NeverType{}, &soltype.NeverType{}},
+		{"unknown", &soltype.UnknownType{}, &soltype.UnknownType{}},
+		{"objects equal up to order", exactObj(propElem("a", num()), propElem("b", str())), exactObj(propElem("b", str()), propElem("a", num()))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.True(t, equalType(tt.a, tt.b), "precondition: equalType")
+			require.Equal(t, 0, compareType(tt.a, tt.b), "compareType must return 0 for equalType-equal types")
+		})
+	}
+}
+
+// TestCompareTypeKindOrder pins the kind ranking that orders dissimilar
+// members so a union of mixed kinds renders deterministically.
+func TestCompareTypeKindOrder(t *testing.T) {
+	// PrimType (4) ranks before LitType (5) ranks before TypeVarType (6).
+	c := &Context{}
+	v := c.freshVar(0)
+	require.Less(t, compareType(num(), numLit(1)), 0, "PrimType < LitType")
+	require.Less(t, compareType(numLit(1), v), 0, "LitType < TypeVarType")
+	require.Less(t, compareType(&soltype.NeverType{}, num()), 0, "NeverType < PrimType")
+	require.Less(t, compareType(&soltype.UnknownType{}, num()), 0, "UnknownType < PrimType")
+}

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -292,14 +292,16 @@ func TestCompareTypeConsistentWithEqual(t *testing.T) {
 }
 
 // TestCompareTypeKindOrder pins the kind ranking that orders dissimilar
-// members so a union of mixed kinds renders deterministically.
+// members so a union of mixed kinds renders deterministically. TypeVarType
+// leads, then PrimType, then LitType, so a quantified parameter shows up
+// before the primitive or literal it is constrained against.
 func TestCompareTypeKindOrder(t *testing.T) {
 	c := &Context{}
 	v := c.freshVar(0)
+	require.Less(t, compareType(v, num()), 0, "TypeVarType < PrimType")
 	require.Less(t, compareType(num(), numLit(1)), 0, "PrimType < LitType")
-	require.Less(t, compareType(numLit(1), v), 0, "LitType < TypeVarType")
-	require.Less(t, compareType(&soltype.NeverType{}, num()), 0, "NeverType < PrimType")
-	require.Less(t, compareType(&soltype.UnknownType{}, num()), 0, "UnknownType < PrimType")
+	require.Less(t, compareType(&soltype.NeverType{}, v), 0, "NeverType < TypeVarType")
+	require.Less(t, compareType(&soltype.UnknownType{}, v), 0, "UnknownType < TypeVarType")
 }
 
 // TestVoidAndNullSortLast pins the convention that the absence markers

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -302,6 +302,45 @@ func TestCompareTypeKindOrder(t *testing.T) {
 	require.Less(t, compareType(&soltype.UnknownType{}, num()), 0, "UnknownType < PrimType")
 }
 
+// TestVoidAndNullSortLast pins the convention that the absence markers
+// NullType and Void appear after data members in canonical order, with
+// NullType before Void. A mixed union such as `number | null | void`
+// surfaces the data first and the absence markers last.
+func TestVoidAndNullSortLast(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []soltype.Type
+		want  string
+	}{
+		{
+			name:  "void sorts after a data member",
+			parts: []soltype.Type{&soltype.Void{}, num()},
+			want:  "number | void",
+		},
+		{
+			name:  "null sorts after a data member",
+			parts: []soltype.Type{&soltype.NullType{}, num()},
+			want:  "number | null",
+		},
+		{
+			name:  "null sorts before void",
+			parts: []soltype.Type{&soltype.Void{}, &soltype.NullType{}, num()},
+			want:  "number | null | void",
+		},
+		{
+			name:  "null before void independent of input order",
+			parts: []soltype.Type{&soltype.Void{}, &soltype.NullType{}},
+			want:  "null | void",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newUnion(nil, tt.parts, false)
+			require.Equal(t, tt.want, soltype.Print(got))
+		})
+	}
+}
+
 // TestCompareTypeDistinctRefsWithUnnamedLifetimes pins the structural
 // comparator fix for borrows. Two RefTypes that differ only in distinct,
 // unnamed LifetimeVars print identically when the top-level Print supplies

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -1,0 +1,174 @@
+package solver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// parseType parses an Escalier type-annotation string into a soltype.Type so
+// tests can author cases like parseType(t, "number | string") rather than
+// hand-building each AST node. It is test-only.
+//
+// The converter handles the surface forms the lattice tests author: the prim
+// keywords number / string / boolean; the atomic keywords never / unknown /
+// void / null; literal types such as `5`, `"x"`, `true`; objects, tuples,
+// owned-mutable `mut T`, unions, and intersections. It does not handle
+// generic references, function annotations, borrows with named lifetimes, or
+// type variables. Tests that need those continue to build the soltype value
+// directly.
+//
+// A union or intersection is built through newUnion / newIntersection with no
+// Context, so the result is normalized exactly as the production combine path
+// would produce it. ast.UnionTypeAnn carries no Inexact flag today (that
+// arrives with M6 PR4), so parseType always produces an exact union. A test
+// that needs an inexact union mints one through newUnion(..., true).
+func parseType(t *testing.T, s string) soltype.Type {
+	t.Helper()
+	ta, errs := parser.ParseTypeAnn(context.Background(), s)
+	require.Empty(t, errs, "parser errors for %q", s)
+	require.NotNil(t, ta, "parser returned nil TypeAnn for %q", s)
+	return toSoltype(t, ta)
+}
+
+// parseTypes is the slice-input variant. It threads each string through
+// parseType and returns the resulting members in input order, so a test can
+// write `newUnion(nil, parseTypes(t, "number", "string"), false)`.
+func parseTypes(t *testing.T, parts ...string) []soltype.Type {
+	t.Helper()
+	out := make([]soltype.Type, len(parts))
+	for i, p := range parts {
+		out[i] = parseType(t, p)
+	}
+	return out
+}
+
+// toSoltype walks one ast.TypeAnn node into a soltype.Type. Unsupported
+// nodes fail the test rather than degrading silently, so a typo in a test
+// string surfaces immediately.
+func toSoltype(t *testing.T, ta ast.TypeAnn) soltype.Type {
+	t.Helper()
+	switch ta := ta.(type) {
+	case *ast.NumberTypeAnn:
+		return num()
+	case *ast.StringTypeAnn:
+		return str()
+	case *ast.BooleanTypeAnn:
+		return boolT()
+	case *ast.NeverTypeAnn:
+		return &soltype.NeverType{}
+	case *ast.UnknownTypeAnn:
+		return &soltype.UnknownType{}
+	case *ast.VoidTypeAnn:
+		return &soltype.Void{}
+	case *ast.LitTypeAnn:
+		return litToSoltype(t, ta.Lit)
+	case *ast.UnionTypeAnn:
+		members := make([]soltype.Type, len(ta.Types))
+		for i, m := range ta.Types {
+			members[i] = toSoltype(t, m)
+		}
+		return newUnion(nil, members, false)
+	case *ast.IntersectionTypeAnn:
+		members := make([]soltype.Type, len(ta.Types))
+		for i, m := range ta.Types {
+			members[i] = toSoltype(t, m)
+		}
+		return newIntersection(nil, members)
+	case *ast.ObjectTypeAnn:
+		return objectToSoltype(t, ta)
+	case *ast.TupleTypeAnn:
+		elems := make([]soltype.Type, len(ta.Elems))
+		for i, e := range ta.Elems {
+			elems[i] = toSoltype(t, e)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
+	case *ast.MutableTypeAnn:
+		inner := toSoltype(t, ta.Target)
+		ri, ok := inner.(soltype.RefInner)
+		require.True(t, ok, "parseType: `mut` over a non-borrowable type %T", inner)
+		return &soltype.RefType{Mut: true, Lt: nil, Inner: ri}
+	}
+	t.Fatalf("parseType: unsupported type annotation %T", ta)
+	return nil
+}
+
+// litToSoltype maps an ast.Lit inside a LitTypeAnn to its soltype value.
+// NullLit maps to NullType, since null is a distinct atomic kind rather than
+// a literal.
+func litToSoltype(t *testing.T, lit ast.Lit) soltype.Type {
+	t.Helper()
+	switch l := lit.(type) {
+	case *ast.NumLit:
+		return &soltype.LitType{Lit: &soltype.NumLit{Value: l.Value}}
+	case *ast.StrLit:
+		return &soltype.LitType{Lit: &soltype.StrLit{Value: l.Value}}
+	case *ast.BoolLit:
+		return &soltype.LitType{Lit: &soltype.BoolLit{Value: l.Value}}
+	case *ast.NullLit:
+		return &soltype.NullType{}
+	}
+	t.Fatalf("parseType: unsupported literal %T", lit)
+	return nil
+}
+
+// objectToSoltype lowers an ObjectTypeAnn into a soltype.ObjectType. Only
+// property elements (`name: T`, `name?: T`) are accepted, mirroring the
+// production resolveObjectTypeAnn arm. Method, getter, setter, index, and
+// spread elements fail the test since the lattice tests do not need them.
+func objectToSoltype(t *testing.T, ta *ast.ObjectTypeAnn) *soltype.ObjectType {
+	t.Helper()
+	elems := make([]soltype.ObjTypeElem, 0, len(ta.Elems))
+	for _, e := range ta.Elems {
+		prop, ok := e.(*ast.PropertyTypeAnn)
+		require.True(t, ok, "parseType: unsupported object element %T", e)
+		name, ok := objKeyName(prop.Name)
+		require.True(t, ok, "parseType: unsupported object key %T", prop.Name)
+		var ft soltype.Type
+		if prop.Value != nil {
+			ft = toSoltype(t, prop.Value)
+		} else {
+			ft = &soltype.UnknownType{}
+		}
+		elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: prop.Optional})
+	}
+	return &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
+}
+
+// TestParseTypeHelperSmoke confirms parseType round-trips a variety of
+// surface forms to the same soltype value the tests would otherwise build
+// by hand.
+func TestParseTypeHelperSmoke(t *testing.T) {
+	tests := []struct {
+		in   string
+		want soltype.Type
+	}{
+		{"number", num()},
+		{"string", str()},
+		{"boolean", boolT()},
+		{"never", &soltype.NeverType{}},
+		{"unknown", &soltype.UnknownType{}},
+		{"void", &soltype.Void{}},
+		{"null", &soltype.NullType{}},
+		{"5", numLit(5)},
+		{`"x"`, strLit("x")},
+		{"true", &soltype.LitType{Lit: &soltype.BoolLit{Value: true}}},
+		{"number | string", &soltype.UnionType{Types: []soltype.Type{num(), str()}}},
+		{"number & string", &soltype.IntersectionType{Types: []soltype.Type{num(), str()}}},
+		{"{x: number}", exactObj(propElem("x", num()))},
+		{"{x: number, ...}", inexactObj(propElem("x", num()))},
+		{"[number, string]", &soltype.TupleType{Elems: []soltype.Type{num(), str()}}},
+		{"[number, ...]", &soltype.TupleType{Elems: []soltype.Type{num()}, Inexact: true}},
+		{"mut {x: number}", mutRef(exactObj(propElem("x", num())))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := parseType(t, tt.in)
+			require.True(t, equalType(tt.want, got), "parseType(%q): want %s, got %s", tt.in, soltype.Print(tt.want), soltype.Print(got))
+		})
+	}
+}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -121,6 +121,13 @@ func isValueType(t soltype.Type) bool {
 	case *soltype.PrimType, *soltype.LitType:
 		return true
 	case *soltype.UnionType:
+		if p.Inexact {
+			// An inexact union has an open tail of unknown type, so the
+			// classification depends on members the union does not name. The
+			// conservative answer is "not a value type". Over-reporting an
+			// alias edge is sound; under-reporting one is not.
+			return false
+		}
 		for _, member := range p.Types {
 			if !isValueType(member) {
 				return false


### PR DESCRIPTION
Introduce `newUnion` and `newIntersection` smart constructors that normalize lattice nodes through a multi-step pipeline. These become the single mint path for `UnionType` and `IntersectionType`, ensuring all lattice output is well-formed and canonical.

The normalization pipeline includes:
- Flattening nested unions/intersections into a flat member list
- Pruning lattice identities (never from unions, unknown from intersections) and ErrorType
- Deduplicating members
- Optionally subsume members when a Context is available (dropping subsumed members)
- Sorting members into canonical order for deterministic rendering and stable caching
- Collapsing single-member or empty unions/intersections to their base types

Key changes:
- Add `lattice.go` with the smart constructors and supporting functions for flattening, pruning, deduplication, subsumption, and comparison
- Add comprehensive tests in `lattice_test.go` covering normalization steps, canonical ordering, and subsumption behavior
- Update `coalesce.go` to route through `newUnion` and `newIntersection` so coalesced output is normalized
- Update `mergeObjectGroup` to use `newIntersection` for property type merging
- Add `HasTypeVar` visitor to `soltype/visitor.go` to detect free type variables (used to gate subsumption)
- Preserve the `Inexact` flag through `UnionType.Accept` in the visitor
- Update `UnionType` documentation to reflect its promotion to a first-class lattice member
- Update error descriptions and type classification to handle inexact unions
- Update test expectations to reflect canonical ordering

The canonical ordering ensures that `newUnion([A, B])` and `newUnion([B, A])` produce identical results, fixing speculative-pinning drift and making the canonical type a stable cache key.

https://claude.ai/code/session_01W6SCMrkNhmpcCuFbZtw3pD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `null` type in the type system.
  * Introduced inexact unions (marked with `...`) to represent open-ended union types.
  * Added type variable detection utility.

* **Bug Fixes**
  * Fixed type constraint handling for inexact union targets.
  * Improved type canonicalization and member ordering in unions and intersections.
  * Enhanced error messages to properly display inexact union markers.

* **Tests**
  * Added comprehensive test coverage for union normalization and type canonicalization.
  * Added tests for type constraint preservation in rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->