### PR TITLE
Grant immutable→mutable upgrade at all value-flow sites

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -90,6 +90,11 @@ type funcCtx struct {
 	async   bool
 	node    ast.Node
 	returns []soltype.Type
+	// returnExprs holds each ReturnStmt's operand expression in the same source order as
+	// returns, with a nil entry for a bare `return`. inferFunc reads it to decide the
+	// immutable→mutable upgrade at a `mut` return annotation. The upgrade fires only when
+	// every returned value is uniquely owned, so the join of the returns is too.
+	returnExprs []ast.Expr
 
 	// written records the widened type stored into a receiver variable's field by a
 	// field-write `recv.prop = source` (M4 C3), keyed by the receiver var's ID and

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -161,43 +161,163 @@ func TestInferOwnedMutFromFreshLiteral(t *testing.T) {
 	})
 }
 
-// The upgrade applies only to a freshly constructed value. A non-fresh source — here a
-// variable — still rejects an immutable→mutable assignment, because the variable could
-// alias a value held immutably elsewhere. That case waits on the lifetime/region work.
-func TestInferOwnedMutFromVariableRejected(t *testing.T) {
-	src := `fn f() {
+// A non-fresh source that is a consuming MOVE of a uniquely-owned place upgrades into an
+// owned-mutable annotation. `val m: mut {x} = cfg` with cfg dead afterward grants m the
+// mutable type, so the write `m.x = 2` succeeds. The move consumes cfg, so the same
+// source with cfg still read afterward is a use-after-move rather than an upgrade error.
+func TestInferOwnedMutFromMovedVariable(t *testing.T) {
+	t.Run("dead source upgrades", func(t *testing.T) {
+		src := `fn f() {
 	val cfg: {x: number} = {x: 1}
 	val m: mut {x: number} = cfg
 	m.x = 2
 }`
-	_, _, errs := inferSource(t, src)
-	require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("live source is a use-after-move", func(t *testing.T) {
+		src := `fn f() {
+	val cfg: {x: number} = {x: 1}
+	val m: mut {x: number} = cfg
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"4:2-4:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
+	})
 }
 
