### PR TITLE
Close type-variable escape detection gap in borrowEscapedToStatic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Escalier is a programming language with a Go-based compiler. The compiler pipeli
 - Use the `Set` ADT from [internal/set/](internal/set/) (`set.NewSet[T]()`, `set.FromSlice(...)`) instead of `map[T]struct{}` or `map[T]bool`.
 - Don't shadow Go builtins (`any`, `error`, `new`, `len`, etc.) or imported type/package aliases with local identifiers. Pick a distinct name (e.g. `anyT`, `errVal`).
 - Avoid parentheticals in comments — they make comments hard to read, especially when nested or combined with em-dashes. Rewrite the aside as a plain sentence, fold it into the main clause, or drop it. Reserve parentheses for short, essential clarifications like a code reference or a concrete example. Prefer several short sentences over one sentence carrying multiple asides.
+- Write comments about what the code does now, not what it did before a change. Drop phrasing like "previously", "used to", "is now", "no longer", and "the old behavior", and don't make a PR number or milestone the subject of a sentence. A comment that narrates the diff goes stale the moment the next change lands. Describe the current behavior and its rationale instead, and leave the history to git.
 
 ## Writing tests
 

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -327,6 +327,21 @@ func objWithBorrowField(borrow *soltype.RefType) *soltype.ObjectType {
 	}}
 }
 
+// escapeVarBothPolarities builds `{a: V, g: fn(V) -> void}` where the one type variable
+// V carries an escaped mut borrow in its UpperBounds. Field `a` reaches V covariantly
+// and field `g`'s parameter reaches it contravariantly, so the walk meets V at both
+// polarities and only the contravariant meeting follows the UpperBounds to the escape.
+func escapeVarBothPolarities() *soltype.ObjectType {
+	v := &soltype.TypeVarType{ID: 13, UpperBounds: []soltype.Type{staticBorrow(true)}}
+	return &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "a", Type: v},
+		&soltype.PropertyElem{Name: "g", Type: &soltype.FuncType{
+			Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: v}},
+			Ret:    &soltype.Void{},
+		}},
+	}}
+}
+
 // TestBorrowEscapedToStatic locks the lifetime-sort query G2 uses in place of the
 // dropped escape bits: a borrow forced to 'static is recognized at its mutability, an
 // owned value or an unforced borrow is not. PR 5 generalizes it to walk the whole
@@ -404,6 +419,13 @@ func TestBorrowEscapedToStatic(t *testing.T) {
 				Inner: objT(),
 			}},
 		}, false, false},
