### PR TITLE
PR 5: Move engine substrate and generalized escape detection

### DIFF
--- a/internal/liveness/moves.go
+++ b/internal/liveness/moves.go
@@ -271,8 +271,11 @@ func (m *MoveInfo) StateBefore(ref StmtRef, v VarID) MoveState {
 }
 
 // StateAfter returns v's move state just after the statement at ref — StateBefore
-// with that statement's own moves applied. A StmtIdx of -1 reads the block entry,
-// where no statement has run, so it equals StateBefore there.
+// with that statement's own moves applied. A StmtIdx of -1 reads block-entry
+// semantics: the block's joined entry state with any synthetic -1 entry-position
+// moves applied, the state just after that synthetic position. It does NOT equal
+// StateBefore at -1 when an entry-position move is recorded, since StateBefore reads
+// the entry state before that move.
 func (m *MoveInfo) StateAfter(ref StmtRef, v VarID) MoveState {
 	if ref.StmtIdx < 0 {
 		return lookupMoveState(m.blockEntry, ref.BlockID, v)

--- a/internal/liveness/moves.go
+++ b/internal/liveness/moves.go
@@ -1,6 +1,10 @@
 package liveness
 
-import "github.com/escalier-lang/escalier/internal/set"
+import (
+	"maps"
+
+	"github.com/escalier-lang/escalier/internal/set"
+)
 
 // MoveState is one binding's position in the consumed lattice — the per-binding
 // move tracking the affine move engine joins at every CFG merge. A binding moves
@@ -72,20 +76,27 @@ type MoveInfo struct {
 	// after[blockID][stmtIdx][v] is v's move state just after that statement —
 	// before with the statement's own moves applied.
 	after [][]map[VarID]MoveState
-	// blockIn[blockID][v] is v's state at the block's entry, the join of every
-	// predecessor's blockOut, before any move recorded at the synthetic -1
-	// position. StateBefore reads it for a StmtIdx -1 query, the position a
-	// decomposed DeclStmt's StmtRef points at (see BuildStmtToRef).
+	// A DeclStmt whose initializer branches is decomposed during CFG construction,
+	// so it occupies no real index in any block's statement list. BuildStmtToRef
+	// instead assigns its StmtRef the index -1, a synthetic position meaning "block
+	// entry, just before statement 0". A StateBefore or StateAfter call whose
+	// ref.StmtIdx is -1 — a "-1 query" — asks for v's move state at that entry
+	// position. blockIn and blockEntry hold the two answers such a query returns.
+	//
+	// blockIn[blockID][v] is v's state on entry to the block: the join of every
+	// predecessor's blockOut, taken before any move recorded at the -1 position is
+	// applied. StateBefore returns it for a -1 query.
 	blockIn []map[VarID]MoveState
-	// blockEntry[blockID][v] is blockIn with the block's -1 entry-position moves
-	// applied — the state just after the synthetic -1 position, which equals
-	// before[blockID][0] for a non-empty block. StateAfter reads it for a -1 query.
+	// blockEntry[blockID][v] is blockIn after the moves recorded at the block's -1
+	// position are applied, so it is the state just after that position. For a
+	// non-empty block it equals before[blockID][0], the state before statement 0.
+	// StateAfter returns it for a -1 query.
 	blockEntry []map[VarID]MoveState
 }
 
-// AnalyzeMoves runs the forward move-state dataflow over a CFG. moves names, per
-// statement, the VarIDs that statement moves — the consume sites PR 6 records
-// while walking the body. A statement absent from the map moves nothing.
+// AnalyzeMoves runs the forward move-state dataflow over a CFG. The moves map
+// records, for each statement, the VarIDs that statement moves — the consume sites
+// PR 6 collects while walking the body. A statement absent from the map moves nothing.
 //
 // The dataflow mirrors AnalyzeFunction's structure but runs FORWARD: liveness
 // flows backward from uses, moves flow forward from consume sites.
@@ -100,7 +111,7 @@ type MoveInfo struct {
 // fixed point converges because state only ever rises in the finite lattice.
 //
 // A StmtRef.StmtIdx of -1 is the synthetic position before a block's first
-// statement. moves entries at index -1 are applied at block entry, before
+// statement. The moves map entries at index -1 are applied at block entry, before
 // statement 0, matching how a decomposed DeclStmt's move would land.
 func AnalyzeMoves(cfg *CFG, moves map[StmtRef]set.Set[VarID]) *MoveInfo {
 	numBlocks := len(cfg.Blocks)
@@ -147,7 +158,11 @@ func AnalyzeMoves(cfg *CFG, moves map[StmtRef]set.Set[VarID]) *MoveInfo {
 	}
 
 	// Per-statement state within each block: start from blockIn and walk forward,
-	// applying each statement's moves in order.
+	// applying each statement's moves in order. applyMoves returns a fresh map and
+	// never mutates its input, so each map the cursor produces is immutable once
+	// created. The slots can therefore store the reference directly — logically equal
+	// points such as after[idx] and before[idx+1] share one map, which is safe because
+	// nothing writes to these maps after AnalyzeMoves returns.
 	before := make([][]map[VarID]MoveState, numBlocks)
 	after := make([][]map[VarID]MoveState, numBlocks)
 	blockEntry := make([]map[VarID]MoveState, numBlocks)
@@ -158,11 +173,11 @@ func AnalyzeMoves(cfg *CFG, moves map[StmtRef]set.Set[VarID]) *MoveInfo {
 
 		// Apply any moves recorded at the synthetic -1 entry position first.
 		state := applyMoves(blockIn[block.ID], movesAt(moves, block.ID, -1))
-		blockEntry[block.ID] = cloneMoveMap(state)
-		for idx := 0; idx < n; idx++ {
-			before[block.ID][idx] = cloneMoveMap(state)
+		blockEntry[block.ID] = state
+		for idx := range n {
+			before[block.ID][idx] = state
 			state = applyMoves(state, movesAt(moves, block.ID, idx))
-			after[block.ID][idx] = cloneMoveMap(state)
+			after[block.ID][idx] = state
 		}
 	}
 
@@ -192,6 +207,7 @@ func joinPreds(block *BasicBlock, blockOut []map[VarID]MoveState) map[VarID]Move
 				joined = JoinMoveState(joined, s)
 			}
 		}
+		// Keep the map sparse: an absent key already means NotMoved, so never store it.
 		if joined != NotMoved {
 			in[v] = joined
 		}
@@ -222,9 +238,7 @@ func movesAt(moves map[StmtRef]set.Set[VarID], blockID, stmtIdx int) set.Set[Var
 
 func cloneMoveMap(m map[VarID]MoveState) map[VarID]MoveState {
 	out := make(map[VarID]MoveState, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
+	maps.Copy(out, m)
 	return out
 }
 

--- a/internal/liveness/moves.go
+++ b/internal/liveness/moves.go
@@ -1,0 +1,284 @@
+package liveness
+
+import "github.com/escalier-lang/escalier/internal/set"
+
+// MoveState is one binding's position in the consumed lattice — the per-binding
+// move tracking the affine move engine joins at every CFG merge. A binding moves
+// when an owned value flows out of it at a consume site (a return, a store, a
+// consuming argument, an escaping capture). The three states answer "has this
+// binding been moved on the paths that reach here":
+//
+//		            MaybeMoved
+//		           /          \
+//		     NotMoved          Moved
+//
+//	  - NotMoved: no reaching path moved it, so a use is allowed.
+//	  - Moved: every reaching path moved it, so a use is an unconditional
+//	    use-after-move.
+//	  - MaybeMoved: some but not all reaching paths moved it, so a use is a
+//	    conditional use-after-move.
+//
+// PR 6 reads these at each use, passing NotMoved and rejecting Moved and
+// MaybeMoved. PR 5 only builds the analysis; it reports no user-facing errors.
+type MoveState int
+
+const (
+	// NotMoved is the lattice bottom-left and the entry state for every binding.
+	// A VarID never recorded as moved is NotMoved everywhere.
+	NotMoved MoveState = iota
+	// Moved means every reaching path moved the binding.
+	Moved
+	// MaybeMoved is the lattice top. It absorbs every join with a disagreeing
+	// state, so once a binding is MaybeMoved it stays MaybeMoved downstream.
+	MaybeMoved
+)
+
+func (s MoveState) String() string {
+	switch s {
+	case NotMoved:
+		return "NotMoved"
+	case Moved:
+		return "Moved"
+	case MaybeMoved:
+		return "MaybeMoved"
+	default:
+		return "MoveState(?)"
+	}
+}
+
+// JoinMoveState is the lattice join ⊔ applied at every CFG merge. Two edges that
+// agree keep their shared state; two that disagree raise the result to
+// MaybeMoved, which then absorbs everything. This is the table in the plan:
+//
+//	| ⊔          | NotMoved   | Moved      | MaybeMoved |
+//	| NotMoved   | NotMoved   | MaybeMoved | MaybeMoved |
+//	| Moved      | MaybeMoved | Moved      | MaybeMoved |
+//	| MaybeMoved | MaybeMoved | MaybeMoved | MaybeMoved |
+func JoinMoveState(a, b MoveState) MoveState {
+	if a == b {
+		return a
+	}
+	return MaybeMoved
+}
+
+// MoveInfo stores the consumed-lattice state computed for a function body, the
+// forward-dataflow counterpart of LivenessInfo. State is indexed by basic block
+// ID and statement index within the block. An absent VarID is NotMoved, so the
+// maps store only the bindings that some path has moved.
+type MoveInfo struct {
+	// before[blockID][stmtIdx][v] is v's move state just before that statement,
+	// joined across every path reaching the statement.
+	before [][]map[VarID]MoveState
+	// after[blockID][stmtIdx][v] is v's move state just after that statement —
+	// before with the statement's own moves applied.
+	after [][]map[VarID]MoveState
+	// blockIn[blockID][v] is v's state at the block's entry, the join of every
+	// predecessor's blockOut, before any move recorded at the synthetic -1
+	// position. StateBefore reads it for a StmtIdx -1 query, the position a
+	// decomposed DeclStmt's StmtRef points at (see BuildStmtToRef).
+	blockIn []map[VarID]MoveState
+	// blockEntry[blockID][v] is blockIn with the block's -1 entry-position moves
+	// applied — the state just after the synthetic -1 position, which equals
+	// before[blockID][0] for a non-empty block. StateAfter reads it for a -1 query.
+	blockEntry []map[VarID]MoveState
+}
+
+// AnalyzeMoves runs the forward move-state dataflow over a CFG. moves names, per
+// statement, the VarIDs that statement moves — the consume sites PR 6 records
+// while walking the body. A statement absent from the map moves nothing.
+//
+// The dataflow mirrors AnalyzeFunction's structure but runs FORWARD: liveness
+// flows backward from uses, moves flow forward from consume sites.
+//
+//	MoveIn[b]  = ⊔ { MoveOut[p] | p ∈ predecessors(b) }
+//	MoveOut[b] = MoveIn[b] with b's moves set to Moved
+//
+// MoveIn[entry] is empty (every binding NotMoved). The join at a merge block with
+// disagreeing predecessors raises a binding to MaybeMoved. A loop back edge feeds
+// the body's MoveOut into the header's MoveIn, so a binding moved inside the loop
+// is MaybeMoved at the header — a use there is a conditional use-after-move. The
+// fixed point converges because state only ever rises in the finite lattice.
+//
+// A StmtRef.StmtIdx of -1 is the synthetic position before a block's first
+// statement. moves entries at index -1 are applied at block entry, before
+// statement 0, matching how a decomposed DeclStmt's move would land.
+func AnalyzeMoves(cfg *CFG, moves map[StmtRef]set.Set[VarID]) *MoveInfo {
+	numBlocks := len(cfg.Blocks)
+
+	// Per-block move set: the union of every statement's moves in the block,
+	// including the synthetic -1 entry position. Applying the block's moves means
+	// overriding each to Moved, since a value cannot be un-moved.
+	blockMoves := make([]set.Set[VarID], numBlocks)
+	for i := range numBlocks {
+		blockMoves[i] = set.NewSet[VarID]()
+	}
+	for ref, vs := range moves {
+		for v := range vs {
+			blockMoves[ref.BlockID].Add(v)
+		}
+	}
+
+	blockIn := make([]map[VarID]MoveState, numBlocks)
+	blockOut := make([]map[VarID]MoveState, numBlocks)
+	for i := range numBlocks {
+		blockIn[i] = map[VarID]MoveState{}
+		blockOut[i] = map[VarID]MoveState{}
+	}
+
+	// Fixed-point iteration. State rises monotonically in the finite three-point
+	// lattice, so this terminates. Reverse block order is a forward-analysis
+	// heuristic; back edges from loops are why more than one pass is needed.
+	changed := true
+	for changed {
+		changed = false
+		for i := range numBlocks {
+			block := cfg.Blocks[i]
+
+			newIn := joinPreds(block, blockOut)
+			newOut := applyMoves(newIn, blockMoves[i])
+
+			if !equalMoveMap(blockIn[i], newIn) || !equalMoveMap(blockOut[i], newOut) {
+				changed = true
+				blockIn[i] = newIn
+				blockOut[i] = newOut
+			}
+		}
+	}
+
+	// Per-statement state within each block: start from blockIn and walk forward,
+	// applying each statement's moves in order.
+	before := make([][]map[VarID]MoveState, numBlocks)
+	after := make([][]map[VarID]MoveState, numBlocks)
+	blockEntry := make([]map[VarID]MoveState, numBlocks)
+	for _, block := range cfg.Blocks {
+		n := len(block.Stmts)
+		before[block.ID] = make([]map[VarID]MoveState, n)
+		after[block.ID] = make([]map[VarID]MoveState, n)
+
+		// Apply any moves recorded at the synthetic -1 entry position first.
+		state := applyMoves(blockIn[block.ID], movesAt(moves, block.ID, -1))
+		blockEntry[block.ID] = cloneMoveMap(state)
+		for idx := 0; idx < n; idx++ {
+			before[block.ID][idx] = cloneMoveMap(state)
+			state = applyMoves(state, movesAt(moves, block.ID, idx))
+			after[block.ID][idx] = cloneMoveMap(state)
+		}
+	}
+
+	return &MoveInfo{before: before, after: after, blockIn: blockIn, blockEntry: blockEntry}
+}
+
+// joinPreds computes a block's entry state as the lattice join of every
+// predecessor's exit state. A binding present in one predecessor's MoveOut but
+// absent from another joins against NotMoved, which raises it to MaybeMoved — so
+// the join must range over the union of all predecessor keys, not one at a time.
+// A block with no predecessors yields the empty map, every binding NotMoved.
+func joinPreds(block *BasicBlock, blockOut []map[VarID]MoveState) map[VarID]MoveState {
+	in := map[VarID]MoveState{}
+	keys := set.NewSet[VarID]()
+	for _, pred := range block.Predecessors {
+		for v := range blockOut[pred.ID] {
+			keys.Add(v)
+		}
+	}
+	for v := range keys {
+		var joined MoveState
+		for i, pred := range block.Predecessors {
+			s := blockOut[pred.ID][v] // absent ⇒ NotMoved (the zero value)
+			if i == 0 {
+				joined = s
+			} else {
+				joined = JoinMoveState(joined, s)
+			}
+		}
+		if joined != NotMoved {
+			in[v] = joined
+		}
+	}
+	return in
+}
+
+// applyMoves returns a copy of state with each VarID in moved overridden to
+// Moved. A move sets the binding to Moved regardless of its prior state, since a
+// value cannot be un-moved; a double move along one path lands on Moved, the case
+// PR 6 reads as an unconditional use-after-move.
+func applyMoves(state map[VarID]MoveState, moved set.Set[VarID]) map[VarID]MoveState {
+	out := cloneMoveMap(state)
+	for v := range moved {
+		out[v] = Moved
+	}
+	return out
+}
+
+// movesAt returns the VarIDs moved at one program point, or an empty set when the
+// point moves nothing.
+func movesAt(moves map[StmtRef]set.Set[VarID], blockID, stmtIdx int) set.Set[VarID] {
+	if vs, ok := moves[StmtRef{BlockID: blockID, StmtIdx: stmtIdx}]; ok {
+		return vs
+	}
+	return set.NewSet[VarID]()
+}
+
+func cloneMoveMap(m map[VarID]MoveState) map[VarID]MoveState {
+	out := make(map[VarID]MoveState, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// equalMoveMap reports whether two state maps assign the same MoveState to every
+// VarID. A missing key is NotMoved, so a map carrying only NotMoved entries
+// equals the empty map.
+func equalMoveMap(a, b map[VarID]MoveState) bool {
+	for k, va := range a {
+		if vb, ok := b[k]; (!ok && va != NotMoved) || (ok && va != vb) {
+			return false
+		}
+	}
+	for k, vb := range b {
+		if _, ok := a[k]; !ok && vb != NotMoved {
+			return false
+		}
+	}
+	return true
+}
+
+// StateBefore returns v's move state just before the statement at ref, joined
+// across every path that reaches it. A StmtIdx of -1 reads the block's entry
+// state, the position a decomposed DeclStmt's StmtRef points at. An out-of-range
+// ref or an unrecorded binding is NotMoved.
+func (m *MoveInfo) StateBefore(ref StmtRef, v VarID) MoveState {
+	if ref.StmtIdx < 0 {
+		return lookupMoveState(m.blockIn, ref.BlockID, v)
+	}
+	return lookupStmtState(m.before, ref, v)
+}
+
+// StateAfter returns v's move state just after the statement at ref — StateBefore
+// with that statement's own moves applied. A StmtIdx of -1 reads the block entry,
+// where no statement has run, so it equals StateBefore there.
+func (m *MoveInfo) StateAfter(ref StmtRef, v VarID) MoveState {
+	if ref.StmtIdx < 0 {
+		return lookupMoveState(m.blockEntry, ref.BlockID, v)
+	}
+	return lookupStmtState(m.after, ref, v)
+}
+
+func lookupMoveState(blockMaps []map[VarID]MoveState, blockID int, v VarID) MoveState {
+	if blockID < 0 || blockID >= len(blockMaps) {
+		return NotMoved
+	}
+	return blockMaps[blockID][v]
+}
+
+func lookupStmtState(stmtMaps [][]map[VarID]MoveState, ref StmtRef, v VarID) MoveState {
+	if ref.BlockID < 0 || ref.BlockID >= len(stmtMaps) {
+		return NotMoved
+	}
+	block := stmtMaps[ref.BlockID]
+	if ref.StmtIdx >= len(block) {
+		return NotMoved
+	}
+	return block[ref.StmtIdx][v]
+}

--- a/internal/liveness/moves.go
+++ b/internal/liveness/moves.go
@@ -126,8 +126,9 @@ func AnalyzeMoves(cfg *CFG, moves map[StmtRef]set.Set[VarID]) *MoveInfo {
 	}
 
 	// Fixed-point iteration. State rises monotonically in the finite three-point
-	// lattice, so this terminates. Reverse block order is a forward-analysis
-	// heuristic; back edges from loops are why more than one pass is needed.
+	// lattice, so this terminates. Forward block order is the heuristic for a
+	// forward analysis, the mirror of AnalyzeFunction's reverse order for backward
+	// liveness; back edges from loops are why more than one pass is needed.
 	changed := true
 	for changed {
 		changed = false

--- a/internal/liveness/moves_test.go
+++ b/internal/liveness/moves_test.go
@@ -1,0 +1,242 @@
+package liveness
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/stretchr/testify/require"
+)
+
+// newBlock builds a CFG basic block with nStmts statement slots. AnalyzeMoves
+// reads only len(Stmts) to size its per-statement arrays, so nil slots are fine.
+func mvBlock(id, nStmts int) *BasicBlock {
+	return &BasicBlock{ID: id, Stmts: make([]ast.Stmt, nStmts)}
+}
+
+// mvEdge wires from → to, populating both the successor and predecessor lists the
+// dataflow reads.
+func mvEdge(from, to *BasicBlock) {
+	from.Successors = append(from.Successors, to)
+	to.Predecessors = append(to.Predecessors, from)
+}
+
+// mvCFG assembles a CFG from blocks. Blocks must be passed with IDs equal to
+// their index, matching BuildCFG's newBlock numbering.
+func mvCFG(blocks ...*BasicBlock) *CFG {
+	return &CFG{Entry: blocks[0], Exit: blocks[len(blocks)-1], Blocks: blocks}
+}
+
+// moves builds a moves map from each StmtRef to the VarIDs that statement moves,
+// the input AnalyzeMoves takes.
+func moves(entries map[StmtRef][]VarID) map[StmtRef]set.Set[VarID] {
+	out := map[StmtRef]set.Set[VarID]{}
+	for ref, vs := range entries {
+		out[ref] = set.FromSlice(vs)
+	}
+	return out
+}
+
+func TestJoinMoveState(t *testing.T) {
+	cases := []struct {
+		a, b, want MoveState
+	}{
+		{NotMoved, NotMoved, NotMoved},
+		{NotMoved, Moved, MaybeMoved},
+		{Moved, NotMoved, MaybeMoved},
+		{Moved, Moved, Moved},
+		{NotMoved, MaybeMoved, MaybeMoved},
+		{Moved, MaybeMoved, MaybeMoved},
+		{MaybeMoved, MaybeMoved, MaybeMoved},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, JoinMoveState(c.a, c.b), "%v ⊔ %v", c.a, c.b)
+		require.Equal(t, c.want, JoinMoveState(c.b, c.a), "%v ⊔ %v (commuted)", c.b, c.a)
+	}
+}
+
+// An if/else where only the then-branch moves x leaves x MaybeMoved at the merge:
+// one reaching path moved it, the other did not.
+func TestMovesIfElseOneBranch(t *testing.T) {
+	const x VarID = 1
+	entry := mvBlock(0, 1) // cond
+	then := mvBlock(1, 1)  // move x
+	els := mvBlock(2, 0)
+	merge := mvBlock(3, 1) // use x
+	mvEdge(entry, then)
+	mvEdge(entry, els)
+	mvEdge(then, merge)
+	mvEdge(els, merge)
+	cfg := mvCFG(entry, then, els, merge)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 1, StmtIdx: 0}: {x},
+	}))
+
+	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 1, StmtIdx: 0}, x))
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 2, StmtIdx: 0}, x))
+	require.Equal(t, MaybeMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
+}
+
+// When both branches move x it is Moved at the merge: every reaching path moved it.
+func TestMovesIfElseBothBranches(t *testing.T) {
+	const x VarID = 1
+	entry := mvBlock(0, 1)
+	then := mvBlock(1, 1)
+	els := mvBlock(2, 1)
+	merge := mvBlock(3, 1)
+	mvEdge(entry, then)
+	mvEdge(entry, els)
+	mvEdge(then, merge)
+	mvEdge(els, merge)
+	cfg := mvCFG(entry, then, els, merge)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 1, StmtIdx: 0}: {x},
+		{BlockID: 2, StmtIdx: 0}: {x},
+	}))
+
+	require.Equal(t, Moved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
+}
+
+// A binding no path moves is NotMoved at the merge.
+func TestMovesIfElseNeitherBranch(t *testing.T) {
+	const x VarID = 1
+	entry := mvBlock(0, 1)
+	then := mvBlock(1, 1)
+	els := mvBlock(2, 1)
+	merge := mvBlock(3, 1)
+	mvEdge(entry, then)
+	mvEdge(entry, els)
+	mvEdge(then, merge)
+	mvEdge(els, merge)
+	cfg := mvCFG(entry, then, els, merge)
+
+	info := AnalyzeMoves(cfg, moves(nil))
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
+}
+
+// A three-arm match: two arms move x, one does not, so x is MaybeMoved at the
+// merge. When every arm moves it, x is Moved.
+func TestMovesMatchArms(t *testing.T) {
+	const x VarID = 1
+	build := func(armsMoving []int) *MoveInfo {
+		entry := mvBlock(0, 1)
+		arm1 := mvBlock(1, 1)
+		arm2 := mvBlock(2, 1)
+		arm3 := mvBlock(3, 1)
+		merge := mvBlock(4, 1)
+		for _, arm := range []*BasicBlock{arm1, arm2, arm3} {
+			mvEdge(entry, arm)
+			mvEdge(arm, merge)
+		}
+		cfg := mvCFG(entry, arm1, arm2, arm3, merge)
+		entries := map[StmtRef][]VarID{}
+		for _, arm := range armsMoving {
+			entries[StmtRef{BlockID: arm, StmtIdx: 0}] = []VarID{x}
+		}
+		return AnalyzeMoves(cfg, moves(entries))
+	}
+
+	twoOfThree := build([]int{1, 2})
+	require.Equal(t, MaybeMoved, twoOfThree.StateBefore(StmtRef{BlockID: 4, StmtIdx: 0}, x))
+
+	allThree := build([]int{1, 2, 3})
+	require.Equal(t, Moved, allThree.StateBefore(StmtRef{BlockID: 4, StmtIdx: 0}, x))
+}
+
+// A loop body that moves x leaves x MaybeMoved at the loop header and at the exit:
+// the body may run zero times (NotMoved) or at least once (Moved), and the back
+// edge joins those into MaybeMoved.
+func TestMovesLoopBackEdge(t *testing.T) {
+	const x VarID = 1
+	entry := mvBlock(0, 0)
+	header := mvBlock(1, 1) // cond, use x
+	body := mvBlock(2, 1)   // move x
+	exit := mvBlock(3, 1)   // use x
+	mvEdge(entry, header)
+	mvEdge(header, body)
+	mvEdge(header, exit)
+	mvEdge(body, header) // back edge
+	cfg := mvCFG(entry, header, body, exit)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 2, StmtIdx: 0}: {x},
+	}))
+
+	require.Equal(t, MaybeMoved, info.StateBefore(StmtRef{BlockID: 1, StmtIdx: 0}, x))
+	require.Equal(t, MaybeMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
+}
+
+// Within one block, move state advances statement by statement: NotMoved before
+// the move, Moved after it and at every later statement.
+func TestMovesSequentialWithinBlock(t *testing.T) {
+	const x VarID = 1
+	b := mvBlock(0, 3) // s0: nothing, s1: move x, s2: use x
+	cfg := mvCFG(b)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 0, StmtIdx: 1}: {x},
+	}))
+
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 0, StmtIdx: 0}, x))
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 0, StmtIdx: 1}, x))
+	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 0, StmtIdx: 1}, x))
+	require.Equal(t, Moved, info.StateBefore(StmtRef{BlockID: 0, StmtIdx: 2}, x))
+}
+
+// A second move along the same path overrides the first rather than failing the
+// analysis: the state stays Moved, the unconditional use-after-move PR 6 reports.
+func TestMovesDoubleMoveStaysMoved(t *testing.T) {
+	const x VarID = 1
+	b := mvBlock(0, 2)
+	cfg := mvCFG(b)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 0, StmtIdx: 0}: {x},
+		{BlockID: 0, StmtIdx: 1}: {x},
+	}))
+
+	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 0, StmtIdx: 0}, x))
+	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 0, StmtIdx: 1}, x))
+}
+
+// Independent bindings keep independent state: moving x along one branch does not
+// disturb y, which no path moves.
+func TestMovesIndependentBindings(t *testing.T) {
+	const x, y VarID = 1, 2
+	entry := mvBlock(0, 1)
+	then := mvBlock(1, 1)
+	els := mvBlock(2, 1)
+	merge := mvBlock(3, 1)
+	mvEdge(entry, then)
+	mvEdge(entry, els)
+	mvEdge(then, merge)
+	mvEdge(els, merge)
+	cfg := mvCFG(entry, then, els, merge)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 1, StmtIdx: 0}: {x},
+	}))
+
+	require.Equal(t, MaybeMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, y))
+}
+
+// A move recorded at the synthetic -1 entry position — where a decomposed
+// DeclStmt's StmtRef points — takes effect at block entry, before statement 0.
+func TestMovesSyntheticEntryPosition(t *testing.T) {
+	const x VarID = 1
+	b := mvBlock(0, 1)
+	cfg := mvCFG(b)
+
+	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
+		{BlockID: 0, StmtIdx: -1}: {x},
+	}))
+
+	// Before the -1 position the entry move has not yet applied; after it, and
+	// before statement 0, it has.
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 0, StmtIdx: -1}, x))
+	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 0, StmtIdx: -1}, x))
+	require.Equal(t, Moved, info.StateBefore(StmtRef{BlockID: 0, StmtIdx: 0}, x))
+}

