### PR TITLE
M6 PR2: Lattice subtyping rules for union and intersection types

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -55,13 +55,13 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	return lo, hi
 }
 
-// commonBorrowEscape returns a representative BorrowEscapeError when EVERY
-// trial errored with BorrowEscapeError only — the signal that the sub is a
-// borrow with a lifetime and not one super-union member could host it. The
-// per-trial slices are speculative output, so this collapses them into a
-// single union-level error that names the lifetime cause; without it the
-// union-super exists rule would shadow BorrowEscape with a generic
-// CannotConstrain that loses the actionable diagnostic.
+// commonBorrowEscape returns a representative BorrowEscapeError when every
+// per-trial error is itself a BorrowEscapeError. That means sub is a borrow
+// with a lifetime and no super-union member could host it. The caller uses the
+// returned value to emit one union-level BorrowEscapeError so the lifetime
+// cause survives. Without this collapse the union-super exists rule would
+// shadow BorrowEscape with a generic CannotConstrain and the actionable
+// diagnostic would be lost.
 func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 	if len(trials) == 0 {
 		return nil
@@ -84,12 +84,13 @@ func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 
 // superAcceptsUnknownTail reports whether super can absorb the open `unknown`
 // tail of an inexact union sub. The tail represents "anything else" beyond the
-// declared members, so only `unknown` itself and an inexact union with its own
-// open tail can take it. Anything else — an exact union, a concrete prim/
-// object/borrow, an intersection — is closed against the tail and the sub is
-// rejected with an InexactUnionIntoExactError before for-all decomposition.
-// A TypeVar super is handled separately by the super-var-deferral gate in the
-// union-sub for-all block, so it never reaches this function.
+// declared members, so only `unknown` itself and another inexact union with
+// its own open tail can take it. Every other shape is closed against the
+// tail. An exact union, a concrete prim, an object, a borrow, and an
+// intersection are all closed. An inexact-union sub flowing into one of them
+// is rejected with an InexactUnionIntoExactError before for-all decomposition
+// runs. A TypeVar super never reaches this function. The super-var-deferral
+// gate in the union-sub for-all block routes it to the var arm instead.
 func superAcceptsUnknownTail(super soltype.Type) bool {
 	switch s := super.(type) {
 	case *soltype.UnknownType:
@@ -192,48 +193,49 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 
 	// M6 PR2: pre-switch lattice block. Carries every rule whose deciding operand
 	// is a union/intersection super, plus the union-sub for-all rule. It precedes
-	// the structural switch because several arms — notably the RefType arm — return
-	// early on a non-variable super and would intercept a lattice super before the
-	// lattice rule fires. The intersection-sub exists rule stays in the switch,
-	// where the dispatch on sub is what matches it.
+	// the structural switch because several structural arms return early on a
+	// non-variable super and would intercept a lattice super before the lattice
+	// rule could fire. The RefType arm is the load-bearing case. The
+	// intersection-sub exists rule stays in the switch, where the dispatch on sub
+	// matches it directly.
 	//
-	// For-all rules fire eagerly with seen shared across branches (every branch
-	// must succeed). The union-super exists rule trials each member under a probe
-	// with a cloned seen, mirroring the overload arm. A variable on the deciding
-	// side falls through to the var arms below, which record the whole
-	// union/intersection as a bound rather than speculatively pinning the variable
-	// to one branch.
+	// For-all rules fire eagerly. Every branch must succeed, so seen is shared
+	// across them. The union-super exists rule trials each member under a probe
+	// with a cloned seen, mirroring the overload arm. When the deciding side is
+	// a variable the block falls through to the var arms below, which record the
+	// whole union or intersection as a bound. That avoids speculatively pinning
+	// the variable to one branch.
 
-	// Union sub for-all: (A | B) <: super ⟹ A <: super and B <: super.
-	// An inexact sub union carries an open `unknown` tail. When the super is
-	// closed — anything other than `unknown` or an inexact union — the tail can't
-	// be guaranteed to satisfy the target, so reject before decomposition with a
-	// single union-level error rather than a per-member cascade. PR4 lands the
-	// parser surface and the third leg of the rule against an exact super union;
-	// the source-reachable check is wired here and against `Inexact == false`
-	// alone until then.
+	// Union sub for-all: (A | B) <: super ⟹ A <: super AND B <: super.
+	// An inexact sub union carries an open `unknown` tail. The tail can only be
+	// guaranteed to satisfy a super that is itself open. When super is closed,
+	// the constraint is doomed regardless of the explicit members, so we append
+	// a single union-level InexactUnionIntoExactError to flag the open-tail
+	// cause, then still run the for-all loop so any explicit-member mismatch
+	// surfaces in the same pass. PR4 lands the parser surface and the third leg
+	// of the rule against an exact super union. Until then the source-reachable
+	// flag is always false and the inexact path fires only against
+	// internally-built inexact unions.
 	//
 	// SUPER-VAR DEFERRAL. When super is a TypeVar, skip decomposition and fall
-	// through to the superVar arm so the WHOLE union is recorded as one lower
+	// through to the superVar arm. The WHOLE union is recorded as one lower
 	// bound on the var. This mirrors the sub-side variable-deferral pattern the
-	// plan calls out (`α <: (B | C)` is not decomposed either). For an exact
-	// union sub the deferral is behavior-equivalent (the var coalesces to the
-	// same union from either bound shape, since combine + newUnion's flatten
-	// step normalizes both forms). For an inexact union sub the deferral is
-	// LOAD-BEARING: the per-member loop discards the inexact flag because the
-	// `...` tail is a flag on UnionType, not a member of Types, so decomposing
-	// would record only `number` and `string` bounds and α would coalesce as
-	// the EXACT `number | string` — silently dropping the open tail and
-	// breaking the soundness of any downstream `match` against α.
+	// plan calls out. `α <: (B | C)` is not decomposed either.
+	//
+	// For an exact union sub the deferral is behavior-equivalent. The var
+	// coalesces to the same union from either bound shape, because combine plus
+	// newUnion's flatten step normalizes both `[A, B]` and `[(A|B)]` to the
+	// same UnionType.
+	//
+	// For an inexact union sub the deferral is LOAD-BEARING. The `...` tail is
+	// a flag on UnionType, not a member of Types. A per-member loop reads only
+	// Types, so it would record `number` and `string` bounds on α and drop the
+	// flag. α would then coalesce as the EXACT `number | string`, and any
+	// downstream `match α { number => ..., string => ... }` would be reported
+	// exhaustive even though a value of any type could flow through the open
+	// tail at runtime and slip past every arm.
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-			// Accumulate the inexact-into-closed error AND the per-member
-			// failures, mirroring the object arm: one bad cast should surface
-			// every independent issue at once. The inexact tail and an
-			// explicit member that doesn't subtype super are independent bugs
-			// (fixing one leaves the other), so reporting only the inexact
-			// gate would hide a real explicit-member mismatch the user
-			// would only discover after fixing the flag.
 			var errs []SolverError
 			if subU.Inexact && !superAcceptsUnknownTail(super) {
 				errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})
@@ -245,15 +247,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// Intersection super for-all: sub <: (A & B) ⟹ sub <: A and sub <: B.
+	// Intersection super for-all: sub <: (A & B) ⟹ sub <: A AND sub <: B.
 	//
-	// SUB-VAR DEFERRAL. Symmetric to the union-sub case above: when sub is a
-	// TypeVar, fall through to the subVar arm so the WHOLE intersection is
-	// recorded as one upper bound on the var. IntersectionType carries no
-	// exactness flag (the plan: "intersection has no exact/inexact variant"),
-	// so unlike the union case there is no soundness-driving asymmetry; the
-	// deferral is for symmetry with the union rule and a one-shape mental
-	// model for variable handling.
+	// SUB-VAR DEFERRAL. Symmetric to the union-sub case above. When sub is a
+	// TypeVar, skip decomposition and fall through to the subVar arm so the
+	// WHOLE intersection is recorded as one upper bound on the var.
+	// IntersectionType has no exactness flag. The plan settles that an
+	// intersection has no exact/inexact variant, so there is no
+	// soundness-driving asymmetry like the union case has. The deferral is
+	// in place for symmetry with the union rule and a one-shape mental
+	// model for how variables interact with the lattice.
 	if supI, ok := super.(*soltype.IntersectionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var errs []SolverError
@@ -264,22 +267,23 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// Union super exists: sub <: (A | B) ⟹ sub <: A or sub <: B. Trialled only
-	// when sub is concrete; a variable sub falls through to the subVar arm, which
+	// Union super exists: sub <: (A | B) ⟹ sub <: A OR sub <: B. Trialled only
+	// when sub is concrete. A variable sub falls through to the subVar arm and
 	// records the whole union as an upper bound. Each member is trialled under a
 	// probe with a cloned seen so a failed arm's bound mutations and coinductive
-	// cache entries don't leak into the next.
+	// cache entries do not leak into the next.
 	//
 	// FREE-VAR MEMBERS ARE SKIPPED. A super-union member that is itself an
-	// unbounded TypeVar would trivially "match" any concrete sub by recording sub
-	// as the var's lower bound — speculative pinning that commits the var to the
-	// first sub that flows in, even when a concrete sibling branch would have
-	// matched cleanly. canonical sort ranks TypeVar before concrete kinds, so
-	// without this skip a `5 <: (α | number)` constraint would always pin α to ≥5
-	// and never even try the number branch. Skipping the var member lets number
-	// succeed; if no concrete branch matches, the rule fails cleanly without
-	// touching α. A var member with bounds is also skipped — its bounds came
-	// from elsewhere and the user did not write `... | α` as a catch-all.
+	// unbounded TypeVar would trivially match any concrete sub by recording
+	// sub as the var's lower bound. That is speculative pinning. The var would
+	// commit to the first sub that flows in, even when a concrete sibling
+	// branch would have matched cleanly. Canonical sort ranks TypeVar before
+	// concrete kinds, so without the skip a `5 <: (α | number)` constraint
+	// would always pin α to ≥5 and never even try the number branch. Skipping
+	// the var member lets number succeed. If no concrete branch matches, the
+	// rule fails cleanly without touching α. A var member that already has
+	// bounds is skipped too. Its bounds were set elsewhere and the user did
+	// not write `... | α` as a catch-all here.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var trialErrs [][]SolverError
@@ -301,26 +305,29 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				trialErrs = append(trialErrs, errs)
 			}
 			if !triedAny {
-				// Every member was a free var. Fall through to the var arms so
-				// the whole union is recorded as an upper bound on sub if sub
-				// has any var-shaped fallback; otherwise the bottom-of-function
-				// CannotConstrainError fires. Don't emit our own here.
+				// Every member was a free var. Fall through to the var arms.
+				// If sub has any var-shaped fallback the whole union is
+				// recorded as an upper bound there. Otherwise the
+				// bottom-of-function CannotConstrainError fires. Either way,
+				// do not emit one here.
 			} else {
-				// Every concrete branch failed. If they all failed for the SAME
-				// reason — a BorrowEscapeError because sub is a borrow flowing
-				// into a union of owned types, for instance — promote that
-				// to a single union-level diagnostic so the lifetime/structural
-				// cause survives. Otherwise emit the generic union-level
-				// CannotConstrainError.
+				// Every concrete branch failed. When they all failed for the
+				// same reason the failure has a single root cause and should
+				// surface as one diagnostic. A borrow sub flowing into a union
+				// of owned types is the case in hand: every trial returns a
+				// BorrowEscapeError, and we promote one of them to the union
+				// level so the lifetime cause survives. Otherwise emit the
+				// generic union-level CannotConstrainError.
 				//
 				// PR5 will let an inexact super-union's open tail absorb a
-				// non-matching concrete sub through the `_ <: unknown` rule;
-				// until then the inexact case is rejected the same as the
+				// non-matching concrete sub through the `_ <: unknown` rule.
+				// Until then the inexact case is rejected the same as the
 				// exact case.
 				if commonBorrowEscape(trialErrs) != nil {
-					// Every BorrowEscape carries the sub borrow on its own Sub
-					// field, so if all trials returned BorrowEscape sub must
-					// itself be a RefType — the type assertion always holds.
+					// Every BorrowEscape carries the sub borrow on its own
+					// Sub field. If every trial returned BorrowEscape, sub
+					// is necessarily a RefType, so the type assertion always
+					// holds.
 					return []SolverError{&BorrowEscapeError{Sub: sub.(*soltype.RefType), Super: super}}
 				}
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -191,6 +191,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 
 	// (A | B) <: super ⟹ A <: super AND B <: super. Inexact sub against a
 	// closed super also emits one InexactUnionIntoExactError for the open tail.
+	// When super is a TypeVar, fall through to the superVar arm so the whole
+	// union (with its Inexact flag) is recorded as one lower bound on the var.
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			var errs []SolverError
@@ -213,7 +215,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// sub <: (A & B) ⟹ sub <: A AND sub <: B.
+	// sub <: (A & B) ⟹ sub <: A AND sub <: B. When sub is a TypeVar, fall
+	// through to the subVar arm so the whole intersection is recorded as one
+	// upper bound on the var.
 	if supI, ok := super.(*soltype.IntersectionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var errs []SolverError

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -227,10 +227,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// breaking the soundness of any downstream `match` against α.
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-			if subU.Inexact && !superAcceptsUnknownTail(super) {
-				return []SolverError{&InexactUnionIntoExactError{Sub: subU, Super: super}}
-			}
+			// Accumulate the inexact-into-closed error AND the per-member
+			// failures, mirroring the object arm: one bad cast should surface
+			// every independent issue at once. The inexact tail and an
+			// explicit member that doesn't subtype super are independent bugs
+			// (fixing one leaves the other), so reporting only the inexact
+			// gate would hide a real explicit-member mismatch the user
+			// would only discover after fixing the flag.
 			var errs []SolverError
+			if subU.Inexact && !superAcceptsUnknownTail(super) {
+				errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})
+			}
 			for _, m := range subU.Types {
 				errs = append(errs, c.constrain(m, super, seen)...)
 			}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -55,6 +55,22 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	return lo, hi
 }
 
+// superAcceptsUnknownTail reports whether super can absorb the open `unknown`
+// tail of an inexact union sub. The tail represents "anything else" beyond the
+// declared members, so only `unknown` itself and an inexact union with its own
+// open tail can take it. Anything else — an exact union, a concrete prim/object/
+// borrow, an intersection — is closed against the tail and the sub is rejected
+// with an InexactUnionIntoExactError before for-all decomposition.
+func superAcceptsUnknownTail(super soltype.Type) bool {
+	switch s := super.(type) {
+	case *soltype.UnknownType:
+		return true
+	case *soltype.UnionType:
+		return s.Inexact
+	}
+	return false
+}
+
 // constraintKey keys the coinductive seen-set by pointer identity (Go's
 // interface == on pointer-backed soltype concretes). Sufficient for M1: cycles
 // in subtype-checking can only form via TypeVarTypes, and TypeVarType pointers
@@ -143,6 +159,81 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	}
 	if _, ok := super.(*soltype.ErrorType); ok {
 		return nil
+	}
+
+	// M6 PR2: pre-switch lattice block. Carries every rule whose deciding operand
+	// is a union/intersection super, plus the union-sub for-all rule. It precedes
+	// the structural switch because several arms — notably the RefType arm — return
+	// early on a non-variable super and would intercept a lattice super before the
+	// lattice rule fires. The intersection-sub exists rule stays in the switch,
+	// where the dispatch on sub is what matches it.
+	//
+	// For-all rules fire eagerly with seen shared across branches (every branch
+	// must succeed). The union-super exists rule trials each member under a probe
+	// with a cloned seen, mirroring the overload arm. A variable on the deciding
+	// side falls through to the var arms below, which record the whole
+	// union/intersection as a bound rather than speculatively pinning the variable
+	// to one branch.
+
+	// Union sub for-all: (A | B) <: super ⟹ A <: super and B <: super.
+	// An inexact sub union carries an open `unknown` tail. When the super is
+	// closed — anything other than `unknown` or an inexact union — the tail can't
+	// be guaranteed to satisfy the target, so reject before decomposition with a
+	// single union-level error rather than a per-member cascade. PR4 lands the
+	// parser surface and the third leg of the rule against an exact super union;
+	// the source-reachable check is wired here and against `Inexact == false`
+	// alone until then.
+	if subU, ok := sub.(*soltype.UnionType); ok {
+		if subU.Inexact && !superAcceptsUnknownTail(super) {
+			return []SolverError{&InexactUnionIntoExactError{Sub: subU, Super: super}}
+		}
+		var errs []SolverError
+		for _, m := range subU.Types {
+			errs = append(errs, c.constrain(m, super, seen)...)
+		}
+		return errs
+	}
+
+	// Intersection super for-all: sub <: (A & B) ⟹ sub <: A and sub <: B.
+	if supI, ok := super.(*soltype.IntersectionType); ok {
+		var errs []SolverError
+		for _, m := range supI.Types {
+			errs = append(errs, c.constrain(sub, m, seen)...)
+		}
+		return errs
+	}
+
+	// Union super exists: sub <: (A | B) ⟹ sub <: A or sub <: B. Trialled only
+	// when sub is concrete; a variable sub falls through to the subVar arm, which
+	// records the whole union as an upper bound. Each member is trialled under a
+	// probe with a cloned seen so a failed arm's bound mutations and coinductive
+	// cache entries don't leak into the next.
+	if supU, ok := super.(*soltype.UnionType); ok {
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
+			var lastErrs []SolverError
+			for _, m := range supU.Types {
+				p := newProbe(c.probe)
+				c.probe = p
+				errs := c.constrain(sub, m, seen.Clone())
+				c.probe = p.parent
+				if len(errs) == 0 {
+					p.Commit()
+					return nil
+				}
+				p.Discard()
+				lastErrs = errs
+			}
+			// No branch matched. Report the failure at the union level rather
+			// than the last-branch failure, since each branch was a speculative
+			// trial — the user wrote "or", not "and". The per-branch details are
+			// dropped on purpose: a per-member cascade would name the union
+			// shape repeatedly without adding information. PR5 will let an
+			// inexact super-union's open tail absorb a non-matching concrete
+			// sub through the `_ <: unknown` rule; until then the inexact case
+			// is rejected the same as the exact case.
+			_ = lastErrs
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
 	}
 
 	// Structural cases first; fall through to the variable cases when a side
