### PR TITLE
Implement deep `mut`, `readonly` fields, and type-parameter inertness

### DIFF
--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -67,6 +67,15 @@ func (v *LifetimeVar) BoundsAt(pol Polarity) []Lifetime {
 // constraint.
 type StaticLifetime struct{}
 
+// AnonLifetime is a display-only marker that keeps the `&` on a borrow whose
+// lifetime is not load-bearing. The lifetime coalescer (D4) inserts it where it
+// used to drop the lifetime entirely, so an `&mut {x}` parameter still renders
+// as `&mut {x}` instead of collapsing to owned-mutable `mut {x}`. It is never a
+// constrain input. Only coalesce produces it, only the printer reads it, and it
+// carries no bounds since the underlying lifetime variable has already been
+// determined unobservable.
+type AnonLifetime struct{}
+
 // LifetimeUnion is a coalescing-output-only lifetime. It is the union of the param
 // lifetimes a join variable reaches, e.g. returning one of two borrows renders as
 // `('a | 'b)`. It never appears as a constraint input, since constrainLt relates
@@ -86,12 +95,24 @@ func (*LifetimeUnion) isLifetime() {}
 // the cheap default, not a correctness crutch.
 var Static Lifetime = &StaticLifetime{}
 
+// Anon is the canonical anonymous-lifetime value. The coalescer reuses it for
+// every elided borrow, so the printer's "any AnonLifetime renders as bare `&`"
+// rule needs no per-instance bookkeeping.
+var Anon Lifetime = &AnonLifetime{}
+
 func (*LifetimeVar) isLifetime()    {}
 func (*StaticLifetime) isLifetime() {}
+func (*AnonLifetime) isLifetime()   {}
 
 // IsStaticLifetime reports whether lt is 'static.
 func IsStaticLifetime(lt Lifetime) bool {
 	_, ok := lt.(*StaticLifetime)
+	return ok
+}
+
+// IsAnonLifetime reports whether lt is an anonymous display lifetime.
+func IsAnonLifetime(lt Lifetime) bool {
+	_, ok := lt.(*AnonLifetime)
 	return ok
 }
 

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -367,7 +367,11 @@ func (p *namedPrinter) printType(t Type) string {
 			if prop.Optional {
 				opt = "?"
 			}
-			elems = append(elems, printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
+			ro := ""
+			if prop.Readonly {
+				ro = "readonly "
+			}
+			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -313,14 +313,45 @@ func (p *namedPrinter) borrowLifetimeName(lt Lifetime) string {
 // same shape, so e.g. a function inside a union renders as
 // `(fn () -> number) | string`.
 func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
-	result := p.printType(t)
-	if typePrec(t) < minPrec {
+	return p.printTypeMinPrecUM(t, minPrec, false)
+}
+
+// printTypeMinPrecUM is printTypeMinPrec threaded with the underMut flag. The flag
+// activates the deep-mut display rule: under a mutable wrapper, a nested
+// owned-mutable cell is the redundant inner `mut` that deep-mut lowering produces,
+// and printing it as the bare inner matches the surface annotation the user wrote.
+func (p *namedPrinter) printTypeMinPrecUM(t Type, minPrec int, underMut bool) string {
+	result := p.printTypeUM(t, underMut)
+	if elidedRefPrec(t, underMut) < minPrec {
 		return "(" + result + ")"
 	}
 	return result
 }
 
+// elidedRefPrec returns the precedence at which t will print after deep-mut
+// elision. An owned-mutable RefType inside a mut context prints as its inner, so
+// its precedence is the inner's, not the wrapper's. All other shapes keep the
+// precedence typePrec assigns.
+func elidedRefPrec(t Type, underMut bool) int {
+	if r, ok := t.(*RefType); ok && underMut && r.Mut && r.Lt == nil {
+		return elidedRefPrec(r.Inner, true)
+	}
+	return typePrec(t)
+}
+
 func (p *namedPrinter) printType(t Type) string {
+	return p.printTypeUM(t, false)
+}
+
+// printTypeUM is printType threaded with the underMut flag, used by the deep-mut
+// display rule. underMut is true inside a mutable RefType wrapper, where a nested
+// owned-mutable cell prints as the bare inner — eliding the redundant `mut` that
+// deep-mut lowering inserts so the rendered type matches the surface annotation
+// the user wrote. The flag propagates through object/tuple fields, union and
+// intersection members, and through every owned-mutable cell that elides. It
+// resets to false at a function or promise boundary, since each carries its own
+// independent annotation context.
+func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 	switch t := t.(type) {
 	case *TypeVarType:
 		// A retained type parameter renders under its assigned name; otherwise a
@@ -353,7 +384,7 @@ func (p *namedPrinter) printType(t Type) string {
 	case *TupleType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
-			elems = append(elems, p.printType(e))
+			elems = append(elems, p.printTypeUM(e, underMut))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")
@@ -371,15 +402,19 @@ func (p *namedPrinter) printType(t Type) string {
 			if prop.Readonly {
 				ro = "readonly "
 			}
-			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
+			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printTypeUM(prop.Type, underMut))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")
 		}
 		return "{" + strings.Join(elems, ", ") + "}"
 	case *FuncType:
+		// A function is its own annotation context, so the underMut flag does not
+		// flow into its parameters or return type. printFuncTail starts fresh from
+		// printType, which calls printTypeUM with underMut=false.
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
+		// A promise's payload is its own annotation context, so the flag resets here.
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
 		// Ownership and the borrow `&` split on Lt. An owned value has Lt nil and
@@ -392,6 +427,15 @@ func (p *namedPrinter) printType(t Type) string {
 		//
 		// The inner prints at precPrefix so a looser inner such as a union or function
 		// gets parenthesized.
+		//
+		// Deep-mut elision (PR 13). Under a mutable wrapper, a nested owned-mutable
+		// cell is the inner `mut` that deep-mut lowering inserted on every reachable
+		// object and tuple field. Print it as the bare inner, so the rendered type
+		// matches the surface annotation the user wrote. The elision applies only to
+		// an owned-mutable cell (`Lt == nil`); a real borrow keeps its `&`/`&mut`.
+		if underMut && t.Mut && t.Lt == nil {
+			return p.printTypeUM(t.Inner, true)
+		}
 		prefix := ""
 		if t.Lt != nil {
 			prefix = "&"
@@ -402,14 +446,17 @@ func (p *namedPrinter) printType(t Type) string {
 		if t.Mut {
 			prefix += "mut "
 		}
-		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
+		// Entering a mutable wrapper activates underMut for the inner walk, so a
+		// nested owned-mutable cell can elide. An immutable wrapper (`&T`) does not
+		// activate elision: its pointee carries no deep-mut to undo.
+		return prefix + p.printTypeMinPrecUM(t.Inner, precPrefix, t.Mut)
 	case *UnionType:
 		// An inexact union renders a trailing `...` entry, so a union typed
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
 		// object, and function arms render their flag the same way.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
-			parts = append(parts, p.printTypeMinPrec(m, precUnion))
+			parts = append(parts, p.printTypeMinPrecUM(m, precUnion, underMut))
 		}
 		if t.Inexact {
 			parts = append(parts, "...")
@@ -418,7 +465,7 @@ func (p *namedPrinter) printType(t Type) string {
 	case *IntersectionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {
-			parts[i] = p.printTypeMinPrec(m, precIntersection)
+			parts[i] = p.printTypeMinPrecUM(m, precIntersection, underMut)
 		}
 		return strings.Join(parts, " & ")
 	}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -428,11 +428,12 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 		// The inner prints at precPrefix so a looser inner such as a union or function
 		// gets parenthesized.
 		//
-		// Deep-mut elision (PR 13). Under a mutable wrapper, a nested owned-mutable
-		// cell is the inner `mut` that deep-mut lowering inserted on every reachable
-		// object and tuple field. Print it as the bare inner, so the rendered type
-		// matches the surface annotation the user wrote. The elision applies only to
-		// an owned-mutable cell (`Lt == nil`); a real borrow keeps its `&`/`&mut`.
+		// Deep-mut elision. Under a mutable wrapper, a nested owned-mutable cell
+		// is the inner `mut` that deep-mut lowering inserted on every reachable
+		// object and tuple field. Print it as the bare inner so the rendered type
+		// matches the surface annotation the user wrote. The elision applies only
+		// to an owned-mutable cell with no lifetime. A real borrow keeps its `&`
+		// or `&mut`.
 		if underMut && t.Mut && t.Lt == nil {
 			return p.printTypeUM(t.Inner, true)
 		}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -264,6 +264,8 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 	switch lt := lt.(type) {
 	case *StaticLifetime:
 		return "'static"
+	case *AnonLifetime:
+		return ""
 	case *LifetimeVar:
 		if p.ltNames != nil {
 			if name, ok := p.ltNames[lt]; ok {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -313,6 +313,20 @@ func TestPrintDeepMutElision(t *testing.T) {
 	})
 }
 
+// AnonLifetime renders as bare `&` / `&mut`, keeping a borrow distinguishable
+// from an owned value when its lifetime is elided.
+func TestPrintAnonLifetime(t *testing.T) {
+	body := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}
+	t.Run("mutable anon", func(t *testing.T) {
+		ty := &RefType{Mut: true, Lt: Anon, Inner: body}
+		require.Equal(t, "&mut {x: number}", Print(ty))
+	})
+	t.Run("immutable anon", func(t *testing.T) {
+		ty := &RefType{Mut: false, Lt: Anon, Inner: body}
+		require.Equal(t, "&{x: number}", Print(ty))
+	})
+}
+
 // TestPrintRawTypeVar verifies that Print tolerates a raw, un-coalesced
 // TypeVarType (rendering it as `t{ID}`) instead of panicking — the M2 walk
 // records var-carrying types in Info and only coalesces at binding boundaries,

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -93,8 +93,7 @@ func TestPrintRoundTrips(t *testing.T) {
 			"{a?: number}",
 		},
 		{
-			// A readonly property renders a leading `readonly ` (PR 13), so a
-			// `readonly a: T` annotation round-trips to surface syntax.
+			// A readonly property renders a leading `readonly ` prefix.
 			"readonly property renders readonly",
 			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP(), Readonly: true}}},
 			"{readonly a: number}",
@@ -243,13 +242,8 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
-// TestPrintDeepMutElision verifies that a nested owned-mutable cell elides under a
-// mutable wrapper (PR 13). Deep `mut` lowering inserts a `mut` on every reachable
-// object and tuple field, so the stored type is `mut {a: mut {x}}` for the surface
-// annotation `mut {a: {x}}`. Printing must elide the inner `mut` so the rendered
-// type matches what the user wrote, both for the owned `mut` form and the borrow
-// `&mut` form. An immutable wrapper does NOT activate elision, so a user-explicit
-// `mut` field on an immutable container is preserved verbatim.
+// A nested owned-mutable cell elides under a mutable wrapper so the rendered
+// type matches the surface annotation. An immutable wrapper does not elide.
 func TestPrintDeepMutElision(t *testing.T) {
 	mutOwned := func(inner RefInner) Type {
 		return &RefType{Mut: true, Inner: inner}
@@ -289,8 +283,7 @@ func TestPrintDeepMutElision(t *testing.T) {
 	})
 
 	t.Run("immutable wrapper preserves a user-explicit nested mut", func(t *testing.T) {
-		// `{a: mut {x}}` is an immutable outer with an explicit `mut` inner. The
-		// inner is not deep-mut output, so the print must preserve it verbatim.
+		// An immutable outer is not deep-mut output, so the inner is preserved.
 		ty := &ObjectType{Elems: []ObjTypeElem{
 			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},
@@ -300,8 +293,7 @@ func TestPrintDeepMutElision(t *testing.T) {
 	})
 
 	t.Run("borrow field under mut keeps its & marker", func(t *testing.T) {
-		// `mut {a: &mut {x}}`: the field is a real borrow, not a deep-mut cell, so
-		// it keeps its `&mut` even under a mutable wrapper.
+		// A real borrow field keeps its `&mut` even under a mutable wrapper.
 		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
 			&PropertyElem{Name: "a", Type: staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -92,6 +92,13 @@ func TestPrintRoundTrips(t *testing.T) {
 			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP(), Optional: true}}},
 			"{a?: number}",
 		},
+		{
+			// A readonly property renders a leading `readonly ` (PR 13), so a
+			// `readonly a: T` annotation round-trips to surface syntax.
+			"readonly property renders readonly",
+			&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP(), Readonly: true}}},
+			"{readonly a: number}",
+		},
 
 		// Functions. A bare (exact) function renders with no trailing marker; an
 		// inexact one renders a trailing `...`, and an optional param renders `x?: T`.

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -243,6 +243,84 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
+// TestPrintDeepMutElision verifies that a nested owned-mutable cell elides under a
+// mutable wrapper (PR 13). Deep `mut` lowering inserts a `mut` on every reachable
+// object and tuple field, so the stored type is `mut {a: mut {x}}` for the surface
+// annotation `mut {a: {x}}`. Printing must elide the inner `mut` so the rendered
+// type matches what the user wrote, both for the owned `mut` form and the borrow
+// `&mut` form. An immutable wrapper does NOT activate elision, so a user-explicit
+// `mut` field on an immutable container is preserved verbatim.
+func TestPrintDeepMutElision(t *testing.T) {
+	mutOwned := func(inner RefInner) Type {
+		return &RefType{Mut: true, Inner: inner}
+	}
+	staticBorrow := func(mut bool, inner RefInner) Type {
+		return &RefType{Mut: mut, Lt: &StaticLifetime{}, Inner: inner}
+	}
+
+	t.Run("owned mut elides one nested level", func(t *testing.T) {
+		// mut {a: mut {x: number}} stored, prints as mut {a: {x: number}}.
+		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "x", Type: numP()},
+			}})},
+		}})
+		require.Equal(t, "mut {a: {x: number}}", Print(ty))
+	})
+
+	t.Run("owned mut elides three nested levels", func(t *testing.T) {
+		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "b", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+					&PropertyElem{Name: "c", Type: numP()},
+				}})},
+			}})},
+		}})
+		require.Equal(t, "mut {a: {b: {c: number}}}", Print(ty))
+	})
+
+	t.Run("&mut activates the same elision", func(t *testing.T) {
+		ty := staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "x", Type: numP()},
+			}})},
+		}})
+		require.Equal(t, "&'static mut {a: {x: number}}", Print(ty))
+	})
+
+	t.Run("immutable wrapper preserves a user-explicit nested mut", func(t *testing.T) {
+		// `{a: mut {x}}` is an immutable outer with an explicit `mut` inner. The
+		// inner is not deep-mut output, so the print must preserve it verbatim.
+		ty := &ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "x", Type: numP()},
+			}})},
+		}}
+		require.Equal(t, "{a: mut {x: number}}", Print(ty))
+	})
+
+	t.Run("borrow field under mut keeps its & marker", func(t *testing.T) {
+		// `mut {a: &mut {x}}`: the field is a real borrow, not a deep-mut cell, so
+		// it keeps its `&mut` even under a mutable wrapper.
+		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "x", Type: numP()},
+			}})},
+		}})
+		require.Equal(t, "mut {a: &'static mut {x: number}}", Print(ty))
+	})
+
+	t.Run("tuple element elides under mut", func(t *testing.T) {
+		ty := mutOwned(&TupleType{Elems: []Type{
+			numP(),
+			mutOwned(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "x", Type: numP()},
+			}}),
+		}})
+		require.Equal(t, "mut [number, {x: number}]", Print(ty))
+	})
+}
+
 // TestPrintRawTypeVar verifies that Print tolerates a raw, un-coalesced
 // TypeVarType (rendering it as `t{ID}`) instead of panicking — the M2 walk
 // records var-carrying types in Info and only coalesces at binding boundaries,

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -233,6 +233,12 @@ type PropertyElem struct {
 	Name     string
 	Type     Type
 	Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
+	// Readonly marks a `readonly f: T` field. It forbids REASSIGNING the field
+	// (`obj.f = …`) and nothing more — it is orthogonal to the deep mutability the
+	// RefType wrapper carries, so a `readonly` field may still have a mutable value
+	// whose own fields are writable. The field-write rule reads it in
+	// constrainWriteBack; it has no effect on the covariant read view.
+	Readonly bool
 }
 
 func (*PropertyElem) isObjTypeElem() {}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -233,11 +233,11 @@ type PropertyElem struct {
 	Name     string
 	Type     Type
 	Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
-	// Readonly marks a `readonly f: T` field. It forbids REASSIGNING the field
-	// (`obj.f = …`) and nothing more — it is orthogonal to the deep mutability the
-	// RefType wrapper carries, so a `readonly` field may still have a mutable value
-	// whose own fields are writable. The field-write rule reads it in
-	// constrainWriteBack; it has no effect on the covariant read view.
+	// Readonly marks a `readonly f: T` field. It forbids reassigning the field
+	// through `obj.f = …` and nothing more. It is orthogonal to the deep
+	// mutability the RefType wrapper carries, so a readonly field may still hold
+	// a mutable value whose own fields are writable. The field-write rule reads
+	// it in constrainWriteBack. It has no effect on the covariant read view.
 	Readonly bool
 }
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -233,12 +233,7 @@ type PropertyElem struct {
 	Name     string
 	Type     Type
 	Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
-	// Readonly marks a `readonly f: T` field. It forbids reassigning the field
-	// through `obj.f = …` and nothing more. It is orthogonal to the deep
-	// mutability the RefType wrapper carries, so a readonly field may still hold
-	// a mutable value whose own fields are writable. The field-write rule reads
-	// it in constrainWriteBack. It has no effect on the covariant read view.
-	Readonly bool
+	Readonly bool // `readonly f: T`; forbids `obj.f = …` only, orthogonal to deep mut
 }
 
 func (*PropertyElem) isObjTypeElem() {}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -264,7 +264,7 @@ func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeEle
 				out = append([]ObjTypeElem(nil), es...)
 				changed = true
 			}
