### PR TITLE
PR 6: Move engine and use-after-move checking

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -125,11 +125,28 @@ type funcCtx struct {
 	cfg *liveness.CFG
 	// moveSites records, per CFG statement position, the VarIDs the ordered walk
 	// has consumed there — a binding moved by a return, a store, a consuming
-	// argument, or an escaping capture. PR 6 records into it while walking the body;
-	// AnalyzeMoves(cfg, moveSites) then yields the branch-merged consumed lattice
-	// the use-after-move check reads. PR 5 builds the analysis and this collector;
-	// the recording and reading land in PR 6, so it stays empty until then.
+	// argument, or an escaping capture. The walk records into it while walking the
+	// body; AnalyzeMoves(cfg, moveSites) then yields the branch-merged consumed
+	// lattice the use-after-move check reads after the body walk completes.
 	moveSites map[liveness.StmtRef]set.Set[liveness.VarID]
+	// moveNodes maps a consumed binding's VarID to the node that moved it, so a
+	// UseAfterMoveError can point its "moved here" related span at the move site. A
+	// binding moved on more than one path keeps the last-recorded move node, which
+	// is a coarse but adequate blame target.
+	moveNodes map[liveness.VarID]ast.Node
+	// useSites records every read of an owned-movable binding while walking the
+	// body, each with the binding's VarID, the CFG point of the read, and the node
+	// to blame. checkUseAfterMoves replays them against the consumed lattice once the
+	// whole body — including loop back edges — has been walked, so a use that some
+	// reaching path moved is caught even when the move is textually later.
+	useSites []moveUse
+	// consumed holds the VarIDs the walk has moved so far, in straight-line order. It
+	// is the synchronous companion to moveSites: where moveSites feeds the post-pass
+	// lattice, consumed lets a flow site see, while walking, that its source was
+	// already moved. The mutability-transition check reads it to skip a binding whose
+	// source is a moved value, since the use-after-move the move engine reports
+	// subsumes the exclusivity conflict the stale 'static-escape query would raise.
+	consumed set.Set[liveness.VarID]
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in
 	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -140,13 +140,6 @@ type funcCtx struct {
 	// whole body — including loop back edges — has been walked, so a use that some
 	// reaching path moved is caught even when the move is textually later.
 	useSites []moveUse
-	// consumed holds the VarIDs the walk has moved so far, in straight-line order. It
-	// is the synchronous companion to moveSites: where moveSites feeds the post-pass
-	// lattice, consumed lets a flow site see, while walking, that its source was
-	// already moved. The mutability-transition check reads it to skip a binding whose
-	// source is a moved value, since the use-after-move the move engine reports
-	// subsumes the exclusivity conflict the stale 'static-escape query would raise.
-	consumed set.Set[liveness.VarID]
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in
 	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -154,7 +154,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 //
 // 2. A bare owned annotation whose initializer is a borrow is a borrow-into-owned
 // escape. A `val` binding consumes an owned source, so a borrowed `p` flowing into a
-// bare owned slot, as in `val q: {x} = p`, does not alias `p`; the constraint takes the
+// bare owned slot, as in `val q: {x} = p`, does not alias `p`. The constraint takes the
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -114,7 +114,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// error and adopting `never` would poison the binding. Keep the inferred
 		// initializer type instead (error recovery).
 		if annT, ok := c.resolveTypeAnn(d.TypeAnn, lvl); ok {
-			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT, lvl)
+			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT)
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
@@ -152,15 +152,12 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // borrow annotation is a reference into a caller's region, not an owned value, so a fresh
 // source flowing into it stays on the strict path.
 //
-// 2. A bare object/tuple annotation whose initializer is a borrow lowers to an immutable
-// reborrow of the initializer rather than an owned slot (M4 G3). See reborrowAnnotation.
-// Binding a borrow into a bare annotation, as in `val q: {x} = p` for `p: mut {x}`, would
-// otherwise trip BorrowEscapeError, since the borrow flows into an owned slot. The old
-// checker accepts this and treats the annotation as a local immutable view of `p` that
-// never escapes. Reborrowing makes the lifetime sort decide. A local view that dies
-// within the source's region carries no escape constraint and is accepted, while one that
-// escapes through a return or a module store still errors.
-func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
+// 2. A bare owned annotation whose initializer is a borrow is a borrow-into-owned
+// escape. A `val` binding consumes an owned source, so a borrowed `p` flowing into a
+// bare owned slot, as in `val q: {x} = p`, does not alias `p`; the constraint takes the
+// ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
+// `val q: &{x} = p` is the opt-in for an alias.
+func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
 		// Constrain a fresh literal against the borrow's immutable skeleton, then
 		// grant the owned-mutable type. Under the lazy deep-mut form (PR 14) the inner
@@ -172,46 +169,8 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 		c.constrain(init, initT, stripOwnedMut(ref.Inner))
 		return annT
 	}
-	if borrow, ok := c.reborrowAnnotation(initT, annT, lvl); ok {
-		c.constrain(init, initT, borrow)
-		return borrow
-	}
 	c.constrain(init, initT, annT)
 	return annT
-}
-
-// reborrowAnnotation lowers a bare object/tuple annotation to an immutable borrow with a
-// fresh lifetime, returning ok=false when the refinement does not apply (M4 G3). It
-// applies only when the initializer's type is itself a borrow carrying a lifetime and
-// the annotation is a bare object or tuple, not an already-borrow `mut`/lifetime form or
-// a non-borrowable primitive.
-//
-// The gate is the source TYPE, not the source syntax. An owned source, whether an
-// immutable object or an owned-mutable one, has no lifetime to outlive, so the existing
-// owned-slot path already accepts it by peeling. Reborrowing it would instead make the
-// binding a borrow with a free lifetime, which then trips BorrowEscapeError the moment
-// the binding flows into any owned position, such as an owned parameter. Only a source
-// that already carries a borrow lifetime needs the reborrow.
-//
-// The fresh lifetime carries no obligation on its own. The RefType <: RefType constrain
-// arm relates it to the source's lifetime through constrainLt. This reborrow constraint
-// runs exactly as the borrow-into-borrow argument path does. A binding that escapes
-// carries D3's escape-to-'static constraint, which the lifetime sort weighs against the
-// reborrow. A binding that stays local and dies within the source's region leaves the
-// fresh lifetime free, so D4's display-time elision drops the wrapper and the binding
-// renders as the bare inner.
-func (c *checker) reborrowAnnotation(initT, annT soltype.Type, lvl int) (soltype.Type, bool) {
-	if src, ok := initT.(*soltype.RefType); !ok || src.Lt == nil {
-		return nil, false
-	}
-	switch inner := annT.(type) {
-	case *soltype.ObjectType:
-		return &soltype.RefType{Mut: false, Lt: c.ctx.freshLifetime(lvl), Inner: inner}, true
-	case *soltype.TupleType:
-		return &soltype.RefType{Mut: false, Lt: c.ctx.freshLifetime(lvl), Inner: inner}, true
-	default:
-		return nil, false
-	}
 }
 
 // stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -112,10 +113,10 @@ func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr) path
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
 		t := c.bindingValue(lvl, b)
 		c.recordType(e, t)
-		// PR 6: record this read so the post-walk use-after-move pass can test it
-		// against the consumed lattice. Use the binding's coalesced type for the
-		// reference-shape decision — a fresh instantiation can hide a mono owned
-		// shape behind a variable.
+		// Record this read so the post-walk use-after-move pass can test it against the
+		// consumed lattice. The binding's coalesced type drives the reference-shape
+		// decision, since a fresh instantiation can hide a mono owned shape behind a
+		// variable.
 		c.recordUse(e, bindingType(b))
 		return pathResult{value: t}
 	}
@@ -280,10 +281,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// produces the function's value. This mirrors the old checker's
 		// inferFuncBody.
 		c.inferBlock(fnScope, lvl, body)
-		// PR 6: with the whole body walked, every move site is recorded, so the
-		// consumed lattice is complete. Replay the recorded reads against it to
-		// report use-after-move. Runs before popFuncCtx restores the outer context,
-		// since it reads this body's move/use state off c.fn.
+		// With the whole body walked, every move site is recorded, so the consumed
+		// lattice is complete. Replay the recorded reads against it to report
+		// use-after-move. This runs before popFuncCtx restores the outer context, since
+		// it reads this body's move and use state off c.fn.
 		c.checkUseAfterMoves()
 		ret = c.joinReturnPoints(node, lvl, c.popFuncCtx(saved))
 	}
@@ -560,10 +561,9 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // display time. A proper rejection of this dangling-borrow case needs the
 // directional lifetime bounds slated for M6.5.
 //
-// PR 3 introduces `&p` and `&mut p` as the explicit borrow form. A binding
-// initializer uses one of them to choose "borrow" over "move", as in
-// `val q = &p` and `val q = &mut p`. The move side establishes ownership only.
-// Consume and use-after-move enforcement lands in PR 6.
+// `&p` and `&mut p` are the explicit borrow form. A binding initializer uses one of
+// them to choose "borrow" over "move", as in `val q = &p` and `val q = &mut p`, so
+// the borrow leaves the source usable where a bare `val q = p` would consume it.
 func (c *checker) inferBorrow(scope *Scope, lvl int, e *ast.BorrowExpr) soltype.Type {
 	// PR 4. An explicit borrow of a field path takes the receiver-bounded
 	// lifetime of the implicit read at field granularity. The dispatch covers
@@ -803,6 +803,11 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 			return c.inferOverloadedCall(scope, lvl, e, b)
 		}
 	}
+	// Resolve the enclosing statement's CFG point before inferring the callee or
+	// arguments. Inferring a child that contains statements, such as an `if` argument,
+	// overwrites c.fn.currentStmt, so reading the point afterward would record an
+	// argument move against an inner branch instead of this call's statement.
+	consumeRef, hasConsumeRef := c.currentStmtRef()
 	callee := c.inferExpr(scope, lvl, e.Callee)
 	args := make([]*soltype.FuncParam, len(e.Args))
 	for i, a := range e.Args {
@@ -825,12 +830,14 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// the missing slots with fresh vars, which impose no constraint on absent args.
 	fn, resolved := resolveFunc(callee)
 	demand := args
+	arityOK := true
 	switch {
 	case resolved && !hasRest(fn) && len(args) > len(fn.Params):
 		// A typed rest param (hasRest) absorbs any number of trailing args, so it is
 		// never "too many" — only a fixed-arity (non-rest) callee trips this lint.
 		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
 		demand = args[:len(fn.Params)]
+		arityOK = false
 	case resolved && len(args) < requiredCount(fn):
 		c.errs = append(c.errs, &NotEnoughArgsError{Call: e, Fn: fn})
 		demand = make([]*soltype.FuncParam, len(fn.Params))
@@ -838,6 +845,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		for i := len(args); i < len(fn.Params); i++ {
 			demand[i] = &soltype.FuncParam{Type: c.freshAt(lvl)}
 		}
+		arityOK = false
 	}
 
 	// callShape is built EXACT with all N params required, on purpose. That gives
@@ -854,29 +862,25 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	c.constrain(e, callee, callShape)
 	if resolved {
 		c.constrain(e, fn.Ret, res)
-		// PR 6: passing an owned argument to a bare owned parameter moves it; a `&`
-		// parameter auto-borrows and leaves the argument usable. consumeCallArgs reads
-		// each declared parameter's ownership to decide.
-		c.consumeCallArgs(e, fn)
+		// Passing an owned argument to a bare owned parameter moves it; a `&`/`&mut`
+		// parameter auto-borrows and leaves the argument usable. A call already rejected
+		// for an arity mismatch records no moves, so a wrong number of arguments does not
+		// also cascade a use-after-move.
+		if arityOK && hasConsumeRef {
+			c.consumeCallArgs(e, fn, consumeRef)
+		}
 	}
 	c.recordType(e, res)
 	return res
 }
 
 // consumeCallArgs consumes each owned argument passed to a bare owned parameter of
