### PR TITLE
Add span-prefixed error messages to test assertions

### DIFF
--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -58,7 +58,8 @@ func TestBlameValAnnotationLiteral(t *testing.T) {
 // A call-arg mismatch blames the offending argument, with the callee's param
 // annotation as the related source.
 func TestBlameCallArgument(t *testing.T) {
-	src := "fn f(x: number) -> number { return x }\nval r = f(\"hi\")"
+	src := `fn f(x: number) -> number { return x }
+val r = f("hi")`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, `2:11-2:15: cannot constrain "hi" <: number`, `"hi"`, "number")
 }
@@ -70,7 +71,8 @@ func TestBlameCallArgument(t *testing.T) {
 // callback-arity failures. The related span is the callee `f` here, derived from
 // the AST, not the callee's definition span resolved through Prov.)
 func TestBlameCallTooManyArgs(t *testing.T) {
-	src := "fn f(x: number) -> number { return x }\nval r = f(1, 2)"
+	src := `fn f(x: number) -> number { return x }
+val r = f(1, 2)`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"2:9-2:16: Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
@@ -81,7 +83,8 @@ func TestBlameCallTooManyArgs(t *testing.T) {
 // callee expression (`f` here, from the AST — not the callee's definition resolved
 // through Prov). `f` requires two params; the call supplies one.
 func TestBlameCallTooFewArgs(t *testing.T) {
-	src := "fn f(x: number, y: number) -> number { return x }\nval r = f(1)"
+	src := `fn f(x: number, y: number) -> number { return x }
+val r = f(1)`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"2:9-2:13: Not enough arguments: expected at least 2, but got 1", "f(1)", "f")
@@ -98,7 +101,8 @@ func TestBlameCallTooFewArgs(t *testing.T) {
 // (e.g. the result of a polymorphic call) does not keep the entry; see
 // TestBlameMissingPropertyPolymorphicReceiverLosesRelated.
 func TestBlameMissingProperty(t *testing.T) {
-	src := "val o = {a: 5}\nval x = o.b"
+	src := `val o = {a: 5}
+val x = o.b`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:11-2:12: object is missing property: b", "b", "{a: 5}")
 }
@@ -111,7 +115,9 @@ func TestBlameMissingProperty(t *testing.T) {
 // improvement holds for var-free callees/receivers, not values that flowed through
 // instantiation.
 func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
-	src := "val mk = fn (v) { return {a: v} }\nval o = mk(5)\nval x = o.b"
+	src := `val mk = fn (v) { return {a: v} }
+val o = mk(5)
+val x = o.b`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "3:11-3:12: object is missing property: b", "b")
 }
@@ -121,7 +127,8 @@ func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
 // containment guard falls back to the use (§3.8). The annotation is the related
 // expected-source.
 func TestBlameIdentifierUseNotDefinition(t *testing.T) {
-	src := "val x = \"hi\"\nval a: number = x"
+	src := `val x = "hi"
+val a: number = x`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, `2:17-2:18: cannot constrain "hi" <: number`, "x", "number")
 }
@@ -147,7 +154,8 @@ func TestBlameUnknownIdentifier(t *testing.T) {
 // A duplicate top-level `val` blames the second decl and exposes the first as a
 // related "previously declared here" span.
 func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
-	src := "val x = 5\nval x = \"hi\""
+	src := `val x = 5
+val x = "hi"`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:1-2:13: Duplicate declaration: x", `val x = "hi"`, "val x = 5")
 }
@@ -155,7 +163,8 @@ func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
 // An unsupported feature (optional chaining) blames the member, not a separate
 // node, and reports the feature name.
 func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
-	src := "val o = {a: 5}\nval x = o?.a"
+	src := `val o = {a: 5}
+val x = o?.a`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:9-2:13: Unsupported: OptionalChain", "o?.a")
 }
@@ -170,7 +179,8 @@ func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
 // and operand-outside-site branches are already covered by TestBlameCallArgument
 // and TestBlameIdentifierUseNotDefinition above.)
 func TestBlameVoidSubjectFallsBackToCallSite(t *testing.T) {
-	src := "fn f() {}\nval x: number = f()"
+	src := `fn f() {}
+val x: number = f()`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:17-2:20: cannot constrain void <: number", "f()", "number")
 }

--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -25,13 +25,14 @@ func spanText(src string, s ast.Span) string {
 	return line[s.Start.Column-1 : s.End.Column-1]
 }
 
-// requireBlame asserts the sole error's message, the source text its primary span
-// covers, and the source text each related span covers (in order). The golden
-// span fixtures (§3.10) use it to pin exact blame against real-parser spans.
+// requireBlame asserts the sole error's span-prefixed message ("line:col-line:col:
+// message"), the source text its primary span covers, and the source text each
+// related span covers (in order). The golden span fixtures (§3.10) use it to pin
+// exact blame against real-parser spans.
 func requireBlame(t *testing.T, src string, errs []SolverError, msg, primary string, related ...string) {
 	t.Helper()
 	require.Len(t, errs, 1)
-	require.Equal(t, msg, errs[0].Message())
+	require.Equal(t, msg, msgWithSpan(errs[0]))
 	require.Equal(t, primary, spanText(src, errs[0].Span()), "primary blame")
 	got := []string{}
 	for _, s := range errs[0].Related() {
@@ -51,7 +52,7 @@ func requireBlame(t *testing.T, src string, errs []SolverError, msg, primary str
 func TestBlameValAnnotationLiteral(t *testing.T) {
 	src := `val x: number = "hi"`
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
+	requireBlame(t, src, errs, `1:17-1:21: cannot constrain "hi" <: number`, `"hi"`, "number")
 }
 
 // A call-arg mismatch blames the offending argument, with the callee's param
@@ -59,7 +60,7 @@ func TestBlameValAnnotationLiteral(t *testing.T) {
 func TestBlameCallArgument(t *testing.T) {
 	src := "fn f(x: number) -> number { return x }\nval r = f(\"hi\")"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, `"hi"`, "number")
+	requireBlame(t, src, errs, `2:11-2:15: cannot constrain "hi" <: number`, `"hi"`, "number")
 }
 
 // A too-many-args direct call is the PR4 extra-arg lint (TooManyArgsError), a
@@ -72,7 +73,7 @@ func TestBlameCallTooManyArgs(t *testing.T) {
 	src := "fn f(x: number) -> number { return x }\nval r = f(1, 2)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
+		"2:9-2:16: Too many arguments: expected at most 1, but got 2", "f(1, 2)", "f")
 }
 
 // A too-few-args direct call is the PR4 too-few lint (NotEnoughArgsError), a BRIDGE
@@ -83,7 +84,7 @@ func TestBlameCallTooFewArgs(t *testing.T) {
 	src := "fn f(x: number, y: number) -> number { return x }\nval r = f(1)"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"Not enough arguments: expected at least 2, but got 1", "f(1)", "f")
+		"2:9-2:13: Not enough arguments: expected at least 2, but got 1", "f(1)", "f")
 }
 
 // A missing-property read blames the member's prop (.foo), not the receiver, with
@@ -99,7 +100,7 @@ func TestBlameCallTooFewArgs(t *testing.T) {
 func TestBlameMissingProperty(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o.b"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
+	requireBlame(t, src, errs, "2:11-2:12: object is missing property: b", "b", "{a: 5}")
 }
 
 // The bound of M3's related-span improvement: a receiver derived from a
@@ -112,7 +113,7 @@ func TestBlameMissingProperty(t *testing.T) {
 func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
 	src := "val mk = fn (v) { return {a: v} }\nval o = mk(5)\nval x = o.b"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "object is missing property: b", "b")
+	requireBlame(t, src, errs, "3:11-3:12: object is missing property: b", "b")
 }
 
 // An identifier-flow mismatch blames the USE, not the definition: x's type traces
@@ -122,7 +123,7 @@ func TestBlameMissingPropertyPolymorphicReceiverLosesRelated(t *testing.T) {
 func TestBlameIdentifierUseNotDefinition(t *testing.T) {
 	src := "val x = \"hi\"\nval a: number = x"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, `cannot constrain "hi" <: number`, "x", "number")
+	requireBlame(t, src, errs, `2:17-2:18: cannot constrain "hi" <: number`, "x", "number")
 }
 
 // An inline receiver DOES resolve its related span: {a: 5} is used directly (not
@@ -131,7 +132,7 @@ func TestBlameIdentifierUseNotDefinition(t *testing.T) {
 func TestBlameMissingPropertyInlineReceiverRelated(t *testing.T) {
 	src := `val x = {a: 5}.b`
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "object is missing property: b", "b", "{a: 5}")
+	requireBlame(t, src, errs, "1:16-1:17: object is missing property: b", "b", "{a: 5}")
 }
 
 // --- Bridge-error span fixtures (self-blaming, no Prov) ---
@@ -140,7 +141,7 @@ func TestBlameMissingPropertyInlineReceiverRelated(t *testing.T) {
 func TestBlameUnknownIdentifier(t *testing.T) {
 	src := `val y = missing`
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unknown identifier: missing", "missing")
+	requireBlame(t, src, errs, "1:9-1:16: Unknown identifier: missing", "missing")
 }
 
 // A duplicate top-level `val` blames the second decl and exposes the first as a
@@ -148,7 +149,7 @@ func TestBlameUnknownIdentifier(t *testing.T) {
 func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
 	src := "val x = 5\nval x = \"hi\""
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Duplicate declaration: x", `val x = "hi"`, "val x = 5")
+	requireBlame(t, src, errs, "2:1-2:13: Duplicate declaration: x", `val x = "hi"`, "val x = 5")
 }
 
 // An unsupported feature (optional chaining) blames the member, not a separate
@@ -156,7 +157,7 @@ func TestBlameDuplicateDeclarationRelatesPrevious(t *testing.T) {
 func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
 	src := "val o = {a: 5}\nval x = o?.a"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unsupported: OptionalChain", "o?.a")
+	requireBlame(t, src, errs, "2:9-2:13: Unsupported: OptionalChain", "o?.a")
 }
 
 // --- Site-fallback fixtures ---
@@ -171,7 +172,7 @@ func TestBlameUnsupportedFeatureOptionalChain(t *testing.T) {
 func TestBlameVoidSubjectFallsBackToCallSite(t *testing.T) {
 	src := "fn f() {}\nval x: number = f()"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "cannot constrain void <: number", "f()", "number")
+	requireBlame(t, src, errs, "2:17-2:20: cannot constrain void <: number", "f()", "number")
 }
 
 // The too-many-args lint on an immediately-invoked function blames the call and
@@ -184,7 +185,7 @@ func TestBlameCallTooManyArgsInlineCalleeRelated(t *testing.T) {
 	src := `val r = (fn (x: number) -> number { return x })(1, 2)`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"Too many arguments: expected at most 1, but got 2",
+		"1:10-1:54: Too many arguments: expected at most 1, but got 2",
 		`fn (x: number) -> number { return x })(1, 2)`,
 		`fn (x: number) -> number { return x }`)
 }

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -20,6 +20,27 @@ func Messages(errs []SolverError) []string {
 	return msgs
 }
 
+// msgWithSpan renders a single error as "line:col-line:col: message", the same
+// span-prefixed form the parser uses. Source-driven tests assert against this so
+// the expected string shows where in the source the error is blamed, which makes
+// the test cases easier to review.
+func msgWithSpan(e SolverError) string {
+	return e.Span().String() + ": " + e.Message()
+}
+
+// messagesWithSpan is the span-prefixed counterpart to Messages, for source-driven
+// tests whose errors carry real source spans.
+func messagesWithSpan(errs []SolverError) []string {
+	if len(errs) == 0 {
+		return nil
+	}
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = msgWithSpan(e)
+	}
+	return msgs
+}
+
 func num() *soltype.PrimType   { return &soltype.PrimType{Prim: soltype.NumPrim} }
 func str() *soltype.PrimType   { return &soltype.PrimType{Prim: soltype.StrPrim} }
 func boolT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.BoolPrim} }

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -47,18 +47,17 @@ func TestImmutableAnnotationRejectsNestedWrite(t *testing.T) {
 	cases := []struct {
 		name string
 		src  string
+		want string
 	}{
-		{"owned immutable", "fn f(p: {a: {x: number}}) { p.a.x = 5 }"},
-		{"immutable borrow", "fn f(p: &{a: {x: number}}) { p.a.x = 5 }"},
+		{"owned immutable", "fn f(p: {a: {x: number}}) { p.a.x = 5 }", "1:29-1:38: cannot constrain immutable object <: mutable object"},
+		{"immutable borrow", "fn f(p: &{a: {x: number}}) { p.a.x = 5 }", "1:30-1:39: cannot constrain immutable object <: mutable object"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
 			// The inner field-read result is a fresh variable; the message resolves it
 			// to its concrete bound so it reads `object`, not an internal `t{N}`.
-			require.Equal(t, []string{
-				"cannot constrain immutable object <: mutable object",
-			}, Messages(errs))
+			require.Equal(t, []string{tc.want}, messagesWithSpan(errs))
 		})
 	}
 }