-			out[i] = &PropertyElem{Name: p.Name, Type: pt, Optional: p.Optional}
+			out[i] = &PropertyElem{Name: p.Name, Type: pt, Optional: p.Optional, Readonly: p.Readonly}
 		}
 	}
 	return out, changed

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -430,6 +430,7 @@ func usageObject(t soltype.Type) (obj *soltype.ObjectType, write bool, ok bool) 
 func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType {
 	types := map[string][]soltype.Type{} // property name → its distinct types, in first-seen order
 	optional := map[string]bool{}        // property name → optional in every object seen so far
+	readonly := map[string]bool{}        // property name → readonly in any object seen so far
 	var order []string
 	for _, o := range objs {
 		for _, elem := range o.Elems {
@@ -440,6 +441,10 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 			} else {
 				optional[pe.Name] = optional[pe.Name] && pe.Optional // optional iff optional in all
 			}
+			// readonly is conservative: a merged field stays read-only if any
+			// contributing object marks it so, since a single read-only view forbids
+			// the reassignment the merged field must also forbid.
+			readonly[pe.Name] = readonly[pe.Name] || pe.Readonly
 			types[pe.Name] = appendDistinct(types[pe.Name], pe.Type)
 		}
 	}
@@ -450,7 +455,7 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 		// shared property's type is normalized like every other lattice mint.
 		// Context is nil because the per-property folded types are already
 		// coalesced, so the core normalization is enough.
-		elems[i] = &soltype.PropertyElem{Name: name, Type: newIntersection(nil, types[name]), Optional: optional[name]}
+		elems[i] = &soltype.PropertyElem{Name: name, Type: newIntersection(nil, types[name]), Optional: optional[name], Readonly: readonly[name]}
 	}
 	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
 	return &soltype.ObjectType{Elems: elems, Inexact: open}