@@ -376,26 +467,33 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return nil
 		}
 	case *soltype.IntersectionType:
-		// Function-intersection sub (PR6 scoped lattice exception): (A & B & …) <: super
-		// iff SOME member <: super. This is the ONE place the overload disjunction touches
-		// the lattice — reached only when an overloaded value (inferIdent synthesizes the
-		// arm intersection) flows into a constraint, e.g. a let-bound overload called
-		// through the binding (`g = f; g(x)`). The disjunction stays confined to the
-		// speculation phase: each member is trialled under a probe in SPECIFICITY order
-		// (the same specificityOrder resolveOverload uses for a direct call, so a call
-		// through a binding resolves to the same arm a direct call would), the first
-		// success commits its bounds and the losers roll back. General IntersectionType
-		// subtyping (objects, distribution, normalization) is out of M3; a coalesced
-		// intersection never reaches constrain as input (the design keeps these
-		// output-only), so this arm is overload-synthesis-only.
+		// Intersection sub "exists" rule: (A & B & …) <: super iff SOME member <: super.
+		// This is the lattice analogue of the union-super exists rule above, and the one
+		// lattice case that stays in the structural switch: the switch dispatches on sub,
+		// so a lattice sub is matched by its own case here without needing the pre-switch
+		// interception the union-super and intersection-super rules require. Each member
+		// is trialled under a probe in SPECIFICITY order (the same specificityOrder
+		// resolveOverload uses for a direct call) and the first success commits its
+		// bounds; the losers roll back.
 		//
-		// Collapse only against a CONCRETE demand. If super is a variable — the overloaded
-		// value is flowing INTO a binding (`intersection <: b.v`) — don't collapse here.
-		// Fall through to the var arm below, which records the intersection WHOLE as a
-		// lower bound. Collapsing now would commit to one arm prematurely and discard the
-		// rest of the overload set. The collapse fires later instead, once that var is
-		// constrained against a concrete function demand (a call shape) and the whole
-		// intersection propagates to it.
+		// Two callers reach this. The overload-synthesis path is the original consumer:
+		// inferIdent builds an intersection out of an overloaded value's arms so a
+		// let-bound overload called through the binding (`g = f; g(x)`) resolves the
+		// arm via the same trial loop a direct call would, in the same order. M6 PR2
+		// adds the second consumer: a general annotation intersection like
+		// `val x: A & B = e` resolves through resolveTypeAnn into an IntersectionType
+		// and reaches here when the binding flows into a constraint. The specificity
+		// ranking still falls out cleanly — specificityOrder ranks a non-function arm
+		// last in declaration order (see overload.go), so a non-function intersection
+		// trials in declaration order without a separate code path.
+		//
+		// Collapse only against a CONCRETE demand. If super is a variable — the
+		// intersection is flowing INTO a binding (`intersection <: b.v`) — don't collapse
+		// here. Fall through to the var arm below, which records the intersection WHOLE
+		// as a lower bound. Collapsing now would commit to one arm prematurely and
+		// discard the rest of the intersection. The collapse fires later instead, once
+		// that var is constrained against a concrete demand and the whole intersection
+		// propagates to it.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
 			funcs := make([]*soltype.FuncType, len(sub.Types))
 			for i, m := range sub.Types {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -181,56 +181,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		return nil
 	}
 
-	// M6 PR2: pre-switch lattice block. Carries every rule whose deciding operand
-	// is a union/intersection super, plus the union-sub for-all rule. It precedes
-	// the structural switch because several structural arms return early on a
-	// non-variable super and would intercept a lattice super before the lattice
-	// rule could fire. The RefType arm is the load-bearing case. The
-	// intersection-sub exists rule stays in the switch, where the dispatch on sub
-	// matches it directly.
-	//
-	// For-all rules fire eagerly. Every branch must succeed, so seen is shared
-	// across them. The union-super exists rule trials each member under a probe
-	// with a cloned seen, mirroring the overload arm. When the deciding side is
-	// a variable the block falls through to the var arms below, which record the
-	// whole union or intersection as a bound. That avoids speculatively pinning
-	// the variable to one branch.
+	// M6 PR2 pre-switch lattice block. The structural switch below dispatches
+	// on sub and several arms return early on a non-variable super (the
+	// RefType arm most importantly), so a union/intersection super has to be
+	// matched here or it would be intercepted as a concrete-non-var demand
+	// before the lattice rule could fire. A variable on the deciding side
+	// falls through to the var arms instead of decomposing, so the whole
+	// union/intersection is recorded as one bound.
 