@@ -76,17 +75,15 @@ func TestDeepMutLowersFreshLiteral(t *testing.T) {
 // its bare inner so the surrounding annotation still resolves, and the fresh literal
 // upgrades into that bare target.
 func TestNestedMutFieldAnnotationRejected(t *testing.T) {
-	want := []string{
-		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
-	}
+	const msg = "owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability"
 	t.Run("object", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val w: mut {a: mut {x: number}} = {a: {x: 0}}`)
-		require.Equal(t, want, Messages(errs))
+		require.Equal(t, []string{"1:20-1:21: " + msg}, messagesWithSpan(errs))
 		require.Equal(t, "mut {a: {x: number}}", values["w"])
 	})
 	t.Run("tuple", func(t *testing.T) {
 		values, _, errs := inferSource(t, `val w: mut [mut {x: number}] = [{x: 0}]`)
-		require.Equal(t, want, Messages(errs))
+		require.Equal(t, []string{"1:17-1:18: " + msg}, messagesWithSpan(errs))
 		require.Equal(t, "mut [{x: number}]", values["w"])
 	})
 }
@@ -94,7 +91,7 @@ func TestNestedMutFieldAnnotationRejected(t *testing.T) {
 // `readonly` rejects `obj.a = …` even on an owned-mutable enclosing object.
 func TestReadonlyRejectsFieldReassignment(t *testing.T) {
 	_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: number}) { obj.a = 5 }")
-	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+	require.Equal(t, []string{"1:39-1:48: cannot assign to readonly property: a"}, messagesWithSpan(errs))
 }
 
 // `readonly` forbids reassigning the field but not mutating through it: `obj.a.b
@@ -107,7 +104,7 @@ func TestReadonlyPermitsValueMutationButNotReassignment(t *testing.T) {
 	})
 	t.Run("reassign the field", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn f(obj: mut {readonly a: {b: number}}) { obj.a = {b: 9} }")
-		require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+		require.Equal(t, []string{"1:44-1:58: cannot assign to readonly property: a"}, messagesWithSpan(errs))
 	})
 }
 
@@ -146,12 +143,12 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 	t.Run("call: readonly source into writable param", func(t *testing.T) {
 		src := "fn sink(o: mut {a: number}) {}\nfn f(obj: mut {readonly a: number}) { sink(obj) }"
 		_, _, errs := inferSource(t, src)
-		require.Equal(t, []string{"readonly field a cannot satisfy a writable field requirement"}, Messages(errs))
+		require.Equal(t, []string{"2:39-2:48: readonly field a cannot satisfy a writable field requirement"}, messagesWithSpan(errs))
 	})
 	t.Run("return: readonly source as writable return", func(t *testing.T) {
 		src := "fn f(obj: mut {readonly a: number}) -> mut {a: number} { return obj }"
 		_, _, errs := inferSource(t, src)
-		require.Equal(t, []string{"readonly field a cannot satisfy a writable field requirement"}, Messages(errs))
+		require.Equal(t, []string{"1:1-1:70: readonly field a cannot satisfy a writable field requirement"}, messagesWithSpan(errs))
 	})
 	t.Run("call: writable source into readonly param is fine", func(t *testing.T) {
 		src := "fn sink(o: mut {readonly a: number}) {}\nfn f(obj: mut {a: number}) { sink(obj) }"
@@ -175,9 +172,9 @@ func TestOwnedMutFieldAnnotationRejected(t *testing.T) {
 	src := "fn f(p: {a: mut {x: number}}) { p.a.x = 5 }"
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
-		"cannot constrain immutable object <: mutable object",
-	}, Messages(errs))
+		"1:17-1:18: owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability",
+		"1:33-1:42: cannot constrain immutable object <: mutable object",
+	}, messagesWithSpan(errs))
 }
 
 // Chained reads through three deep-mut layers stay mutable, so a depth-3 write
@@ -194,7 +191,7 @@ func TestDeepMutChainedReadsAllowDeepWrite(t *testing.T) {
 func TestReadonlyFieldOnImmutableContainerStillRejectsWrite(t *testing.T) {
 	src := "fn f(p: {readonly a: number}) { p.a = 5 }"
 	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{"cannot assign to readonly property: a"}, Messages(errs))
+	require.Equal(t, []string{"1:33-1:40: cannot assign to readonly property: a"}, messagesWithSpan(errs))
 }
 
 // The fresh-literal upgrade reaches into tuples too.
@@ -230,7 +227,7 @@ func TestReadonlyRendersOnReadField(t *testing.T) {
 func TestLazyDeepMutPinsNestedFieldInvariant(t *testing.T) {
 	src := "fn sink(q: mut {a: {x: number | string}}) {}\nfn f(p: mut {a: {x: number}}) { sink(p) }"
 	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{"cannot constrain string <: number"}, Messages(errs))
+	require.Equal(t, []string{"2:33-2:40: cannot constrain string <: number"}, messagesWithSpan(errs))
 }
 
 // The same shapes under an immutable wrapper are covariant, so the strict-subtype
@@ -297,4 +294,3 @@ func TestNestedWriteInfersMutContainerAndRoundTrips(t *testing.T) {
 		require.Empty(t, errs)
 	})
 }
