### PR TITLE
Implement phase-exclusivity checking for borrow transitions

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -182,6 +182,14 @@ type funcCtx struct {
 	// use-after-move subsumes it. Deferring the emission lets the phase decision read
 	// the complete post-walk lattice, so each conflict's path-sensitivity is decided in
 	// one pass.
+	//
+	// INVARIANT: this slice must not be mutated under a discardable probe. The conflicts
+	// here bypass openProbe's errs snapshot, since they reach c.errs only later through
+	// resolvePhaseTransitions, so a discarded trial would not roll them back. It holds
+	// today because checkMutabilityTransition runs only on the non-speculative statement
+	// walk, never inside a probe. A probe opened around a statement walk that can reach
+	// checkMutabilityTransition would have to journal this slice's length in openProbe,
+	// the way errs is journaled.
 	pendingTransitions []*MutabilityTransitionError
 }
 

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -173,6 +173,16 @@ type funcCtx struct {
 	// inferStmt. A reassignment `a = e` lives in expression position, so the transition
 	// checker reads the enclosing statement from here to find its CFG StmtRef.
 	currentStmt ast.Stmt
+	// pendingTransitions holds the phase/exclusivity conflicts the walk found, deferred
+	// for emission until the consumed lattice is complete. checkMutabilityTransition
+	// computes each conflict against the alias and liveness state at the transition's
+	// program point and records it here rather than reporting it inline. After the body
+	// walk, resolvePhaseTransitions emits each one unless the consumed lattice finds its
+	// source moved on every reaching path, in which case the move engine's
+	// use-after-move subsumes it. Deferring the emission lets the phase decision read
+	// the complete post-walk lattice, so each conflict's path-sensitivity is decided in
+	// one pass.
+	pendingTransitions []*MutabilityTransitionError
 }
 
 // pushFuncCtx enters the inference context for function `node` (async controls

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -218,6 +218,32 @@ func TestInferValMutThawWidensLiteral(t *testing.T) {
 	require.Equal(t, "fn () -> mut {x: number}", values["f"])
 }
 
+// Freezing into a `var` binding widens the source's literal fields, since a `var` slot
+// must admit any later reassignment of the field's primitive type. Freezing the
+// singleton `{x: 0}` into `var q` yields `{x: number}`. A plain `val q` keeps the
+// singleton, because an immutable, non-reassignable binding has no widening reason.
+// Both freeze the value immutably; only the `var` slot widens.
+func TestFreezeVarWidensLiteral(t *testing.T) {
+	t.Run("var_widens", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f() {
+  val p = {x: 0}
+  var q = p
+  return q
+}`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> {x: number}", values["f"])
+	})
+	t.Run("val_keeps_singleton", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f() {
+  val p = {x: 0}
+  val q = p
+  return q
+}`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> {x: 0}", values["f"])
+	})
+}
+
 // --- Rule 3 (binding initializer): annotated bindings --------------------------
 
 // `val q: {x} = p` for an owned-immutable p binds q at the annotated owned type.

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -190,9 +190,9 @@ func TestInferValMutPrimitiveUnchanged(t *testing.T) {
 }
 
 // `val mut p = src` thaws an owned-immutable source into an owned-mutable binding.
