### PR TITLE
Track moves and uses at field granularity for partial moves

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -134,11 +134,25 @@ type funcCtx struct {
 	// binding moved on more than one path keeps the last-recorded move node, which
 	// is a coarse but adequate blame target.
 	moveNodes map[liveness.VarID]ast.Node
-	// useSites records every read of an owned-movable binding while walking the
-	// body, each with the binding's VarID, the CFG point of the read, and the node
-	// to blame. checkUseAfterMoves replays them against the consumed lattice once the
-	// whole body — including loop back edges — has been walked, so a use that some
-	// reaching path moved is caught even when the move is textually later.
+	// placeIDs interns a field-level place to the synthetic VarID the consumed lattice
+	// keys on (PR 7). A field-level place is a root binding plus a path of field names
+	// such as `pair.a`. A whole-binding place reuses its root VarID and is never
+	// interned here, so this holds only sub-binding places. The synthetic IDs come from
+	// the module-wide varIDCounter, so they never collide with a real binding's VarID.
+	placeIDs map[string]liveness.VarID
+	// movePlaces records, for every VarID the move engine has consumed, the place it
+	// stands for: a whole binding maps its root VarID to the path-empty place, and a
+	// field move maps its synthetic VarID to the field place. checkUseAfterMoves
+	// scans it to find a moved place whose path is a prefix of, or extends, the place
+	// a use reads — the partial-move conflict test that keeps a moved `pair.a` from
+	// blocking a read of the sibling `pair.b`.
+	movePlaces map[liveness.VarID]movePlace
+	// useSites records every read of a reference-shaped place while walking the body,
+	// each with the place read, the CFG point of the read, and the node to blame. The
+	// place carries the field path, so a read of `pair.a` is distinguished from the
+	// sibling `pair.b`. checkUseAfterMoves replays them against the consumed lattice
+	// once the whole body, loop back edges included, has been walked, so a use that
+	// some reaching path moved is caught even when the move is textually later.
 	useSites []moveUse
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -134,18 +134,23 @@ type funcCtx struct {
 	// binding moved on more than one path keeps the last-recorded move node, which
 	// is a coarse but adequate blame target.
 	moveNodes map[liveness.VarID]ast.Node
-	// placeIDs interns a field-level place to the synthetic VarID the consumed lattice
-	// keys on (PR 7). A field-level place is a root binding plus a path of field names
-	// such as `pair.a`. A whole-binding place reuses its root VarID and is never
-	// interned here, so this holds only sub-binding places. The synthetic IDs come from
-	// the module-wide varIDCounter, so they never collide with a real binding's VarID.
+	// placeIDs assigns each field-level place one synthetic VarID (PR 7). A field-level
+	// place is a root binding plus a path of field segments, such as `pair.a`. The key is
+	// placeKey's encoding of the place, its root VarID followed by each segment's kind and
+	// length-prefixed name, so two places with distinct roots or paths never share a key.
+	// The value is the synthetic VarID the consumed lattice uses to track moves of that
+	// place. Looking up the same place at its move site and at its use site returns one
+	// stable VarID, so the use-after-move check can match them. Whole-binding places are
+	// not stored here; they reuse their root VarID directly. The synthetic VarIDs come
+	// from the module-wide varIDCounter, so they never collide with a real binding's VarID.
 	placeIDs map[string]liveness.VarID
 	// movePlaces records, for every VarID the move engine has consumed, the place it
 	// stands for: a whole binding maps its root VarID to the path-empty place, and a
-	// field move maps its synthetic VarID to the field place. checkUseAfterMoves
-	// scans it to find a moved place whose path is a prefix of, or extends, the place
-	// a use reads — the partial-move conflict test that keeps a moved `pair.a` from
-	// blocking a read of the sibling `pair.b`.
+	// field move maps its synthetic VarID to the field place. A field place's synthetic
+	// VarID is the one placeIDs assigned it, so the two maps agree on which VarID names
+	// the place. checkUseAfterMoves scans it to find a moved place whose path is a prefix
+	// of, or extends, the place a use reads — the partial-move conflict test that keeps a
+	// moved `pair.a` from blocking a read of the sibling `pair.b`.
 	movePlaces map[liveness.VarID]movePlace
 	// useSites records every read of a reference-shaped place while walking the body,
 	// each with the place read, the CFG point of the read, and the node to blame. The

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -446,6 +446,21 @@ func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 
 // --- PR 4: member reads borrow the receiver ---
 
+// A member read off an OWNED receiver yields the field's owned value, not a
+// receiver-bounded borrow, so the field can be moved out of the object (PR 7).
+// Here `pair.a` returns as the owned `{id: number}` and moves out of the frame,
+// where a borrow of a frame-local would be rejected as not living long enough. A
+// borrowed receiver still yields a borrow; the tests below pin that path.
+func TestInferOwnedReceiverFieldReadIsOwned(t *testing.T) {
+	src := `fn f() -> {id: number} {
+  val pair = {a: {id: 1}, b: {id: 2}}
+  return pair.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> {id: number}", values["f"])
+}
+
 // A member read that escapes carries the receiver's borrow lifetime through.
 // Deep `mut` makes the field owned-mutable, so the read yields a mutable borrow.
 func TestInferMemberReadEscapingBorrowsReceiver(t *testing.T) {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -53,7 +53,7 @@ func (c *checker) inferLiteral(e *ast.LiteralExpr) soltype.Type {
 // surfaces it and only a consumer that needs a value rejects it. The error then
 // fires once for both `f(Foo)` and a partial chain `f(A.B)`.
 func (c *checker) inferIdent(scope *Scope, lvl int, e *ast.IdentExpr) soltype.Type {
-	return c.demandValue(c.resolveIdentPath(scope, lvl, e), e)
+	return c.demandValue(c.resolveIdentPath(scope, lvl, e, false), e)
 }
 
 // pathResult is the sum returned by resolvePath: a path expression resolves to
@@ -73,14 +73,22 @@ type pathResult struct {
 // namespace (so Foo.bar and A.B.c walk through), while demandValue — called by
 // every value-position consumer — rejects a namespace result. Any other
 // expression kind in path position is an ordinary value expression.
-func (c *checker) resolvePath(scope *Scope, lvl int, e ast.Expr) pathResult {
+// objPos marks that e sits in the OBJECT position of a member/index chain — a step
+// on the path's spine rather than the whole place read. A spine step records no
+// use-after-move use of its own, since the outermost place read records the full
+// place that subsumes it: reading `pair.a.id` records one use of `pair.a.id`, not a
+// separate whole-binding use of `pair` that would wrongly collide with a partial
+// move of a sibling. inferExpr never threads objPos, so an off-spine subexpression
+// such as a call argument or an index key resolves with objPos false and records its
+// own uses.
+func (c *checker) resolvePath(scope *Scope, lvl int, e ast.Expr, objPos bool) pathResult {
 	switch e := e.(type) {
 	case *ast.IdentExpr:
-		return c.resolveIdentPath(scope, lvl, e)
+		return c.resolveIdentPath(scope, lvl, e, objPos)
 	case *ast.MemberExpr:
-		return c.resolveMemberPath(scope, lvl, e)
+		return c.resolveMemberPath(scope, lvl, e, objPos)
 	case *ast.IndexExpr:
-		return c.resolveIndexPath(scope, lvl, e)
+		return c.resolveIndexPath(scope, lvl, e, objPos)
 	default:
 		return pathResult{value: c.inferExpr(scope, lvl, e)}
 	}
@@ -109,15 +117,18 @@ func (c *checker) demandValue(r pathResult, node ast.Expr) soltype.Type {
 // len > 0 check should never fail in practice — but Schemes is a slice, not a
 // guaranteed-non-empty field, so we guard it anyway: a malformed empty binding
 // degrades to an unknown-identifier error instead of panicking on Schemes[0].
-func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr) pathResult {
+func (c *checker) resolveIdentPath(scope *Scope, lvl int, e *ast.IdentExpr, objPos bool) pathResult {
 	if b, ok := scope.GetValue(e.Name); ok && len(b.Schemes) > 0 {
 		t := c.bindingValue(lvl, b)
 		c.recordType(e, t)
 		// Record this read so the post-walk use-after-move pass can test it against the
 		// consumed lattice. The binding's coalesced type drives the reference-shape
 		// decision, since a fresh instantiation can hide a mono owned shape behind a
-		// variable.
-		c.recordUse(e, bindingType(b))
+		// variable. A spine step of a member chain records nothing here; the outermost
+		// member read records the full place instead.
+		if !objPos {
+			c.recordUse(e, bindingType(b))
+		}
 		return pathResult{value: t}
 	}
 	if ns, ok := scope.GetNamespace(e.Name); ok {
@@ -654,7 +665,7 @@ func (c *checker) wrapBorrow(e *ast.BorrowExpr, lvl int, sub soltype.Type) solty
 // literal key. accessNode is the whole MemberExpr or IndexExpr, used for the
 // Info record on the inner access shape.
 func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, recvExpr ast.Expr, propName string, provNode ast.Node, accessNode ast.Expr) soltype.Type {
-	obj := c.resolvePath(scope, lvl, recvExpr)
+	obj := c.resolvePath(scope, lvl, recvExpr, true)
 	if obj.err {
 		recovery := soltype.Type(&soltype.ErrorType{})
 		c.recordType(accessNode, recovery)
@@ -676,6 +687,10 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 		c.recordType(e, recv)
 		return recv
 	}
+	// Borrowing a field reads its place, so a use-after-move test sees `&obj.f` as a
+	// use of `obj.f`. The receiver resolved with objPos set, so it recorded no
+	// whole-receiver use that would collide with a partial move of a sibling.
+	c.recordMemberUse(accessNode)
 	_, _, recvLt := soltype.UnwrapRef(recv)
 	recvCarrier := soltype.CarrierOf(recv)
 	// Read-after-write cache. A usage-inferred receiver may carry a recorded
@@ -1513,21 +1528,21 @@ func (b *objElemBuilder) add(name string, t soltype.Type, optional, readonly boo
 // a member that resolves to a namespace (A.B used as a value) is rejected.
 // Optional chaining (recv?.prop) needs union/undefined handling and is M6.
 func (c *checker) inferMember(scope *Scope, lvl int, e *ast.MemberExpr) soltype.Type {
-	return c.demandValue(c.resolveMemberPath(scope, lvl, e), e)
+	return c.demandValue(c.resolveMemberPath(scope, lvl, e, false), e)
 }
 
 // inferIndex types `obj[index]` in value position — namespace index access
 // (Foo["bar"]) and the constant-string bracket form of property access
 // (obj["foo-bar"]); dynamic value indexing is M7.
 func (c *checker) inferIndex(scope *Scope, lvl int, e *ast.IndexExpr) soltype.Type {
-	return c.demandValue(c.resolveIndexPath(scope, lvl, e), e)
+	return c.demandValue(c.resolveIndexPath(scope, lvl, e, false), e)
 }
 
 // resolveMemberPath resolves `obj.prop`. It first resolves the object as a path —
 // so a namespace object (Foo.bar, A.B.c) walks through as a non-lexical member
 // lookup — and otherwise types the object as an ordinary value receiver and reads
 // the property structurally.
-func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pathResult {
+func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr, objPos bool) pathResult {
 	if e.OptChain {
 		// Optional chaining (recv?.prop) is wholesale unsupported in M2; report it
 		// up front and do NOT descend into the receiver, so a single diagnostic
@@ -1537,7 +1552,7 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 		c.reportUnsupportedFeature(e, "OptionalChain")
 		return pathResult{err: true}
 	}
-	obj := c.resolvePath(scope, lvl, e.Object)
+	obj := c.resolvePath(scope, lvl, e.Object, true)
 	if obj.err {
 		return pathResult{err: true}
 	}
@@ -1555,6 +1570,13 @@ func (c *checker) resolveMemberPath(scope *Scope, lvl int, e *ast.MemberExpr) pa
 	}
 	if obj.ns != nil {
 		return c.resolveNamespaceMember(lvl, e, obj.ns, e.Prop.Name)
+	}
+	// Record the read of this place as the outermost read of the chain, so a later
+	// use-after-move test sees the full path `pair.a` rather than the spine's bare
+	// root. A spine step has objPos true and records nothing; the full place subsumes
+	// it.
+	if !objPos {
+		c.recordMemberUse(e)
 	}
 	return c.valueMember(lvl, e, obj.value)
 }
@@ -1685,13 +1707,19 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 		}
 		return fieldVar
 	case *soltype.ObjectType, *soltype.TupleType:
-		// A bare object/tuple field is a value the receiver owns. Read it as a
+		// A bare object/tuple field a borrowed receiver lends is read as a
 		// receiver-bounded borrow whose mutability follows the receiver (PR 14): a
-		// mutable receiver yields `&mut`, an immutable one `&`. This is where the
-		// lazy deep-mut rule lives — under `mut {a: {x}}`, `p.a` reads `&mut {x}`.
+		// mutable borrow yields `&mut`, an immutable one `&`. This is where the lazy
+		// deep-mut rule lives — under a `&mut {a: {x}}` receiver, `p.a` reads `&mut {x}`.
 		lt := recvLt
 		if lt == nil {
-			lt = c.ctx.freshLifetime(lvl)
+			// An owned receiver yields the field's owned value, not a borrow, so a
+			// field read can be moved out of it. `pair.a` off an owned `pair` is the
+			// owned field `{x}` and flows into an owned binding, argument, return, or
+			// store as a move that consumes `pair.a`. The move engine keys the consume
+			// on the field's place (PR 7). A mutable receiver yields an owned-mutable
+			// field and an immutable one the bare field.
+			return soltype.NewRef(recvMut, nil, fieldType.(soltype.RefInner))
 		}
 		if recvMut {
 			// Mutable read: keep the concrete field shape as the borrow's inner, the
@@ -1715,12 +1743,12 @@ func (c *checker) fieldReadBorrow(fieldVar *soltype.TypeVarType, recv soltype.Ty
 // property as obj.foo would, and lets the source name a property whose key is not
 // a valid identifier. A dynamic key over a value (array element / index-signature
 // read) needs Array and index types from M7, so it stays unsupported here.
-func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) pathResult {
+func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr, objPos bool) pathResult {
 	if e.OptChain {
 		c.reportUnsupportedFeature(e, "OptionalChain")
 		return pathResult{err: true}
 	}
-	obj := c.resolvePath(scope, lvl, e.Object)
+	obj := c.resolvePath(scope, lvl, e.Object, true)
 	if obj.err {
 		return pathResult{err: true}
 	}
@@ -1733,6 +1761,9 @@ func (c *checker) resolveIndexPath(scope *Scope, lvl int, e *ast.IndexExpr) path
 		return c.resolveNamespaceMember(lvl, e, obj.ns, name)
 	}
 	if name, ok := constStringKey(e.Index); ok {
+		if !objPos {
+			c.recordMemberUse(e)
+		}
 		return c.valueProp(lvl, e, e.Index, name, obj.value)
 	}
 	// A dynamic key over a value (array element / index-signature read) needs Array

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -781,8 +781,7 @@ func (c *checker) inferBorrowOfMember(scope *Scope, lvl int, e *ast.BorrowExpr, 
 func borrowInnerOf(t soltype.Type) (soltype.RefInner, bool) {
 	if r, ok := t.(*soltype.RefType); ok {
 		if r.Lt == nil {
-			ri, ok := r.Inner.(soltype.RefInner)
-			return ri, ok
+			return r.Inner, ok
 		}
 		return nil, false
 	}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -354,6 +354,20 @@ func TestMoveSemantics(t *testing.T) {
 			`,
 			want: []string{"use of moved value 'pair.a.inner'"},
 		},
+		// A field whose key is not a valid identifier is reached by constant-string
+		// index and renders in bracket notation, so the moved place reads back as
+		// `pair["a.b"]` rather than collapsing into the `pair.a.b` nested access.
+		"BracketKeyPartialMove": {
+			src: `
+				fn store(p: {x: number}) {}
+				fn test() {
+					val pair = {"a.b": {x: 1}, c: {x: 2}}
+					store(pair["a.b"])
+					pair["a.b"].x
+				}
+			`,
+			want: []string{`use of moved value 'pair["a.b"]'`},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -246,6 +246,114 @@ func TestMoveSemantics(t *testing.T) {
 				"borrowed value mut object does not live long enough to satisfy object",
 			},
 		},
+		// Moving one field out of an owned object consumes only that field's slot. The
+		// sibling stays usable and a later read of the moved field is a use-after-move
+		// naming the field place (PR 7).
+		"PartialMoveConsumesFieldKeepsSibling": {
+			src: `
+				fn store(p: {id: number}) {}
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					store(pair.a)
+					pair.b.id
+					pair.a.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// Reading a sibling field after a partial move is allowed on its own.
+		"SiblingAfterPartialMoveAccepted": {
+			src: `
+				fn store(p: {id: number}) {}
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					store(pair.a)
+					pair.b.id
+				}
+			`,
+		},
+		// A read of the whole object after a partial move exposes the moved field, so it
+		// is a use-after-move even though a sibling is still live.
+		"WholeObjectReadAfterPartialMove": {
+			src: `
+				fn store(p: {id: number}) {}
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					store(pair.a)
+					pair
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// Binding a field into an owned binding moves that field; a later read of it is a
+		// use-after-move.
+		"PartialMoveViaBinding": {
+			src: `
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					val q = pair.a
+					pair.a.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// Storing a field into a longer-lived object moves it; the sibling stays usable.
+		"PartialMoveViaFieldStore": {
+			src: `
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					val obj: mut {f: {id: number}} = {f: {id: 0}}
+					obj.f = pair.a
+					pair.b.id
+					pair.a.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// A field built into a tuple literal moves as a partial move, the gap PR 6 left
+		// for PR 7 to close; the sibling stays usable.
+		"PartialMoveIntoLiteral": {
+			src: `
+				fn test() {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					val ys = [pair.a]
+					pair.b.id
+					pair.a.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// A field moved on only one branch is a conditional use-after-move at a later
+		// read, joined to MaybeMoved at the branch merge.
+		"ConditionalPartialMove": {
+			src: `
+				fn store(p: {id: number}) {}
+				fn test(cond: boolean) {
+					val pair = {a: {id: 1}, b: {id: 2}}
+					if cond {
+						store(pair.a)
+					} else {
+					}
+					pair.a.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a'"},
+		},
+		// Tracking reaches nested field paths. Moving `pair.a.inner` consumes only that
+		// deep slot, so the sibling `pair.a.keep` stays usable and a read of the moved
+		// slot is a use-after-move naming the full path.
+		"NestedFieldPartialMove": {
+			src: `
+				fn store(p: {id: number}) {}
+				fn test() {
+					val pair = {a: {inner: {id: 1}, keep: {id: 2}}, b: {id: 3}}
+					store(pair.a.inner)
+					pair.a.keep.id
+					pair.a.inner.id
+				}
+			`,
+			want: []string{"use of moved value 'pair.a.inner'"},
+		},
 	}
 
 	for name, tc := range tests {

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -283,7 +283,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"use of partially moved value 'pair'; field 'pair.a' was moved out"},
 		},
 		// Binding a field into an owned binding moves that field; a later read of it is a
 		// use-after-move.

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
@@ -20,15 +21,25 @@ import (
 //   - The flow sites call consumeOwned to record a move into c.fn.moveSites, the
 //     per-statement consume map AnalyzeMoves folds into the branch-merged consumed
 //     lattice from internal/liveness.
-//   - inferIdent calls recordUse for every read of a reference-shaped binding,
-//     accumulating the read sites into c.fn.useSites.
+//   - A read of a reference-shaped binding calls recordUse and a field read calls
+//     recordMemberUse, accumulating the read sites into c.fn.useSites.
 //   - After the body walk, checkUseAfterMoves runs AnalyzeMoves once and replays
-//     each recorded use against the lattice, reporting a UseAfterMoveError when the
-//     binding was Moved or MaybeMoved on a path reaching the read.
+//     each recorded use against the lattice, reporting a UseAfterMoveError when a
+//     conflicting place was Moved or MaybeMoved on a path reaching the read.
 //
 // Running the use check as a post-pass rather than inline is what makes conditional
 // and loop moves correct. The lattice is a fixed point over the whole CFG, so a use
 // that a later or back-edge move reaches is still caught.
+//
+// Moves and uses are tracked at field granularity, not just per binding (PR 7). A
+// move or use names a movePlace: a root binding plus a path of field names such as
+// `pair.a`. The consumed lattice keys on the place rather than the binding. Moving
+// `pair.a` consumes only that field's place, so the sibling `pair.b` stays usable
+// while a later read of `pair.a` is a use-after-move. A whole binding is the
+// path-empty place, so whole-binding moves are unchanged. A use of place U conflicts
+// with a moved place M when one path is a prefix of the other under one root, which
+// catches a read of the moved field, a read of a field beneath it, and a read of the
+// whole object that would expose it.
 //
 // Known limitation: the lattice only ever raises a binding to Moved, never lowers it.
 // Reassigning a `var` after it was moved gives it a fresh value, but the lattice still
@@ -67,13 +78,14 @@ func (e *UseAfterMoveError) Message() string {
 	return fmt.Sprintf("use of moved value '%s'", e.Name)
 }
 
-// moveUse is one recorded read of an owned-movable binding: the binding's VarID,
-// the CFG point of the read, and the node to blame.
+// moveUse is one recorded read of a reference-shaped place: the place read, the CFG
+// point of the read, and the node to blame. The place carries the field path so a
+// read of `pair.a.id` is tested against a partial move of `pair.a`, while a read of
+// the sibling `pair.b` is not.
 type moveUse struct {
-	varID liveness.VarID
+	place movePlace
 	ref   liveness.StmtRef
 	node  ast.Node
-	name  string
 }
 
 // isBorrowType reports whether t is a borrow — a RefType carrying a lifetime.
@@ -136,6 +148,131 @@ func isOwnedMovable(t soltype.Type) bool {
 	return isReferenceShaped(t)
 }
 
+// movePlace identifies the storage location the move engine tracks: a root binding
+// plus a path of field names reached from it by static member or constant-index
+// access. The empty path is the whole binding, so whole-binding moves are the
+// path-length-zero case and need no interning. A move of `pair.a` is the place
+// {root: pair, path: ["a"]}; a later read of `pair.a.id` is {root: pair, path:
+// ["a", "id"]}, and the two conflict because one path is a prefix of the other. A
+// read of `pair.b` is {root: pair, path: ["b"]}, disjoint from `pair.a`, so a
+// partial move of `pair.a` leaves it usable.
+type movePlace struct {
+	root liveness.VarID
+	path []string
+}
+
+// exprPlace returns the place a place-expression names: a binding, or a chain of
+// static member and constant-string index accesses rooted at one binding. ok is
+// false for anything that is not such a place, such as a call result or a literal.
+// A dynamic index falls back to its container place, since the checker cannot prove
+// two dynamic indices disjoint — `arr[i]` and `arr[j]` both resolve to `arr`, so a
+// move through one conservatively blocks a use through the other.
+func exprPlace(e ast.Expr) (movePlace, bool) {
+	switch e := e.(type) {
+	case *ast.IdentExpr:
+		if e.VarID <= 0 {
+			return movePlace{}, false
+		}
+		return movePlace{root: liveness.VarID(e.VarID)}, true
+	case *ast.MemberExpr:
+		if e.OptChain || e.Prop == nil || e.Prop.Name == "" {
+			return movePlace{}, false
+		}
+		base, ok := exprPlace(e.Object)
+		if !ok {
+			return movePlace{}, false
+		}
+		return extendPlace(base, e.Prop.Name), true
+	case *ast.IndexExpr:
+		if e.OptChain {
+			return movePlace{}, false
+		}
+		base, ok := exprPlace(e.Object)
+		if !ok {
+			return movePlace{}, false
+		}
+		if name, ok := constStringKey(e.Index); ok {
+			return extendPlace(base, name), true
+		}
+		// A dynamic index is approximated by its container.
+		return base, true
+	}
+	return movePlace{}, false
+}
+
+// extendPlace returns base with one more field name appended, copying the path so
+// sibling places built from the same base never share backing storage.
+func extendPlace(base movePlace, field string) movePlace {
+	path := make([]string, len(base.path)+1)
+	copy(path, base.path)
+	path[len(base.path)] = field
+	return movePlace{root: base.root, path: path}
+}
+
+// placeKey is the interning key for a field place. A field name cannot contain a
+// NUL, so joining the root and path on NUL keeps `{root, [a, b]}` distinct from
+// `{root, [ab]}`.
+func placeKey(p movePlace) string {
+	return fmt.Sprintf("%d\x00%s", p.root, strings.Join(p.path, "\x00"))
+}
+
+// placeID maps a place to the VarID the consumed lattice keys on. A whole-binding
+// place reuses its root VarID, so whole-binding moves stay keyed exactly as before.
+// A field place interns to a fresh synthetic VarID drawn from the module-wide
+// counter — unique across every body, so it never collides with a real binding —
+// and the mapping is stable within a body, so the same field named at a move site
+// and at a use site resolves to one ID.
+func (c *checker) placeID(p movePlace) liveness.VarID {
+	if len(p.path) == 0 {
+		return p.root
+	}
+	key := placeKey(p)
+	if id, ok := c.fn.placeIDs[key]; ok {
+		return id
+	}
+	id := liveness.VarID(c.varIDCounter)
+	c.varIDCounter++
+	c.fn.placeIDs[key] = id
+	return id
+}
+
+// pathPrefixRelated reports whether two field paths under one root conflict: one is
+// a prefix of the other. Moving `pair.a` conflicts with a use of `pair.a` itself
+// when the paths are equal, of a field beneath it like `pair.a.id` when the move
+// path is a prefix, and of the whole `pair` when the use path is a prefix, since the
+// read would expose the moved field. A use of the disjoint sibling `pair.b` shares
+// no prefix and does not conflict.
+func pathPrefixRelated(a, b []string) bool {
+	n := min(len(a), len(b))
+	for i := range n {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// renderPlace names a place for a diagnostic: the root binding's name followed by
+// its field path, so a whole-binding move renders as `pair` and a field move as
+// `pair.a`.
+func (c *checker) renderPlace(p movePlace) string {
+	name := c.varIDToName(p.root)
+	if len(p.path) == 0 {
+		return name
+	}
+	return name + "." + strings.Join(p.path, ".")
+}
+
+// moveNameOf names the moved value behind a lattice VarID for a diagnostic. A field
+// move resolves through movePlaces to its rendered path; a whole-binding move falls
+// back to the binding name.
+func (c *checker) moveNameOf(id liveness.VarID) string {
+	if p, ok := c.fn.movePlaces[id]; ok {
+		return c.renderPlace(p)
+	}
+	return c.varIDToName(id)
+}
+
 // currentStmtRef resolves the statement currently being walked to its CFG point.
 // It is the program point a use or move records against. ok is false outside a
 // function body or when the statement has no CFG ref.
@@ -164,17 +301,38 @@ func (c *checker) recordUse(e *ast.IdentExpr, t soltype.Type) {
 		return
 	}
 	c.fn.useSites = append(c.fn.useSites, moveUse{
-		varID: liveness.VarID(e.VarID),
+		place: movePlace{root: liveness.VarID(e.VarID)},
 		ref:   ref,
 		node:  e,
-		name:  e.Name,
 	})
 }
 
-// consumeOwned records a move of the owned binding the source expression names,
-// at the given program point, blaming moveNode for the consume. The source must be
-// a plain identifier bound to an owned-movable value; a borrow, value type, fresh
-// literal, or member path consumes nothing here.
+// recordMemberUse records a read of a field place so the use-after-move scan can
+// test it against a partial move of the same place or a prefix of it. The whole
+// member or index expression names the place, even when the field read yields a
+// value type, because reading `pair.a.id` still dereferences `pair.a` and is a
+// use-after-move if `pair.a` was moved. A receiver that is not a tracked place, such
+// as a namespace member, names no movable root and records nothing.
+func (c *checker) recordMemberUse(e ast.Expr) {
+	if c.fn == nil || c.fn.cfg == nil {
+		return
+	}
+	p, ok := exprPlace(e)
+	if !ok || len(p.path) == 0 {
+		return
+	}
+	ref, ok := c.currentStmtRef()
+	if !ok {
+		return
+	}
+	c.fn.useSites = append(c.fn.useSites, moveUse{place: p, ref: ref, node: e})
+}
+
+// consumeOwned records a move of the owned place the source expression names, at the
+// given program point, blaming moveNode for the consume. The source must be a place —
+// a binding or a field path such as `pair.a` — whose value is owned-movable. A borrow,
+// value type, fresh literal, or non-place expression consumes nothing here. A field
+// path consumes only that field's slot, the partial move from PR 7.
 //
 // It does NOT force the moved value's borrows to 'static. A return or local store
 // flows the value out at the call's own lifetime, not 'static, so forcing here would
@@ -185,30 +343,29 @@ func (c *checker) consumeOwned(source ast.Expr, sourceT soltype.Type, moveNode a
 	if c.fn == nil || c.fn.cfg == nil || sourceT == nil {
 		return
 	}
-	ident, ok := source.(*ast.IdentExpr)
-	if !ok || ident.VarID <= 0 {
+	p, ok := exprPlace(source)
+	if !ok {
 		return
 	}
 	if !isOwnedMovable(sourceT) {
 		return
 	}
-	c.recordMove(liveness.VarID(ident.VarID), moveNode, ref)
+	c.recordMovePlace(p, moveNode, ref)
 }
 
 // movesSourceInto reports whether flowing source into a destination of type destT
-// moves the owned binding source names: source is an identifier bound to an
-// owned-movable value and the destination takes ownership rather than borrowing. A
-// borrow destination keeps the source aliased and governed by the exclusivity rule,
-// not consumed. A borrow destination is either a `&` annotation or an explicit
-// `&source` initializer, which is a BorrowExpr rather than a plain identifier and so
+// moves the owned place source names: source is a place — a binding or a field path
+// — bound to an owned-movable value and the destination takes ownership rather than
+// borrowing. A borrow destination keeps the source aliased and governed by the
+// exclusivity rule, not consumed. A borrow destination is either a `&` annotation or
+// an explicit `&source` initializer, which is a BorrowExpr rather than a place and so
 // names no owned source. It is the shared move-or-borrow decision for `val`/`var`
 // bindings and reassignments.
 func (c *checker) movesSourceInto(source ast.Expr, destT soltype.Type) bool {
 	if source == nil || isBorrowType(destT) {
 		return false
 	}
-	ident, ok := source.(*ast.IdentExpr)
-	if !ok || ident.VarID <= 0 {
+	if _, ok := exprPlace(source); !ok {
 		return false
 	}
 	return isOwnedMovable(c.info.TypeOf(source))
@@ -230,49 +387,45 @@ func (c *checker) consumeBindingInit(vd *ast.VarDecl, bindingT soltype.Type, stm
 	c.consumeOwned(vd.Init, c.info.TypeOf(vd.Init), vd.Init, ref)
 }
 
-// consumeAtGlobalWrite consumes the source binding of a module-level store. A store
+// consumeAtGlobalWrite consumes the source place of a module-level store. A store
 // into a 'static global permanently transfers the value, so it consumes the source
 // whether owned or a borrow — using the source afterward could mutate what the global
 // now reads, the leak the affine rule closes. A value-type source copies and a
-// non-identifier source names no binding, so neither consumes.
+// non-place source names no storage, so neither consumes.
 func (c *checker) consumeAtGlobalWrite(source ast.Expr, sourceT soltype.Type, moveNode ast.Node, ref liveness.StmtRef) {
 	if c.fn == nil || c.fn.cfg == nil || sourceT == nil {
 		return
 	}
-	ident, ok := source.(*ast.IdentExpr)
-	if !ok || ident.VarID <= 0 {
+	p, ok := exprPlace(source)
+	if !ok {
 		return
 	}
 	if !isReferenceShaped(sourceT) {
 		return
 	}
-	c.recordMove(liveness.VarID(ident.VarID), moveNode, ref)
+	c.recordMovePlace(p, moveNode, ref)
 }
 
-// consumeIntoLiteral moves an owned identifier built into a fresh object or tuple
-// literal, recording the move at ref, the literal's statement. Storing an owned value
-// into the literal transfers ownership into it, so a later use of the source is a
-// use-after-move. A value-type element copies and a non-identifier element names no
-// binding, so neither consumes. hasRef is false when the literal has no resolvable
+// consumeIntoLiteral moves an owned place built into a fresh object or tuple literal,
+// recording the move at ref, the literal's statement. Storing an owned value into the
+// literal transfers ownership into it, so a later use of the source is a
+// use-after-move. A value-type element copies and a non-place element names no
+// storage, so neither consumes. hasRef is false when the literal has no resolvable
 // statement point, in which case nothing is recorded rather than mis-attributing the
 // move to the zero StmtRef.
 //
-// inferTuple and inferObject call it for each element built from a source binding:
+// inferTuple and inferObject call it for each element built from a source place:
 //
 //	val mut a = {foo: "hello"}
 //	val ys = [a]   // a moves into the tuple
 //	a.foo          // ERROR: use of moved value 'a'
 //
-// Limitation: only a whole-binding identifier element consumes. A member-path element
-// names a sub-place the whole-binding move engine cannot key on, so building one into a
-// literal records no move and a later use of it is not caught:
+// A field-path element consumes only that field, the partial move from PR 7:
 //
 //	val mut pair = {a: {foo: "hi"}, b: {bar: 1}}
-//	val ys = [pair.a]   // pair.a is NOT consumed
-//	pair.a              // accepted today; should be a use-after-move
-//
-// Closing this needs the element/field-level ownership tracking planned for partial
-// moves (PR 7).
+//	val ys = [pair.a]   // pair.a moves into the tuple
+//	pair.a              // ERROR: use of moved value 'pair.a'
+//	pair.b              // OK: sibling untouched
 func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type, ref liveness.StmtRef, hasRef bool) {
 	if !hasRef {
 		return
@@ -280,11 +433,21 @@ func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type, ref livene
 	c.consumeOwned(el, elemT, el, ref)
 }
 
-// recordMove marks varID consumed at ref. A second move of the same binding at the
-// same program point is an intra-statement reuse — `return [x, x]`, `f(x, x)`, the
-// `dup` double move — so it is reported immediately as a use-after-move rather than
-// waiting for the lattice, which is statement-granular and cannot order two moves
-// within one statement.
+// recordMovePlace consumes the place at the given program point, blaming moveNode. It
+// interns the place to its lattice VarID, registers the mapping so the
+// use-after-move scan can recover the path for the prefix test, and records the move
+// into the consumed lattice through recordMove.
+func (c *checker) recordMovePlace(p movePlace, moveNode ast.Node, ref liveness.StmtRef) {
+	id := c.placeID(p)
+	c.fn.movePlaces[id] = p
+	c.recordMove(id, moveNode, ref)
+}
+
+// recordMove marks varID consumed at ref. A second move of the same place at the same
+// program point is an intra-statement reuse — `return [x, x]`, `f(x, x)`, the `dup`
+// double move — so it is reported immediately as a use-after-move rather than waiting
+// for the lattice, which is statement-granular and cannot order two moves within one
+// statement.
 func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref liveness.StmtRef) {
 	if c.fn == nil || c.fn.moveSites == nil || varID <= 0 {
 		return
@@ -296,7 +459,7 @@ func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref livene
 	}
 	if at.Contains(varID) {
 		c.report(&UseAfterMoveError{
-			Name:     c.varIDToName(varID),
+			Name:     c.moveNameOf(varID),
 			use:      moveNode,
 			moveSite: c.fn.moveNodes[varID],
 		})
@@ -315,7 +478,7 @@ func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref livene
 // after the whole body is walked, so a move on a later or loop-back path is
 // already recorded when a use is checked.
 //
-// StateBefore reads the binding's state just before the read's statement, so a move
+// StateBefore reads the place's state just before the read's statement, so a move
 // recorded AT that statement — the consume in `val q = p`, where reading p and
 // moving it share one statement — does not flag its own source read.
 //
@@ -332,18 +495,55 @@ func (c *checker) checkUseAfterMoves() {
 	}
 	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
 	for _, u := range c.fn.useSites {
-		state := info.StateBefore(u.ref, u.varID)
+		state, movedID := c.movedConflict(info, u)
 		if state == liveness.NotMoved {
 			continue
 		}
 		c.report(&UseAfterMoveError{
-			Name:        u.name,
+			Name:        c.moveNameOf(movedID),
 			Conditional: state == liveness.MaybeMoved,
 			use:         u.node,
-			moveSite:    c.fn.moveNodes[u.varID],
+			moveSite:    c.fn.moveNodes[movedID],
 		})
 	}
 	c.reconcileMovedTransitions(info)
+}
+
+// movedConflict finds the strongest consumed state among the moved places that
+// conflict with the use, returning that state and the conflicting move's lattice
+// VarID. A moved place conflicts when it shares the use's root and one path is a
+// prefix of the other, so a use of `pair.a.id` conflicts with a move of `pair.a`, of
+// `pair`, or of `pair.a.id`, while a use of `pair.b` conflicts with none of them. An
+// unconditional Moved is preferred over a conditional MaybeMoved when both reach the
+// use, so the diagnostic reports the definite use-after-move.
+//
+// When two conflicting moves share the strongest state — a whole-object read that
+// exposes both moved `pair.a` and moved `pair.b` — the lower lattice id wins, which
+// is the earlier move in source order, since the synthetic ids are allocated as the
+// walk meets each place. The tiebreak makes the blamed move deterministic across the
+// unordered movePlaces map iteration.
+func (c *checker) movedConflict(info *liveness.MoveInfo, u moveUse) (liveness.MoveState, liveness.VarID) {
+	best := liveness.NotMoved
+	var bestID liveness.VarID
+	for id, p := range c.fn.movePlaces {
+		if p.root != u.place.root || !pathPrefixRelated(p.path, u.place.path) {
+			continue
+		}
+		s := info.StateBefore(u.ref, id)
+		if s == liveness.NotMoved {
+			continue
+		}
+		switch {
+		case best == liveness.NotMoved:
+		case s == liveness.Moved && best == liveness.MaybeMoved:
+		case s == best && id < bestID:
+		default:
+			continue
+		}
+		best = s
+		bestID = id
+	}
+	return best, bestID
 }
 
 // reconcileMovedTransitions drops every mutability-transition error whose source the

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -2,7 +2,9 @@ package solver
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
@@ -36,8 +38,8 @@ import (
 // movePlace docstring for its shape and examples. The consumed lattice keys on the
 // place rather than the binding. Moving `pair.a` consumes only that field's place, so
 // the sibling `pair.b` stays usable while a later read of `pair.a` is a
-// use-after-move. A whole binding is the path-empty place, so whole-binding moves are
-// unchanged. A use of place U conflicts
+// use-after-move. A whole binding is the path-empty place, which a move consumes as a
+// unit. A use of place U conflicts
 // with a moved place M when one path is a prefix of the other under one root, which
 // catches a read of the moved field, a read of a field beneath it, and a read of the
 // whole object that would expose it.
@@ -254,7 +256,7 @@ func placeKey(p movePlace) string {
 }
 
 // placeID maps a place to the VarID the consumed lattice keys on. A whole-binding
-// place reuses its root VarID, so whole-binding moves stay keyed exactly as before.
+// place reuses its root VarID, so it shares the lattice key the binding already has.
 // A field place is assigned a fresh synthetic VarID drawn from the module-wide
 // counter — unique across every body, so it never collides with a real binding —
 // and the mapping is stable within a body, so the same field named at a move site
@@ -291,15 +293,45 @@ func pathPrefixRelated(a, b []placeSeg) bool {
 
 // renderPlace names a place for a diagnostic: the root binding's name followed by
 // its field path, so a whole-binding move renders as `pair` and a field move as
-// `pair.a`.
+// `pair.a`. A segment whose name is not a valid identifier renders in bracket
+// notation, so a constant-index access such as `obj["a.b"]` reads back as
+// `obj["a.b"]` rather than collapsing into the `obj.a.b` nested access.
 func (c *checker) renderPlace(p movePlace) string {
 	var b strings.Builder
 	b.WriteString(c.varIDToName(p.root))
 	for _, seg := range p.path {
-		b.WriteString(".")
-		b.WriteString(seg.name)
+		if isDotPlaceSegment(seg.name) {
+			b.WriteByte('.')
+			b.WriteString(seg.name)
+		} else {
+			b.WriteByte('[')
+			b.WriteString(strconv.Quote(seg.name))
+			b.WriteByte(']')
+		}
 	}
 	return b.String()
+}
+
+// isDotPlaceSegment reports whether a field name can be rendered with dot notation:
+// a valid Escalier identifier, with a leading letter or underscore and
+// letter/underscore/digit runes thereafter. Any other name, such as `a.b` or
+// `foo-bar` from a constant-string index, renders in bracket notation instead.
+func isDotPlaceSegment(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 // moveNameOf names the moved value behind a lattice VarID for a diagnostic. A field
@@ -583,8 +615,8 @@ func (c *checker) movedConflict(info *liveness.MoveInfo, u moveUse) (liveness.Mo
 		}
 		// Keep this conflict only if it is a stronger blame target than the best so
 		// far: the first one found, an unconditional Moved that supersedes a MaybeMoved,
-		// or the same state with a lower lattice id, which is the earlier move in source
-		// order and makes the choice deterministic.
+		// or the same state with a lower lattice id, the tiebreak that makes the choice
+		// deterministic across the unordered movePlaces map iteration.
 		if !(best == liveness.NotMoved ||
 			(s == liveness.Moved && best == liveness.MaybeMoved) ||
 			(s == best && id < bestID)) {

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -32,11 +32,12 @@ import (
 // that a later or back-edge move reaches is still caught.
 //
 // Moves and uses are tracked at field granularity, not just per binding (PR 7). A
-// move or use names a movePlace: a root binding plus a path of field names such as
-// `pair.a`. The consumed lattice keys on the place rather than the binding. Moving
-// `pair.a` consumes only that field's place, so the sibling `pair.b` stays usable
-// while a later read of `pair.a` is a use-after-move. A whole binding is the
-// path-empty place, so whole-binding moves are unchanged. A use of place U conflicts
+// move or use names a movePlace: a root binding plus a path of field names, see the
+// movePlace docstring for its shape and examples. The consumed lattice keys on the
+// place rather than the binding. Moving `pair.a` consumes only that field's place, so
+// the sibling `pair.b` stays usable while a later read of `pair.a` is a
+// use-after-move. A whole binding is the path-empty place, so whole-binding moves are
+// unchanged. A use of place U conflicts
 // with a moved place M when one path is a prefix of the other under one root, which
 // catches a read of the moved field, a read of a field beneath it, and a read of the
 // whole object that would expose it.
@@ -53,8 +54,16 @@ import (
 // MaybeMoved lattice state, so a diagnostic consumer can distinguish a definite
 // use-after-move from a possible one.
 type UseAfterMoveError struct {
-	// Name is the consumed binding's source name, for the message.
+	// Name is the moved place's source name, for the message — `pair.a` when the
+	// field `pair.a` was consumed.
 	Name string
+	// ReadName is the read place's source name, set only for a partial-move read where
+	// it differs from Name — `pair` when the whole object is read after `pair.a` moved.
+	ReadName string
+	// Partial is true when the read place is a strict ancestor of the moved place, so
+	// the read exposes a field that moved out rather than the moved place itself. It
+	// selects the partially-moved wording and pairs with ReadName.
+	Partial bool
 	// Conditional is true when the binding is moved on some but not all paths
 	// reaching the use (the MaybeMoved lattice state), false when every reaching
 	// path moved it (Moved).
@@ -75,6 +84,9 @@ func (e *UseAfterMoveError) Related() []ast.Span {
 	return []ast.Span{e.moveSite.Span()}
 }
 func (e *UseAfterMoveError) Message() string {
+	if e.Partial {
+		return fmt.Sprintf("use of partially moved value '%s'; field '%s' was moved out", e.ReadName, e.Name)
+	}
 	return fmt.Sprintf("use of moved value '%s'", e.Name)
 }
 
@@ -148,17 +160,35 @@ func isOwnedMovable(t soltype.Type) bool {
 	return isReferenceShaped(t)
 }
 
+// placeSeg is one step of a movePlace path: a field reached from the place before it.
+// The kind tags how the field is named. Every segment built today is a namedSeg
+// carrying a field name, so a path models the same field chains as a plain name list.
+// The tag leaves room for a symbol-keyed segment without conflating a symbol key with a
+// string field of the same text. Adding that kind is part of the M7 computed-key work.
+type placeSeg struct {
+	kind placeSegKind
+	name string
+}
+
+type placeSegKind uint8
+
+const (
+	// namedSeg names a field by its string name — a static member `pair.a` or a
+	// string-literal index `obj["a"]`. The segment's name holds that field name.
+	namedSeg placeSegKind = iota
+)
+
 // movePlace identifies the storage location the move engine tracks: a root binding
-// plus a path of field names reached from it by static member or constant-index
+// plus a path of field segments reached from it by static member or constant-index
 // access. The empty path is the whole binding, so whole-binding moves are the
 // path-length-zero case and need no interning. A move of `pair.a` is the place
-// {root: pair, path: ["a"]}; a later read of `pair.a.id` is {root: pair, path:
-// ["a", "id"]}, and the two conflict because one path is a prefix of the other. A
-// read of `pair.b` is {root: pair, path: ["b"]}, disjoint from `pair.a`, so a
-// partial move of `pair.a` leaves it usable.
+// {root: pair, path: [a]}; a later read of `pair.a.id` is {root: pair, path: [a, id]},
+// and the two conflict because one path is a prefix of the other. A read of `pair.b`
+// is {root: pair, path: [b]}, disjoint from `pair.a`, so a partial move of `pair.a`
+// leaves it usable.
 type movePlace struct {
 	root liveness.VarID
-	path []string
+	path []placeSeg
 }
 
 // exprPlace returns the place a place-expression names: a binding, or a chain of
@@ -200,25 +230,32 @@ func exprPlace(e ast.Expr) (movePlace, bool) {
 	return movePlace{}, false
 }
 
-// extendPlace returns base with one more field name appended, copying the path so
-// sibling places built from the same base never share backing storage.
+// extendPlace returns base with one more named field segment appended, copying the
+// path so sibling places built from the same base never share backing storage.
 func extendPlace(base movePlace, field string) movePlace {
-	path := make([]string, len(base.path)+1)
+	path := make([]placeSeg, len(base.path)+1)
 	copy(path, base.path)
-	path[len(base.path)] = field
+	path[len(base.path)] = placeSeg{kind: namedSeg, name: field}
 	return movePlace{root: base.root, path: path}
 }
 
-// placeKey is the interning key for a field place. A field name cannot contain a
-// NUL, so joining the root and path on NUL keeps `{root, [a, b]}` distinct from
-// `{root, [ab]}`.
+// placeKey is the interning key for a field place. Each segment is encoded as its
+// kind and its length-prefixed name, so the encoding is injective for any field name:
+// `{root, [a, b]}` and `{root, [ab]}` stay distinct regardless of which bytes a name
+// contains, since the length prefix delimits each name rather than a separator the name
+// might itself include.
 func placeKey(p movePlace) string {
-	return fmt.Sprintf("%d\x00%s", p.root, strings.Join(p.path, "\x00"))
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d", p.root)
+	for _, seg := range p.path {
+		fmt.Fprintf(&b, "|%d:%d:%s", seg.kind, len(seg.name), seg.name)
+	}
+	return b.String()
 }
 
 // placeID maps a place to the VarID the consumed lattice keys on. A whole-binding
 // place reuses its root VarID, so whole-binding moves stay keyed exactly as before.
-// A field place interns to a fresh synthetic VarID drawn from the module-wide
+// A field place is assigned a fresh synthetic VarID drawn from the module-wide
 // counter — unique across every body, so it never collides with a real binding —
 // and the mapping is stable within a body, so the same field named at a move site
 // and at a use site resolves to one ID.
@@ -242,7 +279,7 @@ func (c *checker) placeID(p movePlace) liveness.VarID {
 // path is a prefix, and of the whole `pair` when the use path is a prefix, since the
 // read would expose the moved field. A use of the disjoint sibling `pair.b` shares
 // no prefix and does not conflict.
-func pathPrefixRelated(a, b []string) bool {
+func pathPrefixRelated(a, b []placeSeg) bool {
 	n := min(len(a), len(b))
 	for i := range n {
 		if a[i] != b[i] {
@@ -256,11 +293,13 @@ func pathPrefixRelated(a, b []string) bool {
 // its field path, so a whole-binding move renders as `pair` and a field move as
 // `pair.a`.
 func (c *checker) renderPlace(p movePlace) string {
-	name := c.varIDToName(p.root)
-	if len(p.path) == 0 {
-		return name
+	var b strings.Builder
+	b.WriteString(c.varIDToName(p.root))
+	for _, seg := range p.path {
+		b.WriteString(".")
+		b.WriteString(seg.name)
 	}
-	return name + "." + strings.Join(p.path, ".")
+	return b.String()
 }
 
 // moveNameOf names the moved value behind a lattice VarID for a diagnostic. A field
@@ -300,11 +339,8 @@ func (c *checker) recordUse(e *ast.IdentExpr, t soltype.Type) {
 	if !ok {
 		return
 	}
-	c.fn.useSites = append(c.fn.useSites, moveUse{
-		place: movePlace{root: liveness.VarID(e.VarID)},
-		ref:   ref,
-		node:  e,
-	})
+	p := movePlace{root: liveness.VarID(e.VarID)}
+	c.fn.useSites = append(c.fn.useSites, moveUse{place: p, ref: ref, node: e})
 }
 
 // recordMemberUse records a read of a field place so the use-after-move scan can
@@ -434,7 +470,7 @@ func (c *checker) consumeIntoLiteral(el ast.Expr, elemT soltype.Type, ref livene
 }
 
 // recordMovePlace consumes the place at the given program point, blaming moveNode. It
-// interns the place to its lattice VarID, registers the mapping so the
+// resolves the place to its lattice VarID, registers the mapping so the
 // use-after-move scan can recover the path for the prefix test, and records the move
 // into the consumed lattice through recordMove.
 func (c *checker) recordMovePlace(p movePlace, moveNode ast.Node, ref liveness.StmtRef) {
@@ -499,8 +535,20 @@ func (c *checker) checkUseAfterMoves() {
 		if state == liveness.NotMoved {
 			continue
 		}
+		// The read place is a partial-move read when it is a strict ancestor of the
+		// moved place: reading the whole `pair` after `pair.a` moved exposes the moved
+		// field. ReadName then names the read; otherwise the read is the moved place
+		// itself or a field beneath it, and Name alone is enough.
+		moved := c.fn.movePlaces[movedID]
+		partial := len(u.place.path) < len(moved.path)
+		readName := ""
+		if partial {
+			readName = c.renderPlace(u.place)
+		}
 		c.report(&UseAfterMoveError{
 			Name:        c.moveNameOf(movedID),
+			ReadName:    readName,
+			Partial:     partial,
 			Conditional: state == liveness.MaybeMoved,
 			use:         u.node,
 			moveSite:    c.fn.moveNodes[movedID],
@@ -533,11 +581,13 @@ func (c *checker) movedConflict(info *liveness.MoveInfo, u moveUse) (liveness.Mo
 		if s == liveness.NotMoved {
 			continue
 		}
-		switch {
-		case best == liveness.NotMoved:
-		case s == liveness.Moved && best == liveness.MaybeMoved:
-		case s == best && id < bestID:
-		default:
+		// Keep this conflict only if it is a stronger blame target than the best so
+		// far: the first one found, an unconditional Moved that supersedes a MaybeMoved,
+		// or the same state with a lower lattice id, which is the earlier move in source
+		// order and makes the choice deterministic.
+		if !(best == liveness.NotMoved ||
+			(s == liveness.Moved && best == liveness.MaybeMoved) ||
+			(s == best && id < bestID)) {
 			continue
 		}
 		best = s

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -759,6 +759,8 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	// lattice over these same blocks once the whole body is walked.
 	c.fn.cfg = cfg
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
+	c.fn.placeIDs = map[string]liveness.VarID{}
+	c.fn.movePlaces = map[liveness.VarID]movePlace{}
 }
 
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1096,6 +1096,38 @@ now resolve to real `soltype` structures rather than opaque placeholders.
       "needs Array types — M7" note (m4-implementation-plan §C3). The write path
       reuses the tuple/array read classification above plus C3's `mut` receiver
       requirement and `widen`.
+- **Field-level move tracking of computed keys (PR 7 follow-up).** The move engine
+  tracks moves and uses at field granularity over a `movePlace` — a root binding plus
+  a path of `placeSeg` segments (`solver/moves.go`). Today the segment representation is
+  already a tagged struct, `placeSeg{kind, name}`, but only the `namedSeg` kind exists,
+  built from a static member (`pair.a`) or a *string-literal* index key (`obj["a"]`) via
+  `constStringKey`. A computed key — `obj[k]`, `obj[Symbol.iterator]` — currently isn't a
+  supported access form, so `exprPlace`/`resolveIndexPath` reach `reportUnsupported` and
+  the move engine never sees it. When this milestone makes computed-key and symbol-keyed
+  member access infer a type, extend the move engine to derive a segment from the index
+  expression's *resolved type*, not its syntax, so a key behind a variable tracks the
+  same place as the literal. Concretely:
+    - **Generalize `constStringKey` to a type-aware `constKey`** for the move engine,
+      keeping the existing syntactic `constStringKey` for the name-resolution call sites
+      that need the literal. Priority: an index whose inferred type is a *singleton*
+      string or number `LitType` → a `namedSeg` carrying that literal, so `obj[k]` with
+      `k: "foo"` keys the same as `obj.foo`; a key whose type is `unique symbol` → a new
+      `symbolSeg` kind keyed on the symbol's stable id. A non-singleton or otherwise
+      non-constant key falls back to the container place, exactly as a dynamic index does
+      now — sound, at worst over-conservative, never a missed use-after-move.
+    - **`soltype` prerequisite for the symbol case.** `soltype` has only the `symbol`
+      primitive (`SymbolPrim`), no unique-symbol type carrying a stable id; the
+      `UniqueSymbolType{Value int}` with that id lives in `internal/type_system`, the old
+      checker. So a unique-symbol `soltype` kind must land first, plumbed through the
+      visitor/printer/constrain/coalesce, before a `symbolSeg` can key on it. Keying on
+      that type id rather than the binding makes `val it = Symbol.iterator` and the
+      original `Symbol.iterator` resolve to one place.
+    - **Wiring.** Add the `symbolSeg` kind to `placeSeg` and render it as
+      `[Symbol.iterator]` in `renderPlace`; thread the index expression's type into
+      `exprPlace` (today a free, purely syntactic function), `recordMemberUse`, and
+      `consumeOwned`; and give `objKeyName` a `ComputedKey` arm so a symbol-keyed object
+      field is tracked. `placeKey` already encodes each segment's kind and length-prefixed
+      name, so it admits a new kind without change.
 
 **Open design question — free type-var members in a union-super exists trial.**
 M6 PR2's union-super exists rule trials each member of `sub <: (A | B | …)`


### PR DESCRIPTION
Implement field-level move tracking so moving one field of an owned object consumes only that field's slot, leaving siblings usable. This closes the gap from PR 6 where partial moves were noted as a limitation.

**Key changes:**

- Add `movePlace` type to represent a storage location as a root binding plus a path of field names (e.g., `pair.a` or `pair.a.inner`). Whole-binding moves use the path-empty place.
- Implement `exprPlace` to extract the place a place-expression names: a binding or a chain of static member and constant-index accesses. Dynamic indices fall back to their container place since the checker cannot prove two dynamic indices disjoint.
- Intern field places to synthetic VarIDs via `placeID`, drawn from the module-wide counter so they never collide with real bindings. Store the mapping in `funcCtx.placeIDs` and `funcCtx.movePlaces` so the use-after-move scan can recover paths for the prefix test.
- Update `recordUse` to track the full place read, not just the binding. Add `recordMemberUse` to record reads of field places so a use of `pair.a.id` is tested against a partial move of `pair.a`.
- Implement `pathPrefixRelated` to test conflict: one path is a prefix of the other under one root. A move of `pair.a` conflicts with a use of `pair.a` itself, a field beneath it like `pair.a.id`, and the whole `pair` (which would expose the moved field), but not the sibling `pair.b`.
- Update `checkUseAfterMoves` to call new `movedConflict` method that finds the strongest consumed state among moved places conflicting with each use, handling ties by preferring unconditional Moved over MaybeMoved and using the lower lattice ID for determinism.
- Thread `objPos` parameter through `resolvePath`, `resolveIdentPath`, `resolveMemberPath`, and `resolveIndexPath` to distinguish spine steps of a member chain (which record no use) from whole-place reads (which record the full place). This prevents a read of `pair.a.id` from wrongly colliding with a partial move of the sibling `pair.b`.
- Update `inferBorrowOfMember` to call `recordMemberUse` so borrowing a field is seen as a use of that field place.
- Add `renderPlace` and `moveNameOf` to format places for diagnostics, showing field paths like `pair.a.inner`.

**Test coverage:**

Add nine test cases covering partial moves: field moves that keep siblings usable, reads of the whole object after a partial move (which expose the moved field), partial moves via binding and field store, partial moves into literals, conditional partial moves, and nested field paths.

https://claude.ai/code/session_01JDoZ7YKL4hZbbczGg1rvhj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced move/use-after-move tracking to operate at object field granularity (including nested fields), so partial moves keep sibling fields usable.
  * Improved handling of field reads from owned receivers, returning owned field values instead of borrows.

* **Bug Fixes**
  * Eliminated false use-after-move reports when only one field of an object was moved.
  * Improved partial-move detection and diagnostics, including clearer moved/read field context.

* **Tests**
  * Added unit and integration coverage for partial moves of object fields across multiple access patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->