-

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -141,7 +141,8 @@ func TestExplicitBorrowOfDeepMutFieldPeels(t *testing.T) {
 // source can fill it through width subtyping.
 func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 	t.Run("call: readonly source into writable param", func(t *testing.T) {
-		src := "fn sink(o: mut {a: number}) {}\nfn f(obj: mut {readonly a: number}) { sink(obj) }"
+		src := `fn sink(o: mut {a: number}) {}
+fn f(obj: mut {readonly a: number}) { sink(obj) }`
 		_, _, errs := inferSource(t, src)
 		require.Equal(t, []string{"2:39-2:48: readonly field a cannot satisfy a writable field requirement"}, messagesWithSpan(errs))
 	})
@@ -151,13 +152,15 @@ func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
 		require.Equal(t, []string{"1:1-1:70: readonly field a cannot satisfy a writable field requirement"}, messagesWithSpan(errs))
 	})
 	t.Run("call: writable source into readonly param is fine", func(t *testing.T) {
-		src := "fn sink(o: mut {readonly a: number}) {}\nfn f(obj: mut {a: number}) { sink(obj) }"
+		src := `fn sink(o: mut {readonly a: number}) {}
+fn f(obj: mut {a: number}) { sink(obj) }`
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 	})
 	t.Run("call: wider source field fills inexact readonly target", func(t *testing.T) {
 		// The write-back is skipped for readonly targets, so width subtyping accepts.
-		src := "fn sink(o: mut {readonly a: {x: number, ...}}) {}\nfn f(obj: mut {a: {x: number, y: number}}) { sink(obj) }"
+		src := `fn sink(o: mut {readonly a: {x: number, ...}}) {}
+fn f(obj: mut {a: {x: number, y: number}}) { sink(obj) }`
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 	})
@@ -204,7 +207,8 @@ func TestDeepMutLowersFreshTupleLiteral(t *testing.T) {
 // A readonly field's value is still deep-mutable, so multiple writes through it
 // check independently.
 func TestReadonlyFieldValueIsDeepMutable(t *testing.T) {
-	src := "fn f(obj: mut {readonly a: {x: number, y: number}}) { obj.a.x = 5\n obj.a.y = 6 }"
+	src := `fn f(obj: mut {readonly a: {x: number, y: number}}) { obj.a.x = 5
+ obj.a.y = 6 }`
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {readonly a: {x: number, y: number}}) -> void", values["f"])
@@ -225,7 +229,8 @@ func TestReadonlyRendersOnReadField(t *testing.T) {
 // `mut {a: {x: number}}` value cannot fill a `mut {a: {x: number | string}}` slot —
 // the same invariance the eager per-cell `mut` lowering produced.
 func TestLazyDeepMutPinsNestedFieldInvariant(t *testing.T) {
-	src := "fn sink(q: mut {a: {x: number | string}}) {}\nfn f(p: mut {a: {x: number}}) { sink(p) }"
+	src := `fn sink(q: mut {a: {x: number | string}}) {}
+fn f(p: mut {a: {x: number}}) { sink(p) }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{"2:33-2:40: cannot constrain string <: number"}, messagesWithSpan(errs))
 }
@@ -235,7 +240,8 @@ func TestLazyDeepMutPinsNestedFieldInvariant(t *testing.T) {
 // that the mut-context flag draws: invariant inside a mutable wrapper, covariant
 // outside one.
 func TestImmutableWrapperKeepsNestedFieldCovariant(t *testing.T) {
-	src := "fn sink(q: {a: {x: number | string}}) {}\nfn f(p: {a: {x: number}}) { sink(p) }"
+	src := `fn sink(q: {a: {x: number | string}}) {}
+fn f(p: {a: {x: number}}) { sink(p) }`
 	_, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 }
@@ -289,7 +295,8 @@ func TestNestedWriteInfersMutContainerAndRoundTrips(t *testing.T) {
 	// Re-feeding the displayed type as a caller's annotation type-checks, so the
 	// signature genuinely round-trips.
 	t.Run("round-trip caller", func(t *testing.T) {
-		src := "fn foo(obj) { obj.p.x = 5 }\nfn caller(a: mut {p: {x: number}}) { foo(a) }"
+		src := `fn foo(obj) { obj.p.x = 5 }
+fn caller(a: mut {p: {x: number}}) { foo(a) }`
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 	})

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -41,7 +41,7 @@ func TestInferInexactObjectAnnotationRejectsExcessLiteralField(t *testing.T) {
 	_, _, errs := inferSource(t, `val r: {x: number, ...} = {x: 1, y: 2}`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &ExtraPropertyError{}, errs[0])
-	require.Equal(t, "object has extra property: y", errs[0].Message())
+	require.Equal(t, "1:37-1:38: object has extra property: y", msgWithSpan(errs[0]))
 }
 
 // The variable escape hatch: a NON-literal source against an inexact target takes
@@ -61,7 +61,7 @@ func TestInferExactObjectAnnotationRejectsExtraField(t *testing.T) {
 	_, _, errs := inferSource(t, `val r: {x: number} = {x: 1, y: 2}`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &ExtraPropertyError{}, errs[0])
-	require.Equal(t, "object has extra property: y", errs[0].Message())
+	require.Equal(t, "1:32-1:33: object has extra property: y", msgWithSpan(errs[0]))
 }
 
 // A tuple annotation resolves to a TupleType and an annotated binding adopts it.
@@ -77,8 +77,8 @@ func TestInferInexactTupleAnnotationRejectsExcessLiteralElements(t *testing.T) {
 	values, _, errs := inferSource(t, `val t: [number, ...] = [1, 2, 3]`)
 	require.Len(t, errs, 2)
 	require.IsType(t, &ExtraElementError{}, errs[0])
-	require.Equal(t, "tuple has extra element at index 1", errs[0].Message())
-	require.Equal(t, "tuple has extra element at index 2", errs[1].Message())
+	require.Equal(t, "1:28-1:29: tuple has extra element at index 1", msgWithSpan(errs[0]))
+	require.Equal(t, "1:31-1:32: tuple has extra element at index 2", msgWithSpan(errs[1]))
 	// The binding still adopts the inexact annotation (error recovery).
 	require.Equal(t, "[number, ...]", values["t"])
 }
@@ -93,8 +93,8 @@ func TestInferInexactTupleAnnotationExcessThroughSpread(t *testing.T) {
 	// Inferred [5, 6, 7] against [number]: indices 1 and 2 are excess, so two errors.
 	require.Len(t, errs, 2)
 	require.IsType(t, &ExtraElementError{}, errs[0])
-	require.Equal(t, "tuple has extra element at index 1", errs[0].Message())
-	require.Equal(t, "tuple has extra element at index 2", errs[1].Message())
+	require.Equal(t, "1:32-1:33: tuple has extra element at index 1", msgWithSpan(errs[0]))
+	require.Equal(t, "1:36-1:37: tuple has extra element at index 2", msgWithSpan(errs[1]))
 	// Per-element blame resolves through prov to each spliced element's own node:
 	// index 1 is the spread's `6`, index 2 is the trailing `7`.
 	require.Equal(t, "6", spanText(src, errs[0].Span()))
@@ -122,19 +122,19 @@ func TestInferMutInexactAnnotationStillChecksExcess(t *testing.T) {
 		_, _, errs := inferSource(t, `val r: mut {x: number, ...} = {x: 1, y: 2}`)
 		msgs := make([]string, len(errs))
 		for i, e := range errs {
-			msgs[i] = e.Message()
+			msgs[i] = msgWithSpan(e)
 		}
-		require.Equal(t, []string{"object has extra property: y"}, msgs)
+		require.Equal(t, []string{"1:41-1:42: object has extra property: y"}, msgs)
 	})
 	t.Run("tuple", func(t *testing.T) {
 		_, _, errs := inferSource(t, `val t: mut [number, ...] = [1, 2, 3]`)
 		msgs := make([]string, len(errs))
 		for i, e := range errs {
-			msgs[i] = e.Message()
+			msgs[i] = msgWithSpan(e)
 		}
 		require.ElementsMatch(t, []string{
-			"tuple has extra element at index 1",
-			"tuple has extra element at index 2",
+			"1:32-1:33: tuple has extra element at index 1",
+			"1:35-1:36: tuple has extra element at index 2",
 		}, msgs)
 	})
 }
@@ -167,7 +167,7 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 func TestInferOwnedMutFromVariableRejected(t *testing.T) {
 	src := "fn f() {\n\tval cfg: {x: number} = {x: 1}\n\tval m: mut {x: number} = cfg\n\tm.x = 2\n}"
 	_, _, errs := inferSource(t, src)
-	require.Equal(t, "cannot constrain immutable object <: mutable object", errs[0].Message())
+	require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
 }
 
 // The freshness check recurses, so a literal that WRAPS a non-fresh element is itself not
@@ -179,13 +179,13 @@ func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
 		src := "fn f() {\n\tval cfg = {x: 1}\n\tval m: mut {p: {x: number}} = {p: cfg}\n\tm\n}"
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain immutable object <: mutable object", errs[0].Message())
+		require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
 	})
 	t.Run("tuple element is a variable", func(t *testing.T) {
 		src := "fn f() {\n\tval cfg = {x: 1}\n\tval t: mut [number, {x: number}] = [1, cfg]\n\tt\n}"
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain immutable tuple <: mutable tuple", errs[0].Message())
+		require.Equal(t, "3:13-3:14: cannot constrain immutable tuple <: mutable tuple", msgWithSpan(errs[0]))
 	})
 }
 

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -165,7 +165,11 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 // variable — still rejects an immutable→mutable assignment, because the variable could
 // alias a value held immutably elsewhere. That case waits on the lifetime/region work.
 func TestInferOwnedMutFromVariableRejected(t *testing.T) {
-	src := "fn f() {\n\tval cfg: {x: number} = {x: 1}\n\tval m: mut {x: number} = cfg\n\tm.x = 2\n}"
+	src := `fn f() {
+	val cfg: {x: number} = {x: 1}
+	val m: mut {x: number} = cfg
+	m.x = 2
+}`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
 }
@@ -176,13 +180,21 @@ func TestInferOwnedMutFromVariableRejected(t *testing.T) {
 // variable: the outer literal is fresh, but a field or element reads a variable.
 func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
 	t.Run("object field is a variable", func(t *testing.T) {
-		src := "fn f() {\n\tval cfg = {x: 1}\n\tval m: mut {p: {x: number}} = {p: cfg}\n\tm\n}"
+		src := `fn f() {
+	val cfg = {x: 1}
+	val m: mut {p: {x: number}} = {p: cfg}
+	m
+}`
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
 		require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
 	})
 	t.Run("tuple element is a variable", func(t *testing.T) {
-		src := "fn f() {\n\tval cfg = {x: 1}\n\tval t: mut [number, {x: number}] = [1, cfg]\n\tt\n}"
+		src := `fn f() {
+	val cfg = {x: 1}
+	val t: mut [number, {x: number}] = [1, cfg]
+	t
+}`
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
 		require.Equal(t, "3:13-3:14: cannot constrain immutable tuple <: mutable tuple", msgWithSpan(errs[0]))

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -31,7 +31,7 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 	t.Run("mismatched type reports one subtype error", func(t *testing.T) {
 		src := "var a: number = 5\nfn f() { a = \"x\" }"
 		_, _, errs := inferSource(t, src)
-		requireBlame(t, src, errs, `cannot constrain "x" <: number`, `"x"`, "number")
+		requireBlame(t, src, errs, `2:14-2:17: cannot constrain "x" <: number`, `"x"`, "number")
 	})
 }
 
@@ -50,7 +50,7 @@ func TestInferAssignToValRejected(t *testing.T) {
 	src := "val a = 5\nfn f() { a = 6 }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"Cannot assign to immutable binding: a", "a = 6", "val a = 5")
+		"2:10-2:15: Cannot assign to immutable binding: a", "a = 6", "val a = 5")
 }
 
 // A function name and a parameter are likewise immutable. A parameter carries no
@@ -60,14 +60,14 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 		src := "fn h() -> number { return 5 }\nfn f() { h = 6 }"
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs,
-			"Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { return 5 }")
+			"2:10-2:15: Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { return 5 }")
 	})
 	t.Run("parameter", func(t *testing.T) {
 		src := "fn f(p: number) { p = 6 }"
 		_, _, errs := inferSource(t, src)
 		// A parameter's binding records its pattern as the source, so Related() points
 		// at the param ("declared immutable here").
-		requireBlame(t, src, errs, "Cannot assign to immutable binding: p", "p = 6", "p")
+		requireBlame(t, src, errs, "1:19-1:24: Cannot assign to immutable binding: p", "p = 6", "p")
 	})
 }
 
@@ -78,12 +78,12 @@ func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
 		src := "val a = 5\nfn g() { 5 = a }"
 		_, _, errs := inferSource(t, src)
-		requireBlame(t, src, errs, "Invalid assignment target: LiteralExpr", "5")
+		requireBlame(t, src, errs, "2:10-2:11: Invalid assignment target: LiteralExpr", "5")
 	})
 	t.Run("call target", func(t *testing.T) {
 		src := "fn f() -> number { return 5 }\nvar a: number = 0\nfn g() { f() = a }"
 		_, _, errs := inferSource(t, src)
-		requireBlame(t, src, errs, "Invalid assignment target: CallExpr", "f()")
+		requireBlame(t, src, errs, "3:10-3:13: Invalid assignment target: CallExpr", "f()")
 	})
 }
 
@@ -112,7 +112,7 @@ func TestInferAssignThroughBrokenBindingNoCascade(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "3:12-3:19: Unknown identifier: missing", msgWithSpan(errs[0]))
 }
 
 // Assigning to an undeclared name surfaces an UnknownIdentifierError on the target
@@ -120,7 +120,7 @@ func TestInferAssignThroughBrokenBindingNoCascade(t *testing.T) {
 func TestInferAssignUnknownTarget(t *testing.T) {
 	src := "fn f() { nope = 5 }"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unknown identifier: nope", "nope")
+	requireBlame(t, src, errs, "1:10-1:14: Unknown identifier: nope", "nope")
 }
 
 // Reassigning a POLYMORPHIC var must not corrupt the binding. inferAssign freshens
@@ -148,7 +148,7 @@ func TestInferAssignTopLevelBrokenBindingNoCascade(t *testing.T) {
 		fn f() { a = 5 }
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "2:11-2:18: Unknown identifier: missing", msgWithSpan(errs[0]))
 	require.Equal(t, "error", values["a"]) // recovered as the sentinel, not never
 }
 
@@ -169,7 +169,7 @@ func TestInferAssignUnionTarget(t *testing.T) {
 		src := "fn f(c: boolean) {\n  var a = if c { 1 } else { 2 }\n  a = 3\n}"
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain 3 <: 1 | 2", errs[0].Message())
+		require.Equal(t, "3:7-3:8: cannot constrain 3 <: 1 | 2", msgWithSpan(errs[0]))
 	})
 }
 
@@ -216,7 +216,7 @@ func TestInferAssignNamespaceTarget(t *testing.T) {
 func TestInferAssignMemberTargetImmutable(t *testing.T) {
 	src := "val o = {x: 5}\nfn f() { o.x = 6 }"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "cannot constrain immutable object <: mutable object", "o.x = 6")
+	requireBlame(t, src, errs, "2:10-2:17: cannot constrain immutable object <: mutable object", "o.x = 6")
 }
 
 // An INDEX target (xs[i] = …) still needs Array and index types (M7), so it stays
@@ -224,7 +224,7 @@ func TestInferAssignMemberTargetImmutable(t *testing.T) {
 func TestInferAssignIndexTargetUnsupported(t *testing.T) {
 	src := "val xs = [1, 2]\nfn f() { xs[0] = 6 }"
 	_, _, errs := inferSource(t, src)
-	requireBlame(t, src, errs, "Unsupported: assignment to a member or index", "xs[0]")
+	requireBlame(t, src, errs, "2:10-2:15: Unsupported: assignment to a member or index", "xs[0]")
 }
 
 // An immutable target with an independently-broken source reports BOTH errors — they
@@ -236,9 +236,9 @@ func TestInferAssignImmutableWithBadRHSReportsBoth(t *testing.T) {
 		fn f() { a = missing }
 	`)
 	require.Equal(t, []string{
-		"Unknown identifier: missing",
-		"Cannot assign to immutable binding: a",
-	}, Messages(errs))
+		"3:16-3:23: Unknown identifier: missing",
+		"3:12-3:23: Cannot assign to immutable binding: a",
+	}, messagesWithSpan(errs))
 }
 
 // A malformed assignment node with a nil operand (hand-built; the real parser

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -29,7 +29,8 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 		require.Equal(t, "fn () -> void", values["f"]) // no return, so the body produces no value
 	})
 	t.Run("mismatched type reports one subtype error", func(t *testing.T) {
-		src := "var a: number = 5\nfn f() { a = \"x\" }"
+		src := `var a: number = 5
+fn f() { a = "x" }`
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, `2:14-2:17: cannot constrain "x" <: number`, `"x"`, "number")
 	})
