### PR TITLE
Implement lazy deep-mut representation (PR 14)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -315,45 +315,18 @@ func (p *namedPrinter) borrowLifetimeName(lt Lifetime) string {
 // same shape, so e.g. a function inside a union renders as
 // `(fn () -> number) | string`.
 func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
-	return p.printTypeMinPrecUM(t, minPrec, false)
-}
-
-// printTypeMinPrecUM is printTypeMinPrec threaded with the underMut flag. The flag
-// activates the deep-mut display rule: under a mutable wrapper, a nested
-// owned-mutable cell is the redundant inner `mut` that deep-mut lowering produces,
-// and printing it as the bare inner matches the surface annotation the user wrote.
-func (p *namedPrinter) printTypeMinPrecUM(t Type, minPrec int, underMut bool) string {
-	result := p.printTypeUM(t, underMut)
-	if elidedRefPrec(t, underMut) < minPrec {
+	result := p.printType(t)
+	if typePrec(t) < minPrec {
 		return "(" + result + ")"
 	}
 	return result
 }
 
-// elidedRefPrec returns the precedence at which t will print after deep-mut
-// elision. An owned-mutable RefType inside a mut context prints as its inner, so
-// its precedence is the inner's, not the wrapper's. All other shapes keep the
-// precedence typePrec assigns.
-func elidedRefPrec(t Type, underMut bool) int {
-	if r, ok := t.(*RefType); ok && underMut && r.Mut && r.Lt == nil {
-		return elidedRefPrec(r.Inner, true)
-	}
-	return typePrec(t)
-}
-
+// printType renders a coalesced type. Under the lazy deep-mut form (PR 14) the
+// stored type already matches the surface annotation the user wrote, so the
+// printer needs no special elision pass — `mut {a: {x}}` is stored and printed
+// verbatim.
 func (p *namedPrinter) printType(t Type) string {
-	return p.printTypeUM(t, false)
-}
-
-// printTypeUM is printType threaded with the underMut flag, used by the deep-mut
-// display rule. underMut is true inside a mutable RefType wrapper, where a nested
-// owned-mutable cell prints as the bare inner — eliding the redundant `mut` that
-// deep-mut lowering inserts so the rendered type matches the surface annotation
-// the user wrote. The flag propagates through object/tuple fields, union and
-// intersection members, and through every owned-mutable cell that elides. It
-// resets to false at a function or promise boundary, since each carries its own
-// independent annotation context.
-func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 	switch t := t.(type) {
 	case *TypeVarType:
 		// A retained type parameter renders under its assigned name; otherwise a
@@ -386,7 +359,7 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 	case *TupleType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
-			elems = append(elems, p.printTypeUM(e, underMut))
+			elems = append(elems, p.printType(e))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")
@@ -404,19 +377,15 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 			if prop.Readonly {
 				ro = "readonly "
 			}
-			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printTypeUM(prop.Type, underMut))
+			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")
 		}
 		return "{" + strings.Join(elems, ", ") + "}"
 	case *FuncType:
-		// A function is its own annotation context, so the underMut flag does not
-		// flow into its parameters or return type. printFuncTail starts fresh from
-		// printType, which calls printTypeUM with underMut=false.
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
-		// A promise's payload is its own annotation context, so the flag resets here.
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
 		// Ownership and the borrow `&` split on Lt. An owned value has Lt nil and
@@ -428,17 +397,8 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 		//	&{x}        &mut {x}        &'a {x}        &'a mut {x}
 		//
 		// The inner prints at precPrefix so a looser inner such as a union or function
-		// gets parenthesized.
-		//
-		// Deep-mut elision. Under a mutable wrapper, a nested owned-mutable cell
-		// is the inner `mut` that deep-mut lowering inserted on every reachable
-		// object and tuple field. Print it as the bare inner so the rendered type
-		// matches the surface annotation the user wrote. The elision applies only
-		// to an owned-mutable cell with no lifetime. A real borrow keeps its `&`
-		// or `&mut`.
-		if underMut && t.Mut && t.Lt == nil {
-			return p.printTypeUM(t.Inner, true)
-		}
+		// gets parenthesized. Under the lazy deep-mut form (PR 14) the inner is the
+		// bare shape the user wrote, so it prints verbatim with no elision pass.
 		prefix := ""
 		if t.Lt != nil {
 			prefix = "&"
@@ -449,17 +409,14 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 		if t.Mut {
 			prefix += "mut "
 		}
-		// Entering a mutable wrapper activates underMut for the inner walk, so a
-		// nested owned-mutable cell can elide. An immutable wrapper (`&T`) does not
-		// activate elision: its pointee carries no deep-mut to undo.
-		return prefix + p.printTypeMinPrecUM(t.Inner, precPrefix, t.Mut)
+		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:
 		// An inexact union renders a trailing `...` entry, so a union typed
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
 		// object, and function arms render their flag the same way.
 		parts := make([]string, 0, len(t.Types)+1)
 		for _, m := range t.Types {
-			parts = append(parts, p.printTypeMinPrecUM(m, precUnion, underMut))
+			parts = append(parts, p.printTypeMinPrec(m, precUnion))
 		}
 		if t.Inexact {
 			parts = append(parts, "...")
@@ -468,7 +425,7 @@ func (p *namedPrinter) printTypeUM(t Type, underMut bool) string {
 	case *IntersectionType:
 		parts := make([]string, len(t.Types))
 		for i, m := range t.Types {
-			parts[i] = p.printTypeMinPrecUM(m, precIntersection, underMut)
+			parts[i] = p.printTypeMinPrec(m, precIntersection)
 		}
 		return strings.Join(parts, " & ")
 	}

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -253,43 +253,48 @@ func TestPrintLazyDeepMutVerbatim(t *testing.T) {
 	staticBorrow := func(mut bool, inner RefInner) Type {
 		return &RefType{Mut: mut, Lt: &StaticLifetime{}, Inner: inner}
 	}
+	objX := func() RefInner {
+		return &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}
+	}
 
-	t.Run("mut over a bare nested object prints verbatim", func(t *testing.T) {
-		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: &ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "x", Type: numP()},
-			}}},
-		}})
-		require.Equal(t, "mut {a: {x: number}}", Print(ty))
-	})
-
-	t.Run("&mut over a bare nested object prints verbatim", func(t *testing.T) {
-		ty := staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: &ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "x", Type: numP()},
-			}}},
-		}})
-		require.Equal(t, "&'static mut {a: {x: number}}", Print(ty))
-	})
-
-	t.Run("an explicit nested owned-mut cell is not hidden", func(t *testing.T) {
-		// No elision: a `mut` field under a `mut` wrapper renders its `mut`.
-		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "x", Type: numP()},
-			}})},
-		}})
-		require.Equal(t, "mut {a: mut {x: number}}", Print(ty))
-	})
-
-	t.Run("borrow field under mut keeps its & marker", func(t *testing.T) {
-		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "x", Type: numP()},
-			}})},
-		}})
-		require.Equal(t, "mut {a: &'static mut {x: number}}", Print(ty))
-	})
+	cases := []struct {
+		name string
+		ty   Type
+		want string
+	}{
+		{
+			name: "mut over a bare nested object prints verbatim",
+			ty:   mutOwned(&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: objX()}}}),
+			want: "mut {a: {x: number}}",
+		},
+		{
+			name: "&mut over a bare nested object prints verbatim",
+			ty:   staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: objX()}}}),
+			want: "&'static mut {a: {x: number}}",
+		},
+		{
+			// No elision: a `mut` field under a `mut` wrapper renders its `mut`.
+			name: "an explicit nested owned-mut object cell is not hidden",
+			ty:   mutOwned(&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: mutOwned(objX())}}}),
+			want: "mut {a: mut {x: number}}",
+		},
+		{
+			// The tuple-element path renders the nested `mut` verbatim too.
+			name: "an explicit nested owned-mut tuple element is not hidden",
+			ty:   mutOwned(&TupleType{Elems: []Type{mutOwned(objX())}}),
+			want: "mut [mut {x: number}]",
+		},
+		{
+			name: "borrow field under mut keeps its & marker",
+			ty:   mutOwned(&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: staticBorrow(true, objX())}}}),
+			want: "mut {a: &'static mut {x: number}}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, Print(tc.ty))
+		})
+	}
 }
 
 // AnonLifetime renders as bare `&` / `&mut`, keeping a borrow distinguishable

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -242,9 +242,11 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
-// A nested owned-mutable cell elides under a mutable wrapper so the rendered
-// type matches the surface annotation. An immutable wrapper does not elide.
-func TestPrintDeepMutElision(t *testing.T) {
+// Under the lazy deep-mut form (PR 14) the stored type matches the surface
+// annotation, so the printer renders it verbatim with no elision pass: a `mut`
+// wrapper over a bare object prints `mut {a: {x}}`, and any explicit nested
+// owned-mut cell prints its `mut` rather than being hidden.
+func TestPrintLazyDeepMutVerbatim(t *testing.T) {
 	mutOwned := func(inner RefInner) Type {
 		return &RefType{Mut: true, Inner: inner}
 	}
@@ -252,64 +254,41 @@ func TestPrintDeepMutElision(t *testing.T) {
 		return &RefType{Mut: mut, Lt: &StaticLifetime{}, Inner: inner}
 	}
 
-	t.Run("owned mut elides one nested level", func(t *testing.T) {
-		// mut {a: mut {x: number}} stored, prints as mut {a: {x: number}}.
+	t.Run("mut over a bare nested object prints verbatim", func(t *testing.T) {
 		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: &ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},
-			}})},
+			}}},
 		}})
 		require.Equal(t, "mut {a: {x: number}}", Print(ty))
 	})
 