-// The move consumes `src` and leaves `p` the sole owner, so it is sound for `p` to be
-// mutable: no reference to the value survives to observe `p`'s later mutations. The
-// binding's mutability comes from the `mut` pattern, not from the source, so `p` is
+// The move consumes `src` and leaves `p` the sole owner. No reference to the value
+// survives to observe `p`'s later mutations, so it is sound for `p` to be mutable. The
+// binding's mutability comes from the `mut` pattern, not from the source. So `p` is
 // `mut {x: number}` and the function returns it at that type.
 func TestInferValMutThawFromVariable(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(src: {x: number}) {

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -189,18 +189,18 @@ func TestInferValMutPrimitiveUnchanged(t *testing.T) {
 	require.Equal(t, "fn () -> 5", values["f"])
 }
 
-// The construction upgrade fires only for a freshly constructed literal. Binding a
-// `mut` to a non-fresh source — here a parameter — does not upgrade it to
-// owned-mutable, since moving an existing owned value into a mutable binding is the
-// thaw move whose consume enforcement lands in PR 8. The binding stays at the
-// source's owned-immutable type for now.
-func TestInferValMutFromVariableNotUpgraded(t *testing.T) {
+// `val mut p = src` thaws an owned-immutable source into an owned-mutable binding.
+// The move consumes `src` and leaves `p` the sole owner, so it is sound for `p` to be
+// mutable: no reference to the value survives to observe `p`'s later mutations. The
+// binding's mutability comes from the `mut` pattern, not from the source, so `p` is
+// `mut {x: number}` and the function returns it at that type.
+func TestInferValMutThawFromVariable(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(src: {x: number}) {
   val mut p = src
   return p
 }`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (src: {x: number}) -> {x: number}", values["f"])
+	require.Equal(t, "fn (src: {x: number}) -> mut {x: number}", values["f"])
 }
 
 // --- Rule 3 (binding initializer): annotated bindings --------------------------

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -203,6 +203,21 @@ func TestInferValMutThawFromVariable(t *testing.T) {
 	require.Equal(t, "fn (src: {x: number}) -> mut {x: number}", values["f"])
 }
 
+// Thawing widens the source's literal fields to their primitive type. `p` holds the
+// singleton `{x: 0}`, and thawing it into `val mut q` yields `mut {x: number}` rather
+// than `mut {x: 0}`. A mutable cell admits any value of the field's primitive type, so
+// a write like `q.x = 5` would otherwise be rejected against a `0` singleton. This is
+// the same widening the fresh-literal `val mut q = {x: 0}` upgrade applies.
+func TestInferValMutThawWidensLiteral(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  val p = {x: 0}
+  val mut q = p
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {x: number}", values["f"])
+}
+
 // --- Rule 3 (binding initializer): annotated bindings --------------------------
 
 // `val q: {x} = p` for an owned-immutable p binds q at the annotated owned type.

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -237,7 +237,9 @@ func stripOwnedMut(t soltype.Type) soltype.Type {
 // binding moves an owned value out of a place. A place is a binding or a field path
 // such as `p` or `pair.a`, and its value moves when it is a concrete owned object,
 // tuple, or owned RefType. Such a binding takes ownership of the value, so the
-// binding's declared mutability replaces the source's, the thaw and freeze of PR 8.
+// binding's declared mutability replaces the source's. A `val mut q` thaws an
+// owned-immutable source into a mutable binding, and a plain `val q` freezes an
+// owned-mutable source into an immutable one.
 //
 // A borrow, value type, fresh literal, generic type-parameter value, or non-place
 // initializer is not a place move and keeps the ordinary inference. exprPlace also

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -99,6 +99,34 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		} else if d.Kind == ast.VarKind {
 			initT = widened
 		}
+	case d.TypeAnn == nil && c.bindingMovesOwnedPlace(d.Pattern, d.Init, initT):
+		// `val q = p` / `val mut q = p` moves an owned value out of the place `p`
+		// into the new binding `q`. The move consumes `p` and leaves `q` the sole
+		// owner, so `q`'s mutability is taken from the binding pattern rather than
+		// inherited from `p`. A `val mut q` thaws an owned-immutable source into an
+		// owned-mutable binding, and a plain `val q` freezes an owned-mutable source
+		// into an owned-immutable one. consumeBindingInit records the consume for the
+		// same binding, and trackAliasesForIdentPat seeds `q` as a fresh owner.
+		if isMutableIdentPat(d.Pattern) {
+			// Thaw: widen the source's literal fields and wrap the result in an
+			// owned-mutable cell, the same owned-mutable cell the fresh-literal
+			// `val mut q = {…}` upgrade above produces. A place move's source is an
+			// object, tuple, or owned RefType, so the widened type is a RefInner and
+			// the wrap always applies.
+			if inner, ok := widen(stripOwnedMut(initT)).(soltype.RefInner); ok {
+				ref := soltype.NewRef(true, nil, inner)
+				c.recordProv(ref, d.Init, OwnedMutConstruction)
+				initT = ref
+			}
+		} else {
+			// Freeze: take the source's immutable skeleton, so a later write through
+			// `q` is rejected. A `var` slot still widens so a reassignment can store
+			// another value of the widened shape.
+			initT = stripOwnedMut(initT)
+			if d.Kind == ast.VarKind {
+				initT = widen(initT)
+			}
+		}
 	case d.TypeAnn != nil:
 		// M2.5: constrain the initializer against the annotation (the one
 		// non-provenance addition, §3.7), so `val x: number = "hi"` produces a
@@ -203,6 +231,26 @@ func stripOwnedMut(t soltype.Type) soltype.Type {
 	default:
 		return t
 	}
+}
+
+// bindingMovesOwnedPlace reports whether the unannotated initializer of an IdentPat
+// binding moves an owned value out of a place. A place is a binding or a field path
+// such as `p` or `pair.a`, and its value moves when it is a concrete owned object,
+// tuple, or owned RefType. Such a binding takes ownership of the value, so the
+// binding's declared mutability replaces the source's, the thaw and freeze of PR 8.
+//
+// A borrow, value type, fresh literal, generic type-parameter value, or non-place
+// initializer is not a place move and keeps the ordinary inference. exprPlace also
+// fails outside a function body, where the rename pass has assigned no VarID, so the
+// mutability rewrite is confined to bodies where the move engine enforces the consume.
+func (c *checker) bindingMovesOwnedPlace(pat ast.Pat, init ast.Expr, initT soltype.Type) bool {
+	if _, ok := pat.(*ast.IdentPat); !ok {
+		return false
+	}
+	if _, ok := exprPlace(init); !ok {
+		return false
+	}
+	return isConcreteOwned(initT)
 }
 
 // isMutableIdentPat reports whether p is a simple identifier binding written with

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -377,3 +377,42 @@ func TestMoveSemantics(t *testing.T) {
 		})
 	}
 }
+
+// TestThawMove covers the immutable→mutable thaw of PR 8: `val mut q = p` for an
+// owned-immutable `p` moves `p` into the mutable binding `q` and consumes it. The move
+// leaves `q` the sole owner, so `q` may be mutable and `q.x = 5` is accepted with no
+// immutable-object error. The later `p.x` reads `p` after it was moved, a
+// use-after-move, which is the only diagnostic. This is the requirements' thawing
+// example.
+func TestThawMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val p = {x: 0}
+			val mut q = p
+			q.x = 5
+			p.x
+		}
+	`)
+	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+}
+
+// TestFreezeMove covers the mutable→immutable freeze of PR 8: a plain `val q = p` for
+// an owned-mutable `p` moves `p` into the immutable binding `q` and consumes it. The
+// binding's mutability comes from the pattern, so `q` is immutable and the write
+// `q.x = 5` is rejected, while the later `p.x` is a use-after-move on the consumed
+// source. Both diagnostics stand. This is the plan's freeze example.
+func TestFreezeMove(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn test() {
+			val mut p = {x: 0}
+			p.x = 42
+			val q = p
+			q.x = 5
+			p.x
+		}
+	`)
+	require.Equal(t, []string{
+		"cannot constrain immutable object <: mutable object",
+		"use of moved value 'p'",
+	}, Messages(errs))
+}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -416,3 +416,18 @@ func TestFreezeMove(t *testing.T) {
 		"use of moved value 'p'",
 	}, Messages(errs))
 }
+
+// TestFreezeMoveAllowed shows the freeze move itself is allowed: binding an
+// owned-mutable `p` into a plain `val q` moves the value into an immutable owner and
+// consumes `p`. With `p` never used again, the move produces no error, and `q` is
+// owned-immutable — `fn (p: mut {x: number}) -> {x: number}` — so the value is returned
+// at the frozen type. This is the mirror of TestInferValMutThawFromVariable, which
+// thaws an owned-immutable source into an owned-mutable binding.
+func TestFreezeMoveAllowed(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) {
+  val q = p
+  return q
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: mut {x: number}) -> {x: number}", values["f"])
+}

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -378,11 +378,11 @@ func TestMoveSemantics(t *testing.T) {
 	}
 }
 
-// TestThawMove covers the immutable→mutable thaw of PR 8: `val mut q = p` for an
+// TestThawMove covers the immutable→mutable thaw. `val mut q = p` for an
 // owned-immutable `p` moves `p` into the mutable binding `q` and consumes it. The move
-// leaves `q` the sole owner, so `q` may be mutable and `q.x = 5` is accepted with no
-// immutable-object error. The later `p.x` reads `p` after it was moved, a
-// use-after-move, which is the only diagnostic. This is the requirements' thawing
+// leaves `q` the sole owner, so `q` may be mutable, and `q.x = 5` is accepted with no
+// immutable-object error. The later `p.x` reads `p` after it was moved. That read is a
+// use-after-move, and it is the only diagnostic. This is the requirements' thawing
 // example.
 func TestThawMove(t *testing.T) {
 	_, _, errs := inferSource(t, `
@@ -396,11 +396,11 @@ func TestThawMove(t *testing.T) {
 	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
 }
 
-// TestFreezeMove covers the mutable→immutable freeze of PR 8: a plain `val q = p` for
-// an owned-mutable `p` moves `p` into the immutable binding `q` and consumes it. The
+// TestFreezeMove covers the mutable→immutable freeze. A plain `val q = p` for an
+// owned-mutable `p` moves `p` into the immutable binding `q` and consumes it. The
 // binding's mutability comes from the pattern, so `q` is immutable and the write
-// `q.x = 5` is rejected, while the later `p.x` is a use-after-move on the consumed
-// source. Both diagnostics stand. This is the plan's freeze example.
+// `q.x = 5` is rejected. The later `p.x` is a use-after-move on the consumed source.
+// Both diagnostics stand. This is the plan's freeze example.
 func TestFreezeMove(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn test() {
@@ -417,12 +417,13 @@ func TestFreezeMove(t *testing.T) {
 	}, Messages(errs))
 }
 
-// TestFreezeMoveAllowed shows the freeze move itself is allowed: binding an
+// TestFreezeMoveAllowed shows the freeze move itself is allowed. Binding an
 // owned-mutable `p` into a plain `val q` moves the value into an immutable owner and
-// consumes `p`. With `p` never used again, the move produces no error, and `q` is
-// owned-immutable — `fn (p: mut {x: number}) -> {x: number}` — so the value is returned
-// at the frozen type. This is the mirror of TestInferValMutThawFromVariable, which
-// thaws an owned-immutable source into an owned-mutable binding.
+// consumes `p`. With `p` never used again, the move produces no error. `q` is
+// owned-immutable, so the function returns the value at the frozen type
+// `fn (p: mut {x: number}) -> {x: number}`. This is the mirror of
+// TestInferValMutThawFromVariable, which thaws an owned-immutable source into an
+// owned-mutable binding.
 func TestFreezeMoveAllowed(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f(p: mut {x: number}) {
   val q = p

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -550,15 +550,15 @@ func (c *checker) recordMove(varID liveness.VarID, moveNode ast.Node, ref livene
 // recorded AT that statement — the consume in `val q = p`, where reading p and
 // moving it share one statement — does not flag its own source read.
 //
-// It also reconciles the exclusivity diagnostic against the same lattice: a
-// mutability-transition error whose source the lattice finds already moved at the
-// transition point is subsumed by a use-after-move, so reconcileMovedTransitions drops
-// it.
+// It also resolves the phase/exclusivity diagnostics against the same lattice:
+// resolvePhaseTransitions emits each conflict the walk recorded unless the lattice
+// finds its source moved on every path reaching the transition, where the
+// use-after-move subsumes it.
 func (c *checker) checkUseAfterMoves() {
 	if c.fn == nil || c.fn.cfg == nil {
 		return
 	}
-	if len(c.fn.useSites) == 0 && len(c.fn.moveSites) == 0 {
+	if len(c.fn.useSites) == 0 && len(c.fn.moveSites) == 0 && len(c.fn.pendingTransitions) == 0 {
 		return
 	}
 	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
@@ -586,7 +586,7 @@ func (c *checker) checkUseAfterMoves() {
 			moveSite:    c.fn.moveNodes[movedID],
 		})
 	}
-	c.reconcileMovedTransitions(info)
+	c.resolvePhaseTransitions(info)
 }
 
 // movedConflict finds the strongest consumed state among the moved places that
@@ -628,32 +628,30 @@ func (c *checker) movedConflict(info *liveness.MoveInfo, u moveUse) (liveness.Mo
 	return best, bestID
 }
 
-// reconcileMovedTransitions drops every mutability-transition error whose source the
-// consumed lattice finds moved on a path reaching the transition. Such an error is a
-// stale exclusivity conflict off a value the move engine already reports a
-// use-after-move for, so keeping it would double-report. Querying the path-sensitive
-// lattice rather than a synchronous flag is what makes this precise: a source moved on
-// only one branch is NotMoved on a sibling branch, so a real exclusivity conflict there
-// survives.
+// resolvePhaseTransitions emits the phase/exclusivity conflicts the walk recorded,
+// deciding each against the now-complete consumed lattice. A mutable owned value sits
+// in one of two phases that never overlap: an immutable phase with any number of `&`
+// borrows, or a mutable phase with any number of `&mut` borrows. A recorded conflict
+// is a borrow of the opposite phase still live across the transition.
+//
+// The lattice makes the decision path-sensitive:
+//   - Moved on every path reaching the transition: the move engine already reports a
+//     use-after-move at that point, which subsumes the conflict, so it is dropped.
+//   - MaybeMoved, moved on some reaching paths but not all: the non-moving paths are a
+//     real phase conflict, so the error is kept. The moving paths read as the
+//     conditional use-after-move the move engine reports there, so both diagnostics
+//     stand, each describing the paths it governs.
+//   - NotMoved: an ordinary phase conflict, kept.
 //
 // The query is scoped to this body for free. Module-wide VarID numbering means this
-// body's lattice never marks another body's source moved, so an error from a different
-// body reads NotMoved here and is kept.
-//
-// A MaybeMoved source — moved on some but not all paths reaching the transition — is
-// dropped too, since keeping it would double-report alongside the conditional
-// use-after-move on the moving paths. That loses a real exclusivity conflict on the
-// non-moving paths of such a source, a narrow residual the PR 8 phase reframing closes
-// by deciding exclusivity from the lattice and alias set in one pass.
-func (c *checker) reconcileMovedTransitions(info *liveness.MoveInfo) {
-	kept := c.errs[:0]
-	for _, e := range c.errs {
-		if mt, ok := e.(*MutabilityTransitionError); ok && mt.sourceVarID > 0 {
-			if info.StateBefore(mt.ref, mt.sourceVarID) != liveness.NotMoved {
-				continue
-			}
+// body's lattice never marks another body's source moved, so a conflict whose source
+// lives in a different body reads NotMoved here and is kept.
+func (c *checker) resolvePhaseTransitions(info *liveness.MoveInfo) {
+	for _, e := range c.fn.pendingTransitions {
+		if e.sourceVarID > 0 && info.StateBefore(e.ref, e.sourceVarID) == liveness.Moved {
+			continue
 		}
-		kept = append(kept, e)
+		c.errs = append(c.errs, e)
 	}
-	c.errs = kept
+	c.fn.pendingTransitions = nil
 }

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -235,6 +235,17 @@ func (p *Probe) Commit() {
 // completes the "leaves no trace" guarantee alongside the bound + Info/Prov
 // journaling, so a speculative trial may safely route failures through the
 // error-accumulating walk, not only the error-returning Constrain.
+//
+// The "leaves no trace" guarantee covers errs, bounds, and the Info/Prov side
+// tables. It does NOT cover funcCtx.pendingTransitions, the deferred phase/exclusivity
+// conflicts. Those are recorded by the statement walk (checkMutabilityTransition) and
+// emitted only after the body walk by resolvePhaseTransitions, so they never pass
+// through the errs snapshot above. This is sound only because the transition checks run
+// outside any open probe: every openProbe site wraps a type-level Context.Constrain
+// trial, not a statement or assignment walk. If a probe is ever opened around a body
+// walk that can reach checkMutabilityTransition, a discarded trial would leak a spurious
+// phase conflict. Journal len(c.fn.pendingTransitions) here and truncate it on rollback
+// at that point, mirroring the errs snapshot.
 func (c *checker) openProbe() *Probe {
 	p := newProbe(c.ctx.probe)
 	c.ctx.probe = p

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -129,6 +129,20 @@ func transitionMessages(t *testing.T, errs []SolverError) []string {
 	return msgs
 }
 
+// pendingMessages renders the phase conflicts checkMutabilityTransition recorded on the
+// checker's funcCtx. A direct call to checkMutabilityTransition records its conflict for
+// the post-pass rather than emitting it, so a unit test that drives the check in
+// isolation reads the recorded conflict here. The from-source tests instead read
+// c.errs, since their full-pipeline run lets resolvePhaseTransitions drain the recorded
+// conflicts into the error list.
+func pendingMessages(c *checker) []string {
+	var msgs []string
+	for _, e := range c.fn.pendingTransitions {
+		msgs = append(msgs, e.Message())
+	}
+	return msgs
+}
+
 // staticBorrow builds a mut/immutable borrow whose lifetime is forced to 'static,
 // the shape borrowEscapedToStatic recognizes as a permanent outside alias (G2). The
 // 'static upper bound is what D3's constrainEscape adds when a borrow escapes.
@@ -141,6 +155,12 @@ func staticBorrow(mut bool) *soltype.RefType {
 // HasStatic{Mut,Imm}Alias bits: a source whose borrow escaped to 'static is a
 // permanent outside alias, so a transition conflicts even when the source is locally
 // dead after the transition point. Without the escape the same state is conflict-free.
+//
+// checkMutabilityTransition records its conflict for the post-pass rather than
+// emitting it, so these unit tests read the recorded conflict through pendingMessages.
+// They isolate the conflict computation — the escape query, its polarity, and the
+// target-dead early return — which runs at the transition point regardless of the
+// later lattice decision.
 func TestStaticEscapeTransition(t *testing.T) {
 	const (
 		src = liveness.VarID(1)
@@ -166,7 +186,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{tgt}))
 		c.fn.varIDTypes[src] = staticBorrow(true)
 		c.checkMutabilityTransition(src, tgt, "p", "snap", false, true, false, false, transitionRef, transitionSite)
-		require.Empty(t, transitionMessages(t, c.errs))
+		require.Empty(t, pendingMessages(c))
 	})
 
 	// Would correspond to:
@@ -187,7 +207,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, false, transitionRef, transitionSite)
 		require.Equal(t, []string{
 			"cannot assign 'p' to immutable 'snap': a `'static` escape still has mutable access to 'p' after this point",
-		}, transitionMessages(t, c.errs))
+		}, pendingMessages(c))
 	})
 
 	// This isolates ONE transition: aliasing p into the immutable `snap`, where snap is
@@ -208,7 +228,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 		c := transitionFixture(names, a, set.FromSlice([]liveness.VarID{src}))
 		c.fn.varIDTypes[src] = staticBorrow(true)
 		c.checkMutabilityTransition(src, tgt, "p", "snap", true, false, false, false, transitionRef, transitionSite)
-		require.Empty(t, transitionMessages(t, c.errs))
+		require.Empty(t, pendingMessages(c))
 	})
 }
 
@@ -736,4 +756,121 @@ func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 		`)
 		require.Empty(t, transitionMessages(t, errs))
 	})
+}
+
+// TestBorrowPhaseExclusion covers the borrow-phase reframing of PR 8: a mutable owned
+// value sits in either an immutable phase, with any number of `&` borrows, or a mutable
+// phase, with any number of `&mut` borrows, and the two never overlap. An immutable
+// borrow taken while a mutable borrow of the same value is live crosses the phases and
+// is rejected, while several mutable borrows of one value coexist.
+func TestBorrowPhaseExclusion(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// An immutable borrow `s` taken while the mutable borrow `m` is still live mixes
+		// the immutable and mutable phases, so it is rejected. `m` is the live mutable
+		// access the message names.
+		"ImmutableBorrowWhileMutableLive_Error": {
+			src: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val m: &mut {x: number} = a
+					val s: &{x: number} = a
+					m.x = 2
+					s
+				}
+			`,
+			want: []string{
+				"cannot assign 'a' to immutable 's': 'm' still has mutable access to 'a' after this point",
+			},
+		},
+		// Two mutable borrows of one value stay within the mutable phase, so both are
+		// legal. Escalier is single-threaded, so simultaneous mutable borrows race
+		// nothing; the phase rule forbids only mixing the two kinds.
+		"MultipleMutableBorrows_OK": {
+			src: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val b: &mut {x: number} = a
+					val c: &mut {x: number} = a
+					b.x = 2
+					c.x = 3
+					a.x
+				}
+			`,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, transitionMessages(t, errs))
+		})
+	}
+}
+
+// TestPhaseConflictUnderConditionalMove covers the path-sensitive phase decision of
+// PR 8, taken from the consumed lattice in one post-pass. A phase conflict is dropped
+// only when the source is moved on EVERY path reaching the transition, where the move
+// engine's use-after-move subsumes it. When the source is moved on only some paths, the
+// conflict survives for the paths that did not move it.
+func TestPhaseConflictUnderConditionalMove(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// `a` is moved on the `if` arm and untouched on the `else` arm, so it is moved on
+		// some but not all paths reaching the `val snapshot` transition. The immutable
+		// borrow there conflicts with the later mutable use `a.x = 2` on the paths that
+		// did not move `a`, so the phase conflict is reported. The paths that did move it
+		// read each later use of `a` — the borrow and the mutation — as a conditional
+		// use-after-move.
+		"SomePathsMove_ConflictSurvives": {
+			src: `
+				fn sink(p: mut {x: number}) {}
+				fn test(cond: boolean) {
+					val a: mut {x: number} = {x: 1}
+					if cond {
+						sink(a)
+					} else {
+						a.x = 1
+					}
+					val snapshot: &{x: number} = a
+					a.x = 2
+					snapshot
+				}
+			`,
+			want: []string{
+				"use of moved value 'a'",
+				"use of moved value 'a'",
+				"cannot assign 'a' to immutable 'snapshot': 'a' is still used mutably after this point",
+			},
+		},
+		// `a` is moved unconditionally before the transition, so it is moved on every
+		// path reaching it. The move engine reports the later uses of `a` as
+		// use-after-move, and the phase conflict is subsumed, so no transition error is
+		// reported alongside them.
+		"AllPathsMove_ConflictSubsumed": {
+			src: `
+				fn sink(p: mut {x: number}) {}
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					sink(a)
+					val snapshot: &{x: number} = a
+					a.x = 2
+					snapshot
+				}
+			`,
+			want: []string{
+				"use of moved value 'a'",
+				"use of moved value 'a'",
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, transitionMessages(t, errs))
+		})
+	}
 }

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -768,6 +768,18 @@ func TestBorrowPhaseExclusion(t *testing.T) {
 		src  string
 		want []string
 	}{
+		// An immutable borrow of a mutable owned value is legal on its own. The borrow
+		// puts the value in the immutable phase for its lifetime, and no mutable access
+		// overlaps it here, so there is no phase conflict.
+		"ImmutableBorrowOfMutable_OK": {
+			src: `
+				fn test() {
+					val a: mut {x: number} = {x: 1}
+					val s: &{x: number} = a
+					s
+				}
+			`,
+		},
 		// An immutable borrow `s` taken while the mutable borrow `m` is still live mixes
 		// the immutable and mutable phases, so it is rejected. `m` is the live mutable
 		// access the message names.

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -758,11 +758,11 @@ func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 	})
 }
 
-// TestBorrowPhaseExclusion covers the borrow-phase reframing of PR 8: a mutable owned
-// value sits in either an immutable phase, with any number of `&` borrows, or a mutable
-// phase, with any number of `&mut` borrows, and the two never overlap. An immutable
-// borrow taken while a mutable borrow of the same value is live crosses the phases and
-// is rejected, while several mutable borrows of one value coexist.
+// TestBorrowPhaseExclusion covers the borrow-phase rule. A mutable owned value sits in
+// one of two phases that never overlap. The immutable phase holds any number of `&`
+// borrows. The mutable phase holds any number of `&mut` borrows. An immutable borrow
+// taken while a mutable borrow of the same value is live crosses the phases and is
+// rejected, while several mutable borrows of one value coexist.
 func TestBorrowPhaseExclusion(t *testing.T) {
 	tests := map[string]struct {
 		src  string
@@ -787,7 +787,7 @@ func TestBorrowPhaseExclusion(t *testing.T) {
 		},
 		// Two mutable borrows of one value stay within the mutable phase, so both are
 		// legal. Escalier is single-threaded, so simultaneous mutable borrows race
-		// nothing; the phase rule forbids only mixing the two kinds.
+		// nothing. The phase rule forbids only mixing the two kinds.
 		"MultipleMutableBorrows_OK": {
 			src: `
 				fn test() {
@@ -809,11 +809,11 @@ func TestBorrowPhaseExclusion(t *testing.T) {
 	}
 }
 
