### PR TITLE
Make mutability uniformly deep through type arguments

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -261,7 +261,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		return soltype.EnterResult{}
 	}
 	rep := c.simp.rep(v)
-	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both() && !boundsPin(rep)
+	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both() && !hasEqualBounds(rep)
 	if c.seen.Contains(rep) {
 		// A cycle back to a variable already on the path: a retained type parameter
 		// keeps its name (a rough μ-reference, refined in M3's precise μ-rendering),
@@ -348,8 +348,8 @@ func renderScheme(s TypeScheme) string {
 	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
 }
 
-// boundsPin reports whether v is pinned to a single concrete type — its lower and
-// upper bound sets are non-empty and structurally equal — so it has no freedom as a
+// hasEqualBounds reports whether v's lower and upper bound sets are non-empty and
+// structurally equal, which pins it to a single concrete type: it has no freedom as a
 // type parameter and is inlined rather than retained. This arises for the receiver
 // var of a deep-mut nested write (#779): `obj.p.x = 5` makes obj.p invariant inside
 // the mut container, and the residual write-back gives it equal lower and upper
@@ -358,7 +358,7 @@ func renderScheme(s TypeScheme) string {
 // such as the `v` in `fn (obj, v) { obj.x = v }`, has no such matched bounds — its
 // invariance comes from the field write-view with no concrete bound on both sides —
 // so it is still retained.
-func boundsPin(v *soltype.TypeVarType) bool {
+func hasEqualBounds(v *soltype.TypeVarType) bool {
 	lo := withoutSelf(v, v.LowerBounds)
 	hi := withoutSelf(v, v.UpperBounds)
 	if len(lo) == 0 || len(hi) == 0 {
@@ -369,7 +369,7 @@ func boundsPin(v *soltype.TypeVarType) bool {
 
 // withoutSelf drops a vacuous self-reference (v <: v) from a bound list. The deep-mut
 // write chain can leave a var with a self-edge among its bounds; it constrains
-// nothing, so boundsPin ignores it when comparing the lower and upper bound sets.
+// nothing, so hasEqualBounds ignores it when comparing the lower and upper bound sets.
 func withoutSelf(v *soltype.TypeVarType, bounds []soltype.Type) []soltype.Type {
 	out := bounds[:0:0]
 	for _, b := range bounds {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -32,6 +32,7 @@ import (
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
+	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
 	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
@@ -82,6 +83,82 @@ func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type 
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
 	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
 	return t
+}
+
+// bubbleOwnedMut rewrites a coalesced display type so no owned-mutable cell ever
+// sits inside an immutable object or tuple (#779). `mut` is deep, so an owned-mut
+// field is equivalent to making the whole container `mut`: `{p: mut {x}}` means the
+// same as `mut {p: {x}}`. The nested form is the one the C3 field-write fold produces
+// for `obj.p.x = 5`, and it is no longer a valid annotation, so the rendered
+// signature must take the bubbled-up form to stay re-writable.
+//
+// It runs at DISPLAY time only, over the already-coalesced type — the operative
+// bounds the solver checks against are untouched, so this changes only how an
+// inferred signature is printed, never what it accepts. A `&`/`&mut` borrow field
+// carries a lifetime and references external storage, so it is left in place; only an
+// owned-mut cell (Mut set, Lt nil) bubbles.
+func bubbleOwnedMut(t soltype.Type) soltype.Type {
+	return t.Accept(&mutBubbler{}, soltype.Positive)
+}
+
+// mutBubbler is the rewriting visitor behind bubbleOwnedMut. The lift happens in
+// ExitType, bottom-up: by the time an object/tuple is exited its children are already
+// bubbled, so a child that bubbled to an owned-mut cell is visible here and lifts the
+// cell one level further out.
+type mutBubbler struct{}
+
+func (b *mutBubbler) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	return soltype.EnterResult{}
+}
+
+func (b *mutBubbler) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.ObjectType:
+		anyMut := false
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			ft := p.Type
+			if inner, isMut, lt := soltype.UnwrapRef(ft); isMut && lt == nil {
+				anyMut = true
+				ft = inner // strip the redundant cell; the container's `mut` covers it
+			}
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: ft, Optional: p.Optional, Readonly: p.Readonly}
+		}
+		obj := &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+		if anyMut {
+			return soltype.NewRef(true, nil, obj)
+		}
+		return obj
+	case *soltype.TupleType:
+		anyMut := false
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			if inner, isMut, lt := soltype.UnwrapRef(e); isMut && lt == nil {
+				anyMut = true
+				e = inner
+			}
+			elems[i] = e
+		}
+		tup := &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+		if anyMut {
+			return soltype.NewRef(true, nil, tup)
+		}
+		return tup
+	case *soltype.RefType:
+		// An owned-mut wrapper over an inner that itself bubbled to owned-mut would be a
+		// redundant `mut mut {…}`. Collapse it so the wrapper stays single.
+		if t.Mut && t.Lt == nil {
+			if inner, isMut, lt := soltype.UnwrapRef(t.Inner); isMut && lt == nil {
+				if ri, ok := inner.(soltype.RefInner); ok {
+					return &soltype.RefType{Mut: true, Lt: nil, Inner: ri}
+				}
+			}
+		}
+		return t
+	default:
+		return t
+	}
 }
 
 // widenVar lowers a widenable `var` binding's coalesced value to its primitive
@@ -151,6 +228,7 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 		genLevel: genLevel,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
+	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
 	// A scheme display is always coalesced from the Positive root.
 	return coalesceLifetimes(c, soltype.Positive) // D4: resolve borrow lifetimes to their display form
 }
@@ -183,7 +261,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		return soltype.EnterResult{}
 	}
 	rep := c.simp.rep(v)
-	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both()
+	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both() && !boundsPin(rep)
 	if c.seen.Contains(rep) {
 		// A cycle back to a variable already on the path: a retained type parameter
 		// keeps its name (a rough μ-reference, refined in M3's precise μ-rendering),
@@ -268,6 +346,61 @@ func renderScheme(s TypeScheme) string {
 		})
 	}
 	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