-	t.Run("owned mut elides three nested levels", func(t *testing.T) {
-		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "b", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
-					&PropertyElem{Name: "c", Type: numP()},
-				}})},
-			}})},
-		}})
-		require.Equal(t, "mut {a: {b: {c: number}}}", Print(ty))
-	})
-
-	t.Run("&mut activates the same elision", func(t *testing.T) {
+	t.Run("&mut over a bare nested object prints verbatim", func(t *testing.T) {
 		ty := staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
-			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
+			&PropertyElem{Name: "a", Type: &ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},
-			}})},
+			}}},
 		}})
 		require.Equal(t, "&'static mut {a: {x: number}}", Print(ty))
 	})
 
-	t.Run("immutable wrapper preserves a user-explicit nested mut", func(t *testing.T) {
-		// An immutable outer is not deep-mut output, so the inner is preserved.
-		ty := &ObjectType{Elems: []ObjTypeElem{
+	t.Run("an explicit nested owned-mut cell is not hidden", func(t *testing.T) {
+		// No elision: a `mut` field under a `mut` wrapper renders its `mut`.
+		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
 			&PropertyElem{Name: "a", Type: mutOwned(&ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},
 			}})},
-		}}
-		require.Equal(t, "{a: mut {x: number}}", Print(ty))
+		}})
+		require.Equal(t, "mut {a: mut {x: number}}", Print(ty))
 	})
 
 	t.Run("borrow field under mut keeps its & marker", func(t *testing.T) {
-		// A real borrow field keeps its `&mut` even under a mutable wrapper.
 		ty := mutOwned(&ObjectType{Elems: []ObjTypeElem{
 			&PropertyElem{Name: "a", Type: staticBorrow(true, &ObjectType{Elems: []ObjTypeElem{
 				&PropertyElem{Name: "x", Type: numP()},
 			}})},
 		}})
 		require.Equal(t, "mut {a: &'static mut {x: number}}", Print(ty))
-	})
-
-	t.Run("tuple element elides under mut", func(t *testing.T) {
-		ty := mutOwned(&TupleType{Elems: []Type{
-			numP(),
-			mutOwned(&ObjectType{Elems: []ObjTypeElem{
-				&PropertyElem{Name: "x", Type: numP()},
-			}}),
-		}})
-		require.Equal(t, "mut [number, {x: number}]", Print(ty))
 	})
 }
 

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -127,78 +127,35 @@ type ltExtrudeKey struct {
 // target `x` is the super. The checker-level wrapper (checker.constrain) names
 // these source/target, which map to sub/super here.
 func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
-	return c.constrain(sub, super, set.NewSet[constraintKey]())
+	return c.constrain(sub, super, set.NewSet[constraintKey](), false)
 }
 
-// constrainWriteBack is the contravariant WRITE view of a mutable borrow's inner
-// (the RefType <: RefType rule, step 2). For each field the target object NAMES it
-// constrains target.field <: source.field, so combined with the covariant read view
-// that field is invariant. It ranges over the TARGET's fields only — not the whole
-// object — so an inexact target (a field write `obj.x = v` lowers to mut {x: v, ...})
-// pins its named fields without forcing the source down to exactly that field set.
-//
-// A field the target names but the source lacks is already reported by the read
-// view's MissingPropertyError, so it is skipped here to avoid a double report. When
-// the target is EXACT the read view has already forced the source to the same field
-// set, so this per-field pass is complete. Non-object inners — a TypeVarType
-// mid-inference, a tuple — fall back to a full contravariant constraint, the prior
-// whole-inner behavior.
-func (c *Context) constrainWriteBack(target, source soltype.Type, seen set.Set[constraintKey]) []SolverError {
-	targetObj, ok := target.(*soltype.ObjectType)
-	if !ok {
-		return c.constrain(target, source, seen)
+// needsResidualWriteBack reports whether a mutable borrow's inner needs an explicit
+// contravariant write view in the RefType arm (PR 14). The ObjectType and TupleType
+// arms pin their fields invariant via the mut-context flag, so a matched
+// object/object or tuple/tuple inner is already invariant and needs no residual.
+// Any other inner — a type variable mid-inference, or two mismatched structural
+// kinds — is not reached by the flag's structural arm, so the whole reverse
+// constraint pins it.
+func needsResidualWriteBack(sub, sup soltype.Type) bool {
+	if _, ok := sub.(*soltype.ObjectType); ok {
+		_, ok := sup.(*soltype.ObjectType)
+		return !ok
 	}
-	var errs []SolverError
-	for _, elem := range targetObj.Elems {
-		p := soltype.AsProperty(elem)
-		// A readonly source field can't fill a writable target slot. The literal
-		// `obj.f = v` site is caught in inferMemberAssign; this arm fires on
-		// structural subtyping flows (call args, returns, re-bindings).
-		if !p.Readonly && sourceFieldIsReadonly(source, p.Name) {
-			errs = append(errs, &ReadonlyFieldSubtypeError{Field: p.Name})
-			continue
-		}
-		// A readonly target needs only the covariant read view above, so skip the
-		// invariance-pinning writeBack. This lets a more specific source field
-		// fill a readonly target.
-		if p.Readonly {
-			continue
-		}
-		if sourceObj, ok := source.(*soltype.ObjectType); ok {
-			if sp, ok := sourceObj.Prop(p.Name); ok {
-				errs = append(errs, c.constrain(p.Type, sp.Type, seen)...)
-			}
-		}
+	if _, ok := sub.(*soltype.TupleType); ok {
+		_, ok := sup.(*soltype.TupleType)
+		return !ok
 	}
-	// A non-object source (TypeVar, intersection, tuple) takes the prior whole-
-	// inner contravariant constraint; the readonly check above already inspected
-	// it via sourceFieldIsReadonly.
-	if _, ok := source.(*soltype.ObjectType); !ok {
-		errs = append(errs, c.constrain(target, source, seen)...)
-	}
-	return errs
+	return true
 }
 
-// sourceFieldIsReadonly reports whether `source`'s named field is readonly. An
-// intersection inherits readonly from any object member. A TypeVar's readonly
-// flows through mergeObjectGroup at coalesce time, so it's not consulted here.
-func sourceFieldIsReadonly(source soltype.Type, name string) bool {
-	switch s := source.(type) {
-	case *soltype.ObjectType:
-		if p, ok := s.Prop(name); ok {
-			return p.Readonly
-		}
-	case *soltype.IntersectionType:
-		for _, m := range s.Types {
-			if sourceFieldIsReadonly(m, name) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]) []SolverError {
+// constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: it
+// is true when the constraint sits inside a mutable borrow's inner, where the
+// object/tuple arms treat each named field invariantly rather than covariantly.
+// The RefType arm sets it from the target borrow's mutability, the object/tuple
+// arms propagate it into their fields, and the function and promise arms reset it,
+// since each carries its own annotation context.
+func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) []SolverError {
 	key := constraintKey{sub, super}
 	if seen.Contains(key) {
 		return nil
@@ -248,7 +205,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				}
 			}
 			for _, m := range subU.Types {
-				errs = append(errs, c.constrain(m, super, seen)...)
+				errs = append(errs, c.constrain(m, super, seen, mutCtx)...)
 			}
 			return errs
 		}
@@ -261,7 +218,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			var errs []SolverError
 			for _, m := range supI.Types {
-				errs = append(errs, c.constrain(sub, m, seen)...)
+				errs = append(errs, c.constrain(sub, m, seen, mutCtx)...)
 			}
 			return errs
 		}
@@ -281,7 +238,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				triedAny = true
 				p := newProbe(c.probe)
 				c.probe = p
-				errs := c.constrain(sub, m, seen.Clone())
+				errs := c.constrain(sub, m, seen.Clone(), mutCtx)
 				c.probe = p.parent
 				if len(errs) == 0 {
 					p.Commit()
@@ -359,12 +316,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// function is unreachable from M3 source anyway (resolveTypeAnn resolves no
 			// function annotations), so the extra positions are left unchecked here for
 			// now. For every M3-reachable input (exact functions only) the loop is complete.
+			// A function is its own annotation context, so the deep-mut flag does
+			// not flow into its parameters or return type.
 			var errs []SolverError
 			n := min(len(sub.Params), len(sup.Params))
 			for i := 0; i < n; i++ {
-				errs = append(errs, c.constrain(sup.Params[i].Type, sub.Params[i].Type, seen)...) // contravariant
+				errs = append(errs, c.constrain(sup.Params[i].Type, sub.Params[i].Type, seen, false)...) // contravariant
 			}
-			return append(errs, c.constrain(sub.Ret, sup.Ret, seen)...) // covariant
+			return append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...) // covariant
 		}
 	case *soltype.TupleType:
 		if sup, ok := super.(*soltype.TupleType); ok {
@@ -395,7 +354,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// `[A, ...]` lets the sub be longer, so sup is the shorter side.
 			// This walks the shared prefix and keeps sup.Elems[i] in bounds.
 			for i := range sup.Elems {
-				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen)...) // covariant
+				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen, mutCtx)...) // covariant read view
+				// Inside a mutable wrapper every element is invariant (PR 14): the
+				// contravariant write view pins it, mirroring the eager form's
+				// per-cell `mut`. Outside one, elements stay covariant.
+				if mutCtx {
+					errs = append(errs, c.constrain(sup.Elems[i], sub.Elems[i], seen, mutCtx)...)
+				}
 			}
 			return errs
 		}
