### PR TITLE
Implement per-leaf mutability in destructuring patterns

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -716,11 +716,26 @@ func (*AwaitOutsideAsyncError) isSolverError()            {}
 func (*ReturnOutsideFunctionError) isSolverError()        {}
 func (*AsyncReturnNotPromiseError) isSolverError()        {}
 func (*NonExhaustiveMatchError) isSolverError()           {}
+func (*MutLeafThroughSharedBorrowError) isSolverError()   {}
 
 func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }
 func (e *NonExhaustiveMatchError) Related() []ast.Span { return nil }
 func (e *NonExhaustiveMatchError) Message() string {
 	return "match is not exhaustive; add a catch-all branch"
+}
+
+// MutLeafThroughSharedBorrowError fires when a destructuring pattern marks a leaf
+// `mut` while the scrutinee is an immutable `&` borrow. A `mut` leaf projects mutable
+// access to its slot, which cannot be obtained through a shared borrow, so the leaf is
+// rejected. It self-blames the leaf's pattern node.
+type MutLeafThroughSharedBorrowError struct {
+	Node ast.Node
+}
+
+func (e *MutLeafThroughSharedBorrowError) Span() ast.Span      { return e.Node.Span() }
+func (e *MutLeafThroughSharedBorrowError) Related() []ast.Span { return nil }
+func (e *MutLeafThroughSharedBorrowError) Message() string {
+	return "cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"
 }
 
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -257,8 +257,8 @@ func (c *checker) bindingMovesOwnedPlace(pat ast.Pat, init ast.Expr, initT solty
 
 // isMutableIdentPat reports whether p is a simple identifier binding written with
 // the `mut` prefix, as in `val mut q = …`. The construction upgrade applies only to
-// an IdentPat; a `mut` leaf inside a destructuring pattern carries the same flag but
-// needs the per-leaf projection work the destructuring mutability path owns.
+// an IdentPat. A `mut` leaf inside a destructuring pattern carries the same flag and
+// is thawed per-leaf by applyBindMode during bindPattern, not here.
 func isMutableIdentPat(p ast.Pat) bool {
 	ip, ok := p.(*ast.IdentPat)
 	return ok && ip.Mutable

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1946,9 +1946,10 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	c.recordProv(res, e, MatchBranch)
 	for _, arm := range e.Cases {
 		// Each arm binds its pattern's leaves in a fresh child scope so a name bound
-		// by one arm is invisible to the next. bindPattern peels any borrow wrapper
-		// and emits the inexact member-lookup requirements, surfacing a missing field
-		// or wrong tuple arity as it does for `val` destructuring.
+		// by one arm is invisible to the next. bindPattern peels the scrutinee's borrow
+		// for the member-lookup requirements but reapplies the binding mode to each
+		// leaf, so a leaf of a `&mut` scrutinee binds as a `&mut` borrow, just as `val`
+		// destructuring does. A missing field or wrong tuple arity surfaces here too.
 		armScope := scope.Child()
 		c.bindPattern(armScope, lvl, arm.Pattern, scrutinee, nil)
 		if arm.Guard != nil {

--- a/internal/solver/infer_pattern_mut_test.go
+++ b/internal/solver/infer_pattern_mut_test.go
@@ -113,10 +113,11 @@ func TestDestructureMutLeaf(t *testing.T) {
 				return p
 			}`},
 		// `&mut` borrow scrutinee (Rust ergonomics): an unmarked leaf is also a mutable
-		// borrow, so a write through it succeeds without the `mut` marker.
+		// borrow, so a write through it succeeds without the `mut` marker. Both leaves
+		// are plain, so the write-through-unmarked path is exercised on its own.
 		"MutBorrowPlainLeafWrite": {src: `
 			fn f(line: &mut [{x: number}, {y: number}]) {
-				val [mut p, q] = line
+				val [p, q] = line
 				q.y = 5
 				p.x = 1
 				return 0
@@ -169,26 +170,36 @@ func TestDestructureMutLeafRendersThawedCell(t *testing.T) {
 }
 
 // TestDestructureMutBorrowLeafRendersBorrow checks that a leaf projected from a `&mut`
-// scrutinee renders as a mutable borrow bounded by the scrutinee, and a `&` scrutinee
-// projects a shared borrow. The return annotations pin the expected leaf types.
+// scrutinee is a mutable borrow bounded by the scrutinee, and a `&` scrutinee projects
+// a shared borrow.
 func TestDestructureMutBorrowLeafRendersBorrow(t *testing.T) {
+	// A shared-borrow leaf renders cleanly, so the inferred function type pins the
+	// projected `&'a {y: number}` directly: the leaf shares the scrutinee's lifetime.
+	t.Run("SharedBorrow", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			fn f(line: &[{x: number}, {y: number}]) {
+				val [p, q] = line
+				return q
+			}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <'a>(line: &'a [{x: number}, {y: number}]) -> &'a {y: number}", values["f"])
+	})
+	// A `mut` leaf routes its projection through a fresh variable so a write can widen
+	// the element, which does not survive the return-join cleanly — a returned `&mut`
+	// leaf renders as `T0 | {y: number}` rather than `&mut {y: number}`. So the leaf is
+	// pinned against a `&mut {y: number}` return annotation instead: an owned or shared
+	// `q` would fail that constraint, so acceptance confirms `q` is a `&mut` borrow. The
+	// write-through behavior is covered by TestDestructureMutLeaf.
 	t.Run("MutBorrow", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
+		values, _, errs := inferSource(t, `
 			fn f(line: &mut [{x: number}, {y: number}]) -> &mut {y: number} {
 				val [p, mut q] = line
 				return q
 			}
 		`)
 		require.Empty(t, errs)
-	})
-	t.Run("SharedBorrow", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn f(line: &[{x: number}, {y: number}]) -> &{y: number} {
-				val [p, q] = line
-				return q
-			}
-		`)
-		require.Empty(t, errs)
+		require.Equal(t, "fn <'a>(line: &'a mut [{x: number}, {y: number}]) -> &'a mut {y: number}", values["f"])
 	})
 }
 

--- a/internal/solver/infer_pattern_mut_test.go
+++ b/internal/solver/infer_pattern_mut_test.go
@@ -35,7 +35,7 @@ func TestDestructureMutLeaf(t *testing.T) {
 				val [p, q] = line
 				q.y = 5
 				return p
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"5:5-5:12: cannot constrain immutable object <: mutable object"}},
 		// Owned scrutinee, object key-value form: `{a: mut m}` is mutable, `{b: n}` not.
 		"OwnedObjectKeyValueMutLeaf": {src: `
 			fn f() {
@@ -50,7 +50,7 @@ func TestDestructureMutLeaf(t *testing.T) {
 				val {a: m, b: n} = pt
 				m.x = 5
 				return n
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"5:5-5:12: cannot constrain immutable object <: mutable object"}},
 		// Owned scrutinee, object shorthand form: `{mut x}` is mutable.
 		"OwnedObjectShorthandMutLeaf": {src: `
 			fn f() {
@@ -80,7 +80,7 @@ func TestDestructureMutLeaf(t *testing.T) {
 						p
 					}
 				}
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"6:7-6:14: cannot constrain immutable object <: mutable object"}},
 		// A destructured `mut` parameter leaf is mutable.
 		"OwnedParamMutLeaf": {src: `
 			fn f([a, mut b]: [{x: number}, {y: number}]) {
@@ -91,20 +91,20 @@ func TestDestructureMutLeaf(t *testing.T) {
 			fn f([a, b]: [{x: number}, {y: number}]) {
 				b.y = 5
 				return a
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"3:5-3:12: cannot constrain immutable object <: mutable object"}},
 		// Shared `&` borrow scrutinee: a `mut` leaf is rejected.
 		"SharedBorrowMutLeafRejected": {src: `
 			fn f(line: &[{x: number}, {y: number}]) {
 				val [p, mut q] = line
 				return p
-			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+			}`, want: []string{"3:13-3:18: cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
 		// Shared `&` borrow scrutinee: an unmarked leaf is a shared borrow, so a write errors.
 		"SharedBorrowPlainLeafWriteErrors": {src: `
 			fn f(line: &[{x: number}, {y: number}]) {
 				val [p, q] = line
 				q.y = 5
 				return p
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"4:5-4:12: cannot constrain immutable object <: mutable object"}},
 		// `&mut` borrow scrutinee: a `mut` leaf is a mutable borrow, so a write succeeds.
 		"MutBorrowMutLeafWrite": {src: `
 			fn f(line: &mut [{x: number}, {y: number}]) {
@@ -148,7 +148,7 @@ func TestDestructureMutLeaf(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, Messages(errs))
+			require.Equal(t, tc.want, messagesWithSpan(errs))
 		})
 	}
 }
@@ -254,7 +254,7 @@ func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
 				match line {
 					[p, mut q] => { 0 }
 				}
-			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+			}`, want: []string{"4:10-4:15: cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
 		// `&` scrutinee: an unmarked leaf is a shared borrow, so a write through it errors.
 		"SharedBorrowPlainLeafWriteErrors": {src: `
 			fn f(line: &[{x: number}, {y: number}]) {
@@ -264,7 +264,7 @@ func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
 						0
 					}
 				}
-			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+			}`, want: []string{"5:7-5:14: cannot constrain immutable object <: mutable object"}},
 		// A `mut` leaf is rejected against a `&` borrow EXPRESSION scrutinee too, not
 		// only a `&` parameter.
 		"SharedBorrowExprMutLeafRejected": {src: `
@@ -273,7 +273,7 @@ func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
 				match (&line) {
 					[p, mut q] => { 0 }
 				}
-			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+			}`, want: []string{"5:10-5:15: cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
 		// The binding mode propagates into a nested pattern of a borrowed `match`
 		// scrutinee, so a deeply nested `mut` leaf is a mutable borrow.
 		"NestedMutBorrowLeaf": {src: `
@@ -289,7 +289,7 @@ func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, Messages(errs))
+			require.Equal(t, tc.want, messagesWithSpan(errs))
 		})
 	}
 }

