### PR TITLE
docs(affine): make mut deep with type parameters inert

### DIFF
--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -50,8 +50,10 @@ type-former PRs, 9 and 10, additionally depend on **M6** of
 union and intersection formers together with union-scrutinee narrowing. PR 11, the
 connected-component moves, is a further move-engine extension and stays on M4. PR 12,
 `Freeze`/`Thaw`, additionally depends on **M9**, the mapped and conditional type
-operators. So PRs 1 through 8 and 11 can proceed once M4 is in place, 9 and 10 wait
-on M6, and 12 waits on M9.
+operators. PR 13, deep `mut` with `readonly`, is foundational mut-semantics work that
+stays on M4 and is best sequenced early, since PR 12 and the affine model's mutability
+all build on it. So PRs 1 through 8, 11, and 13 can proceed once M4 is in place, 9 and
+10 wait on M6, and 12 waits on M9.
 
 ## Parsing borrows without a syntax mode
 
@@ -245,7 +247,8 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium |
 | 11 | Connected-component moves for graphs | 6, 7 | Large |
-| 12 | `Freeze`/`Thaw` deep mut↔immut utility types | 8, 11, M9 | Large |
+| 12 | `Freeze`/`Thaw` deep mut↔immut utility types | 8, 11, 13, M9 | Large |
+| 13 | Deep `mut`, type-parameter inertness, and `readonly` | 1, 2 | Medium |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -644,9 +647,11 @@ externally-aliased nodes still error.
 
 ### PR 12 — `Freeze`/`Thaw` deep mut↔immut utility types
 
-Goal: the `Freeze<T>` and `Thaw<T>` utility types for deep mutability conversion. See
+Goal: the `Freeze<T>` and `Thaw<T>` utility types for deep mutability conversion that
+reaches *through type-parameter boundaries* — the one place deep `mut` and the
+freeze/thaw moves stop (PR 13), so a container's element types get rewritten too. See
 "Freeze and Thaw" in the requirements. Depends on the mapped/conditional-type
-machinery (M9) and the freeze/thaw moves (PR 8).
+machinery (M9), the freeze/thaw moves (PR 8), and deep `mut` (PR 13).
 
 - Add the modifier-rewrite capability to mapped/conditional types: a type-level
   operator that matches a `&mut`/`mut` reference and yields its immutable form, and
@@ -669,6 +674,37 @@ recovers `Node`; a component-owned graph frozen in one move; a write through a
 
 Acceptance: `Freeze`/`Thaw` produce the deep types and are sound through the
 freeze/thaw moves, with no runtime cost.
+
+### PR 13 — Deep `mut`, type-parameter inertness, and `readonly`
+
+Goal: make `mut` deep with type parameters inert, and add the `readonly` field
+modifier. This is foundational mut-semantics work that the affine model and PR 12
+build on; it depends only on the parser (PR 1) and the `&`/`mut` lowering (PR 2) and
+can land early, independent of the move engine. See "Mutability depth and type
+parameters" in the requirements.
+
+- Lower a `mut`/`&mut` annotation by setting `RefType.Mut` deeply through the type's
+  concrete structure, not just the outermost `RefType`. Apply the modifier to the
+  type constructor's body *before* type-argument substitution, so a type parameter is
+  inert: `mut Foo<Point>` is `(mut Foo)<Point>`. The same distribution covers the `&`
+  of `&mut`, so borrow-ness and mutability reach equally far and both stop at the
+  parameter slot.
+- Treat a bare `mut T` as inert until `T` is instantiated, then take its natural
+  meaning, so `mut T` at `T = Point` lowers to `mut Point`.
+- Parser: add the `readonly` field modifier to object type annotations
+  ([internal/parser/type_ann.go](../../internal/parser/type_ann.go)), and lower it to
+  a per-field no-reassignment flag on the object type. `readonly` governs only whether
+  `obj.f = …` is allowed; it is orthogonal to deep mutability.
+- This changes the current shallow-`mut` lowering, so migrate the affected solver
+  snapshots.
+
+Tests: `mut Array<Point>` is a mutable array of immutable points; `mut {a: {b}}` and
+`&mut {a: {x}}` are deep; `mut Line<Point>` over `type Line<P> = {p1: P, p2: P}` keeps
+the points immutable while a concrete `mut Line` is deep; `readonly` rejects field
+reassignment but still permits mutating the field's value when that value is mutable.
+
+Acceptance: `mut`/`&mut` are deep with type parameters inert, and `readonly` forbids
+reassignment only.
 
 ---
 

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -115,6 +115,38 @@ responsible for the value and whether a transfer consumes the source. Mutability
 decides whether writes are allowed. Move/affine semantics governs the ownership
 axis; the mutability axis is governed by the existing exclusivity rule.
 