@@ -433,7 +398,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					errs = append(errs, &OptionalPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
 					continue
 				}
-				errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen)...) // covariant
+				errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen, mutCtx)...) // covariant read view
+				// Inside a mutable wrapper (PR 14), a writable field is also
+				// invariant: the contravariant write view pins it, so combined with
+				// the read view above the field set is invariant. This is the
+				// per-field write pin the eager form's constrainWriteBack did. A
+				// readonly TARGET field needs only the read view, so a wider source
+				// can fill it. A readonly SOURCE field cannot fill a writable target
+				// slot, the structural-flow twin of inferMemberAssign's upfront check.
+				if mutCtx && !superProp.Readonly {
+					if subProp.Readonly {
+						errs = append(errs, &ReadonlyFieldSubtypeError{Field: superProp.Name})
+						continue
+					}
+					errs = append(errs, c.constrain(superProp.Type, subProp.Type, seen, mutCtx)...) // contravariant write view
+				}
 			}
 			// One-way exactness (02-design-notes §"Exactness"):
 			//   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
@@ -461,7 +440,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// `Promise<T>` (Awaited<T> lands in M9). When the two sides are unrelated
 			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
 			// CannotConstrainError below, matching the function/tuple/record arms.
-			return c.constrain(sub.Inner, sup.Inner, seen)
+			// A promise's payload is its own annotation context, so the deep-mut
+			// flag resets here.
+			return c.constrain(sub.Inner, sup.Inner, seen, false)
 		}
 	case *soltype.RefType:
 		// THE GATE (M4 C2): the single RefType <: RefType rule. The mut-driven inner
@@ -474,16 +455,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if !sub.Mut && sup.Mut {
 				return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
 			}
-			// 2. Inner variance: the read view is always covariant; a mutable target
-			//    also takes a contravariant write view, and read + write together make
-			//    every field the target NAMES invariant. The write view is per-field over
-			//    the target's named fields (constrainWriteBack), not a whole-object
-			//    constraint, so an INEXACT target tolerates extra fields on the source
-			//    while still pinning its named fields. So `mut {x, y} <: mut {x, ...}`
-			//    SUCCEEDS — the inexact target names only x, which stays invariant, and y
-			//    is hidden, not writable through the target — while `mut {x: 5} <: mut {x:
-			//    number}` still rejects (x invariant: number <: 5 fails) and an EXACT
-			//    target still demands an identical field set (the read view rejects extras).
+			// 2. Inner variance (PR 14): the read view is always covariant. A mutable
+			//    target also makes every field it NAMES invariant. That per-field
+			//    invariance is carried by the mut-context flag — set true here for a
+			//    mutable target — which the ObjectType/TupleType arms read to add the
+			//    contravariant write view per named field. An INEXACT target tolerates
+			//    extra fields on the source while still pinning its named fields. So
+			//    `mut {x, y} <: mut {x, ...}` SUCCEEDS — the inexact target names only
+			//    x, which stays invariant, and y is hidden, not writable through the
+			//    target — while `mut {x: 5} <: mut {x: number}` still rejects (x
+			//    invariant: number <: 5 fails) and an EXACT target still demands an
+			//    identical field set (the read view rejects extras).
 			//
 			//    A literal-typed field like the `5` in `mut {x: 5}` only arises from an
 			//    ANNOTATION. A field WRITE never produces one: inferMemberAssign builds the
@@ -492,15 +474,19 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//    mutation — a later write may store any number — so the stored literal widens
 			//    to its primitive before it becomes the field's type.
 			//
-			//    The write view gates on `sup.Mut`, which is load-bearing-equivalent to
+			//    The flag passes `sup.Mut`, which is load-bearing-equivalent to
 			//    `sub.Mut && sup.Mut`: the mutability check above already returned for
 			//    `!sub.Mut && sup.Mut`, so reaching here with sup.Mut implies sub.Mut.
-			//    If that earlier gate is ever weakened, re-gate the write view explicitly
+			//    If that earlier gate is ever weakened, re-gate the flag explicitly
 			//    or it would impose a spurious contravariant constraint on an immutable
 			//    source.
-			errs := c.constrain(sub.Inner, sup.Inner, seen)
-			if sup.Mut {
-				errs = append(errs, c.constrainWriteBack(sup.Inner, sub.Inner, seen)...)
+			errs := c.constrain(sub.Inner, sup.Inner, seen, sup.Mut)
+			// The structural arms only reach the write view when both inners are the
+			// same object/tuple kind. A non-structural inner — a type variable
+			// mid-inference, or two mismatched kinds — needs the whole reverse
+			// constraint to stay invariant, the write view's residual case.
+			if sup.Mut && needsResidualWriteBack(sub.Inner, sup.Inner) {
+				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen, false)...)
 			}
 			// 3. Lifetime outlives, covariant (M4 D2). Active now that borrows carry
 			//    lifetimes. D1 minted the sort. Each borrow site mints a lifetime:
@@ -528,7 +514,9 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sub.Lt != nil {
 				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
 			}
-			return c.constrain(sub.Inner, super, seen)
+			// Peeling an owned value into a bare slot is a covariant read, so the
+			// deep-mut flag resets.
+			return c.constrain(sub.Inner, super, seen, false)
 		}
 	case *soltype.Void:
 		if _, ok := super.(*soltype.Void); ok {
@@ -565,7 +553,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				c.probe = p
 				// A cloned seen keeps each arm's coinductive cache independent, so a failed
 				// arm's entries can't wrongly short-circuit a later arm to success.
-				errs := c.constrain(sub.Types[idx], super, seen.Clone())
+				errs := c.constrain(sub.Types[idx], super, seen.Clone(), mutCtx)
 				c.probe = p.parent
 				if len(errs) == 0 {
 					p.Commit()
@@ -588,7 +576,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	if sup, ok := super.(*soltype.RefType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			if inner, ok := sub.(soltype.RefInner); ok {
-				return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, sup, seen)
+				return c.constrain(&soltype.RefType{Mut: false, Lt: nil, Inner: inner}, sup, seen, mutCtx)
 			}
 		}
 	}
@@ -598,14 +586,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if soltype.LevelOf(super) <= subVar.Level {
 			c.addUpperBound(subVar, super)
 			var errs []SolverError
+			// A variable is a boundary for the deep-mut flag: each recorded bound
+			// carries its own RefType wrapper, which re-establishes the flag when it
+			// propagates, so the closure step itself runs flag-free.
 			for _, lb := range subVar.LowerBounds {
-				errs = append(errs, c.constrain(lb, super, seen)...)
+				errs = append(errs, c.constrain(lb, super, seen, false)...)
 			}
 			return errs
 		}
 		// super lives at an inner level: extrude it out so it isn't wrongly
 		// generalized at subVar's level.
-		return c.constrain(sub, c.extrude(super, soltype.Negative, subVar.Level, map[extrudeKey]*soltype.TypeVarType{}), seen)
+		return c.constrain(sub, c.extrude(super, soltype.Negative, subVar.Level, map[extrudeKey]*soltype.TypeVarType{}), seen, mutCtx)
 	}
 	// super is a variable: symmetric — record sub as a lower bound, propagate uppers.
 	if superVar, ok := super.(*soltype.TypeVarType); ok {
@@ -613,11 +604,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			c.addLowerBound(superVar, sub)
 			var errs []SolverError
 			for _, ub := range superVar.UpperBounds {
-				errs = append(errs, c.constrain(sub, ub, seen)...)
+				errs = append(errs, c.constrain(sub, ub, seen, false)...)
 			}
 			return errs
 		}
-		return c.constrain(c.extrude(sub, soltype.Positive, superVar.Level, map[extrudeKey]*soltype.TypeVarType{}), super, seen)
+		return c.constrain(c.extrude(sub, soltype.Positive, superVar.Level, map[extrudeKey]*soltype.TypeVarType{}), super, seen, mutCtx)
 	}
 
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -131,12 +131,10 @@ func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 }
 
 // needsResidualWriteBack reports whether a mutable borrow's inner needs an explicit