--- a/internal/solver/infer_pattern_mut_test.go
+++ b/internal/solver/infer_pattern_mut_test.go
@@ -247,6 +247,17 @@ func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
 					}
 				}
 			}`},
+		// `&mut` scrutinee, object pattern (Rust ergonomics): an unmarked field leaf is
+		// also a mutable borrow, so the write succeeds without the `mut` marker.
+		"MutBorrowObjectPlainLeaf": {src: `
+			fn f(pt: &mut {a: {x: number}, b: {y: number}}) {
+				match pt {
+					{a: m, b: n} => {
+						m.x = 5
+						0
+					}
+				}
+			}`},
 		// `&` scrutinee: a `mut` leaf of a match arm is rejected — mutable access cannot
 		// be projected out of an immutable borrow.
 		"SharedBorrowMutLeafRejected": {src: `

--- a/internal/solver/infer_pattern_mut_test.go
+++ b/internal/solver/infer_pattern_mut_test.go
@@ -1,0 +1,193 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Per-leaf `mut` in destructuring patterns (#793). Mutability is per leaf and written
+// inside the pattern. The binding mode flows from the scrutinee's outermost borrow:
+// an owned scrutinee moves each leaf out, a `&mut` scrutinee projects a mutable borrow
+// of each leaf, and a `&` scrutinee projects a shared borrow where a `mut` leaf is
+// rejected.
+
+// TestDestructureMutLeaf covers the owned, shared-borrow, and mutable-borrow forms of
+// per-leaf mutability across `val` destructuring, function params, and `match` arms.
+// Each case asserts the exact set of error messages, empty for a well-typed program.
+func TestDestructureMutLeaf(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Owned scrutinee: a `mut` tuple leaf is owned-mutable, so a write succeeds.
+		"OwnedTupleMutLeafWrite": {src: `
+			fn f() {
+				val line = [{x: 0}, {y: 0}]
+				val [p, mut q] = line
+				q.y = 5
+				return p
+			}`},
+		// Owned scrutinee: an unmarked tuple leaf is immutable, so the same write errors.
+		"OwnedTuplePlainLeafWriteErrors": {src: `
+			fn f() {
+				val line = [{x: 0}, {y: 0}]
+				val [p, q] = line
+				q.y = 5
+				return p
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// Owned scrutinee, object key-value form: `{a: mut m}` is mutable, `{b: n}` not.
+		"OwnedObjectKeyValueMutLeaf": {src: `
+			fn f() {
+				val pt = {a: {x: 0}, b: {y: 0}}
+				val {a: mut m, b: n} = pt
+				m.x = 5
+				return n
+			}`},
+		"OwnedObjectKeyValuePlainLeafWriteErrors": {src: `
+			fn f() {
+				val pt = {a: {x: 0}, b: {y: 0}}
+				val {a: m, b: n} = pt
+				m.x = 5
+				return n
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// Owned scrutinee, object shorthand form: `{mut x}` is mutable.
+		"OwnedObjectShorthandMutLeaf": {src: `
+			fn f() {
+				val pt = {x: {a: 0}, y: 0}
+				val {mut x, y} = pt
+				x.a = 5
+				return y
+			}`},
+		// A `mut` leaf in a `match` arm over an owned scrutinee is mutable.
+		"OwnedMatchMutLeaf": {src: `
+			fn f() {
+				val line = [{x: 0}, {y: 0}]
+				match line {
+					[p, mut q] => {
+						q.y = 5
+						p
+					}
+				}
+			}`},
+		// An unmarked leaf in a `match` arm over an owned scrutinee is immutable.
+		"OwnedMatchPlainLeafWriteErrors": {src: `
+			fn f() {
+				val line = [{x: 0}, {y: 0}]
+				match line {
+					[p, q] => {
+						q.y = 5
+						p
+					}
+				}
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// A destructured `mut` parameter leaf is mutable.
+		"OwnedParamMutLeaf": {src: `
+			fn f([a, mut b]: [{x: number}, {y: number}]) {
+				b.y = 5
+				return a
+			}`},
+		"OwnedParamPlainLeafWriteErrors": {src: `
+			fn f([a, b]: [{x: number}, {y: number}]) {
+				b.y = 5
+				return a
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// Shared `&` borrow scrutinee: a `mut` leaf is rejected.
+		"SharedBorrowMutLeafRejected": {src: `
+			fn f(line: &[{x: number}, {y: number}]) {
+				val [p, mut q] = line
+				return p
+			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+		// Shared `&` borrow scrutinee: an unmarked leaf is a shared borrow, so a write errors.
+		"SharedBorrowPlainLeafWriteErrors": {src: `
+			fn f(line: &[{x: number}, {y: number}]) {
+				val [p, q] = line
+				q.y = 5
+				return p
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// `&mut` borrow scrutinee: a `mut` leaf is a mutable borrow, so a write succeeds.
+		"MutBorrowMutLeafWrite": {src: `
+			fn f(line: &mut [{x: number}, {y: number}]) {
+				val [p, mut q] = line
+				q.y = 5
+				return p
+			}`},
+		// `&mut` borrow scrutinee (Rust ergonomics): an unmarked leaf is also a mutable
+		// borrow, so a write through it succeeds without the `mut` marker.
+		"MutBorrowPlainLeafWrite": {src: `
+			fn f(line: &mut [{x: number}, {y: number}]) {
+				val [mut p, q] = line
+				q.y = 5
+				p.x = 1
+				return 0
+			}`},
+		// The binding mode propagates into nested patterns, so a deeply nested `mut`
+		// leaf of a `&mut` scrutinee is a mutable borrow.
+		"NestedMutBorrowLeaf": {src: `
+			fn f(line: &mut [[{x: number}]]) {
+				val [[mut a]] = line
+				a.x = 5
+				return 0
+			}`},
+		// A primitive element of a borrowed scrutinee is copied, not borrowed, so the
+		// leaf binds at the primitive's value type and satisfies a `number` return —
+		// it is not wrapped in a `&mut number`/`&number` that would fail the lifetime
+		// check.
+		"MutBorrowPrimitiveLeafCopies": {src: `
+			fn f(line: &mut [number, {y: number}]) -> number {
+				val [a, q] = line
+				return a
+			}`},
+		"SharedBorrowPrimitiveLeafCopies": {src: `
+			fn f(line: &[number, {y: number}]) -> number {
+				val [a, q] = line
+				return a
+			}`},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, Messages(errs))
+		})
+	}
+}
+
+// TestDestructureMutLeafRendersThawedCell checks that an owned `mut` leaf moved out of
+// a concrete scrutinee renders as a clean owned-mutable cell with widened fields, the
+// destructuring analogue of the `val mut q = p` thaw.
+func TestDestructureMutLeafRendersThawedCell(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f() {
+			val line = [{x: 0}, {y: 0}]
+			val [p, mut q] = line
+			q.y = 5
+			return q
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> mut {y: number}", values["f"])
+}
+
+// TestDestructureMutBorrowLeafRendersBorrow checks that a leaf projected from a `&mut`
+// scrutinee renders as a mutable borrow bounded by the scrutinee, and a `&` scrutinee
+// projects a shared borrow. The return annotations pin the expected leaf types.
+func TestDestructureMutBorrowLeafRendersBorrow(t *testing.T) {
+	t.Run("MutBorrow", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(line: &mut [{x: number}, {y: number}]) -> &mut {y: number} {
+				val [p, mut q] = line
+				return q
+			}
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("SharedBorrow", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(line: &[{x: number}, {y: number}]) -> &{y: number} {
+				val [p, q] = line
+				return q
+			}
+		`)
+		require.Empty(t, errs)
+	})
+}

--- a/internal/solver/infer_pattern_mut_test.go
+++ b/internal/solver/infer_pattern_mut_test.go
@@ -191,3 +191,94 @@ func TestDestructureMutBorrowLeafRendersBorrow(t *testing.T) {
 		require.Empty(t, errs)
 	})
 }
+
+// TestMatchBorrowedScrutineeMutLeaf covers per-leaf mutability in `match` arms whose
+// scrutinee is a borrowed reference, the pattern-matching analogue of the `val`
+// destructuring cases. The binding mode flows from the scrutinee's borrow into each
+// arm's pattern: a `&mut` scrutinee projects mutable leaves, a `&` scrutinee projects
+// shared leaves and rejects a `mut` leaf. A leaf never moves out of a borrowed
+// scrutinee. The scrutinee is a borrow PARAMETER, the supported `&mut`/`&` path; a
+// `&mut` borrow expression of a local owned value is a separate, unlanded path.
+func TestMatchBorrowedScrutineeMutLeaf(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// `&mut` scrutinee: a `mut` leaf of a match arm is a mutable borrow, so a write
+		// through it succeeds.
+		"MutBorrowMutLeafWrite": {src: `
+			fn f(line: &mut [{x: number}, {y: number}]) {
+				match line {
+					[p, mut q] => {
+						q.y = 5
+						0
+					}
+				}
+			}`},
+		// `&mut` scrutinee (Rust ergonomics): an unmarked leaf is also a mutable borrow,
+		// so a write through it succeeds without the `mut` marker.
+		"MutBorrowPlainLeafWrite": {src: `
+			fn f(line: &mut [{x: number}, {y: number}]) {
+				match line {
+					[p, q] => {
+						q.y = 5
+						0
+					}
+				}
+			}`},
+		// `&mut` scrutinee, object pattern: `{a: mut m}` is a mutable borrow leaf.
+		"MutBorrowObjectMutLeaf": {src: `
+			fn f(pt: &mut {a: {x: number}, b: {y: number}}) {
+				match pt {
+					{a: mut m, b: n} => {
+						m.x = 5
+						0
+					}
+				}
+			}`},
+		// `&` scrutinee: a `mut` leaf of a match arm is rejected — mutable access cannot
+		// be projected out of an immutable borrow.
+		"SharedBorrowMutLeafRejected": {src: `
+			fn f(line: &[{x: number}, {y: number}]) {
+				match line {
+					[p, mut q] => { 0 }
+				}
+			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+		// `&` scrutinee: an unmarked leaf is a shared borrow, so a write through it errors.
+		"SharedBorrowPlainLeafWriteErrors": {src: `
+			fn f(line: &[{x: number}, {y: number}]) {
+				match line {
+					[p, q] => {
+						q.y = 5
+						0
+					}
+				}
+			}`, want: []string{"cannot constrain immutable object <: mutable object"}},
+		// A `mut` leaf is rejected against a `&` borrow EXPRESSION scrutinee too, not
+		// only a `&` parameter.
+		"SharedBorrowExprMutLeafRejected": {src: `
+			fn f() {
+				val line = [{x: 0}, {y: 0}]
+				match (&line) {
+					[p, mut q] => { 0 }
+				}
+			}`, want: []string{"cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"}},
+		// The binding mode propagates into a nested pattern of a borrowed `match`
+		// scrutinee, so a deeply nested `mut` leaf is a mutable borrow.
+		"NestedMutBorrowLeaf": {src: `
+			fn f(line: &mut [[{x: number}]]) {
+				match line {
+					[[mut a]] => {
+						a.x = 5
+						0
+					}
+				}
+			}`},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, Messages(errs))
+		})
+	}
+}

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -167,8 +167,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// bound, which cannot reject a refutable literal sub-pattern of the wrong kind.
 		// The upper bound makes a nested literal flow against the real element type, so
 		// `[a, "hi"]` against `[number, number]` reports the mismatch.
-		tup, _ := scrutinee.(*soltype.TupleType)
-		if tup != nil {
+		if tup, ok := scrutinee.(*soltype.TupleType); ok {
 			for i := range fixed {
 				if i < len(tup.Elems) {
 					c.constrain(fixed[i], elemTypes[i], tup.Elems[i])

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -48,14 +48,70 @@ func defineLeafMono(scope *Scope, name string, t soltype.Type, _ ast.Node) {
 	scope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
 }
 
+// bindMode records how a pattern's leaves bind to the scrutinee, derived from the
+// scrutinee's outermost borrow and propagated unchanged into nested sub-patterns
+// (Rust match ergonomics). An owned scrutinee moves each leaf out; a borrowed
+// scrutinee projects a receiver-bounded borrow of each leaf, never a move. The
+// `lt` is the scrutinee's borrow lifetime, which every projected leaf borrow shares,
+// so a leaf cannot outlive the scrutinee.
+type bindMode struct {
+	borrow borrowMode
+	lt     soltype.Lifetime
+}
+
+type borrowMode byte
+
+const (
+	// bmOwned: the scrutinee is an owned value. Each leaf is moved out, taking its
+	// declared mutability — a plain leaf is owned-immutable, a `mut` leaf owned-mutable.
+	bmOwned borrowMode = iota
+	// bmShared: the scrutinee is an immutable `&` borrow. Each leaf is a shared borrow
+	// bounded by the scrutinee's lifetime. A `mut` leaf is an error: mutable access
+	// cannot be obtained through an immutable borrow.
+	bmShared
+	// bmMut: the scrutinee is a `&mut` borrow. Each leaf is a mutable borrow bounded by
+	// the scrutinee's lifetime (Rust match ergonomics), so a `mut` marker is redundant.
+	bmMut
+)
+
+// bindModeOf derives the binding mode from the scrutinee's outermost borrow. Only a
+// borrow with a real lifetime is a reference; an owned-mutable cell (`mut {…}` with a
+// nil lifetime) is an owned value, so its leaves move out and take their own declared
+// mutability rather than projecting a borrow.
+func bindModeOf(scrutinee soltype.Type) bindMode {
+	if r, ok := scrutinee.(*soltype.RefType); ok && r.Lt != nil {
+		if r.Mut {
+			return bindMode{borrow: bmMut, lt: r.Lt}
+		}
+		return bindMode{borrow: bmShared, lt: r.Lt}
+	}
+	return bindMode{borrow: bmOwned}
+}
+
 // bindPatternWith is bindPattern parameterized by the leaf-placement strategy. See
 // bindPattern for the pattern-typing contract. The emit decides where each bound
-// leaf lands.
+// leaf lands. The binding mode is derived from the scrutinee here and threaded into
+// the recursive walk so nested leaves inherit the scrutinee's borrow.
 func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	return c.bindPatMode(scope, lvl, pat, scrutinee, soltype.CarrierOf(scrutinee), bindModeOf(scrutinee), leafTypes, emit)
+}
+
+// bindPatMode is bindPatternWith's recursive core, carrying the binding mode the
+// top-level scrutinee fixed. The mode propagates unchanged into every sub-pattern, so
+// a leaf of `&mut [a, [b]]` binds `b` as a `&mut` borrow just as it binds `a`.
+//
+// concrete is the scrutinee's resolved type for this level when it is statically known
+// — the tuple element or object field a leaf projects, rather than the fresh
+// projection variable carried in `scrutinee`. An owned `mut` leaf thaws this concrete
+// type so it renders as a clean `mut {…}` cell instead of a variable inside the cell.
+// It is nil when the scrutinee's shape is not statically known, where the thaw falls
+// back to the projection variable.
+func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, mode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
 	case *ast.IdentPat:
 		t := c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
+		t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), mode)
 		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit)
 		return &soltype.IdentPat{Name: p.Name}
 
@@ -110,16 +166,26 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 		// bound, which cannot reject a refutable literal sub-pattern of the wrong kind.
 		// The upper bound makes a nested literal flow against the real element type, so
 		// `[a, "hi"]` against `[number, number]` reports the mismatch.
-		if tup, ok := scrutinee.(*soltype.TupleType); ok {
+		tup, _ := scrutinee.(*soltype.TupleType)
+		if tup != nil {
 			for i := range fixed {
 				if i < len(tup.Elems) {
 					c.constrain(fixed[i], elemTypes[i], tup.Elems[i])
 				}
 			}
 		}
+		// Child concrete types come from the threaded concrete tuple, not from the
+		// scrutinee: at a nested level the scrutinee is the parent's element variable,
+		// so only the threaded concrete still carries the element shape a borrowed leaf
+		// must inspect to decide whether to borrow.
+		concreteTup, _ := concrete.(*soltype.TupleType)
 		subs := make([]soltype.Pat, len(fixed))
 		for i, e := range fixed {
-			subs[i] = c.bindPatternWith(scope, lvl, e, elemTypes[i], leafTypes, emit)
+			var elemConcrete soltype.Type
+			if concreteTup != nil && i < len(concreteTup.Elems) {
+				elemConcrete = concreteTup.Elems[i]
+			}
+			subs[i] = c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, mode, leafTypes, emit)
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
@@ -134,6 +200,7 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 				beta := c.freshAt(lvl)
 				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, e.Default != nil))
 				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
+				t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), mode)
 				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