-	// Union sub for-all: (A | B) <: super ⟹ A <: super AND B <: super.
-	// An inexact sub union carries an open `unknown` tail. The tail can only be
-	// guaranteed to satisfy a super that is itself open. When super is closed,
-	// the constraint is doomed regardless of the explicit members, so we append
-	// a single union-level InexactUnionIntoExactError to flag the open-tail
-	// cause, then still run the for-all loop so any explicit-member mismatch
-	// surfaces in the same pass. PR4 lands the parser surface and the third leg
-	// of the rule against an exact super union. Until then the source-reachable
-	// flag is always false and the inexact path fires only against
-	// internally-built inexact unions.
-	//
-	// SUPER-VAR DEFERRAL. When super is a TypeVar, skip decomposition and fall
-	// through to the superVar arm. The WHOLE union is recorded as one lower
-	// bound on the var. This mirrors the sub-side variable-deferral pattern the
-	// plan calls out. `α <: (B | C)` is not decomposed either.
-	//
-	// For an exact union sub the deferral is behavior-equivalent. The var
-	// coalesces to the same union from either bound shape, because combine plus
-	// newUnion's flatten step normalizes both `[A, B]` and `[(A|B)]` to the
-	// same UnionType.
-	//
-	// For an inexact union sub the deferral is LOAD-BEARING. The `...` tail is
-	// a flag on UnionType, not a member of Types. A per-member loop reads only
-	// Types, so it would record `number` and `string` bounds on α and drop the
-	// flag. α would then coalesce as the EXACT `number | string`, and any
-	// downstream `match α { number => ..., string => ... }` would be reported
-	// exhaustive even though a value of any type could flow through the open
-	// tail at runtime and slip past every arm.
+	// (A | B) <: super ⟹ A <: super AND B <: super. Inexact sub against a
+	// closed super also emits one InexactUnionIntoExactError for the open tail.
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			var errs []SolverError
 			if subU.Inexact {
-				// The open tail can only be absorbed by an `unknown` super
-				// or by another inexact union. Any other shape is closed
-				// against the tail and gets the union-level diagnostic.
 				closed := true
 				switch s := super.(type) {
 				case *soltype.UnknownType:
@@ -249,16 +213,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// Intersection super for-all: sub <: (A & B) ⟹ sub <: A AND sub <: B.
-	//
-	// SUB-VAR DEFERRAL. Symmetric to the union-sub case above. When sub is a
-	// TypeVar, skip decomposition and fall through to the subVar arm so the
-	// WHOLE intersection is recorded as one upper bound on the var.
-	// IntersectionType has no exactness flag. The plan settles that an
-	// intersection has no exact/inexact variant, so there is no
-	// soundness-driving asymmetry like the union case has. The deferral is
-	// in place for symmetry with the union rule and a one-shape mental
-	// model for how variables interact with the lattice.
+	// sub <: (A & B) ⟹ sub <: A AND sub <: B.
 	if supI, ok := super.(*soltype.IntersectionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var errs []SolverError
@@ -269,23 +224,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// Union super exists: sub <: (A | B) ⟹ sub <: A OR sub <: B. Trialled only
-	// when sub is concrete. A variable sub falls through to the subVar arm and
-	// records the whole union as an upper bound. Each member is trialled under a
-	// probe with a cloned seen so a failed arm's bound mutations and coinductive
-	// cache entries do not leak into the next.
-	//
-	// FREE-VAR MEMBERS ARE SKIPPED. A super-union member that is itself an
-	// unbounded TypeVar would trivially match any concrete sub by recording
-	// sub as the var's lower bound. That is speculative pinning. The var would
-	// commit to the first sub that flows in, even when a concrete sibling
-	// branch would have matched cleanly. Canonical sort ranks TypeVar before
-	// concrete kinds, so without the skip a `5 <: (α | number)` constraint
-	// would always pin α to ≥5 and never even try the number branch. Skipping
-	// the var member lets number succeed. If no concrete branch matches, the
-	// rule fails cleanly without touching α. A var member that already has
-	// bounds is skipped too. Its bounds were set elsewhere and the user did
-	// not write `... | α` as a catch-all here.
+	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each member under a probe;
+	// the first success commits, the losers roll back. Free TypeVar members
+	// are skipped to avoid speculatively pinning them to sub.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var trialErrs [][]SolverError
@@ -307,29 +248,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				trialErrs = append(trialErrs, errs)
 			}
 			if !triedAny {
-				// Every member was a free var. Fall through to the var arms.
-				// If sub has any var-shaped fallback the whole union is
-				// recorded as an upper bound there. Otherwise the
-				// bottom-of-function CannotConstrainError fires. Either way,
-				// do not emit one here.
+				// Every member was a free var; fall through to the var arms.
 			} else {
-				// Every concrete branch failed. When they all failed for the
-				// same reason the failure has a single root cause and should
-				// surface as one diagnostic. A borrow sub flowing into a union
-				// of owned types is the case in hand: every trial returns a
-				// BorrowEscapeError, and we promote one of them to the union
-				// level so the lifetime cause survives. Otherwise emit the
-				// generic union-level CannotConstrainError.
-				//
-				// PR5 will let an inexact super-union's open tail absorb a
-				// non-matching concrete sub through the `_ <: unknown` rule.
-				// Until then the inexact case is rejected the same as the
-				// exact case.
+				// Every concrete branch failed. Promote a uniform
+				// BorrowEscape outcome so the lifetime cause survives;
+				// otherwise emit the generic union-level error.
 				if commonBorrowEscape(trialErrs) != nil {
-					// Every BorrowEscape carries the sub borrow on its own
-					// Sub field. If every trial returned BorrowEscape, sub
-					// is necessarily a RefType, so the type assertion always
-					// holds.
 					return []SolverError{&BorrowEscapeError{Sub: sub.(*soltype.RefType), Super: super}}
 				}
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -85,18 +85,14 @@ func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 // superAcceptsUnknownTail reports whether super can absorb the open `unknown`
 // tail of an inexact union sub. The tail represents "anything else" beyond the
 // declared members, so only `unknown` itself and an inexact union with its own
-// open tail can take it. A TypeVarType super is ALSO accepted: a free
-// inference variable has no commitments yet, so deferring to the var arm and
-// recording the whole inexact union as an upper bound is sound — later
-// concrete demands on the var run the gate against a real closed target.
-// Anything else — an exact union, a concrete prim/object/borrow, an
-// intersection — is closed against the tail and the sub is rejected with an
-// InexactUnionIntoExactError before for-all decomposition.
+// open tail can take it. Anything else — an exact union, a concrete prim/
+// object/borrow, an intersection — is closed against the tail and the sub is
+// rejected with an InexactUnionIntoExactError before for-all decomposition.
+// A TypeVar super is handled separately by the super-var-deferral gate in the
+// union-sub for-all block, so it never reaches this function.
 func superAcceptsUnknownTail(super soltype.Type) bool {
 	switch s := super.(type) {
 	case *soltype.UnknownType:
-		return true
-	case *soltype.TypeVarType:
 		return true
 	case *soltype.UnionType:
 		return s.Inexact
@@ -216,24 +212,49 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// parser surface and the third leg of the rule against an exact super union;
 	// the source-reachable check is wired here and against `Inexact == false`
 	// alone until then.
+	//
+	// SUPER-VAR DEFERRAL. When super is a TypeVar, skip decomposition and fall
+	// through to the superVar arm so the WHOLE union is recorded as one lower
+	// bound on the var. This mirrors the sub-side variable-deferral pattern the
+	// plan calls out (`α <: (B | C)` is not decomposed either). For an exact
+	// union sub the deferral is behavior-equivalent (the var coalesces to the
+	// same union from either bound shape, since combine + newUnion's flatten
+	// step normalizes both forms). For an inexact union sub the deferral is
+	// LOAD-BEARING: the per-member loop discards the inexact flag because the
+	// `...` tail is a flag on UnionType, not a member of Types, so decomposing
+	// would record only `number` and `string` bounds and α would coalesce as
+	// the EXACT `number | string` — silently dropping the open tail and
+	// breaking the soundness of any downstream `match` against α.
 	if subU, ok := sub.(*soltype.UnionType); ok {
-		if subU.Inexact && !superAcceptsUnknownTail(super) {
-			return []SolverError{&InexactUnionIntoExactError{Sub: subU, Super: super}}
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if subU.Inexact && !superAcceptsUnknownTail(super) {
+				return []SolverError{&InexactUnionIntoExactError{Sub: subU, Super: super}}
+			}
+			var errs []SolverError
+			for _, m := range subU.Types {
+				errs = append(errs, c.constrain(m, super, seen)...)
+			}
+			return errs
 		}
-		var errs []SolverError
-		for _, m := range subU.Types {
-			errs = append(errs, c.constrain(m, super, seen)...)
-		}
-		return errs
 	}
 
 	// Intersection super for-all: sub <: (A & B) ⟹ sub <: A and sub <: B.
+	//
+	// SUB-VAR DEFERRAL. Symmetric to the union-sub case above: when sub is a
+	// TypeVar, fall through to the subVar arm so the WHOLE intersection is
+	// recorded as one upper bound on the var. IntersectionType carries no
+	// exactness flag (the plan: "intersection has no exact/inexact variant"),
+	// so unlike the union case there is no soundness-driving asymmetry; the
+	// deferral is for symmetry with the union rule and a one-shape mental
+	// model for variable handling.
 	if supI, ok := super.(*soltype.IntersectionType); ok {
-		var errs []SolverError
-		for _, m := range supI.Types {
-			errs = append(errs, c.constrain(sub, m, seen)...)
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
+			var errs []SolverError
+			for _, m := range supI.Types {
+				errs = append(errs, c.constrain(sub, m, seen)...)
+			}
+			return errs
 		}
-		return errs
 	}
 
 	// Union super exists: sub <: (A | B) ⟹ sub <: A or sub <: B. Trialled only

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -496,33 +496,25 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return nil
 		}
 	case *soltype.IntersectionType:
-		// Intersection sub "exists" rule: (A & B & …) <: super iff SOME member <: super.
-		// This is the lattice analogue of the union-super exists rule above, and the one
-		// lattice case that stays in the structural switch: the switch dispatches on sub,
-		// so a lattice sub is matched by its own case here without needing the pre-switch
-		// interception the union-super and intersection-super rules require. Each member
-		// is trialled under a probe in SPECIFICITY order (the same specificityOrder
-		// resolveOverload uses for a direct call) and the first success commits its
-		// bounds; the losers roll back.
+		// (A & B) <: super ⟹ A <: super OR B <: super. Trial each member in
+		// specificity order under a probe; the first success commits. Stays in
+		// the structural switch (not the pre-switch block) because the switch
+		// already dispatches on sub, so a lattice sub is matched by its own case
+		// here without needing a pre-switch interception. When super is a
+		// TypeVar, fall through to the superVar arm so the whole intersection is
+		// recorded as one lower bound rather than committing to one arm and
+		// discarding the rest. Two callers reach this:
 		//
-		// Two callers reach this. The overload-synthesis path is the original consumer:
-		// inferIdent builds an intersection out of an overloaded value's arms so a
-		// let-bound overload called through the binding (`g = f; g(x)`) resolves the
-		// arm via the same trial loop a direct call would, in the same order. M6 PR2
-		// adds the second consumer: a general annotation intersection like
-		// `val x: A & B = e` resolves through resolveTypeAnn into an IntersectionType
-		// and reaches here when the binding flows into a constraint. The specificity
-		// ranking still falls out cleanly — specificityOrder ranks a non-function arm
-		// last in declaration order (see overload.go), so a non-function intersection
-		// trials in declaration order without a separate code path.
-		//
-		// Collapse only against a CONCRETE demand. If super is a variable — the
-		// intersection is flowing INTO a binding (`intersection <: b.v`) — don't collapse
-		// here. Fall through to the var arm below, which records the intersection WHOLE
-		// as a lower bound. Collapsing now would commit to one arm prematurely and
-		// discard the rest of the intersection. The collapse fires later instead, once
-		// that var is constrained against a concrete demand and the whole intersection
-		// propagates to it.
+		//   - Overload synthesis. inferIdent builds an intersection out of an
+		//     overloaded value's arms so a let-bound overload called through the
+		//     binding (`g = f; g(x)`) resolves the arm via the same trial loop a
+		//     direct call would, in the same order.
+		//   - Annotation input (M6 PR2). `val x: A & B = e` resolves through
+		//     resolveTypeAnn into an IntersectionType and reaches here when the
+		//     binding flows into a constraint. specificityOrder ranks
+		//     non-function arms last in declaration order, so a non-function
+		//     intersection trials in declaration order without a separate code
+		//     path.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
 			funcs := make([]*soltype.FuncType, len(sub.Types))
 			for i, m := range sub.Types {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -57,11 +57,20 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 
 // commonBorrowEscape returns a representative BorrowEscapeError when every
 // per-trial error is itself a BorrowEscapeError. That means sub is a borrow
-// with a lifetime and no super-union member could host it. The caller uses the
-// returned value to emit one union-level BorrowEscapeError so the lifetime
-// cause survives. Without this collapse the union-super exists rule would
-// shadow BorrowEscape with a generic CannotConstrain and the actionable
-// diagnostic would be lost.
+// with a lifetime and no super-union member could host it. The caller uses
+// the returned value to emit one union-level BorrowEscapeError so the
+// lifetime cause survives. Without this collapse the union-super exists
+// rule would shadow BorrowEscape with a generic CannotConstrain and the
+// actionable diagnostic would be lost.
+//
+// Example. With `&'a {x: number} <: (number | string)`:
+//   - trial `&'a {x: number} <: number`: BorrowEscapeError (the borrow can't fit a number slot)
+//   - trial `&'a {x: number} <: string`: BorrowEscapeError (same)
+//
+// Both trials returned the same shape, so commonBorrowEscape returns one of
+// them. The caller emits `BorrowEscapeError{Sub: borrow, Super: union}` and
+// the user sees "borrow does not live long enough" rather than the unhelpful
+// "cannot constrain mut object <: number | string".
 func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 	if len(trials) == 0 {
 		return nil
@@ -80,25 +89,6 @@ func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 		}
 	}
 	return first
-}
-
-// superAcceptsUnknownTail reports whether super can absorb the open `unknown`
-// tail of an inexact union sub. The tail represents "anything else" beyond the
-// declared members, so only `unknown` itself and another inexact union with
-// its own open tail can take it. Every other shape is closed against the
-// tail. An exact union, a concrete prim, an object, a borrow, and an
-// intersection are all closed. An inexact-union sub flowing into one of them
-// is rejected with an InexactUnionIntoExactError before for-all decomposition
-// runs. A TypeVar super never reaches this function. The super-var-deferral
-// gate in the union-sub for-all block routes it to the var arm instead.
-func superAcceptsUnknownTail(super soltype.Type) bool {
-	switch s := super.(type) {
-	case *soltype.UnknownType:
-		return true
-	case *soltype.UnionType:
-		return s.Inexact
-	}
-	return false
 }
 
 // constraintKey keys the coinductive seen-set by pointer identity (Go's
@@ -237,8 +227,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			var errs []SolverError
-			if subU.Inexact && !superAcceptsUnknownTail(super) {
-				errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})
+			if subU.Inexact {
+				// The open tail can only be absorbed by an `unknown` super
+				// or by another inexact union. Any other shape is closed
+				// against the tail and gets the union-level diagnostic.
+				closed := true
+				switch s := super.(type) {
+				case *soltype.UnknownType:
+					closed = false
+				case *soltype.UnionType:
+					closed = !s.Inexact
+				}
+				if closed {
+					errs = append(errs, &InexactUnionIntoExactError{Sub: subU, Super: super})
+				}
 			}
 			for _, m := range subU.Types {
 				errs = append(errs, c.constrain(m, super, seen)...)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -55,15 +55,48 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	return lo, hi
 }
 
+// commonBorrowEscape returns a representative BorrowEscapeError when EVERY
+// trial errored with BorrowEscapeError only — the signal that the sub is a
+// borrow with a lifetime and not one super-union member could host it. The
+// per-trial slices are speculative output, so this collapses them into a
+// single union-level error that names the lifetime cause; without it the
+// union-super exists rule would shadow BorrowEscape with a generic
+// CannotConstrain that loses the actionable diagnostic.
+func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
+	if len(trials) == 0 {
+		return nil
+	}
+	var first *BorrowEscapeError
+	for _, errs := range trials {
+		if len(errs) != 1 {
+			return nil
+		}
+		esc, ok := errs[0].(*BorrowEscapeError)
+		if !ok {
+			return nil
+		}
+		if first == nil {
+			first = esc
+		}
+	}
+	return first
+}
+
 // superAcceptsUnknownTail reports whether super can absorb the open `unknown`
 // tail of an inexact union sub. The tail represents "anything else" beyond the
 // declared members, so only `unknown` itself and an inexact union with its own
-// open tail can take it. Anything else — an exact union, a concrete prim/object/
-// borrow, an intersection — is closed against the tail and the sub is rejected
-// with an InexactUnionIntoExactError before for-all decomposition.
+// open tail can take it. A TypeVarType super is ALSO accepted: a free
+// inference variable has no commitments yet, so deferring to the var arm and
+// recording the whole inexact union as an upper bound is sound — later
+// concrete demands on the var run the gate against a real closed target.
+// Anything else — an exact union, a concrete prim/object/borrow, an
+// intersection — is closed against the tail and the sub is rejected with an
+// InexactUnionIntoExactError before for-all decomposition.
 func superAcceptsUnknownTail(super soltype.Type) bool {
 	switch s := super.(type) {
 	case *soltype.UnknownType:
+		return true
+	case *soltype.TypeVarType:
 		return true
 	case *soltype.UnionType:
 		return s.Inexact
@@ -208,10 +241,26 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// records the whole union as an upper bound. Each member is trialled under a
 	// probe with a cloned seen so a failed arm's bound mutations and coinductive
 	// cache entries don't leak into the next.
+	//
+	// FREE-VAR MEMBERS ARE SKIPPED. A super-union member that is itself an
+	// unbounded TypeVar would trivially "match" any concrete sub by recording sub
+	// as the var's lower bound — speculative pinning that commits the var to the
+	// first sub that flows in, even when a concrete sibling branch would have
+	// matched cleanly. canonical sort ranks TypeVar before concrete kinds, so
+	// without this skip a `5 <: (α | number)` constraint would always pin α to ≥5
+	// and never even try the number branch. Skipping the var member lets number
+	// succeed; if no concrete branch matches, the rule fails cleanly without
+	// touching α. A var member with bounds is also skipped — its bounds came
+	// from elsewhere and the user did not write `... | α` as a catch-all.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
-			var lastErrs []SolverError
+			var trialErrs [][]SolverError
+			triedAny := false
 			for _, m := range supU.Types {
+				if _, isVar := m.(*soltype.TypeVarType); isVar {
+					continue
+				}
+				triedAny = true
 				p := newProbe(c.probe)
 				c.probe = p
 				errs := c.constrain(sub, m, seen.Clone())
@@ -221,18 +270,33 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					return nil
 				}
 				p.Discard()
-				lastErrs = errs
+				trialErrs = append(trialErrs, errs)
 			}
-			// No branch matched. Report the failure at the union level rather
-			// than the last-branch failure, since each branch was a speculative
-			// trial — the user wrote "or", not "and". The per-branch details are
-			// dropped on purpose: a per-member cascade would name the union
-			// shape repeatedly without adding information. PR5 will let an
-			// inexact super-union's open tail absorb a non-matching concrete
-			// sub through the `_ <: unknown` rule; until then the inexact case
-			// is rejected the same as the exact case.
-			_ = lastErrs
-			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+			if !triedAny {
+				// Every member was a free var. Fall through to the var arms so
+				// the whole union is recorded as an upper bound on sub if sub
+				// has any var-shaped fallback; otherwise the bottom-of-function
+				// CannotConstrainError fires. Don't emit our own here.
+			} else {
+				// Every concrete branch failed. If they all failed for the SAME
+				// reason — a BorrowEscapeError because sub is a borrow flowing
+				// into a union of owned types, for instance — promote that
+				// to a single union-level diagnostic so the lifetime/structural
+				// cause survives. Otherwise emit the generic union-level
+				// CannotConstrainError.
+				//
+				// PR5 will let an inexact super-union's open tail absorb a
+				// non-matching concrete sub through the `_ <: unknown` rule;
+				// until then the inexact case is rejected the same as the
+				// exact case.
+				if commonBorrowEscape(trialErrs) != nil {
+					// Every BorrowEscape carries the sub borrow on its own Sub
+					// field, so if all trials returned BorrowEscape sub must
+					// itself be a RefType — the type assertion always holds.
+					return []SolverError{&BorrowEscapeError{Sub: sub.(*soltype.RefType), Super: super}}
+				}
+				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+			}
 		}
 	}
 

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -1,0 +1,202 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6 PR2: lattice subtyping rules in constrain ---
+//
+// The pre-switch lattice block carries every rule whose deciding operand is a
+// union/intersection super, plus the union-sub for-all rule. These tests
+// exercise the rules against hand-built lattice nodes through the Constrain
+// API, so the assertions are independent of source-level annotation surface.
+// The annotation-input path is exercised separately under infer_lattice_test.go.
+
+// TestConstrainUnionSubForAll covers the union-sub "for all" rule:
+// (A | B) <: super decomposes into A <: super AND B <: super, eagerly,
+// regardless of what is on the super side.
+func TestConstrainUnionSubForAll(t *testing.T) {
+	t.Run("both branches match concrete super", func(t *testing.T) {
+		// (number | string) <: unknown-style super that accepts both. Use a
+		// concrete object-typed super where each branch fails for a different
+		// reason; the rule should report BOTH branch failures.
+		c := &Context{}
+		sub := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(sub, sub)) // every union is its own subtype
+	})
+
+	t.Run("one branch fails, one branch passes — for-all rejects", func(t *testing.T) {
+		// (number | string) <: number. number <: number ok, string <: number
+		// fails. The for-all rule reports the failed branch.
+		c := &Context{}
+		sub := newUnion(nil, parseTypes(t, "number", "string"), false)
+		errs := c.Constrain(sub, num())
+		require.Equal(t, []string{"cannot constrain string <: number"}, Messages(errs))
+	})
+
+	t.Run("union sub against a variable super", func(t *testing.T) {
+		// (number | string) <: α. For-all decomposes to number <: α AND
+		// string <: α, so both end up as lower bounds of α. The var arm
+		// records each one; the variable is NOT pinned to the union — it
+		// gains TWO lower bounds independently.
+		c := &Context{}
+		a := c.freshVar(0)
+		sub := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(sub, a))
+		require.Len(t, a.LowerBounds, 2)
+	})
+}
+
+// TestConstrainIntersectionSuperForAll covers the intersection-super
+// "for all" rule: sub <: (A & B) decomposes into sub <: A AND sub <: B.
+func TestConstrainIntersectionSuperForAll(t *testing.T) {
+	t.Run("sub satisfies every member", func(t *testing.T) {
+		// 5 <: (number & number). Both members are number, both succeed.
+		c := &Context{}
+		super := newIntersection(nil, parseTypes(t, "number", "number"))
+		// Deduplication collapses the intersection to a single member.
+		require.Empty(t, c.Constrain(numLit(5), super))
+	})
+
+	t.Run("sub fails one member", func(t *testing.T) {
+		// "x" <: (number & string). The for-all reports the failed branch.
+		c := &Context{}
+		super := &soltype.IntersectionType{Types: parseTypes(t, "number", "string")}
+		errs := c.Constrain(strLit("x"), super)
+		require.Equal(t, []string{`cannot constrain "x" <: number`}, Messages(errs))
+	})
+
+	t.Run("variable sub against an intersection super", func(t *testing.T) {
+		// α <: (number & string). For-all decomposes to α <: number AND
+		// α <: string, so both end up as upper bounds of α — the variable
+		// is NOT pinned to the intersection.
+		c := &Context{}
+		a := c.freshVar(0)
+		super := &soltype.IntersectionType{Types: parseTypes(t, "number", "string")}
+		require.Empty(t, c.Constrain(a, super))
+		require.Len(t, a.UpperBounds, 2)
+	})
+}
+
+// TestConstrainUnionSuperExists covers the union-super "exists" rule:
+// sub <: (A | B) trials each member under a probe; the first success commits,
+// the losers roll back. Only fires when sub is concrete; a variable sub falls
+// through to the var arm and records the WHOLE union as an upper bound.
+func TestConstrainUnionSuperExists(t *testing.T) {
+	t.Run("concrete sub matches a branch", func(t *testing.T) {
+		// number <: (number | string). The first branch matches; the rule
+		// returns nil without trialling the second.
+		c := &Context{}
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(num(), super))
+	})
+
+	t.Run("concrete sub matches the second branch", func(t *testing.T) {
+		c := &Context{}
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(str(), super))
+	})
+
+	t.Run("concrete sub matches no branch", func(t *testing.T) {
+		// boolean <: (number | string). No branch matches; report the
+		// union-level mismatch rather than the last-branch failure.
+		c := &Context{}
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		errs := c.Constrain(boolT(), super)
+		require.Equal(t, []string{"cannot constrain boolean <: number | string"}, Messages(errs))
+	})
+
+	t.Run("literal sub picks the matching primitive branch", func(t *testing.T) {
+		// 5 <: (number | string). The literal-to-primitive rule fires inside
+		// the trial and commits the number branch.
+		c := &Context{}
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(numLit(5), super))
+	})
+
+	t.Run("variable sub records whole union, not a branch", func(t *testing.T) {
+		// α <: (number | string). The exists rule is gated to a concrete
+		// sub, so the variable falls through to the subVar arm, which
+		// records the WHOLE union as a single upper bound — exactly the
+		// speculative-pinning avoidance the design calls for.
+		c := &Context{}
+		a := c.freshVar(0)
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(a, super))
+		require.Len(t, a.UpperBounds, 1)
+		_, isUnion := a.UpperBounds[0].(*soltype.UnionType)
+		require.True(t, isUnion, "variable sub should record the union whole, got %T", a.UpperBounds[0])
+	})
+
+	t.Run("losing branch records no upper bound on the variable", func(t *testing.T) {
+		// A failed exists trial that touched a variable must not leak its
+		// bound mutation into the final state. Set up: super union has a
+		// fresh var as one branch and an incompatible prim as the other; a
+		// concrete LITERAL sub matches the var branch by recording itself
+		// as a lower bound — the committing trial. The losing prim-branch
+		// trial would have added a bound to the var too if it weren't
+		// discarded; the assertion is that the variable carries exactly
+		// one lower bound, from the winning branch.
+		c := &Context{}
+		extra := c.freshVar(0)
+		super := newUnion(nil, []soltype.Type{extra, num()}, false)
+
+		// "hi" <: (extra | number). The number branch fails (StrLit vs
+		// NumPrim), so the trial of "hi" <: extra commits and records "hi"
+		// as a lower bound of extra. extra should have exactly one bound.
+		require.Empty(t, c.Constrain(strLit("hi"), super))
+		require.Len(t, extra.LowerBounds, 1)
+	})
+}
+
+// TestConstrainUnionPrecedesRefArm proves the pre-switch placement: a
+// borrow flowing into a union of borrows must match a member, NOT hit the
+// RefType arm's "non-variable super" path that treats a union super as a
+// concrete-non-variable demand and rejects the borrow.
+func TestConstrainUnionPrecedesRefArm(t *testing.T) {
+	// &mut {x: number} <: (&mut {x: number} | &mut {y: string}). The lattice
+	// block must match the first union member before the RefType arm in the
+	// structural switch can intercept and treat the super as a concrete
+	// non-borrow. Build the borrows with no lifetimes so the BorrowEscape
+	// path is also out of the question.
+	c := &Context{}
+	mutXNum := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
+	mutYStr := &soltype.RefType{Mut: true, Inner: exactObj(propElem("y", str()))}
+	super := newUnion(nil, []soltype.Type{mutXNum, mutYStr}, false)
+
+	sub := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
+	require.Empty(t, c.Constrain(sub, super))
+}
+
+// TestConstrainInexactUnionIntoClosedRejects covers the inexact-into-closed
+// rule. The flag and the parser surface land in PR4; until then the rule
+// fires only against an internally-built inexact union, which the test mints
+// directly through the smart constructor.
+func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
+	c := &Context{}
+	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
+	errs := c.Constrain(sub, num())
+	require.Len(t, errs, 1)
+	require.IsType(t, &InexactUnionIntoExactError{}, errs[0])
+	require.Equal(t, "cannot constrain number | string | ... <: number", errs[0].Message())
+}
+
+func TestConstrainInexactUnionIntoUnknownAccepts(t *testing.T) {
+	// An inexact sub union flowing into `unknown` — the only super in PR2 that
+	// can absorb the open tail.
+	c := &Context{}
+	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
+	// The decomposition produces `number <: unknown` and `string <: unknown`.
+	// PR5 lands the `_ <: unknown` rule; until then those are CannotConstrain
+	// fall-throughs, so this case still errors — what the test asserts is that
+	// the inexact-into-closed gate did NOT fire (no InexactUnionIntoExactError),
+	// since unknown is recognized as accepting the open tail.
+	errs := c.Constrain(sub, &soltype.UnknownType{})
+	for _, e := range errs {
+		_, isInexact := e.(*InexactUnionIntoExactError)
+		require.False(t, isInexact, "inexact-into-closed should not fire against unknown super")
+	}
+}

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -178,9 +178,17 @@ func TestConstrainUnionPrecedesRefArm(t *testing.T) {
 
 // TestConstrainInexactUnionIntoClosedRejects covers the inexact-into-closed
 // rule: an inexact sub union carries an open `unknown` tail that a closed
-// (non-inexact-union, non-unknown, non-var) super cannot absorb.
+// (non-inexact-union, non-unknown, non-var) super cannot absorb. The rule
+// accumulates BOTH the union-level inexact error AND the per-member
+// failures, mirroring the object arm — the inexact tail and an explicit
+// member that doesn't subtype super are independent bugs, so surfacing
+// only the inexact error would hide the member mismatch the user would
+// only discover after fixing the flag.
 //
-//	(number | string | ...) <: number    rejects with InexactUnionIntoExact
+//	(number | string | ...) <: number    rejects with:
+//	  - InexactUnionIntoExactError (the open tail can't fit number)
+//	  - CannotConstrainError       (string <: number)
+//	  (number <: number succeeds and contributes nothing)
 //
 // The flag and the parser surface land in PR4; until then the rule fires
 // only against an internally-built inexact union, which the test mints
@@ -189,9 +197,11 @@ func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	c := &Context{}
 	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
 	errs := c.Constrain(sub, num())
-	require.Len(t, errs, 1)
+	require.Len(t, errs, 2)
 	require.IsType(t, &InexactUnionIntoExactError{}, errs[0])
 	require.Equal(t, "cannot constrain number | string | ... <: number", errs[0].Message())
+	require.IsType(t, &CannotConstrainError{}, errs[1])
+	require.Equal(t, "cannot constrain string <: number", errs[1].Message())
 }
 
 // Regression: a borrow with a lifetime flowing into a union of owned types

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -131,24 +131,23 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 		require.True(t, isUnion, "variable sub should record the union whole, got %T", a.UpperBounds[0])
 	})
 