-// contravariant write view in the RefType arm (PR 14). The ObjectType and TupleType
-// arms pin their fields invariant via the mut-context flag, so a matched
-// object/object or tuple/tuple inner is already invariant and needs no residual.
-// Any other inner — a type variable mid-inference, or two mismatched structural
-// kinds — is not reached by the flag's structural arm, so the whole reverse
-// constraint pins it.
+// contravariant write view in the RefType arm (PR 14). The object/tuple arms pin
+// matched object/object and tuple/tuple inners via the mut-context flag, so those
+// need no residual. Any other inner — a type variable, or two mismatched kinds —
+// the flag's structural arm does not reach, so the whole reverse constraint pins it.
 func needsResidualWriteBack(sub, sup soltype.Type) bool {
 	if _, ok := sub.(*soltype.ObjectType); ok {
 		_, ok := sup.(*soltype.ObjectType)
@@ -149,12 +147,11 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 	return true
 }
 
-// constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: it
-// is true when the constraint sits inside a mutable borrow's inner, where the
-// object/tuple arms treat each named field invariantly rather than covariantly.
-// The RefType arm sets it from the target borrow's mutability, the object/tuple
-// arms propagate it into their fields, and the function and promise arms reset it,
-// since each carries its own annotation context.
+// constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: true
+// inside a mutable borrow's inner, where the object/tuple arms treat each named
+// field as invariant rather than covariant. The RefType arm sets it from the target
+// borrow's mutability, the object/tuple arms propagate it, and the function and
+// promise arms reset it since each carries its own annotation context.
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) []SolverError {
 	key := constraintKey{sub, super}
 	if seen.Contains(key) {
@@ -316,8 +313,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// function is unreachable from M3 source anyway (resolveTypeAnn resolves no
 			// function annotations), so the extra positions are left unchecked here for
 			// now. For every M3-reachable input (exact functions only) the loop is complete.
-			// A function is its own annotation context, so the deep-mut flag does
-			// not flow into its parameters or return type.
+			// A function is its own annotation context, so the deep-mut flag resets.
 			var errs []SolverError
 			n := min(len(sub.Params), len(sup.Params))
 			for i := 0; i < n; i++ {
@@ -356,8 +352,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			for i := range sup.Elems {
 				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen, mutCtx)...) // covariant read view
 				// Inside a mutable wrapper every element is invariant (PR 14): the
-				// contravariant write view pins it, mirroring the eager form's
-				// per-cell `mut`. Outside one, elements stay covariant.
+				// contravariant write view pins it. Outside one, elements stay covariant.
 				if mutCtx {
 					errs = append(errs, c.constrain(sup.Elems[i], sub.Elems[i], seen, mutCtx)...)
 				}
@@ -399,13 +394,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					continue
 				}
 				errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen, mutCtx)...) // covariant read view
-				// Inside a mutable wrapper (PR 14), a writable field is also
-				// invariant: the contravariant write view pins it, so combined with
-				// the read view above the field set is invariant. This is the
-				// per-field write pin the eager form's constrainWriteBack did. A
-				// readonly TARGET field needs only the read view, so a wider source
-				// can fill it. A readonly SOURCE field cannot fill a writable target
-				// slot, the structural-flow twin of inferMemberAssign's upfront check.
+				// Inside a mutable wrapper (PR 14), a writable field is invariant: the
+				// contravariant write view below pins it, the per-field write the eager
+				// form's constrainWriteBack did. A readonly TARGET needs only the read
+				// view, so a wider source can fill it; a readonly SOURCE cannot fill a
+				// writable target slot, the structural twin of inferMemberAssign's check.
 				if mutCtx && !superProp.Readonly {
 					if subProp.Readonly {
 						errs = append(errs, &ReadonlyFieldSubtypeError{Field: superProp.Name})
@@ -440,8 +433,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// `Promise<T>` (Awaited<T> lands in M9). When the two sides are unrelated
 			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
 			// CannotConstrainError below, matching the function/tuple/record arms.
-			// A promise's payload is its own annotation context, so the deep-mut
-			// flag resets here.
+			// A promise's payload is its own annotation context, so the flag resets.
 			return c.constrain(sub.Inner, sup.Inner, seen, false)
 		}
 	case *soltype.RefType:
@@ -455,36 +447,26 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if !sub.Mut && sup.Mut {
 				return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
 			}
-			// 2. Inner variance (PR 14): the read view is always covariant. A mutable
-			//    target also makes every field it NAMES invariant. That per-field
-			//    invariance is carried by the mut-context flag — set true here for a
-			//    mutable target — which the ObjectType/TupleType arms read to add the
-			//    contravariant write view per named field. An INEXACT target tolerates
-			//    extra fields on the source while still pinning its named fields. So
-			//    `mut {x, y} <: mut {x, ...}` SUCCEEDS — the inexact target names only
-			//    x, which stays invariant, and y is hidden, not writable through the
-			//    target — while `mut {x: 5} <: mut {x: number}` still rejects (x
-			//    invariant: number <: 5 fails) and an EXACT target still demands an
-			//    identical field set (the read view rejects extras).
+			// 2. Inner variance (PR 14): the read view is always covariant; a mutable
+			//    target also makes every field it NAMES invariant. That per-field pin is
+			//    carried by the mut-context flag, set to sup.Mut here, which the
+			//    ObjectType/TupleType arms read to add the contravariant write view. An
+			//    INEXACT target tolerates extra source fields while still pinning its
+			//    named ones, so `mut {x, y} <: mut {x, ...}` SUCCEEDS — the inexact target
+			//    names only x — while `mut {x: 5} <: mut {x: number}` still rejects (x
+			//    invariant) and an EXACT target demands an identical field set.
 			//
 			//    A literal-typed field like the `5` in `mut {x: 5}` only arises from an
-			//    ANNOTATION. A field WRITE never produces one: inferMemberAssign builds the
-			//    requirement with widen(source), so `obj.x = 5` lowers to `mut {x: number,
-			//    ...}`, not `mut {x: 5, ...}`. Writing through a mut receiver is itself a
-			//    mutation — a later write may store any number — so the stored literal widens
-			//    to its primitive before it becomes the field's type.
+			//    ANNOTATION. inferMemberAssign builds its requirement with widen(source),
+			//    so `obj.x = 5` lowers to `mut {x: number, ...}`, not `mut {x: 5, ...}`.
 			//
-			//    The flag passes `sup.Mut`, which is load-bearing-equivalent to
-			//    `sub.Mut && sup.Mut`: the mutability check above already returned for
-			//    `!sub.Mut && sup.Mut`, so reaching here with sup.Mut implies sub.Mut.
-			//    If that earlier gate is ever weakened, re-gate the flag explicitly
-			//    or it would impose a spurious contravariant constraint on an immutable
-			//    source.
+			//    The flag passes `sup.Mut`, equivalent to `sub.Mut && sup.Mut`: the check
+			//    above already returned for `!sub.Mut && sup.Mut`, so reaching here with
+			//    sup.Mut implies sub.Mut. If that gate is ever weakened, re-gate the flag.
 			errs := c.constrain(sub.Inner, sup.Inner, seen, sup.Mut)
-			// The structural arms only reach the write view when both inners are the
-			// same object/tuple kind. A non-structural inner — a type variable
-			// mid-inference, or two mismatched kinds — needs the whole reverse
-			// constraint to stay invariant, the write view's residual case.
+			// The arms above only reach the write view when both inners are the same
+			// object/tuple kind. Any other inner — a type variable, or two mismatched
+			// kinds — needs the whole reverse constraint to stay invariant.
 			if sup.Mut && needsResidualWriteBack(sub.Inner, sup.Inner) {
 				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen, false)...)
 			}
@@ -514,8 +496,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sub.Lt != nil {
 				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
 			}
-			// Peeling an owned value into a bare slot is a covariant read, so the
-			// deep-mut flag resets.
+			// Peeling an owned value into a bare slot is a covariant read; flag resets.
 			return c.constrain(sub.Inner, super, seen, false)
 		}
 	case *soltype.Void:
@@ -586,9 +567,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if soltype.LevelOf(super) <= subVar.Level {
 			c.addUpperBound(subVar, super)
 			var errs []SolverError
-			// A variable is a boundary for the deep-mut flag: each recorded bound
-			// carries its own RefType wrapper, which re-establishes the flag when it
-			// propagates, so the closure step itself runs flag-free.
+			// A variable is a boundary for the deep-mut flag: a recorded RefType bound
+			// re-establishes the flag when it propagates, so this step runs flag-free.
 			for _, lb := range subVar.LowerBounds {
 				errs = append(errs, c.constrain(lb, super, seen, false)...)
 			}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -100,7 +100,17 @@ func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 // redundant cache entries, not infinite loops. M4's recursive types (aliases,
 // letrec) must preserve this property — see m1-implementation-plan §3.3
 // "Forward requirements for the named-ref node design".
-type constraintKey struct{ sub, super soltype.Type }
+//
+// mutCtx is part of the key (PR 14): the same (sub, super) pair means something
+// different inside a mutable borrow's inner, where the object/tuple arms add the
+// contravariant write view, than in a covariant position. Keying without it would
+// let a covariant visit cache-skip a later invariant visit and drop the write-view
+// check. The flag is position-determined and takes two values, so it keeps the key
+// set finite and the recursion terminating.
+type constraintKey struct {
+	sub, super soltype.Type
+	mutCtx     bool
+}
 
 // extrudeKey keys extrude's per-extrusion cache by both the origin variable's
 // ID and the polarity it was reached in, so the same variable copied in
@@ -153,7 +163,7 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // borrow's mutability, the object/tuple arms propagate it, and the function and
 // promise arms reset it since each carries its own annotation context.
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) []SolverError {
-	key := constraintKey{sub, super}
+	key := constraintKey{sub, super, mutCtx}
 	if seen.Contains(key) {
 		return nil
 	}

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -3,7 +3,6 @@ package solver
 import (
 	"testing"
 
-	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -188,32 +187,26 @@ func TestReadonlyRendersOnReadField(t *testing.T) {
 	require.Equal(t, "fn (obj: {readonly a: number}) -> number", values["f"])
 }
 
-// applyDeepMut leaves a TypeVarType field untouched, the M4-expressible core of
-// `mut Foo<Point>` == `(mut Foo)<Point>` — full generics land in M7.
-func TestApplyDeepMutLeavesTypeParameterInert(t *testing.T) {
-	tv := &soltype.TypeVarType{ID: 99}
-	concrete := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-		&soltype.PropertyElem{Name: "x", Type: &soltype.PrimType{Prim: soltype.NumPrim}},
-	}}
-	inner := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
-		&soltype.PropertyElem{Name: "p", Type: tv},
-		&soltype.PropertyElem{Name: "q", Type: concrete},
-	}}
-	c := newChecker()
-	got := c.applyDeepMut(inner)
-	obj, ok := got.(*soltype.ObjectType)
-	require.True(t, ok)
+// --- PR 14: lazy deep-mut representation ---
 