@@ -39,7 +40,8 @@ func TestInferAssignAnnotatedVar(t *testing.T) {
 // reassigning a DIFFERENT literal of the same primitive (`a = 6` ⇒ `6 <: number`)
 // checks. A `val` keeps the literal singleton (see TestInferAssignToValRejected).
 func TestInferAssignUnannotatedVarLiteralWidened(t *testing.T) {
-	values, _, errs := inferSource(t, "var a = 5\nfn f() { a = 6 }")
+	values, _, errs := inferSource(t, `var a = 5
+fn f() { a = 6 }`)
 	require.Empty(t, errs)
 	require.Equal(t, "number", values["a"])
 }
@@ -47,7 +49,8 @@ func TestInferAssignUnannotatedVarLiteralWidened(t *testing.T) {
 // Reassigning a `val` is rejected: only a `var` is reassignable. The error blames
 // the assignment and relates the `val` declaration ("declared immutable here").
 func TestInferAssignToValRejected(t *testing.T) {
-	src := "val a = 5\nfn f() { a = 6 }"
+	src := `val a = 5
+fn f() { a = 6 }`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
 		"2:10-2:15: Cannot assign to immutable binding: a", "a = 6", "val a = 5")
@@ -57,7 +60,8 @@ func TestInferAssignToValRejected(t *testing.T) {
 // introducing declaration source node, so its error has no related span.
 func TestInferAssignToImmutableNonVal(t *testing.T) {
 	t.Run("function name", func(t *testing.T) {
-		src := "fn h() -> number { return 5 }\nfn f() { h = 6 }"
+		src := `fn h() -> number { return 5 }
+fn f() { h = 6 }`
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs,
 			"2:10-2:15: Cannot assign to immutable binding: h", "h = 6", "fn h() -> number { return 5 }")
@@ -76,12 +80,15 @@ func TestInferAssignToImmutableNonVal(t *testing.T) {
 // index target another (unsupported pending Array types, M7).
 func TestInferAssignInvalidTarget(t *testing.T) {
 	t.Run("literal target", func(t *testing.T) {
-		src := "val a = 5\nfn g() { 5 = a }"
+		src := `val a = 5
+fn g() { 5 = a }`
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, "2:10-2:11: Invalid assignment target: LiteralExpr", "5")
 	})
 	t.Run("call target", func(t *testing.T) {
-		src := "fn f() -> number { return 5 }\nvar a: number = 0\nfn g() { f() = a }"
+		src := `fn f() -> number { return 5 }
+var a: number = 0
+fn g() { f() = a }`
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, "3:10-3:13: Invalid assignment target: CallExpr", "f()")
 	})
@@ -166,7 +173,10 @@ func TestInferAssignUnionTarget(t *testing.T) {
 		require.Empty(t, errs)
 	})
 	t.Run("non-member rejected once", func(t *testing.T) {
-		src := "fn f(c: boolean) {\n  var a = if c { 1 } else { 2 }\n  a = 3\n}"
+		src := `fn f(c: boolean) {
+  var a = if c { 1 } else { 2 }
+  a = 3
+}`
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
 		require.Equal(t, "3:7-3:8: cannot constrain 3 <: 1 | 2", msgWithSpan(errs[0]))
@@ -214,7 +224,8 @@ func TestInferAssignNamespaceTarget(t *testing.T) {
 // rejected: the write requires `o <: mut {x: number, ...}`, and an immutable object
 // cannot fill the mutable slot (the C2 gate's mutability rule).
 func TestInferAssignMemberTargetImmutable(t *testing.T) {
-	src := "val o = {x: 5}\nfn f() { o.x = 6 }"
+	src := `val o = {x: 5}
+fn f() { o.x = 6 }`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:10-2:17: cannot constrain immutable object <: mutable object", "o.x = 6")
 }
@@ -222,7 +233,8 @@ func TestInferAssignMemberTargetImmutable(t *testing.T) {
 // An INDEX target (xs[i] = …) still needs Array and index types (M7), so it stays
 // an unsupported feature — distinct from a member target, which C3 now types.
 func TestInferAssignIndexTargetUnsupported(t *testing.T) {
-	src := "val xs = [1, 2]\nfn f() { xs[0] = 6 }"
+	src := `val xs = [1, 2]
+fn f() { xs[0] = 6 }`
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs, "2:10-2:15: Unsupported: assignment to a member or index", "xs[0]")
 }

--- a/internal/solver/infer_async_test.go
+++ b/internal/solver/infer_async_test.go
@@ -100,7 +100,7 @@ func TestInferAsyncBareReturnAnnotationRejected(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "async function return type must be a Promise; write Promise<...> or Promise<_>", errs[0].Message())
+	require.Equal(t, "2:19-2:25: async function return type must be a Promise; write Promise<...> or Promise<_>", msgWithSpan(errs[0]))
 	require.Equal(t, "fn () -> Promise<5>", values["f"])
 }
 
@@ -110,7 +110,7 @@ func TestInferAsyncBareReturnAnnotationBlame(t *testing.T) {
 	src := "async fn f() -> number { return 5 }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"async function return type must be a Promise; write Promise<...> or Promise<_>",
+		"1:17-1:23: async function return type must be a Promise; write Promise<...> or Promise<_>",
 		"number",
 		"async fn f() -> number { return 5 }")
 }
@@ -138,7 +138,7 @@ func TestInferAwaitOutsideAsyncRejected(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+	require.Equal(t, "3:4-3:11: await can only be used inside an async function", msgWithSpan(errs[0]))
 }
 
 // The await-outside-async error points Related() at the enclosing (non-async)
@@ -148,7 +148,7 @@ func TestInferAwaitOutsideAsyncBlamesEnclosingFn(t *testing.T) {
 	src := "fn f(p: Promise<string>) { await p }"
 	_, _, errs := inferSource(t, src)
 	requireBlame(t, src, errs,
-		"await can only be used inside an async function", "await p",
+		"1:28-1:35: await can only be used inside an async function", "await p",
 		"fn f(p: Promise<string>) { await p }")
 }
 
@@ -178,7 +178,7 @@ func TestInferAwaitOfNonPromiseFails(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain number <: Promise<t1>", errs[0].Message())
+	require.Equal(t, "3:4-3:11: cannot constrain number <: Promise<t1>", msgWithSpan(errs[0]))
 }
 
 // `await` inside an async fn nested under a non-async outer must still resolve
@@ -208,7 +208,7 @@ func TestInferAwaitInOuterAfterInnerAsync(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+	require.Equal(t, "4:4-4:11: await can only be used inside an async function", msgWithSpan(errs[0]))
 }
 
 // --- Block return-point join ---
@@ -258,8 +258,8 @@ func TestInferBlockNonTailReturnCheckedAgainstAnnotation(t *testing.T) {
 	// join var has "oops" as a lower bound, propagated through constrain to the
 	// return annotation. The string literal's primitive does not satisfy number.
 	require.Len(t, errs, 1)
-	require.Contains(t, errs[0].Message(), `"oops"`)
-	require.Contains(t, errs[0].Message(), "number")
+	require.Contains(t, msgWithSpan(errs[0]), `"oops"`)
+	require.Contains(t, msgWithSpan(errs[0]), "number")
 }
 
 // An `async fn` joined with multiple returns wraps the join in Promise. The
@@ -313,7 +313,7 @@ func TestInferIfElseConditionMustBeBool(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain string <: boolean", errs[0].Message())
+	require.Equal(t, "3:7-3:8: cannot constrain string <: boolean", msgWithSpan(errs[0]))
 }
 
 // --- Unit-level (against hand-built AST) ---
@@ -380,7 +380,7 @@ func TestInferIfElseUnknownConditionNoCascade(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: undeclared", errs[0].Message())
+	require.Equal(t, "3:14-3:24: Unknown identifier: undeclared", msgWithSpan(errs[0]))
 	require.Equal(t, "fn () -> 1 | 2", values["pick"])
 }
 
@@ -395,7 +395,7 @@ func TestInferAwaitUnknownArgNoCascade(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: undeclared", errs[0].Message())
+	require.Equal(t, "3:17-3:27: Unknown identifier: undeclared", msgWithSpan(errs[0]))
 	require.Equal(t, "fn () -> Promise<never>", values["f"])
 }
 
@@ -411,7 +411,7 @@ func TestInferPromiseUnsupportedInnerKeepsWrapper(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "2:19-2:25: Unsupported: BigintTypeAnn", msgWithSpan(errs[0]))
 	require.Equal(t, "fn (p: Promise<unknown>) -> 0", values["f"])
 }
 
@@ -426,7 +426,7 @@ func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: BigintTypeAnn", errs[0].Message())
+	require.Equal(t, "2:19-2:25: Unsupported: BigintTypeAnn", msgWithSpan(errs[0]))
 	require.Equal(t, "fn <T0>(p: Promise<T0>) -> Promise<T0>", values["f"])
 }
 
@@ -437,15 +437,18 @@ func TestInferPromiseUnsupportedInnerGeneralizes(t *testing.T) {
 // drop the annotation. Both surface forms: `Promise<'a, T>` (lifetime arg) and
 // `'a Promise<T>` (leading lifetime).
 func TestInferPromiseLifetimeRejected(t *testing.T) {
-	tests := map[string]string{
-		"lifetime arg":     "fn f(p: Promise<'a, number>) { 0 }",
-		"leading lifetime": "fn f(p: 'a Promise<number>) { 0 }",
+	tests := map[string]struct {
+		src  string
+		want string
+	}{
+		"lifetime arg":     {"fn f(p: Promise<'a, number>) { 0 }", "1:9-1:28: Unsupported: lifetime annotation on Promise"},
+		"leading lifetime": {"fn f(p: 'a Promise<number>) { 0 }", "1:12-1:27: Unsupported: lifetime annotation on Promise"},
 	}
-	for name, src := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, src)
+			_, _, errs := inferSource(t, tc.src)
 			require.Len(t, errs, 1)
-			require.Equal(t, "Unsupported: lifetime annotation on Promise", errs[0].Message())
+			require.Equal(t, tc.want, msgWithSpan(errs[0]))
 		})
 	}
 }
@@ -460,7 +463,7 @@ func TestInferReturnOutsideFunctionRejected(t *testing.T) {
 		val x = if true { return 5 } else { 6 }
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "return can only be used inside a function", errs[0].Message())
+	require.Equal(t, "2:21-2:29: return can only be used inside a function", msgWithSpan(errs[0]))
 	require.Equal(t, "6", values["x"])
 }
 
@@ -518,8 +521,8 @@ func TestInferIfElseBothBranchesDivergeYieldsNever(t *testing.T) {
 		val x = if true { return 1 } else { return 2 }
 	`)
 	require.Len(t, errs, 2)
-	require.Equal(t, "return can only be used inside a function", errs[0].Message())
-	require.Equal(t, "return can only be used inside a function", errs[1].Message())
+	require.Equal(t, "2:21-2:29: return can only be used inside a function", msgWithSpan(errs[0]))
+	require.Equal(t, "2:39-2:47: return can only be used inside a function", msgWithSpan(errs[1]))
 	require.Equal(t, "never", values["x"])
 }
 

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -67,7 +67,7 @@ func TestInferValBorrowFromOwnedImm(t *testing.T) {
 }`)
 	require.Equal(t, []string{
 		"cannot return borrow of local 'p': 'p' does not live long enough",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -95,7 +95,7 @@ func TestInferValMutBorrowFromOwnedMut(t *testing.T) {
 }`)
 	require.Equal(t, []string{
 		"cannot return borrow of local 'p': 'p' does not live long enough",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -107,8 +107,8 @@ func TestInferBorrowMutOnImmutableRejected(t *testing.T) {
   return q
 }`)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
-	}, Messages(errs))
+		"2:11-2:17: cannot constrain immutable object <: mutable object",
+	}, messagesWithSpan(errs))
 }
 
 // --- Rule 3 (binding initializer): owned-mutable construction ------------------
@@ -270,7 +270,7 @@ func TestInferValAnnotatedBorrowImm(t *testing.T) {
 }`)
 	require.Equal(t, []string{
 		"cannot return borrow of local 'p': 'p' does not live long enough",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -286,7 +286,7 @@ func TestInferValAnnotatedBorrowMut(t *testing.T) {
 }`)
 	require.Equal(t, []string{
 		"cannot return borrow of local 'p': 'p' does not live long enough",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -331,8 +331,8 @@ fn f(p: {x: number}) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
-	}, Messages(errs))
+		"5:10-5:16: cannot constrain immutable object <: mutable object",
+	}, messagesWithSpan(errs))
 }
 
 // --- Borrow expressions infer to borrow types ----------------------------------
@@ -362,7 +362,7 @@ func TestInferBorrowExprMutFromOwnedMut(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: mut {x: number}) { return &mut p }`)
 	require.Equal(t, []string{
 		"cannot return borrow of local 'p': 'p' does not live long enough",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -373,8 +373,8 @@ func TestInferBorrowExprMutFromOwnedMut(t *testing.T) {
 func TestInferBorrowExprAbsorbsUnknownIdentifier(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f() { return &q }`)
 	require.Equal(t, []string{
-		"Unknown identifier: q",
-	}, Messages(errs))
+		"1:18-1:19: Unknown identifier: q",
+	}, messagesWithSpan(errs))
 }
 
 // A borrow of a primitive value reports the unsupported-borrow diagnostic once.
@@ -383,8 +383,8 @@ func TestInferBorrowExprAbsorbsUnknownIdentifier(t *testing.T) {
 func TestInferBorrowExprOfPrimitiveRecovers(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f() { return &5 }`)
 	require.Equal(t, []string{
-		"Unsupported: borrow of a non-borrowable type",
-	}, Messages(errs))
+		"1:17-1:19: Unsupported: borrow of a non-borrowable type",
+	}, messagesWithSpan(errs))
 }
 
 // Passing an explicit `&p` argument into a `&` parameter type-checks the same as

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -63,8 +63,8 @@ fn f(p: &mut {x: number}) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"borrowed value mut object does not live long enough to satisfy object",
-	}, Messages(errs))
+		"4:9-4:25: borrowed value mut object does not live long enough to satisfy object",
+	}, messagesWithSpan(errs))
 }
 
 // The companion to the escape case: passing the same borrow into a function
@@ -110,8 +110,8 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
-	}, Messages(errs))
+		"2:3-2:10: cannot constrain immutable object <: mutable object",
+	}, messagesWithSpan(errs))
 }
 
 // Returning one of two borrows with DISTINCT lifetimes joins them into a single
@@ -225,9 +225,9 @@ func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"cannot constrain number <: string",
-		"cannot constrain string <: number",
-	}, Messages(errs))
+		"1:18-1:24: cannot constrain number <: string",
+		"1:39-1:45: cannot constrain string <: number",
+	}, messagesWithSpan(errs))
 }
 
 // A return set mixing a borrow with an OWNED value does not join. joinBorrows
@@ -256,7 +256,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
 		"mixed-ownership union: members disagree on ownership; make ownership uniform first",
-	}, Messages(errs))
+	}, messagesWithSpan(errs))
 }
 */
 
@@ -332,8 +332,8 @@ func TestInferBorrowAliasEscapingOwnedReturnRejected(t *testing.T) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"borrowed value object does not live long enough to satisfy object",
-	}, Messages(errs))
+		"1:30-1:41: borrowed value object does not live long enough to satisfy object",
+	}, messagesWithSpan(errs))
 }
 
 // An owned-immutable source binds through an owned annotation as an owned
@@ -441,7 +441,7 @@ func TestInferNamedBorrowLifetimeShared(t *testing.T) {
 // fabricating a borrow over a non-borrowable type.
 func TestInferBorrowOfNonBorrowableRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f(p: &number) -> number { return 0 }`)
-	require.Equal(t, []string{"Unsupported: borrow of a non-borrowable type"}, Messages(errs))
+	require.Equal(t, []string{"1:9-1:16: Unsupported: borrow of a non-borrowable type"}, messagesWithSpan(errs))
 }
 
 // --- PR 4: member reads borrow the receiver ---