-	t.Run("losing branch records no upper bound on the variable", func(t *testing.T) {
-		// A failed exists trial that touched a variable must not leak its
-		// bound mutation into the final state. Set up: super union has a
-		// fresh var as one branch and an incompatible prim as the other; a
-		// concrete LITERAL sub matches the var branch by recording itself
-		// as a lower bound — the committing trial. The losing prim-branch
-		// trial would have added a bound to the var too if it weren't
-		// discarded; the assertion is that the variable carries exactly
-		// one lower bound, from the winning branch.
+	t.Run("free-var super member is skipped, not pinned by the trial", func(t *testing.T) {
+		// A super-union member that is itself an unbounded TypeVar must not
+		// be trialled — that would speculatively pin it to sub. Set up: super
+		// union has a fresh var as one branch and an incompatible prim as
+		// the other; trialling the var would trivially succeed by recording
+		// "hi" as its lower bound. The fix skips the var member; the number
+		// trial fails ("hi" vs number); the rule reports a clean union-level
+		// CannotConstrainError and the variable carries NO bounds.
 		c := &Context{}
 		extra := c.freshVar(0)
 		super := newUnion(nil, []soltype.Type{extra, num()}, false)
 
-		// "hi" <: (extra | number). The number branch fails (StrLit vs
-		// NumPrim), so the trial of "hi" <: extra commits and records "hi"
-		// as a lower bound of extra. extra should have exactly one bound.
-		require.Empty(t, c.Constrain(strLit("hi"), super))
-		require.Len(t, extra.LowerBounds, 1)
+		errs := c.Constrain(strLit("hi"), super)
+		require.Len(t, errs, 1)
+		require.IsType(t, &CannotConstrainError{}, errs[0])
+		require.Empty(t, extra.LowerBounds)
+		require.Empty(t, extra.UpperBounds)
 	})
 }
 
@@ -182,6 +181,37 @@ func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.IsType(t, &InexactUnionIntoExactError{}, errs[0])
 	require.Equal(t, "cannot constrain number | string | ... <: number", errs[0].Message())
+}
+
+// Regression: a borrow with a lifetime flowing into a union of owned types
+// must surface as a BorrowEscapeError rather than collapsing to a generic
+// union-level CannotConstrainError. Each per-member trial reports
+// BorrowEscape internally; the union-super exists rule promotes that to a
+// single union-level BorrowEscape so the lifetime cause survives.
+func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
+	c := &Context{}
+	lt := c.freshLifetime(0)
+	borrow := &soltype.RefType{Mut: false, Lt: lt, Inner: exactObj(propElem("x", num()))}
+	super := newUnion(nil, []soltype.Type{num(), str()}, false)
+
+	errs := c.Constrain(borrow, super)
+	require.Len(t, errs, 1)
+	require.IsType(t, &BorrowEscapeError{}, errs[0])
+}
+
+// Regression: an inexact union flowing into a free inference variable must
+// be recorded as an upper bound of the variable, not rejected with
+// InexactUnionIntoExactError. superAcceptsUnknownTail returns true for
+// TypeVar so the gate doesn't fire; the for-all decomposition recurses on
+// each member, and each constraint (number <: α, string <: α) records a
+// lower bound on α. The variable receives both bounds; no error.
+func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
+	c := &Context{}
+	alpha := c.freshVar(0)
+	sub := &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true}
+
+	require.Empty(t, c.Constrain(sub, alpha))
+	require.Len(t, alpha.LowerBounds, 2)
 }
 
 func TestConstrainInexactUnionIntoUnknownAccepts(t *testing.T) {

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -155,12 +155,13 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 // borrow flowing into a union of borrows must match a member, NOT hit the
 // RefType arm's "non-variable super" path that treats a union super as a
 // concrete-non-variable demand and rejects the borrow.
+//
+//	mut {x: number} <: (mut {x: number} | mut {y: string})    succeeds
 func TestConstrainUnionPrecedesRefArm(t *testing.T) {
-	// &mut {x: number} <: (&mut {x: number} | &mut {y: string}). The lattice
-	// block must match the first union member before the RefType arm in the
-	// structural switch can intercept and treat the super as a concrete
-	// non-borrow. Build the borrows with no lifetimes so the BorrowEscape
-	// path is also out of the question.
+	// The lattice block must match the first union member before the RefType
+	// arm in the structural switch can intercept and treat the super as a
+	// concrete non-borrow. Build the borrows with no lifetimes so the
+	// BorrowEscape path is also out of the question.
 	c := &Context{}
 	mutXNum := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
 	mutYStr := &soltype.RefType{Mut: true, Inner: exactObj(propElem("y", str()))}
@@ -171,8 +172,13 @@ func TestConstrainUnionPrecedesRefArm(t *testing.T) {
 }
 
 // TestConstrainInexactUnionIntoClosedRejects covers the inexact-into-closed
-// rule. The flag and the parser surface land in PR4; until then the rule
-// fires only against an internally-built inexact union, which the test mints
+// rule: an inexact sub union carries an open `unknown` tail that a closed
+// (non-inexact-union, non-unknown, non-var) super cannot absorb.
+//
+//	(number | string | ...) <: number    rejects with InexactUnionIntoExact
+//
+// The flag and the parser surface land in PR4; until then the rule fires
+// only against an internally-built inexact union, which the test mints
 // directly through the smart constructor.
 func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	c := &Context{}
@@ -185,9 +191,13 @@ func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 
 // Regression: a borrow with a lifetime flowing into a union of owned types
 // must surface as a BorrowEscapeError rather than collapsing to a generic
-// union-level CannotConstrainError. Each per-member trial reports
-// BorrowEscape internally; the union-super exists rule promotes that to a
-// single union-level BorrowEscape so the lifetime cause survives.
+// union-level CannotConstrainError.
+//
+//	&'a {x: number} <: (number | string)    BorrowEscapeError, not CannotConstrain
+//
+// Each per-member trial reports BorrowEscape internally; the union-super
+// exists rule promotes that to a single union-level BorrowEscape so the
+// lifetime cause survives.
 func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
 	c := &Context{}
 	lt := c.freshLifetime(0)
@@ -201,10 +211,13 @@ func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
 
 // Regression: an inexact union flowing into a free inference variable must
 // be recorded as an upper bound of the variable, not rejected with
-// InexactUnionIntoExactError. superAcceptsUnknownTail returns true for
-// TypeVar so the gate doesn't fire; the for-all decomposition recurses on
-// each member, and each constraint (number <: α, string <: α) records a
-// lower bound on α. The variable receives both bounds; no error.
+// InexactUnionIntoExactError.
+//
+//	(number | string | ...) <: α    defers; α gains number and string as lower bounds
+//
+// superAcceptsUnknownTail returns true for TypeVar so the gate doesn't
+// fire; the for-all decomposition recurses on each member, and each
+// constraint (number <: α, string <: α) records a lower bound on α.
 func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 	c := &Context{}
 	alpha := c.freshVar(0)
@@ -214,16 +227,21 @@ func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 	require.Len(t, alpha.LowerBounds, 2)
 }
 
+// TestConstrainInexactUnionIntoUnknownAccepts covers the other accepting
+// super for an inexact sub union: `unknown` (the lattice top) absorbs the
+// open tail.
+//
+//	(number | string | ...) <: unknown    inexact-into-closed gate does NOT fire
+//
+// The decomposition produces `number <: unknown` and `string <: unknown`.
+// PR5 lands the `_ <: unknown` (⊤) rule; until then those are
+// CannotConstrain fall-throughs, so this case still errors — what the test
+// asserts is that the inexact-into-closed gate did NOT fire (no
+// InexactUnionIntoExactError), since unknown is recognized as accepting the
+// open tail.
 func TestConstrainInexactUnionIntoUnknownAccepts(t *testing.T) {
-	// An inexact sub union flowing into `unknown` — the only super in PR2 that
-	// can absorb the open tail.
 	c := &Context{}
 	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
-	// The decomposition produces `number <: unknown` and `string <: unknown`.
-	// PR5 lands the `_ <: unknown` rule; until then those are CannotConstrain
-	// fall-throughs, so this case still errors — what the test asserts is that
-	// the inexact-into-closed gate did NOT fire (no InexactUnionIntoExactError),
-	// since unknown is recognized as accepting the open tail.
 	errs := c.Constrain(sub, &soltype.UnknownType{})
 	for _, e := range errs {
 		_, isInexact := e.(*InexactUnionIntoExactError)

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -41,8 +41,9 @@ func TestConstrainUnionSubForAll(t *testing.T) {
 		// (number | string) <: α. The for-all rule defers when super is a
 		// TypeVar so the WHOLE union is recorded as one lower bound on α.
 		// Coalesce builds the same `number | string` either way, but the
-		// deferral preserves the union shape on the bound list — and the
-		// inexact flag, when present (see TestConstrainInexactUnionIntoVarDefers).
+		// deferral preserves the union shape on the bound list. It also
+		// preserves the inexact flag when present. See
+		// TestConstrainInexactUnionIntoVarDefers for the soundness payoff.
 		c := &Context{}
 		a := c.freshVar(0)
 		sub := newUnion(nil, parseTypes(t, "number", "string"), false)
@@ -75,7 +76,8 @@ func TestConstrainIntersectionSuperForAll(t *testing.T) {
 	t.Run("variable sub against an intersection super defers", func(t *testing.T) {
 		// α <: (number & string). The for-all rule defers when sub is a
 		// TypeVar so the WHOLE intersection is recorded as one upper bound
-		// on α — the symmetric twin of the union-sub super-var deferral.
+		// on α. This is the symmetric twin of the union-sub super-var
+		// deferral.
 		c := &Context{}
 		a := c.freshVar(0)
 		super := &soltype.IntersectionType{Types: parseTypes(t, "number", "string")}
@@ -125,7 +127,7 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 	t.Run("variable sub records whole union, not a branch", func(t *testing.T) {
 		// α <: (number | string). The exists rule is gated to a concrete
 		// sub, so the variable falls through to the subVar arm, which
-		// records the WHOLE union as a single upper bound — exactly the
+		// records the WHOLE union as a single upper bound. That is the
 		// speculative-pinning avoidance the design calls for.
 		c := &Context{}
 		a := c.freshVar(0)
@@ -138,12 +140,14 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 
 	t.Run("free-var super member is skipped, not pinned by the trial", func(t *testing.T) {
 		// A super-union member that is itself an unbounded TypeVar must not
-		// be trialled — that would speculatively pin it to sub. Set up: super
-		// union has a fresh var as one branch and an incompatible prim as
-		// the other; trialling the var would trivially succeed by recording
-		// "hi" as its lower bound. The fix skips the var member; the number
-		// trial fails ("hi" vs number); the rule reports a clean union-level
-		// CannotConstrainError and the variable carries NO bounds.
+		// be trialled. Trialling it would speculatively pin it to sub. The
+		// super union here has a fresh var on one branch and an
+		// incompatible prim on the other. Trialling the var would trivially
+		// succeed by recording "hi" as its lower bound. The rule skips the
+		// var member instead. The number trial then fails on its own merits
+		// (StrLit "hi" against PrimType number), the rule reports a clean
+		// union-level CannotConstrainError, and the variable carries no
+		// bounds.
 		c := &Context{}
 		extra := c.freshVar(0)
 		super := newUnion(nil, []soltype.Type{extra, num()}, false)
@@ -177,22 +181,24 @@ func TestConstrainUnionPrecedesRefArm(t *testing.T) {
 }
 
 // TestConstrainInexactUnionIntoClosedRejects covers the inexact-into-closed
-// rule: an inexact sub union carries an open `unknown` tail that a closed
-// (non-inexact-union, non-unknown, non-var) super cannot absorb. The rule
-// accumulates BOTH the union-level inexact error AND the per-member
-// failures, mirroring the object arm — the inexact tail and an explicit
-// member that doesn't subtype super are independent bugs, so surfacing
-// only the inexact error would hide the member mismatch the user would
-// only discover after fixing the flag.
+// rule. An inexact sub union carries an open `unknown` tail that a closed
+// super cannot absorb. A closed super here is any super that is not an
+// inexact union, not unknown, and not a TypeVar.
+//
+// The rule accumulates BOTH the union-level inexact error AND the per-member
+// failures, mirroring the object arm. The open tail and an explicit member
+// that doesn't subtype super are independent bugs. Surfacing only the
+// inexact error would hide the member mismatch the user would otherwise
+// discover on the next compile.
 //
 //	(number | string | ...) <: number    rejects with:
-//	  - InexactUnionIntoExactError (the open tail can't fit number)
-//	  - CannotConstrainError       (string <: number)
-//	  (number <: number succeeds and contributes nothing)
+//	  - InexactUnionIntoExactError    the open tail can't fit number
+//	  - CannotConstrainError          string <: number
+//	  number <: number succeeds and contributes nothing
 //
-// The flag and the parser surface land in PR4; until then the rule fires
-// only against an internally-built inexact union, which the test mints
-// directly through the smart constructor.
+// The flag and the parser surface for `A | B | ...` land in PR4. Until then
+// the rule fires only against an internally-built inexact union, which the
+// test mints directly through the smart constructor.
 func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	c := &Context{}
 	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
@@ -210,7 +216,7 @@ func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 //
 //	&'a {x: number} <: (number | string)    BorrowEscapeError, not CannotConstrain
 //
-// Each per-member trial reports BorrowEscape internally; the union-super
+// Each per-member trial reports BorrowEscape internally. The union-super
 // exists rule promotes that to a single union-level BorrowEscape so the
 // lifetime cause survives.
 func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
@@ -228,14 +234,14 @@ func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
 // be recorded as a single whole-union lower bound on the variable so the
 // inexact flag rides through coalesce.
 //
-//	(number | string | ...) <: α    defers; α gains the whole union as one lower bound
+//	(number | string | ...) <: α    α gains the whole inexact union as one lower bound
 //
 // The union-sub for-all rule defers to the superVar arm when super is a
 // TypeVar. Decomposing per-member would record only `number` and `string`
-// bounds — the `...` is a flag on UnionType, not a member of Types, so a
+// bounds. The `...` is a flag on UnionType, not a member of Types, so a
 // per-member loop silently drops it and α coalesces as the EXACT
 // `number | string`. That would break the soundness of any downstream match
-// against α; the inexact tail could carry a value of any type at runtime
+// against α. The inexact tail could carry a value of any type at runtime
 // that no member arm covers.
 func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 	c := &Context{}
@@ -250,17 +256,17 @@ func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 }
 
 // TestConstrainInexactUnionIntoUnknownAccepts covers the other accepting
-// super for an inexact sub union: `unknown` (the lattice top) absorbs the
-// open tail.
+// super for an inexact sub union. `unknown` is the lattice top, so it
+// absorbs the open tail.
 //
 //	(number | string | ...) <: unknown    inexact-into-closed gate does NOT fire
 //
 // The decomposition produces `number <: unknown` and `string <: unknown`.
-// PR5 lands the `_ <: unknown` (⊤) rule; until then those are
-// CannotConstrain fall-throughs, so this case still errors — what the test
-// asserts is that the inexact-into-closed gate did NOT fire (no
-// InexactUnionIntoExactError), since unknown is recognized as accepting the
-// open tail.
+// PR5 lands the `_ <: unknown` rule. Until then those are CannotConstrain
+// fall-throughs, so this case still errors. What the test asserts is that
+// the inexact-into-closed gate did not fire, since unknown is recognized
+// as accepting the open tail. No InexactUnionIntoExactError appears in the
+// error list.
 func TestConstrainInexactUnionIntoUnknownAccepts(t *testing.T) {
 	c := &Context{}
 	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -37,16 +37,19 @@ func TestConstrainUnionSubForAll(t *testing.T) {
 		require.Equal(t, []string{"cannot constrain string <: number"}, Messages(errs))
 	})
 
-	t.Run("union sub against a variable super", func(t *testing.T) {
-		// (number | string) <: α. For-all decomposes to number <: α AND
-		// string <: α, so both end up as lower bounds of α. The var arm
-		// records each one; the variable is NOT pinned to the union — it
-		// gains TWO lower bounds independently.
+	t.Run("union sub against a variable super defers", func(t *testing.T) {
+		// (number | string) <: α. The for-all rule defers when super is a
+		// TypeVar so the WHOLE union is recorded as one lower bound on α.
+		// Coalesce builds the same `number | string` either way, but the
+		// deferral preserves the union shape on the bound list — and the
+		// inexact flag, when present (see TestConstrainInexactUnionIntoVarDefers).
 		c := &Context{}
 		a := c.freshVar(0)
 		sub := newUnion(nil, parseTypes(t, "number", "string"), false)
 		require.Empty(t, c.Constrain(sub, a))
-		require.Len(t, a.LowerBounds, 2)
+		require.Len(t, a.LowerBounds, 1)
+		_, isUnion := a.LowerBounds[0].(*soltype.UnionType)
+		require.True(t, isUnion, "expected the whole union as one bound, got %T", a.LowerBounds[0])
 	})
 }
 
@@ -69,15 +72,17 @@ func TestConstrainIntersectionSuperForAll(t *testing.T) {
 		require.Equal(t, []string{`cannot constrain "x" <: number`}, Messages(errs))
 	})
 
-	t.Run("variable sub against an intersection super", func(t *testing.T) {
-		// α <: (number & string). For-all decomposes to α <: number AND
-		// α <: string, so both end up as upper bounds of α — the variable
-		// is NOT pinned to the intersection.
+	t.Run("variable sub against an intersection super defers", func(t *testing.T) {
+		// α <: (number & string). The for-all rule defers when sub is a
+		// TypeVar so the WHOLE intersection is recorded as one upper bound
+		// on α — the symmetric twin of the union-sub super-var deferral.
 		c := &Context{}
 		a := c.freshVar(0)
 		super := &soltype.IntersectionType{Types: parseTypes(t, "number", "string")}
 		require.Empty(t, c.Constrain(a, super))
-		require.Len(t, a.UpperBounds, 2)
+		require.Len(t, a.UpperBounds, 1)
+		_, isIntersection := a.UpperBounds[0].(*soltype.IntersectionType)
+		require.True(t, isIntersection, "expected the whole intersection as one bound, got %T", a.UpperBounds[0])
 	})
 }
 
@@ -210,21 +215,28 @@ func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
 }
 
 // Regression: an inexact union flowing into a free inference variable must
-// be recorded as an upper bound of the variable, not rejected with
-// InexactUnionIntoExactError.
+// be recorded as a single whole-union lower bound on the variable so the
+// inexact flag rides through coalesce.
 //
-//	(number | string | ...) <: α    defers; α gains number and string as lower bounds
+//	(number | string | ...) <: α    defers; α gains the whole union as one lower bound
 //
-// superAcceptsUnknownTail returns true for TypeVar so the gate doesn't
-// fire; the for-all decomposition recurses on each member, and each
-// constraint (number <: α, string <: α) records a lower bound on α.
+// The union-sub for-all rule defers to the superVar arm when super is a
+// TypeVar. Decomposing per-member would record only `number` and `string`
+// bounds — the `...` is a flag on UnionType, not a member of Types, so a
+// per-member loop silently drops it and α coalesces as the EXACT
+// `number | string`. That would break the soundness of any downstream match
+// against α; the inexact tail could carry a value of any type at runtime
+// that no member arm covers.
 func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 	c := &Context{}
 	alpha := c.freshVar(0)
 	sub := &soltype.UnionType{Types: []soltype.Type{num(), str()}, Inexact: true}
 
 	require.Empty(t, c.Constrain(sub, alpha))
-	require.Len(t, alpha.LowerBounds, 2)
+	require.Len(t, alpha.LowerBounds, 1)
+	lb, ok := alpha.LowerBounds[0].(*soltype.UnionType)
+	require.True(t, ok, "expected the whole inexact union as one bound, got %T", alpha.LowerBounds[0])
+	require.True(t, lb.Inexact, "inexact flag must survive the bound record")
 }
 
 // TestConstrainInexactUnionIntoUnknownAccepts covers the other accepting

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -121,6 +121,19 @@ type InexactTupleIntoExactError struct {
 	site       ast.Node
 }
 
+// InexactUnionIntoExactError is the union twin of InexactIntoExactError. An
+// inexact union `A | B | ...` carries an open tail of unknown additional
+// members, so it cannot flow into a closed target — an exact union, or any
+// non-union concrete the open tail could violate. The base form lands in M6 PR2.
+// The flag itself, and the parser surface for `A | B | ...`, lands in PR4, so
+// the rule fires only against an internally-built inexact union until then.
+type InexactUnionIntoExactError struct {
+	Sub   *soltype.UnionType
+	Super soltype.Type
+	prov  NodeResolver
+	site  ast.Node
+}
+
 // ExtraPropertyError fires on ObjectType <: ObjectType when the super is exact and
 // the sub carries a property the super does not declare — width is rejected against
 // an exact target. One error fires per extra property, carrying its name.
@@ -222,6 +235,7 @@ func (*InexactTupleSpreadError) isSolverError()  {}
 func (*MissingPropertyError) isSolverError()     {}
 func (*InexactIntoExactError) isSolverError()    {}
 func (*InexactTupleIntoExactError) isSolverError() {}
+func (*InexactUnionIntoExactError) isSolverError() {}
 func (*ExtraPropertyError) isSolverError()       {}
 func (*ExtraElementError) isSolverError()        {}
 func (*OptionalPropertyError) isSolverError()    {}
@@ -269,6 +283,11 @@ func (e *InexactIntoExactError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
 }
 func (e *InexactIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *InexactUnionIntoExactError) Span() ast.Span {
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
+}
+func (e *InexactUnionIntoExactError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *ExtraPropertyError) Span() ast.Span {
 	// The extra property lives on the sub (source); blame it, degrade to the super
@@ -868,6 +887,10 @@ func (e *InexactIntoExactError) Message() string {
 
 func (e *InexactTupleIntoExactError) Message() string {
 	return "cannot constrain inexact tuple <: exact tuple"
+}
+
+func (e *InexactUnionIntoExactError) Message() string {
+	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.Sub), describe(e.Super))
 }
 
 func (e *ExtraPropertyError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -123,10 +123,11 @@ type InexactTupleIntoExactError struct {
 
 // InexactUnionIntoExactError is the union twin of InexactIntoExactError. An
 // inexact union `A | B | ...` carries an open tail of unknown additional
-// members, so it cannot flow into a closed target — an exact union, or any
-// non-union concrete the open tail could violate. The base form lands in M6 PR2.
-// The flag itself, and the parser surface for `A | B | ...`, lands in PR4, so
-// the rule fires only against an internally-built inexact union until then.
+// members, so it cannot flow into a closed target. A closed target is either
+// an exact union or any non-union concrete the open tail could violate. The
+// base form lands in M6 PR2. The flag itself and the parser surface for
+// `A | B | ...` land in PR4. Until then the rule fires only against an
+// internally-built inexact union.
 type InexactUnionIntoExactError struct {
 	Sub   *soltype.UnionType
 	Super soltype.Type

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -197,6 +197,8 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *InexactTupleIntoExactError:
 			err.prov, err.site = c.prov, n
+		case *InexactUnionIntoExactError:
+			err.prov, err.site = c.prov, n
 		case *ExtraPropertyError:
 			err.prov, err.site = c.prov, n
 		case *OptionalPropertyError:

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -7,13 +7,7 @@ import (
 )
 
 // --- M6 PR2: union/intersection annotation input through resolveTypeAnn ---
-//
-// Source-level tests for the annotation path. They cover what the constrain
-// lattice block accepts/rejects when the lattice node comes from a written
-// type annotation, plus printer round-trip and Prov-cascade-safe recovery.
 
-// A `number | string` annotation resolves to a UnionType and accepts an
-// initializer that flows into ONE of the members.
 func TestInferUnionAnnotationAcceptsMember(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | string = 5`)
 	require.Empty(t, errs)
@@ -26,10 +20,8 @@ func TestInferUnionAnnotationAcceptsOtherMember(t *testing.T) {
 	require.Equal(t, "number | string", values["x"])
 }
 
-// A `number | string` annotation rejects a value that is not a subtype of any
-// member. The error names the whole union as the supertype. Use a function
-// parameter as the source so the inferred sub is a primitive type, not a
-// literal.
+// `b` is a function param so the inferred sub is `boolean` rather than a
+// `true`/`false` literal — otherwise the error message would not match.
 func TestInferUnionAnnotationRejectsNonMember(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn check(b: boolean) {
@@ -41,29 +33,20 @@ func TestInferUnionAnnotationRejectsNonMember(t *testing.T) {
 	require.Equal(t, "cannot constrain boolean <: number | string", errs[0].Message())
 }
 
-// A union annotation round-trips through the printer. The rendered binding
-// type matches what the user wrote, modulo canonical member order. Distinct
-// primitives sort in declaration order in this case, so the round-trip is
-// exact.
 func TestInferUnionAnnotationRoundTrip(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | string | boolean = 5`)
 	require.Empty(t, errs)
 	require.Equal(t, "number | string | boolean", values["x"])
 }
 
-// An intersection annotation accepts a value that is a subtype of EVERY
-// member. The for-all rule decomposes per member. The members here are
-// inexact so a literal carrying fields from both sides satisfies each side
-// through width subtyping. An exact `{x: number}` would reject the extra
-// `y` field.
+// Members are inexact so the literal's union of fields satisfies each side
+// through width subtyping. Exact members would reject the cross-field.
 func TestInferIntersectionAnnotationAcceptsValueAtBothMembers(t *testing.T) {
 	values, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1, y: "hi"}`)
 	require.Empty(t, errs)
 	require.Equal(t, "{x: number, ...} & {y: string, ...}", values["r"])
 }
 
-// An intersection annotation rejects a value that misses a member's
-// requirements. The for-all rule reports the failed branch.
 func TestInferIntersectionAnnotationRejectsMissingMember(t *testing.T) {
 	_, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1}`)
 	require.Len(t, errs, 1)
@@ -71,42 +54,25 @@ func TestInferIntersectionAnnotationRejectsMissingMember(t *testing.T) {
 	require.Equal(t, "object is missing property: y", errs[0].Message())
 }
 
-// A union annotation whose members are themselves unions flattens at the
-// smart-constructor level. `(A | B) | C` renders as `A | B | C` rather
-// than nesting.
 func TestInferUnionAnnotationFlattens(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: (number | string) | boolean = 5`)
 	require.Empty(t, errs)
 	require.Equal(t, "number | string | boolean", values["x"])
 }
 
-// Subsumed-member elimination collapses a redundant member at the
-// annotation site, since newUnion runs subsumption when handed the
-// checker's Context. `number | number` dedups before subsumption even runs.
-// Exercising subsumption proper would need a literal-versus-primitive pair
-// like `1 | number`, but `ast.LitTypeAnn` is not yet a resolveTypeAnn-
-// supported node. The dedup test stands in until literal annotations land.
+// `number | number` exercises dedup, not subsumption proper — the
+// literal-vs-primitive case `1 | number` needs LitTypeAnn support in
+// resolveTypeAnn first.
 func TestInferUnionAnnotationDedups(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | number = 5`)
 	require.Equal(t, []string(nil), Messages(errs))
 	require.Equal(t, "number", values["x"])
 }
 
-// A union annotation whose first member is a borrow type. The lattice block
-// must match the borrow against the borrow member before the structural
-// switch's RefType arm can intercept and treat the union super as a concrete
-// non-variable demand. Without the pre-switch placement, the RefType arm
-// would see "super is not a variable" and peel the sub to a non-borrow,
-// dropping its mutability and rejecting the assignment.
+// Regression for the pre-switch placement of the union-super exists rule:
+// without it the RefType arm in the structural switch would intercept and
+// reject the borrow before the lattice rule could match the borrow member.
 func TestInferUnionAnnotationBorrowMember(t *testing.T) {
-	// A function-param borrow flows into a union member. The union-sub
-	// for-all rule does not apply here, since the union is the SUPER. Only
-	// the pre-switch union-super exists rule can route the borrow to the
-	// matching member. Without it the RefType arm in the structural switch
-	// would see the union super and reject the borrow at the peel step. The
-	// annotation member sets the type the param is borrowed as, so the
-	// trial against the matching member succeeds through ordinary RefType
-	// <: RefType.
 	values, _, errs := inferSource(t, `
 		fn check(r: &mut {x: number}) {
 			val v: &mut {x: number} | number = r

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -41,9 +41,10 @@ func TestInferUnionAnnotationRejectsNonMember(t *testing.T) {
 	require.Equal(t, "cannot constrain boolean <: number | string", errs[0].Message())
 }
 
-// A union annotation round-trips through the printer: the rendered binding
-// type matches what the user wrote (modulo canonical member order, which
-// matches declaration order for distinct primitives in this case).
+// A union annotation round-trips through the printer. The rendered binding
+// type matches what the user wrote, modulo canonical member order. Distinct
+// primitives sort in declaration order in this case, so the round-trip is
+// exact.
 func TestInferUnionAnnotationRoundTrip(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | string | boolean = 5`)
 	require.Empty(t, errs)
@@ -51,9 +52,10 @@ func TestInferUnionAnnotationRoundTrip(t *testing.T) {
 }
 
 // An intersection annotation accepts a value that is a subtype of EVERY
-// member. The for-all rule decomposes per member. Use inexact members so a
-// literal carrying fields from both sides satisfies each side through width
-// subtyping — an exact `{x: number}` would reject the extra `y` field.
+// member. The for-all rule decomposes per member. The members here are
+// inexact so a literal carrying fields from both sides satisfies each side
+// through width subtyping. An exact `{x: number}` would reject the extra
+// `y` field.
 func TestInferIntersectionAnnotationAcceptsValueAtBothMembers(t *testing.T) {
 	values, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1, y: "hi"}`)
 	require.Empty(t, errs)
@@ -70,7 +72,7 @@ func TestInferIntersectionAnnotationRejectsMissingMember(t *testing.T) {
 }
 
 // A union annotation whose members are themselves unions flattens at the
-// smart-constructor level — `(A | B) | C` renders as `A | B | C` rather
+// smart-constructor level. `(A | B) | C` renders as `A | B | C` rather
 // than nesting.
 func TestInferUnionAnnotationFlattens(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: (number | string) | boolean = 5`)
@@ -80,29 +82,31 @@ func TestInferUnionAnnotationFlattens(t *testing.T) {
 
 // Subsumed-member elimination collapses a redundant member at the
 // annotation site, since newUnion runs subsumption when handed the
-// checker's Context. `number | number` dedups before subsumption runs;
-// to exercise subsumption proper a literal-versus-primitive pair would
-// be needed, but `ast.LitTypeAnn` isn't a resolveTypeAnn-supported node
-// yet, so the dedup test stands in until literal annotations land.
+// checker's Context. `number | number` dedups before subsumption even runs.
+// Exercising subsumption proper would need a literal-versus-primitive pair
+// like `1 | number`, but `ast.LitTypeAnn` is not yet a resolveTypeAnn-
+// supported node. The dedup test stands in until literal annotations land.
 func TestInferUnionAnnotationDedups(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | number = 5`)
 	require.Equal(t, []string(nil), Messages(errs))
 	require.Equal(t, "number", values["x"])
 }
 
-// A union of a borrow type and a value type — the lattice block must match
-// the borrow against the borrow member before the structural switch's
-// RefType arm intercepts and treats the union super as a concrete non-
-// variable demand. Without the pre-switch placement, the RefType arm would
-// see "super is not a variable" and peel the sub to a non-borrow, dropping
-// its mutability and rejecting the assignment.
+// A union annotation whose first member is a borrow type. The lattice block
+// must match the borrow against the borrow member before the structural
+// switch's RefType arm can intercept and treat the union super as a concrete
+// non-variable demand. Without the pre-switch placement, the RefType arm
+// would see "super is not a variable" and peel the sub to a non-borrow,
+// dropping its mutability and rejecting the assignment.
 func TestInferUnionAnnotationBorrowMember(t *testing.T) {
-	// A function-param borrow flows into a union member; the for-all rule
-	// here would not save us — the SUPER is the union. Without the pre-
-	// switch placement the RefType arm would see the union super and reject
-	// the borrow at the "peel" step. The annotation member sets the type the
-	// param is borrowed as, so the trial against the matching member succeeds
-	// through ordinary RefType <: RefType.
+	// A function-param borrow flows into a union member. The union-sub
+	// for-all rule does not apply here, since the union is the SUPER. Only
+	// the pre-switch union-super exists rule can route the borrow to the
+	// matching member. Without it the RefType arm in the structural switch
+	// would see the union super and reject the borrow at the peel step. The
+	// annotation member sets the type the param is borrowed as, so the
+	// trial against the matching member succeeds through ordinary RefType
+	// <: RefType.
 	values, _, errs := inferSource(t, `
 		fn check(r: &mut {x: number}) {
 			val v: &mut {x: number} | number = r

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -1,0 +1,113 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6 PR2: union/intersection annotation input through resolveTypeAnn ---
+//
+// Source-level tests for the annotation path. They cover what the constrain
+// lattice block accepts/rejects when the lattice node comes from a written
+// type annotation, plus printer round-trip and Prov-cascade-safe recovery.
+
+// A `number | string` annotation resolves to a UnionType and accepts an
+// initializer that flows into ONE of the members.
+func TestInferUnionAnnotationAcceptsMember(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: number | string = 5`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | string", values["x"])
+}
+
+func TestInferUnionAnnotationAcceptsOtherMember(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: number | string = "hi"`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | string", values["x"])
+}
+
+// A `number | string` annotation rejects a value that is not a subtype of any
+// member. The error names the whole union as the supertype. Use a function
+// parameter as the source so the inferred sub is a primitive type, not a
+// literal.
+func TestInferUnionAnnotationRejectsNonMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn check(b: boolean) {
+			val x: number | string = b
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "cannot constrain boolean <: number | string", errs[0].Message())
+}
+
+// A union annotation round-trips through the printer: the rendered binding
+// type matches what the user wrote (modulo canonical member order, which
+// matches declaration order for distinct primitives in this case).
+func TestInferUnionAnnotationRoundTrip(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: number | string | boolean = 5`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | string | boolean", values["x"])
+}
+
+// An intersection annotation accepts a value that is a subtype of EVERY
+// member. The for-all rule decomposes per member. Use inexact members so a
+// literal carrying fields from both sides satisfies each side through width
+// subtyping — an exact `{x: number}` would reject the extra `y` field.
+func TestInferIntersectionAnnotationAcceptsValueAtBothMembers(t *testing.T) {
+	values, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1, y: "hi"}`)
+	require.Empty(t, errs)
+	require.Equal(t, "{x: number, ...} & {y: string, ...}", values["r"])
+}
+
+// An intersection annotation rejects a value that misses a member's
+// requirements. The for-all rule reports the failed branch.
+func TestInferIntersectionAnnotationRejectsMissingMember(t *testing.T) {
+	_, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1}`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &MissingPropertyError{}, errs[0])
+	require.Equal(t, "object is missing property: y", errs[0].Message())
+}
+
+// A union annotation whose members are themselves unions flattens at the
+// smart-constructor level — `(A | B) | C` renders as `A | B | C` rather
+// than nesting.
+func TestInferUnionAnnotationFlattens(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: (number | string) | boolean = 5`)
+	require.Empty(t, errs)
+	require.Equal(t, "number | string | boolean", values["x"])
+}
+
+// Subsumed-member elimination collapses a redundant member at the
+// annotation site, since newUnion runs subsumption when handed the
+// checker's Context. `number | number` dedups before subsumption runs;
+// to exercise subsumption proper a literal-versus-primitive pair would
+// be needed, but `ast.LitTypeAnn` isn't a resolveTypeAnn-supported node
+// yet, so the dedup test stands in until literal annotations land.
+func TestInferUnionAnnotationDedups(t *testing.T) {
+	values, _, errs := inferSource(t, `val x: number | number = 5`)
+	require.Equal(t, []string(nil), Messages(errs))
+	require.Equal(t, "number", values["x"])
+}
+
+// A union of a borrow type and a value type — the lattice block must match
+// the borrow against the borrow member before the structural switch's
+// RefType arm intercepts and treats the union super as a concrete non-
+// variable demand. Without the pre-switch placement, the RefType arm would
+// see "super is not a variable" and peel the sub to a non-borrow, dropping
+// its mutability and rejecting the assignment.
+func TestInferUnionAnnotationBorrowMember(t *testing.T) {
+	// A function-param borrow flows into a union member; the for-all rule
+	// here would not save us — the SUPER is the union. Without the pre-
+	// switch placement the RefType arm would see the union super and reject
+	// the borrow at the "peel" step. The annotation member sets the type the
+	// param is borrowed as, so the trial against the matching member succeeds
+	// through ordinary RefType <: RefType.
+	values, _, errs := inferSource(t, `
+		fn check(r: &mut {x: number}) {
+			val v: &mut {x: number} | number = r
+		}
+	`)
+	require.Equal(t, []string(nil), Messages(errs))
+	require.Equal(t, "fn (r: mut {x: number}) -> void", values["check"])
+}

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -89,6 +89,18 @@ func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 	return nil, false
 }
 
+// hasProv reports whether t already carries a FromAST origin in the Prov
+// table. Used by the union/intersection annotation arms to decide whether
+// the smart constructor's result needs its own Prov entry: a single-member
+// collapse that returns an input member's pointer leaves the child's Prov
+// intact, while a fresh-pointer result (a new UnionType, or a
+// freshAt-recovered TypeVar with no Prov yet) needs the outer annotation
+// recorded.
+func (c *checker) hasProv(t soltype.Type) bool {
+	_, ok := c.prov[t].(FromAST)
+	return ok
+}
+
 // recordProv records that t was minted from node n for reason kind — the inverse
 // of recordType (info.setType). Sparse by intent: only the node-derived
 // construction sites call it; synthesized types (coalesced/extruded, M3+) get no

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -90,12 +90,12 @@ func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 }
 
 // hasProv reports whether t already carries a FromAST origin in the Prov
-// table. Used by the union/intersection annotation arms to decide whether
-// the smart constructor's result needs its own Prov entry: a single-member
-// collapse that returns an input member's pointer leaves the child's Prov
-// intact, while a fresh-pointer result (a new UnionType, or a
-// freshAt-recovered TypeVar with no Prov yet) needs the outer annotation
-// recorded.
+// table. The union and intersection annotation arms call it to decide
+// whether the smart constructor's result needs its own Prov entry. A
+// single-member collapse returns an input member's pointer and leaves the
+// child's Prov intact. A fresh-pointer result needs the outer annotation
+// recorded. Both a brand-new UnionType and a freshAt-recovered TypeVar
+// fall in the second case, since neither carries Prov yet.
 func (c *checker) hasProv(t soltype.Type) bool {
 	_, ok := c.prov[t].(FromAST)
 	return ok

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -89,13 +89,7 @@ func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 	return nil, false
 }
 
-// hasProv reports whether t already carries a FromAST origin in the Prov
-// table. The union and intersection annotation arms call it to decide
-// whether the smart constructor's result needs its own Prov entry. A
-// single-member collapse returns an input member's pointer and leaves the
-// child's Prov intact. A fresh-pointer result needs the outer annotation
-// recorded. Both a brand-new UnionType and a freshAt-recovered TypeVar
-// fall in the second case, since neither carries Prov yet.
+// hasProv reports whether t already carries a FromAST origin in the Prov table.
 func (c *checker) hasProv(t soltype.Type) bool {
 	_, ok := c.prov[t].(FromAST)
 	return ok

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -190,13 +190,18 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 		}
 	}
 	t := newUnion(c.ctx, members, false)
-	// Record provenance only when newUnion produced a FRESH pointer. A
-	// single-member collapse (`number | number` ⇒ `number`, or the
-	// subsumption case `1 | number` ⇒ `number`) returns an input member's
-	// pointer that already carries Prov from its own annotation; re-recording
+	// Record provenance only when the result has no Prov yet. The smart
+	// constructor's single-member collapse (`number | number` ⇒ `number`,
+	// subsumption `1 | number` ⇒ `number`) returns an input member's pointer
+	// that already carries Prov from its own annotation, so re-recording
 	// against the outer union node would overwrite the narrower blame and
-	// trip the debugProv unique-pointer guard.
-	if !isInputMember(t, members) {
+	// trip the debugProv unique-pointer guard. A pointer-identity check
+	// would miss the case where the survivor is a `freshAt`-recovered
+	// TypeVar — freshAt doesn't recordProv, so that survivor is in
+	// `members` but has no Prov, and the annotation node would end up with
+	// no entry at all. Gating on the Prov state instead of identity records
+	// blame in that case too.
+	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}
 	return t, true
@@ -217,25 +222,11 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 		}
 	}
 	t := newIntersection(c.ctx, members)
-	// Skip Prov recording on a collapsed result — same reason as the union
-	// arm.
-	if !isInputMember(t, members) {
+	// Same Prov-state gate as the union arm — see resolveUnionTypeAnn.
+	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}
 	return t, true
-}
-
-// isInputMember reports whether t shares pointer identity with one of the
-// resolved member types. The smart constructors return an input member as-is
-// for the single-member collapse case, so this guard avoids re-recording Prov
-// against a pointer that already carries a child annotation's blame.
-func isInputMember(t soltype.Type, members []soltype.Type) bool {
-	for _, m := range members {
-		if t == m {
-			return true
-		}
-	}
-	return false
 }
 
 // resolveMutableTypeAnn lowers a `mut T` annotation to an owned-mutable borrow,

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -173,12 +173,12 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 }
 
 // resolveUnionTypeAnn lowers `A | B | …` to a soltype.UnionType through
-// newUnion. Each member resolves recursively; an unsupported member recovers
-// to a fresh var so the union shape survives — mirroring the Promise<bad> and
+// newUnion. Each member resolves recursively. An unsupported member recovers
+// to a fresh var so the union shape survives, mirroring the Promise<bad> and
 // object/tuple cascade-safe recovery. The Context-bearing newUnion call also
 // runs subsumed-member elimination, so a literal-and-its-primitive pair like
 // `1 | number` collapses to `number` at the annotation site. PR4 lands the
-// surface `... ` inexact marker; until then ast.UnionTypeAnn carries no flag
+// surface `...` inexact marker. Until then ast.UnionTypeAnn carries no flag
 // and the resulting union is always exact.
 func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
@@ -191,16 +191,16 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 	}
 	t := newUnion(c.ctx, members, false)
 	// Record provenance only when the result has no Prov yet. The smart
