### PR TITLE
Remove milestone/PR references from comments

### DIFF
--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -24,7 +24,7 @@ type Lifetime interface{ isLifetime() }
 // a discarded speculation trial truncates them back.
 //
 // Level brings the lifetime sort into the let-generalization hierarchy that
-// TypeVarType already rides (M4 D2.5). A lifetime minted onto a generalizable
+// TypeVarType already rides. A lifetime minted onto a generalizable
 // parameter sits ABOVE its scheme's generalize-level, so instantiate freshens it
 // per use just as it does a type parameter, and two call sites of a
 // borrow-passing function never share one LifetimeVar's bounds. The MLsub level
@@ -38,7 +38,7 @@ type LifetimeVar struct {
 	LowerBounds []Lifetime
 	UpperBounds []Lifetime
 
-	// Join marks an internal lifetime minted at a multi-source join site (M4 D3).
+	// Join marks an internal lifetime minted at a multi-source join site.
 	// A join site is a return or branch that unites several borrows with distinct
 	// lifetimes. A join variable is NOT a borrow origin, so it is never named in
 	// the output. It renders as the union of the param lifetimes it reaches through
@@ -68,8 +68,9 @@ func (v *LifetimeVar) BoundsAt(pol Polarity) []Lifetime {
 type StaticLifetime struct{}
 
 // AnonLifetime is a display-only marker that keeps the `&` on a borrow whose
-// lifetime is not load-bearing. The lifetime coalescer (D4) inserts it where it
-// used to drop the lifetime entirely, so an `&mut {x}` parameter still renders
+// lifetime is not load-bearing. The lifetime coalescer inserts it where
+// dropping the lifetime entirely would change the rendering, so an `&mut {x}`
+// parameter still renders
 // as `&mut {x}` instead of collapsing to owned-mutable `mut {x}`. It is never a
 // constrain input. Only coalesce produces it, only the printer reads it, and it
 // carries no bounds since the underlying lifetime variable has already been

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -9,10 +9,10 @@ import (
 	"github.com/escalier-lang/escalier/internal/set"
 )
 
-// Precedence levels for type operators, matching the Escalier parser (and
-// type_system/print_type.go). Higher values bind more tightly. M4 adds precPrefix
-// for the `mut`/lifetime borrow prefix (RefType); type_system's other prefix forms
-// (keyof, ...T) land with their later milestones.
+// Precedence levels for type operators, matching the Escalier parser and
+// type_system/print_type.go. Higher values bind more tightly. precPrefix covers
+// the `mut`/lifetime borrow prefix on a RefType. type_system's other prefix forms
+// such as keyof and ...T are added later.
 const (
 	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
 	precUnion        = 3 // A | B
@@ -21,7 +21,7 @@ const (
 	precAtom         = 6 // primary types, never need parens
 )
 
-// typePrec returns the printing precedence of a coalesced M1 type.
+// typePrec returns the printing precedence of a coalesced type.
 func typePrec(t Type) int {
 	switch t.(type) {
 	case *FuncType:
@@ -43,36 +43,36 @@ func typePrec(t Type) int {
 
 // Print renders a coalesced Type as an Escalier type-annotation string.
 //
-// This is Delta #2 of m1-implementation-plan §2.2: a native soltype printer that
-// shares NO code with type_system.PrintType but deliberately mirrors its surface
-// forms so the two checkers' rendered types stay string-comparable in M7's
-// differential harness. It renders the M1 coalesced type set only
-// (PrimType/LitType/FuncType/TupleType/Void/NeverType/UnknownType/UnionType/
-// IntersectionType). Print itself emits no <T0, ...> quantifier prefix — a
-// monotype has no parameters to name; PrintAsScheme renders the generalized form.
+// It is a native soltype printer that shares NO code with type_system.PrintType
+// but deliberately mirrors its surface forms so the two checkers' rendered types
+// stay string-comparable in the differential harness. It renders the coalesced
+// type set PrimType, LitType, FuncType, TupleType, Void, NeverType, UnknownType,
+// UnionType, and IntersectionType. Print itself emits no <T0, ...> quantifier
+// prefix, since a monotype has no parameters to name. PrintAsScheme renders the
+// generalized form.
 //
-// Print is distinct from solver's describe(): describe renders a RAW,
-// uncoalesced type (t0, function, number) mid-constrain for error messages,
-// whereas Print renders a COALESCED type as user-facing syntax. They look
-// similar but operate at different stages and must not be merged (§2.2).
+// Print is distinct from the solver's describe(). describe renders a RAW,
+// uncoalesced type such as t0, function, or number mid-constrain for error
+// messages, whereas Print renders a COALESCED type as user-facing syntax. They
+// look similar but operate at different stages and must not be merged.
 //
 // Print's normal input is a coalesced type, but it also tolerates a raw,
-// un-coalesced TypeVarType (rendering it as `t{ID}`) rather than panicking: the
-// M2 walk records var-carrying types in its Info side table and coalesces only
-// at binding boundaries, so a consumer may legitimately print an inner node's
-// still-raw type (M2 plan §7).
+// un-coalesced TypeVarType, rendering it as `t{ID}` rather than panicking. The
+// walk records var-carrying types in its Info side table and coalesces only at
+// binding boundaries, so a consumer may legitimately print an inner node's
+// still-raw type.
 func Print(t Type) string {
 	return (&namedPrinter{}).printType(t)
 }
 
-// PrintAsScheme renders a coalesced GENERALIZED type (M3): it collects the type's
-// free variables into a <T0, T1, …> quantifier prefix and renders each as its
-// assigned name. A type with no free variables renders exactly as Print would (no
-// prefix), so PrintAsScheme is safe on a monotype. The prefix attaches to a
-// function (`fn <T0>(…) -> …`, matching Escalier's generic-function surface
-// syntax); a non-function body carrying free variables — not produced by M3's
-// generalization, which only generalizes function values — falls back to a
-// leading <…> group.
+// PrintAsScheme renders a coalesced GENERALIZED type. It collects the type's free
+// variables into a <T0, T1, …> quantifier prefix and renders each as its assigned
+// name. A type with no free variables renders exactly as Print would, with no
+// prefix, so PrintAsScheme is safe on a monotype. The prefix attaches to a
+// function as `fn <T0>(…) -> …`, matching Escalier's generic-function surface
+// syntax. A non-function body carrying free variables, which generalization does
+// not produce since it only generalizes function values, falls back to a leading
+// <…> group.
 //
 // Variables are named by first appearance in print order (params left to right,
 // then return; tuple elements; record fields), so the same coalesced variable
@@ -103,7 +103,7 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 		names[v] = name
 		labels = append(labels, name)
 	}
-	// Borrow lifetimes left in the coalesced type by D4's coalesceLifetimes are all
+	// Borrow lifetimes left in the coalesced type by coalesceLifetimes are all
 	// nameable param lifetimes. A connect-nothing one was already elided, and a join
 	// expanded to a union of these. Name each 'a, 'b, … in first-appearance order and
 	// add it to the quantifier prefix after the type parameters.
@@ -128,7 +128,7 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 }
 
 // typeParamName is the surface name for the i-th quantified type parameter: T0,
-// T1, …, matching the planned `fn <T0>(x: T0) -> T0` rendering.
+// T1, …, matching the `fn <T0>(x: T0) -> T0` rendering.
 func typeParamName(i int) string {
 	return "T" + strconv.Itoa(i)
 }
@@ -251,7 +251,7 @@ type namedPrinter struct {
 	names map[*TypeVarType]string
 	// ltNames maps a retained lifetime variable to its surface name (`'a`, `'b`,
 	// …). It is nil for plain Print, where a lifetime var renders as the raw
-	// `'l{ID}` debug form; D4's display-time coalescing populates it so a
+	// `'l{ID}` debug form. Display-time coalescing populates it so a
 	// param-originated lifetime renders under its quantified name.
 	ltNames map[*LifetimeVar]string
 }
@@ -322,20 +322,19 @@ func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
 	return result
 }
 
-// printType renders a coalesced type. Under the lazy deep-mut form (PR 14) the
-// stored type already matches the surface annotation the user wrote, so the
-// printer needs no special elision pass — `mut {a: {x}}` is stored and printed
-// verbatim.
+// printType renders a coalesced type. Under the lazy deep-mut form the stored type
+// already matches the surface annotation the user wrote, so the printer needs no
+// special elision pass. `mut {a: {x}}` is stored and printed verbatim.
 func (p *namedPrinter) printType(t Type) string {
 	switch t := t.(type) {
 	case *TypeVarType:
 		// A retained type parameter renders under its assigned name; otherwise a
-		// raw, un-coalesced variable. Coalesced monotype output never contains one
-		// (every variable is inlined to its bounds, m1-implementation-plan Delta #1),
-		// but the M2 walk records raw, var-carrying types in Info and only coalesces
-		// at binding boundaries — so a consumer printing an inner node's type
-		// directly may hand Print a live variable. Render it as `t{ID}` (matching
-		// solver's describe()) rather than panicking. See the M2 plan §7.
+		// raw, un-coalesced variable. Coalesced monotype output never contains one,
+		// since every variable is inlined to its bounds, but the walk records raw,
+		// var-carrying types in Info and only coalesces at binding boundaries. A
+		// consumer printing an inner node's type directly may hand Print a live
+		// variable. Render it as `t{ID}`, matching the solver's describe(), rather
+		// than panicking.
 		if p.names != nil {
 			if name, ok := p.names[t]; ok {
 				return name
@@ -397,8 +396,8 @@ func (p *namedPrinter) printType(t Type) string {
 		//	&{x}        &mut {x}        &'a {x}        &'a mut {x}
 		//
 		// The inner prints at precPrefix so a looser inner such as a union or function
-		// gets parenthesized. Under the lazy deep-mut form (PR 14) the inner is the
-		// bare shape the user wrote, so it prints verbatim with no elision pass.
+		// gets parenthesized. Under the lazy deep-mut form the inner is the bare shape
+		// the user wrote, so it prints verbatim with no elision pass.
 		prefix := ""
 		if t.Lt != nil {
 			prefix = "&"
@@ -436,10 +435,10 @@ func (p *namedPrinter) printType(t Type) string {
 // leading "fn" keyword. Kept as a separate helper so PrintAsScheme can compose it
 // with a <...> quantifier prefix without byte-slicing the "fn " back off.
 //
-// PR4 markers: an optional parameter renders as `x?: T`, and an INEXACT function
-// renders a trailing `...` entry (`fn (x: T, ...) -> R`) so the exactness it
-// carries round-trips to surface syntax. An exact function (the common case)
-// renders with no marker.
+// Surface markers: an optional parameter renders as `x?: T`, and an INEXACT
+// function renders a trailing `...` entry such as `fn (x: T, ...) -> R` so the
+// exactness it carries round-trips to surface syntax. An exact function, the
+// common case, renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	ps := make([]string, 0, len(t.Params)+1)
 	for i, param := range t.Params {
@@ -459,11 +458,10 @@ func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 }
 
-// paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or
-// otherwise-unknown pattern falls back to a positional name ("arg0", "arg1",
-// ...). M2's destructuring Pat concretes add their own arms here. The optional
-// `?` marker is appended by printFuncTail, not here, so callers that only want
-// the bare name (none today) stay unaffected.
+// paramName renders p.Pattern. A nil or otherwise-unknown pattern falls back to a
+// positional name such as "arg0" or "arg1". The destructuring Pat concretes add
+// their own arms here. The optional `?` marker is appended by printFuncTail, not
+// here, so a caller that only wants the bare name stays unaffected.
 func paramName(p *FuncParam, i int) string {
 	if s, ok := printPat(p.Pattern); ok {
 		return s
@@ -471,7 +469,7 @@ func paramName(p *FuncParam, i int) string {
 	return "arg" + strconv.Itoa(i)
 }
 
-// printPat renders a parameter pattern in Escalier surface syntax (M4 E1). A
+// printPat renders a parameter pattern in Escalier surface syntax. A
 // pattern carries only sub-patterns and literal values, never a Type, so it
 // renders without the namedPrinter's type context. ok=false for a nil or unknown
 // pattern, so paramName falls back to a positional name.

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -23,11 +23,11 @@ func restP(name string, t Type) *FuncParam {
 	return &FuncParam{Pattern: &IdentPat{Name: name}, Type: t, Rest: true}
 }
 
-// TestPrintRoundTrips covers the short, stable round-trips for the M1 coalesced
-// type set: primitives, literals, the lattice bounds, tuples, multi-arg
-// functions, and multi-element unions/intersections. Per CLAUDE.md these are the
-// short stable strings, so they use require.Equal; the richer nested shapes
-// (which exercise precedence parenthesization) use MatchInlineSnapshot below.
+// TestPrintRoundTrips covers the short, stable round-trips for the coalesced type
+// set: primitives, literals, the lattice bounds, tuples, multi-arg functions, and
+// multi-element unions/intersections. Per CLAUDE.md these are the short stable
+// strings, so they use require.Equal. The richer nested shapes that exercise
+// precedence parenthesization use MatchInlineSnapshot below.
 func TestPrintRoundTrips(t *testing.T) {
 	tests := []struct {
 		name string
@@ -48,7 +48,7 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"never", &NeverType{}, "never"},
 		{"unknown", &UnknownType{}, "unknown"},
 		{"void", &Void{}, "void"},
-		{"error", &ErrorType{}, "error"}, // PR8 recovery sentinel
+		{"error", &ErrorType{}, "error"}, // recovery sentinel
 
 		// Tuples.
 		{"empty tuple", &TupleType{}, "[]"},
@@ -134,11 +134,11 @@ func TestPrintRoundTrips(t *testing.T) {
 		{"null atom", &NullType{}, "null"},
 		{"intersection pair", &IntersectionType{Types: []Type{numP(), strP()}}, "number & string"},
 
-		// Promises (M3).
+		// Promises.
 		{"promise of prim", &PromiseType{Inner: numP()}, "Promise<number>"},
 		{"nested promise", &PromiseType{Inner: &PromiseType{Inner: strP()}}, "Promise<Promise<string>>"},
 
-		// Borrows (M4). Ownership and the borrow `&` split on Lt. An owned value has Lt
+		// Borrows. Ownership and the borrow `&` split on Lt. An owned value has Lt
 		// nil and renders bare, as owned-mutable `mut {x}`. A borrow has Lt set and leads
 		// with `&`. The inner object or tuple is brace- or bracket-delimited, so it needs
 		// no parens. An un-named LifetimeVar is an inferred borrow and prints as a bare
@@ -242,10 +242,10 @@ func TestPrintNestedPrecedence(t *testing.T) {
 	})
 }
 
-// Under the lazy deep-mut form (PR 14) the stored type matches the surface
-// annotation, so the printer renders it verbatim with no elision pass: a `mut`
-// wrapper over a bare object prints `mut {a: {x}}`, and any explicit nested
-// owned-mut cell prints its `mut` rather than being hidden.
+// Under the lazy deep-mut form the stored type matches the surface annotation, so
+// the printer renders it verbatim with no elision pass. A `mut` wrapper over a
+// bare object prints `mut {a: {x}}`, and any explicit nested owned-mut cell prints
+// its `mut` rather than being hidden.
 func TestPrintLazyDeepMutVerbatim(t *testing.T) {
 	mutOwned := func(inner RefInner) Type {
 		return &RefType{Mut: true, Inner: inner}
@@ -312,10 +312,10 @@ func TestPrintAnonLifetime(t *testing.T) {
 }
 
 // TestPrintRawTypeVar verifies that Print tolerates a raw, un-coalesced
-// TypeVarType (rendering it as `t{ID}`) instead of panicking — the M2 walk
-// records var-carrying types in Info and only coalesces at binding boundaries,
-// so a consumer can hand Print a live variable, standalone or nested in a
-// function. See print.go's printType TypeVarType arm.
+// TypeVarType, rendering it as `t{ID}` instead of panicking. The walk records
+// var-carrying types in Info and only coalesces at binding boundaries, so a
+// consumer can hand Print a live variable, standalone or nested in a function.
+// See print.go's printType TypeVarType arm.
 func TestPrintRawTypeVar(t *testing.T) {
 	t.Run("bare variable", func(t *testing.T) {
 		require.Equal(t, "t7", Print(&TypeVarType{ID: 7}))
@@ -331,9 +331,9 @@ func TestPrintRawTypeVar(t *testing.T) {
 }
 
 // TestPrintUnnamedParamFallback verifies that a parameter with no IdentPat
-// pattern falls back to a positional name (arg0, arg1, ...), numbered by param
-// index. This path isn't reachable in M1 (params are always IdentPat), but the
-// fallback exists for nil/unknown patterns, so it's covered directly here.
+// pattern falls back to a positional name such as arg0 or arg1, numbered by param
+// index. The fallback exists for nil or unknown patterns, so it is covered
+// directly here.
 func TestPrintUnnamedParamFallback(t *testing.T) {
 	fn := &FuncType{
 		Params: []*FuncParam{
@@ -345,9 +345,9 @@ func TestPrintUnnamedParamFallback(t *testing.T) {
 	require.Equal(t, "fn (arg0: number, arg1: string) -> boolean", Print(fn))
 }
 
-// A destructuring parameter renders its pattern (M4 E1). Each Pat concrete in the
-// sealed set has a printPat arm, including the M5 constructor patterns
-// ExtractorPat and InstancePat, which are forward-declared members of the set.
+// A destructuring parameter renders its pattern. Each Pat concrete in the sealed
+// set has a printPat arm, including the constructor patterns ExtractorPat and
+// InstancePat, which are forward-declared members of the set.
 func TestPrintDestructuringParamPatterns(t *testing.T) {
 	tests := []struct {
 		name string
@@ -401,9 +401,9 @@ func TestPrintDestructuringParamPatterns(t *testing.T) {
 	}
 }
 
-// TestPrintScheme covers the M3 quantifier-prefix rendering: a generalized type's
-// free variables are collected into a <T0, T1, …> prefix (named by first
-// appearance in print order) and rendered under those names, while a variable-free
+// TestPrintScheme covers the quantifier-prefix rendering. A generalized type's
+// free variables are collected into a <T0, T1, …> prefix, named by first
+// appearance in print order, and rendered under those names, while a variable-free
 // type renders exactly as Print would.
 func TestPrintScheme(t *testing.T) {
 	t.Run("no free vars renders as Print", func(t *testing.T) {
@@ -466,8 +466,8 @@ func TestPrintScheme(t *testing.T) {
 		a := &TypeVarType{ID: 1, Level: 1}
 		// fn (p: mut {x: a}) -> a: freeTypeVars must descend through the RefType
 		// wrapper into its inner object to find a, so the borrowed param and the
-		// return share the one type parameter T0. This is the realistic C3 shape — a
-		// field-write makes the receiver a `mut` object — surviving M3 generalization.
+		// return share the one type parameter T0. This is the realistic shape where a
+		// field-write makes the receiver a `mut` object, surviving generalization.
 		ty := &FuncType{
 			Params: []*FuncParam{identP("p", &RefType{Mut: true,
 				Inner: &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: a}}}})},

--- a/internal/soltype/ref.go
+++ b/internal/soltype/ref.go
@@ -4,7 +4,7 @@ package soltype
 // cell back to the bare inner so no *RefType ever names a value that isn't really a
 // borrow. A type-switch on *RefType can therefore assume the wrapper is meaningful.
 // Construct a &RefType literal directly when that cell must survive — the
-// bare<:RefType constrain arm (C2) does, to re-dispatch a source as an immutable
+// bare<:RefType constrain arm does, to re-dispatch a source as an immutable
 // view without recursing forever.
 func NewRef(mut bool, lt Lifetime, inner RefInner) Type {
 	if !mut && lt == nil {

--- a/internal/soltype/ref_test.go
+++ b/internal/soltype/ref_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // NewRef collapses the degenerate immutable-no-lifetime cell to the bare inner, and
-// keeps the wrapper for every meaningful borrow. Lt is always nil in C1, so the
+// keeps the wrapper for every meaningful borrow. Lt is always nil today, so the
 // only meaningful borrow constructible here is the owned-mutable one.
 func TestNewRef(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -2,39 +2,38 @@ package soltype
 
 import "fmt"
 
-// Type is the sealed interface for all soltype nodes. (Production name for the
-// spike's SimpleType; marker renamed isSimpleType -> isType.)
+// Type is the sealed interface for all soltype nodes.
 //
-// Accept threads a polarity-flipping rewriting visitor over the node (visitor.go);
-// the structural type→type transforms (coalesce / extrude / freshenAbove) are
-// implemented on top of it so variance and the rebuild-from-children boilerplate
-// live in one place. The marker isType stays unexported so the interface is sealed
-// to this package.
+// Accept threads a polarity-flipping rewriting visitor over the node, defined in
+// visitor.go. The structural type→type transforms coalesce, extrude, and
+// freshenAbove are implemented on top of it so variance and the
+// rebuild-from-children boilerplate live in one place. The marker isType stays
+// unexported so the interface is sealed to this package.
 type Type interface {
 	isType()
 	Accept(v TypeVisitor, pol Polarity) Type
 }
 
 // TypeVarType is an inference variable carrying Simple-sub lower/upper bound
-// lists plus the level at which it was created (for let-generalization in M3).
+// lists plus the level at which it was created, used for let-generalization.
 type TypeVarType struct {
 	ID          int
 	Level       int
 	LowerBounds []Type
 	UpperBounds []Type
-	// Open marks the variable of an `open` parameter (M4 B2). It is read only at
-	// display-time coalescing: a usage-inferred object on an open var's upper
-	// bounds stays inexact (row-polymorphic) instead of closing to exact. It has
+	// Open marks the variable of an `open` parameter. It is read only at
+	// display-time coalescing. A usage-inferred object on an open var's upper
+	// bounds stays inexact, row-polymorphic, instead of closing to exact. It has
 	// no effect on constraint solving.
 	Open bool
-	// Widenable marks the binding var of an un-annotated `var` (M4 B3). Like Open
-	// it is read only at coalescing: a widenable var's coalesced value has its
-	// literals lowered to their primitives (`5` ⇒ number) in covariant position,
-	// so a mutable cell reads back as the primitive it may later hold. It has no
+	// Widenable marks the binding var of an un-annotated `var`. Like Open it is
+	// read only at coalescing. A widenable var's coalesced value has its literals
+	// lowered to their primitives, so `5` becomes number in covariant position and
+	// a mutable cell reads back as the primitive it may later hold. It has no
 	// effect on constraint solving. This stays sound while the only position that
-	// demands a literal super-type is the reassignment slot — itself a coalesced
-	// view — because no other site can observe the literal the graph still holds;
-	// literal type annotations (a second such site) are a later milestone.
+	// demands a literal super-type is the reassignment slot, itself a coalesced
+	// view, because no other site can observe the literal the graph still holds.
+	// Literal type annotations would be a second such site.
 	Widenable bool
 }
 
@@ -47,12 +46,13 @@ func (v *TypeVarType) BoundsAt(pol Polarity) []Type {
 	return v.UpperBounds
 }
 
-// Prim is the closed set of primitives M1 carries. Mirrors the type_system
-// package's Prim enum, but only the three M1's tests exercise; M2+ extends
-// Prim (BigIntPrim, SymbolPrim) and Lit (BigIntLit, NullLit, UndefinedLit)
-// to the full type_system set as the parser bridge surfaces them. The
-// additions are inert from constrain's perspective — same prim/literal arms
-// with one more concrete each — so the deferral is purely scope, not design.
+// Prim is the closed set of primitives soltype carries. It mirrors the
+// type_system package's Prim enum, but carries only the three the tests
+// exercise. Further primitives such as BigIntPrim and SymbolPrim, and further
+// literals such as BigIntLit, NullLit, and UndefinedLit, extend Prim and Lit to
+// the full type_system set as the parser bridge surfaces them. The additions are
+// inert from constrain's perspective, the same prim and literal arms with one
+// more concrete each.
 type Prim int
 
 const (
@@ -64,8 +64,8 @@ const (
 type PrimType struct{ Prim Prim }
 
 // Lit is the sealed interface for literal values inside a LitType.
-// Mirrors type_system.Lit (with NumLit/StrLit/BoolLit concretes) so each
-// literal kind carries exactly the value field it needs — no flat struct
+// It mirrors type_system.Lit with NumLit, StrLit, and BoolLit concretes so each
+// literal kind carries exactly the value field it needs, avoiding a flat struct
 // where two of three value fields are dead per instance.
 type Lit interface{ isLit() }
 
@@ -96,25 +96,24 @@ func (l *LitType) Equal(o *LitType) bool {
 	}
 }
 
-// Pat is the sealed interface for parameter patterns. Mirrors the role of
-// type_system.Pat (and ast.Pat) but lives in soltype to keep soltype ast-free.
-// M1 ships a single concrete (IdentPat); M2 adds destructuring concretes
-// (TuplePat, RecordPat, …) as the parser bridge surfaces them, with no
-// FuncParam restructuring.
+// Pat is the sealed interface for parameter patterns. It mirrors the role of
+// type_system.Pat and ast.Pat but lives in soltype to keep soltype ast-free.
+// Destructuring concretes such as TuplePat and RecordPat are added as the parser
+// bridge surfaces them, with no FuncParam restructuring.
 type Pat interface{ isPat() }
 
 type IdentPat struct{ Name string }
 
 func (*IdentPat) isPat() {}
 
-// TuplePat is a tuple destructuring pattern (M4 E1). Its sub-patterns are
+// TuplePat is a tuple destructuring pattern. Its sub-patterns are
 // positional. It is carried on a destructured FuncParam.Pattern so the parameter
 // renders and round-trips. The solver's pattern-typing helper produces it.
 type TuplePat struct{ Elems []Pat }
 
 func (*TuplePat) isPat() {}
 
-// ObjectPat is an object destructuring pattern (M4 E1). Each field names a
+// ObjectPat is an object destructuring pattern. Each field names a
 // property and binds its value through a sub-pattern. A bare `{x}` shorthand is
 // an ObjectPatField whose Value is an IdentPat of the same name.
 type ObjectPat struct{ Fields []*ObjectPatField }
@@ -127,23 +126,22 @@ type ObjectPatField struct {
 	Value Pat
 }
 
-// LitPat matches a literal value (M4 E1). It binds nothing. It is carried for
-// rendering and for E2's match-arm typing.
+// LitPat matches a literal value. It binds nothing. It is carried for rendering
+// and for match-arm typing.
 type LitPat struct{ Lit Lit }
 
 func (*LitPat) isPat() {}
 
-// WildcardPat (`_`) matches anything and binds nothing (M4 E1).
+// WildcardPat (`_`) matches anything and binds nothing.
 type WildcardPat struct{}
 
 func (*WildcardPat) isPat() {}
 
 // ExtractorPat is a constructor/extractor pattern such as `Some(v)` or
-// `Point(x, y)`. The solver does not yet produce it; it is a forward-declared
-// member of the sealed set, the structural mirror of ast.ExtractorPat, and lands
-// with the constructor patterns in M5. Name is the qualified constructor name
-// rendered as a string, since soltype stays ast-free. Args are positional
-// sub-patterns.
+// `Point(x, y)`. The solver does not yet produce it. It is a forward-declared
+// member of the sealed set and the structural mirror of ast.ExtractorPat. Name
+// is the qualified constructor name rendered as a string, since soltype stays
+// ast-free. Args are positional sub-patterns.
 type ExtractorPat struct {
 	Name string
 	Args []Pat
@@ -152,9 +150,9 @@ type ExtractorPat struct {
 func (*ExtractorPat) isPat() {}
 
 // InstancePat is a class-instance pattern such as `Point { x, y }`. Like
-// ExtractorPat it is forward-declared here, the mirror of ast.InstancePat, and
-// lands with classes in M5. ClassName is the qualified class name as a string;
-// Object is the field sub-pattern.
+// ExtractorPat it is forward-declared here, the mirror of ast.InstancePat.
+// ClassName is the qualified class name as a string. Object is the field
+// sub-pattern.
 type InstancePat struct {
 	ClassName string
 	Object    *ObjectPat
@@ -162,38 +160,39 @@ type InstancePat struct {
 
 func (*InstancePat) isPat() {}
 
-// FuncParam mirrors type_system.FuncParam. Pattern is reachable only through Pat
-// concretes M1 defines (IdentPat). M3 (PR4) adds Optional: an `x?` parameter
-// lowers the function's `required` count (the accept-set lower bound) without
-// removing the parameter from the declared list — it stays at its position with
-// its type, the slot simply may go unsupplied.
+// FuncParam mirrors type_system.FuncParam. Pattern is reachable through the Pat
+// concretes such as IdentPat. Optional marks an `x?` parameter. It lowers the
+// function's `required` count, the accept-set lower bound, without removing the
+// parameter from the declared list. The parameter stays at its position with its
+// type, the slot simply may go unsupplied.
 type FuncParam struct {
 	Pattern  Pat
 	Type     Type
-	Optional bool // PR4: x? — lowers `required` without changing arity (len(Params))
-	// Rest marks a typed rest param (`...xs: T[]`), which must be the LAST param: it
+	Optional bool // x? — lowers `required` without changing arity (len(Params))
+	// Rest marks a typed rest param (`...xs: T[]`), which must be the LAST param. It
 	// binds zero or more trailing arguments, so it is never required and lifts the
-	// function's accept-set upper bound to ∞ (#677 §4.2.3) — distinct from the inexact
-	// `...` marker (which is callback-only). Per-extra element-type checking (§4.2.2)
-	// needs Array types and is M4; M3 models only the arity effect.
+	// function's accept-set upper bound to ∞. This is distinct from the inexact
+	// `...` marker, which is callback-only. Per-extra element-type checking needs
+	// Array types; this models only the arity effect.
 	Rest bool
 }
 
-// FuncType is a (possibly multi-argument) function type. M3 (PR4) adds Inexact: a
-// bare `fn(p1..pn)` is exact (tolerates at most n arguments — accept-set
-// [required, n]); a `fn(p1..pn, ...)` written with a trailing `...` is inexact (it
-// tolerates extra arguments when used as a callback — accept-set [required, ∞)).
-// Exactness governs callback subtyping, not direct calls (#677); see solver's
-// acceptSet / the FuncType<:FuncType constrain rule.
+// FuncType is a possibly multi-argument function type. Inexact distinguishes two
+// forms. A bare `fn(p1..pn)` is exact and tolerates at most n arguments, an
+// accept-set of [required, n]. A `fn(p1..pn, ...)` written with a trailing `...`
+// is inexact and tolerates extra arguments when used as a callback, an accept-set
+// of [required, ∞). Exactness governs callback subtyping, not direct calls. See
+// the solver's acceptSet and the FuncType<:FuncType constrain rule.
 //
-// The flag is Inexact (not Exact) so the ZERO VALUE is exact, matching Escalier's
-// exact-by-default semantics: a function minted without thinking about exactness is
-// correctly exact, and the structural rewriters (coalesce, extrude, freshenAbove)
-// carry the flag through unchanged. Only the parser's `...` marker sets it.
+// The flag is Inexact rather than Exact so the ZERO VALUE is exact, matching
+// Escalier's exact-by-default semantics. A function minted without thinking about
+// exactness is correctly exact, and the structural rewriters coalesce, extrude,
+// and freshenAbove carry the flag through unchanged. Only the parser's `...`
+// marker sets it.
 type FuncType struct {
 	Params  []*FuncParam
 	Ret     Type
-	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
+	Inexact bool // trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 }
 
 // TupleType is a tuple type. Inexact follows the ObjectType/FuncType convention:
@@ -205,18 +204,18 @@ type TupleType struct {
 	Inexact bool // trailing `...` ⇒ true
 }
 
-// ObjectType is the structural object type — the carrier for object literals,
-// object/interface annotations, and (M5) class instance bodies, so one
-// structural-decomposition routine serves all three. It promotes M2's
-// RecordType{Fields} to an ordered element list. M4 ships only PropertyElem;
-// MethodElem/GetterElem/SetterElem arrive in M5, and IndexSigElem plus the
-// object rest/spread RestElem in M9, each a new ObjTypeElem arm.
+// ObjectType is the structural object type, the carrier for object literals,
+// object/interface annotations, and class instance bodies, so one
+// structural-decomposition routine serves all three. It promotes the earlier
+// RecordType{Fields} to an ordered element list. It currently carries only
+// PropertyElem. MethodElem, GetterElem, SetterElem, IndexSigElem, and the object
+// rest/spread RestElem each add a new ObjTypeElem arm later.
 //
-// Inexact follows M3's FuncType convention: the zero value is exact, matching
-// Escalier's exact-by-default semantics, so every object M2 already mints —
-// literals, member-access requirements — is exact by default with no
+// Inexact follows the FuncType convention. The zero value is exact, matching
+// Escalier's exact-by-default semantics, so every object already minted, both
+// literals and member-access requirements, is exact by default with no
 // construction-site churn. Only the parser's trailing `...` marker sets it.
-// Subtyping matches elements by name (order is irrelevant); the slice order is
+// Subtyping matches elements by name, so order is irrelevant. The slice order is
 // preserved only for stable rendering.
 type ObjectType struct {
 	Elems   []ObjTypeElem // ordered, name-deduped (last wins); Prop(name) lookup
@@ -224,15 +223,15 @@ type ObjectType struct {
 }
 
 // ObjTypeElem is the sealed set of object members, mirroring type_system's
-// ObjTypeElem. M4 ships PropertyElem only; method/getter/setter members (M5),
-// index signatures and the object rest/spread (M9) add arms later.
+// ObjTypeElem. It currently carries PropertyElem only. Method, getter, and setter
+// members, index signatures, and the object rest/spread add arms later.
 type ObjTypeElem interface{ isObjTypeElem() }
 
 // PropertyElem is one named value property of an ObjectType.
 type PropertyElem struct {
 	Name     string
 	Type     Type
-	Optional bool // `x?: T`; the M9 object-spread show-through rule keys off it
+	Optional bool // `x?: T`; the object-spread show-through rule keys off it
 	Readonly bool // `readonly f: T`; forbids `obj.f = …` only, orthogonal to deep mut
 }
 
@@ -241,10 +240,10 @@ func (*PropertyElem) isObjTypeElem() {}
 // Prop returns the named property and whether it is present. Property names are
 // unique in a well-formed ObjectType — the constraint solver dedups duplicate
 // keys (last value wins) when it builds an object from a literal — so the first
-// match is the property. The scan is linear because objects are small; it is the
+// match is the property. The scan is linear because objects are small. It is the
 // single canonical property lookup shared by constraining, structural equality,
-// and member access. M4's Elems are all PropertyElem; M5 widens the lookup to
-// method/getter/setter members.
+// and member access. The Elems are currently all PropertyElem; the lookup widens
+// to method/getter/setter members later.
 func (o *ObjectType) Prop(name string) (*PropertyElem, bool) {
 	for _, e := range o.Elems {
 		if p, ok := e.(*PropertyElem); ok && p.Name == name {
@@ -254,15 +253,16 @@ func (o *ObjectType) Prop(name string) (*PropertyElem, bool) {
 	return nil, false
 }
 
-// AsProperty narrows an ObjTypeElem to its *PropertyElem. M4 ships PropertyElem
-// as the only ObjTypeElem kind, so any other element is a bug: a later member
-// kind (method/getter/setter in M5, index signature or object rest/spread in M9)
-// wired up without extending the call site that processes every element. It
-// panics rather than silently skipping, matching type_system's unknown-element
-// convention (print_type.go panics on an unhandled ObjTypeElem) and the M4 plan's
-// standing rule that a missed element kind must fail loudly, not vanish from
-// subtyping, equality, or rendering. Use it at sites that must visit EVERY
-// element; name lookups like Prop legitimately skip non-matching kinds instead.
+// AsProperty narrows an ObjTypeElem to its *PropertyElem. PropertyElem is
+// currently the only ObjTypeElem kind, so any other element is a bug. It would be
+// a later member kind such as a method, getter, setter, index signature, or
+// object rest/spread wired up without extending the call site that processes
+// every element. It panics rather than silently skipping, matching type_system's
+// unknown-element convention where print_type.go panics on an unhandled
+// ObjTypeElem, and the standing rule that a missed element kind must fail loudly,
+// not vanish from subtyping, equality, or rendering. Use it at sites that must
+// visit EVERY element. Name lookups like Prop legitimately skip non-matching
+// kinds instead.
 func AsProperty(e ObjTypeElem) *PropertyElem {
 	p, ok := e.(*PropertyElem)
 	if !ok {
@@ -279,15 +279,16 @@ func AsProperty(e ObjTypeElem) *PropertyElem {
 //	Mut=true  Lt=nil   owned mutable
 //	Mut=true  Lt='a    mutable borrow
 //
-// The single RefType<:RefType constrain rule (M4 C2) reads Mut for inner variance
-// and Lt for the lifetime outlives check. M4 D1 lands the Lifetime sort (the
-// LifetimeVar/StaticLifetime concretes, freshLifetime, constrainLt, the probe
-// extension); D2 attaches a fresh lifetime to a borrowed parameter and activates
-// the rule's outlives step. Until D2 every minted RefType still carries Lt == nil,
-// so the immutable-borrow and lifetime forms above are only reached once D2 lands.
+// The single RefType<:RefType constrain rule reads Mut for inner variance and Lt
+// for the lifetime outlives check. The Lifetime sort comprises the LifetimeVar
+// and StaticLifetime concretes, freshLifetime, constrainLt, and the probe
+// extension. A fresh lifetime is attached to a borrowed parameter, activating the
+// rule's outlives step. Until lifetimes originate on borrows every minted RefType
+// still carries Lt == nil, so the immutable-borrow and lifetime forms above are
+// only reached once that lands.
 type RefType struct {
 	Mut   bool
-	Lt    Lifetime // nilable; carries a lifetime once D2 attaches one to a borrow
+	Lt    Lifetime // nilable; carries a lifetime once one is attached to a borrow
 	Inner RefInner
 }
 
@@ -299,11 +300,11 @@ type RefType struct {
 // `Promise<mut 'a Point>` is a PromiseType whose type argument is a RefType, which
 // is well-formed.
 //
-// M4 admits ObjectType / TupleType / TypeVarType. The TypeVarType arm covers a
-// borrow whose content is still an inference variable; the content invariant — that
-// it resolves to a borrowable type — is checked at constrain time. UnionType /
-// IntersectionType (M6 inputs), AliasType (M7), and ClassType (M5) add their
-// isRefInner arms with those milestones.
+// It currently admits ObjectType, TupleType, and TypeVarType. The TypeVarType arm
+// covers a borrow whose content is still an inference variable. The content
+// invariant, that it resolves to a borrowable type, is checked at constrain time.
+// UnionType, IntersectionType, AliasType, and ClassType add their isRefInner arms
+// later.
 type RefInner interface {
 	Type
 	isRefInner()
@@ -314,15 +315,14 @@ func (*TupleType) isRefInner()   {}
 func (*TypeVarType) isRefInner() {}
 
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
-// M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
-// scope narrow: it is the one stdlib generic the milestone needs typed (Iterable/
-// Generator wait until M5+). The real, alias-driven `Promise<T>` lookup arrives
-// with TypeRef ingestion in M7; until then, an `async fn () -> T` mints a
-// PromiseType{T} externally and `await e` constrains `e <: PromiseType{U}` for a
-// fresh U. Inner is covariant under subtyping (Promise<L> <: Promise<R> iff
-// L <: R) and the `await` rule does NOT recursively flatten (so awaiting
-// `Promise<Promise<T>>` yields `Promise<T>`, matching the milestone's
-// no-auto-flatten contract — flattening is `Awaited<T>`, M9).
+// It is a dedicated concrete rather than a generic TypeRefType, keeping the scope
+// narrow. It is the one stdlib generic typed directly; Iterable and Generator
+// wait. The real, alias-driven `Promise<T>` lookup arrives with TypeRef
+// ingestion. Until then, an `async fn () -> T` mints a PromiseType{T} externally
+// and `await e` constrains `e <: PromiseType{U}` for a fresh U. Inner is covariant
+// under subtyping, so Promise<L> <: Promise<R> iff L <: R. The `await` rule does
+// NOT recursively flatten, so awaiting `Promise<Promise<T>>` yields `Promise<T>`,
+// matching the no-auto-flatten contract. Flattening is `Awaited<T>`.
 type PromiseType struct{ Inner Type }
 
 // Void is the result type of a statement block with no value.
@@ -335,28 +335,28 @@ type Void struct{}
 // first.
 type NullType struct{}
 
-// NeverType (⊥) and UnknownType (⊤) are the bottom/top of the subtype lattice —
-// the coalesced output of an empty-bounds single-polarity variable (positive ⇒
-// never, negative ⇒ unknown). The spike emits these via type_system; M1 carries
-// them natively because they're fundamental to the lattice, not optional sugar.
+// NeverType (⊥) and UnknownType (⊤) are the bottom and top of the subtype
+// lattice, the coalesced output of an empty-bounds single-polarity variable. A
+// positive variable coalesces to never, a negative one to unknown. soltype
+// carries them natively because they are fundamental to the lattice, not optional
+// sugar.
 type NeverType struct{}
 type UnknownType struct{}
 
 // UnionType / IntersectionType are coalesced-output nodes for multi-bound
-// single-polarity variables (positive ⇒ union of lowers, negative ⇒ intersection
-// of uppers). The spike emits these via type_system.NewUnionType /
-// NewIntersectionType; M1 carries them natively so coalescing returns
-// soltype.Type in every case. M6 promotes them to first-class lattice members:
-// legal `constrain` inputs (M6 PR2), writable annotations (M6 PR2), and the
-// subjects of a normalization pass (M6 PR1).
+// single-polarity variables. A positive variable coalesces to a union of its
+// lowers, a negative one to an intersection of its uppers. soltype carries them
+// natively so coalescing returns soltype.Type in every case. They are later
+// promoted to first-class lattice members: legal `constrain` inputs, writable
+// annotations, and the subjects of a normalization pass.
 //
 // UnionType.Inexact flags whether the union is open. A bare `A | B` is
 // exact, so its inhabitants are exactly A ∪ B. An `A | B | ...` written with
-// a trailing `...` is inexact: at least these, with an unknown-typed tail.
+// a trailing `...` is inexact, meaning at least these, with an unknown-typed tail.
 // The flag is Inexact rather than Exact so the zero value is exact, matching
 // the ObjectType, TupleType, and FuncType convention. IntersectionType
 // carries no exactness flag, since exactness is a property of the result
-// rather than the meet. The flag and the smart constructors land with M6 PR1.
+// rather than the meet.
 type UnionType struct {
 	Types []Type
 	// Inexact tracks the trailing `...` marker. The zero value is exact.
@@ -364,17 +364,16 @@ type UnionType struct {
 }
 type IntersectionType struct{ Types []Type }
 
-// ErrorType is the error-recovery sentinel (M3 PR8) — a childless atom distinct
-// from never (⊥) and unknown (⊤). Unlike those two, which are coalesced-OUTPUT
-// only ("appear only as coalesced output, never as constrain inputs", above),
-// ErrorType is a legal constrain INPUT that ABSORBS in both directions: any
-// constraint with an ErrorType operand trivially succeeds. report (solver) mints
-// it as the value-position placeholder after emitting a diagnostic, so the
-// placeholder never cascades a second, spurious failure — the standard "error
-// type" of TS / Roslyn / GHC. It is never user-spellable (distinct from a future
-// `any`) and never produced from user syntax; it renders as `error` for
-// diagnostics/debug only.
-type ErrorType struct{} // ⊤⊥ absorbing sentinel; see PR8
+// ErrorType is the error-recovery sentinel, a childless atom distinct from never
+// (⊥) and unknown (⊤). Unlike those two, which are coalesced-OUTPUT only and never
+// appear as constrain inputs, ErrorType is a legal constrain INPUT that ABSORBS in
+// both directions, so any constraint with an ErrorType operand trivially succeeds.
+// The solver's report mints it as the value-position placeholder after emitting a
+// diagnostic, so the placeholder never cascades a second, spurious failure. This
+// is the standard "error type" of TS, Roslyn, and GHC. It is never user-spellable,
+// distinct from a future `any`, and never produced from user syntax. It renders as
+// `error` for diagnostics and debug only.
+type ErrorType struct{} // ⊤⊥ absorbing sentinel
 
 func (*TypeVarType) isType()      {}
 func (*PrimType) isType()         {}
@@ -393,7 +392,7 @@ func (*IntersectionType) isType() {}
 func (*ErrorType) isType()        {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
-// Trimmed to the M1 type set (grows back as later milestones add formers).
+// It covers the current type set and grows as new formers are added.
 func LevelOf(t Type) int {
 	switch t := t.(type) {
 	case *TypeVarType:
@@ -419,13 +418,13 @@ func LevelOf(t Type) int {
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:
-		// A borrow's level is the max of its inner content's and its lifetime's (M4
-		// D2.5). The lifetime is a SECOND quantifiable variable on the wrapper: a
-		// concrete-inner borrow whose lifetime var sits above a freshen/extrude limit
-		// must NOT be pruned and shared whole, or two instantiations would alias one
-		// LifetimeVar. Folding the lifetime level in here is the load-bearing change
-		// that makes the level prune descend into such a borrow to freshen its
-		// lifetime. LevelOfLifetime returns 0 for 'static and a nil slot.
+		// A borrow's level is the max of its inner content's and its lifetime's. The
+		// lifetime is a SECOND quantifiable variable on the wrapper. A concrete-inner
+		// borrow whose lifetime var sits above a freshen/extrude limit must NOT be
+		// pruned and shared whole, or two instantiations would alias one LifetimeVar.
+		// Folding the lifetime level in here is the load-bearing change that makes the
+		// level prune descend into such a borrow to freshen its lifetime.
+		// LevelOfLifetime returns 0 for 'static and a nil slot.
 		return max(LevelOf(t.Inner), LevelOfLifetime(t.Lt))
 	// Union and Intersection recurse into their members for the same reason, but only
 	// the IntersectionType arm is load-bearing today. overloadIntersection (solver) is

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -15,12 +15,12 @@ type EnterResult struct {
 
 // TypeVisitor is a polarity-threading rewriting visitor over soltype.Type. Unlike
 // type_system's visitor it carries Polarity, and Accept flips it on contravariant
-// positions (function parameters) so variance knowledge lives in ONE place rather
-// than being re-spelled in every type→type transform (coalesce / extrude /
-// freshenAbove). EnterType fires before child traversal — it may prune, replace,
-// or take over the recursion via SkipChildren (the var node's bounds are a side
-// graph, not tree children, so each transform handles TypeVarType itself in
-// EnterType). ExitType fires after, bottom-up, as a function of the
+// positions such as function parameters so variance knowledge lives in ONE place
+// rather than being re-spelled in every type→type transform such as coalesce,
+// extrude, and freshenAbove. EnterType fires before child traversal. It may prune,
+// replace, or take over the recursion via SkipChildren. The var node's bounds are
+// a side graph, not tree children, so each transform handles TypeVarType itself in
+// EnterType. ExitType fires after, bottom-up, as a function of the
 // already-rewritten children.
 type TypeVisitor interface {
 	EnterType(t Type, pol Polarity) EnterResult
@@ -146,25 +146,25 @@ func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	// The inner is visited ONCE in the current polarity — the read view. When Mut,
-	// the inner is also a write view (the contravariant constrain step in C2), but
+	// The inner is visited ONCE in the current polarity, the read view. When Mut,
+	// the inner is also a write view through the contravariant constrain step, but
 	// the rewriting transforms visit it a single time and share fresh vars through
-	// their own cache, exactly as the spike's extrude treated a Mut inner. The
-	// lifetime is not a Type, so Accept never walks it; only the lifetime-aware
-	// passes (D4) do.
+	// their own cache. The lifetime is not a Type, so Accept never walks it; only
+	// the lifetime-aware passes do.
 	//
-	// KNOWN GAP (D2): C2's constrain rule makes a Mut borrow's inner INVARIANT (it
-	// adds both a read and a write constraint), but this single covariant visit means
+	// KNOWN GAP: the constrain rule makes a Mut borrow's inner INVARIANT, adding both
+	// a read and a write constraint, but this single covariant visit means
 	// extrude/freshenAbove wire an out-of-level inner var through only one bound
-	// direction. This is inert today — no inference path mints a RefType, so extrude
-	// never sees a real Mut borrow — and Accept is shared with coalesce, which WANTS a
-	// single covariant visit, so the fix belongs in extrude/freshenAbove (not here)
-	// once borrows originate (D2) and the case becomes reachable and testable.
+	// direction. This is inert today, since no inference path mints a RefType, so
+	// extrude never sees a real Mut borrow. Accept is shared with coalesce, which
+	// WANTS a single covariant visit, so the fix belongs in extrude/freshenAbove
+	// rather than here once borrows originate and the case becomes reachable and
+	// testable.
 	//
 	// The OCCURRENCE-analysis half of this invariance is already handled separately,
-	// not here: simplify.go's recordMutWriteView walks a Mut inner in the flipped
+	// not here. simplify.go's recordMutWriteView walks a Mut inner in the flipped
 	// polarity for the occurrence and co-occurrence visitors, so a var written through
-	// a mut field is retained as a type parameter rather than dropped (#737). That is a
+	// a mut field is retained as a type parameter rather than dropped. That is a
 	// record-only pass, so it can add the write view without the double visit coalesce
 	// must avoid.
 	inner := cur.Inner.Accept(v, pol)
@@ -251,8 +251,8 @@ func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, b
 }
 
 // acceptObjElems walks each property's type covariantly, copy-on-write like
-// acceptParams. M4's elements are all PropertyElem; later member kinds add their
-// own variance treatment here.
+// acceptParams. The elements are currently all PropertyElem; later member kinds
+// add their own variance treatment here.
 func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeElem, bool) {
 	out := es
 	changed := false
@@ -298,4 +298,3 @@ func (s *typeVarSeeker) EnterType(t Type, _ Polarity) EnterResult {
 }
 
 func (s *typeVarSeeker) ExitType(t Type, _ Polarity) Type { return t }
-

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -202,10 +202,9 @@ func TestAcceptDescendDifferentKindPanics(t *testing.T) {
 }
 
 // An Accept rewrite over an inexact ObjectType carries the Inexact flag onto the
-// rebuilt object. The old RecordType rebuild had no flag to carry; the M4
-// ObjectType.Accept must copy it (visitor.go), or a coalesce/extrude/freshenAbove
-// pass would silently turn an inexact object exact. This pins the property the A1
-// plan flagged as a latent bug the new field exposes.
+// rebuilt object. The old RecordType rebuild had no flag to carry; ObjectType.Accept
+// must copy it in visitor.go, or a coalesce/extrude/freshenAbove pass would silently
+// turn an inexact object exact. This pins a latent bug the Inexact field exposes.
 func TestAcceptObjectPreservesInexact(t *testing.T) {
 	num := &PrimType{Prim: NumPrim}
 	str := &PrimType{Prim: StrPrim}

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -11,8 +11,8 @@ import (
 
 // spanText returns the source substring covered by s. Columns are 1-indexed and
 // the end is exclusive (the lexer's convention), so a token at columns [c, c+n)
-// renders n characters. M2.5's error spans are single-line; a multi-line span is
-// not expected here and yields "".
+// renders n characters. Error spans are single-line; a multi-line span is not
+// expected here and yields "".
 func spanText(src string, s ast.Span) string {
 	lines := strings.Split(src, "\n")
 	if s.Start.Line < 1 || s.Start.Line > len(lines) || s.Start.Line != s.End.Line {
@@ -27,7 +27,7 @@ func spanText(src string, s ast.Span) string {
 
 // requireBlame asserts the sole error's message, the source text its primary span
 // covers, and the source text each related span covers (in order). The golden
-// span fixtures (§3.10) use it to pin exact blame against real-parser spans.
+// span fixtures use it to pin exact blame against real-parser spans.
 func requireBlame(t *testing.T, src string, errs []SolverError, msg, primary string, related ...string) {
 	t.Helper()
 	require.Len(t, errs, 1)
@@ -44,10 +44,10 @@ func requireBlame(t *testing.T, src string, errs []SolverError, msg, primary str
 	require.Equal(t, want, got, "related blame")
 }
 
-// --- Golden span fixtures (§3.10): exact blame against real-parser spans ---
+// --- Golden span fixtures: exact blame against real-parser spans ---
 
 // A val-annotation mismatch blames the offending literal, with the annotation as
-// the related expected-source — the milestone's headline fixture (§3.7).
+// the related expected-source. This is the headline fixture.
 func TestBlameValAnnotationLiteral(t *testing.T) {
 	src := `val x: number = "hi"`
 	_, _, errs := inferSource(t, src)
@@ -62,12 +62,11 @@ func TestBlameCallArgument(t *testing.T) {
 	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
 }
 
-// A too-many-args direct call is the PR4 extra-arg lint (TooManyArgsError), a
-// BRIDGE error that self-blames the whole call and relates the callee expression.
-// (It supersedes the FuncArityMismatch this fixture asserted before PR4 — too-many
-// is now the lint's uniform message, while FuncArityMismatch keeps the too-few /
+// A too-many-args direct call is the extra-arg lint (TooManyArgsError), a BRIDGE
+// error that self-blames the whole call and relates the callee expression. Too-many
+// is the lint's uniform message, while FuncArityMismatch keeps the too-few and
 // callback-arity failures. The related span is the callee `f` here, derived from
-// the AST, not the callee's definition span resolved through Prov.)
+// the AST, not the callee's definition span resolved through Prov.
 func TestBlameCallTooManyArgs(t *testing.T) {
 	src := "fn f(x: number) -> number { return x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
@@ -75,10 +74,10 @@ func TestBlameCallTooManyArgs(t *testing.T) {
 		"Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
 }
 
-// A too-few-args direct call is the PR4 too-few lint (NotEnoughArgsError), a BRIDGE
-// error symmetric to TooManyArgsError: it self-blames the whole call and relates the
-// callee expression (`f` here, from the AST — not the callee's definition resolved
-// through Prov). `f` requires two params; the call supplies one.
+// A too-few-args direct call is the too-few lint (NotEnoughArgsError), a BRIDGE
+// error symmetric to TooManyArgsError. It self-blames the whole call and relates
+// the callee expression, `f` here, from the AST rather than the callee's definition
+// resolved through Prov. `f` requires two params; the call supplies one.
 func TestBlameCallTooFewArgs(t *testing.T) {
 	src := "fn f(x: number, y: number) -> number { return x }\nval r = f(1)"
 	_, _, errs := inferSource(t, src)
@@ -87,14 +86,12 @@ func TestBlameCallTooFewArgs(t *testing.T) {
 }
 
 // A missing-property read blames the member's prop (.foo), not the receiver, with
-// the receiver's definition as the related span. Like TestBlameCallArity, M2.5
-// resolved that related span only for an inline receiver (a named receiver was
-// coalesced to a fresh ObjectType with no Prov entry); M3's generalize-and-share
-// instantiation keeps a VAR-FREE receiver's original object — here `{a: 5}` is
-// monomorphic, so it is shared unchanged through instantiation (recorded
-// ObjectField against the literal) — so the named receiver's related span now
-// resolves. A receiver whose value flowed through an instantiation that REBUILT it
-// (e.g. the result of a polymorphic call) does not keep the entry; see
+// the receiver's definition as the related span. Generalize-and-share
+// instantiation keeps a VAR-FREE receiver's original object. Here `{a: 5}` is
+// monomorphic, so it is shared unchanged through instantiation with an ObjectField
+// recorded against the literal, so the named receiver's related span resolves. A
+// receiver whose value flowed through an instantiation that REBUILT it, such as the
+// result of a polymorphic call, does not keep the entry; see
 // TestBlameMissingPropertyPolymorphicReceiverLosesRelated.
 func TestBlameMissingProperty(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o.b"
@@ -102,8 +99,8 @@ func TestBlameMissingProperty(t *testing.T) {
 	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
 }
 
-// The bound of M3's related-span improvement: a receiver derived from a
-// POLYMORPHIC call loses its related "defined here" span. Instantiating `mk`
+// The bound of the related-span improvement. A receiver derived from a POLYMORPHIC
+// call loses its related "defined here" span. Instantiating `mk`
 // freshens its body, rebuilding the record into a fresh pointer with no Prov
 // entry, so the missing-property error carries no related receiver span — unlike
 // the direct var-free literal in TestBlameMissingProperty. Documents that the
@@ -115,9 +112,9 @@ func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
 	requireBlame(t, src, errs, "object is missing property: b", "b")
 }
 
-// An identifier-flow mismatch blames the USE, not the definition: x's type traces
+// An identifier-flow mismatch blames the USE, not the definition. x's type traces
 // to its definition, which is not inside the use's constraint node, so the
-// containment guard falls back to the use (§3.8). The annotation is the related
+// containment guard falls back to the use. The annotation is the related
 // expected-source.
 func TestBlameIdentifierUseNotDefinition(t *testing.T) {
 	src := "val x = \"hi\"\nval a: number = x"
@@ -196,12 +193,12 @@ func tspan(sl, sc, el, ec int) ast.Span {
 }
 
 // The three site-carrying constraint kinds degrade to the constraint site when
-// NEITHER operand resolves through Prov, rather than returning the zero span
-// (which a consumer would mis-render as 0:0). Unlike every fixture above, this path
-// is UNREACHABLE from M2.5 source — FuncArity always records the call-shape,
+// NEITHER operand resolves through Prov, rather than returning the zero span that a
+// consumer would mis-render as 0:0. Unlike every fixture above, this path is
+// UNREACHABLE from source today. FuncArity always records the call-shape,
 // MissingProperty always records the field var, and tuple <: tuple cannot fire
-// without a tuple sink — so it must be exercised with hand-built errors and a
-// seeded Prov here; it becomes live with M4 record/tuple sinks.
+// without a tuple sink, so it must be exercised with hand-built errors and a seeded
+// Prov here. It becomes live once record/tuple sinks land.
 func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 	site := ast.NewIdent("site", tspan(7, 3, 7, 12))
 
@@ -260,11 +257,11 @@ func TestConstraintKindsFallBackToSiteWhenUnrecorded(t *testing.T) {
 
 // checker.constrain stamps prov + the constraint node onto EVERY constraint-error
 // kind it forwards, so each error's Span() resolves to a real source span instead
-// of the zero span. The object errors (InexactIntoExactError, ExtraPropertyError,
-// OptionalPropertyError) were added in M4 A1; this pins that their switch arms
-// exist — a missing arm leaves prov/site nil and Span() degrades to 0:0. Exercised
-// directly through c.constrain because an exact-object sink is not reachable from
-// source until object annotations land (A3).
+// of the zero span. This pins that the switch arms for the object errors
+// InexactIntoExactError, ExtraPropertyError, and OptionalPropertyError exist. A
+// missing arm leaves prov/site nil and Span() degrades to 0:0. Exercised directly
+// through c.constrain because an exact-object sink is not reachable from source
+// until object annotations land.
 func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 	node := ast.NewIdent("site", tspan(4, 2, 4, 6))
 
@@ -300,7 +297,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 	})
 }
 
-// --- M2.5 finding #1: unsupported-annotation recovery (no spurious `<: never`) ---
+// --- Unsupported-annotation recovery: no spurious `<: never` ---
 
 // An unsupported annotation reports ITS OWN error once and the binding recovers to
 // the type it would otherwise infer — no cascade `cannot constrain e <: never`, no
@@ -328,10 +325,11 @@ func TestUnsupportedAnnotationRecovers(t *testing.T) {
 	}
 }
 
-// A VarDecl with a nil pattern (not produced by the parser, which synthesizes a
-// placeholder, but possible in a hand-built AST) must blame the decl without
-// panicking — honoring M2's "never a panic" guarantee now that Span() is lazy
-// (it derefs the stored node on demand). Mirrors inferFunc's nil-param fallback.
+// A VarDecl with a nil pattern must blame the decl without panicking. The parser
+// synthesizes a placeholder instead, so a nil pattern is only possible in a
+// hand-built AST. This honors the "never a panic" guarantee now that Span() is
+// lazy and derefs the stored node on demand. Mirrors inferFunc's nil-param
+// fallback.
 func TestNilVarDeclPatternBlamesDeclWithoutPanic(t *testing.T) {
 	c := newChecker()
 	d := ast.NewVarDecl(ast.ValKind, nil, nil, numExpr(5), false, false, testSpan())

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -9,31 +9,25 @@ import (
 )
 
 // coalesce walks a bound-carrying soltype.Type and returns a *coalesced*
-// soltype.Type in which every TypeVarType has been inlined to its bounds
-// (Delta #1 in m1-implementation-plan §2.2): positive position ⇒ the union of
-// the variable's lower bounds, negative position ⇒ the intersection of its
-// upper bounds, with empty bounds collapsing to never (⊥, positive) or unknown
-// (⊤, negative).
+// soltype.Type in which every TypeVarType has been inlined to its bounds. A
+// positive position yields the union of the variable's lower bounds, a negative
+// position yields the intersection of its upper bounds, with empty bounds
+// collapsing to never (⊥, positive) or unknown (⊤, negative).
 //
-// It is a package-private free function in M1 — it needs no Context (no shared
-// counters or occurrence state until M3 reintroduces them). Unlike the spike,
-// M1's coalescer is uniformly inlining: no bipolar-variable retention, no
-// occurrence-analysis input, no named-ref output node. That whole
-// polymorphism-rendering bundle lands in M3 (§3.3).
+// It is a package-private free function that needs no Context, since it carries
+// no shared counters or occurrence state. The coalescer is uniformly inlining:
+// no bipolar-variable retention, no occurrence-analysis input, no named-ref
+// output node.
 //
-// M1 had no `seen` recursion guard: the M1 type set has no recursive formers
-// (no aliases, no recursive types), so a uniform-inline walk terminates on a
-// bound graph built from non-recursive source. M2's SCC driver (PR-5) breaks
-// that assumption — a mutually-recursive group can build a cyclic var↔var bound
-// graph (constrain appends var-to-var bounds and terminates on cycles via its
-// own coinductive seen-set; coalesce would not) — so PR-5 pulls forward the
-// path-scoped recursion guard the plan slated for M3 (m2-implementation-plan §7).
-// See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
-// recursive rendering; this guard only keeps the monomorphic walk total.
+// A mutually-recursive group can build a cyclic var↔var bound graph. constrain
+// appends var-to-var bounds and terminates on cycles via its own coinductive
+// seen-set, while coalesce would not, so coalesce carries a path-scoped
+// recursion guard. See coalesceRec for the guard's behavior. The guard only
+// keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
-	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
-	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
+	c = bubbleOwnedMut(c)            // lift an owned-mut cell out of an immutable container
+	return coalesceLifetimes(c, pol) // resolve borrow lifetimes to their display form
 }
 
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the
@@ -57,10 +51,9 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 		return soltype.EnterResult{}
 	}
 	// Re-entering a variable already on the current path is an ungrounded recursive
-	// position (no concrete type breaks the cycle). It collapses to the polarity
+	// position, where no concrete type breaks the cycle. It collapses to the polarity
 	// identity — the same value the position degenerates to when its bounds are
-	// empty — which keeps the inline walk total. A precise μ-bound rendering of
-	// such recursion is M3.
+	// empty — which keeps the inline walk total.
 	if c.seen.Contains(v) {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}
 	}
@@ -81,14 +74,14 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 
 func (c *coalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
-	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
+	// post-pass, which needs the whole type to analyze lifetime occurrence.
 	return t
 }
 
 // bubbleOwnedMut rewrites a coalesced display type so no owned-mutable cell ever
-// sits inside an immutable object or tuple (#779). `mut` is deep, so an owned-mut
+// sits inside an immutable object or tuple. `mut` is deep, so an owned-mut
 // field is equivalent to making the whole container `mut`: `{p: mut {x}}` means the
-// same as `mut {p: {x}}`. The nested form is the one the C3 field-write fold produces
+// same as `mut {p: {x}}`. The nested form is the one the field-write fold produces
 // for `obj.p.x = 5`, and it is no longer a valid annotation, so the rendered
 // signature must take the bubbled-up form to stay re-writable.
 //
@@ -162,7 +155,7 @@ func (b *mutBubbler) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type
 }
 
 // widenVar lowers a widenable `var` binding's coalesced value to its primitive
-// (M4 B3) when it is read in covariant (Positive) position — `var a = 5` ⇒
+// when it is read in covariant (Positive) position — `var a = 5` ⇒
 // number, `var p = {x: 0}` ⇒ {x: number}. It runs AFTER combine, so a union of
 // literals from distinct branches (`var a = if c { 1 } else { 2 }`) is left as
 // `1 | 2`: widen passes a UnionType through, matching the reassignment rule that
@@ -212,25 +205,25 @@ type occKey struct {
 // reduces, node for node, to coalesce(t, Positive), keeping every monomorphic
 // render unchanged.
 //
-// simplifyScheme (PR2) runs the co-occurrence analysis up front and hands the
+// simplifyScheme runs the co-occurrence analysis up front and hands the
 // coalescer the resulting merge classes, which it only reads. Distinct quantified
 // variables that always appear together resolve to one representative and so share
 // a single type parameter. That collapses outer's
 // `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` to `fn <T0>(y: T0) -> [T0, T0]`.
 //
-// The retain decision degenerates to PR1's when nothing merges and symmetrization
-// surfaces no extra occurrence. Each variable is then its own representative with
-// its own polarities, so the check is exactly PR1's per-variable both-polarities
-// test.
+// The retain decision degenerates to the per-variable test when nothing merges and
+// symmetrization surfaces no extra occurrence. Each variable is then its own
+// representative with its own polarities, so the check is exactly the per-variable
+// both-polarities test.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 	c := t.Accept(&schemeCoalescer{
 		simp:     simplifyScheme(t, genLevel),
 		genLevel: genLevel,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
-	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
+	c = bubbleOwnedMut(c) // lift an owned-mut cell out of an immutable container
 	// A scheme display is always coalesced from the Positive root.
-	return coalesceLifetimes(c, soltype.Positive) // D4: resolve borrow lifetimes to their display form
+	return coalesceLifetimes(c, soltype.Positive) // resolve borrow lifetimes to their display form
 }
 
 // schemeCoalescer is the soltype-visitor form of coalesceScheme. It has the same
@@ -264,8 +257,8 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both() && !hasEqualBounds(rep)
 	if c.seen.Contains(rep) {
 		// A cycle back to a variable already on the path: a retained type parameter
-		// keeps its name (a rough μ-reference, refined in M3's precise μ-rendering),
-		// an inlined variable collapses to the polarity identity.
+		// keeps its name as a rough μ-reference, an inlined variable collapses to the
+		// polarity identity.
 		if retain {
 			return soltype.EnterResult{Type: rep, SkipChildren: true}
 		}
@@ -309,7 +302,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 
 func (c *schemeCoalescer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	// Borrow lifetimes are left raw here and resolved by the coalesceLifetimes
-	// post-pass, which needs the whole type to analyze lifetime occurrence (D4).
+	// post-pass, which needs the whole type to analyze lifetime occurrence.
 	return t
 }
 
@@ -351,7 +344,7 @@ func renderScheme(s TypeScheme) string {
 // hasEqualBounds reports whether v's lower and upper bound sets are non-empty and
 // structurally equal, which pins it to a single concrete type: it has no freedom as a
 // type parameter and is inlined rather than retained. This arises for the receiver
-// var of a deep-mut nested write (#779): `obj.p.x = 5` makes obj.p invariant inside
+// var of a deep-mut nested write: `obj.p.x = 5` makes obj.p invariant inside
 // the mut container, and the residual write-back gives it equal lower and upper
 // bounds `{x: number, ...}`. Retaining it would surface a spurious `T0 & {x: number}`
 // where the pinned `{x: number}` is exact. A var with a genuine type-parameter role,
@@ -416,28 +409,26 @@ func emptyOf(pol soltype.Polarity) soltype.Type {
 
 // combine builds a soltype.UnionType (Positive) or soltype.IntersectionType
 // (Negative) of parts, returning the sole element directly when only one
-// remains. The UnionType/IntersectionType nodes ship in M1 (soltype/type.go) so
-// combine can always return a native soltype.Type.
+// remains.
 //
 // In Negative position the object parts are first folded into a single object by
-// foldUsageBounds (B1) so member-access requirements on one receiver render as one
+// foldUsageBounds so member-access requirements on one receiver render as one
 // compact object rather than an intersection of one-property objects. The folded
-// object closes to exact unless `open` is set — an `open` parameter (B2) stays
+// object closes to exact unless `open` is set — an `open` parameter stays
 // row-polymorphic (inexact). This is the DISPLAY fold; sealUsageObjects runs the
 // same foldUsageBounds operatively on the stored bounds at generalization.
 func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type {
 	if pol == soltype.Negative {
 		parts = foldUsageBounds(parts, open)
 	}
-	// Route through the M6 PR1 smart constructors so the coalesced output is
+	// Route through the smart constructors so the coalesced output is
 	// flattened, deduped, lattice-identity-pruned, and canonically ordered.
 	// The Context is nil here. Members are already coalesced and concrete, so
 	// the core normalization is enough. Subsumption is reserved for the
-	// Context-bearing mint sites resolveTypeAnn in PR2 and joinBorrows in PR6.
+	// Context-bearing mint sites resolveTypeAnn and joinBorrows.
 	// The single-member collapse is handled by the constructor.
 	//
-	// Coalesced unions are exact by default. An inferred shape is closed
-	// unless PR4 threads an inexact source flag through to here.
+	// Coalesced unions are exact by default. An inferred shape is closed.
 	if pol == soltype.Positive {
 		return newUnion(nil, parts, false)
 	}
@@ -468,26 +459,26 @@ func combine(pol soltype.Polarity, parts []soltype.Type, open bool) soltype.Type
 // non-member object to mergeObjectGroup/AsProperty.
 //
 // Member-access requirements on one receiver arrive as separate inexact
-// one-property objects: A1's inferMember lowers `obj.a; obj.b` to the upper bounds
+// one-property objects: inferMember lowers `obj.a; obj.b` to the upper bounds
 // `{a: β, ...}` and `{b: γ, ...}` on the receiver var. Folding them yields
 // `{a: β, b: γ}` instead of the non-compact `{a: β, ...} & {b: γ, ...}`. A
 // property appearing in several parts becomes the intersection of its types,
 // because `obj <: {a: β}` and `obj <: {a: γ}` together require `obj.a <: β & γ`.
 //
-// Policy A (exact-types spec §8.1): the folded usage object closes to EXACT once
+// The folded usage object closes to EXACT once
 // body inference has produced every selection on the receiver. The per-access
-// requirements stay inexact (A1); only this folded result is sealed. The `open`
-// parameter marker (B2) is the opt-out: when set, the folded object stays inexact
+// requirements stay inexact; only this folded result is sealed. The `open`
+// parameter marker is the opt-out: when set, the folded object stays inexact
 // so the param is row-polymorphic and callers may pass objects with extra fields.
 //
-// Whole-object `mut` merge (M4 C3): the field-write path records a write `obj.x =
+// Whole-object `mut` merge: the field-write path records a write `obj.x =
 // 5` as a MUTABLE inexact requirement `mut {x: number, ...}` on the receiver var,
 // alongside the bare inexact reads. When ANY write is present, every selection —
 // reads and writes alike — folds into ONE object wrapped in `mut`, following
-// internal/checker rather than the spike's per-field partition: `obj.x = 5; obj.y =
+// internal/checker rather than a per-field partition: `obj.x = 5; obj.y =
 // 10` ⇒ `mut {x, y}` and the mixed `val x = obj.bar; obj.baz = 5` ⇒
 // `mut {bar, baz}` — a single object, not `{bar} & mut {baz}`. With
-// no write the reads fold into a bare (immutable) object, the pre-C3 behavior. The
+// no write the reads fold into a bare immutable object. The
 // tradeoff: wrapping the whole object in `mut` makes read-only fields invariant
 // rather than covariant; for a generalized function this is invisible because each
 // read-only field is a fresh-per-call type parameter.
@@ -591,7 +582,7 @@ func mergeObjectGroup(objs []*soltype.ObjectType, open bool) *soltype.ObjectType
 		// coalesced, so the core normalization is enough.
 		elems[i] = &soltype.PropertyElem{Name: name, Type: newIntersection(nil, types[name]), Optional: optional[name], Readonly: readonly[name]}
 	}
-	// Closed (Inexact: false) by Policy A; an `open` param leaves it inexact (B2).
+	// Closed (Inexact: false) by the close-to-exact rule; an `open` param leaves it inexact.
 	return &soltype.ObjectType{Elems: elems, Inexact: open}
 }
 
@@ -608,9 +599,7 @@ func appendDistinct(parts []soltype.Type, t soltype.Type) []soltype.Type {
 }
 
 // dedup removes structurally-equal parts, preserving first-occurrence order.
-// The spike deduplicated by rendered string (via type_system.PrintType); M1
-// has no printer in `solver` yet (it ships in PR4, in `soltype`), so M1
-// deduplicates by structural equality instead.
+// It deduplicates by structural equality.
 func dedup(parts []soltype.Type) []soltype.Type {
 	out := make([]soltype.Type, 0, len(parts))
 	for _, p := range parts {
@@ -710,7 +699,7 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the
-		// lifetimes must match: D2 mints borrow lifetimes, so two borrows differing only
+		// lifetimes must match. Borrows carry lifetimes, so two borrows differing only
 		// in lifetime are NOT equal. Without the Lt check, dedup would collapse them and
 		// silently drop a lifetime the solver computed. ltEqual compares a LifetimeVar by
 		// pointer and 'static by value.
@@ -718,7 +707,7 @@ func equalType(a, b soltype.Type) bool {
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
-		// one. The M6 PR1 newUnion imposes canonical member order at
+		// one. newUnion imposes canonical member order at
 		// construction, so the positional equalTypeSlice is order-stable and
 		// two unions over the same member set are now equal whatever order
 		// their members were minted in.
@@ -730,13 +719,13 @@ func equalType(a, b soltype.Type) bool {
 	return false
 }
 
-// ltEqual reports lifetime equality for equalType's RefType arm (D2). Each lifetime
+// ltEqual reports lifetime equality for equalType's RefType arm. Each lifetime
 // form has its own equality rule:
 //   - A LifetimeVar is identity-keyed. Two are equal only when they are the same
 //     pointer.
 //   - 'static is a value, so any two StaticLifetimes are equal.
 //   - A nil lifetime is an owned-mutable borrow. It equals only another nil.
-//   - A LifetimeUnion is the union form a join variable coalesces to in D3, such as
+//   - A LifetimeUnion is the union form a join variable coalesces to, such as
 //     'a | 'b. Two are equal when they hold the same members, pairwise equal in
 //     order. This lets two RefTypes carrying the same coalesced union dedup.
 //

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -17,7 +17,7 @@ func TestCoalesceAtomsPassThrough(t *testing.T) {
 		{"void", &soltype.Void{}},
 		{"never", &soltype.NeverType{}},
 		{"unknown", &soltype.UnknownType{}},
-		{"error", &soltype.ErrorType{}}, // PR8 recovery sentinel: a childless atom
+		{"error", &soltype.ErrorType{}}, // recovery sentinel: a childless atom
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -95,9 +95,10 @@ func TestCoalesceMultiBound(t *testing.T) {
 	})
 }
 
-// TestCoalesceNegativeObjectMerge pins B1: a negative variable carrying several
-// member-access requirements as separate inexact one-property objects coalesces to
-// a single EXACT object (Policy A), not an intersection of one-property objects.
+// TestCoalesceNegativeObjectMerge pins the negative-object merge: a negative
+// variable carrying several member-access requirements as separate inexact
+// one-property objects coalesces to a single EXACT object, not an intersection of
+// one-property objects.
 // This is the receiver of `fn (p) { p.a; p.b }`, whose body lands `{a: …, ...}` and
 // `{b: …, ...}` on p's upper bounds.
 func TestCoalesceNegativeObjectMerge(t *testing.T) {
@@ -153,7 +154,7 @@ func TestCoalesceNegativeObjectMerge(t *testing.T) {
 			num(),
 		}
 		got := coalesce(p, soltype.Negative)
-		// Members are in canonical order (M6 PR1): PrimType ranks before
+		// Members are in canonical order: PrimType ranks before
 		// ObjectType, so `number & {a: number}`.
 		want := &soltype.IntersectionType{Types: []soltype.Type{
 			num(),
@@ -163,7 +164,7 @@ func TestCoalesceNegativeObjectMerge(t *testing.T) {
 	})
 }
 
-// TestCoalesceMutWriteFold pins the C3 whole-object mut merge: a field-write bound
+// TestCoalesceMutWriteFold pins the whole-object mut merge: a field-write bound
 // (a mut-wrapped inexact object) folds with the receiver's reads into ONE object,
 // and the presence of any write wraps the merged object in `mut`. usageObject is the
 // classifier that routes both read and write requirements into the fold.
@@ -192,7 +193,7 @@ func TestCoalesceMutWriteFold(t *testing.T) {
 		require.True(t, equalType(want, got), "got %s", soltype.Print(got))
 	})
 
-	// With no write, reads fold into a bare (immutable) object — the pre-C3 behavior,
+	// With no write, reads fold into a bare immutable object,
 	// confirming the mut wrap is gated on an actual write.
 	t.Run("reads only fold to a bare object", func(t *testing.T) {
 		c := &Context{}
@@ -232,9 +233,9 @@ func TestUsageObject(t *testing.T) {
 	}
 }
 
-// TestCoalesceOpenVarStaysInexact pins B2: an `open` parameter var's folded usage
-// object stays inexact (row-polymorphic) instead of closing to exact. The Open flag
-// on the var is the opt-out from B1's Policy-A close.
+// TestCoalesceOpenVarStaysInexact pins the open-var rule: an `open` parameter var's
+// folded usage object stays inexact and row-polymorphic instead of closing to exact.
+// The Open flag on the var is the opt-out from the close to exact.
 func TestCoalesceOpenVarStaysInexact(t *testing.T) {
 	// An open var with two member-access requirements folds to one INEXACT object.
 	t.Run("open var folds to inexact object", func(t *testing.T) {
@@ -260,7 +261,7 @@ func TestCoalesceOpenVarStaysInexact(t *testing.T) {
 		require.True(t, equalType(inexactObj(propElem("x", num())), got), "got %s", soltype.Print(got))
 	})
 
-	// The un-open peer closes to exact (the B1 baseline), so the flag is what
+	// The un-open peer closes to exact, so the flag is what
 	// distinguishes them.
 	t.Run("closed peer folds to exact object", func(t *testing.T) {
 		c := &Context{}
@@ -280,7 +281,8 @@ func TestCoalesceStructuralRecursion(t *testing.T) {
 	// the parameter type (negative) and the return type (positive). With empty
 	// bounds, the uniform-inline coalescer renders the degenerate
 	// `fn (x: unknown) -> never`: the param var is negative-empty ⇒ unknown, the
-	// return var is positive-empty ⇒ never. (The named-`<T0>` rendering is M3.)
+	// return var is positive-empty ⇒ never. The named-`<T0>` rendering arrives with
+	// generalization.
 	c := &Context{}
 	a := c.freshVar(0)
 	fn := &soltype.FuncType{
@@ -296,7 +298,7 @@ func TestCoalesceStructuralRecursion(t *testing.T) {
 	require.True(t, equalType(want, got))
 }
 
-// TestCoalesceBorrowedVarInnerPeels pins review finding 1: coalescing a borrow whose
+// TestCoalesceBorrowedVarInnerPeels pins borrow-inner peeling: coalescing a borrow whose
 // inner is an inference variable inlines that variable to its bounds. RefInner admits
 // *TypeVarType, so `mut β` is well-formed mid-inference. When β inlines to a
 // non-borrowable type — a primitive bound, or never for empty bounds — the borrow
@@ -325,7 +327,7 @@ func TestCoalesceBorrowedVarInnerPeels(t *testing.T) {
 // when the borrow's inner stays a RefInner after coalescing (here the inner is an
 // OBJECT containing a variable, not a bare variable), the `mut` wrapper must SURVIVE.
 // `mut {x: β}` with β bounded by number coalesces to `mut {x: number}`, not a peeled
-// `{x: number}` — the realistic shape C3's field-write inference produces.
+// `{x: number}` — the realistic shape the field-write inference produces.
 func TestCoalesceBorrowPreservesWrapper(t *testing.T) {
 	c := &Context{}
 	v := c.freshVar(0)
@@ -378,9 +380,8 @@ func TestEqualTypeRef(t *testing.T) {
 
 // equalType on ObjectType must discriminate on the Inexact flag and on each
 // property's Optional marker (mirroring the FuncType arm's Inexact / param-Optional
-// checks), and must be order-independent. Without the Optional check (M4 A1 review
-// fix #2) {a: T} and {a?: T} would compare equal and coalesce/simplify would drop
-// optionality.
+// checks), and must be order-independent. Without the Optional check {a: T} and
+// {a?: T} would compare equal and coalesce/simplify would drop optionality.
 func TestEqualTypeObject(t *testing.T) {
 	optProp := func(name string, ty soltype.Type) *soltype.PropertyElem {
 		return &soltype.PropertyElem{Name: name, Type: ty, Optional: true}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -13,7 +13,7 @@ const unboundedArity = math.MaxInt
 
 // hasRest reports whether f's LAST parameter is a typed rest param (`...xs: T[]`).
 // A rest param binds zero or more trailing arguments, so it never counts toward the
-// required floor and lifts the accept-set upper bound to ∞ (#677 §4.2.3) — the same
+// required floor and lifts the accept-set upper bound to ∞ — the same
 // upper-bound effect as the inexact `...` marker, reached a different way.
 func hasRest(f *soltype.FuncType) bool {
 	n := len(f.Params)
@@ -40,9 +40,9 @@ func requiredCount(f *soltype.FuncType) int {
 }
 
 // acceptSet is the inclusive range [lo, hi] of argument counts f tolerates when
-// invoked (#677 §4.2.1): lo = requiredCount(f); hi = len(f.Params) when f has a
+// invoked: lo = requiredCount(f); hi = len(f.Params) when f has a
 // finite arity, and unboundedArity when its upper bound is open — either because it
-// is inexact (the `...` marker) OR because its last param is a typed rest (§4.2.3).
+// is inexact (the `...` marker) OR because its last param is a typed rest.
 // Read a supertype callback slot's accept-set as "the argument counts whoever holds
 // this slot may invoke the supplied function with."
 func acceptSet(f *soltype.FuncType) (lo, hi int) {
@@ -92,16 +92,15 @@ func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
 }
 
 // constraintKey keys the coinductive seen-set by pointer identity (Go's
-// interface == on pointer-backed soltype concretes). Sufficient for M1: cycles
+// interface == on pointer-backed soltype concretes). Cycles
 // in subtype-checking can only form via TypeVarTypes, and TypeVarType pointers
 // are stable throughout inference (extrude allocates fresh vars, but those are
 // stable thereafter; structural decomposition hands child pointers around
 // without copying). Structurally-equal-but-pointer-distinct duplicates produce
-// redundant cache entries, not infinite loops. M4's recursive types (aliases,
-// letrec) must preserve this property — see m1-implementation-plan §3.3
-// "Forward requirements for the named-ref node design".
+// redundant cache entries, not infinite loops. Recursive types such as aliases
+// and letrec must preserve this property.
 //
-// mutCtx is part of the key (PR 14): the same (sub, super) pair means something
+// mutCtx is part of the key: the same (sub, super) pair means something
 // different inside a mutable borrow's inner, where the object/tuple arms add the
 // contravariant write view, than in a covariant position. Keying without it would
 // let a covariant visit cache-skip a later invariant visit and drop the write-view
@@ -120,7 +119,7 @@ type extrudeKey struct {
 	pol soltype.Polarity
 }
 
-// ltExtrudeKey is the lifetime-sort twin of extrudeKey (M4 D2.5): it keys the
+// ltExtrudeKey is the lifetime-sort twin of extrudeKey: it keys the
 // lifetime extrusion cache by the origin LifetimeVar's ID and polarity, so a
 // lifetime reached in both polarities yields two fresh vars with opposite outlives
 // wiring, exactly as the type-var cache does.
@@ -141,7 +140,7 @@ func (c *Context) Constrain(sub, super soltype.Type) []SolverError {
 }
 
 // needsResidualWriteBack reports whether a mutable borrow's inner needs an explicit
-// contravariant write view in the RefType arm (PR 14). The object/tuple arms pin
+// contravariant write view in the RefType arm. The object/tuple arms pin
 // matched object/object and tuple/tuple inners via the mut-context flag, so those
 // need no residual. Any other inner — a type variable, or two mismatched kinds —
 // the flag's structural arm does not reach, so the whole reverse constraint pins it.
@@ -157,7 +156,7 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 	return true
 }
 
-// constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: true
+// constrain asserts sub <: super. mutCtx is the deep-mut context flag: true
 // inside a mutable borrow's inner, where the object/tuple arms treat each named
 // field as invariant rather than covariant. The RefType arm sets it from the target
 // borrow's mutability, the object/tuple arms propagate it, and the function and
@@ -169,7 +168,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	}
 	seen.Add(key)
 
-	// Error-recovery sentinel (PR8): an ErrorType operand carries an
+	// Error-recovery sentinel: an ErrorType operand carries an
 	// already-reported diagnostic, so it ABSORBS in both directions — the
 	// constraint trivially succeeds. Short-circuiting here, ABOVE the structural
 	// switch and the variable arms, keeps it out of every bound list, so a
@@ -184,7 +183,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		return nil
 	}
 
-	// M6 PR2 pre-switch lattice block. The structural switch below dispatches
+	// Pre-switch lattice block. The structural switch below dispatches
 	// on sub and several arms return early on a non-variable super (the
 	// RefType arm most importantly), so a union/intersection super has to be
 	// matched here or it would be intercepted as a concrete-non-var demand
@@ -293,7 +292,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.FuncType:
 		if sup, ok := super.(*soltype.FuncType); ok {
-			// Accept-set subtyping (#677 §4.2.1): read super as a callback slot.
+			// Accept-set subtyping: read super as a callback slot.
 			// sub <: super iff accept(sub) ⊇ accept(super) — sub must tolerate every
 			// argument count a holder of super may invoke it with. With
 			// accept(sub) = [loSub, hiSub] and accept(super) = [loSup, hiSup]:
@@ -302,8 +301,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// The upper-bound clause is what exactness governs (an exact sub caps hiSub
 			// at len(sub.Params), so it can't fill a wider/inexact slot); the lower-bound
 			// clause is the `required` part (a typed-rest/optional lowers it). This
-			// subsumes M2's exact-same-arity rule: two EXACT functions have accept
-			// [r, n], so ⊇ forces equal upper bounds, i.e. the old same-arity check.
+			// subsumes the exact-same-arity rule: two EXACT functions have accept
+			// [r, n], so ⊇ forces equal upper bounds, i.e. the same-arity check.
 			loSub, hiSub := acceptSet(sub)
 			loSup, hiSup := acceptSet(sup)
 			if loSub > loSup || hiSub < hiSup {
@@ -315,14 +314,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// declares there must be optional (the lo gate forced loSub <= loSup) and so
 			// is simply never passed.
 			//
-			// KNOWN GAP (M4): when super is INEXACT and sub declares MORE params than
+			// KNOWN GAP: when super is INEXACT and sub declares MORE params than
 			// super, super's `...` tail may supply arbitrarily-typed args at sub's extra
 			// positions, so soundness demands `unknown <: sub.Params[i].Type` there —
-			// exact-types §4.2.1.2 "Variation B", the load-bearing rejection. That check
-			// needs the `_ <: unknown` (⊤) rule constrain lacks until M6, and an inexact
-			// function is unreachable from M3 source anyway (resolveTypeAnn resolves no
+			// the load-bearing rejection. That check
+			// needs the `_ <: unknown` (⊤) rule constrain does not yet have, and an inexact
+			// function is unreachable from current source anyway (resolveTypeAnn resolves no
 			// function annotations), so the extra positions are left unchecked here for
-			// now. For every M3-reachable input (exact functions only) the loop is complete.
+			// now. For every reachable input (exact functions only) the loop is complete.
 			// A function is its own annotation context, so the deep-mut flag resets.
 			var errs []SolverError
 			n := min(len(sub.Params), len(sup.Params))
@@ -361,7 +360,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// This walks the shared prefix and keeps sup.Elems[i] in bounds.
 			for i := range sup.Elems {
 				errs = append(errs, c.constrain(sub.Elems[i], sup.Elems[i], seen, mutCtx)...) // covariant read view
-				// Inside a mutable wrapper every element is invariant (PR 14): the
+				// Inside a mutable wrapper every element is invariant: the
 				// contravariant write view pins it. Outside one, elements stay covariant.
 				if mutCtx {
 					errs = append(errs, c.constrain(sup.Elems[i], sub.Elems[i], seen, mutCtx)...)
@@ -371,7 +370,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.ObjectType:
 		if sup, ok := super.(*soltype.ObjectType); ok {
-			// One ObjectType <: ObjectType rule serves both uses the M2 arm
+			// One ObjectType <: ObjectType rule serves both uses an earlier arm
 			// conflated: member-access field SELECTION (the super is an inexact
 			// "has at least this field" requirement minted by inferMember) and
 			// concrete object <: object SUBTYPING for object-typed params/annotations.
@@ -391,7 +390,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//     optional): covariant on the property type.
 			var errs []SolverError
 			for _, superElem := range sup.Elems {
-				superProp := soltype.AsProperty(superElem) // M4: every elem is a property
+				superProp := soltype.AsProperty(superElem) // every elem is a property
 				subProp, ok := sub.Prop(superProp.Name)
 				if !ok {
 					if !superProp.Optional {
@@ -404,7 +403,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					continue
 				}
 				errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen, mutCtx)...) // covariant read view
-				// Inside a mutable wrapper (PR 14), a writable field is invariant: the
+				// Inside a mutable wrapper, a writable field is invariant: the
 				// contravariant write view below pins it, the per-field write the eager
 				// form's constrainWriteBack did. A readonly TARGET needs only the read
 				// view, so a wider source can fill it; a readonly SOURCE cannot fill a
@@ -417,7 +416,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					errs = append(errs, c.constrain(superProp.Type, subProp.Type, seen, mutCtx)...) // contravariant write view
 				}
 			}
-			// One-way exactness (02-design-notes §"Exactness"):
+			// One-way exactness:
 			//   exact <: inexact    ok (width)      inexact <: inexact   ok (width)
 			//   exact <: exact      same member set  inexact <: exact     rejected
 			// When the super is inexact, width tolerance is the complete rule and the
@@ -440,15 +439,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if sup, ok := super.(*soltype.PromiseType); ok {
 			// PromiseType is covariant in its Inner: Promise<L> <: Promise<R> iff
 			// L <: R. No auto-flatten — `await Promise<Promise<T>>` yields
-			// `Promise<T>` (Awaited<T> lands in M9). When the two sides are unrelated
+			// `Promise<T>`. When the two sides are unrelated
 			// concretes (e.g. Promise<L> <: Tuple), fall through to the generic
 			// CannotConstrainError below, matching the function/tuple/record arms.
 			// A promise's payload is its own annotation context, so the flag resets.
 			return c.constrain(sub.Inner, sup.Inner, seen, false)
 		}
 	case *soltype.RefType:
-		// THE GATE (M4 C2): the single RefType <: RefType rule. The mut-driven inner
-		// invariance is the highest-risk encoding in the migration — see the M4 plan.
+		// THE GATE: the single RefType <: RefType rule. The mut-driven inner
+		// invariance is the highest-risk encoding in the migration.
 		if sup, ok := super.(*soltype.RefType); ok {
 			// 1. Mutability compatibility: an immutable source cannot fill a mutable
 			//    slot (writing through the target would mutate a read-only borrow). The
@@ -457,7 +456,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if !sub.Mut && sup.Mut {
 				return []SolverError{&MutabilityMismatchError{Sub: sub, Super: sup}}
 			}
-			// 2. Inner variance (PR 14): the read view is always covariant; a mutable
+			// 2. Inner variance: the read view is always covariant; a mutable
 			//    target also makes every field it NAMES invariant. That per-field pin is
 			//    carried by the mut-context flag, set to sup.Mut here, which the
 			//    ObjectType/TupleType arms read to add the contravariant write view. An
@@ -480,8 +479,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sup.Mut && needsResidualWriteBack(sub.Inner, sup.Inner) {
 				errs = append(errs, c.constrain(sup.Inner, sub.Inner, seen, false)...)
 			}
-			// 3. Lifetime outlives, covariant (M4 D2). Active now that borrows carry
-			//    lifetimes. D1 minted the sort. Each borrow site mints a lifetime:
+			// 3. Lifetime outlives, covariant. Active now that borrows carry
+			//    lifetimes. Each borrow site mints a lifetime:
 			//    resolveLifetimeAnn for an `&` annotation and inferBorrow for an
 			//    `&p` expression.
 			switch {
@@ -499,7 +498,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 		// RefType <: a concrete non-borrow: peel to the inner. An owned value (Lt nil)
 		// satisfies a bare slot; a borrow escaping into an owned slot is a
-		// BorrowEscapeError (live in D2). When super is a VARIABLE, fall through to the
+		// BorrowEscapeError. When super is a VARIABLE, fall through to the
 		// var arm so the WHOLE borrow is recorded as a bound — peeling there would drop
 		// its mutability.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
@@ -527,7 +526,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		//     overloaded value's arms so a let-bound overload called through the
 		//     binding (`g = f; g(x)`) resolves the arm via the same trial loop a
 		//     direct call would, in the same order.
-		//   - Annotation input (M6 PR2). `val x: A & B = e` resolves through
+		//   - Annotation input. `val x: A & B = e` resolves through
 		//     resolveTypeAnn into an IntersectionType and reaches here when the
 		//     binding flows into a constraint. specificityOrder ranks
 		//     non-function arms last in declaration order, so a non-function
@@ -611,7 +610,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 type ltPair struct{ sub, super soltype.Lifetime }
 
 // constrainLt asserts the outlives relation sub <: super between lifetimes,
-// mirroring constrain for the type sort. It is the M4 D1 lifetime-sort solver: a
+// mirroring constrain for the type sort. It is the lifetime-sort solver: a
 // variable on the left gains an upper bound, a variable on the right a lower
 // bound, and a var-to-var constraint records BOTH directions so each variable
 // sees the full relationship at coalescing — the type sort gets symmetry from a
@@ -625,8 +624,8 @@ type ltPair struct{ sub, super soltype.Lifetime }
 //
 // Bound appends route through addLowerLtBound/addUpperLtBound so a speculation
 // trial journals them; the (sub, super)-keyed seen-set terminates cycles. The
-// rule is written and unit-tested now; the RefType constrain arm activates it in
-// D2 (its lifetime step is inert while every Lt is nil).
+// rule is written and unit-tested now; the RefType constrain arm activates it
+// (its lifetime step is inert while every Lt is nil).
 func (c *Context) constrainLt(sub, super soltype.Lifetime) {
 	c.constrainLtSeen(sub, super, set.NewSet[ltPair]())
 }
@@ -645,8 +644,8 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	superVar, superIsVar := super.(*soltype.LifetimeVar)
 	if subIsVar {
 		// Maintain the level invariant: a bound's level must not exceed the var's, or
-		// the freshener/extruder level prune over the lifetime sort becomes unsound (M4
-		// D2.5). super sits in subVar's upper bounds, a negative-position slot, so when
+		// the freshener/extruder level prune over the lifetime sort becomes unsound.
+		// super sits in subVar's upper bounds, a negative-position slot, so when
 		// it is inner to subVar extrude it out before recording, mirroring constrain's
 		// var arm. extrudeOuterAsUpper reuses an existing outer-extruded proxy of super
 		// if one is already a bound, so a repeated constraint does not mint a second
@@ -675,7 +674,7 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 }
 
 // extrudeOuterAsUpper returns the lifetime to record as v's upper bound when
-// constraining v <: lt (M4 D2.5). lt is shared when it is not inner to v. When it
+// constraining v <: lt. lt is shared when it is not inner to v. When it
 // is, it is extruded out to v's level so v's bound is never inner to v. A repeated
 // constraint must not mint a fresh proxy each time, or the ContainsLifetime dedup —
 // which keys on identity — never matches and bounds accumulate. So an existing
@@ -720,7 +719,7 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 
 // extrudeLt copies a lifetime so a LifetimeVar inner to lvl is replaced by a fresh
 // lifetime at lvl, wired to the original through the polarity-appropriate outlives
-// bound (M4 D2.5) — the lifetime-sort twin of extrude's var node. The cache is
+// bound — the lifetime-sort twin of extrude's var node. The cache is
 // keyed by (var ID, polarity) for the same reason the type-var cache is. A
 // 'static, nil slot, or lifetime at lvl or outside it extrudes to itself. Bound
 // appends route through the journaling helpers; mutating the ORIGINAL var's bound is
@@ -740,7 +739,7 @@ func (c *Context) extrudeLt(lt soltype.Lifetime, pol soltype.Polarity, lvl int, 
 	cache[key] = nlv
 	// Remember which lifetime nlv is an outer-extruded proxy of, so a repeated outlives
 	// constraint can reuse this proxy instead of minting a second one (constrainLt's
-	// findExtrudedLtBound dedup, M4 D2.5).
+	// findExtrudedLtBound dedup).
 	c.recordLtProxy(nlv, lv)
 	if pol == soltype.Positive {
 		c.addUpperLtBound(lv, nlv)
@@ -765,7 +764,7 @@ type extruder struct {
 	c     *Context
 	lvl   int
 	cache map[extrudeKey]*soltype.TypeVarType
-	// ltCache is the lifetime-sort twin of cache (M4 D2.5); see extrudeLt.
+	// ltCache is the lifetime-sort twin of cache; see extrudeLt.
 	ltCache map[ltExtrudeKey]*soltype.LifetimeVar
 }
 
@@ -776,7 +775,7 @@ func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Enter
 	}
 	if r, ok := t.(*soltype.RefType); ok {
 		// A borrow's lifetime is covariant on the wrapper and never walked by Accept, so
-		// extrude it here in the wrapper's polarity (M4 D2.5). refLifetimeResult then
+		// extrude it here in the wrapper's polarity. refLifetimeResult then
 		// hands back a RefType carrying the fresh lifetime for the descend path to
 		// rebuild Inner around, or signals an ordinary rebuild when no extrusion was
 		// needed. The cache is allocated on first use so a borrow-free pass pays nothing.

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M6 PR2: lattice subtyping rules in constrain ---
+// --- Lattice subtyping rules in constrain ---
 //
 // The pre-switch lattice block carries every rule whose deciding operand is a
 // union/intersection super, plus the union-sub for-all rule. These tests
@@ -196,9 +196,9 @@ func TestConstrainUnionPrecedesRefArm(t *testing.T) {
 //	  - CannotConstrainError          string <: number
 //	  number <: number succeeds and contributes nothing
 //
-// The flag and the parser surface for `A | B | ...` land in PR4. Until then
-// the rule fires only against an internally-built inexact union, which the
-// test mints directly through the smart constructor.
+// Until the parser surface for `A | B | ...` exists, the rule fires only against
+// an internally-built inexact union, which the test mints directly through the
+// smart constructor.
 func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	c := &Context{}
 	sub := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
@@ -262,7 +262,7 @@ func TestConstrainInexactUnionIntoVarDefers(t *testing.T) {
 //	(number | string | ...) <: unknown    inexact-into-closed gate does NOT fire
 //
 // The decomposition produces `number <: unknown` and `string <: unknown`.
-// PR5 lands the `_ <: unknown` rule. Until then those are CannotConstrain
+// Until the `_ <: unknown` rule exists, those are CannotConstrain
 // fall-throughs, so this case still errors. What the test asserts is that
 // the inexact-into-closed gate did not fire, since unknown is recognized
 // as accepting the open tail. No InexactUnionIntoExactError appears in the

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -148,7 +148,7 @@ func TestConstrainFunctionVariance(t *testing.T) {
 	})
 }
 
-// TestConstrainFunctionAcceptSet exercises the PR4 accept-set rule (#677 §4.2.1):
+// TestConstrainFunctionAcceptSet exercises the accept-set rule:
 // G <: F iff accept(G) ⊇ accept(F), with params contravariant and return covariant.
 // Read F (the super) as the callback slot.
 func TestConstrainFunctionAcceptSet(t *testing.T) {
@@ -176,7 +176,7 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 		require.Same(t, f, fa.Super)
 	})
 
-	// The #677 callback matrix for an exact fn(x, y) slot: fn(x, y), fn(x, ...), and
+	// The callback matrix for an exact fn(x, y) slot: fn(x, y), fn(x, ...), and
 	// fn(...) are all accepted; exact fn(x) (too narrow upper bound) and a 3-param
 	// function (demands more than the slot supplies) are rejected.
 	slot := func() *soltype.FuncType { return exactFn(num(), identParam("x", num()), identParam("y", num())) }
@@ -213,7 +213,7 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 	})
 
 	// Exact </: inexact: an exact function's finite upper bound cannot cover an
-	// inexact slot's ∞ (the asymmetry §4.2.1.1 explains).
+	// inexact slot's ∞. This asymmetry is what exactness encodes.
 	t.Run("exact fn(x) rejected by inexact fn(x, ...) slot", func(t *testing.T) {
 		c := &Context{}
 		require.Equal(t,
@@ -244,7 +244,7 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 }
 
 // TestAcceptSetRestParam pins the arity arithmetic for a typed rest param: it lifts
-// the upper bound to ∞ and never counts toward the required floor (#677 §4.2.3).
+// the upper bound to ∞ and never counts toward the required floor.
 func TestAcceptSetRestParam(t *testing.T) {
 	t.Run("fn(a, b, ...rest): required 2, upper unbounded", func(t *testing.T) {
 		f := &soltype.FuncType{Params: []*soltype.FuncParam{identParam("a", num()), identParam("b", num()), restParam("rest", num())}, Ret: num()}
@@ -343,7 +343,7 @@ func TestConstrainTuple(t *testing.T) {
 	})
 
 	// [number, string, boolean] <: [number, ...]: a longer tuple satisfies an
-	// inexact super, matching the shared prefix element-wise (the A2 width arm).
+	// inexact super, matching the shared prefix element-wise via the width arm.
 	t.Run("longer fills inexact (width)", func(t *testing.T) {
 		c := &Context{}
 		t1 := &soltype.TupleType{Elems: []soltype.Type{num(), str(), boolT()}}
@@ -402,17 +402,17 @@ func propElem(name string, t soltype.Type) *soltype.PropertyElem {
 	return &soltype.PropertyElem{Name: name, Type: t}
 }
 
-// mutRef builds an owned-mutable borrow for the RefType constrain tests (C2). Lt is
-// always nil in C2 — the lifetime sort lands in D1 — so the owned-mutable wrapper is
-// the only meaningful borrow constructible here. A real immutable borrow needs a
-// lifetime (`Mut: false, Lt: 'a`), so its helper arrives in D2; the bare <: RefType
+// mutRef builds an owned-mutable borrow for the RefType constrain tests. Lt is
+// always nil here, so the owned-mutable wrapper is the only meaningful borrow
+// constructible at this point. A real immutable borrow needs a lifetime
+// (`Mut: false, Lt: 'a`), so its helper exists elsewhere; the bare <: RefType
 // arm mints the degenerate `Mut: false, Lt: nil` view internally with a struct
 // literal, not through a helper.
 func mutRef(inner soltype.RefInner) *soltype.RefType {
 	return &soltype.RefType{Mut: true, Inner: inner}
 }
 
-// TestConstrainDescribesRefOperand pins review finding 2: describe must NAME a
+// TestConstrainDescribesRefOperand pins that describe must NAME a
 // RefType operand in a constraint failure, not render it as `?`. A non-borrowable
 // source (a primitive) against a mut-borrow target is not wrappable by the
 // bare <: RefType arm, so it falls through to CannotConstrainError carrying the
@@ -433,7 +433,7 @@ func inexactObj(elems ...soltype.ObjTypeElem) *soltype.ObjectType {
 	return &soltype.ObjectType{Elems: elems, Inexact: true}
 }
 
-// TestConstrainObject exercises the one-way object exactness rule (A1): width
+// TestConstrainObject exercises the one-way object exactness rule: width
 // tolerance is inexactness on the super, and an exact super fixes its member set.
 //
 // want is the expected rendered messages (nil for a clean constraint); check, when
@@ -648,7 +648,7 @@ func TestConstrainObject(t *testing.T) {
 	}
 }
 
-// TestConstrainRef exercises the single RefType <: RefType rule — THE GATE (C2).
+// TestConstrainRef exercises the single RefType <: RefType rule — THE GATE.
 // The headline property is mut-driven inner invariance: a mutable target takes both
 // a covariant read view and a contravariant write view, so the inner is invariant.
 func TestConstrainRef(t *testing.T) {
@@ -702,7 +702,7 @@ func TestConstrainRef(t *testing.T) {
 		{
 			// The same two object inners as bare (immutable) values width-succeed: an
 			// immutable borrow is covariant, so the missing-on-write-view problem never
-			// arises. This is the contrast the plan draws against the mut case above.
+			// arises. This is the contrast against the mut case above.
 			name:  "immutable width succeeds where mut invariance rejects",
 			sub:   exactObj(propElem("x", num()), propElem("y", num())),
 			super: inexactObj(propElem("x", num())),
@@ -739,7 +739,7 @@ func TestConstrainRef(t *testing.T) {
 		},
 		{
 			// number <: mut {x}: a non-borrowable source cannot be wrapped, so it falls
-			// through to CannotConstrainError naming the borrow (review finding 2).
+			// through to CannotConstrainError naming the borrow.
 			name:  "non-borrowable source <: borrow names the borrow",
 			sub:   num(),
 			super: mutRef(exactObj(propElem("x", num()))),
@@ -803,7 +803,7 @@ func TestConstrainVoid(t *testing.T) {
 		Messages(c.Constrain(&soltype.Void{}, num())))
 }
 
-// PR8: the ErrorType recovery sentinel ABSORBS in both directions — a constraint
+// The ErrorType recovery sentinel ABSORBS in both directions — a constraint
 // with an ErrorType operand trivially succeeds, so a reported diagnostic's
 // placeholder never cascades. Pinned against every concrete shape, on both sides.
 func TestConstrainErrorTypeAbsorbs(t *testing.T) {
@@ -831,7 +831,7 @@ func TestConstrainErrorTypeAbsorbs(t *testing.T) {
 	}
 }
 
-// PR8: ErrorType short-circuits ABOVE the variable arms, so it never enters a
+// ErrorType short-circuits ABOVE the variable arms, so it never enters a
 // var's bound list — coalesce / extrude / freshenAbove then never see it
 // propagated through bounds.
 func TestConstrainErrorTypeNeverEntersVarBounds(t *testing.T) {

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -2,17 +2,17 @@ package solver
 
 import "github.com/escalier-lang/escalier/internal/soltype"
 
-// Context owns the engine's mutable counters. M1 carries ONLY varCounter; M4 D1
-// adds lifetimeCounter for the lifetime sort. M4 C3's read-after-write cache,
-// the `written` map, lives on the checker's per-function context, not here.
+// Context owns the engine's mutable counters: varCounter for type vars and
+// lifetimeCounter for the lifetime sort. The read-after-write cache, the
+// `written` map, lives on the checker's per-function context, not here.
 //
-// M3 (PR5) adds the nullable probe pointer. The engine's bound-mutating core
-// (constrain/extrude) lives on *Context, so the speculation journal must live
-// here too: when probe is non-nil, every bound append snapshots the variable's
-// bound-list lengths so a discarded trial can truncate them back. nil is the
-// non-speculative path — the common case — and pays only a nil check per append.
-// The push/pop discipline (openProbe/closeProbe) lives on the checker carrier,
-// which also owns the side-table cleanups (Info/Prov).
+// The nullable probe pointer drives speculation. The engine's bound-mutating
+// core, constrain and extrude, lives on *Context, so the speculation journal
+// lives here too. When probe is non-nil, every bound append snapshots the
+// variable's bound-list lengths so a discarded trial can truncate them back. nil
+// is the non-speculative path, the common case, and pays only a nil check per
+// append. The push/pop discipline, openProbe and closeProbe, lives on the
+// checker carrier, which also owns the Info and Prov side-table cleanups.
 //
 // Bound lists are extended ONLY through addLowerBound/addUpperBound, which fuse
 // the probe snapshot with the append. A bare `v.LowerBounds = append(...)` must
@@ -23,16 +23,16 @@ type Context struct {
 	varCounter int
 	probe      *Probe
 
-	// lifetimeCounter mints the next LifetimeVar id (M4 D1). Lifetimes are a
-	// SECOND bounded sort solved by the same machinery as types: a fresh lifetime
-	// gets the next id here, its bounds are extended only through
-	// addLowerLtBound/addUpperLtBound, and a speculation trial journals it under
-	// the same probe discipline as a TypeVarType.
+	// lifetimeCounter mints the next LifetimeVar id. Lifetimes are a SECOND bounded
+	// sort solved by the same machinery as types. A fresh lifetime gets the next id
+	// here, its bounds are extended only through addLowerLtBound/addUpperLtBound, and
+	// a speculation trial journals it under the same probe discipline as a
+	// TypeVarType.
 	lifetimeCounter int
 
 	// ltProxyOrigin maps an outer-extruded lifetime proxy to the lifetime it was
-	// extruded from (M4 D2.5). constrainLt consults it through findLtProxy to reuse
-	// an existing proxy for a repeated cross-level outlives constraint, so the bound
+	// extruded from. constrainLt consults it through findLtProxy to reuse an existing
+	// proxy for a repeated cross-level outlives constraint, so the bound
 	// dedup is not defeated by minting a fresh proxy each time. It is metadata only
 	// and is never rolled back: a stale entry for a proxy that a discarded trial
 	// removed from its bound list is simply never matched, since findLtProxy scans
@@ -49,19 +49,19 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 }
 
 // freshLifetime allocates a new lifetime variable at the given level, assigning it
-// the next id in sequence. Lifetimes now ride the same let-generalization level
-// hierarchy as types (M4 D2.5): a lifetime minted inside its scheme's
-// generalize-level is freshened per instantiation, so two uses of a
-// borrow-passing function never share one LifetimeVar.
+// the next id in sequence. Lifetimes ride the same let-generalization level
+// hierarchy as types. A lifetime minted inside its scheme's generalize-level is
+// freshened per instantiation, so two uses of a borrow-passing function never
+// share one LifetimeVar.
 func (c *Context) freshLifetime(level int) *soltype.LifetimeVar {
 	lv := &soltype.LifetimeVar{ID: c.lifetimeCounter, Level: level}
 	c.lifetimeCounter++
 	return lv
 }
 
-// freshJoinLifetime allocates a lifetime variable for a multi-source join site
-// (M4 D3). A join site is a return or branch uniting several borrows. It is
-// identical to freshLifetime but sets Join, so coalesceLifetime expands it to the
+// freshJoinLifetime allocates a lifetime variable for a multi-source join site.
+// A join site is a return or branch uniting several borrows. It is identical to
+// freshLifetime but sets Join, so coalesceLifetime expands it to the
 // union of the param lifetimes it reaches rather than naming it as a borrow origin.
 func (c *Context) freshJoinLifetime(level int) *soltype.LifetimeVar {
 	lv := c.freshLifetime(level)
@@ -86,8 +86,8 @@ func (c *Context) addUpperLtBound(v *soltype.LifetimeVar, lt soltype.Lifetime) {
 }
 
 // recordLtProxy notes that proxy is an outer-extruded copy of origin, so a later
-// repeated outlives constraint can reuse the proxy rather than mint a new one (M4
-// D2.5). Lazily allocates the map.
+// repeated outlives constraint can reuse the proxy rather than mint a new one.
+// Lazily allocates the map.
 func (c *Context) recordLtProxy(proxy *soltype.LifetimeVar, origin soltype.Lifetime) {
 	if c.ltProxyOrigin == nil {
 		c.ltProxyOrigin = map[*soltype.LifetimeVar]soltype.Lifetime{}

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR 13: deep, uniform `mut` and `readonly` ---
+// --- deep, uniform `mut` and `readonly` ---
 
 // `mut` is deep: every nested layer becomes writable, so `p.a.x = 5` is legal
 // through `mut {a: {x}}` and `&mut {a: {x}}`.
@@ -71,7 +71,7 @@ func TestDeepMutLowersFreshLiteral(t *testing.T) {
 }
 
 // An explicit nested `mut` field or element inside a non-mut container is rejected at
-// the annotation site (#779): `mut {a: mut {x}}` and `mut [mut {x}]` each carry an
+// the annotation site. `mut {a: mut {x}}` and `mut [mut {x}]` each carry an
 // owned-mut cell on a field of an inner immutable container. The cell is recovered to
 // its bare inner so the surrounding annotation still resolves, and the fresh literal
 // upgrades into that bare target.
@@ -166,9 +166,9 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 	})
 }
 
-// An owned-mutable field inside an immutable container — `{a: mut {x}}` — is now
-// rejected at the annotation site (#779): interior mutability is the proper mechanism
-// for that case (#618), and inference never produces the shape either, so the type is
+// An owned-mutable field inside an immutable container — `{a: mut {x}}` — is
+// rejected at the annotation site. Interior mutability is the proper mechanism
+// for that case, and inference never produces the shape either, so the type is
 // no longer reachable. The annotation reports MutFieldError and recovers to the bare
 // `{a: {x}}`; the body's write through the immutable receiver then fails as before.
 func TestOwnedMutFieldAnnotationRejected(t *testing.T) {
@@ -220,9 +220,9 @@ func TestReadonlyRendersOnReadField(t *testing.T) {
 	require.Equal(t, "fn (obj: {readonly a: number}) -> number", values["f"])
 }
 
-// --- PR 14: lazy deep-mut representation ---
+// --- lazy deep-mut representation ---
 
-// Under the lazy form (PR 14), the mut-context flag pins a nested field invariant
+// Under the lazy form, the mut-context flag pins a nested field invariant
 // inside a mutable wrapper. A field whose type is a strict subtype of the target's
 // field passes the covariant read view but fails the contravariant write view, so a
 // `mut {a: {x: number}}` value cannot fill a `mut {a: {x: number | string}}` slot —
@@ -243,10 +243,10 @@ func TestImmutableWrapperKeepsNestedFieldCovariant(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// --- #779: no owned-mutable field inside a non-mut container ---
+// --- no owned-mutable field inside a non-mut container ---
 
 // A `&`/`&mut` borrow field inside a non-mut container stays legal: it references
-// external storage, not an interior owned-mutable cell, so #779 leaves it alone.
+// external storage, not an interior owned-mutable cell, so the rule leaves it alone.
 func TestBorrowFieldInImmutableContainerIsLegal(t *testing.T) {
 	t.Run("shared borrow field", func(t *testing.T) {
 		values, _, errs := inferSource(t, "fn f(p: {a: &{x: number}}) -> &{x: number} { return p.a }")
@@ -260,7 +260,7 @@ func TestBorrowFieldInImmutableContainerIsLegal(t *testing.T) {
 	})
 }
 
-// The #779 round-trip: a nested write infers a mut container whose displayed
+// The round-trip property: a nested write infers a mut container whose displayed
 // signature is a valid annotation, and a caller passing exactly that displayed type
 // is accepted. Inference never produces a `mut` field inside a non-mut container, so
 // what it prints can always be written back.
@@ -297,4 +297,3 @@ func TestNestedWriteInfersMutContainerAndRoundTrips(t *testing.T) {
 		require.Empty(t, errs)
 	})
 }
-

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -1,10 +1,9 @@
 // Package solver is the production algebraic-subtyping engine for Escalier's new
-// checker, promoted from the internal/simplesub spike (Milestone M1 of the
-// SimpleSub migration). It implements the core of Lionel Parreaux's "Simple-sub"
-// algorithm over the structural-core subset of the type system:
+// checker. It implements the core of Lionel Parreaux's "Simple-sub" algorithm
+// over the structural-core subset of the type system:
 //
 //   - fresh inference variables that carry lower/upper *bound lists* plus a level
-//     (for let-generalization in a later milestone),
+//     for let-generalization,
 //   - a constrain(sub <: super) primitive with a coinductive seen-cache, plus
 //     level-aware extrusion, and
 //   - polarity-driven coalescing that inlines every variable to its bounds,
@@ -13,11 +12,11 @@
 // The type representation, the printer, and the Polarity enum live in the
 // sibling internal/soltype package; the engine (constrain/extrude),
 // coalescing, and the mutable Context live here. solver imports soltype and
-// internal/ast (for the
-// Info side table's key type); neither ast nor type_system imports solver, so
-// the package is acyclic and additive — it shares no code with type_system.
+// internal/ast for the Info side table's key type. Neither ast nor type_system
+// imports solver, so the package is acyclic and additive, sharing no code with
+// type_system.
 //
-// M3 (PR1) adds let-generalization on top of M2's walk: TypeSchemes (poly.go —
+// Let-generalization sits on top of the walk: TypeSchemes (poly.go —
 // MonoScheme/PolyScheme + ValueBinding.Schemes), instantiate/freshenAbove for
 // per-use fresh variables, generalization at the SCC boundary (module.go) and at
 // body-level `val`s (infer_decl.go), the inferIdent instantiation hook, the
@@ -26,7 +25,7 @@
 // (coalesce.go's coalesceScheme) with the printer's <T0, …> quantifier prefix
 // (soltype.PrintAsScheme).
 //
-// M3 (PR2) completes scheme rendering with CO-OCCURRENCE merging (simplify.go):
+// Scheme rendering also performs CO-OCCURRENCE merging (simplify.go):
 // distinct quantified variables that always appear together are unioned over a
 // symmetrized bound graph, so coalesceScheme renders them as one type parameter.
 // The parameter in
@@ -41,32 +40,30 @@
 // Simplification runs at display time, leaving the raw scheme body intact for
 // instantiation.
 //
-// M3 (PR5) adds the probe (probe.go): a speculation journal over the engine's
-// bound-list mutations (a per-variable length snapshot, truncated back on
-// discard) plus side-table (Info/Prov/errs) rollback closures, with push/pop
+// The probe (probe.go) is a speculation journal over the engine's
+// bound-list mutations — a per-variable length snapshot, truncated back on
+// discard — plus side-table (Info/Prov/errs) rollback closures, with push/pop
 // nesting that hands a committed child's rollback obligation up to its parent. The active
 // probe lives on *Context (next to the bound-mutating constrain/extrude); the
-// open/close discipline lives on the checker carrier. PR6's overload resolution
-// is its first consumer — each candidate is trialled under a probe and the losers
-// rolled back — but it is general speculation infrastructure reused beyond M3.
+// open/close discipline lives on the checker carrier. Overload resolution is one
+// consumer — each candidate is trialled under a probe and the losers rolled back
+// — but it is general speculation infrastructure.
 //
-// M3 (PR6) adds function overloading for free functions (overload.go): a name with
-// more than one top-level FuncDecl binds to a multi-scheme ValueBinding
+// Function overloading for free functions (overload.go) binds a name with
+// more than one top-level FuncDecl to a multi-scheme ValueBinding
 // (b.IsOverloaded()), one scheme per arm. Resolution is a phase DISTINCT from
 // constrain — the "callable in several ways" disjunction stays out of the subtype
 // lattice — so a direct overloaded call routes through resolveOverload, which trials
-// the arms (reusing the PR5 probe) and commits the winner. Arms are tried
+// the arms under a probe and commits the winner. Arms are tried
 // most-specific-first when no argument is an unconstrained variable, and fall back to
 // declaration order otherwise. The one scoped lattice exception is the VALUE-position
 // type of an overloaded name — the intersection of its arms — which is collapsed back to a
 // single arm only when it meets a concrete call shape.
 //
-// What is still deferred (each lands in a later milestone): records / mut /
-// lifetimes (M4), classes and the general union/intersection *subtyping rules* in
-// constrain (M5/M6), type-level operators (M5/M8), and DEFERRED OVERLOAD RESOLUTION
-// when a call argument is still an unconstrained variable — today's first-match
-// fallback over-narrows the enclosing function, and the real fix rides with M4/M5
-// object-arg and method overloads (#723). M1 ships UnionType/IntersectionType *nodes*
-// for coalesced output; their general lattice rules in constrain remain deferred (PR6
-// adds only the function-intersection-sub arm above).
+// Some behavior remains unmodeled. Overload resolution when a call argument is
+// still an unconstrained variable falls back to first-match, which over-narrows
+// the enclosing function. The general union/intersection subtyping rules in
+// constrain are not yet wired. UnionType and IntersectionType *nodes* exist for
+// coalesced output, but their general lattice rules in constrain are deferred;
+// only the function-intersection-sub arm above is implemented.
 package solver

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -15,12 +15,11 @@ import (
 // error refers to — e.g. navigate to a type's declaration — without reparsing
 // the message. Modeled on internal/checker/error.go's shape.
 //
-// M2.5 makes every Span() node-derived: bridge kinds self-blame from the AST node
-// they carry, and constraint kinds resolve their offending operand to its minting
-// node through the Prov side table (per-operand blame, §3.5). Related() exposes
-// secondary contributing nodes (the expected-source alongside the actual-source;
-// the prior declaration alongside the duplicate). errSpan/setSpan are gone — no
-// error is stamped after the fact.
+// Every Span() is node-derived. Bridge kinds self-blame from the AST node they
+// carry, and constraint kinds resolve their offending operand to its minting node
+// through the Prov side table for per-operand blame. Related() exposes secondary
+// contributing nodes, the expected-source alongside the actual-source and the prior
+// declaration alongside the duplicate. No error is stamped after the fact.
 type SolverError interface {
 	isSolverError()
 	Message() string
@@ -32,51 +31,44 @@ type SolverError interface {
 // prim/prim mismatch, lit/lit mismatch, lit/prim mismatch, and the generic
 // "no rule applies" fall-through at the end of constrain.
 //
-// Sub is the "actual" value, Super the "expected"; blame follows Sub to its minting
-// node (when that node lies inside the constraint site — the containment guard
-// that keeps identifier-flow blame on the use, not the definition, §3.8) and falls
-// back to site otherwise. This is the only constraint kind that keeps a site
-// fallback: its actual-value operand can legitimately resolve outside the
-// constraint (an ident's definition) or not at all (a Void result).
+// Sub is the "actual" value, Super the "expected". Blame follows Sub to its minting
+// node when that node lies inside the constraint site, the containment guard that
+// keeps identifier-flow blame on the use rather than the definition, and falls back
+// to site otherwise. This is the only constraint kind that keeps a site fallback:
+// its actual-value operand can legitimately resolve outside the constraint, as an
+// ident's definition, or not at all, as a Void result.
 type CannotConstrainError struct {
 	Sub, Super soltype.Type
-	prov       NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
-	site       ast.Node     // M2.5: the constraint node n — the use, the fallback when Sub has no entry
+	prov       NodeResolver // type→node index; assigned after Constrain returns
+	site       ast.Node     // the constraint node n — the use, the fallback when Sub has no entry
 }
 
 // FuncArityMismatchError fires on FuncType <: FuncType when the two arities
-// differ (M1's exact-function rule; exact-by-default requires the same number
-// of params). Holds the full FuncTypes, not just the arities, so consumers can
-// report param/return types too. M3 narrows the firing conditions when the
-// exactness flag adds the inexact fewer-params-is-subtype arm.
+// differ, the exact-function rule where exact-by-default requires the same number
+// of params. Holds the full FuncTypes, not just the arities, so consumers can
+// report param/return types too.
 //
-// The subject is the super call-shape (a fresh FuncType{args, res} minted per call,
-// recorded against the CallExpr), so Span() resolves precisely to the call;
+// The subject is the super call-shape, a fresh FuncType{args, res} minted per call
+// and recorded against the CallExpr, so Span() resolves precisely to the call.
 // Related() follows the sub callee to a "defined here" span. site is the
-// constraint node, used as a coarse fallback when neither operand resolves (e.g.
-// once M3 produces higher-order FuncArity errors whose super isn't a recorded
-// call-shape) so blame never degrades to the zero span.
+// constraint node, used as a coarse fallback when neither operand resolves, so
+// blame never degrades to the zero span.
 type FuncArityMismatchError struct {
 	Sub, Super *soltype.FuncType
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback when no operand resolves
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback when no operand resolves
 }
 
 // TupleLengthMismatchError fires on TupleType <: TupleType with different
-// lengths (M1's exact-tuple case; M4 may narrow the firing conditions when the
-// inexact flag is added).
+// lengths, the exact-tuple case.
 //
-// The subject is the sub tuple literal (recorded by inferTuple); Related() points
-// at the super expected-source. Not actually reachable in M2.5 — a tuple <: tuple
-// constraint needs a tuple sink (annotation/param) resolveTypeAnn does not yet
-// produce — so its blame is wired but exercised from M4. site is the constraint
-// node, the coarse fallback when neither tuple resolves (e.g. an M4 tuple
-// annotation whose elements aren't recorded) so blame never degrades to the zero
-// span.
+// The subject is the sub tuple literal recorded by inferTuple. Related() points
+// at the super expected-source. site is the constraint node, the coarse fallback
+// when neither tuple resolves, so blame never degrades to the zero span.
 type TupleLengthMismatchError struct {
 	Sub, Super *soltype.TupleType
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback when no operand resolves
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback when no operand resolves
 }
 
 // MissingPropertyError fires on ObjectType <: ObjectType when the super requires a
@@ -88,18 +80,18 @@ type TupleLengthMismatchError struct {
 //
 // The subject is the property's inner result var (Super.Prop(Name)), minted by
 // inferMember and recorded against the .prop identifier — so Span() blames the
-// member's prop (.foo), not the receiver. Name stays: the absent property name is
-// not recoverable from a single node (the super may require several properties).
+// member's prop (.foo), not the receiver. Name stays, since the absent property name
+// is not recoverable from a single node when the super requires several properties.
 // site is the constraint node, the coarse fallback when the property var has no
-// entry — reachable for a concrete object <: object requirement whose property
-// types are coalesced/annotation-minted (and therefore not recorded by
-// inferMember); for member access it never fires, but it keeps blame off the zero
+// entry. It is reachable for a concrete object <: object requirement whose property
+// types are coalesced or annotation-minted and therefore not recorded by
+// inferMember. For member access it never fires, but it keeps blame off the zero
 // span.
 type MissingPropertyError struct {
 	Sub, Super *soltype.ObjectType
 	Name       string
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback when the property var has no entry
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback when the property var has no entry
 }
 
 // InexactIntoExactError fires on ObjectType <: ObjectType when the super is exact
@@ -107,8 +99,8 @@ type MissingPropertyError struct {
 // properties, so it cannot satisfy an exact target that fixes its member set.
 type InexactIntoExactError struct {
 	Sub, Super *soltype.ObjectType
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback
 }
 
 // InexactTupleIntoExactError is the tuple twin of InexactIntoExactError. An
@@ -125,9 +117,7 @@ type InexactTupleIntoExactError struct {
 // inexact union `A | B | ...` carries an open tail of unknown additional
 // members, so it cannot flow into a closed target. A closed target is either
 // an exact union or any non-union concrete the open tail could violate. The
-// base form lands in M6 PR2. The flag itself and the parser surface for
-// `A | B | ...` land in PR4. Until then the rule fires only against an
-// internally-built inexact union.
+// rule currently fires only against an internally-built inexact union.
 type InexactUnionIntoExactError struct {
 	Sub   *soltype.UnionType
 	Super soltype.Type
@@ -141,12 +131,12 @@ type InexactUnionIntoExactError struct {
 type ExtraPropertyError struct {
 	Sub, Super *soltype.ObjectType
 	Name       string
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback
 }
 
 // ExtraElementError is the tuple analogue of ExtraPropertyError, fired by the
-// construction-site excess check (A3): a tuple LITERAL checked against a tuple
+// construction-site excess check: a tuple LITERAL checked against a tuple
 // annotation may not carry elements beyond the target's declared set, even when
 // the target is inexact (`[number, ...]`). It is the parallel of the direct-call
 // extra-arg lint: an inexact tail tolerates extra elements from a non-literal
@@ -156,8 +146,8 @@ type ExtraPropertyError struct {
 type ExtraElementError struct {
 	Sub, Super *soltype.TupleType
 	Index      int
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: the excess element node fallback
+	prov       NodeResolver // type→node index
+	site       ast.Node     // the excess element node fallback
 }
 
 // OptionalPropertyError fires on ObjectType <: ObjectType when a property is
@@ -169,8 +159,8 @@ type ExtraElementError struct {
 type OptionalPropertyError struct {
 	Sub, Super *soltype.ObjectType
 	Name       string
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback
 }
 
 // MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
@@ -181,32 +171,30 @@ type OptionalPropertyError struct {
 // bare source is wrapped as an immutable view before re-dispatch.
 type MutabilityMismatchError struct {
 	Sub, Super *soltype.RefType
-	prov       NodeResolver // M2.5: type→node index (§3.5)
-	site       ast.Node     // M2.5: constraint node fallback
+	prov       NodeResolver // type→node index
+	site       ast.Node     // constraint node fallback
 }
 
 // BorrowEscapeError fires when a borrow outlives the slot it flows into: a borrowed
 // value (Lt != nil) constrained against an owned slot (Lt == nil), either a bare
-// supertype or a RefType super with no lifetime. The firing path is INERT in C2 —
-// every RefType carries Lt == nil until the lifetime sort lands (D1) and borrows
-// originate (D2) — so the struct is wired now and exercised from D2.
+// supertype or a RefType super with no lifetime. The firing path is currently inert.
+// Every RefType carries Lt == nil until the lifetime sort lands and borrows
+// originate, so the struct is wired but not yet exercised.
 //
-// It is intentionally UNTESTED until then, and currently unconstructible: soltype.Lifetime
-// has no concrete implementors, so no non-nil Lt exists to drive any firing branch.
-// The Message format and the describe-the-whole-borrow choice are first observed in
-// D2; coverage of Message/Span/Related is deferred to that PR.
+// It is currently unconstructible: soltype.Lifetime has no concrete implementors, so
+// no non-nil Lt exists to drive any firing branch.
 type BorrowEscapeError struct {
 	Sub   *soltype.RefType
 	Super soltype.Type
-	prov  NodeResolver // M2.5: type→node index (§3.5)
-	site  ast.Node     // M2.5: constraint node fallback
+	prov  NodeResolver // type→node index
+	site  ast.Node     // constraint node fallback
 }
 
 // SpreadNotTupleError fires when a tuple-literal spread element ([...xs]) has an
-// operand that does not infer to a tuple. M4 handles only the concrete-literal
-// splice: the operand's element types are copied into the literal in order, so it
-// must be a TupleType. A spread of any other type, such as an Array (M7), cannot
-// be spliced statically. Two type-level cousins defer to M7/M9: a tuple-spread
+// operand that does not infer to a tuple. Only the concrete-literal splice is
+// handled: the operand's element types are copied into the literal in order, so it
+// must be a TupleType. A spread of any other type, such as an Array, cannot be
+// spliced statically. Two type-level cousins are not yet handled: a tuple-spread
 // type over an abstract operand [...P, x], and a typed variadic tail
 // [number, ...Array<number>]. Spread is the offending spread element and carries
 // the blame span. Operand is the type it inferred to.
@@ -220,8 +208,8 @@ type SpreadNotTupleError struct {
 // element of the literal. An inexact tuple has unknown length, so an element written
 // after the spread would land at an unknown position and the result tuple's shape
 // could not be pinned. A trailing inexact spread is allowed and makes the whole
-// result inexact. The variadic-tail forms such as [number, ...Array<number>] defer
-// to M7/M9. Spread is the offending spread element and carries the blame span.
+// result inexact. The variadic-tail forms such as [number, ...Array<number>] are
+// not yet handled. Spread is the offending spread element and carries the blame span.
 // Operand is the inexact tuple it inferred to.
 type InexactTupleSpreadError struct {
 	Spread  *ast.ArraySpreadExpr
@@ -232,7 +220,7 @@ type InexactTupleSpreadError struct {
 // value or a tuple element inside a non-mut container — `{a: mut {x}}` or
 // `[mut {x}]`. An owned-mutable cell nested inside an immutable container is
 // misleading: the enclosing container's immutability already reaches into the
-// field, so the field is not actually writable, and interior mutability (#618) is
+// field, so the field is not actually writable, and interior mutability is
 // the proper mechanism for the case the user wants. A borrow field (`&T`,
 // `&mut T`) is a reference to external storage, not an interior owned-mutable
 // cell, so it stays legal. The annotation node carries the blame span.
@@ -262,26 +250,26 @@ type ReadonlyFieldSubtypeError struct {
 	site  ast.Node
 }
 
-func (*CannotConstrainError) isSolverError()      {}
-func (*MutFieldError) isSolverError()             {}
-func (*ReadonlyFieldError) isSolverError()        {}
-func (*ReadonlyFieldSubtypeError) isSolverError() {}
-func (*FuncArityMismatchError) isSolverError()    {}
-func (*TupleLengthMismatchError) isSolverError() {}
-func (*SpreadNotTupleError) isSolverError()      {}
-func (*InexactTupleSpreadError) isSolverError()  {}
-func (*MissingPropertyError) isSolverError()     {}
-func (*InexactIntoExactError) isSolverError()    {}
+func (*CannotConstrainError) isSolverError()       {}
+func (*MutFieldError) isSolverError()              {}
+func (*ReadonlyFieldError) isSolverError()         {}
+func (*ReadonlyFieldSubtypeError) isSolverError()  {}
+func (*FuncArityMismatchError) isSolverError()     {}
+func (*TupleLengthMismatchError) isSolverError()   {}
+func (*SpreadNotTupleError) isSolverError()        {}
+func (*InexactTupleSpreadError) isSolverError()    {}
+func (*MissingPropertyError) isSolverError()       {}
+func (*InexactIntoExactError) isSolverError()      {}
 func (*InexactTupleIntoExactError) isSolverError() {}
 func (*InexactUnionIntoExactError) isSolverError() {}
-func (*ExtraPropertyError) isSolverError()       {}
-func (*ExtraElementError) isSolverError()        {}
-func (*OptionalPropertyError) isSolverError()    {}
-func (*MutabilityMismatchError) isSolverError()  {}
-func (*BorrowEscapeError) isSolverError()        {}
+func (*ExtraPropertyError) isSolverError()         {}
+func (*ExtraElementError) isSolverError()          {}
+func (*OptionalPropertyError) isSolverError()      {}
+func (*MutabilityMismatchError) isSolverError()    {}
+func (*BorrowEscapeError) isSolverError()          {}
 
-// --- Per-operand blame (§3.5): each constraint kind follows its operands through
-// Prov on demand, falling back to its own site (where it keeps one) ---
+// --- Per-operand blame: each constraint kind follows its operands through
+// Prov on demand, falling back to its own site where it keeps one ---
 
 func (e *CannotConstrainError) Span() ast.Span      { return spanOf(e.prov, e.Sub, e.site) }
 func (e *CannotConstrainError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
@@ -377,13 +365,12 @@ func (e *BorrowEscapeError) Span() ast.Span {
 func (e *BorrowEscapeError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
-// site, and the site itself otherwise (or when op has no entry). The containment
-// guard is the M2.5 fix for identifier-flow blame: for f("hi") the operand ("hi")
-// is minted inside the call, so the narrower operand wins; for val a: number = x
-// the operand (x's type) traces to x's *definition*, which is NOT inside the use
-// site, so the use (site) wins — an ident-use error points at the use, not the
-// definition (§3.8). In M3+, NodeFor chases interior Origin edges to the nearest
-// AST leaf; in M2.5 it is a single lookup.
+// site, and the site itself otherwise, or when op has no entry. The containment
+// guard handles identifier-flow blame. For f("hi") the operand "hi" is minted
+// inside the call, so the narrower operand wins. For val a: number = x the operand,
+// x's type, traces to x's *definition*, which is NOT inside the use site, so the use
+// wins: an ident-use error points at the use, not the definition. NodeFor is a
+// single lookup.
 func spanOf(p NodeResolver, op soltype.Type, site ast.Node) ast.Span {
 	if p != nil && site != nil {
 		if n, ok := p.NodeFor(op); ok && site.Span().ContainsSpan(n.Span()) {
@@ -399,7 +386,7 @@ func spanOf(p NodeResolver, op soltype.Type, site ast.Node) ast.Span {
 // callers' subject operands are minted *at* the constraint (a call-shape, a tuple
 // literal, a member's field var), so the first resolved operand is already the
 // narrowest blame. The site fallback keeps blame off the zero span when an
-// operand is unrecorded (a degrade path reachable from M4).
+// operand is unrecorded on a degrade path.
 func spanOfFirst(p NodeResolver, site ast.Node, ops ...soltype.Type) ast.Span {
 	if p != nil {
 		for _, op := range ops {
@@ -422,8 +409,8 @@ func spanOfNode(site ast.Node) ast.Span {
 }
 
 // relatedOf resolves each operand that has an entry to a related span and drops
-// the ones that don't (no fallback — a missing related node is simply omitted),
-// deduped by span (§3.6).
+// the ones that don't, with no fallback so a missing related node is simply omitted,
+// deduped by span.
 func relatedOf(p NodeResolver, ops ...soltype.Type) []ast.Span {
 	if p == nil {
 		return nil
@@ -448,8 +435,8 @@ func appendUnique(spans []ast.Span, s ast.Span) []ast.Span {
 	return append(spans, s)
 }
 
-// --- M2 bridge errors (born in the walk with the offending ast.Node in hand,
-// so they self-blame: Span() is the node's own span, no post-hoc stamping) ---
+// --- Bridge errors born in the walk with the offending ast.Node in hand,
+// so they self-blame. Span() is the node's own span, with no post-hoc stamping ---
 
 // UnknownIdentifierError fires when a value-position identifier resolves to no
 // binding in the scope chain.
@@ -459,8 +446,8 @@ type UnknownIdentifierError struct {
 
 // NamespaceUsedAsValueError fires when a path expression resolves to a namespace
 // in value position. Namespaces are a separate binding sort and never flow as
-// values. M4 moves the rejection off inferIdent to the value-position consumer
-// (demandValue): a namespace is legal in the object position of a member/index
+// values. The rejection sits in the value-position consumer demandValue rather than
+// in inferIdent, since a namespace is legal in the object position of a member/index
 // chain, so this fires for both a bare `f(Foo)` and a partial chain `f(A.B)` where
 // the chain stops at a namespace. Node is the offending path expression (the blame
 // span); NS is the namespace it resolved to.
@@ -488,19 +475,20 @@ type DynamicNamespaceIndexError struct {
 	NS    *Namespace
 }
 
-// UnsupportedNodeError is the M2-subset guard: an AST node whose KIND is outside
-// the M2 walk's coverage (kind = astKind(Node)). Unlike BodyDeclNotAllowedError
-// this is a temporary scope gate, not a permanent language rule — later milestones
-// widen coverage and remove arms. The "the node is fine, a FEATURE of it isn't"
-// case (e.g. optional chaining on a supported MemberExpr) is UnsupportedFeatureError.
+// UnsupportedNodeError is the subset guard: an AST node whose KIND is outside
+// the walk's current coverage (kind = astKind(Node)). Unlike BodyDeclNotAllowedError
+// this is a temporary scope gate, not a permanent language rule, so widening coverage
+// removes arms. The "the node is fine, a FEATURE of it isn't" case, such as optional
+// chaining on a supported MemberExpr, is UnsupportedFeatureError.
 type UnsupportedNodeError struct {
 	Node ast.Node
 }
 
 // UnsupportedFeatureError is the sibling of UnsupportedNodeError for the case
-// where the node kind IS supported but a feature of it is not — e.g. a generic
-// function (the FuncExpr is fine, type params are M3) or optional chaining (the
-// MemberExpr is fine, recv?.foo is M6). The node carries the blame span; Feature
+// where the node kind IS supported but a feature of it is not. Examples are a generic
+// function, where the FuncExpr is fine but type params are not yet supported, and
+// optional chaining, where the MemberExpr is fine but recv?.foo is not yet supported.
+// The node carries the blame span; Feature
 // names what is unsupported (not derivable from astKind, which would name the
 // supported parent).
 type UnsupportedFeatureError struct {
@@ -509,40 +497,40 @@ type UnsupportedFeatureError struct {
 }
 
 // BodyDeclNotAllowedError fires when a statement-level declaration in a function
-// body is anything other than a VarDecl. This is a permanent language rule
-// (§3.2), not the temporary subset gate above: body decls are VarDecl-only.
+// body is anything other than a VarDecl. This is a permanent language rule,
+// not the temporary subset gate above: body decls are VarDecl-only.
 type BodyDeclNotAllowedError struct {
 	Decl ast.Decl
 }
 
 // MissingInitializerError fires when a `val`/`var` declaration has no
-// initializer. M2 has no way to bind such a name yet — annotation-only binding
-// needs TypeAnn→soltype resolution that lands in a later PR — so this is its own
-// kind rather than a generic UnsupportedNodeError: it marks an annotation-driven
-// binding the walk can't infer, not an AST node shape outside the subset.
+// initializer. There is no way to bind such a name yet, since annotation-only
+// binding needs TypeAnn→soltype resolution that is not yet implemented, so this is
+// its own kind rather than a generic UnsupportedNodeError: it marks an
+// annotation-driven binding the walk can't infer, not an AST node shape outside the
+// subset.
 type MissingInitializerError struct {
 	Decl *ast.VarDecl
 }
 
 // DuplicateDeclarationError fires when a top-level `val`/`var` rebinds a name
-// already declared in the module scope. Unlike a function (whose repeated
-// top-level declarations are overloads, supported from PR-3), a variable may be
-// declared only once per scope; the first binding is kept.
+// already declared in the module scope. Unlike a function, whose repeated
+// top-level declarations are overloads, a variable may be declared only once per
+// scope; the first binding is kept.
 //
 // Decl is the rejected redeclaration (the blame span); Previous is the kept first
 // declaration, surfaced via Related() as "previously declared here". Name is the
 // resolved binding-key name — retained alongside the nodes because it may be a
 // qualified key name distinct from the decl's local identifier, and the message
-// wants the canonical name (§3.4 caveat).
+// wants the canonical name.
 type DuplicateDeclarationError struct {
 	Decl, Previous ast.Decl
 	Name           string
 }
 
-// NoMatchingOverloadError fires when a call to an overloaded name (PR6) matches
+// NoMatchingOverloadError fires when a call to an overloaded name matches
 // none of the overload set's arms — every candidate either disagreed on arity or
-// failed to accept the supplied argument types. It replaces M2's interim
-// OverloadNotSupportedError (overloading is now real).
+// failed to accept the supplied argument types.
 //
 // It is a BRIDGE error: born in resolveOverload with the *ast.CallExpr in hand, so
 // it self-blames (Span() is the call) and relates the callee expression. Candidates
@@ -555,7 +543,7 @@ type NoMatchingOverloadError struct {
 
 // UnannotatedRecursiveOverloadError fires when an overloaded function participates
 // in a mutually-recursive group (a dep-graph component with more than one binding)
-// without fully-annotated overload signatures (PR6). Fixed-point iteration over
+// without fully-annotated overload signatures. Fixed-point iteration over
 // overload choices is not guaranteed to converge under subtyping, so the overload
 // set must be ground before the group is inferred; self-recursion (a singleton
 // component) is softer and does not trip this. The binding degrades to its first
@@ -569,7 +557,7 @@ type UnannotatedRecursiveOverloadError struct {
 	Name string
 }
 
-// DuplicateOverloadError fires when two arms of an overload set (PR6) are
+// DuplicateOverloadError fires when two arms of an overload set are
 // indistinguishable for dispatch: they share an arity and have pointwise-equal
 // parameter types, so no call could ever select one over the other. An overload set
 // compiles to a single runtime function that dispatches on argument types, so two
@@ -584,7 +572,7 @@ type DuplicateOverloadError struct {
 }
 
 // TooManyArgsError fires when a DIRECT call supplies more arguments than the
-// (concrete) callee declares — the #677 §4.2.3 extra-arg lint, which rejects
+// (concrete) callee declares — the extra-arg lint, which rejects
 // too-many for exact AND inexact callees alike (an inexact function tolerates
 // extras only as a callback, not at a visible call site). It is the uniform
 // too-many message; the surviving FuncArityMismatchError covers "too few /
@@ -615,10 +603,10 @@ type NotEnoughArgsError struct {
 }
 
 // AwaitOutsideAsyncError fires when an `await` expression appears outside the
-// body of an `async fn` (the walk's rule, not the type rule — per M3's plan,
-// "Awaiting outside an `async` function is rejected by the AST walk, not by the
-// type rule"). The argument is still walked (so any errors inside it surface),
-// but the await contributes a `never` placeholder so callers don't cascade.
+// body of an `async fn`. This is the walk's rule, not the type rule: awaiting
+// outside an `async` function is rejected by the AST walk. The argument is still
+// walked so any errors inside it surface, but the await contributes a `never`
+// placeholder so callers don't cascade.
 //
 // EnclosingFn is the (non-async) function the await sits in, when there is one —
 // the function the user would mark `async` to fix the error, surfaced via
@@ -653,11 +641,11 @@ type AsyncReturnNotPromiseError struct {
 }
 
 // InvalidAssignmentTargetError fires when the left-hand side of an assignment
-// (`a = expr`) is not an assignable place. M3's only assignable target is an
+// (`a = expr`) is not an assignable place. The only assignable target is an
 // IdentExpr resolving to a `var` binding; a literal, call, or any other non-place
 // target is rejected here. A member or index target such as `obj.x = …` is instead
 // reported as an UnsupportedFeatureError: it is a valid place whose type rule needs
-// object/array types (M4), not a fundamentally invalid target.
+// object/array types not yet supported, not a fundamentally invalid target.
 //
 // It is a BRIDGE error: born in inferAssign with the offending target node in hand,
 // so it self-blames (Span() is the target's own span); it carries no related node.
@@ -667,8 +655,8 @@ type InvalidAssignmentTargetError struct {
 
 // CannotAssignToImmutableError fires when a reassignment (`a = expr`) targets a
 // binding that is not a `var` — a `val`, a function, a parameter, or a prelude
-// binding. The binding-level mutability gate (PR8); `mut`-field / alias / lifetime
-// mutability is M4.
+// binding. This is the binding-level mutability gate; `mut`-field, alias, and
+// lifetime mutability are not yet supported.
 //
 // It is a BRIDGE error: born in inferAssign with the assignment node in hand, so
 // it self-blames the whole assignment (Span()). Decl is the introducing
@@ -683,12 +671,12 @@ type CannotAssignToImmutableError struct {
 }
 
 // NonExhaustiveMatchError fires when a `match` expression does not cover every
-// value its scrutinee can take, so a value could fall through every arm. In M4 the
+// value its scrutinee can take, so a value could fall through every arm. The
 // coverage decision reads only the scrutinee's structural exactness. An exact object
 // or tuple scrutinee is covered by a structural arm matching its shape. An inexact
 // scrutinee carries an open tail of unknown values, so it requires a catch-all arm.
 // A catch-all is an unguarded wildcard `_` or identifier pattern. Union-scrutinee
-// exhaustiveness is M6 and enum exhaustiveness is M5, and both extend this same form.
+// and enum exhaustiveness are not yet handled, and both extend this same form.
 //
 // It is a bridge error born in inferMatch with the match node in hand, so it
 // self-blames the whole match through Span and carries no related node.
@@ -1006,9 +994,8 @@ func (e *ReadonlyFieldSubtypeError) Message() string {
 
 // describe renders a RAW, uncoalesced type for in-flight error messages (t0,
 // function, number). Distinct from soltype.Print, which renders coalesced
-// output as user-facing Escalier syntax (see m1-implementation-plan §2.2). It
-// lives in solver because it walks bound-carrying variables, and its wording
-// matches the spike's verbatim so test assertions stay stable.
+// output as user-facing Escalier syntax. It lives in solver because it walks
+// bound-carrying variables.
 func describe(t soltype.Type) string {
 	switch t := t.(type) {
 	case *soltype.PrimType:
@@ -1043,10 +1030,9 @@ func describe(t soltype.Type) string {
 		return "Promise<" + describe(t.Inner) + ">"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
-		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2
-		// attaches lifetimes, so Lt may be non-nil here, but a raw `'l{id}` in a
-		// diagnostic is noise. Naming lands in D4; until then an escape message reads
-		// `mut object` without naming which borrow escaped.
+		// recursing like the Promise arm. The lifetime is deliberately NOT rendered:
+		// Lt may be non-nil here, but a raw `'l{id}` in a diagnostic is noise. An escape
+		// message reads `mut object` without naming which borrow escaped.
 		prefix := ""
 		if t.Mut {
 			prefix = "mut "

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -6,29 +6,28 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// checker is the per-inference-run carrier for the M2 constraint-generating
-// walk. It wraps M1's *Context (the fresh-var counter + Constrain), threads the
-// Info side table that records node→type, and accumulates SolverErrors. It is
-// the method receiver for the whole walk.
+// checker is the per-inference-run carrier for the constraint-generating walk. It
+// wraps the *Context (the fresh-var counter + Constrain), threads the Info side
+// table that records node→type, and accumulates SolverErrors. It is the method
+// receiver for the whole walk.
 //
 // The walk is a direct recursive switch over ast.Expr/Stmt/Decl, NOT the shared
 // ast.Visitor. This is a deliberate deviation from the CLAUDE.md "use the
 // existing visitor" convention: constraint generation is bottom-up and
 // value-producing (every node synthesizes a soltype.Type), which the visitor —
 // shaped for enter/exit transformation with no per-node synthesized value — does
-// not model cleanly. The shape matches both the simplesub spike's typeTerm and
-// the old checker's inferExpr. See m2-implementation-plan §3.2.
+// not model cleanly.
 type checker struct {
-	ctx  *Context      // M1: freshVar(level), Constrain(sub, super) []SolverError
-	info *Info         // M1: node → soltype.Type side table (unexported setType)
-	prov Prov          // M2.5: soltype.Type → Origin (leaf FromAST only), the inverse of info
-	errs []SolverError // accumulated; mirrors the spike's []error threading
+	ctx  *Context      // freshVar(level), Constrain(sub, super) []SolverError
+	info *Info         // node → soltype.Type side table (unexported setType)
+	prov Prov          // soltype.Type → Origin (leaf FromAST only), the inverse of info
+	errs []SolverError // accumulated
 
 	// fn is the enclosing function context for the body currently being walked —
 	// its async flag (does `await` here resolve?), the function's AST node (for
 	// await-outside-async blame), and the live list of every ReturnStmt expression
-	// type collected from the body so far (PR3). It is nil at module top-level (and
-	// inside a top-level `val` initializer): a top-level `await` is rejected by
+	// type collected from the body so far. It is nil at module top-level and
+	// inside a top-level `val` initializer: a top-level `await` is rejected by
 	// inferAwait, and a top-level `return` — reachable inside an `if` in a `val`
 	// initializer — by inferStmt's ReturnOutsideFunctionError. inferFunc pushes a
 	// fresh context on entry and pops it on exit, so a nested function has its own
@@ -42,7 +41,7 @@ type checker struct {
 	// by tests that exercise the guard. See recordProv.
 	debugProv bool
 
-	// varIDCounter is the module-wide running allocator for liveness VarIDs (M4 G1).
+	// varIDCounter is the module-wide running allocator for liveness VarIDs.
 	// Each function body's pre-pass renames its locals starting from this counter and
 	// then advances it, so VarIDs are unique across every body in one inference run
 	// rather than restarting at 1 per body. That makes a binding's VarID name the same
@@ -53,7 +52,7 @@ type checker struct {
 
 	// preludeNames caches the immutable prelude root scope's sorted value names so the
 	// liveness pre-pass collects them once instead of re-walking and re-sorting the
-	// prelude for every function body (M4 G1). preludeNamesRoot is the scope the cache
+	// prelude for every function body. preludeNamesRoot is the scope the cache
 	// was computed for. collectOuterBindings recomputes if a different root appears.
 	preludeNames     []string
 	preludeNamesRoot *Scope
@@ -67,7 +66,7 @@ type checker struct {
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the
-// property name — the key into a function body's `written` map (M4 C3).
+// property name — the key into a function body's `written` map.
 type fieldKey struct {
 	recvID int
 	field  string
@@ -91,7 +90,7 @@ type funcCtx struct {
 	returns []soltype.Type
 
 	// written records the widened type stored into a receiver variable's field by a
-	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and
+	// field-write `recv.prop = source`, keyed by the receiver var's ID and
 	// the property name. A later read of the same field returns this concrete type
 	// instead of minting a fresh var, so `obj.x = 5; obj.x` is `number`
 	// (read-after-write). It is purely a precision win: write-after-read already
@@ -107,7 +106,7 @@ type funcCtx struct {
 	written map[fieldKey]soltype.Type
 
 	// liveness, aliases, stmtToRef, and varIDNames are the mutability-transition
-	// checking state for THIS function body (M4 G1), populated by runLivenessPrePass
+	// checking state for THIS function body, populated by runLivenessPrePass
 	// before the body is walked. They are the new-checker analogue of the old
 	// checker's Context.Liveness/Aliases/StmtToRef/VarIDNames. Scoping them to funcCtx
 	// gives a nested function its own liveness analysis for free. Push/pop isolates them
@@ -118,16 +117,16 @@ type funcCtx struct {
 	stmtToRef  map[ast.Stmt]liveness.StmtRef
 	varIDNames map[liveness.VarID]string
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
-	// the transition checker uses to query the lifetime sort for a `'static` escape in
-	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow
-	// lifetime D3 forced `<: 'static` has a permanent outside alias, and that borrow's
-	// Mut supplies its mutability. The stored type is the SAME pointer the inference
-	// graph mutates. So a lifetime that a later global write `sink = p` forces to
+	// the transition checker uses to query the lifetime sort for a `'static` escape.
+	// A value whose borrow lifetime was forced `<: 'static` has a permanent outside
+	// alias, and that borrow's Mut supplies its mutability. The stored type is the SAME
+	// pointer the inference graph mutates. So a lifetime that a later global write
+	// `sink = p` forces to
 	// 'static after the binding is recorded is visible here through the shared
 	// LifetimeVar. Populated at the same sites that seed alias mutability: parameter
 	// leaves, decl bindings, and reassignment targets.
 	varIDTypes map[liveness.VarID]soltype.Type
-	// currentStmt is the enclosing statement currently being walked (M4 G1), set by
+	// currentStmt is the enclosing statement currently being walked, set by
 	// inferStmt. A reassignment `a = e` lives in expression position, so the transition
 	// checker reads the enclosing statement from here to find its CFG StmtRef.
 	currentStmt ast.Stmt
@@ -179,10 +178,10 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 //  1. Assign the Prov table and the constraint node n to the error.
 //  2. The error's Span()/Related() then resolve per-operand blame through Prov on
 //     demand. When an operand has no Prov entry, blame falls back to n's span,
-//     never the zero span (§3.5).
+//     never the zero span.
 //
 // The engine never touches Prov. These fields are assigned after Constrain returns,
-// so the hot loop stays off the table. That is the perf invariant, §3.9. Bridge
+// so the hot loop stays off the table. That is the perf invariant. Bridge
 // errors never flow through here; they self-blame from their own node.
 func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 	for _, e := range c.ctx.Constrain(source, target) {
@@ -219,11 +218,11 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 }
 
 // report accumulates a structured error and returns the error-recovery sentinel
-// (PR8) so a caller can `return c.report(...)` in value position. ErrorType
+// so a caller can `return c.report(...)` in value position. ErrorType
 // absorbs in both directions inside constrain, so this placeholder never cascades
-// a second, spurious failure — replacing M2's overloaded `never` placeholder
-// (never is the lattice bottom, coalesced-output only, with no constrain-input
-// rule). It is minted ONLY here, where a diagnostic was definitely emitted, never
+// a second, spurious failure. It avoids overloading the `never` placeholder, which
+// is the lattice bottom, coalesced-output only, with no constrain-input rule. It is
+// minted ONLY here, where a diagnostic was definitely emitted, never
 // by freshVar — the discipline that keeps absorption from silently hiding a
 // genuine checker bug.
 func (c *checker) report(e SolverError) soltype.Type {
@@ -232,7 +231,7 @@ func (c *checker) report(e SolverError) soltype.Type {
 }
 
 // reportUnsupported records an UnsupportedNodeError for an AST node whose kind is
-// outside the M2 subset. The node self-blames: both the span and the rendered kind
+// outside the supported subset. The node self-blames: both the span and the rendered kind
 // (astKind) come from it. When the unsupported thing is a child carried by its
 // parent — an object property's computed key, a function's destructuring pattern —
 // pass that child node directly (it embeds ast.Node and carries its own, narrower
@@ -251,11 +250,11 @@ func (c *checker) reportUnsupportedFeature(node ast.Node, feature string) soltyp
 }
 
 // recordType records t as the inferred type of n in the Info side table. Wraps
-// the unexported setType — which is why the whole M2 walk lives in package
+// the unexported setType — which is why the whole walk lives in package
 // solver. The AST stays untouched (no InferredType() writes); Info is the single
 // source of truth for node→type.
 //
-// Under a probe (M3 PR5) snapshotMapEntry captures the prior entry and registers
+// Under a probe, snapshotMapEntry captures the prior entry and registers
 // a rollback closure, so a discarded speculative trial leaves Info exactly as it
 // was — the entry restored if n had one, deleted if it did not.
 func (c *checker) recordType(n ast.Node, t soltype.Type) {
@@ -263,12 +262,12 @@ func (c *checker) recordType(n ast.Node, t soltype.Type) {
 	c.info.setType(n, t)
 }
 
-// inferExpr dispatches on the concrete expression kind. PR-1 wired the two leaf
-// cases (literals, identifiers); PR-3 adds the function/application walk
-// (FuncExpr, CallExpr — the block/statement walk they drive lives in
-// infer_stmt.go); PR-4 adds tuples, object literals, and member access; M3 adds
-// await/if-else and (PR8) the assignment form of BinaryExpr. Every remaining kind
-// falls through to a clean UnsupportedNodeError (never a panic).
+// inferExpr dispatches on the concrete expression kind. It covers the leaf
+// cases (literals, identifiers), the function/application walk (FuncExpr,
+// CallExpr — the block/statement walk they drive lives in infer_stmt.go), tuples,
+// object literals, member access, await/if-else, and the assignment form of
+// BinaryExpr. Every remaining kind falls through to a clean UnsupportedNodeError
+// (never a panic).
 func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
@@ -296,9 +295,9 @@ func (c *checker) inferExpr(scope *Scope, lvl int, e ast.Expr) soltype.Type {
 	case *ast.BorrowExpr:
 		return c.inferBorrow(scope, lvl, e)
 	case *ast.BinaryExpr:
-		// PR8 handles the ASSIGNMENT op only (`a = expr`); every other binary
+		// Only the ASSIGNMENT op is handled here (`a = expr`); every other binary
 		// operator (+, ==, &&, ++, …) needs the operator-scheme walk over the prelude
-		// bindings, a separate unlanded PR, so it stays UnsupportedNodeError.
+		// bindings, which is not yet implemented, so it stays UnsupportedNodeError.
 		if e.Op == ast.Assign {
 			return c.inferAssign(scope, lvl, e)
 		}

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 A3: object / tuple / mut type annotations + the construction-site
-// excess-member check (exact-types §§2.2.4, 3.2.4) ---
+// --- object / tuple / mut type annotations and the construction-site
+// excess-member check ---
 
 // An object annotation resolves to an ObjectType and an annotated binding adopts
 // it, so the rendered binding type is the annotation, trailing `...` and all.
@@ -35,8 +35,8 @@ func TestInferInexactObjectAnnotationDeclaredFields(t *testing.T) {
 }
 
 // A literal carrying a field the inexact target does not declare is rejected — the
-// construction-site excess check fires even though the target is inexact (parallel
-// to the direct-call extra-arg rejection, exact-types §2.2.4).
+// construction-site excess check fires even though the target is inexact, parallel
+// to the direct-call extra-arg rejection.
 func TestInferInexactObjectAnnotationRejectsExcessLiteralField(t *testing.T) {
 	_, _, errs := inferSource(t, `val r: {x: number, ...} = {x: 1, y: 2}`)
 	require.Len(t, errs, 1)
@@ -198,9 +198,9 @@ func TestInferOwnedMutNestedMutFieldUpgraded(t *testing.T) {
 }
 
 // A `mut T` annotation lowers to a borrow (RefType{Mut: true}); a function
-// parameter typed `mut {x: number}` originates a fresh borrow lifetime (D2), and a
+// parameter typed `mut {x: number}` originates a fresh borrow lifetime, and a
 // member read through it peels the borrow to resolve the inner property. The lifetime
-// is unused in the result, since the body returns a number, not the borrow, so D4's
+// is unused in the result, since the body returns a number, not the borrow, so
 // display-time elision drops it and the param renders as plain owned-mutable `mut {…}`.
 func TestInferMutObjectAnnotation(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) -> number { return p.x }`)

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR8: reassignment typing (`a = expr`) ---
+// --- Reassignment typing (`a = expr`) ---
 //
 // `a = expr` parses as an ast.BinaryExpr with Op == ast.Assign — the only binary
-// operator the M3 walk handles. The target must be a mutable (`var`) place; the
+// operator the walk handles. The target must be a mutable (`var`) place; the
 // source must be a subtype of the binding's type; the assignment expression evaluates
 // to the value just stored, so its type is the target's slot type. Reassignment
 // lives in expression position, so these tests exercise it inside a function body
@@ -35,7 +35,7 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 	})
 }
 
-// An un-annotated `var a = 5` widens its binding to `number` (M4 B3), so
+// An un-annotated `var a = 5` widens its binding to `number`, so
 // reassigning a DIFFERENT literal of the same primitive (`a = 6` ⇒ `6 <: number`)
 // checks. A `val` keeps the literal singleton (see TestInferAssignToValRejected).
 func TestInferAssignUnannotatedVarLiteralWidened(t *testing.T) {
@@ -72,8 +72,8 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 }
 
 // A non-place target — a literal or a call — is an InvalidAssignmentTargetError that
-// blames the target. A member target takes a separate path (a field write, C3) and an
-// index target another (unsupported pending Array types, M7).
+// blames the target. A member target takes a separate path as a field write, and an
+// index target another that is unsupported pending Array types.
 func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
 		src := "val a = 5\nfn g() { 5 = a }"
@@ -153,8 +153,9 @@ func TestInferAssignTopLevelBrokenBindingNoCascade(t *testing.T) {
 }
 
 // Reassigning a union-typed var applies the union-target rule: a member assigns, a
-// non-member is rejected once. (Union subtyping in general is M6; inferAssign trials
-// the members under a probe so a legal member assignment isn't wrongly rejected.)
+// non-member is rejected once. General union subtyping is not yet available, so
+// inferAssign trials the members under a probe so a legal member assignment isn't
+// wrongly rejected.
 func TestInferAssignUnionTarget(t *testing.T) {
 	t.Run("member assigns", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
@@ -173,15 +174,15 @@ func TestInferAssignUnionTarget(t *testing.T) {
 	})
 }
 
-// KNOWN GAP (M6): assigning an inference-variable source into a union target
+// KNOWN GAP: assigning an inference-variable source into a union target
 // over-narrows the variable. `a = x` for an un-annotated param `x` and `a: 1 | 2`
 // commits the first matching member (`x <: 1`), so `x` infers as `1` rather than
-// the sound `1 | 2`. This is INCOMPLETE, not unsound (the committed bound is always
-// stronger than required, so no invalid program is accepted), and it is not fixable
+// the sound `1 | 2`. This is INCOMPLETE, not unsound. The committed bound is always
+// stronger than required, so no invalid program is accepted. It is not fixable
 // in constrainAssign — falling through to constrain(source, union) injects the
 // coalesced union node into source's bound list and panics the coalescer. The correct
-// fix is M6's first-class union subtyping with inference variables. This pins the
-// interim behavior so the M6 change is visible: when it lands, `x` becomes `1 | 2`
+// fix is first-class union subtyping with inference variables. This pins the
+// interim behavior so the change is visible: once it lands, `x` becomes `1 | 2`
 // and this assertion must be updated. See constrainAssign's KNOWN GAP note.
 func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
 	values, _, errs := inferSource(t, `
@@ -191,13 +192,13 @@ func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// M6 target: "fn (c: boolean, x: 1 | 2) -> void".
+	// Sound target: "fn (c: boolean, x: 1 | 2) -> void".
 	require.Equal(t, "fn (c: boolean, x: 1) -> void", values["f"])
 }
 
 // A namespace name as an assignment target reports NamespaceUsedAsValue, mirroring
 // inferIdent's value-position behavior (not UnknownIdentifier). Hand-built because
-// namespace declarations are themselves unsupported in M3, so a namespace never
+// namespace declarations are themselves unsupported, so a namespace never
 // enters scope via real source — same construction as TestInferIdentNamespaceUsedAsValue.
 func TestInferAssignNamespaceTarget(t *testing.T) {
 	c := newChecker()
@@ -209,18 +210,18 @@ func TestInferAssignNamespaceTarget(t *testing.T) {
 	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
 }
 
-// A member target (obj.x = …) is a field write (M4 C3). Writing to a field of an
+// A member target (obj.x = …) is a field write. Writing to a field of an
 // IMMUTABLE object — here `o` is `val`-bound, so its `{x: 5}` is immutable — is
 // rejected: the write requires `o <: mut {x: number, ...}`, and an immutable object
-// cannot fill the mutable slot (the C2 gate's mutability rule).
+// cannot fill the mutable slot, which is the borrow gate's mutability rule.
 func TestInferAssignMemberTargetImmutable(t *testing.T) {
 	src := "val o = {x: 5}\nfn f() { o.x = 6 }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "cannot constrain immutable object <: mutable object", "o.x = 6")
 }
 
-// An INDEX target (xs[i] = …) still needs Array and index types (M7), so it stays
-// an unsupported feature — distinct from a member target, which C3 now types.
+// An INDEX target (xs[i] = …) still needs Array and index types, so it stays
+// an unsupported feature — distinct from a member target, which is now typed.
 func TestInferAssignIndexTargetUnsupported(t *testing.T) {
 	src := "val xs = [1, 2]\nfn f() { xs[0] = 6 }"
 	_, _, errs := inferSource(t, src)

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PR3 — async / await / return-point join, against real source through
-// inferSource. The PR builds on M2's monomorphic walk: the body of an `async fn`
-// types exactly like a plain function, then its EXTERNAL return wraps in
-// Promise<T>; `await e` constrains `e <: Promise<U>` and yields `U`; the
-// collected ReturnStmts join before constraining against the return annotation.
-// No auto-flatten of nested Promise<Promise<T>> — that is M9's Awaited<T>.
+// Async / await / return-point join, against real source through inferSource. The
+// body of an `async fn` types exactly like a plain function, then its EXTERNAL
+// return wraps in Promise<T>; `await e` constrains `e <: Promise<U>` and yields
+// `U`; the collected ReturnStmts join before constraining against the return
+// annotation. There is no auto-flatten of nested Promise<Promise<T>>; that is a
+// later Awaited<T>.
 
 // --- async fn external wrap ---
 
@@ -60,7 +60,7 @@ func TestInferAwaitUnwrapsPromise(t *testing.T) {
 
 // No auto-flatten: `await p` where `p: Promise<Promise<number>>` yields
 // `Promise<number>` — one layer peeled, the rest preserved (the constraint is
-// `p <: Promise<U>`, so U = Promise<number>; Awaited<T>'s recursive flatten is M9).
+// `p <: Promise<U>`, so U = Promise<number>; a recursive Awaited<T> flatten is future work).
 // With NO return annotation the async fn wraps that inferred return, so the external
 // type is Promise<Promise<number>> — which only holds if await peeled exactly one
 // layer (a full flatten would give `number`, wrapping to `Promise<number>`).
@@ -130,7 +130,7 @@ func TestInferAsyncPromiseWildcardReturnInferred(t *testing.T) {
 
 // `await` outside an `async fn` is a WALK rejection — not a type rule failure.
 // The AwaitOutsideAsyncError carries the await node and produces the ErrorType
-// recovery placeholder (PR8) so a downstream consumer doesn't cascade.
+// recovery placeholder so a downstream consumer doesn't cascade.
 func TestInferAwaitOutsideAsyncRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(p: Promise<string>) {
@@ -213,7 +213,7 @@ func TestInferAwaitInOuterAfterInnerAsync(t *testing.T) {
 
 // --- Block return-point join ---
 
-// The headline PR3 join: `fn () { if c { return 1 } return "x" }` collects BOTH
+// The headline join: `fn () { if c { return 1 } return "x" }` collects BOTH
 // returns and joins them with the tail. The function externally returns
 // 1 | "x".
 func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
@@ -224,9 +224,8 @@ func TestInferBlockReturnJoinAcrossIf(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// The two return points coalesce into a union, canonicalized by M6 PR1's
-	// newUnion. NumLit sorts before StrLit within the LitType kind, so 1
-	// comes before "x".
+	// The two return points coalesce into a union, canonicalized by newUnion.
+	// NumLit sorts before StrLit within the LitType kind, so 1 comes before "x".
 	require.Equal(t, `fn (c: boolean) -> 1 | "x"`, values["h"])
 }
 
@@ -245,8 +244,8 @@ func TestInferBlockReturnAnnotationCheckedAgainstAllReturns(t *testing.T) {
 }
 
 // A non-tail return whose type CONFLICTS with the declared return annotation
-// must be reported. Pre-PR3 (M2) the non-tail return was dropped silently; PR3
-// joins it with the tail and constrains the join against the annotation.
+// must be reported. The non-tail return joins with the tail, and the join is
+// constrained against the annotation.
 func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(c: boolean) -> number {
@@ -263,8 +262,7 @@ func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
 }
 
 // An `async fn` joined with multiple returns wraps the join in Promise. The
-// external return is Promise<1 | "x">. Members are in canonical order under
-// M6 PR1.
+// external return is Promise<1 | "x">. Members are in canonical order.
 func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		async fn f(c: boolean) {
@@ -280,8 +278,8 @@ func TestInferAsyncFnWithJoinedReturnsWrapped(t *testing.T) {
 
 // An if/else used as an expression is the join of its branches, observed
 // through an explicit `return` (a bare tail would be discarded). Without
-// generalization on the binding (PR1's value-only generalization for `val =
-// fn`), the binding here is monomorphic-frozen to the join.
+// value-only generalization on the binding, the binding here is
+// monomorphic-frozen to the join.
 func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn pick(c: boolean) {
@@ -293,7 +291,7 @@ func TestInferIfElseExprValueIsBranchJoin(t *testing.T) {
 }
 
 // An if without an else folds in void from the missing alt, so
-// `return if c { 5 }` returns `5 | void`. Void sorts last in M6 PR1's
+// `return if c { 5 }` returns `5 | void`. Void sorts last in the
 // canonical order, so the data member 5 leads.
 func TestInferIfElseExprMissingAltIsVoid(t *testing.T) {
 	values, _, errs := inferSource(t, `
@@ -364,11 +362,11 @@ func TestInferNestedFnReturnsScoped(t *testing.T) {
 // --- Error-recovery: no cascading on a failed sub-expression ---
 //
 // A reported diagnostic leaves the ErrorType recovery placeholder in expression
-// position (c.report, PR8). ErrorType absorbs in both directions inside constrain,
+// position via c.report. ErrorType absorbs in both directions inside constrain,
 // so the if-condition and await-argument checks no longer cascade a spurious second
 // `cannot constrain … <: …` on top of the real error — exactly ONE diagnostic
-// surfaces. (Before PR8, inferIfElse/inferAwait hand-guarded against a `never`
-// placeholder at each site; PR8 retired those guards for the absorbing sentinel.)
+// surfaces. The absorbing sentinel replaces per-site hand-guards against a `never`
+// placeholder in inferIfElse and inferAwait.
 
 // A failed `if` condition (unknown identifier) yields a single UnknownIdentifierError
 // — not also a `never <: boolean`. The branches still type, so the if value is their
@@ -430,7 +428,7 @@ func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 	require.Equal(t, "fn <T0>(p: Promise<T0>) -> Promise<T0>", values["f"])
 }
 
-// --- Rejected forms (#6, #7) ---
+// --- Rejected forms ---
 
 // A lifetime-annotated Promise is rejected, not silently coerced to a plain
 // Promise<T> — the soltype PromiseType carries no lifetime, so accepting it would
@@ -523,7 +521,7 @@ func TestInferIfElseBothBranchesDivergeYieldsNever(t *testing.T) {
 	require.Equal(t, "never", values["x"])
 }
 
-// #719/#720: dead code after a diverging statement no longer contributes to the
+// Dead code after a diverging statement does not contribute to the
 // function's value. Both branches return, so x's initializer diverges entirely
 // and the unreachable `[x]` statement is walked but discarded — the function's
 // return type is exactly the join of its return points, 1 | 2.
@@ -538,7 +536,7 @@ func TestInferDeadTailAfterDivergingValDiscarded(t *testing.T) {
 	require.Equal(t, "fn (c: boolean) -> 1 | 2", values["f"])
 }
 
-// #719/#720: a statement after a `return` is dead code and does not contribute
+// A statement after a `return` is dead code and does not contribute
 // to the function's value — `fn g() { return 1; 2 }` is `1`, not `1 | 2`.
 func TestInferStatementAfterReturnDiscarded(t *testing.T) {
 	values, _, errs := inferSource(t, `

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR 3: annotation-literal ownership, owned/borrow params, auto-borrow ---
+// --- Annotation-literal ownership, owned/borrow params, auto-borrow ---
 //
 // Rule 2: a `&` parameter is a borrow and a bare parameter is owned. Rule 3:
 // `val q = p` / `val q = &p` and the annotated forms `val q: {x} = p` /
@@ -15,7 +15,7 @@ import (
 
 // --- Rule 2 (params) -----------------------------------------------------------
 
-// A bare `mut` parameter is OWNED-mutable, not a borrow. Under the pre-PR 3
+// A bare `mut` parameter is OWNED-mutable, not a borrow. Under the earlier
 // borrow-by-default convention, a `mut T` param picked up a fresh inferred
 // lifetime. Now only an explicit `&` annotation borrows, so the rendered
 // signature carries no lifetime quantifier on a bare-mut returning function.
@@ -35,8 +35,8 @@ func TestInferBareImmutableParamIsOwned(t *testing.T) {
 
 // --- Rule 3 (binding initializer): inferred bindings, owned operand ------------
 
-// `val q = p` for an owned-immutable p establishes q as owned-immutable. PR 6
-// will make this consume p. For now it only establishes the owned binding.
+// `val q = p` for an owned-immutable p establishes q as owned-immutable. A later
+// change will make this consume p. For now it only establishes the owned binding.
 func TestInferValOwnedImmFromOwnedImm(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: {x: number}) {
   val q = p
@@ -49,16 +49,16 @@ func TestInferValOwnedImmFromOwnedImm(t *testing.T) {
 // `val q = &p` for an owned-immutable p establishes q as an immutable borrow.
 // The borrow lifetime is inferred and carried through to the return.
 //
-// DISABLED until lifetime-bounds (M6.5) lands.
+// DISABLED until directional lifetime bounds land.
 //
 // Returning a borrow of a locally-owned `p` is unsound: `p` is destroyed when
 // `f` returns, so `q` dangles. The current solver under-checks this because
-// the fresh lifetime on `&p` has no upper bound from `p` (an owned value has
-// no lifetime), and D4 elides the unconstrained lifetime to render the result
-// as owned. PR 5 of the affine plan generalizes escape detection at returns,
-// which will force the lifetime to 'static and change the rendering, but the
-// hard rejection needs M6.5's directional lifetime bounds. Re-enable then and
-// assert the borrow-of-local diagnostic instead of the empty error list.
+// the fresh lifetime on `&p` has no upper bound from `p`, since an owned value
+// has no lifetime, and the elision pass drops the unconstrained lifetime to
+// render the result as owned. Generalizing escape detection at returns will
+// force the lifetime to 'static and change the rendering, but the hard
+// rejection needs directional lifetime bounds. Re-enable then and assert the
+// borrow-of-local diagnostic instead of the empty error list.
 /*
 func TestInferValBorrowFromOwnedImm(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: {x: number}) {
@@ -83,10 +83,10 @@ func TestInferValMutOwnedFromOwnedMut(t *testing.T) {
 
 // `val q = &mut p` for an owned-mutable p establishes q as a mutable borrow.
 //
-// DISABLED until lifetime-bounds (M6.5) lands. Same under-checking as
+// DISABLED until directional lifetime bounds land. Same under-checking as
 // TestInferValBorrowFromOwnedImm: the borrow of a locally-owned `p` escapes
 // through the return without a lifetime that can refute it. Re-enable when
-// M6.5 lifetime bounds catch the dangling-borrow case.
+// lifetime bounds catch the dangling-borrow case.
 /*
 func TestInferValMutBorrowFromOwnedMut(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: mut {x: number}) {
@@ -126,7 +126,7 @@ func TestInferValAnnotatedOwnedImm(t *testing.T) {
 // `val q: &{x} = p` for an owned p auto-borrows p into the annotated borrow slot.
 // The constrain rule's bare<:RefType arm wraps p as an immutable view.
 //
-// DISABLED until lifetime-bounds (M6.5) lands. The annotated borrow form has
+// DISABLED until directional lifetime bounds land. The annotated borrow form has
 // the same dangling-borrow soundness gap as the inferred `val q = &p` case
 // in TestInferValBorrowFromOwnedImm.
 /*
@@ -143,7 +143,7 @@ func TestInferValAnnotatedBorrowImm(t *testing.T) {
 
 // `val q: &mut {x} = p` for an owned-mutable p auto-borrows p as a mutable borrow.
 //
-// DISABLED until lifetime-bounds (M6.5) lands. Mutable analogue of
+// DISABLED until directional lifetime bounds land. Mutable analogue of
 // TestInferValAnnotatedBorrowImm.
 /*
 func TestInferValAnnotatedBorrowMut(t *testing.T) {
@@ -216,14 +216,14 @@ func TestInferBorrowExprImmReturnedCarriesLifetime(t *testing.T) {
 
 // `&mut p` on an owned-mutable p infers a mutable borrow.
 //
-// DISABLED until lifetime-bounds (M6.5) lands.
+// DISABLED until directional lifetime bounds land.
 //
 // Returning a borrow expression `&mut p` for a locally-owned `p` is unsound:
 // `p` is destroyed when the function returns, so the borrow dangles. The
 // current solver under-checks this because the fresh lifetime on `&mut p`
-// has no anchor and D4 elides it to render the result as `mut {x: number}`.
-// PR 5 will force the lifetime to 'static at the return, but the hard
-// rejection still needs M6.5's directional lifetime bounds.
+// has no anchor and the elision pass drops it to render the result as
+// `mut {x: number}`. Forcing the lifetime to 'static at the return is part of
+// it, but the hard rejection still needs directional lifetime bounds.
 /*
 func TestInferBorrowExprMutFromOwnedMut(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return &mut p }`)

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 D2/D4: borrow origination + display-time lifetime naming and elision ---
+// --- Borrow origination + display-time lifetime naming and elision ---
 //
-// These assert the D4 display form. A param lifetime that reaches the output is
+// These assert the display form. A param lifetime that reaches the output is
 // named 'a, 'b, … and quantified in a leading <…> prefix. A param lifetime that
 // connects nothing, never reaching an output, has its NAME elided but its `&`
 // kept, so the displayed borrow stays distinguishable from an owned value.
@@ -16,7 +16,7 @@ import (
 // A `&mut` param returned unchanged carries its lifetime to the result: the same
 // lifetime appears on both the parameter and the return type, so the borrow flows
 // out at the lifetime it came in. Occurring in both positions, it is named `'a`
-// and quantified. This is the IdentityRefReturn acceptance (M4 D4).
+// and quantified. This is the IdentityRefReturn acceptance.
 func TestInferIdentityRefReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}) { return p }`)
 	require.Empty(t, errs)
@@ -52,8 +52,7 @@ func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 // Passing a borrow into a function whose parameter is an OWNED (bare) object is the
 // borrow-into-owned-slot escape: the RefType<:bare arm rejects because the source
 // carries a lifetime and the target owns its value. This is the only path that
-// exercises the escape guard D2 activated — before D2 every Lt was nil, so it never
-// fired.
+// exercises the escape guard. It fires once a borrow carries a non-nil lifetime.
 func TestInferBorrowEscapesIntoOwnedArg(t *testing.T) {
 	src := `fn use(o: {x: number}) -> number {
   return o.x
@@ -102,7 +101,7 @@ func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
 
 // Writing a field of a NON-`mut` owned object is rejected: the write lowers to the
 // mutable requirement `mut {x, ...}`, and an immutable owned object cannot fill a
-// mutable slot. This confirms the field-write requirement's fresh lifetime (D2) did
+// mutable slot. This confirms the field-write requirement's fresh lifetime did
 // not loosen the mutability gate — an owned-but-immutable receiver still fails.
 func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 	src := `fn g(o: {x: number}) {
@@ -116,10 +115,10 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 
 // Returning one of two borrows with DISTINCT lifetimes joins them into a single
 // borrow whose lifetime is the union of theirs. This is the ConditionalUnionReturn
-// acceptance (M4 D3). The return-point join mints a fresh join lifetime bounded
+// acceptance. The return-point join mints a fresh join lifetime bounded
 // below by 'l0 and 'l1, which coalesces to `('l0 | 'l1)` in the positive return
 // position. The param lifetimes 'l0/'l1 stay named on the borrows they originate.
-// D4 renders them `'a`/`'b` and the union `('a | 'b)`.
+// The display renders them `'a`/`'b` and the union `('a | 'b)`.
 func TestInferConditionalUnionReturn(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: number}) {
   if true {
@@ -139,7 +138,7 @@ func TestInferConditionalUnionReturn(t *testing.T) {
 // object's field set is invariant, so uniting `mut {x}` and `mut {y}` would invent a
 // writable field absent from one branch. joinBorrows rejects the mismatch and the
 // return falls back to the generic union, preserving both borrows with their own
-// lifetimes (M4 D3).
+// lifetimes.
 func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {y: number}) {
   if true {
@@ -180,11 +179,11 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 // A GENERALIZED joined-borrow function keeps its lifetime union after instantiation.
 // A caller that passes two of its own borrows still sees a two-lifetime union, not a
 // single name. This is the only end-to-end exercise of the Join flag riding through
-// freshenAbove/extrude (D2.5). If the flag were dropped on the freshened join
+// freshenAbove/extrude. If the flag were dropped on the freshened join
 // lifetime, the instantiated return would coalesce to one lifetime instead of a
 // union. `pick` renders `mut ('a | 'b) {…}` over its two param lifetimes.
 // Instantiating it inside `use` freshens the join and its two members to use-level
-// lifetimes. D4's component-based expansion resolves those intermediaries back to
+// lifetimes. The component-based expansion resolves those intermediaries back to
 // `use`'s own param lifetimes, so `use` renders the same clean `mut ('a | 'b) {…}`
 // over `a` and `b` rather than the raw freshened ids.
 func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {
@@ -208,13 +207,12 @@ fn use(a: &mut {x: number}, b: &mut {x: number}) {
 // object's fields are observable in both directions, so the join pins each shared
 // field invariant, and `number` vs `string` for `x` fails that pin in both
 // directions. This locks in that the soundness constraint actually fires rather than
-// silently unifying incompatible borrows (M4 D3).
+// silently unifying incompatible borrows.
 //
-// FUTURE (M6): this error is the conservative M4 default. M6 may relax it to a
+// FUTURE: this error is the conservative default. A later relaxation may turn it into a
 // read-until-narrowed union — `(&'a mut {x: number}) | (&'b mut {x: string})`, readable
-// always and writable only after narrowing — to match TypeScript. See 01-milestones.md
-// M6, "Permissive mut-borrow joins". When that lands, this test changes from asserting
-// an error to asserting the union.
+// always and writable only after narrowing — to match TypeScript. When that lands, this
+// test changes from asserting an error to asserting the union.
 func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
   if true {
@@ -234,16 +232,15 @@ func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
 // requires every input to be a mutable borrow carrying a lifetime, and an object
 // literal is owned rather than a RefType. The all-borrows gate falls back to the
 // generic union, so the result keeps the borrow's lifetime alongside the owned
-// literal (M4 D3).
+// literal.
 //
-// DISABLED until PR 9 lands.
+// DISABLED until mixed-ownership unions are rejected.
 //
-// PR 9 of the affine semantics plan ("Reject mixed-ownership unions and
-// intersections") makes a type whose members disagree on ownership an error
-// rather than a silent union. Once it lands, this source should fail at the
-// if-else join with a "mixed-ownership union" diagnostic against the union
-// site instead of producing the union shown below. Re-enable then and flip
-// the assertion from a successful render to an error list.
+// Once a type whose members disagree on ownership becomes an error rather than a
+// silent union, this source should fail at the if-else join with a
+// "mixed-ownership union" diagnostic against the union site instead of producing
+// the union shown below. Re-enable then and flip the assertion from a successful
+// render to an error list.
 /*
 func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 	src := `fn f(p: &mut {x: number}) {
@@ -261,7 +258,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 */
 
 // A borrowed parameter written into module-level storage escapes to 'static. This is
-// the EscapingRefIntoStatic acceptance (M4 D3), now reachable from real source.
+// the EscapingRefIntoStatic acceptance, now reachable from real source.
 // `cache` stores its borrow `p` into the module-level `var sink`, a global write. The
 // stored value outlives every borrow region, so p's lifetime is forced `<: 'static`
 // and the parameter renders `&'static mut {x: number}` rather than under a borrow
@@ -310,7 +307,7 @@ func TestInferImmutableBorrowAliasLocally(t *testing.T) {
 
 // An immutable borrow alias that is RETURNED carries its lifetime to the output.
 // The borrow flows out at p's lifetime, so the return renders an immutable borrow
-// over the same named lifetime as the parameter. This is the D4 display path for
+// over the same named lifetime as the parameter. This is the display path for
 // a borrow alias that reaches an output.
 func TestInferImmutableBorrowAliasReturnedCarriesLifetime(t *testing.T) {
 	src := `fn f(p: &mut {x: number}) {
@@ -406,7 +403,7 @@ func TestInferInexactBorrowAlias(t *testing.T) {
 	require.Equal(t, "fn <'a>(p: &'a mut {x: number, y: number}) -> &'a {x: number, ...}", values["f"])
 }
 
-// --- PR2: lowering `&` borrow annotations to RefType ---
+// --- Lowering `&` borrow annotations to RefType ---
 
 // A bare `&` parameter lowers to an immutable borrow with a fresh inferred lifetime.
 // Returned, the borrow carries that lifetime to the output, which is then load-bearing
@@ -444,7 +441,7 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 	require.Equal(t, []string{"Unsupported: borrow of a non-borrowable type"}, Messages(errs))
 }
 
-// --- PR 4: member reads borrow the receiver ---
+// --- Member reads borrow the receiver ---
 
 // A member read that escapes carries the receiver's borrow lifetime through.
 // Deep `mut` makes the field owned-mutable, so the read yields a mutable borrow.
@@ -460,7 +457,7 @@ func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {
 }
 
 // A member read consumed inside the body leaves the receiver lifetime free,
-// so D4's display-time elision drops it from the rendered signature. `obj.a`
+// so the display-time elision drops it from the rendered signature. `obj.a`
 // reads as a borrow inside the body, but the binding `q` never escapes, so
 // the param's borrow lifetime does not need to be named.
 func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
@@ -475,7 +472,7 @@ func TestInferMemberReadLocalElidesLifetime(t *testing.T) {
 // A field whose static type is itself an immutable borrow reads through as
 // the same borrow rather than nesting under the receiver's lifetime. The
 // flat copy-out keeps reads of `&T` fields from producing `& &T` types,
-// setting up PR 9's nested-borrow normalization. Here `obj.a: &{x: number}`
+// setting up later nested-borrow normalization. Here `obj.a: &{x: number}`
 // reads back as a `&'a {x: number}` at the field's own annotation-minted
 // lifetime, not a depth-two borrow over the receiver.
 func TestInferMemberReadFlatBorrowOfRefField(t *testing.T) {
@@ -494,7 +491,7 @@ func TestInferMemberReadFlatBorrowOfRefField(t *testing.T) {
 // nesting under the receiver's. The TypeVar result var coalesces to the
 // concrete field type, and the function returns that `&mut` borrow at the
 // annotation-minted lifetime. Aliasing exclusivity on the surviving mut
-// borrow needs the move-engine work in PR 6, and PR 9 normalizes the
+// borrow needs later move-engine work, and a later normalization handles the
 // otherwise uninhabitable `&mut &mut` shape.
 func TestInferMemberReadOfMutBorrowField(t *testing.T) {
 	src := `fn f(p: {a: &mut {x: number}}) {
@@ -508,10 +505,10 @@ func TestInferMemberReadOfMutBorrowField(t *testing.T) {
 }
 
 // A primitive field stays a value, since `PrimType` is not a `RefInner`. The
-// PR 4 wrap is skipped and the read returns the primitive directly. This is
-// the same shape pre-PR-4 returned. Pinning it here guards against the wrap
-// firing on non-borrowable fields and tripping the bare<:RefType escape
-// guard when the field flows into a primitive sink.
+// receiver-borrow wrap is skipped and the read returns the primitive directly.
+// Pinning it here guards against the wrap firing on non-borrowable fields and
+// tripping the bare<:RefType escape guard when the field flows into a primitive
+// sink.
 func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
 	src := `fn f(p: &mut {x: number}) {
   return p.x
@@ -522,7 +519,7 @@ func TestInferMemberReadPrimitiveStaysValue(t *testing.T) {
 }
 
 // An explicit `&obj.f` shares the receiver-bounded lifetime of the implicit
-// read. PR 4 routes a `&`-of-MemberExpr through inferBorrowOfMember, which
+// read. A `&`-of-MemberExpr routes through inferBorrowOfMember, which
 // produces a `&` borrow at the receiver lifetime. This matches the shape the
 // implicit read produces, with no extra wrapping. Both the param and the
 // return render at the receiver's named lifetime.
@@ -540,7 +537,7 @@ func TestInferExplicitBorrowOfMemberSharesLifetime(t *testing.T) {
 // An explicit `&mut obj.g` mutably borrows the field at the receiver's
 // lifetime when the receiver supports a mutable view. The receiver is an
 // owned-mut object, so the mut requirement lowers via the RefType <: RefType
-// rule. The partial-moves work in PR 7 adds path-granular tracking that
+// rule. Later partial-moves work adds path-granular tracking that
 // leaves a disjoint sibling such as `obj.a` independently usable. This test
 // pins the typing rule only.
 func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
@@ -569,7 +566,7 @@ func TestInferExplicitMutBorrowOfMemberOnImmutableRejected(t *testing.T) {
 	}, Messages(errs))
 }
 
-// A usage-inferred receiver keeps its pre-PR-4 read behaviour. A
+// A usage-inferred receiver keeps its plain field-read behaviour. A
 // usage-inferred receiver is an un-annotated param whose shape the body's
 // uses determine. The wrap fires only off a concrete ObjectType carrier, so
 // a TypeVar carrier returns the field's result var directly. The param

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -19,14 +19,14 @@ import (
 //
 // A top-level destructuring VarDecl never reaches here. inferComponent intercepts
 // each of its leaf keys via destructureDecl and binds them through
-// bindModuleDestructureLeaf (M4 E3). The destructuring arm below is a defensive
+// bindModuleDestructureLeaf. The destructuring arm below is a defensive
 // guard for a hand-built AST that bypasses that path.
 //
 // ok=false cases, each already reported:
 //   - VarDecl without an initializer → MissingInitializerError
-//   - VarDecl with a destructuring pattern → UnsupportedNodeError (initializer
-//     still walked first, so it surfaces its own errors)
-//   - any decl kind outside the M2 subset → UnsupportedNodeError
+//   - VarDecl with a destructuring pattern → UnsupportedNodeError, with the
+//     initializer still walked first so it surfaces its own errors
+//   - any other decl kind → UnsupportedNodeError
 func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
@@ -35,12 +35,11 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 			return nil, nil, false
 		}
 		if _, named := varName(d); !named {
-			// Destructuring patterns (TuplePat/ObjectPat) need the tuple/record
-			// types that arrive in M4. The initializer was already walked above
-			// (its errors surfaced); report the pattern and produce no binding. A
-			// nil pattern (not produced by the parser, which synthesizes a
-			// placeholder, but possible in a hand-built AST) blames the decl instead,
-			// mirroring inferFunc — never a nil-node Span() panic.
+			// A top-level destructuring pattern is not bound here. The initializer
+			// was already walked above, so its errors surfaced; report the pattern
+			// and produce no binding. A nil pattern blames the decl instead,
+			// mirroring inferFunc, so a hand-built AST never triggers a nil-node
+			// Span() panic. The parser itself synthesizes a placeholder pattern.
 			if d.Pattern != nil {
 				c.reportUnsupported(d.Pattern)
 			} else {
@@ -70,8 +69,8 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 // Walks the initializer regardless so it still surfaces its own errors, and
 // binds nothing — the caller owns scope placement.
 //
-// A `val`/`var` with no initializer needs a type annotation (TypeAnn support lands
-// in a later PR); for now it reports MissingInitializerError and returns ok=false.
+// A `val`/`var` with no initializer reports MissingInitializerError and returns
+// ok=false.
 func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (soltype.Type, bool) {
 	if d.Init == nil {
 		c.report(&MissingInitializerError{Decl: d})
@@ -80,11 +79,11 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
 	case d.TypeAnn != nil:
-		// M2.5: constrain the initializer against the annotation (the one
-		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
-		// CannotConstrainError whose Sub (the "hi" literal) carries a
-		// LiteralInference origin — precise blame, with the annotation as the
-		// related node. The constraint node is the initializer, so even the
+		// Constrain the initializer against the annotation, so
+		// `val x: number = "hi"` produces a CannotConstrainError whose Sub, the
+		// "hi" literal, carries a LiteralInference origin. Blame is precise, with
+		// the annotation as the related node. The constraint node is the
+		// initializer, so even the
 		// fallback span is the initializer, not the whole decl; the binding then
 		// adopts the annotated type.
 		//
@@ -92,14 +91,14 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// (ok=false): resolveTypeAnn already reported it and returned a `never`
 		// placeholder, so constraining `initT <: never` would cascade a spurious
 		// error and adopting `never` would poison the binding. Keep the inferred
-		// initializer type instead (error recovery).
+		// initializer type instead for error recovery.
 		if annT, ok := c.resolveTypeAnn(d.TypeAnn, lvl); ok {
 			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT, lvl)
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
 	case d.Kind == ast.VarKind:
-		// M4 B3: eager-widen a DIRECT literal initializer to its primitive at the
+		// Eager-widen a DIRECT literal initializer to its primitive at the
 		// constraint level (`5` ⇒ number), recursively through objects/tuples. This
 		// is the constraint-level half of widening: the widened type propagates
 		// through the bound graph, so a read of the binding widens too
@@ -119,12 +118,12 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // the written annotation in two refinements over a plain constrain.
 //
 // 1. A freshly constructed, unaliased initializer flowing into an OWNED-mutable
-// annotation is allowed to take that mutable type. The C2 gate rejects immutable <:
+// annotation is allowed to take that mutable type. The strict path rejects immutable <:
 // mutable structurally, because writing through the target would otherwise mutate a
 // read-only value. But that is only unsound when a live immutable alias to the source
 // exists. A freshly constructed literal has none. It is uniquely owned, so granting it
-// the annotated mutable type is safe. This is Rule 2 with an empty alias set. The
-// construction case is `val items: mut {x} = {x: 1}`. The decision belongs at this
+// the annotated mutable type is safe. This is the empty-alias-set case of the
+// owned-mutable upgrade. The construction case is `val items: mut {x} = {x: 1}`. The decision belongs at this
 // value-flow site, which can see the source is fresh, not in the liveness-blind
 // constrain engine. The upgrade constrains the initializer's shape against the borrow's
 // INNER, its covariant read view, exactly as the non-mut path constrains against the
@@ -133,7 +132,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // source flowing into it stays on the strict path.
 //
 // 2. A bare object/tuple annotation whose initializer is a borrow lowers to an immutable
-// reborrow of the initializer rather than an owned slot (M4 G3). See reborrowAnnotation.
+// reborrow of the initializer rather than an owned slot. See reborrowAnnotation.
 // Binding a borrow into a bare annotation, as in `val q: {x} = p` for `p: mut {x}`, would
 // otherwise trip BorrowEscapeError, since the borrow flows into an owned slot. The old
 // checker accepts this and treats the annotation as a local immutable view of `p` that
@@ -143,9 +142,9 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
 		// Constrain a fresh literal against the borrow's immutable skeleton, then
-		// grant the owned-mutable type. Under the lazy deep-mut form (PR 14) the inner
+		// grant the owned-mutable type. Under the lazy deep-mut form the inner
 		// is already bare, and a nested `mut {x}` field inside a non-mut container is
-		// now rejected at the annotation site (#779), so stripOwnedMut is a defensive
+		// rejected at the annotation site, so stripOwnedMut is a defensive
 		// no-op here. It is kept so a fresh literal still flows covariantly into any
 		// owned-mut cell that reaches this point. A fully fresh literal is uniquely
 		// owned at every level, so the upgrade is sound the whole way down.
@@ -161,7 +160,7 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 }
 
 // reborrowAnnotation lowers a bare object/tuple annotation to an immutable borrow with a
-// fresh lifetime, returning ok=false when the refinement does not apply (M4 G3). It
+// fresh lifetime, returning ok=false when the refinement does not apply. It
 // applies only when the initializer's type is itself a borrow carrying a lifetime and
 // the annotation is a bare object or tuple, not an already-borrow `mut`/lifetime form or
 // a non-borrowable primitive.
@@ -176,9 +175,9 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 // The fresh lifetime carries no obligation on its own. The RefType <: RefType constrain
 // arm relates it to the source's lifetime through constrainLt. This reborrow constraint
 // runs exactly as the borrow-into-borrow argument path does. A binding that escapes
-// carries D3's escape-to-'static constraint, which the lifetime sort weighs against the
+// carries the escape-to-'static constraint, which the lifetime sort weighs against the
 // reborrow. A binding that stays local and dies within the source's region leaves the
-// fresh lifetime free, so D4's display-time elision drops the wrapper and the binding
+// fresh lifetime free, so the display-time elision drops the wrapper and the binding
 // renders as the bare inner.
 func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype.Type, bool) {
 	if src, ok := initT.(*soltype.RefType); !ok || src.Lt == nil {
@@ -195,10 +194,10 @@ func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype
 }
 
 // stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
-// cell (Mut set, Lt nil) and recursing through objects and tuples. Borrows are
-// left untouched. Under the lazy deep-mut form (PR 14) a plain `mut {a: {x}}` stores
-// a bare inner, and a nested `mut {x}` field inside a non-mut container is now
-// rejected at the annotation site (#779), so there is usually nothing to strip; the
+// cell with Mut set and Lt nil, recursing through objects and tuples. Borrows are
+// left untouched. Under the lazy deep-mut form a plain `mut {a: {x}}` stores
+// a bare inner, and a nested `mut {x}` field inside a non-mut container is
+// rejected at the annotation site, so there is usually nothing to strip. The
 // peel is retained defensively so a fresh literal can upgrade into any deeply-mutable
 // target the whole way down.
 func stripOwnedMut(t soltype.Type) soltype.Type {
@@ -234,7 +233,7 @@ func stripOwnedMut(t soltype.Type) soltype.Type {
 // variable could alias a value held immutably elsewhere. Being identifier-free also
 // makes it sound without VarIDs, so it holds at module top level where the liveness
 // pre-pass has not run. A richer freshness judgment over provably-unique non-literal
-// expressions is the lifetime/region work (M4 G2).
+// expressions is left to the lifetime/region machinery.
 func isFreshlyConstructed(e ast.Expr) bool {
 	switch e := e.(type) {
 	case *ast.LiteralExpr:
@@ -262,7 +261,7 @@ func isFreshlyConstructed(e ast.Expr) bool {
 	}
 }
 
-// checkExcessLiteralMembers is the construction-site excess check (M4 A3): a
+// checkExcessLiteralMembers is the construction-site excess check. A
 // syntactic object/tuple LITERAL checked against an object/tuple annotation may
 // not carry members the target does not declare, EVEN when the target is inexact
 // (`{x, ...}` / `[number, ...]`). It is the construction-site twin of the
@@ -270,18 +269,18 @@ func isFreshlyConstructed(e ast.Expr) bool {
 // subtyping (an inexact target admits extras), but a literal spells out its
 // members, so an undeclared one is a construction error.
 //
-// SCOPE (M4 A3): it is wired here, at annotated `val`/`var` bindings, only. The
-// twin sites the rule will eventually cover — literal call arguments and return
-// positions checked against an inexact annotation — defer to the milestone work
-// that adds annotated call/return checking; until then a literal flowing into an
-// inexact target through those paths takes ordinary width subtyping.
+// It is wired here, at annotated `val`/`var` bindings, only. The twin sites the
+// rule does not yet cover are literal call arguments and return positions checked
+// against an inexact annotation. Until annotated call/return checking adds them, a
+// literal flowing into an inexact target through those paths takes ordinary width
+// subtyping.
 //
 // It fires only for an INEXACT target. An exact target already rejects extras
 // through the ordinary ObjectType/TupleType constrain arm (ExtraPropertyError /
 // TupleLengthMismatchError run by the c.constrain call above), so checking it here
-// too would double-report. The errors reuse A1's ExtraPropertyError for objects
-// and the parallel ExtraElementError for tuples, wired with the same Prov table /
-// site as the constraint path so blame resolves to the offending member.
+// too would double-report. The errors reuse ExtraPropertyError for objects
+// and the parallel ExtraElementError for tuples, wired with the same Prov table
+// and site as the constraint path so blame resolves to the offending member.
 //
 // A `mut T` annotation resolves to a RefType wrapping the object/tuple, so peel
 // the borrow first: the excess rule is about the literal's SHAPE versus the
@@ -350,13 +349,12 @@ func (c *checker) checkExcessLiteralMembers(e ast.Expr, sub, annT soltype.Type) 
 	}
 }
 
-// inferVarDecl types a body-level `val`/`var` into a GENERALIZED ValueBinding —
-// the let-polymorphism rule (M3, PR1) that replaces M2's coalesce-at-binding
-// freeze. It infers the initializer one level deeper (lvl+1) and generalizes at
+// inferVarDecl types a body-level `val`/`var` into a GENERALIZED ValueBinding
+// under the let-polymorphism rule. It infers the initializer one level deeper (lvl+1) and generalizes at
 // lvl: variables created in the initializer (level > lvl) become reusable type parameters,
 // while variables captured from an enclosing scope (level <= lvl) stay shared — so
 // `fn (y) { val getY = fn () { y }; [getY(), getY()] }` keeps getY's captured `y`
-// instead of freezing it to `never`, the bug eager coalescing caused. A body-level
+// instead of freezing it to `never`, the bug that eager coalescing caused. A body-level
 // `val` is never recursive (the name is bound only after its initializer is typed),
 // so there is no pre-binding or binding var; the SCC driver owns the recursive top-level
 // path (see inferDeclDef). ok=false when there is no initializer.
@@ -366,7 +364,7 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 		return ValueBinding{}, false
 	}
 	bound := initType
-	// M4 B3: an un-annotated body-level `var` widens at coalesce time like its
+	// An un-annotated body-level `var` widens at coalesce time like its
 	// top-level peer. The top-level SCC path flags the binding var it already
 	// mints; a body-level binding has none — it generalizes the initializer
 	// directly — so wrap the initializer in a fresh widenable var (initType <: v)
@@ -390,8 +388,8 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
 	// plain soltype.Print — same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
-	// PR8: carry the introducing decl's kind so inferAssign can gate reassignment —
-	// only a `var` is reassignable, a `val` is not.
+	// Carry the introducing decl's kind so inferAssign can gate reassignment.
+	// Only a `var` is reassignable, a `val` is not.
 	return ValueBinding{
 		Schemes: []TypeScheme{scheme},
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: d}},
@@ -400,7 +398,7 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 }
 
 // inferDestructureDecl types a body-level destructuring `val`/`var` such as
-// `val {x, y} = p` or `val [a, b] = t` (M4 E1). It types the initializer through
+// `val {x, y} = p` or `val [a, b] = t`. It types the initializer through
 // the shared inferVarDeclInit core, so an annotation is honored and a `var`
 // initializer is widened, then binds the pattern's leaves against that type via
 // bindPattern.
@@ -426,9 +424,8 @@ func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with
-// ok=false for any other pattern shape. M2 binds IdentPat-only patterns,
-// mirroring M1's IdentPat-only FuncParam. Body-level destructuring such as
-// `val [a, b] = …` is handled by inferDestructureDecl (M4 E1). Top-level
+// ok=false for any other pattern shape. Body-level destructuring such as
+// `val [a, b] = …` is handled by inferDestructureDecl. Top-level
 // destructuring still defers, since it needs the SCC driver to bind several names
 // from one decl.
 func varName(d *ast.VarDecl) (string, bool) {
@@ -443,11 +440,11 @@ func varName(d *ast.VarDecl) (string, bool) {
 // driver (inferComponent) owns scope placement and generalization. It binds a
 // self/mutually recursive group to a fresh var first so each body can see itself
 // (and its group peers), constrains this raw type into that var, and generalizes
-// the group once complete (PR1). Returning the raw type directly (rather than
-// round-tripping through a single-MonoScheme ValueBinding) removes the unchecked
+// the group once complete. Returning the raw type directly, rather than
+// round-tripping through a single-MonoScheme ValueBinding, removes the unchecked
 // `.(*MonoScheme)` assertion the SCC driver would otherwise need. Repeated
 // top-level FuncDecls under one name are constrained into the same var as
-// monomorphic overload arms; the overload-intersection representation is M3.
+// monomorphic overload arms, then represented as an overload intersection.
 func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) (soltype.Type, provenance.Provenance) {
 	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
 	return t, &ast.NodeProvenance{Node: d}

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR4: function exactness (#677), source-level behaviors ---
+// --- function exactness, source-level behaviors ---
 
 // A written function value is EXACT, so calling it with exactly its declared arity
 // type-checks. This is the regression the exact call-demand guards: an INEXACT
@@ -80,10 +80,9 @@ func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 	require.Equal(t, "Not enough arguments: expected at least 2, but got 1", errs[0].Message())
 }
 
-// A function value declared with the trailing `...` marker now parses (PR4 parser
-// support) and is inferred INEXACT: its rendered type carries the `...`, but the
-// direct-call lint still rejects extra args (§4.2.3 — inexactness governs callback
-// subtyping, not direct calls).
+// A function value declared with the trailing `...` marker parses and is inferred
+// INEXACT: its rendered type carries the `...`, but the direct-call lint still
+// rejects extra args. Inexactness governs callback subtyping, not direct calls.
 func TestInferInexactFunctionValue(t *testing.T) {
 	t.Run("renders with the inexact marker", func(t *testing.T) {
 		values, _, errs := inferSource(t, `fn f(x: number, ...) -> number { return x }`)
@@ -113,9 +112,9 @@ func TestInferTooFewArgsRespectsOptional(t *testing.T) {
 }
 
 // A typed rest param absorbs trailing arguments, so a direct call with more args
-// than declared is NOT too-many (#677 §4.2.3) — but too-few still applies to the
-// fixed params. Rest params have no source syntax in M3 (inferFunc reports them
-// unsupported), so this is built by hand — unlike the inexact `...` marker, which is
+// than declared is NOT too-many, but too-few still applies to the fixed params.
+// Rest params have no source syntax yet, since inferFunc reports them unsupported,
+// so this is built by hand. This is unlike the inexact `...` marker, which is
 // source-expressible and covered via inferSource in TestInferInexactFunctionValue.
 func TestInferCallRestCalleeArity(t *testing.T) {
 	// fn g(x: number, ...rest: number): one fixed param + a rest.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -11,10 +11,10 @@ import (
 )
 
 // inferLiteral types a literal expression as its singleton soltype.LitType and
-// records it in Info. M1's soltype.Lit set is num/str/bool only; the remaining
-// ast literal kinds (regex, bigint, null, undefined) fall through to the M2
-// subset guard until later milestones extend soltype.Lit (§ soltype/type.go
-// Prim/Lit note).
+// records it in Info. The soltype.Lit set is num/str/bool only; the remaining
+// ast literal kinds (regex, bigint, null, undefined) fall through to the
+// subset guard until soltype.Lit is extended. See the Prim/Lit note in
+// soltype/type.go.
 func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 	var lit soltype.Lit
 	switch l := e.Lit.(type) {
@@ -33,21 +33,19 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 	return t
 }
 
-// inferIdent resolves a value-position identifier through the scope chain — the
-// production form of the spike's *Var case crossed with design-notes §"The
-// constraint-generating AST walk". M3 (PR1) slots in the instantiation hook M2
-// left as a TODO: an ordinary binding instantiates its sole scheme at the current
-// level, so a polymorphic let gives each use fresh variables (a MonoScheme
-// instantiates to itself, preserving M2's behavior for the monomorphic bindings).
+// inferIdent resolves a value-position identifier through the scope chain. An
+// ordinary binding instantiates its sole scheme at the current level, so a
+// polymorphic let gives each use fresh variables (a MonoScheme instantiates to
+// itself, leaving the monomorphic bindings unchanged).
 //
 // An overloaded binding's value-position type is the intersection of its arms,
-// resolved through the probe — that is PR6 and unreachable today (M2 rejects
-// multi-FuncDecl names, so no overloaded binding is ever bound), so PR1 asserts
-// the single-scheme invariant rather than branching on it.
+// resolved through the probe — that is unreachable today, since multi-FuncDecl
+// names are rejected, so no overloaded binding is ever bound. The single-scheme
+// invariant is therefore asserted rather than branched on.
 //
 // A namespace name in value position is an error — namespaces are a separate
-// binding sort and never flow as values. M4 moves that rejection OFF inferIdent
-// to the value-position consumer (demandValue): a namespace is legal in the
+// binding sort and never flow as values. That rejection lives OFF inferIdent,
+// in the value-position consumer (demandValue): a namespace is legal in the
 // OBJECT position of a member/index chain (Foo.bar, A.B.c), so resolvePath
 // surfaces it and only a consumer that needs a value rejects it. The error then
 // fires once for both `f(Foo)` and a partial chain `f(A.B)`.
@@ -122,7 +120,7 @@ func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr) path
 }
 
 // bindingValue instantiates a value binding at lvl for value position. An
-// overloaded binding (PR6) — `val g = f`, or `f` passed as an argument — is the
+// overloaded binding — `val g = f`, or `f` passed as an argument — is the
 // intersection of its arms (the one scoped lattice exception; see
 // overloadIntersection and constrain's IntersectionType arm). An ordinary binding
 // instantiates its sole scheme, so each use gets fresh variables. A direct call
@@ -136,7 +134,7 @@ func (c *checker) bindingValue(lvl int, b ValueBinding) soltype.Type {
 }
 
 // astKind returns a short surface name for any AST node — an expression,
-// literal, declaration, or pattern — used in the M2 subset-guard error messages.
+// literal, declaration, or pattern — used in the subset-guard error messages.
 // It strips the leading "*ast." from the Go type name so e.g. *ast.BinaryExpr
 // renders as "BinaryExpr". One helper serves every guard site (inferExpr,
 // inferLiteral, inferDeclDef) so the format lives in a single place.
@@ -145,13 +143,12 @@ func astKind(n any) string {
 }
 
 // inferFuncExpr types a function expression as a soltype.FuncType and records it
-// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl
-// (the plan's "reuse inferFuncExpr on the decl's sig+body", factored so neither
-// side owns the other). M2 is monomorphic: any TypeParams on the signature are a
-// generic function (M3) and are diagnosed as unsupported by inferFunc, not
-// silently erased; an un-annotated param simply gets a fresh var, which
-// coalesces to unknown/never at render time rather than a <T0> quantifier
-// (generalization is M3).
+// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl,
+// factored so neither side owns the other. The walk is monomorphic: any TypeParams
+// on the signature are a generic function and are diagnosed as unsupported by
+// inferFunc, not silently erased; an un-annotated param simply gets a fresh var,
+// which coalesces to unknown/never at render time rather than a <T0> quantifier,
+// since generalization is not yet implemented.
 func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type {
 	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e)
 	c.recordType(e, t)
@@ -179,25 +176,25 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	defer func() { c.namedLifetimes = savedNamedLts }()
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
-		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the
-		// type-param feature that is not — so diagnose it as an unsupported feature
+		// which are not yet implemented. The FuncExpr/FuncDecl kind itself is
+		// supported — it is the type-param feature that is not — so diagnose it
+		// as an unsupported feature
 		// (blaming the function node) rather than silently erasing the params, then
 		// continue inferring monomorphically.
 		c.reportUnsupportedFeature(node, "TypeParam")
 	}
 	fnScope := scope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
-	// paramTypes maps each bound parameter name to its soltype, consumed by the M4
-	// G1 liveness pre-pass to seed parameter alias mutability.
+	// paramTypes maps each bound parameter name to its soltype, consumed by the
+	// liveness pre-pass to seed parameter alias mutability.
 	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(p, lvl)
-		// Rule 2 of PR 3. A bare annotation is owned and only an `&` annotation
-		// borrows. An `&` annotation already mints its lifetime in
-		// resolveLifetimeAnn, so a parameter has nothing to attach here. A bare
-		// `mut T` stays owned-mutable.
+		// A bare annotation is owned and only an `&` annotation borrows. An `&`
+		// annotation already mints its lifetime in resolveLifetimeAnn, so a parameter
+		// has nothing to attach here. A bare `mut T` stays owned-mutable.
 		// An `open` un-annotated param keeps its usage-inferred object inexact at
-		// display time (B2). The marker only makes sense for an inferred var; an
+		// display time. The marker only makes sense for an inferred var; an
 		// annotated param's exactness is fixed by its annotation, and paramType
 		// returns the resolved annotation (not a var) in that case.
 		if p.Open {
@@ -223,13 +220,14 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			paramTypes[name] = pt
 			// An `x?` parameter (parsed onto ast.Param.Optional) lowers the function's
 			// `required` count without dropping the param — carried onto the soltype so
-			// the accept-set rule and the printer (x?: T) see it. KNOWN GAP (M6): the
+			// the accept-set rule and the printer (x?: T) see it. KNOWN GAP: the
 			// in-body binding keeps the param's declared type (pt), NOT widened to
 			// `pt | undefined`, so a body that reads an omitted optional sees it at the
-			// narrower type. Widening needs undefined/unions (M6); M3 has neither.
+			// narrower type. Widening needs undefined and unions, which are not yet
+			// available.
 			params[i] = &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: pt, Optional: p.Optional}
 		} else if p.Pattern != nil {
-			// M4 E1: a destructuring parameter such as `{x, y}` or `[a, b]`. bindPattern
+			// A destructuring parameter such as `{x, y}` or `[a, b]`. bindPattern
 			// binds each leaf into the function scope against the param's type and returns
 			// the soltype mirror the printer renders. It also writes each leaf's type into
 			// paramTypes, keyed by leaf name, so the liveness pre-pass seeds the leaf's
@@ -256,11 +254,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	var ret soltype.Type = &soltype.Void{}
 	hasBody := body != nil
 	if hasBody {
-		// PR3: open a fresh function context so every ReturnStmt encountered while
+		// Open a fresh function context so every ReturnStmt encountered while
 		// walking the body lands in our own returns list (a nested fn inside this
 		// body opens its own context, so its returns never leak out here).
 		saved := c.pushFuncCtx(sig.Async, node)
-		// M4 G1: run the liveness pre-pass before walking the body so mutability
+		// Run the liveness pre-pass before walking the body so mutability
 		// transitions are checked. It renames the body's variable nodes (writing the
 		// VarIDs DetermineAliasSource and the alias tracker read) and seeds the
 		// parameter alias sets onto c.fn. recordParamVarIDs then copies each param's
@@ -289,8 +287,8 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// for a bare annotation like `async fn () -> number`).
 	//
 	// Non-async: the annotation governs the return directly — the body is
-	// constrained `<: annotation` and the function returns the annotation (M2's
-	// rule). An unsupported annotation (ok=false) was already reported by
+	// constrained `<: annotation` and the function returns the annotation. An
+	// unsupported annotation (ok=false) was already reported by
 	// resolveTypeAnn; recover by keeping the inferred body type (or unknown when
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
@@ -311,7 +309,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	}
 	// A bare function value is exact (accept-set [required, len(Params)]): it rejects
 	// extra arguments. A trailing `...` in the signature (sig.Inexact) marks it
-	// inexact — it tolerates extra args when used as a callback (#677 §4.1), accept
+	// inexact — it tolerates extra args when used as a callback, accept
 	// [required, ∞). Note exactness governs callback subtyping, not direct calls: an
 	// inexact value still rejects extras at a visible call site (the inferCall lint).
 	ft := &soltype.FuncType{Params: params, Ret: ret, Inexact: sig.Inexact}
@@ -319,7 +317,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is
 	// re-minted by coalescing at binding time, so the entry is exact for inline
-	// callees; M3's FromInstantiation makes named-callee blame precise.)
+	// callees; FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
 	return ft
 }
@@ -331,7 +329,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 // do, and match are not walked yet, so such a body cannot be recognized as
 // diverging, and constrain has no `never <: T` arm — a raw NeverType minted here
 // would spuriously fail the body-vs-annotation check. Recovery placeholders are
-// the absorbing ErrorType sentinel (PR8), never a raw NeverType. A single return
+// the absorbing ErrorType sentinel, never a raw NeverType. A single return
 // is the return type directly — no join var, no indirection. Multiple returns
 // flow through a fresh join variable whose coalesced positive face is their
 // union, constrained in source order so the rendered union reflects source
@@ -343,7 +341,7 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 	case 1:
 		return collected[0]
 	default:
-		// M4 D3: several returns of borrowed objects that differ only in lifetime join
+		// Several returns of borrowed objects that differ only in lifetime join
 		// into one borrow whose lifetime unites theirs. So `if c { return p } else {
 		// return q }` over two `&mut` params is `&('a | 'b) mut {…}` rather than the
 		// un-joined `&'a mut {…} | &'b mut {…}`. A mixed or non-borrow set falls through to
@@ -361,7 +359,7 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 }
 
 // joinBorrows synthesizes the join of several borrowed objects that differ only in
-// lifetime (M4 D3). It applies only when EVERY input is a mutable borrow of an
+// lifetime. It applies only when EVERY input is a mutable borrow of an
 // object, all sharing the same field-name set with each carrying a lifetime. The
 // result is one mutable borrow whose lifetime is a fresh JOIN variable bounded below
 // by each input's lifetime, so a positive-position result coalesces to `('a | 'b)`.
@@ -371,8 +369,8 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 // absent from one input.
 //
 // ok=false leaves the caller on its generic union path. A usage-inferred borrow is a
-// type variable here, not a concrete RefType, so it returns ok=false. This matches
-// the spike, which joins only concrete mut records.
+// type variable here, not a concrete RefType, so it returns ok=false. Only concrete
+// mut records are joined.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
 	refs := make([]*soltype.RefType, len(types))
 	objs := make([]*soltype.ObjectType, len(types))
@@ -411,7 +409,7 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 }
 
 // constrainEscape constrains every borrow lifetime reachable in t to outlive
-// 'static (M4 D3). It is the rule for a value flowing into module-level or otherwise
+// 'static. It is the rule for a value flowing into module-level or otherwise
 // 'static storage. A borrow that escapes its region must live forever, so each
 // lifetime variable v gains the upper bound 'static. coalesceLifetime then resolves
 // such a forced lifetime to 'static.
@@ -423,8 +421,8 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 //
 // There is one boundary. The visitor treats a TypeVarType as a leaf, so a borrow
 // reachable only through a usage-inferred variable is not forced here. That is the
-// same place the global-write CarrierOf peel stops, and the deeper handling rides
-// M4 G2.
+// same place the global-write CarrierOf peel stops; the deeper handling is not yet
+// implemented.
 func (c *checker) constrainEscape(t soltype.Type) {
 	t.Accept(escapeVisitor{c: c}, soltype.Positive)
 }
@@ -470,10 +468,10 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 // a fresh var the body's return flows into, inferring the inner. A bare annotation
 // (`async fn () -> number`) is an AsyncReturnNotPromiseError; recovery wraps the
 // inferred body return so the external face stays Promise-shaped. With no
-// annotation the inferred body return (bodyType) is wrapped directly — preserving
-// M3's "wrap an inferred return" model and its no-auto-flatten behavior (a body
+// annotation the inferred body return (bodyType) is wrapped directly — following
+// the "wrap an inferred return" model and its no-auto-flatten behavior (a body
 // that already returns a Promise still wraps: `async fn (p: Promise<T>) { return
-// await p }` is `Promise<Promise<T>>`; Awaited<T> is M9).
+// await p }` is `Promise<Promise<T>>`; Awaited<T> is not yet supported).
 func (c *checker) asyncReturn(node ast.Node, ann ast.TypeAnn, bodyType soltype.Type, hasBody bool, lvl int) soltype.Type {
 	if ann == nil {
 		return c.wrapPromise(node, bodyType)
@@ -516,7 +514,7 @@ func (c *checker) wrapPromise(node ast.Node, inner soltype.Type) soltype.Type {
 }
 
 // paramType resolves a param's type: its annotation when present, else a fresh
-// inference variable at the current level (the spike's "fresh var per param").
+// inference variable at the current level — a fresh var per param.
 // An unsupported annotation (ok=false) already reported its own error; the param
 // adopts a fresh var rather than the `never` placeholder so the body and any
 // call site recover against an unconstrained variable instead of cascading
@@ -545,23 +543,23 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // Concretely, `fn f(p: mut {x: number}) { return &mut p }` renders as
 // `fn (p: mut {x: number}) -> mut {x: number}`. The fresh lifetime on `&mut p`
 // has no upper bound from `p` because `p` is owned (Lt nil), so it occurs only
-// positively in the return, fails the param-lifetime test, and D4 elides the
-// wrapper. The borrow is real in the type graph; the elision just hides it at
+// positively in the return, fails the param-lifetime test, and the display rule
+// elides the wrapper. The borrow is real in the type graph; the elision just hides it at
 // display time. A proper rejection of this dangling-borrow case needs the
-// directional lifetime bounds slated for M6.5.
+// directional lifetime bounds, which are not yet implemented.
 //
-// PR 3 introduces `&p` and `&mut p` as the explicit borrow form. A binding
-// initializer uses one of them to choose "borrow" over "move", as in
-// `val q = &p` and `val q = &mut p`. The move side establishes ownership only.
-// Consume and use-after-move enforcement lands in PR 6.
+// `&p` and `&mut p` are the explicit borrow form. A binding initializer uses one
+// of them to choose "borrow" over "move", as in `val q = &p` and `val q = &mut p`.
+// The move side establishes ownership only. Consume and use-after-move enforcement
+// is not yet implemented.
 func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.Type {
-	// PR 4. An explicit borrow of a field path takes the receiver-bounded
+	// An explicit borrow of a field path takes the receiver-bounded
 	// lifetime of the implicit read at field granularity. The dispatch covers
 	// both `MemberExpr` and the constant-string `IndexExpr` form, so
 	// `&mut obj["foo"]` behaves the same as `&mut obj.foo`. A `&mut` of a
 	// reference-shaped field has to go through this path. The ordinary borrow
 	// path would reject it as a mutability mismatch against the immutable
-	// wrap PR 4's `fieldReadBorrow` puts on an implicit read.
+	// wrap `fieldReadBorrow` puts on an implicit read.
 	switch arg := e.Arg.(type) {
 	case *ast.MemberExpr:
 		if !arg.OptChain && arg.Prop != nil && arg.Prop.Name != "" {
@@ -618,8 +616,8 @@ func (c *checker) wrapBorrow(e *ast.BorrowExpr, lvl int, sub soltype.Type) solty
 }
 
 // inferBorrowOfMember types `&obj.f` and `&mut obj.f`, plus the constant-string
-// index form `&obj["foo"]` and `&mut obj["foo"]`, applying PR 4 rule 4. It
-// reads the field as a borrow bounded by the receiver at the requested
+// index form `&obj["foo"]` and `&mut obj["foo"]`, applying the field-borrow rule.
+// It reads the field as a borrow bounded by the receiver at the requested
 // mutability. An owned receiver mints a fresh lifetime. A borrowed receiver's
 // lifetime passes through. A `&mut` borrow requires the receiver to support a
 // mutable view of the field, expressed as the same mutable inexact requirement
@@ -630,11 +628,11 @@ func (c *checker) wrapBorrow(e *ast.BorrowExpr, lvl int, sub soltype.Type) solty
 // `&Foo.bar` for namespace `Foo` is the form that hits this case. There is no
 // receiver region to bound the borrow's lifetime. The namespace case resolves
 // the member through resolveNamespaceMember and falls through to wrapBorrow on
-// the resolved value, matching the pre-PR-4 path.
+// the resolved value, matching the plain-value path.
 //
 // Path-granular tracking that leaves a disjoint sibling such as `obj.g`
-// independently usable is the partial-moves work in PR 7. PR 4 ships only the
-// typing rule.
+// independently usable is the partial-moves work, not yet implemented. Only the
+// typing rule is shipped here.
 //
 // The arguments name the parts of the field access uniformly across the two
 // shapes the dispatch in inferBorrow accepts. recvExpr is the receiver
@@ -744,7 +742,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 }
 
 // borrowInnerOf returns the RefInner an explicit `&`/`&mut obj.f` should re-wrap
-// at the receiver's lifetime. The lazy deep-mut form (PR 14) no longer synthesizes
+// at the receiver's lifetime. The lazy deep-mut form no longer synthesizes
 // owned-mut cells for a plain `mut {a: {x}}`, so a field is usually the bare
 // object/tuple the user wrote, returned by the ordinary RefInner cast. Two RefType
 // cases remain, the same shapes fieldReadBorrow distinguishes:
@@ -766,8 +764,8 @@ func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 }
 
 // inferCall types a function application. It types the callee and each argument,
-// allocates a fresh result var, and constrains callee <: fn(args) -> res — the
-// production form of the spike's *App case. The result var picks up the callee's
+// allocates a fresh result var, and constrains callee <: fn(args) -> res. The
+// result var picks up the callee's
 // return type (covariantly) and renders as that once coalesced; an arity or
 // argument mismatch surfaces as a constraint error stamped with the call's span.
 //
@@ -780,10 +778,10 @@ func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 // named/generalized callee, which inferIdent now resolves through instantiate — see
 // resolveFunc); both recover, so recovery no longer regresses for named callees.
 //
-// PR4 adds two #677 pieces: an EXACT all-required call demand, and the extra-arg
-// lint that rejects passing more arguments than a concrete callee declares.
+// Two call-site pieces apply here: an EXACT all-required call demand, and the
+// extra-arg lint that rejects passing more arguments than a concrete callee declares.
 func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type {
-	// PR6: a DIRECT call to an overloaded name resolves against the overload set via
+	// A DIRECT call to an overloaded name resolves against the overload set via
 	// resolveOverload, a phase distinct from constrain — so the disjunction stays out of
 	// the lattice. A call through an intermediate binding (`g = f; g(x)`) doesn't match
 	// here; it routes through the value-position intersection (constrain's
@@ -801,7 +799,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, Application)
 
-	// Arity lints (#677 §4.2.3): a DIRECT call rejects too-many AND too-few arguments
+	// Arity lints: a DIRECT call rejects too-many AND too-few arguments
 	// — for exact AND inexact callees alike. These are call-site checks the subtype
 	// lattice does not model uniformly (an inexact callee tolerates extras as a
 	// *callback*, accept-set [required, ∞), but supplying extras to a call you can see
@@ -849,7 +847,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	return res
 }
 
-// inferOverloadedCall types a direct call to an overloaded name (PR6). It infers
+// inferOverloadedCall types a direct call to an overloaded name. It infers
 // the types of the arguments, records the callee's overload type for Info, and
 // resolves the call through resolveOverload, which trials each arm under a probe
 // and commits the winner. Unlike the ordinary path it emits no callee <: callShape
@@ -878,8 +876,8 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 // function would lose return recovery and yield `never`.
 //
 // ok=false means no concrete func was found (e.g. a deferred callee with no lower
-// bound yet) — the caller skips return recovery. PR1 bindings have at most one
-// func lower bound; overload sets (PR6) resolve through resolveOverload, not here.
+// bound yet) — the caller skips return recovery. Ordinary bindings have at most one
+// func lower bound; overload sets resolve through resolveOverload, not here.
 func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:
@@ -895,13 +893,13 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 }
 
 // inferAssign types a reassignment `target = source` — the only BinaryExpr form the
-// M3 walk handles. The source value is typed first (so its own errors surface
+// walk handles. The source value is typed first (so its own errors surface
 // regardless of the target's validity), then the target is resolved and gated:
 //
 //   - The target must be a place: an IdentExpr resolving to a value binding. A
-//     literal, call, member, or any other non-place target is an
-//     InvalidAssignmentTargetError (member targets `obj.x = …` need record types,
-//     M4). An ident that resolves to no binding is an UnknownIdentifierError.
+//     literal, call, or any other non-place target is an
+//     InvalidAssignmentTargetError. An ident that resolves to no binding is an
+//     UnknownIdentifierError.
 //   - The binding must be reassignable: only a `var` (Kind == VarKind) is. A `val`,
 //     function, parameter, or prelude binding is a CannotAssignToImmutableError.
 //
@@ -909,7 +907,7 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 // the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
 // being stored must be a subtype of the slot. Reassigning an annotated `var a:
 // number = 5` with `a = 6` checks; an un-annotated `var a = 5` now widens its
-// binding to `number` (M4 B3), so `a = 6` checks there too.
+// binding to `number`, so `a = 6` checks there too.
 //
 // The assignment EXPRESSION evaluates to the value just stored, so its type is the
 // target binding's slot type — `val b = (a = 6)` for `var a: number` yields
@@ -924,7 +922,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	if e.Left == nil || e.Right == nil {
 		return c.reportUnsupported(e)
 	}
-	// M4 G1: snapshot the enclosing statement BEFORE walking the RHS. Reassignment
+	// Snapshot the enclosing statement BEFORE walking the RHS. Reassignment
 	// transition checking needs this assignment's statement to find its CFG StmtRef,
 	// but walking an RHS that contains statements re-enters inferStmt and overwrites
 	// c.fn.currentStmt. A `b = if c { … } else { … }`, a match, or a block expression
@@ -943,8 +941,8 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	target, ok := e.Left.(*ast.IdentExpr)
 	if !ok {
 		// A member target (obj.x = …) is a field write: the receiver must accept a
-		// write to that field (M4 C3). An index target (xs[i] = …) still needs Array
-		// and index types (M7), so it stays unsupported, distinct from a fundamentally
+		// write to that field. An index target (xs[i] = …) still needs Array
+		// and index types, so it stays unsupported, distinct from a fundamentally
 		// invalid target like `5 = x` or `f() = x`, which is an
 		// InvalidAssignmentTargetError.
 		switch left := e.Left.(type) {
@@ -982,8 +980,8 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// fresh instantiation: instantiating a generalized binding yields a var carrying
 	// only its LOWER bounds (the read/covariant face), so `a = "x"` for `var a:
 	// number` would merely add another lower bound and wrongly succeed. The coalesced
-	// type is the concrete slot type — `number` for an annotated var, and (since M4
-	// B3) the widened `number` for an un-annotated `var a = 5`, so `a = 6` ⇒
+	// type is the concrete slot type — `number` for an annotated var, and now
+	// the widened `number` for an un-annotated `var a = 5`, so `a = 6` ⇒
 	// `6 <: number` checks.
 	//
 	// freshenAll copies the coalesced type so constraining the source cannot mutate
@@ -1001,7 +999,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// the `b.Kind != ast.VarKind` gate above before reaching here.
 	targetT := c.freshenAll(schemeType(b.Schemes[0]), lvl)
 	c.recordType(target, targetT)
-	// M4 G1: track the alias this reassignment creates and check its mutability
+	// Track the alias this reassignment creates and check its mutability
 	// transition, but only when the constraint below succeeds — an ill-typed
 	// reassignment must not seed a false-positive transition error off types that
 	// never matched. assignErrsBefore captures the pre-constraint error count.
@@ -1009,7 +1007,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	if b.ModuleLevel {
 		// This is a global write, a store into module-level storage that lives for the
 		// program's whole run. Any borrow the value carries must outlive every borrow
-		// region, so it escapes to 'static (M4 D3).
+		// region, so it escapes to 'static.
 		//
 		// The value-compatibility check runs against the source's CARRIER, not the
 		// borrow itself. A borrow forced to 'static is owned-forever, so it satisfies an
@@ -1018,7 +1016,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// NOT escape. CarrierOf is the identity on a non-borrow source, so an ordinary
 		// global write such as `n = 5` is unaffected. The peel only looks through a
 		// top-level borrow and drops the source's mutability check. The fuller treatment
-		// of an escaped borrow's mutability rides M4 G2.
+		// of an escaped borrow's mutability is not yet implemented.
 		//
 		// Escape runs only when the compatibility check passes, so a rejected store does
 		// not leave the source's lifetime forced to 'static. So `var sink = {…}; fn(p:
@@ -1034,20 +1032,20 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			// not double-counted as a prior permanent alias.
 			c.checkGlobalWriteTransition(target, e.Right, bindingType(b), assignStmt)
 			c.constrainEscape(sourceT)
-			// KNOWN GAP (#762): this store is accepted even though it is not sound in
+			// KNOWN GAP: this store is accepted even though it is not sound in
 			// general. checkGlobalWriteTransition is an in-body check only. The store
 			// escapes the source to 'static, but nothing forces the CALLER to pass a
 			// unique 'static borrow, so the caller may retain a live mutable alias to the
 			// same value and mutate it after the call, which the immutable global then
 			// observes. Closing this needs the call site to enforce the 'static borrow as
-			// unique, which is the borrow checker's job. Move/affine semantics (#762),
-			// under the sound borrow checker (#618), will eventually reject it.
+			// unique, which is the borrow checker's job. Move/affine semantics, under a
+			// sound borrow checker, will eventually reject it.
 		}
 	} else {
 		c.constrainAssign(e, sourceT, targetT)
 	}
 	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
-		// Track against the binding's own type, not the freshened targetT. The G2
+		// Track against the binding's own type, not the freshened targetT. The
 		// escape query reads the recorded type, and a later global write forces the
 		// lifetime on the binding's shared pointer. The freshened copy carries an
 		// independent lifetime var that the escape never touches. isMutableType reads
@@ -1066,20 +1064,20 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	return valueT
 }
 
-// inferMemberAssign types a field write `recv.prop = source` (M4 C3). It extends
+// inferMemberAssign types a field write `recv.prop = source`. It extends
 // inferAssign's member-target branch: the receiver must ACCEPT a write to prop, so
 // the source is constrained against a mutable, inexact one-property requirement
 //
 //	recv <: mut {prop: widen(source), ...}
 //
 // The inexact requirement says "must accept a write to this field," not "is exactly
-// this shape." The mut wrapper makes the receiver a mutable cell, which the C3
+// this shape." The mut wrapper makes the receiver a mutable cell, which the
 // coalesce fold collapses with the receiver's other selections into one `mut`
 // object. The stored value is WIDENED (5 ⇒ number) because writing through a `mut`
 // receiver is itself a mutation — a later write may store any number — mirroring
-// the `var`-binding widening (B3).
+// the `var`-binding widening.
 //
-// The write requirement carries a fresh lifetime (D2): a mut-borrow receiver of
+// The write requirement carries a fresh lifetime: a mut-borrow receiver of
 // any lifetime is accepted (the fresh var imposes no obligation), and an owned
 // receiver satisfies the borrow slot by the RefType rule.
 //
@@ -1097,7 +1095,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	voidT := soltype.Type(&soltype.Void{})
 	if m.OptChain {
 		// `recv?.prop = …` is not a meaningful assignment target; optional chaining is
-		// M6 regardless, so report the whole target as unsupported rather than typing it.
+		// unsupported regardless, so report the whole target as unsupported rather than typing it.
 		c.reportUnsupportedFeature(e.Left, "assignment to a member or index")
 		return voidT
 	}
@@ -1121,7 +1119,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	}
 	req := &soltype.RefType{
 		Mut: true,
-		// A fresh lifetime imposes no obligation on the receiver (D2): constrainLt
+		// A fresh lifetime imposes no obligation on the receiver: constrainLt
 		// gives the new variable an upper bound and constrains nothing back, so a
 		// mut-borrow receiver of ANY lifetime satisfies the write requirement. A
 		// nil slot lifetime would instead reject a borrow receiver as an escape.
@@ -1134,7 +1132,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	errsBefore := len(c.errs)
 	c.constrain(e, recv, req)
 	c.recordWritten(recv, m.Prop.Name, w)
-	// M4 G1: when the written value aliases a variable, merge the receiver's and the
+	// When the written value aliases a variable, merge the receiver's and the
 	// source's alias sets so a later transition off either sees the shared value. Only
 	// when the write type-checked, so a rejected write does not record a bogus alias.
 	if c.fn != nil && len(c.errs) == errsBefore {
@@ -1149,7 +1147,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 // inferWriteReceiver infers the receiver of a field write `recv.prop = …`. Each
 // member/index step in the receiver CHAIN imposes a MUTABLE requirement on its own
 // receiver rather than the immutable read a plain access would, so writing one nested
-// field marks the whole container `mut` (#779): `fn foo(obj) { obj.p.x = 5 }` infers
+// field marks the whole container `mut`: `fn foo(obj) { obj.p.x = 5 }` infers
 // `obj: mut {p: …}`, the mutability propagating up to the outermost container. The
 // alternative — an owned-mut cell on the inner field inside an immutable container —
 // is no longer a valid annotation, so inference must not produce it.
@@ -1182,7 +1180,7 @@ func (c *checker) inferWriteReceiver(scope *Scope, lvl int, e ast.Expr) soltype.
 // mutFieldRead reads property `name` off `recv` as the receiver of a write chain.
 // When the receiver's shape is still an inference variable, it imposes a MUTABLE
 // requirement `mut {name: fieldVar, ...}` so the inferred container folds `mut` at
-// coalesce time (#779) and hands back a mutable borrow of the field, the deep-mut read
+// coalesce time and hands back a mutable borrow of the field, the deep-mut read
 // view, so a deeper write relates the field covariantly under the mut-context
 // invariance. When the receiver is already concrete — an annotated `mut {…}` or a
 // borrow — it defers to valueProp's ordinary read: the deep-mut machinery already
@@ -1191,7 +1189,7 @@ func (c *checker) inferWriteReceiver(scope *Scope, lvl int, e ast.Expr) soltype.
 // access node a constraint failure points at; provNode is the node the fresh field
 // var's provenance records.
 func (c *checker) mutFieldRead(lvl int, blame ast.Node, provNode ast.Node, name string, recv soltype.Type) soltype.Type {
-	// Read-after-write (M4 C3): a field already written to the same receiver var
+	// Read-after-write: a field already written to the same receiver var
 	// returns the recorded concrete type, the same shortcut valueProp takes.
 	if c.fn != nil {
 		if v, ok := recv.(*soltype.TypeVarType); ok {
@@ -1209,7 +1207,7 @@ func (c *checker) mutFieldRead(lvl int, blame ast.Node, provNode ast.Node, name 
 	c.recordProv(fieldVar, provNode, MemberAccess)
 	c.constrain(blame, recv, &soltype.RefType{
 		Mut: true,
-		// A fresh lifetime imposes no obligation on the receiver (D2), matching the
+		// A fresh lifetime imposes no obligation on the receiver, matching the
 		// leaf write requirement in inferMemberAssign.
 		Lt: c.ctx.freshLifetime(lvl),
 		Inner: &soltype.ObjectType{
@@ -1240,11 +1238,11 @@ func (c *checker) recordWritten(recv soltype.Type, name string, t soltype.Type) 
 // constrainAssign asserts `source <: target` for a reassignment. For a UNION target
 // it applies the union-target rule — X <: (A | B) iff X <: A or X <: B — by trying
 // each member speculatively under a probe, committing the first that holds. constrain
-// itself has no UnionType-super rule until M6, so without this a legal assignment of a
+// itself has no UnionType-super rule yet, so without this a legal assignment of a
 // union member (`var a = if c { 1 } else { 2 }; a = 1`) would be wrongly rejected.
 // A non-union target takes the ordinary single-constraint path.
 //
-// KNOWN GAP (M6): when `source` is (or contains) an inference variable, committing the
+// KNOWN GAP: when `source` is (or contains) an inference variable, committing the
 // first matching member over-narrows it. `var a = 1 | 2; a = x` for an un-annotated
 // param `x` commits `x <: 1` and infers `x: 1` instead of the sound `x: 1 | 2`,
 // which can wrongly reject a later use of `x` that needs `2`. This is INCOMPLETE,
@@ -1253,7 +1251,7 @@ func (c *checker) recordWritten(recv soltype.Type, name string, t soltype.Type) 
 // through to constrain(source, target)" injects the COALESCED union node into source's
 // bound list and panics the coalescer (coalesced output must never re-enter the
 // graph). A correct fix needs first-class union subtyping with inference variables
-// — M6's deferred union/intersection rules in constrain. Pinned by
+// — the deferred union/intersection rules in constrain. Pinned by
 // TestInferAssignUnionTargetVarRHSOverNarrows.
 func (c *checker) constrainAssign(n ast.Node, source, target soltype.Type) {
 	union, ok := target.(*soltype.UnionType)
@@ -1300,15 +1298,15 @@ func bindingDecl(b ValueBinding) ast.Node {
 //
 // A spread element ([...xs]) splices the operand's element types into the literal.
 // For example, [...pair, 3] over pair: [number, string] builds
-// [number, string, number]. M4 handles only this concrete-literal splice: the
+// [number, string, number]. Only this concrete-literal splice is handled: the
 // operand must infer to a TupleType. An inexact operand ([number, ...]) has unknown
 // length, so it may only be spread as the last element. There its known prefix
 // extends the literal and its unknown tail makes the result inexact too. An inexact
 // operand anywhere else would put a later element at an unknown position, which is an
 // InexactTupleSpreadError. A spread of any other type is a SpreadNotTupleError. A
 // spread whose operand already errored is absorbed silently, so the recovery
-// sentinel does not cascade a second diagnostic. Two type-level cousins defer to
-// M7/M9: a tuple-spread type over an abstract operand [...P, x], and a typed
+// sentinel does not cascade a second diagnostic. Two type-level cousins are not yet
+// supported: a tuple-spread type over an abstract operand [...P, x], and a typed
 // variadic tail [number, ...Array<number>].
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
 	elems := make([]soltype.Type, 0, len(e.Elems))
@@ -1346,9 +1344,9 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 // with a static key folds into the object. A static key is an identifier label, a
 // string-literal key, or a numeric key like {0: v}. The forms it does not cover
 // each report an UnsupportedNodeError and are skipped rather than panicking:
-//   - spreads ({...o}), deferred to M9 with object rest/spread,
-//   - method/constructor elements, which arrive with classes in M5,
-//   - computed keys ({[k]: v}), which need M9 index signatures,
+//   - spreads ({...o}), part of the not-yet-supported object rest/spread,
+//   - method/constructor elements, which arrive with classes,
+//   - computed keys ({[k]: v}), which need index signatures,
 //   - shorthand ({x}, a property with no value).
 //
 // Usage-inference depth builds on this elsewhere, for example inferring an open
@@ -1363,9 +1361,9 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
-			// ObjSpreadExpr is object rest/spread, which is M9. The method and
+			// ObjSpreadExpr is object rest/spread, not yet supported. The method and
 			// constructor elements CallableExpr and ConstructorExpr arrive with
-			// classes in M5.
+			// classes.
 			c.reportUnsupported(elem)
 			continue
 		}
@@ -1376,8 +1374,8 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		}
 		name, ok := objKeyName(prop.Name)
 		if !ok {
-			// A computed key ({[k]: v}) carries no static property name, so it is M9.
-			// Blame the key itself, which has its own narrower span, not the whole
+			// A computed key ({[k]: v}) carries no static property name, so it is not
+			// yet supported. Blame the key itself, which has its own narrower span, not the whole
 			// property.
 			c.reportUnsupported(prop.Name)
 			continue
@@ -1427,14 +1425,14 @@ func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly boo
 // inferMember types a field read (recv.prop) in value position: it resolves the
 // member as a path and demands a value, so a property read returns its type while
 // a member that resolves to a namespace (A.B used as a value) is rejected.
-// Optional chaining (recv?.prop) needs union/undefined handling and is M6.
+// Optional chaining (recv?.prop) needs union/undefined handling and is not yet supported.
 func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
 	return c.demandValue(c.resolveMemberPath(scope, lvl, e), e)
 }
 
 // inferIndex types `obj[index]` in value position — namespace index access
 // (Foo["bar"]) and the constant-string bracket form of property access
-// (obj["foo-bar"]); dynamic value indexing is M7.
+// (obj["foo-bar"]); dynamic value indexing is not yet supported.
 func (c *checker) inferIndex(scope *Scope, lvl int, e *ast.IndexExpr) soltype.Type {
 	return c.demandValue(c.resolveIndexPath(scope, lvl, e), e)
 }
@@ -1445,7 +1443,7 @@ func (c *checker) inferIndex(scope *Scope, lvl int, e *ast.IndexExpr) soltype.Ty
 // the property structurally.
 func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pathResult {
 	if e.OptChain {
-		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
+		// Optional chaining (recv?.prop) is wholesale unsupported; report it
 		// up front and do NOT descend into the receiver, so a single diagnostic
 		// stands for the construct instead of cascading the receiver's errors. The
 		// MemberExpr kind is supported — it is the optional-chain feature that is
@@ -1461,7 +1459,7 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 		// A malformed `recv.` with no valid property name: the parser already
 		// reported the missing identifier, so constraining recv <: {"": res} here
 		// would only layer a spurious "object is missing property: " on top. Yield
-		// the ErrorType recovery sentinel (PR8) — NOT a raw never — so that if this
+		// the ErrorType recovery sentinel — NOT a raw never — so that if this
 		// read flows into a sink (`if recv. {}`, `await recv.`, `var x = recv.`) the
 		// sentinel absorbs in constrain rather than cascading `never <: …`. report
 		// already emitted the diagnostic here (via the parser), so no extra error.
@@ -1476,17 +1474,17 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 }
 
 // valueMember reads property prop off a value receiver: it allocates a fresh
-// result var and constrains recv <: {prop: fieldVar, ...} — the basic form from the
-// plan's §3.2 table. The requirement is INEXACT: a member read asks only that the
+// result var and constrains recv <: {prop: fieldVar, ...} — the basic member-read
+// form. The requirement is INEXACT: a member read asks only that the
 // receiver has AT LEAST this property, so width tolerance is expressed as
 // inexactness rather than as an unconditionally width-tolerant arm.
 //
 // This inexactness currently flows out to the inferred param type. A param used
 // only through member reads coalesces to its upper bound, so `fn (p) { p.foo }`
-// infers an inexact param `{foo: number, ...}`. M4 phase B PR B1 ("close
-// usage-inferred shapes to exact") will seal that coalesced result to exact via
-// the Policy-A close, rendering `{foo: number}`. The per-access requirement minted
-// here stays inexact; only the coalesced result is closed.
+// infers an inexact param `{foo: number, ...}`. A later close of usage-inferred
+// shapes to exact will seal that coalesced result to exact,
+// rendering `{foo: number}`. The per-access requirement minted here stays inexact;
+// only the coalesced result is closed.
 //
 // The ObjectType <: ObjectType arm of constrain lowers fieldVar from the receiver's
 // matching property (so fieldVar coalesces to that property's type); a receiver
@@ -1506,7 +1504,7 @@ func (c *checker) valueMember(lvl int, e *ast.MemberExpr, recv soltype.Type) pat
 // — so a missing-property read blames the property, not the receiver. name is the
 // property key being read.
 func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name string, recv soltype.Type) pathResult {
-	// Read-after-write (M4 C3): a read of a field just written to the same receiver
+	// Read-after-write: a read of a field just written to the same receiver
 	// var returns the recorded concrete type instead of minting a fresh var, so
 	// `obj.x = 5; obj.x` is `number`. The write already constrained the receiver to
 	// carry the field, so no additional requirement is needed here.
@@ -1527,7 +1525,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 			}
 		}
 	}
-	// Strip the borrow wrapper before building the field-read requirement (D2):
+	// Strip the borrow wrapper before building the field-read requirement:
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
 	//     the field's value, not the borrow.
 	//   - It keeps the requirement off the RefType, so the RefType<:bare escape
@@ -1537,32 +1535,32 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	fieldVar := c.freshAt(lvl)
 	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner fieldVar, so the record would be a dead
-	// entry (§3.3).
+	// entry.
 	c.recordProv(fieldVar, provNode, MemberAccess)
 	c.constrain(blame, recvCarrier, &soltype.ObjectType{
 		Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: fieldVar}},
 		Inexact: true, // "has at least this property" — width tolerance is inexactness
 	})
 	// fieldReadBorrow takes the whole receiver and unwraps mut/lifetime internally,
-	// applying PR 4 rule 4 to produce the field-bounded borrow.
+	// applying the field-borrow rule to produce the field-bounded borrow.
 	out := c.fieldReadBorrow(fieldVar, recv, name, lvl)
 	c.recordType(blame, out)
 	return pathResult{value: out}
 }
 
-// fieldReadBorrow applies PR 4 rule 4. A member read yields a borrow of the
-// field bounded by the receiver when the field is reference-shaped. An owned
+// fieldReadBorrow applies the field-borrow rule. A member read yields a borrow of
+// the field bounded by the receiver when the field is reference-shaped. An owned
 // receiver mints a fresh lifetime here. A borrowed receiver's lifetime passes
 // through. The wrap reads the field's static shape off a concrete receiver
 // carrier. A primitive or function field stays a value, since PrimType and
 // FuncType are excluded from RefInner. A field whose static type is itself an
 // immutable borrow copies the borrow out flat rather than nesting, setting up
-// PR 9's nested-borrow normalization.
+// the nested-borrow normalization.
 //
 // A receiver whose shape is not statically known returns the existing `fieldVar`
 // unchanged. A usage-inferred TypeVar carrier and an index path with no
 // concrete property both fall into this branch. The inferred-receiver paths
-// keep their pre-PR-4 behaviour, so only annotated reference shapes pick up
+// keep their earlier behaviour, so only annotated reference shapes pick up
 // the new borrow.
 func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Type, name string, lvl int) soltype.Type {
 	_, recvMut, recvLt := soltype.UnwrapRef(recv)
@@ -1578,8 +1576,8 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 	case *soltype.RefType:
 		if fieldType.Lt == nil {
 			// An owned-mutable field cell — formerly an explicit `mut {x}` field, the
-			// awkward interior-mutability shape now rejected at the annotation site
-			// (#779). Read it as a receiver-bounded borrow, capping `mut` by the
+			// awkward interior-mutability shape now rejected at the annotation site.
+			// Read it as a receiver-bounded borrow, capping `mut` by the
 			// receiver's mutability. The lazy deep-mut form does not mint these for a
 			// plain `mut {a: {x}}`; that field is bare, handled by the bare arm below.
 			// This arm is therefore defensive — kept for any owned-mut cell that still
@@ -1595,14 +1593,14 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 			// freely duplicable, so the read hands back the field's borrow at
 			// its own lifetime rather than nesting under the receiver's. A
 			// `&mut` field falls through to the no-wrap branch. Aliasing a
-			// mutable borrow needs the move-engine work in PR 6, and PR 9
+			// mutable borrow needs the move-engine work, and a later change
 			// retires the depth-two `&mut &mut` shape entirely.
 			return fieldType
 		}
 		return fieldVar
 	case *soltype.ObjectType, *soltype.TupleType:
 		// A bare object/tuple field is a value the receiver owns. Read it as a
-		// receiver-bounded borrow whose mutability follows the receiver (PR 14): a
+		// receiver-bounded borrow whose mutability follows the receiver: a
 		// mutable receiver yields `&mut`, an immutable one `&`. This is where the
 		// lazy deep-mut rule lives — under `mut {a: {x}}`, `p.a` reads `&mut {x}`.
 		lt := recvLt
@@ -1617,7 +1615,7 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 			// polarities and widen it into a union that peels the borrow.
 			return &soltype.RefType{Mut: true, Lt: lt, Inner: fieldType.(soltype.RefInner)}
 		}
-		// Immutable read: route through the fresh field-read var (PR 4).
+		// Immutable read: route through the fresh field-read var.
 		return &soltype.RefType{Mut: false, Lt: lt, Inner: fieldVar}
 	default:
 		return fieldVar
@@ -1630,7 +1628,7 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 // key is the bracket form of property access — obj["foo-bar"] reads the same
 // property as obj.foo would, and lets the source name a property whose key is not
 // a valid identifier. A dynamic key over a value (array element / index-signature
-// read) needs Array and index types from M7, so it stays unsupported here.
+// read) needs Array and index types, so it stays unsupported here.
 func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) pathResult {
 	if e.OptChain {
 		c.reportUnsupportedFeature(e, "OptionalChain")
@@ -1652,8 +1650,8 @@ func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) path
 		return c.valueProp(lvl, e, e.Index, name, obj.value)
 	}
 	// A dynamic key over a value (array element / index-signature read) needs Array
-	// and index types, which land in M7; until then it is outside the supported
-	// subset.
+	// and index types, which are not yet implemented; until then it is outside the
+	// supported subset.
 	c.reportUnsupported(e)
 	return pathResult{err: true}
 }
@@ -1695,7 +1693,7 @@ func constStringKey(e ast.Expr) (string, bool) {
 // key all map to a field. A numeric key is coerced to its string form the way
 // JavaScript does, so {0: v} names the field "0". A computed key ({[k]: v}) carries
 // no static name and returns false so the caller can raise a structured error.
-// Full index-signature support rides M9.
+// Full index-signature support is not yet implemented.
 func objKeyName(k ast.ObjKey) (string, bool) {
 	switch k := k.(type) {
 	case *ast.IdentExpr:
@@ -1709,9 +1707,9 @@ func objKeyName(k ast.ObjKey) (string, bool) {
 	}
 }
 
-// identPatName reads the name of an IdentPat. M2 binds IdentPat-only patterns
-// (mirroring M1's IdentPat-only FuncParam); the comma-ok form lets callers raise
-// a structured error for the destructuring patterns deferred to M4.
+// identPatName reads the name of an IdentPat. Only IdentPat patterns are bound
+// directly here; the comma-ok form lets callers raise a structured error for
+// destructuring patterns.
 func identPatName(pat ast.Pat) (string, bool) {
 	if ip, ok := pat.(*ast.IdentPat); ok {
 		return ip.Name, true
@@ -1720,10 +1718,9 @@ func identPatName(pat ast.Pat) (string, bool) {
 }
 
 // inferAwait types `await e`. The argument is constrained `<: Promise<U>` for a
-// fresh U, and U is the await's value type — exactly the rule M3's milestone
-// pins ("`await e` requires `e <: Promise<U>` for some `U` and produces `U`",
-// 01-milestones.md §M3). No auto-flatten: U may itself be a Promise, so
-// `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is M9). `await`
+// fresh U, and U is the await's value type — `await e` requires `e <: Promise<U>`
+// for some `U` and produces `U`. No auto-flatten: U may itself be a Promise, so
+// `await Promise<Promise<T>>` yields `Promise<T>` (Awaited<T> is not yet supported). `await`
 // outside an `async` function is rejected by the WALK (this function), not the
 // type rule — the argument is still walked so its own errors surface, and the
 // await contributes a `never` placeholder so a downstream consumer doesn't see a
@@ -1738,7 +1735,7 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 		if c.fn != nil {
 			enclosing = c.fn.node
 		}
-		// report returns the ErrorType recovery placeholder (PR8), so the rejected
+		// report returns the ErrorType recovery placeholder, so the rejected
 		// await never cascades a downstream `<unknown> <: T` on top of this error.
 		t := c.report(&AwaitOutsideAsyncError{Await: e, EnclosingFn: enclosing})
 		c.recordType(e, t)
@@ -1752,10 +1749,10 @@ func (c *checker) inferAwait(scope *Scope, lvl int, e *ast.AwaitExpr) soltype.Ty
 	// (`e.Arg`), already recorded by inferExpr; the synthesized Promise wrapper is
 	// internal scaffolding for the constraint, not a user-authored type.
 	//
-	// PR8: a failed argument is the ErrorType recovery placeholder, which absorbs in
+	// A failed argument is the ErrorType recovery placeholder, which absorbs in
 	// constrain, so `<unknown> <: Promise<U>` no longer cascades a spurious second
 	// diagnostic — res then stays unbound and coalesces to `never`, the right
-	// recovery for awaiting something broken. The M2-era isRecoveryPlaceholder guard
+	// recovery for awaiting something broken. The earlier isRecoveryPlaceholder guard
 	// this site used is gone.
 	c.constrain(e, arg, &soltype.PromiseType{Inner: res})
 	c.recordType(e, res)
@@ -1790,9 +1787,9 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 	// Related() echo Span(). This matches inferAwait's synthesized Promise and
 	// inferMember's synthesized record requirement, both deliberately unrecorded.
 	//
-	// PR8: a failed condition is the ErrorType recovery placeholder, which absorbs
+	// A failed condition is the ErrorType recovery placeholder, which absorbs
 	// in constrain, so `<unknown> <: boolean` no longer cascades a spurious second
-	// diagnostic — the M2-era isRecoveryPlaceholder guard this site used is gone.
+	// diagnostic — the earlier isRecoveryPlaceholder guard this site used is gone.
 	c.constrain(e.Cond, cond, &soltype.PrimType{Prim: soltype.BoolPrim})
 	consT, consDiverges := c.inferBlock(scope.Child(), lvl, &e.Cons)
 	var altT soltype.Type = &soltype.Void{}
@@ -1819,7 +1816,7 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 
 // inferMatch types a `match` expression. The scrutinee is inferred once. Each arm
 // then types its pattern against the scrutinee in a child scope carrying the arm's
-// bindings, the same E1 bindPattern path `val` destructuring uses. An optional `if`
+// bindings, the same bindPattern path `val` destructuring uses. An optional `if`
 // guard is typed as a boolean, then the arm body is inferred. Every non-diverging
 // arm body is constrained into one fresh branch-join var, exactly as inferIfElse
 // joins its two branches. A diverging arm contributes `never`, so when every arm
@@ -1856,13 +1853,13 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 }
 
 // checkMatchExhaustive reports a NonExhaustiveMatchError when no arm covers every
-// value the scrutinee can take. M4 drives the decision solely from the scrutinee's
+// value the scrutinee can take. The decision is driven solely from the scrutinee's
 // structural exactness. An exact object or tuple has a fixed shape, so a structural
 // arm matching it covers every value. An inexact object or tuple carries an open
 // tail of unknown values, so only an unguarded catch-all covers it. A catch-all is
 // a wildcard `_` or an identifier pattern. A scrutinee that is neither an object nor
-// a tuple is not checked here. Union-scrutinee exhaustiveness is M6 and enum
-// exhaustiveness is M5, and both extend this same path.
+// a tuple is not checked here. Union-scrutinee and enum exhaustiveness are not yet
+// implemented, and both extend this same path.
 func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type) {
 	inexact, isStructural := structuralInexact(soltype.CarrierOf(scrutinee))
 	if !isStructural {
@@ -1879,7 +1876,7 @@ func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type)
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether
-// the type is one of those structural forms at all. M4's match exhaustiveness reads
+// the type is one of those structural forms at all. Match exhaustiveness reads
 // nothing else off the scrutinee.
 func structuralInexact(t soltype.Type) (inexact bool, ok bool) {
 	switch t := t.(type) {
@@ -1914,8 +1911,8 @@ func armCoversShape(p ast.Pat, inexact bool) bool {
 // irrefutablePat reports whether a pattern matches every value of a compatible
 // type, so it can never fail at runtime. A wildcard or identifier binds
 // unconditionally. An object or tuple pattern is irrefutable only when all of its
-// sub-patterns are. A literal pattern can fail, and the constructor patterns deferred
-// to M5 are refutable, so both return false.
+// sub-patterns are. A literal pattern can fail, and the not-yet-supported constructor
+// patterns are refutable, so both return false.
 func irrefutablePat(p ast.Pat) bool {
 	switch p := p.(type) {
 	case *ast.WildcardPat, *ast.IdentPat:
@@ -1937,7 +1934,7 @@ func irrefutablePat(p ast.Pat) bool {
 					return false
 				}
 			default:
-				// ObjRestPat is M9; treat anything else as refutable.
+				// ObjRestPat is not yet supported; treat anything else as refutable.
 				return false
 			}
 		}
@@ -1984,7 +1981,7 @@ func stmtDiverges(s ast.Stmt) bool {
 // arguments). The recursive switch is the right shape; the visitor is for the dual
 // problem of collecting every `return` regardless of position.
 //
-// MatchExpr is walked by inferMatch in M4 E2, so its arm reflects real source. A
+// MatchExpr is walked by inferMatch, so its arm reflects real source. A
 // match diverges when every arm body does. ThrowExpr and DoExpr are not yet walked
 // by the solver, which reports them unsupported, so those arms are unreachable from
 // real source today. They are kept in place so a form's divergence is already

--- a/internal/solver/infer_expr_test.go
+++ b/internal/solver/infer_expr_test.go
@@ -39,13 +39,13 @@ func TestInferLiteral(t *testing.T) {
 	}
 }
 
-// A literal kind outside M1's soltype.Lit set (regex, bigint, null, undefined)
-// is an M2 subset miss, not a crash.
+// A literal kind outside the soltype.Lit set (regex, bigint, null, undefined)
+// is an unsupported-subset miss, not a crash.
 func TestInferLiteralUnsupported(t *testing.T) {
 	c := newChecker()
 	e := ast.NewLitExpr(ast.NewNull(testSpan()))
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
+	require.IsType(t, &soltype.ErrorType{}, got) // report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported: NullLit", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -79,7 +79,7 @@ func TestInferIdentUnknown(t *testing.T) {
 	c := newChecker()
 	e := ast.NewIdent("nope", testSpan())
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
+	require.IsType(t, &soltype.ErrorType{}, got) // report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unknown identifier: nope", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -92,7 +92,7 @@ func TestInferIdentNamespaceUsedAsValue(t *testing.T) {
 
 	e := ast.NewIdent("Foo", testSpan())
 	got := c.inferExpr(scope, 0, e)
-	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
+	require.IsType(t, &soltype.ErrorType{}, got) // report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Namespace used as a value: Foo", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -105,7 +105,7 @@ func TestInferExprUnsupportedNode(t *testing.T) {
 	e := ast.NewBinary(left, right, ast.Plus, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
+	require.IsType(t, &soltype.ErrorType{}, got) // report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported: BinaryExpr", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -17,9 +17,9 @@ func render(t soltype.Type) string {
 	return soltype.Print(coalesce(t, soltype.Positive))
 }
 
-// renderBinding renders a value binding's (sole, in PR1) scheme to its Escalier
-// type string — the test-side view of what a name resolves to, including any
-// <T0, …> quantifier prefix generalization left behind.
+// renderBinding renders a value binding's sole scheme to its Escalier type string,
+// the test-side view of what a name resolves to, including any <T0, …> quantifier
+// prefix generalization left behind.
 func renderBinding(b ValueBinding) string {
 	return renderScheme(b.Schemes[0])
 }
@@ -37,10 +37,10 @@ func TestInferFuncExprAnnotated(t *testing.T) {
 	require.Same(t, got, c.info.TypeOf(e))
 }
 
-// An un-annotated param gets a fresh var. M2 is monomorphic — without
-// generalization (M3) the var coalesces to the lattice bounds (unknown in
-// contravariant param position, never in covariant return position) rather than
-// a <T0> quantifier.
+// An un-annotated param gets a fresh var. Inference is monomorphic here. Without
+// generalization the var coalesces to the lattice bounds, unknown in contravariant
+// param position and never in covariant return position, rather than a <T0>
+// quantifier.
 func TestInferFuncExprUnannotatedIsMonomorphic(t *testing.T) {
 	c := newChecker()
 	// fn (x) { return x }
@@ -118,14 +118,14 @@ func TestInferFuncDeclBodylessReturnAnnotation(t *testing.T) {
 	require.Equal(t, "fn () -> number", render(ty))
 }
 
-// A bodyless function with an UNSUPPORTED return annotation recovers to `unknown`
-// (the honest "couldn't resolve the declared return"), not the synthetic `void`
-// (which would falsely signal "returns nothing" to callers). The annotation error
-// is still reported once. Reachable only via a nil-body AST — from source the
-// parser gives a declare fn a non-nil empty block (so hasBody is true).
+// A bodyless function with an UNSUPPORTED return annotation recovers to `unknown`,
+// the honest "couldn't resolve the declared return", not the synthetic `void` that
+// would falsely signal "returns nothing" to callers. The annotation error is still
+// reported once. Reachable only via a nil-body AST. From source the parser gives a
+// declare fn a non-nil empty block, so hasBody is true.
 func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 	c := newChecker()
-	// declare fn now() -> bigint   (bigint is unsupported in M2)
+	// declare fn now() -> bigint   (bigint is unsupported)
 	d := ast.NewFuncDecl(
 		ast.NewIdentifier("now", testSpan()), nil, nil,
 		nil, ast.NewBigintTypeAnn(testSpan()), nil,
@@ -140,8 +140,8 @@ func TestInferFuncDeclBodylessUnsupportedReturnRecoversToUnknown(t *testing.T) {
 }
 
 // A param that arrives without a pattern must report a clean error, not panic on
-// p.Span() (which dereferences the nil pattern). Not reachable from the real
-// parser, but the walk must uphold M2's "never a panic" guarantee.
+// p.Span() which dereferences the nil pattern. Not reachable from the real parser,
+// but the walk must uphold the "never a panic" guarantee.
 func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 	c := newChecker()
 	e := funcExpr([]*ast.Param{{Pattern: nil}}, nil, block(exprStmt(numExpr(1))))
@@ -151,9 +151,9 @@ func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// A destructuring parameter binds its leaves and renders its pattern (M4 E1). The
-// leaves below go unused, so each slot coalesces to `unknown`. The point is that
-// the param is accepted and rendered, not reported as unsupported.
+// A destructuring parameter binds its leaves and renders its pattern. The leaves
+// below go unused, so each slot coalesces to `unknown`. The point is that the param
+// is accepted and rendered, not reported as unsupported.
 func TestInferFuncExprDestructuringParam(t *testing.T) {
 	c := newChecker()
 	// fn ([a, b]) { 1 }
@@ -169,7 +169,8 @@ func TestInferFuncExprDestructuringParam(t *testing.T) {
 }
 
 // A generic function (fn <T>() { ... }) is diagnosed rather than silently erased
-// to a monomorphic type — type schemes / generalization are M3.
+// to a monomorphic type, since type schemes and generalization are not supported
+// yet.
 func TestInferFuncExprGenericUnsupported(t *testing.T) {
 	c := newChecker()
 	// fn <T>() { 1 }
@@ -211,8 +212,8 @@ func TestInferCallArgMismatch(t *testing.T) {
 	require.Equal(t, "number", render(got))
 }
 
-// Too-many args at a direct call is the PR4 extra-arg lint (TooManyArgsError, the
-// uniform too-many message), not a FuncArityMismatch — and the constraint receives
+// Too-many args at a direct call is the extra-arg lint (TooManyArgsError, the
+// uniform too-many message), not a FuncArityMismatch, and the constraint receives
 // only the arity-matched prefix, so the lint is the SOLE diagnostic.
 func TestInferCallTooManyArgs(t *testing.T) {
 	c := newChecker()
@@ -228,8 +229,8 @@ func TestInferCallTooManyArgs(t *testing.T) {
 	require.Equal(t, "number", render(got))
 }
 
-// Too-few args at a direct call is the PR4 too-few lint (NotEnoughArgsError, the
-// symmetric twin of TooManyArgsError) — the demand is padded to the callee's arity
+// Too-few args at a direct call is the too-few lint (NotEnoughArgsError, the
+// symmetric twin of TooManyArgsError). The demand is padded to the callee's arity
 // so the lint is the SOLE diagnostic, not a doubled lint + FuncArityMismatch.
 func TestInferCallTooFewArgs(t *testing.T) {
 	c := newChecker()
@@ -298,9 +299,9 @@ func TestInferBlockReturnStmt(t *testing.T) {
 	require.Equal(t, "5", render(got))
 }
 
-// Each val introduces a fresh, independent binding; a later val of the same name
-// rebinds it (overwrite, no constraint linking the two), so the tail sees the
-// later type even though it is unrelated to the earlier one (§3.2).
+// Each val introduces a fresh, independent binding. A later val of the same name
+// rebinds it as an overwrite with no constraint linking the two, so the tail sees
+// the later type even though it is unrelated to the earlier one.
 func TestInferBlockRedeclarationRebinds(t *testing.T) {
 	c := newChecker()
 	// { val x = "hello"; val x = 5; x }
@@ -346,13 +347,13 @@ func TestInferFuncDecl(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", render(ty))
 }
 
-// A truly recursive function: foo's body calls itself. PR-3 has no SCC driver
-// (that's PR-5), so foo is pre-bound to a fresh var the way inferComponent will,
-// letting the body reference itself through inferCall. With unconditional
-// recursion the function never returns — a base case would need a conditional,
-// which arrives in a later milestone — so its return type coalesces to `never`.
-// (`foo(x + 1)` would be the textbook shape, but `+` is a BinaryExpr, which
-// PR-3 doesn't type yet; `foo(x)` exercises the same recursive-call path.)
+// A truly recursive function: foo's body calls itself. Without an SCC driver here,
+// foo is pre-bound to a fresh var the way inferComponent will, letting the body
+// reference itself through inferCall. With unconditional recursion the function
+// never returns, since a base case would need a conditional, so its return type
+// coalesces to `never`. `foo(x + 1)` would be the textbook shape, but `+` is a
+// BinaryExpr that is not typed here; `foo(x)` exercises the same recursive-call
+// path.
 func TestInferFuncDeclSelfReference(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M6 PR2: union/intersection annotation input through resolveTypeAnn ---
+// --- Union/intersection annotation input through resolveTypeAnn ---
 
 func TestInferUnionAnnotationAcceptsMember(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | string = 5`)

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 C3: field-write inference + read-after-write ---
+// --- Field-write inference + read-after-write ---
 //
 // A field write `recv.prop = source` extends inferAssign's member-target branch. It
-// constrains `recv <: mut {prop: widen(source), ...}` — a mutable, inexact
-// one-property requirement — and the C3 coalesce fold collapses every selection on
-// the receiver (reads and writes) into one `mut` object once any field is written.
+// constrains `recv <: mut {prop: widen(source), ...}`, a mutable, inexact
+// one-property requirement, and the coalesce fold collapses every selection on the
+// receiver, reads and writes alike, into one `mut` object once any field is written.
 // The stored value is widened (5 ⇒ number) because writing through a `mut` receiver
 // is itself a mutation. These tests exercise the feature end to end through inferred
 // function signatures.
@@ -34,10 +34,10 @@ func TestInferMemberAssignReadAfterWrite(t *testing.T) {
 	require.Equal(t, "fn (obj: mut {x: number}) -> number", values["foo"])
 }
 
-// A mixed read and write folds into ONE `mut` object rather than the spike's
-// `{bar: …} & mut {baz: …}` intersection: the presence of any write makes every
-// selection — the read-only `bar` included — fold into the mutable object. Folding
-// `bar` into the `mut` object makes it invariant (#737), so its var occurs in both
+// A mixed read and write folds into ONE `mut` object rather than a
+// `{bar: …} & mut {baz: …}` intersection. The presence of any write makes every
+// selection, the read-only `bar` included, fold into the mutable object. Folding
+// `bar` into the `mut` object makes it invariant, so its var occurs in both
 // polarities and is retained as a type parameter `T0` the caller picks, rather than
 // inlined to `unknown`. The written `baz` is the widened `number`.
 func TestInferMemberAssignMixedReadWrite(t *testing.T) {
@@ -46,7 +46,7 @@ func TestInferMemberAssignMixedReadWrite(t *testing.T) {
 	require.Equal(t, "fn <T0>(obj: mut {bar: T0, baz: number}) -> void", values["foo"])
 }
 
-// A compound written value widens recursively via the shared widen (B3): writing
+// A compound written value widens recursively via the shared widen. Writing
 // `{x: 0}` stores `{x: number}`, not the literal `{x: 0}`.
 func TestInferMemberAssignCompoundValueWidens(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.p = {x: 0} }")
@@ -74,7 +74,7 @@ func TestInferMemberAssignSameFieldTwice(t *testing.T) {
 // A written field and a read-only field that ESCAPES (is returned) fold into one
 // `mut` object: the written `x` is `number`, while the returned `y` becomes a real
 // type parameter rather than collapsing to `unknown`, because it occurs in an output
-// position. This is the key interplay between the C3 mut-merge and generalization.
+// position. This is the key interplay between the mut-merge and generalization.
 func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj.y }")
 	require.Empty(t, errs)
@@ -84,15 +84,15 @@ func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
 // Write-after-read on the SAME field needs no `written`-map support: the read mints
 // `T0` and constrains `obj <: {x: T0}`, the later write adds `obj <: mut {x: number}`,
 // and the two upper bounds merge so the field folds to `T0 & number`. The read's
-// value (returned `x`) stays `T0`. This pins the plan's claim that write-after-read
-// falls out of ordinary constraint accumulation, the reverse of read-after-write.
+// value, the returned `x`, stays `T0`. Write-after-read falls out of ordinary
+// constraint accumulation, the reverse of read-after-write.
 func TestInferMemberAssignWriteAfterRead(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.x\n obj.x = 5\n return x }")
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
 }
 
-// A write through a nested receiver marks the WHOLE container `mut` (#779): writing
+// A write through a nested receiver marks the WHOLE container `mut`. Writing
 // `obj.p.x` makes `obj` itself mutable rather than nesting an owned-mut cell on the
 // `p` field. `mut` is deep, so `mut {p: {x: number}}` already makes `p.x` writable,
 // and unlike the rejected `{p: mut {x: number}}` it is a valid annotation — the
@@ -104,7 +104,7 @@ func TestInferMemberAssignNestedReceiver(t *testing.T) {
 	require.Equal(t, "fn (obj: mut {p: {x: number}}) -> void", values["foo"])
 }
 
-// An `open` param's written object stays row-polymorphic: the C3 fold passes the
+// An `open` param's written object stays row-polymorphic. The fold passes the
 // var's Open flag to mergeObjectGroup, so the merged `mut` object is inexact and
 // callers may pass an object with extra fields.
 func TestInferMemberAssignOpenParam(t *testing.T) {
@@ -122,7 +122,7 @@ func TestInferMemberAssignWrittenObjectEscapes(t *testing.T) {
 	require.Equal(t, "fn <T0>(obj: T0 & mut {x: number}) -> T0", values["foo"])
 }
 
-// Writing a parameter's value into a field LINKS their types (#737). The write
+// Writing a parameter's value into a field LINKS their types. The write
 // `obj.x = v` makes the field's type the variable `v`, and because the field is
 // `mut` — hence invariant — `v` occurs in BOTH polarities, so single-polarity
 // elimination retains it as a shared type parameter instead of inlining each
@@ -141,9 +141,9 @@ func TestInferMemberAssignVariableValueLinked(t *testing.T) {
 // declared fields. Before the per-field write view this reported spurious
 // "missing property: y" / "inexact <: exact" errors.
 //
-// The annotated `mut` param originates a borrow lifetime (D2), but it is unused in
-// the void result, so D4's display-time elision drops it and the param renders as
-// plain owned-mutable `mut {…}`.
+// The annotated `mut` param originates a borrow lifetime, but it is unused in the
+// void result, so the display-time elision drops it and the param renders as plain
+// owned-mutable `mut {…}`.
 func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
 	values, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = 5 }")
 	require.Empty(t, errs)
@@ -174,7 +174,7 @@ func TestInferMemberAssignAnnotatedMutMissingField(t *testing.T) {
 // on the receiver var with no constraint relating them. Pinned so the gap is
 // explicit; a future soundness pass over conflicting writes should surface an error
 // here and update this assertion.
-// TODO(#738): report conflicting writes to one field instead of folding to an
+// TODO: report conflicting writes to one field instead of folding to an
 // uninhabited intersection.
 func TestInferMemberAssignConflictingWritesNoError(t *testing.T) {
 	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = \"hi\" }")

--- a/internal/solver/infer_module_destructure_test.go
+++ b/internal/solver/infer_module_destructure_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// M4 E3: a top-level destructuring `val [a, b] = …` binds SEVERAL names from one
+// A top-level destructuring `val [a, b] = …` binds SEVERAL names from one
 // decl. The SCC driver fans the decl across its leaf binding keys, types the
 // initializer once, and lowers each leaf's projected type into its pre-bound var.
 // This replaces the former TestInferModuleDestructuringPatternUnsupported, which
@@ -34,7 +34,7 @@ func TestInferModuleDestructuring(t *testing.T) {
 		{
 			// A `var` tuple destructuring widens each leaf to its primitive, the
 			// constraint-level widening inferVarDeclInit applies to a direct literal
-			// initializer (M4 B3), so the leaves read back as `number`.
+			// initializer, so the leaves read back as `number`.
 			name:   "tuple var widens",
 			src:    `var [a, b] = [1, 2]`,
 			values: map[string]string{"a": "number", "b": "number"},
@@ -91,7 +91,7 @@ func TestInferModuleDestructuring(t *testing.T) {
 			values: map[string]string{"x": "5", "z": "5"},
 		},
 		{
-			// Phase 3 generalizes each leaf key independently, so a destructured leaf
+			// Generalization treats each leaf key independently, so a destructured leaf
 			// bound to a polymorphic function generalizes to its own scheme and
 			// instantiates fresh at each call site. That is full let-polymorphism, not a
 			// shared monomorphic projection.
@@ -105,7 +105,7 @@ func TestInferModuleDestructuring(t *testing.T) {
 		},
 		{
 			// An un-annotated `var` object destructuring widens each leaf to its
-			// primitive, the object twin of the tuple case (M4 B3), so a later
+			// primitive, the object twin of the tuple case, so a later
 			// reassignment of the same primitive checks.
 			name:   "object var widens",
 			src:    `var {x} = {x: 5}`,

--- a/internal/solver/infer_namespace_test.go
+++ b/internal/solver/infer_namespace_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// F1: namespace member lookup (resolvePath). Namespaces never enter scope via real
-// source yet (namespace declarations are unsupported in M3), so these tests
-// hand-build the Namespace structure and feed path expressions straight into the
-// walk — the same construction as TestInferIdentNamespaceUsedAsValue.
+// Namespace member lookup via resolvePath. Namespace declarations are not yet
+// supported in source, so these tests hand-build the Namespace structure and feed
+// path expressions straight into the walk, the same construction as
+// TestInferIdentNamespaceUsedAsValue.
 
 func numScheme() []TypeScheme {
 	return []TypeScheme{monoScheme(&soltype.PrimType{Prim: soltype.NumPrim})}
@@ -139,8 +139,9 @@ func TestInferNamespaceDynamicIndex(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// An index into a value (array element / index-signature read) is M7, still
-// outside the supported subset — the namespace path doesn't accidentally accept it.
+// An index into a value, such as an array element or index-signature read, is
+// not yet in the supported subset, so the namespace path must not accidentally
+// accept it.
 func TestInferValueIndexUnsupported(t *testing.T) {
 	c := newChecker()
 	scope := NewScope()
@@ -157,7 +158,7 @@ func TestInferValueIndexUnsupported(t *testing.T) {
 // resolves through the namespace path and borrows the resolved value. The
 // receiver-bounded path in inferBorrowOfMember bails to wrapBorrow when the
 // receiver is a namespace, since a namespace has no value region to bound the
-// borrow's lifetime. Pre-fix this case errored with NamespaceUsedAsValueError
+// borrow's lifetime. This case previously errored with NamespaceUsedAsValueError
 // because the intercept routed the receiver through inferExpr, which rejects
 // a namespace in value position.
 func TestInferBorrowOfNamespaceMember(t *testing.T) {

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -73,7 +73,7 @@ func TestInferTupleSpreadMultipleExact(t *testing.T) {
 	require.Len(t, tup.Elems, 4)  // 2 + 2 spliced elements
 }
 
-// Spreading a non-tuple value is a typed error: M4 splices concrete tuple
+// Spreading a non-tuple value is a typed error: the spread splices concrete tuple
 // literals only, so the operand must infer to a tuple.
 func TestInferTupleSpreadNonTuple(t *testing.T) {
 	c := newChecker()
@@ -205,8 +205,8 @@ func TestInferObjectDuplicateKeyLastWins(t *testing.T) {
 	require.True(t, equalType(obj, obj), "equalType must be reflexive for a deduped object")
 }
 
-// Shorthand ({x}) is a property with no value — deferred to M4. It reports a
-// clean UnsupportedNodeError and is skipped (the rest of the object still types).
+// Shorthand ({x}) is a property with no value and is not yet supported. It reports
+// a clean UnsupportedNodeError and is skipped, so the rest of the object still types.
 func TestInferObjectShorthandUnsupported(t *testing.T) {
 	c := newChecker()
 	shorthand := ast.NewProperty(ast.NewIdent("x", testSpan()), false, false, nil, testSpan())
@@ -217,8 +217,8 @@ func TestInferObjectShorthandUnsupported(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// A spread element ({...o}) is M4; it reports unsupported without walking its
-// value, so the unknown `o` inside it never surfaces a second error.
+// A spread element ({...o}) is not yet supported; it reports unsupported without
+// walking its value, so the unknown `o` inside it never surfaces a second error.
 func TestInferObjectSpreadUnsupported(t *testing.T) {
 	c := newChecker()
 	spread := ast.NewRestSpread(identExpr("o"), testSpan())
@@ -228,7 +228,7 @@ func TestInferObjectSpreadUnsupported(t *testing.T) {
 	require.Equal(t, "Unsupported: ObjSpreadExpr", c.errs[0].Message())
 }
 
-// A computed key ({[k]: v}) carries no static field name — M4.
+// A computed key ({[k]: v}) carries no static field name and is not yet supported.
 func TestInferObjectComputedKeyUnsupported(t *testing.T) {
 	c := newChecker()
 	computed := ast.NewProperty(ast.NewComputedKey(identExpr("k")), false, false, numExpr(1), testSpan())
@@ -266,13 +266,13 @@ func TestInferMemberMissingProperty(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// Optional chaining (recv?.prop) needs union/undefined handling — M6.
+// Optional chaining (recv?.prop) needs union/undefined handling and is not yet supported.
 func TestInferMemberOptionalChainUnsupported(t *testing.T) {
 	c := newChecker()
 	e := ast.NewMember(objExpr(prop("a", numExpr(5))), ast.NewIdentifier("a", testSpan()), true, testSpan())
 
 	got := c.inferExpr(NewScope(), 0, e)
-	require.IsType(t, &soltype.ErrorType{}, got) // PR8: report's recovery placeholder
+	require.IsType(t, &soltype.ErrorType{}, got) // report's recovery placeholder
 	require.Len(t, c.errs, 1)
 	require.Equal(t, "Unsupported: OptionalChain", c.errs[0].Message())
 	require.Equal(t, testSpan(), c.errs[0].Span())
@@ -294,7 +294,7 @@ func TestInferMemberOptionalChainDoesNotDescendIntoReceiver(t *testing.T) {
 // A malformed `recv.` (no valid property name) leaves Prop.Name empty; the
 // parser has already reported the missing identifier, so the walk must NOT layer
 // a spurious "object is missing property: " on top. It yields the ErrorType
-// recovery sentinel (PR8) — not a raw never — so that if the read flows into a
+// recovery sentinel — not a raw never — so that if the read flows into a
 // sink (`if recv. {}`, `await recv.`, `var x = recv.`) the sentinel absorbs in
 // constrain rather than cascading `never <: …`. It reports nothing itself.
 func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
@@ -309,8 +309,8 @@ func TestInferMemberEmptyPropertyNameIsSilent(t *testing.T) {
 }
 
 // A function reading a field of its param synthesizes an inexact "has at least this
-// field" requirement during body inference (A1's selection-vs-concrete split), then
-// SEALS it to exact at generalization (B1/B2's operative close): `p` is `non-open`
+// field" requirement during body inference via the selection-vs-concrete split, then
+// SEALS it to exact at generalization. `p` is `non-open`
 // and never escapes — `p.a`'s result is returned, but `p` itself is not — so its
 // requirement closes to exact `{a: number}` and a wider argument is rejected. An
 // `open` param keeps the row-polymorphic form and accepts the wider object. This

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestInferOpenParam exercises the `open` parameter marker end to end (M4 B2): an
-// `open` param's usage-inferred object renders row-polymorphic (inexact), while an
-// un-`open` peer closes to exact (the B1 Policy-A close). Passing an object with
-// extra fields to the open param checks.
+// TestInferOpenParam exercises the `open` parameter marker end to end. An `open`
+// param's usage-inferred object renders row-polymorphic and inexact, while an
+// un-`open` peer closes to exact. Passing an object with extra fields to the open
+// param checks.
 func TestInferOpenParam(t *testing.T) {
 	t.Run("open param renders inexact", func(t *testing.T) {
 		values, _, errs := inferSource(t, "fn dist(open p) { p.x\n p.y }")
@@ -28,8 +28,8 @@ func TestInferOpenParam(t *testing.T) {
 		require.Empty(t, errs)
 	})
 
-	// The operative seal (B2): a closed param's requirement is sealed to exact at
-	// generalization, so a call passing an object with extra fields is rejected.
+	// A closed param's requirement is sealed to exact at generalization, so a call
+	// passing an object with extra fields is rejected.
 	t.Run("passing extra fields to a closed param rejects", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
 		require.Len(t, errs, 1)

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PR6 — function overloading for free functions. A name with more than one
-// top-level FuncDecl is an overload set; a direct call resolves to the arm whose
-// parameter accepts the argument, via resolveOverload (a phase distinct from
-// constrain, driven by the PR5 probe).
+// Function overloading for free functions. A name with more than one top-level
+// FuncDecl is an overload set. A direct call resolves to the arm whose parameter
+// accepts the argument, via resolveOverload, a phase distinct from constrain and
+// driven by the resolution probe.
 
 // Per-argument-type resolution: f(5) picks the number arm, f("hi") the string arm,
 // each call yielding that arm's return type.
@@ -102,8 +102,8 @@ func TestInferOverloadSpecificityBeatsDeclarationOrder(t *testing.T) {
 // A call with an unconstrained argument (a still-unconstrained parameter variable)
 // falls back to declaration-order first-match: f(y) inside `fn (y) {…}` resolves to
 // the first arm and pins y to that arm's parameter type. This over-narrows the
-// enclosing function (g then rejects a later g("hi")) — a documented MVP limitation
-// whose real fix (deferred resolution) is tracked in #723.
+// enclosing function, so g then rejects a later g("hi"). It is a known limitation
+// whose real fix is deferred resolution.
 func TestInferOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return x }
@@ -146,8 +146,8 @@ func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
 // A self-recursive fully-annotated overload type-checks: each arm's recursive call
 // resolves against the whole pre-bound overload set (the number arm's f(x) hits the
 // number arm, the string arm's hits the string arm), so neither arm is wrongly
-// checked against the other. (Before the pre-binding fix this reported two spurious
-// `cannot constrain` errors because the recursive reference saw only the first arm.)
+// checked against the other. Before the pre-binding fix this reported two spurious
+// `cannot constrain` errors because the recursive reference saw only the first arm.
 func TestInferOverloadSelfRecursiveAnnotated(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return f(x) }
@@ -188,9 +188,9 @@ func TestInferOverloadNonRecursiveAnnotatedAllowed(t *testing.T) {
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
 }
 
-// Value-position use (PR6 scoped lattice exception): a let-bound overloaded name is
-// the INTERSECTION of its arms, and calling THROUGH that binding resolves each call
-// via constrain's function-intersection-sub arm — g(5) ⇒ number, g("hi") ⇒ string.
+// Value-position use: a let-bound overloaded name is the INTERSECTION of its arms,
+// and calling THROUGH that binding resolves each call via constrain's
+// function-intersection-sub arm — g(5) ⇒ number, g("hi") ⇒ string.
 func TestInferOverloadValuePosition(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return x }
@@ -264,7 +264,7 @@ func TestInferOverloadThreeArmSpecificity(t *testing.T) {
 	require.Equal(t, "true", values["r"], "falls back to the generic arm")
 }
 
-// Resolution rollback (exercising the PR5 probe): the first-tried arm (string) is a
+// Resolution rollback exercising the resolution probe: the first-tried arm (string) is a
 // non-match for a number-bounded argument variable; its speculative `arg <: string`
 // upper bound must be rolled back, so after resolution the argument var carries ONLY
 // the winning (number) arm's bound — never the loser's. Built directly so the

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 E1: structural destructuring patterns ---
+// --- structural destructuring patterns ---
 
 // An object pattern in a `val` binds each named field at its field type. The
 // function below reads the bound names back, so the inferred return shows the
@@ -88,7 +88,7 @@ func TestInferObjectPatternParam(t *testing.T) {
 }
 
 // An UN-annotated destructuring parameter infers its shape from the leaves' uses
-// (usage-based inference), closing the coalesced object to exact (Policy A).
+// through usage-based inference, closing the coalesced object to exact.
 func TestInferObjectPatternParamInferred(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn g({a, b}) {
@@ -165,7 +165,7 @@ func TestInferObjectPatternLeafDefault(t *testing.T) {
 
 // A trailing rest element relaxes the tuple requirement to an inexact prefix, so
 // the fixed slots bind without a spurious arity error. The rest element itself is
-// reported unsupported, since typed rest tuples are M9.
+// reported unsupported, since typed rest tuples are not implemented yet.
 func TestInferTuplePatternRestPrefix(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(t: [number, string, boolean]) {
@@ -194,8 +194,8 @@ func TestInferDestructuredLeafClosureCapture(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number}) -> number", values["f"])
 }
 
-// A `var` tuple destructuring widens each leaf to its primitive, the B3 widening
-// applied through the initializer.
+// A `var` tuple destructuring widens each leaf to its primitive, applying the
+// literal widening through the initializer.
 func TestInferVarTupleDestructureWidens(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f() {
@@ -245,7 +245,7 @@ func TestInferObjectPatternLeafDefaultViolatesAnnotation(t *testing.T) {
 	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
 }
 
-// --- M4 E2: the `match` expression ---
+// --- the `match` expression ---
 
 // A match over a structural pattern binds the pattern's leaves and types the arm
 // body against them. An exact-object scrutinee with a matching structural arm is
@@ -265,7 +265,7 @@ func TestInferMatchBindsArm(t *testing.T) {
 // An unannotated param used only as a match scrutinee infers its shape from the arm
 // patterns, the same usage-based inference a member read drives. Each arm's pattern
 // emits its member-lookup requirements onto the scrutinee var. A bound field the body
-// never uses lands as `unknown`, and the inferred object closes to exact (Policy A).
+// never uses lands as `unknown`, and the inferred object closes to exact.
 func TestInferMatchParamUsageObject(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p) {

--- a/internal/solver/infer_poly_test.go
+++ b/internal/solver/infer_poly_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PR1 let-generalization, Category-A acceptance against real source. M2 froze
-// every top-level binding to a coalesced monotype; PR1 generalizes at the SCC
-// boundary so a polymorphic binding is instantiated fresh per use.
+// Let-generalization acceptance against real source. Generalization
+// happens at the SCC boundary so a polymorphic binding is instantiated fresh per
+// use.
 //
 // Each test pins the rendered signature, exercising the printer's <T0, …> prefix.
 // A render is COMPACT when the signature names the fewest type parameters it can,
 // with no two always-together variables left as separate parameters.
 //
 // Identity is compact from the same variable appearing in both positions; the
-// captured-param case (InnerCapturesOuterParam) needs PR2's co-occurrence merging
+// captured-param case (InnerCapturesOuterParam) needs co-occurrence merging
 // to collapse its three always-together variables into one type parameter. The
 // two-types-of-use BEHAVIOR is asserted alongside the render as the real proof of
 // polymorphism.
@@ -27,7 +27,8 @@ import (
 func TestInferModuleTopLevelLetPolymorphism(t *testing.T) {
 	t.Run("render", func(t *testing.T) {
 		// Identity's param and return are the same variable, so its render is
-		// compact even before PR2 — this pins the <T0> quantifier prefix.
+		// compact even without co-occurrence merging — this pins the <T0>
+		// quantifier prefix.
 		values, _, errs := inferSource(t, `fn id(x) { return x }`)
 		require.Empty(t, errs)
 		require.Equal(t, map[string]string{"id": "fn <T0>(x: T0) -> T0"}, values)
@@ -50,7 +51,7 @@ func TestInferModuleTopLevelLetPolymorphism(t *testing.T) {
 
 // Applying a polymorphic identity at two different argument types in one
 // expression yields each argument's own type (not their union), so the tuple is
-// ["hello", 5]. This is the headline Category-A render — compact in PR1 because
+// ["hello", 5]. This is the headline render — compact because
 // every remaining variable coalesces to a concrete literal.
 func TestInferModuleIdentityPolymorphism(t *testing.T) {
 	values, _, errs := inferSource(t, `
@@ -65,12 +66,12 @@ func TestInferModuleIdentityPolymorphism(t *testing.T) {
 }
 
 // A body-level inner function that captures an outer parameter keeps the capture
-// through generalization (M2's eager body-level coalescing froze it to `never`).
-// The param flows to both tuple positions through two fresh result variables, so
-// the raw scheme carries three distinct quantified variables — PR1 rendered the
-// non-compact `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`. PR2's co-occurrence merging
-// recognises that the three always appear together and collapses them to one type
-// parameter: `fn <T0>(y: T0) -> [T0, T0]`. Applying outer to 5 still yields [5, 5],
+// through generalization. The param flows to both tuple positions through two
+// fresh result variables, so the raw scheme carries three distinct quantified
+// variables, which without merging would render the non-compact
+// `fn <T0, T1>(y: T0 & T1) -> [T0, T1]`. Co-occurrence merging recognises that the
+// three always appear together and collapses them to one type parameter:
+// `fn <T0>(y: T0) -> [T0, T0]`. Applying outer to 5 still yields [5, 5],
 // confirming the merge preserves the input→output connection.
 func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 	values, _, errs := inferSource(t, `
@@ -87,7 +88,7 @@ func TestInferModuleInnerCapturesOuterParam(t *testing.T) {
 
 // Let-polymorphism extends to body-level `val`s: an inner polymorphic function
 // used at two types within the same body resolves each use independently. A
-// monomorphic body-level binding (M2) would render [5 | "hi", 5 | "hi"].
+// monomorphic body-level binding would render [5 | "hi", 5 | "hi"].
 func TestInferModuleBodyLevelLetPolymorphism(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val f = fn () {
@@ -126,8 +127,8 @@ func TestInferModulePolymorphicWithParameterOnlyVar(t *testing.T) {
 	}, values)
 }
 
-// A recursive group generalizes without looping (the coalesce seen-guard, shipped
-// in M2 PR-5, keeps the cyclic var↔var bound graph total under generalization too).
+// A recursive group generalizes without looping. The coalesce seen-guard keeps the
+// cyclic var↔var bound graph total under generalization too.
 // The ungrounded mutual recursion bottoms out: each param is unused (parameter-only
 // ⇒ unknown) and each return is an ungrounded recursive position (⇒ never). The
 // real contract is that inference TERMINATES rather than hangs.

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- PR8 Part 1: the ErrorType error-recovery sentinel, end-to-end ---
+// --- The ErrorType error-recovery sentinel, end-to-end ---
 //
 // report mints ErrorType (not never) as the value-position recovery placeholder
 // after emitting a diagnostic. ErrorType absorbs in both directions inside
-// constrain, so a single reported error never cascades a spurious second one — at
+// constrain, so a single reported error never cascades a spurious second one at
 // any sink the broken value later flows into. These exercise that through the real
-// parser, complementing the constrain-level unit tests (constrain_test.go) and the
-// if/await cascade tests (infer_async_test.go).
+// parser, complementing the constrain-level unit tests in constrain_test.go and the
+// if/await cascade tests in infer_async_test.go.
 
 // A value bound to a broken (unknown-identifier) initializer flows into a call
 // argument WITHOUT producing a second error: the ErrorType placeholder absorbs the
@@ -34,8 +34,8 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 }
 
 // An unsupported expression recovers to the ErrorType sentinel and flows on without
-// cascading. Here the unsupported expression is an object spread, which is M9. The
-// only error is the unsupported-node one, and the surrounding object still builds.
+// cascading. Here the unsupported expression is an object spread. The only error is
+// the unsupported-node one, and the surrounding object still builds.
 func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val o = {...xs}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -10,7 +10,7 @@ import (
 // with whether the block DIVERGES (always transfers control out before reaching
 // its tail, so it completes no value). The block runs in the scope it is given —
 // the caller establishes it (inferFunc passes the param scope, so body-level
-// val/var redeclarations overwrite alongside the params, per §3.2). soltype.Void
+// val/var redeclarations overwrite alongside the params). soltype.Void
 // is the result of a block that ends in a declaration or a value-free statement.
 //
 // The divergence flag is the single source of truth for "this block produces no
@@ -40,12 +40,12 @@ func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) (soltype.Type,
 // inferStmt types a single statement and returns the value it contributes to
 // the enclosing block (void for declarations and bare returns without an
 // operand). Body-level declarations are VarDecl-only: a DeclStmt wrapping any
-// other decl kind is a permanent BodyDeclNotAllowedError (§3.2), not the
-// temporary subset gate. Each val/var introduces a fresh, independent binding
+// other decl kind is a BodyDeclNotAllowedError. Each val/var introduces a
+// fresh, independent binding
 // and overwrites the name's slot in the current scope, so redeclaration rebinds
 // without constraining the old and new types together.
 func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
-	// M4 G1: record the enclosing statement so a reassignment in expression position
+	// Record the enclosing statement so a reassignment in expression position
 	// can find its CFG StmtRef for transition checking. A no-op outside a function
 	// body (c.fn == nil), where no liveness analysis ran.
 	if c.fn != nil {
@@ -87,18 +87,18 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				c.reportUnsupported(vd)
 				return &soltype.Void{}
 			}
-			// M4 E1: a destructuring `val`/`var` such as `{x, y} = …` or `[a, b] = …`.
+			// A destructuring `val`/`var` such as `{x, y} = …` or `[a, b] = …`.
 			// Type the initializer, then bind the pattern's leaves against it as
 			// monomorphic projections.
 			c.inferDestructureDecl(scope, lvl, vd)
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is
-		// allowed and overwrites the name's slot (§3.2). inferVarDecl reports a
+		// allowed and overwrites the name's slot. inferVarDecl reports a
 		// missing initializer itself and returns ok=false; bind only when it
 		// produced a type.
 		if b, ok := c.inferVarDecl(scope, lvl, vd); ok {
-			// M4 G1: carry the rename-assigned VarID onto the binding so a later
+			// Carry the rename-assigned VarID onto the binding so a later
 			// closure capture resolves this body-level binding to its alias set, then
 			// track the alias the declaration creates and check its mutability
 			// transition. Both are no-ops outside a function body (c.fn == nil).

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -55,8 +55,8 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 	values = make(map[string]string, len(scope.values))
 	for name, b := range scope.values {
 		if b.IsOverloaded() {
-			// PR6: an overload set renders as the intersection of its arms (declaration
-			// order), matching the value-position type of the overloaded name.
+			// An overload set renders as the intersection of its arms in declaration
+			// order, matching the value-position type of the overloaded name.
 			arms := make([]soltype.Type, len(b.Schemes))
 			for i, s := range b.Schemes {
 				arms[i] = schemeType(s)
@@ -64,7 +64,7 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 			values[name] = soltype.Print(&soltype.IntersectionType{Types: arms})
 			continue
 		}
-		// PR1: an ordinary binding holds exactly one scheme; renderScheme adds the
+		// An ordinary binding holds exactly one scheme; renderScheme adds the
 		// <T0, …> quantifier prefix when generalization left type parameters behind.
 		values[name] = renderScheme(b.Schemes[0])
 	}
@@ -72,17 +72,17 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 	return values, types, errs
 }
 
-// inferSource is the single-file table harness (§3.6) — fast, no on-disk
-// fixtures. It is the one-file case of inferSources.
+// inferSource is the single-file table harness — fast, no on-disk fixtures. It is
+// the one-file case of inferSources.
 func inferSource(t *testing.T, src string) (values, types map[string]string, errs []SolverError) {
 	t.Helper()
 	return inferSources(t, map[string]string{"input.esc": src})
 }
 
-// inferSources is the multi-file table harness (§3.6): several in-memory sources
-// keyed by file path, parsed into one combined module and inferred together. This
+// inferSources is the multi-file table harness. Several in-memory sources keyed by
+// file path are parsed into one combined module and inferred together. This
 // exercises the exact dep-graph-spanning-files path an on-disk fixture would, with
-// no package.json / file-discovery ceremony (the real fixture harness is M8).
+// no package.json or file-discovery ceremony.
 func inferSources(t *testing.T, srcs map[string]string) (values, types map[string]string, errs []SolverError) {
 	t.Helper()
 	return inferModule(parseModuleFiles(t, srcs))
@@ -146,8 +146,8 @@ func TestInferModuleValDecls(t *testing.T) {
 	}
 }
 
-// PR-4: object literals, tuple literals, and member access infer end-to-end
-// through the real parser pipeline. Field reads resolve through a record-typed
+// Object literals, tuple literals, and member access infer end-to-end through the
+// real parser pipeline. Field reads resolve through a record-typed
 // binding (constrain's record <: record arm lowers the result from the matching
 // field), and a read of an absent field surfaces a MissingPropertyError.
 func TestInferModuleObjectsAndTuples(t *testing.T) {
@@ -204,14 +204,14 @@ func TestInferModuleFieldReadMissingProperty(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "object is missing property: b", errs[0].Message())
-	// M2.5: blame the member's prop, not the whole decl.
+	// Blame the member's prop, not the whole decl.
 	require.Equal(t, "b", spanText(src, errs[0].Span()))
 	require.Equal(t, map[string]string{"o": "{a: 5}", "x": "never"}, values)
 }
 
-// A forward reference — a decl that uses a name defined later in the source —
-// failed in PR-2 (source-order walk). PR-5 orders declarations by the dep graph,
-// so x's component is inferred before y's and the reference now resolves.
+// A forward reference is a decl that uses a name defined later in the source.
+// Declarations are ordered by the dep graph, so x's component is inferred before
+// y's and the reference resolves.
 func TestInferModuleForwardReferenceResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val y = x
@@ -221,33 +221,32 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 	require.Equal(t, map[string]string{"x": "5", "y": "5"}, values)
 }
 
-// A top-level declaration outside the M2 subset reports a clean
-// UnsupportedNodeError rather than panicking. A type alias is such a decl — type
-// bindings are M3+ — so it registers a type-sort dep_graph key the SCC driver
-// reports as unsupported. (FuncDecl, unsupported at the module level through
-// PR-2, is now wired in by PR-5; see the func/recursion tests.)
+// A top-level declaration outside the supported subset reports a clean
+// UnsupportedNodeError rather than panicking. A type alias is such a decl, so it
+// registers a type-sort dep_graph key the SCC driver reports as unsupported.
+// FuncDecl is wired into the module walk; see the func/recursion tests.
 func TestInferModuleUnsupportedDecl(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported: TypeDecl", errs[0].Message())
-	// M2.5: the error self-blames from the decl node.
+	// The error self-blames from the decl node.
 	require.Equal(t, src, spanText(src, errs[0].Span()))
 	// The unsupported decl must not leak a type binding.
 	require.NotContains(t, types, "Foo")
 }
 
-// A `val` with no initializer can't be inferred in M2 (annotation-driven binding
-// needs TypeAnn support that lands later); it reports MissingInitializerError and
-// binds NOTHING, so a later reference still fails as an unknown identifier rather
-// than silently resolving to a placeholder.
+// A `val` with no initializer can't be inferred yet, since annotation-driven
+// binding needs TypeAnn support. It reports MissingInitializerError and binds
+// NOTHING, so a later reference still fails as an unknown identifier rather than
+// silently resolving to a placeholder.
 func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
 	src := `declare val x: number`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
-	// M2.5: the error self-blames from the decl node (whose span, per the parser,
-	// covers the binder but not the trailing annotation).
+	// The error self-blames from the decl node, whose span, per the parser,
+	// covers the binder but not the trailing annotation.
 	require.Equal(t, "declare val x", spanText(src, errs[0].Span()))
 	require.Empty(t, values)
 }
@@ -262,8 +261,8 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 	require.Len(t, errs, 2)
 	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
 	require.Equal(t, "Unknown identifier: x", errs[1].Message())
-	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
-	// sentinel (`val y = <unknown>`) recovers AS `error` rather than freezing to
+	// A binding whose definition is wholly the ErrorType recovery sentinel,
+	// as in `val y = <unknown>`, recovers AS `error` rather than freezing to
 	// `never`, so downstream uses of y absorb instead of cascading `<: never`.
 	require.Equal(t, map[string]string{"y": "error"}, values)
 }
@@ -278,15 +277,15 @@ func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Duplicate declaration: x", errs[0].Message())
-	// M2.5: blame the second decl; relate the first ("previously declared here").
+	// Blame the second decl; relate the first as "previously declared here".
 	require.Equal(t, `val x = "hi"`, spanText(src, errs[0].Span()))
 	require.Len(t, errs[0].Related(), 1)
 	require.Equal(t, `val x = 5`, spanText(src, errs[0].Related()[0]))
 	require.Equal(t, map[string]string{"x": "5"}, values)
 }
 
-// #720: a function body's last expression is NOT an implicit return — only an
-// explicit `return` produces the function's value, mirroring the old checker's
+// A function body's last expression is NOT an implicit return — only an explicit
+// `return` produces the function's value, mirroring the old checker's
 // inferFuncBody. The bare tail is still walked for its checking side effects,
 // but its value is discarded and the body returns void.
 func TestInferFuncBodyTailIsNotImplicitReturn(t *testing.T) {
@@ -309,10 +308,10 @@ func TestInferFuncBodyDiscardedTailStillChecked(t *testing.T) {
 	require.Equal(t, "fn () -> void", values["f"])
 }
 
-// PR-5: dep_graph SCC ordering wires top-level FuncDecls into the module walk and
-// makes inference order-independent. Each case asserts the rendered MONOMORPHIC
-// binding types end-to-end — recursion resolves through the group var, but M1
-// ships no schemes so nothing generalizes (no <T0>); that is M3.
+// dep_graph SCC ordering wires top-level FuncDecls into the module walk and makes
+// inference order-independent. Each case asserts the rendered MONOMORPHIC binding
+// types end-to-end. Recursion resolves through the group var, but no schemes ship
+// yet so nothing generalizes and no <T0> appears.
 func TestInferModuleSCCOrdering(t *testing.T) {
 	tests := []struct {
 		name string
@@ -333,8 +332,9 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 			},
 		},
 		{
-			// A self-recursive function with no base case (M2 has no conditionals)
-			// never returns, so its return type coalesces to never. It resolves
+			// A self-recursive function with no base case, since conditionals are
+			// not supported yet, never returns, so its return type coalesces to
+			// never. It resolves
 			// because the SCC driver pre-binds foo to a var before its body.
 			name: "SelfRecursive",
 			src:  `fn foo(x: number) { return foo(x) }`,
@@ -375,13 +375,11 @@ func TestInferModuleSCCOrdering(t *testing.T) {
 	}
 }
 
-// An ungrounded mutually-recursive group — each body calls the other with no
-// return annotation and no base case — builds a cyclic var↔var bound graph.
-// M1's coalesce had no recursion guard, so a guard-free inline walk would loop
-// here forever; PR-5 pulls the M3 path-scoped guard forward (coalesce.go,
-// m2-implementation-plan §7), collapsing the ungrounded recursive return to
-// never (⊥). The assertion is really a termination test: it must complete rather
-// than hang.
+// An ungrounded mutually-recursive group, where each body calls the other with no
+// return annotation and no base case, builds a cyclic var↔var bound graph. A
+// guard-free inline walk would loop here forever. The path-scoped guard in
+// coalesce.go collapses the ungrounded recursive return to never (⊥). The
+// assertion is really a termination test. It must complete rather than hang.
 func TestInferModuleUngroundedMutualRecursionTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn a(n: number) { return b(n) }
@@ -414,10 +412,10 @@ func TestInferModuleValInRecursiveGroupUsesRawType(t *testing.T) {
 	}, values)
 }
 
-// PR6: repeated top-level functions of the same name are an OVERLOAD SET. The
-// binding renders as the intersection of its arms, and a call resolves to the arm
-// whose parameter accepts the argument — f(5) picks the number arm, f("hi") the
-// string arm. (This replaces M2's interim OverloadNotSupportedError.)
+// Repeated top-level functions of the same name are an OVERLOAD SET. The binding
+// renders as the intersection of its arms, and a call resolves to the arm whose
+// parameter accepts the argument. f(5) picks the number arm, f("hi") the string
+// arm.
 func TestInferModuleFunctionOverloadResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return x }
@@ -451,13 +449,13 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 	require.NotContains(t, types, "Foo")
 }
 
-// PR-6: multi-file resolution. Several in-memory files are parsed into one
-// combined module (parser.ParseLibFiles unions files that share a path-derived
-// namespace) and inferred together; a top-level `val`/`fn` in one file resolves a
-// binding from another by root-namespace short name. This is the M2 exit
-// criterion — a multi-file module resolving via the dep graph — exercised
-// end-to-end through the real parser + InferModule + soltype printer. All
-// inference is MONOMORPHIC (M1 ships no schemes; <T0> generalization is M3).
+// Multi-file resolution. Several in-memory files are parsed into one combined
+// module, where parser.ParseLibFiles unions files that share a path-derived
+// namespace, and inferred together. A top-level `val`/`fn` in one file resolves a
+// binding from another by root-namespace short name. A multi-file module resolving
+// via the dep graph is exercised end-to-end through the real parser, InferModule,
+// and the soltype printer. All inference is MONOMORPHIC, since no schemes ship yet
+// and no <T0> generalization appears.
 func TestInferMultiFile(t *testing.T) {
 	tests := []struct {
 		name string
@@ -531,19 +529,20 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 	})
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
-	// M2.5: the error self-blames from the ident node.
+	// The error self-blames from the ident node.
 	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
-	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
-	// sentinel recovers AS `error` rather than freezing to `never`.
+	// A binding whose definition is wholly the ErrorType recovery sentinel
+	// recovers AS `error` rather than freezing to `never`.
 	require.Equal(t, map[string]string{"y": "error", "z": "5"}, values)
 }
 
-// Error recovery for a NAMED callee: a too-many-args call still yields the
-// callee's declared return type (not `never`), matching the inline-callee recovery
-// asserted by TestInferCallTooManyArgs. M3's inferIdent returns an instantiated
-// var rather than a concrete FuncType, so inferCall recovers the return through the
-// var's FuncType lower bound (resolveFunc); without that, `r` regressed to `never`.
-// PR4: too-many is the extra-arg lint (TooManyArgsError), not a FuncArityMismatch.
+// Error recovery for a NAMED callee. A too-many-args call still yields the
+// callee's declared return type, not `never`, matching the inline-callee recovery
+// asserted by TestInferCallTooManyArgs. inferIdent returns an instantiated var
+// rather than a concrete FuncType, so inferCall recovers the return through the
+// var's FuncType lower bound via resolveFunc. Without that, `r` regressed to
+// `never`. Too-many is the extra-arg lint (TooManyArgsError), not a
+// FuncArityMismatch.
 func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(x: number) -> number { return x }

--- a/internal/solver/info.go
+++ b/internal/solver/info.go
@@ -7,8 +7,7 @@ import (
 
 // Info is the AST->type side table (à la go/types.Info). The new checker records
 // inferred types here rather than mutating ast nodes via InferredType() /
-// SetInferredType(). No probe/cleanup discipline in M1 — that arrives with
-// Prov/Probe in a later milestone.
+// SetInferredType().
 type Info struct {
 	types map[ast.Node]soltype.Type
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -7,10 +7,10 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// newUnion and newIntersection are the M6 PR1 smart constructors. They are
+// newUnion and newIntersection are the smart constructors. They are
 // the single mint path for UnionType and IntersectionType. Every site that
 // builds a lattice node routes through them, so coalesced output, the
-// shared-property meet in mergeObjectGroup, PR2's annotation input, and PR6's
+// shared-property meet in mergeObjectGroup, the annotation input, and the
 // permissive borrow join all produce well-formed, canonical, deduplicated
 // lattice nodes without re-spelling the rules.
 //
@@ -19,8 +19,8 @@ import (
 // identities, ErrorType elision, dedup, canonical order, and collapse. Every
 // caller needs it. Subsumption runs only when the caller passes a Context,
 // because the subtype test it uses calls c.constrain under a probe. combine
-// and mergeObjectGroup pass nil. resolveTypeAnn from PR2 and joinBorrows from
-// PR6 pass their checker's Context.
+// and mergeObjectGroup pass nil. resolveTypeAnn and joinBorrows pass their
+// checker's Context.
 //
 // Canonical member order keeps equalType positional and cheap. Two unions
 // over the same members hold them in the same order, so equalTypeSlice
@@ -247,7 +247,7 @@ func collapseIntersection(pruned []soltype.Type, hadError bool) soltype.Type {
 // pass pre-sorts the input by compareType, so the iteration order is
 // canonical and newUnion([A, B]) and newUnion([B, A]) drop the same member
 // when A and B subsume each other but differ structurally. That is the
-// canonicalization contract the M6 plan asserts.
+// canonicalization contract.
 func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, sibling soltype.Type) bool) []soltype.Type {
 	if len(parts) < 2 {
 		return parts

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -28,8 +28,8 @@ func TestNewUnionNormalization(t *testing.T) {
 			name: "inexact nested member makes outer inexact",
 			// A nested inexact UnionType carries the inexact flag out to the
 			// outer mint. parseType cannot author an inexact union literal
-			// today (PR4 lands the surface marker), so the nested member is
-			// built from a parsed exact union with Inexact flipped.
+			// today, since the surface marker is not available, so the nested
+			// member is built from a parsed exact union with Inexact flipped.
 			parts:   []soltype.Type{&soltype.UnionType{Types: []soltype.Type{num()}, Inexact: true}, parseType(t, "string")},
 			inexact: false,
 			want:    &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true},
@@ -185,9 +185,9 @@ func TestNewIntersectionNormalization(t *testing.T) {
 	}
 }
 
-// TestNewUnionCanonicalOrder is the M6 PR1 gate against speculative-pinning
-// drift. A union of a member list and of its shuffle must render identically
-// and compare equalType-equal.
+// TestNewUnionCanonicalOrder is the gate against speculative-pinning drift. A
+// union of a member list and of its shuffle must render identically and compare
+// equalType-equal.
 func TestNewUnionCanonicalOrder(t *testing.T) {
 	a := newUnion(nil, parseTypes(t, "number", "string"), false)
 	b := newUnion(nil, parseTypes(t, "string", "number"), false)
@@ -231,9 +231,9 @@ func TestNewIntersectionSubsumeWithContext(t *testing.T) {
 	require.True(t, equalType(parseType(t, "{x: number, y: string, ...}"), got), "got %s", soltype.Print(got))
 }
 
-// TestSubsumeMutualPicksCanonicalSurvivor pins the M6 PR1 canonicalization
-// fix. When two members mutually subsume but are not equalType-equal, the
-// survivor must be deterministic across input shuffles.
+// TestSubsumeMutualPicksCanonicalSurvivor pins the canonicalization behavior.
+// When two members mutually subsume but are not equalType-equal, the survivor must
+// be deterministic across input shuffles.
 //
 // Function callback subtyping is the case that triggers mutual subsumption
 // today. A typed-rest function `(...xs: T[]) -> R` and an inexact
@@ -274,7 +274,7 @@ func TestSubsumeMutualPicksCanonicalSurvivor(t *testing.T) {
 // TestNewUnionNoSubsumeWithoutContext is the negative case. Without a
 // Context, the constructor leaves non-equal subsumable members in place.
 // This is the `combine` posture, where coalesced output is deduped and
-// lattice-pruned but not subsumed. PR8 closes this gap at the finalization
+// lattice-pruned but not subsumed. The gap is closed at the finalization
 // boundaries.
 func TestNewUnionNoSubsumeWithoutContext(t *testing.T) {
 	got := newUnion(nil, parseTypes(t, "number", "1"), false)

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -7,7 +7,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Display-time lifetime coalescing (M4 D4). The structural coalescers (coalesce /
+// Display-time lifetime coalescing. The structural coalescers (coalesce /
 // coalesceScheme) rebuild a type through the shared visitor, which carries every
 // RefType lifetime through unchanged because a Lifetime is not a Type. They leave
 // the RAW lifetime variables in place: a borrow parameter's originated lifetime, a
@@ -43,11 +43,11 @@ import (
 //     argument lifetime and the callee's freshened parameter lifetime, related only
 //     by a mix of upper and lower bounds, so reachability cannot be confined to one
 //     bound direction. A lifetime forced to 'static renders 'static and absorbs.
-//     FUTURE (M6.5, lifetime bounds): this undirected grouping is a D4
-//     approximation, sound only because independent param lifetimes never share a
-//     bound-graph component. M6.5 replaces it with directional reasoning over the
-//     LowerBounds/UpperBounds edges, rendering a join as precise where-clauses like
-//     `where 'a: 'c, 'b: 'c` rather than collapsing it to the union ('a | 'b).
+//     This undirected grouping is an approximation, sound only because independent
+//     param lifetimes never share a bound-graph component. A future directional
+//     reasoning over the LowerBounds/UpperBounds edges could render a join as
+//     precise where-clauses like `where 'a: 'c, 'b: 'c` rather than collapsing it
+//     to the union ('a | 'b).
 //
 // coalesceLifetimes resolves the borrow lifetimes left raw by the structural
 // coalescers. pol is the root polarity the type was coalesced at, threaded through
@@ -115,9 +115,9 @@ type ltAnalysis struct {
 // independent param borrows through a shared intermediary would break it. The two
 // would be unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing
 // that case needs directional reasoning, or first-class lifetime bounds, which the
-// union rendering deliberately does not yet model. M6.5 (lifetime bounds) is the
-// milestone that retires this undirected grouping, replacing it with directional
-// reasoning over the LowerBounds/UpperBounds edges. See the join-expansion note above.
+// union rendering deliberately does not yet model. Directional reasoning over the
+// LowerBounds/UpperBounds edges would retire this undirected grouping. See the
+// join-expansion note above.
 func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
 	uf := newUnionFind()
 	vars := map[int]*soltype.LifetimeVar{}

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 D2.5: lifetime-sort generalization (levels + per-instantiation freshening) ---
+// --- lifetime-sort generalization: levels and per-instantiation freshening ---
 //
-// A lifetime carried by a borrow now rides the same let-generalization level
-// hierarchy as a type variable: a lifetime minted above its scheme's
-// generalize-level is a quantified param lifetime, freshened per instantiation, so
-// two uses of a borrow-passing function never share one LifetimeVar's bounds.
-// These tests drive freshenAbove (the instantiation copy) directly, mirroring how
-// lifetime_test.go drives constrainLt directly.
+// A lifetime carried by a borrow rides the same let-generalization level hierarchy
+// as a type variable: a lifetime minted above its scheme's generalize-level is a
+// quantified param lifetime, freshened per instantiation, so two uses of a
+// borrow-passing function never share one LifetimeVar's bounds. These tests drive
+// freshenAbove, the instantiation copy, directly, mirroring how lifetime_test.go
+// drives constrainLt directly.
 
 // mutObjAt builds `mut <lt> {x: number}` — a borrow carrying the given lifetime,
 // the minimal shape that exercises a RefType lifetime through the rewriters.
@@ -83,8 +83,9 @@ func TestFreshenTwoInstantiationsGetDistinctLifetimes(t *testing.T) {
 
 // Constraining one instantiation's lifetime does not perturb another's: the two
 // freshened lifetimes have independent bound lists. This is the contamination a
-// shared LifetimeVar would have caused — before D2.5 both call sites aliased the
-// scheme's one lifetime var, so a bound from one site leaked into the other.
+// shared LifetimeVar would have caused. Without per-instantiation freshening both
+// call sites aliased the scheme's one lifetime var, so a bound from one site leaked
+// into the other.
 func TestFreshenInstantiationsAreNonContaminating(t *testing.T) {
 	c := newChecker()
 	lt := c.ctx.freshLifetime(1)
@@ -142,10 +143,10 @@ func TestFreshenCopiesLifetimeBoundsUnderProbe(t *testing.T) {
 	require.Len(t, lt.UpperBounds, 1, "the original scheme lifetime's bound is untouched by the discarded trial")
 }
 
-// Source-level regression: the D2 IdentityRefReturn acceptance still renders the
-// shared param lifetime on the generalized scheme. D2.5 freshens lifetimes at
-// instantiation, but the scheme body keeps its original param lifetime. D4 names it
-// `'a` since it reaches both the parameter and the return.
+// Source-level regression: an identity-returning borrow function still renders the
+// shared param lifetime on the generalized scheme. Freshening copies lifetimes at
+// instantiation, but the scheme body keeps its original param lifetime. Lifetime
+// naming names it `'a` since it reaches both the parameter and the return.
 func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}) { return p }`)
 	require.Empty(t, errs)
@@ -153,9 +154,9 @@ func TestInferIdentityRefReturnStillRendersAfterGeneralization(t *testing.T) {
 }
 
 // Source-level regression: a borrow-passing function called at two distinct sites
-// typechecks cleanly. Before D2.5 both calls shared the callee's one param
-// lifetime, linking the two borrows; freshening per instantiation keeps them
-// independent so neither call contaminates the other.
+// typechecks cleanly. Previously both calls shared the callee's one param lifetime,
+// linking the two borrows. Freshening per instantiation keeps them independent so
+// neither call contaminates the other.
 func TestInferBorrowFnCalledAtTwoSites(t *testing.T) {
 	src := `fn use(o: mut {x: number}) -> number {
   return o.x
@@ -172,7 +173,7 @@ fn f(a: mut {x: number}, b: mut {x: number}) {
 // --- extruder lifetime arm ---
 //
 // extrude copies a type so a variable above the target level is replaced by a
-// fresh var at that level, wired to the original. D2.5 extends it to the lifetime
+// fresh var at that level, wired to the original. It also extends to the lifetime
 // sort: a borrow's lifetime above the level is extruded too. These drive extrude
 // directly, the first tests to do so.
 

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -114,8 +114,8 @@ func TestConstrainLtReflexiveIsNoOp(t *testing.T) {
 }
 
 // A borrowed value flowing into 'static storage has its lifetime forced to outlive
-// 'static. This is the EscapingRefIntoStatic acceptance (M4 D3). constrainEscape
-// constrains the borrow's lifetime `<: 'static`, so coalescing the borrow renders it
+// 'static. constrainEscape constrains the borrow's lifetime `<: 'static`, so
+// coalescing the borrow renders it
 // `&'static mut {x: number}` rather than under the param's own name. No Escalier
 // construct routes a borrow into static storage yet, since a borrow originates only
 // at a parameter, so this exercises the rule's mechanism directly.
@@ -172,10 +172,10 @@ func mutPointRef(lt soltype.Lifetime) *soltype.RefType {
 }
 
 // borrowFn wraps a return type in a function whose parameters carry the given borrow
-// lifetimes. D4 names a lifetime only when it originates at a parameter, which means
-// it occurs in a negative position. So a join's member lifetimes must appear on
-// parameters to be named or expanded, exactly how joinBorrows produces them from
-// real source.
+// lifetimes. Lifetime naming names a lifetime only when it originates at a parameter,
+// which means it occurs in a negative position. So a join's member lifetimes must
+// appear on parameters to be named or expanded, exactly how joinBorrows produces them
+// from real source.
 func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(paramLts))
 	for i, lt := range paramLts {
@@ -188,9 +188,9 @@ func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType 
 }
 
 // Escaping a JOINED borrow forces every param lifetime the join reaches to outlive
-// 'static, so the whole `('a | 'b)` union collapses to a single 'static. This is the
-// join↔escape interaction (M4 D3). constrainEscape constrains the join lifetime
-// `<: 'static`, which propagates through its lower bounds to each member, and
+// 'static, so the whole `('a | 'b)` union collapses to a single 'static.
+// constrainEscape constrains the join lifetime `<: 'static`, which propagates
+// through its lower bounds to each member, and
 // coalesceLifetimes then absorbs the union to 'static rather than expanding it.
 func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	c := newChecker()
@@ -218,8 +218,8 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// D4 elision keeps the `&` on a connect-nothing borrow by parking its lifetime on
-// the Anon sentinel, so an immutable borrow whose lifetime reaches no output
+// Lifetime elision keeps the `&` on a connect-nothing borrow by parking its lifetime
+// on the Anon sentinel, so an immutable borrow whose lifetime reaches no output
 // still renders as `&{x}` rather than collapsing to the bare inner. The mutable
 // case keeps the `&mut` form for the same reason.
 func TestImmutableConnectNothingBorrowKeepsRef(t *testing.T) {
@@ -349,7 +349,7 @@ func TestProbeLifetimeCommittedChildCoveredByParentDiscard(t *testing.T) {
 	require.Empty(t, b.LowerBounds)
 }
 
-// Test 1 — the lower-bound propagation branch. TestConstrainLtPropagatesTransitively
+// The lower-bound propagation branch. TestConstrainLtPropagatesTransitively
 // exercises propagation through the SUPER variable's upper bounds; this exercises the
 // distinct `subVar.LowerBounds` loop: with lb <: a already recorded, constraining
 // a <: super must propagate lb <: super through a's existing lower bound.
@@ -367,7 +367,7 @@ func TestConstrainLtPropagatesThroughLowerBounds(t *testing.T) {
 	require.Contains(t, super.LowerBounds, soltype.Lifetime(lb), "super sees lb as a lower bound from the same propagation")
 }
 
-// Test 2 — a probe discard rolls back vars touched TRANSITIVELY, not just the ones
+// A probe discard rolls back vars touched TRANSITIVELY, not just the ones
 // named at the constrainLt call site. With a <: b set pre-probe, a single
 // constrainLt(x, a) under the probe touches x, a, AND b (x <: a <: b), and the
 // discard must truncate every probe-era bound while leaving the pre-probe ones.
@@ -397,7 +397,7 @@ func TestProbeDiscardRollsBackTransitivelyTouchedLifetimes(t *testing.T) {
 	require.Equal(t, soltype.Lifetime(a), b.LowerBounds[0], "b's pre-probe lower bound survives")
 }
 
-// Test 3 — recordLt journals a lifetime var at most once per probe, even across
+// recordLt journals a lifetime var at most once per probe, even across
 // several appends to it, so the single snapshot truncates every later append on
 // discard. Mirrors the type sort's TestProbeRecordDedupsPerVariable. Each
 // constrainLt(a, …) also touches its super var, so the probe holds three entries
@@ -425,7 +425,7 @@ func TestProbeRecordLtDedupsPerLifetimeVar(t *testing.T) {
 	require.Empty(t, a.UpperBounds, "both speculative bounds on a are truncated via the single journal entry")
 }
 
-// Test 5 — a probe built directly as &Probe{} (bypassing newProbe) is safe for the
+// A probe built directly as &Probe{} (bypassing newProbe) is safe for the
 // lifetime sort too: ltTouched is lazily created on first recordLt, so there is no
 // nil-map panic. Mirrors the type sort's TestProbeBareLiteralIsNilMapSafe.
 func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
@@ -444,7 +444,7 @@ func TestProbeBareLiteralLifetimeIsNilMapSafe(t *testing.T) {
 	require.Empty(t, b.LowerBounds)
 }
 
-// Test 6a — a discarded child reverts only ITS OWN lifetime appends, leaving the
+// A discarded child reverts only ITS OWN lifetime appends, leaving the
 // parent's journal and the var's parent-era bounds intact. Mirrors the type sort's
 // TestDiscardedChildLeavesParentJournalIntact.
 func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
@@ -468,7 +468,7 @@ func TestProbeLifetimeDiscardedChildLeavesParentJournalIntact(t *testing.T) {
 	require.Empty(t, a.UpperBounds, "the parent discard reverts its own lifetime bound")
 }
 
-// Test 6b — when the parent has NOT touched a lifetime var the committed child did,
+// When the parent has NOT touched a lifetime var the committed child did,
 // the child's snapshot is inherited so the parent discard reverts the child's bound
 // to the var's pre-child length. Mirrors TestCommittedChildInheritsUntouchedVarSnapshot.
 func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
@@ -487,7 +487,7 @@ func TestProbeLifetimeCommittedChildInheritsUntouchedVarSnapshot(t *testing.T) {
 	require.Empty(t, b.LowerBounds)
 }
 
-// Test 7 — re-constraining a lifetime bound already present journals nothing: the
+// Re-constraining a lifetime bound already present journals nothing: the
 // ContainsLifetime guard skips the append, so no recordLt fires and a discard is a
 // clean no-op that leaves the pre-probe bound untouched. This verifies the
 // "no journal entry without an append" invariant for the lifetime sort.
@@ -508,12 +508,12 @@ func TestProbeReconstrainingPresentLifetimeBoundJournalsNothing(t *testing.T) {
 	require.Equal(t, soltype.Lifetime(b), a.UpperBounds[0])
 }
 
-// Test 8 — the lifetime bound minted by the RefType constrain arm itself is
+// The lifetime bound minted by the RefType constrain arm itself is
 // journaled, so a discarded trial rolls it back. The earlier probe tests drive
-// constrainLt directly; this drives it THROUGH constrain over two `mut` borrows
-// (the now-active step 3, D2), confirming the RefType arm participates in the same
-// speculation discipline as a direct constrainLt call. Without journaling here, a
-// failed overload trial that constrained two borrows would leak a lifetime bound.
+// constrainLt directly. This drives it THROUGH constrain over two `mut` borrows,
+// confirming the RefType arm participates in the same speculation discipline as a
+// direct constrainLt call. Without journaling here, a failed overload trial that
+// constrained two borrows would leak a lifetime bound.
 func TestProbeRollsBackLifetimeBoundFromRefArm(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -16,24 +16,18 @@ import (
 // stdlib-type placeholders resolve through the parent), the Info side table, and
 // any SolverErrors.
 //
-// PR-5 replaces PR-2's source-order loop with dep_graph SCC ordering: a decl that
-// forward-references a name defined later in the source, or that mutually
-// recurses with another decl, now infers correctly because BuildDepGraph
-// topologically orders the strongly connected components and inferComponent makes
-// every member of a group visible before inferring any of their bodies.
-// Inference is MONOMORPHIC — M1 ships no schemes, so each binding's var stays as its
-// coalesced monomorphic type; the generalization that yields <T0> rendering is
-// M3.
+// Declarations are ordered by dep_graph SCC ordering rather than source order: a
+// decl that forward-references a name defined later in the source, or that mutually
+// recurses with another decl, infers correctly because BuildDepGraph topologically
+// orders the strongly connected components and inferComponent makes every member of
+// a group visible before inferring any of their bodies.
 //
-// Multi-file (PR-6) needs no separate entry point: parser.ParseLibFiles already
+// Multi-file inference needs no separate entry point. parser.ParseLibFiles already
 // assembles several sources into one *ast.Module, unioning files that share a
 // path-derived namespace into the same Namespace.Decls. BuildDepGraph then spans
 // every file, so a `val`/`fn` in one file resolving a top-level `val`/`fn` in
 // another is just an ordinary cross-component reference the SCC ordering already
-// handles — that is the M2 "multi-file module resolves via the dep graph" exit
-// criterion. Cross-file references in M2 use root-namespace short names; qualified
-// namespace-member access (`Foo.bar`) is M4, and third-party `@types`/`.d.ts`
-// ingestion (internal/resolver) is M7 — M2 engages neither.
+// handles.
 func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 	c := newChecker()
 	scope := sharedPrelude().Child()
@@ -52,7 +46,7 @@ func InferModule(module *ast.Module) (*Scope, *Info, []SolverError) {
 // graph did not model.
 func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph) {
 	handled := set.NewSet[ast.Decl]()
-	// M4 E3: dep_graph fans one top-level destructuring `val {x, y} = …` across one
+	// dep_graph fans one top-level destructuring `val {x, y} = …` across one
 	// SCC component per leaf key. Its initializer is typed and its pattern bound
 	// once, memoized here on the first leaf reached. Each leaf component then
 	// constrains its own projected type into its binding var.
@@ -75,9 +69,9 @@ func (c *checker) inferDepGraph(scope *Scope, lvl int, module *ast.Module, g *de
 	})
 }
 
-// overloadArm is one collected arm of an overload set (PR6): a top-level FuncDecl's
-// raw inferred type plus whether its signature is fully annotated (the recursion
-// gate) and the decl itself (for per-arm Info recording in phase 3).
+// overloadArm is one collected arm of an overload set: a top-level FuncDecl's
+// raw inferred type plus whether its signature is fully annotated for the recursion
+// gate and the decl itself for per-arm Info recording in phase 3.
 type overloadArm struct {
 	decl      *ast.FuncDecl
 	t         soltype.Type // the arm's RAW (variable-carrying) inferred FuncType
@@ -96,22 +90,22 @@ type componentBinding struct {
 	// infoNode is the AST node phase 3 records the binding's generalized display type
 	// on, for Info and go-to-definition. It is the binding's own name-bearing node: a
 	// VarDecl's pattern, a FuncDecl's name, or — for a top-level destructuring — the
-	// individual pattern leaf this key binds, e.g. the `a` IdentPat of `val [a, b] = …`
-	// (M4 E3). A destructuring records per leaf rather than on the whole decl pattern,
+	// individual pattern leaf this key binds, e.g. the `a` IdentPat of `val [a, b] = …`.
+	// A destructuring records per leaf rather than on the whole decl pattern,
 	// which its sibling leaf keys share.
 	infoNode ast.Node
 	bound    bool // a definition was inferred and constrained
 	// isVarDecl reports whether the primary decl is a VarDecl, i.e. a `val` or a `var`
 	// rather than a function. It is NOT the `var`-vs-`val` distinction — that is kind.
 	isVarDecl bool
-	kind      ast.VariableKind // PR8: the primary definition's kind — VarKind ⇒ reassignable
+	kind      ast.VariableKind // the primary definition's kind — VarKind ⇒ reassignable
 	// recovered marks that a contributing definition was WHOLLY the ErrorType recovery
 	// sentinel (e.g. `val a = <unknown ident>`). ErrorType absorbs in constrain, so it
 	// leaves no bound on the binding var; phase 3 uses this to recover the binding AS
-	// ErrorType rather than freezing an unbound var to `never` (which would cascade
-	// `<: never` at every later use). See PR8 / inferComponent phase 3.
+	// ErrorType rather than freezing an unbound var to `never`, which would cascade
+	// `<: never` at every later use. See inferComponent phase 3.
 	recovered bool
-	// arms collects every top-level FuncDecl under this key (PR6). len <= 1 is an
+	// arms collects every top-level FuncDecl under this key. len <= 1 is an
 	// ordinary function (or a non-function binding, len == 0); len > 1 is an overload
 	// set, bound as a multi-scheme ValueBinding in phase 3. arms[i] lines up with the
 	// FuncDecl's entry in sources.
@@ -123,28 +117,20 @@ type componentBinding struct {
 	// first-arm var; phase 2 only checks each arm's body. An overload with any
 	// un-annotated arm cannot be signature-bound (its signature isn't known without
 	// inferring the body), so it stays on the ordinary group-var path and cannot be
-	// mutually recursive (the gate forbids it). See checkOverloadAnnotations / annotatedOverloadArms.
+	// mutually recursive, since the gate forbids it. See checkOverloadAnnotations / annotatedOverloadArms.
 	signatureBound bool
 }
 
 // inferComponent infers one strongly connected component — a group of
-// mutually-recursive (or, in the singleton case, independent) top-level bindings
-// — and binds each name in scope. It follows the spike's LetRecGroup discipline
-// with NO placeholder/patching phase (the single biggest simplification the
-// simple-sub bridge buys over the old checker's two-phase
-// placeholder/definition pass):
+// mutually-recursive, or in the singleton case independent, top-level bindings —
+// and binds each name in scope. It runs in three phases with no
+// placeholder/patching pass:
 //
 //  1. give every VALUE binding in the component a fresh var at lvl+1 and define
 //     it in scope BEFORE any body is inferred, so a mutually-recursive reference
 //     resolves through the var;
 //  2. infer each declaration's definition at lvl+1 and constrain it <: its var;
-//  3. rebind each name to the coalesced MONOMORPHIC type of its var.
-//
-// M2 does NOT generalize (M1 ships no schemes): step 3 freezes each binding at
-// its coalesced monomorphic type rather than wrapping it in a PolyScheme. The
-// generalization that turns these into reusable polymorphic bindings — the <T0>
-// rendering — is M3. M2's contribution is correct ordering and recursive
-// resolution.
+//  3. generalize each name's var into a scheme and rebind it.
 func (c *checker) inferComponent(
 	scope *Scope, lvl int, module *ast.Module, g *dep_graph.DepGraph,
 	component []dep_graph.BindingKey, handled set.Set[ast.Decl],
@@ -152,8 +138,8 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
-	// Recursion gate (PR6): an overloaded function in a mutually-recursive component
-	// (more than one binding) must have fully-annotated arms, since the overload set
+	// Recursion gate: an overloaded function in a mutually-recursive component of
+	// more than one binding must have fully-annotated arms, since the overload set
 	// has to be ground before bodies are inferred — fixed-point iteration over
 	// overload choices is not guaranteed to converge under subtyping. The gate reports
 	// the offending participants and returns the set of keys to degrade to a single
@@ -162,14 +148,14 @@ func (c *checker) inferComponent(
 	rejected := c.checkOverloadAnnotations(g, component)
 
 	// Phase 1: a fresh var per value binding, all defined before any body so a
-	// mutually-recursive reference resolves through the var. M2 only infers value
-	// bindings; type-sort keys are handled (as unsupported) after the value walk.
+	// mutually-recursive reference resolves through the var. Only value bindings are
+	// inferred; type-sort keys are reported as unsupported after the value walk.
 	bindings := make(map[dep_graph.BindingKey]*componentBinding, len(component))
 	for _, key := range component {
 		if key.Kind() != dep_graph.DepKindValue {
 			continue
 		}
-		// PR6: a fully-annotated overload set is pre-bound to the whole SET, built from
+		// A fully-annotated overload set is pre-bound to the whole SET, built from
 		// arm signatures alone (body-free), so references within the component resolve
 		// against every arm via resolveOverload instead of seeing only a single
 		// first-arm binding var (which would make a recursive arm — or a value capture —
@@ -230,7 +216,7 @@ func (c *checker) inferComponent(
 			continue
 		}
 		for _, d := range g.GetDecls(key) {
-			// M4 E3: a top-level destructuring `val [a, b] = …` / `val {x, y} = …`
+			// A top-level destructuring `val [a, b] = …` / `val {x, y} = …`
 			// registers one decl under one leaf key per bound name. Bind it per key it
 			// appears under, before the handled-dedup that gates ordinary decls, so a
 			// destructuring decl sharing a name with another decl still binds its other
@@ -262,8 +248,8 @@ func (c *checker) inferComponent(
 			// list is kept only for a future multi-target go-to-definition that wants to
 			// reach every contributing decl, duplicates included.
 			b.sources = append(b.sources, src)
-			// PR8: a definition that is wholly the ErrorType recovery sentinel leaves no
-			// bound on the binding var (ErrorType absorbs in constrain). Remember it so
+			// A definition that is wholly the ErrorType recovery sentinel leaves no
+			// bound on the binding var, since ErrorType absorbs in constrain. Remember it so
 			// phase 3 can recover the binding as ErrorType instead of `never`.
 			if _, isErr := t.(*soltype.ErrorType); isErr {
 				b.recovered = true
@@ -283,12 +269,12 @@ func (c *checker) inferComponent(
 				} else if isFunc {
 					b.infoNode = fd.Name
 				}
-				// PR8: carry the decl's kind so phase 3 can gate reassignment — a top-level
-				// `var` is reassignable (e.g. from a function body that closes over it);
+				// Carry the decl's kind so phase 3 can gate reassignment. A top-level
+				// `var` is reassignable, e.g. from a function body that closes over it;
 				// a `val`/`fn` is not. A FuncDecl leaves kind at its ValKind zero value.
 				if isVarDecl {
 					b.kind = vd.Kind
-					// M4 B3: an un-annotated `var` widens at coalesce time, so its literal
+					// An un-annotated `var` widens at coalesce time, so its literal
 					// initializer reads back as the primitive (`var a = 5` ⇒ number) and a
 					// later reassignment of the same primitive checks. An annotated `var`
 					// adopts its annotation, which needs no widening.
@@ -296,7 +282,7 @@ func (c *checker) inferComponent(
 						b.v.Widenable = true
 					}
 				}
-				// PR6: when the primary decl is a function, record it as the first arm. If
+				// When the primary decl is a function, record it as the first arm. If
 				// more FuncDecls follow under this name it becomes an overload set; otherwise
 				// it stays a lone function.
 				if isFunc {
@@ -304,8 +290,8 @@ func (c *checker) inferComponent(
 				}
 				continue
 			}
-			// Past the first decl, the binding already has its primary definition. PR6
-			// treats a repeated FuncDecl as another overload arm. It was already inferred
+			// Past the first decl, the binding already has its primary definition. A
+			// repeated FuncDecl is treated as another overload arm. It was already inferred
 			// independently above, so collect it and let phase 3 bind the full set as a
 			// multi-scheme overload binding. Every other repeat keeps the first decl and
 			// reports a duplicate — a second `val`/`var`, or a FuncDecl colliding with a
@@ -322,9 +308,9 @@ func (c *checker) inferComponent(
 		}
 	}
 
-	// Non-value keys (type aliases, classes, …) are outside the M2 subset. Report
-	// each contributing decl once, skipping any already handled by a value key (a
-	// class/enum contributes both a value and a type key for the same decl).
+	// Non-value keys such as type aliases and classes are not yet supported. Report
+	// each contributing decl once, skipping any already handled by a value key, since
+	// a class/enum contributes both a value and a type key for the same decl.
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -341,8 +327,8 @@ func (c *checker) inferComponent(
 	// Phase 3: rebind each value name to its coalesced monomorphic type. A binding
 	// whose declarations all failed to produce a definition (missing initializer,
 	// destructuring, unsupported kind) is removed rather than left as a `never`
-	// placeholder, matching PR-2: a later reference to it is then a genuine
-	// unknown-identifier error instead of resolving to a stray binding.
+	// placeholder, so a later reference to it is a genuine unknown-identifier error
+	// instead of resolving to a stray binding.
 	for _, key := range component {
 		b, isValue := bindings[key]
 		if !isValue {
@@ -352,7 +338,7 @@ func (c *checker) inferComponent(
 			scope.removeValue(key.Name())
 			continue
 		}
-		// A PR6 overload set is a name with more than one FuncDecl arm. This branch binds
+		// An overload set is a name with more than one FuncDecl arm. This branch binds
 		// such a set when the recursion gate did not reject it. A rejected set is a
 		// mutually-recursive unannotated overload. It is excluded here and degrades to its
 		// first arm below.
@@ -413,19 +399,18 @@ func (c *checker) inferComponent(
 			scope.defineValue(key.Name(), ValueBinding{Schemes: schemes, Sources: srcs, ModuleLevel: true})
 			continue
 		}
-		// Generalize the binding var at the component's level (was: coalesce to a
-		// monotype). Every variable at Level > lvl becomes a quantified type
-		// parameter, captured outer variables do not — turning M2's monomorphic
-		// freeze into real let-polymorphism (PR1). A rejected overload degrades here to
-		// its first arm: b.v carries only the primary (first arm) definition.
+		// Generalize the binding var at the component's level. Every variable at
+		// Level > lvl becomes a quantified type parameter, while captured outer
+		// variables do not, giving real let-polymorphism. A rejected overload degrades
+		// here to its first arm: b.v carries only the primary first-arm definition.
 		//
-		// PR8: a binding whose definition was wholly the ErrorType sentinel left its
-		// binding var with no bound (ErrorType absorbs in constrain), so generalizing it
+		// A binding whose definition was wholly the ErrorType sentinel left its binding
+		// var with no bound, since ErrorType absorbs in constrain, so generalizing it
 		// would freeze the binding to `never` and cascade `<: never` at every later use
-		// (a reassignment, a call arg, …). Recover it AS the error sentinel instead,
-		// matching the body-level path (inferVarDecl) and keeping downstream uses
+		// such as a reassignment or a call arg. Recover it AS the error sentinel instead,
+		// matching the body-level path inferVarDecl and keeping downstream uses
 		// absorbing. Guarded by an empty binding var so a binding that ALSO picked up a
-		// real type (a recovered overload arm alongside a good one) still generalizes.
+		// real type, a recovered overload arm alongside a good one, still generalizes.
 		var scheme TypeScheme
 		if b.recovered && len(b.v.LowerBounds) == 0 {
 			scheme = &MonoScheme{Ty: &soltype.ErrorType{}}
@@ -450,8 +435,8 @@ func (c *checker) inferComponent(
 	}
 }
 
-// moduleDestructure memoizes a top-level destructuring decl's typed pattern (M4
-// E3). dep_graph fans one `val {x, y} = …` across one component per bound name, so
+// moduleDestructure memoizes a top-level destructuring decl's typed pattern.
+// dep_graph fans one `val {x, y} = …` across one component per bound name, so
 // every leaf key points at the same decl. The pattern must be typed and bound only
 // ONCE — typing the initializer or re-binding the pattern per leaf would re-report
 // its errors and duplicate work — so the first leaf key whose component is processed
@@ -495,7 +480,7 @@ func asDestructureDecl(d ast.Decl) *ast.VarDecl {
 }
 
 // bindModuleDestructureLeaf binds one leaf of a top-level destructuring decl into
-// its pre-bound binding var (M4 E3). destructurePattern types the decl's pattern
+// its pre-bound binding var. destructurePattern types the decl's pattern
 // once and memoizes it. This call looks up THIS key's projected leaf type and
 // constrains it into b.v, so phase 3 generalizes the leaf independently. `key` is
 // this leaf's binding key. Its bound name is the key name minus the decl's namespace
@@ -533,7 +518,7 @@ func (c *checker) bindModuleDestructureLeaf(
 	if md.recovered {
 		b.recovered = true
 	}
-	// M4 B3: an un-annotated `var` leaf widens at coalesce time, so a literal it
+	// An un-annotated `var` leaf widens at coalesce time, so a literal it
 	// binds reads back as the primitive and a later reassignment of the same
 	// primitive checks. An annotated `var` adopts its annotation, which needs no
 	// widening. A `val` leaf is a fixed singleton.
@@ -544,7 +529,7 @@ func (c *checker) bindModuleDestructureLeaf(
 
 // destructurePattern types a top-level destructuring decl's initializer and binds
 // its pattern ONCE, memoizing the per-leaf projected types so each leaf component
-// reuses them (M4 E3). The initializer flows through the shared inferVarDeclInit
+// reuses them. The initializer flows through the shared inferVarDeclInit
 // core, so an annotation is honored and a `var` initializer is widened, exactly as
 // the body-level path does. The pattern is bound with a collecting emit that records
 // each leaf's projection without defining it in scope. Phase 1 already pre-bound
@@ -586,7 +571,7 @@ func leafName(g *dep_graph.DepGraph, key dep_graph.BindingKey) string {
 	return name
 }
 
-// checkOverloadAnnotations enforces the PR6 recursion gate. It returns the set of
+// checkOverloadAnnotations enforces the recursion gate. It returns the set of
 // overloaded keys that failed the gate; phase 3 degrades each of them to its first arm.
 // A singleton component is never gated, since self-recursion is softer. Only a
 // genuinely mutually-recursive group of more than one binding requires its overloaded
@@ -639,7 +624,7 @@ func funcOnlyDecls(g *dep_graph.DepGraph, key dep_graph.BindingKey) []*ast.FuncD
 }
 
 // annotatedOverloadArms returns key's FuncDecls when it is a function-only overload
-// set that can be PRE-BOUND from signatures alone (PR6): more than one FuncDecl, NO
+// set that can be PRE-BOUND from signatures alone: more than one FuncDecl, NO
 // `val`/`var` mixed under the name, and every arm fully annotated (so its signature
 // is known without inferring the body). Returns nil otherwise — those keys take the
 // ordinary group-var path, where each arm is inferred independently and the set is

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -8,32 +8,31 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Overload resolution, introduced in PR6. A name with more than one top-level FuncDecl
-// is an overload set. Its ValueBinding carries one TypeScheme per arm ordered by source
-// position. armPosLess in module.go defines that order as file path, then line, then column.
-// A set whose arms span several files in a lib/ therefore reads top-to-bottom, file by
-// file alphabetically, independent of the order sources reached the parser.
+// Overload resolution. A name with more than one top-level FuncDecl is an overload set.
+// Its ValueBinding carries one TypeScheme per arm ordered by source position. armPosLess
+// in module.go defines that order as file path, then line, then column. A set whose arms
+// span several files in a lib/ therefore reads top-to-bottom, file by file alphabetically,
+// independent of the order sources reached the parser.
 //
 // Resolution is a phase distinct from constrain. The disjunction "callable in several
-// ways" stays out of the subtype lattice. It is driven by the PR5 probe. Each candidate
+// ways" stays out of the subtype lattice. It is driven by the probe. Each candidate
 // is trialled under a probe and the losers are rolled back, so a failed trial leaves no
 // bounds on the argument variables and no stray Info or Prov entries.
 //
-// Specificity ordering is the one documented rule, reused by M4 object-arg and M5 method
-// overloads. When every argument carries type information, meaning none is an
-// unconstrained variable, candidates are tried most-specific-first. Arm A is more
-// specific than B when they share an arity and every parameter of A is a structural
-// subtype of B's, with at least one strict. So a concrete `(x: number)` outranks a
-// generic `(x: T)`.
+// Specificity ordering is the one documented rule. When every argument carries type
+// information, meaning none is an unconstrained variable, candidates are tried
+// most-specific-first. Arm A is more specific than B when they share an arity and every
+// parameter of A is a structural subtype of B's, with at least one strict. So a concrete
+// `(x: number)` outranks a generic `(x: T)`.
 //
 // Specificity is only a partial order. Incomparable arms fall back to declaration order
 // through a stable sort. Arms are incomparable when they have different literal tags,
 // disjoint shapes, or different arities.
 //
 // When an argument is still a fully-unconstrained variable, the call cannot rank arms
-// confidently, so resolution defers to plain declaration-order first-match. This is the
-// documented MVP fallback, with no speculative pinning and backtracking. The first arm
-// whose argument constraints succeed wins. Its bounds are committed and the rest roll back.
+// confidently, so resolution defers to plain declaration-order first-match. There is no
+// speculative pinning and backtracking. The first arm whose argument constraints succeed
+// wins. Its bounds are committed and the rest roll back.
 
 // resolveOverload picks one arm of the overload set b for the call and returns that
 // arm's instantiated return type. It commits the winning arm's argument constraints and
@@ -71,12 +70,12 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // error-returning Context.Constrain rather than the accumulating checker.constrain, so a
 // rejected argument never reaches c.errs even before the probe's errs rollback.
 //
-// Arity follows the direct-call accept-set from #677, reusing acceptSet so the overload
-// arity gate and the FuncType<:FuncType constraint gate can never drift. A count below
-// acceptSet's lower bound is too few, and a count above its upper bound is too many.
-// Either is a non-match, unless the arm is inexact or has a rest. Extra arguments that
-// such an arm absorbs impose no per-element constraint here. That per-element check needs
-// Array types, which arrive in M4.
+// Arity follows the direct-call accept-set, reusing acceptSet so the overload arity gate
+// and the FuncType<:FuncType constraint gate can never drift. A count below acceptSet's
+// lower bound is too few, and a count above its upper bound is too many. Either is a
+// non-match, unless the arm is inexact or has a rest. Extra arguments that such an arm
+// absorbs impose no per-element constraint here. That per-element check needs Array types,
+// which are not yet implemented.
 func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bool {
 	n := len(args)
 	if lo, hi := acceptSet(inst); n < lo || n > hi {
@@ -87,7 +86,7 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 			// Past the fixed params, or AT a trailing rest param. The rest or inexact tail
 			// absorbs this and every later argument. Don't constrain a scalar argument
 			// against the rest param's ARRAY element type, since Params[i].Type is `T[]`.
-			// Per-element checking is M4.
+			// Per-element checking is not yet implemented.
 			break
 		}
 		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); len(errs) > 0 {
@@ -169,7 +168,7 @@ func specificityOrder(funcs []*soltype.FuncType) []int {
 // hasUnconstrainedArg reports whether any top-level call argument is a fully-unconstrained
 // inference variable — a bare var with no bounds either way, which carries no type
 // information to rank overloads by. overloadOrder treats a true result as "can't rank the
-// arms" and falls back to declaration order (see there and #723).
+// arms" and falls back to declaration order.
 //
 // The check is shallow by design: a compound that merely WRAPS a bare var (a tuple,
 // record, or func) doesn't count, since structuralSubtype ranks such shapes as a tie and

--- a/internal/solver/parse_type_test.go
+++ b/internal/solver/parse_type_test.go
@@ -24,9 +24,9 @@ import (
 //
 // A union or intersection is built through newUnion / newIntersection with no
 // Context, so the result is normalized exactly as the production combine path
-// would produce it. ast.UnionTypeAnn carries no Inexact flag today (that
-// arrives with M6 PR4), so parseType always produces an exact union. A test
-// that needs an inexact union mints one through newUnion(..., true).
+// would produce it. ast.UnionTypeAnn carries no Inexact flag today, so parseType
+// always produces an exact union. A test that needs an inexact union mints one
+// through newUnion(..., true).
 func parseType(t *testing.T, s string) soltype.Type {
 	t.Helper()
 	ta, errs := parser.ParseTypeAnn(context.Background(), s)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -7,9 +7,9 @@ import (
 
 // bindPattern types an ast.Pat against a scrutinee type, binding every leaf
 // identifier the pattern introduces into scope and returning the soltype.Pat
-// mirror used to render a destructured parameter (M4 E1). It is the
-// structural-pattern path shared by `val`/`var` destructuring and function-param
-// destructuring. E2's `match` arms reuse it too.
+// mirror used to render a destructured parameter. It is the structural-pattern
+// path shared by `val`/`var` destructuring and function-param destructuring.
+// `match` arms reuse it too.
 //
 // A pattern dispatches through the member-lookup constraint path, not subtyping.
 // An ObjectPat `{x, y}` against a scrutinee `s` emits `s <: {x: βx, ...}` and
@@ -30,7 +30,7 @@ import (
 // bindPattern places each leaf as a monomorphic binding in scope, the body-level
 // and function-param strategy. The top-level driver needs the leaves constrained
 // into pre-bound binding vars instead, so it calls bindPatternWith with its own
-// emit (M4 E3).
+// emit.
 func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type) soltype.Pat {
 	return c.bindPatternWith(scope, lvl, pat, scrutinee, leafTypes, defineLeafMono)
 }
@@ -38,7 +38,7 @@ func (c *checker) bindPattern(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 // leafEmit places one bound leaf: it receives the leaf's name, its projected type,
 // and its pattern node. defineLeafMono defines a fresh monomorphic binding in scope
 // for the body-level and function-param paths. The top-level driver passes an emit
-// that constrains the leaf's type into a pre-bound binding var instead (M4 E3).
+// that constrains the leaf's type into a pre-bound binding var instead.
 type leafEmit func(scope *Scope, name string, t soltype.Type, node ast.Node)
 
 // defineLeafMono is the default leaf-placement strategy: it defines the leaf as a
@@ -75,7 +75,7 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 		// arm. For a NESTED slot the scrutinee here is the field's covariant result
 		// var, which carries no upper bound. So a kind mismatch like `{x: "hi"}`
 		// against `{x: number}` is not yet rejected. The refutable literal-pattern
-		// check lands with E2's `match`, which this path is laid out to extend. A
+		// check lands with `match`, which this path is laid out to extend. A
 		// literal pattern binds nothing.
 		c.constrain(p, lt, scrutinee)
 		c.recordType(p, lt)
@@ -86,8 +86,8 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 		// long as the fixed prefix, so the requirement becomes an INEXACT tuple over
 		// the fixed elements. Without a rest the requirement stays exact and a wrong
 		// arity is a TupleLengthMismatchError. The rest element itself needs typed
-		// rest tuples, which arrive in M9, so it is reported unsupported and binds
-		// nothing.
+		// rest tuples, which are not yet implemented, so it is reported unsupported
+		// and binds nothing.
 		fixed := make([]ast.Pat, 0, len(p.Elems))
 		inexact := false
 		for _, e := range p.Elems {
@@ -157,7 +157,7 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 				sub := c.bindPatternWith(scope, lvl, e.Value, beta, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			default:
-				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
+				// ObjRestPat (`{...rest}`) needs object rest types, which are not yet implemented.
 				c.reportUnsupported(elem)
 			}
 		}
@@ -165,9 +165,9 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 		return &soltype.ObjectPat{Fields: fields}
 
 	default:
-		// ExtractorPat and InstancePat are the constructor patterns; they are M5. A
-		// bare RestPat is only meaningful inside a tuple or object. Report and bind
-		// nothing.
+		// ExtractorPat and InstancePat are the constructor patterns; they are not yet
+		// implemented. A bare RestPat is only meaningful inside a tuple or object.
+		// Report and bind nothing.
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
@@ -227,7 +227,7 @@ func propReq(name string, t soltype.Type, optional bool) *soltype.ObjectType {
 }
 
 // litTypeOf lowers an ast literal to its soltype LitType, mirroring inferLiteral.
-// ok=false for a literal kind outside the M-subset (the caller reports it).
+// ok=false for a literal kind that is not yet supported, which the caller reports.
 func (c *checker) litTypeOf(lit ast.Lit) (*soltype.LitType, bool) {
 	switch l := lit.(type) {
 	case *ast.NumLit:

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -7,27 +7,27 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// TypeScheme is a name's generalized type — the M3 replacement for M2's plain
-// soltype.Type binding. A MonoScheme is a value that does not generalize (a
-// parameter, a current-level initializer during inference, a body-level `val`, a prelude
-// operator); a PolyScheme carries a generalize-level so each use can be
-// instantiated with fresh variables (let-polymorphism). The IsAnnotated bit is
-// forward-looking metadata for PR6's overload-recursion gate — PR1 sets it false
-// and never reads it.
+// TypeScheme is a name's generalized type. A MonoScheme is a value that does not
+// generalize, such as a parameter, a current-level initializer during inference,
+// a body-level `val`, or a prelude operator. A PolyScheme carries a
+// generalize-level so each use can be instantiated with fresh variables, the
+// let-polymorphism path. The IsAnnotated bit is forward-looking metadata for the
+// overload-recursion gate. It is currently always false and never read.
 type TypeScheme interface {
 	isScheme()
 	// IsAnnotated reports whether this scheme came from a user-written signature.
-	// PR1 always returns false; PR6 sets it per overload arm and folds it over a
-	// binding's arms for the mutual-recursion-needs-annotation rule.
+	// It is currently always false. Overload resolution sets it per overload arm
+	// and folds it over a binding's arms for the mutual-recursion-needs-annotation
+	// rule.
 	IsAnnotated() bool
 }
 
 // MonoScheme is a non-generalized type. instantiate returns its Ty unchanged, so
-// every use shares the same variables — the monomorphic discipline M2 had for
-// every binding, now scoped to the bindings that genuinely must not generalize.
+// every use shares the same variables. This monomorphic discipline is scoped to
+// the bindings that genuinely must not generalize.
 type MonoScheme struct {
 	Ty        soltype.Type
-	Annotated bool // PR6 only — consulted solely for overload arms
+	Annotated bool // consulted solely for overload arms
 }
 
 // PolyScheme is a generalized type. Body is the RAW (variable-carrying) type so
@@ -38,7 +38,7 @@ type MonoScheme struct {
 type PolyScheme struct {
 	Level     int
 	Body      soltype.Type
-	Annotated bool // PR6 only — set per overload arm; folds for the recursion gate
+	Annotated bool // set per overload arm; folds for the recursion gate
 
 	// coalesced memoizes the display type. A Body is immutable after
 	// generalization. Later components instantiate fresh copies rather than
@@ -67,17 +67,17 @@ func (sc *PolyScheme) display() soltype.Type {
 func (s *MonoScheme) IsAnnotated() bool { return s.Annotated }
 func (s *PolyScheme) IsAnnotated() bool { return s.Annotated }
 
-// monoScheme wraps a raw type as a single-scheme value binding's scheme — the
-// common case for the param/prelude/body-level/raw-def bindings PR1 does not
-// generalize.
+// monoScheme wraps a raw type as a single-scheme value binding's scheme, the
+// common case for the param, prelude, body-level, and raw-def bindings that do
+// not generalize.
 func monoScheme(t soltype.Type) TypeScheme { return &MonoScheme{Ty: t} }
 
 // instantiate produces a usable type from a scheme at level lvl. A MonoScheme
 // instantiates to its type unchanged; a PolyScheme freshens every quantified
 // variable (Level > scheme.Level) with a fresh variable at lvl, bounds and all,
 // so two uses of a polymorphic binding never share inference variables. This is
-// the inferIdent value-position hook M2 left as a TODO — M2 returned the binding
-// type directly; PR1 routes it through here.
+// the inferIdent value-position hook: rather than returning the binding type
+// directly, the value position routes it through here.
 func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 	switch sc := s.(type) {
 	case *MonoScheme:
@@ -96,9 +96,10 @@ func (c *checker) instantiate(s TypeScheme, lvl int) soltype.Type {
 // the cache BEFORE its bounds are freshened so a recursive bound that references
 // the original resolves to the in-progress copy rather than looping.
 //
-// PR1 lands this hand-rolled, parallel to coalesce/extrude; PR7 collapses all
-// three onto a shared soltype rewriting visitor with no behavior change. Unlike
-// those two it ignores polarity (it freshens uniformly, no variance flip).
+// This is hand-rolled, parallel to coalesce/extrude. A future change could
+// collapse all three onto a shared soltype rewriting visitor with no behavior
+// change. Unlike those two it ignores polarity, freshening uniformly with no
+// variance flip.
 func (c *checker) freshenAbove(lim int, t soltype.Type, lvl int, cache map[*soltype.TypeVarType]*soltype.TypeVarType) soltype.Type {
 	return t.Accept(&freshener{
 		c:     c,
@@ -121,7 +122,7 @@ type freshener struct {
 	lvl   int
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
 	// lt freshens a borrow's lifetime, the second quantifiable sort Accept does not
-	// walk (M4 D2.5). It shares the freshener's lim/lvl and lazily allocates its own
+	// walk. It shares the freshener's lim/lvl and lazily allocates its own
 	// cache, so a borrow that flows to both a parameter and the return type keeps one
 	// shared fresh lifetime across them.
 	lt ltFreshener
@@ -137,12 +138,12 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	//     does NOT descend into the var's bounds — so this prune is sound only because
 	//     the MLsub level invariant holds (a var's level >= the level of everything in
 	//     its bounds, maintained by constrain/extrude). LevelOf DOES recurse into the
-	//     structural formers, INCLUDING Union/Intersection (PR6 made an overloaded
-	//     value's arm IntersectionType a legal scheme-body/constrain input — see
-	//     soltype.LevelOf): without that, a generic arm's Level>lim var would hide under
+	//     structural formers, INCLUDING Union/Intersection, because an overloaded
+	//     value's arm IntersectionType is a legal scheme-body and constrain input, see
+	//     soltype.LevelOf. Without that, a generic arm's Level>lim var would hide under
 	//     the level-0 intersection and two instantiations of a let-bound overload would
-	//     alias a variable that should have been fresh. The analogous extrude
-	//     (constrain.go) rests on the same level invariant.
+	//     alias a variable that should have been fresh. The analogous extrude in
+	//     constrain.go rests on the same level invariant.
 	//  2. (Identity) The shared subtree's pointer is reused across every instantiation
 	//     and the scheme body, so compound nodes are NOT uniquely minted per use. Prov
 	//     and Info are pointer-keyed; a shared monomorphic node keeps its one original
@@ -155,8 +156,8 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	}
 	if r, ok := t.(*soltype.RefType); ok {
 		// A borrow's lifetime is not a Type, so Accept carries it through unchanged and
-		// neither the structural rebuild below nor the var arm would ever freshen it
-		// (M4 D2.5). ltFreshener.fresh replaces a quantified param lifetime
+		// neither the structural rebuild below nor the var arm would ever freshen it.
+		// ltFreshener.fresh replaces a quantified param lifetime
 		// (Level > lim) and shares a captured, 'static, or nil one; refLifetimeResult
 		// then either hands back a RefType carrying the fresh lifetime or signals an
 		// ordinary descent so Accept rebuilds Inner.
@@ -180,8 +181,8 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	nv.Widenable = v.Widenable
 	f.cache[v] = nv
 	// Mint the FromInstantiation interior edge: the fresh var was copied from v.
-	// PR1 only records the edge; the multi-hop renderer that chases it back to an
-	// AST leaf is M11.5 (NodeFor still resolves only FromAST today).
+	// Only the edge is recorded; the multi-hop renderer that chases it back to an
+	// AST leaf is not yet implemented, so NodeFor still resolves only FromAST today.
 	f.c.recordInstantiation(nv, v)
 	// nv is freshly minted here, so these whole-slice bound assignments are
 	// intentionally NOT journaled by the probe (see Probe's doc): a fresh var is
@@ -226,8 +227,8 @@ type allFreshener struct {
 	c     *checker
 	lvl   int
 	cache map[*soltype.TypeVarType]*soltype.TypeVarType
-	// lt freshens a borrow's lifetime, which Accept does not walk (M4 D2.5). Without
-	// this arm a reassigned borrow-typed binding would keep its scheme's lifetime, so
+	// lt freshens a borrow's lifetime, which Accept does not walk. Without this arm
+	// a reassigned borrow-typed binding would keep its scheme's lifetime, so
 	// constraining the reassignment source would mutate the binding's own lifetime —
 	// the cross-use contamination freshenAll exists to prevent, here for the lifetime
 	// sort.
@@ -269,8 +270,8 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 	return out
 }
 
-// ltFreshener freshens lifetime variables for the rewriting visitors (M4 D2.5).
-// Accept never walks a RefType's lifetime, because a Lifetime is not a Type, so each
+// ltFreshener freshens lifetime variables for the rewriting visitors. Accept
+// never walks a RefType's lifetime, because a Lifetime is not a Type, so each
 // lifetime-aware visitor delegates here through refLifetimeResult. A LifetimeVar
 // inside lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
 // lvl and freshens its bounds, so each use gets its own lifetime and constraining
@@ -363,13 +364,13 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 //
 // sealUsageObjects runs first, the one body rewrite generalize performs: it is the
 // finalize point where a non-escaping usage-inferred object closes to exact in the
-// OPERATIVE body, so callers cannot pass extra fields (Policy A / B2). See its doc.
+// OPERATIVE body, so callers cannot pass extra fields. See its doc.
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
 	c.sealUsageObjects(t, lvl)
 	return &PolyScheme{Level: lvl, Body: t}
 }
 
-// sealUsageObjects is the operative half of Policy A (B2). Body inference records a
+// sealUsageObjects is the operative half of the usage-object sealing rule. Body inference records a
 // member access `p.x` as an INEXACT upper bound `{x: β, ...}` on the receiver var,
 // and it must stay inexact while the body is walked: two exact requirements on one
 // var contradict (`p <: {x}` and `p <: {y}` cannot both hold for an object with
@@ -381,7 +382,7 @@ func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
 //
 // A var is sealed only when ALL of these hold, so the row stays open exactly where
 // it must:
-//   - it is not `open` (the explicit row-polymorphic opt-out, B2),
+//   - it is not `open`, the explicit row-polymorphic opt-out,
 //   - it occurs only in NEGATIVE position: a var that also reaches an output
 //     position escapes, and its object must keep the open row so the returned value
 //     retains the caller's extra fields (`fn (obj) { obj.x; return obj }`),
@@ -414,7 +415,7 @@ func (c *checker) sealUsageObjects(t soltype.Type, lvl int) {
 		if v.Open || v.Level <= lvl {
 			continue
 		}
-		// A deep-mut nested-write receiver, such as obj.p in `obj.p.x = 5` (#779), is
+		// A deep-mut nested-write receiver, such as obj.p in `obj.p.x = 5`, is
 		// PINNED: the residual write-back gives it equal inexact lower and upper bounds
 		// `{x: number, ...}`. It occurs in both polarities (invariant inside the mut
 		// container), so the negative-only test below skips it, yet it must still seal

--- a/internal/solver/poly_test.go
+++ b/internal/solver/poly_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // A MonoScheme instantiates to its exact type — same pointer, no freshening — so a
-// monomorphic binding behaves as M2's plain type did.
+// monomorphic binding behaves as a plain type does.
 func TestInstantiateMonoSchemeReturnsSameType(t *testing.T) {
 	c := newChecker()
 	ty := &soltype.PrimType{Prim: soltype.NumPrim}
@@ -77,9 +77,9 @@ func TestFreshenAboveFreshensBoundsAndHandlesCycles(t *testing.T) {
 }
 
 // instantiate records a FromInstantiation provenance edge for each freshened
-// variable, pointing back at the variable it was copied from — the first interior
-// Origin (M3, PR1). A MonoScheme instantiation records nothing (it freshens no
-// variable).
+// variable, pointing back at the variable it was copied from. This is the first
+// interior Origin. A MonoScheme instantiation records nothing because it freshens no
+// variable.
 func TestInstantiateRecordsFromInstantiation(t *testing.T) {
 	c := newChecker()
 	a := &soltype.TypeVarType{ID: 1, Level: 1}
@@ -92,7 +92,8 @@ func TestInstantiateRecordsFromInstantiation(t *testing.T) {
 	require.True(t, ok, "the edge is FromInstantiation")
 	require.Same(t, a, fi.From, "it points back at the original quantified var")
 
-	// NodeFor still resolves only FromAST leaves; the interior chain renderer is M11.5.
+	// NodeFor resolves only FromAST leaves; the interior chain renderer is not wired
+	// up yet.
 	_, ok = c.prov.NodeFor(got)
 	require.False(t, ok)
 }
@@ -110,7 +111,7 @@ func TestGeneralizeWrapsRawBody(t *testing.T) {
 }
 
 // IsOverloaded reflects the scheme-slice cardinality: one scheme is an ordinary
-// binding, more than one is an overload set (PR6). PR1 only ever builds the former.
+// binding, more than one is an overload set.
 func TestValueBindingIsOverloaded(t *testing.T) {
 	ordinary := ValueBinding{Schemes: []TypeScheme{monoScheme(&soltype.NeverType{})}}
 	require.False(t, ordinary.IsOverloaded())

--- a/internal/solver/prelude.go
+++ b/internal/solver/prelude.go
@@ -27,16 +27,14 @@ func sharedPrelude() *Scope {
 // two hand-seeded sorts:
 //
 //   - operator/builtin value bindings — the monomorphic-over-primitives schemes
-//     the BinaryExpr/UnaryExpr walk resolves (the BinaryExpr walk itself is a
-//     later PR; the bindings live here from PR-1). A near-mechanical port of the
-//     old checker's addOperatorBindings from type_system constructors to soltype
-//     ones.
-//   - placeholder stdlib *type* bindings (§3.8) — opaque stubs so a reference to
-//     Promise/Iterable/… resolves without an unbound-name error. M2 seeds
-//     placeholders only; real ingestion (real structures, arity) is M7.
+//     the BinaryExpr/UnaryExpr walk resolves. A port of the old checker's
+//     addOperatorBindings from type_system constructors to soltype ones.
+//   - placeholder stdlib *type* bindings — opaque stubs so a reference to
+//     Promise/Iterable/… resolves without an unbound-name error. These are
+//     placeholders only, with no real structure or arity.
 //
-// Nothing here imports internal/checker or internal/type_system — that is the
-// M2 gate.
+// Nothing here imports internal/checker or internal/type_system, so the package
+// stays acyclic.
 func NewPrelude() *Scope {
 	s := NewScope()
 	addOperatorBindings(s)
@@ -63,20 +61,14 @@ func opFunc(ret soltype.Type, params ...soltype.Type) *soltype.FuncType {
 }
 
 // addOperatorBindings seeds the built-in operators, every one monomorphic over
-// primitives (so they need no generics/unions/lib types). Richer forms (bigint
-// arithmetic, string <, generic equality) are refinements that land with their
-// enabling milestone (overloads M3, unions M6), not M2.
+// primitives so they need no generics, unions, or lib types. Richer forms such
+// as bigint arithmetic, string `<`, and generic equality are not yet modeled.
 //
-// LATENT TRAP for PR-3 (==/!= over unknown): the equality operators are seeded
-// with `unknown` (⊤) parameters, but M1's constrain has NO `T <: UnknownType`
-// rule — its switch handles prim/lit/func/tuple/void plus the two TypeVar arms,
-// and an UnknownType super falls through to CannotConstrainError. Nothing applies
-// the operators in PR-1 (BinaryExpr is still UnsupportedNodeError), so this is
-// inert today; but the moment the operator/call walk lands, `1 == 2` will
-// constrain `1 <: unknown` and fail with a spurious "cannot constrain 1 <:
-// unknown". When wiring PR-3, either give the engine an `_ <: UnknownType => ok`
-// arm (UnknownType as ⊤) or seed ==/!= with fresh per-call vars instead, and add
-// a `1 == 2 ⇒ boolean` regression test.
+// The equality operators are seeded with `unknown` (⊤) parameters. constrain has
+// no `T <: UnknownType` rule, so an UnknownType super falls through to
+// CannotConstrainError. Applying ==/!= to a non-unknown operand therefore needs
+// either an `_ <: UnknownType => ok` arm treating UnknownType as ⊤, or ==/!=
+// seeded with fresh per-call vars instead.
 func addOperatorBindings(s *Scope) {
 	num := func() soltype.Type { return prim(soltype.NumPrim) }
 	str := func() soltype.Type { return prim(soltype.StrPrim) }
@@ -86,7 +78,7 @@ func addOperatorBindings(s *Scope) {
 	define := func(t soltype.Type, names ...string) {
 		for _, name := range names {
 			// Prelude operators are monomorphic over primitives — a MonoScheme that
-			// instantiates to itself (generic operators are a later milestone).
+			// instantiates to itself.
 			s.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
 		}
 	}
@@ -99,10 +91,9 @@ func addOperatorBindings(s *Scope) {
 	define(opFunc(str(), str(), str()), "++")
 }
 
-// stdlibTypePlaceholders are the names downstream type rules reference (await,
-// for-in, yield, iteration built-ins). M2 must make them *resolve* even though
-// the rules that consume them — and the real generic definitions — land later
-// (real ingestion is M7).
+// stdlibTypePlaceholders are the names downstream type rules reference for
+// await, for-in, yield, and the iteration built-ins. They exist so those names
+// *resolve*, even though the real generic definitions are not yet ingested.
 var stdlibTypePlaceholders = []string{
 	"Promise",
 	"Iterable",
@@ -113,8 +104,8 @@ var stdlibTypePlaceholders = []string{
 }
 
 // addStdlibTypePlaceholders seeds each stdlib type name as an opaque unknown
-// stub so a reference resolves without an unbound-name error. No structure, no
-// arity — M7 swaps these for real types.
+// stub so a reference resolves without an unbound-name error. The stubs carry no
+// structure and no arity.
 func addStdlibTypePlaceholders(s *Scope) {
 	for _, name := range stdlibTypePlaceholders {
 		s.defineType(name, TypeBinding{Type: &soltype.UnknownType{}})

--- a/internal/solver/print_test.go
+++ b/internal/solver/print_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMultiBoundRenders is the M1 end-to-end demo that the engine→coalesce→print
+// TestMultiBoundRenders is the end-to-end demo that the engine→coalesce→print
 // pipeline is wired up correctly: a variable with two distinct lower bounds,
 // coalesced in positive position, renders as a union of those bounds.
 //
 // It lives in package solver (not soltype) because it drives the engine's
 // unexported Context/freshVar and coalesce, then reaches soltype.Print across
-// the package boundary — soltype must not import solver (m1-implementation-plan
-// §3.1), so the pipeline can only be exercised from this side.
+// the package boundary. soltype must not import solver, so the pipeline can only
+// be exercised from this side.
 func TestMultiBoundRenders(t *testing.T) {
 	c := &Context{}
 	a := c.freshVar(1)

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -5,9 +5,9 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Probe is the M3 (PR5) speculation journal: it records the mutations a
-// tentative inference does so a *discarded* trial leaves no trace. Two kinds of
-// mutation are journaled:
+// Probe is the speculation journal: it records the mutations a tentative
+// inference does so a *discarded* trial leaves no trace. Two kinds of mutation
+// are journaled:
 //
 //  1. Bound appends. Every TypeVarType the trial appends a bound to (via
 //     addLowerBound/addUpperBound) is recorded once, with its bound-list lengths
@@ -38,14 +38,14 @@ import (
 // top-level commit makes the mutations permanent and drops the journal. The
 // active probe lives on *Context (the engine's bound-mutating core is there); the
 // push/pop discipline and side-table registration live on the checker carrier
-// (openProbe/closeProbe), which owns Info/Prov/errs. PR6 (overloading) is the
-// first consumer: each candidate overload is trialled under a probe and the
-// losers rolled back.
+// (openProbe/closeProbe), which owns Info/Prov/errs. Overloading is the first
+// consumer: each candidate overload is trialled under a probe and the losers
+// rolled back.
 //
-// M4 D1 adds a SECOND bounded sort, LifetimeVar. The probe stays concrete instead
-// of abstracting over "things with bound lists". The plan's discarded `Bounded`
-// interface would have been that abstraction, but Go can't fit it because the
-// truncate methods would be unexported on soltype types. So the probe carries a
+// The probe also journals a SECOND bounded sort, LifetimeVar. The probe stays
+// concrete instead of abstracting over "things with bound lists". A `Bounded`
+// interface would be that abstraction, but Go can't fit it because the truncate
+// methods would be unexported on soltype types. So the probe carries a
 // PARALLEL journal of its own: ltEntries, ltTouched, and recordLt. That journal
 // follows the same length-snapshot and truncate-on-discard discipline as the
 // *TypeVarType path. The cost is two near-identical discard paths. The gain is no

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -7,20 +7,20 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Prov is the inverse of Info: soltype.Type → the origin that minted it. Sparse —
-// shared/interned/synthesized types may be absent (an honest miss, not a lie: see
-// the leaf/interior split in planning/simple_sub/m2.5-implementation-plan.md §3.8).
-// Keyed by pointer identity, exactly like Info.
+// Prov is the inverse of Info: soltype.Type → the origin that minted it. Sparse.
+// Shared, interned, or synthesized types may be absent, an honest miss rather
+// than a lie, following the leaf/interior split. Keyed by pointer identity,
+// exactly like Info.
 //
-// M2.5 shipped the FromAST leaf variant; M3 (PR1) adds the first interior edge,
-// FromInstantiation. The remaining interior variants
-// (FromBoundPropagation/FromExtrusion/FromCoalesce) ride along with the later
-// operations that mint them — which is why Origin is an interface, so each adds a
-// variant rather than changing the map's value type.
+// The FromAST leaf variant and the FromInstantiation interior edge are
+// implemented. The remaining interior variants FromBoundPropagation,
+// FromExtrusion, and FromCoalesce ride along with the operations that mint them.
+// That is why Origin is an interface, so each adds a variant rather than changing
+// the map's value type.
 type Prov map[soltype.Type]Origin
 
-// Origin is a tagged sum naming the kind of hop that minted a type. M2.5 shipped
-// the FromAST leaf; M3 adds FromInstantiation; the rest are deferred.
+// Origin is a tagged sum naming the kind of hop that minted a type. The FromAST
+// leaf and FromInstantiation are implemented; the rest are deferred.
 type Origin interface{ isOrigin() }
 
 // FromAST is the leaf: a direct AST cause for a freshly-minted type.
@@ -31,11 +31,11 @@ type FromAST struct {
 
 func (FromAST) isOrigin() {}
 
-// FromInstantiation is the first interior edge (M3, PR1): a variable minted by
-// instantiating a polymorphic scheme (freshenAbove) copied it from From, the
-// pre-freshening type. It carries no AST node of its own — the renderer that
-// chases the From chain back to the nearest AST leaf is deferred to M11.5, so
-// NodeFor still resolves only FromAST. PR1 mints the edge; nothing reads it yet.
+// FromInstantiation is the first interior edge. A variable minted by
+// instantiating a polymorphic scheme through freshenAbove copied it from From, the
+// pre-freshening type. It carries no AST node of its own. The renderer that chases
+// the From chain back to the nearest AST leaf is not yet implemented, so NodeFor
+// still resolves only FromAST. The edge is minted but nothing reads it yet.
 type FromInstantiation struct {
 	From soltype.Type
 }
@@ -44,7 +44,7 @@ func (FromInstantiation) isOrigin() {}
 
 // ASTOriginKind tags WHY a node minted a type, so a renderer/LSP can phrase blame
 // ("the literal here", "this argument", "field `x`") without re-deriving it from
-// the AST node's concrete type. M2.5's blame only needs the node, so the kind is
+// the AST node's concrete type. Current blame only needs the node, so the kind is
 // forward-looking metadata.
 type ASTOriginKind int
 
@@ -67,10 +67,10 @@ const (
 	BorrowExprOrigin                        // a RefType minted by inferBorrow from a `&p` / `&mut p` expression
 )
 
-// NodeResolver resolves an operand type to the AST node that minted it. M2.5's
-// Prov implements it as a single map lookup; M3+ can supply a resolver that
-// chases interior Origin edges (FromInstantiation, …) to the nearest AST leaf
-// without changing any caller — that is the "follow the provenance chain" path.
+// NodeResolver resolves an operand type to the AST node that minted it. Prov
+// implements it as a single map lookup. A future resolver can chase interior
+// Origin edges such as FromInstantiation to the nearest AST leaf without changing
+// any caller, the "follow the provenance chain" path.
 //
 // Named NodeResolver rather than Provenance to avoid shadowing the imported
 // `provenance` package / `provenance.Provenance` binding-source marker used
@@ -80,8 +80,8 @@ type NodeResolver interface {
 }
 
 // NodeFor returns the AST node that minted t, when one was recorded. An
-// unrecorded operand (a Void result, a shared atom resolved elsewhere, or an
-// M3+ synthesized type) is an honest miss.
+// unrecorded operand is an honest miss, such as a Void result, a shared atom
+// resolved elsewhere, or a synthesized type.
 func (p Prov) NodeFor(t soltype.Type) (ast.Node, bool) {
 	if o, ok := p[t].(FromAST); ok {
 		return o.Node, true
@@ -97,9 +97,9 @@ func (c *checker) hasProv(t soltype.Type) bool {
 
 // recordProv records that t was minted from node n for reason kind — the inverse
 // of recordType (info.setType). Sparse by intent: only the node-derived
-// construction sites call it; synthesized types (coalesced/extruded, M3+) get no
-// entry. Called only in the walk (construction), never in constrain/coalesce, so
-// the hot inference path never consults Prov (the perf invariant, §3.9).
+// construction sites call it; synthesized types such as coalesced or extruded
+// types get no entry. Called only in the walk, never in constrain/coalesce, so
+// the hot inference path never consults Prov, the perf invariant.
 //
 // Invariant: every type passed here is a FRESHLY-minted, unique pointer, so a
 // record never collides with a different node. Blame correctness depends on it —

--- a/internal/solver/prov_test.go
+++ b/internal/solver/prov_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // requireOrigin asserts the Prov table records ty as minted from node for reason
-// kind — the FromAST leaf the M2.5 population sites write (§3.3).
+// kind — the FromAST leaf the population sites write.
 func requireOrigin(t *testing.T, c *checker, ty soltype.Type, node ast.Node, kind ASTOriginKind) {
 	t.Helper()
 	o, ok := c.prov[ty]
@@ -92,7 +92,7 @@ func TestProvFuncTypeAndParamBinding(t *testing.T) {
 
 // An annotated param's fresh PrimType is recorded against its annotation
 // (AnnotationType), and the ParamBinding origin is NOT recorded for it — its blame
-// rides on the annotation (the fresh-atom discipline, §3.3).
+// rides on the annotation, following the fresh-atom discipline.
 func TestProvAnnotatedParamUsesAnnotationOrigin(t *testing.T) {
 	c := newChecker()
 	ann := numAnn()
@@ -114,7 +114,7 @@ func TestProvAnnotationType(t *testing.T) {
 	requireOrigin(t, c, ty, ta, AnnotationType)
 }
 
-// An identifier use records NOTHING (§3.3): recording against the binding's shared
+// An identifier use records NOTHING: recording against the binding's shared
 // atom would overwrite the definition's origin. So inferring a bare ident over a
 // pre-bound atom leaves the table empty.
 func TestProvIdentRecordsNothing(t *testing.T) {
@@ -125,7 +125,7 @@ func TestProvIdentRecordsNothing(t *testing.T) {
 	require.Empty(t, c.prov, "an ident use must record no provenance")
 }
 
-// The honest absence (§3.2): a synthesized (coalesced) type has no Prov entry, so
+// The honest absence: a synthesized coalesced type has no Prov entry, so
 // NodeFor reports a miss rather than lying.
 func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
 	c := newChecker()
@@ -135,7 +135,7 @@ func TestProvCoalescedTypeHasNoEntry(t *testing.T) {
 	require.False(t, ok, "a coalesced type must have no provenance entry")
 }
 
-// The debugProv guard (finding #5) enforces the unique-pointer invariant: recording
+// The debugProv guard enforces the unique-pointer invariant: recording
 // the SAME type pointer against a DIFFERENT node panics (catching a future
 // interned/coalesced-pointer reuse that would silently mis-blame), while
 // re-recording against the same node is idempotent and allowed.

--- a/internal/solver/regression_test.go
+++ b/internal/solver/regression_test.go
@@ -22,10 +22,10 @@ import (
 // conflate "terminates" with "renders this exact shape".
 //
 // NOTE: a regression that bypasses the `seen` guard stack-overflows here, which
-// is a fatal (uncatchable) crash that takes down the whole package test binary
-// rather than failing this test in isolation. Tracked in
-// https://github.com/escalier-lang/escalier/issues/702 (add a recursion-depth
-// ceiling to coalesce so a guard bypass fails cleanly instead of crashing).
+// is a fatal uncatchable crash that takes down the whole package test binary
+// rather than failing this test in isolation. Tracked in #702, which proposes a
+// recursion-depth ceiling for coalesce so a guard bypass fails cleanly instead
+// of crashing.
 func TestInferModuleRecursiveRecordTerminates(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f() { return {x: f()} }`)
 	require.Empty(t, errs, "unexpected inference errors")
@@ -63,9 +63,9 @@ func TestInferModuleFuncDeclRecordsInfoType(t *testing.T) {
 
 // A POLYMORPHIC binding's Info entry retains its quantified type-parameter vars, so
 // it must be rendered with soltype.PrintAsScheme (the var-aware renderer); plain
-// soltype.Print shows the raw t{ID} debug form. (PR1: the recorded display type is
-// NOT var-free for generalized bindings — the inverse of
-// TestInferModuleFuncDeclRecordsInfoType, whose fixture is monomorphic.)
+// soltype.Print shows the raw t{ID} debug form. The recorded display type is
+// NOT var-free for generalized bindings, the inverse of
+// TestInferModuleFuncDeclRecordsInfoType, whose fixture is monomorphic.
 func TestInferModulePolymorphicFuncDeclInfoNeedsPrintScheme(t *testing.T) {
 	module := parseModule(t, `fn id(x) { return x }`)
 	_, info, errs := InferModule(module)

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -6,38 +6,37 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// ValueBinding is a name's value-sort binding. M3 (PR1) replaces M2's plain
-// MONOMORPHIC soltype.Type with a *slice* of TypeSchemes: exactly one for an
-// ordinary value (the let-generalization swap), and — once PR6 lands — more than
-// one for an overload set, in declaration order. Holding the slice now (rather
-// than a nullable OverloadSet field) makes "is the scheme nil when overloaded?"
-// unrepresentable: cardinality is just len(Schemes), and Schemes[i] lines up with
+// ValueBinding is a name's value-sort binding. It holds a slice of TypeSchemes:
+// exactly one for an ordinary value through the let-generalization swap, and more
+// than one for an overload set, in declaration order. Holding the slice rather
+// than a nullable OverloadSet field makes "is the scheme nil when overloaded?"
+// unrepresentable. Cardinality is just len(Schemes), and Schemes[i] lines up with
 // the arm at Sources[i].
 type ValueBinding struct {
-	Schemes []TypeScheme // 1 = ordinary binding; >1 = overload set (PR6)
-	// Sources holds every decl that contributes to this binding, in source order:
-	// for a plain `val`/`fn` that is the single introducing decl, but a name with
-	// multiple top-level FuncDecls (overloads) — or an erroneous redeclaration —
-	// accumulates one entry per arm, including arms M2 currently rejects. This lets
-	// a future go-to-definition navigate to all of them. Empty for prelude bindings.
+	Schemes []TypeScheme // 1 = ordinary binding; >1 = overload set
+	// Sources holds every decl that contributes to this binding, in source order.
+	// For a plain `val`/`fn` that is the single introducing decl, but a name with
+	// multiple top-level FuncDecls or an erroneous redeclaration accumulates one
+	// entry per arm. This lets a future go-to-definition navigate to all of them.
+	// Empty for prelude bindings.
 	Sources []provenance.Provenance
 	// Kind is the binding's declaration kind: VarKind for a reassignable `var`,
 	// ValKind for everything else (a `val`, a function, a parameter, and every
 	// prelude binding — all left at the zero value, ValKind). inferAssign gates
 	// reassignment on Kind == VarKind, reporting CannotAssignToImmutableError for any
-	// other kind. This is the binding-level REASSIGNABILITY gate only — deliberately
-	// SEPARATE from type-level mutability (`mut`-field / aliasing / lifetime
-	// transitions, M4), which is a property of the TYPE, not of this binding.
+	// other kind. This is the binding-level REASSIGNABILITY gate only, deliberately
+	// SEPARATE from type-level mutability such as `mut`-field, aliasing, and
+	// lifetime transitions, which is a property of the TYPE, not of this binding.
 	Kind ast.VariableKind
 	// ModuleLevel marks a top-level binding — one defined directly in the module
 	// scope, as opposed to a function parameter or body-local `val`/`var`. It is set
 	// only by inferComponent's phase-3 definitions, the module's SCC bindings, and
 	// left false for every nested binding. inferAssign reads it to recognise a GLOBAL
 	// WRITE: storing a value into module-level storage outlives every borrow region,
-	// so a borrowed value written there escapes to 'static (M4 D3).
+	// so a borrowed value written there escapes to 'static.
 	ModuleLevel bool
 	// VarID is the liveness VarID assigned to this binding's name by the function
-	// body's rename pass (M4 G1), or 0 for a binding outside any liveness-analysed
+	// body's rename pass, or 0 for a binding outside any liveness-analysed
 	// body (every top-level binding, and any binding minted before its enclosing
 	// body's prepass runs). The mutability-transition checker reads it to resolve a
 	// captured outer variable back to its alias set — the new-checker analogue of the
@@ -47,32 +46,30 @@ type ValueBinding struct {
 }
 
 // IsOverloaded reports whether this binding is an overload set. Consumers MUST
-// check it before routing: an ordinary call (false) keeps M2's shipped
-// subtype-constraint path, while an overloaded call (true) goes through
-// resolveOverload (PR6). inferIdent's value-position lookup branches on it too.
-// PR1 only ever builds single-scheme bindings, so this is always false today; the
-// helper lands now so the ordinary path reads !b.IsOverloaded() from the start.
+// check it before routing. An ordinary call, false, keeps the subtype-constraint
+// path, while an overloaded call, true, goes through resolveOverload. inferIdent's
+// value-position lookup branches on it too.
 func (b ValueBinding) IsOverloaded() bool { return len(b.Schemes) > 1 }
 
-// TypeBinding is a name's type-sort binding. M2 only ever populates this with
-// the hand-seeded stdlib-type placeholders (§3.8); real type aliases/classes are
-// M3+. The shape lands now because it is load-bearing for the two-map test
-// harness.
+// TypeBinding is a name's type-sort binding. It is currently populated only with
+// the hand-seeded stdlib-type placeholders; real type aliases and classes are not
+// yet wired in. The shape is load-bearing for the two-map test harness.
 type TypeBinding struct {
 	Type soltype.Type
 	// Sources holds every decl that contributes to this type binding, in source
 	// order — mirroring ValueBinding.Sources. A plain `type`/`class` has a single
-	// entry; interface declaration-merging (multiple `interface T` under one name)
+	// entry; interface declaration-merging, multiple `interface T` under one name,
 	// accumulates one per arm. Empty for the prelude type placeholders. Not yet
-	// populated — M2 only seeds stdlib-type placeholders here; real type aliases
-	// and classes (and their merging) land in M3+.
+	// populated. Only stdlib-type placeholders are seeded here; real type aliases
+	// and classes, and their merging, are not yet wired in.
 	Sources []provenance.Provenance
 }
 
-// Namespace is the third binding sort — a separate kind from a soltype.Type, so
-// a namespace never flows as a value. M2 keeps the structure (for qualified
-// BindingKey resolution across files) and the free-floating
-// NamespaceUsedAsValueError; the member-access *lookup* (Foo.bar) is M4.
+// Namespace is the third binding sort, a separate kind from a soltype.Type, so a
+// namespace never flows as a value. It keeps the structure for qualified
+// BindingKey resolution across files and the free-floating
+// NamespaceUsedAsValueError. The member-access lookup, Foo.bar, is not yet
+// implemented.
 type Namespace struct {
 	Name   string // qualified, from dep_graph.GetNamespace
 	Values map[string]ValueBinding
@@ -80,9 +77,8 @@ type Namespace struct {
 	Nested map[string]*Namespace
 }
 
-// Scope is the package-owned, multi-sorted analogue of type_system's scope (the
-// milestone forbids reusing type_system's). It has one map per binding sort plus
-// a parent link for lexical lookup.
+// Scope is the package-owned, multi-sorted analogue of type_system's scope. It
+// has one map per binding sort plus a parent link for lexical lookup.
 //
 // Why namespaces are stored by pointer while values/types are stored by value:
 // the distinction is by *kind*, not by slot. A Namespace is a shared, mutable,
@@ -122,9 +118,9 @@ func (s *Scope) Child() *Scope {
 
 // defineValue inserts b under name in THIS scope's value map. It OVERWRITES any
 // existing binding for name in this scope — it does not panic or error on a
-// duplicate the way the old checker's setValue does. Two M2 paths rely on the
-// overwrite: body-level variable redeclaration (§3.2) and inferComponent, which
-// binds each rec-group name twice (fresh var, then coalesced type) (§3.7).
+// duplicate the way the old checker's setValue does. Two paths rely on the
+// overwrite: body-level variable redeclaration, and inferComponent, which binds
+// each rec-group name twice, first a fresh var, then the coalesced type.
 func (s *Scope) defineValue(name string, b ValueBinding) {
 	s.values[name] = b
 }

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -26,9 +26,8 @@ import (
 //     seed the alias/liveness tables;
 //  4. walk the block in source order through inferBlock.
 //
-// M4 shipped every building block this uses: the pre-pass, the per-body funcCtx, the
-// alias tracker, and the transition checker. The only new code is this entry point
-// that runs them over a script body. There is no new inference.
+// This entry point reuses the pre-pass, the per-body funcCtx, the alias tracker, and
+// the transition checker, running them over a script body. It adds no new inference.
 //
 // The pushed funcCtx carries no async flag and a nil node. A top-level `await` is
 // rejected the same way it is at module top level. There is no enclosing function to

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -54,7 +54,7 @@ func TestInferScriptSourceOrder(t *testing.T) {
 	require.Equal(t, "5", values["y"])
 }
 
-// TestScriptTransitionParity is the milestone's central claim: a `mut`→immutable
+// TestScriptTransitionParity is the central claim: a `mut`→immutable
 // transition at script top level is checked identically to the same statements
 // wrapped in a function body. Each case runs through InferScript directly, then again
 // through InferModule after being indented into `fn test() { … }`. The two error lists

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -8,7 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Co-occurrence merging (PR2). Single-polarity elimination already lives in
+// Co-occurrence merging. Single-polarity elimination already lives in
 // coalesceScheme — a variable occurring in only one polarity is dropped in favour
 // of its bound. The remaining simplification is merging DISTINCT quantified
 // variables that always appear together so a signature renders with one type
@@ -122,7 +122,7 @@ func (vc *varCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Typ
 // lower bounds or the intersection of its uppers. Adding the reverse edge to those
 // lists would pull a spurious variable into that union or intersection and change
 // the rendered type. So the symmetric view is built here, leaving the canonical
-// scheme body untouched. The spike instead mutated the bound lists in place.
+// scheme body untouched.
 type mirror struct {
 	lower map[int][]soltype.Type // extra lower-bound vars: u <: v recorded on u.UpperBounds
 	upper map[int][]soltype.Type // extra upper-bound vars: v <: u recorded on u.LowerBounds
@@ -164,7 +164,7 @@ func (m *mirror) effectiveBounds(v *soltype.TypeVarType, pol soltype.Polarity) [
 }
 
 // recordMutWriteView reflects a `mut` borrow's INVARIANCE into a polarity-recording
-// visitor (#737). The C2 constrain rule makes every field a `mut` target names
+// visitor. The constrain rule makes every field a `mut` target names
 // invariant — it adds a covariant read view and, under the mut-context flag, a
 // contravariant write view — but RefType.Accept walks the inner only covariantly
 // (the read view; see visitor.go). So a variable that appears only inside a `mut`

--- a/internal/solver/simplify_test.go
+++ b/internal/solver/simplify_test.go
@@ -16,8 +16,8 @@ func fparam(name string, t soltype.Type) *soltype.FuncParam {
 // Co-occurrence merging collapses distinct quantified variables that always appear
 // together. The shape mirrors `outer` from the polymorphism suite: a parameter
 // variable a flows to two result variables b, c (a's upper bounds), both returned
-// in a tuple. PR1 retained all three as separate type parameters
-// (`fn <T0, T1>(x: T0 & T1) -> [T0, T1]`); PR2 merges them to one.
+// in a tuple. Without the merge all three stay separate type parameters
+// (`fn <T0, T1>(x: T0 & T1) -> [T0, T1]`); the merge collapses them to one.
 func TestCoalesceSchemeMergesCoOccurring(t *testing.T) {
 	b := &soltype.TypeVarType{ID: 2, Level: 1}
 	c := &soltype.TypeVarType{ID: 3, Level: 1}

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- M4 G1: mutability-transition checking ---
+// --- Mutability-transition checking ---
 //
 // The transition checker is ported from the old checker (check_transitions.go), with
 // its two type predicates reimplemented over soltype.
@@ -26,7 +26,7 @@ import (
 // What stays at the unit level cannot be reproduced cleanly from source:
 //   - The type predicates isValueType / isMutableType / isSourceMutable and the
 //     borrowEscapedToStatic query are Go-level functions, tested directly.
-//   - The G2 static-escape cases (TestStaticEscapeTransition) isolate the lifetime
+//   - The static-escape cases (TestStaticEscapeTransition) isolate the lifetime
 //     query, its polarity, the transitive-member reach, and the target-dead early
 //     return. From source those are confounded by the global-write store error and the
 //     borrow-into-owned-slot escape, or are not constructible at all. The feature's
@@ -130,14 +130,14 @@ func transitionMessages(t *testing.T, errs []SolverError) []string {
 }
 
 // staticBorrow builds a mut/immutable borrow whose lifetime is forced to 'static,
-// the shape borrowEscapedToStatic recognizes as a permanent outside alias (G2). The
-// 'static upper bound is what D3's constrainEscape adds when a borrow escapes.
+// the shape borrowEscapedToStatic recognizes as a permanent outside alias. The
+// 'static upper bound is what constrainEscape adds when a borrow escapes.
 func staticBorrow(mut bool) *soltype.RefType {
 	lt := &soltype.LifetimeVar{ID: 1, UpperBounds: []soltype.Lifetime{soltype.Static}}
 	return &soltype.RefType{Mut: mut, Lt: lt, Inner: objT()}
 }
 
-// TestStaticEscapeTransition covers G2's lifetime-sort replacement for the dropped
+// TestStaticEscapeTransition covers the lifetime-sort replacement for the dropped
 // HasStatic{Mut,Imm}Alias bits: a source whose borrow escaped to 'static is a
 // permanent outside alias, so a transition conflicts even when the source is locally
 // dead after the transition point. Without the escape the same state is conflict-free.
@@ -177,7 +177,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 	// drives the same conflict. This covers borrowEscapedToStatic's *StaticLifetime
 	// branch through the full transition path. The source-level form above is not
 	// constructible yet: a lifetime annotation attaches only to a type reference, which
-	// needs M7's TypeRef resolution, so this stays at the unit level until then.
+	// needs TypeRef resolution, so this stays at the unit level until then.
 	t.Run("Rule1_ExplicitStaticLifetime_Error", func(t *testing.T) {
 		a := liveness.NewAliasTracker()
 		a.NewValue(src, liveness.AliasMutable)
@@ -198,7 +198,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 	//
 	// It does NOT model the escape-creating store. In a full program that store, e.g.
 	// `sink = p` into an immutable global with p staying live, is itself a Rule 1 error
-	// once Option 1 checks module-level write targets. TestStaticEscapeTransitionFromSource
+	// once the checker checks module-level write targets. TestStaticEscapeTransitionFromSource
 	// runs the whole program and reports it; this unit test checks a single transition,
 	// so the two are not the same situation and this one correctly reports nothing.
 	t.Run("MutEscape_TargetDead_OK", func(t *testing.T) {
@@ -213,21 +213,22 @@ func TestStaticEscapeTransition(t *testing.T) {
 }
 
 // TestStaticEscapeTransitionFromSource is the end-to-end counterpart. A `&mut`
-// borrow stored into module-level `sink` escapes to 'static (D3), creating a
+// borrow stored into module-level `sink` escapes to 'static, creating a
 // permanent alias outside the function, then is aliased into the immutable
 // `snap`. The program surfaces two errors, both asserted.
 //
 //  1. The global-write transition at `sink = p`. Storing the mutable borrow into
 //     the immutable global `sink` while `p` stays live afterward is a
 //     mut→immutable transition against a permanent target.
-//  2. The static-escape transition at `val snap = p` (G2). `p` escaped to
+//  2. The static-escape transition at `val snap = p`. `p` escaped to
 //     'static via the earlier store, so aliasing it into immutable `snap`
 //     conflicts. The query over `p`'s 'static-forced lifetime is what reports
 //     it, named as a `'static` escape.
 //
-// Before G2 the dropped HasStaticMutAlias bit was never set, so case 2 was
-// silently accepted as a false negative. Before the global-write check, case 1
-// was missed entirely because the module-level target is not a tracked local.
+// Before the static-escape query, the dropped HasStaticMutAlias bit was never
+// set, so case 2 was silently accepted as a false negative. Before the
+// global-write check, case 1 was missed entirely because the module-level target
+// is not a tracked local.
 //
 // `val snap: &{x} = p` aliases the borrow at a fresh lifetime. The lifetime sort
 // and the transition pass produce the verdict above, which is case 2.
@@ -237,16 +238,14 @@ func TestStaticEscapeTransition(t *testing.T) {
 // conflict fires purely because `p` escaped to 'static, not because `p` is
 // locally live. The liveness loop skips the dead `p`. Only the escape query
 // reports it.
-// DISABLED until PR 6 lands.
 //
-// PR 6 of the affine semantics plan moves the global-write site from the
-// transition-checker onto the move engine. The plan says: "The global-write
-// site stops dropping mutability and instead consumes, per 'Move subsumes the
-// escape-site logic.'" Once that lands, `sink = p` consumes `p`, the later
-// `val snap: &{x: number} = p` is a use-after-move, and the two transition
-// diagnostics asserted below are replaced by a single UseAfterMoveError
-// against the `p` in `val snap = p`. Re-enable then and switch the assertion
-// to the UseAfterMove message.
+// DISABLED until the global-write site consumes its source.
+//
+// Once the global-write site stops dropping mutability and instead consumes
+// its source, `sink = p` consumes `p`, the later `val snap: &{x: number} = p`
+// is a use-after-move, and the two transition diagnostics asserted below are
+// replaced by a single UseAfterMoveError against the `p` in `val snap = p`.
+// Re-enable then and switch the assertion to the UseAfterMove message.
 /*
 func TestStaticEscapeTransitionFromSource(t *testing.T) {
 	_, _, errs := inferSource(t, `
@@ -267,11 +266,11 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 }
 */
 
-// TestGlobalWriteMutTransition covers Option 1: a store into a module-level binding is a
-// mutability transition against a permanent, always-live target. The local reassignment
-// path skips module-level targets, so before this the store went unchecked. This is an
-// in-body check only; it does not catch a caller that retains a mutable alias to a value
-// stored into an immutable global (see the dead-source case below).
+// TestGlobalWriteMutTransition covers the global-write check: a store into a module-level
+// binding is a mutability transition against a permanent, always-live target. The local
+// reassignment path skips module-level targets, so before this the store went unchecked.
+// This is an in-body check only; it does not catch a caller that retains a mutable alias
+// to a value stored into an immutable global (see the dead-source case below).
 func TestGlobalWriteMutTransition(t *testing.T) {
 	// Storing a mut borrow into the immutable global `sink`, then mutating through the
 	// borrow, is a mut→immutable transition: `sink` permanently observes a value that p
@@ -289,12 +288,12 @@ func TestGlobalWriteMutTransition(t *testing.T) {
 		}, transitionMessages(t, errs))
 	})
 
-	// When the source is dead within this body, Option 1's in-body check reports
+	// When the source is dead within this body, the in-body check reports
 	// nothing. This is NOT a soundness guarantee. The store still escapes p to 'static,
 	// and the CALLER may keep a live mutable alias to the same value and mutate it after
 	// the call, so the immutable `sink` observes a mutation. Catching that needs the call
-	// site to enforce the 'static borrow as unique, which is the borrow checker's job
-	// (#618, #762), not this pass. The assertion pins current behavior and is expected to
+	// site to enforce the 'static borrow as unique, which is the borrow checker's job,
+	// not this pass. The assertion pins current behavior and is expected to
 	// gain an error once the caller-side check lands.
 	t.Run("dead_in_body_source_no_inbody_conflict", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
@@ -318,7 +317,7 @@ func TestGlobalWriteMutTransition(t *testing.T) {
 	})
 }
 
-// TestBorrowEscapedToStatic locks the lifetime-sort query G2 uses in place of the
+// TestBorrowEscapedToStatic locks the lifetime-sort query used in place of the
 // dropped escape bits: a borrow forced to 'static is recognized with its mutability, an
 // owned value or an unforced borrow is not.
 func TestBorrowEscapedToStatic(t *testing.T) {
@@ -438,14 +437,14 @@ func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
 // into the immutable q. p mutates `p.x = 5` and q stays live for the later
 // `q.x` read, so both are live across the alias. Rule 1 fires.
 //
-// DISABLED until PR 6 lands.
+// DISABLED until val/var bindings consume their source.
 //
-// PR 6 of the affine semantics plan makes `val`/`var` bindings flow sites
-// that consume the source. Once it lands, `val q: {x} = p` consumes p, so
-// `p.x = 5` is a use-after-move rather than a live-source Rule 1 transition,
-// and the diagnostic changes to a UseAfterMoveError that names both the
-// move site (the `val q` binding) and the use site (`p.x = 5`). Re-enable
-// then and update the assertion to match the new error.
+// Once `val`/`var` bindings become flow sites that consume the source,
+// `val q: {x} = p` consumes p, so `p.x = 5` is a use-after-move rather than a
+// live-source Rule 1 transition, and the diagnostic changes to a
+// UseAfterMoveError that names both the move site (the `val q` binding) and the
+// use site (`p.x = 5`). Re-enable then and update the assertion to match the
+// new error.
 /*
 func TestTransitionWiringReportsRule1Error(t *testing.T) {
 	_, _, errs := inferSource(t, `
@@ -540,10 +539,10 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				"cannot assign 'z' to immutable 'sink': 'p' still has mutable access to 'z' after this point",
 			},
 		},
-		// G3 binds a `mut` borrow into a bare annotation by reborrowing it as a local
+		// Binding a `mut` borrow into a bare annotation reborrows it as a local
 		// immutable view. `snap` dies within `p`'s region and never escapes, so the
 		// lifetime sort accepts it, matching internal/checker, which has no borrow-escape
-		// concept here. Before G3 this reported the divergent "does not live long enough".
+		// concept here. Earlier this reported the divergent "does not live long enough".
 		"UnforcedLifetime_LocalReborrow_OK": {
 			src: `
 				fn f(p: mut {x: number}) {

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Mutability-transition checking, ported from internal/checker/check_transitions.go
-// and internal/checker/liveness_prepass.go (M4 G1). The liveness/CFG/alias-tracking
+// and internal/checker/liveness_prepass.go. The liveness/CFG/alias-tracking
 // machinery in internal/liveness is reused verbatim. Only two pieces are reimplemented
 // over soltype rather than type_system:
 //
@@ -29,15 +29,14 @@ import (
 // nil, so every entry point below is a no-op. That is correct for a module, whose
 // top-level declarations are dependency-ordered rather than a linear body. A script is
 // different: its top-level statements run in source order with function-body semantics.
-// So when script inference lands it must give the script body the same per-body liveness
-// context a function gets, by running runLivenessPrePass over the script statements
-// under a funcCtx, or these checks stay silently skipped there. The old checker's
-// InferScript ran the pre-pass over the whole script body for this reason.
+// So InferScript gives the script body the same per-body liveness context a function
+// gets, by running runLivenessPrePass over the script statements under a funcCtx.
+// Without that the checks would stay silently skipped there.
 
 // staticConflictName is a sentinel placeholder used in
 // MutabilityTransitionError.ConflictingVars to represent a permanent alias from a
-// `'static` escape. M4 G2 populates it by querying the lifetime sort. A member of the
-// source's alias set whose borrow lifetime D3 forced `<: 'static` is the permanent
+// `'static` escape. It is populated by querying the lifetime sort. A member of the
+// source's alias set whose borrow lifetime is forced `<: 'static` is the permanent
 // outside reference this sentinel stands for. The message renders it specially rather
 // than printing the literal sentinel.
 const staticConflictName = "<static escape>"
@@ -150,19 +149,17 @@ func isMutableType(t soltype.Type) bool {
 
 // borrowEscapedToStatic reports whether the variable's recorded type carries a
 // top-level borrow whose lifetime is forced to 'static, and that borrow's
-// mutability. It is the lifetime-sort replacement for the dropped
-// HasStatic{Mut,Imm}Alias bits in M4 G2. A borrow escapes when it is stored where it
-// outlives the function. D3's constrainEscape then pins its lifetime `<: 'static`, so
-// the value has a permanent outside alias of its mutability.
+// mutability. A borrow escapes when it is stored where it outlives the function.
+// constrainEscape then pins its lifetime `<: 'static`, so the value has a permanent
+// outside alias of its mutability.
 //
-// Only the top-level RefType is inspected, matching the bits' "this value escaped"
-// semantics rather than "a field of this value escaped". An owned value, a borrow
-// with an unforced lifetime, or an unrecorded variable returns escaped=false.
+// Only the top-level RefType is inspected, matching "this value escaped" semantics
+// rather than "a field of this value escaped". An owned value, a borrow with an
+// unforced lifetime, or an unrecorded variable returns escaped=false.
 //
-// KNOWN GAP (M4 G2 carry-over): a borrow reachable only through a usage-inferred
-// TypeVarType, or one nested in a field, is not seen here. The deeper fix resolves a
-// value's borrows through the constraint graph rather than its top-level type. See the
-// G2 note in planning/simple_sub/m4-implementation-plan.md.
+// KNOWN GAP: a borrow reachable only through a usage-inferred TypeVarType, or one
+// nested in a field, is not seen here. The deeper fix resolves a value's borrows
+// through the constraint graph rather than its top-level type.
 func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (mut bool, escaped bool) {
 	if c.fn == nil || c.fn.varIDTypes == nil {
 		return false, false
@@ -187,7 +184,7 @@ func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (mut bool, escaped
 	return false, false
 }
 
-// recordVarIDType records a tracked variable's soltype into the G2 escape bridge,
+// recordVarIDType records a tracked variable's soltype into the escape bridge,
 // guarding the nil map at module top-level where no pre-pass ran.
 func (c *checker) recordVarIDType(varID liveness.VarID, t soltype.Type) {
 	if c.fn == nil || c.fn.varIDTypes == nil || varID <= 0 {
@@ -266,9 +263,8 @@ func (c *checker) checkMutabilityTransition(
 		for varID, aliasMut := range aliasSet.Members {
 			// A borrow on this member forced to 'static is a permanent outside
 			// reference. It outlives the function, so no liveness check is meaningful
-			// and it always counts as a live alias of its escaped mutability. This is
-			// G2's lifetime-sort replacement for the dropped HasStatic{Mut,Imm}Alias
-			// bits.
+			// and it always counts as a live alias of its escaped mutability. The
+			// lifetime sort records this through a forced `<: 'static` bound.
 			//
 			// The conflict test is escMut == sourceMut, compared against the SOURCE, not
 			// the target. Past the early return sourceMut != targetMut holds, so
@@ -323,8 +319,8 @@ func (c *checker) checkMutabilityTransition(
 // trackAliasesForVarDecl records the alias a body-level `val`/`var` with an
 // initializer creates, then checks its mutability transition. It covers an IdentPat
 // binding. It also covers closure capture when the initializer is a FuncExpr.
-// Destructuring patterns are unsupported in the new checker until the pattern PRs
-// land, and a non-IdentPat decl produces no binding anyway.
+// A non-IdentPat decl produces no binding here, so this path only handles the
+// IdentPat case.
 func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindingT soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil || decl.Init == nil {
 		return
@@ -426,7 +422,7 @@ func (c *checker) trackCapturedAliases(
 		if !found || b.VarID <= 0 {
 			continue
 		}
-		// Cross-frame guard (M4 G1). A binding stores the VarID of the body that
+		// Cross-frame guard. A binding stores the VarID of the body that
 		// declared it. Module-wide numbering keeps those ids distinct across bodies, so
 		// they no longer collide, but a captured variable from an outer frame still does
 		// not appear in THIS frame's varIDNames or liveness tables. Track a capture only
@@ -434,8 +430,8 @@ func (c *checker) trackCapturedAliases(
 		// body's rename assigned b.VarID to this name. A capture from an outer frame
 		// reaches past its immediate enclosing function, so its liveness lives in another
 		// body's tables and cannot be queried here. Skipping is sound. It misses that
-		// transition rather than inventing one. The real cross-frame fix rides G2's
-		// lifetime-escape bridge; see the G2 note in m4-implementation-plan. This is
+		// transition rather than inventing one. The real cross-frame fix would resolve
+		// the capture through the lifetime-escape bridge. This is
 		// unreachable today because a captured mutable is a borrow, which cannot yet be
 		// aliased into a local.
 		if name, ok := c.fn.varIDNames[liveness.VarID(b.VarID)]; !ok || name != capture.Name {
@@ -512,11 +508,11 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 // parameter stored into an immutable global escapes to 'static, but the caller may
 // retain its own live mutable alias to the same value and mutate it after the call, so
 // the immutable global observes a mutation. Catching that needs the call site to enforce
-// the 'static borrow as unique, which is the borrow checker's job (#618 lifetime
-// enforcement, #762 move semantics), not this pass.
+// the 'static borrow as unique, which is the borrow checker's job through lifetime
+// enforcement and move semantics, not this pass.
 //
 // Run BEFORE constrainEscape so the source's own about-to-happen escape is not
-// double-counted by the G2 escape query as a prior permanent alias.
+// double-counted by the escape query as a prior permanent alias.
 func (c *checker) checkGlobalWriteTransition(target *ast.IdentExpr, rhs ast.Expr, slotType soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil {
 		return
@@ -624,7 +620,7 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 
 	// Initialize the alias tracker and seed each parameter leaf so aliases from
 	// parameters are tracked and mutability transitions involving them are detected.
-	// varIDTypes is the VarID → soltype bridge the `'static`-escape query reads in G2.
+	// varIDTypes is the VarID → soltype bridge the `'static`-escape query reads.
 	// seedParamLeafAliases records each param leaf's type into it alongside the alias
 	// mutability it derives from the same type.
 	aliases := liveness.NewAliasTracker()
@@ -641,11 +637,11 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias
 // tracker with one alias set per leaf binding, reading each leaf's mutability from
 // paramTypes so transitions involving the leaf are checked correctly. It also records
-// each leaf's type into varIDTypes, the bridge the G2 `'static`-escape query reads.
+// each leaf's type into varIDTypes, the bridge the `'static`-escape query reads.
 //
 // paramTypes is keyed by leaf name. An IdentPat parameter contributes the parameter
-// itself, and a destructuring param (M4 E1) contributes one entry per leaf via
-// bindPattern, so the lookup below resolves every leaf.
+// itself, and a destructuring param contributes one entry per leaf via bindPattern,
+// so the lookup below resolves every leaf.
 //
 // KNOWN LIMITATION: a destructured leaf's type is a fresh inference variable at
 // pre-pass time, before constraints are coalesced, so isMutableType sees a bare var
@@ -664,7 +660,7 @@ func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.
 				if isMutableType(t) {
 					mut = liveness.AliasMutable
 				}
-				// Record the leaf's type for the G2 escape query. An IdentPat param
+				// Record the leaf's type for the escape query. An IdentPat param
 				// binding is mono, so the body's reads instantiate this same pointer
 				// and a lifetime it later escapes to 'static is visible through it. A
 				// destructured leaf records a fresh var, which is not a RefType, so the
@@ -733,10 +729,10 @@ func sortedValueNames(s *Scope) []string {
 }
 
 // recordParamVarIDs copies each parameter leaf's rename-assigned VarID onto its
-// scope binding (M4 G1), so a closure that captures the parameter resolves it to
-// its alias set through trackCapturedAliases. It walks every leaf, so a
-// destructuring parameter's leaves (M4 E1) are covered alongside a plain IdentPat
-// parameter. Runs after the pre-pass, since the rename is what assigns the VarIDs.
+// scope binding, so a closure that captures the parameter resolves it to its alias
+// set through trackCapturedAliases. It walks every leaf, so a destructuring
+// parameter's leaves are covered alongside a plain IdentPat parameter. Runs after
+// the pre-pass, since the rename is what assigns the VarIDs.
 func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
 	for _, p := range params {
 		ast.ForEachLeafBinding(p.Pattern, func(name string, varID int) {
@@ -752,7 +748,7 @@ func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
 }
 
 // trackDestructureLeaves wires a body-level destructuring `val`/`var`'s leaves
-// (M4 E1) into the liveness machinery, the IdentPat path's per-leaf analogue. For
+// into the liveness machinery, the IdentPat path's per-leaf analogue. For
 // each leaf it copies the rename-assigned VarID onto the binding — so a closure
 // capturing the leaf resolves its alias set — and registers the leaf as a tracked
 // value carrying its mutability, so a later mutation or reassignment through it is

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -5,19 +5,18 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type,
-// returning ok=false when the annotation is outside the supported set. M2 needs
-// only the primitive annotations that annotated params and return types use
-// (number/string/boolean); everything richer — type references, generics,
-// object/tuple/function annotations, unions — is represented by types later
-// milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here, with
+// resolveTypeAnn converts a supported type annotation into a soltype.Type,
+// returning ok=false when the annotation is outside the supported set. The
+// primitive annotations that annotated params and return types use
+// (number/string/boolean) are supported here. An annotation whose representation
+// is not yet supported resolves to an UnsupportedNodeError, with
 // ok=false and a `never` placeholder so a caller can recover by keeping the type
 // it already inferred (rather than constraining against / adopting `never`, which
 // would cascade a spurious `<: never` error and poison the binding). It takes the
 // current inference level `lvl` so a supported generic with an UNSUPPORTED inner (a
 // malformed `Promise<…>`) can recover its inner to a fresh var at the right level
 // while keeping the wrapper; the primitive arms ignore lvl. Full name resolution
-// against the type scope still arrives with TypeRef support (M7).
+// against the type scope still arrives with later TypeRef support.
 func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	switch ta := ta.(type) {
 	case *ast.NumberTypeAnn:
@@ -27,24 +26,24 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
 	case *ast.TypeRefTypeAnn:
-		// M3 (PR3) recognises a single generic stdlib reference: Promise<T>. The
-		// real, alias-driven TypeRef resolution arrives in M7 — until then, any
+		// Only a single generic stdlib reference is recognised here: Promise<T>. The
+		// real, alias-driven TypeRef resolution arrives later — until then, any
 		// other name (or arity) reports unsupported with a `never` placeholder so
 		// the caller can recover by keeping the inferred type.
 		//
-		// FOOTGUN (removed in M7): this matches the bare NAME "Promise" WITHOUT
+		// FOOTGUN: this matches the bare NAME "Promise" WITHOUT
 		// consulting the type scope, so it would preempt any user-defined
 		// `type Promise<T> = …` alias. That is harmless today (user type aliases
 		// don't resolve yet, and the prelude only seeds Promise as an opaque
-		// placeholder), but M7's scope-driven TypeRef resolution MUST replace this
-		// hardcoded check — resolve the name through the scope first — so a real
+		// placeholder), but the eventual scope-driven TypeRef resolution MUST replace
+		// this hardcoded check — resolve the name through the scope first — so a real
 		// alias wins instead of being silently shadowed by this stub.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
 			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
-			// supported: M3's PromiseType carries no lifetime, so silently accepting it
+			// supported: PromiseType carries no lifetime, so silently accepting it
 			// would drop the lifetime. Reject it as an unsupported feature rather than
-			// coercing to a plain Promise<T>. (Lifetimes on referenced types land with
-			// the wider TypeRef/lifetime work.)
+			// coercing to a plain Promise<T>. Lifetimes on referenced types land with
+			// the wider TypeRef/lifetime work.
 			if len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
 				return c.reportUnsupportedFeature(ta, "lifetime annotation on Promise"), false
 			}
@@ -61,11 +60,11 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 				// `unknown` inner would instead cascade a spurious `<: never` / `<:
 				// unknown`, since constrain has no rule for either as an input).
 				//
-				// PR8 (planning/simple_sub/m3-implementation-plan.md) deliberately
-				// KEEPS this fresh var rather than substituting its ErrorType sentinel:
-				// PR8 repoints only the no-good-type recovery, and this one yields a
-				// strictly better type — the fresh var generalizes (`Promise<_>` ⇒
-				// `Promise<T0>`) where ErrorType would freeze it to `Promise<error>`.
+				// This deliberately KEEPS the fresh var rather than substituting the
+				// ErrorType sentinel: the sentinel recovery applies only to the
+				// no-good-type case, and this one yields a strictly better type — the
+				// fresh var generalizes (`Promise<_>` ⇒ `Promise<T0>`) where ErrorType
+				// would freeze it to `Promise<error>`.
 				inner = c.freshAt(lvl)
 			}
 			t := &soltype.PromiseType{Inner: inner}
@@ -101,10 +100,10 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 }
 
 // resolveObjectTypeAnn lowers an object type annotation to a soltype.ObjectType,
-// honoring the trailing `...` inexact marker. M4 ships PropertyElem only: a
-// `name: T` / `name?: T` property resolves to a PropertyElem; method/getter/setter
-// members (M5), mapped/index signatures and the object rest/spread (M9) are not
-// part of M4's object and report an unsupported feature, with the object still
+// honoring the trailing `...` inexact marker. Only PropertyElem is supported: a
+// `name: T` / `name?: T` property resolves to a PropertyElem. Method/getter/setter
+// members, mapped/index signatures, and the object rest/spread are not yet
+// supported and report an unsupported feature, with the object still
 // built from the properties that do resolve. Duplicate keys follow the
 // last-wins-first-position dedup inferObject uses, keeping property names unique.
 //
@@ -131,7 +130,7 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 		var ft soltype.Type = c.freshAt(lvl)
 		if prop.Value != nil {
 			value := prop.Value
-			// An owned-mutable field `{a: mut {x}}` is rejected (#779): a `mut` cell
+			// An owned-mutable field `{a: mut {x}}` is rejected: a `mut` cell
 			// nested inside a non-mut container is misleading, since the container's
 			// immutability already reaches into the field. Recover to the field's bare
 			// inner so the object keeps a sensible shape. A `&`/`&mut` borrow field is a
@@ -156,8 +155,8 @@ func (c *checker) resolveObjectTypeAnn(ta *ast.ObjectTypeAnn, lvl int) (soltype.
 
 // resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType,
 // honoring the trailing `...` inexact marker. A rest-spread / variadic element
-// (`[...P]`, `[number, ...Array<number>]`) defers with its type-level feature
-// (M9 / M7) and reports unsupported; the bare trailing `...` inexact marker is
+// (`[...P]`, `[number, ...Array<number>]`) is not yet supported and reports
+// unsupported; the bare trailing `...` inexact marker is
 // carried on ta.Inexact, not as an element. An element whose annotation is
 // unsupported recovers to a fresh var so the tuple keeps its arity.
 func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
@@ -168,7 +167,7 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 			unsupported = true
 			continue
 		}
-		// An owned-mutable element `[mut {x}]` is rejected (#779), the tuple twin of
+		// An owned-mutable element `[mut {x}]` is rejected, the tuple twin of
 		// the object-property rejection above: a `mut` cell nested inside a non-mut
 		// container is misleading. Recover to the element's bare inner. A `&`/`&mut`
 		// borrow element stays legal — it references external storage.
@@ -193,7 +192,7 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 // resolveUnionTypeAnn lowers `A | B | …` through newUnion. An unsupported
 // member recovers to a fresh var so the union shape survives, mirroring the
 // Promise<bad> and object/tuple cascade-safe recovery. The Inexact flag and
-// its parser surface land in PR4.
+// its parser surface are not yet implemented.
 func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {
@@ -235,16 +234,16 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 }
 
 // resolveMutableTypeAnn lowers a `mut T` annotation to an owned-mutable borrow,
-// RefType{Mut: true, Lt: nil, Inner: T} (the C1 RefType wrapper). The lifetime
-// borrow forms (`'a T`, `mut 'a T`) still defer: a named lifetime needs the
-// lifetime sort (D1), and the parser already rejects a lifetime before a non-
-// reference inner, so only the no-lifetime `mut` form reaches here.
+// RefType{Mut: true, Lt: nil, Inner: T}. The lifetime borrow forms (`'a T`,
+// `mut 'a T`) still defer: a named lifetime needs the lifetime sort, and the
+// parser already rejects a lifetime before a non-reference inner, so only the
+// no-lifetime `mut` form reaches here.
 //
 // `mut` over a non-borrowable inner (a primitive, function, promise — anything
 // outside RefInner) is a no-op in the value-types model: there is nothing to
 // borrow. It reports an unsupported feature rather than fabricating a borrow over
 // a type the wrapper cannot hold.
-// resolveMutableTypeAnn stores the lazy deep-mut form (PR 14): the inner is wrapped
+// resolveMutableTypeAnn stores the lazy deep-mut form: the inner is wrapped
 // in one owned-mutable RefType without rewriting its children. `mut {a: {x}}` stays
 // `mut {a: {x}}` rather than deepening to `mut {a: mut {x}}`. The deep-mut rule —
 // every nested object/tuple field is invariant and reads back mutable — is applied
@@ -291,7 +290,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	if !ok {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
-	// The lazy deep-mut form (PR 14) stores `&mut {a: {x}}` verbatim; the deep-mut
+	// The lazy deep-mut form stores `&mut {a: {x}}` verbatim; the deep-mut
 	// rule is applied at access and constrain time rather than by rewriting the
 	// pointee's children here.
 	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
@@ -336,7 +335,7 @@ func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 }
 
 // annPrim mints a FRESH PrimType for an annotation and records it against the
-// annotation node (AnnotationType origin) — the "fresh-atom discipline" (§3.3).
+// annotation node (AnnotationType origin) — the "fresh-atom discipline".
 //
 // Why fresh, rather than a single shared/interned `number` value? Provenance is
 // the reason. The Prov side table is keyed by POINTER IDENTITY
@@ -347,7 +346,7 @@ func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 //   - Precise blame. A unique atom per annotation lets `val x: number = "hi"`
 //     resolve its `number` operand back to the exact annotation node — surfaced as
 //     the related "expected here" span — and lets a prim/prim mismatch blame the
-//     offending annotation instead of degrading to the constraint site (§3.3, §3.7).
+//     offending annotation instead of degrading to the constraint site.
 //   - No Prov-invariant conflict. recordProv requires each type pointer to map to a
 //     single node; the debugProv guard panics when a pointer is re-recorded against
 //     a DIFFERENT node (prov.go). A shared `number` would be recorded against every

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -10,7 +10,7 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 // and re-wrapped via NewRef. Every other type passes through unchanged.
 //
 // It is the new-checker analogue of internal/checker's widenLiteral /
-// widenObjectLiterals / widenTupleLiterals (unify.go). M4 B3 calls it in two
+// widenObjectLiterals / widenTupleLiterals (unify.go). It is called in two
 // places, both for an un-annotated `var`:
 //   - eagerly on a DIRECT literal initializer in inferVarDeclInit, widening at
 //     the constraint level so the widened type propagates through the bound graph
@@ -19,7 +19,7 @@ import "github.com/escalier-lang/escalier/internal/soltype"
 //     which catches a literal that arrives through a REFERENCE (`var y = x`) and
 //     is still a variable when inferVarDeclInit runs.
 //
-// A `val` keeps its fixed literal. C3's field-write path reuses it: writing
+// A `val` keeps its fixed literal. The field-write path reuses it. Writing
 // through a `mut` receiver is itself a mutation, so the stored value widens too.
 func widen(t soltype.Type) soltype.Type {
 	switch t := t.(type) {

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// M4 B3: an un-annotated `var` binding widens its initializer's literal types to
+// An un-annotated `var` binding widens its initializer's literal types to
 // their primitives, recursively through objects and tuples, so a mutable cell can
 // later hold a different value of the same primitive. A `val` is a fixed
 // singleton and keeps its literal type. These exercise the rendered binding type
@@ -82,13 +82,13 @@ func TestInferVarWideningReassignment(t *testing.T) {
 	})
 }
 
-// widen's structural arms are exercised directly here because no M4 source can
-// yet produce a borrow-typed or inexact var initializer — C3's field-write path
-// is the first consumer of the RefType arm, and inexactness only reaches a var
-// binding through annotations (which take the annotation, not widening). These
-// pin the helper's full contract — literal lowering, recursive object/tuple
-// descent preserving Inexact, RefType peel/re-wrap preserving Mut, and
-// passthrough of already-widened or still-variable types — that C3 relies on.
+// widen's structural arms are exercised directly here because no source can yet
+// produce a borrow-typed or inexact var initializer. A field-write path is the
+// first consumer of the RefType arm, and inexactness only reaches a var binding
+// through an annotation, which takes the annotation rather than widening. These
+// pin the helper's full contract: literal lowering, recursive object and tuple
+// descent preserving Inexact, RefType peel and re-wrap preserving Mut, and
+// passthrough of already-widened or still-variable types.
 func TestWidenHelper(t *testing.T) {
 	numLit := &soltype.LitType{Lit: &soltype.NumLit{Value: 5}}
 	objLit := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
@@ -166,13 +166,13 @@ func TestInferVarWideningThroughReference(t *testing.T) {
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["y"])
 	})
-	// Reference widening rides the Widenable flag at coalesce time (display, the
-	// reassignment slot, the binding's own type), but the literal still flows into
-	// the bound graph unwidened, so a read of the reference-widened var into a new
-	// binding keeps the precise literal: `val z = y` ⇒ z: 5. A direct literal
-	// widens at the constraint level instead, so ITS reads widen (see
-	// TestInferVarWideningPropagatesToReads). z: 5 is sound — z is an immutable
-	// snapshot of the value 5 — and this pins the narrow remaining corner.
+	// Reference widening rides the Widenable flag at coalesce time, covering
+	// display, the reassignment slot, and the binding's own type. The literal still
+	// flows into the bound graph unwidened, so a read of the reference-widened var
+	// into a new binding keeps the precise literal: `val z = y` ⇒ z: 5. A direct
+	// literal widens at the constraint level instead, so ITS reads widen. See
+	// TestInferVarWideningPropagatesToReads. z: 5 is sound because z is an immutable
+	// snapshot of the value 5, and this pins the narrow remaining corner.
 	t.Run("reading a reference-widened var keeps the literal", func(t *testing.T) {
 		values, _, errs := inferSource(t, "val x = 5\nvar y = x\nval z = y")
 		require.Empty(t, errs)


### PR DESCRIPTION
Clean up documentation comments throughout the solver and soltype packages by removing references to specific milestones (M1–M6) and pull request numbers (PR1–PR13) that are no longer meaningful to readers. These markers were used during development to track which features landed in which phase, but they clutter the codebase and make comments harder to read.

The changes preserve all technical content and explanations while simplifying the prose to follow CLAUDE.md's guidance on avoiding parentheticals and unnecessary asides. Comments now focus on what the code does rather than when it was added.

Key changes:
- Removed milestone markers (M1, M2, M3, M4, etc.) and PR numbers from ~80 comment blocks across solver and soltype packages
- Simplified prose in comments to be more direct and readable
- Preserved all technical explanations, constraints, and design rationale
- Updated comments in test files to match the main code cleanup

https://claude.ai/code/session_018wBGkYEFDhDgnDV6bheqW6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of namespace member access in type inference, including borrowing namespace members correctly.
  * Tightened reassignment typing so inferred results stay more precise in some union-target cases.
  * Refined error-span reporting and recovery behavior so diagnostics point to the right source more consistently.

* **Tests**
  * Added coverage for unsupported value indexing and borrowing namespace members.
  * Expanded regression coverage across inference, overloads, lifetimes, and coalescing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->