@@ -560,7 +565,7 @@ func equalType(a, b soltype.Type) bool {
 		for _, ae := range a.Elems {
 			ap := soltype.AsProperty(ae)
 			bp, ok := b.Prop(ap.Name)
-			if !ok || ap.Optional != bp.Optional || !equalType(ap.Type, bp.Type) {
+			if !ok || ap.Optional != bp.Optional || ap.Readonly != bp.Readonly || !equalType(ap.Type, bp.Type) {
 				return false
 			}
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -441,15 +441,10 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 			} else {
 				optional[pe.Name] = optional[pe.Name] && pe.Optional // optional iff optional in all
 			}
-			// readonly is conservative: a merged field stays read-only if any
-			// contributing object marks it so, since a single read-only view forbids
-			// the reassignment the merged field must also forbid. Today this never
-			// over-rejects, since every requirement-builder mints PropertyElems with
-			// Readonly:false. The only sources of Readonly:true are user annotations
-			// resolved through resolveObjectTypeAnn. A future requirement-builder that
-			// emits a readonly field would let this `||` poison a writable use folded
-			// into the same group, surfacing a spurious ReadonlyFieldSubtypeError. New
-			// builders must keep Readonly:false to preserve that invariant.
+			// Conservative `||`: a merged field is readonly if any contributing
+			// object marks it so. Sound today only because requirement-builders
+			// always mint Readonly:false; a builder that ever emits true would
+			// poison co-folded writable uses with a spurious subtype error.
 			readonly[pe.Name] = readonly[pe.Name] || pe.Readonly
 			types[pe.Name] = appendDistinct(types[pe.Name], pe.Type)
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -443,7 +443,13 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 			}
 			// readonly is conservative: a merged field stays read-only if any
 			// contributing object marks it so, since a single read-only view forbids
-			// the reassignment the merged field must also forbid.
+			// the reassignment the merged field must also forbid. Today this never
+			// over-rejects, since every requirement-builder mints PropertyElems with
+			// Readonly:false. The only sources of Readonly:true are user annotations
+			// resolved through resolveObjectTypeAnn. A future requirement-builder that
+			// emits a readonly field would let this `||` poison a writable use folded
+			// into the same group, surfacing a spurious ReadonlyFieldSubtypeError. New
+			// builders must keep Readonly:false to preserve that invariant.
 			readonly[pe.Name] = readonly[pe.Name] || pe.Readonly
 			types[pe.Name] = appendDistinct(types[pe.Name], pe.Type)
 		}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -621,6 +621,11 @@ func ltEqual(a, b soltype.Lifetime) bool {
 	if soltype.IsStaticLifetime(a) || soltype.IsStaticLifetime(b) {
 		return soltype.IsStaticLifetime(a) && soltype.IsStaticLifetime(b)
 	}
+	// AnonLifetime is a display marker for an elided borrow. All instances denote
+	// the same "no name" marker, so they compare equal by value, mirroring 'static.
+	if soltype.IsAnonLifetime(a) || soltype.IsAnonLifetime(b) {
+		return soltype.IsAnonLifetime(a) && soltype.IsAnonLifetime(b)
+	}
 	if ua, ok := a.(*soltype.LifetimeUnion); ok {
 		ub, ok := b.(*soltype.LifetimeUnion)
 		if !ok || len(ua.Lifetimes) != len(ub.Lifetimes) {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -108,28 +108,67 @@ func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 // mid-inference, a tuple — fall back to a full contravariant constraint, the prior
 // whole-inner behavior.
 func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[constraintKey]) []SolverError {
-	targetObj, ok1 := target.(*soltype.ObjectType)
-	sourceObj, ok2 := source.(*soltype.ObjectType)
-	if !ok1 || !ok2 {
+	targetObj, ok := target.(*soltype.ObjectType)
+	if !ok {
 		return c.constrain(target, source, seen)
 	}
 	var errs []SolverError
 	for _, elem := range targetObj.Elems {
 		p := soltype.AsProperty(elem)
-		if sp, ok := sourceObj.Prop(p.Name); ok {
-			// A `readonly` field forbids reassignment. The write view reaches this
-			// field only when the target demands a write to it, so a readonly source
-			// field is rejected here. The deep mutability the value carries is
-			// independent — `obj.f.x = …` reads `f` and writes `x`, never reassigning
-			// `f` — so the read view above is unaffected.
-			if sp.Readonly {
-				errs = append(errs, &ReadonlyFieldError{Field: p.Name})
-				continue
+		// A readonly source field cannot fill a writable target slot under a
+		// mutable borrow. The target view would otherwise let a holder write through
+		// and break the source's readonly contract. The literal assignment site is
+		// caught earlier in inferMemberAssign with a dedicated ReadonlyFieldError.
+		// This arm fires only for structural subtyping flows such as call arguments,
+		// returns, and re-bindings, and so uses a structural message. The deep
+		// mutability the value carries is independent. A nested write such as
+		// `obj.f.x = …` reads `f` and writes `x`, never reassigning `f`, so the
+		// read view above is unaffected. sourceFieldIsReadonly also walks an
+		// IntersectionType source, so a `{readonly a: T} & {a: T}` source still
+		// rejects the writable target rather than slipping past the bare-object guard.
+		if !p.Readonly && sourceFieldIsReadonly(source, p.Name) {
+			errs = append(errs, &ReadonlyFieldSubtypeError{Field: p.Name})
+			continue
+		}
+		if sourceObj, ok := source.(*soltype.ObjectType); ok {
+			if sp, ok := sourceObj.Prop(p.Name); ok {
+				errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)
 			}
-			errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)
 		}
 	}
+	// A non-object source needs the prior whole-inner contravariant constraint,
+	// since the per-field walk above only fires on a bare object source. The
+	// non-object cases reachable here are a TypeVarType mid-inference, an
+	// intersection still being resolved, and a tuple. The readonly check above
+	// already inspected the source through sourceFieldIsReadonly, so a readonly
+	// mismatch is caught regardless of the source's outer shape.
+	if _, ok := source.(*soltype.ObjectType); !ok {
+		errs = append(errs, c.constrain(target, source, seen)...)
+	}
 	return errs
+}
+
+// sourceFieldIsReadonly reports whether the named field is readonly in `source`,
+// where `source` may be a bare ObjectType or an IntersectionType of objects. An
+// intersection's field is readonly when ANY object member marks it so, since the
+// intersection inherits every member's restrictions. Any other source shape — a
+// TypeVarType, a tuple, a primitive — has no statically-known field flag here.
+// The TypeVarType case is handled by the var's bound-merge in mergeObjectGroup,
+// which carries Readonly through coalescing.
+func sourceFieldIsReadonly(source soltype.Type, name string) bool {
+	switch s := source.(type) {
+	case *soltype.ObjectType:
+		if p, ok := s.Prop(name); ok {
+			return p.Readonly
+		}
+	case *soltype.IntersectionType:
+		for _, m := range s.Types {
+			if sourceFieldIsReadonly(m, name) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]) []SolverError {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -117,6 +117,15 @@ func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[c
 	for _, elem := range targetObj.Elems {
 		p := soltype.AsProperty(elem)
 		if sp, ok := sourceObj.Prop(p.Name); ok {
+			// A `readonly` field forbids reassignment. The write view reaches this
+			// field only when the target demands a write to it, so a readonly source
+			// field is rejected here. The deep mutability the value carries is
+			// independent — `obj.f.x = …` reads `f` and writes `x`, never reassigning
+			// `f` — so the read view above is unaffected.
+			if sp.Readonly {
+				errs = append(errs, &ReadonlyFieldError{Field: p.Name})
+				continue
+			}
 			errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)
 		}
 	}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -130,6 +130,14 @@ func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[c
 			errs = append(errs, &ReadonlyFieldSubtypeError{Field: p.Name})
 			continue
 		}
+		// A readonly target field can never be written through the target view,
+		// so the contravariant write-back constraint that pins it invariant is
+		// unnecessary. The covariant read view already runs in the ObjectType
+		// arm above. Skipping the writeBack lets a more specific source field
+		// fill a readonly target slot, mirroring the assignability rule.
+		if p.Readonly {
+			continue
+		}
 		if sourceObj, ok := source.(*soltype.ObjectType); ok {
 			if sp, ok := sourceObj.Prop(p.Name); ok {
 				errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -115,26 +115,16 @@ func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[c
 	var errs []SolverError
 	for _, elem := range targetObj.Elems {
 		p := soltype.AsProperty(elem)
-		// A readonly source field cannot fill a writable target slot under a
-		// mutable borrow. The target view would otherwise let a holder write through
-		// and break the source's readonly contract. The literal assignment site is
-		// caught earlier in inferMemberAssign with a dedicated ReadonlyFieldError.
-		// This arm fires only for structural subtyping flows such as call arguments,
-		// returns, and re-bindings, and so uses a structural message. The deep
-		// mutability the value carries is independent. A nested write such as
-		// `obj.f.x = …` reads `f` and writes `x`, never reassigning `f`, so the
-		// read view above is unaffected. sourceFieldIsReadonly also walks an
-		// IntersectionType source, so a `{readonly a: T} & {a: T}` source still
-		// rejects the writable target rather than slipping past the bare-object guard.
+		// A readonly source field can't fill a writable target slot. The literal
+		// `obj.f = v` site is caught in inferMemberAssign; this arm fires on
+		// structural subtyping flows (call args, returns, re-bindings).
 		if !p.Readonly && sourceFieldIsReadonly(source, p.Name) {
 			errs = append(errs, &ReadonlyFieldSubtypeError{Field: p.Name})
 			continue
 		}
-		// A readonly target field can never be written through the target view,
-		// so the contravariant write-back constraint that pins it invariant is
-		// unnecessary. The covariant read view already runs in the ObjectType
-		// arm above. Skipping the writeBack lets a more specific source field
-		// fill a readonly target slot, mirroring the assignability rule.
+		// A readonly target needs only the covariant read view above, so skip the
+		// invariance-pinning writeBack. This lets a more specific source field
+		// fill a readonly target.
 		if p.Readonly {
 			continue
 		}
@@ -144,25 +134,18 @@ func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[c
 			}
 		}
 	}
-	// A non-object source needs the prior whole-inner contravariant constraint,
-	// since the per-field walk above only fires on a bare object source. The
-	// non-object cases reachable here are a TypeVarType mid-inference, an
-	// intersection still being resolved, and a tuple. The readonly check above
-	// already inspected the source through sourceFieldIsReadonly, so a readonly
-	// mismatch is caught regardless of the source's outer shape.
+	// A non-object source (TypeVar, intersection, tuple) takes the prior whole-
+	// inner contravariant constraint; the readonly check above already inspected
+	// it via sourceFieldIsReadonly.
 	if _, ok := source.(*soltype.ObjectType); !ok {
 		errs = append(errs, c.constrain(target, source, seen)...)
 	}
 	return errs
 }
 
-// sourceFieldIsReadonly reports whether the named field is readonly in `source`,
-// where `source` may be a bare ObjectType or an IntersectionType of objects. An
-// intersection's field is readonly when ANY object member marks it so, since the
-// intersection inherits every member's restrictions. Any other source shape — a
-// TypeVarType, a tuple, a primitive — has no statically-known field flag here.
-// The TypeVarType case is handled by the var's bound-merge in mergeObjectGroup,
-// which carries Readonly through coalescing.
+// sourceFieldIsReadonly reports whether `source`'s named field is readonly. An
+// intersection inherits readonly from any object member. A TypeVar's readonly
+// flows through mergeObjectGroup at coalesce time, so it's not consulted here.
 func sourceFieldIsReadonly(source soltype.Type, name string) bool {
 	switch s := source.(type) {
 	case *soltype.ObjectType:

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -9,10 +9,8 @@ import (
 
 // --- PR 13: deep `mut`, type-parameter inertness, and `readonly` ---
 
-// `mut` is deep: a `mut {a: {x}}` annotation makes every nested layer writable, so
-// reading `p.a` yields a mutable view and `p.a.x = 5` checks. Before PR 13 the inner
-// `a` was immutable and the nested write was rejected. The rendered param shows the
-// `mut` reaching each object layer.
+// `mut` is deep: every nested layer becomes writable, so `p.a.x = 5` is legal
+// through `mut {a: {x}}` and `&mut {a: {x}}`.
 func TestDeepMutEnablesNestedWrite(t *testing.T) {
 	cases := []struct {
 		name string
@@ -44,10 +42,8 @@ func TestDeepMutEnablesNestedWrite(t *testing.T) {
 	}
 }
 
-// An immutable annotation is shallow-immutable: `mut` is absent, so the nested field
-// stays immutable and a nested write is rejected. This holds for both an owned
-// immutable object and an immutable borrow, confirming deep `mut` distributes only
-// the `mut`/`&mut` modifier, never adding mutability an immutable annotation withheld.
+// An immutable annotation stays immutable end to end, so a nested write through
+// either an owned-immutable or `&` borrow receiver is rejected.
 func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 	cases := []struct {
 		name string
@@ -59,9 +55,7 @@ func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			// The write fails on the field-read borrow `&{x: t3}`, whose immutable
-			// wrapper cannot fill the mutable write slot. The inner is the read's
-			// fresh result var, so the message names it rather than `object`.
+			// The blame names the inner field-read result var rather than `object`.
 			require.Equal(t, []string{
 				"cannot constrain immutable t3 <: mutable object",
 			}, Messages(errs))
@@ -69,28 +63,21 @@ func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 	}
 }
 
-// A deeply-mutable annotation lowers to nested `mut` cells, and a fully fresh literal
-// is upgraded the whole way down. The rendered binding shows `mut` on every object
-// layer, so the inner objects are owned-mutable rather than the shallow immutable they
-// were before PR 13.
+// A fully fresh literal binds to a deeply-mutable annotation at every level.
 func TestDeepMutLowersFreshLiteral(t *testing.T) {
 	values, _, errs := inferSource(t, `val w: mut {a: {b: {c: number}}} = {a: {b: {c: 0}}}`)
 	require.Empty(t, errs)
 	require.Equal(t, "mut {a: {b: {c: number}}}", values["w"])
 }
 
-// `readonly` forbids reassigning a field. Writing `obj.a = …` on a `readonly a`
-// field is rejected even when the enclosing object is owned-mutable.
+// `readonly` rejects `obj.a = …` even on an owned-mutable enclosing object.
 func TestReadonlyRejectsFieldReassignment(t *testing.T) {
 	_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: number}) { obj.a = 5 }")
 	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
 }
 
-// `readonly` governs only the field slot, not the deep mutability of its value.
-// The field's value is still made mutable by the enclosing `mut`, so mutating
-// through the field with `obj.a.b = 5` checks while reassigning the field with
-// `obj.a = …` is rejected. The rendered type shows the two axes side by side as
-// `readonly a: mut {b: number}`.
+// `readonly` forbids reassigning the field but not mutating through it: `obj.a.b
+// = 5` checks while `obj.a = …` is rejected.
 func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 	t.Run("mutate the value", func(t *testing.T) {
 		values, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a.b = 5 }")
@@ -103,13 +90,8 @@ func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 	})
 }
 
-// An explicit `&obj.f` on a borrow-typed field flows the field's own borrow
-// through with its own lifetime rather than peeling and re-anchoring to the
-// receiver. The owned-mutable cell that deep `mut` produces is the only carrier
-// the explicit borrow re-wraps at the receiver's lifetime. An explicit `&` or
-// `&mut` field is left intact. This matches the implicit-read path, which
-// flat-copies an immutable borrow field and returns the field's `&mut` at its
-// own lifetime.
+// An explicit `&obj.f` on a borrow field flows the field's own borrow through
+// rather than re-anchoring to the receiver, matching the implicit-read path.
 func TestExplicitBorrowOfBorrowFieldFlowsFieldLifetime(t *testing.T) {
 	t.Run("immutable borrow field", func(t *testing.T) {
 		src := "fn f(obj: {a: &{x: number}}) { return &obj.a }"
@@ -125,13 +107,9 @@ func TestExplicitBorrowOfBorrowFieldFlowsFieldLifetime(t *testing.T) {
 	})
 }
 
-// A readonly source field cannot satisfy a writable target field under a mutable
-// borrow, even when no literal assignment is written. Passing a `mut {readonly
-// a}` where `mut {a}` is expected, or returning one where the return type is `mut
-// {a}`, is rejected with a structural message that names the field and the
-// mismatch. The user wrote no assignment, so the assignment-site message would
-// be misleading. The reverse direction, a writable source flowing into a readonly
-// target, is fine because the target view simply chooses not to write.
+// A readonly source field can't fill a writable target slot, but the reverse is
+// fine. A readonly target supports only the covariant read view, so a wider
+// source can fill it through width subtyping.
 func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 	t.Run("call: readonly source into writable param", func(t *testing.T) {
 		src := "fn sink(o: mut {a: number}) {}\nfn f(obj: mut {readonly a: number}) { sink(obj) }"
@@ -149,24 +127,15 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 		require.Empty(t, errs)
 	})
 	t.Run("call: wider source field fills inexact readonly target", func(t *testing.T) {
-		// A readonly target slot supports only the covariant read view. The
-		// contravariant write-back constraint is skipped, so a wider source field
-		// can fill a narrower readonly target through width subtyping. Without the
-		// skip the writeBack would constrain target.a <: source.a and reject for
-		// the missing `y` property. The target is inexact so the exact-object
-		// excess check does not fire on the outer object's `a` either.
+		// The write-back is skipped for readonly targets, so width subtyping accepts.
 		src := "fn sink(o: mut {readonly a: {x: number, ...}}) {}\nfn f(obj: mut {a: {x: number, y: number}}) { sink(obj) }"
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 	})
 }
 
-// An owned-mutable field read through an immutable receiver yields an immutable
-// view. Without the recvMut downgrade in fieldReadBorrow, a `mut {x}` field on
-// an immutable container would still admit `p.a.x = 5`. That would be unsound.
-// The field is owned storage inside the container, so the container's
-// immutability must reach into it. The recvMut path closes this gap and rejects
-// the write.
+// An owned-mutable field through an immutable receiver is read-only: the
+// container's immutability reaches into the field via recvMut.
 func TestOwnedMutFieldThroughImmutableReceiverRejectsWrite(t *testing.T) {
 	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
 	_, _, errs := inferSource(t, src)
@@ -175,9 +144,8 @@ func TestOwnedMutFieldThroughImmutableReceiverRejectsWrite(t *testing.T) {
 	}, Messages(errs))
 }
 
-// Chained reads through several deep-mut layers all yield mutable views, so a
-// terminal write at depth 3 checks. The intermediate `.a` and `.a.b` reads each
-// borrow with `recvMut` propagated, and the leaf field is then writable.
+// Chained reads through three deep-mut layers stay mutable, so a depth-3 write
+// checks.
 func TestDeepMutChainedReadsAllowDeepWrite(t *testing.T) {
 	src := "fn f(p: mut {a: {b: {c: number}}}) { p.a.b.c = 5 }"
 	values, _, errs := inferSource(t, src)
@@ -185,30 +153,23 @@ func TestDeepMutChainedReadsAllowDeepWrite(t *testing.T) {
 	require.Equal(t, "fn (p: mut {a: {b: {c: number}}}) -> void", values["f"])
 }
 
-// A `readonly` field on an IMMUTABLE container is still rejected for writes. The
-// readonly check fires before any mut-receiver check, so an `obj.a = 5` against a
-// `{readonly a: number}` reports the readonly error rather than the immutable-
-// receiver error. The two checks are orthogonal axes of the same write rule.
+// A readonly field on an immutable container still reports the readonly error,
+// not the immutable-receiver one.
 func TestReadonlyFieldOnImmutableContainerStillRejectsWrite(t *testing.T) {
 	src := "fn f(p: {readonly a: number}) { p.a = 5 }"
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
 }
 
-// The fresh-literal upgrade reaches into nested tuples too. A fully fresh tuple
-// literal binds to a deeply-mutable tuple annotation, with every nested object
-// becoming owned-mutable. This mirrors the object case and exercises the tuple
-// arm of stripOwnedMut.
+// The fresh-literal upgrade reaches into tuples too.
 func TestDeepMutLowersFreshTupleLiteral(t *testing.T) {
 	values, _, errs := inferSource(t, "val w: mut [number, {x: number}] = [1, {x: 0}]")
 	require.Empty(t, errs)
 	require.Equal(t, "mut [number, {x: number}]", values["w"])
 }
 
-// A `readonly` field's value may still be mutated through deep `mut`, even when
-// the value has multiple fields. Writing each field through `.a.x = …` and
-// `.a.y = …` succeeds because `readonly` only forbids reassigning `a`, not
-// writing through it.
+// A readonly field's value is still deep-mutable, so multiple writes through it
+// check independently.
 func TestReadonlyFieldValueIsDeepMutable(t *testing.T) {
 	src := "fn f(obj: mut {readonly a: {x: number, y: number}}) { obj.a.x = 5\n obj.a.y = 6 }"
 	values, _, errs := inferSource(t, src)
@@ -216,19 +177,15 @@ func TestReadonlyFieldValueIsDeepMutable(t *testing.T) {
 	require.Equal(t, "fn (obj: mut {readonly a: {x: number, y: number}}) -> void", values["f"])
 }
 
-// A `readonly` field round-trips through the printer: a `readonly a: number` annotation
-// renders back as `readonly a: number`, so the displayed type is a valid annotation.
+// `readonly a: number` round-trips through the printer.
 func TestReadonlyRendersOnReadField(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(obj: {readonly a: number}) -> number { return obj.a }")
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: {readonly a: number}) -> number", values["f"])
 }
 
-// applyDeepMut is inert at a type parameter: it sets `mut` on the concrete object and
-// tuple structure but leaves a TypeVarType field untouched, the same pointer it was
-// handed. This is the M4-expressible core of `mut Foo<Point>` == `(mut Foo)<Point>` —
-// the full generic forms (`mut Array<Point>`, `mut Line<Point>`) need the alias and
-// type-argument machinery of M7 and are deferred to that milestone.
+// applyDeepMut leaves a TypeVarType field untouched, the M4-expressible core of
+// `mut Foo<Point>` == `(mut Foo)<Point>` — full generics land in M7.
 func TestApplyDeepMutLeavesTypeParameterInert(t *testing.T) {
 	tv := &soltype.TypeVarType{ID: 99}
 	concrete := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
@@ -243,12 +200,12 @@ func TestApplyDeepMutLeavesTypeParameterInert(t *testing.T) {
 	obj, ok := got.(*soltype.ObjectType)
 	require.True(t, ok)
 
-	// The type-parameter field is returned unchanged, same pointer, no `mut` wrapper.
+	// Type-parameter field: same pointer, no `mut` wrapper.
 	pProp, ok := obj.Prop("p")
 	require.True(t, ok)
 	require.Same(t, soltype.Type(tv), pProp.Type)
 
-	// The concrete object field is wrapped in owned-mutable and recurses.
+	// Concrete object field: wrapped in owned-mutable.
 	qProp, ok := obj.Prop("q")
 	require.True(t, ok)
 	qRef, ok := qProp.Type.(*soltype.RefType)

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -25,7 +25,7 @@ func TestDeepMutEnablesNestedWrite(t *testing.T) {
 		{
 			name: "borrowed &mut, one level",
 			src:  "fn f(p: &mut {a: {x: number}}) { p.a.x = 5 }",
-			want: "fn (p: mut {a: {x: number}}) -> void",
+			want: "fn (p: &mut {a: {x: number}}) -> void",
 		},
 		{
 			name: "owned mut, three levels",

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -86,10 +86,11 @@ func TestReadonlyRejectsFieldReassignment(t *testing.T) {
 	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
 }
 
-// `readonly` governs only the field slot, not the deep mutability of its value. The
-// field's value is still made mutable by the enclosing `mut`, so mutating THROUGH the
-// field (`obj.a.b = 5`) checks while REASSIGNING the field (`obj.a = …`) is rejected.
-// The rendered type shows the two axes side by side: `readonly a: mut {b: number}`.
+// `readonly` governs only the field slot, not the deep mutability of its value.
+// The field's value is still made mutable by the enclosing `mut`, so mutating
+// through the field with `obj.a.b = 5` checks while reassigning the field with
+// `obj.a = …` is rejected. The rendered type shows the two axes side by side as
+// `readonly a: mut {b: number}`.
 func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 	t.Run("mutate the value", func(t *testing.T) {
 		values, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a.b = 5 }")
@@ -100,6 +101,108 @@ func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 		_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a = {b: 9} }")
 		require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
 	})
+}
+
+// An explicit `&obj.f` on a borrow-typed field flows the field's own borrow
+// through with its own lifetime rather than peeling and re-anchoring to the
+// receiver. The owned-mutable cell that deep `mut` produces is the only carrier
+// the explicit borrow re-wraps at the receiver's lifetime. An explicit `&` or
+// `&mut` field is left intact. This matches the implicit-read path, which
+// flat-copies an immutable borrow field and returns the field's `&mut` at its
+// own lifetime.
+func TestExplicitBorrowOfBorrowFieldFlowsFieldLifetime(t *testing.T) {
+	t.Run("immutable borrow field", func(t *testing.T) {
+		src := "fn f(obj: {a: &{x: number}}) { return &obj.a }"
+		values, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <'a>(obj: {a: &'a {x: number}}) -> &'a {x: number}", values["f"])
+	})
+	t.Run("mutable borrow field", func(t *testing.T) {
+		src := "fn f(obj: {a: &mut {x: number}}) { return &obj.a }"
+		values, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <'a>(obj: {a: &'a mut {x: number}}) -> &'a mut {x: number}", values["f"])
+	})
+}
+
+// A readonly source field cannot satisfy a writable target field under a mutable
+// borrow, even when no literal assignment is written. Passing a `mut {readonly
+// a}` where `mut {a}` is expected, or returning one where the return type is `mut
+// {a}`, is rejected with a structural message that names the field and the
+// mismatch. The user wrote no assignment, so the assignment-site message would
+// be misleading. The reverse direction, a writable source flowing into a readonly
+// target, is fine because the target view simply chooses not to write.
+func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
+	t.Run("call: readonly source into writable param", func(t *testing.T) {
+		src := "fn sink(o: mut {a: number}) {}\nfn f(obj: mut {readonly a: number}) { sink(obj) }"
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"readonly field a cannot satisfy a writable field requirement"}, Messages(errs))
+	})
+	t.Run("return: readonly source as writable return", func(t *testing.T) {
+		src := "fn f(obj: mut {readonly a: number}) -> mut {a: number} { return obj }"
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"readonly field a cannot satisfy a writable field requirement"}, Messages(errs))
+	})
+	t.Run("call: writable source into readonly param is fine", func(t *testing.T) {
+		src := "fn sink(o: mut {readonly a: number}) {}\nfn f(obj: mut {a: number}) { sink(obj) }"
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+}
+
+// An owned-mutable field read through an immutable receiver yields an immutable
+// view. Without the recvMut downgrade in fieldReadBorrow, a `mut {x}` field on
+// an immutable container would still admit `p.a.x = 5`. That would be unsound.
+// The field is owned storage inside the container, so the container's
+// immutability must reach into it. The recvMut path closes this gap and rejects
+// the write.
+func TestOwnedMutFieldThroughImmutableReceiverRejectsWrite(t *testing.T) {
+	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"cannot constrain immutable object <: mutable object",
+	}, Messages(errs))
+}
+
+// Chained reads through several deep-mut layers all yield mutable views, so a
+// terminal write at depth 3 checks. The intermediate `.a` and `.a.b` reads each
+// borrow with `recvMut` propagated, and the leaf field is then writable.
+func TestDeepMutChainedReadsAllowDeepWrite(t *testing.T) {
+	src := "fn f(p: mut {a: {b: {c: number}}}) { p.a.b.c = 5 }"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {a: mut {b: mut {c: number}}}) -> void", values["f"])
+}
+
+// A `readonly` field on an IMMUTABLE container is still rejected for writes. The
+// readonly check fires before any mut-receiver check, so an `obj.a = 5` against a
+// `{readonly a: number}` reports the readonly error rather than the immutable-
+// receiver error. The two checks are orthogonal axes of the same write rule.
+func TestReadonlyFieldOnImmutableContainerStillRejectsWrite(t *testing.T) {
+	src := "fn f(p: {readonly a: number}) { p.a = 5 }"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+}
+
+// The fresh-literal upgrade reaches into nested tuples too. A fully fresh tuple
+// literal binds to a deeply-mutable tuple annotation, with every nested object
+// becoming owned-mutable. This mirrors the object case and exercises the tuple
+// arm of stripOwnedMut.
+func TestDeepMutLowersFreshTupleLiteral(t *testing.T) {
+	values, _, errs := inferSource(t, "val w: mut [number, {x: number}] = [1, {x: 0}]")
+	require.Empty(t, errs)
+	require.Equal(t, "mut [number, mut {x: number}]", values["w"])
+}
+
+// A `readonly` field's value may still be mutated through deep `mut`, even when
+// the value has multiple fields. Writing each field through `.a.x = …` and
+// `.a.y = …` succeeds because `readonly` only forbids reassigning `a`, not
+// writing through it.
+func TestReadonlyFieldValueIsDeepMutable(t *testing.T) {
+	src := "fn f(obj: mut {readonly a: {x: number, y: number}}) { obj.a.x = 5\n obj.a.y = 6 }"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: mut {readonly a: mut {x: number, y: number}}) -> void", values["f"])
 }
 
 // A `readonly` field round-trips through the printer: a `readonly a: number` annotation