--- a/internal/liveness/moves_test.go
+++ b/internal/liveness/moves_test.go
@@ -10,7 +10,7 @@ import (
 
 // newBlock builds a CFG basic block with nStmts statement slots. AnalyzeMoves
 // reads only len(Stmts) to size its per-statement arrays, so nil slots are fine.
-func mvBlock(id, nStmts int) *BasicBlock {
+func newBlock(id, nStmts int) *BasicBlock {
 	return &BasicBlock{ID: id, Stmts: make([]ast.Stmt, nStmts)}
 }
 
@@ -21,9 +21,9 @@ func mvEdge(from, to *BasicBlock) {
 	to.Predecessors = append(to.Predecessors, from)
 }
 
-// mvCFG assembles a CFG from blocks. Blocks must be passed with IDs equal to
+// newCFG assembles a CFG from blocks. Blocks must be passed with IDs equal to
 // their index, matching BuildCFG's newBlock numbering.
-func mvCFG(blocks ...*BasicBlock) *CFG {
+func newCFG(blocks ...*BasicBlock) *CFG {
 	return &CFG{Entry: blocks[0], Exit: blocks[len(blocks)-1], Blocks: blocks}
 }
 
@@ -59,15 +59,15 @@ func TestJoinMoveState(t *testing.T) {
 // one reaching path moved it, the other did not.
 func TestMovesIfElseOneBranch(t *testing.T) {
 	const x VarID = 1
-	entry := mvBlock(0, 1) // cond
-	then := mvBlock(1, 1)  // move x
-	els := mvBlock(2, 0)
-	merge := mvBlock(3, 1) // use x
+	entry := newBlock(0, 1) // cond
+	then := newBlock(1, 1)  // move x
+	els := newBlock(2, 0)
+	merge := newBlock(3, 1) // use x
 	mvEdge(entry, then)
 	mvEdge(entry, els)
 	mvEdge(then, merge)
 	mvEdge(els, merge)
-	cfg := mvCFG(entry, then, els, merge)
+	cfg := newCFG(entry, then, els, merge)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 1, StmtIdx: 0}: {x},
@@ -81,15 +81,15 @@ func TestMovesIfElseOneBranch(t *testing.T) {
 // When both branches move x it is Moved at the merge: every reaching path moved it.
 func TestMovesIfElseBothBranches(t *testing.T) {
 	const x VarID = 1
-	entry := mvBlock(0, 1)
-	then := mvBlock(1, 1)
-	els := mvBlock(2, 1)
-	merge := mvBlock(3, 1)
+	entry := newBlock(0, 1)
+	then := newBlock(1, 1)
+	els := newBlock(2, 1)
+	merge := newBlock(3, 1)
 	mvEdge(entry, then)
 	mvEdge(entry, els)
 	mvEdge(then, merge)
 	mvEdge(els, merge)
-	cfg := mvCFG(entry, then, els, merge)
+	cfg := newCFG(entry, then, els, merge)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 1, StmtIdx: 0}: {x},
@@ -102,15 +102,15 @@ func TestMovesIfElseBothBranches(t *testing.T) {
 // A binding no path moves is NotMoved at the merge.
 func TestMovesIfElseNeitherBranch(t *testing.T) {
 	const x VarID = 1
-	entry := mvBlock(0, 1)
-	then := mvBlock(1, 1)
-	els := mvBlock(2, 1)
-	merge := mvBlock(3, 1)
+	entry := newBlock(0, 1)
+	then := newBlock(1, 1)
+	els := newBlock(2, 1)
+	merge := newBlock(3, 1)
 	mvEdge(entry, then)
 	mvEdge(entry, els)
 	mvEdge(then, merge)
 	mvEdge(els, merge)
-	cfg := mvCFG(entry, then, els, merge)
+	cfg := newCFG(entry, then, els, merge)
 
 	info := AnalyzeMoves(cfg, moves(nil))
 	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
@@ -121,16 +121,16 @@ func TestMovesIfElseNeitherBranch(t *testing.T) {
 func TestMovesMatchArms(t *testing.T) {
 	const x VarID = 1
 	build := func(armsMoving []int) *MoveInfo {
-		entry := mvBlock(0, 1)
-		arm1 := mvBlock(1, 1)
-		arm2 := mvBlock(2, 1)
-		arm3 := mvBlock(3, 1)
-		merge := mvBlock(4, 1)
+		entry := newBlock(0, 1)
+		arm1 := newBlock(1, 1)
+		arm2 := newBlock(2, 1)
+		arm3 := newBlock(3, 1)
+		merge := newBlock(4, 1)
 		for _, arm := range []*BasicBlock{arm1, arm2, arm3} {
 			mvEdge(entry, arm)
 			mvEdge(arm, merge)
 		}
-		cfg := mvCFG(entry, arm1, arm2, arm3, merge)
+		cfg := newCFG(entry, arm1, arm2, arm3, merge)
 		entries := map[StmtRef][]VarID{}
 		for _, arm := range armsMoving {
 			entries[StmtRef{BlockID: arm, StmtIdx: 0}] = []VarID{x}
@@ -150,15 +150,15 @@ func TestMovesMatchArms(t *testing.T) {
 // edge joins those into MaybeMoved.
 func TestMovesLoopBackEdge(t *testing.T) {
 	const x VarID = 1
-	entry := mvBlock(0, 0)
-	header := mvBlock(1, 1) // cond, use x
-	body := mvBlock(2, 1)   // move x
-	exit := mvBlock(3, 1)   // use x
+	entry := newBlock(0, 0)
+	header := newBlock(1, 1) // cond, use x
+	body := newBlock(2, 1)   // move x
+	exit := newBlock(3, 1)   // use x
 	mvEdge(entry, header)
 	mvEdge(header, body)
 	mvEdge(header, exit)
 	mvEdge(body, header) // back edge
-	cfg := mvCFG(entry, header, body, exit)
+	cfg := newCFG(entry, header, body, exit)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 2, StmtIdx: 0}: {x},
@@ -172,8 +172,8 @@ func TestMovesLoopBackEdge(t *testing.T) {
 // the move, Moved after it and at every later statement.
 func TestMovesSequentialWithinBlock(t *testing.T) {
 	const x VarID = 1
-	b := mvBlock(0, 3) // s0: nothing, s1: move x, s2: use x
-	cfg := mvCFG(b)
+	b := newBlock(0, 3) // s0: nothing, s1: move x, s2: use x
+	cfg := newCFG(b)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 0, StmtIdx: 1}: {x},
@@ -189,8 +189,8 @@ func TestMovesSequentialWithinBlock(t *testing.T) {
 // analysis: the state stays Moved, the unconditional use-after-move PR 6 reports.
 func TestMovesDoubleMoveStaysMoved(t *testing.T) {
 	const x VarID = 1
-	b := mvBlock(0, 2)
-	cfg := mvCFG(b)
+	b := newBlock(0, 2)
+	cfg := newCFG(b)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 0, StmtIdx: 0}: {x},
@@ -205,15 +205,15 @@ func TestMovesDoubleMoveStaysMoved(t *testing.T) {
 // disturb y, which no path moves.
 func TestMovesIndependentBindings(t *testing.T) {
 	const x, y VarID = 1, 2
-	entry := mvBlock(0, 1)
-	then := mvBlock(1, 1)
-	els := mvBlock(2, 1)
-	merge := mvBlock(3, 1)
+	entry := newBlock(0, 1)
+	then := newBlock(1, 1)
+	els := newBlock(2, 1)
+	merge := newBlock(3, 1)
 	mvEdge(entry, then)
 	mvEdge(entry, els)
 	mvEdge(then, merge)
 	mvEdge(els, merge)
-	cfg := mvCFG(entry, then, els, merge)
+	cfg := newCFG(entry, then, els, merge)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 1, StmtIdx: 0}: {x},
@@ -227,8 +227,8 @@ func TestMovesIndependentBindings(t *testing.T) {
 // DeclStmt's StmtRef points — takes effect at block entry, before statement 0.
 func TestMovesSyntheticEntryPosition(t *testing.T) {
 	const x VarID = 1
-	b := mvBlock(0, 1)
-	cfg := mvCFG(b)
+	b := newBlock(0, 1)
+	cfg := newCFG(b)
 
 	info := AnalyzeMoves(cfg, moves(map[StmtRef][]VarID{
 		{BlockID: 0, StmtIdx: -1}: {x},

--- a/internal/liveness/moves_test.go
+++ b/internal/liveness/moves_test.go
@@ -74,7 +74,10 @@ func TestMovesIfElseOneBranch(t *testing.T) {
 	}))
 
 	require.Equal(t, Moved, info.StateAfter(StmtRef{BlockID: 1, StmtIdx: 0}, x))
-	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 2, StmtIdx: 0}, x))
+	// The else block has no statements, so query its entry position (StmtIdx -1).
+	// StmtIdx 0 would hit the out-of-range fallback and pass without reading the
+	// block's real joined entry state.
+	require.Equal(t, NotMoved, info.StateBefore(StmtRef{BlockID: 2, StmtIdx: -1}, x))
 	require.Equal(t, MaybeMoved, info.StateBefore(StmtRef{BlockID: 3, StmtIdx: 0}, x))
 }
 

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -117,6 +118,18 @@ type funcCtx struct {
 	aliases    *liveness.AliasTracker
 	stmtToRef  map[ast.Stmt]liveness.StmtRef
 	varIDNames map[liveness.VarID]string
+	// cfg is this body's control-flow graph, retained from the pre-pass so the move
+	// engine can run AnalyzeMoves over it. liveness and stmtToRef are derived from
+	// it; the move engine's branch-merged consumed lattice joins over the same
+	// blocks (PR 5). nil at module top-level, where no pre-pass runs.
+	cfg *liveness.CFG
+	// moveSites records, per CFG statement position, the VarIDs the ordered walk
+	// has consumed there — a binding moved by a return, a store, a consuming
+	// argument, or an escaping capture. PR 6 records into it while walking the body;
+	// AnalyzeMoves(cfg, moveSites) then yields the branch-merged consumed lattice
+	// the use-after-move check reads. PR 5 builds the analysis and this collector;
+	// the recording and reading land in PR 6, so it stays empty until then.
+	moveSites map[liveness.StmtRef]set.Set[liveness.VarID]
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in
 	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -318,38 +318,51 @@ func TestGlobalWriteMutTransition(t *testing.T) {
 	})
 }
 
+// objWithBorrowField builds `{f: <borrow>}` — an owned object carrying a borrow in
+// its `f` property. It models a value whose escape lives in a field, not at the top
+// level, the nested case PR 5 closes.
+func objWithBorrowField(borrow *soltype.RefType) *soltype.ObjectType {
+	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "f", Type: borrow},
+	}}
+}
+
 // TestBorrowEscapedToStatic locks the lifetime-sort query G2 uses in place of the
-// dropped escape bits: a borrow forced to 'static is recognized with its mutability, an
-// owned value or an unforced borrow is not.
+// dropped escape bits: a borrow forced to 'static is recognized at its mutability, an
+// owned value or an unforced borrow is not. PR 5 generalizes it to walk the whole
+// type, so a borrow nested in a field escapes too, reported per mutability.
 func TestBorrowEscapedToStatic(t *testing.T) {
 	c := transitionFixture(nil, liveness.NewAliasTracker(), set.NewSet[liveness.VarID]())
 
 	// `mut {x}` whose lifetime a global write forced to 'static, e.g. a `mut` param
 	// after `sink = p`. Escaped, mutably.
 	c.fn.varIDTypes[1] = staticBorrow(true)
-	mut, escaped := c.borrowEscapedToStatic(1)
-	require.True(t, escaped)
-	require.True(t, mut)
+	escMut, escImm := c.borrowEscapedToStatic(1)
+	require.True(t, escMut)
+	require.False(t, escImm)
 
 	// The immutable analogue: a `{x}` borrow forced to 'static. Escaped, immutably.
 	c.fn.varIDTypes[2] = staticBorrow(false)
-	mut, escaped = c.borrowEscapedToStatic(2)
-	require.True(t, escaped)
-	require.False(t, mut)
+	escMut, escImm = c.borrowEscapedToStatic(2)
+	require.False(t, escMut)
+	require.True(t, escImm)
 
 	// An explicit annotation `mut 'static {x}` escapes too.
 	c.fn.varIDTypes[3] = &soltype.RefType{Mut: true, Lt: soltype.Static, Inner: objT()}
-	_, escaped = c.borrowEscapedToStatic(3)
-	require.True(t, escaped)
+	escMut, escImm = c.borrowEscapedToStatic(3)
+	require.True(t, escMut)
+	require.False(t, escImm)
 
 	// An owned value such as `val v = {x: 0}` never escapes.
 	c.fn.varIDTypes[4] = objT()
-	_, escaped = c.borrowEscapedToStatic(4)
-	require.False(t, escaped)
+	escMut, escImm = c.borrowEscapedToStatic(4)
+	require.False(t, escMut)
+	require.False(t, escImm)
 
 	// An unrecorded variable does not escape.
-	_, escaped = c.borrowEscapedToStatic(99)
-	require.False(t, escaped)
+	escMut, escImm = c.borrowEscapedToStatic(99)
+	require.False(t, escMut)
+	require.False(t, escImm)
 
 	// 'static in the LOWER bounds is not an escape. The escape constraint `v <:
 	// 'static` adds an UPPER bound, so a lower-bound 'static, which can arise from a
@@ -359,8 +372,35 @@ func TestBorrowEscapedToStatic(t *testing.T) {
 		Lt:    &soltype.LifetimeVar{ID: 5, LowerBounds: []soltype.Lifetime{soltype.Static}},
 		Inner: objT(),
 	}
-	_, escaped = c.borrowEscapedToStatic(5)
-	require.False(t, escaped)
+	escMut, escImm = c.borrowEscapedToStatic(5)
+	require.False(t, escMut)
+	require.False(t, escImm)
+
+	// PR 5 nested case: an owned object `{f: mut 'static {x}}` whose FIELD is a borrow
+	// forced to 'static. The top-level type is an owned object, so the pre-PR-5
+	// top-level-only query missed it; the structural walk now reports the mutable
+	// escape in the field.
+	c.fn.varIDTypes[6] = objWithBorrowField(staticBorrow(true))
+	escMut, escImm = c.borrowEscapedToStatic(6)
+	require.True(t, escMut)
+	require.False(t, escImm)
+
+	// A nested IMMUTABLE escaped borrow is reported on the immutable side.
+	c.fn.varIDTypes[7] = objWithBorrowField(staticBorrow(false))
+	escMut, escImm = c.borrowEscapedToStatic(7)
+	require.False(t, escMut)
+	require.True(t, escImm)
+
+	// A nested borrow whose lifetime is NOT forced to 'static does not escape, just as
+	// at the top level.
+	c.fn.varIDTypes[8] = objWithBorrowField(&soltype.RefType{
+		Mut:   true,
+		Lt:    &soltype.LifetimeVar{ID: 8},
+		Inner: objT(),
+	})
+	escMut, escImm = c.borrowEscapedToStatic(8)
+	require.False(t, escMut)
+	require.False(t, escImm)
 }
 
 // TestTransitionReassignNestedRHS guards the currentStmt fix: a reassignment whose

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -334,73 +334,59 @@ func objWithBorrowField(borrow *soltype.RefType) *soltype.ObjectType {
 func TestBorrowEscapedToStatic(t *testing.T) {
 	c := transitionFixture(nil, liveness.NewAliasTracker(), set.NewSet[liveness.VarID]())
 
-	// `mut {x}` whose lifetime a global write forced to 'static, e.g. a `mut` param
-	// after `sink = p`. Escaped, mutably.
-	c.fn.varIDTypes[1] = staticBorrow(true)
-	escMut, escImm := c.borrowEscapedToStatic(1)
-	require.True(t, escMut)
-	require.False(t, escImm)
-
-	// The immutable analogue: a `{x}` borrow forced to 'static. Escaped, immutably.
-	c.fn.varIDTypes[2] = staticBorrow(false)
-	escMut, escImm = c.borrowEscapedToStatic(2)
-	require.False(t, escMut)
-	require.True(t, escImm)
-
-	// An explicit annotation `mut 'static {x}` escapes too.
-	c.fn.varIDTypes[3] = &soltype.RefType{Mut: true, Lt: soltype.Static, Inner: objT()}
-	escMut, escImm = c.borrowEscapedToStatic(3)
-	require.True(t, escMut)
-	require.False(t, escImm)
-
-	// An owned value such as `val v = {x: 0}` never escapes.
-	c.fn.varIDTypes[4] = objT()
-	escMut, escImm = c.borrowEscapedToStatic(4)
-	require.False(t, escMut)
-	require.False(t, escImm)
-
-	// An unrecorded variable does not escape.
-	escMut, escImm = c.borrowEscapedToStatic(99)
-	require.False(t, escMut)
-	require.False(t, escImm)
-
-	// 'static in the LOWER bounds is not an escape. The escape constraint `v <:
-	// 'static` adds an UPPER bound, so a lower-bound 'static, which can arise from a
-	// join member, must not be read as an escape. forcedToStatic would over-report it.
-	c.fn.varIDTypes[5] = &soltype.RefType{
-		Mut:   true,
-		Lt:    &soltype.LifetimeVar{ID: 5, LowerBounds: []soltype.Lifetime{soltype.Static}},
-		Inner: objT(),
+	cases := []struct {
+		name string
+		// varID is the tracked variable to query. typ is its recorded type, or nil to
+		// leave the variable unrecorded.
+		varID            liveness.VarID
+		typ              soltype.Type
+		wantMut, wantImm bool
+	}{
+		// `mut {x}` whose lifetime a global write forced to 'static, e.g. a `mut` param
+		// after `sink = p`. Escaped, mutably.
+		{"top-level mut borrow forced to 'static", 1, staticBorrow(true), true, false},
+		// The immutable analogue: a `{x}` borrow forced to 'static. Escaped, immutably.
+		{"top-level imm borrow forced to 'static", 2, staticBorrow(false), false, true},
+		// An explicit annotation `mut 'static {x}` escapes too.
+		{"explicit mut 'static annotation", 3, &soltype.RefType{Mut: true, Lt: soltype.Static, Inner: objT()}, true, false},
+		// An owned value such as `val v = {x: 0}` never escapes.
+		{"owned value never escapes", 4, objT(), false, false},
+		// An unrecorded variable does not escape.
+		{"unrecorded variable", 99, nil, false, false},
+		// 'static in the LOWER bounds is not an escape. The escape constraint `v <:
+		// 'static` adds an UPPER bound, so a lower-bound 'static, which can arise from a
+		// join member, must not be read as an escape. forcedToStatic would over-report it.
+		{"lower-bound 'static is not an escape", 5, &soltype.RefType{
+			Mut:   true,
+			Lt:    &soltype.LifetimeVar{ID: 5, LowerBounds: []soltype.Lifetime{soltype.Static}},
+			Inner: objT(),
+		}, false, false},
+		// PR 5 nested case: an owned object `{f: mut 'static {x}}` whose FIELD is a borrow
+		// forced to 'static. The top-level type is an owned object, so the pre-PR-5
+		// top-level-only query missed it; the structural walk now reports the mutable
+		// escape in the field.
+		{"nested mut borrow field forced to 'static", 6, objWithBorrowField(staticBorrow(true)), true, false},
+		// A nested IMMUTABLE escaped borrow is reported on the immutable side.
+		{"nested imm borrow field forced to 'static", 7, objWithBorrowField(staticBorrow(false)), false, true},
+		// A nested borrow whose lifetime is NOT forced to 'static does not escape, just
+		// as at the top level.
+		{"nested borrow field with unforced lifetime", 8, objWithBorrowField(&soltype.RefType{
+			Mut:   true,
+			Lt:    &soltype.LifetimeVar{ID: 8},
+			Inner: objT(),
+		}), false, false},
 	}
-	escMut, escImm = c.borrowEscapedToStatic(5)
-	require.False(t, escMut)
-	require.False(t, escImm)
 
-	// PR 5 nested case: an owned object `{f: mut 'static {x}}` whose FIELD is a borrow
-	// forced to 'static. The top-level type is an owned object, so the pre-PR-5
-	// top-level-only query missed it; the structural walk now reports the mutable
-	// escape in the field.
-	c.fn.varIDTypes[6] = objWithBorrowField(staticBorrow(true))
-	escMut, escImm = c.borrowEscapedToStatic(6)
-	require.True(t, escMut)
-	require.False(t, escImm)
-
-	// A nested IMMUTABLE escaped borrow is reported on the immutable side.
-	c.fn.varIDTypes[7] = objWithBorrowField(staticBorrow(false))
-	escMut, escImm = c.borrowEscapedToStatic(7)
-	require.False(t, escMut)
-	require.True(t, escImm)
-
-	// A nested borrow whose lifetime is NOT forced to 'static does not escape, just as
-	// at the top level.
-	c.fn.varIDTypes[8] = objWithBorrowField(&soltype.RefType{
-		Mut:   true,
-		Lt:    &soltype.LifetimeVar{ID: 8},
-		Inner: objT(),
-	})
-	escMut, escImm = c.borrowEscapedToStatic(8)
-	require.False(t, escMut)
-	require.False(t, escImm)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.typ != nil {
+				c.fn.varIDTypes[tc.varID] = tc.typ
+			}
+			escMut, escImm := c.borrowEscapedToStatic(tc.varID)
+			require.Equal(t, tc.wantMut, escMut)
+			require.Equal(t, tc.wantImm, escImm)
+		})
+	}
 }
 
 // TestTransitionReassignNestedRHS guards the currentStmt fix: a reassignment whose

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -636,6 +636,11 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.stmtToRef = stmtToRef
 	c.fn.varIDNames = renameResult.VarIDNames
 	c.fn.varIDTypes = varIDTypes
+	// Retain the CFG and a fresh consume-site collector for the move engine (PR 5).
+	// The branch-merged consumed lattice (liveness.AnalyzeMoves) joins over these
+	// same blocks. PR 6 records consume sites into moveSites while walking the body.
+	c.fn.cfg = cfg
+	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
 }
 
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -148,43 +148,77 @@ func isMutableType(t soltype.Type) bool {
 	return false
 }
 
-// borrowEscapedToStatic reports whether the variable's recorded type carries a
-// top-level borrow whose lifetime is forced to 'static, and that borrow's
-// mutability. It is the lifetime-sort replacement for the dropped
-// HasStatic{Mut,Imm}Alias bits in M4 G2. A borrow escapes when it is stored where it
-// outlives the function. D3's constrainEscape then pins its lifetime `<: 'static`, so
-// the value has a permanent outside alias of its mutability.
+// borrowEscapedToStatic reports, for the variable's recorded type, whether it
+// carries a borrow forced to 'static at each mutability — escapedMut for a mutable
+// escaped borrow, escapedImm for an immutable one. It is the lifetime-sort
+// replacement for the dropped HasStatic{Mut,Imm}Alias bits in M4 G2. A borrow
+// escapes when it is stored where it outlives the function. D3's constrainEscape
+// then pins its lifetime `<: 'static`, so the value has a permanent outside alias of
+// that borrow's mutability.
 //
-// Only the top-level RefType is inspected, matching the bits' "this value escaped"
-// semantics rather than "a field of this value escaped". An owned value, a borrow
-// with an unforced lifetime, or an unrecorded variable returns escaped=false.
+// The whole recorded type is walked, not just its top-level RefType (PR 5). A borrow
+// nested in a field or tuple element — for example the `&'static mut {…}` field of an
+// object stored into a global — is now seen, closing the nested-escape gap that made
+// a move past such a borrow unsound. Both mutabilities are reported because a value
+// can carry both a mutable and an immutable escaped borrow in different positions,
+// and Rule 1 and Rule 2 each conflict with one of them. An owned value, a borrow with
+// an unforced lifetime, or an unrecorded variable returns both false.
 //
-// KNOWN GAP (M4 G2 carry-over): a borrow reachable only through a usage-inferred
-// TypeVarType, or one nested in a field, is not seen here. The deeper fix resolves a
-// value's borrows through the constraint graph rather than its top-level type. See the
-// G2 note in planning/simple_sub/m4-implementation-plan.md.
-func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (mut bool, escaped bool) {
+// REMAINING GAP (M4 G2 carry-over): a borrow reachable only through a usage-inferred
+// TypeVarType is still not seen, because the soltype visitor treats a type variable as
+// a leaf and does not descend into its bounds. Resolving a value's borrows through the
+// constraint graph rather than its structural type is the deeper G2 fix. See the G2
+// note in planning/simple_sub/m4-implementation-plan.md.
+func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escapedImm bool) {
 	if c.fn == nil || c.fn.varIDTypes == nil {
 		return false, false
 	}
-	r, ok := c.fn.varIDTypes[varID].(*soltype.RefType)
-	if !ok || r.Lt == nil {
+	t, ok := c.fn.varIDTypes[varID]
+	if !ok || t == nil {
 		return false, false
 	}
-	switch lt := r.Lt.(type) {
-	case *soltype.StaticLifetime:
-		return r.Mut, true
-	case *soltype.LifetimeVar:
-		// The escape is the constraint `v <: 'static`, which adds 'static as an
-		// UPPER bound. Query that bound directly rather than the display-time
-		// forcedToStatic, which also matches a lower-bound 'static. A lower-bound
-		// 'static can arise from a join member and does not mean v escaped, so
-		// reusing forcedToStatic here would over-report an escape.
-		if soltype.ContainsLifetime(lt.UpperBounds, soltype.Static) {
-			return r.Mut, true
+	v := &escapeDetectVisitor{}
+	t.Accept(v, soltype.Positive)
+	return v.foundMut, v.foundImm
+}
+
+// escapeDetectVisitor records whether the walked type carries any borrow forced to
+// 'static, split by the borrow's mutability. It rewrites nothing; EnterType inspects
+// each RefType and the shared visitor carries the descent through inner carriers,
+// object properties, and tuple elements. A TypeVarType is a visitor leaf, so a borrow
+// reachable only through a usage-inferred variable is not reached — the REMAINING GAP
+// on borrowEscapedToStatic.
+type escapeDetectVisitor struct {
+	foundMut bool
+	foundImm bool
+}
+
+func (v *escapeDetectVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if r, ok := t.(*soltype.RefType); ok && lifetimeEscapedToStatic(r.Lt) {
+		if r.Mut {
+			v.foundMut = true
+		} else {
+			v.foundImm = true
 		}
 	}
-	return false, false
+	return soltype.EnterResult{}
+}
+
+func (*escapeDetectVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// lifetimeEscapedToStatic reports whether a borrow's lifetime has been forced to
+// outlive 'static — the escape constraint `v <: 'static`, which adds 'static as an
+// UPPER bound. A literal *StaticLifetime escapes outright. A lower-bound 'static does
+// not: it can arise from a join member and does not mean the borrow escaped, so the
+// display-time forcedToStatic, which also matches a lower bound, would over-report.
+func lifetimeEscapedToStatic(lt soltype.Lifetime) bool {
+	switch lt := lt.(type) {
+	case *soltype.StaticLifetime:
+		return true
+	case *soltype.LifetimeVar:
+		return soltype.ContainsLifetime(lt.UpperBounds, soltype.Static)
+	}
+	return false
 }
 
 // recordVarIDType records a tracked variable's soltype into the G2 escape bridge,
@@ -283,8 +317,12 @@ func (c *checker) checkMutabilityTransition(
 			// under Rule 1 and aliasMut == Immutable under Rule 2, i.e. aliasMut ==
 			// sourceMut. The escape check runs that same predicate for a permanent alias
 			// rather than a live local one. Checked before the liveness skip so a member
-			// that is locally dead but has escaped still counts.
-			if escMut, escaped := c.borrowEscapedToStatic(varID); escaped && escMut == sourceMut {
+			// that is locally dead but has escaped still counts. A value can carry an
+			// escaped borrow of each mutability, so select the one matching sourceMut:
+			// Rule 1's source is mutable and conflicts with a permanent MUTABLE escape,
+			// Rule 2's immutable source with a permanent IMMUTABLE escape.
+			escMut, escImm := c.borrowEscapedToStatic(varID)
+			if (sourceMut && escMut) || (!sourceMut && escImm) {
 				conflictingSet.Add(staticConflictName)
 			}
 			if !fn.liveness.IsLiveAfter(assignRef, varID) {

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -150,11 +150,9 @@ func isMutableType(t soltype.Type) bool {
 
 // borrowEscapedToStatic reports, for the variable's recorded type, whether it
 // carries a borrow forced to 'static at each mutability — escapedMut for a mutable
-// escaped borrow, escapedImm for an immutable one. It is the lifetime-sort
-// replacement for the dropped HasStatic{Mut,Imm}Alias bits in M4 G2. A borrow
-// escapes when it is stored where it outlives the function. D3's constrainEscape
-// then pins its lifetime `<: 'static`, so the value has a permanent outside alias of
-// that borrow's mutability.
+// escaped borrow, escapedImm for an immutable one. A borrow escapes when it is stored
+// where it outlives the function. D3's constrainEscape then pins its lifetime
+// `<: 'static`, so the value has a permanent outside alias of that borrow's mutability.
 //
 // The whole recorded type is walked, not just its top-level RefType (PR 5). A borrow
 // nested in a field or tuple element — for example the `&'static mut {…}` field of an
@@ -300,9 +298,7 @@ func (c *checker) checkMutabilityTransition(
 		for varID, aliasMut := range aliasSet.Members {
 			// A borrow on this member forced to 'static is a permanent outside
 			// reference. It outlives the function, so no liveness check is meaningful
-			// and it always counts as a live alias of its escaped mutability. This is
-			// G2's lifetime-sort replacement for the dropped HasStatic{Mut,Imm}Alias
-			// bits.
+			// and it always counts as a live alias of its escaped mutability.
 			//
 			// The conflict test is escMut == sourceMut, compared against the SOURCE, not
 			// the target. Past the early return sourceMut != targetMut holds, so

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -237,22 +237,24 @@ lifetime. Chained access `a.b.c` composes the rule at each link.
 
 ## PR sequence
 
-| PR | Title | Depends on | Rough size |
-|----|-------|-----------|-----------|
-| 1 | `&` grammar, `RefTypeAnn` node, printer | — | Medium |
-| 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium |
-| 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium |
-| 4 | Member reads borrow the receiver | 3 | Medium |
-| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large |
-| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large |
-| 7 | Partial moves and field-level ownership | 6 | Medium |
-| 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium |
-| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium |
-| 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium |
-| 11 | Connected-component moves for graphs | 6, 7 | Large |
-| 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — |
-| 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium |
-| 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large |
+Status legend: ✅ done · 🚧 in progress · ⬜ not started.
+
+| PR | Title | Depends on | Rough size | Status |
+|----|-------|-----------|-----------|--------|
+| 1 | `&` grammar, `RefTypeAnn` node, printer | — | Medium | ✅ done (#769) |
+| 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium | ✅ done (#770) |
+| 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium | ✅ done (#771) |
+| 4 | Member reads borrow the receiver | 3 | Medium | ✅ done (#773) |
+| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | 🚧 in progress |
+| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ⬜ not started |
+| 7 | Partial moves and field-level ownership | 6 | Medium | ⬜ not started |
+| 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ⬜ not started |
+| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ⬜ not started |
+| 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium | ⬜ not started |
+| 11 | Connected-component moves for graphs | 6, 7 | Large | ⬜ not started |
+| 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — | ❌ retired |
+| 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
+| 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 


### PR DESCRIPTION
Implements the move-state dataflow analysis and generalizes escape detection to support nested borrows, laying the foundation for the affine move engine (PR 6).

## Summary

This PR adds the consumed-lattice analysis that tracks which bindings have been moved along each control-flow path. It also extends escape detection to walk the entire type structure rather than inspecting only the top-level RefType, closing a gap where nested escaped borrows (e.g., in object fields) were missed.

## Key changes

- **Move-state dataflow analysis** (`internal/liveness/moves.go`): Implements `AnalyzeMoves`, a forward dataflow that computes per-binding move state (NotMoved, Moved, or MaybeMoved) at each program point. The three-state lattice joins at CFG merges, raising disagreeing states to MaybeMoved. Handles loop back edges and synthetic entry positions for decomposed declarations.

- **Escape detection generalization** (`internal/solver/transitions.go`): Replaces the top-level-only RefType check with a structural type visitor (`escapeDetectVisitor`) that walks through object properties, tuple elements, and other carriers. Now reports escaped borrows per mutability (mutable vs. immutable) since a value can carry both. Fixes the nested-escape gap where a borrow in an object field was not detected.

- **CFG and move-site retention** (`internal/solver/infer.go`): Stores the CFG and a move-site map in the function context so the move engine can run the analysis. The pre-pass now collects consume sites (returns, stores, consuming arguments, escaping captures) for PR 6 to read.

- **Comprehensive test coverage** (`internal/liveness/moves_test.go`, `internal/solver/transition_test.go`): Tests the lattice join, if/else branching, loops with back edges, sequential moves within blocks, and nested escaped borrows.

- **Planning update** (`planning/affine_semantics/implementation_plan.md`): Adds status tracking (✅ done, 🚧 in progress, ⬜ not started) to the PR sequence and clarifies PR 5's scope.

## Implementation notes

The move-state analysis mirrors the liveness analysis structure but runs forward instead of backward. Fixed-point iteration over the CFG converges because state rises monotonically in the finite lattice. The escape visitor uses the existing soltype visitor infrastructure to avoid hand-rolling a new traversal, though it does not yet descend into usage-inferred TypeVarTypes (a remaining gap for a deeper constraint-graph fix in M4 G2).

https://claude.ai/code/session_0171Ju7GH1cwN6SbSny8kp1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added affine move-state analysis across control flow (branches, loops, and sequential statements) with per-statement “before/after” state queries.
* **Bug Fixes**
  * Improved handling of `'static`-forced borrow escape detection, distinguishing mutable vs immutable cases, including nested-field scenarios.
  * Enhanced move-related state and consumption tracking to avoid incorrect boundary/repeated-move results.
* **Tests**
  * Added unit tests covering move-state joins, branching, loops, and the synthetic entry position.
* **Documentation**
  * Updated planning notes with a clearer status legend and revised progress table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->