@@ -580,8 +580,8 @@ func TestInferExplicitMutBorrowOfMemberOnImmutableRejected(t *testing.T) {
 }`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
-	}, Messages(errs))
+		"1:11-1:28: cannot constrain immutable object <: mutable object",
+	}, messagesWithSpan(errs))
 }
 
 // A usage-inferred receiver keeps its pre-PR-4 read behaviour. A

--- a/internal/solver/infer_exact_test.go
+++ b/internal/solver/infer_exact_test.go
@@ -32,7 +32,7 @@ func TestInferCallExactTooManyArgsSingleDiagnostic(t *testing.T) {
 		val r = f(1, 2, 3)
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Too many arguments: expected at most 2, but got 3", errs[0].Message())
+	require.Equal(t, "3:11-3:21: Too many arguments: expected at most 2, but got 3", msgWithSpan(errs[0]))
 }
 
 // An `x?` optional parameter parsed from source carries onto the function type: it
@@ -62,7 +62,7 @@ func TestInferOptionalParamCallArity(t *testing.T) {
 			val c = f(1, 2, 3)
 		`)
 		require.Len(t, errs, 1)
-		require.Equal(t, "Too many arguments: expected at most 2, but got 3", errs[0].Message())
+		require.Equal(t, "3:12-3:22: Too many arguments: expected at most 2, but got 3", msgWithSpan(errs[0]))
 	})
 }
 
@@ -77,7 +77,7 @@ func TestInferNonTrailingOptionalRequiresAllArgs(t *testing.T) {
 		val r = f(1)
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Not enough arguments: expected at least 2, but got 1", errs[0].Message())
+	require.Equal(t, "3:11-3:15: Not enough arguments: expected at least 2, but got 1", msgWithSpan(errs[0]))
 }
 
 // A function value declared with the trailing `...` marker now parses (PR4 parser
@@ -97,7 +97,7 @@ func TestInferInexactFunctionValue(t *testing.T) {
 			val r = f(1, 2)
 		`)
 		require.Len(t, errs, 1)
-		require.Equal(t, "Too many arguments: expected at most 1, but got 2", errs[0].Message())
+		require.Equal(t, "3:12-3:19: Too many arguments: expected at most 1, but got 2", msgWithSpan(errs[0]))
 	})
 }
 
@@ -109,7 +109,7 @@ func TestInferTooFewArgsRespectsOptional(t *testing.T) {
 		val r = f()
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Not enough arguments: expected at least 1, but got 0", errs[0].Message())
+	require.Equal(t, "3:11-3:14: Not enough arguments: expected at least 1, but got 0", msgWithSpan(errs[0]))
 }
 
 // A typed rest param absorbs trailing arguments, so a direct call with more args

--- a/internal/solver/infer_lattice_test.go
+++ b/internal/solver/infer_lattice_test.go
@@ -30,7 +30,7 @@ func TestInferUnionAnnotationRejectsNonMember(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &CannotConstrainError{}, errs[0])
-	require.Equal(t, "cannot constrain boolean <: number | string", errs[0].Message())
+	require.Equal(t, "3:29-3:30: cannot constrain boolean <: number | string", msgWithSpan(errs[0]))
 }
 
 func TestInferUnionAnnotationRoundTrip(t *testing.T) {
@@ -51,7 +51,7 @@ func TestInferIntersectionAnnotationRejectsMissingMember(t *testing.T) {
 	_, _, errs := inferSource(t, `val r: {x: number, ...} & {y: string, ...} = {x: 1}`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &MissingPropertyError{}, errs[0])
-	require.Equal(t, "object is missing property: y", errs[0].Message())
+	require.Equal(t, "1:31-1:37: object is missing property: y", msgWithSpan(errs[0]))
 }
 
 func TestInferUnionAnnotationFlattens(t *testing.T) {
@@ -65,7 +65,7 @@ func TestInferUnionAnnotationFlattens(t *testing.T) {
 // resolveTypeAnn first.
 func TestInferUnionAnnotationDedups(t *testing.T) {
 	values, _, errs := inferSource(t, `val x: number | number = 5`)
-	require.Equal(t, []string(nil), Messages(errs))
+	require.Equal(t, []string(nil), messagesWithSpan(errs))
 	require.Equal(t, "number", values["x"])
 }
 
@@ -78,6 +78,6 @@ func TestInferUnionAnnotationBorrowMember(t *testing.T) {
 			val v: &mut {x: number} | number = r
 		}
 	`)
-	require.Equal(t, []string(nil), Messages(errs))
+	require.Equal(t, []string(nil), messagesWithSpan(errs))
 	require.Equal(t, "fn (r: &mut {x: number}) -> void", values["check"])
 }

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -156,9 +156,9 @@ func TestInferMemberAssignAnnotatedMutObject(t *testing.T) {
 func TestInferMemberAssignAnnotatedMutWrongType(t *testing.T) {
 	_, _, errs := inferSource(t, "fn f(obj: mut {x: number, y: string}) { obj.x = \"bad\" }")
 	require.Equal(t, []string{
-		"cannot constrain number <: string",
-		"cannot constrain string <: number",
-	}, Messages(errs))
+		"1:41-1:54: cannot constrain number <: string",
+		"1:41-1:54: cannot constrain string <: number",
+	}, messagesWithSpan(errs))
 }
 
 // Writing a field absent from an EXACT annotated mut object still errors: the read
@@ -166,7 +166,7 @@ func TestInferMemberAssignAnnotatedMutWrongType(t *testing.T) {
 func TestInferMemberAssignAnnotatedMutMissingField(t *testing.T) {
 	src := "fn f(obj: mut {x: number}) { obj.z = 5 }"
 	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{"object is missing property: z"}, Messages(errs))
+	require.Equal(t, []string{"1:15-1:26: object is missing property: z"}, messagesWithSpan(errs))
 }
 
 // KNOWN GAP: two writes of INCOMPATIBLE types to one field produce an uninhabited

--- a/internal/solver/infer_member_assign_test.go
+++ b/internal/solver/infer_member_assign_test.go
@@ -20,7 +20,8 @@ import (
 // contributes a mutable one-property requirement, and the fold unions them and wraps
 // the whole object in `mut`.
 func TestInferMemberAssignTwoWrites(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.y = 10 }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ obj.y = 10 }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number, y: number}) -> void", values["foo"])
 }
@@ -29,7 +30,8 @@ func TestInferMemberAssignTwoWrites(t *testing.T) {
 // recorded concrete (widened) type, not a fresh var, so `obj.x = 5; return obj.x` is
 // `number`. The receiver renders `mut {x: number}` from the single write.
 func TestInferMemberAssignReadAfterWrite(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj.x }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ return obj.x }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number}) -> number", values["foo"])
 }
@@ -41,7 +43,8 @@ func TestInferMemberAssignReadAfterWrite(t *testing.T) {
 // polarities and is retained as a type parameter `T0` the caller picks, rather than
 // inlined to `unknown`. The written `baz` is the widened `number`.
 func TestInferMemberAssignMixedReadWrite(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.bar\n obj.baz = 5 }")
+	values, _, errs := inferSource(t, `fn foo(obj) { val x = obj.bar
+ obj.baz = 5 }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T0>(obj: mut {bar: T0, baz: number}) -> void", values["foo"])
 }
@@ -58,7 +61,8 @@ func TestInferMemberAssignCompoundValueWidens(t *testing.T) {
 // widened source: `val r = (obj.x = 5)` ⇒ r: number, used inside a function so the
 // receiver is an inferable place.
 func TestInferMemberAssignValueIsStored(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { val r = (obj.x = 5)\n return r }")
+	values, _, errs := inferSource(t, `fn foo(obj) { val r = (obj.x = 5)
+ return r }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number}) -> number", values["foo"])
 }
@@ -66,7 +70,8 @@ func TestInferMemberAssignValueIsStored(t *testing.T) {
 // Writing different literal values to the same field is the same widened primitive,
 // so the field stays `number` (no contradiction between `5` and `10`).
 func TestInferMemberAssignSameFieldTwice(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = 10 }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ obj.x = 10 }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number}) -> void", values["foo"])
 }
@@ -76,7 +81,8 @@ func TestInferMemberAssignSameFieldTwice(t *testing.T) {
 // type parameter rather than collapsing to `unknown`, because it occurs in an output
 // position. This is the key interplay between the C3 mut-merge and generalization.
 func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj.y }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ return obj.y }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T0>(obj: mut {x: number, y: T0}) -> T0", values["foo"])
 }
@@ -87,7 +93,9 @@ func TestInferMemberAssignWrittenAndEscapingReadField(t *testing.T) {
 // value (returned `x`) stays `T0`. This pins the plan's claim that write-after-read
 // falls out of ordinary constraint accumulation, the reverse of read-after-write.
 func TestInferMemberAssignWriteAfterRead(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { val x = obj.x\n obj.x = 5\n return x }")
+	values, _, errs := inferSource(t, `fn foo(obj) { val x = obj.x
+ obj.x = 5
+ return x }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T0>(obj: mut {x: T0 & number}) -> T0", values["foo"])
 }
@@ -117,7 +125,8 @@ func TestInferMemberAssignOpenParam(t *testing.T) {
 // occurs in an output position, so the param keeps an open row and renders as the
 // written requirement intersected with the returned type parameter.
 func TestInferMemberAssignWrittenObjectEscapes(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n return obj }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ return obj }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T0>(obj: T0 & mut {x: number}) -> T0", values["foo"])
 }
@@ -177,7 +186,8 @@ func TestInferMemberAssignAnnotatedMutMissingField(t *testing.T) {
 // TODO(#738): report conflicting writes to one field instead of folding to an
 // uninhabited intersection.
 func TestInferMemberAssignConflictingWritesNoError(t *testing.T) {
-	values, _, errs := inferSource(t, "fn foo(obj) { obj.x = 5\n obj.x = \"hi\" }")
+	values, _, errs := inferSource(t, `fn foo(obj) { obj.x = 5
+ obj.x = "hi" }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn (obj: mut {x: number & string}) -> void", values["foo"])
 }

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -26,7 +26,7 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"5:6-5:9: use of moved value 'p'"},
 		},
 		// An explicit `&` borrow does not move the source.
 		"BorrowBindingKeepsSource": {
@@ -58,7 +58,7 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"6:6-6:9: use of moved value 'p'"},
 		},
 		// Passing an owned value to a `&` parameter auto-borrows and keeps it usable.
 		"BorrowParameterKeepsArgument": {
@@ -84,8 +84,8 @@ func TestMoveSemantics(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"Too many arguments: expected at most 1, but got 2",
-				"use of moved value 'p'",
+				"5:6-5:17: Too many arguments: expected at most 1, but got 2",
+				"6:6-6:9: use of moved value 'p'",
 			},
 		},
 		// Returning an owned value moves it out of the frame. A second occurrence of the
@@ -97,7 +97,7 @@ func TestMoveSemantics(t *testing.T) {
 					return [x, x]
 				}
 			`,
-			want: []string{"use of moved value 'x'"},
+			want: []string{"3:17-3:18: use of moved value 'x'"},
 		},
 		// A borrow parameter is copied, not moved, so the body may return it twice. This
 		// is the concrete counterpart to the generic `fn dup<T>(x: &T)`; the
@@ -118,7 +118,7 @@ func TestMoveSemantics(t *testing.T) {
 					xs
 				}
 			`,
-			want: []string{"use of moved value 'xs'"},
+			want: []string{"5:6-5:8: use of moved value 'xs'"},
 		},
 		// A value moved on only one branch is a conditional use-after-move at a later
 		// read, since some reaching path moved it.
@@ -134,7 +134,7 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"9:6-9:9: use of moved value 'p'"},
 		},
 		// A value moved on every branch is an unconditional use-after-move at a later
 		// read.
@@ -151,7 +151,7 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"10:6-10:9: use of moved value 'p'"},
 		},
 		// A move confined to one branch does not consume the source on the path that did
 		// not move it, so a use inside the untouched branch is allowed.
@@ -178,7 +178,7 @@ func TestMoveSemantics(t *testing.T) {
 					p.x
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"6:6-6:9: use of moved value 'p'"},
 		},
 		// The move reconciliation is path-sensitive. A consuming move of p on one branch
 		// does not suppress the exclusivity check for p on a sibling branch where it was