+}
+
+// boundsPin reports whether v is pinned to a single concrete type — its lower and
+// upper bound sets are non-empty and structurally equal — so it has no freedom as a
+// type parameter and is inlined rather than retained. This arises for the receiver
+// var of a deep-mut nested write (#779): `obj.p.x = 5` makes obj.p invariant inside
+// the mut container, and the residual write-back gives it equal lower and upper
+// bounds `{x: number, ...}`. Retaining it would surface a spurious `T0 & {x: number}`
+// where the pinned `{x: number}` is exact. A var with a genuine type-parameter role,
+// such as the `v` in `fn (obj, v) { obj.x = v }`, has no such matched bounds — its
+// invariance comes from the field write-view with no concrete bound on both sides —
+// so it is still retained.
+func boundsPin(v *soltype.TypeVarType) bool {
+	lo := withoutSelf(v, v.LowerBounds)
+	hi := withoutSelf(v, v.UpperBounds)
+	if len(lo) == 0 || len(hi) == 0 {
+		return false
+	}
+	return sameBoundSet(lo, hi)
+}
+
+// withoutSelf drops a vacuous self-reference (v <: v) from a bound list. The deep-mut
+// write chain can leave a var with a self-edge among its bounds; it constrains
+// nothing, so boundsPin ignores it when comparing the lower and upper bound sets.
+func withoutSelf(v *soltype.TypeVarType, bounds []soltype.Type) []soltype.Type {
+	out := bounds[:0:0]
+	for _, b := range bounds {
+		if bv, ok := b.(*soltype.TypeVarType); ok && bv == v {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+// sameBoundSet reports whether two bound lists hold structurally-equal types as sets,
+// ignoring order and multiplicity.
+func sameBoundSet(a, b []soltype.Type) bool {
+	return boundsSubset(a, b) && boundsSubset(b, a)
+}
+
+func boundsSubset(a, b []soltype.Type) bool {
+	for _, x := range a {
+		found := false
+		for _, y := range b {
+			if equalType(x, y) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // emptyOf returns the lattice identity for a polarity: never (⊥, the identity of

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -76,7 +76,7 @@ func TestDeepMutLowersFreshLiteral(t *testing.T) {
 // upgrades into that bare target.
 func TestNestedMutFieldAnnotationRejected(t *testing.T) {
 	want := []string{
-		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)",
+		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
 	}
 	t.Run("object", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val w: mut {a: mut {x: number}} = {a: {x: 0}}`)
@@ -174,7 +174,7 @@ func TestOwnedMutFieldAnnotationRejected(t *testing.T) {
 	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)",
+		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
 		"cannot constrain immutable t3 <: mutable object",
 	}, Messages(errs))
 }

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -54,9 +54,10 @@ func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			// The blame names the inner field-read result var rather than `object`.
+			// The inner field-read result is a fresh variable; the message resolves it
+			// to its concrete bound so it reads `object`, not an internal `t{N}`.
 			require.Equal(t, []string{
-				"cannot constrain immutable t3 <: mutable object",
+				"cannot constrain immutable object <: mutable object",
 			}, Messages(errs))
 		})
 	}
@@ -175,7 +176,7 @@ func TestOwnedMutFieldAnnotationRejected(t *testing.T) {
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
-		"cannot constrain immutable t3 <: mutable object",
+		"cannot constrain immutable object <: mutable object",
 	}, Messages(errs))
 }
 

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -69,19 +69,24 @@ func TestDeepMutLowersFreshLiteral(t *testing.T) {
 	require.Equal(t, "mut {a: {b: {c: number}}}", values["w"])
 }
 
-// A fresh literal also upgrades into a target with an EXPLICIT nested `mut` field
-// (#779): stripOwnedMut peels the owned-mut cell so the immutable literal flows in
-// covariantly, the same the whole way down for tuples.
-func TestDeepMutLowersFreshLiteralIntoExplicitNestedMut(t *testing.T) {
+// An explicit nested `mut` field or element inside a non-mut container is rejected at
+// the annotation site (#779): `mut {a: mut {x}}` and `mut [mut {x}]` each carry an
+// owned-mut cell on a field of an inner immutable container. The cell is recovered to
+// its bare inner so the surrounding annotation still resolves, and the fresh literal
+// upgrades into that bare target.
+func TestNestedMutFieldAnnotationRejected(t *testing.T) {
+	want := []string{
+		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)",
+	}
 	t.Run("object", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val w: mut {a: mut {x: number}} = {a: {x: 0}}`)
-		require.Empty(t, errs)
-		require.Equal(t, "mut {a: mut {x: number}}", values["w"])
+		require.Equal(t, want, Messages(errs))
+		require.Equal(t, "mut {a: {x: number}}", values["w"])
 	})
 	t.Run("tuple", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val w: mut [mut {x: number}] = [{x: 0}]`)
-		require.Empty(t, errs)
-		require.Equal(t, "mut [mut {x: number}]", values["w"])
+		require.Equal(t, want, Messages(errs))
+		require.Equal(t, "mut [{x: number}]", values["w"])
 	})
 }
 
@@ -122,16 +127,15 @@ func TestExplicitBorrowOfBorrowFieldFlowsFieldLifetime(t *testing.T) {
 	})
 }
 
-// An explicit owned-mut field `mut {x}` borrowed with `&mut obj.a` peels the
-// owned-mut cell so the result is a clean `&mut {x: number}`. borrowInnerOf must
-// keep peeling owned-mut cells under the lazy form; routing the read through the
-// fresh check var instead would let the co-occurrence pass widen it to a union
-// and strip the borrow.
-func TestExplicitBorrowOfOwnedMutFieldPeels(t *testing.T) {
-	src := "fn f(p: mut {a: mut {x: number}}) { return &mut p.a }"
+// Borrowing a field of a deep-mut container with `&mut obj.a` yields a clean
+// `&mut {x: number}`: the deep-mut read view of `a` off the mutable receiver is a
+// mutable borrow of its bare inner. Routing the read through the fresh check var
+// instead would let the co-occurrence pass widen it to a union and strip the borrow.
+func TestExplicitBorrowOfDeepMutFieldPeels(t *testing.T) {
+	src := "fn f(p: mut {a: {x: number}}) { return &mut p.a }"
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: mut {a: mut {x: number}}) -> &mut {x: number}", values["f"])
+	require.Equal(t, "fn (p: mut {a: {x: number}}) -> &mut {x: number}", values["f"])
 }
 
 // A readonly source field can't fill a writable target slot, but the reverse is
@@ -161,17 +165,17 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 	})
 }
 
-// An owned-mutable field through an immutable receiver is read-only: the
-// container's immutability reaches into the field via recvMut. The annotation
-// itself is the awkward part — `{a: mut {x}}` shouldn't be writable as a user
-// type at all, since interior mutability is the proper mechanism (#618). #779
-// tracks rejecting the annotation outright once inference is updated to never
-// produce the same shape in a return type.
-func TestOwnedMutFieldThroughImmutableReceiverRejectsWrite(t *testing.T) {
+// An owned-mutable field inside an immutable container — `{a: mut {x}}` — is now
+// rejected at the annotation site (#779): interior mutability is the proper mechanism
+// for that case (#618), and inference never produces the shape either, so the type is
+// no longer reachable. The annotation reports MutFieldError and recovers to the bare
+// `{a: {x}}`; the body's write through the immutable receiver then fails as before.
+func TestOwnedMutFieldAnnotationRejected(t *testing.T) {
 	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
+		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)",
+		"cannot constrain immutable t3 <: mutable object",
 	}, Messages(errs))
 }
 
@@ -236,5 +240,60 @@ func TestImmutableWrapperKeepsNestedFieldCovariant(t *testing.T) {
 	src := "fn sink(q: {a: {x: number | string}}) {}\nfn f(p: {a: {x: number}}) { sink(p) }"
 	_, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
+}
+
+// --- #779: no owned-mutable field inside a non-mut container ---
+
+// A `&`/`&mut` borrow field inside a non-mut container stays legal: it references
+// external storage, not an interior owned-mutable cell, so #779 leaves it alone.
+func TestBorrowFieldInImmutableContainerIsLegal(t *testing.T) {
+	t.Run("shared borrow field", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn f(p: {a: &{x: number}}) -> &{x: number} { return p.a }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn <'a>(p: {a: &'a {x: number}}) -> &'a {x: number}", values["f"])
+	})
+	t.Run("mutable borrow field", func(t *testing.T) {
+		values, _, errs := inferSource(t, "fn f(p: {a: &mut {x: number}}) { p.a.x = 5 }")
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: {a: &mut {x: number}}) -> void", values["f"])
+	})
+}
+
+// The #779 round-trip: a nested write infers a mut container whose displayed
+// signature is a valid annotation, and a caller passing exactly that displayed type
+// is accepted. Inference never produces a `mut` field inside a non-mut container, so
+// what it prints can always be written back.
+func TestNestedWriteInfersMutContainerAndRoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "one level",
+			src:  "fn foo(obj) { obj.p.x = 5 }",
+			want: "fn (obj: mut {p: {x: number}}) -> void",
+		},
+		{
+			name: "three levels",
+			src:  "fn foo(obj) { obj.a.b.c = 5 }",
+			want: "fn (obj: mut {a: {b: {c: number}}}) -> void",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values["foo"])
+		})
+	}
+
+	// Re-feeding the displayed type as a caller's annotation type-checks, so the
+	// signature genuinely round-trips.
+	t.Run("round-trip caller", func(t *testing.T) {
+		src := "fn foo(obj) { obj.p.x = 5 }\nfn caller(a: mut {p: {x: number}}) { foo(a) }"
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
 }
 

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR 13: deep `mut`, type-parameter inertness, and `readonly` ---
+// --- PR 13: deep, uniform `mut` and `readonly` ---
 
 // `mut` is deep: every nested layer becomes writable, so `p.a.x = 5` is legal
 // through `mut {a: {x}}` and `&mut {a: {x}}`.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -956,7 +956,7 @@ func (e *BorrowEscapeError) Message() string {
 func (e *MutFieldError) Span() ast.Span      { return e.Ann.Span() }
 func (e *MutFieldError) Related() []ast.Span { return nil }
 func (e *MutFieldError) Message() string {
-	return "owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)"
+	return "owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability"
 }
 
 func (e *ReadonlyFieldError) Span() ast.Span      { return spanOfNode(e.site) }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -228,6 +228,18 @@ type InexactTupleSpreadError struct {
 	Operand *soltype.TupleType
 }
 
+// MutFieldError fires when a `mut T` annotation appears as an object property
+// value or a tuple element inside a non-mut container — `{a: mut {x}}` or
+// `[mut {x}]`. An owned-mutable cell nested inside an immutable container is
+// misleading: the enclosing container's immutability already reaches into the
+// field, so the field is not actually writable, and interior mutability (#618) is
+// the proper mechanism for the case the user wants. A borrow field (`&T`,
+// `&mut T`) is a reference to external storage, not an interior owned-mutable
+// cell, so it stays legal. The annotation node carries the blame span.
+type MutFieldError struct {
+	Ann *ast.MutableTypeAnn
+}
+
 // ReadonlyFieldError fires on a literal field-assignment `obj.f = …` whose target
 // field is declared `readonly`. The assignment-site check lives in
 // inferMemberAssign, which catches the case directly so the diagnostic blames the
@@ -251,6 +263,7 @@ type ReadonlyFieldSubtypeError struct {
 }
 
 func (*CannotConstrainError) isSolverError()      {}
+func (*MutFieldError) isSolverError()             {}
 func (*ReadonlyFieldError) isSolverError()        {}
 func (*ReadonlyFieldSubtypeError) isSolverError() {}
 func (*FuncArityMismatchError) isSolverError()    {}
@@ -938,6 +951,12 @@ func (e *MutabilityMismatchError) Message() string {
 func (e *BorrowEscapeError) Message() string {
 	return fmt.Sprintf("borrowed value %s does not live long enough to satisfy %s",
 		describe(e.Sub), describe(e.Super))
+}
+
+func (e *MutFieldError) Span() ast.Span      { return e.Ann.Span() }
+func (e *MutFieldError) Related() []ast.Span { return nil }
+func (e *MutFieldError) Message() string {
+	return "owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or wait for interior mutability (#618)"
 }
 
 func (e *ReadonlyFieldError) Span() ast.Span      { return spanOfNode(e.site) }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -945,7 +945,40 @@ func (e *OptionalPropertyError) Message() string {
 
 func (e *MutabilityMismatchError) Message() string {
 	return fmt.Sprintf("cannot constrain immutable %s <: mutable %s",
-		describe(e.Sub.Inner), describe(e.Super.Inner))
+		describeBorrowInner(e.Sub.Inner), describeBorrowInner(e.Super.Inner))
+}
+
+// describeBorrowInner renders the pointee of a borrow for a diagnostic. An immutable
+// field read routes its result through a fresh field-read variable (fieldReadBorrow),
+// so the borrow's inner can be an inference variable whose raw `t{N}` name means
+// nothing to a user. When it is, resolve it to a concrete bound so the message names
+// the actual shape — `immutable object`, not `immutable t3`. Prefer a lower bound, the
+// value that flowed in; fall back to an upper bound, then to the bare variable when it
+// carries no concrete bound.
+func describeBorrowInner(t soltype.Type) string {
+	if v, ok := t.(*soltype.TypeVarType); ok {
+		if b, ok := concreteBoundOf(v); ok {
+			return describe(b)
+		}
+	}
+	return describe(t)
+}
+
+// concreteBoundOf returns a non-variable bound of v, preferring lower bounds, or
+// ok=false when every bound is itself a variable or v has none. It never recurses
+// through a variable bound, so it cannot loop on a cyclic bound graph.
+func concreteBoundOf(v *soltype.TypeVarType) (soltype.Type, bool) {
+	for _, b := range v.LowerBounds {
+		if _, isVar := b.(*soltype.TypeVarType); !isVar {
+			return b, true
+		}
+	}
+	for _, b := range v.UpperBounds {
+		if _, isVar := b.(*soltype.TypeVarType); !isVar {
+			return b, true
+		}
+	}
+	return nil, false
 }
 
 func (e *BorrowEscapeError) Message() string {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -144,11 +144,11 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
 		// Constrain a fresh literal against the borrow's immutable skeleton, then
 		// grant the owned-mutable type. Under the lazy deep-mut form (PR 14) the inner
-		// is usually already bare, so stripOwnedMut is a no-op; an explicit nested
-		// `mut {x}` field (#779) still carries owned-mut cells, which the strip peels
-		// so the immutable fresh literal flows into them covariantly. A fully fresh
-		// literal is uniquely owned at every level, so the upgrade is sound the whole
-		// way down.
+		// is already bare, and a nested `mut {x}` field inside a non-mut container is
+		// now rejected at the annotation site (#779), so stripOwnedMut is a defensive
+		// no-op here. It is kept so a fresh literal still flows covariantly into any
+		// owned-mut cell that reaches this point. A fully fresh literal is uniquely
+		// owned at every level, so the upgrade is sound the whole way down.
 		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}
@@ -196,10 +196,11 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 
 // stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
 // cell (Mut set, Lt nil) and recursing through objects and tuples. Borrows are
-// left untouched. The lazy deep-mut form (PR 14) usually leaves nothing to strip,
-// since a plain `mut {a: {x}}` stores a bare inner; this peels the owned-mut cells
-// an explicit nested `mut {x}` field (#779) still carries, so a fresh literal can
-// upgrade into a deeply-mutable target the whole way down.
+// left untouched. Under the lazy deep-mut form (PR 14) a plain `mut {a: {x}}` stores
+// a bare inner, and a nested `mut {x}` field inside a non-mut container is now
+// rejected at the annotation site (#779), so there is usually nothing to strip; the
+// peel is retained defensively so a fresh literal can upgrade into any deeply-mutable
+// target the whole way down.
 func stripOwnedMut(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.RefType:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1106,7 +1106,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		// name, so emit nothing further and recover to void.
 		return voidT
 	}
-	recv := c.inferExpr(scope, lvl, m.Object)
+	recv := c.inferWriteReceiver(scope, lvl, m.Object)
 	w := widen(source)
 	// Catch a readonly write at the assignment site so the diagnostic blames it
 	// outright; a TypeVar receiver falls through to the structural
@@ -1144,6 +1144,82 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	// `void` recovery type inferAssign recorded on e before dispatching here.
 	c.recordType(e, w)
 	return w
+}
+
+// inferWriteReceiver infers the receiver of a field write `recv.prop = …`. Each
+// member/index step in the receiver CHAIN imposes a MUTABLE requirement on its own
+// receiver rather than the immutable read a plain access would, so writing one nested
+// field marks the whole container `mut` (#779): `fn foo(obj) { obj.p.x = 5 }` infers
+// `obj: mut {p: …}`, the mutability propagating up to the outermost container. The
+// alternative — an owned-mut cell on the inner field inside an immutable container —
+// is no longer a valid annotation, so inference must not produce it.
+//
+// Only the direct receiver of an assignment takes this path; a plain read elsewhere
+// in the body stays immutable. A bare identifier reads through ordinary inferExpr,
+// since there is no enclosing container to mark.
+func (c *checker) inferWriteReceiver(scope *Scope, lvl int, e ast.Expr) soltype.Type {
+	switch e := e.(type) {
+	case *ast.MemberExpr:
+		if e.OptChain || e.Prop == nil || e.Prop.Name == "" {
+			return c.inferExpr(scope, lvl, e)
+		}
+		recv := c.inferWriteReceiver(scope, lvl, e.Object)
+		return c.mutFieldRead(lvl, e, e.Prop, e.Prop.Name, recv)
+	case *ast.IndexExpr:
+		// A constant-string index `obj["p"].x = …` reads the same field `obj.p` would,
+		// so it propagates mutability the same way. A dynamic key is not a supported
+		// place and falls through to the ordinary path.
+		if name, ok := constStringKey(e.Index); ok && !e.OptChain {
+			recv := c.inferWriteReceiver(scope, lvl, e.Object)
+			return c.mutFieldRead(lvl, e, e.Index, name, recv)
+		}
+		return c.inferExpr(scope, lvl, e)
+	default:
+		return c.inferExpr(scope, lvl, e)
+	}
+}
+
+// mutFieldRead reads property `name` off `recv` as the receiver of a write chain.
+// When the receiver's shape is still an inference variable, it imposes a MUTABLE
+// requirement `mut {name: fieldVar, ...}` so the inferred container folds `mut` at
+// coalesce time (#779) and hands back a mutable borrow of the field, the deep-mut read
+// view, so a deeper write relates the field covariantly under the mut-context
+// invariance. When the receiver is already concrete — an annotated `mut {…}` or a
+// borrow — it defers to valueProp's ordinary read: the deep-mut machinery already
+// yields a mutable borrow off a mut receiver, and imposing a fresh inexact requirement
+// would clash with the annotation's exact shape under the write-back. blame is the
+// access node a constraint failure points at; provNode is the node the fresh field
+// var's provenance records.
+func (c *checker) mutFieldRead(lvl int, blame ast.Node, provNode ast.Node, name string, recv soltype.Type) soltype.Type {
+	// Read-after-write (M4 C3): a field already written to the same receiver var
+	// returns the recorded concrete type, the same shortcut valueProp takes.
+	if c.fn != nil {
+		if v, ok := recv.(*soltype.TypeVarType); ok {
+			if t, found := c.fn.written[fieldKey{recvID: v.ID, field: name}]; found {
+				c.recordType(blame, t)
+				return t
+			}
+		}
+	}
+	if _, isVar := soltype.CarrierOf(recv).(*soltype.TypeVarType); !isVar {
+		// Concrete receiver: a plain read composes the chain correctly.
+		return c.valueProp(lvl, blame, provNode, name, recv).value
+	}
+	fieldVar := c.freshAt(lvl)
+	c.recordProv(fieldVar, provNode, MemberAccess)
+	c.constrain(blame, recv, &soltype.RefType{
+		Mut: true,
+		// A fresh lifetime imposes no obligation on the receiver (D2), matching the
+		// leaf write requirement in inferMemberAssign.
+		Lt: c.ctx.freshLifetime(lvl),
+		Inner: &soltype.ObjectType{
+			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: fieldVar}},
+			Inexact: true,
+		},
+	})
+	out := soltype.NewRef(true, c.ctx.freshLifetime(lvl), fieldVar)
+	c.recordType(blame, out)
+	return out
 }
 
 // recordWritten remembers that field `name` of receiver `recv` was written with
@@ -1501,11 +1577,13 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 	switch fieldType := prop.Type.(type) {
 	case *soltype.RefType:
 		if fieldType.Lt == nil {
-			// An owned-mutable field cell — an explicit `mut {x}` field, the awkward
-			// interior-mutability shape (#779). Read it as a receiver-bounded borrow,
-			// capping `mut` by the receiver's mutability. The lazy deep-mut form no
-			// longer mints these for a plain `mut {a: {x}}`; that field is bare,
-			// handled by the bare arm below.
+			// An owned-mutable field cell — formerly an explicit `mut {x}` field, the
+			// awkward interior-mutability shape now rejected at the annotation site
+			// (#779). Read it as a receiver-bounded borrow, capping `mut` by the
+			// receiver's mutability. The lazy deep-mut form does not mint these for a
+			// plain `mut {a: {x}}`; that field is bare, handled by the bare arm below.
+			// This arm is therefore defensive — kept for any owned-mut cell that still
+			// reaches a read.
 			lt := recvLt
 			if lt == nil {
 				lt = c.ctx.freshLifetime(lvl)

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -92,13 +92,16 @@ func TestInferMemberAssignWriteAfterRead(t *testing.T) {
 	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
 }
 
-// A write through a nested receiver wraps only the INNER object in `mut`: `obj` is
-// read for `.p` but never written, so it stays immutable, while `obj.p` is the
-// mutable cell that field `x` is written through. The mut wrap is per-receiver.
+// A write through a nested receiver marks the WHOLE container `mut` (#779): writing
+// `obj.p.x` makes `obj` itself mutable rather than nesting an owned-mut cell on the
+// `p` field. `mut` is deep, so `mut {p: {x: number}}` already makes `p.x` writable,
+// and unlike the rejected `{p: mut {x: number}}` it is a valid annotation — the
+// displayed signature round-trips. The cost is precision: a caller must pass a mutable
+// container even though only the nested field is written.
 func TestInferMemberAssignNestedReceiver(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.p.x = 5 }")
 	require.Empty(t, errs)
-	require.Equal(t, "fn (obj: {p: mut {x: number}}) -> void", values["foo"])
+	require.Equal(t, "fn (obj: mut {p: {x: number}}) -> void", values["foo"])
 }
 
 // An `open` param's written object stays row-polymorphic: the C3 fold passes the

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -422,7 +422,7 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 		// rejects a caller passing the exact `{x: number}` the displayed signature
 		// shows, breaking the round-trip. Close BOTH bound directions so the operative
 		// type matches the display, which inlines the pinned var to its exact bound.
-		if boundsPin(v) {
+		if hasEqualBounds(v) {
 			v.UpperBounds = foldUsageBounds(v.UpperBounds, v.Open)
 			v.LowerBounds = foldUsageBounds(v.LowerBounds, v.Open)
 			continue

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -411,7 +411,23 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 	propagateOpen(vars)
 
 	for id, v := range vars {
-		if v.Open || v.Level <= lvl || len(v.LowerBounds) > 0 {
+		if v.Open || v.Level <= lvl {
+			continue
+		}
+		// A deep-mut nested-write receiver, such as obj.p in `obj.p.x = 5` (#779), is
+		// PINNED: the residual write-back gives it equal inexact lower and upper bounds
+		// `{x: number, ...}`. It occurs in both polarities (invariant inside the mut
+		// container), so the negative-only test below skips it, yet it must still seal
+		// to an EXACT inner — otherwise the operative invariance check `t <: caller.p`
+		// rejects a caller passing the exact `{x: number}` the displayed signature
+		// shows, breaking the round-trip. Close BOTH bound directions so the operative
+		// type matches the display, which inlines the pinned var to its exact bound.
+		if boundsPin(v) {
+			v.UpperBounds = foldUsageBounds(v.UpperBounds, v.Open)
+			v.LowerBounds = foldUsageBounds(v.LowerBounds, v.Open)
+			continue
+		}
+		if len(v.LowerBounds) > 0 {
 			continue
 		}
 		o := occ[id]

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -130,7 +130,17 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 		// the object shape cascade-safe — mirroring the Promise<bad> recovery.
 		var ft soltype.Type = c.freshAt(lvl)
 		if prop.Value != nil {
-			if t, ok := c.resolveTypeAnn(prop.Value, lvl); ok {
+			value := prop.Value
+			// An owned-mutable field `{a: mut {x}}` is rejected (#779): a `mut` cell
+			// nested inside a non-mut container is misleading, since the container's
+			// immutability already reaches into the field. Recover to the field's bare
+			// inner so the object keeps a sensible shape. A `&`/`&mut` borrow field is a
+			// reference to external storage, not an interior cell, so it stays legal.
+			if mta, ok := value.(*ast.MutableTypeAnn); ok {
+				c.report(&MutFieldError{Ann: mta})
+				value = mta.Target
+			}
+			if t, ok := c.resolveTypeAnn(value, lvl); ok {
 				ft = t
 			}
 		}
@@ -157,6 +167,14 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 		if _, isRest := el.(*ast.RestSpreadTypeAnn); isRest {
 			unsupported = true
 			continue
+		}
+		// An owned-mutable element `[mut {x}]` is rejected (#779), the tuple twin of
+		// the object-property rejection above: a `mut` cell nested inside a non-mut
+		// container is misleading. Recover to the element's bare inner. A `&`/`&mut`
+		// borrow element stays legal — it references external storage.
+		if mta, ok := el.(*ast.MutableTypeAnn); ok {
+			c.report(&MutFieldError{Ann: mta})
+			el = mta.Target
 		}
 		if t, ok := c.resolveTypeAnn(el, lvl); ok {
 			elems = append(elems, t)

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -48,13 +48,15 @@ The move-engine work, PRs 1 through 8, builds only on this M4 substrate. The
 type-former PRs, 9 and 10, additionally depend on **M6** of
 [planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md), which lands
 union and intersection formers together with union-scrutinee narrowing. PR 11, the
-connected-component moves, is a further move-engine extension and stays on M4. PR 12,
-`Freeze`/`Thaw`, additionally depends on **M9**, the mapped and conditional type
-operators. PR 13, deep `mut` with `readonly`, is foundational mut-semantics work that
-stays on M4 and is best sequenced early, since PR 12 and the affine model's mutability
-all build on it. PR 14 reshapes the PR 13 representation from an eager lowering to a
-lazy one that stores the surface annotation, also on M4. So PRs 1 through 8, 11, 13,
-and 14 can proceed once M4 is in place, 9 and 10 wait on M6, and 12 waits on M9.
+connected-component moves, is a further move-engine extension and stays on M4. PR 12 is
+retired: because mutability is uniformly deep, the freeze/thaw binding moves (PR 8) and
+the connected-component move (PR 11) already convert a whole graph between mutable and
+immutable, so no `Freeze`/`Thaw` mapped type and no M9 dependency remain. PR 13, deep
+uniform `mut` with `readonly`, is foundational mut-semantics work that stays on M4 and
+is best sequenced early, since the affine model's mutability builds on it. PR 14
+reshapes the PR 13 representation from an eager lowering to a lazy one that stores the
+surface annotation, also on M4. So PRs 1 through 8, 11, 13, and 14 can proceed once M4
+is in place, and 9 and 10 wait on M6.
 
 ## Parsing borrows without a syntax mode
 
@@ -248,8 +250,8 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium |
 | 11 | Connected-component moves for graphs | 6, 7 | Large |
-| 12 | `Freeze`/`Thaw` deep mut↔immut utility types | 8, 11, 13, M9 | Large |
-| 13 | Deep `mut`, type-parameter inertness, and `readonly` | 1, 2 | Medium |
+| 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — |
+| 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
@@ -647,52 +649,40 @@ binding is rejected.
 Acceptance: a self-contained graph, cyclic or acyclic, can be returned or stored;
 externally-aliased nodes still error.
 
-### PR 12 — `Freeze`/`Thaw` deep mut↔immut utility types
+### PR 12 — retired (`Freeze`/`Thaw` utility types)
 
-Goal: the `Freeze<T>` and `Thaw<T>` utility types for deep mutability conversion that
-reaches *through type-parameter boundaries* — the one place deep `mut` and the
-freeze/thaw moves stop (PR 13), so a container's element types get rewritten too. See
-"Freeze and Thaw" in the requirements. Depends on the mapped/conditional-type
-machinery (M9), the freeze/thaw moves (PR 8), and deep `mut` (PR 13).
+This PR is removed. It existed to convert a structure between mutable and immutable
+*through type-parameter boundaries*, the one place an earlier design let deep `mut`
+stop. With mutability uniformly deep (PR 13), `mut` already flows through type
+arguments into a container's element types, so there is no boundary left for a mapped
+type to cross. Freezing and thawing are then just the binding moves: moving a value
+into an immutable binding freezes it, into a `val mut` binding thaws it, each reaching
+the whole owned structure. A whole graph converts in one move via the connected-
+component move (PR 11) — consuming the one owning binding kills every mutable path at
+once, which is what licenses reading the component's `&mut` edges as `&`. The M9
+mapped/conditional-type machinery is no longer a dependency of the affine model. See
+"Freezing and thawing" in the requirements.
 
-- Add the modifier-rewrite capability to mapped/conditional types: a type-level
-  operator that matches a `&mut`/`mut` reference and yields its immutable form, and
-  the inverse, analogous to TypeScript's `-readonly`/`+readonly` but on the
-  borrow/`mut` axis, applied recursively.
-- Define `Freeze<T>` and `Thaw<T>` as recursive mapped-plus-conditional types over
-  objects, arrays, tuples, and borrows, with the self-referential recursion resolved
-  by the existing recursion machinery, so `Freeze<Node>` is the recursive
-  `{ value: number, peers: Array<&Freeze<Node>> }`.
-- Wire soundness to the move, not the mapped type: assigning into `Freeze<T>` is the
-  mutable-to-immutable freeze move from PR 8, and `Thaw<T>` the immutable-to-mutable
-  move, each reusing that PR's preconditions — all mutable paths dead, or no live
-  immutable observer. There is no runtime transformation; the value is unchanged.
-- Compose with PR 11: a single-owner or component-moved graph freezes in one move,
-  because consuming the one binding kills every mutable path at once.
+### PR 13 — Deep, uniform `mut` and `readonly`
 
-Tests: `Freeze<Node>` renders as the deep-immutable recursive type; `Thaw<Freeze<Node>>`
-recovers `Node`; a component-owned graph frozen in one move; a write through a
-`Freeze<>` value rejected; the immutable-field over-thaw caveat asserted.
-
-Acceptance: `Freeze`/`Thaw` produce the deep types and are sound through the
-freeze/thaw moves, with no runtime cost.
-
-### PR 13 — Deep `mut`, type-parameter inertness, and `readonly`
-
-Goal: make `mut` deep with type parameters inert, and add the `readonly` field
-modifier. This is foundational mut-semantics work that the affine model and PR 12
-build on; it depends only on the parser (PR 1) and the `&`/`mut` lowering (PR 2) and
-can land early, independent of the move engine. See "Mutability depth and type
-parameters" in the requirements.
+Goal: make `mut` deep and uniform — flowing through a type's concrete structure *and*
+through its type arguments — and add the `readonly` field modifier. This is
+foundational mut-semantics work that the affine model builds on; it depends only on the
+parser (PR 1) and the `&`/`mut` lowering (PR 2) and can land early, independent of the
+move engine. See "Mutability depth" in the requirements.
 
 - Lower a `mut`/`&mut` annotation by setting `RefType.Mut` deeply through the type's
-  concrete structure, not just the outermost `RefType`. Apply the modifier to the
-  type constructor's body *before* type-argument substitution, so a type parameter is
-  inert: `mut Foo<Point>` is `(mut Foo)<Point>`. The same distribution covers the `&`
-  of `&mut`, so borrow-ness and mutability reach equally far and both stop at the
-  parameter slot.
-- Treat a bare `mut T` as inert until `T` is instantiated, then take its natural
-  meaning, so `mut T` at `T = Point` lowers to `mut Point`.
+  whole reachable structure, not just the outermost `RefType`. The modifier flows
+  through type arguments as well, so `mut Foo<Point>` makes both `Foo`'s body and the
+  substituted `Point` writable; the same distribution covers the `&` of `&mut`, so
+  borrow-ness and mutability reach equally far. A `&`/`&mut` field is the one boundary:
+  the enclosing modifier does not flip an explicitly-written borrow field's mutability.
+- Treat a bare `mut T` as the mutable view at every instantiation, so `mut T` at
+  `T = Point` lowers to `mut Point`, and `mut Array<T>` yields `mut T` elements. Real
+  type-argument resolution for stdlib containers lands with TypeRef support (M7); until
+  then the uniform-deep rule is exercised on the structural object/tuple forms, and the
+  container element case follows the same `recvMut` propagation once `Array<T>`
+  resolves.
 - Parser: add the `readonly` field modifier to object type annotations
   ([internal/parser/type_ann.go](../../internal/parser/type_ann.go)), and lower it to
   a per-field no-reassignment flag on the object type. `readonly` governs only whether
@@ -700,13 +690,13 @@ parameters" in the requirements.
 - This changes the current shallow-`mut` lowering, so migrate the affected solver
   snapshots.
 
-Tests: `mut Array<Point>` is a mutable array of immutable points; `mut {a: {b}}` and
-`&mut {a: {x}}` are deep; `mut Line<Point>` over `type Line<P> = {p1: P, p2: P}` keeps
-the points immutable while a concrete `mut Line` is deep; `readonly` rejects field
-reassignment but still permits mutating the field's value when that value is mutable.
+Tests: `mut Array<Point>` is a fully mutable array of mutable points; `mut {a: {b}}`
+and `&mut {a: {x}}` are deep; `mut Foo<Point>` over `type Foo<T> = {a: T}` makes both
+the `a` layer and the `Point` writable; `readonly` rejects field reassignment but still
+permits mutating the field's value when that value is mutable.
 
-Acceptance: `mut`/`&mut` are deep with type parameters inert, and `readonly` forbids
-reassignment only.
+Acceptance: `mut`/`&mut` are deep and uniform, flowing through type arguments, and
+`readonly` forbids reassignment only.
 
 ### PR 14 — Lazy deep `mut`: store the surface form, push the rule to access and constrain
 
@@ -788,11 +778,11 @@ than through the field types.
 - **Cross-package moves.** Move behaviour at the boundary of imported, body-less
   declarations depends on declared lifetimes and is left to the library-import
   work, consistent with the requirements.
-- **Interior-mutability escape hatches.** Moving a self-contained graph (PR 11) and
-  `Freeze`/`Thaw` (PR 12) cover the cyclic and acyclic cases where the graph owns its
-  own nodes. What stays deferred is the case they do not: a mutable cyclic structure
-  whose nodes are referenced from outside the graph, with no single owner — a
-  `Cell`-like wrapper, tracked separately under #618.
+- **Interior-mutability escape hatches.** Moving a self-contained graph (PR 11) plus
+  the freeze/thaw binding moves (PR 8) cover the cyclic and acyclic cases where the
+  graph owns its own nodes. What stays deferred is the case they do not: a mutable
+  cyclic structure whose nodes are referenced from outside the graph, with no single
+  owner — a `Cell`-like wrapper, tracked separately under #618.
 - **Diagnostic wording.** Each PR ships a working diagnostic; final wording and
   blame spans for use-after-move and move-on-escape are tuned as the engine
   settles.

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -115,37 +115,34 @@ responsible for the value and whether a transfer consumes the source. Mutability
 decides whether writes are allowed. Move/affine semantics governs the ownership
 axis; the mutability axis is governed by the existing exclusivity rule.
 
-### Mutability depth and type parameters
+### Mutability depth
 
-Mutability is **deep**. A `mut` applies to a type constructor's body and propagates
-through its concrete structure, so `mut {a: {b: {c: number}}}` makes every layer
+Mutability is **deep and uniform**. A `mut` applies to a type and propagates through
+its entire reachable structure, so `mut {a: {b: {c: number}}}` makes every layer
 writable, and `&mut {a: {x: number}}` lets you write `p.a.x`, not only `p.a`. The
 borrow and the mutability of `&mut` distribute together — the whole modifier applies
 to the body — so `&` reaches exactly as far as `mut`.
 
-A modifier stops only at a **type parameter**, which is inert: it does not cross into
-the type substituted for a parameter. Equivalently, `mut Foo<Point>` is
-`(mut Foo)<Point>` — apply `mut` to `Foo`'s body, leaving the `T` slot untouched, then
-substitute `Point` into that inert slot. For `type Foo<T> = {a: {b: {c: T}}}`,
-`mut Foo<Point>` makes the `a`, `b`, and `c` layers writable but leaves the `Point`
-immutable.
+The modifier flows through **type arguments** too; it does not stop at a type
+parameter. `mut Foo<Point>` makes both `Foo`'s body and the `Point` it holds writable.
+For `type Foo<T> = {a: {b: {c: T}}}`, `mut Foo<Point>` makes the `a`, `b`, and `c`
+layers and the `Point` itself all writable.
 
-The common container case falls out of this. `Array<T>` holds its elements in a
-type-parameter slot, so `mut Array<Point>` is a mutable array of immutable points:
-you may push, reorder, and reassign elements, but not mutate a point's fields. To get
-mutable elements you write the mutability into the argument, `mut Array<mut Point>`,
-and an immutable array of mutable points is `Array<mut Point>`. A `mut` written on a
-bare parameter is inert until the parameter is known, then takes its natural meaning,
-so `mut T` at `T = Point` is `mut Point`.
+The common container case follows. `Array<T>` owns its elements, so `mut Array<Point>`
+is a fully mutable array of mutable points: you may push, reorder, and reassign
+elements, *and* mutate a point's fields. `Array<Point>` with no `mut` is immutable all
+the way down. A bare `mut T` takes its natural meaning at every instantiation, so
+`mut T` at `T = Point` is `mut Point`, and the elements of `mut Array<T>` are `mut T`.
 
-Because deep `mut` flows through concrete structure, differentiating an inner object's
-mutability from its container's is done by **parameterizing**. Write
-`type Line<P> = {p1: P, p2: P}` and use `mut Line<Point>` for a mutable line of
-immutable points; a plain `type Line = {p1: Point, p2: Point}` under `mut` is mutable
-all the way down. The one field-level modifier is **`readonly`**, which forbids
-*reassigning* a field and nothing more. `{readonly a: T}` rejects `obj.a = …` but says
-nothing about the deep mutability of `a`'s value; `readonly` governs the slot, while
-`mut` and parameterization govern depth.
+Because mutability is uniform through the structure a value **owns**, depth is
+all-or-nothing: an owned value is mutable to its leaves or immutable to its leaves, the
+way a `mut`/non-`mut` binding governs everything it owns. There is no "mutable
+container, immutable element" type; to hold immutable data, the owner is immutable. The
+one boundary is a **borrow** — a `&`/`&mut` field is a window into another value and
+carries its own mutability, not the enclosing modifier's. The one field-level modifier
+is **`readonly`**, which forbids *reassigning* a field and nothing more.
+`{readonly a: T}` rejects `obj.a = …` but says nothing about the deep mutability of
+`a`'s value; `readonly` governs the slot, `mut` governs depth.
 
 ### Borrows of a mutable owned value
 
@@ -497,53 +494,46 @@ component moves as a whole: a program may return or store the graph, or keep usi
 its nodes locally, but not both. This is the single-binding move rule lifted to the
 connected component.
 
-## Freeze and Thaw
+## Freezing and thawing
 
-Freezing a value by moving it into an immutable binding is deep through the value's
-concrete structure, but it stops at type-parameter boundaries, since a modifier is
-inert to type parameters. So freezing a `Node` makes its `value` and its `peers`
-array immutable, but the `peers` elements have type `&mut Node` — the element type of
-`Array`, a type argument — so the container freeze never reaches them and they stay
-mutable. Closing that gap is exactly what `Freeze<T>` is for.
+Freezing a value means moving it into an immutable binding; thawing means moving it
+into a `val mut` binding. Because mutability is deep and uniform, both reach the whole
+structure the value owns — including container elements, which `mut` flows into through
+the element type argument. There is no separate utility type to convert mutable and
+immutable forms; the binding's mutability already governs the whole reachable owned
+structure, so the move *is* the freeze or thaw.
 
-To convert a whole structure between mutable and immutable, use the `Freeze<T>` and
-`Thaw<T>` utility types. `Freeze<T>` is a deep, recursive mapped type that rewrites
-every reachable `&mut` to `&` and every `mut` container to its immutable form;
-`Thaw<T>` is the opposite direction. For the node type above:
-
-```esc
-type Freeze<Node>        // { value: number, peers: Array<&Freeze<Node>> }
-type Thaw<Freeze<Node>>  // { value: number, peers: Array<&mut Node> } — recovers Node
-```
-
-`Freeze<Node>` recurses into the peer references, so a frozen node's edges point at
-frozen nodes; the result is a recursive, self-referential type, resolved by the same
-machinery that resolves `Node`.
-
-The types are purely type-level and carry no runtime cost: the value is unchanged,
-the type is stricter or looser. Soundness comes from the move, not the mapped type.
-Assigning a value into `Freeze<T>` is the mutable-to-immutable freeze move — it
-consumes the source and requires every mutable path to the reachable structure to be
-dead. `Thaw<T>` is the immutable-to-mutable move and requires no live immutable
-observer. The mapped type names the deep target; the move supplies the guarantee
-that no conflicting path survives.
+The transition carries no runtime cost: the value is unchanged, the type is stricter or
+looser. Soundness comes from the move. The freeze consumes the source and requires
+every mutable path to the reachable structure to be dead; the thaw consumes the source
+and requires no live immutable observer. The move is what guarantees no conflicting path
+survives, so the frozen value's type can read its formerly-`&mut` edges as `&`.
 
 This pairs with the connected-component move. When a graph is owned as a single
 component — a returned component, or an arena whose one binding owns every node —
 consuming that binding kills every mutable path at once, so the whole graph freezes
-in one sound move. Take the `build` function from the previous section, whose `Node`
-edges are `&mut` and so leave the returned graph mutable through them:
+in one sound move. Take the `build` function from the previous section. Binding its
+result immutably freezes the whole component, edges included:
 
 ```esc
-val g = build()                 // g: Node — the moved-out {a, b} component
-g.peers[0].value = 20           // OK — the `&mut` edge is a type argument of `Array`,
-                                // inert to g's immutability; this is the type-parameter gap
+val g = build()                 // g: Node — the moved-out {a, b} component, bound
+                                // immutably, so the whole component is now immutable
+// g.peers[0].value = 20        // ERROR: g is immutable to its leaves; the move that
+                                // produced it left no mutable path, so the edges read `&`
+print(g.peers[0].value)         // OK — read
+```
 
-val frozen: Freeze<Node> = g    // deep-freeze the whole component in one move; g consumed
-print(frozen.peers[0].value)    // OK — read
-// frozen.peers[0].value = 5    // ERROR: Freeze<Node> is deeply immutable; the edges are now `&`
+To keep the component writable, bind it mutably; to freeze one that is currently
+mutable, move it into an immutable binding, which consumes the source:
 
-val mut h: Thaw<Freeze<Node>> = frozen   // thaw back to a mutable graph; recovers Node; frozen consumed
+```esc
+val mut g = build()             // keep the component mutable
+g.peers[0].value = 20           // OK — mutable to the leaves
+
+val frozen = g                  // deep-freeze the whole component in one move; g consumed
+// frozen.peers[0].value = 5    // ERROR: frozen is deeply immutable; the edges are now `&`
+
+val mut h = frozen              // thaw back to a mutable graph in one move; frozen consumed
 h.peers[0].value = 7            // mutation allowed again
 ```
 
@@ -558,9 +548,9 @@ freeze creates a second mutable path into the component, and the freeze is then
 rejected:
 
 ```esc
-val g = build()
+val mut g = build()
 val first = g.peers[0]          // first: &mut Node — a live mutable borrow into the component
-val frozen: Freeze<Node> = g    // ERROR: `first` is a live mutable path into the
+val frozen = g                  // ERROR: `first` is a live mutable path into the
                                 // component, so "every mutable path dead" fails
 first.value = 5                 // the later use that keeps `first` live across the freeze
 ```
@@ -573,12 +563,14 @@ mutate a value an immutable view now depends on. Catching this needs alias track
 that reaches a borrow of an internal node, not only a borrow of the root `g`, which
 is the alias-set reasoning in "Relationship to the mutability-transition checker."
 
-Two caveats. `Thaw` is not a faithful inverse for a type with genuinely-immutable
-fields. It deep-mutables everything, so `Thaw<Freeze<T>>` recovers `T` only when `T`
-was fully mutable. And `Freeze<T>` is the opt-in to deep immutability *through type
-parameters*. A bare type is already deeply immutable in its own concrete structure,
-but a modifier is inert to type arguments, so a container's elements stay as their
-argument type spells them; `Freeze<T>` is what rewrites those element types too.
+One caveat. Thawing is not a faithful inverse for a component that mixes mutable and
+immutable edges. The freeze made every internal edge `&`, and the thaw makes every
+internal edge `&mut`, so a freeze followed by a thaw recovers the original type only
+when the whole component was mutable to begin with. An edge authored `&` independent of
+any freeze comes back `&mut` — sound, since the consuming move leaves the thawed value
+the sole owner, but wider than the author wrote. `readonly` is unaffected: it is a
+structural field annotation, not part of the `mut`/immutable wrapper, so it survives a
+freeze and thaw unchanged.
 
 ## Why the invariant holds
 
@@ -932,9 +924,10 @@ policy choosing it.
   moves apply at element granularity, as in the partial-moves section.
 - **Functions** are value types. They copy and are never wrapped in `RefType`. The
   lifetimes inside a function signature elide or show by the display rules.
-- **Generic containers** such as `Array<T>` own their elements, so `arr[i]` yields a
-  `&T` bounded by the array's lifetime, and `&mut Array<T>` is a mutable borrow of
-  the container.
+- **Generic containers** such as `Array<T>` own their elements, so an index read
+  borrows an element bounded by the array's lifetime. Mutability is uniform with the
+  container: `arr[i]` off an immutable array yields `&T`, and off a `mut`/`&mut` array
+  yields `&mut T`, since `mut` reaches through the element type argument.
 - **Conditional and mapped types** compute a shape without reference to ownership.
   The wrapper is applied to the computed result, so a conditional type that selects
   between branches yields a pointee shape that a borrow then wraps.
@@ -944,11 +937,11 @@ policy choosing it.
 - **Linearity / mandatory consumption.** Values need not be consumed; unused
   owned values are dropped. Out of scope.
 - **Interior-mutability escape hatches.** Moving a self-contained cyclic or acyclic
-  graph is specified above under "Moving a graph," and `Freeze`/`Thaw` convert such a
-  graph between mutable and immutable. What remains out of scope is the case those do
-  not cover: a mutable cyclic structure whose nodes are referenced from outside the
-  graph, with no single owner — a `Cell`-like wrapper, noted in #618 as a separate
-  concern.
+  graph is specified above under "Moving a graph," and the freeze/thaw moves convert
+  such a graph between mutable and immutable. What remains out of scope is the case
+  those do not cover: a mutable cyclic structure whose nodes are referenced from
+  outside the graph, with no single owner — a `Cell`-like wrapper, noted in #618 as a
+  separate concern.
 - **Field-granular tracking depth.** Partial moves target field granularity. How
   deep the tracking goes through nested objects and through dynamic index
   expressions is an implementation-precision question for the plan, with the

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -148,6 +148,16 @@ writable `{a: T}` target, because a holder of the target could reassign through 
 and break the source's read-only guarantee. The reverse is allowed: a writable
 `{a: T}` value satisfies a `{readonly a: T}` target, since the target only ever reads.
 
+The borrow boundary is what lets one data structure **mix** mutable and immutable
+data. A borrow carries its own mutability, so it decouples a container's mutability
+from its elements'. `mut Array<&Point>` is a mutable array of immutable points. You
+may push, reorder, and reassign elements, but each `&Point` element is a read-only
+window, so you cannot mutate a point through it. Its dual, `Array<&mut Point>`, is an
+immutable array of mutable points. The array's shape is fixed, with no push, reorder,
+or reassign, yet each `&mut Point` element lets you write through to its point. The
+trade-off is ownership. The array holds borrows, so the points live elsewhere rather
+than in the array, and their lifetimes must outlive it.
+
 ### Borrows of a mutable owned value
 
 A mutable owned value may be borrowed many times over. Its borrows fall into two

--- a/planning/affine_semantics/requirements.md
+++ b/planning/affine_semantics/requirements.md
@@ -140,9 +140,13 @@ way a `mut`/non-`mut` binding governs everything it owns. There is no "mutable
 container, immutable element" type; to hold immutable data, the owner is immutable. The
 one boundary is a **borrow** — a `&`/`&mut` field is a window into another value and
 carries its own mutability, not the enclosing modifier's. The one field-level modifier
-is **`readonly`**, which forbids *reassigning* a field and nothing more.
+is **`readonly`**, which forbids *reassigning* a field.
 `{readonly a: T}` rejects `obj.a = …` but says nothing about the deep mutability of
-`a`'s value; `readonly` governs the slot, `mut` governs depth.
+`a`'s value, so `readonly` governs the slot and `mut` governs depth. `readonly` also
+constrains structural compatibility. A `{readonly a: T}` value cannot satisfy a
+writable `{a: T}` target, because a holder of the target could reassign through `a`
+and break the source's read-only guarantee. The reverse is allowed: a writable
+`{a: T}` value satisfies a `{readonly a: T}` target, since the target only ever reads.
 
 ### Borrows of a mutable owned value
 
@@ -568,7 +572,20 @@ immutable edges. The freeze made every internal edge `&`, and the thaw makes eve
 internal edge `&mut`, so a freeze followed by a thaw recovers the original type only
 when the whole component was mutable to begin with. An edge authored `&` independent of
 any freeze comes back `&mut` — sound, since the consuming move leaves the thawed value
-the sole owner, but wider than the author wrote. `readonly` is unaffected: it is a
+the sole owner, but wider than the author wrote.
+
+```esc
+val mut g = build()   // g: mut {hot: &mut Node, cold: &Node} — `cold` authored `&`
+val frozen = g        // freeze: every internal edge reads `&`
+                      //   frozen: {hot: &Node, cold: &Node}
+val mut thawed = frozen // thaw: every internal edge comes back `&mut`
+                      //   thawed: mut {hot: &mut Node, cold: &mut Node}
+                      // `cold` widened from `&` to `&mut`. This is intentional and
+                      // sound: the consuming move leaves `thawed` the sole owner, so no
+                      // immutable view still depends on `cold`.
+```
+
+`readonly` is unaffected: it is a
 structural field annotation, not part of the `mut`/immutable wrapper, so it survives a
 freeze and thaw unchanged.
 


### PR DESCRIPTION
This change implements uniform deep mutability for the affine semantics, where `mut` flows through both a type's concrete structure and its type arguments. Previously, `mut` stopped at type-parameter boundaries; now `mut Foo<Point>` makes both `Foo`'s body and the substituted `Point` writable.

## Key changes

**Requirements and design documentation:**
- Rewrote "Mutability depth" section to describe uniform deep `mut` flowing through type arguments, eliminating the type-parameter inertness model
- Removed the `Freeze<T>` and `Thaw<T>` utility types from the design; freezing and thawing are now just binding moves (moving into immutable or `val mut` bindings)
- Updated "Freezing and thawing" section to explain that the binding's mutability already governs the whole reachable owned structure, so no separate mapped type is needed
- Retired PR 12 (`Freeze`/`Thaw` utility types) from the implementation plan; it is subsumed by uniform deep `mut` plus the freeze/thaw moves from PR 8 and connected-component moves from PR 11
- Renamed PR 13 from "Deep `mut`, type-parameter inertness, and `readonly`" to "Deep, uniform `mut` and `readonly`"

**Solver implementation:**
- Added `bubbleOwnedMut` function to rewrite display types so no owned-mutable cell sits inside an immutable container. Since `mut` is deep, `{p: mut {x}}` is equivalent to `mut {p: {x}}`; the bubbled form is what inference produces and what can be re-annotated
- Added `boundsPin` check to detect when a type variable is pinned to a single concrete type by equal lower and upper bounds, preventing spurious type parameters in signatures for deep-mut nested writes
- Updated `inferWriteReceiver` and `mutFieldRead` to propagate mutability up the entire receiver chain for nested field writes, so `obj.p.x = 5` infers `obj: mut {p: {x: number}}` rather than nesting an owned-mut cell
- Added `MutFieldError` to reject owned-mutable field annotations like `{a: mut {x}}` at the annotation site, since they are no longer valid under uniform deep `mut`
- Updated `sealUsageObjects` to close both bound directions for pinned variables so the operative type matches the display signature

**Tests:**
- Updated `TestDeepMutLowersFreshLiteral*` tests to reflect that nested `mut` fields in non-mut containers are now rejected at annotation time
- Renamed and updated `TestOwnedMutFieldThroughImmutableReceiverRejectsWrite` to `TestOwnedMutFieldAnnotationRejected` to test the annotation-site rejection
- Added `TestBorrowFieldInImmutableContainerIsLegal` to confirm that `&`/`&mut` borrow fields (which reference external storage) remain legal inside non-mut containers
- Added `TestNestedWriteInfersMutContainerAndRoundTrips` to verify that inferred signatures from nested writes are valid annotations and round-trip correctly
- Updated `TestInferMemberAssignWriteAfterRead` to reflect the new behavior where nested writes mark the whole container `mut`

## Implementation notes

The change eliminates the type-parameter boundary as a stopping point for `mut` propagation. Under the new model, mutability is all-or-nothing for owned values: an owned value is mutable to its leaves or immutable to its leaves, matching how a `mut`/non-`mut` binding governs everything it owns. Borrows (`&`/`&mut` fields) remain the one boundary, since they reference external storage and carry their own mutability independent of the enclosing modifier.

The `bubbleOwnedMut` rewrite runs at display time only, over already-coalesced types, so it changes only how inferred signatures are printed, never what the solver accepts. This ensures that what inference produces can always be written back as a valid annotation.

https://claude.ai/code/session_0111R3T94sXvgDvBmFz3KxqE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of nested `mut` annotations in objects and tuples, with clearer recovery for valid mutable structures.
  * Updated write-chain inference so mutability now propagates through nested field and index updates more consistently.

* **Bug Fixes**
  * Nested mutable fields inside non-mutable containers now produce a clearer, targeted error.
  * Borrowing through deep mutable fields and nested writes now infer the expected container mutability and round-trip correctly.

* **Documentation**
  * Updated internal notes to match the latest deep mutability behavior and rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->