-	// Type-parameter field: same pointer, no `mut` wrapper.
-	pProp, ok := obj.Prop("p")
-	require.True(t, ok)
-	require.Same(t, soltype.Type(tv), pProp.Type)
-
-	// Concrete object field: wrapped in owned-mutable.
-	qProp, ok := obj.Prop("q")
-	require.True(t, ok)
-	qRef, ok := qProp.Type.(*soltype.RefType)
-	require.True(t, ok)
-	require.True(t, qRef.Mut)
-	require.Nil(t, qRef.Lt)
+// Under the lazy form (PR 14), the mut-context flag pins a nested field invariant
+// inside a mutable wrapper. A field whose type is a strict subtype of the target's
+// field passes the covariant read view but fails the contravariant write view, so a
+// `mut {a: {x: number}}` value cannot fill a `mut {a: {x: number | string}}` slot —
+// the same invariance the eager per-cell `mut` lowering produced.
+func TestLazyDeepMutPinsNestedFieldInvariant(t *testing.T) {
+	src := "fn sink(q: mut {a: {x: number | string}}) {}\nfn f(p: mut {a: {x: number}}) { sink(p) }"
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{"cannot constrain string <: number"}, Messages(errs))
 }
+
+// The same shapes under an immutable wrapper are covariant, so the strict-subtype
+// field is accepted through ordinary width/depth subtyping. This is the contrast
+// that the mut-context flag draws: invariant inside a mutable wrapper, covariant
+// outside one.
+func TestImmutableWrapperKeepsNestedFieldCovariant(t *testing.T) {
+	src := "fn sink(q: {a: {x: number | string}}) {}\nfn f(p: {a: {x: number}}) { sink(p) }"
+	_, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+}
+

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -69,6 +69,22 @@ func TestDeepMutLowersFreshLiteral(t *testing.T) {
 	require.Equal(t, "mut {a: {b: {c: number}}}", values["w"])
 }
 
+// A fresh literal also upgrades into a target with an EXPLICIT nested `mut` field
+// (#779): stripOwnedMut peels the owned-mut cell so the immutable literal flows in
+// covariantly, the same the whole way down for tuples.
+func TestDeepMutLowersFreshLiteralIntoExplicitNestedMut(t *testing.T) {
+	t.Run("object", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val w: mut {a: mut {x: number}} = {a: {x: 0}}`)
+		require.Empty(t, errs)
+		require.Equal(t, "mut {a: mut {x: number}}", values["w"])
+	})
+	t.Run("tuple", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val w: mut [mut {x: number}] = [{x: 0}]`)
+		require.Empty(t, errs)
+		require.Equal(t, "mut [mut {x: number}]", values["w"])
+	})
+}
+
 // `readonly` rejects `obj.a = …` even on an owned-mutable enclosing object.
 func TestReadonlyRejectsFieldReassignment(t *testing.T) {
 	_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: number}) { obj.a = 5 }")

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -106,6 +106,18 @@ func TestExplicitBorrowOfBorrowFieldFlowsFieldLifetime(t *testing.T) {
 	})
 }
 
+// An explicit owned-mut field `mut {x}` borrowed with `&mut obj.a` peels the
+// owned-mut cell so the result is a clean `&mut {x: number}`. borrowInnerOf must
+// keep peeling owned-mut cells under the lazy form; routing the read through the
+// fresh check var instead would let the co-occurrence pass widen it to a union
+// and strip the borrow.
+func TestExplicitBorrowOfOwnedMutFieldPeels(t *testing.T) {
+	src := "fn f(p: mut {a: mut {x: number}}) { return &mut p.a }"
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {a: mut {x: number}}) -> &mut {x: number}", values["f"])
+}
+
 // A readonly source field can't fill a writable target slot, but the reverse is
 // fine. A readonly target supports only the covariant read view, so a wider
 // source can fill it through width subtyping.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -241,9 +241,10 @@ type ReadonlyFieldError struct {
 // non-readonly target field through structural subtyping under a mutable borrow:
 // a `mut {readonly a: T}` cannot fill a `mut {a: T}` slot, since the target view
 // would otherwise let a holder write through and break the source's readonly
-// contract. The check sits in constrainWriteBack, the contravariant write view of
-// a mutable borrow, and blames whatever site triggered the constraint, typically
-// the call argument or return that flows the value out.
+// contract. The check sits in the ObjectType <: ObjectType arm under the
+// mut-context flag, the contravariant write view of a mutable borrow, and blames
+// whatever site triggered the constraint, typically the call argument or return
+// that flows the value out.
 type ReadonlyFieldSubtypeError struct {
 	Field string
 	site  ast.Node

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -142,10 +142,12 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // escapes through a return or a module store still errors.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
-		// Constrain a fresh literal against the deep-mut annotation's immutable
-		// skeleton, then grant the deep-mut type. A fully fresh literal is uniquely
-		// owned at every level, so the upgrade is sound the whole way down.
-		c.constrain(init, initT, stripOwnedMut(ref.Inner))
+		// Constrain a fresh literal against the borrow's bare inner, then grant the
+		// owned-mutable type. Under the lazy deep-mut form (PR 14) the inner is the
+		// bare shape the user wrote, so the fresh literal flows into it covariantly
+		// with nothing to strip. A fully fresh literal is uniquely owned at every
+		// level, so the upgrade is sound the whole way down.
+		c.constrain(init, initT, ref.Inner)
 		return annT
 	}
 	if borrow, ok := c.reborrowAnnotation(initT, annT, lvl); ok {
@@ -187,34 +189,6 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 		return &soltype.RefType{Mut: false, Lt: c.ctx.freshLifetime(lvl), Inner: inner}, true
 	default:
 		return nil, false
-	}
-}
-
-// stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
-// cell (Mut set, Lt nil) and recursing through objects and tuples. Borrows are
-// left untouched.
-func stripOwnedMut(t soltype.Type) soltype.Type {
-	switch t := t.(type) {
-	case *soltype.RefType:
-		if t.Mut && t.Lt == nil {
-			return stripOwnedMut(t.Inner)
-		}
-		return t
-	case *soltype.ObjectType:
-		elems := make([]soltype.ObjTypeElem, len(t.Elems))
-		for i, e := range t.Elems {
-			p := soltype.AsProperty(e)
-			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: stripOwnedMut(p.Type), Optional: p.Optional, Readonly: p.Readonly}
-		}
-		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
-	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = stripOwnedMut(e)
-		}
-		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
-	default:
-		return t
 	}
 }
 

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -142,12 +142,14 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // escapes through a return or a module store still errors.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
-		// Constrain a fresh literal against the borrow's bare inner, then grant the
-		// owned-mutable type. Under the lazy deep-mut form (PR 14) the inner is the
-		// bare shape the user wrote, so the fresh literal flows into it covariantly
-		// with nothing to strip. A fully fresh literal is uniquely owned at every
-		// level, so the upgrade is sound the whole way down.
-		c.constrain(init, initT, ref.Inner)
+		// Constrain a fresh literal against the borrow's immutable skeleton, then
+		// grant the owned-mutable type. Under the lazy deep-mut form (PR 14) the inner
+		// is usually already bare, so stripOwnedMut is a no-op; an explicit nested
+		// `mut {x}` field (#779) still carries owned-mut cells, which the strip peels
+		// so the immutable fresh literal flows into them covariantly. A fully fresh
+		// literal is uniquely owned at every level, so the upgrade is sound the whole
+		// way down.
+		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}
 	if borrow, ok := c.reborrowAnnotation(initT, annT, lvl); ok {
@@ -189,6 +191,37 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 		return &soltype.RefType{Mut: false, Lt: c.ctx.freshLifetime(lvl), Inner: inner}, true
 	default:
 		return nil, false
+	}
+}
+
+// stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
+// cell (Mut set, Lt nil) and recursing through objects and tuples. Borrows are
+// left untouched. The lazy deep-mut form (PR 14) usually leaves nothing to strip,
+// since a plain `mut {a: {x}}` stores a bare inner; this peels the owned-mut cells
+// an explicit nested `mut {x}` field (#779) still carries, so a fresh literal can
+// upgrade into a deeply-mutable target the whole way down.
+func stripOwnedMut(t soltype.Type) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if t.Mut && t.Lt == nil {
+			return stripOwnedMut(t.Inner)
+		}
+		return t
+	case *soltype.ObjectType:
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: stripOwnedMut(p.Type), Optional: p.Optional, Readonly: p.Readonly}
+		}
+		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = stripOwnedMut(e)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+	default:
+		return t
 	}
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -693,10 +693,10 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// pass widen it into a union node that is not a `RefInner` and peel the borrow
 	// wrapper away. The pass widens because the mut-context flag pins the field
 	// invariant, so the same var occurs in both polarities.