@@ -199,7 +199,7 @@ func TestMoveSemantics(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'p' to immutable 'snapshot': 'p' is still used mutably after this point",
+				"8:7-8:37: cannot assign 'p' to immutable 'snapshot': 'p' is still used mutably after this point",
 			},
 		},
 		// Storing p into the global consumes it, so the later borrow `val snap = p` is a
@@ -213,7 +213,7 @@ func TestMoveSemantics(t *testing.T) {
 					snap
 				}
 			`,
-			want: []string{"use of moved value 'p'"},
+			want: []string{"5:31-5:32: use of moved value 'p'"},
 		},
 		// Moving a value while a mutable borrow of it is live is rejected: freezing p
 		// into immutable q while r still holds a mutable borrow would let r mutate a
@@ -229,7 +229,7 @@ func TestMoveSemantics(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'p' to immutable 'q': 'r' still has mutable access to 'p' after this point",
+				"5:6-5:28: cannot assign 'p' to immutable 'q': 'r' still has mutable access to 'p' after this point",
 			},
 		},
 		// Binding a borrowed source into a bare owned annotation is a borrow-into-owned
@@ -243,7 +243,7 @@ func TestMoveSemantics(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"borrowed value mut object does not live long enough to satisfy object",
+				"2:13-2:29: borrowed value mut object does not live long enough to satisfy object",
 			},
 		},
 		// Moving one field out of an owned object consumes only that field's slot. The
@@ -259,7 +259,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"7:6-7:15: use of moved value 'pair.a'"},
 		},
 		// Reading a sibling field after a partial move is allowed on its own.
 		"SiblingAfterPartialMoveAccepted": {
@@ -283,7 +283,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair
 				}
 			`,
-			want: []string{"use of partially moved value 'pair'; field 'pair.a' was moved out"},
+			want: []string{"6:6-6:10: use of partially moved value 'pair'; field 'pair.a' was moved out"},
 		},
 		// Binding a field into an owned binding moves that field; a later read of it is a
 		// use-after-move.
@@ -295,7 +295,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"5:6-5:15: use of moved value 'pair.a'"},
 		},
 		// Storing a field into a longer-lived object moves it; the sibling stays usable.
 		"PartialMoveViaFieldStore": {
@@ -308,7 +308,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"7:6-7:15: use of moved value 'pair.a'"},
 		},
 		// A field built into a tuple literal moves as a partial move, the gap PR 6 left
 		// for PR 7 to close; the sibling stays usable.
@@ -321,7 +321,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"6:6-6:15: use of moved value 'pair.a'"},
 		},
 		// A field moved on only one branch is a conditional use-after-move at a later
 		// read, joined to MaybeMoved at the branch merge.
@@ -337,7 +337,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a'"},
+			want: []string{"9:6-9:15: use of moved value 'pair.a'"},
 		},
 		// Tracking reaches nested field paths. Moving `pair.a.inner` consumes only that
 		// deep slot, so the sibling `pair.a.keep` stays usable and a read of the moved
@@ -352,7 +352,7 @@ func TestMoveSemantics(t *testing.T) {
 					pair.a.inner.id
 				}
 			`,
-			want: []string{"use of moved value 'pair.a.inner'"},
+			want: []string{"7:6-7:21: use of moved value 'pair.a.inner'"},
 		},
 		// A field whose key is not a valid identifier is reached by constant-string
 		// index and renders in bracket notation, so the moved place reads back as
@@ -366,14 +366,14 @@ func TestMoveSemantics(t *testing.T) {
 					pair["a.b"].x
 				}
 			`,
-			want: []string{`use of moved value 'pair["a.b"]'`},
+			want: []string{`6:6-6:19: use of moved value 'pair["a.b"]'`},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, Messages(errs))
+			require.Equal(t, tc.want, messagesWithSpan(errs))
 		})
 	}
 }
@@ -393,7 +393,7 @@ func TestThawMove(t *testing.T) {
 			p.x
 		}
 	`)
-	require.Equal(t, []string{"use of moved value 'p'"}, Messages(errs))
+	require.Equal(t, []string{"6:4-6:7: use of moved value 'p'"}, messagesWithSpan(errs))
 }
 
 // TestFreezeMove covers the mutable→immutable freeze. A plain `val q = p` for an
@@ -412,9 +412,9 @@ func TestFreezeMove(t *testing.T) {
 		}
 	`)
 	require.Equal(t, []string{
-		"cannot constrain immutable object <: mutable object",
-		"use of moved value 'p'",
-	}, Messages(errs))
+		"6:4-6:11: cannot constrain immutable object <: mutable object",
+		"7:4-7:7: use of moved value 'p'",
+	}, messagesWithSpan(errs))
 }
 
 // TestFreezeMoveAllowed shows the freeze move itself is allowed. Binding an

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -94,7 +94,7 @@ func TestInferTupleSpreadInexactNotLast(t *testing.T) {
 		fn f(z: [number, ...]) { return [...z, 1] }
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot spread an inexact tuple except as the last element", errs[0].Message())
+	require.Equal(t, "2:36-2:40: cannot spread an inexact tuple except as the last element", msgWithSpan(errs[0]))
 }
 
 // A trailing inexact spread is sound: the operand's known prefix extends the
@@ -323,7 +323,7 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 		`
 		_, _, errs := inferSource(t, src)
 		require.Len(t, errs, 1)
-		require.Equal(t, "object has extra property: b", errs[0].Message())
+		require.Equal(t, "3:24-3:25: object has extra property: b", msgWithSpan(errs[0]))
 	})
 
 	t.Run("wider object is accepted for an open param", func(t *testing.T) {
@@ -345,8 +345,8 @@ func TestInferModuleMemberReadAcceptsWiderArg(t *testing.T) {
 		// missing `a` and the extra `b`. The object arm reports missing properties
 		// before extra ones.
 		require.Len(t, errs, 2)
-		require.Equal(t, "object is missing property: a", errs[0].Message())
-		require.Equal(t, "object has extra property: b", errs[1].Message())
+		require.Equal(t, "3:14-3:20: object is missing property: a", msgWithSpan(errs[0]))
+		require.Equal(t, "3:18-3:19: object has extra property: b", msgWithSpan(errs[1]))
 		// Blame the offending argument {b: 2} — the object that lacks the field — not
 		// the whole call. The requirement's field var is freshened on instantiation
 		// and carries no prov, so MissingPropertyError's blame degrades to the Sub

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -12,33 +12,41 @@ import (
 // extra fields to the open param checks.
 func TestInferOpenParam(t *testing.T) {
 	t.Run("open param renders inexact", func(t *testing.T) {
-		values, _, errs := inferSource(t, "fn dist(open p) { p.x\n p.y }")
+		values, _, errs := inferSource(t, `fn dist(open p) { p.x
+ p.y }`)
 		require.Empty(t, errs)
 		require.Equal(t, "fn (p: {x: unknown, y: unknown, ...}) -> void", values["dist"])
 	})
 
 	t.Run("un-open peer renders exact", func(t *testing.T) {
-		values, _, errs := inferSource(t, "fn dist(p) { p.x\n p.y }")
+		values, _, errs := inferSource(t, `fn dist(p) { p.x
+ p.y }`)
 		require.Empty(t, errs)
 		require.Equal(t, "fn (p: {x: unknown, y: unknown}) -> void", values["dist"])
 	})
 
 	t.Run("passing extra fields to an open param checks", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(open p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
+		_, _, errs := inferSource(t, `fn foo(open p) { p.x
+ p.y }
+val r = foo({x: 1, y: 2, z: 3})`)
 		require.Empty(t, errs)
 	})
 
 	// The operative seal (B2): a closed param's requirement is sealed to exact at
 	// generalization, so a call passing an object with extra fields is rejected.
 	t.Run("passing extra fields to a closed param rejects", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
+		_, _, errs := inferSource(t, `fn foo(p) { p.x
+ p.y }
+val r = foo({x: 1, y: 2, z: 3})`)
 		require.Len(t, errs, 1)
 		require.Equal(t, "3:29-3:30: object has extra property: z", msgWithSpan(errs[0]))
 	})
 
 	// An exact argument still checks against a closed param.
 	t.Run("passing the exact shape to a closed param checks", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2})")
+		_, _, errs := inferSource(t, `fn foo(p) { p.x
+ p.y }
+val r = foo({x: 1, y: 2})`)
 		require.Empty(t, errs)
 	})
 
@@ -69,23 +77,27 @@ func TestInferOpenParamNested(t *testing.T) {
 	})
 
 	t.Run("open accepts an extra field on the nested object", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(open p) { p.a.b }\nval r = foo({a: {b: 1, c: 2}})")
+		_, _, errs := inferSource(t, `fn foo(open p) { p.a.b }
+val r = foo({a: {b: 1, c: 2}})`)
 		require.Empty(t, errs)
 	})
 
 	t.Run("open accepts an extra field on the outer object", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(open p) { p.a.b }\nval r = foo({a: {b: 1}, d: 2})")
+		_, _, errs := inferSource(t, `fn foo(open p) { p.a.b }
+val r = foo({a: {b: 1}, d: 2})`)
 		require.Empty(t, errs)
 	})
 
 	t.Run("closed rejects an extra field on the nested object", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1, c: 2}})")
+		_, _, errs := inferSource(t, `fn foo(p) { p.a.b }
+val r = foo({a: {b: 1, c: 2}})`)
 		require.Len(t, errs, 1)
 		require.Equal(t, "2:27-2:28: object has extra property: c", msgWithSpan(errs[0]))
 	})
 
 	t.Run("closed rejects an extra field on the outer object", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1}, d: 2})")
+		_, _, errs := inferSource(t, `fn foo(p) { p.a.b }
+val r = foo({a: {b: 1}, d: 2})`)
 		require.Len(t, errs, 1)
 		require.Equal(t, "2:28-2:29: object has extra property: d", msgWithSpan(errs[0]))
 	})

--- a/internal/solver/infer_open_test.go
+++ b/internal/solver/infer_open_test.go
@@ -33,7 +33,7 @@ func TestInferOpenParam(t *testing.T) {
 	t.Run("passing extra fields to a closed param rejects", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn foo(p) { p.x\n p.y }\nval r = foo({x: 1, y: 2, z: 3})")
 		require.Len(t, errs, 1)
-		require.Equal(t, "object has extra property: z", errs[0].Message())
+		require.Equal(t, "3:29-3:30: object has extra property: z", msgWithSpan(errs[0]))
 	})
 
 	// An exact argument still checks against a closed param.
@@ -81,12 +81,12 @@ func TestInferOpenParamNested(t *testing.T) {
 	t.Run("closed rejects an extra field on the nested object", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1, c: 2}})")
 		require.Len(t, errs, 1)
-		require.Equal(t, "object has extra property: c", errs[0].Message())
+		require.Equal(t, "2:27-2:28: object has extra property: c", msgWithSpan(errs[0]))
 	})
 
 	t.Run("closed rejects an extra field on the outer object", func(t *testing.T) {
 		_, _, errs := inferSource(t, "fn foo(p) { p.a.b }\nval r = foo({a: {b: 1}, d: 2})")
 		require.Len(t, errs, 1)
-		require.Equal(t, "object has extra property: d", errs[0].Message())
+		require.Equal(t, "2:28-2:29: object has extra property: d", msgWithSpan(errs[0]))
 	})
 }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -58,8 +58,8 @@ func TestInferOverloadDuplicateParamTypesRejected(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		"Overload arms must have distinguishable parameter types: f",
-		errs[0].Message())
+		"3:3-3:45: Overload arms must have distinguishable parameter types: f",
+		msgWithSpan(errs[0]))
 }
 
 // Cross-file declaration order is pinned to SOURCE POSITION (file path alphabetically,
@@ -124,8 +124,8 @@ func TestInferOverloadNoMatch(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		"No matching overload for this call\n  fn (x: number) -> number\n  fn (x: string) -> string",
-		errs[0].Message())
+		"4:11-4:18: No matching overload for this call\n  fn (x: number) -> number\n  fn (x: string) -> string",
+		msgWithSpan(errs[0]))
 }
 
 // A mutually-recursive group containing an overloaded function with un-annotated
@@ -139,8 +139,8 @@ func TestInferOverloadMutualRecursionRequiresAnnotation(t *testing.T) {
 	`)
 	require.Len(t, errs, 1)
 	require.Equal(t,
-		"Overloaded function in a recursive group must have fully-annotated signatures: f",
-		errs[0].Message())
+		"2:3-2:19: Overloaded function in a recursive group must have fully-annotated signatures: f",
+		msgWithSpan(errs[0]))
 }
 
 // A self-recursive fully-annotated overload type-checks: each arm's recursive call