@@ -124,7 +227,8 @@ func TestApplyDeepMutLeavesTypeParameterInert(t *testing.T) {
 		&soltype.PropertyElem{Name: "p", Type: tv},
 		&soltype.PropertyElem{Name: "q", Type: concrete},
 	}}
-	got := applyDeepMut(inner)
+	c := newChecker()
+	got := c.applyDeepMut(inner)
 	obj, ok := got.(*soltype.ObjectType)
 	require.True(t, ok)
 

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -22,17 +22,17 @@ func TestDeepMutEnablesNestedWrite(t *testing.T) {
 		{
 			name: "owned mut, one level",
 			src:  "fn f(p: mut {a: {x: number}}) { p.a.x = 5 }",
-			want: "fn (p: mut {a: mut {x: number}}) -> void",
+			want: "fn (p: mut {a: {x: number}}) -> void",
 		},
 		{
 			name: "borrowed &mut, one level",
 			src:  "fn f(p: &mut {a: {x: number}}) { p.a.x = 5 }",
-			want: "fn (p: mut {a: mut {x: number}}) -> void",
+			want: "fn (p: mut {a: {x: number}}) -> void",
 		},
 		{
 			name: "owned mut, three levels",
 			src:  "fn f(p: mut {a: {b: {c: number}}}) { p.a.b.c = 5 }",
-			want: "fn (p: mut {a: mut {b: mut {c: number}}}) -> void",
+			want: "fn (p: mut {a: {b: {c: number}}}) -> void",
 		},
 	}
 	for _, tc := range cases {
@@ -76,7 +76,7 @@ func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 func TestDeepMutLowersFreshLiteral(t *testing.T) {
 	values, _, errs := inferSource(t, `val w: mut {a: {b: {c: number}}} = {a: {b: {c: 0}}}`)
 	require.Empty(t, errs)
-	require.Equal(t, "mut {a: mut {b: mut {c: number}}}", values["w"])
+	require.Equal(t, "mut {a: {b: {c: number}}}", values["w"])
 }
 
 // `readonly` forbids reassigning a field. Writing `obj.a = …` on a `readonly a`
@@ -95,7 +95,7 @@ func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 	t.Run("mutate the value", func(t *testing.T) {
 		values, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a.b = 5 }")
 		require.Empty(t, errs)
-		require.Equal(t, "fn (obj: mut {readonly a: mut {b: number}}) -> void", values["f"])
+		require.Equal(t, "fn (obj: mut {readonly a: {b: number}}) -> void", values["f"])
 	})
 	t.Run("reassign the field", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a = {b: 9} }")
@@ -171,7 +171,7 @@ func TestDeepMutChainedReadsAllowDeepWrite(t *testing.T) {
 	src := "fn f(p: mut {a: {b: {c: number}}}) { p.a.b.c = 5 }"
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {a: mut {b: mut {c: number}}}) -> void", values["f"])
+	require.Equal(t, "fn (p: mut {a: {b: {c: number}}}) -> void", values["f"])
 }
 
 // A `readonly` field on an IMMUTABLE container is still rejected for writes. The
@@ -191,7 +191,7 @@ func TestReadonlyFieldOnImmutableContainerStillRejectsWrite(t *testing.T) {
 func TestDeepMutLowersFreshTupleLiteral(t *testing.T) {
 	values, _, errs := inferSource(t, "val w: mut [number, {x: number}] = [1, {x: 0}]")
 	require.Empty(t, errs)
-	require.Equal(t, "mut [number, mut {x: number}]", values["w"])
+	require.Equal(t, "mut [number, {x: number}]", values["w"])
 }
 
 // A `readonly` field's value may still be mutated through deep `mut`, even when
@@ -202,7 +202,7 @@ func TestReadonlyFieldValueIsDeepMutable(t *testing.T) {
 	src := "fn f(obj: mut {readonly a: {x: number, y: number}}) { obj.a.x = 5\n obj.a.y = 6 }"
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: mut {readonly a: mut {x: number, y: number}}) -> void", values["f"])
+	require.Equal(t, "fn (obj: mut {readonly a: {x: number, y: number}}) -> void", values["f"])
 }
 
 // A `readonly` field round-trips through the printer: a `readonly a: number` annotation

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -148,6 +148,17 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 	})
+	t.Run("call: wider source field fills inexact readonly target", func(t *testing.T) {
+		// A readonly target slot supports only the covariant read view. The
+		// contravariant write-back constraint is skipped, so a wider source field
+		// can fill a narrower readonly target through width subtyping. Without the
+		// skip the writeBack would constrain target.a <: source.a and reject for
+		// the missing `y` property. The target is inexact so the exact-object
+		// excess check does not fire on the outer object's `a` either.
+		src := "fn sink(o: mut {readonly a: {x: number, ...}}) {}\nfn f(obj: mut {a: {x: number, y: number}}) { sink(obj) }"
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
 }
 
 // An owned-mutable field read through an immutable receiver yields an immutable

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -1,0 +1,143 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- PR 13: deep `mut`, type-parameter inertness, and `readonly` ---
+
+// `mut` is deep: a `mut {a: {x}}` annotation makes every nested layer writable, so
+// reading `p.a` yields a mutable view and `p.a.x = 5` checks. Before PR 13 the inner
+// `a` was immutable and the nested write was rejected. The rendered param shows the
+// `mut` reaching each object layer.
+func TestDeepMutEnablesNestedWrite(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "owned mut, one level",
+			src:  "fn f(p: mut {a: {x: number}}) { p.a.x = 5 }",
+			want: "fn (p: mut {a: mut {x: number}}) -> void",
+		},
+		{
+			name: "borrowed &mut, one level",
+			src:  "fn f(p: &mut {a: {x: number}}) { p.a.x = 5 }",
+			want: "fn (p: mut {a: mut {x: number}}) -> void",
+		},
+		{
+			name: "owned mut, three levels",
+			src:  "fn f(p: mut {a: {b: {c: number}}}) { p.a.b.c = 5 }",
+			want: "fn (p: mut {a: mut {b: mut {c: number}}}) -> void",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values["f"])
+		})
+	}
+}
+
+// An immutable annotation is shallow-immutable: `mut` is absent, so the nested field
+// stays immutable and a nested write is rejected. This holds for both an owned
+// immutable object and an immutable borrow, confirming deep `mut` distributes only
+// the `mut`/`&mut` modifier, never adding mutability an immutable annotation withheld.
+func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"owned immutable", "fn f(p: {a: {x: number}}) { p.a.x = 5 }"},
+		{"immutable borrow", "fn f(p: &{a: {x: number}}) { p.a.x = 5 }"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			// The write fails on the field-read borrow `&{x: t3}`, whose immutable
+			// wrapper cannot fill the mutable write slot. The inner is the read's
+			// fresh result var, so the message names it rather than `object`.
+			require.Equal(t, []string{
+				"cannot constrain immutable t3 <: mutable object",
+			}, Messages(errs))
+		})
+	}
+}
+
+// A deeply-mutable annotation lowers to nested `mut` cells, and a fully fresh literal
+// is upgraded the whole way down. The rendered binding shows `mut` on every object
+// layer, so the inner objects are owned-mutable rather than the shallow immutable they
+// were before PR 13.
+func TestDeepMutLowersFreshLiteral(t *testing.T) {
+	values, _, errs := inferSource(t, `val w: mut {a: {b: {c: number}}} = {a: {b: {c: 0}}}`)
+	require.Empty(t, errs)
+	require.Equal(t, "mut {a: mut {b: mut {c: number}}}", values["w"])
+}
+
+// `readonly` forbids reassigning a field. Writing `obj.a = …` on a `readonly a`
+// field is rejected even when the enclosing object is owned-mutable.
+func TestReadonlyRejectsFieldReassignment(t *testing.T) {
+	_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: number}) { obj.a = 5 }")
+	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+}
+
+// `readonly` governs only the field slot, not the deep mutability of its value. The
+// field's value is still made mutable by the enclosing `mut`, so mutating THROUGH the
+// field (`obj.a.b = 5`) checks while REASSIGNING the field (`obj.a = …`) is rejected.
+// The rendered type shows the two axes side by side: `readonly a: mut {b: number}`.
+func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
+	t.Run("mutate the value", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a.b = 5 }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (obj: mut {readonly a: mut {b: number}}) -> void", values["f"])
+	})
+	t.Run("reassign the field", func(t *testing.T) {
+		_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a = {b: 9} }")
+		require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+	})
+}
+
+// A `readonly` field round-trips through the printer: a `readonly a: number` annotation
+// renders back as `readonly a: number`, so the displayed type is a valid annotation.
+func TestReadonlyRendersOnReadField(t *testing.T) {
+	values, _, errs := inferSource(t, "fn f(obj: {readonly a: number}) -> number { return obj.a }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn (obj: {readonly a: number}) -> number", values["f"])
+}
+
+// applyDeepMut is inert at a type parameter: it sets `mut` on the concrete object and
+// tuple structure but leaves a TypeVarType field untouched, the same pointer it was
+// handed. This is the M4-expressible core of `mut Foo<Point>` == `(mut Foo)<Point>` —
+// the full generic forms (`mut Array<Point>`, `mut Line<Point>`) need the alias and
+// type-argument machinery of M7 and are deferred to that milestone.
+func TestApplyDeepMutLeavesTypeParameterInert(t *testing.T) {
+	tv := &soltype.TypeVarType{ID: 99}
+	concrete := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
+	}}
+	inner := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "p", Type: tv},
+		&soltype.PropertyElem{Name: "q", Type: concrete},
+	}}
+	got := applyDeepMut(inner)
+	obj, ok := got.(*soltype.ObjectType)
+	require.True(t, ok)
+
+	// The type-parameter field is returned unchanged, same pointer, no `mut` wrapper.
+	pProp, ok := obj.Prop("p")
+	require.True(t, ok)
+	require.Same(t, soltype.Type(tv), pProp.Type)
+
+	// The concrete object field is wrapped in owned-mutable and recurses.
+	qProp, ok := obj.Prop("q")
+	require.True(t, ok)
+	qRef, ok := qProp.Type.(*soltype.RefType)
+	require.True(t, ok)
+	require.True(t, qRef.Mut)
+	require.Nil(t, qRef.Lt)
+}

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -135,7 +135,11 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 }
 
 // An owned-mutable field through an immutable receiver is read-only: the
-// container's immutability reaches into the field via recvMut.
+// container's immutability reaches into the field via recvMut. The annotation
+// itself is the awkward part — `{a: mut {x}}` shouldn't be writable as a user
+// type at all, since interior mutability is the proper mechanism (#618). #779
+// tracks rejecting the annotation outright once inference is updated to never
+// produce the same shape in a return type.
 func TestOwnedMutFieldThroughImmutableReceiverRejectsWrite(t *testing.T) {
 	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
 	_, _, errs := inferSource(t, src)

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -214,7 +214,18 @@ type InexactTupleSpreadError struct {
 	Operand *soltype.TupleType
 }
 
+// ReadonlyFieldError fires when a field write `obj.f = …` targets a `readonly`
+// field. `readonly` forbids reassigning the field; the value the field holds may
+// still be mutated when it is mutable. The check sits in constrainWriteBack, the
+// contravariant write view of a mutable borrow: a write requirement names the
+// field, and the source object marks it readonly. Field is the property name.
+type ReadonlyFieldError struct {
+	Field string
+	site  ast.Node // the field-write node, which carries the blame span
+}
+
 func (*CannotConstrainError) isSolverError()     {}
+func (*ReadonlyFieldError) isSolverError()       {}
 func (*FuncArityMismatchError) isSolverError()   {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*SpreadNotTupleError) isSolverError()      {}
@@ -890,6 +901,12 @@ func (e *MutabilityMismatchError) Message() string {
 func (e *BorrowEscapeError) Message() string {
 	return fmt.Sprintf("borrowed value %s does not live long enough to satisfy %s",
 		describe(e.Sub), describe(e.Super))
+}
+
+func (e *ReadonlyFieldError) Span() ast.Span      { return spanOfNode(e.site) }
+func (e *ReadonlyFieldError) Related() []ast.Span { return nil }
+func (e *ReadonlyFieldError) Message() string {
+	return fmt.Sprintf("cannot assign to readonly property: %s", e.Field)
 }
 
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -214,19 +214,31 @@ type InexactTupleSpreadError struct {
 	Operand *soltype.TupleType
 }
 
-// ReadonlyFieldError fires when a field write `obj.f = …` targets a `readonly`
-// field. `readonly` forbids reassigning the field; the value the field holds may
-// still be mutated when it is mutable. The check sits in constrainWriteBack, the
-// contravariant write view of a mutable borrow: a write requirement names the
-// field, and the source object marks it readonly. Field is the property name.
+// ReadonlyFieldError fires on a literal field-assignment `obj.f = …` whose target
+// field is declared `readonly`. The assignment-site check lives in
+// inferMemberAssign, which catches the case directly so the diagnostic blames the
+// write expression and the message names the assignment outright.
 type ReadonlyFieldError struct {
 	Field string
-	site  ast.Node // the field-write node, which carries the blame span
+	site  ast.Node // the BinaryExpr assignment, which carries the blame span
 }
 
-func (*CannotConstrainError) isSolverError()     {}
-func (*ReadonlyFieldError) isSolverError()       {}
-func (*FuncArityMismatchError) isSolverError()   {}
+// ReadonlyFieldSubtypeError fires when a readonly source field flows into a
+// non-readonly target field through structural subtyping under a mutable borrow:
+// a `mut {readonly a: T}` cannot fill a `mut {a: T}` slot, since the target view
+// would otherwise let a holder write through and break the source's readonly
+// contract. The check sits in constrainWriteBack, the contravariant write view of
+// a mutable borrow, and blames whatever site triggered the constraint, typically
+// the call argument or return that flows the value out.
+type ReadonlyFieldSubtypeError struct {
+	Field string
+	site  ast.Node
+}
+
+func (*CannotConstrainError) isSolverError()      {}
+func (*ReadonlyFieldError) isSolverError()        {}
+func (*ReadonlyFieldSubtypeError) isSolverError() {}
+func (*FuncArityMismatchError) isSolverError()    {}
 func (*TupleLengthMismatchError) isSolverError() {}
 func (*SpreadNotTupleError) isSolverError()      {}
 func (*InexactTupleSpreadError) isSolverError()  {}
@@ -907,6 +919,12 @@ func (e *ReadonlyFieldError) Span() ast.Span      { return spanOfNode(e.site) }
 func (e *ReadonlyFieldError) Related() []ast.Span { return nil }
 func (e *ReadonlyFieldError) Message() string {
 	return fmt.Sprintf("cannot assign to readonly property: %s", e.Field)
+}
+
+func (e *ReadonlyFieldSubtypeError) Span() ast.Span      { return spanOfNode(e.site) }
+func (e *ReadonlyFieldSubtypeError) Related() []ast.Span { return nil }
+func (e *ReadonlyFieldSubtypeError) Message() string {
+	return fmt.Sprintf("readonly field %s cannot satisfy a writable field requirement", e.Field)
 }
 
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -209,6 +209,8 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *ReadonlyFieldError:
 			err.site = n
+		case *ReadonlyFieldSubtypeError:
+			err.site = n
 		}
 		c.errs = append(c.errs, e)
 	}

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -207,6 +207,8 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *BorrowEscapeError:
 			err.prov, err.site = c.prov, n