@@ -154,7 +221,7 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 						c.constrain(e, beta, prop.Type)
 					}
 				}
-				sub := c.bindPatternWith(scope, lvl, e.Value, beta, leafTypes, emit)
+				sub := c.bindPatMode(scope, lvl, e.Value, beta, fieldConcrete(concrete, e.Key.Name), mode, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			default:
 				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
@@ -193,6 +260,119 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 		c.constrain(def, defT, bound)
 	}
 	return bound
+}
+
+// applyBindMode wraps a destructured leaf's slot type according to the scrutinee's
+// binding mode and the leaf's own `mut` marker, returning the type the leaf binds at.
+//
+//   - Owned scrutinee: the leaf is moved out. A `mut` leaf thaws into an owned-mutable
+//     cell so a later write through it succeeds; a plain leaf keeps the slot's immutable
+//     type.
+//   - `&` scrutinee: the leaf is a shared borrow bounded by the scrutinee's lifetime.
+//     A `mut` leaf is rejected — mutable access cannot be projected out of an immutable
+//     borrow — and recovers as the shared borrow.
+//   - `&mut` scrutinee: the leaf is a mutable borrow bounded by the scrutinee's
+//     lifetime, so the `mut` marker is redundant.
+//
+// The borrow wrap is gated on the concrete element being borrowable, mirroring
+// fieldReadBorrow: a primitive or function element is copied, not borrowed, so it is
+// returned unchanged. A leaf whose element shape is not statically known — concrete is
+// nil — is also returned unchanged rather than borrowed, the same conservative choice
+// fieldReadBorrow makes for an unknown receiver.
+func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, mode bindMode) soltype.Type {
+	switch mode.borrow {
+	case bmShared:
+		if mut {
+			c.report(&MutLeafThroughSharedBorrowError{Node: node})
+		}
+		if ri, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
+			return soltype.NewRef(false, mode.lt, ri)
+		}
+		return slot
+	case bmMut:
+		if _, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
+			// Route the projection through a fresh variable rather than wrapping the
+			// slot directly. A tuple/object pattern pins each leaf's slot to the
+			// scrutinee's concrete element as an upper bound, which makes the slot
+			// invariantly exact under the `&mut` wrapper, so an inexact write
+			// requirement `mut {y, ...}` would clash with the exact element. The fresh
+			// variable takes the slot only as a lower bound, leaving its shape free to
+			// absorb the write requirement.
+			v := c.freshAt(lvl)
+			c.constrain(node, slot, v)
+			return soltype.NewRef(true, mode.lt, v)
+		}
+		return slot
+	default: // bmOwned
+		if mut {
+			return c.thawOwnedLeaf(lvl, node, slot, concrete)
+		}
+		return slot
+	}
+}
+
+// thawOwnedLeaf turns a `mut` leaf moved out of an owned scrutinee into an
+// owned-mutable cell, the destructuring analogue of the `val mut q = p` thaw in
+// inferVarDeclInit. When the leaf's projected type is statically known — the common
+// case where the scrutinee is a concrete tuple or object — the cell wraps the
+// widened concrete type directly, so it renders as a clean `mut {y: number}` and a
+// later write checks against the concrete shape, exactly as the IdentPat thaw does.
+//
+// When the projected type is not statically known, concrete is nil and the thaw
+// routes the projection variable through a fresh widenable variable: the slot flows
+// in as a lower bound and widening at coalesce time turns a literal field into its
+// primitive. The cell then carries a variable rather than a concrete object, which is
+// less precise to render but still admits the write.
+func (c *checker) thawOwnedLeaf(lvl int, node ast.Node, slot, concrete soltype.Type) soltype.Type {
+	if concrete != nil {
+		widened := widen(stripOwnedMut(concrete))
+		inner, ok := widened.(soltype.RefInner)
+		if !ok {
+			// A primitive or function leaf is not borrowable, so `mut` is a no-op — it
+			// keeps its slot type, mirroring `val mut a = 1` keeping the primitive. Only
+			// an object or tuple leaf thaws into a mutable cell.
+			return slot
+		}
+		ref := soltype.NewRef(true, nil, inner)
+		c.recordProv(ref, node, OwnedMutConstruction)
+		return ref
+	}
+	v := c.freshAt(lvl)
+	v.Widenable = true
+	c.constrain(node, slot, v)
+	ref := soltype.NewRef(true, nil, v)
+	c.recordProv(ref, node, OwnedMutConstruction)
+	return ref
+}
+
+// concreteLeaf resolves the concrete type a leaf binds at. A leaf with its own type
+// annotation adopts that annotation rather than the scrutinee's projected type, so the
+// scrutinee-derived concrete hint does not apply and is dropped. Otherwise the
+// scrutinee-derived concrete type is used, which is non-nil only when the scrutinee's
+// shape is statically known. A concrete type that is still an inference variable is
+// treated as unknown, since wrapping a variable defeats the clean-rendering the hint
+// exists to provide.
+func (c *checker) concreteLeaf(concrete soltype.Type, typeAnn ast.TypeAnn) soltype.Type {
+	if typeAnn != nil {
+		return nil
+	}
+	if _, isVar := concrete.(*soltype.TypeVarType); isVar {
+		return nil
+	}
+	return concrete
+}
+
+// fieldConcrete returns field `name`'s type from a concrete object type, or nil when
+// t is not a concrete object or lacks the field. It reads the threaded concrete type,
+// so it resolves a field even at a nested level where the scrutinee is a projection
+// variable. It is the object-pattern analogue of indexing a concrete tuple's elements.
+func fieldConcrete(t soltype.Type, name string) soltype.Type {
+	if o, ok := t.(*soltype.ObjectType); ok {
+		if prop, found := o.Prop(name); found {
+			return prop.Type
+		}
+	}
+	return nil
 }
 
 // patternDefaultsField reports whether a destructured field's value sub-pattern

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -65,10 +65,10 @@ const (
 	// bmOwned marks an owned scrutinee. Each leaf is moved out and takes its declared
 	// mutability. A plain leaf is owned-immutable. A `mut` leaf is owned-mutable.
 	bmOwned borrowMode = iota
-	// bmShared marks an immutable `&` borrow scrutinee. Each leaf is a shared borrow
+	// bmImm marks an immutable `&` borrow scrutinee. Each leaf is a shared borrow
 	// bounded by the scrutinee's lifetime. A `mut` leaf is an error. Mutable access
 	// cannot be obtained through an immutable borrow.
-	bmShared
+	bmImm
 	// bmMut marks a `&mut` borrow scrutinee. Each leaf is a mutable borrow bounded by
 	// the scrutinee's lifetime, following Rust's match ergonomics. A `mut` marker is
 	// redundant here.
@@ -84,7 +84,7 @@ func bindModeOf(scrutinee soltype.Type) bindMode {
 		if r.Mut {
 			return bindMode{borrow: bmMut, lt: r.Lt}
 		}
-		return bindMode{borrow: bmShared, lt: r.Lt}
+		return bindMode{borrow: bmImm, lt: r.Lt}
 	}
 	return bindMode{borrow: bmOwned}
 }