-// The freshness check recurses, so a literal that WRAPS a non-fresh element is itself not
-// freshly constructed and gets no upgrade. This is the recursive false path of
-// isFreshlyConstructed, distinct from TestInferOwnedMutFromVariableRejected's top-level
-// variable: the outer literal is fresh, but a field or element reads a variable.
-func TestInferOwnedMutFreshnessRecurses(t *testing.T) {
-	t.Run("object field is a variable", func(t *testing.T) {
+// The upgrade recurses through a literal that wraps a moved place: the outer literal is
+// fresh and the wrapped `cfg` is a consuming move of an owned variable, so the whole
+// value is uniquely owned and upgrades. A live read of `cfg` afterward is a
+// use-after-move, since building the literal consumed it.
+func TestInferOwnedMutFromMovedVariableNested(t *testing.T) {
+	t.Run("object field is a moved variable", func(t *testing.T) {
 		src := `fn f() {
 	val cfg = {x: 1}
 	val m: mut {p: {x: number}} = {p: cfg}
 	m
 }`
 		_, _, errs := inferSource(t, src)
-		require.Len(t, errs, 1)
-		require.Equal(t, "3:13-3:14: cannot constrain immutable object <: mutable object", msgWithSpan(errs[0]))
+		require.Empty(t, errs)
 	})
-	t.Run("tuple element is a variable", func(t *testing.T) {
+	t.Run("tuple element is a moved variable", func(t *testing.T) {
 		src := `fn f() {
 	val cfg = {x: 1}
 	val t: mut [number, {x: number}] = [1, cfg]
 	t
 }`
 		_, _, errs := inferSource(t, src)
-		require.Len(t, errs, 1)
-		require.Equal(t, "3:13-3:14: cannot constrain immutable tuple <: mutable tuple", msgWithSpan(errs[0]))
+		require.Empty(t, errs)
+	})
+	t.Run("live nested source is a use-after-move", func(t *testing.T) {
+		src := `fn f() {
+	val cfg = {x: 1}
+	val m: mut {p: {x: number}} = {p: cfg}
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"4:2-4:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
+	})
+}
+
+// The immutable→mutable upgrade is consulted at every value-flow site into an
+// owned-mutable slot through the shared tryUpgradeIntoMutSlot helper, not only the
+// declaration initializer. A reassignment into a `mut` var, an argument against a `mut`
+// parameter, and a `mut` return annotation each accept a fresh literal and a moved
+// owned variable, and each move consumes the source.
+
+// A reassignment into a `mut` var grants the upgrade: both a fresh literal and a moved
+// owned variable satisfy the var's mutable type. The moved source is consumed, so a read
+// of it after the reassignment is a use-after-move.
+func TestInferOwnedMutReassign(t *testing.T) {
+	t.Run("fresh literal", func(t *testing.T) {
+		src := `fn f() {
+	var m: mut {x: number} = {x: 0}
+	m = {x: 1}
+	m.x = 2
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("moved variable", func(t *testing.T) {
+		src := `fn f() {
+	var m: mut {x: number} = {x: 0}
+	val cfg: {x: number} = {x: 1}
+	m = cfg
+	m.x = 2
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("live source is a use-after-move", func(t *testing.T) {
+		src := `fn f() {
+	var m: mut {x: number} = {x: 0}
+	val cfg: {x: number} = {x: 1}
+	m = cfg
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"5:2-5:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
+	})
+}
+
+// An argument against a `mut` parameter grants the upgrade, so `f({x: 1})` and `f(cfg)`
+// type-check for an owned-mutable parameter. Passing the moved variable consumes it, so a
+// later read is a use-after-move.
+func TestInferOwnedMutCallArgument(t *testing.T) {
+	t.Run("fresh literal", func(t *testing.T) {
+		src := `fn sink(q: mut {x: number}) {}
+fn f() { sink({x: 1}) }`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("moved variable", func(t *testing.T) {
+		src := `fn sink(q: mut {x: number}) {}
+fn f() {
+	val cfg: {x: number} = {x: 1}
+	sink(cfg)
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("live argument is a use-after-move", func(t *testing.T) {
+		src := `fn sink(q: mut {x: number}) {}
+fn f() {
+	val cfg: {x: number} = {x: 1}
+	sink(cfg)
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"5:2-5:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
+	})
+	t.Run("already-mutable argument keeps strict invariance", func(t *testing.T) {
+		// An owned-mutable argument is not upgraded; it flows through the strict mut<:mut
+		// constraint, which pins the nested field invariant, so a narrower field is
+		// rejected rather than silently accepted through the upgrade's covariant view.
+		src := `fn sink(q: mut {a: {x: number | string}}) {}
+fn f(p: mut {a: {x: number}}) { sink(p) }`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"2:33-2:40: cannot constrain string <: number"}, messagesWithSpan(errs))
+	})
+}
+
+// A `mut` return annotation grants the upgrade for a uniquely-owned body value, so a
+// function returning a fresh literal or a moved owned variable is typed as returning the
+// owned-mutable value.
+func TestInferOwnedMutReturn(t *testing.T) {
+	t.Run("fresh literal", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f() -> mut {x: number} { return {x: 1} }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> mut {x: number}", values["f"])
+	})
+	t.Run("moved variable", func(t *testing.T) {
+		src := `fn f() -> mut {x: number} {
+	val cfg: {x: number} = {x: 1}
+	return cfg
+}`
+		values, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+		require.Equal(t, "fn () -> mut {x: number}", values["f"])
 	})
 }
 

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -323,6 +323,47 @@ func TestInferOwnedMutReturn(t *testing.T) {
 	})
 }
 
+// A field write into a mutable container's field is the fifth value-flow site. A fresh
+// literal and a moved owned variable both store into the field, the move consumes its
+// source, and an immutable receiver is rejected. The container's field is bare under the
+// lazy deep-mut form, so the shared helper is consulted and declines, leaving the ordinary
+// path to accept the owned value. The helper's owned-mutable-field upgrade branch itself
+// needs a field whose type is owned-mutable, which #779 makes unconstructible from source
+// today, so no case here drives that branch.
+func TestInferOwnedMutFieldWrite(t *testing.T) {
+	t.Run("fresh literal", func(t *testing.T) {
+		src := `fn f(obj: mut {a: {x: number}}) {
+	obj.a = {x: 5}
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("moved variable", func(t *testing.T) {
+		src := `fn f(obj: mut {a: {x: number}}) {
+	val cfg: {x: number} = {x: 5}
+	obj.a = cfg
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("live source is a use-after-move", func(t *testing.T) {
+		src := `fn f(obj: mut {a: {x: number}}) {
+	val cfg: {x: number} = {x: 5}
+	obj.a = cfg
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"4:2-4:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
+	})
+	t.Run("immutable receiver rejected", func(t *testing.T) {
+		src := `fn f(obj: {a: {x: number}}) {
+	obj.a = {x: 5}
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"2:2-2:16: cannot constrain immutable object <: mutable object"}, messagesWithSpan(errs))
+	})
+}
+
 // A source carrying an already-owned-mutable cell is not upgraded, even when the cell is
 // nested inside a fresh literal. The covariant read view the upgrade constrains against
 // would widen that cell's element type, so the source falls through to the strict mut<:mut

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -192,10 +192,12 @@ func TestInferOwnedMutFromMovedVariable(t *testing.T) {
 // use-after-move, since building the literal consumed it.
 func TestInferOwnedMutFromMovedVariableNested(t *testing.T) {
 	t.Run("object field is a moved variable", func(t *testing.T) {
+		// The write through m.p proves the upgrade reaches the nested field: m.p is
+		// mutable, so storing a new number into m.p.x type-checks.
 		src := `fn f() {
 	val cfg = {x: 1}
 	val m: mut {p: {x: number}} = {p: cfg}
-	m
+	m.p.x = 9
 }`
 		_, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
@@ -318,6 +320,62 @@ func TestInferOwnedMutReturn(t *testing.T) {
 		values, _, errs := inferSource(t, src)
 		require.Empty(t, errs)
 		require.Equal(t, "fn () -> mut {x: number}", values["f"])
+	})
+}
+
+// A source carrying an already-owned-mutable cell is not upgraded, even when the cell is
+// nested inside a fresh literal. The covariant read view the upgrade constrains against
+// would widen that cell's element type, so the source falls through to the strict mut<:mut
+// path, which rejects the immutable wrapper against the mutable slot. This guards against
+// covariantly widening `{p: inner}` with `inner: mut {x: number}` into a wider field.
+func TestInferOwnedMutNestedOwnedMutRejected(t *testing.T) {
+	t.Run("declaration", func(t *testing.T) {
+		src := `fn f() {
+	val inner: mut {x: number} = {x: 0}
+	val m: mut {p: {x: number | string}} = {p: inner}
+	m
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"3:13-3:14: cannot constrain immutable object <: mutable object"}, messagesWithSpan(errs))
+	})
+	t.Run("return", func(t *testing.T) {
+		src := `fn f() -> mut {p: {x: number | string}} {
+	val inner: mut {x: number} = {x: 0}
+	return {p: inner}
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"1:15-1:16: cannot constrain immutable object <: mutable object"}, messagesWithSpan(errs))
+	})
+}
+
+// A module-level `mut` global takes the upgrade on reassignment just like a local `mut`
+// var, so a fresh literal and a moved owned variable both store into it. The store
+// consumes a moved source, so a later read of it is a use-after-move.
+func TestInferOwnedMutModuleGlobalWrite(t *testing.T) {
+	t.Run("fresh literal", func(t *testing.T) {
+		src := `var sink: mut {x: number} = {x: 0}
+fn f() { sink = {x: 1} }`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("moved variable", func(t *testing.T) {
+		src := `var sink: mut {x: number} = {x: 0}
+fn f() {
+	val cfg: {x: number} = {x: 1}
+	sink = cfg
+}`
+		_, _, errs := inferSource(t, src)
+		require.Empty(t, errs)
+	})
+	t.Run("live source is a use-after-move", func(t *testing.T) {
+		src := `var sink: mut {x: number} = {x: 0}
+fn f() {
+	val cfg: {x: number} = {x: 1}
+	sink = cfg
+	cfg.x
+}`
+		_, _, errs := inferSource(t, src)
+		require.Equal(t, []string{"5:2-5:7: use of moved value 'cfg'"}, messagesWithSpan(errs))
 	})
 }
 

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -223,7 +223,7 @@ func TestInferOwnedMutFromMovedVariableNested(t *testing.T) {
 }
 
 // The immutable→mutable upgrade is consulted at every value-flow site into an
-// owned-mutable target through the shared tryUpgradeIntoMutSlot helper, not only the
+// owned-mutable target through the shared tryUpgradeToOwnedMut helper, not only the
 // declaration initializer. A reassignment into a `mut` var, an argument against a `mut`
 // parameter, and a `mut` return annotation each accept a fresh literal and a moved
 // owned variable, and each move consumes the source.

--- a/internal/solver/infer_ann_test.go
+++ b/internal/solver/infer_ann_test.go
@@ -223,7 +223,7 @@ func TestInferOwnedMutFromMovedVariableNested(t *testing.T) {
 }
 
 // The immutable→mutable upgrade is consulted at every value-flow site into an
-// owned-mutable slot through the shared tryUpgradeIntoMutSlot helper, not only the
+// owned-mutable target through the shared tryUpgradeIntoMutSlot helper, not only the
 // declaration initializer. A reassignment into a `mut` var, an argument against a `mut`
 // parameter, and a `mut` return annotation each accept a fresh literal and a moved
 // owned variable, and each move consumes the source.
@@ -367,7 +367,7 @@ func TestInferOwnedMutFieldWrite(t *testing.T) {
 // A source carrying an already-owned-mutable cell is not upgraded, even when the cell is
 // nested inside a fresh literal. The covariant read view the upgrade constrains against
 // would widen that cell's element type, so the source falls through to the strict mut<:mut
-// path, which rejects the immutable wrapper against the mutable slot. This guards against
+// path, which rejects the immutable wrapper against the mutable target. This guards against
 // covariantly widening `{p: inner}` with `inner: mut {x: number}` into a wider field.
 func TestInferOwnedMutNestedOwnedMutRejected(t *testing.T) {
 	t.Run("declaration", func(t *testing.T) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -228,36 +228,38 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targe
 	return true
 }
 
-// canUpgradeToOwnedMut reports whether a value built by src may be granted an
-// owned-mutable type when it flows into an owned-mutable slot. The grant is sound when
+// canUpgradeToOwnedMut reports whether the value built by src may be granted an
+// owned-mutable type when it flows into an owned-mutable slot. The grant is sound only when
 // the value is uniquely owned, so no live immutable alias can observe a write through the
-// new mutable view. This is Rule 2 of the mutability-transition checker with an empty
-// alias set.
+// new mutable view. This is Rule 2 of the mutability-transition checker with an empty alias
+// set. Three cases show what it returns and why:
 //
-// Two source shapes qualify:
-//   - A syntactically fresh literal, unaliased by construction: a primitive literal, or
-//     an object/tuple literal whose every element itself qualifies. This shape needs no
-//     VarID, so it holds at module top level where the liveness pre-pass has not run.
-//   - A consuming move of a uniquely-owned place that carries no owned-mutable cell: a
-//     variable or field path bound to a concrete owned value whose type has no owned-mut
-//     anywhere, recognised by movesOwnedPlace and containsOwnedMut. exprPlace ties the
-//     place to a VarID, so this shape holds only inside a function body, where the move
-//     engine consumes the source and a later use of it is a use-after-move.
+//   - A syntactically fresh literal returns true. In `val m: mut {x} = {x: 1}` the literal
+//     is newly built and nothing else refers to it, so it is uniquely owned and granting it
+//     mutability aliases nothing. A fresh literal carries no identifier and needs no VarID,
+//     so this case holds at module top level where the liveness pre-pass has not run.
+//
+//   - A consuming move of an owned place returns true. In `val m: mut {x} = cfg` the move
+//     consumes `cfg` and leaves `m` the sole owner, so again no live alias remains, and a
+//     later use of `cfg` is a use-after-move. exprPlace ties the place to a VarID, so this
+//     case holds only inside a function body where the move engine records the consume.
+//
+//   - A literal wrapping an owned-mutable leaf returns false. In `{p: inner}` with
+//     `inner: mut {x: number}`, `inner` already holds a mutable cell. The upgrade constrains
+//     the source against the slot's covariant read view, which would widen that cell — for
+//     example accept it where `mut {x: number | string}` is expected — and that is unsound.
+//     Returning false routes the source to the strict mut<:mut path, which pins the cell's
+//     element type invariant. containsOwnedMut is recursive, so an owned-mutable cell at any
+//     depth rejects the whole source.
 //
 // It generalizes the fresh-literal-only isFreshlyConstructed: both share the
-// freshLiteralShape recursion and differ only at a non-literal leaf, where this predicate
-// accepts an owned-place move. The recursion reaches a moved place nested inside a fresh
-// literal, so `{p: cfg}` qualifies when `cfg` is a dead owned variable even though the
-// literal is not identifier-free.
+// freshLiteralShape recursion and differ only at a non-literal leaf, which this predicate
+// accepts when it is an owned-place move carrying no owned-mutable cell. The recursion
+// reaches such a leaf nested inside a fresh literal, so `{p: cfg}` qualifies when `cfg` is a
+// dead owned variable even though the literal is not identifier-free.
 //
-// An owned-mutable leaf is rejected at every depth. The upgrade constrains the source
-// against the slot's covariant read view, which is sound only when the source carries no
-// mutable cell to widen. An already-mutable cell, top-level or nested, must instead take
-// the strict mut<:mut path that pins its element type invariant, so `{p: inner}` with
-// `inner: mut {x}` falls through to that path rather than widening `inner` covariantly.
-//
-// SOUNDNESS: a leaf this predicate admits must be consumed by the move engine, so a later
-// use of it is a use-after-move. That holds because movesOwnedPlace gates on
+// SOUNDNESS: every leaf this predicate admits must be consumed by the move engine, so a
+// later use of it is a use-after-move. That holds because movesOwnedPlace gates on
 // isConcreteOwned, a strict subset of the isOwnedMovable set consumeOwned moves at every
 // flow site, so the upgrade set is a subset of the consume set. Widening movesOwnedPlace
 // toward a place consumeOwned does not move would break this and grant a mutable view with

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -202,20 +202,20 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 }
 
 // tryUpgradeIntoMutSlot grants the immutable→mutable upgrade when a value of type srcT,
-// built by src, flows into the target type slot. The upgrade fires only when slot is
-// owned-mutable — a RefType with Mut set and a nil lifetime — and src is uniquely owned
-// per canUpgradeToOwnedMut. It then constrains srcT against the slot's immutable
-// read view, stripOwnedMut of the inner, the same covariant check the non-mut path runs,
-// and returns true. Otherwise it constrains nothing and returns false, leaving the
-// caller to run its ordinary constraint against slot.
+// built by src, flows into the target type targetSlot. The upgrade fires only when
+// targetSlot is owned-mutable — a RefType with Mut set and a nil lifetime — and src is
+// uniquely owned per canUpgradeToOwnedMut. It then constrains srcT against the slot's
+// immutable read view, stripOwnedMut of the inner, the same covariant check the non-mut
+// path runs, and returns true. Otherwise it constrains nothing and returns false, leaving
+// the caller to run its ordinary constraint against targetSlot.
 //
 // This is the one shared decision every value-flow site into a `mut` slot consults: the
 // declaration initializer, a reassignment target, a `mut` call argument, a `mut` return,
 // and a `mut` field write. site is the node blamed on failure. src is the source
 // expression, which canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast
 // path and the place-move path.
-func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, slot soltype.Type) bool {
-	ref, ok := slot.(*soltype.RefType)
+func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targetSlot soltype.Type) bool {
+	ref, ok := targetSlot.(*soltype.RefType)
 	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
 		return false
 	}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -183,7 +183,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // visible only here, so this site decides whether the source is uniquely owned and then
 // hands the solver a check it can do soundly.
 //
-// tryUpgradeIntoMutSlot constrains the initializer's shape against the borrow's INNER, its
+// tryUpgradeToOwnedMut constrains the initializer's shape against the borrow's INNER, its
 // covariant read view, exactly as the non-mut path constrains against the annotation
 // directly. A borrow annotation is a reference into a caller's region, not an owned value,
 // so a source flowing into it stays on the strict path.
@@ -194,35 +194,35 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
-	if c.tryUpgradeIntoMutSlot(init, init, initT, annT) {
+	if c.tryUpgradeToOwnedMut(init, init, initT, annT) {
 		return annT
 	}
 	c.constrain(init, initT, annT)
 	return annT
 }
 
-// tryUpgradeIntoMutSlot grants the immutable→mutable upgrade when a value of type srcT,
-// built by src, flows into the target type targetSlot. The upgrade fires only when
-// targetSlot is owned-mutable — a RefType with Mut set and a nil lifetime — and src is
-// uniquely owned per canUpgradeToOwnedMut. It then constrains srcT against targetSlot's
-// immutable read view, stripOwnedMut of the inner, the same covariant check the non-mut
-// path runs, and returns true. Otherwise it constrains nothing and returns false, leaving
-// the caller to run its ordinary constraint against targetSlot.
+// tryUpgradeToOwnedMut grants the immutable→mutable upgrade when a value of type srcT,
+// built by src, flows into the type target. The upgrade fires only when target is
+// owned-mutable — a RefType with Mut set and a nil lifetime — and src is uniquely owned
+// per canUpgradeToOwnedMut. It then constrains srcT against target's immutable read view,
+// stripOwnedMut of the inner, the same covariant check the non-mut path runs, and returns
+// true. Otherwise it constrains nothing and returns false, leaving the caller to run its
+// ordinary constraint against target.
 //
-// targetSlot is whatever owned-mutable type the value flows into at a given site, and
-// every such site routes through here: the declaration initializer's annotation, a
-// reassignment target's binding type, a `mut` parameter type, a `mut` return annotation,
-// and a `mut` field's type. site is the node blamed on failure. src is the source
-// expression, which canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast
-// path and the place-move path.
-func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targetSlot soltype.Type) bool {
-	ref, ok := targetSlot.(*soltype.RefType)
+// target is whatever owned-mutable type the value flows into at a given site, and every
+// such site routes through here: the declaration initializer's annotation, the binding
+// type of a reassignment, a `mut` parameter type, a `mut` return annotation, and a `mut`
+// field's type. site is the node blamed on failure. src is the source expression, which
+// canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast path and the
+// place-move path.
+func (c *checker) tryUpgradeToOwnedMut(site ast.Node, src ast.Expr, srcT, target soltype.Type) bool {
+	ref, ok := target.(*soltype.RefType)
 	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
 		return false
 	}
 	// Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}` field
 	// inside a non-mut container is rejected at the annotation site (#779), so stripOwnedMut
-	// is a defensive no-op for most targetSlot types. It still lets a uniquely-owned source
+	// is a defensive no-op for most target types. It still lets a uniquely-owned source
 	// flow covariantly into any owned-mut cell that reaches here. A fully uniquely-owned
 	// source is owned at every level, so the upgrade is sound the whole way down.
 	c.constrain(site, srcT, stripOwnedMut(ref.Inner))

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -211,13 +211,6 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, slot 
 	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
 		return false
 	}
-	// An already-owned-mutable source satisfies the slot through the ordinary mut<:mut
-	// constraint, which pins nested fields invariant. The upgrade only grants mutability
-	// to a value that lacks it, so skip it here and let the strict path run. Constraining
-	// against the stripped inner would otherwise drop that invariance.
-	if isOwnedMut(srcT) {
-		return false
-	}
 	// Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}` field
 	// inside a non-mut container is rejected at the annotation site (#779), so stripOwnedMut
 	// is a defensive no-op for most slots. It still lets a uniquely-owned source flow
@@ -237,16 +230,23 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, slot 
 //   - A syntactically fresh literal, unaliased by construction: a primitive literal, or
 //     an object/tuple literal whose every element itself qualifies. This shape needs no
 //     VarID, so it holds at module top level where the liveness pre-pass has not run.
-//   - A consuming move of a uniquely-owned place: a variable or field path bound to a
-//     concrete owned value, recognised by movesOwnedPlace. exprPlace ties the place to a
-//     VarID, so this shape holds only inside a function body, where the move engine
-//     consumes the source and a later use of it is a use-after-move.
+//   - A consuming move of a uniquely-owned place that carries no owned-mutable cell: a
+//     variable or field path bound to a concrete owned value whose type has no owned-mut
+//     anywhere, recognised by movesOwnedPlace and containsOwnedMut. exprPlace ties the
+//     place to a VarID, so this shape holds only inside a function body, where the move
+//     engine consumes the source and a later use of it is a use-after-move.
 //
 // It generalizes the fresh-literal-only isFreshlyConstructed: both share the
 // freshLiteralShape recursion and differ only at a non-literal leaf, where this predicate
 // accepts an owned-place move. The recursion reaches a moved place nested inside a fresh
 // literal, so `{p: cfg}` qualifies when `cfg` is a dead owned variable even though the
 // literal is not identifier-free.
+//
+// An owned-mutable leaf is rejected at every depth. The upgrade constrains the source
+// against the slot's covariant read view, which is sound only when the source carries no
+// mutable cell to widen. An already-mutable cell, top-level or nested, must instead take
+// the strict mut<:mut path that pins its element type invariant, so `{p: inner}` with
+// `inner: mut {x}` falls through to that path rather than widening `inner` covariantly.
 //
 // SOUNDNESS: a leaf this predicate admits must be consumed by the move engine, so a later
 // use of it is a use-after-move. That holds because movesOwnedPlace gates on
@@ -256,7 +256,8 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, slot 
 // no backing move.
 func (c *checker) canUpgradeToOwnedMut(src ast.Expr) bool {
 	return freshLiteralShape(src, func(leaf ast.Expr) bool {
-		return movesOwnedPlace(leaf, c.info.TypeOf(leaf))
+		t := c.info.TypeOf(leaf)
+		return !containsOwnedMut(t) && movesOwnedPlace(leaf, t)
 	})
 }
 
@@ -344,12 +345,12 @@ func (c *checker) bindingMovesOwnedPlace(pat ast.Pat, init ast.Expr, initT solty
 }
 
 // movesOwnedPlace reports whether init names a uniquely-owned place whose value moves
-// when it flows into an owning slot: init is a place — a binding or a field path, so
-// exprPlace succeeds — bound to a concrete owned object, tuple, or owned RefType. The
-// move consumes the place, leaving the destination its sole owner. exprPlace fails
-// outside a function body, where the rename pass has assigned no VarID, so a move is
-// confined to bodies where the move engine enforces the consume. It is the place-move
-// half of both bindingMovesOwnedPlace and the canUpgradeToOwnedMut leaf check.
+// when it flows into an owning slot. A place is a binding or a field path, so exprPlace
+// succeeds on it. Its value moves when it is a concrete owned object, tuple, or owned
+// RefType. The move consumes the place and leaves the destination its sole owner.
+// exprPlace fails outside a function body, where the rename pass has assigned no VarID, so
+// a move is confined to bodies where the move engine enforces the consume. This is the
+// place-move half of both bindingMovesOwnedPlace and the canUpgradeToOwnedMut leaf check.
 func movesOwnedPlace(init ast.Expr, initT soltype.Type) bool {
 	if _, ok := exprPlace(init); !ok {
 		return false
@@ -359,11 +360,40 @@ func movesOwnedPlace(init ast.Expr, initT soltype.Type) bool {
 
 // isOwnedMut reports whether t is an owned-mutable cell — a RefType with Mut set and a
 // nil lifetime. It is the shape a `mut T` annotation lowers to and the shape the
-// immutable→mutable upgrade grants, so both the slot and the source are tested against it
-// at the value-flow sites.
+// immutable→mutable upgrade grants.
 func isOwnedMut(t soltype.Type) bool {
 	ref, ok := t.(*soltype.RefType)
 	return ok && ref.Mut && ref.Lt == nil
+}
+
+// containsOwnedMut reports whether t is an owned-mutable cell or holds one nested inside
+// an object or tuple. It detects exactly what stripOwnedMut would peel. The
+// immutable→mutable upgrade constrains the source against the slot's covariant read view,
+// which is sound only when the source has no mutable cell to widen, so canUpgradeToOwnedMut
+// rejects a source where this returns true and routes it to the strict mut<:mut path. A
+// borrow's pointee belongs to another region, so it is left to the borrow rules and not
+// recursed into.
+func containsOwnedMut(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		return isOwnedMut(t)
+	case *soltype.ObjectType:
+		for _, e := range t.Elems {
+			if containsOwnedMut(soltype.AsProperty(e).Type) {
+				return true
+			}
+		}
+		return false
+	case *soltype.TupleType:
+		for _, e := range t.Elems {
+			if containsOwnedMut(e) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
 }
 
 // isMutableIdentPat reports whether p is a simple identifier binding written with

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -204,14 +204,15 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 // tryUpgradeIntoMutSlot grants the immutable→mutable upgrade when a value of type srcT,
 // built by src, flows into the target type targetSlot. The upgrade fires only when
 // targetSlot is owned-mutable — a RefType with Mut set and a nil lifetime — and src is
-// uniquely owned per canUpgradeToOwnedMut. It then constrains srcT against the slot's
+// uniquely owned per canUpgradeToOwnedMut. It then constrains srcT against targetSlot's
 // immutable read view, stripOwnedMut of the inner, the same covariant check the non-mut
 // path runs, and returns true. Otherwise it constrains nothing and returns false, leaving
 // the caller to run its ordinary constraint against targetSlot.
 //
-// This is the one shared decision every value-flow site into a `mut` slot consults: the
-// declaration initializer, a reassignment target, a `mut` call argument, a `mut` return,
-// and a `mut` field write. site is the node blamed on failure. src is the source
+// targetSlot is whatever owned-mutable type the value flows into at a given site, and
+// every such site routes through here: the declaration initializer's annotation, a
+// reassignment target's binding type, a `mut` parameter type, a `mut` return annotation,
+// and a `mut` field's type. site is the node blamed on failure. src is the source
 // expression, which canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast
 // path and the place-move path.
 func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targetSlot soltype.Type) bool {
@@ -221,18 +222,18 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targe
 	}
 	// Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}` field
 	// inside a non-mut container is rejected at the annotation site (#779), so stripOwnedMut
-	// is a defensive no-op for most slots. It still lets a uniquely-owned source flow
-	// covariantly into any owned-mut cell that reaches here. A fully uniquely-owned source
-	// is owned at every level, so the upgrade is sound the whole way down.
+	// is a defensive no-op for most targetSlot types. It still lets a uniquely-owned source
+	// flow covariantly into any owned-mut cell that reaches here. A fully uniquely-owned
+	// source is owned at every level, so the upgrade is sound the whole way down.
 	c.constrain(site, srcT, stripOwnedMut(ref.Inner))
 	return true
 }
 
 // canUpgradeToOwnedMut reports whether the value built by src may be granted an
-// owned-mutable type when it flows into an owned-mutable slot. The grant is sound only when
-// the value is uniquely owned, so no live immutable alias can observe a write through the
-// new mutable view. This is Rule 2 of the mutability-transition checker with an empty alias
-// set. Three cases show what it returns and why:
+// owned-mutable type when it flows into an owned-mutable target. The grant is sound only
+// when the value is uniquely owned, so no live immutable alias can observe a write through
+// the new mutable view. This is Rule 2 of the mutability-transition checker with an empty
+// alias set. Three cases show what it returns and why:
 //
 //   - A syntactically fresh literal returns true. In `val m: mut {x} = {x: 1}` the literal
 //     is newly built and nothing else refers to it, so it is uniquely owned and granting it
@@ -246,7 +247,7 @@ func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, targe
 //
 //   - A literal wrapping an owned-mutable leaf returns false. In `{p: inner}` with
 //     `inner: mut {x: number}`, `inner` already holds a mutable cell. The upgrade constrains
-//     the source against the slot's covariant read view, which would widen that cell — for
+//     the source against the target's covariant read view, which would widen that cell — for
 //     example accept it where `mut {x: number | string}` is expected — and that is unsound.
 //     Returning false routes the source to the strict mut<:mut path, which pins the cell's
 //     element type invariant. containsOwnedMut is recursive, so an owned-mutable cell at any
@@ -355,8 +356,8 @@ func (c *checker) bindingMovesOwnedPlace(pat ast.Pat, init ast.Expr, initT solty
 }
 
 // movesOwnedPlace reports whether init names a uniquely-owned place whose value moves
-// when it flows into an owning slot. A place is a binding or a field path, so exprPlace
-// succeeds on it. Its value moves when it is a concrete owned object, tuple, or owned
+// when it flows into an owning destination. A place is a binding or a field path, so
+// exprPlace succeeds on it. Its value moves when it is a concrete owned object, tuple, or owned
 // RefType. The move consumes the place and leaves the destination its sole owner.
 // exprPlace fails outside a function body, where the rename pass has assigned no VarID, so
 // a move is confined to bodies where the move engine enforces the consume. This is the
@@ -378,7 +379,7 @@ func isOwnedMut(t soltype.Type) bool {
 
 // containsOwnedMut reports whether t is an owned-mutable cell or holds one nested inside
 // an object or tuple. It detects exactly what stripOwnedMut would peel. The
-// immutable→mutable upgrade constrains the source against the slot's covariant read view,
+// immutable→mutable upgrade constrains the source against the target's covariant read view,
 // which is sound only when the source has no mutable cell to widen, so canUpgradeToOwnedMut
 // rejects a source where this returns true and routes it to the strict mut<:mut path. A
 // borrow's pointee belongs to another region, so it is left to the borrow rules and not

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -173,12 +173,20 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // none, so granting it the annotated mutable type is safe. This is Rule 2 with an empty
 // alias set. Two sources qualify, both recognised by canUpgradeToOwnedMut: a freshly
 // constructed literal such as `val items: mut {x} = {x: 1}`, and a consuming move of an
-// owned place such as `val m: mut {x} = cfg` where `cfg` is dead afterward. The decision
-// belongs at this value-flow site, which can see the source, not in the liveness-blind
-// constrain engine. tryUpgradeIntoMutSlot constrains the initializer's shape against the
-// borrow's INNER, its covariant read view, exactly as the non-mut path constrains
-// against the annotation directly. A borrow annotation is a reference into a caller's
-// region, not an owned value, so a source flowing into it stays on the strict path.
+// owned place such as `val m: mut {x} = cfg` where `cfg` is dead afterward.
+//
+// The decision belongs at this value-flow site rather than inside the constraint solver.
+// The solver, c.constrain, compares only the two types. It has no access to the source
+// expression, to variable liveness, or to the move analysis, so it cannot tell whether
+// the source is the sole owner of its value or is shared with a live immutable alias.
+// Lacking that information it always rejects immutable <: mutable. That information is
+// visible only here, so this site decides whether the source is uniquely owned and then
+// hands the solver a check it can do soundly.
+//
+// tryUpgradeIntoMutSlot constrains the initializer's shape against the borrow's INNER, its
+// covariant read view, exactly as the non-mut path constrains against the annotation
+// directly. A borrow annotation is a reference into a caller's region, not an owned value,
+// so a source flowing into it stays on the strict path.
 //
 // 2. A bare owned annotation whose initializer is a borrow is a borrow-into-owned
 // escape. A `val` binding consumes an owned source, so a borrowed `p` flowing into a

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -202,9 +202,9 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 }
 
 // tryUpgradeIntoMutSlot grants the immutable→mutable upgrade when a value of type srcT,
-// built by src, flows into the owned-mutable slot slot. The upgrade fires only when slot
-// is owned-mutable — a RefType with Mut set and a nil lifetime — and src is uniquely
-// owned per canUpgradeToOwnedMut. It then constrains srcT against the slot's immutable
+// built by src, flows into the target type slot. The upgrade fires only when slot is
+// owned-mutable — a RefType with Mut set and a nil lifetime — and src is uniquely owned
+// per canUpgradeToOwnedMut. It then constrains srcT against the slot's immutable
 // read view, stripOwnedMut of the inner, the same covariant check the non-mut path runs,
 // and returns true. Otherwise it constrains nothing and returns false, leaving the
 // caller to run its ordinary constraint against slot.

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -166,19 +166,19 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // resolved annotation and returns the type the binding adopts, which may differ from
 // the written annotation in two refinements over a plain constrain.
 //
-// 1. A freshly constructed, unaliased initializer flowing into an OWNED-mutable
-// annotation is allowed to take that mutable type. The C2 gate rejects immutable <:
-// mutable structurally, because writing through the target would otherwise mutate a
-// read-only value. But that is only unsound when a live immutable alias to the source
-// exists. A freshly constructed literal has none. It is uniquely owned, so granting it
-// the annotated mutable type is safe. This is Rule 2 with an empty alias set. The
-// construction case is `val items: mut {x} = {x: 1}`. The decision belongs at this
-// value-flow site, which can see the source is fresh, not in the liveness-blind
-// constrain engine. The upgrade constrains the initializer's shape against the borrow's
-// INNER, its covariant read view, exactly as the non-mut path constrains against the
-// annotation directly. It is gated on an owned-mutable annotation whose `Lt` is nil. A
-// borrow annotation is a reference into a caller's region, not an owned value, so a fresh
-// source flowing into it stays on the strict path.
+// 1. A uniquely-owned initializer flowing into an OWNED-mutable annotation is allowed to
+// take that mutable type. The C2 gate rejects immutable <: mutable structurally, because
+// writing through the target would otherwise mutate a read-only value. But that is only
+// unsound when a live immutable alias to the source exists. A uniquely-owned source has
+// none, so granting it the annotated mutable type is safe. This is Rule 2 with an empty
+// alias set. Two sources qualify, both recognised by canUpgradeToOwnedMut: a freshly
+// constructed literal such as `val items: mut {x} = {x: 1}`, and a consuming move of an
+// owned place such as `val m: mut {x} = cfg` where `cfg` is dead afterward. The decision
+// belongs at this value-flow site, which can see the source, not in the liveness-blind
+// constrain engine. tryUpgradeIntoMutSlot constrains the initializer's shape against the
+// borrow's INNER, its covariant read view, exactly as the non-mut path constrains
+// against the annotation directly. A borrow annotation is a reference into a caller's
+// region, not an owned value, so a source flowing into it stays on the strict path.
 //
 // 2. A bare owned annotation whose initializer is a borrow is a borrow-into-owned
 // escape. A `val` binding consumes an owned source, so a borrowed `p` flowing into a
@@ -186,19 +186,110 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
-	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && isFreshlyConstructed(init) {
-		// Constrain a fresh literal against the borrow's immutable skeleton, then
-		// grant the owned-mutable type. Under the lazy deep-mut form (PR 14) the inner
-		// is already bare, and a nested `mut {x}` field inside a non-mut container is
-		// now rejected at the annotation site (#779), so stripOwnedMut is a defensive
-		// no-op here. It is kept so a fresh literal still flows covariantly into any
-		// owned-mut cell that reaches this point. A fully fresh literal is uniquely
-		// owned at every level, so the upgrade is sound the whole way down.
-		c.constrain(init, initT, stripOwnedMut(ref.Inner))
+	if c.tryUpgradeIntoMutSlot(init, init, initT, annT) {
 		return annT
 	}
 	c.constrain(init, initT, annT)
 	return annT
+}
+
+// tryUpgradeIntoMutSlot grants the immutable→mutable upgrade when a value of type srcT,
+// built by src, flows into the owned-mutable slot slot. The upgrade fires only when slot
+// is owned-mutable — a RefType with Mut set and a nil lifetime — and src is uniquely
+// owned per canUpgradeToOwnedMut. It then constrains srcT against the slot's immutable
+// read view, stripOwnedMut of the inner, the same covariant check the non-mut path runs,
+// and returns true. Otherwise it constrains nothing and returns false, leaving the
+// caller to run its ordinary constraint against slot.
+//
+// This is the one shared decision every value-flow site into a `mut` slot consults: the
+// declaration initializer, a reassignment target, a `mut` call argument, a `mut` return,
+// and a `mut` field write. site is the node blamed on failure. src is the source
+// expression, which canUpgradeToOwnedMut inspects for the syntactic fresh-literal fast
+// path and the place-move path.
+func (c *checker) tryUpgradeIntoMutSlot(site ast.Node, src ast.Expr, srcT, slot soltype.Type) bool {
+	ref, ok := slot.(*soltype.RefType)
+	if !ok || !ref.Mut || ref.Lt != nil || !c.canUpgradeToOwnedMut(src) {
+		return false
+	}
+	// An already-owned-mutable source satisfies the slot through the ordinary mut<:mut
+	// constraint, which pins nested fields invariant. The upgrade only grants mutability
+	// to a value that lacks it, so skip it here and let the strict path run. Constraining
+	// against the stripped inner would otherwise drop that invariance.
+	if isOwnedMut(srcT) {
+		return false
+	}
+	// Under the lazy deep-mut form the inner is already bare, and a nested `mut {x}` field
+	// inside a non-mut container is rejected at the annotation site (#779), so stripOwnedMut
+	// is a defensive no-op for most slots. It still lets a uniquely-owned source flow
+	// covariantly into any owned-mut cell that reaches here. A fully uniquely-owned source
+	// is owned at every level, so the upgrade is sound the whole way down.
+	c.constrain(site, srcT, stripOwnedMut(ref.Inner))
+	return true
+}
+
+// canUpgradeToOwnedMut reports whether a value built by src may be granted an
+// owned-mutable type when it flows into an owned-mutable slot. The grant is sound when
+// the value is uniquely owned, so no live immutable alias can observe a write through the
+// new mutable view. This is Rule 2 of the mutability-transition checker with an empty
+// alias set.
+//
+// Two source shapes qualify:
+//   - A syntactically fresh literal, unaliased by construction: a primitive literal, or
+//     an object/tuple literal whose every element itself qualifies. This shape needs no
+//     VarID, so it holds at module top level where the liveness pre-pass has not run.
+//   - A consuming move of a uniquely-owned place: a variable or field path bound to a
+//     concrete owned value, recognised by movesOwnedPlace. exprPlace ties the place to a
+//     VarID, so this shape holds only inside a function body, where the move engine
+//     consumes the source and a later use of it is a use-after-move.
+//
+// It generalizes the fresh-literal-only isFreshlyConstructed: both share the
+// freshLiteralShape recursion and differ only at a non-literal leaf, where this predicate
+// accepts an owned-place move. The recursion reaches a moved place nested inside a fresh
+// literal, so `{p: cfg}` qualifies when `cfg` is a dead owned variable even though the
+// literal is not identifier-free.
+//
+// SOUNDNESS: a leaf this predicate admits must be consumed by the move engine, so a later
+// use of it is a use-after-move. That holds because movesOwnedPlace gates on
+// isConcreteOwned, a strict subset of the isOwnedMovable set consumeOwned moves at every
+// flow site, so the upgrade set is a subset of the consume set. Widening movesOwnedPlace
+// toward a place consumeOwned does not move would break this and grant a mutable view with
+// no backing move.
+func (c *checker) canUpgradeToOwnedMut(src ast.Expr) bool {
+	return freshLiteralShape(src, func(leaf ast.Expr) bool {
+		return movesOwnedPlace(leaf, c.info.TypeOf(leaf))
+	})
+}
+
+// freshLiteralShape reports whether e is a primitive literal, or an object/tuple literal
+// whose every element satisfies leafOK. It is the structural recursion shared by
+// isFreshlyConstructed and canUpgradeToOwnedMut, which differ only in what they accept at
+// a non-literal leaf. isFreshlyConstructed accepts nothing there; canUpgradeToOwnedMut
+// accepts a uniquely-owned place move.
+func freshLiteralShape(e ast.Expr, leafOK func(ast.Expr) bool) bool {
+	switch e := e.(type) {
+	case *ast.LiteralExpr:
+		return true
+	case *ast.TupleExpr:
+		for _, elem := range e.Elems {
+			if !freshLiteralShape(elem, leafOK) {
+				return false
+			}
+		}
+		return true
+	case *ast.ObjectExpr:
+		for _, elem := range e.Elems {
+			prop, ok := elem.(*ast.PropertyExpr)
+			if !ok || prop.Value == nil {
+				return false
+			}
+			if !freshLiteralShape(prop.Value, leafOK) {
+				return false
+			}
+		}
+		return true
+	default:
+		return leafOK(e)
+	}
 }
 
 // stripOwnedMut returns t's deeply-immutable skeleton by peeling every owned-mut
@@ -249,10 +340,30 @@ func (c *checker) bindingMovesOwnedPlace(pat ast.Pat, init ast.Expr, initT solty
 	if _, ok := pat.(*ast.IdentPat); !ok {
 		return false
 	}
+	return movesOwnedPlace(init, initT)
+}
+
+// movesOwnedPlace reports whether init names a uniquely-owned place whose value moves
+// when it flows into an owning slot: init is a place — a binding or a field path, so
+// exprPlace succeeds — bound to a concrete owned object, tuple, or owned RefType. The
+// move consumes the place, leaving the destination its sole owner. exprPlace fails
+// outside a function body, where the rename pass has assigned no VarID, so a move is
+// confined to bodies where the move engine enforces the consume. It is the place-move
+// half of both bindingMovesOwnedPlace and the canUpgradeToOwnedMut leaf check.
+func movesOwnedPlace(init ast.Expr, initT soltype.Type) bool {
 	if _, ok := exprPlace(init); !ok {
 		return false
 	}
 	return isConcreteOwned(initT)
+}
+
+// isOwnedMut reports whether t is an owned-mutable cell — a RefType with Mut set and a
+// nil lifetime. It is the shape a `mut T` annotation lowers to and the shape the
+// immutable→mutable upgrade grants, so both the slot and the source are tested against it
+// at the value-flow sites.
+func isOwnedMut(t soltype.Type) bool {
+	ref, ok := t.(*soltype.RefType)
+	return ok && ref.Mut && ref.Lt == nil
 }
 
 // isMutableIdentPat reports whether p is a simple identifier binding written with
@@ -271,33 +382,11 @@ func isMutableIdentPat(p ast.Pat) bool {
 // call, member access, or spread disqualifies the whole expression, because a captured
 // variable could alias a value held immutably elsewhere. Being identifier-free also
 // makes it sound without VarIDs, so it holds at module top level where the liveness
-// pre-pass has not run. A richer freshness judgment over provably-unique non-literal
-// expressions is the lifetime/region work (M4 G2).
+// pre-pass has not run. canUpgradeToOwnedMut is the richer judgment that also admits an
+// owned-place move; both run through freshLiteralShape and differ only at a non-literal
+// leaf, which this predicate always rejects.
 func isFreshlyConstructed(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.LiteralExpr:
-		return true
-	case *ast.TupleExpr:
-		for _, elem := range e.Elems {
-			if !isFreshlyConstructed(elem) {
-				return false
-			}
-		}
-		return true
-	case *ast.ObjectExpr:
-		for _, elem := range e.Elems {
-			prop, ok := elem.(*ast.PropertyExpr)
-			if !ok || prop.Value == nil {
-				return false
-			}
-			if !isFreshlyConstructed(prop.Value) {
-				return false
-			}
-		}
-		return true
-	default:
-		return false
-	}
+	return freshLiteralShape(e, func(ast.Expr) bool { return false })
 }
 
 // checkExcessLiteralMembers is the construction-site excess check (M4 A3): a

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -390,7 +390,7 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 // function yields a value as owned-mutable only when each returned value is uniquely
 // owned, so a single non-upgradable return on any path blocks the grant and the strict
 // constraint runs. With the grant the joined return shape is constrained against the
-// return annotation's immutable read view, the same covariant check tryUpgradeIntoMutSlot
+// return annotation's immutable read view, the same covariant check tryUpgradeToOwnedMut
 // runs at the other value-flow sites. The join is not a single source expression, so the
 // decision is made here rather than through that per-expression helper.
 func (c *checker) constrainReturnAgainstAnnotation(node ast.Node, retExprs []ast.Expr, ret, annT soltype.Type) {
@@ -908,7 +908,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// strict path.
 	if resolved {
 		for i := 0; i < len(e.Args) && i < len(fn.Params); i++ {
-			if c.tryUpgradeIntoMutSlot(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
+			if c.tryUpgradeToOwnedMut(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
 				// The upgrade constrained the argument's shape against the parameter's
 				// immutable read view, so pin this argument's demand entry to the parameter's
 				// own type; the callee <: callShape constraint below then re-checks it as
@@ -1144,7 +1144,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// immutable→mutable upgrade as the local reassignment path, so `sink = {x: 1}`
 		// type-checks. The carrier feeds the upgrade for the same reason it feeds the
 		// strict check below: a borrow forced to 'static satisfies the owned global.
-		if !c.tryUpgradeIntoMutSlot(e, e.Right, soltype.CarrierOf(sourceT), targetT) {
+		if !c.tryUpgradeToOwnedMut(e, e.Right, soltype.CarrierOf(sourceT), targetT) {
 			c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
 		}
 		if len(c.errs) == errsBefore {
@@ -1176,7 +1176,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			// unique, which is the borrow checker's job. Move/affine semantics (#762),
 			// under the sound borrow checker (#618), will eventually reject it.
 		}
-	} else if !c.tryUpgradeIntoMutSlot(e, e.Right, sourceT, targetT) {
+	} else if !c.tryUpgradeToOwnedMut(e, e.Right, sourceT, targetT) {
 		// A uniquely-owned source reassigned into an owned-mutable `var` takes the
 		// immutable→mutable upgrade, the same grant the annotated declaration makes. The
 		// upgrade fires only for a RefType target, so a union target still routes through
@@ -1261,7 +1261,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	// rejects the annotation, so no source program reaches this branch today. The guard
 	// keeps the field write consistent for when one does.
 	if recvObj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType); ok {
-		if prop, ok := recvObj.Prop(m.Prop.Name); ok && c.tryUpgradeIntoMutSlot(e.Right, e.Right, source, prop.Type) {
+		if prop, ok := recvObj.Prop(m.Prop.Name); ok && c.tryUpgradeToOwnedMut(e.Right, e.Right, source, prop.Type) {
 			w = prop.Type
 		}
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -401,18 +401,17 @@ func (c *checker) constrainReturnAgainstAnnotation(node ast.Node, retExprs []ast
 	c.constrain(node, ret, annT)
 }
 
-// allReturnsUpgradable reports whether every return operand is uniquely owned and lacks
-// mutability per canUpgradeToOwnedMut. An empty set, a bare `return` with a nil operand,
-// an already-owned-mutable operand, or any non-upgradable operand makes it false. An
-// already-mutable return satisfies the slot through the strict mut<:mut constraint, which
-// pins nested fields invariant, so the grant applies only when the whole join is
-// uniquely owned and immutable.
+// allReturnsUpgradable reports whether every return operand is upgradable per
+// canUpgradeToOwnedMut, which already rejects an operand carrying an owned-mutable cell at
+// any depth. An empty set, a bare `return` with a nil operand, or any non-upgradable
+// operand makes it false, so the grant applies only when the whole join is uniquely owned
+// and immutable.
 func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 	if len(retExprs) == 0 {
 		return false
 	}
 	for _, e := range retExprs {
-		if e == nil || isOwnedMut(c.info.TypeOf(e)) || !c.canUpgradeToOwnedMut(e) {
+		if e == nil || !c.canUpgradeToOwnedMut(e) {
 			return false
 		}
 	}
@@ -1140,7 +1139,13 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// not leave the source's lifetime forced to 'static. So `var sink = {…}; fn(p:
 		// mut {…}) { sink = p }` reports p as `mut 'static {…}`.
 		errsBefore := len(c.errs)
-		c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
+		// A uniquely-owned source stored into an owned-mutable global takes the same
+		// immutable→mutable upgrade as the local reassignment path, so `sink = {x: 1}`
+		// type-checks. The carrier feeds the upgrade for the same reason it feeds the
+		// strict check below: a borrow forced to 'static satisfies the owned slot.
+		if !c.tryUpgradeIntoMutSlot(e, e.Right, soltype.CarrierOf(sourceT), targetT) {
+			c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
+		}
 		if len(c.errs) == errsBefore {
 			// The store aliases the source into a permanent module-level slot. If the
 			// source's mutability differs from the slot's and the source stays live at

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -271,6 +271,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	}
 
 	var ret soltype.Type = &soltype.Void{}
+	var retExprs []ast.Expr
 	hasBody := body != nil
 	if hasBody {
 		// PR3: open a fresh function context so every ReturnStmt encountered while
@@ -297,6 +298,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 		// use-after-move. This runs before popFuncCtx restores the outer context, since
 		// it reads this body's move and use state off c.fn.
 		c.checkUseAfterMoves()
+		retExprs = c.fn.returnExprs
 		ret = c.joinReturnPoints(node, lvl, c.popFuncCtx(saved))
 	}
 	// Return-annotation handling diverges by async-ness.
@@ -324,7 +326,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// function simply adopts the annotation (constraining the synthetic Void
 			// would raise a spurious `void <: T`).
 			if hasBody {
-				c.constrain(node, ret, annT) // body <: declared return
+				c.constrainReturnAgainstAnnotation(node, retExprs, ret, annT) // body <: declared return
 			}
 			ret = annT
 		} else if !hasBody {
@@ -380,6 +382,41 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		}
 		return joinVar
 	}
+}
+
+// constrainReturnAgainstAnnotation constrains a function body's joined return type
+// against its declared return annotation, granting the immutable→mutable upgrade when
+// the annotation is an owned-mutable slot and EVERY return value is uniquely owned. A
+// function yields a value as owned-mutable only when each returned value is uniquely
+// owned, so a single non-upgradable return on any path blocks the grant and the strict
+// constraint runs. With the grant the joined return shape is constrained against the
+// slot's immutable read view, the same covariant check tryUpgradeIntoMutSlot runs at the
+// other value-flow sites. The join is not a single source expression, so the decision is
+// made here rather than through that per-expression helper.
+func (c *checker) constrainReturnAgainstAnnotation(node ast.Node, retExprs []ast.Expr, ret, annT soltype.Type) {
+	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && c.allReturnsUpgradable(retExprs) {
+		c.constrain(node, ret, stripOwnedMut(ref.Inner))
+		return
+	}
+	c.constrain(node, ret, annT)
+}
+
+// allReturnsUpgradable reports whether every return operand is uniquely owned and lacks
+// mutability per canUpgradeToOwnedMut. An empty set, a bare `return` with a nil operand,
+// an already-owned-mutable operand, or any non-upgradable operand makes it false. An
+// already-mutable return satisfies the slot through the strict mut<:mut constraint, which
+// pins nested fields invariant, so the grant applies only when the whole join is
+// uniquely owned and immutable.
+func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
+	if len(retExprs) == 0 {
+		return false
+	}
+	for _, e := range retExprs {
+		if e == nil || isOwnedMut(c.info.TypeOf(e)) || !c.canUpgradeToOwnedMut(e) {
+			return false
+		}
+	}
+	return true
 }
 
 // joinBorrows synthesizes the join of several borrowed objects that differ only in
@@ -859,6 +896,28 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		}
 	}
 
+	// Grant the immutable→mutable upgrade per argument: a uniquely-owned argument
+	// flowing into an owned-mutable parameter takes the mutable type, the same grant the
+	// annotated declaration makes, so `f({x: 1})` and `f(cfg)` for an owned-mutable
+	// parameter type-check. The argument's shape is constrained covariantly against the
+	// parameter's immutable read view, and the demand slot is pinned to the parameter's
+	// own type so the callee <: callShape constraint below does not re-check it strictly.
+	// consumeCallArgs still moves the argument, since an owned-mutable parameter is
+	// concrete-owned. It runs only for a resolved callee, where the parameter types are
+	// known. A deferred callee, one called through a `var`, keeps every argument on the
+	// strict path.
+	if resolved {
+		for i := 0; i < len(e.Args) && i < len(fn.Params); i++ {
+			if c.tryUpgradeIntoMutSlot(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
+				// The upgrade constrained the argument's shape against the parameter's
+				// immutable read view, so pin the demand slot to the parameter's own type;
+				// the callee <: callShape constraint below then re-checks it as param<:param
+				// rather than strictly rejecting the immutable argument.
+				demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
+			}
+		}
+	}
+
 	// callShape is built EXACT with all N params required, on purpose. That gives
 	// it accept-set [N, N] (N = arg count), so the callee <: callShape constraint
 	// reads "the callee must accept exactly N args" — it holds iff
@@ -1111,7 +1170,11 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			// unique, which is the borrow checker's job. Move/affine semantics (#762),
 			// under the sound borrow checker (#618), will eventually reject it.
 		}
-	} else {
+	} else if !c.tryUpgradeIntoMutSlot(e, e.Right, sourceT, targetT) {
+		// A uniquely-owned source reassigned into an owned-mutable `var` takes the
+		// immutable→mutable upgrade, the same grant the annotated declaration makes. The
+		// upgrade fires only for a RefType target, so a union target still routes through
+		// constrainAssign's per-member trial below.
 		c.constrainAssign(e, sourceT, targetT)
 	}
 	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
@@ -1184,6 +1247,18 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 	}
 	recv := c.inferWriteReceiver(scope, lvl, m.Object)
 	w := widen(source)
+	// An owned-mutable field takes the immutable→mutable upgrade through the same shared
+	// helper as the other value-flow sites, so the field write stays consistent with them:
+	// a uniquely-owned source is constrained covariantly against the field's read view, and
+	// the field's owned-mutable type is stored. The field's declared type is read off the
+	// receiver's carrier. An owned-mutable field arises only through inference, since #779
+	// rejects the annotation, so no source program reaches this branch today. The guard
+	// keeps the field write consistent for when one does.
+	if recvObj, ok := soltype.CarrierOf(recv).(*soltype.ObjectType); ok {
+		if prop, ok := recvObj.Prop(m.Prop.Name); ok && c.tryUpgradeIntoMutSlot(e.Right, e.Right, source, prop.Type) {
+			w = prop.Type
+		}
+	}
 	// Catch a readonly write at the assignment site so the diagnostic blames it
 	// outright; a TypeVar receiver falls through to the structural
 	// ReadonlyFieldSubtypeError the ObjectType write view raises.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -386,13 +386,13 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 
 // constrainReturnAgainstAnnotation constrains a function body's joined return type
 // against its declared return annotation, granting the immutable→mutable upgrade when
-// the annotation is an owned-mutable slot and EVERY return value is uniquely owned. A
+// the return annotation is owned-mutable and EVERY return value is uniquely owned. A
 // function yields a value as owned-mutable only when each returned value is uniquely
 // owned, so a single non-upgradable return on any path blocks the grant and the strict
 // constraint runs. With the grant the joined return shape is constrained against the
-// slot's immutable read view, the same covariant check tryUpgradeIntoMutSlot runs at the
-// other value-flow sites. The join is not a single source expression, so the decision is
-// made here rather than through that per-expression helper.
+// return annotation's immutable read view, the same covariant check tryUpgradeIntoMutSlot
+// runs at the other value-flow sites. The join is not a single source expression, so the
+// decision is made here rather than through that per-expression helper.
 func (c *checker) constrainReturnAgainstAnnotation(node ast.Node, retExprs []ast.Expr, ret, annT soltype.Type) {
 	if ref, ok := annT.(*soltype.RefType); ok && ref.Mut && ref.Lt == nil && c.allReturnsUpgradable(retExprs) {
 		c.constrain(node, ret, stripOwnedMut(ref.Inner))
@@ -899,8 +899,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// flowing into an owned-mutable parameter takes the mutable type, the same grant the
 	// annotated declaration makes, so `f({x: 1})` and `f(cfg)` for an owned-mutable
 	// parameter type-check. The argument's shape is constrained covariantly against the
-	// parameter's immutable read view, and the demand slot is pinned to the parameter's
-	// own type so the callee <: callShape constraint below does not re-check it strictly.
+	// parameter's immutable read view, and the demand entry for that argument is pinned to
+	// the parameter's own type so the callee <: callShape constraint below does not re-check
+	// it strictly.
 	// consumeCallArgs still moves the argument, since an owned-mutable parameter is
 	// concrete-owned. It runs only for a resolved callee, where the parameter types are
 	// known. A deferred callee, one called through a `var`, keeps every argument on the
@@ -909,9 +910,9 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		for i := 0; i < len(e.Args) && i < len(fn.Params); i++ {
 			if c.tryUpgradeIntoMutSlot(e.Args[i], e.Args[i], demand[i].Type, fn.Params[i].Type) {
 				// The upgrade constrained the argument's shape against the parameter's
-				// immutable read view, so pin the demand slot to the parameter's own type;
-				// the callee <: callShape constraint below then re-checks it as param<:param
-				// rather than strictly rejecting the immutable argument.
+				// immutable read view, so pin this argument's demand entry to the parameter's
+				// own type; the callee <: callShape constraint below then re-checks it as
+				// param<:param rather than strictly rejecting the immutable argument.
 				demand[i] = &soltype.FuncParam{Type: fn.Params[i].Type}
 			}
 		}
@@ -1142,7 +1143,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// A uniquely-owned source stored into an owned-mutable global takes the same
 		// immutable→mutable upgrade as the local reassignment path, so `sink = {x: 1}`
 		// type-checks. The carrier feeds the upgrade for the same reason it feeds the
-		// strict check below: a borrow forced to 'static satisfies the owned slot.
+		// strict check below: a borrow forced to 'static satisfies the owned global.
 		if !c.tryUpgradeIntoMutSlot(e, e.Right, soltype.CarrierOf(sourceT), targetT) {
 			c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
 		}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -65,6 +65,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		if c.fn != nil {
 			c.fn.returns = append(c.fn.returns, t)
+			c.fn.returnExprs = append(c.fn.returnExprs, s.Expr)
 			// Returning an owned value moves it out of the call frame, so the source
 			// binding is consumed and a later use is a use-after-move. A returned borrow
 			// flows out at its own lifetime and is not consumed here.

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -612,8 +612,8 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 			`,
 		},
 		// Storing the owned `p` into the global `sink` moves it, so binding `p` again
-		// into `snap` is a use-after-move; the bind is also a type error, since an
-		// immutable value cannot satisfy a mutable slot.
+		// into `snap` is a use-after-move. The bind itself takes the immutable→mutable
+		// upgrade, since `p` is a uniquely-owned place, so the move is the only error.
 		"Rule2_ImmEscape_SourceDead_Error": {
 			src: `
 				var sink = {x: 0}
@@ -624,7 +624,6 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 				}
 			`,
 			want: []string{
-				"5:21-5:22: cannot constrain immutable object <: mutable object",
 				"5:35-5:36: use of moved value 'p'",
 			},
 		},
@@ -709,11 +708,11 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 }
 
 // TestRule2TransitionFromSource covers binding an immutable value into an owned `mut`
-// slot. The bind is a type error — an immutable object cannot satisfy a mutable slot —
-// and it also moves the owned `config` into `mutableConfig`, so the later `config.x`
-// read is a use-after-move. Both messages are asserted. Owned-into-owned is a move
-// under the affine rule, so the old Rule 2 exclusivity transition no longer applies
-// here; the move governs the source instead.
+// slot while the source stays live afterward. The bind takes the immutable→mutable
+// upgrade — config is a uniquely-owned place, so granting mutableConfig the mutable type
+// aliases nothing live — and the move consumes config, so the later `config.x` read is a
+// use-after-move. Owned-into-owned is a move under the affine rule, so the move governs
+// the source rather than a Rule 2 exclusivity transition or an immutable<:mutable error.
 func TestRule2TransitionFromSource(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn test() {
@@ -723,8 +722,7 @@ func TestRule2TransitionFromSource(t *testing.T) {
 			config.x
 		}
 	`)
-	require.ElementsMatch(t, []string{
-		"4:27-4:28: cannot constrain immutable object <: mutable object",
+	require.Equal(t, []string{
 		"6:4-6:12: use of moved value 'config'",
 	}, messagesWithSpan(errs))
 }


### PR DESCRIPTION
Extend the immutable→mutable upgrade beyond declaration initializers to all value-flow sites where a value flows into an owned-mutable slot: reassignments, call arguments, return values, and field writes. The upgrade now accepts both freshly-constructed literals and consuming moves of uniquely-owned places, making the type system more permissive while maintaining soundness through the move engine.

**Key changes:**

- Refactor the upgrade logic into a shared `tryUpgradeIntoMutSlot` helper that all value-flow sites consult, replacing the inline check in `constrainInitAgainstAnnotation`.
- Introduce `canUpgradeToOwnedMut` to recognize two sources of unique ownership: syntactically fresh literals (via the new `freshLiteralShape` recursion) and consuming moves of owned places (via `movesOwnedPlace`). Extract `isFreshlyConstructed` to use the same `freshLiteralShape` recursion, differing only in what they accept at non-literal leaves.
- Add `isOwnedMut` helper to identify owned-mutable cells (RefType with Mut set and nil lifetime).
- Apply the upgrade at reassignment targets in `inferAssign`, call arguments in `inferCall`, return values in `constrainReturnAgainstAnnotation` (which checks that all returns are upgradable), and field writes in `inferMemberAssign`.
- Track return expressions in `funcCtx.returnExprs` alongside their types so `constrainReturnAgainstAnnotation` can inspect each return operand for upgradability.
- Guard the upgrade for already-owned-mutable sources: they flow through the strict mut<:mut constraint to preserve nested-field invariance rather than the covariant upgrade path.

**Implementation details:**

The upgrade is sound because `movesOwnedPlace` gates on `isConcreteOwned`, a strict subset of the places `consumeOwned` moves at every flow site. A source the upgrade admits is consumed by the move engine, so a later use is a use-after-move. The recursion through `freshLiteralShape` reaches moved places nested inside fresh literals, so `{p: cfg}` qualifies when `cfg` is a dead owned variable.

https://claude.ai/code/session_01MYuB77D3d4Ct6U2VYnpxJR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved move-based mutability upgrades when values are assigned, passed, returned, or written into mutable fields—especially for uniquely owned sources, including nested tuples/objects and module/global writes.
  * Function return checking now more accurately accounts for multiple return expressions when applying these upgrades.

* **Bug Fixes**
  * Reduced unnecessary type-constraining errors for immutable→mutable upgrade cases, relying instead on appropriate “use of moved value” diagnostics when a moved source is accessed afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->