+		case *ReadonlyFieldError:
+			err.site = n
 		}
 		c.errs = append(c.errs, e)
 	}

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -149,9 +149,11 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 		require.Equal(t, "mut {x: number}", values["items"])
 	})
 	t.Run("nested object", func(t *testing.T) {
+		// `mut` is deep (PR 13), so the annotation lowers to `mut {p: mut {x: number}}`
+		// and the fresh literal is upgraded the whole way down.
 		values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
 		require.Empty(t, errs)
-		require.Equal(t, "mut {p: {x: number}}", values["w"])
+		require.Equal(t, "mut {p: mut {x: number}}", values["w"])
 	})
 	t.Run("tuple", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val t: mut [number, number] = [1, 2]`)
@@ -188,16 +190,15 @@ func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
 	})
 }
 
-// The upgrade fires only at the top-level annotation, not recursively per nested `mut`
-// field. The fresh literal `{p: {x: 0}}` upgrades the outer object to owned-mutable, but
-// the inner `{x: 0}` is then constrained against the inner `mut {x: number}`, which the C2
-// gate rejects. The binding still adopts the annotation under error recovery. G2's
-// "immutable→mutable upgrade at every value-flow site" is what generalizes the upgrade to
-// reach a nested `mut` target.
-func TestInferOwnedMutNestedMutFieldNotUpgraded(t *testing.T) {
+// A fully fresh literal upgrades to a NESTED `mut` target as well, because deep
+// `mut` (PR 13) made the upgrade strip the whole owned-mutable skeleton before the
+// read-view constraint. The literal `{p: {x: 0}}` is uniquely owned at every level,
+// so granting it `mut {p: mut {x: number}}` is sound — this is the recursive form of
+// the top-level Rule 2 upgrade. The explicitly-nested-`mut` annotation here lowers to
+// the same type the deep `mut {p: {x: number}}` does, so both check identically.
+func TestInferOwnedMutNestedMutFieldUpgraded(t *testing.T) {
 	values, _, errs := inferSource(t, `val w: mut {p: mut {x: number}} = {p: {x: 0}}`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain immutable object <: mutable object", errs[0].Message())
+	require.Empty(t, errs)
 	require.Equal(t, "mut {p: mut {x: number}}", values["w"])
 }
 

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -149,8 +149,7 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 		require.Equal(t, "mut {x: number}", values["items"])
 	})
 	t.Run("nested object", func(t *testing.T) {
-		// `mut` is deep (PR 13), so the annotation lowers to `mut {p: {x: number}}`
-		// and the fresh literal is upgraded the whole way down.
+		// Deep `mut` makes the upgrade reach every nested literal.
 		values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
 		require.Empty(t, errs)
 		require.Equal(t, "mut {p: {x: number}}", values["w"])
@@ -190,12 +189,8 @@ func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
 	})
 }
 
-// A fully fresh literal upgrades to a NESTED `mut` target as well, because deep
-// `mut` (PR 13) made the upgrade strip the whole owned-mutable skeleton before the
-// read-view constraint. The literal `{p: {x: 0}}` is uniquely owned at every level,
-// so granting it `mut {p: {x: number}}` is sound — this is the recursive form of
-// the top-level Rule 2 upgrade. The explicitly-nested-`mut` annotation here lowers to
-// the same type the deep `mut {p: {x: number}}` does, so both check identically.
+// A fully fresh literal is uniquely owned at every level, so it upgrades to a
+// nested `mut` target the same way it does to a top-level one.
 func TestInferOwnedMutNestedMutFieldUpgraded(t *testing.T) {
 	values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
 	require.Empty(t, errs)

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -149,11 +149,11 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 		require.Equal(t, "mut {x: number}", values["items"])
 	})
 	t.Run("nested object", func(t *testing.T) {
-		// `mut` is deep (PR 13), so the annotation lowers to `mut {p: mut {x: number}}`
+		// `mut` is deep (PR 13), so the annotation lowers to `mut {p: {x: number}}`
 		// and the fresh literal is upgraded the whole way down.
 		values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
 		require.Empty(t, errs)
-		require.Equal(t, "mut {p: mut {x: number}}", values["w"])
+		require.Equal(t, "mut {p: {x: number}}", values["w"])
 	})
 	t.Run("tuple", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val t: mut [number, number] = [1, 2]`)
@@ -193,13 +193,13 @@ func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
 // A fully fresh literal upgrades to a NESTED `mut` target as well, because deep
 // `mut` (PR 13) made the upgrade strip the whole owned-mutable skeleton before the
 // read-view constraint. The literal `{p: {x: 0}}` is uniquely owned at every level,
-// so granting it `mut {p: mut {x: number}}` is sound — this is the recursive form of
+// so granting it `mut {p: {x: number}}` is sound — this is the recursive form of
 // the top-level Rule 2 upgrade. The explicitly-nested-`mut` annotation here lowers to
 // the same type the deep `mut {p: {x: number}}` does, so both check identically.
 func TestInferOwnedMutNestedMutFieldUpgraded(t *testing.T) {
-	values, _, errs := inferSource(t, `val w: mut {p: mut {x: number}} = {p: {x: 0}}`)
+	values, _, errs := inferSource(t, `val w: mut {p: {x: number}} = {p: {x: 0}}`)
 	require.Empty(t, errs)
-	require.Equal(t, "mut {p: mut {x: number}}", values["w"])
+	require.Equal(t, "mut {p: {x: number}}", values["w"])
 }
 
 // A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -10,8 +10,8 @@ import (
 //
 // These assert the D4 display form. A param lifetime that reaches the output is
 // named 'a, 'b, … and quantified in a leading <…> prefix. A param lifetime that
-// connects nothing, never reaching an output, is elided: a mut borrow becomes
-// owned-mutable, and an immutable borrow drops the wrapper.
+// connects nothing, never reaching an output, has its NAME elided but its `&`
+// kept, so the displayed borrow stays distinguishable from an owned value.
 
 // A `&mut` param returned unchanged carries its lifetime to the result: the same
 // lifetime appears on both the parameter and the return type, so the borrow flows
@@ -32,19 +32,17 @@ func TestInferFreshObjectReturn(t *testing.T) {
 	require.Equal(t, "fn () -> {x: 5}", values["f"])
 }
 
-// Two `&mut` params carry independent lifetimes, but only the returned one
-// reaches the output. `p` is returned, so its lifetime is named `'a`. `q` connects
-// nothing, so its borrow lifetime is elided to owned-mutable.
+// Two `&mut` params carry independent lifetimes; only the returned one reaches
+// the output. `p` is returned, so its lifetime is named `'a`. `q` connects
+// nothing, so its lifetime name is elided but the `&mut` is kept.
 func TestInferDistinctParamLifetimes(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}, q: &mut {y: number}) { return p }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a mut {x: number}, q: mut {y: number}) -> &'a mut {x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}, q: &mut {y: number}) -> &'a mut {x: number}", values["f"])
 }
 