@@ -325,7 +325,7 @@ func TestInferOverloadMixedWithValIsDuplicate(t *testing.T) {
 		val f = 5
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Duplicate declaration: f", errs[0].Message())
+	require.Equal(t, "4:3-4:12: Duplicate declaration: f", msgWithSpan(errs[0]))
 	require.Equal(t, "(fn (x: number) -> number) & (fn (x: string) -> string)", values["f"],
 		"the two functions still overload; only the val is rejected")
 }
@@ -341,7 +341,7 @@ func TestInferOverloadMixedWithValCrossFileIsDuplicate(t *testing.T) {
 		"b.esc": `val f = 5`,
 	})
 	require.Len(t, errs, 1)
-	require.Equal(t, "Duplicate declaration: f", errs[0].Message())
+	require.Equal(t, "1:1-1:10: Duplicate declaration: f", msgWithSpan(errs[0]))
 	require.Equal(t, "fn (x: number) -> number", values["f"],
 		"the cross-file val is rejected; the fn binding survives")
 }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -74,7 +74,8 @@ func TestInferOverloadCrossFileDeclarationOrder(t *testing.T) {
 	defer cancel()
 	sources := []*ast.Source{
 		{ID: 0, Path: "b.esc", Contents: `fn f(x: string) -> boolean { return true }`},
-		{ID: 1, Path: "a.esc", Contents: "fn f(x: number) -> string { return \"s\" }\nval r = f(5)"},
+		{ID: 1, Path: "a.esc", Contents: `fn f(x: number) -> string { return "s" }
+val r = f(5)`},
 	}
 	module, parseErrs := parser.ParseLibFiles(ctx, sources)
 	require.Empty(t, parseErrs, "expected no parse errors")

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -46,7 +46,7 @@ func TestInferValObjectPatternMissingField(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "object is missing property: z", errs[0].Message())
+	require.Equal(t, "2:11-2:22: object is missing property: z", msgWithSpan(errs[0]))
 }
 
 // A tuple pattern binds per slot at the slot's element type. Reordering the bound
@@ -72,7 +72,7 @@ func TestInferValTuplePatternWrongArity(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain tuple of length 2 <: tuple of length 3", errs[0].Message())
+	require.Equal(t, "2:11-2:27: cannot constrain tuple of length 2 <: tuple of length 3", msgWithSpan(errs[0]))
 }
 
 // A destructuring parameter types like a `val` destructuring of the argument: the
@@ -134,7 +134,7 @@ func TestInferObjectPatternLeafTypeAnnConflict(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain number <: string", errs[0].Message())
+	require.Equal(t, "3:9-3:20: cannot constrain number <: string", msgWithSpan(errs[0]))
 }
 
 // A matching leaf type annotation checks and is adopted as the leaf's type.
@@ -174,7 +174,7 @@ func TestInferTuplePatternRestPrefix(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: RestPat", errs[0].Message())
+	require.Equal(t, "3:12-3:19: Unsupported: RestPat", msgWithSpan(errs[0]))
 	require.Equal(t, "fn (t: [number, string, boolean]) -> number", values["f"])
 }
 
@@ -242,7 +242,7 @@ func TestInferObjectPatternLeafDefaultViolatesAnnotation(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+	require.Equal(t, `3:23-3:27: cannot constrain "hi" <: number`, msgWithSpan(errs[0]))
 }
 
 // --- M4 E2: the `match` expression ---
@@ -335,7 +335,7 @@ func TestInferMatchInexactNeedsCatchAll(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "match is not exhaustive; add a catch-all branch", errs[0].Message())
+	require.Equal(t, "3:11-5:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
 // An inexact-object scrutinee with an unguarded catch-all arm is exhaustive.
@@ -364,7 +364,7 @@ func TestInferMatchGuardedArmDoesNotCover(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "match is not exhaustive; add a catch-all branch", errs[0].Message())
+	require.Equal(t, "3:11-5:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
 // A guard is typed as a boolean over the arm's bindings, so a non-boolean guard is
@@ -379,7 +379,7 @@ func TestInferMatchGuardMustBeBoolean(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain number <: boolean", errs[0].Message())
+	require.Equal(t, "4:12-4:13: cannot constrain number <: boolean", msgWithSpan(errs[0]))
 }
 
 // An arm whose only structural pattern is refutable does not cover an exact
@@ -394,7 +394,7 @@ func TestInferMatchRefutableArmNonExhaustive(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "match is not exhaustive; add a catch-all branch", errs[0].Message())
+	require.Equal(t, "3:11-5:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
 // A nested literal pattern flows against the scrutinee's concrete field type, so a
@@ -409,7 +409,7 @@ func TestInferMatchNestedWrongLiteralRejected(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+	require.Equal(t, `4:9-4:13: cannot constrain "hi" <: number`, msgWithSpan(errs[0]))
 }
 
 // The same check applies to a nested literal in a tuple pattern element.
@@ -423,7 +423,7 @@ func TestInferMatchTupleNestedWrongLiteralRejected(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+	require.Equal(t, `4:9-4:13: cannot constrain "hi" <: number`, msgWithSpan(errs[0]))
 }
 
 // A correctly-typed nested literal pattern still type-checks.

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -28,7 +28,7 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "4:12-4:19: Unknown identifier: missing", msgWithSpan(errs[0]))
 	// id's call still recovers its declared return type — the error arg absorbs.
 	require.Equal(t, "fn () -> number", values["f"])
 }
@@ -43,6 +43,6 @@ func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	// One error for the spread itself; `xs` is never walked (so no extra
 	// unknown-identifier), and the broken element does not cascade.
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: ObjSpreadExpr", errs[0].Message())
+	require.Equal(t, "2:12-2:17: Unsupported: ObjSpreadExpr", msgWithSpan(errs[0]))
 	require.Equal(t, "{}", values["o"])
 }

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -203,7 +203,7 @@ func TestInferModuleFieldReadMissingProperty(t *testing.T) {
 	`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "object is missing property: b", errs[0].Message())
+	require.Equal(t, "3:13-3:14: object is missing property: b", msgWithSpan(errs[0]))
 	// M2.5: blame the member's prop, not the whole decl.
 	require.Equal(t, "b", spanText(src, errs[0].Span()))
 	require.Equal(t, map[string]string{"o": "{a: 5}", "x": "never"}, values)
@@ -230,7 +230,7 @@ func TestInferModuleUnsupportedDecl(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: TypeDecl", errs[0].Message())
+	require.Equal(t, "1:1-1:18: Unsupported: TypeDecl", msgWithSpan(errs[0]))
 	// M2.5: the error self-blames from the decl node.
 	require.Equal(t, src, spanText(src, errs[0].Span()))
 	// The unsupported decl must not leak a type binding.
@@ -245,7 +245,7 @@ func TestInferModuleVarDeclWithoutInitializer(t *testing.T) {
 	src := `declare val x: number`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
+	require.Equal(t, "1:1-1:14: Variable declaration requires an initializer: x", msgWithSpan(errs[0]))
 	// M2.5: the error self-blames from the decl node (whose span, per the parser,
 	// covers the binder but not the trailing annotation).
 	require.Equal(t, "declare val x", spanText(src, errs[0].Span()))
@@ -260,8 +260,8 @@ func TestInferModuleNoInitializerDoesNotLeakBinding(t *testing.T) {
 		val y = x
 	`)
 	require.Len(t, errs, 2)
-	require.Equal(t, "Variable declaration requires an initializer: x", errs[0].Message())
-	require.Equal(t, "Unknown identifier: x", errs[1].Message())
+	require.Equal(t, "2:3-2:16: Variable declaration requires an initializer: x", msgWithSpan(errs[0]))
+	require.Equal(t, "3:11-3:12: Unknown identifier: x", msgWithSpan(errs[1]))
 	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
 	// sentinel (`val y = <unknown>`) recovers AS `error` rather than freezing to
 	// `never`, so downstream uses of y absorb instead of cascading `<: never`.
@@ -277,7 +277,7 @@ func TestInferModuleDuplicateTopLevelValIsError(t *testing.T) {
 	`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Duplicate declaration: x", errs[0].Message())
+	require.Equal(t, "3:3-3:15: Duplicate declaration: x", msgWithSpan(errs[0]))
 	// M2.5: blame the second decl; relate the first ("previously declared here").
 	require.Equal(t, `val x = "hi"`, spanText(src, errs[0].Span()))
 	require.Len(t, errs[0].Related(), 1)
@@ -305,7 +305,7 @@ func TestInferFuncBodyDiscardedTailStillChecked(t *testing.T) {
 	src := `fn f() { missing }`
 	values, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "1:10-1:17: Unknown identifier: missing", msgWithSpan(errs[0]))
 	require.Equal(t, "fn () -> void", values["f"])
 }
 
@@ -445,7 +445,7 @@ func TestInferModuleNamespaceDeclUnsupported(t *testing.T) {
 		}
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unsupported: NamespaceDecl", errs[0].Message())
+	require.Equal(t, "2:3-4:4: Unsupported: NamespaceDecl", msgWithSpan(errs[0]))
 	require.Empty(t, values)
 	// The unsupported decl must not leak a type binding for the namespace.
 	require.NotContains(t, types, "Foo")
@@ -530,7 +530,7 @@ func TestInferMultiFileUnknownIdentifier(t *testing.T) {
 		"b.esc": `val z = 5`,
 	})
 	require.Len(t, errs, 1)
-	require.Equal(t, "Unknown identifier: missing", errs[0].Message())
+	require.Equal(t, "1:9-1:16: Unknown identifier: missing", msgWithSpan(errs[0]))
 	// M2.5: the error self-blames from the ident node.
 	require.Equal(t, "missing", spanText(srcA, errs[0].Span()))
 	// PR8 (Fix A): a binding whose definition is wholly the ErrorType recovery
@@ -550,6 +550,6 @@ func TestInferModuleNamedCalleeArityMismatchRecoversReturn(t *testing.T) {
 		val r = f(1, 2)
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "Too many arguments: expected at most 1, but got 2", errs[0].Message())
+	require.Equal(t, "3:11-3:18: Too many arguments: expected at most 1, but got 2", msgWithSpan(errs[0]))
 	require.Equal(t, "number", values["r"], "the result recovers to the declared return, not never")
 }

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -147,7 +147,7 @@ func TestScriptLinearScoping(t *testing.T) {
 	`
 	_, _, scriptErrs := inferScriptSource(t, src)
 	require.Len(t, scriptErrs, 1)
-	require.Equal(t, "Unknown identifier: x", scriptErrs[0].Message())
+	require.Equal(t, "2:11-2:12: Unknown identifier: x", msgWithSpan(scriptErrs[0]))
 
 	// The identical source is well-formed as a module. The dep graph types `val x`
 	// before the `val y` that refers to it.
@@ -184,7 +184,7 @@ func TestScriptRedeclaration(t *testing.T) {
 	// The same source is a duplicate-declaration error as a module.
 	_, _, moduleErrs := inferSource(t, src)
 	require.Len(t, moduleErrs, 1)
-	require.Equal(t, "Duplicate declaration: x", moduleErrs[0].Message())
+	require.Equal(t, "3:3-3:15: Duplicate declaration: x", msgWithSpan(moduleErrs[0]))
 }
 
 // TestScriptReassignTransition exercises the reassignment transition path
@@ -204,8 +204,8 @@ func TestScriptReassignTransition(t *testing.T) {
 			snap
 		`)
 		require.Equal(t, []string{
-			"use of moved value 'items'",
-		}, transitionMessages(t, errs))
+			"5:4-5:9: use of moved value 'items'",
+		}, transitionMessagesWithSpan(t, errs))
 	})
 
 	t.Run("source_dead_ok", func(t *testing.T) {
@@ -249,6 +249,6 @@ func TestScriptAwaitOutsideAsync(t *testing.T) {
 		val y = await x
 	`)
 	require.Len(t, errs, 1)
-	require.Equal(t, "await can only be used inside an async function", errs[0].Message())
+	require.Equal(t, "3:11-3:18: await can only be used inside an async function", msgWithSpan(errs[0]))
 	require.Empty(t, errs[0].Related())
 }

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -129,6 +129,17 @@ func transitionMessages(t *testing.T, errs []SolverError) []string {
 	return msgs
 }
 
+// transitionMessagesWithSpan is the span-prefixed counterpart to transitionMessages,
+// for source-driven tests whose errors carry real source spans.
+func transitionMessagesWithSpan(t *testing.T, errs []SolverError) []string {
+	t.Helper()
+	var msgs []string
+	for _, e := range errs {
+		msgs = append(msgs, msgWithSpan(e))
+	}
+	return msgs
+}
+
 // pendingMessages renders the phase conflicts checkMutabilityTransition recorded on the
 // checker's funcCtx. A direct call to checkMutabilityTransition records its conflict for
 // the post-pass rather than emitting it, so a unit test that drives the check in