-	chk := c.freshAt(lvl)
-	c.recordProv(chk, provNode, MemberAccess)
+	fieldVar := c.freshAt(lvl)
+	c.recordProv(fieldVar, provNode, MemberAccess)
 	propSelection := soltype.ObjectType{
-		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: chk}},
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: propName, Type: fieldVar}},
 		Inexact: true,
 	}
 	if e.Mut {
@@ -710,13 +710,13 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		c.constrain(e, recvCarrier, &propSelection)
 	}
 	// Choose the inner so the borrow wrapper survives. The co-occurrence pass
-	// peels any borrow whose inner is the bare check var `chk`, so giving the
+	// peels any borrow whose inner is the bare field var `fieldVar`, so giving the
 	// result a concrete inner is what keeps it rendering as a `RefType`. Pick
 	// the most precise shape available: a read-after-write cache hit first,
-	// then the property type from the receiver's annotation, and `chk` itself
+	// then the property type from the receiver's annotation, and `fieldVar` itself
 	// only when neither is known. borrowInnerOf peels owned-mut cells (deep-mut
 	// output) but leaves borrow fields intact so they keep their own lifetime.
-	var inner soltype.RefInner = chk
+	var inner soltype.RefInner = fieldVar
 	if cachedT != nil {
 		if ri, ok := borrowInnerOf(cachedT); ok {
 			inner = ri
@@ -738,7 +738,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// fieldReadBorrow makes the same wrap decision valueProp uses, so hover
 	// on the inner `obj.f` reads the same whether it stands alone or under
 	// `&obj.f` or `&mut obj.f`.
-	c.recordType(accessNode, c.fieldReadBorrow(chk, recv, propName, lvl))
+	c.recordType(accessNode, c.fieldReadBorrow(fieldVar, recv, propName, lvl))
 	c.recordType(e, target)
 	return target
 }
@@ -1400,7 +1400,7 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 }
 
 // valueMember reads property prop off a value receiver: it allocates a fresh
-// result var and constrains recv <: {prop: res, ...} — the basic form from the
+// result var and constrains recv <: {prop: fieldVar, ...} — the basic form from the
 // plan's §3.2 table. The requirement is INEXACT: a member read asks only that the
 // receiver has AT LEAST this property, so width tolerance is expressed as
 // inexactness rather than as an unconditionally width-tolerant arm.
@@ -1412,9 +1412,9 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 // the Policy-A close, rendering `{foo: number}`. The per-access requirement minted
 // here stays inexact; only the coalesced result is closed.
 //
-// The ObjectType <: ObjectType arm of constrain lowers res from the receiver's
-// matching property (so res coalesces to that property's type); a receiver missing
-// the property surfaces as a MissingPropertyError stamped with the member's span.
+// The ObjectType <: ObjectType arm of constrain lowers fieldVar from the receiver's
+// matching property (so fieldVar coalesces to that property's type); a receiver
+// missing the property surfaces as a MissingPropertyError stamped with the member's span.
 func (c *checker) valueMember(lvl int, e *ast.MemberExpr, recv soltype.Type) pathResult {
 	// Record the fresh result var against the .prop IDENTIFIER (not the whole
 	// MemberExpr), so a missing-property read blames the property (.foo), not the
@@ -1436,7 +1436,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// carry the field, so no additional requirement is needed here.
 	//
 	// Provenance is deliberately NOT recorded on the returned type. Unlike the fresh
-	// `res` below, the recorded type is SHARED — it also sits in the `written` map, in
+	// `fieldVar` below, the recorded type is SHARED — it also sits in the `written` map, in
 	// the write's requirement, and is handed to every read of this field — so it is not
 	// the freshly-minted unique pointer recordProv requires (recording it would panic
 	// under debugProv and mis-blame the other aliases). A later constraint failure on
@@ -1458,18 +1458,18 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	//     guard fires only when the borrow flows into an owned slot, not on a read.
 	//   - A non-borrow receiver is returned unchanged, leaving plain vars untouched.
 	recvCarrier := soltype.CarrierOf(recv)
-	res := c.freshAt(lvl)
-	// The member-requirement record {prop: res} is deliberately NOT recorded —
-	// MissingPropertyError blames this inner res var, so the record would be a dead
+	fieldVar := c.freshAt(lvl)
+	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
+	// MissingPropertyError blames this inner fieldVar, so the record would be a dead
 	// entry (§3.3).
-	c.recordProv(res, provNode, MemberAccess)
+	c.recordProv(fieldVar, provNode, MemberAccess)
 	c.constrain(blame, recvCarrier, &soltype.ObjectType{
-		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: res}},
+		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: fieldVar}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
 	// fieldReadBorrow takes the whole receiver and unwraps mut/lifetime internally,
 	// applying PR 4 rule 4 to produce the field-bounded borrow.
-	out := c.fieldReadBorrow(res, recv, name, lvl)
+	out := c.fieldReadBorrow(fieldVar, recv, name, lvl)
 	c.recordType(blame, out)
 	return pathResult{value: out}
 }
@@ -1483,24 +1483,24 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 // immutable borrow copies the borrow out flat rather than nesting, setting up
 // PR 9's nested-borrow normalization.
 //
-// A receiver whose shape is not statically known returns the existing `res`
-// var unchanged. A usage-inferred TypeVar carrier and an index path with no
+// A receiver whose shape is not statically known returns the existing `fieldVar`
+// unchanged. A usage-inferred TypeVar carrier and an index path with no
 // concrete property both fall into this branch. The inferred-receiver paths
 // keep their pre-PR-4 behaviour, so only annotated reference shapes pick up
 // the new borrow.
-func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, name string, lvl int) soltype.Type {
+func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Type, name string, lvl int) soltype.Type {
 	_, recvMut, recvLt := soltype.UnwrapRef(recv)
 	obj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType)
 	if !ok {
-		return res
+		return fieldVar
 	}
 	prop, ok := obj.Prop(name)
 	if !ok {
-		return res
+		return fieldVar
 	}
-	switch ft := prop.Type.(type) {
+	switch fieldType := prop.Type.(type) {
 	case *soltype.RefType:
-		if ft.Lt == nil {
+		if fieldType.Lt == nil {
 			// An owned-mutable field cell — an explicit `mut {x}` field, the awkward
 			// interior-mutability shape (#779). Read it as a receiver-bounded borrow,
 			// capping `mut` by the receiver's mutability. The lazy deep-mut form no
@@ -1510,18 +1510,18 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)
 			}
-			return &soltype.RefType{Mut: ft.Mut && recvMut, Lt: lt, Inner: ft.Inner}
+			return &soltype.RefType{Mut: fieldType.Mut && recvMut, Lt: lt, Inner: fieldType.Inner}
 		}
-		if !ft.Mut {
+		if !fieldType.Mut {
 			// Flat copy-out of an immutable borrow field. Immutable borrows are
 			// freely duplicable, so the read hands back the field's borrow at
 			// its own lifetime rather than nesting under the receiver's. A
 			// `&mut` field falls through to the no-wrap branch. Aliasing a
 			// mutable borrow needs the move-engine work in PR 6, and PR 9
 			// retires the depth-two `&mut &mut` shape entirely.
-			return ft
+			return fieldType
 		}
-		return res
+		return fieldVar
 	case *soltype.ObjectType, *soltype.TupleType:
 		// A bare object/tuple field is a value the receiver owns. Read it as a
 		// receiver-bounded borrow whose mutability follows the receiver (PR 14): a
@@ -1535,14 +1535,14 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 			// Mutable read: keep the concrete field shape as the borrow's inner, the
 			// role the eager form's owned-mut cell played, so a chained read `p.a.b.c`
 			// sees the nested structure and the borrow survives the co-occurrence pass.
-			// Routing it through `res` would pin the var invariant in both polarities
-			// and widen it into a union that peels the borrow.
-			return &soltype.RefType{Mut: true, Lt: lt, Inner: ft.(soltype.RefInner)}
+			// Routing it through `fieldVar` would pin the var invariant in both
+			// polarities and widen it into a union that peels the borrow.
+			return &soltype.RefType{Mut: true, Lt: lt, Inner: fieldType.(soltype.RefInner)}
 		}
 		// Immutable read: route through the fresh field-read var (PR 4).
-		return &soltype.RefType{Mut: false, Lt: lt, Inner: res}
+		return &soltype.RefType{Mut: false, Lt: lt, Inner: fieldVar}
 	default:
-		return res
+		return fieldVar
 	}
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -691,9 +691,8 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	//
 	// Routing the result through the fresh field var would let the
 	// co-occurrence pass widen it into a union node that is not a `RefInner`
-	// and peel the borrow wrapper away. The pass widens because `mut`
-	// constrainWriteBack pins the field invariant, so the same var occurs in
-	// both polarities.
+	// and peel the borrow wrapper away. The pass widens because the mut-context
+	// flag pins the field invariant, so the same var occurs in both polarities.
 	chk := c.freshAt(lvl)
 	c.recordProv(chk, provNode, MemberAccess)
 	propSelection := soltype.ObjectType{
@@ -745,17 +744,12 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime. It peels an owned-mut cell (deep-mut output) and
-// returns a bare object or tuple as-is, but returns ok=false for a borrow field
-// so the caller leaves the field's own borrow flowing through unchanged.
+// at the receiver's lifetime. Under the lazy deep-mut form (PR 14) a field's
+// value is the bare shape the user wrote, never a synthesized owned-mut cell, so
+// this is the ordinary RefInner cast: a bare object or tuple field re-wraps,
+// while a borrow field (a RefType, which is not a RefInner) returns ok=false so
+// the caller leaves the field's own borrow flowing through unchanged.
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
-	if r, ok := t.(*soltype.RefType); ok {
-		if r.Lt == nil {
-			ri, ok := r.Inner.(soltype.RefInner)
-			return ri, ok
-		}
-		return nil, false
-	}
 	ri, ok := t.(soltype.RefInner)
 	return ri, ok
 }