-// the resolved callee. A `&`/`&mut` parameter borrows, so it leaves the argument
-// usable; an unannotated parameter, whose ownership is a fresh inference variable
-// rather than a concrete owned shape, is left to borrow conservatively, so only a
-// parameter typed as a concrete owned object, tuple, or owned RefType consumes its
-// argument here.
-func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType) {
-	if c.fn == nil || c.fn.cfg == nil {
-		return
-	}
-	ref, ok := c.currentStmtRef()
-	if !ok {
-		return
-	}
+// the resolved callee, recording the move at ref, the call's statement. A `&`/`&mut`
+// parameter borrows, so it leaves the argument usable. An unannotated parameter, whose
+// ownership is a fresh inference variable rather than a concrete owned shape, is left
+// to borrow conservatively, so only a parameter typed as a concrete owned object,
+// tuple, or owned RefType consumes its argument.
+func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
 	for i, arg := range e.Args {
 		if i >= len(fn.Params) {
 			break
@@ -988,7 +992,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// InvalidAssignmentTargetError.
 		switch left := e.Left.(type) {
 		case *ast.MemberExpr:
-			return c.inferMemberAssign(scope, lvl, e, left, sourceT)
+			return c.inferMemberAssign(scope, lvl, e, left, sourceT, assignStmt)
 		case *ast.IndexExpr:
 			c.reportUnsupportedFeature(e.Left, "assignment to a member or index")
 		default:
@@ -1073,12 +1077,12 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			// not double-counted as a prior permanent alias.
 			c.checkGlobalWriteTransition(target, e.Right, bindingType(b), assignStmt)
 			c.constrainEscape(sourceT)
-			// PR 6: the store transfers the value into a permanent 'static slot, so it
-			// consumes the source binding. A later use of the source is then a
-			// use-after-move, the affine rule that closes the leak the global write
-			// otherwise allowed. checkGlobalWriteTransition above skips the source's own
-			// self-conflict, leaving the consume to govern the source and the exclusivity
-			// rule to govern any OTHER live alias of the same value.
+			// The store transfers the value into a permanent 'static slot, so it consumes
+			// the source binding. A later use of the source is then a use-after-move, the
+			// affine rule that closes the leak the global write otherwise allowed.
+			// checkGlobalWriteTransition above skips the source's own self-conflict,
+			// leaving the consume to govern the source and the exclusivity rule to govern
+			// any OTHER live alias of the same value.
 			if c.fn != nil {
 				if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 					c.consumeAtGlobalWrite(e.Right, sourceT, e.Right, ref)
@@ -1103,9 +1107,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// independent lifetime var that the escape never touches. isMutableType reads
 		// the same top-level Mut from either, so the alias mutability is unchanged.
 		c.trackAliasesForAssignment(target, e.Right, bindingType(b), assignStmt)
-		// PR 6: a non-module reassignment that moves its source consumes it. The
-		// global-write branch above runs its own consume, so this covers only the
-		// local-slot reassignment.
+		// A non-module reassignment that moves its source consumes it. The global-write
+		// branch above runs its own consume, so this covers only the local-slot
+		// reassignment.
 		if !b.ModuleLevel && c.movesSourceInto(e.Right, bindingType(b)) {
 			if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 				c.consumeOwned(e.Right, c.info.TypeOf(e.Right), e.Right, ref)
@@ -1151,7 +1155,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 // When the receiver is a variable, the widened type is recorded in `written` so a
 // later read of the same field returns it (read-after-write; see valueProp). The
 // assignment evaluates to the value just stored, so its type is the widened source.
-func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m *ast.MemberExpr, source soltype.Type) soltype.Type {
+func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m *ast.MemberExpr, source soltype.Type, assignStmt ast.Stmt) soltype.Type {
 	voidT := soltype.Type(&soltype.Void{})
 	if m.OptChain {
 		// `recv?.prop = …` is not a meaningful assignment target; optional chaining is
@@ -1197,10 +1201,12 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	// when the write type-checked, so a rejected write does not record a bogus alias.
 	if c.fn != nil && len(c.errs) == errsBefore {
 		c.trackAliasesForPropAssignment(e.Left, e.Right)
-		// PR 6: storing an owned value into a field transfers ownership into the
-		// receiver, so the source binding is consumed and a later use of it is a
-		// use-after-move.
-		if ref, ok := c.currentStmtRef(); ok {
+		// Storing an owned value into a field transfers ownership into the receiver, so
+		// the source binding is consumed and a later use of it is a use-after-move. The
+		// move records against the assignment's statement, resolved from assignStmt
+		// rather than c.fn.currentStmt, which inferring the receiver and source may have
+		// overwritten with an inner branch statement.
+		if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 			c.consumeOwned(e.Right, source, e.Right, ref)
 		}
 	}
@@ -1375,6 +1381,9 @@ func bindingDecl(b ValueBinding) ast.Node {
 // M7/M9: a tuple-spread type over an abstract operand [...P, x], and a typed
 // variadic tail [number, ...Array<number>].
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
+	// Resolve the enclosing statement's CFG point before inferring elements, which can
+	// overwrite c.fn.currentStmt with an inner branch statement.
+	litRef, hasLitRef := c.currentStmtRef()
 	elems := make([]soltype.Type, 0, len(e.Elems))
 	inexact := false
 	for i, el := range e.Elems {
@@ -1382,8 +1391,8 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 		if !ok {
 			elemT := c.inferExpr(scope, lvl, el)
 			elems = append(elems, elemT)
-			// PR 6: building an owned value into the tuple moves it.
-			c.consumeIntoLiteral(el, elemT)
+			// Building an owned value into the tuple moves it.
+			c.consumeIntoLiteral(el, elemT, litRef, hasLitRef)
 			continue
 		}
 		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
@@ -1396,6 +1405,9 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 			if op.Inexact {
 				inexact = true // a trailing inexact spread carries through
 			}
+			// Spreading an owned tuple moves its elements into the new tuple, so the
+			// spread operand is consumed.
+			c.consumeIntoLiteral(spread.Value, op, litRef, hasLitRef)
 		case *soltype.ErrorType:
 			// The operand already reported its own failure; absorb it rather than
 			// layering a SpreadNotTupleError on the recovery sentinel.
@@ -1426,6 +1438,9 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 // property at its first position ({a: 1, b: 2, a: 3} ⇒ {a: 3, b: 2}). This keeps
 // property names unique, the invariant ObjectType.Prop / equalType rely on.
 func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
+	// Resolve the enclosing statement's CFG point before inferring property values,
+	// which can overwrite c.fn.currentStmt with an inner branch statement.
+	litRef, hasLitRef := c.currentStmtRef()
 	b := newObjElemBuilder(len(e.Elems))
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
@@ -1451,8 +1466,8 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
 		b.add(name, ft, false, false) // a literal property is never optional or readonly
-		// PR 6: building an owned value into the object moves it.
-		c.consumeIntoLiteral(prop.Value, ft)
+		// Building an owned value into the object moves it.
+		c.consumeIntoLiteral(prop.Value, ft, litRef, hasLitRef)
 	}
 	t := &soltype.ObjectType{Elems: b.elems}
 	c.recordType(e, t)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -830,14 +830,12 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// the missing slots with fresh vars, which impose no constraint on absent args.
 	fn, resolved := resolveFunc(callee)
 	demand := args
-	arityOK := true
 	switch {
 	case resolved && !hasRest(fn) && len(args) > len(fn.Params):
 		// A typed rest param (hasRest) absorbs any number of trailing args, so it is
 		// never "too many" — only a fixed-arity (non-rest) callee trips this lint.
 		c.errs = append(c.errs, &TooManyArgsError{Call: e, Fn: fn})
 		demand = args[:len(fn.Params)]
-		arityOK = false
 	case resolved && len(args) < requiredCount(fn):
 		c.errs = append(c.errs, &NotEnoughArgsError{Call: e, Fn: fn})
 		demand = make([]*soltype.FuncParam, len(fn.Params))
@@ -845,7 +843,6 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		for i := len(args); i < len(fn.Params); i++ {
 			demand[i] = &soltype.FuncParam{Type: c.freshAt(lvl)}
 		}
-		arityOK = false
 	}
 
 	// callShape is built EXACT with all N params required, on purpose. That gives
@@ -863,10 +860,11 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	if resolved {
 		c.constrain(e, fn.Ret, res)
 		// Passing an owned argument to a bare owned parameter moves it; a `&`/`&mut`
-		// parameter auto-borrows and leaves the argument usable. A call already rejected
-		// for an arity mismatch records no moves, so a wrong number of arguments does not
-		// also cascade a use-after-move.
-		if arityOK && hasConsumeRef {
+		// parameter auto-borrows and leaves the argument usable. An arity-mismatched call
+		// still moves each argument that lines up with a parameter, so `store(p, p)` moves
+		// the first p and a later use of p is a use-after-move. consumeCallArgs skips the
+		// extra arguments that have no corresponding parameter.
+		if hasConsumeRef {
 			c.consumeCallArgs(e, fn, consumeRef)
 		}
 	}
@@ -879,7 +877,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 // parameter borrows, so it leaves the argument usable. An unannotated parameter, whose
 // ownership is a fresh inference variable rather than a concrete owned shape, is left
 // to borrow conservatively, so only a parameter typed as a concrete owned object,
-// tuple, or owned RefType consumes its argument.
+// tuple, or owned RefType consumes its argument. An extra argument beyond the declared
+// parameters, the surplus of a too-many-arguments call, has no parameter to move into,
+// so it is skipped.
 func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liveness.StmtRef) {
 	for i, arg := range e.Args {
 		if i >= len(fn.Params) {
@@ -1383,7 +1383,7 @@ func bindingDecl(b ValueBinding) ast.Node {
 func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Type {
 	// Resolve the enclosing statement's CFG point before inferring elements, which can
 	// overwrite c.fn.currentStmt with an inner branch statement.
-	litRef, hasLitRef := c.currentStmtRef()
+	stmtRef, hasStmtRef := c.currentStmtRef()
 	elems := make([]soltype.Type, 0, len(e.Elems))
 	inexact := false
 	for i, el := range e.Elems {
@@ -1392,7 +1392,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 			elemT := c.inferExpr(scope, lvl, el)
 			elems = append(elems, elemT)
 			// Building an owned value into the tuple moves it.
-			c.consumeIntoLiteral(el, elemT, litRef, hasLitRef)
+			c.consumeIntoLiteral(el, elemT, stmtRef, hasStmtRef)
 			continue
 		}
 		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
@@ -1407,7 +1407,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 			}
 			// Spreading an owned tuple moves its elements into the new tuple, so the
 			// spread operand is consumed.
-			c.consumeIntoLiteral(spread.Value, op, litRef, hasLitRef)
+			c.consumeIntoLiteral(spread.Value, op, stmtRef, hasStmtRef)
 		case *soltype.ErrorType:
 			// The operand already reported its own failure; absorb it rather than
 			// layering a SpreadNotTupleError on the recovery sentinel.
@@ -1440,7 +1440,7 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.Type {
 	// Resolve the enclosing statement's CFG point before inferring property values,
 	// which can overwrite c.fn.currentStmt with an inner branch statement.
-	litRef, hasLitRef := c.currentStmtRef()
+	stmtRef, hasStmtRef := c.currentStmtRef()
 	b := newObjElemBuilder(len(e.Elems))
 	for _, elem := range e.Elems {
 		prop, ok := elem.(*ast.PropertyExpr)
@@ -1467,7 +1467,7 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		ft := c.inferExpr(scope, lvl, prop.Value)
 		b.add(name, ft, false, false) // a literal property is never optional or readonly
 		// Building an owned value into the object moves it.
-		c.consumeIntoLiteral(prop.Value, ft, litRef, hasLitRef)
+		c.consumeIntoLiteral(prop.Value, ft, stmtRef, hasStmtRef)
 	}
 	t := &soltype.ObjectType{Elems: b.elems}
 	c.recordType(e, t)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -112,6 +112,11 @@ func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr) path
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
 		t := c.bindingValue(lvl, b)
 		c.recordType(e, t)
+		// PR 6: record this read so the post-walk use-after-move pass can test it
+		// against the consumed lattice. Use the binding's coalesced type for the
+		// reference-shape decision — a fresh instantiation can hide a mono owned
+		// shape behind a variable.
+		c.recordUse(e, bindingType(b))
 		return pathResult{value: t}
 	}
 	if ns, ok := scope.GetNamespace(e.Name); ok {
@@ -275,6 +280,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// produces the function's value. This mirrors the old checker's
 		// inferFuncBody.
 		c.inferBlock(fnScope, lvl, body)
+		// PR 6: with the whole body walked, every move site is recorded, so the
+		// consumed lattice is complete. Replay the recorded reads against it to
+		// report use-after-move. Runs before popFuncCtx restores the outer context,
+		// since it reads this body's move/use state off c.fn.
+		c.checkUseAfterMoves()
 		ret = c.joinReturnPoints(node, lvl, c.popFuncCtx(saved))
 	}
 	// Return-annotation handling diverges by async-ness.
@@ -844,9 +854,38 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	c.constrain(e, callee, callShape)
 	if resolved {
 		c.constrain(e, fn.Ret, res)
+		// PR 6: passing an owned argument to a bare owned parameter moves it; a `&`
+		// parameter auto-borrows and leaves the argument usable. consumeCallArgs reads
+		// each declared parameter's ownership to decide.
+		c.consumeCallArgs(e, fn)
 	}
 	c.recordType(e, res)
 	return res
+}
+
+// consumeCallArgs consumes each owned argument passed to a bare owned parameter of
+// the resolved callee. A `&`/`&mut` parameter borrows, so it leaves the argument
+// usable; an unannotated parameter, whose ownership is a fresh inference variable
+// rather than a concrete owned shape, is left to borrow conservatively, so only a
+// parameter typed as a concrete owned object, tuple, or owned RefType consumes its
+// argument here.
+func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType) {
+	if c.fn == nil || c.fn.cfg == nil {
+		return
+	}
+	ref, ok := c.currentStmtRef()
+	if !ok {
+		return
+	}
+	for i, arg := range e.Args {
+		if i >= len(fn.Params) {
+			break
+		}
+		if !isConcreteOwned(fn.Params[i].Type) {
+			continue
+		}
+		c.consumeOwned(arg, c.info.TypeOf(arg), arg, ref)
+	}
 }
 
 // inferOverloadedCall types a direct call to an overloaded name (PR6). It infers
@@ -1034,6 +1073,17 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			// not double-counted as a prior permanent alias.
 			c.checkGlobalWriteTransition(target, e.Right, bindingType(b), assignStmt)
 			c.constrainEscape(sourceT)
+			// PR 6: the store transfers the value into a permanent 'static slot, so it
+			// consumes the source binding. A later use of the source is then a
+			// use-after-move, the affine rule that closes the leak the global write
+			// otherwise allowed. checkGlobalWriteTransition above skips the source's own
+			// self-conflict, leaving the consume to govern the source and the exclusivity
+			// rule to govern any OTHER live alias of the same value.
+			if c.fn != nil {
+				if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
+					c.consumeAtGlobalWrite(e.Right, sourceT, e.Right, ref)
+				}
+			}
 			// KNOWN GAP (#762): this store is accepted even though it is not sound in
 			// general. checkGlobalWriteTransition is an in-body check only. The store
 			// escapes the source to 'static, but nothing forces the CALLER to pass a
@@ -1053,6 +1103,14 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// independent lifetime var that the escape never touches. isMutableType reads
 		// the same top-level Mut from either, so the alias mutability is unchanged.
 		c.trackAliasesForAssignment(target, e.Right, bindingType(b), assignStmt)
+		// PR 6: a non-module reassignment that moves its source consumes it. The
+		// global-write branch above runs its own consume, so this covers only the
+		// local-slot reassignment.
+		if !b.ModuleLevel && c.movesSourceInto(e.Right, bindingType(b)) {
+			if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
+				c.consumeOwned(e.Right, c.info.TypeOf(e.Right), e.Right, ref)
+			}
+		}
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use
@@ -1139,6 +1197,12 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	// when the write type-checked, so a rejected write does not record a bogus alias.
 	if c.fn != nil && len(c.errs) == errsBefore {
 		c.trackAliasesForPropAssignment(e.Left, e.Right)
+		// PR 6: storing an owned value into a field transfers ownership into the
+		// receiver, so the source binding is consumed and a later use of it is a
+		// use-after-move.
+		if ref, ok := c.currentStmtRef(); ok {
+			c.consumeOwned(e.Right, source, e.Right, ref)
+		}
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.
@@ -1316,7 +1380,10 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 	for i, el := range e.Elems {
 		spread, ok := el.(*ast.ArraySpreadExpr)
 		if !ok {
-			elems = append(elems, c.inferExpr(scope, lvl, el))
+			elemT := c.inferExpr(scope, lvl, el)
+			elems = append(elems, elemT)
+			// PR 6: building an owned value into the tuple moves it.
+			c.consumeIntoLiteral(el, elemT)
 			continue
 		}
 		switch op := c.inferExpr(scope, lvl, spread.Value).(type) {
@@ -1384,6 +1451,8 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
 		b.add(name, ft, false, false) // a literal property is never optional or readonly
+		// PR 6: building an owned value into the object moves it.
+		c.consumeIntoLiteral(prop.Value, ft)
 	}
 	t := &soltype.ObjectType{Elems: b.elems}
 	c.recordType(e, t)

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -1,0 +1,185 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Move / use-after-move tests for PR 6 of the affine-semantics plan. Each flow site
+// — a binding, a reassignment, a return, an owned-parameter argument, and a
+// module-level write — consumes an owned source, so a later use of it is a
+// use-after-move. A borrow site leaves the source usable.
+
+// A `val` binding of an owned value into another owned binding moves it, so the
+// later use of the source is a use-after-move. This is the freeze direction: the
+// owned-mutable source is moved into an immutable binding and consumed.
+func TestMoveValBindingConsumesSource(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val q = p
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// Binding through an explicit `&` borrow does NOT move the source: `val q = &p`
+// borrows p, so the later read of p is allowed.
+func TestMoveBorrowBindingKeepsSource(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val q = &p
+			p.x
+		}
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// A `&` annotation borrows rather than moves, so the source stays usable.
+func TestMoveBorrowAnnotationKeepsSource(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val p: mut {x: number} = {x: 0}
+			val q: &{x: number} = p
+			p.x
+		}
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// Passing an owned value to a bare owned parameter moves it into the callee, so the
+// caller's later use is a use-after-move. This is the `storeGlobally` example.
+func TestMoveOwnedArgumentConsumed(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn store(p: {x: number}) {}
+		fn test() {
+			val p = {x: 0}
+			store(p)
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// Passing an owned value to a `&` parameter auto-borrows, so the caller keeps the
+// value and its later use is fine.
+func TestMoveBorrowParameterKeepsArgument(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn read(p: &{x: number}) {}
+		fn test() {
+			val p = {x: 0}
+			read(p)
+			p.x
+		}
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// Returning an owned value moves it out of the frame. A second occurrence of the
+// same owned binding in the returned tuple is a use-after-move, the `dup` reuse
+// within a single statement.
+func TestMoveReturnDuplicateIsUseAfterMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn dup(x: {a: number}) -> [{a: number}, {a: number}] {
+			return [x, x]
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'x'"}, Messages(errs))
+}
+
+// The `&` form of the duplicate succeeds: a borrow parameter is copied, not moved, so
+// the body may return it twice. This is the concrete counterpart to the generic
+// `fn dup<T>(x: &T)`; the type-parameter form awaits TypeParam support in the new
+// solver (M7), where `fn dup<T>(x: T) -> [T, T]` is the no-Copy rejection case and
+// the `&T` form the accepted one.
+func TestMoveDupBorrowParameterAccepted(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn dup(x: &{a: number}) -> [&{a: number}, &{a: number}] {
+			return [x, x]
+		}
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// A value moved on only one branch of an if/else is a conditional use-after-move at
+// a later read: some reaching path moved it.
+func TestMoveConditionalUseAfterMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn store(p: {x: number}) {}
+		fn test(cond: boolean) {
+			val p = {x: 0}
+			if cond {
+				store(p)
+			} else {
+			}
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// A value moved on every branch is an unconditional use-after-move at a later read.
+func TestMoveBothBranchesUseAfterMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn store(p: {x: number}) {}
+		fn test(cond: boolean) {
+			val p = {x: 0}
+			if cond {
+				store(p)
+			} else {
+				store(p)
+			}
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// A move confined to one branch does not consume the source on the path that did
+// not move it: a use INSIDE the untouched branch is allowed.
+func TestMoveBranchLocalDoesNotLeak(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn store(p: {x: number}) {}
+		fn test(cond: boolean) {
+			val p = {x: 0}
+			if cond {
+				store(p)
+			} else {
+				p.x
+			}
+		}
+	`)
+	require.Empty(t, Messages(errs))
+}
+
+// Storing an owned value into a field moves it into the receiver, so the source's
+// later use is a use-after-move.
+func TestMoveFieldStoreConsumesSource(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val obj: mut {f: {x: number}} = {f: {x: 0}}
+			val p = {x: 1}
+			obj.f = p
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// PR 6 retires the M4 G3 implicit reborrow: binding a borrowed source into a bare
+// owned annotation is now a borrow-into-owned escape, rejected rather than silently
+// reborrowed. The explicit `&` form remains the opt-in for an alias.
+func TestMoveBorrowedIntoOwnedAnnotationRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: &mut {x: number}) {
+			val q: {x: number} = p
+			return q
+		}
+	`)
+	require.Equal(t, []string{
+		"borrowed value mut object does not live long enough to satisfy object",
+	}, Messages(errs))
+}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -71,9 +71,10 @@ func TestMoveSemantics(t *testing.T) {
 				}
 			`,
 		},
-		// A call rejected for an arity mismatch records no moves, so a wrong argument
-		// count does not also cascade a use-after-move.
-		"ArityMismatchSkipsConsume": {
+		// A too-many-arguments call still moves each argument that lines up with a
+		// parameter, so the first p in store(p, p) is consumed and the later p.x is a
+		// use-after-move. The surplus second argument has no parameter to move into.
+		"ArityMismatchConsumesMatchedArgs": {
 			src: `
 				fn store(p: {x: number}) {}
 				fn test() {
@@ -82,7 +83,10 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"Too many arguments: expected at most 1, but got 2"},
+			want: []string{
+				"Too many arguments: expected at most 1, but got 2",
+				"use of moved value 'p'",
+			},
 		},
 		// Returning an owned value moves it out of the frame. A second occurrence of the
 		// same owned binding in the returned tuple is a use-after-move within one

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -169,6 +169,47 @@ func TestMoveFieldStoreConsumesSource(t *testing.T) {
 	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
 }
 
+// The move reconciliation is path-sensitive. A consuming move of `p` on one branch
+// does not suppress the exclusivity check for `p` on a sibling branch where it was not
+// moved: the immutable borrow `snapshot` of a still-mutated `p` is a real Rule 1
+// conflict and is reported, even though `p` is moved on the other branch. The consumed
+// lattice reads `p` as NotMoved on the else path, so the transition survives
+// reconciliation.
+func TestMovePathSensitiveExclusivityKept(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn store(p: {x: number}) {}
+		fn test(cond: boolean) {
+			val p: mut {x: number} = {x: 0}
+			if cond {
+				store(p)
+			} else {
+				val snapshot: &{x: number} = p
+				p.x = 5
+				snapshot
+			}
+		}
+	`)
+	require.Equal(t, []string{
+		"cannot assign 'p' to immutable 'snapshot': 'p' is still used mutably after this point",
+	}, Messages(errs))
+}
+
+// The reconciliation drops the redundant exclusivity conflict when the source really is
+// moved before the transition: storing `p` into the global consumes it, so the later
+// borrow `val snap = p` is a single use-after-move, not also a stale 'static-escape
+// transition.
+func TestMoveGlobalEscapeReportsSingleUseAfterMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		var sink = {x: 0}
+		fn cache(p: &mut {x: number}) {
+			sink = p
+			val snap: &{x: number} = p
+			snap
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
 // PR 6 retires the M4 G3 implicit reborrow: binding a borrowed source into a bare
 // owned annotation is now a borrow-into-owned escape, rejected rather than silently
 // reborrowed. The explicit `&` form remains the opt-in for an alias.

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -6,221 +6,248 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Move / use-after-move tests for PR 6 of the affine-semantics plan. Each flow site
-// — a binding, a reassignment, a return, an owned-parameter argument, and a
-// module-level write — consumes an owned source, so a later use of it is a
-// use-after-move. A borrow site leaves the source usable.
+// Move and use-after-move tests for the affine move engine. Each flow site consumes
+// an owned source, so a later use of it is a use-after-move. The flow sites are a
+// binding, a reassignment, a return, an owned-parameter argument, a field store, an
+// object or tuple literal element, and a module-level write. A borrow site leaves the
+// source usable. want is nil for the cases that check cleanly.
+func TestMoveSemantics(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Binding an owned value into another owned binding moves it, so the later use of
+		// the source is a use-after-move.
+		"ValBindingConsumesSource": {
+			src: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val q = p
+					p.x
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// An explicit `&` borrow does not move the source.
+		"BorrowBindingKeepsSource": {
+			src: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val q = &p
+					p.x
+				}
+			`,
+		},
+		// A `&` annotation borrows rather than moves, so the source stays usable.
+		"BorrowAnnotationKeepsSource": {
+			src: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val q: &{x: number} = p
+					p.x
+				}
+			`,
+		},
+		// Passing an owned value to a bare owned parameter moves it into the callee.
+		"OwnedArgumentConsumed": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test() {
+					val p = {x: 0}
+					store(p)
+					p.x
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// Passing an owned value to a `&` parameter auto-borrows and keeps it usable.
+		"BorrowParameterKeepsArgument": {
+			src: `
+				fn read(p: &{x: number}) {}
+				fn test() {
+					val p = {x: 0}
+					read(p)
+					p.x
+				}
+			`,
+		},
+		// A call rejected for an arity mismatch records no moves, so a wrong argument
+		// count does not also cascade a use-after-move.
+		"ArityMismatchSkipsConsume": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test() {
+					val p = {x: 0}
+					store(p, p)
+					p.x
+				}
+			`,
+			want: []string{"Too many arguments: expected at most 1, but got 2"},
+		},
+		// Returning an owned value moves it out of the frame. A second occurrence of the
+		// same owned binding in the returned tuple is a use-after-move within one
+		// statement.
+		"ReturnDuplicateIsUseAfterMove": {
+			src: `
+				fn dup(x: {a: number}) -> [{a: number}, {a: number}] {
+					return [x, x]
+				}
+			`,
+			want: []string{"use of moved value 'x'"},
+		},
+		// A borrow parameter is copied, not moved, so the body may return it twice. This
+		// is the concrete counterpart to the generic `fn dup<T>(x: &T)`; the
+		// type-parameter form awaits TypeParam support in the new solver.
+		"DupBorrowParameterAccepted": {
+			src: `
+				fn dup(x: &{a: number}) -> [&{a: number}, &{a: number}] {
+					return [x, x]
+				}
+			`,
+		},
+		// Spreading an owned tuple moves its elements into the new tuple.
+		"TupleSpreadConsumesSource": {
+			src: `
+				fn test() {
+					val xs: [{a: number}] = [{a: 1}]
+					val ys = [...xs]
+					xs
+				}
+			`,
+			want: []string{"use of moved value 'xs'"},
+		},
+		// A value moved on only one branch is a conditional use-after-move at a later
+		// read, since some reaching path moved it.
+		"ConditionalUseAfterMove": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test(cond: boolean) {
+					val p = {x: 0}
+					if cond {
+						store(p)
+					} else {
+					}
+					p.x
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// A value moved on every branch is an unconditional use-after-move at a later
+		// read.
+		"BothBranchesUseAfterMove": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test(cond: boolean) {
+					val p = {x: 0}
+					if cond {
+						store(p)
+					} else {
+						store(p)
+					}
+					p.x
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// A move confined to one branch does not consume the source on the path that did
+		// not move it, so a use inside the untouched branch is allowed.
+		"BranchLocalDoesNotLeak": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test(cond: boolean) {
+					val p = {x: 0}
+					if cond {
+						store(p)
+					} else {
+						p.x
+					}
+				}
+			`,
+		},
+		// Storing an owned value into a field moves it into the receiver.
+		"FieldStoreConsumesSource": {
+			src: `
+				fn test() {
+					val obj: mut {f: {x: number}} = {f: {x: 0}}
+					val p = {x: 1}
+					obj.f = p
+					p.x
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// The move reconciliation is path-sensitive. A consuming move of p on one branch
+		// does not suppress the exclusivity check for p on a sibling branch where it was
+		// not moved, so the immutable borrow of a still-mutated p is a real Rule 1
+		// conflict and is reported.
+		"PathSensitiveExclusivityKept": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test(cond: boolean) {
+					val p: mut {x: number} = {x: 0}
+					if cond {
+						store(p)
+					} else {
+						val snapshot: &{x: number} = p
+						p.x = 5
+						snapshot
+					}
+				}
+			`,
+			want: []string{
+				"cannot assign 'p' to immutable 'snapshot': 'p' is still used mutably after this point",
+			},
+		},
+		// Storing p into the global consumes it, so the later borrow `val snap = p` is a
+		// single use-after-move, not also a stale 'static-escape transition.
+		"GlobalEscapeReportsSingleUseAfterMove": {
+			src: `
+				var sink = {x: 0}
+				fn cache(p: &mut {x: number}) {
+					sink = p
+					val snap: &{x: number} = p
+					snap
+				}
+			`,
+			want: []string{"use of moved value 'p'"},
+		},
+		// Moving a value while a mutable borrow of it is live is rejected: freezing p
+		// into immutable q while r still holds a mutable borrow would let r mutate a
+		// value q reads as immutable.
+		"MoveWithLiveBorrowRejected": {
+			src: `
+				fn test() {
+					val p: mut {x: number} = {x: 0}
+					val r: &mut {x: number} = p
+					val q: {x: number} = p
+					r.x = 5
+					q.x
+				}
+			`,
+			want: []string{
+				"cannot assign 'p' to immutable 'q': 'r' still has mutable access to 'p' after this point",
+			},
+		},
+		// Binding a borrowed source into a bare owned annotation is a borrow-into-owned
+		// escape, rejected rather than silently reborrowed. The explicit `&` form remains
+		// the opt-in for an alias.
+		"BorrowedIntoOwnedAnnotationRejected": {
+			src: `
+				fn f(p: &mut {x: number}) {
+					val q: {x: number} = p
+					return q
+				}
+			`,
+			want: []string{
+				"borrowed value mut object does not live long enough to satisfy object",
+			},
+		},
+	}
 
-// A `val` binding of an owned value into another owned binding moves it, so the
-// later use of the source is a use-after-move. This is the freeze direction: the
-// owned-mutable source is moved into an immutable binding and consumed.
-func TestMoveValBindingConsumesSource(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			val q = p
-			p.x
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// Binding through an explicit `&` borrow does NOT move the source: `val q = &p`
-// borrows p, so the later read of p is allowed.
-func TestMoveBorrowBindingKeepsSource(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			val q = &p
-			p.x
-		}
-	`)
-	require.Empty(t, Messages(errs))
-}
-
-// A `&` annotation borrows rather than moves, so the source stays usable.
-func TestMoveBorrowAnnotationKeepsSource(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn test() {
-			val p: mut {x: number} = {x: 0}
-			val q: &{x: number} = p
-			p.x
-		}
-	`)
-	require.Empty(t, Messages(errs))
-}
-
-// Passing an owned value to a bare owned parameter moves it into the callee, so the
-// caller's later use is a use-after-move. This is the `storeGlobally` example.
-func TestMoveOwnedArgumentConsumed(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn store(p: {x: number}) {}
-		fn test() {
-			val p = {x: 0}
-			store(p)
-			p.x
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// Passing an owned value to a `&` parameter auto-borrows, so the caller keeps the
-// value and its later use is fine.
-func TestMoveBorrowParameterKeepsArgument(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn read(p: &{x: number}) {}
-		fn test() {
-			val p = {x: 0}
-			read(p)
-			p.x
-		}
-	`)
-	require.Empty(t, Messages(errs))
-}
-
-// Returning an owned value moves it out of the frame. A second occurrence of the
-// same owned binding in the returned tuple is a use-after-move, the `dup` reuse
-// within a single statement.
-func TestMoveReturnDuplicateIsUseAfterMove(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn dup(x: {a: number}) -> [{a: number}, {a: number}] {
-			return [x, x]
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'x'"}, Messages(errs))
-}
-
-// The `&` form of the duplicate succeeds: a borrow parameter is copied, not moved, so
-// the body may return it twice. This is the concrete counterpart to the generic
-// `fn dup<T>(x: &T)`; the type-parameter form awaits TypeParam support in the new
-// solver (M7), where `fn dup<T>(x: T) -> [T, T]` is the no-Copy rejection case and
-// the `&T` form the accepted one.
-func TestMoveDupBorrowParameterAccepted(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn dup(x: &{a: number}) -> [&{a: number}, &{a: number}] {
-			return [x, x]
-		}
-	`)
-	require.Empty(t, Messages(errs))
-}
-
-// A value moved on only one branch of an if/else is a conditional use-after-move at
-// a later read: some reaching path moved it.
-func TestMoveConditionalUseAfterMove(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn store(p: {x: number}) {}
-		fn test(cond: boolean) {
-			val p = {x: 0}
-			if cond {
-				store(p)
-			} else {
-			}
-			p.x
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// A value moved on every branch is an unconditional use-after-move at a later read.
-func TestMoveBothBranchesUseAfterMove(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn store(p: {x: number}) {}
-		fn test(cond: boolean) {
-			val p = {x: 0}
-			if cond {
-				store(p)
-			} else {
-				store(p)
-			}
-			p.x
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// A move confined to one branch does not consume the source on the path that did
-// not move it: a use INSIDE the untouched branch is allowed.
-func TestMoveBranchLocalDoesNotLeak(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn store(p: {x: number}) {}
-		fn test(cond: boolean) {
-			val p = {x: 0}
-			if cond {
-				store(p)
-			} else {
-				p.x
-			}
-		}
-	`)
-	require.Empty(t, Messages(errs))
-}
-
-// Storing an owned value into a field moves it into the receiver, so the source's
-// later use is a use-after-move.
-func TestMoveFieldStoreConsumesSource(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn test() {
-			val obj: mut {f: {x: number}} = {f: {x: 0}}
-			val p = {x: 1}
-			obj.f = p
-			p.x
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// The move reconciliation is path-sensitive. A consuming move of `p` on one branch
-// does not suppress the exclusivity check for `p` on a sibling branch where it was not
-// moved: the immutable borrow `snapshot` of a still-mutated `p` is a real Rule 1
-// conflict and is reported, even though `p` is moved on the other branch. The consumed
-// lattice reads `p` as NotMoved on the else path, so the transition survives
-// reconciliation.
-func TestMovePathSensitiveExclusivityKept(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn store(p: {x: number}) {}
-		fn test(cond: boolean) {
-			val p: mut {x: number} = {x: 0}
-			if cond {
-				store(p)
-			} else {
-				val snapshot: &{x: number} = p
-				p.x = 5
-				snapshot
-			}
-		}
-	`)
-	require.Equal(t, []string{
-		"cannot assign 'p' to immutable 'snapshot': 'p' is still used mutably after this point",
-	}, Messages(errs))
-}
-
-// The reconciliation drops the redundant exclusivity conflict when the source really is
-// moved before the transition: storing `p` into the global consumes it, so the later
-// borrow `val snap = p` is a single use-after-move, not also a stale 'static-escape
-// transition.
-func TestMoveGlobalEscapeReportsSingleUseAfterMove(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		var sink = {x: 0}
-		fn cache(p: &mut {x: number}) {
-			sink = p
-			val snap: &{x: number} = p
-			snap
-		}
-	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
-}
-
-// PR 6 retires the M4 G3 implicit reborrow: binding a borrowed source into a bare
-// owned annotation is now a borrow-into-owned escape, rejected rather than silently
-// reborrowed. The explicit `&` form remains the opt-in for an alias.
-func TestMoveBorrowedIntoOwnedAnnotationRejected(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(p: &mut {x: number}) {
-			val q: {x: number} = p
-			return q
-		}
-	`)
-	require.Equal(t, []string{
-		"borrowed value mut object does not live long enough to satisfy object",
-	}, Messages(errs))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, Messages(errs))
+		})
+	}
 }

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -65,9 +65,9 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		if c.fn != nil {
 			c.fn.returns = append(c.fn.returns, t)
-			// PR 6: returning an owned value moves it out of the call frame, so the
-			// source binding is consumed and a later use is a use-after-move. A returned
-			// borrow flows out at its own lifetime and is not consumed here.
+			// Returning an owned value moves it out of the call frame, so the source
+			// binding is consumed and a later use is a use-after-move. A returned borrow
+			// flows out at its own lifetime and is not consumed here.
 			if s.Expr != nil {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.consumeOwned(s.Expr, t, s.Expr, ref)

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -65,6 +65,14 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		if c.fn != nil {
 			c.fn.returns = append(c.fn.returns, t)
+			// PR 6: returning an owned value moves it out of the call frame, so the
+			// source binding is consumed and a later use is a use-after-move. A returned
+			// borrow flows out at its own lifetime and is not consumed here.
+			if s.Expr != nil {
+				if ref, ok := c.fn.stmtToRef[s]; ok {
+					c.consumeOwned(s.Expr, t, s.Expr, ref)
+				}
+			}
 		} else {
 			// A `return` reached outside any function body — e.g. inside an `if` that
 			// is part of a top-level `val` initializer (`val x = if c { return 1 }
@@ -108,6 +116,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			scope.defineValue(name, b) // overwrite ⇒ same-name redeclaration rebinds
 			if c.fn != nil {
 				c.trackAliasesForVarDecl(scope, vd, bindingType(b), s)
+				c.consumeBindingInit(vd, bindingType(b), s)
 			}
 		}
 		return &soltype.Void{}

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -89,6 +89,10 @@ func isBorrowType(t soltype.Type) bool {
 // consume, so every read of one is recorded as a use to test against the consumed
 // lattice. Value types copy and are never consumed, so their reads are not tracked. A
 // value type is a primitive, a function, or a promise.
+//
+// A bare type variable counts here but is excluded by isConcreteOwned, so the two are
+// conservative in opposite directions on an unresolved variable. This side tracks the
+// read so a use-after-move is not missed if the variable resolves to a movable shape.
 func isReferenceShaped(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.ObjectType, *soltype.TupleType, *soltype.RefType, *soltype.TypeVarType:
@@ -101,6 +105,11 @@ func isReferenceShaped(t soltype.Type) bool {
 // object, tuple, or owned RefType — excluding a bare type variable. A consuming
 // parameter must be spelled as a concrete owned shape, so a fresh inference variable
 // for an unannotated parameter does not consume its argument.
+//
+// Excluding the bare type variable is the opposite of isReferenceShaped, which includes
+// it, so the two are conservative in opposite directions on an unresolved variable. This
+// side consumes nothing it cannot confirm is owned, so the caller's argument is not
+// over-consumed if the variable resolves to a value type.
 func isConcreteOwned(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.ObjectType, *soltype.TupleType:
@@ -247,6 +256,23 @@ func (c *checker) consumeAtGlobalWrite(source ast.Expr, sourceT soltype.Type, mo
 // binding, so neither consumes. hasRef is false when the literal has no resolvable
 // statement point, in which case nothing is recorded rather than mis-attributing the
 // move to the zero StmtRef.
+//
+// inferTuple and inferObject call it for each element built from a source binding:
+//
+//	val mut a = {foo: "hello"}
+//	val ys = [a]   // a moves into the tuple
+//	a.foo          // ERROR: use of moved value 'a'
+//
+// Limitation: only a whole-binding identifier element consumes. A member-path element
+// names a sub-place the whole-binding move engine cannot key on, so building one into a
+// literal records no move and a later use of it is not caught:
+//
+//	val mut pair = {a: {foo: "hi"}, b: {bar: 1}}
+//	val ys = [pair.a]   // pair.a is NOT consumed
+//	pair.a              // accepted today; should be a use-after-move
+//
+// Closing this needs the element/field-level ownership tracking planned for partial
+// moves (PR 7).
 func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type, ref liveness.StmtRef, hasRef bool) {
 	if !hasRef {
 		return

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -278,36 +278,10 @@ func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref livene
 		return
 	}
 	at.Add(varID)
-	if c.fn.consumed != nil {
-		c.fn.consumed.Add(varID)
-	}
 	if c.fn.moveNodes == nil {
 		c.fn.moveNodes = map[liveness.VarID]ast.Node{}
 	}
 	c.fn.moveNodes[varID] = moveNode
-}
-
-// sourceAlreadyMoved reports whether source names a binding the walk has already
-// consumed. A binding that borrows or aliases such a source is a use-after-move, which
-// the move engine reports, so the mutability-transition check skips it rather than
-// raising a redundant exclusivity conflict off the moved value's stale 'static-escape
-// state.
-//
-// The consumed set accumulates over the whole walk and is not path-sensitive, so a
-// move on one branch suppresses the exclusivity check for the same binding on a
-// sibling branch where it was not moved. That is a narrow false negative in the
-// exclusivity diagnostic, traded for keeping the common straight-line case free of a
-// double report. A path-sensitive answer would need the consumed lattice, which is not
-// built until after the walk.
-func (c *checker) sourceAlreadyMoved(source ast.Expr) bool {
-	if c.fn == nil || c.fn.consumed == nil {
-		return false
-	}
-	ident, ok := source.(*ast.IdentExpr)
-	if !ok || ident.VarID <= 0 {
-		return false
-	}
-	return c.fn.consumed.Contains(liveness.VarID(ident.VarID))
 }
 
 // checkUseAfterMoves runs the consumed-lattice dataflow over the function body's
@@ -319,8 +293,16 @@ func (c *checker) sourceAlreadyMoved(source ast.Expr) bool {
 // StateBefore reads the binding's state just before the read's statement, so a move
 // recorded AT that statement — the consume in `val q = p`, where reading p and
 // moving it share one statement — does not flag its own source read.
+//
+// It also reconciles the exclusivity diagnostic against the same lattice: a
+// mutability-transition error whose source the lattice finds already moved at the
+// transition point is subsumed by a use-after-move, so reconcileMovedTransitions drops
+// it.
 func (c *checker) checkUseAfterMoves() {
-	if c.fn == nil || c.fn.cfg == nil || len(c.fn.useSites) == 0 {
+	if c.fn == nil || c.fn.cfg == nil {
+		return
+	}
+	if len(c.fn.useSites) == 0 && len(c.fn.moveSites) == 0 {
 		return
 	}
 	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
@@ -336,4 +318,35 @@ func (c *checker) checkUseAfterMoves() {
 			moveSite:    c.fn.moveNodes[u.varID],
 		})
 	}
+	c.reconcileMovedTransitions(info)
+}
+
+// reconcileMovedTransitions drops every mutability-transition error whose source the
+// consumed lattice finds moved on a path reaching the transition. Such an error is a
+// stale exclusivity conflict off a value the move engine already reports a
+// use-after-move for, so keeping it would double-report. Querying the path-sensitive
+// lattice rather than a synchronous flag is what makes this precise: a source moved on
+// only one branch is NotMoved on a sibling branch, so a real exclusivity conflict there
+// survives.
+//
+// The query is scoped to this body for free. Module-wide VarID numbering means this
+// body's lattice never marks another body's source moved, so an error from a different
+// body reads NotMoved here and is kept.
+//
+// A MaybeMoved source — moved on some but not all paths reaching the transition — is
+// dropped too, since keeping it would double-report alongside the conditional
+// use-after-move on the moving paths. That loses a real exclusivity conflict on the
+// non-moving paths of such a source, a narrow residual the PR 8 phase reframing closes
+// by deciding exclusivity from the lattice and alias set in one pass.
+func (c *checker) reconcileMovedTransitions(info *liveness.MoveInfo) {
+	kept := c.errs[:0]
+	for _, e := range c.errs {
+		if mt, ok := e.(*MutabilityTransitionError); ok && mt.sourceVarID > 0 {
+			if info.StateBefore(mt.ref, mt.sourceVarID) != liveness.NotMoved {
+				continue
+			}
+		}
+		kept = append(kept, e)
+	}
+	c.errs = kept
 }

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -1,0 +1,339 @@
+package solver
+
+import (
+	"fmt"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// The move engine (PR 6 of the affine-semantics plan). When an owned value flows
+// out of its source binding at a flow site — a `val`/`var` binding, a
+// reassignment, a `return`, a field or element store, a consuming argument, an
+// escaping closure capture, or a module-level write — ownership MOVES out of that
+// binding, the binding is CONSUMED, and any later use of it is a use-after-move
+// error.
+//
+// The engine has three parts:
+//
+//   - The flow sites call consumeOwned to record a move into c.fn.moveSites, the
+//     per-statement consume map AnalyzeMoves folds into the branch-merged consumed
+//     lattice from internal/liveness.
+//   - inferIdent calls recordUse for every read of a reference-shaped binding,
+//     accumulating the read sites into c.fn.useSites.
+//   - After the body walk, checkUseAfterMoves runs AnalyzeMoves once and replays
+//     each recorded use against the lattice, reporting a UseAfterMoveError when the
+//     binding was Moved or MaybeMoved on a path reaching the read.
+//
+// Running the use check as a post-pass rather than inline is what makes conditional
+// and loop moves correct: the lattice is a fixed point over the whole CFG, so a use
+// that a later or back-edge move reaches is still caught.
+//
+// Known limitation: the lattice only ever raises a binding to Moved, never lowers it.
+// Reassigning a `var` after it was moved gives it a fresh value, but the lattice still
+// reads it as Moved, so a use after `q = …` re-initializes a consumed q reports a
+// spurious use-after-move. Clearing a moved binding at its reassignment is left to a
+// later precision pass.
+
+// UseAfterMoveError is reported when a binding is read after an owned value has
+// moved out of it. It blames the read and points its related span at the move
+// site. Conditional records whether only SOME reaching paths moved the binding —
+// a MaybeMoved lattice state — so a diagnostic consumer can distinguish a definite
+// use-after-move from a possible one.
+type UseAfterMoveError struct {
+	// Name is the consumed binding's source name, for the message.
+	Name string
+	// Conditional is true when the binding is moved on some but not all paths
+	// reaching the use (the MaybeMoved lattice state), false when every reaching
+	// path moved it (Moved).
+	Conditional bool
+	// use is the read being rejected; it self-blames from here.
+	use ast.Node
+	// moveSite is the consume that moved the binding, used for the related span. It
+	// may be nil when the move node was not recorded.
+	moveSite ast.Node
+}
+
+func (*UseAfterMoveError) isSolverError()   {}
+func (e *UseAfterMoveError) Span() ast.Span { return e.use.Span() }
+func (e *UseAfterMoveError) Related() []ast.Span {
+	if e.moveSite == nil {
+		return nil
+	}
+	return []ast.Span{e.moveSite.Span()}
+}
+func (e *UseAfterMoveError) Message() string {
+	return fmt.Sprintf("use of moved value '%s'", e.Name)
+}
+
+// moveUse is one recorded read of an owned-movable binding: the binding's VarID,
+// the CFG point of the read, and the node to blame.
+type moveUse struct {
+	varID liveness.VarID
+	ref   liveness.StmtRef
+	node  ast.Node
+	name  string
+}
+
+// isBorrowType reports whether t is a borrow — a RefType carrying a lifetime.
+// Owned-immutable collapses to the bare inner and owned-mutable is a RefType with
+// a nil lifetime, so only a non-nil Lt marks a borrow.
+func isBorrowType(t soltype.Type) bool {
+	r, ok := t.(*soltype.RefType)
+	return ok && r.Lt != nil
+}
+
+// isReferenceShaped reports whether t is a reference-shaped value — an object,
+// tuple, borrow, owned RefType, or type-parameter variable. These are the values a
+// move can consume, so every read of one is recorded as a use to test against the
+// consumed lattice. Value types — primitives, functions, promises — copy and are
+// never consumed, so their reads are not tracked.
+func isReferenceShaped(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.ObjectType, *soltype.TupleType, *soltype.RefType, *soltype.TypeVarType:
+		return true
+	}
+	return false
+}
+
+// isConcreteOwned reports whether t is a CONCRETE owned reference shape — an owned
+// object, tuple, or owned RefType — excluding a bare type variable. A consuming
+// parameter must be spelled as a concrete owned shape, so a fresh inference variable
+// for an unannotated parameter does not consume its argument.
+func isConcreteOwned(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.ObjectType, *soltype.TupleType:
+		return true
+	case *soltype.RefType:
+		return !isBorrowType(t)
+	}
+	return false
+}
+
+// isOwnedMovable reports whether t is an owned reference-shaped value, the kind a
+// move at an owned destination consumes. Value types copy and borrows alias, so
+// neither moves at an owned site. An owned object, tuple, or owned-mutable RefType
+// moves, as does a bare type-parameter variable: generic code treats a `T` value as
+// non-duplicable, the conservative affine assumption that makes
+// `fn dup<T>(x: T) -> [T, T]` a double move.
+//
+// A borrow moves only when it escapes to a longer-lived region, which a module-level
+// write forces; that case is consumed through consumeAtGlobalWrite, not here.
+func isOwnedMovable(t soltype.Type) bool {
+	if isBorrowType(t) {
+		return false
+	}
+	return isReferenceShaped(t)
+}
+
+// currentStmtRef resolves the statement currently being walked to its CFG point.
+// It is the program point a use or move records against. ok is false outside a
+// function body or when the statement has no CFG ref.
+func (c *checker) currentStmtRef() (liveness.StmtRef, bool) {
+	if c.fn == nil || c.fn.stmtToRef == nil || c.fn.currentStmt == nil {
+		return liveness.StmtRef{}, false
+	}
+	ref, ok := c.fn.stmtToRef[c.fn.currentStmt]
+	return ref, ok
+}
+
+// recordUse records a read of identifier e whose value is reference-shaped, so
+// checkUseAfterMoves can later test it against the consumed lattice. Borrows are
+// recorded alongside owned values, because a borrow stored into a 'static global is
+// consumed too. A read of a value type, a non-local, or a binding outside a function
+// body records nothing.
+func (c *checker) recordUse(e *ast.IdentExpr, t soltype.Type) {
+	if c.fn == nil || c.fn.cfg == nil || e.VarID <= 0 {
+		return
+	}
+	if !isReferenceShaped(t) {
+		return
+	}
+	ref, ok := c.currentStmtRef()
+	if !ok {
+		return
+	}
+	c.fn.useSites = append(c.fn.useSites, moveUse{
+		varID: liveness.VarID(e.VarID),
+		ref:   ref,
+		node:  e,
+		name:  e.Name,
+	})
+}
+
+// consumeOwned records a move of the owned binding the source expression names,
+// at the given program point, blaming moveNode for the consume. The source must be
+// a plain identifier bound to an owned-movable value; a borrow, value type, fresh
+// literal, or member path consumes nothing here.
+//
+// It does NOT force the moved value's borrows to 'static. A return or local store
+// flows the value out at the call's own lifetime, not 'static, so forcing here would
+// wrongly collapse a finite param-lifetime borrow — `fn (p: &'a {x}) -> &'a {x}`
+// returns p at 'a, not 'static. The 'static forcing runs only where the destination
+// is genuinely permanent, the module-level write in consumeAtGlobalWrite.
+func (c *checker) consumeOwned(source ast.Expr, sourceT soltype.Type, moveNode ast.Node, ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.cfg == nil || sourceT == nil {
+		return
+	}
+	ident, ok := source.(*ast.IdentExpr)
+	if !ok || ident.VarID <= 0 {
+		return
+	}
+	if !isOwnedMovable(sourceT) {
+		return
+	}
+	c.recordMove(liveness.VarID(ident.VarID), moveNode, ref)
+}
+
+// movesSourceInto reports whether flowing source into a destination of type destT
+// moves the owned binding source names: source is an identifier bound to an
+// owned-movable value and the destination takes ownership rather than borrowing. A
+// borrow destination — a `&` annotation or an explicit `&source` initializer, which
+// is a BorrowExpr rather than a plain identifier — keeps the source aliased and
+// governed by the exclusivity rule, not consumed. It is the shared move-or-borrow
+// decision for `val`/`var` bindings and reassignments.
+func (c *checker) movesSourceInto(source ast.Expr, destT soltype.Type) bool {
+	if source == nil || isBorrowType(destT) {
+		return false
+	}
+	ident, ok := source.(*ast.IdentExpr)
+	if !ok || ident.VarID <= 0 {
+		return false
+	}
+	return isOwnedMovable(c.info.TypeOf(source))
+}
+
+// consumeBindingInit moves the owned source a `val`/`var` initializer names into
+// the new binding. `val q = p` for an owned p consumes p; a borrow binding leaves
+// p usable, whether the borrow comes from a `&` annotation — `val q: &{x} = p` — or
+// an explicit `&p` initializer, which is a BorrowExpr rather than a plain
+// identifier and so names no owned source to consume.
+func (c *checker) consumeBindingInit(vd *ast.VarDecl, bindingT soltype.Type, stmt ast.Stmt) {
+	if !c.movesSourceInto(vd.Init, bindingT) {
+		return
+	}
+	ref, ok := c.fn.stmtToRef[stmt]
+	if !ok {
+		return
+	}
+	c.consumeOwned(vd.Init, c.info.TypeOf(vd.Init), vd.Init, ref)
+}
+
+// consumeAtGlobalWrite consumes the source binding of a module-level store. A store
+// into a 'static global permanently transfers the value, so it consumes the source
+// whether owned or a borrow — using the source afterward could mutate what the global
+// now reads, the leak the affine rule closes. A value-type source copies and a
+// non-identifier source names no binding, so neither consumes.
+func (c *checker) consumeAtGlobalWrite(source ast.Expr, sourceT soltype.Type, moveNode ast.Node, ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.cfg == nil || sourceT == nil {
+		return
+	}
+	ident, ok := source.(*ast.IdentExpr)
+	if !ok || ident.VarID <= 0 {
+		return
+	}
+	if !isReferenceShaped(sourceT) {
+		return
+	}
+	c.recordMove(liveness.VarID(ident.VarID), moveNode, ref)
+}
+
+// consumeIntoLiteral moves an owned identifier built into a fresh object or tuple
+// literal: storing an owned value into the literal transfers ownership into it, so a
+// later use of the source is a use-after-move. A value-type element copies and a
+// non-identifier element names no binding, so neither consumes.
+func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type) {
+	if c.fn == nil || c.fn.cfg == nil {
+		return
+	}
+	ref, ok := c.currentStmtRef()
+	if !ok {
+		return
+	}
+	c.consumeOwned(el, elemT, el, ref)
+}
+
+// recordMove marks varID consumed at ref. A second move of the same binding at the
+// same program point is an intra-statement reuse — `return [x, x]`, `f(x, x)`, the
+// `dup` double move — so it is reported immediately as a use-after-move rather than
+// waiting for the lattice, which is statement-granular and cannot order two moves
+// within one statement.
+func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.moveSites == nil || varID <= 0 {
+		return
+	}
+	at := c.fn.moveSites[ref]
+	if at == nil {
+		at = set.NewSet[liveness.VarID]()
+		c.fn.moveSites[ref] = at
+	}
+	if at.Contains(varID) {
+		c.report(&UseAfterMoveError{
+			Name:     c.varIDToName(varID),
+			use:      moveNode,
+			moveSite: c.fn.moveNodes[varID],
+		})
+		return
+	}
+	at.Add(varID)
+	if c.fn.consumed != nil {
+		c.fn.consumed.Add(varID)
+	}
+	if c.fn.moveNodes == nil {
+		c.fn.moveNodes = map[liveness.VarID]ast.Node{}
+	}
+	c.fn.moveNodes[varID] = moveNode
+}
+
+// sourceAlreadyMoved reports whether source names a binding the walk has already
+// consumed. A binding that borrows or aliases such a source is a use-after-move, which
+// the move engine reports, so the mutability-transition check skips it rather than
+// raising a redundant exclusivity conflict off the moved value's stale 'static-escape
+// state.
+//
+// The consumed set accumulates over the whole walk and is not path-sensitive, so a
+// move on one branch suppresses the exclusivity check for the same binding on a
+// sibling branch where it was not moved. That is a narrow false negative in the
+// exclusivity diagnostic, traded for keeping the common straight-line case free of a
+// double report. A path-sensitive answer would need the consumed lattice, which is not
+// built until after the walk.
+func (c *checker) sourceAlreadyMoved(source ast.Expr) bool {
+	if c.fn == nil || c.fn.consumed == nil {
+		return false
+	}
+	ident, ok := source.(*ast.IdentExpr)
+	if !ok || ident.VarID <= 0 {
+		return false
+	}
+	return c.fn.consumed.Contains(liveness.VarID(ident.VarID))
+}
+
+// checkUseAfterMoves runs the consumed-lattice dataflow over the function body's
+// CFG and reports a UseAfterMoveError for every recorded read of a binding the
+// lattice finds Moved or MaybeMoved at the read's program point. It runs once,
+// after the whole body is walked, so a move on a later or loop-back path is
+// already recorded when a use is checked.
+//
+// StateBefore reads the binding's state just before the read's statement, so a move
+// recorded AT that statement — the consume in `val q = p`, where reading p and
+// moving it share one statement — does not flag its own source read.
+func (c *checker) checkUseAfterMoves() {
+	if c.fn == nil || c.fn.cfg == nil || len(c.fn.useSites) == 0 {
+		return
+	}
+	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
+	for _, u := range c.fn.useSites {
+		state := info.StateBefore(u.ref, u.varID)
+		if state == liveness.NotMoved {
+			continue
+		}
+		c.report(&UseAfterMoveError{
+			Name:        u.name,
+			Conditional: state == liveness.MaybeMoved,
+			use:         u.node,
+			moveSite:    c.fn.moveNodes[u.varID],
+		})
+	}
+}

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -9,14 +9,13 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// The move engine (PR 6 of the affine-semantics plan). When an owned value flows
-// out of its source binding at a flow site — a `val`/`var` binding, a
-// reassignment, a `return`, a field or element store, a consuming argument, an
-// escaping closure capture, or a module-level write — ownership MOVES out of that
-// binding, the binding is CONSUMED, and any later use of it is a use-after-move
-// error.
+// The move engine implements affine move semantics. When an owned value flows out of
+// its source binding at a flow site, ownership moves out of that binding, the binding
+// is consumed, and any later use of it is a use-after-move error. The flow sites are a
+// `val`/`var` binding, a reassignment, a `return`, a field or element store, a
+// consuming argument, an escaping closure capture, and a module-level write.
 //
-// The engine has three parts:
+// The engine has three parts.
 //
 //   - The flow sites call consumeOwned to record a move into c.fn.moveSites, the
 //     per-statement consume map AnalyzeMoves folds into the branch-merged consumed
@@ -28,7 +27,7 @@ import (
 //     binding was Moved or MaybeMoved on a path reaching the read.
 //
 // Running the use check as a post-pass rather than inline is what makes conditional
-// and loop moves correct: the lattice is a fixed point over the whole CFG, so a use
+// and loop moves correct. The lattice is a fixed point over the whole CFG, so a use
 // that a later or back-edge move reaches is still caught.
 //
 // Known limitation: the lattice only ever raises a binding to Moved, never lowers it.
@@ -38,9 +37,9 @@ import (
 // later precision pass.
 
 // UseAfterMoveError is reported when a binding is read after an owned value has
-// moved out of it. It blames the read and points its related span at the move
-// site. Conditional records whether only SOME reaching paths moved the binding —
-// a MaybeMoved lattice state — so a diagnostic consumer can distinguish a definite
+// moved out of it. It blames the read and points its related span at the move site.
+// Conditional records whether only some reaching paths moved the binding, the
+// MaybeMoved lattice state, so a diagnostic consumer can distinguish a definite
 // use-after-move from a possible one.
 type UseAfterMoveError struct {
 	// Name is the consumed binding's source name, for the message.
@@ -85,11 +84,11 @@ func isBorrowType(t soltype.Type) bool {
 	return ok && r.Lt != nil
 }
 
-// isReferenceShaped reports whether t is a reference-shaped value — an object,
-// tuple, borrow, owned RefType, or type-parameter variable. These are the values a
-// move can consume, so every read of one is recorded as a use to test against the
-// consumed lattice. Value types — primitives, functions, promises — copy and are
-// never consumed, so their reads are not tracked.
+// isReferenceShaped reports whether t is a reference-shaped value: an object, tuple,
+// borrow, owned RefType, or type-parameter variable. These are the values a move can
+// consume, so every read of one is recorded as a use to test against the consumed
+// lattice. Value types copy and are never consumed, so their reads are not tracked. A
+// value type is a primitive, a function, or a promise.
 func isReferenceShaped(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.ObjectType, *soltype.TupleType, *soltype.RefType, *soltype.TypeVarType:
@@ -190,10 +189,11 @@ func (c *checker) consumeOwned(source ast.Expr, sourceT soltype.Type, moveNode a
 // movesSourceInto reports whether flowing source into a destination of type destT
 // moves the owned binding source names: source is an identifier bound to an
 // owned-movable value and the destination takes ownership rather than borrowing. A
-// borrow destination — a `&` annotation or an explicit `&source` initializer, which
-// is a BorrowExpr rather than a plain identifier — keeps the source aliased and
-// governed by the exclusivity rule, not consumed. It is the shared move-or-borrow
-// decision for `val`/`var` bindings and reassignments.
+// borrow destination keeps the source aliased and governed by the exclusivity rule,
+// not consumed. A borrow destination is either a `&` annotation or an explicit
+// `&source` initializer, which is a BorrowExpr rather than a plain identifier and so
+// names no owned source. It is the shared move-or-borrow decision for `val`/`var`
+// bindings and reassignments.
 func (c *checker) movesSourceInto(source ast.Expr, destT soltype.Type) bool {
 	if source == nil || isBorrowType(destT) {
 		return false
@@ -241,15 +241,14 @@ func (c *checker) consumeAtGlobalWrite(source ast.Expr, sourceT soltype.Type, mo
 }
 
 // consumeIntoLiteral moves an owned identifier built into a fresh object or tuple
-// literal: storing an owned value into the literal transfers ownership into it, so a
-// later use of the source is a use-after-move. A value-type element copies and a
-// non-identifier element names no binding, so neither consumes.
-func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type) {
-	if c.fn == nil || c.fn.cfg == nil {
-		return
-	}
-	ref, ok := c.currentStmtRef()
-	if !ok {
+// literal, recording the move at ref, the literal's statement. Storing an owned value
+// into the literal transfers ownership into it, so a later use of the source is a
+// use-after-move. A value-type element copies and a non-identifier element names no
+// binding, so neither consumes. hasRef is false when the literal has no resolvable
+// statement point, in which case nothing is recorded rather than mis-attributing the
+// move to the zero StmtRef.
+func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type, ref liveness.StmtRef, hasRef bool) {
+	if !hasRef {
 		return
 	}
 	c.consumeOwned(el, elemT, el, ref)

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -57,9 +57,9 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// and divergence flag are discarded, just as inferFunc discards them. A script,
 	// like a function body, produces no value from its last statement.
 	c.inferBlock(scope, 0, scriptBody)
-	// PR 6: a script body runs with function-body semantics, so the move engine
-	// applies here too. With the whole body walked, replay the recorded reads
-	// against the consumed lattice to report use-after-move.
+	// A script body runs with function-body semantics, so the move engine applies
+	// here too. With the whole body walked, replay the recorded reads against the
+	// consumed lattice to report use-after-move.
 	c.checkUseAfterMoves()
 
 	return scope, c.info, c.errs

--- a/internal/solver/script.go
+++ b/internal/solver/script.go
@@ -57,6 +57,10 @@ func InferScript(script *ast.Script) (*Scope, *Info, []SolverError) {
 	// and divergence flag are discarded, just as inferFunc discards them. A script,
 	// like a function body, produces no value from its last statement.
 	c.inferBlock(scope, 0, scriptBody)
+	// PR 6: a script body runs with function-body semantics, so the move engine
+	// applies here too. With the whole body walked, replay the recorded reads
+	// against the consumed lattice to report use-after-move.
+	c.checkUseAfterMoves()
 
 	return scope, c.info, c.errs
 }

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -68,14 +68,13 @@ func TestScriptTransitionParity(t *testing.T) {
 		stmts string
 		want  []string
 	}{
-		// Rule 1, the mut→immutable case, errors when the mutable source is live after
-		// the alias. This is the Accept example. A top-level `val items: mut {…}` aliased
-		// to an immutable binding and then used mutably reports the Rule 1 transition
-		// error.
+		// Rule 1, the mut→immutable case, errors when the mutable source is live after an
+		// immutable borrow of it. A top-level `val items: mut {…}` borrowed immutably and
+		// then used mutably reports the Rule 1 transition error.
 		"Rule1_SourceLive_Error": {
 			stmts: `
 				val items: mut {x: number} = {x: 1}
-				val snapshot: {x: number} = items
+				val snapshot: &{x: number} = items
 				items.x = 2
 				snapshot
 			`,
@@ -83,31 +82,31 @@ func TestScriptTransitionParity(t *testing.T) {
 				"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
 			},
 		},
-		// Rule 1: safe when the mutable source is dead after the alias.
+		// Rule 1: safe when the mutable source is dead after the borrow.
 		"Rule1_SourceDead_OK": {
 			stmts: `
 				val items: mut {x: number} = {x: 1}
 				items.x = 2
-				val snapshot: {x: number} = items
+				val snapshot: &{x: number} = items
 				snapshot
 			`,
 		},
-		// Rule 3: two mutable aliases of the same value are always allowed.
+		// Rule 3: two mutable borrows of the same value are always allowed.
 		"Rule3_MultipleMutableAliases_OK": {
 			stmts: `
 				val a: mut {x: number} = {x: 1}
-				val b: mut {x: number} = a
+				val b: &mut {x: number} = a
 				b.x = 2
 				a.x
 			`,
 		},
-		// Chain aliasing through a mutable intermediate: the conflict names the live
-		// mutable alias, not the source itself.
+		// Chain aliasing through a mutable borrow: the conflict names the live mutable
+		// alias, not the source itself.
 		"ChainAlias_TargetLive_Error": {
 			stmts: `
 				val a: mut {x: number} = {x: 1}
-				val b: mut {x: number} = a
-				val c: {x: number} = b
+				val b: &mut {x: number} = a
+				val c: &{x: number} = b
 				a.x = 2
 				c
 			`,
@@ -192,9 +191,9 @@ func TestScriptRedeclaration(t *testing.T) {
 // (inferAssign), distinct from the declaration-aliasing path the other parity cases
 // drive. inferAssign reads the enclosing statement from c.fn.currentStmt to find its
 // CFG StmtRef, which only exists because InferScript installs a funcCtx and runs the
-// liveness pre-pass over the script body. Reassigning a live mutable owned value into
-// an immutable binding is a Rule 1 transition. Mutating it before the reassignment
-// makes it dead, and the transition stays silent.
+// liveness pre-pass over the script body. Reassigning an owned value into an owned slot
+// moves it, so the later use of the source is a use-after-move. Mutating it before the
+// reassignment makes it dead, and the move stays silent.
 func TestScriptReassignTransition(t *testing.T) {
 	t.Run("source_live_error", func(t *testing.T) {
 		_, _, errs := inferScriptSource(t, `
@@ -205,7 +204,7 @@ func TestScriptReassignTransition(t *testing.T) {
 			snap
 		`)
 		require.Equal(t, []string{
-			"cannot assign 'items' to immutable 'snap': 'items' is still used mutably after this point",
+			"use of moved value 'items'",
 		}, transitionMessages(t, errs))
 	})
 

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -165,7 +165,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 		a.AddAlias(tgt, src, liveness.AliasMutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{tgt}))
 		c.fn.varIDTypes[src] = staticBorrow(true)
-		c.checkMutabilityTransition(src, tgt, "p", "snap", false, true, false, transitionRef, transitionSite)
+		c.checkMutabilityTransition(src, tgt, "p", "snap", false, true, false, false, transitionRef, transitionSite)
 		require.Empty(t, transitionMessages(t, c.errs))
 	})
 
@@ -184,7 +184,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 		a.AddAlias(tgt, src, liveness.AliasImmutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{tgt}))
 		c.fn.varIDTypes[src] = &soltype.RefType{Mut: true, Lt: soltype.Static, Inner: objT()}
-		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, transitionRef, transitionSite)
+		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, false, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'p' to immutable 'snap': a `'static` escape still has mutable access to 'p' after this point",
 		}, transitionMessages(t, c.errs))
@@ -207,47 +207,17 @@ func TestStaticEscapeTransition(t *testing.T) {
 		a.AddAlias(tgt, src, liveness.AliasImmutable)
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{src}))
 		c.fn.varIDTypes[src] = staticBorrow(true)
-		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, transitionRef, transitionSite)
+		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, false, transitionRef, transitionSite)
 		require.Empty(t, transitionMessages(t, c.errs))
 	})
 }
 
-// TestStaticEscapeTransitionFromSource is the end-to-end counterpart. A `&mut`
-// borrow stored into module-level `sink` escapes to 'static (D3), creating a
-// permanent alias outside the function, then is aliased into the immutable
-// `snap`. The program surfaces two errors, both asserted.
-//
-//  1. The global-write transition at `sink = p`. Storing the mutable borrow into
-//     the immutable global `sink` while `p` stays live afterward is a
-//     mut→immutable transition against a permanent target.
-//  2. The static-escape transition at `val snap = p` (G2). `p` escaped to
-//     'static via the earlier store, so aliasing it into immutable `snap`
-//     conflicts. The query over `p`'s 'static-forced lifetime is what reports
-//     it, named as a `'static` escape.
-//
-// Before G2 the dropped HasStaticMutAlias bit was never set, so case 2 was
-// silently accepted as a false negative. Before the global-write check, case 1
-// was missed entirely because the module-level target is not a tracked local.
-//
-// `val snap: &{x} = p` aliases the borrow at a fresh lifetime. The lifetime sort
-// and the transition pass produce the verdict above, which is case 2.
-//
-// Case 2 also covers the source-dead property a unit test used to isolate. `p`
-// is dead after `val snap = p` because only `snap` is read afterward, so the
-// conflict fires purely because `p` escaped to 'static, not because `p` is
-// locally live. The liveness loop skips the dead `p`. Only the escape query
-// reports it.
-// DISABLED until PR 6 lands.
-//
-// PR 6 of the affine semantics plan moves the global-write site from the
-// transition-checker onto the move engine. The plan says: "The global-write
-// site stops dropping mutability and instead consumes, per 'Move subsumes the
-// escape-site logic.'" Once that lands, `sink = p` consumes `p`, the later
-// `val snap: &{x: number} = p` is a use-after-move, and the two transition
-// diagnostics asserted below are replaced by a single UseAfterMoveError
-// against the `p` in `val snap = p`. Re-enable then and switch the assertion
-// to the UseAfterMove message.
-/*
+// TestStaticEscapeTransitionFromSource is the end-to-end move-engine counterpart.
+// Storing the borrow `p` into the module-level `sink` consumes p: the store transfers
+// it into the permanent 'static slot, so the later `val snap: &{x: number} = p` reads a
+// moved value and is a use-after-move. The global-write exclusivity check skips the
+// consumed source's self-conflict, so the single UseAfterMoveError is the only
+// diagnostic.
 func TestStaticEscapeTransitionFromSource(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		var sink = {x: 0}
@@ -265,7 +235,6 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 		"use of moved value 'p'",
 	}, msgs)
 }
-*/
 
 // TestGlobalWriteMutTransition covers Option 1: a store into a module-level binding is a
 // mutability transition against a permanent, always-live target. The local reassignment
@@ -273,9 +242,10 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 // in-body check only; it does not catch a caller that retains a mutable alias to a value
 // stored into an immutable global (see the dead-source case below).
 func TestGlobalWriteMutTransition(t *testing.T) {
-	// Storing a mut borrow into the immutable global `sink`, then mutating through the
-	// borrow, is a mut→immutable transition: `sink` permanently observes a value that p
-	// still mutates. p stays live via the field write, so Rule 1 fires.
+	// Storing an owned-mutable value into the global `sink` moves it: the store
+	// transfers ownership into the permanent slot, so the later `p.x = 5` is a
+	// use-after-move. This is the motivating `leak` example — the move consumes p, so
+	// the mutation that would let `sink` observe a later write is rejected.
 	t.Run("mut_into_immutable_global_then_mutate_error", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
 			var sink = {x: 0}
@@ -285,7 +255,7 @@ func TestGlobalWriteMutTransition(t *testing.T) {
 			}
 		`)
 		require.Equal(t, []string{
-			"cannot assign 'p' to immutable 'sink': 'p' is still used mutably after this point",
+			"use of moved value 'p'",
 		}, transitionMessages(t, errs))
 	})
 
@@ -506,25 +476,13 @@ func TestTransitionWiringNoSpuriousErrors(t *testing.T) {
 	}
 }
 
-// TestTransitionWiringReportsRule1Error is the error counterpart to
-// TestTransitionWiringNoSpuriousErrors. It proves the wired pre-pass reports a
-// real mut→immutable (Rule 1) transition error from source, not just that it
-// stays silent on benign bodies.
+// TestTransitionWiringReportsMoveError is the error counterpart to
+// TestTransitionWiringNoSpuriousErrors. It proves the wired body walk reports a real
+// use-after-move from source, not just that it stays silent on benign bodies.
 //
-// p is an owned-mutable parameter. The mut decay at `val q: {x} = p` aliases p
-// into the immutable q. p mutates `p.x = 5` and q stays live for the later
-// `q.x` read, so both are live across the alias. Rule 1 fires.
-//
-// DISABLED until PR 6 lands.
-//
-// PR 6 of the affine semantics plan makes `val`/`var` bindings flow sites
-// that consume the source. Once it lands, `val q: {x} = p` consumes p, so
-// `p.x = 5` is a use-after-move rather than a live-source Rule 1 transition,
-// and the diagnostic changes to a UseAfterMoveError that names both the
-// move site (the `val q` binding) and the use site (`p.x = 5`). Re-enable
-// then and update the assertion to match the new error.
-/*
-func TestTransitionWiringReportsRule1Error(t *testing.T) {
+// p is an owned-mutable parameter. Binding it into the owned `val q: {x} = p` moves
+// p and consumes it, so the later `p.x = 5` is a use-after-move.
+func TestTransitionWiringReportsMoveError(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn test(p: mut {x: number}) {
 			val q: {x: number} = p
@@ -540,7 +498,6 @@ func TestTransitionWiringReportsRule1Error(t *testing.T) {
 		"use of moved value 'p'",
 	}, msgs)
 }
-*/
 
 // TestCollectOuterBindingsPreludeCache covers the outer-binding collection that feeds
 // the rename pass: every reachable value name maps to a distinct negative id, the
@@ -565,21 +522,24 @@ func TestCollectOuterBindingsPreludeCache(t *testing.T) {
 	require.Equal(t, first, c.collectOuterBindings(scope))
 }
 
-// TestMutabilityTransitionsFromSource reproduces the old checker's transition cases at
-// the source level, now reachable because a fresh literal can be constructed into an
-// owned-mutable binding. Each case mints its mutable value with `val x: mut {…} = {…}`,
-// aliases it, and asserts the transition verdict. want is empty for the safe cases.
+// TestMutabilityTransitionsFromSource exercises the mutability-exclusivity rule from
+// source. Each case mints an owned-mutable value with `val x: mut {…} = {…}`, borrows
+// it with `&`/`&mut`, and asserts the transition verdict. The aliasing cases borrow
+// explicitly, since binding an owned value into another owned binding moves it rather
+// than aliasing it, which the move-engine tests cover separately. want is empty for the
+// safe cases.
 func TestMutabilityTransitionsFromSource(t *testing.T) {
 	tests := map[string]struct {
 		src  string
 		want []string
 	}{
-		// Rule 1 (mut→immutable): error when the mutable source is live after the alias.
+		// Rule 1 (mut→immutable): error when the mutable source is live after an
+		// immutable borrow of it.
 		"Rule1_SourceLive_Error": {
 			src: `
 				fn test() {
 					val items: mut {x: number} = {x: 1}
-					val snapshot: {x: number} = items
+					val snapshot: &{x: number} = items
 					items.x = 2
 					snapshot
 				}
@@ -588,13 +548,13 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
 			},
 		},
-		// Rule 1: safe when the mutable source is dead after the alias.
+		// Rule 1: safe when the mutable source is dead after the borrow.
 		"Rule1_SourceDead_OK": {
 			src: `
 				fn test() {
 					val items: mut {x: number} = {x: 1}
 					items.x = 2
-					val snapshot: {x: number} = items
+					val snapshot: &{x: number} = items
 					snapshot
 				}
 			`,
@@ -628,6 +588,9 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 		},
+		// Storing the owned `p` into the global `sink` moves it, so binding `p` again
+		// into `snap` is a use-after-move; the bind is also a type error, since an
+		// immutable value cannot satisfy a mutable slot.
 		"Rule2_ImmEscape_SourceDead_Error": {
 			src: `
 				var sink = {x: 0}
@@ -639,27 +602,28 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 			`,
 			want: []string{
 				"cannot constrain immutable object <: mutable object",
+				"use of moved value 'p'",
 			},
 		},
-		// Rule 3: two mutable aliases of the same value are always allowed.
+		// Rule 3: two mutable borrows of the same value are always allowed.
 		"Rule3_MultipleMutableAliases_OK": {
 			src: `
 				fn test() {
 					val a: mut {x: number} = {x: 1}
-					val b: mut {x: number} = a
+					val b: &mut {x: number} = a
 					b.x = 2
 					a.x
 				}
 			`,
 		},
-		// Chain aliasing through a mutable intermediate: the conflict names the live
-		// mutable alias, not the source itself.
+		// Chain aliasing through a mutable borrow: the conflict names the live mutable
+		// alias, not the source itself.
 		"ChainAlias_TargetLive_Error": {
 			src: `
 				fn test() {
 					val a: mut {x: number} = {x: 1}
-					val b: mut {x: number} = a
-					val c: {x: number} = b
+					val b: &mut {x: number} = a
+					val c: &{x: number} = b
 					a.x = 2
 					c
 				}
@@ -683,27 +647,27 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				"cannot assign 'a' to immutable 'c': 'a' is still used mutably after this point",
 			},
 		},
-		// Rule 1: safe when the immutable target is dead. snapshot is never read, so there
+		// Rule 1: safe when the immutable borrow is dead. snapshot is never read, so there
 		// is no window where the immutable view and the live mutable source overlap.
 		"Rule1_TargetDead_OK": {
 			src: `
 				fn test() {
 					val items: mut {x: number} = {x: 1}
-					val snapshot: {x: number} = items
+					val snapshot: &{x: number} = items
 					items.x = 2
 				}
 			`,
 		},
 		// Conditional aliasing where the SOURCE is mut and sits in two alias sets. c
-		// aliases both a and b, then c→frozen is the mut→immutable transition while c
-		// stays live. c is reported once, not once per set.
+		// aliases both a and b, then borrowing c immutably as frozen is the mut→immutable
+		// transition while c stays live. c is reported once, not once per set.
 		"Conditional_SourceMutInTwoSets_Error": {
 			src: `
 				fn test(cond: boolean) {
 					val a: mut {x: number} = {x: 0}
 					val b: mut {x: number} = {x: 1}
 					val c: mut {x: number} = if cond { a } else { b }
-					val frozen: {x: number} = c
+					val frozen: &{x: number} = c
 					c.x = 3
 					frozen
 				}
@@ -721,11 +685,12 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 	}
 }
 
-// TestRule2TransitionFromSource covers the Rule 2 immutable→mut transition from source.
-// Binding an immutable value into a `mut` slot is a type error, but the decl path runs
-// transition tracking unconditionally, so the Rule 2 transition error rides along with
-// it. config stays live, so the immutable→mut alias conflicts. Both messages are
-// asserted; this is the source-level home for the old constructed-state Rule 2 case.
+// TestRule2TransitionFromSource covers binding an immutable value into an owned `mut`
+// slot. The bind is a type error — an immutable object cannot satisfy a mutable slot —
+// and it also moves the owned `config` into `mutableConfig`, so the later `config.x`
+// read is a use-after-move. Both messages are asserted. Owned-into-owned is a move
+// under the affine rule, so the old Rule 2 exclusivity transition no longer applies
+// here; the move governs the source instead.
 func TestRule2TransitionFromSource(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn test() {
@@ -741,7 +706,7 @@ func TestRule2TransitionFromSource(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{
 		"cannot constrain immutable object <: mutable object",
-		"cannot assign 'config' to mutable 'mutableConfig': 'config' is still used immutably after this point",
+		"use of moved value 'config'",
 	}, msgs)
 }
 
@@ -752,8 +717,9 @@ func TestRule2TransitionFromSource(t *testing.T) {
 // the owned-mutable source these cases reassign from.
 func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 	t.Run("source_live_error", func(t *testing.T) {
-		// items is reassigned into immutable snap, then mutated, so both are live across
-		// the reassignment.
+		// Reassigning the owned `items` into the owned `snap` slot moves it: snap drops
+		// its old value and takes ownership of items, so the later `items.x = 2` is a
+		// use-after-move.
 		_, _, errs := inferSource(t, `
 			fn f() {
 				var snap: {x: number} = {x: 0}
@@ -764,7 +730,7 @@ func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 			}
 		`)
 		require.Equal(t, []string{
-			"cannot assign 'items' to immutable 'snap': 'items' is still used mutably after this point",
+			"use of moved value 'items'",
 		}, transitionMessages(t, errs))
 	})
 

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -227,13 +227,9 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 			snap
 		}
 	`)
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Message()
-	}
 	require.ElementsMatch(t, []string{
 		"use of moved value 'p'",
-	}, msgs)
+	}, Messages(errs))
 }
 
 // TestGlobalWriteMutTransition covers Option 1: a store into a module-level binding is a
@@ -490,13 +486,9 @@ func TestTransitionWiringReportsMoveError(t *testing.T) {
 			q.x
 		}
 	`)
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Message()
-	}
 	require.ElementsMatch(t, []string{
 		"use of moved value 'p'",
-	}, msgs)
+	}, Messages(errs))
 }
 
 // TestCollectOuterBindingsPreludeCache covers the outer-binding collection that feeds
@@ -700,14 +692,10 @@ func TestRule2TransitionFromSource(t *testing.T) {
 			config.x
 		}
 	`)
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Message()
-	}
 	require.ElementsMatch(t, []string{
 		"cannot constrain immutable object <: mutable object",
 		"use of moved value 'config'",
-	}, msgs)
+	}, Messages(errs))
 }
 
 // TestMutabilityTransitionReassignFromSource exercises the reassignment transition path

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -59,6 +59,13 @@ type MutabilityTransitionError struct {
 	MutToImmutable bool
 	// node is the transition site, used for blame (the decl or assignment).
 	node ast.Node
+	// sourceVarID and ref locate the transition's source binding and program point
+	// for the post-pass move reconciliation. When the consumed lattice finds the
+	// source already moved on a path reaching ref, the move engine reports a
+	// use-after-move there, which subsumes this exclusivity conflict, so
+	// reconcileMovedTransitions drops it.
+	sourceVarID liveness.VarID
+	ref         liveness.StmtRef
 }
 
 func (*MutabilityTransitionError) isSolverError()        {}
@@ -386,6 +393,8 @@ func (c *checker) checkMutabilityTransition(
 		ConflictingVars: conflicting,
 		MutToImmutable:  sourceMut && !targetMut,
 		node:            node,
+		sourceVarID:     sourceVarID,
+		ref:             assignRef,
 	})
 }
 
@@ -462,16 +471,6 @@ func (c *checker) trackAliasesForIdentPat(
 	// exclusivity rule that governs a retained borrow. consumeBindingInit records the
 	// consume for the same binding.
 	if c.movesSourceInto(init, bindingT) {
-		c.fn.aliases.NewValue(targetVarID, aliasMut)
-		return
-	}
-
-	// PR 6: borrowing or aliasing a source the walk has already moved is a
-	// use-after-move, which the move engine reports against this read. Register the
-	// target as a fresh value and skip the exclusivity check, so the stale
-	// 'static-escape state the consumed source still carries does not raise a second,
-	// redundant transition error.
-	if c.sourceAlreadyMoved(init) {
 		c.fn.aliases.NewValue(targetVarID, aliasMut)
 		return
 	}
@@ -575,14 +574,6 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	// aliasing, and let the move engine govern a later use of p. consumeReassignSource
 	// records the consume for the same assignment.
 	if c.movesSourceInto(rhs, targetType) {
-		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
-		return
-	}
-
-	// PR 6: reassigning from a source the walk has already moved is a use-after-move,
-	// reported by the move engine. Reassign to no source and skip the exclusivity
-	// check, matching the binding path.
-	if c.sourceAlreadyMoved(rhs) {
 		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
 		return
 	}
@@ -745,11 +736,9 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.varIDTypes = varIDTypes
 	// Retain the CFG and the move-engine state. The body walk records consume sites
 	// into moveSites, which liveness.AnalyzeMoves folds into the branch-merged consumed
-	// lattice over these same blocks. consumed mirrors that synchronously for the
-	// transition check; both start empty for this body.
+	// lattice over these same blocks once the whole body is walked.
 	c.fn.cfg = cfg
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
-	c.fn.consumed = set.NewSet[liveness.VarID]()
 }
 
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -297,6 +297,7 @@ func (c *checker) checkMutabilityTransition(
 	sourceMut bool,
 	targetMut bool,
 	targetAlwaysLive bool,
+	sourceConsumed bool,
 	assignRef liveness.StmtRef,
 	node ast.Node,
 ) {
@@ -322,6 +323,14 @@ func (c *checker) checkMutabilityTransition(
 	conflictingSet := set.NewSet[string]()
 	for _, aliasSet := range fn.aliases.GetAliasSets(sourceVarID) {
 		for varID, aliasMut := range aliasSet.Members {
+			// PR 6: when the move engine consumes the source at this site — a
+			// module-level write moves the stored value out — the source's own later
+			// use is a use-after-move, not an exclusivity conflict. Skip the source's
+			// self-conflict so the consume governs it and only OTHER live aliases of the
+			// value raise a transition error, the alias-set residual the move leaves.
+			if sourceConsumed && varID == sourceVarID {
+				continue
+			}
 			// A borrow on this member forced to 'static is a permanent outside
 			// reference. It outlives the function, so no liveness check is meaningful
 			// and it always counts as a live alias of its escaped mutability.
@@ -425,7 +434,7 @@ func (c *checker) checkTransitionsAgainst(
 		c.checkMutabilityTransition(
 			sourceVarID, targetVarID,
 			c.varIDToName(sourceVarID), targetName,
-			c.isSourceMutable(sourceVarID), targetMut, false, stmtRef, node,
+			c.isSourceMutable(sourceVarID), targetMut, false, false, stmtRef, node,
 		)
 	}
 }
@@ -446,6 +455,26 @@ func (c *checker) trackAliasesForIdentPat(
 	targetMut := isMutableType(bindingT)
 	aliasMut := aliasMutability(targetMut)
 	c.recordVarIDType(targetVarID, bindingT)
+
+	// PR 6: a binding that MOVES its source is not an alias of it. The source is
+	// consumed and the target becomes a fresh owner, so register a new value and let
+	// the move engine's use-after-move check govern a later use, rather than the
+	// exclusivity rule that governs a retained borrow. consumeBindingInit records the
+	// consume for the same binding.
+	if c.movesSourceInto(init, bindingT) {
+		c.fn.aliases.NewValue(targetVarID, aliasMut)
+		return
+	}
+
+	// PR 6: borrowing or aliasing a source the walk has already moved is a
+	// use-after-move, which the move engine reports against this read. Register the
+	// target as a fresh value and skip the exclusivity check, so the stale
+	// 'static-escape state the consumed source still carries does not raise a second,
+	// redundant transition error.
+	if c.sourceAlreadyMoved(init) {
+		c.fn.aliases.NewValue(targetVarID, aliasMut)
+		return
+	}
 
 	source := liveness.DetermineAliasSource(init)
 	switch source.RootKind() {
@@ -540,6 +569,24 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	aliasMut := aliasMutability(targetMut)
 	c.recordVarIDType(targetVarID, targetType)
 
+	// PR 6: a reassignment that MOVES its source — `q = p` for an owned p into an
+	// owned slot — drops the previous value of q and takes ownership of p's value, so
+	// q becomes a fresh owner and p is consumed. Reassign to no source rather than
+	// aliasing, and let the move engine govern a later use of p. consumeReassignSource
+	// records the consume for the same assignment.
+	if c.movesSourceInto(rhs, targetType) {
+		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
+		return
+	}
+
+	// PR 6: reassigning from a source the walk has already moved is a use-after-move,
+	// reported by the move engine. Reassign to no source and skip the exclusivity
+	// check, matching the binding path.
+	if c.sourceAlreadyMoved(rhs) {
+		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
+		return
+	}
+
 	source := liveness.DetermineAliasSource(rhs)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable:
@@ -593,7 +640,7 @@ func (c *checker) checkGlobalWriteTransition(target *ast.IdentExpr, rhs ast.Expr
 			c.checkMutabilityTransition(
 				sourceVarID, 0,
 				c.varIDToName(sourceVarID), target.Name,
-				c.isSourceMutable(sourceVarID), targetMut, true, stmtRef, target,
+				c.isSourceMutable(sourceVarID), targetMut, true, true, stmtRef, target,
 			)
 		}
 	}
@@ -696,11 +743,13 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.stmtToRef = stmtToRef
 	c.fn.varIDNames = renameResult.VarIDNames
 	c.fn.varIDTypes = varIDTypes
-	// Retain the CFG and a fresh consume-site collector for the move engine (PR 5).
-	// The branch-merged consumed lattice (liveness.AnalyzeMoves) joins over these
-	// same blocks. PR 6 records consume sites into moveSites while walking the body.
+	// Retain the CFG and the move-engine state. The body walk records consume sites
+	// into moveSites, which liveness.AnalyzeMoves folds into the branch-merged consumed
+	// lattice over these same blocks. consumed mirrors that synchronously for the
+	// transition check; both start empty for this body.
 	c.fn.cfg = cfg
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
+	c.fn.consumed = set.NewSet[liveness.VarID]()
 }
 
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -427,6 +427,9 @@ func (c *checker) trackAliasesForVarDecl(scope *Scope, decl *ast.VarDecl, bindin
 // point. It is the shared core of the decl and reassignment paths. The single-source
 // case is just the one-element instance of this loop, so neither path open-codes its
 // own copy. A no-op when the statement has no StmtRef.
+// sourceConsumed marks that the move engine consumes each source at this site, so the
+// check skips the source's own self-conflict — the use-after-move governs the source —
+// and reports only OTHER live aliases that conflict with the new view.
 func (c *checker) checkTransitionsAgainst(
 	sourceIDs []liveness.VarID,
 	targetVarID liveness.VarID,
@@ -434,6 +437,7 @@ func (c *checker) checkTransitionsAgainst(
 	targetMut bool,
 	enclosingStmt ast.Stmt,
 	node ast.Node,
+	sourceConsumed bool,
 ) {
 	stmtRef, hasRef := c.fn.stmtToRef[enclosingStmt]
 	if !hasRef {
@@ -443,7 +447,7 @@ func (c *checker) checkTransitionsAgainst(
 		c.checkMutabilityTransition(
 			sourceVarID, targetVarID,
 			c.varIDToName(sourceVarID), targetName,
-			c.isSourceMutable(sourceVarID), targetMut, false, false, stmtRef, node,
+			c.isSourceMutable(sourceVarID), targetMut, false, sourceConsumed, stmtRef, node,
 		)
 	}
 }
@@ -465,12 +469,20 @@ func (c *checker) trackAliasesForIdentPat(
 	aliasMut := aliasMutability(targetMut)
 	c.recordVarIDType(targetVarID, bindingT)
 
-	// PR 6: a binding that MOVES its source is not an alias of it. The source is
-	// consumed and the target becomes a fresh owner, so register a new value and let
-	// the move engine's use-after-move check govern a later use, rather than the
-	// exclusivity rule that governs a retained borrow. consumeBindingInit records the
-	// consume for the same binding.
+	// A binding that MOVES its source is not an alias of it. The source is consumed and
+	// the target becomes a fresh owner, so register a new value rather than an alias
+	// edge, and let the move engine's use-after-move check govern a later use of the
+	// source. consumeBindingInit records the consume for the same binding. The move
+	// still requires the source to have no conflicting live borrow at this point, so
+	// run the exclusivity check against the source's OTHER aliases with sourceConsumed
+	// set, which skips the source's own self-conflict.
 	if c.movesSourceInto(init, bindingT) {
+		if ident, ok := init.(*ast.IdentExpr); ok && ident.VarID > 0 {
+			c.checkTransitionsAgainst(
+				[]liveness.VarID{liveness.VarID(ident.VarID)},
+				targetVarID, identPat.Name, targetMut, enclosingStmt, node, true,
+			)
+		}
 		c.fn.aliases.NewValue(targetVarID, aliasMut)
 		return
 	}
@@ -485,7 +497,7 @@ func (c *checker) trackAliasesForIdentPat(
 		for _, sourceVarID := range sourceIDs {
 			c.fn.aliases.AddAlias(targetVarID, sourceVarID, aliasMut)
 		}
-		c.checkTransitionsAgainst(sourceIDs, targetVarID, identPat.Name, targetMut, enclosingStmt, node)
+		c.checkTransitionsAgainst(sourceIDs, targetVarID, identPat.Name, targetMut, enclosingStmt, node, false)
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		c.fn.aliases.NewValue(targetVarID, aliasMut)
 	}
@@ -542,7 +554,7 @@ func (c *checker) trackCapturedAliases(
 		// frame, so the helper's varIDToName(enclosingVarID) is capture.Name.
 		c.checkTransitionsAgainst(
 			[]liveness.VarID{enclosingVarID}, closureVarID,
-			c.varIDToName(closureVarID), capture.IsMutable, enclosingStmt, node,
+			c.varIDToName(closureVarID), capture.IsMutable, enclosingStmt, node, false,
 		)
 	}
 }
@@ -568,12 +580,20 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	aliasMut := aliasMutability(targetMut)
 	c.recordVarIDType(targetVarID, targetType)
 
-	// PR 6: a reassignment that MOVES its source — `q = p` for an owned p into an
-	// owned slot — drops the previous value of q and takes ownership of p's value, so
-	// q becomes a fresh owner and p is consumed. Reassign to no source rather than
-	// aliasing, and let the move engine govern a later use of p. consumeReassignSource
-	// records the consume for the same assignment.
+	// A reassignment that MOVES its source — `q = p` for an owned p into an owned slot
+	// — drops the previous value of q and takes ownership of p's value, so q becomes a
+	// fresh owner and p is consumed. Reassign to no source rather than aliasing, and let
+	// the move engine govern a later use of p; inferAssign records the consume through
+	// consumeOwned for the same assignment. The move still requires no conflicting live
+	// borrow of the source, so run the exclusivity check against p's OTHER aliases with
+	// sourceConsumed set, which skips p's own self-conflict.
 	if c.movesSourceInto(rhs, targetType) {
+		if ident, ok := rhs.(*ast.IdentExpr); ok && ident.VarID > 0 {
+			c.checkTransitionsAgainst(
+				[]liveness.VarID{liveness.VarID(ident.VarID)},
+				targetVarID, target.Name, targetMut, enclosingStmt, target, true,
+			)
+		}
 		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
 		return
 	}
@@ -584,14 +604,14 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 		// Check the transition before reassigning. The single-source reassign rewires
 		// the target's membership, so checking first reads the pre-reassign alias state.
 		sourceVarID := source.UniqueVarIDs()[0]
-		c.checkTransitionsAgainst([]liveness.VarID{sourceVarID}, targetVarID, target.Name, targetMut, enclosingStmt, target)
+		c.checkTransitionsAgainst([]liveness.VarID{sourceVarID}, targetVarID, target.Name, targetMut, enclosingStmt, target, false)
 		c.fn.aliases.Reassign(targetVarID, &sourceVarID, aliasMut)
 	case liveness.AliasSourceMultiple:
 		// Conditional aliasing: reassign to all sources BEFORE checking transitions so
 		// alias state stays consistent regardless of whether errors are reported.
 		sourceIDs := source.UniqueVarIDs()
 		c.fn.aliases.ReassignMulti(targetVarID, sourceIDs, aliasMut)
-		c.checkTransitionsAgainst(sourceIDs, targetVarID, target.Name, targetMut, enclosingStmt, target)
+		c.checkTransitionsAgainst(sourceIDs, targetVarID, target.Name, targetMut, enclosingStmt, target, false)
 	case liveness.AliasSourceFresh, liveness.AliasSourceUnknown:
 		c.fn.aliases.Reassign(targetVarID, nil, aliasMut)
 	}

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -249,7 +249,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium | ✅ done (#771) |
 | 4 | Member reads borrow the receiver | 3 | Medium | ✅ done (#773) |
 | 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 6 |
-| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ⬜ not started |
+| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ✅ done; escaping-closure-capture moves and the return/argument `constrainEscape` forcing deferred |
 | 7 | Partial moves and field-level ownership | 6 | Medium | ⬜ not started |
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ⬜ not started |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ⬜ not started |

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -511,6 +511,18 @@ sites. Files for the deferred forcing:
   on one branch and untouched on another is consumed only on the moving paths, and a
   later use is an error only if some reaching path moved it.
 - Add `UseAfterMoveError`, reported against both the move site and the use site.
+- Reconcile the residual exclusivity check against the lattice. The mut/immut
+  transition check runs inline during the walk, so when a global write consumes a
+  source it would also raise the M4 G2 `borrowEscapedToStatic` self-conflict at a
+  later alias of that source, double-reporting alongside the use-after-move.
+  `reconcileMovedTransitions`
+  ([internal/solver/moves.go](../../internal/solver/moves.go)) drops a
+  `MutabilityTransitionError` whose source the lattice finds moved at the
+  transition's program point, since the move engine reports the use-after-move
+  there. The lattice query keeps this path-sensitive: a source moved on one branch
+  is `NotMoved` on a sibling, so a real exclusivity conflict there survives. PR 8
+  finishes this by driving the phase decision from the lattice directly rather than
+  inline-plus-reconcile; see PR 8.
 - This subsumes the "no Copy bound" requirement: reusing an owned type-parameter
   value triggers a second move and a use-after-move error, with no extra machinery.
   Add a test showing `fn dup<T>(x: T) -> [T, T]` fails and the `&T` form succeeds.
@@ -580,12 +592,32 @@ exclusivity.
   number of `&` borrows or a mutable phase with any number of `&mut` borrows, and
   the two never overlap. The existing liveness-driven mut/immut conflict check is
   the mechanism; this PR aligns it to phases over lifetimes.
+- Move the exclusivity check fully onto the consumed lattice. PR 6 runs the
+  mut/immut transition check inline during the walk and then reconciles it against
+  the lattice in a post-pass: `reconcileMovedTransitions`
+  ([internal/solver/moves.go](../../internal/solver/moves.go)) drops a
+  `MutabilityTransitionError` whose source the lattice finds moved at the transition
+  point, since the move engine already reports a use-after-move there. That
+  reconciliation is the seed of the phase reframing, not the end state. The inline
+  check still mutates the alias tracker as it walks and cannot consult the
+  post-walk lattice while running, so a transition that depends on per-path move
+  state is decided in two steps rather than one. PR 8 should finish the move:
+  drive the phase/exclusivity decision from the lattice and the alias set directly
+  in the post-pass, so the inline check and the separate reconciliation collapse
+  into one lattice-driven pass. With that done, the
+  [internal/solver/transition_test.go](../../internal/solver/transition_test.go)
+  static-escape unit tests, which pin the M4 G2 `borrowEscapedToStatic` self-conflict
+  the move now subsumes, can be retired or rephrased as phase tests.
 
 Tests: the thaw example with a use-after-move on the immutable source; the
 multiple-`&mut` example staying legal; an immutable borrow overlapping a `&mut`
-being rejected.
+being rejected; a borrow-alias exclusivity conflict on a branch where the value is
+NOT moved still reported, while the same conflict on a branch where it IS moved
+reads as a single use-after-move.
 
-Acceptance: both transitions are moves, and exclusivity reads as the phase rule.
+Acceptance: both transitions are moves, exclusivity reads as the phase rule, and
+the phase decision is taken in one lattice-driven post-pass rather than an inline
+check plus a reconciliation.
 
 ### PR 9 — Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization
 


### PR DESCRIPTION
Implements the move engine for PR 6 of the affine-semantics plan. Owned values now move out of their source bindings at flow sites (val/var bindings, reassignments, returns, field/element stores, consuming arguments, and module-level writes), and later reads of moved bindings are reported as use-after-move errors.

The implementation has three parts:

- **Flow sites record moves**: `consumeOwned`, `consumeBindingInit`, `consumeAtGlobalWrite`, and `consumeIntoLiteral` record moves into `c.fn.moveSites` during the body walk. `consumeCallArgs` consumes owned arguments passed to bare owned parameters.
- **Reads are recorded**: `recordUse` accumulates reference-shaped reads into `c.fn.useSites` for later checking.
- **Post-walk checking**: `checkUseAfterMoves` runs the consumed-lattice dataflow after the body walk completes and replays recorded reads against it, reporting `UseAfterMoveError` when a binding was moved on a reaching path.

The lattice is statement-granular and branch-merged, so conditional moves are correctly handled: a use reached by a move on only some paths is a conditional use-after-move, and a use inside an untouched branch is allowed even if a sibling branch moved the value.

Intra-statement reuse (like `return [x, x]`) is caught immediately by `recordMove` rather than waiting for the lattice, since the lattice cannot order two moves within one statement.

The move engine also reconciles with the exclusivity check: `reconcileMovedTransitions` drops a `MutabilityTransitionError` whose source the lattice finds moved at the transition point, since the move engine reports a use-after-move there instead.

Notable changes:

- Removed the M4 G3 implicit reborrow in `constrainInitAgainstAnnotation`: binding a borrowed source into a bare owned annotation is now a borrow-into-owned escape, rejected rather than silently reborrowed. The explicit `&` form remains the opt-in for an alias.
- Module-level writes now consume their source (via `consumeAtGlobalWrite`) rather than just checking a transition, closing the leak the affine rule prevents.
- `checkMutabilityTransition` gains a `sourceConsumed` parameter to skip the source's self-conflict when the move engine consumes it.
- Updated test assertions in `transition_test.go` and `script_test.go` to reflect the new move-based diagnostics.

https://claude.ai/code/session_01YHQM5hovRfV8SZ8m2FhYvs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer “use of moved value” diagnostics for ownership errors, including links to the read and move locations when available.
  * Expanded move detection across returns, function calls, assignments, object/tuple construction, and field updates.

* **Bug Fixes**
  * Improved handling of borrow vs. owned values so valid borrowed reads no longer trigger move errors.
  * Updated script and transition checks so ownership-related issues now report more consistent, path-sensitive messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->