-	// constructor's single-member collapse (`number | number` ⇒ `number`,
-	// subsumption `1 | number` ⇒ `number`) returns an input member's pointer
-	// that already carries Prov from its own annotation, so re-recording
-	// against the outer union node would overwrite the narrower blame and
-	// trip the debugProv unique-pointer guard. A pointer-identity check
-	// would miss the case where the survivor is a `freshAt`-recovered
-	// TypeVar — freshAt doesn't recordProv, so that survivor is in
-	// `members` but has no Prov, and the annotation node would end up with
-	// no entry at all. Gating on the Prov state instead of identity records
-	// blame in that case too.
+	// constructor can collapse to a single member. `number | number` ⇒
+	// `number` and the subsumption case `1 | number` ⇒ `number` both
+	// return an input member's pointer, which already carries Prov from its
+	// own annotation. Re-recording against the outer union node would
+	// overwrite the narrower blame and trip the debugProv unique-pointer
+	// guard. A pointer-identity check would miss the case where the
+	// survivor is a `freshAt`-recovered TypeVar. freshAt does not
+	// recordProv, so the survivor is in `members` but has no Prov, and the
+	// annotation node would end up with no entry at all. Gating on the
+	// Prov state instead of identity records blame in that case too.
 	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}
@@ -211,7 +211,8 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 // lowers `A & B & …` through newIntersection. The Context-bearing call runs
 // subsumed-member elimination, so a pair like `{x} & {x, y}` collapses to the
 // narrower `{x, y}` at the annotation site. An IntersectionType carries no