@@ -1104,8 +1098,8 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	recv := c.inferExpr(scope, lvl, m.Object)
 	w := widen(source)
 	// Catch a readonly write at the assignment site so the diagnostic blames it
-	// outright; a TypeVar receiver falls through to constrainWriteBack's structural
-	// message.
+	// outright; a TypeVar receiver falls through to the structural
+	// ReadonlyFieldSubtypeError the ObjectType write view raises.
 	if recvObj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType); ok {
 		if prop, ok := recvObj.Prop(m.Prop.Name); ok && prop.Readonly {
 			c.report(&ReadonlyFieldError{Field: m.Prop.Name, site: e})
@@ -1496,8 +1490,12 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 	switch ft := prop.Type.(type) {
 	case *soltype.RefType:
 		if ft.Lt == nil {
-			// Owned-mut field (deep-mut output): borrow it bounded by the receiver
-			// and keep `mut` only when the receiver itself grants a mutable view.
+			// An owned-mutable field cell — the user wrote an explicit `mut {x}`
+			// field, the awkward interior-mutability shape (#779). Read it as a
+			// receiver-bounded borrow, capping `mut` by the receiver's own
+			// mutability so an immutable receiver yields an immutable view. The
+			// lazy deep-mut form no longer mints these for a plain `mut {a: {x}}`;
+			// that field is a bare object, handled by the bare arm below.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)
@@ -1515,11 +1513,25 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 		}
 		return res
 	case *soltype.ObjectType, *soltype.TupleType:
-		_ = ft
+		// A bare object/tuple field is a value the receiver owns. Read it as a
+		// receiver-bounded borrow whose mutability follows the receiver (PR 14):
+		// a mutable receiver yields `&mut`, an immutable one `&`. This is where
+		// the lazy deep-mut rule lives — under `mut {a: {x}}`, reading `p.a`
+		// produces `&mut {x}`, so `p.a.x = 5` checks.
 		lt := recvLt
 		if lt == nil {
 			lt = c.ctx.freshLifetime(lvl)
 		}
+		if recvMut {
+			// Mutable read: keep the concrete field shape as the borrow's inner,
+			// the role the eager form's owned-mut cell played. A chained read
+			// (`p.a.b.c`) then sees the nested object/tuple structure, and the
+			// borrow survives the co-occurrence pass — routing a mutable field
+			// through the fresh `res` var would pin it invariant in both
+			// polarities and widen it into a union that peels the borrow.
+			return &soltype.RefType{Mut: true, Lt: lt, Inner: ft.(soltype.RefInner)}
+		}
+		// Immutable read: route through the fresh field-read var (PR 4).
 		return &soltype.RefType{Mut: false, Lt: lt, Inner: res}
 	default:
 		return res

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -689,10 +689,10 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 	// wires its Inner to the receiver's static property type when one is
 	// known, so the wrap survives coalescing.
 	//
-	// Routing the result through the fresh field var would let the
-	// co-occurrence pass widen it into a union node that is not a `RefInner`
-	// and peel the borrow wrapper away. The pass widens because the mut-context
-	// flag pins the field invariant, so the same var occurs in both polarities.
+	// Routing the result through the fresh field var would let the co-occurrence
+	// pass widen it into a union node that is not a `RefInner` and peel the borrow
+	// wrapper away. The pass widens because the mut-context flag pins the field
+	// invariant, so the same var occurs in both polarities.
 	chk := c.freshAt(lvl)
 	c.recordProv(chk, provNode, MemberAccess)
 	propSelection := soltype.ObjectType{
@@ -744,16 +744,15 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime. The lazy deep-mut form (PR 14) no longer
-// synthesizes owned-mut cells for a plain `mut {a: {x}}`, so a field is usually
-// the bare object/tuple the user wrote, returned by the ordinary RefInner cast.
-// Two cases still need handling, the same shapes fieldReadBorrow distinguishes:
-//   - An explicit `mut {x}` field is an owned-mut cell, a RefType with Lt nil.
-//     Peel it to its bare inner so `&mut obj.f` re-wraps a clean `{x}` rather than
-//     leaving the fresh check var, which the co-occurrence pass would widen into a
-//     union and strip the borrow.
-//   - A borrow field, a RefType with Lt set, returns ok=false so the caller leaves
-//     the field's own borrow flowing through unchanged.
+// at the receiver's lifetime. The lazy deep-mut form (PR 14) no longer synthesizes
+// owned-mut cells for a plain `mut {a: {x}}`, so a field is usually the bare
+// object/tuple the user wrote, returned by the ordinary RefInner cast. Two RefType
+// cases remain, the same shapes fieldReadBorrow distinguishes:
+//   - An explicit `mut {x}` field, Lt nil: peel to its bare inner so `&mut obj.f`
+//     re-wraps a clean `{x}` rather than the fresh check var, which the
+//     co-occurrence pass would widen into a union and strip the borrow.
+//   - A borrow field, Lt set: return ok=false so the field's own borrow flows
+//     through unchanged.
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 	if r, ok := t.(*soltype.RefType); ok {
 		if r.Lt == nil {
@@ -1502,12 +1501,11 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 	switch ft := prop.Type.(type) {
 	case *soltype.RefType:
 		if ft.Lt == nil {
-			// An owned-mutable field cell — the user wrote an explicit `mut {x}`
-			// field, the awkward interior-mutability shape (#779). Read it as a
-			// receiver-bounded borrow, capping `mut` by the receiver's own
-			// mutability so an immutable receiver yields an immutable view. The
-			// lazy deep-mut form no longer mints these for a plain `mut {a: {x}}`;
-			// that field is a bare object, handled by the bare arm below.
+			// An owned-mutable field cell — an explicit `mut {x}` field, the awkward
+			// interior-mutability shape (#779). Read it as a receiver-bounded borrow,
+			// capping `mut` by the receiver's mutability. The lazy deep-mut form no
+			// longer mints these for a plain `mut {a: {x}}`; that field is bare,
+			// handled by the bare arm below.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)
@@ -1526,21 +1524,19 @@ func (c *checker) fieldReadBorrow(res *soltype.TypeVarType, recv soltype.Type, n
 		return res
 	case *soltype.ObjectType, *soltype.TupleType:
 		// A bare object/tuple field is a value the receiver owns. Read it as a
-		// receiver-bounded borrow whose mutability follows the receiver (PR 14):
-		// a mutable receiver yields `&mut`, an immutable one `&`. This is where
-		// the lazy deep-mut rule lives — under `mut {a: {x}}`, reading `p.a`
-		// produces `&mut {x}`, so `p.a.x = 5` checks.
+		// receiver-bounded borrow whose mutability follows the receiver (PR 14): a
+		// mutable receiver yields `&mut`, an immutable one `&`. This is where the
+		// lazy deep-mut rule lives — under `mut {a: {x}}`, `p.a` reads `&mut {x}`.
 		lt := recvLt
 		if lt == nil {
 			lt = c.ctx.freshLifetime(lvl)
 		}
 		if recvMut {
-			// Mutable read: keep the concrete field shape as the borrow's inner,
-			// the role the eager form's owned-mut cell played. A chained read
-			// (`p.a.b.c`) then sees the nested object/tuple structure, and the
-			// borrow survives the co-occurrence pass — routing a mutable field
-			// through the fresh `res` var would pin it invariant in both
-			// polarities and widen it into a union that peels the borrow.
+			// Mutable read: keep the concrete field shape as the borrow's inner, the
+			// role the eager form's owned-mut cell played, so a chained read `p.a.b.c`
+			// sees the nested structure and the borrow survives the co-occurrence pass.
+			// Routing it through `res` would pin the var invariant in both polarities
+			// and widen it into a union that peels the borrow.
 			return &soltype.RefType{Mut: true, Lt: lt, Inner: ft.(soltype.RefInner)}
 		}
 		// Immutable read: route through the fresh field-read var (PR 4).

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -744,12 +744,24 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime. Under the lazy deep-mut form (PR 14) a field's
-// value is the bare shape the user wrote, never a synthesized owned-mut cell, so
-// this is the ordinary RefInner cast: a bare object or tuple field re-wraps,
-// while a borrow field (a RefType, which is not a RefInner) returns ok=false so
-// the caller leaves the field's own borrow flowing through unchanged.
+// at the receiver's lifetime. The lazy deep-mut form (PR 14) no longer
+// synthesizes owned-mut cells for a plain `mut {a: {x}}`, so a field is usually
+// the bare object/tuple the user wrote, returned by the ordinary RefInner cast.
+// Two cases still need handling, the same shapes fieldReadBorrow distinguishes:
+//   - An explicit `mut {x}` field is an owned-mut cell, a RefType with Lt nil.
+//     Peel it to its bare inner so `&mut obj.f` re-wraps a clean `{x}` rather than
+//     leaving the fresh check var, which the co-occurrence pass would widen into a
+//     union and strip the borrow.
+//   - A borrow field, a RefType with Lt set, returns ok=false so the caller leaves
+//     the field's own borrow flowing through unchanged.
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
+	if r, ok := t.(*soltype.RefType); ok {
+		if r.Lt == nil {
+			ri, ok := r.Inner.(soltype.RefInner)
+			return ri, ok
+		}
+		return nil, false
+	}
 	ri, ok := t.(soltype.RefInner)
 	return ri, ok
 }

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -79,5 +79,5 @@ func TestInferUnionAnnotationBorrowMember(t *testing.T) {
 		}
 	`)
 	require.Equal(t, []string(nil), Messages(errs))
-	require.Equal(t, "fn (r: mut {x: number}) -> void", values["check"])
+	require.Equal(t, "fn (r: &mut {x: number}) -> void", values["check"])
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -311,7 +311,7 @@ func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
 	p := newProbe(c.probe)
 	c.probe = p
-	errs := c.constrain(sub, super, set.NewSet[constraintKey]())
+	errs := c.constrain(sub, super, set.NewSet[constraintKey](), false)
 	c.probe = p.parent
 	p.Discard()
 	return len(errs) == 0

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -165,9 +165,10 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 
 // recordMutWriteView reflects a `mut` borrow's INVARIANCE into a polarity-recording
 // visitor (#737). The C2 constrain rule makes every field a `mut` target names
-// invariant — it adds a covariant read view and a contravariant write view
-// (constrainWriteBack) — but RefType.Accept walks the inner only covariantly (the
-// read view; see visitor.go). So a variable that appears only inside a `mut` field,
+// invariant — it adds a covariant read view and, under the mut-context flag, a
+// contravariant write view — but RefType.Accept walks the inner only covariantly
+// (the read view; see visitor.go). So a variable that appears only inside a `mut`
+// field,
 // such as the `v` in `fn (obj, v) { obj.x = v }`, would be seen in one polarity and
 // dropped by single-polarity elimination, severing the link between the field and
 // the value written into it.

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -226,72 +226,20 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 // outside RefInner) is a no-op in the value-types model: there is nothing to
 // borrow. It reports an unsupported feature rather than fabricating a borrow over
 // a type the wrapper cannot hold.
+// resolveMutableTypeAnn stores the lazy deep-mut form (PR 14): the inner is wrapped
+// in one owned-mutable RefType without rewriting its children. `mut {a: {x}}` stays
+// `mut {a: {x}}` rather than deepening to `mut {a: mut {x}}`. The deep-mut rule —
+// every nested object/tuple field is invariant and reads back mutable — is applied
+// at access and constrain time, via fieldReadBorrow's recvMut propagation and
+// constrain's mut-context flag, so the stored type matches the surface annotation.
 func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltype.Type, bool) {
 	ri, ok := c.borrowInner(ta.Target, lvl)
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "mut on a non-borrowable type"), false
 	}
-	t := soltype.NewRef(true, nil, c.applyDeepMut(ri))
+	t := soltype.NewRef(true, nil, ri)
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
-}
-
-// applyDeepMut deepens `ri` by wrapping every reachable bare object/tuple
-// component in owned-mut, returning the rebuilt RefInner. Type parameters and
-// value types (primitives, functions, promises) are inert; an already-borrow
-// field is left as-is. Rebuilt nodes inherit the source's provenance so
-// "expected here" spans survive. Hand-rolled rather than visitor-based to keep
-// that prov carry-through, matching widen.go.
-func (c *checker) applyDeepMut(ri soltype.RefInner) soltype.RefInner {
-	switch t := ri.(type) {
-	case *soltype.ObjectType:
-		elems := make([]soltype.ObjTypeElem, len(t.Elems))
-		for i, e := range t.Elems {
-			p := soltype.AsProperty(e)
-			elems[i] = &soltype.PropertyElem{
-				Name:     p.Name,
-				Type:     c.deepMutComponent(p.Type),
-				Optional: p.Optional,
-				Readonly: p.Readonly,
-			}
-		}
-		out := &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
-		c.inheritProv(out, t)
-		return out
-	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = c.deepMutComponent(e)
-		}
-		out := &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
-		c.inheritProv(out, t)
-		return out
-	default:
-		// A TypeVarType is inert, so it is returned unchanged.
-		return ri
-	}
-}
-
-// deepMutComponent wraps a bare object/tuple field or element in owned-mut and
-// recurses; every other shape passes through unchanged.
-func (c *checker) deepMutComponent(t soltype.Type) soltype.Type {
-	switch t := t.(type) {
-	case *soltype.ObjectType:
-		return &soltype.RefType{Mut: true, Inner: c.applyDeepMut(t)}
-	case *soltype.TupleType:
-		return &soltype.RefType{Mut: true, Inner: c.applyDeepMut(t)}
-	default:
-		return t
-	}
-}
-
-// inheritProv copies `from`'s provenance entry onto `to`, used by the deep-mut
-// walk so a rebuilt object or tuple keeps the original annotation's blame span.
-// Skips silently when `from` has no entry.
-func (c *checker) inheritProv(to, from soltype.Type) {
-	if o, ok := c.prov[from].(FromAST); ok {
-		c.recordProv(to, o.Node, o.Kind)
-	}
 }
 
 // borrowInner resolves the pointee of a `mut` or `&` annotation to a RefInner, the
@@ -325,10 +273,9 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
-	// `&mut` deepens the pointee like `mut` does; `&` leaves it untouched.
-	if ta.Mut {
-		ri = c.applyDeepMut(ri)
-	}
+	// The lazy deep-mut form (PR 14) stores `&mut {a: {x}}` verbatim; the deep-mut
+	// rule is applied at access and constrain time rather than by rewriting the
+	// pointee's children here.
 	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true


### PR DESCRIPTION
Replace the eager deep-mut lowering with a lazy representation that stores `mut` annotations verbatim and applies the deep-mut invariance rule at constraint and access time.

## Summary

The eager form synthesized owned-mutable RefType cells for every nested object and tuple field inside a `mut` annotation, then used a special `constrainWriteBack` pass to pin those fields invariant during subtyping. The lazy form stores the bare shape the user wrote and instead uses a `mutCtx` flag threaded through constraint checking to mark when a constraint sits inside a mutable borrow's inner. The ObjectType and TupleType arms read this flag to add a contravariant write view per named field, achieving the same invariance without rewriting the type.

## Key changes

- **constrain.go**: Add `mutCtx` boolean parameter to `constrain()` and propagate it through all recursive calls. The RefType arm sets it from `sup.Mut` when constraining the inner; ObjectType and TupleType arms add a contravariant write view when `mutCtx` is true; function and promise arms reset it to false since they carry their own annotation context. Replace `constrainWriteBack()` with `needsResidualWriteBack()`, a simple predicate that identifies when a non-structural inner (type variable or mismatched kinds) needs an explicit reverse constraint.

- **type_ann.go**: Remove `applyDeepMut()` and `deepMutComponent()` functions that synthesized owned-mut cells. Store `mut` annotations with their bare inner directly. Remove the deep-mut rewriting from `resolveRefTypeAnn()` for `&mut` borrows.

- **print.go**: Remove the `underMut` flag and `printTypeUM()` function that elided nested owned-mut cells. The printer now renders types verbatim since the stored form matches the surface annotation.

- **infer_expr.go**: Update `fieldReadBorrow()` to apply the lazy deep-mut rule: a bare object/tuple field under a mutable receiver yields `&mut`, under an immutable receiver yields `&`. Remove the comment about `constrainWriteBack` and update references to the mut-context flag.

- **infer_decl.go**: Remove `stripOwnedMut()` function. Simplify `constrainInitAgainstAnnotation()` to constrain against the bare inner directly since no owned-mut cells are synthesized.

- **errors.go**: Update `ReadonlyFieldSubtypeError` comment to reference the ObjectType write view instead of `constrainWriteBack`.

- **simplify.go**: Update comment about invariance recording to reference the mut-context flag instead of `constrainWriteBack`.

- **Tests**: Replace `TestApplyDeepMutLeavesTypeParameterInert` with two new tests (`TestLazyDeepMutPinsNestedFieldInvariant` and `TestImmutableWrapperKeepsNestedFieldCovariant`) that verify the lazy form pins nested fields invariant inside a mutable wrapper but keeps them covariant outside one. Update `TestPrintDeepMutElision` to `TestPrintLazyDeepMutVerbatim` and simplify test cases since no elision occurs. Add `TestExplicitBorrowOfOwnedMutFieldPeels` to verify that explicit `mut {x}` fields are still peeled correctly. Update `TestInferUnionAnnotationBorrowMember` fixture expectation.

## Implementation details

The mut-context flag is a boundary at type variables and when exiting annotation contexts (functions, promises, borrow peeling). Each recorded bound on a type variable carries its own RefType wrapper, which re-establishes the flag when the bound propagates during closure, so the closure step itself runs flag-free. This prevents spurious invariance constraints from leaking across variable boundaries.

The `needsResidualWriteBack()` check ensures that when both inners are the same structural kind (object/object or tuple/tuple), the per-field write views added by the ObjectType and TupleType arms are sufficient. Only non-structural inners—type variables mid-inference or mismatched kinds—need an explicit whole-inner reverse constraint.

https://claude.ai/code/session_01TotNCyzUgCEXbanhHoN4xS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of nested `mut` types, keeping user-written shapes visible in printed output and error messages.
  * Borrowing from mutable fields now preserves the expected mutable form more consistently.

* **Bug Fixes**
  * Fixed subtype checking for mutable wrappers so nested fields are treated correctly as invariant when needed.
  * Corrected type inference for object and tuple field reads under mutable borrows.
  * Updated type annotation handling to avoid overly eager type reshaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->