+		// The same type variable reached at both polarities, with its escaped borrow only
+		// in the UpperBounds. Field `a` reaches V covariantly, where BoundsAt follows the
+		// empty LowerBounds, and field `g`'s parameter reaches the same V contravariantly,
+		// where BoundsAt follows the UpperBounds and finds the escape. Memoizing the visited
+		// variable per polarity is what lets the second, contravariant visit run after the
+		// first; a variable-only memo would skip it and miss the escape.
+		{"escape in upper bound of a type var reached at both polarities", 13, escapeVarBothPolarities(), true, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -378,8 +378,7 @@ func TestBorrowEscapedToStatic(t *testing.T) {
 		// #787: a borrow reachable only through a usage-inferred type variable. The
 		// recorded type is a bare TypeVarType whose LOWER bounds hold an escaped mut
 		// borrow, the shape a branch-join variable such as `sink = if c { p } else { … }`
-		// produces. The shared visitor treats a type variable as a leaf, so the pre-fix
-		// query missed it; descending into the bounds reports the mutable escape.
+		// produces. The query descends into the bounds and reports the mutable escape.
 		{"mut escape in type-var lower bound", 9, &soltype.TypeVarType{
 			ID:          9,
 			LowerBounds: []soltype.Type{staticBorrow(true)},

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -375,6 +375,36 @@ func TestBorrowEscapedToStatic(t *testing.T) {
 			Lt:    &soltype.LifetimeVar{ID: 8},
 			Inner: objT(),
 		}), false, false},
+		// #787: a borrow reachable only through a usage-inferred type variable. The
+		// recorded type is a bare TypeVarType whose LOWER bounds hold an escaped mut
+		// borrow, the shape a branch-join variable such as `sink = if c { p } else { … }`
+		// produces. The shared visitor treats a type variable as a leaf, so the pre-fix
+		// query missed it; descending into the bounds reports the mutable escape.
+		{"mut escape in type-var lower bound", 9, &soltype.TypeVarType{
+			ID:          9,
+			LowerBounds: []soltype.Type{staticBorrow(true)},
+		}, true, false},
+		// The immutable analogue through a type variable.
+		{"imm escape in type-var lower bound", 10, &soltype.TypeVarType{
+			ID:          10,
+			LowerBounds: []soltype.Type{staticBorrow(false)},
+		}, false, true},
+		// The escaped borrow nested in a field of a type variable's lower bound, so the
+		// walk must descend through both the bounds side graph and the field.
+		{"escape in field of type-var lower bound", 11, &soltype.TypeVarType{
+			ID:          11,
+			LowerBounds: []soltype.Type{objWithBorrowField(staticBorrow(true))},
+		}, true, false},
+		// A type variable whose lower bound is an unforced borrow does not escape, matching
+		// the structural cases.
+		{"type-var lower bound with unforced lifetime", 12, &soltype.TypeVarType{
+			ID: 12,
+			LowerBounds: []soltype.Type{&soltype.RefType{
+				Mut:   true,
+				Lt:    &soltype.LifetimeVar{ID: 12},
+				Inner: objT(),
+			}},
+		}, false, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -375,10 +375,10 @@ func TestBorrowEscapedToStatic(t *testing.T) {
 			Lt:    &soltype.LifetimeVar{ID: 8},
 			Inner: objT(),
 		}), false, false},
-		// #787: a borrow reachable only through a usage-inferred type variable. The
-		// recorded type is a bare TypeVarType whose LOWER bounds hold an escaped mut
-		// borrow, the shape a branch-join variable such as `sink = if c { p } else { … }`
-		// produces. The query descends into the bounds and reports the mutable escape.
+		// A borrow reachable only through a usage-inferred type variable. The recorded
+		// type is a bare TypeVarType whose LOWER bounds hold an escaped mut borrow, the
+		// shape a branch-join variable such as `sink = if c { p } else { … }` produces.
+		// The query descends into the bounds and reports the mutable escape.
 		{"mut escape in type-var lower bound", 9, &soltype.TypeVarType{
 			ID:          9,
 			LowerBounds: []soltype.Type{staticBorrow(true)},

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -156,17 +156,15 @@ func isMutableType(t soltype.Type) bool {
 //
 // The whole recorded type is walked, not just its top-level RefType (PR 5). A borrow
 // nested in a field or tuple element — for example the `&'static mut {…}` field of an
-// object stored into a global — is now seen, closing the nested-escape gap that made
-// a move past such a borrow unsound. Both mutabilities are reported because a value
-// can carry both a mutable and an immutable escaped borrow in different positions,
-// and Rule 1 and Rule 2 each conflict with one of them. An owned value, a borrow with
-// an unforced lifetime, or an unrecorded variable returns both false.
-//
-// REMAINING GAP (M4 G2 carry-over): a borrow reachable only through a usage-inferred
-// TypeVarType is still not seen, because the soltype visitor treats a type variable as
-// a leaf and does not descend into its bounds. Resolving a value's borrows through the
-// constraint graph rather than its structural type is the deeper G2 fix. See the G2
-// note in planning/simple_sub/m4-implementation-plan.md.
+// object stored into a global — is seen, closing the nested-escape gap that made a
+// move past such a borrow unsound. A borrow reachable only through a usage-inferred
+// TypeVarType is also seen (#787): the walk descends into a type variable's bounds,
+// so an escape hidden behind a branch-join variable such as `sink = if c { p } else
+// { … }`, whose source is the join variable rather than a bare RefType, is no longer
+// missed. Both mutabilities are reported because a value can carry both a mutable and
+// an immutable escaped borrow in different positions, and Rule 1 and Rule 2 each
+// conflict with one of them. An owned value, a borrow with an unforced lifetime, or an
+// unrecorded variable returns both false.
 func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escapedImm bool) {
 	if c.fn == nil || c.fn.varIDTypes == nil {
 		return false, false
@@ -183,20 +181,41 @@ func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escap
 // escapeDetectVisitor records whether the walked type carries any borrow forced to
 // 'static, split by the borrow's mutability. It rewrites nothing; EnterType inspects
 // each RefType and the shared visitor carries the descent through inner carriers,
-// object properties, and tuple elements. A TypeVarType is a visitor leaf, so a borrow
-// reachable only through a usage-inferred variable is not reached — the REMAINING GAP
-// on borrowEscapedToStatic.
+// object properties, and tuple elements.
+//
+// The shared visitor treats a TypeVarType as a leaf and does not descend into its
+// bounds (its bounds are a side graph, not tree children). So EnterType walks a type
+// variable's bounds itself, resolving a borrow reachable only through a usage-inferred
+// variable (#787). The bounds relevant to the current polarity are followed —
+// LowerBounds in Positive position, where the variable stands for what flowed into it
+// — so an escaped borrow joined into a branch variable is seen. seen guards the
+// pointer-keyed cycles a bounds graph can hold.
 type escapeDetectVisitor struct {
 	foundMut bool
 	foundImm bool
+	seen     map[*soltype.TypeVarType]bool
 }
 
-func (v *escapeDetectVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
-	if r, ok := t.(*soltype.RefType); ok && lifetimeEscapedToStatic(r.Lt) {
-		if r.Mut {
-			v.foundMut = true
-		} else {
-			v.foundImm = true
+func (v *escapeDetectVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if lifetimeEscapedToStatic(t.Lt) {
+			if t.Mut {
+				v.foundMut = true
+			} else {
+				v.foundImm = true
+			}
+		}
+	case *soltype.TypeVarType:
+		if v.seen == nil {
+			v.seen = map[*soltype.TypeVarType]bool{}
+		}
+		if v.seen[t] {
+			return soltype.EnterResult{}
+		}
+		v.seen[t] = true
+		for _, bound := range t.BoundsAt(pol) {
+			bound.Accept(v, pol)
 		}
 	}
 	return soltype.EnterResult{}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -193,7 +193,7 @@ func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escap
 type escapeDetectVisitor struct {
 	foundMut bool
 	foundImm bool
-	seen     map[*soltype.TypeVarType]bool
+	seen     set.Set[*soltype.TypeVarType]
 }
 
 func (v *escapeDetectVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -208,12 +208,12 @@ func (v *escapeDetectVisitor) EnterType(t soltype.Type, pol soltype.Polarity) so
 		}
 	case *soltype.TypeVarType:
 		if v.seen == nil {
-			v.seen = map[*soltype.TypeVarType]bool{}
+			v.seen = set.NewSet[*soltype.TypeVarType]()
 		}
-		if v.seen[t] {
+		if v.seen.Contains(t) {
 			return soltype.EnterResult{}
 		}
-		v.seen[t] = true
+		v.seen.Add(t)
 		for _, bound := range t.BoundsAt(pol) {
 			bound.Accept(v, pol)
 		}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -187,11 +187,19 @@ func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escap
 // usage-inferred variable. It follows the bounds relevant to the current polarity, the
 // LowerBounds in Positive position, where the variable stands for what flowed into it.
 // An escaped borrow joined into a branch variable is therefore seen. The seen set
-// guards against cycles in the bounds graph.
+// guards against cycles in the bounds graph. It keys on the variable together with the
+// polarity, since the bounds followed depend on the polarity, so a variable reached at
+// both polarities is explored once in each direction.
 type escapeDetectVisitor struct {
 	foundMut bool
 	foundImm bool
-	seen     set.Set[*soltype.TypeVarType]
+	seen     set.Set[seenVar]
+}
+
+// seenVar identifies one visited (type variable, polarity) pair in the bounds walk.
+type seenVar struct {
+	tv  *soltype.TypeVarType
+	pol soltype.Polarity
 }
 
 func (v *escapeDetectVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -206,12 +214,13 @@ func (v *escapeDetectVisitor) EnterType(t soltype.Type, pol soltype.Polarity) so
 		}
 	case *soltype.TypeVarType:
 		if v.seen == nil {
-			v.seen = set.NewSet[*soltype.TypeVarType]()
+			v.seen = set.NewSet[seenVar]()
 		}
-		if v.seen.Contains(t) {
+		key := seenVar{tv: t, pol: pol}
+		if v.seen.Contains(key) {
 			return soltype.EnterResult{}
 		}
-		v.seen.Add(t)
+		v.seen.Add(key)
 		for _, bound := range t.BoundsAt(pol) {
 			bound.Accept(v, pol)
 		}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -154,17 +154,15 @@ func isMutableType(t soltype.Type) bool {
 // where it outlives the function. D3's constrainEscape then pins its lifetime
 // `<: 'static`, so the value has a permanent outside alias of that borrow's mutability.
 //
-// The whole recorded type is walked, not just its top-level RefType (PR 5). A borrow
-// nested in a field or tuple element — for example the `&'static mut {…}` field of an
-// object stored into a global — is seen, closing the nested-escape gap that made a
-// move past such a borrow unsound. A borrow reachable only through a usage-inferred
-// TypeVarType is also seen (#787): the walk descends into a type variable's bounds,
-// so an escape hidden behind a branch-join variable such as `sink = if c { p } else
-// { … }`, whose source is the join variable rather than a bare RefType, is no longer
-// missed. Both mutabilities are reported because a value can carry both a mutable and
-// an immutable escaped borrow in different positions, and Rule 1 and Rule 2 each
-// conflict with one of them. An owned value, a borrow with an unforced lifetime, or an
-// unrecorded variable returns both false.
+// The whole recorded type is walked, every structural position and every type
+// variable's bounds, so a borrow forced to 'static is seen wherever it sits: at the
+// top level, nested in a field or tuple element such as the `&'static mut {…}` field
+// of an object stored into a global, or reachable only through a usage-inferred
+// TypeVarType such as the join variable of `sink = if c { p } else { … }`. Missing any
+// of these would make a move past that borrow unsound. Both mutabilities are reported
+// because a value can carry both a mutable and an immutable escaped borrow in different
+// positions, and Rule 1 and Rule 2 each conflict with one of them. An owned value, a
+// borrow with an unforced lifetime, or an unrecorded variable returns both false.
 func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escapedImm bool) {
 	if c.fn == nil || c.fn.varIDTypes == nil {
 		return false, false

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -182,12 +182,12 @@ func (c *checker) borrowEscapedToStatic(varID liveness.VarID) (escapedMut, escap
 // object properties, and tuple elements.
 //
 // The shared visitor treats a TypeVarType as a leaf and does not descend into its
-// bounds (its bounds are a side graph, not tree children). So EnterType walks a type
-// variable's bounds itself, resolving a borrow reachable only through a usage-inferred
-// variable (#787). The bounds relevant to the current polarity are followed —
-// LowerBounds in Positive position, where the variable stands for what flowed into it
-// — so an escaped borrow joined into a branch variable is seen. seen guards the
-// pointer-keyed cycles a bounds graph can hold.
+// bounds, since those bounds are a side graph rather than tree children. So EnterType
+// walks a type variable's bounds itself to resolve a borrow reachable only through a
+// usage-inferred variable. It follows the bounds relevant to the current polarity, the
+// LowerBounds in Positive position, where the variable stands for what flowed into it.
+// An escaped borrow joined into a branch variable is therefore seen. The seen set
+// guards against cycles in the bounds graph.
 type escapeDetectVisitor struct {
 	foundMut bool
 	foundImm bool

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -141,12 +141,15 @@ inspects only the top-level `RefType`, so a borrow nested in a field or reached
 through a usage-inferred type variable is missed, a known gap.
 
 Decision: the move engine **generalizes escape detection to every value-flow-out
-site** before any consume logic is written, and identifies consumption sites
-explicitly at returns, field and element stores, owned-parameter arguments, and
-escaping closure captures. The nested and type-variable escape gap is closed as
-part of this work, since a move that misses a nested escape is unsound. This is why
-the move engine is split across PR 5 (escape generalization and the consumed
-lattice) and PR 6 (the consume and use-after-move behaviour).
+site**, and identifies consumption sites explicitly at returns, field and element
+stores, owned-parameter arguments, and escaping closure captures. The nested and
+type-variable escape gap is closed as part of this work, since a move that misses a
+nested escape is unsound. This is why the move engine is split across PR 5 and PR 6.
+PR 5 landed the consumed lattice and the `borrowEscapedToStatic` detection-gap
+closure (#786, #787). The `constrainEscape` forcing at the non-global flow sites was
+deferred from PR 5 to PR 6, where it rides alongside the consume over the same sites
+rather than running as a separate earlier pass; see "Deferred from PR 5" under PR 6.
+The consume and use-after-move behaviour is PR 6's own scope.
 
 ### Narrowing comes from M6, not this plan
 
@@ -245,7 +248,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium | ✅ done (#770) |
 | 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium | ✅ done (#771) |
 | 4 | Member reads borrow the receiver | 3 | Medium | ✅ done (#773) |
-| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | 🚧 in progress |
+| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 6 |
 | 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ⬜ not started |
 | 7 | Partial moves and field-level ownership | 6 | Medium | ⬜ not started |
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ⬜ not started |
@@ -412,19 +415,19 @@ Goal: stand up the two pieces the move rule needs, with no use-after-move errors
 yet. See "Where the move analysis lives" and "Escape detection is generalized, not
 queried" above.
 
-Status: the consumed lattice and the `borrowEscapedToStatic` detection-gap closure
-have landed. What remains is the `constrainEscape` generalization to the non-global
-flow sites, the first half of the first bullet below. PR 5 stays in progress until
-that lands.
+Status: done. PR 5's scope is the consumed lattice and the `borrowEscapedToStatic`
+detection-gap closure, both of which landed. The `constrainEscape` generalization to
+the non-global flow sites, the forcing half of the first bullet below, was deferred to
+PR 6, where the same sites are revisited for the consume; see "Deferred from PR 5"
+under PR 6.
 
 - Generalize escape detection beyond the single module-level write site. Two halves:
   - Run `constrainEscape` at returns, field and element stores, owned-parameter
-    arguments, and escaping closure captures. **Remaining** — today only the
+    arguments, and escaping closure captures. **Deferred to PR 6** — today only the
     module-level global write forces escape
     ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
-    `b.ModuleLevel` store). Files:
-    [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
-    [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go).
+    `b.ModuleLevel` store). This forcing is folded into PR 6's consume bullet so the
+    escape forcing and the consume land together over one pass of these sites.
   - Close the top-level-only gap in `borrowEscapedToStatic` so a borrow nested in a
     field, or reached through a usage-inferred type variable, is seen. **Done** — the
     nested field/element case landed in #786, and the usage-inferred `TypeVarType`
@@ -466,21 +469,44 @@ PR 6 reads the state at each use, passing `NotMoved` and rejecting `Moved` and
 `MaybeMoved`.
 
 Tests: unit tests that the consumed lattice merges correctly across if/else, match,
-and loops; tests that escape now fires at returns, stores, arguments, and captures.
+and loops; unit tests that `borrowEscapedToStatic` sees a borrow nested in a field or
+tuple element and one reachable only through a usage-inferred type variable. The tests
+that escape fires at returns, stores, arguments, and captures move to PR 6 with the
+`constrainEscape` forcing they exercise.
 
-Acceptance: escape is detected at every value-flow-out site, and the consumed
-lattice reports correct per-path state. No user-facing errors yet.
+Acceptance: the consumed lattice reports correct per-path state, and the escape query
+sees every borrow in a recorded type, including nested and type-variable positions. The
+"escape forced at every value-flow-out site" criterion moves to PR 6 with the deferred
+`constrainEscape` generalization. No user-facing errors yet.
 
 ### PR 6 — Consume and use-after-move at every flow site, conditional moves
 
 Goal: turn the PR 5 substrate into the affine rule. When an owned value escapes its
 source region, ownership moves, the source is consumed, and a later use is an error.
 
+Deferred from PR 5: the `constrainEscape` generalization to the non-global flow sites
+lands here, not in PR 5. PR 5 was scoped to the consumed lattice and the
+`borrowEscapedToStatic` detection-gap closure, both of which landed (#786 escape
+nesting, #787 the usage-inferred `TypeVarType` case). What did not land in PR 5 is the
+forcing half of its first bullet: today only the module-level global write runs
+`constrainEscape` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)
+at the `b.ModuleLevel` store), so a borrow that flows out through a return, a field or
+element store, an owned-parameter argument, or an escaping closure capture is not yet
+forced `<: 'static`. That generalization is folded into the consume bullet below,
+because PR 6 already revisits exactly these sites to consume the source, so the escape
+forcing and the consume are wired in together rather than in two passes over the same
+sites. Files for the deferred forcing:
+[internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
+[internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go).
+
 - Consume the source at each flow site: `val`/`var` binding, reassignment that drops
   the previous owner, `return`, field and element stores, owned-parameter arguments,
   and escaping closure captures. The global-write site stops dropping mutability and
   instead consumes, per "Move subsumes the escape-site logic." This is also where a
-  bare owned parameter finally consumes its argument, the behaviour PR 3 deferred.
+  bare owned parameter finally consumes its argument, the behaviour PR 3 deferred. At
+  each of these same sites, run the `constrainEscape` forcing deferred from PR 5 so a
+  borrow flowing out is pinned `<: 'static` before the source is consumed, closing the
+  forcing gap left after PR 5.
 - Conditional moves are path-sensitive through the consumed lattice: a value moved
   on one branch and untouched on another is consumed only on the moving paths, and a
   later use is an error only if some reaching path moved it.
@@ -508,9 +534,10 @@ capture by an escaping closure; an if/else where only one branch moves; a
 `val q: {x} = p_borrow` that was silently accepted under G3 is now rejected.
 
 Acceptance: every flow site moves or borrows correctly, including per-branch
-behaviour, and use-after-move names both sites. A borrowed source flowing into a
-bare owned annotation is rejected, with the explicit `&` form preserved as the
-opt-in for an alias.
+behaviour, and use-after-move names both sites. A borrow flowing out is forced
+`<: 'static` at every value-flow-out site, the `constrainEscape` generalization
+deferred from PR 5. A borrowed source flowing into a bare owned annotation is
+rejected, with the explicit `&` form preserved as the opt-in for an alias.
 
 ### PR 7 — Partial moves and field-level ownership
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -412,15 +412,26 @@ Goal: stand up the two pieces the move rule needs, with no use-after-move errors
 yet. See "Where the move analysis lives" and "Escape detection is generalized, not
 queried" above.
 
-- Generalize escape detection beyond the single module-level write site. Run
-  `constrainEscape` at returns, field and element stores, owned-parameter
-  arguments, and escaping closure captures, and close the top-level-only gap in
-  `borrowEscapedToStatic` so a borrow nested in a field or reached through a
-  usage-inferred type variable is seen. Files:
-  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
-  [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go),
-  [internal/solver/transitions.go](../../internal/solver/transitions.go).
-- Build the branch-merged per-binding consumed lattice over the existing CFG. Add
+Status: the consumed lattice and the `borrowEscapedToStatic` detection-gap closure
+have landed. What remains is the `constrainEscape` generalization to the non-global
+flow sites, the first half of the first bullet below. PR 5 stays in progress until
+that lands.
+
+- Generalize escape detection beyond the single module-level write site. Two halves:
+  - Run `constrainEscape` at returns, field and element stores, owned-parameter
+    arguments, and escaping closure captures. **Remaining** — today only the
+    module-level global write forces escape
+    ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
+    `b.ModuleLevel` store). Files:
+    [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
+    [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go).
+  - Close the top-level-only gap in `borrowEscapedToStatic` so a borrow nested in a
+    field, or reached through a usage-inferred type variable, is seen. **Done** — the
+    nested field/element case landed in #786, and the usage-inferred `TypeVarType`
+    case landed for #787 by descending into a type variable's bounds in
+    `escapeDetectVisitor` ([internal/solver/transitions.go](../../internal/solver/transitions.go)).
+- Build the branch-merged per-binding consumed lattice over the existing CFG. **Done**
+  in #786. Add
   "moved on some path" and "moved on all paths" state that joins at the CFG merge
   blocks from [internal/liveness](../../internal/liveness), keyed by `VarID` and
   queried at `StmtRef` granularity, alongside the existing liveness and alias state


### PR DESCRIPTION
Extends `borrowEscapedToStatic` to detect escapes reachable through usage-inferred type variables, closing a gap that made moves past such borrows unsound.

The `escapeDetectVisitor` now descends into a `TypeVarType`'s bounds when walking a recorded type, rather than treating the type variable as a leaf. This resolves escapes hidden behind branch-join variables like `sink = if c { p } else { … }`, where the source is the join variable rather than a bare `RefType`. The visitor tracks seen type variables to avoid cycles in the bounds graph.

The walk follows bounds relevant to the current polarity — `LowerBounds` in positive position — so an escaped borrow joined into a branch variable is detected. Both nested-field and type-variable cases are now covered, closing the detection gap that PR 5 deferred.

Updates the planning document to reflect that PR 5 landed the consumed lattice and both escape detection gaps (#786 nested fields, #787 type variables), while deferring the `constrainEscape` forcing generalization to PR 6 where it rides alongside the consume over the same sites.

Adds test cases for escapes in type-variable bounds, including nested fields within bounds and unforced lifetimes that should not be reported as escaped.

https://claude.ai/code/session_01KawJHMzJxXLoY3Fyba7taf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of borrowed values that escape in more complex type cases, including nested and inferred type-variable scenarios.
  * Corrected handling so some borrowed values are no longer incorrectly reported as escaping, while mutable and immutable cases are still distinguished properly.
* **Documentation**
  * Updated the implementation plan to reflect the completed escape-detection improvements and revised release sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->