-// exactness flag — exactness is a property of the result, not the meet.
+// exactness flag. Exactness is a property of the result of the meet, not of
+// the meet itself.
 func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -182,6 +182,9 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 		if t, ok := c.resolveTypeAnn(m, lvl); ok {
 			members[i] = t
 		} else {
+			// freshAt over ErrorType: preserves the source's union shape
+			// in the rendered type. pruneUnion would drop an ErrorType
+			// member and collapse the union.
 			members[i] = c.freshAt(lvl)
 		}
 	}
@@ -203,7 +206,7 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 		if t, ok := c.resolveTypeAnn(m, lvl); ok {
 			members[i] = t
 		} else {
-			members[i] = c.freshAt(lvl)
+			members[i] = c.freshAt(lvl) // see resolveUnionTypeAnn
 		}
 	}
 	t := newIntersection(c.ctx, members)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -172,14 +172,10 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 	return t, true
 }
 
-// resolveUnionTypeAnn lowers `A | B | …` to a soltype.UnionType through
-// newUnion. Each member resolves recursively. An unsupported member recovers
-// to a fresh var so the union shape survives, mirroring the Promise<bad> and
-// object/tuple cascade-safe recovery. The Context-bearing newUnion call also
-// runs subsumed-member elimination, so a literal-and-its-primitive pair like
-// `1 | number` collapses to `number` at the annotation site. PR4 lands the
-// surface `...` inexact marker. Until then ast.UnionTypeAnn carries no flag
-// and the resulting union is always exact.
+// resolveUnionTypeAnn lowers `A | B | …` through newUnion. An unsupported
+// member recovers to a fresh var so the union shape survives, mirroring the
+// Promise<bad> and object/tuple cascade-safe recovery. The Inexact flag and
+// its parser surface land in PR4.
 func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {
@@ -190,29 +186,17 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 		}
 	}
 	t := newUnion(c.ctx, members, false)
-	// Record provenance only when the result has no Prov yet. The smart
-	// constructor can collapse to a single member. `number | number` ⇒
-	// `number` and the subsumption case `1 | number` ⇒ `number` both
-	// return an input member's pointer, which already carries Prov from its
-	// own annotation. Re-recording against the outer union node would
-	// overwrite the narrower blame and trip the debugProv unique-pointer
-	// guard. A pointer-identity check would miss the case where the
-	// survivor is a `freshAt`-recovered TypeVar. freshAt does not
-	// recordProv, so the survivor is in `members` but has no Prov, and the
-	// annotation node would end up with no entry at all. Gating on the
-	// Prov state instead of identity records blame in that case too.
+	// newUnion can collapse to an input member's pointer (single-member
+	// dedup, or subsumption). Re-recording Prov on a pointer that already
+	// carries it would overwrite the narrower child-annotation blame and
+	// trip the debugProv guard.
 	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}
 	return t, true
 }
 
-// resolveIntersectionTypeAnn is the meet twin of resolveUnionTypeAnn. It
-// lowers `A & B & …` through newIntersection. The Context-bearing call runs
-// subsumed-member elimination, so a pair like `{x} & {x, y}` collapses to the
-// narrower `{x, y}` at the annotation site. An IntersectionType carries no
-// exactness flag. Exactness is a property of the result of the meet, not of
-// the meet itself.
+// resolveIntersectionTypeAnn is the meet twin of resolveUnionTypeAnn.
 func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {
@@ -223,7 +207,6 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 		}
 	}
 	t := newIntersection(c.ctx, members)
-	// Same Prov-state gate as the union arm — see resolveUnionTypeAnn.
 	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -81,6 +81,10 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 		return c.resolveMutableTypeAnn(ta, lvl)
 	case *ast.RefTypeAnn:
 		return c.resolveRefTypeAnn(ta, lvl)