-// TestPhaseConflictUnderConditionalMove covers the path-sensitive phase decision of
-// PR 8, taken from the consumed lattice in one post-pass. A phase conflict is dropped
-// only when the source is moved on EVERY path reaching the transition, where the move
-// engine's use-after-move subsumes it. When the source is moved on only some paths, the
-// conflict survives for the paths that did not move it.
+// TestPhaseConflictUnderConditionalMove covers the path-sensitive phase decision taken
+// from the consumed lattice in one post-pass. A phase conflict is dropped only when the
+// source is moved on EVERY path reaching the transition. There the move engine's
+// use-after-move subsumes it. When the source is moved on only some paths, the conflict
+// survives for the paths that did not move it.
 func TestPhaseConflictUnderConditionalMove(t *testing.T) {
 	tests := map[string]struct {
 		src  string
@@ -822,9 +822,9 @@ func TestPhaseConflictUnderConditionalMove(t *testing.T) {
 		// `a` is moved on the `if` arm and untouched on the `else` arm, so it is moved on
 		// some but not all paths reaching the `val snapshot` transition. The immutable
 		// borrow there conflicts with the later mutable use `a.x = 2` on the paths that
-		// did not move `a`, so the phase conflict is reported. The paths that did move it
-		// read each later use of `a` — the borrow and the mutation — as a conditional
-		// use-after-move.
+		// did not move `a`, so the phase conflict is reported. On the paths that did
+		// move `a`, each later use of it, the borrow and the mutation, reads as a
+		// conditional use-after-move.
 		"SomePathsMove_ConflictSurvives": {
 			src: `
 				fn sink(p: mut {x: number}) {}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -387,7 +387,11 @@ func (c *checker) checkMutabilityTransition(
 	conflicting := conflictingSet.ToSlice()
 	sort.Strings(conflicting)
 
-	c.errs = append(c.errs, &MutabilityTransitionError{
+	// Record the conflict rather than reporting it now. It is computed from the alias
+	// and liveness state at this program point. Whether it survives depends on the
+	// consumed lattice, which is complete only after the whole body is walked, so
+	// resolvePhaseTransitions makes that call in the post-pass.
+	c.fn.pendingTransitions = append(c.fn.pendingTransitions, &MutabilityTransitionError{
 		SourceVar:       sourceVarName,
 		TargetVar:       targetVarName,
 		ConflictingVars: conflicting,

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -251,7 +251,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 6 |
 | 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ✅ done; escaping-closure-capture moves and the return/argument `constrainEscape` forcing deferred |
 | 7 | Partial moves and field-level ownership | 6 | Medium | ⬜ not started |
-| 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ⬜ not started |
+| 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ✅ done |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ⬜ not started |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium | ⬜ not started |
 | 11 | Connected-component moves for graphs | 6, 7 | Large | ⬜ not started |

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -250,7 +250,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 4 | Member reads borrow the receiver | 3 | Medium | ✅ done (#773) |
 | 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 6 |
 | 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ✅ done; escaping-closure-capture moves and the return/argument `constrainEscape` forcing deferred |
-| 7 | Partial moves and field-level ownership | 6 | Medium | ⬜ not started |
+| 7 | Partial moves and field-level ownership | 6 | Medium | ✅ done (#791) |
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ✅ done |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ⬜ not started |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium | ⬜ not started |


### PR DESCRIPTION
Implement the phase-exclusivity checking from PR 8 of the affine semantics plan. A mutable owned value sits in one of two phases that never overlap: an immutable phase with any number of `&` borrows, or a mutable phase with any number of `&mut` borrows. A borrow of the opposite phase while the source is still live is rejected.

Key changes:

- **Defer transition conflict emission**: `checkMutabilityTransition` now records conflicts in `funcCtx.pendingTransitions` rather than reporting them immediately. This allows the decision to be made after the consumed lattice is complete, enabling path-sensitive analysis.

- **Resolve conflicts in post-pass**: `resolvePhaseTransitions` (renamed from `reconcileMovedTransitions`) emits each recorded conflict unless the consumed lattice finds the source moved on every path reaching the transition. When moved on all paths, the move engine's use-after-move subsumes the conflict. When moved on some but not all paths, the conflict survives on the non-moving paths.

- **Implement place moves with thaw/freeze**: `bindingMovesOwnedPlace` detects when an unannotated binding moves an owned value out of a place (a binding or field path). The binding's declared mutability replaces the source's: `val mut q = p` thaws an owned-immutable source into owned-mutable, while `val q = p` freezes an owned-mutable source into owned-immutable. This is implemented in `inferVarDeclInit` with `stripOwnedMut` and widening logic.

- **Add test coverage**: New tests cover borrow-phase exclusion (immutable borrows rejected while mutable borrows are live, multiple mutable borrows allowed), path-sensitive conflict resolution under conditional moves, and the thaw/freeze semantics for place moves.

The implementation makes the phase decision path-sensitive by querying the consumed lattice in one pass after the body walk, rather than making a synchronous decision at the transition point.

https://claude.ai/code/session_01Y9QqRa8dAbPmpHGVpSfthn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of mutable and immutable value moves, including support for thawing and freezing behavior in variable bindings.
  * Added clearer phase-conflict handling during borrow and move analysis.

* **Bug Fixes**
  * Reduced misleading diagnostics by deferring certain conflict checks until move information is fully available.
  * Improved consistency of errors for conditional moves and borrow-phase exclusions.

* **Tests**
  * Expanded coverage for thaw/freeze moves, phase conflicts, and borrow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->