+### Mutability depth and type parameters
+
+Mutability is **deep**. A `mut` applies to a type constructor's body and propagates
+through its concrete structure, so `mut {a: {b: {c: number}}}` makes every layer
+writable, and `&mut {a: {x: number}}` lets you write `p.a.x`, not only `p.a`. The
+borrow and the mutability of `&mut` distribute together — the whole modifier applies
+to the body — so `&` reaches exactly as far as `mut`.
+
+A modifier stops only at a **type parameter**, which is inert: it does not cross into
+the type substituted for a parameter. Equivalently, `mut Foo<Point>` is
+`(mut Foo)<Point>` — apply `mut` to `Foo`'s body, leaving the `T` slot untouched, then
+substitute `Point` into that inert slot. For `type Foo<T> = {a: {b: {c: T}}}`,
+`mut Foo<Point>` makes the `a`, `b`, and `c` layers writable but leaves the `Point`
+immutable.
+
+The common container case falls out of this. `Array<T>` holds its elements in a
+type-parameter slot, so `mut Array<Point>` is a mutable array of immutable points:
+you may push, reorder, and reassign elements, but not mutate a point's fields. To get
+mutable elements you write the mutability into the argument, `mut Array<mut Point>`,
+and an immutable array of mutable points is `Array<mut Point>`. A `mut` written on a
+bare parameter is inert until the parameter is known, then takes its natural meaning,
+so `mut T` at `T = Point` is `mut Point`.
+
+Because deep `mut` flows through concrete structure, differentiating an inner object's
+mutability from its container's is done by **parameterizing**. Write
+`type Line<P> = {p1: P, p2: P}` and use `mut Line<Point>` for a mutable line of
+immutable points; a plain `type Line = {p1: Point, p2: Point}` under `mut` is mutable
+all the way down. The one field-level modifier is **`readonly`**, which forbids
+*reassigning* a field and nothing more. `{readonly a: T}` rejects `obj.a = …` but says
+nothing about the deep mutability of `a`'s value; `readonly` governs the slot, while
+`mut` and parameterization govern depth.
+
 ### Borrows of a mutable owned value
 
 A mutable owned value may be borrowed many times over. Its borrows fall into two
@@ -467,11 +499,12 @@ connected component.
 
 ## Freeze and Thaw
 
-The freeze and thaw moves change mutability only at the level of the value moved; a
-nested `&mut` or `mut` field keeps its mutability, because Escalier is shallow by
-default — an immutable type may hold mutable fields. So moving a graph's root into an
-immutable binding does not freeze the graph, because the `&mut` cross-edges and `mut`
-field types are part of the node type and stay mutable.
+Freezing a value by moving it into an immutable binding is deep through the value's
+concrete structure, but it stops at type-parameter boundaries, since a modifier is
+inert to type parameters. So freezing a `Node` makes its `value` and its `peers`
+array immutable, but the `peers` elements have type `&mut Node` — the element type of
+`Array`, a type argument — so the container freeze never reaches them and they stay
+mutable. Closing that gap is exactly what `Freeze<T>` is for.
 
 To convert a whole structure between mutable and immutable, use the `Freeze<T>` and
 `Thaw<T>` utility types. `Freeze<T>` is a deep, recursive mapped type that rewrites