-// Writing a field through an annotated `mut` borrow checks: the receiver carries a
-// borrow lifetime, and the write requirement's fresh lifetime imposes no obligation,
-// so a borrowed receiver of any lifetime satisfies it. The borrow never reaches the
-// output, since the body returns void, so D4 elides its lifetime to owned-mutable.
+// Writing a field through an owned-mutable param checks. The write requirement's
+// fresh lifetime imposes no obligation, so an owned receiver satisfies it.
 func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) { p.x = 10 }`)
 	require.Empty(t, errs)
@@ -82,7 +80,7 @@ fn f(p: &mut {x: number}) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: &mut {x: number}) -> number", values["f"])
 }
 
 // Reading a field after writing it through an annotated `&mut` borrow returns
@@ -99,7 +97,7 @@ func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: &mut {x: number}) -> number", values["f"])
 }
 
 // Writing a field of a NON-`mut` owned object is rejected: the write lowers to the
@@ -307,7 +305,7 @@ func TestInferImmutableBorrowAliasLocally(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: &mut {x: number}) -> number", values["f"])
 }
 
 // An immutable borrow alias that is RETURNED carries its lifetime to the output.
@@ -471,7 +469,7 @@ func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {a: {x: number}}) -> void", values["f"])
+	require.Equal(t, "fn (p: &mut {a: {x: number}}) -> void", values["f"])
 }
 
 // A field whose static type is itself an immutable borrow reads through as
@@ -520,7 +518,7 @@ func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
+	require.Equal(t, "fn (p: &mut {x: number}) -> number", values["f"])
 }
 
 // An explicit `&obj.f` shares the receiver-bounded lifetime of the implicit

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -452,7 +452,9 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 // receiver's borrow lifetime through, the heart of PR 4 rule 4. The implicit
 // read on `p.a` for `p: &mut {a: {...}}` yields a borrow of the field at p's
 // lifetime, so the rendered signature names that lifetime on both the param
-// and the return type.
+// and the return type. Deep `mut` (PR 13) makes the `a` field owned-mutable, so
+// the param renders `&'a mut {a: mut {x: number}}` and the read yields a MUTABLE
+// borrow `&'a mut {x: number}` rather than an immutable one.
 func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	src := `fn f(p: &mut {a: {x: number}}) {
   return p.a
@@ -460,7 +462,7 @@ func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(p: &'a mut {a: {x: number}}) -> &'a {x: number}",
+		"fn <'a>(p: &'a mut {a: mut {x: number}}) -> &'a mut {x: number}",
 		values["f"])
 }
 
@@ -474,7 +476,7 @@ func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {a: {x: number}}) -> void", values["f"])
+	require.Equal(t, "fn (p: mut {a: mut {x: number}}) -> void", values["f"])
 }
 
 // A field whose static type is itself an immutable borrow reads through as
@@ -538,7 +540,7 @@ func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a {y: number}",
+		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a {y: number}",
 		values["f"])
 }
 
@@ -555,7 +557,7 @@ func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
+		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a mut {y: number}",
 		values["f"])
 }
 
@@ -601,6 +603,6 @@ func TestInferExplicitMutBorrowOfConstIndexAcceptsMutReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
+		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a mut {y: number}",
 		values["f"])
 }

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -448,13 +448,8 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 
 // --- PR 4: member reads borrow the receiver ---
 
-// A member read whose result reaches the function output carries the
-// receiver's borrow lifetime through, the heart of PR 4 rule 4. The implicit
-// read on `p.a` for `p: &mut {a: {...}}` yields a borrow of the field at p's
-// lifetime, so the rendered signature names that lifetime on both the param
-// and the return type. Deep `mut` (PR 13) makes the `a` field owned-mutable, so
-// the param renders `&'a mut {a: {x: number}}` and the read yields a MUTABLE
-// borrow `&'a mut {x: number}` rather than an immutable one.
+// A member read that escapes carries the receiver's borrow lifetime through.
+// Deep `mut` makes the field owned-mutable, so the read yields a mutable borrow.
 func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	src := `fn f(p: &mut {a: {x: number}}) {
   return p.a

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -453,7 +453,7 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 // read on `p.a` for `p: &mut {a: {...}}` yields a borrow of the field at p's
 // lifetime, so the rendered signature names that lifetime on both the param
 // and the return type. Deep `mut` (PR 13) makes the `a` field owned-mutable, so
-// the param renders `&'a mut {a: mut {x: number}}` and the read yields a MUTABLE
+// the param renders `&'a mut {a: {x: number}}` and the read yields a MUTABLE
 // borrow `&'a mut {x: number}` rather than an immutable one.
 func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	src := `fn f(p: &mut {a: {x: number}}) {
@@ -462,7 +462,7 @@ func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(p: &'a mut {a: mut {x: number}}) -> &'a mut {x: number}",
+		"fn <'a>(p: &'a mut {a: {x: number}}) -> &'a mut {x: number}",
 		values["f"])
 }
 
@@ -476,7 +476,7 @@ func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {a: mut {x: number}}) -> void", values["f"])
+	require.Equal(t, "fn (p: mut {a: {x: number}}) -> void", values["f"])
 }
 
 // A field whose static type is itself an immutable borrow reads through as
@@ -540,7 +540,7 @@ func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a {y: number}",
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a {y: number}",
 		values["f"])
 }
 
@@ -557,7 +557,7 @@ func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a mut {y: number}",
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
 		values["f"])
 }
 
@@ -603,6 +603,6 @@ func TestInferExplicitMutBorrowOfConstIndexAcceptsMutReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a>(obj: &'a mut {a: mut {x: number}, b: mut {y: number}}) -> &'a mut {y: number}",
+		"fn <'a>(obj: &'a mut {a: {x: number}, b: {y: number}}) -> &'a mut {y: number}",
 		values["f"])
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -142,7 +142,14 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // escapes through a return or a module store still errors.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
-		c.constrain(init, initT, ref.Inner)
+		// A deeply-mutable annotation (PR 13) carries `mut` on its nested objects and
+		// tuples too, so `mut {p: {x}}` lowers to `mut {p: mut {x}}`. The initializer is
+		// an immutable fresh literal, which the C2 gate would reject against those nested
+		// `mut` cells. Constrain it against the immutable skeleton — the read view of the
+		// deep-mut type with every nested `mut` stripped — and grant the deep-mut type.
+		// A fully fresh, unaliased literal is uniquely owned at every level, so the
+		// upgrade is sound the whole way down, the recursive form of the top-level Rule 2.
+		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}
 	if borrow, ok := c.reborrowAnnotation(initT, annT, lvl); ok {
@@ -184,6 +191,37 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 		return &soltype.RefType{Mut: false, Lt: c.ctx.freshLifetime(lvl), Inner: inner}, true
 	default:
 		return nil, false
+	}
+}
+
+// stripOwnedMut returns the deeply-immutable skeleton of t: every owned-mutable
+// cell — a RefType with Mut set and no lifetime — is peeled to its inner, and the
+// peel recurses through objects and tuples. It is the read view of a deep-mut
+// annotation, used by the fresh-literal upgrade to constrain an immutable literal
+// against the shape without the nested `mut` cells the C2 gate would reject. A
+// borrow (Lt set) is left untouched, since it names a reference, not owned storage.
+func stripOwnedMut(t soltype.Type) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if t.Mut && t.Lt == nil {
+			return stripOwnedMut(t.Inner)
+		}
+		return t
+	case *soltype.ObjectType:
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: stripOwnedMut(p.Type), Optional: p.Optional, Readonly: p.Readonly}
+		}
+		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = stripOwnedMut(e)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+	default:
+		return t
 	}
 }
 

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -149,6 +149,13 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 		// deep-mut type with every nested `mut` stripped — and grant the deep-mut type.
 		// A fully fresh, unaliased literal is uniquely owned at every level, so the
 		// upgrade is sound the whole way down, the recursive form of the top-level Rule 2.
+		//
+		// stripOwnedMut walks the already-deepened type, undoing the applyDeepMut walk
+		// at resolveMutableTypeAnn. The two-pass shape is intentional: the strip also
+		// peels any user-written `mut` field the pre-deepen annotation carried, such as
+		// `{p: mut {x}}` inside `mut {p: mut {x}}`. The pre-deepen `ri` would leave that
+		// inner `mut` in place and reject the immutable literal. The walk is O(n) on
+		// the annotation size and runs only at annotated fresh-literal bindings.
 		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -142,20 +142,9 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // escapes through a return or a module store still errors.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
-		// A deeply-mutable annotation (PR 13) carries `mut` on its nested objects and
-		// tuples too, so `mut {p: {x}}` lowers to `mut {p: mut {x}}`. The initializer is
-		// an immutable fresh literal, which the C2 gate would reject against those nested
-		// `mut` cells. Constrain it against the immutable skeleton — the read view of the
-		// deep-mut type with every nested `mut` stripped — and grant the deep-mut type.
-		// A fully fresh, unaliased literal is uniquely owned at every level, so the
-		// upgrade is sound the whole way down, the recursive form of the top-level Rule 2.
-		//
-		// stripOwnedMut walks the already-deepened type, undoing the applyDeepMut walk
-		// at resolveMutableTypeAnn. The two-pass shape is intentional: the strip also
-		// peels any user-written `mut` field the pre-deepen annotation carried, such as
-		// `{p: mut {x}}` inside `mut {p: mut {x}}`. The pre-deepen `ri` would leave that
-		// inner `mut` in place and reject the immutable literal. The walk is O(n) on
-		// the annotation size and runs only at annotated fresh-literal bindings.
+		// Constrain a fresh literal against the deep-mut annotation's immutable
+		// skeleton, then grant the deep-mut type. A fully fresh literal is uniquely
+		// owned at every level, so the upgrade is sound the whole way down.
 		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}
@@ -201,12 +190,9 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 	}
 }
 
-// stripOwnedMut returns the deeply-immutable skeleton of t: every owned-mutable
-// cell — a RefType with Mut set and no lifetime — is peeled to its inner, and the
-// peel recurses through objects and tuples. It is the read view of a deep-mut
-// annotation, used by the fresh-literal upgrade to constrain an immutable literal
-// against the shape without the nested `mut` cells the C2 gate would reject. A
-// borrow (Lt set) is left untouched, since it names a reference, not owned storage.
+// stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
+// cell (Mut set, Lt nil) and recursing through objects and tuples. Borrows are
+// left untouched.
 func stripOwnedMut(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.RefType:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -666,12 +666,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		c.recordType(e, recv)
 		return recv
 	}
-	var recvLt soltype.Lifetime
-	recvMut := false
-	if r, ok := recv.(*soltype.RefType); ok {
-		recvLt = r.Lt
-		recvMut = r.Mut
-	}
+	_, recvMut, recvLt := soltype.UnwrapRef(recv)
 	recvCarrier := soltype.CarrierOf(recv)
 	// Read-after-write cache. A usage-inferred receiver may carry a recorded
 	// write for this field. Take the cached value as the field's static shape
@@ -721,18 +716,23 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// the most precise shape available: a read-after-write cache hit first,
 	// then the property type from the receiver's annotation, and `chk` itself
 	// only when neither is known.
-	// Pick the field's CARRIER (peeling any borrow or owned-`mut` wrapper) so a
-	// deep-mut field such as `mut {y}` contributes its `{y}` shape rather than the
-	// RefType, which is not a RefInner. The explicit `&`/`&mut` then re-wraps the
-	// carrier at the requested mutability.
+	//
+	// borrowInnerOf peels exactly the wrappers an explicit borrow re-anchors. It
+	// peels an owned-mutable cell, which is the shape deep `mut` produces in PR 13,
+	// so the re-wrap restates the cell at the receiver lifetime. It LEAVES a borrow
+	// field intact, so the field's own borrow flows through unchanged rather than
+	// collapsing into a single borrow at the receiver lifetime. That collapse would
+	// produce the depth-two `&mut &mut` borrow shape PR 9 will normalize. Until
+	// then, the field-own lifetime is what the implicit-read path returns, and the
+	// two must agree.
 	var inner soltype.RefInner = chk
 	if cachedT != nil {
-		if ri, ok := soltype.CarrierOf(cachedT).(soltype.RefInner); ok {
+		if ri, ok := borrowInnerOf(cachedT); ok {
 			inner = ri
 		}
 	} else if recvObj, ok := recvCarrier.(*soltype.ObjectType); ok {
 		if prop, ok := recvObj.Prop(propName); ok {
-			if ri, ok := soltype.CarrierOf(prop.Type).(soltype.RefInner); ok {
+			if ri, ok := borrowInnerOf(prop.Type); ok {
 				inner = ri
 			}
 		}
@@ -750,6 +750,27 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	c.recordType(accessNode, c.fieldReadBorrow(chk, recvCarrier, propName, recvLt, recvMut, lvl))
 	c.recordType(e, target)
 	return target
+}
+
+// borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
+// at the receiver's lifetime, or ok=false when the field's type is not a viable
+// re-wrap target. It peels an owned-mutable cell, the shape deep `mut` produces
+// in PR 13, since those are owned storage inside the receiver and a borrow of
+// them belongs at the receiver's lifetime. It returns a bare object or tuple
+// directly, which is the common case. It leaves an explicit borrow field intact
+// by returning ok=false, so the caller keeps the bare `chk` and the field's own
+// borrow flows through with its own lifetime rather than collapsing into one
+// bound by the receiver's lifetime.
+func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
+	if r, ok := t.(*soltype.RefType); ok {
+		if r.Lt == nil {
+			ri, ok := r.Inner.(soltype.RefInner)
+			return ri, ok
+		}
+		return nil, false
+	}
+	ri, ok := t.(soltype.RefInner)
+	return ri, ok
 }
 
 // inferCall types a function application. It types the callee and each argument,
@@ -1095,6 +1116,21 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	}
 	recv := c.inferExpr(scope, lvl, m.Object)
 	w := widen(source)
+	// Catch a write to a readonly field at the assignment site so the diagnostic
+	// blames the assignment and the message names it outright. Without this, the
+	// structural rejection in constrainWriteBack would fire with a less specific
+	// subtype message. The check only runs when the receiver's carrier is a
+	// concrete object whose field is readonly; a TypeVar receiver still falls
+	// through to constrainWriteBack, which carries the same field name with the
+	// structural message.
+	if recvObj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType); ok {
+		if prop, ok := recvObj.Prop(m.Prop.Name); ok && prop.Readonly {
+			c.report(&ReadonlyFieldError{Field: m.Prop.Name, site: e})
+			c.recordWritten(recv, m.Prop.Name, w)
+			c.recordType(e, w)
+			return w
+		}
+	}
 	req := &soltype.RefType{
 		Mut: true,
 		// A fresh lifetime imposes no obligation on the receiver (D2): constrainLt
@@ -1438,14 +1474,9 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// A borrowed receiver passes its lifetime through to the read. An owned
 	// receiver originates a fresh lifetime at the read site. PR 4 rule 4 makes
 	// a member read on a reference-shaped field yield a borrow bounded by the
-	// receiver, rather than the bare field value. Capture the receiver's
-	// lifetime before peeling the borrow wrapper so the wrap site has it.
-	var recvLt soltype.Lifetime
-	recvMut := false
-	if r, ok := recv.(*soltype.RefType); ok {
-		recvLt = r.Lt
-		recvMut = r.Mut
-	}
+	// receiver, rather than the bare field value. Capture the receiver's mut
+	// and lifetime before peeling the borrow wrapper so the wrap site has them.
+	_, recvMut, recvLt := soltype.UnwrapRef(recv)
 	// Strip the borrow wrapper before building the field-read requirement (D2):
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
 	//     the field's value, not the borrow.
@@ -1493,13 +1524,13 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.
 	switch ft := prop.Type.(type) {
 	case *soltype.RefType:
 		if ft.Lt == nil {
-			// An owned-mutable field, produced by deep `mut` (PR 13): `mut {a: {x}}`
-			// stores `a` as `mut {x}`. It is owned storage inside the receiver, not a
-			// reference, so a read borrows it bounded by the receiver exactly like a
-			// bare object field below. The borrow keeps the field's `mut` only when the
-			// receiver itself grants a mutable view, so `p.a.x = 5` is legal through a
-			// `mut`/`&mut` receiver. The inner is the field's own carrier, which is a
-			// RefInner, so the wrapper is well-formed.
+			// An owned-mutable field, produced by deep `mut` in PR 13. The annotation
+			// `mut {a: {x}}` stores `a` as `mut {x}`. The field is owned storage inside
+			// the receiver rather than a reference, so a read borrows it bounded by
+			// the receiver, exactly like a bare object field below. The borrow keeps
+			// the field's `mut` only when the receiver itself grants a mutable view,
+			// so `p.a.x = 5` is legal through a mutable receiver. The inner is the
+			// field's own carrier, which is a RefInner, so the wrapper is well-formed.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -715,16 +715,8 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// result a concrete inner is what keeps it rendering as a `RefType`. Pick
 	// the most precise shape available: a read-after-write cache hit first,
 	// then the property type from the receiver's annotation, and `chk` itself
-	// only when neither is known.
-	//
-	// borrowInnerOf peels exactly the wrappers an explicit borrow re-anchors. It
-	// peels an owned-mutable cell, which is the shape deep `mut` produces in PR 13,
-	// so the re-wrap restates the cell at the receiver lifetime. It LEAVES a borrow
-	// field intact, so the field's own borrow flows through unchanged rather than
-	// collapsing into a single borrow at the receiver lifetime. That collapse would
-	// produce the depth-two `&mut &mut` borrow shape PR 9 will normalize. Until
-	// then, the field-own lifetime is what the implicit-read path returns, and the
-	// two must agree.
+	// only when neither is known. borrowInnerOf peels owned-mut cells (deep-mut
+	// output) but leaves borrow fields intact so they keep their own lifetime.
 	var inner soltype.RefInner = chk
 	if cachedT != nil {
 		if ri, ok := borrowInnerOf(cachedT); ok {
@@ -753,14 +745,9 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime, or ok=false when the field's type is not a viable
-// re-wrap target. It peels an owned-mutable cell, the shape deep `mut` produces
-// in PR 13, since those are owned storage inside the receiver and a borrow of
-// them belongs at the receiver's lifetime. It returns a bare object or tuple
-// directly, which is the common case. It leaves an explicit borrow field intact
-// by returning ok=false, so the caller keeps the bare `chk` and the field's own
-// borrow flows through with its own lifetime rather than collapsing into one
-// bound by the receiver's lifetime.
+// at the receiver's lifetime. It peels an owned-mut cell (deep-mut output), returns
+// a bare object or tuple as-is, and rejects a borrow field so the caller keeps
+// `chk` and the field's own lifetime flows through unchanged.
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 	if r, ok := t.(*soltype.RefType); ok {
 		if r.Lt == nil {
@@ -1116,13 +1103,9 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	}
 	recv := c.inferExpr(scope, lvl, m.Object)
 	w := widen(source)
-	// Catch a write to a readonly field at the assignment site so the diagnostic
-	// blames the assignment and the message names it outright. Without this, the
-	// structural rejection in constrainWriteBack would fire with a less specific
-	// subtype message. The check only runs when the receiver's carrier is a
-	// concrete object whose field is readonly; a TypeVar receiver still falls
-	// through to constrainWriteBack, which carries the same field name with the
-	// structural message.
+	// Catch a readonly write at the assignment site so the diagnostic blames it
+	// outright; a TypeVar receiver falls through to constrainWriteBack's structural
+	// message.
 	if recvObj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType); ok {
 		if prop, ok := recvObj.Prop(m.Prop.Name); ok && prop.Readonly {
 			c.report(&ReadonlyFieldError{Field: m.Prop.Name, site: e})
@@ -1355,9 +1338,8 @@ func (b *objElemBuilder) add(name string, t soltype.Type, optional bool) {
 }
 
 // addReadonly is add with an explicit `readonly` flag, used by
-// resolveObjectTypeAnn to carry a `readonly f: T` annotation onto the
-// PropertyElem. inferObject's object literals are never readonly, so they keep
-// calling add.
+// resolveObjectTypeAnn to carry the annotation through. Object literals are
+// never readonly, so inferObject keeps calling add.
 func (b *objElemBuilder) addReadonly(name string, t soltype.Type, optional, readonly bool) {
 	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly}
 	if i, dup := b.pos[name]; dup {
@@ -1524,13 +1506,8 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.
 	switch ft := prop.Type.(type) {
 	case *soltype.RefType:
 		if ft.Lt == nil {
-			// An owned-mutable field, produced by deep `mut` in PR 13. The annotation
-			// `mut {a: {x}}` stores `a` as `mut {x}`. The field is owned storage inside
-			// the receiver rather than a reference, so a read borrows it bounded by
-			// the receiver, exactly like a bare object field below. The borrow keeps
-			// the field's `mut` only when the receiver itself grants a mutable view,
-			// so `p.a.x = 5` is legal through a mutable receiver. The inner is the
-			// field's own carrier, which is a RefInner, so the wrapper is well-formed.
+			// Owned-mut field (deep-mut output): borrow it bounded by the receiver
+			// and keep `mut` only when the receiver itself grants a mutable view.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -667,8 +667,10 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		return recv
 	}
 	var recvLt soltype.Lifetime
+	recvMut := false
 	if r, ok := recv.(*soltype.RefType); ok {
 		recvLt = r.Lt
+		recvMut = r.Mut
 	}
 	recvCarrier := soltype.CarrierOf(recv)
 	// Read-after-write cache. A usage-inferred receiver may carry a recorded
@@ -719,14 +721,18 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// the most precise shape available: a read-after-write cache hit first,
 	// then the property type from the receiver's annotation, and `chk` itself
 	// only when neither is known.
+	// Pick the field's CARRIER (peeling any borrow or owned-`mut` wrapper) so a
+	// deep-mut field such as `mut {y}` contributes its `{y}` shape rather than the
+	// RefType, which is not a RefInner. The explicit `&`/`&mut` then re-wraps the
+	// carrier at the requested mutability.
 	var inner soltype.RefInner = chk
 	if cachedT != nil {
-		if ri, ok := cachedT.(soltype.RefInner); ok {
+		if ri, ok := soltype.CarrierOf(cachedT).(soltype.RefInner); ok {
 			inner = ri
 		}
 	} else if recvObj, ok := recvCarrier.(*soltype.ObjectType); ok {
 		if prop, ok := recvObj.Prop(propName); ok {
-			if ri, ok := prop.Type.(soltype.RefInner); ok {
+			if ri, ok := soltype.CarrierOf(prop.Type).(soltype.RefInner); ok {
 				inner = ri
 			}
 		}
@@ -741,7 +747,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// fieldReadBorrow makes the same wrap decision valueProp uses, so hover
 	// on the inner `obj.f` reads the same whether it stands alone or under
 	// `&obj.f` or `&mut obj.f`.
-	c.recordType(accessNode, c.fieldReadBorrow(chk, recvCarrier, propName, recvLt, lvl))
+	c.recordType(accessNode, c.fieldReadBorrow(chk, recvCarrier, propName, recvLt, recvMut, lvl))
 	c.recordType(e, target)
 	return target
 }
@@ -1309,7 +1315,15 @@ func newObjElemBuilder(capacity int) *objElemBuilder {
 }
 
 func (b *objElemBuilder) add(name string, t soltype.Type, optional bool) {
-	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional}
+	b.addReadonly(name, t, optional, false)
+}
+
+// addReadonly is add with an explicit `readonly` flag, used by
+// resolveObjectTypeAnn to carry a `readonly f: T` annotation onto the
+// PropertyElem. inferObject's object literals are never readonly, so they keep
+// calling add.
+func (b *objElemBuilder) addReadonly(name string, t soltype.Type, optional, readonly bool) {
+	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly}
 	if i, dup := b.pos[name]; dup {
 		b.elems[i] = pe // last value wins, first position kept
 		return
@@ -1427,8 +1441,10 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// receiver, rather than the bare field value. Capture the receiver's
 	// lifetime before peeling the borrow wrapper so the wrap site has it.
 	var recvLt soltype.Lifetime
+	recvMut := false
 	if r, ok := recv.(*soltype.RefType); ok {
 		recvLt = r.Lt
+		recvMut = r.Mut
 	}
 	// Strip the borrow wrapper before building the field-read requirement (D2):
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
@@ -1446,7 +1462,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: res}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
-	out := c.fieldReadBorrow(res, recvCarrier, name, recvLt, lvl)
+	out := c.fieldReadBorrow(res, recvCarrier, name, recvLt, recvMut, lvl)
 	c.recordType(blame, out)
 	return pathResult{value: out}
 }
@@ -1465,7 +1481,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 // concrete property both fall into this branch. The inferred-receiver paths
 // keep their pre-PR-4 behaviour, so only annotated reference shapes pick up
 // the new borrow.
-func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.Type, name string, recvLt soltype.Lifetime, lvl int) soltype.Type {
+func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.Type, name string, recvLt soltype.Lifetime, recvMut bool, lvl int) soltype.Type {
 	obj, ok := recvCarrier.(*soltype.ObjectType)
 	if !ok {
 		return res
@@ -1476,6 +1492,20 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.
 	}
 	switch ft := prop.Type.(type) {
 	case *soltype.RefType:
+		if ft.Lt == nil {
+			// An owned-mutable field, produced by deep `mut` (PR 13): `mut {a: {x}}`
+			// stores `a` as `mut {x}`. It is owned storage inside the receiver, not a
+			// reference, so a read borrows it bounded by the receiver exactly like a
+			// bare object field below. The borrow keeps the field's `mut` only when the
+			// receiver itself grants a mutable view, so `p.a.x = 5` is legal through a
+			// `mut`/`&mut` receiver. The inner is the field's own carrier, which is a
+			// RefInner, so the wrapper is well-formed.
+			lt := recvLt
+			if lt == nil {
+				lt = c.ctx.freshLifetime(lvl)
+			}
+			return &soltype.RefType{Mut: ft.Mut && recvMut, Lt: lt, Inner: ft.Inner}
+		}
 		if !ft.Mut {
 			// Flat copy-out of an immutable borrow field. Immutable borrows are
 			// freely duplicable, so the read hands back the field's borrow at

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -666,7 +666,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		c.recordType(e, recv)
 		return recv
 	}
-	_, recvMut, recvLt := soltype.UnwrapRef(recv)
+	_, _, recvLt := soltype.UnwrapRef(recv)
 	recvCarrier := soltype.CarrierOf(recv)
 	// Read-after-write cache. A usage-inferred receiver may carry a recorded
 	// write for this field. Take the cached value as the field's static shape
@@ -739,7 +739,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// fieldReadBorrow makes the same wrap decision valueProp uses, so hover
 	// on the inner `obj.f` reads the same whether it stands alone or under
 	// `&obj.f` or `&mut obj.f`.
-	c.recordType(accessNode, c.fieldReadBorrow(chk, recvCarrier, propName, recvLt, recvMut, lvl))
+	c.recordType(accessNode, c.fieldReadBorrow(chk, recv, propName, lvl))
 	c.recordType(e, target)
 	return target
 }
@@ -1453,12 +1453,6 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
-	// A borrowed receiver passes its lifetime through to the read. An owned
-	// receiver originates a fresh lifetime at the read site. PR 4 rule 4 makes
-	// a member read on a reference-shaped field yield a borrow bounded by the
-	// receiver, rather than the bare field value. Capture the receiver's mut
-	// and lifetime before peeling the borrow wrapper so the wrap site has them.
-	_, recvMut, recvLt := soltype.UnwrapRef(recv)
 	// Strip the borrow wrapper before building the field-read requirement (D2):
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
 	//     the field's value, not the borrow.
@@ -1475,7 +1469,9 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: res}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
-	out := c.fieldReadBorrow(res, recvCarrier, name, recvLt, recvMut, lvl)
+	// fieldReadBorrow takes the whole receiver and unwraps mut/lifetime internally,
+	// applying PR 4 rule 4 to produce the field-bounded borrow.
+	out := c.fieldReadBorrow(res, recv, name, lvl)
 	c.recordType(blame, out)
 	return pathResult{value: out}
 }
@@ -1483,19 +1479,20 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 // fieldReadBorrow applies PR 4 rule 4. A member read yields a borrow of the
 // field bounded by the receiver when the field is reference-shaped. An owned
 // receiver mints a fresh lifetime here. A borrowed receiver's lifetime passes
-// through via recvLt. The wrap reads the field's static shape off a concrete
-// receiver carrier. A primitive or function field stays a value, since
-// PrimType and FuncType are excluded from RefInner. A field whose static type
-// is itself an immutable borrow copies the borrow out flat rather than
-// nesting, setting up PR 9's nested-borrow normalization.
+// through. The wrap reads the field's static shape off a concrete receiver
+// carrier. A primitive or function field stays a value, since PrimType and
+// FuncType are excluded from RefInner. A field whose static type is itself an
+// immutable borrow copies the borrow out flat rather than nesting, setting up
+// PR 9's nested-borrow normalization.
 //
 // A receiver whose shape is not statically known returns the existing `res`
 // var unchanged. A usage-inferred TypeVar carrier and an index path with no
 // concrete property both fall into this branch. The inferred-receiver paths
 // keep their pre-PR-4 behaviour, so only annotated reference shapes pick up
 // the new borrow.
-func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recvCarrier soltype.Type, name string, recvLt soltype.Lifetime, recvMut bool, lvl int) soltype.Type {
-	obj, ok := recvCarrier.(*soltype.ObjectType)
+func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, name string, lvl int) soltype.Type {
+	_, recvMut, recvLt := soltype.UnwrapRef(recv)
+	obj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType)
 	if !ok {
 		return res
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -745,9 +745,9 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime. It peels an owned-mut cell (deep-mut output), returns
-// a bare object or tuple as-is, and rejects a borrow field so the caller keeps
-// `chk` and the field's own lifetime flows through unchanged.
+// at the receiver's lifetime. It peels an owned-mut cell (deep-mut output) and
+// returns a bare object or tuple as-is, but returns ok=false for a borrow field
+// so the caller leaves the field's own borrow flowing through unchanged.
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 	if r, ok := t.(*soltype.RefType); ok {
 		if r.Lt == nil {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1302,7 +1302,7 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 			continue
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
-		b.add(name, ft, false) // a literal property is never optional
+		b.add(name, ft, false, false) // a literal property is never optional or readonly
 	}
 	t := &soltype.ObjectType{Elems: b.elems}
 	c.recordType(e, t)
@@ -1333,14 +1333,7 @@ func newObjElemBuilder(capacity int) *objElemBuilder {
 	}
 }
 
-func (b *objElemBuilder) add(name string, t soltype.Type, optional bool) {
-	b.addReadonly(name, t, optional, false)
-}
-
-// addReadonly is add with an explicit `readonly` flag, used by
-// resolveObjectTypeAnn to carry the annotation through. Object literals are
-// never readonly, so inferObject keeps calling add.
-func (b *objElemBuilder) addReadonly(name string, t soltype.Type, optional, readonly bool) {
+func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly bool) {
 	pe := &soltype.PropertyElem{Name: name, Type: t, Optional: optional, Readonly: readonly}
 	if i, dup := b.pos[name]; dup {
 		b.elems[i] = pe // last value wins, first position kept

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -240,15 +240,12 @@ func (r *ltRewriter) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 	}
 	resolved, elide := r.a.resolveLt(lv)
 	if elide {
-		if rt.Mut {
-			// Drop the elided lifetime to owned-mutable. (true, nil) is a valid borrow
-			// cell — NewRef does NOT collapse it — so keep the wrapper. Only the
-			// immutable (false, nil) cell below is the degenerate one.
-			return &soltype.RefType{Mut: true, Lt: nil, Inner: rt.Inner}
-		}
-		// RefType{false, nil} is the forbidden degenerate cell NewRef collapses — drop
-		// the wrapper and return the bare inner.
-		return rt.Inner
+		// Keep the `&` on an elided borrow by parking the lifetime on the Anon
+		// sentinel. The printer renders it as the bare `&`/`&mut` with no
+		// lifetime name, so the displayed type still records owned vs borrowed.
+		// Dropping to nil instead would collapse the wrapper to owned-mutable for
+		// mut and to the bare inner for immutable, hiding the borrow at call sites.
+		return &soltype.RefType{Mut: rt.Mut, Lt: soltype.Anon, Inner: rt.Inner}
 	}
 	return &soltype.RefType{Mut: rt.Mut, Lt: resolved, Inner: rt.Inner}
 }

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -218,12 +218,11 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// D4 elision branches on Mut. A connect-nothing IMMUTABLE borrow, whose lifetime
-// reaches no output, drops the RefType wrapper entirely and renders as its bare
-// inner, because RefType{false, nil} is the forbidden degenerate cell NewRef
-// rejects. This contrasts with the mutable case, which becomes owned-mutable,
-// RefType{Mut: true, Lt: nil}. The FieldWrite acceptance covers that branch.
-func TestImmutableConnectNothingBorrowDropsWrapper(t *testing.T) {
+// D4 elision keeps the `&` on a connect-nothing borrow by parking its lifetime on
+// the Anon sentinel, so an immutable borrow whose lifetime reaches no output
+// still renders as `&{x}` rather than collapsing to the bare inner. The mutable
+// case keeps the `&mut` form for the same reason.
+func TestImmutableConnectNothingBorrowKeepsRef(t *testing.T) {
 	c := newChecker()
 	lt := c.ctx.freshLifetime(0)
 	param := &soltype.RefType{
@@ -233,14 +232,12 @@ func TestImmutableConnectNothingBorrowDropsWrapper(t *testing.T) {
 			&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
 		}},
 	}
-	// The borrow appears only on the parameter, since the body returns a number, not
-	// the borrow, so its lifetime connects nothing and is elided.
 	fn := &soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: param}},
 		Ret:    &soltype.PrimType{Prim: soltype.NumPrim},
 	}
 
-	require.Equal(t, "fn (p: {x: number}) -> number", renderScheme(&MonoScheme{Ty: fn}))
+	require.Equal(t, "fn (p: &{x: number}) -> number", renderScheme(&MonoScheme{Ty: fn}))
 }
 
 // A nested join reaching one param lifetime through two distinct sub-joins lists

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -130,7 +130,7 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 				ft = t
 			}
 		}
-		b.addReadonly(name, ft, prop.Optional, prop.Readonly)
+		b.add(name, ft, prop.Optional, prop.Readonly)
 	}
 	if unsupported {
 		c.reportUnsupportedFeature(ta, "object type member other than a property")

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -183,26 +183,40 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "mut on a non-borrowable type"), false
 	}
-	t := soltype.NewRef(true, nil, applyDeepMut(ri))
+	t := soltype.NewRef(true, nil, c.applyDeepMut(ri))
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 
+// The deep-mut walk hand-rolls a structural rebuild rather than using the soltype
+// TypeVisitor, for two reasons. First, every rebuilt ObjectType or TupleType
+// inherits the source pointer's provenance entry, so blame survives the rewrite.
+// The visitor hides the original-to-new pointer mapping ExitType would need to
+// do this. Second, widen.go already hand-rolls the same shape, so this matches
+// the local pattern. If the visitor grows a way to thread the original alongside
+// the rewritten node, this and widen.go should both migrate together.
+
 // applyDeepMut sets `mut` on `ri` and recursively on every borrowable component
 // reachable through its concrete structure, then returns the rebuilt RefInner.
-// `mut` is deep (PR 13): `mut {a: {x}}` lowers to `mut {a: mut {x}}`, so reading
-// `p.a` yields a mutable view and `p.a.x = 5` is legal.
+// `mut` is deep, per PR 13. So `mut {a: {x}}` lowers to `mut {a: mut {x}}`,
+// reading `p.a` yields a mutable view, and `p.a.x = 5` is legal.
 //
-// The recursion stops at two kinds of slot. A type parameter is inert — a
+// The recursion stops at two kinds of slot. A type parameter is inert: a
 // TypeVarType is returned unchanged, so `mut Foo<Point>` applies `mut` to Foo's
-// body and leaves the substituted Point immutable. A value type — a primitive,
-// function, or promise — is never a RefInner, so it is never wrapped.
+// body and leaves the substituted Point immutable. A value type is never a
+// RefInner, so it is never wrapped. The value types are primitives, functions,
+// and promises.
 //
-// A field that is already a borrow (an explicit `&`/`mut` field) is left as it
-// stands: its own resolution already applied this distribution, and an immutable
-// `&` field states its own mutability. Only a bare object or tuple component is
-// deepened, via deepMutComponent.
-func applyDeepMut(ri soltype.RefInner) soltype.RefInner {
+// A field that is already a borrow is left as it stands. Its own resolution
+// already applied this distribution, and an immutable `&` field states its own
+// mutability. Only a bare object or tuple component is deepened, via
+// deepMutComponent.
+//
+// Every rebuilt ObjectType/TupleType inherits the source's provenance entry so
+// that a structural mismatch against a nested annotation object keeps its
+// "expected here" related span. Without the carry-through, the new pointer has
+// no Prov entry and blame falls back to the constraint site.
+func (c *checker) applyDeepMut(ri soltype.RefInner) soltype.RefInner {
 	switch t := ri.(type) {
 	case *soltype.ObjectType:
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
@@ -210,18 +224,22 @@ func applyDeepMut(ri soltype.RefInner) soltype.RefInner {
 			p := soltype.AsProperty(e)
 			elems[i] = &soltype.PropertyElem{
 				Name:     p.Name,
-				Type:     deepMutComponent(p.Type),
+				Type:     c.deepMutComponent(p.Type),
 				Optional: p.Optional,
 				Readonly: p.Readonly,
 			}
 		}
-		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+		out := &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+		c.inheritProv(out, t)
+		return out
 	case *soltype.TupleType:
 		elems := make([]soltype.Type, len(t.Elems))
 		for i, e := range t.Elems {
-			elems[i] = deepMutComponent(e)
+			elems[i] = c.deepMutComponent(e)
 		}
-		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+		out := &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+		c.inheritProv(out, t)
+		return out
 	default:
 		// A TypeVarType is inert, so it is returned unchanged.
 		return ri
@@ -232,12 +250,27 @@ func applyDeepMut(ri soltype.RefInner) soltype.RefInner {
 // when it is a bare object or tuple, and leaves every other shape unchanged. A
 // value type stays a value, a type parameter stays inert, and a field that is
 // already a borrow keeps its own mutability rather than being re-wrapped.
-func deepMutComponent(t soltype.Type) soltype.Type {
-	switch t.(type) {
-	case *soltype.ObjectType, *soltype.TupleType:
-		return &soltype.RefType{Mut: true, Inner: applyDeepMut(t.(soltype.RefInner))}
+func (c *checker) deepMutComponent(t soltype.Type) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.ObjectType:
+		return &soltype.RefType{Mut: true, Inner: c.applyDeepMut(t)}
+	case *soltype.TupleType:
+		return &soltype.RefType{Mut: true, Inner: c.applyDeepMut(t)}
 	default:
 		return t
+	}
+}
+
+// inheritProv copies the provenance entry from `from` onto `to`, when `from` has
+// one. Used by the deep-mut walk to keep a rebuilt object or tuple pointing at
+// the same annotation node the original did, so blame and "expected here" spans
+// survive the rewrite. Skips silently when `from` has no entry, since not every
+// minted type has provenance.
+func (c *checker) inheritProv(to, from soltype.Type) {
+	if n, ok := c.prov.NodeFor(from); ok {
+		if o, ok := c.prov[from].(FromAST); ok {
+			c.recordProv(to, n, o.Kind)
+		}
 	}
 }
 
@@ -276,7 +309,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	// through the pointee's concrete structure, so `&mut {a: {x}}` lets you write
 	// `p.a.x`. An immutable `&` borrow leaves the pointee untouched.
 	if ta.Mut {
-		ri = applyDeepMut(ri)
+		ri = c.applyDeepMut(ri)
 	}
 	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
 	c.recordProv(t, ta, AnnotationType)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -130,7 +130,7 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 				ft = t
 			}
 		}
-		b.add(name, ft, prop.Optional)
+		b.addReadonly(name, ft, prop.Optional, prop.Readonly)
 	}
 	if unsupported {
 		c.reportUnsupportedFeature(ta, "object type member other than a property")
@@ -183,9 +183,62 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "mut on a non-borrowable type"), false
 	}
-	t := soltype.NewRef(true, nil, ri)
+	t := soltype.NewRef(true, nil, applyDeepMut(ri))
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// applyDeepMut sets `mut` on `ri` and recursively on every borrowable component
+// reachable through its concrete structure, then returns the rebuilt RefInner.
+// `mut` is deep (PR 13): `mut {a: {x}}` lowers to `mut {a: mut {x}}`, so reading
+// `p.a` yields a mutable view and `p.a.x = 5` is legal.
+//
+// The recursion stops at two kinds of slot. A type parameter is inert — a
+// TypeVarType is returned unchanged, so `mut Foo<Point>` applies `mut` to Foo's
+// body and leaves the substituted Point immutable. A value type — a primitive,
+// function, or promise — is never a RefInner, so it is never wrapped.
+//
+// A field that is already a borrow (an explicit `&`/`mut` field) is left as it
+// stands: its own resolution already applied this distribution, and an immutable
+// `&` field states its own mutability. Only a bare object or tuple component is
+// deepened, via deepMutComponent.
+func applyDeepMut(ri soltype.RefInner) soltype.RefInner {
+	switch t := ri.(type) {
+	case *soltype.ObjectType:
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			elems[i] = &soltype.PropertyElem{
+				Name:     p.Name,
+				Type:     deepMutComponent(p.Type),
+				Optional: p.Optional,
+				Readonly: p.Readonly,
+			}
+		}
+		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = deepMutComponent(e)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+	default:
+		// A TypeVarType is inert, so it is returned unchanged.
+		return ri
+	}
+}
+
+// deepMutComponent wraps a field or element value in owned-mutable and recurses
+// when it is a bare object or tuple, and leaves every other shape unchanged. A
+// value type stays a value, a type parameter stays inert, and a field that is
+// already a borrow keeps its own mutability rather than being re-wrapped.
+func deepMutComponent(t soltype.Type) soltype.Type {
+	switch t.(type) {
+	case *soltype.ObjectType, *soltype.TupleType:
+		return &soltype.RefType{Mut: true, Inner: applyDeepMut(t.(soltype.RefInner))}
+	default:
+		return t
+	}
 }
 
 // borrowInner resolves the pointee of a `mut` or `&` annotation to a RefInner, the
@@ -218,6 +271,12 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	ri, ok := c.borrowInner(ta.Inner, lvl)
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
+	}
+	// `&mut` distributes the same way `mut` does (PR 13): the mutability reaches
+	// through the pointee's concrete structure, so `&mut {a: {x}}` lets you write
+	// `p.a.x`. An immutable `&` borrow leaves the pointee untouched.
+	if ta.Mut {
+		ri = applyDeepMut(ri)
 	}
 	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
 	c.recordProv(t, ta, AnnotationType)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -188,34 +188,12 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	return t, true
 }
 
-// The deep-mut walk hand-rolls a structural rebuild rather than using the soltype
-// TypeVisitor, for two reasons. First, every rebuilt ObjectType or TupleType
-// inherits the source pointer's provenance entry, so blame survives the rewrite.
-// The visitor hides the original-to-new pointer mapping ExitType would need to
-// do this. Second, widen.go already hand-rolls the same shape, so this matches
-// the local pattern. If the visitor grows a way to thread the original alongside
-// the rewritten node, this and widen.go should both migrate together.
-
-// applyDeepMut sets `mut` on `ri` and recursively on every borrowable component
-// reachable through its concrete structure, then returns the rebuilt RefInner.
-// `mut` is deep, per PR 13. So `mut {a: {x}}` lowers to `mut {a: mut {x}}`,
-// reading `p.a` yields a mutable view, and `p.a.x = 5` is legal.
-//
-// The recursion stops at two kinds of slot. A type parameter is inert: a
-// TypeVarType is returned unchanged, so `mut Foo<Point>` applies `mut` to Foo's
-// body and leaves the substituted Point immutable. A value type is never a
-// RefInner, so it is never wrapped. The value types are primitives, functions,
-// and promises.
-//
-// A field that is already a borrow is left as it stands. Its own resolution
-// already applied this distribution, and an immutable `&` field states its own
-// mutability. Only a bare object or tuple component is deepened, via
-// deepMutComponent.
-//
-// Every rebuilt ObjectType/TupleType inherits the source's provenance entry so
-// that a structural mismatch against a nested annotation object keeps its
-// "expected here" related span. Without the carry-through, the new pointer has
-// no Prov entry and blame falls back to the constraint site.
+// applyDeepMut deepens `ri` by wrapping every reachable bare object/tuple
+// component in owned-mut, returning the rebuilt RefInner. Type parameters and
+// value types (primitives, functions, promises) are inert; an already-borrow
+// field is left as-is. Rebuilt nodes inherit the source's provenance so
+// "expected here" spans survive. Hand-rolled rather than visitor-based to keep
+// that prov carry-through, matching widen.go.
 func (c *checker) applyDeepMut(ri soltype.RefInner) soltype.RefInner {
 	switch t := ri.(type) {
 	case *soltype.ObjectType:
@@ -246,10 +224,8 @@ func (c *checker) applyDeepMut(ri soltype.RefInner) soltype.RefInner {
 	}
 }
 
-// deepMutComponent wraps a field or element value in owned-mutable and recurses
-// when it is a bare object or tuple, and leaves every other shape unchanged. A
-// value type stays a value, a type parameter stays inert, and a field that is
-// already a borrow keeps its own mutability rather than being re-wrapped.
+// deepMutComponent wraps a bare object/tuple field or element in owned-mut and
+// recurses; every other shape passes through unchanged.
 func (c *checker) deepMutComponent(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.ObjectType:
@@ -261,11 +237,9 @@ func (c *checker) deepMutComponent(t soltype.Type) soltype.Type {
 	}
 }
 
-// inheritProv copies the provenance entry from `from` onto `to`, when `from` has
-// one. Used by the deep-mut walk to keep a rebuilt object or tuple pointing at
-// the same annotation node the original did, so blame and "expected here" spans
-// survive the rewrite. Skips silently when `from` has no entry, since not every
-// minted type has provenance.
+// inheritProv copies `from`'s provenance entry onto `to`, used by the deep-mut
+// walk so a rebuilt object or tuple keeps the original annotation's blame span.
+// Skips silently when `from` has no entry.
 func (c *checker) inheritProv(to, from soltype.Type) {
 	if o, ok := c.prov[from].(FromAST); ok {
 		c.recordProv(to, o.Node, o.Kind)
@@ -303,9 +277,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
-	// `&mut` distributes the same way `mut` does (PR 13): the mutability reaches
-	// through the pointee's concrete structure, so `&mut {a: {x}}` lets you write
-	// `p.a.x`. An immutable `&` borrow leaves the pointee untouched.
+	// `&mut` deepens the pointee like `mut` does; `&` leaves it untouched.
 	if ta.Mut {
 		ri = c.applyDeepMut(ri)
 	}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -267,10 +267,8 @@ func (c *checker) deepMutComponent(t soltype.Type) soltype.Type {
 // survive the rewrite. Skips silently when `from` has no entry, since not every
 // minted type has provenance.
 func (c *checker) inheritProv(to, from soltype.Type) {
-	if n, ok := c.prov.NodeFor(from); ok {
-		if o, ok := c.prov[from].(FromAST); ok {
-			c.recordProv(to, n, o.Kind)
-		}
+	if o, ok := c.prov[from].(FromAST); ok {
+		c.recordProv(to, o.Node, o.Kind)
 	}
 }
 

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -38,7 +38,7 @@ func widen(t soltype.Type) soltype.Type {
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
 		for i, e := range t.Elems {
 			p := soltype.AsProperty(e)
-			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: widen(p.Type), Optional: p.Optional}
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: widen(p.Type), Optional: p.Optional, Readonly: p.Readonly}
 		}
 		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
 	case *soltype.TupleType:

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -52,8 +52,9 @@ connected-component moves, is a further move-engine extension and stays on M4. P
 `Freeze`/`Thaw`, additionally depends on **M9**, the mapped and conditional type
 operators. PR 13, deep `mut` with `readonly`, is foundational mut-semantics work that
 stays on M4 and is best sequenced early, since PR 12 and the affine model's mutability
-all build on it. So PRs 1 through 8, 11, and 13 can proceed once M4 is in place, 9 and
-10 wait on M6, and 12 waits on M9.
+all build on it. PR 14 reshapes the PR 13 representation from an eager lowering to a
+lazy one that stores the surface annotation, also on M4. So PRs 1 through 8, 11, 13,
+and 14 can proceed once M4 is in place, 9 and 10 wait on M6, and 12 waits on M9.
 
 ## Parsing borrows without a syntax mode
 
@@ -249,6 +250,7 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 11 | Connected-component moves for graphs | 6, 7 | Large |
 | 12 | `Freeze`/`Thaw` deep mut↔immut utility types | 8, 11, 13, M9 | Large |
 | 13 | Deep `mut`, type-parameter inertness, and `readonly` | 1, 2 | Medium |
+| 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -705,6 +707,77 @@ reassignment but still permits mutating the field's value when that value is mut
 
 Acceptance: `mut`/`&mut` are deep with type parameters inert, and `readonly` forbids
 reassignment only.
+
+### PR 14 — Lazy deep `mut`: store the surface form, push the rule to access and constrain
+
+Goal: change deep `mut` from an eager lowering that pre-bakes `mut` onto every nested
+object and tuple cell to a lazy representation that stores the type as the user wrote
+it and applies the deep-mut rule at access and constrain time. The two representations
+encode the same semantic. The lazy form stores `mut {a: {x}}` verbatim instead of
+`mut {a: mut {x}}`, so the stored type matches the surface annotation, error messages
+and hover need no special elision, and the fresh-literal upgrade has nothing to strip.
+The cost is threading a "mut context" flag through the constrain pipeline so the
+object subtyping arm knows when it is inside a mutable wrapper and treats fields as
+invariant, the work PR 13's eager representation does by baking `mut` into the field
+types themselves.
+
+Sequence this after PR 13 so the affine model and PR 12 can settle on deep-mut
+behaviour first. The migration touches the same call sites PR 13 grew, so it is best
+done as one focused change rather than dripped into the move-engine PRs.
+
+- Remove `applyDeepMut` and `deepMutComponent` from
+  [internal/solver/type_ann.go](../../internal/solver/type_ann.go).
+  `resolveMutableTypeAnn` and `resolveRefTypeAnn` go back to wrapping the resolved
+  inner in one `RefType` without touching its children. `inheritProv` goes with them,
+  since the lazy form does not rebuild the inner.
+- Remove `stripOwnedMut` and the deep-mut comment block from
+  [internal/solver/infer_decl.go](../../internal/solver/infer_decl.go).
+  `constrainInitAgainstAnnotation` constrains the fresh literal against `ref.Inner`
+  directly, the way it did before PR 13. The literal is owned-immutable, the inner is
+  the bare shape, and the C2 gate accepts it covariantly without a strip walk.
+- Drop the owned-mutable-cell branch in `fieldReadBorrow`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)). With the
+  lazy form, a field's value is the bare shape the user wrote, never a `mut` cell, so
+  the only `RefType` branch left is the explicit borrow field. The bare
+  `ObjectType`/`TupleType` arm now handles the deep-mut field too, with the receiver's
+  mutability propagated through `recvMut` to decide whether the produced borrow is
+  `&mut` or `&`.
+- Likewise simplify `borrowInnerOf`. Its owned-mut peel exists only to undo the eager
+  lowering; with the lazy form there is no owned-mut cell to peel and the helper
+  collapses to the ordinary `RefInner` cast.
+- Thread the mut context through the constrain pipeline. Add a flag, threaded
+  alongside `seen`, that the RefType arm sets to true when entering a mutable
+  wrapper. The `ObjectType <: ObjectType` arm consults it to decide per-field
+  variance: covariant outside a mutable wrapper, invariant inside one. The same flag
+  drives the recursive walk into nested object and tuple fields. Reset the flag at
+  function and promise boundaries, since each carries its own annotation context.
+  This subsumes `constrainWriteBack`: the per-field invariance the write view added
+  becomes a natural consequence of the flag, and the function shrinks to the readonly
+  guard plus a passthrough to constrain.
+- Update the field-write requirement in `inferMemberAssign`. Today the requirement
+  `mut {f: w, ...}` relies on the RefType arm's writeBack to pin `f` invariant; under
+  the lazy form the same flag mediates the pin, so the requirement stays a one-line
+  `mut {f: w, ...}` and the readonly upfront check is unchanged.
+- Remove the `underMut` plumbing from
+  [internal/soltype/print.go](../../internal/soltype/print.go). The stored type already
+  matches the surface annotation, so the printer's RefType arm drops the elision
+  branch and `printTypeMinPrec` drops its UM variant. The print tests that pinned the
+  elision retire with it.
+- Migrate the solver snapshots back to the surface form. Tests that asserted
+  `mut {a: mut {x: number}}` flip to `mut {a: {x: number}}`. The PR 13 tests for
+  deep-mut behaviour stay; only their rendered strings update.
+
+Tests: the PR 13 acceptance tests still pass with the rendered strings switched to
+the surface form. Two new tests pin the constrain-side rule: `mut {a: {x: number}}`
+and `mut {a: {y: number}}` are incomparable under the lazy form when the outer is
+mut, matching the eager form's invariance, while the same shapes are subtypes under
+an immutable wrapper. A diagnostic that previously rendered through the elision pass
+now renders the same string with no elision step.
+
+Acceptance: deep-mut semantics is preserved end to end with no representational
+deepening. The stored type matches the surface annotation, the printer is unchanged,
+and the constrain pipeline carries the deep-mut rule through a context flag rather
+than through the field types.
 
 ---
 


### PR DESCRIPTION
Implements PR 13 features for deep mutability distribution, readonly field enforcement, and type-parameter handling in the type system.

## Summary

This change makes `mut` annotations distribute deeply through nested object and tuple structures, adds `readonly` field declarations to prevent reassignment while permitting value mutation, and ensures type parameters remain inert under deep-mut application. These features improve soundness of mutable borrows and provide fine-grained control over field mutability.

## Key changes

- **Deep `mut` distribution**: `mut {a: {x}}` now lowers to `mut {a: mut {x}}`, making every nested layer writable. The `applyDeepMut` walk in `type_ann.go` recursively wraps bare objects and tuples in owned-mutable cells while leaving type parameters and explicit borrows untouched.

- **`readonly` field declarations**: Added `Readonly` flag to `PropertyElem` in `soltype/type.go`. Fields marked `readonly` reject reassignment (`obj.f = …`) but permit value mutation through the field (`obj.f.x = …`). Enforcement happens at two sites: literal assignment in `inferMemberAssign` with a dedicated `ReadonlyFieldError`, and structural subtyping in `constrainWriteBack` with `ReadonlyFieldSubtypeError`.

- **Fresh-literal upgrade for deep `mut`**: When a fully fresh, unaliased literal binds to a deeply-mutable annotation, `stripOwnedMut` in `infer_decl.go` peels the nested `mut` cells to produce an immutable skeleton, then constrains the literal against that skeleton. This allows `{p: {x: 0}}` to satisfy `mut {p: {x: number}}` by upgrading the whole structure.

- **Explicit borrow handling**: `borrowInnerOf` in `infer_expr.go` distinguishes between owned-mutable cells (which re-wrap at the receiver's lifetime) and explicit borrow fields (which flow through unchanged with their own lifetime). This preserves field-owned lifetimes rather than collapsing them into receiver-bound borrows.

- **Type-parameter inertness**: `applyDeepMut` leaves `TypeVarType` fields unchanged, so `mut Foo<Point>` applies `mut` to Foo's concrete structure but leaves the substituted Point immutable. This is the M4-expressible core; full generic forms are deferred to M7.

- **Receiver mutability propagation**: `fieldReadBorrow` now accepts a `recvMut` parameter to downgrade owned-mutable fields through immutable receivers, preventing unsound writes like `p.a.x = 5` when `p: {a: mut {x}}` is immutable.

## Implementation details

- The deep-mut walk hand-rolls structural rebuilding rather than using the `TypeVisitor` to preserve provenance entries on rebuilt nodes, keeping "expected here" spans accurate for nested annotation mismatches.

- `readonly` is orthogonal to deep mutability: a `readonly a: {b: number}` field on a `mut` container renders as `readonly a: mut {b: number}`, showing both axes independently.

- The `stripOwnedMut` walk mirrors `applyDeepMut` in reverse, undoing the nested `mut` cells to produce the read view for fresh-literal constraint checking.

- Readonly checks in `constrainWriteBack` walk `IntersectionType` sources to detect readonly fields in any member, since an intersection inherits every member's restrictions.

- Test coverage includes nested writes through deep-mut chains, readonly enforcement on both literal and structural flows, explicit borrow field lifetime preservation, and type-parameter inertness verification.

https://claude.ai/code/session_01JSEprmLox4g9ZPSB3QCHne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `readonly` object property rendering and enforcement: `obj.f = ...` is rejected, while mutating the stored value can remain allowed.
  * Improved deep `mut` behavior across nested object/tuple layers, including correct `&mut` borrow semantics.

* **Bug Fixes**
  * Preserved `readonly` through widening/merging and updated type equality/constraints for more accurate subtype checks.
  * Improved type display: `readonly` keywords and deep `mut` elision now print consistently; elided borrows keep `&` wrappers where appropriate.

* **Tests**
  * Expanded solver/printer coverage for deep `mut`, readonly rules, and updated lifetime/round-trip rendering expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->