+	case *ast.UnionTypeAnn:
+		return c.resolveUnionTypeAnn(ta, lvl)
+	case *ast.IntersectionTypeAnn:
+		return c.resolveIntersectionTypeAnn(ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -166,6 +170,72 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 	t := &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// resolveUnionTypeAnn lowers `A | B | …` to a soltype.UnionType through
+// newUnion. Each member resolves recursively; an unsupported member recovers
+// to a fresh var so the union shape survives — mirroring the Promise<bad> and
+// object/tuple cascade-safe recovery. The Context-bearing newUnion call also
+// runs subsumed-member elimination, so a literal-and-its-primitive pair like
+// `1 | number` collapses to `number` at the annotation site. PR4 lands the
+// surface `... ` inexact marker; until then ast.UnionTypeAnn carries no flag
+// and the resulting union is always exact.
+func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
+	members := make([]soltype.Type, len(ta.Types))
+	for i, m := range ta.Types {
+		if t, ok := c.resolveTypeAnn(m, lvl); ok {
+			members[i] = t
+		} else {
+			members[i] = c.freshAt(lvl)
+		}
+	}
+	t := newUnion(c.ctx, members, false)
+	// Record provenance only when newUnion produced a FRESH pointer. A
+	// single-member collapse (`number | number` ⇒ `number`, or the
+	// subsumption case `1 | number` ⇒ `number`) returns an input member's
+	// pointer that already carries Prov from its own annotation; re-recording
+	// against the outer union node would overwrite the narrower blame and
+	// trip the debugProv unique-pointer guard.
+	if !isInputMember(t, members) {
+		c.recordProv(t, ta, AnnotationType)
+	}
+	return t, true
+}
+
+// resolveIntersectionTypeAnn is the meet twin of resolveUnionTypeAnn. It
+// lowers `A & B & …` through newIntersection. The Context-bearing call runs
+// subsumed-member elimination, so a pair like `{x} & {x, y}` collapses to the
+// narrower `{x, y}` at the annotation site. An IntersectionType carries no
+// exactness flag — exactness is a property of the result, not the meet.
+func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl int) (soltype.Type, bool) {
+	members := make([]soltype.Type, len(ta.Types))
+	for i, m := range ta.Types {
+		if t, ok := c.resolveTypeAnn(m, lvl); ok {
+			members[i] = t
+		} else {
+			members[i] = c.freshAt(lvl)
+		}
+	}
+	t := newIntersection(c.ctx, members)
+	// Skip Prov recording on a collapsed result — same reason as the union
+	// arm.
+	if !isInputMember(t, members) {
+		c.recordProv(t, ta, AnnotationType)
+	}
+	return t, true
+}
+
+// isInputMember reports whether t shares pointer identity with one of the
+// resolved member types. The smart constructors return an input member as-is
+// for the single-member collapse case, so this guard avoids re-recording Prov
+// against a pointer that already carries a child annotation's blame.
+func isInputMember(t soltype.Type, members []soltype.Type) bool {
+	for _, m := range members {
+		if t == m {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveMutableTypeAnn lowers a `mut T` annotation to an owned-mutable borrow,

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1139,6 +1139,32 @@ variable-shaped members through the same probe machinery. That is how
 asymmetric today. The resolution chosen here should either align them or
 document why the union and intersection cases warrant different treatment.
 
+**Trial-and-commit diagnostic follow-ups (after generic-union surface lands).**
+M6 PR2.5 takes the cheapest mitigations against the first-success-commits
+failure modes: a shared trial helper, specificity-ordered candidates, and
+deletion of the M5-era `constrainAssign` workaround
+([m6-implementation-plan.md](m6-implementation-plan.md) §PR2.5). The two
+deferred mitigations bite once M7 makes generic-union annotations reachable
+from source, since user-written `T | A` is the case where over-constrained
+inner variables actually surface to the user. Land them once that happens:
+
+- **Tag committed bounds with their union-trial origin.** When the trial
+  commits, mark the added bounds (or the var) with a side-table entry
+  pointing at the union annotation node. When a downstream constraint fails
+  on a tagged var, the diagnostic engine chases the tag and emits "this var
+  was committed to branch A of (A | B) at <span>; later use needs B."
+  Replaces today's flat "string is not number" with a breadcrumb back to the
+  union choice that forced the conflict. Probe-safe via the existing
+  rollback hook discipline.
+- **Ambient-time ambiguity detection.** After the first trial commits,
+  optionally peek at later branches under throwaway probes. When another
+  branch would also succeed AND would have added different bounds, emit a
+  warning at the union annotation site asking the user to disambiguate.
+  Catches over-constraint at declaration time rather than at downstream use.
+  Roughly doubles the work for ambiguous unions, which matches the cost of
+  the original failure mode. Worth landing once user reports of confusion
+  start coming in.
+
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
 to real `soltype` structures and type-checks (not placeholders); `import { … }
@@ -1441,6 +1467,33 @@ reduce through the M9 operator machinery.
   module-level state and then mutating it. Tracked at #762, the use-after-move
   item of the broader sound borrow checker #618. It needs its own RFC and is
   layered after the M12 flip, not slotted into the M-series.
+- **Backtracking + disjunctive bounds — beyond the M-series.** The structural
+  fix for the first-success-commits failure modes in `internal/solver`. Today
+  four trial sites (`resolveOverload`, the IntersectionType-sub arm, the M6
+  PR2 union-super exists rule, and the pre-PR2.5 `constrainAssign`) all pick
+  the first candidate that holds and never reconsider. M6 PR2.5 lands the
+  cheap mitigations (shared helper, specificity ordering, fewer sites), and
+  M7 adds two diagnostic-quality follow-ups (trial-origin tagging and
+  ambient-time ambiguity warnings). The remaining failure modes
+  (over-constraining inner vars without warning, no backtracking when a
+  downstream constraint contradicts the commit, loss of cross-variable
+  correlation across trial branches) require a structurally different
+  solver. Two complementary directions:
+  - **True backtracking.** A search-based solver that unwinds the committed
+    trial when a downstream constraint contradicts it and retries the next
+    candidate. Fixes failure modes #1, #4, and #5 from the post-PR2
+    post-mortem. Bounded backtracking (only revisit the most recent trial)
+    is tractable; full backtracking through propagated bound graphs is an
+    open research problem at this language's scale.
+  - **Disjunctive bound representation.** Let a var carry "γ ≤ A OR γ ≤ B"
+    as a first-class constraint rather than picking one and committing.
+    Fixes failure mode #6 (cross-variable correlation) by recording the
+    correlation explicitly. Requires row-types or refinement-types machinery
+    in the bound graph, which is a fundamentally different solver.
+  Both are large undertakings, post-MVP, and warrant their own RFCs. The
+  realistic short-term path is to keep accumulating the diagnostic and
+  ergonomic mitigations PR2.5 and M7 land, and revisit the structural fix
+  if user reports show the failure modes biting at scale.
 
 ## Dependency / risk ordering rationale
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1097,6 +1097,47 @@ now resolve to real `soltype` structures rather than opaque placeholders.
       reuses the tuple/array read classification above plus C3's `mut` receiver
       requirement and `widen`.
 
+**Open design question — free type-var members in a union-super exists trial.**
+M6 PR2's union-super exists rule trials each member of `sub <: (A | B | …)`
+under a probe and commits the first success
+([m6-implementation-plan.md](m6-implementation-plan.md) §PR2). The rule
+deliberately SKIPS direct `TypeVarType` members in the trial loop: canonical
+sort ranks `TypeVar` before concrete kinds, so without the skip a
+`5 <: (α | number)` constraint would trial `α` first, succeed trivially by
+recording `5` as `α`'s lower bound, and commit — pinning `α` to ≥5 and never
+trying the `number` branch (the "speculative pinning" the design avoids).
+
+The skip is sound but incomplete. Today no source path can reach it: PR2's
+`resolveTypeAnn` arms produce unions whose members are resolved concretes,
+and a user-written `T` doesn't resolve until M7. Once it does, a generic-union
+annotation becomes reachable:
+
+```
+fn f<T>(x: T | number) { ... }
+f("hi")          // currently fails: cannot constrain string <: T | number
+                 // even though T := string would type-check
+```
+
+The conservative skip rejects this call; a fully complete rule would bind
+`T := string` as a last-resort catch-all. The two designs to choose between
+when M7 lands generic-union surface:
+
+- **Keep the skip.** Simpler, no speculative pinning. A user wanting "var as
+  catch-all" reorders the union, names the branch explicitly, or splits the
+  binding.
+- **Two-pass exists trial.** Try concrete members first; if none commit, try
+  var members in a second pass. Preserves completeness without first-pin
+  behavior. PR7's `if-let` / `let-else` narrowing reuses the same exists path
+  ([m6-implementation-plan.md](m6-implementation-plan.md) §PR7), so this
+  choice also decides whether `if let x: T = u` over `u: T | number` can bind
+  `T` to the matched branch.
+
+The IntersectionType-sub overload arm in `constrain.go` already trials
+variable-shaped members through the same probe machinery (that is how
+`g = f; g(x)` resolves when `f`'s arms involve type vars). The two arms are
+asymmetric today; the resolution chosen here should either align them or
+document why the union and intersection cases warrant different treatment.
+
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
 to real `soltype` structures and type-checks (not placeholders); `import { … }

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1123,9 +1123,16 @@ The conservative skip rejects this call. A fully complete rule would bind
 `T := string` as a last-resort catch-all. The two designs to choose between
 when M7 lands generic-union surface:
 
-- **Keep the skip.** Simpler, no speculative pinning. A user wanting a
-  "var as catch-all" reorders the union, names the branch explicitly, or
-  splits the binding.
+- **Keep the skip.** Simpler, no speculative pinning. The honest mitigation
+  is restructuring the user's code away from the generic union: split into
+  separate signatures (`fn fT<T>(x: T)` and `fn fN(x: number)`) or use a
+  discriminating wrapper (`type Boxed<T> = {kind: "var", val: T} | {kind:
+  "num", val: number}`). Two superficially-attractive workarounds DON'T
+  work: reordering the union does nothing because `newUnion` canonicalizes
+  member order at construction, and explicit type arguments at the call
+  site (`f<string>("hi")`) aren't syntax `CallExpr` supports today. So
+  "keep the skip" forces a real structural rewrite at every call site, not
+  a one-line tweak.
 - **Two-pass exists trial.** Try concrete members first. If none commit,
   try var members in a second pass. Preserves completeness without
   first-pin behavior. PR7's `if-let` / `let-else` narrowing reuses the same

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1099,18 +1099,19 @@ now resolve to real `soltype` structures rather than opaque placeholders.
 
 **Open design question — free type-var members in a union-super exists trial.**
 M6 PR2's union-super exists rule trials each member of `sub <: (A | B | …)`
-under a probe and commits the first success
-([m6-implementation-plan.md](m6-implementation-plan.md) §PR2). The rule
-deliberately SKIPS direct `TypeVarType` members in the trial loop: canonical
-sort ranks `TypeVar` before concrete kinds, so without the skip a
+under a probe and commits the first success. See
+[m6-implementation-plan.md](m6-implementation-plan.md) §PR2 for the rule. The
+rule deliberately SKIPS direct `TypeVarType` members in the trial loop.
+Canonical sort ranks `TypeVar` before concrete kinds, so without the skip a
 `5 <: (α | number)` constraint would trial `α` first, succeed trivially by
-recording `5` as `α`'s lower bound, and commit — pinning `α` to ≥5 and never
-trying the `number` branch (the "speculative pinning" the design avoids).
+recording `5` as `α`'s lower bound, and commit. `α` would then be pinned to
+≥5 and the `number` branch would never run. The skip avoids this
+speculative pinning.
 
-The skip is sound but incomplete. Today no source path can reach it: PR2's
+The skip is sound but incomplete. No source path can reach it today. PR2's
 `resolveTypeAnn` arms produce unions whose members are resolved concretes,
-and a user-written `T` doesn't resolve until M7. Once it does, a generic-union
-annotation becomes reachable:
+and a user-written `T` does not resolve until M7. Once it does, a
+generic-union annotation becomes reachable:
 
 ```
 fn f<T>(x: T | number) { ... }
@@ -1118,24 +1119,24 @@ f("hi")          // currently fails: cannot constrain string <: T | number
                  // even though T := string would type-check
 ```
 
-The conservative skip rejects this call; a fully complete rule would bind
+The conservative skip rejects this call. A fully complete rule would bind
 `T := string` as a last-resort catch-all. The two designs to choose between
 when M7 lands generic-union surface:
 
-- **Keep the skip.** Simpler, no speculative pinning. A user wanting "var as
-  catch-all" reorders the union, names the branch explicitly, or splits the
-  binding.
-- **Two-pass exists trial.** Try concrete members first; if none commit, try
-  var members in a second pass. Preserves completeness without first-pin
-  behavior. PR7's `if-let` / `let-else` narrowing reuses the same exists path
-  ([m6-implementation-plan.md](m6-implementation-plan.md) §PR7), so this
-  choice also decides whether `if let x: T = u` over `u: T | number` can bind
-  `T` to the matched branch.
+- **Keep the skip.** Simpler, no speculative pinning. A user wanting a
+  "var as catch-all" reorders the union, names the branch explicitly, or
+  splits the binding.
+- **Two-pass exists trial.** Try concrete members first. If none commit,
+  try var members in a second pass. Preserves completeness without
+  first-pin behavior. PR7's `if-let` / `let-else` narrowing reuses the same
+  exists path. See [m6-implementation-plan.md](m6-implementation-plan.md)
+  §PR7. So this choice also decides whether `if let x: T = u` over
+  `u: T | number` can bind `T` to the matched branch.
 
 The IntersectionType-sub overload arm in `constrain.go` already trials
-variable-shaped members through the same probe machinery (that is how
-`g = f; g(x)` resolves when `f`'s arms involve type vars). The two arms are
-asymmetric today; the resolution chosen here should either align them or
+variable-shaped members through the same probe machinery. That is how
+`g = f; g(x)` resolves when `f`'s arms involve type vars. The two arms are
+asymmetric today. The resolution chosen here should either align them or
 document why the union and intersection cases warrant different treatment.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1140,30 +1140,58 @@ asymmetric today. The resolution chosen here should either align them or
 document why the union and intersection cases warrant different treatment.
 
 **Trial-and-commit diagnostic follow-ups (after generic-union surface lands).**
-M6 PR2.5 takes the cheapest mitigations against the first-success-commits
-failure modes: a shared trial helper, specificity-ordered candidates, and
-deletion of the M5-era `constrainAssign` workaround
-([m6-implementation-plan.md](m6-implementation-plan.md) §PR2.5). The two
-deferred mitigations bite once M7 makes generic-union annotations reachable
-from source, since user-written `T | A` is the case where over-constrained
-inner variables actually surface to the user. Land them once that happens:
+M6 PR2 introduced the union-super exists rule, which trials each member of
+`sub <: (A | B | …)` and commits the first success. Three sibling sites in
+`internal/solver` use the same pattern: `resolveOverload`, the
+IntersectionType-sub arm, and `constrainAssign`. All four share the same
+**first-success-commits failure modes**:
 
-- **Tag committed bounds with their union-trial origin.** When the trial
-  commits, mark the added bounds (or the var) with a side-table entry
-  pointing at the union annotation node. When a downstream constraint fails
-  on a tagged var, the diagnostic engine chases the tag and emits "this var
-  was committed to branch A of (A | B) at <span>; later use needs B."
-  Replaces today's flat "string is not number" with a breadcrumb back to the
-  union choice that forced the conflict. Probe-safe via the existing
-  rollback hook discipline.
-- **Ambient-time ambiguity detection.** After the first trial commits,
-  optionally peek at later branches under throwaway probes. When another
-  branch would also succeed AND would have added different bounds, emit a
-  warning at the union annotation site asking the user to disambiguate.
-  Catches over-constraint at declaration time rather than at downstream use.
-  Roughly doubles the work for ambiguous unions, which matches the cost of
-  the original failure mode. Worth landing once user reports of confusion
-  start coming in.
+1. **Over-constraining inner inference variables.** A trial that succeeds
+   by adding bounds to vars nested in sub or super locks those vars to the
+   chosen branch. A later use that would have matched a different branch
+   is rejected.
+2. **Order-dependence on canonical sort, not user intent.** Members are
+   trialled in `compareType` order. The user's source order is not what
+   decides the winner.
+3. **Brittleness to union-membership changes.** Adding a member can shift
+   canonical sort and change which branch wins, making a seemingly
+   additive change alter downstream behavior.
+4. **Misleading downstream error messages.** When the committed bound
+   conflicts with a later use, the error blames the later constraint with
+   no breadcrumb back to the union trial that forced the commitment.
+5. **No backtracking.** Once committed, the system never reconsiders. A
+   later contradiction errors instead of unwinding to try the next branch.
+6. **Loss of cross-variable correlation.** A trial that touches multiple
+   correlated variables locks them together to one branch. A user
+   expecting the disjunction to remain open across both vars finds it
+   doesn't.
+
+M6 PR2.5 takes the cheapest mitigations: a shared trial helper,
+specificity-ordered candidates, and deletion of the M5-era
+`constrainAssign` workaround
+([m6-implementation-plan.md](m6-implementation-plan.md) §PR2.5). The two
+deferred mitigations bite once M7 makes generic-union annotations
+reachable from source, since user-written `T | A` is the case where
+over-constrained inner variables (failure mode #1) actually surface to the
+user. Land them once that happens:
+
+- **Tag committed bounds with their union-trial origin** (addresses
+  failure mode #4). When the trial commits, mark the added bounds (or the
+  var) with a side-table entry pointing at the union annotation node.
+  When a downstream constraint fails on a tagged var, the diagnostic
+  engine chases the tag and emits "this var was committed to branch A of
+  (A | B) at <span>; later use needs B." Replaces today's flat "string is
+  not number" with a breadcrumb back to the union choice that forced the
+  conflict. Probe-safe via the existing rollback hook discipline.
+- **Ambient-time ambiguity detection** (addresses failure mode #1 at
+  declaration time). After the first trial commits, optionally peek at
+  later branches under throwaway probes. When another branch would also
+  succeed AND would have added different bounds, emit a warning at the
+  union annotation site asking the user to disambiguate. Catches
+  over-constraint at declaration time rather than at downstream use.
+  Roughly doubles the work for ambiguous unions, which matches the cost
+  of the original failure mode. Worth landing once user reports of
+  confusion start coming in.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
@@ -1481,10 +1509,11 @@ reduce through the M9 operator machinery.
   solver. Two complementary directions:
   - **True backtracking.** A search-based solver that unwinds the committed
     trial when a downstream constraint contradicts it and retries the next
-    candidate. Fixes failure modes #1, #4, and #5 from the post-PR2
-    post-mortem. Bounded backtracking (only revisit the most recent trial)
-    is tractable; full backtracking through propagated bound graphs is an
-    open research problem at this language's scale.
+    candidate. Fixes failure modes #1 (over-constraining inner vars), #4
+    (misleading errors), and #5 (no backtracking) from the M7 enumeration
+    above. Bounded backtracking — only revisit the most recent trial — is
+    tractable; full backtracking through propagated bound graphs is an open
+    research problem at this language's scale.
   - **Disjunctive bound representation.** Let a var carry "γ ≤ A OR γ ≤ B"
     as a first-class constraint rather than picking one and committing.
     Fixes failure mode #6 (cross-variable correlation) by recording the

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -831,6 +831,31 @@ through is rejected; an `if let r2: mut {x: number} = r` over a PR6 read-only un
 allows `r2.x = 5` while `r` keeps its union type; the scrutinee's own type is unchanged
 after both forms.
 
+**Decision pending: free type-var members in the union-super exists trial.**
+PR7's `if-let` pattern reuses the union-super exists rule PR2 shipped, which
+today SKIPS direct TypeVar members of the super union to avoid speculative
+pinning. The skip is sound but rejects `if let x: T = u` over `u: T | number`
+when no concrete branch matches, even when `T := matched-type` would
+type-check. Two designs were on the table at PR2 time and the choice was
+explicitly deferred to PR7. See [01-milestones.md](01-milestones.md) §M7
+"Open design question — free type-var members in a union-super exists trial"
+for the full enumeration. Short version:
+
+- **Keep the skip.** The honest mitigation is restructuring code away from
+  the generic union (split signatures, discriminating wrapper). The
+  reorder-the-union and explicit-type-argument workarounds DON'T work in
+  Escalier today.
+- **Two-pass exists trial.** Trial concrete members first; if none commit,
+  trial var members in a second pass. Roughly one-day implementation: ~20
+  lines in `constrain.go`, one existing test rewrite, two new test cases,
+  one comment update, and resolve the M7 open question.
+
+The deferred decision is what `if let x: T = u` should do for the generic
+case, so PR7 is the natural place to make the call. Land the chosen rule
+as part of PR7 (or as a tail commit on PR2 if the implementer decides
+before PR7 starts) and update both the M7 open question and the comment
+on the union-super exists rule in `constrain.go`.
+
 ### PR8 — Subsume inferred types at finalization
 
 Close the subsumption gap for inferred types without threading a Context through the

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -516,10 +516,12 @@ systems do. The ordering choice still has to be a total order consistent
 with `equalType` for the trial sequence to be reproducible. Use the
 existing `compareType` for tie-breaks.
 
-**Out of scope here.** The diagnostic-tagging work (point #4 in the
-post-mortem) and the ambient-time ambiguity warning (point #5) are deferred
-to a later milestone — see [01-milestones.md](01-milestones.md) §M7, which
-notes both as follow-ups to the generic-union surface. The structurally
+**Out of scope here.** Two further diagnostic-quality mitigations are
+deferred to M7: tagging committed bounds with their union-trial origin
+(so a downstream error chases the tag), and ambient-time ambiguity
+detection (so the over-constraint surfaces at declaration time, not at
+downstream use). See [01-milestones.md](01-milestones.md) §M7 for the
+enumerated failure modes and the deferred mitigations. The structurally
 larger fixes — true backtracking and disjunctive bound representation —
 are post-MVP work; see [01-milestones.md](01-milestones.md) "Later
 (post-MVP)".

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -146,6 +146,7 @@ PR1 (representation + normalization)
  ├─► PR2 (constrain lattice rules + union/intersection annotation input)
  │     ├─► PR2.5 (trial-and-commit cleanup: shared helper, specificity order,
  │     │          delete constrainAssign)
+ │     ├─► PR2.7 (tighter BorrowEscape promotion: lifetime-blocker check)
  │     └─► PR4 (union exactness flag + match exhaustiveness leg)
  ├─► PR3 (monomorphic function-type annotations)
  │     └─► PR5 (⊤/⊥ rules + Variation-B close — now testable end-to-end)
@@ -165,6 +166,12 @@ PR1 (representation + normalization)
   before PR4's exactness one-way rule changes how the union-super exists
   rule renders its diagnostics. Independent of PR3/PR5/PR6/PR7/PR8 — purely a
   cleanup of the sites PR2 has just touched.
+- **PR2.7 depends only on PR2** and is independent of every other PR. It is a
+  diagnostic-quality fix in the BorrowEscape firing condition that tightens
+  both the single-trial RefType arm and the PR2 `commonBorrowEscape`
+  union-level promotion. The constraint outcome doesn't change — only which
+  error fires when it fails. Could land before or after PR2.5; no ordering
+  dependency between the two.
 - **PR3 (function annotations) feeds PR5.** The `_ <: unknown` rule itself needs
   only PR1, but its reason for existing — the Variation-B check — is only
   *reachable* once an inexact function annotation can reach `constrain`, which is
@@ -526,6 +533,84 @@ specificity ordering still respects the "no free TypeVar members" rule.
 
 **Depends on:** PR2 (the union-super exists rule, the new trial site this
 cleanup consolidates).
+
+---
+
+### PR2.7 — Tighter `BorrowEscapeError` promotion: only fire when the lifetime is the genuine blocker
+
+Diagnostic-quality fix for the `BorrowEscapeError` class. Today the rule fires
+whenever a borrow with a non-nil lifetime constrains against a non-RefType
+non-var super, regardless of whether the inner would have matched if the
+borrow weren't there. This is misleading whenever the inner is also a shape
+mismatch: the error reads "borrowed value … does not live long enough to
+satisfy …", which suggests "extend the lifetime and this would work" when in
+fact the inner shape doesn't fit either way. The PR2 union-level promotion
+through `commonBorrowEscape` inherits the same problem: every per-trial
+BorrowEscape gets promoted, even when no branch's shape would have matched
+even with the lifetime stripped.
+
+**The rule.** Emit BorrowEscapeError only when peeling the borrow's inner
+would have satisfied the super. Otherwise emit the shape-mismatch error
+that peeling would have produced (typically a CannotConstrainError or a
+deeper structural-arm error). Concretely:
+
+- **Single-trial RefType arm** ([constrain.go:368-373](../../internal/solver/constrain.go)).
+  Before returning `BorrowEscapeError{Sub: sub, Super: super}`, trial
+  `sub.Inner <: super` under a discard probe. If it succeeds, the lifetime
+  was the genuine blocker; emit BorrowEscape. If it fails, surface the
+  inner-trial error instead — that's the actual root cause.
+- **Union-level promotion** (`commonBorrowEscape` in
+  [constrain.go](../../internal/solver/constrain.go)). Replace the
+  "every trial returned BorrowEscape" check with the stronger "peeling
+  sub's inner against the union super has at least one branch that would
+  have succeeded." The check reuses the existing union-super exists rule
+  through `c.constrain(sub.Inner, super, ...)` under a discard probe.
+
+The probe makes the inner re-trial side-effect-free: any bound mutations
+the peeling would have caused are rolled back before the rule decides
+which error to emit.
+
+**Example pairs.** Each pair shows the misleading message today and the
+clearer message after PR2.7:
+
+```
+&'a {x: number} <: number
+  today:    borrowed value &'a object does not live long enough to satisfy number
+  PR2.7:    cannot constrain object <: number
+            (peeling: {x: number} <: number fails — shape, not lifetime)
+
+&'a {x: number} <: {x: number}
+  today:    borrowed value &'a object does not live long enough to satisfy object
+  PR2.7:    borrowed value &'a object does not live long enough to satisfy object
+            (peeling: {x: number} <: {x: number} succeeds — lifetime IS the blocker)
+
+&'a {x: number} <: (number | string)
+  today:    borrowed value &'a object does not live long enough to satisfy number | string
+  PR2.7:    cannot constrain object <: number | string
+            (peeling: every branch is a shape mismatch — lifetime is incidental)
+
+&'a {x: number} <: (number | {x: number})
+  today:    borrowed value &'a object does not live long enough to satisfy number | {x: number}
+  PR2.7:    borrowed value &'a object does not live long enough to satisfy number | {x: number}
+            (peeling: branch 2 succeeds — lifetime IS the blocker for the matching branch)
+```
+
+**Out of scope.** The error class itself is not renamed. The fix is
+about WHEN it fires, not what it says. A separate diagnostic-rewording
+pass could revisit the "does not live long enough" phrasing once the
+firing condition is provably "lifetime was the genuine blocker."
+
+**Tests.** A new table for each of the four example shapes above. Each
+asserts both the error kind and the full message. The
+`TestConstrainUnionSuperPreservesBorrowEscape` regression updates to use
+the meaningful shape (`&'a {x:number} <: (number | {x:number})`), since
+the original test happens to be in the misleading-cause column. Add a
+sibling test for the non-union case so the single-trial RefType arm's
+new behavior is also pinned.
+
+**Depends on:** PR2 (the union-super exists rule and `commonBorrowEscape`
+helper this tightens). Independent of PR2.5, PR3, PR4, PR5, PR6, PR7,
+PR8 — purely a diagnostic-quality fix in the constrain code path.
 
 ---
 

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -144,6 +144,8 @@ and the *rules*.
 ```
 PR1 (representation + normalization)
  ├─► PR2 (constrain lattice rules + union/intersection annotation input)
+ │     ├─► PR2.5 (trial-and-commit cleanup: shared helper, specificity order,
+ │     │          delete constrainAssign)
  │     └─► PR4 (union exactness flag + match exhaustiveness leg)
  ├─► PR3 (monomorphic function-type annotations)
  │     └─► PR5 (⊤/⊥ rules + Variation-B close — now testable end-to-end)
@@ -158,6 +160,11 @@ PR1 (representation + normalization)
   M2.5's `Prov` discipline was.
 - **PR2 before PR4** because the exactness one-way rule is a refinement of the
   base lattice rules PR2 installs.
+- **PR2.5 depends only on PR2** and could land before or after PR4. Landing it
+  early makes the trial-and-commit machinery uniform across the four sites
+  before PR4's exactness one-way rule changes how the union-super exists
+  rule renders its diagnostics. Independent of PR3/PR5/PR6/PR7/PR8 — purely a
+  cleanup of the sites PR2 has just touched.
 - **PR3 (function annotations) feeds PR5.** The `_ <: unknown` rule itself needs
   only PR1, but its reason for existing — the Variation-B check — is only
   *reachable* once an inexact function annotation can reach `constrain`, which is
@@ -450,6 +457,75 @@ rendered binding type, not bound internals); `(A & B) <: C` picks a member;
 `A <: (B | C)` for concrete `A` picks a branch and a non-member is rejected;
 both round-trip through the printer; an inferred union from a multi-branch return
 still renders (regression against PR1's normalization).
+
+---
+
+### PR2.5 — Trial-and-commit cleanup: shared helper, specificity order, delete `constrainAssign`
+
+Cleanup pass over the trial-and-commit sites the union-super exists rule joined
+in PR2. With PR2 landed, the solver has four such sites: the original
+overload-resolution path in `resolveOverload`
+([overload.go:43](../../internal/solver/overload.go)), the intersection-sub
+arm in `constrain`, the new union-super exists rule, and the M5-era
+`constrainAssign` workaround in
+[infer_expr.go:991](../../internal/solver/infer_expr.go). All four share the
+same shape — iterate members, probe-trial each, commit on first success,
+collect per-trial errors on failure — and the same user-visible failure modes:
+over-constraining inner inference variables, order-dependence on canonical
+sort, brittleness to union-membership changes, and misleading downstream
+errors. PR2.5 lands the three lowest-cost mitigations as one cleanup.
+
+**Delete `constrainAssign`.** Its doc-comment already flags itself as a
+pre-M6 workaround for assigning into a union target, with the deliberately
+not-fixable shape pointing at "M6's deferred union/intersection rules in
+`constrain`" as the proper fix. PR2 lands those rules. Route assignment
+through `c.constrain` and delete the function. Verify that the pinned
+regression `TestInferAssignUnionTargetVarRHSOverNarrows` still passes
+through the new path; if its expected behavior diverges, update the
+assertion in place rather than reinstating the workaround. Reduces the
+trial-and-commit surface from four sites to three.
+
+**Extract a shared `trialAndCommit` helper.** All three remaining sites have
+the same outline: a candidate order, a per-candidate trial body, a
+first-success commit, and a per-trial error collector for the failure path.
+Pull this into one helper in the probe package (or beside it in
+`constrain.go`), parameterised by the trial body callback and the candidate
+list. Each call site shrinks to a one-liner over its own candidate order
+plus the per-candidate work. Concentrates every later mitigation into one
+location and catches silent drift in the probe / cloned-`seen` discipline
+between the rules. The intersection-sub arm's specificity-order use stays
+the same. The union-super exists rule's free-var-member skip rides on top.
+
+**Specificity-ordered trials, not canonical-ordered.** The
+IntersectionType-sub arm already uses `specificityOrder`
+([overload.go:143](../../internal/solver/overload.go)) for its FuncType-only
+case. Extend the ordering to general types — LitType before PrimType,
+narrower object before wider, etc. — and route the union-super exists rule
+through it. Most-specific-first means adding a less-specific union member
+does not change which branch wins, which addresses the brittleness failure
+mode head-on. The order also matches intuition better than canonical sort
+on member kind, since "the more specific branch wins" is what most type
+systems do. The ordering choice still has to be a total order consistent
+with `equalType` for the trial sequence to be reproducible. Use the
+existing `compareType` for tie-breaks.
+
+**Out of scope here.** The diagnostic-tagging work (point #4 in the
+post-mortem) and the ambient-time ambiguity warning (point #5) are deferred
+to a later milestone — see [01-milestones.md](01-milestones.md) §M7, which
+notes both as follow-ups to the generic-union surface. The structurally
+larger fixes — true backtracking and disjunctive bound representation —
+are post-MVP work; see [01-milestones.md](01-milestones.md) "Later
+(post-MVP)".
+
+**Tests.** A new table in the constrain-tests file: for each rule (overload,
+intersection-sub, union-super exists), adding a less-specific member to the
+candidate list does not change which branch commits. A regression that
+removing `constrainAssign` keeps every existing assignment test passing.
+The free-var-member skip in the union-super rule is unaffected since
+specificity ordering still respects the "no free TypeVar members" rule.
+
+**Depends on:** PR2 (the union-super exists rule, the new trial site this
+cleanup consolidates).
 
 ---
 


### PR DESCRIPTION
Implements lattice subtyping rules for union and intersection types in the constraint solver, enabling type annotations with union and intersection syntax.

## Summary

This PR adds support for union (`A | B`) and intersection (`A & B`) type annotations in the type system. The constraint solver now handles lattice subtyping rules that decompose these composite types into constraints on their members. Union and intersection types can now flow through the type inference system and be used in variable annotations.

## Key changes

- **Pre-switch lattice block in `constrain.go`**: Added three lattice rules that fire before the structural type switch to avoid early interception by other arms (notably `RefType`):
  - Union sub for-all rule: `(A | B) <: super` decomposes to `A <: super AND B <: super`
  - Intersection super for-all rule: `sub <: (A & B)` decomposes to `sub <: A AND sub <: B`
  - Union super exists rule: `sub <: (A | B)` trials each concrete member and commits the first success, with special handling to skip free type variables and preserve `BorrowEscapeError` diagnostics

- **Inexact union validation**: Added `superAcceptsUnknownTail()` to gate inexact unions (with open `...` tail) against closed targets, rejecting with `InexactUnionIntoExactError` before decomposition. Inexact unions are allowed to flow into `unknown`, type variables, or other inexact unions.

- **Type annotation support in `type_ann.go`**: Added `resolveUnionTypeAnn()` and `resolveIntersectionTypeAnn()` to lower union and intersection annotations through smart constructors that perform member deduplication and subsumption elimination. Provenance tracking gates on type state to avoid overwriting narrower blame from collapsed members.

- **Error type in `errors.go`**: Added `InexactUnionIntoExactError` for rejected inexact unions flowing into closed targets.

- **Intersection sub exists rule refinement in `constrain.go`**: Clarified that the existing intersection-sub exists rule (which trials members in specificity order) now serves both overload synthesis and general annotation intersections.

- **Comprehensive test coverage**: Added `constrain_lattice_test.go` with 11 tests exercising lattice rules through the `Constrain` API, and `infer_lattice_test.go` with 10 source-level tests covering annotation input, round-tripping, and error cases.

## Implementation details

The union super exists rule uses a probe-and-rollback pattern to trial each member without leaking speculative bounds. Free type variables in union members are skipped to avoid premature pinning. When all concrete branches fail with `BorrowEscapeError`, the rule promotes a single union-level `BorrowEscapeError` to preserve the lifetime diagnostic rather than collapsing to a generic `CannotConstrainError`.

Provenance tracking for union and intersection annotations gates on whether the result already carries a `FromAST` entry, preserving blame from single-member collapses while recording the outer annotation for fresh results.

https://claude.ai/code/session_01XbuJHTX3WQqXdpMXaM52o6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced type annotation support for union (`|`) and intersection (`&`) types, including flattening and deduplication.
* **Bug Fixes**
  * Improved lattice-based constraint handling for union/intersection “for all” and “exists” cases, including correct union-vs-reference matching order.
  * Added more precise diagnostics when inexact unions are constrained into exact targets, while preserving borrow-escape behavior.
* **Tests**
  * Expanded unit coverage for lattice subtyping and inference across union/intersection scenarios.
* **Documentation**
  * Updated milestone notes with deeper discussion of union-super “exists” trials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->