@@ -503,8 +536,8 @@ edges are `&mut` and so leave the returned graph mutable through them:
 
 ```esc
 val g = build()                 // g: Node — the moved-out {a, b} component
-g.peers[0].value = 20           // OK — a node is mutated through a `&mut` edge, even
-                                // though g's own slots are immutable; this is the shallow gap
+g.peers[0].value = 20           // OK — the `&mut` edge is a type argument of `Array`,
+                                // inert to g's immutability; this is the type-parameter gap
 
 val frozen: Freeze<Node> = g    // deep-freeze the whole component in one move; g consumed
 print(frozen.peers[0].value)    // OK — read
@@ -542,9 +575,10 @@ is the alias-set reasoning in "Relationship to the mutability-transition checker
 
 Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable
 fields. It deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
-was fully mutable. And `Freeze<T>` is the deliberate opt-in to deep immutability; the
-default stays shallow, so a type is deeply immutable only where the program asks for
-it with `Freeze`.
+was fully mutable. And `Freeze<T>` is the opt-in to deep immutability *through type
+parameters*. A bare type is already deeply immutable in its own concrete structure,
+but a modifier is inert to type arguments, so a container's elements stay as their
+argument type spells them; `Freeze<T>` is what rewrites those element types too.
 
 ## Why the invariant holds
 


### PR DESCRIPTION
Changes `mut` from shallow to deep across the affine docs, per the four points settled in design discussion. Doc-only, on top of the move/affine docs already in `main`.

## The rule

`mut` is **deep**: it applies to a type constructor's body and propagates through its concrete structure, so `mut {a: {b: {c: number}}}` makes every layer writable and `&mut {a: {x}}` lets you write `p.a.x`. The `&` of `&mut` distributes the same way — borrow-ness and mutability reach equally far.

The one stop is a **type parameter**, which is inert: `mut Foo<Point>` is `(mut Foo)<Point>` — apply `mut` to `Foo`'s body, then substitute `Point` into the untouched slot. That makes the common container case fall out for free: `mut Array<Point>` is a *mutable array of immutable points*. You write `mut Array<mut Point>` for mutable elements, and `Array<mut Point>` for an immutable array of mutable points.

## The four points

1. **Deep `mut` + type-parameter inertness**, with the `(mut Foo)<Point>` framing, the `&`/`mut` symmetry, the `Array` container cases, and `mut T` (inert until `T` is concrete).
2. **`readonly`** is the one field modifier and forbids *reassignment only* (`{readonly a: T}` rejects `obj.a = …`, says nothing about deep mutability). Differentiating inner-vs-container mutability is done by **parameterizing** (`type Line<P> = {p1: P, p2: P}`).
3. **Freeze/Thaw reframed.** Its motivation shifts from "shallow by default" to "deep but stops at type-parameter boundaries" — a `Node`'s `peers: Array<&mut Node>` edges survive a freeze because `&mut Node` is `Array`'s type argument, and `Freeze<T>` is precisely what reaches through to rewrite them. The `build()` example's "shallow gap" comment and the closing caveat are updated to match; the rest of the section is intact.
4. **Plan:** new **PR 13 — Deep `mut`, type-parameter inertness, and `readonly`** (foundational, M4-only, deps PR 1/2), with PR 12's dependency on it threaded through and the milestone overview updated.

## Files

- `requirements.md` — new "Mutability depth and type parameters" subsection; reframed Freeze/Thaw opener, `build()` comment, and caveat. No "shallow" framing remains.
- `implementation_plan.md` — PR 13 added, PR 12 reframed to "reach through type parameters," overview updated.

Doc-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRtFcbx97cPbvFiq1cn1mK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRtFcbx97cPbvFiq1cn1mK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deep mutability semantics and type-parameter boundary specifications.
  * Refined implementation plan sequencing and PR dependency structure.
  * Enhanced immutability utility documentation with improved examples.
  * Expanded specifications with detailed constraints, test requirements, and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->