@@ -282,7 +282,7 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 // fieldReadBorrow makes for an unknown receiver.
 func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, mode bindMode) soltype.Type {
 	switch mode.borrow {
-	case bmShared:
+	case bmImm:
 		if mut {
 			c.report(&MutLeafThroughSharedBorrowError{Node: node})
 		}

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -48,12 +48,12 @@ func defineLeafMono(scope *Scope, name string, t soltype.Type, _ ast.Node) {
 	scope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(t)}})
 }
 
-// bindMode records how a pattern's leaves bind to the scrutinee, derived from the
-// scrutinee's outermost borrow and propagated unchanged into nested sub-patterns
-// (Rust match ergonomics). An owned scrutinee moves each leaf out; a borrowed
-// scrutinee projects a receiver-bounded borrow of each leaf, never a move. The
-// `lt` is the scrutinee's borrow lifetime, which every projected leaf borrow shares,
-// so a leaf cannot outlive the scrutinee.
+// bindMode records how a pattern's leaves bind to the scrutinee. It is derived from
+// the scrutinee's outermost borrow and propagated unchanged into nested sub-patterns,
+// following Rust's match ergonomics. An owned scrutinee moves each leaf out. A
+// borrowed scrutinee projects a receiver-bounded borrow of each leaf and never moves.
+// lt is the scrutinee's borrow lifetime. Every projected leaf borrow shares it, so a
+// leaf cannot outlive the scrutinee.
 type bindMode struct {
 	borrow borrowMode
 	lt     soltype.Lifetime
@@ -62,22 +62,23 @@ type bindMode struct {
 type borrowMode byte
 
 const (
-	// bmOwned: the scrutinee is an owned value. Each leaf is moved out, taking its
-	// declared mutability — a plain leaf is owned-immutable, a `mut` leaf owned-mutable.
+	// bmOwned marks an owned scrutinee. Each leaf is moved out and takes its declared
+	// mutability. A plain leaf is owned-immutable. A `mut` leaf is owned-mutable.
 	bmOwned borrowMode = iota
-	// bmShared: the scrutinee is an immutable `&` borrow. Each leaf is a shared borrow
-	// bounded by the scrutinee's lifetime. A `mut` leaf is an error: mutable access
+	// bmShared marks an immutable `&` borrow scrutinee. Each leaf is a shared borrow
+	// bounded by the scrutinee's lifetime. A `mut` leaf is an error. Mutable access
 	// cannot be obtained through an immutable borrow.
 	bmShared
-	// bmMut: the scrutinee is a `&mut` borrow. Each leaf is a mutable borrow bounded by
-	// the scrutinee's lifetime (Rust match ergonomics), so a `mut` marker is redundant.
+	// bmMut marks a `&mut` borrow scrutinee. Each leaf is a mutable borrow bounded by
+	// the scrutinee's lifetime, following Rust's match ergonomics. A `mut` marker is
+	// redundant here.
 	bmMut
 )
 
 // bindModeOf derives the binding mode from the scrutinee's outermost borrow. Only a
-// borrow with a real lifetime is a reference; an owned-mutable cell (`mut {…}` with a
-// nil lifetime) is an owned value, so its leaves move out and take their own declared
-// mutability rather than projecting a borrow.
+// borrow with a real lifetime is a reference. An owned-mutable cell has a nil lifetime
+// and is an owned value. Its leaves move out and take their own declared mutability
+// rather than projecting a borrow.
 func bindModeOf(scrutinee soltype.Type) bindMode {
 	if r, ok := scrutinee.(*soltype.RefType); ok && r.Lt != nil {
 		if r.Mut {
@@ -100,12 +101,12 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 // top-level scrutinee fixed. The mode propagates unchanged into every sub-pattern, so
 // a leaf of `&mut [a, [b]]` binds `b` as a `&mut` borrow just as it binds `a`.
 //
-// concrete is the scrutinee's resolved type for this level when it is statically known
-// — the tuple element or object field a leaf projects, rather than the fresh
-// projection variable carried in `scrutinee`. An owned `mut` leaf thaws this concrete
-// type so it renders as a clean `mut {…}` cell instead of a variable inside the cell.
-// It is nil when the scrutinee's shape is not statically known, where the thaw falls
-// back to the projection variable.
+// concrete is the scrutinee's resolved type for this level when it is statically
+// known. It is the tuple element or object field a leaf projects, not the fresh
+// projection variable carried in scrutinee. An owned `mut` leaf thaws concrete, so it
+// renders as a clean `mut {…}` cell rather than a variable inside the cell. concrete
+// is nil when the scrutinee's shape is not statically known. The thaw then falls back
+// to the projection variable.
 func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, mode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
@@ -263,21 +264,21 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 }
 
 // applyBindMode wraps a destructured leaf's slot type according to the scrutinee's
-// binding mode and the leaf's own `mut` marker, returning the type the leaf binds at.
+// binding mode and the leaf's own `mut` marker. It returns the type the leaf binds at.
 //
 //   - Owned scrutinee: the leaf is moved out. A `mut` leaf thaws into an owned-mutable
-//     cell so a later write through it succeeds; a plain leaf keeps the slot's immutable
-//     type.
+//     cell, so a later write through it succeeds. A plain leaf keeps the slot's
+//     immutable type.
 //   - `&` scrutinee: the leaf is a shared borrow bounded by the scrutinee's lifetime.
-//     A `mut` leaf is rejected — mutable access cannot be projected out of an immutable
-//     borrow — and recovers as the shared borrow.
+//     A `mut` leaf is rejected and recovers as the shared borrow. Mutable access cannot
+//     be projected out of an immutable borrow.
 //   - `&mut` scrutinee: the leaf is a mutable borrow bounded by the scrutinee's
-//     lifetime, so the `mut` marker is redundant.
+//     lifetime. The `mut` marker is redundant.
 //
 // The borrow wrap is gated on the concrete element being borrowable, mirroring
-// fieldReadBorrow: a primitive or function element is copied, not borrowed, so it is
-// returned unchanged. A leaf whose element shape is not statically known — concrete is
-// nil — is also returned unchanged rather than borrowed, the same conservative choice
+// fieldReadBorrow. A primitive or function element is copied, not borrowed, so it is
+// returned unchanged. A leaf whose element shape is not statically known has a nil
+// concrete and is also returned unchanged. This is the same conservative choice
 // fieldReadBorrow makes for an unknown receiver.
 func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, mode bindMode) soltype.Type {
 	switch mode.borrow {
@@ -292,11 +293,11 @@ func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete
 	case bmMut:
 		if _, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
 			// Route the projection through a fresh variable rather than wrapping the
-			// slot directly. A tuple/object pattern pins each leaf's slot to the
-			// scrutinee's concrete element as an upper bound, which makes the slot
+			// slot directly. A tuple or object pattern pins each leaf's slot to the
+			// scrutinee's concrete element as an upper bound. That makes the slot
 			// invariantly exact under the `&mut` wrapper, so an inexact write
 			// requirement `mut {y, ...}` would clash with the exact element. The fresh
-			// variable takes the slot only as a lower bound, leaving its shape free to
+			// variable takes the slot only as a lower bound. Its shape stays free to
 			// absorb the write requirement.
 			v := c.freshAt(lvl)
 			c.constrain(node, slot, v)
@@ -312,23 +313,23 @@ func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete
 }
 
 // thawOwnedLeaf turns a `mut` leaf moved out of an owned scrutinee into an
-// owned-mutable cell, the destructuring analogue of the `val mut q = p` thaw in
-// inferVarDeclInit. When the leaf's projected type is statically known — the common
-// case where the scrutinee is a concrete tuple or object — the cell wraps the
-// widened concrete type directly, so it renders as a clean `mut {y: number}` and a
-// later write checks against the concrete shape, exactly as the IdentPat thaw does.
+// owned-mutable cell. It is the destructuring analogue of the `val mut q = p` thaw in
+// inferVarDeclInit. When the leaf's projected type is statically known the cell wraps
+// the widened concrete type directly. The common case is a concrete tuple or object
+// scrutinee. The cell then renders as a clean `mut {y: number}`, and a later write
+// checks against the concrete shape, exactly as the IdentPat thaw does.
 //
-// When the projected type is not statically known, concrete is nil and the thaw
-// routes the projection variable through a fresh widenable variable: the slot flows
-// in as a lower bound and widening at coalesce time turns a literal field into its
-// primitive. The cell then carries a variable rather than a concrete object, which is
-// less precise to render but still admits the write.
+// When the projected type is not statically known, concrete is nil. The thaw then
+// routes the projection variable through a fresh widenable variable. The slot flows in
+// as a lower bound, and widening at coalesce time turns a literal field into its
+// primitive. The cell carries a variable rather than a concrete object. That is less
+// precise to render but still admits the write.
 func (c *checker) thawOwnedLeaf(lvl int, node ast.Node, slot, concrete soltype.Type) soltype.Type {
 	if concrete != nil {
 		widened := widen(stripOwnedMut(concrete))
 		inner, ok := widened.(soltype.RefInner)
 		if !ok {
-			// A primitive or function leaf is not borrowable, so `mut` is a no-op — it
+			// A primitive or function leaf is not borrowable, so `mut` is a no-op. It
 			// keeps its slot type, mirroring `val mut a = 1` keeping the primitive. Only
 			// an object or tuple leaf thaws into a mutable cell.
 			return slot

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -107,12 +107,12 @@ func (c *checker) bindPatternWith(scope *Scope, lvl int, pat ast.Pat, scrutinee 
 // renders as a clean `mut {…}` cell rather than a variable inside the cell. concrete
 // is nil when the scrutinee's shape is not statically known. The thaw then falls back
 // to the projection variable.
-func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, mode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee soltype.Type, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	scrutinee = soltype.CarrierOf(scrutinee)
 	switch p := pat.(type) {
 	case *ast.IdentPat:
 		t := c.applyLeafExtras(scope, lvl, p, scrutinee, p.TypeAnn, p.Default)
-		t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), mode)
+		t = c.applyBindMode(lvl, p, p.Mutable, t, c.concreteLeaf(concrete, p.TypeAnn), scrutineeMode)
 		c.bindLeaf(scope, p.Name, t, p, leafTypes, emit)
 		return &soltype.IdentPat{Name: p.Name}
 
@@ -186,7 +186,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 			if concreteTup != nil && i < len(concreteTup.Elems) {
 				elemConcrete = concreteTup.Elems[i]
 			}
-			subs[i] = c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, mode, leafTypes, emit)
+			subs[i] = c.bindPatMode(scope, lvl, e, elemTypes[i], elemConcrete, scrutineeMode, leafTypes, emit)
 		}
 		c.recordType(p, scrutinee)
 		return &soltype.TuplePat{Elems: subs}
@@ -201,7 +201,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 				beta := c.freshAt(lvl)
 				c.constrain(e, scrutinee, propReq(e.Key.Name, beta, e.Default != nil))
 				t := c.applyLeafExtras(scope, lvl, e, beta, e.TypeAnn, e.Default)
-				t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), mode)
+				t = c.applyBindMode(lvl, e, e.Mutable, t, c.concreteLeaf(fieldConcrete(concrete, e.Key.Name), e.TypeAnn), scrutineeMode)
 				c.bindLeaf(scope, e.Key.Name, t, e, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{
 					Name:  e.Key.Name,
@@ -222,7 +222,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 						c.constrain(e, beta, prop.Type)
 					}
 				}
-				sub := c.bindPatMode(scope, lvl, e.Value, beta, fieldConcrete(concrete, e.Key.Name), mode, leafTypes, emit)
+				sub := c.bindPatMode(scope, lvl, e.Value, beta, fieldConcrete(concrete, e.Key.Name), scrutineeMode, leafTypes, emit)
 				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: sub})
 			default:
 				// ObjRestPat (`{...rest}`) needs object rest types, which arrive in M9.
@@ -280,14 +280,14 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 // returned unchanged. A leaf whose element shape is not statically known has a nil
 // concrete and is also returned unchanged. This is the same conservative choice
 // fieldReadBorrow makes for an unknown receiver.
-func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, mode bindMode) soltype.Type {
-	switch mode.borrow {
+func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, scrutineeMode bindMode) soltype.Type {
+	switch scrutineeMode.borrow {
 	case bmImm:
 		if mut {
 			c.report(&MutLeafThroughSharedBorrowError{Node: node})
 		}
 		if ri, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
-			return soltype.NewRef(false, mode.lt, ri)
+			return soltype.NewRef(false, scrutineeMode.lt, ri)
 		}
 		return slot
 	case bmMut:
@@ -301,7 +301,7 @@ func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete
 			// absorb the write requirement.
 			v := c.freshAt(lvl)
 			c.constrain(node, slot, v)
-			return soltype.NewRef(true, mode.lt, v)
+			return soltype.NewRef(true, scrutineeMode.lt, v)
 		}
 		return slot
 	default: // bmOwned

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -774,14 +774,11 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 //
 // paramTypes is keyed by leaf name. An IdentPat parameter contributes the parameter
 // itself, and a destructuring param (M4 E1) contributes one entry per leaf via
-// bindPattern, so the lookup below resolves every leaf.
-//
-// KNOWN LIMITATION: a destructured leaf's type is a fresh inference variable at
-// pre-pass time, before constraints are coalesced, so isMutableType sees a bare var
-// rather than a RefType and a `mut` leaf still seeds AliasImmutable. Seeding a
-// destructured `mut` leaf accurately needs the leaf's resolved type, which is not
-// available until after the body walk. This is deferred with the rest of the
-// destructuring mutability work.
+// bindPattern, so the lookup below resolves every leaf. bindPattern runs before this
+// pre-pass for parameters and applies each leaf's binding mode, so a `mut` leaf moved
+// out of an owned param already carries its thawed owned-mutable type and a leaf
+// projected from a `&mut` param its mutable borrow. isMutableType therefore sees a
+// RefType and seeds AliasMutable for those leaves.
 func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.Type, aliases *liveness.AliasTracker, varIDTypes map[liveness.VarID]soltype.Type) {
 	for _, param := range astParams {
 		ast.ForEachLeafBinding(param.Pattern, func(name string, varID int) {
@@ -796,9 +793,8 @@ func seedParamLeafAliases(astParams []*ast.Param, paramTypes map[string]soltype.
 				// Record the leaf's type for the G2 escape query. An IdentPat param
 				// binding is mono, so the body's reads instantiate this same pointer
 				// and a lifetime it later escapes to 'static is visible through it. A
-				// destructured leaf records a fresh var, which is not a RefType, so the
-				// escape query returns escaped=false for it, matching the KNOWN
-				// LIMITATION above.
+				// destructured leaf records the type bindPattern resolved for it,
+				// including the `mut`/borrow wrapper its binding mode applied.
 				varIDTypes[liveness.VarID(varID)] = t
 			}
 			aliases.NewValue(liveness.VarID(varID), mut)
@@ -891,9 +887,10 @@ func recordParamVarIDs(fnScope *Scope, params []*ast.Param) {
 // the initializer. A destructured leaf reads a PROJECTION of the initializer. For
 // example `x` from `val {x} = p` is `p.x`, not `p`. That projection is not a
 // variable the liveness graph names, so the leaf is registered as its own value.
-// A leaf whose resolved type is a `mut` borrow still seeds AliasImmutable here,
-// since the leaf's type is an unresolved inference variable at this point. That
-// timing gap is the destructuring-mutability work deferred with the rest.
+// bindPattern runs before this and applies each leaf's binding mode, so a `mut` leaf
+// already carries its thawed owned-mutable type or its mutable borrow. The leaf's
+// scope binding therefore reports the resolved mutability, which isMutableType reads
+// to seed AliasMutable.
 func (c *checker) trackDestructureLeaves(scope *Scope, pat ast.Pat) {
 	ast.ForEachLeafBinding(pat, func(name string, varID int) {
 		if varID <= 0 {


### PR DESCRIPTION
Adds support for per-leaf `mut` markers in destructuring patterns, where mutability is declared inline for individual bindings rather than at the pattern level. The binding mode (owned, shared borrow, or mutable borrow) flows from the scrutinee's outermost borrow and propagates into nested sub-patterns.

Key changes:

- Added `bindMode` type to track how pattern leaves bind to the scrutinee: owned values move each leaf out with its declared mutability, `&` borrows project shared borrows and reject `mut` leaves, and `&mut` borrows project mutable borrows (Rust match ergonomics).
- Refactored `bindPatternWith` into `bindPatMode` to thread the binding mode through recursive pattern walks, ensuring nested leaves inherit the scrutinee's borrow.
- Implemented `applyBindMode` to wrap leaf types according to binding mode and the `mut` marker: owned `mut` leaves thaw into owned-mutable cells, borrowed leaves project the appropriate borrow, and `mut` through a shared borrow is rejected with a new error.
- Added `thawOwnedLeaf` to render owned `mut` leaves as clean `mut {…}` cells with widened fields, mirroring the `val mut q = p` thaw behavior.
- Threaded concrete element types through pattern recursion so borrowed leaves can inspect the element shape to decide whether to borrow (primitives are copied, not borrowed).
- Updated parameter liveness seeding to use the resolved leaf types from `bindPattern`, which now includes the binding mode wrapper, so `mut` leaves correctly seed `AliasMutable`.
- Added `MutLeafThroughSharedBorrowError` for the case where a `mut` leaf appears in a pattern destructuring a shared `&` borrow.
- Comprehensive test coverage in `infer_pattern_mut_test.go` for owned, shared-borrow, and mutable-borrow scrutinees across `val` destructuring, function parameters, and `match` arms.

https://claude.ai/code/session_014DyZWN32DT5kWavJJGUNDF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Destructuring patterns now handle `mut` on individual leaves more accurately across tuples, objects, function parameters, and `match` arms.
  * Borrowed values are now reflected more consistently in inferred leaf types.

* **Bug Fixes**
  * Added a clearer error when trying to bind a `mut` leaf through an immutable borrow.
  * Improved type checking for nested destructuring with borrowed scrutinees, including better handling of mutable borrows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->