### PR TITLE
Infer owned-mutable from fresh literal construction

### DIFF
--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -111,6 +111,98 @@ func TestInferBorrowMutOnImmutableRejected(t *testing.T) {
 	}, Messages(errs))
 }
 
+// --- Rule 3 (binding initializer): owned-mutable construction ------------------
+
+// `val mut q = {…}` from a freshly constructed literal builds an owned-mutable
+// value, the unannotated mirror of `val q: mut {x} = {x: 1}`. A fresh literal is
+// uniquely owned, so granting it the mutable type aliases nothing. The literal's
+// field widens, since the mutable cell admits any `number`, so the result is
+// `mut {x: number}` rather than `mut {x: 0}`.
+func TestInferValMutConstructsOwnedMut(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val mut q = {x: 0}
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {x: number}", values["f"])
+}
+
+// `var mut q = {…}` constructs owned-mutable too. The reassignable binding and the
+// mutable value are orthogonal: both widen the literal, so the cell renders the
+// same `mut {x: number}` as the `val mut` form.
+func TestInferVarMutConstructsOwnedMut(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  var mut q = {x: 0}
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {x: number}", values["f"])
+}
+
+// The owned-mutable construction is deep and uniform, reaching nested objects and
+// tuple elements, so `val mut q = {a: {b: 1}}` is mutable to its leaves.
+func TestInferValMutConstructsDeepOwnedMut(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val mut q = {a: {b: 1}}
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {a: {b: number}}", values["f"])
+}
+
+// A constructed owned-mutable value admits an ordinary field write. The widened
+// field is `number`, so `q.x = 5` checks where a non-widened `mut {x: 0}` would
+// reject `5 <: 0` under the mutable field's invariance.
+func TestInferValMutConstructedAllowsFieldWrite(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val mut q = {x: 0}
+  q.x = 5
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {x: number}", values["f"])
+}
+
+// A constructed owned-mutable value can be borrowed `&mut`. The mutable cell fills
+// the mutable borrow slot, so `&mut q` checks where an owned-immutable q would fail
+// the mutability gate. This is the construction-side companion to
+// TestInferValMutBorrowFromOwnedMut, which sources owned-mutable from a parameter.
+func TestInferValMutConstructedBorrowsMut(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val mut q = {x: 0}
+  val r = &mut q
+  return r
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> &mut {x: number}", values["f"])
+}
+
+// A `mut` binding of a primitive is unchanged: a primitive is a value type with no
+// interior mutability, so it is not wrapped in an owned-mutable borrow. A `val mut`
+// keeps the literal singleton, exactly as a plain `val` would.
+func TestInferValMutPrimitiveUnchanged(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val mut n = 5
+  return n
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> 5", values["f"])
+}
+
+// The construction upgrade fires only for a freshly constructed literal. Binding a
+// `mut` to a non-fresh source — here a parameter — does not upgrade it to
+// owned-mutable, since moving an existing owned value into a mutable binding is the
+// thaw move whose consume enforcement lands in PR 8. The binding stays at the
+// source's owned-immutable type for now.
+func TestInferValMutFromVariableNotUpgraded(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(src: {x: number}) {
+  val mut p = src
+  return p
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (src: {x: number}) -> {x: number}", values["f"])
+}
+
 // --- Rule 3 (binding initializer): annotated bindings --------------------------
 
 // `val q: {x} = p` for an owned-immutable p binds q at the annotated owned type.

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -79,6 +79,25 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
+	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && isFreshlyConstructed(d.Init):
+		// An unannotated `val mut q = {…}` / `var mut q = {…}` from a freshly
+		// constructed literal constructs an owned-mutable value. This is the
+		// unannotated mirror of `val q: mut {x} = {x: 1}`, which
+		// constrainInitAgainstAnnotation upgrades through the same fresh-literal
+		// reasoning: a fresh literal is uniquely owned, so granting it the mutable
+		// type aliases nothing. The literal's fields widen, since a mutable cell
+		// admits any value of the field's primitive type, so `val mut q = {x: 1}`
+		// is `mut {x: number}` rather than `mut {x: 1}` — the latter would reject
+		// the ordinary write `q.x = 2`. A non-borrowable initializer (a primitive)
+		// has no interior mutability to make mutable, so it falls back to the
+		// var-widening / val-keep behaviour below.
+		if inner, ok := widen(initT).(soltype.RefInner); ok {
+			ref := &soltype.RefType{Mut: true, Lt: nil, Inner: inner}
+			c.recordProv(ref, d.Init, OwnedMutConstruction)
+			initT = ref
+		} else if d.Kind == ast.VarKind {
+			initT = widen(initT)
+		}
 	case d.TypeAnn != nil:
 		// M2.5: constrain the initializer against the annotation (the one
 		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
@@ -224,6 +243,15 @@ func stripOwnedMut(t soltype.Type) soltype.Type {
 	default:
 		return t
 	}
+}
+
+// isMutableIdentPat reports whether p is a simple identifier binding written with
+// the `mut` prefix, as in `val mut q = …`. The construction upgrade applies only to
+// an IdentPat; a `mut` leaf inside a destructuring pattern carries the same flag but
+// needs the per-leaf projection work the destructuring mutability path owns.
+func isMutableIdentPat(p ast.Pat) bool {
+	ip, ok := p.(*ast.IdentPat)
+	return ok && ip.Mutable
 }
 
 // isFreshlyConstructed reports whether e is a syntactically fresh, unaliased value: a

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -81,22 +81,23 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	switch {
 	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && isFreshlyConstructed(d.Init):
 		// An unannotated `val mut q = {…}` / `var mut q = {…}` from a freshly
-		// constructed literal constructs an owned-mutable value. This is the
-		// unannotated mirror of `val q: mut {x} = {x: 1}`, which
-		// constrainInitAgainstAnnotation upgrades through the same fresh-literal
-		// reasoning: a fresh literal is uniquely owned, so granting it the mutable
+		// constructed literal constructs an owned-mutable value. This mirrors the
+		// annotated `val q: mut {x} = {x: 1}` upgrade in
+		// constrainInitAgainstAnnotation, which uses the same fresh-literal
+		// reasoning. A fresh literal is uniquely owned, so granting it the mutable
 		// type aliases nothing. The literal's fields widen, since a mutable cell
-		// admits any value of the field's primitive type, so `val mut q = {x: 1}`
-		// is `mut {x: number}` rather than `mut {x: 1}` — the latter would reject
-		// the ordinary write `q.x = 2`. A non-borrowable initializer (a primitive)
-		// has no interior mutability to make mutable, so it falls back to the
-		// var-widening / val-keep behaviour below.
-		if inner, ok := widen(initT).(soltype.RefInner); ok {
-			ref := &soltype.RefType{Mut: true, Lt: nil, Inner: inner}
+		// admits any value of the field's primitive type. So `val mut q = {x: 1}`
+		// is `mut {x: number}`. A `mut {x: 1}` would reject the ordinary write
+		// `q.x = 2`. A primitive initializer is not borrowable and has no interior
+		// mutability to make mutable, so it falls back to the var-widening and
+		// val-keep behaviour below.
+		widened := widen(initT)
+		if inner, ok := widened.(soltype.RefInner); ok {
+			ref := soltype.NewRef(true, nil, inner)
 			c.recordProv(ref, d.Init, OwnedMutConstruction)
 			initT = ref
 		} else if d.Kind == ast.VarKind {
-			initT = widen(initT)
+			initT = widened
 		}
 	case d.TypeAnn != nil:
 		// M2.5: constrain the initializer against the annotation (the one

--- a/internal/solver/prov.go
+++ b/internal/solver/prov.go
@@ -65,6 +65,7 @@ const (
 	IfElseBranch                            // a fresh branch-join var from inferIfElse (the union of cons / alt)
 	MatchBranch                             // a fresh branch-join var from inferMatch (the union of every arm body)
 	BorrowExprOrigin                        // a RefType minted by inferBorrow from a `&p` / `&mut p` expression
+	OwnedMutConstruction                    // an owned-mutable RefType minted for `val mut q = {…}` from a fresh literal
 )
 
 // NodeResolver resolves an operand type to the AST node that minted it. M2.5's


### PR DESCRIPTION
Implement the unannotated form of owned-mutable construction: `val mut q = {…}` and `var mut q = {…}` now infer an owned-mutable type when initialized from a freshly constructed literal.

This mirrors the annotated upgrade in `constrainInitAgainstAnnotation` (e.g., `val q: mut {x} = {x: 1}`). Since a fresh literal is uniquely owned, granting it the mutable type aliases nothing. The literal's fields widen to admit any value of their primitive type, so `val mut q = {x: 1}` infers `mut {x: number}` rather than `mut {x: 1}`.

Key changes:

- Add `isMutableIdentPat` helper to detect simple `mut` identifier bindings (not destructuring patterns).
- Add `isFreshlyConstructed` check in `inferVarDeclInit` to gate the upgrade to fresh literals only.
- When both conditions hold, widen the initializer type and wrap it in an owned-mutable reference, recording `OwnedMutConstruction` provenance.
- Primitives fall back to normal widening (for `var`) or literal preservation (for `val`) since they have no interior mutability.
- Non-fresh sources (e.g., parameters) do not upgrade, preserving the source's owned-immutable type.

Add comprehensive test coverage for the new behavior: basic construction, deep nesting, field writes, mutable borrows, primitives, and non-fresh sources.

https://claude.ai/code/session_01T1cjeu3ED6USG2sWEQdj6U