@@ -248,8 +259,8 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 		}
 	`)
 	require.ElementsMatch(t, []string{
-		"use of moved value 'p'",
-	}, Messages(errs))
+		"5:29-5:30: use of moved value 'p'",
+	}, messagesWithSpan(errs))
 }
 
 // TestGlobalWriteMutTransition covers Option 1: a store into a module-level binding is a
@@ -271,8 +282,8 @@ func TestGlobalWriteMutTransition(t *testing.T) {
 			}
 		`)
 		require.Equal(t, []string{
-			"use of moved value 'p'",
-		}, transitionMessages(t, errs))
+			"5:5-5:6: use of moved value 'p'",
+		}, transitionMessagesWithSpan(t, errs))
 	})
 
 	// When the source is dead within this body, Option 1's in-body check reports
@@ -507,8 +518,8 @@ func TestTransitionWiringReportsMoveError(t *testing.T) {
 		}
 	`)
 	require.ElementsMatch(t, []string{
-		"use of moved value 'p'",
-	}, Messages(errs))
+		"4:4-4:5: use of moved value 'p'",
+	}, messagesWithSpan(errs))
 }
 
 // TestCollectOuterBindingsPreludeCache covers the outer-binding collection that feeds
@@ -557,7 +568,7 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
+				"4:6-4:40: cannot assign 'items' to immutable 'snapshot': 'items' is still used mutably after this point",
 			},
 		},
 		// Rule 1: safe when the mutable source is dead after the borrow.
@@ -586,7 +597,7 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'z' to immutable 'sink': 'p' still has mutable access to 'z' after this point",
+				"5:7-5:11: cannot assign 'z' to immutable 'sink': 'p' still has mutable access to 'z' after this point",
 			},
 		},
 		// G3 binds a `mut` borrow into a bare annotation by reborrowing it as a local
@@ -613,8 +624,8 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot constrain immutable object <: mutable object",
-				"use of moved value 'p'",
+				"5:21-5:22: cannot constrain immutable object <: mutable object",
+				"5:35-5:36: use of moved value 'p'",
 			},
 		},
 		// Rule 3: two mutable borrows of the same value are always allowed.
@@ -641,7 +652,7 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'b' to immutable 'c': 'a' still has mutable access to 'b' after this point",
+				"5:6-5:29: cannot assign 'b' to immutable 'c': 'a' still has mutable access to 'b' after this point",
 			},
 		},
 		// Conditional aliasing: c aliases both branches; a is live after the transition.
@@ -656,7 +667,7 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'a' to immutable 'c': 'a' is still used mutably after this point",
+				"5:6-5:51: cannot assign 'a' to immutable 'c': 'a' is still used mutably after this point",
 			},
 		},
 		// Rule 1: safe when the immutable borrow is dead. snapshot is never read, so there
@@ -685,14 +696,14 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'c' to immutable 'frozen': 'c' is still used mutably after this point",
+				"6:6-6:34: cannot assign 'c' to immutable 'frozen': 'c' is still used mutably after this point",
 			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, transitionMessages(t, errs))
+			require.Equal(t, tc.want, transitionMessagesWithSpan(t, errs))
 		})
 	}
 }
@@ -713,9 +724,9 @@ func TestRule2TransitionFromSource(t *testing.T) {
 		}
 	`)
 	require.ElementsMatch(t, []string{
-		"cannot constrain immutable object <: mutable object",
-		"use of moved value 'config'",
-	}, Messages(errs))
+		"4:27-4:28: cannot constrain immutable object <: mutable object",
+		"6:4-6:12: use of moved value 'config'",
+	}, messagesWithSpan(errs))
 }
 
 // TestMutabilityTransitionReassignFromSource exercises the reassignment transition path
@@ -738,8 +749,8 @@ func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 			}
 		`)
 		require.Equal(t, []string{
-			"use of moved value 'items'",
-		}, transitionMessages(t, errs))
+			"6:5-6:10: use of moved value 'items'",
+		}, transitionMessagesWithSpan(t, errs))
 	})
 
 	t.Run("source_dead_ok", func(t *testing.T) {
@@ -754,7 +765,7 @@ func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 				snap
 			}
 		`)
-		require.Empty(t, transitionMessages(t, errs))
+		require.Empty(t, transitionMessagesWithSpan(t, errs))
 	})
 }
 
@@ -794,7 +805,7 @@ func TestBorrowPhaseExclusion(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"cannot assign 'a' to immutable 's': 'm' still has mutable access to 'a' after this point",
+				"5:6-5:29: cannot assign 'a' to immutable 's': 'm' still has mutable access to 'a' after this point",
 			},
 		},
 		// Two mutable borrows of one value stay within the mutable phase, so both are
@@ -816,7 +827,7 @@ func TestBorrowPhaseExclusion(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, transitionMessages(t, errs))
+			require.Equal(t, tc.want, transitionMessagesWithSpan(t, errs))
 		})
 	}
 }
@@ -853,9 +864,9 @@ func TestPhaseConflictUnderConditionalMove(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"use of moved value 'a'",
-				"use of moved value 'a'",
-				"cannot assign 'a' to immutable 'snapshot': 'a' is still used mutably after this point",
+				"10:35-10:36: use of moved value 'a'",
+				"11:6-11:7: use of moved value 'a'",
+				"10:6-10:36: cannot assign 'a' to immutable 'snapshot': 'a' is still used mutably after this point",
 			},
 		},
 		// `a` is moved unconditionally before the transition, so it is moved on every
@@ -874,15 +885,15 @@ func TestPhaseConflictUnderConditionalMove(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"use of moved value 'a'",
-				"use of moved value 'a'",
+				"6:35-6:36: use of moved value 'a'",
+				"7:6-7:7: use of moved value 'a'",
 			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, _, errs := inferSource(t, tc.src)
-			require.Equal(t, tc.want, transitionMessages(t, errs))
+			require.Equal(t, tc.want, transitionMessagesWithSpan(t, errs))
 		})
 	}
 }

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -71,12 +71,14 @@ func TestInferVarLiteralWidening(t *testing.T) {
 // binding is the widened primitive, not `any`.
 func TestInferVarWideningReassignment(t *testing.T) {
 	t.Run("same-primitive reassignment checks", func(t *testing.T) {
-		values, _, errs := inferSource(t, "var a = 5\nfn f() { a = 6 }")
+		values, _, errs := inferSource(t, `var a = 5
+fn f() { a = 6 }`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["a"])
 	})
 	t.Run("different-primitive reassignment rejected", func(t *testing.T) {
-		src := "var a = 5\nfn f() { a = \"x\" }"
+		src := `var a = 5
+fn f() { a = "x" }`
 		_, _, errs := inferSource(t, src)
 		requireBlame(t, src, errs, `2:14-2:17: cannot constrain "x" <: number`, `"x"`)
 	})
@@ -157,12 +159,15 @@ func TestWidenHelper(t *testing.T) {
 // behaves like a direct literal.
 func TestInferVarWideningThroughReference(t *testing.T) {
 	t.Run("var from a val reference widens to the primitive", func(t *testing.T) {
-		values, _, errs := inferSource(t, "val x = 5\nvar y = x")
+		values, _, errs := inferSource(t, `val x = 5
+var y = x`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["y"])
 	})
 	t.Run("reassigning the widened var checks", func(t *testing.T) {
-		values, _, errs := inferSource(t, "val x = 5\nvar y = x\nfn f() { y = 6 }")
+		values, _, errs := inferSource(t, `val x = 5
+var y = x
+fn f() { y = 6 }`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["y"])
 	})
@@ -174,7 +179,9 @@ func TestInferVarWideningThroughReference(t *testing.T) {
 	// TestInferVarWideningPropagatesToReads). z: 5 is sound — z is an immutable
 	// snapshot of the value 5 — and this pins the narrow remaining corner.
 	t.Run("reading a reference-widened var keeps the literal", func(t *testing.T) {
-		values, _, errs := inferSource(t, "val x = 5\nvar y = x\nval z = y")
+		values, _, errs := inferSource(t, `val x = 5
+var y = x
+val z = y`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["y"])
 		require.Equal(t, "5", values["z"])
@@ -188,13 +195,15 @@ func TestInferVarWideningThroughReference(t *testing.T) {
 // unwidened).
 func TestInferVarWideningPropagatesToReads(t *testing.T) {
 	t.Run("scalar read widens", func(t *testing.T) {
-		values, _, errs := inferSource(t, "var a = 5\nval z = a")
+		values, _, errs := inferSource(t, `var a = 5
+val z = a`)
 		require.Empty(t, errs)
 		require.Equal(t, "number", values["a"])
 		require.Equal(t, "number", values["z"])
 	})
 	t.Run("object read widens", func(t *testing.T) {
-		values, _, errs := inferSource(t, "var p = {x: 0}\nval q = p")
+		values, _, errs := inferSource(t, `var p = {x: 0}
+val q = p`)
 		require.Empty(t, errs)
 		require.Equal(t, "{x: number}", values["q"])
 	})
@@ -205,7 +214,9 @@ func TestInferVarWideningPropagatesToReads(t *testing.T) {
 // inside the same function checks and the binding reads back as the primitive.
 func TestInferVarWideningBodyLevel(t *testing.T) {
 	t.Run("direct literal widens and reassigns", func(t *testing.T) {
-		values, _, errs := inferSource(t, "fn f() { var a = 5\n  a = 6\n  return a }")
+		values, _, errs := inferSource(t, `fn f() { var a = 5
+  a = 6
+  return a }`)
 		require.Empty(t, errs)
 		require.Equal(t, "fn () -> number", values["f"])
 	})
@@ -213,7 +224,9 @@ func TestInferVarWideningBodyLevel(t *testing.T) {
 	// Widenable flag, so the reassignment slot is the primitive and `y = 6` checks
 	// — the body-level twin of TestInferVarWideningThroughReference.
 	t.Run("reference widens and reassigns", func(t *testing.T) {
-		_, _, errs := inferSource(t, "fn f() { val x = 5\n  var y = x\n  y = 6 }")
+		_, _, errs := inferSource(t, `fn f() { val x = 5
+  var y = x
+  y = 6 }`)
 		require.Empty(t, errs)
 	})
 }
@@ -225,12 +238,14 @@ func TestInferVarWideningBodyLevel(t *testing.T) {
 // `var p = {x: 0}` at the constraint level.
 func TestInferVarWideningReferenceStructural(t *testing.T) {
 	t.Run("object", func(t *testing.T) {
-		values, _, errs := inferSource(t, "val o = {x: 0}\nvar p = o")
+		values, _, errs := inferSource(t, `val o = {x: 0}
+var p = o`)
 		require.Empty(t, errs)
 		require.Equal(t, "{x: number}", values["p"])
 	})
 	t.Run("tuple", func(t *testing.T) {
-		values, _, errs := inferSource(t, "val o = [1, 2]\nvar p = o")
+		values, _, errs := inferSource(t, `val o = [1, 2]
+var p = o`)
 		require.Empty(t, errs)
 		require.Equal(t, "[number, number]", values["p"])
 	})

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -78,7 +78,7 @@ func TestInferVarWideningReassignment(t *testing.T) {
 	t.Run("different-primitive reassignment rejected", func(t *testing.T) {
 		src := "var a = 5\nfn f() { a = \"x\" }"
 		_, _, errs := inferSource(t, src)
-		requireBlame(t, src, errs, `cannot constrain "x" <: number`, `"x"`)
+		requireBlame(t, src, errs, `2:14-2:17: cannot constrain "x" <: number`, `"x"`)
 	})
 }
 


### PR DESCRIPTION
Update test assertions across the solver package to include source location information in error messages. This makes test failures more informative by showing exactly where in the source code each error is blamed.

**Key changes:**

- Add `msgWithSpan()` and `messagesWithSpan()` helper functions to `constrain_test.go` that format errors as "line:col-line:col: message"
- Add `transitionMessagesWithSpan()` helper to `transition_test.go` for span-prefixed error messages in transition tests
- Update `requireBlame()` in `blame_test.go` to assert span-prefixed messages instead of bare messages
- Replace all test assertions that check error messages with span-prefixed versions across 15+ test files
- Update test source strings to use raw string literals for multi-line code, improving readability

The span prefix shows the exact location of the error in the source, making it easier to verify that errors are blamed at the correct position. This aligns with how the parser reports errors and makes test cases self-documenting about where the blame should land.

https://claude.ai/code/session_01EkEaLhM294CVzWsPnTXPyB