### PR TITLE
Clarify terminology: "slot" → "parameter", "destination", "property", "binding"

### DIFF
--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -301,7 +301,7 @@ func TestConstrainStampsObjectExactnessErrors(t *testing.T) {
 
 	t.Run("OptionalPropertyError", func(t *testing.T) {
 		c := newChecker()
-		// {x?: number} <: {x: number}: an optional source cannot fill a required slot.
+		// {x?: number} <: {x: number}: an optional source cannot fill a required property.
 		c.constrain(node,
 			exactObj(&soltype.PropertyElem{Name: "x", Type: num(), Optional: true}),
 			exactObj(propElem("x", num())))

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -43,8 +43,8 @@ func requiredCount(f *soltype.FuncType) int {
 // invoked (#677 §4.2.1): lo = requiredCount(f); hi = len(f.Params) when f has a
 // finite arity, and unboundedArity when its upper bound is open — either because it
 // is inexact (the `...` marker) OR because its last param is a typed rest (§4.2.3).
-// Read a supertype callback slot's accept-set as "the argument counts whoever holds
-// this slot may invoke the supplied function with."
+// Read a supertype callback parameter's accept-set as "the argument counts whoever
+// holds this parameter may invoke the supplied function with."
 func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	lo = requiredCount(f)
 	if f.Inexact || hasRest(f) {
@@ -64,7 +64,7 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 // actionable diagnostic would be lost.
 //
 // Example. With `&'a {x: number} <: (number | string)`:
-//   - trial `&'a {x: number} <: number`: BorrowEscapeError (the borrow can't fit a number slot)
+//   - trial `&'a {x: number} <: number`: BorrowEscapeError (the borrow can't fit a number destination)
 //   - trial `&'a {x: number} <: string`: BorrowEscapeError (same)
 //
 // Both trials returned the same shape, so commonBorrowEscape returns one of
@@ -293,14 +293,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.FuncType:
 		if sup, ok := super.(*soltype.FuncType); ok {
-			// Accept-set subtyping (#677 §4.2.1): read super as a callback slot.
+			// Accept-set subtyping (#677 §4.2.1): read super as a callback parameter.
 			// sub <: super iff accept(sub) ⊇ accept(super) — sub must tolerate every
 			// argument count a holder of super may invoke it with. With
 			// accept(sub) = [loSub, hiSub] and accept(super) = [loSup, hiSup]:
 			//   - loSub <= loSup — sub must not DEMAND more args than super might supply,
 			//   - hiSub >= hiSup — sub must not REFUSE an arg count super might supply.
 			// The upper-bound clause is what exactness governs (an exact sub caps hiSub
-			// at len(sub.Params), so it can't fill a wider/inexact slot); the lower-bound
+			// at len(sub.Params), so it can't fill a wider/inexact parameter); the lower-bound
 			// clause is the `required` part (a typed-rest/optional lowers it). This
 			// subsumes M2's exact-same-arity rule: two EXACT functions have accept
 			// [r, n], so ⊇ forces equal upper bounds, i.e. the old same-arity check.
@@ -384,7 +384,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//   - absent on the sub: a MissingPropertyError only when the super
 			//     property is REQUIRED; an optional super property may be absent.
 			//   - present on both, optional on the sub but required on the super: the
-			//     source may omit it, so it cannot fill a required slot —
+			//     source may omit it, so it cannot fill a required property —
 			//     OptionalPropertyError, and skip the covariant type check (the
 			//     presence mismatch already rejects the constraint).
 			//   - otherwise (required<:required, required<:optional, optional<:
@@ -408,7 +408,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				// contravariant write view below pins it, the per-field write the eager
 				// form's constrainWriteBack did. A readonly TARGET needs only the read
 				// view, so a wider source can fill it; a readonly SOURCE cannot fill a
-				// writable target slot, the structural twin of inferMemberAssign's check.
+				// writable target field, the structural twin of inferMemberAssign's check.
 				if mutCtx && !superProp.Readonly {
 					if subProp.Readonly {
 						errs = append(errs, &ReadonlyFieldSubtypeError{Field: superProp.Name})
@@ -451,7 +451,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// invariance is the highest-risk encoding in the migration — see the M4 plan.
 		if sup, ok := super.(*soltype.RefType); ok {
 			// 1. Mutability compatibility: an immutable source cannot fill a mutable
-			//    slot (writing through the target would mutate a read-only borrow). The
+			//    target (writing through the target would mutate a read-only borrow). The
 			//    reverse, mut-decay (mut sub, immutable super), is allowed and falls
 			//    through to the covariant read view below.
 			if !sub.Mut && sup.Mut {
@@ -490,15 +490,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				// outlives lattice, mirroring the covariant read view on the inner.
 				c.constrainLt(sup.Lt, sub.Lt)
 			case sub.Lt == nil && sup.Lt != nil:
-				// An owned source satisfies any borrow slot — no lifetime constraint.
+				// An owned source satisfies any borrow destination — no lifetime constraint.
 			case sub.Lt != nil && sup.Lt == nil:
-				// A borrow flowing into an owned slot escapes its region.
+				// A borrow flowing into an owned destination escapes its region.
 				errs = append(errs, &BorrowEscapeError{Sub: sub, Super: sup})
 			}
 			return errs
 		}
 		// RefType <: a concrete non-borrow: peel to the inner. An owned value (Lt nil)
-		// satisfies a bare slot; a borrow escaping into an owned slot is a
+		// satisfies a bare destination; a borrow escaping into an owned destination is a
 		// BorrowEscapeError (live in D2). When super is a VARIABLE, fall through to the
 		// var arm so the WHOLE borrow is recorded as a bound — peeling there would drop
 		// its mutability.
@@ -506,7 +506,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sub.Lt != nil {
 				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
 			}
-			// Peeling an owned value into a bare slot is a covariant read; flag resets.
+			// Peeling an owned value into a bare destination is a covariant read; flag resets.
 			return c.constrain(sub.Inner, super, seen, false)
 		}
 	case *soltype.Void:
@@ -646,7 +646,7 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 	if subIsVar {
 		// Maintain the level invariant: a bound's level must not exceed the var's, or
 		// the freshener/extruder level prune over the lifetime sort becomes unsound (M4
-		// D2.5). super sits in subVar's upper bounds, a negative-position slot, so when
+		// D2.5). super sits in subVar's upper bounds, a negative position, so when
 		// it is inner to subVar extrude it out before recording, mirroring constrain's
 		// var arm. extrudeOuterAsUpper reuses an existing outer-extruded proxy of super
 		// if one is already a bound, so a repeated constraint does not mint a second
@@ -661,7 +661,7 @@ func (c *Context) constrainLtSeen(sub, super soltype.Lifetime, seen set.Set[ltPa
 		}
 	}
 	if superIsVar {
-		// sub sits in superVar's lower bounds, a positive-position slot; extrude it out
+		// sub sits in superVar's lower bounds, a positive position; extrude it out
 		// to superVar's level for the same invariant, reusing an existing proxy.
 		recSub := c.extrudeOuterAsLower(sub, superVar)
 		if !soltype.ContainsLifetime(superVar.LowerBounds, recSub) {
@@ -722,7 +722,7 @@ func (c *Context) extrude(t soltype.Type, pol soltype.Polarity, lvl int, cache m
 // lifetime at lvl, wired to the original through the polarity-appropriate outlives
 // bound (M4 D2.5) — the lifetime-sort twin of extrude's var node. The cache is
 // keyed by (var ID, polarity) for the same reason the type-var cache is. A
-// 'static, nil slot, or lifetime at lvl or outside it extrudes to itself. Bound
+// 'static, nil lifetime, or lifetime at lvl or outside it extrudes to itself. Bound
 // appends route through the journaling helpers; mutating the ORIGINAL var's bound is
 // the append a Discard must truncate. The fresh var's appends are a harmless no-op,
 // since a fresh var is unreachable after a Discard.

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -171,7 +171,7 @@ func TestConstrainFunctionVariance(t *testing.T) {
 
 // TestConstrainFunctionAcceptSet exercises the PR4 accept-set rule (#677 §4.2.1):
 // G <: F iff accept(G) ⊇ accept(F), with params contravariant and return covariant.
-// Read F (the super) as the callback slot.
+// Read F (the super) as the callback parameter.
 func TestConstrainFunctionAcceptSet(t *testing.T) {
 	// Two EXACT functions relate by the old same-arity rule: accept is [n, n] on both
 	// sides, so ⊇ forces equal arity.
@@ -183,9 +183,9 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 		))
 	})
 
-	// An exact supplier cannot fill a WIDER exact slot: accept [1,1] does not contain
-	// the slot's count 2 (upper-bound failure, hiG < hiF).
-	t.Run("exact fn(x) rejected by fn(x, y) slot", func(t *testing.T) {
+	// An exact supplier cannot fill a WIDER exact callback parameter: accept [1,1] does
+	// not contain the callback parameter's count 2 (upper-bound failure, hiG < hiF).
+	t.Run("exact fn(x) rejected by fn(x, y) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := exactFn(num(), identParam("x", num()))
 		f := exactFn(num(), identParam("x", num()), identParam("y", num()))
@@ -197,45 +197,46 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 		require.Same(t, f, fa.Super)
 	})
 
-	// The #677 callback matrix for an exact fn(x, y) slot: fn(x, y), fn(x, ...), and
-	// fn(...) are all accepted; exact fn(x) (too narrow upper bound) and a 3-param
-	// function (demands more than the slot supplies) are rejected.
-	slot := func() *soltype.FuncType { return exactFn(num(), identParam("x", num()), identParam("y", num())) }
-	t.Run("exact fn(x, y) fills fn(x, y) slot", func(t *testing.T) {
+	// The #677 callback matrix for an exact fn(x, y) callback parameter: fn(x, y),
+	// fn(x, ...), and fn(...) are all accepted; exact fn(x) (too narrow upper bound) and
+	// a 3-param function (demands more than the callback parameter supplies) are rejected.
+	callbackParam := func() *soltype.FuncType { return exactFn(num(), identParam("x", num()), identParam("y", num())) }
+	t.Run("exact fn(x, y) fills fn(x, y) callback parameter", func(t *testing.T) {
 		c := &Context{}
-		require.Empty(t, c.Constrain(exactFn(num(), identParam("x", num()), identParam("y", num())), slot()))
+		require.Empty(t, c.Constrain(exactFn(num(), identParam("x", num()), identParam("y", num())), callbackParam()))
 	})
-	t.Run("inexact fn(x, ...) fills fn(x, y) slot", func(t *testing.T) {
+	t.Run("inexact fn(x, ...) fills fn(x, y) callback parameter", func(t *testing.T) {
 		c := &Context{}
-		// accept(G) = [1, ∞) ⊇ accept(slot) = [2, 2]; the slot's arg 2 is tolerated,
-		// the single shared param checked contravariantly.
-		require.Empty(t, c.Constrain(inexactFn(num(), identParam("x", num())), slot()))
+		// accept(G) = [1, ∞) ⊇ accept(callbackParam) = [2, 2]; the callback parameter's
+		// arg 2 is tolerated, the single shared param checked contravariantly.
+		require.Empty(t, c.Constrain(inexactFn(num(), identParam("x", num())), callbackParam()))
 	})
-	t.Run("inexact fn(...) fills fn(x, y) slot", func(t *testing.T) {
+	t.Run("inexact fn(...) fills fn(x, y) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		// accept(G) = [0, ∞) ⊇ [2, 2]: a zero-param inexact function fills any exact
-		// slot whose required count it meets. This is the case exactness exists to permit.
-		require.Empty(t, c.Constrain(inexactFn(num()), slot()))
+		// callback parameter whose required count it meets. This is the case exactness
+		// exists to permit.
+		require.Empty(t, c.Constrain(inexactFn(num()), callbackParam()))
 	})
-	t.Run("exact fn(x) rejected by fn(x, y) slot (matrix)", func(t *testing.T) {
+	t.Run("exact fn(x) rejected by fn(x, y) callback parameter (matrix)", func(t *testing.T) {
 		c := &Context{}
 		require.Equal(t,
 			[]string{"cannot constrain function of arity 1 <: function of arity 2"},
-			Messages(c.Constrain(exactFn(num(), identParam("x", num())), slot())))
+			Messages(c.Constrain(exactFn(num(), identParam("x", num())), callbackParam())))
 	})
-	t.Run("3-param fn rejected by fn(x, y) slot", func(t *testing.T) {
+	t.Run("3-param fn rejected by fn(x, y) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := exactFn(num(), identParam("x", num()), identParam("y", num()), identParam("z", num()))
-		// accept(G) = [3, 3]; the slot supplies 2, below G's required 3 → lower-bound
-		// failure (loG > loF).
+		// accept(G) = [3, 3]; the callback parameter supplies 2, below G's required 3 →
+		// lower-bound failure (loG > loF).
 		require.Equal(t,
 			[]string{"cannot constrain function of arity 3 <: function of arity 2"},
-			Messages(c.Constrain(g, slot())))
+			Messages(c.Constrain(g, callbackParam())))
 	})
 
 	// Exact </: inexact: an exact function's finite upper bound cannot cover an
-	// inexact slot's ∞ (the asymmetry §4.2.1.1 explains).
-	t.Run("exact fn(x) rejected by inexact fn(x, ...) slot", func(t *testing.T) {
+	// inexact callback parameter's ∞ (the asymmetry §4.2.1.1 explains).
+	t.Run("exact fn(x) rejected by inexact fn(x, ...) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		require.Equal(t,
 			[]string{"cannot constrain function of arity 1 <: function of arity 1"},
@@ -244,7 +245,7 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 
 	// Inexact <: inexact: the classic "fewer params is okay" rule — both upper bounds
 	// are ∞, the supplier just needs to handle the consumer's required params.
-	t.Run("inexact fn(x, ...) fills inexact fn(x, y, ...) slot", func(t *testing.T) {
+	t.Run("inexact fn(x, ...) fills inexact fn(x, y, ...) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		require.Empty(t, c.Constrain(
 			inexactFn(num(), identParam("x", num())),
@@ -253,9 +254,9 @@ func TestConstrainFunctionAcceptSet(t *testing.T) {
 	})
 
 	// Optional params lower `required` without changing arity: exact fn(a, b?)
-	// (accept [1, 2]) fills the narrower exact fn(a) slot (accept [1, 1]) — the slot
-	// never supplies the optional argument.
-	t.Run("exact fn(a, b?) fills fn(a) slot", func(t *testing.T) {
+	// (accept [1, 2]) fills the narrower exact fn(a) callback parameter (accept [1, 1]) —
+	// the callback parameter never supplies the optional argument.
+	t.Run("exact fn(a, b?) fills fn(a) callback parameter", func(t *testing.T) {
 		c := &Context{}
 		require.Empty(t, c.Constrain(
 			exactFn(num(), identParam("a", num()), optParam("b", num())),
@@ -296,9 +297,10 @@ func TestConstrainFunctionRestParam(t *testing.T) {
 		return &soltype.FuncType{Params: params, Ret: ret}
 	}
 
-	// fn(a, ...rest) (accept [1, ∞)) fills a WIDER exact slot fn(a, b, c) (accept
-	// [3, 3]): the rest absorbs the slot's extra arguments — the case rest exists for.
-	t.Run("rest fn fills a wider exact slot", func(t *testing.T) {
+	// fn(a, ...rest) (accept [1, ∞)) fills a WIDER exact callback parameter fn(a, b, c)
+	// (accept [3, 3]): the rest absorbs the callback parameter's extra arguments — the
+	// case rest exists for.
+	t.Run("rest fn fills a wider exact callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := restFn(num(), identParam("a", num()), restParam("rest", num()))
 		f := exactFn(num(), identParam("a", num()), identParam("b", num()), identParam("c", num()))
@@ -306,18 +308,18 @@ func TestConstrainFunctionRestParam(t *testing.T) {
 	})
 
 	// A rest fn and an inexact fn have the same ∞ upper bound, so a rest fn fills an
-	// inexact slot of matching required arity.
-	t.Run("rest fn fills an inexact slot", func(t *testing.T) {
+	// inexact callback parameter of matching required arity.
+	t.Run("rest fn fills an inexact callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := restFn(num(), identParam("a", num()), restParam("rest", num()))
 		f := inexactFn(num(), identParam("a", num()))
 		require.Empty(t, c.Constrain(g, f))
 	})
 
-	// An exact fn(a, b) (accept [2, 2]) is REJECTED by a `fn(...rest)` slot (accept
-	// [0, ∞)): the slot may invoke with zero args, but g demands two — a lower-bound
-	// failure (loG=2 > loF=0), exactness aside.
-	t.Run("exact fn rejected by a zero-required rest slot", func(t *testing.T) {
+	// An exact fn(a, b) (accept [2, 2]) is REJECTED by a `fn(...rest)` callback parameter
+	// (accept [0, ∞)): the callback parameter may invoke with zero args, but g demands
+	// two — a lower-bound failure (loG=2 > loF=0), exactness aside.
+	t.Run("exact fn rejected by a zero-required rest callback parameter", func(t *testing.T) {
 		c := &Context{}
 		g := exactFn(num(), identParam("a", num()), identParam("b", num()))
 		f := restFn(num(), restParam("rest", num()))
@@ -604,8 +606,8 @@ func TestConstrainObject(t *testing.T) {
 		},
 		// PropertyElem.Optional is part of the object shape, so subtyping is
 		// presence-aware: an optional target property may be absent on the source,
-		// and a required source property fills an optional target slot, but an
-		// optional source property cannot fill a required target slot.
+		// and a required source property fills an optional target property, but an
+		// optional source property cannot fill a required target property.
 		{
 			// {} <: {x?: number}: an optional target property may be absent.
 			name:  "absent source satisfies optional target property",
@@ -614,7 +616,7 @@ func TestConstrainObject(t *testing.T) {
 		},
 		{
 			// {x?: number} <: {x: number}: the source may omit x, so it cannot fill a
-			// required slot.
+			// required property.
 			name:  "optional source rejected by required target",
 			sub:   exactObj(optProp("x", num())),
 			super: exactObj(propElem("x", num())),
@@ -628,7 +630,7 @@ func TestConstrainObject(t *testing.T) {
 			},
 		},
 		{
-			// {x: number} <: {x?: number}: a required property fills an optional slot.
+			// {x: number} <: {x?: number}: a required property fills an optional property.
 			name:  "required source fills optional target property",
 			sub:   exactObj(propElem("x", num())),
 			super: exactObj(optProp("x", num())),
@@ -737,7 +739,7 @@ func TestConstrainRef(t *testing.T) {
 		},
 		{
 			// {x} <: mut {x}: the reverse is rejected. The bare source is wrapped as an
-			// immutable view, and an immutable source cannot fill a mutable slot.
+			// immutable view, and an immutable source cannot fill a mutable destination.
 			name:  "bare <: mut rejected (mutability)",
 			sub:   exactObj(propElem("x", num())),
 			super: mutRef(exactObj(propElem("x", num()))),

--- a/internal/solver/deep_mut_test.go
+++ b/internal/solver/deep_mut_test.go
@@ -136,7 +136,7 @@ func TestExplicitBorrowOfDeepMutFieldPeels(t *testing.T) {
 	require.Equal(t, "fn (p: mut {a: {x: number}}) -> &mut {x: number}", values["f"])
 }
 
-// A readonly source field can't fill a writable target slot, but the reverse is
+// A readonly source field can't fill a writable target field, but the reverse is
 // fine. A readonly target supports only the covariant read view, so a wider
 // source can fill it through width subtyping.
 func TestReadonlySubtypingFlowsThroughCallAndReturn(t *testing.T) {
@@ -226,7 +226,7 @@ func TestReadonlyRendersOnReadField(t *testing.T) {
 // Under the lazy form (PR 14), the mut-context flag pins a nested field invariant
 // inside a mutable wrapper. A field whose type is a strict subtype of the target's
 // field passes the covariant read view but fails the contravariant write view, so a
-// `mut {a: {x: number}}` value cannot fill a `mut {a: {x: number | string}}` slot —
+// `mut {a: {x: number}}` value cannot fill a `mut {a: {x: number | string}}` destination —
 // the same invariance the eager per-cell `mut` lowering produced.
 func TestLazyDeepMutPinsNestedFieldInvariant(t *testing.T) {
 	src := `fn sink(q: mut {a: {x: number | string}}) {}

--- a/internal/solver/doc.go
+++ b/internal/solver/doc.go
@@ -36,7 +36,7 @@
 //		return [getY(), getY()]
 //	}
 //
-// reaches both tuple slots through two result variables, so the raw
+// reaches both tuple elements through two result variables, so the raw
 // `fn <T0, T1>(y: T0 & T1) -> [T0, T1]` becomes `fn <T0>(y: T0) -> [T0, T0]`.
 // Simplification runs at display time, leaving the raw scheme body intact for
 // instantiation.

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -165,7 +165,7 @@ type ExtraElementError struct {
 // the property, so it cannot satisfy a target that requires it present (the object
 // analogue of TypeScript's "Property 'x' is optional in type … but required in
 // type …"). The converse — a required source property filling an optional target
-// slot — is fine, so only this direction errors.
+// property — is fine, so only this direction errors.
 type OptionalPropertyError struct {
 	Sub, Super *soltype.ObjectType
 	Name       string
@@ -176,7 +176,7 @@ type OptionalPropertyError struct {
 // MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
 // borrow but the super is mutable: writing through the mutable target would mutate a
 // value the source only lent out as read-only, so an immutable reference cannot fill
-// a mutable slot. The reverse — a mutable source decaying to an immutable target — is
+// a mutable target. The reverse — a mutable source decaying to an immutable target — is
 // fine, so only this direction errors. It also fires for `{x} <: mut {x}`, where the
 // bare source is wrapped as an immutable view before re-dispatch.
 type MutabilityMismatchError struct {
@@ -185,8 +185,8 @@ type MutabilityMismatchError struct {
 	site       ast.Node     // M2.5: constraint node fallback
 }
 
-// BorrowEscapeError fires when a borrow outlives the slot it flows into: a borrowed
-// value (Lt != nil) constrained against an owned slot (Lt == nil), either a bare
+// BorrowEscapeError fires when a borrow outlives the destination it flows into: a borrowed
+// value (Lt != nil) constrained against an owned destination (Lt == nil), either a bare
 // supertype or a RefType super with no lifetime. The firing path is INERT in C2 —
 // every RefType carries Lt == nil until the lifetime sort lands (D1) and borrows
 // originate (D2) — so the struct is wired now and exercised from D2.
@@ -251,7 +251,7 @@ type ReadonlyFieldError struct {
 
 // ReadonlyFieldSubtypeError fires when a readonly source field flows into a
 // non-readonly target field through structural subtyping under a mutable borrow:
-// a `mut {readonly a: T}` cannot fill a `mut {a: T}` slot, since the target view
+// a `mut {readonly a: T}` cannot fill a `mut {a: T}` target, since the target view
 // would otherwise let a holder write through and break the source's readonly
 // contract. The check sits in the ObjectType <: ObjectType arm under the
 // mut-context flag, the contravariant write view of a mutable borrow, and blames
@@ -370,7 +370,7 @@ func (e *MutabilityMismatchError) Span() ast.Span {
 func (e *MutabilityMismatchError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
 
 func (e *BorrowEscapeError) Span() ast.Span {
-	// The escaping borrow is the subject; blame it, degrade to the slot it escaped
+	// The escaping borrow is the subject; blame it, degrade to the destination it escaped
 	// into, else the site.
 	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
 }
@@ -726,7 +726,7 @@ func (e *NonExhaustiveMatchError) Message() string {
 
 // MutLeafThroughSharedBorrowError fires when a destructuring pattern marks a leaf
 // `mut` while the scrutinee is an immutable `&` borrow. A `mut` leaf projects mutable
-// access to its slot, which cannot be obtained through a shared borrow, so the leaf is
+// access to the value it binds, which cannot be obtained through a shared borrow, so the leaf is
 // rejected. It self-blames the leaf's pattern node.
 type MutLeafThroughSharedBorrowError struct {
 	Node ast.Node

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -12,7 +12,7 @@ import (
 // `a = expr` parses as an ast.BinaryExpr with Op == ast.Assign — the only binary
 // operator the M3 walk handles. The target must be a mutable (`var`) place; the
 // source must be a subtype of the binding's type; the assignment expression evaluates
-// to the value just stored, so its type is the target's slot type. Reassignment
+// to the value just stored, so its type is the target's type. Reassignment
 // lives in expression position, so these tests exercise it inside a function body
 // (or a top-level `val` initializer).
 
@@ -95,7 +95,7 @@ fn g() { f() = a }`
 }
 
 // The assignment expression evaluates to the value just stored, so its type is the
-// target's slot type: `val b = (a = 6)` for `var a: number` ⇒ b: number.
+// target's type: `val b = (a = 6)` for `var a: number` ⇒ b: number.
 func TestInferAssignValuePositionIsTargetType(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		var a: number = 5
@@ -131,7 +131,7 @@ func TestInferAssignUnknownTarget(t *testing.T) {
 }
 
 // Reassigning a POLYMORPHIC var must not corrupt the binding. inferAssign freshens
-// the binding's coalesced slot type before constraining, so the source flows into
+// the binding's coalesced type before constraining, so the source flows into
 // throwaway copies rather than the binding's retained type-parameter vars; `id`
 // keeps its generic type and a later `id("hello")` still type-checks.
 func TestInferAssignPolyVarNoCorruption(t *testing.T) {
@@ -222,7 +222,7 @@ func TestInferAssignNamespaceTarget(t *testing.T) {
 // A member target (obj.x = …) is a field write (M4 C3). Writing to a field of an
 // IMMUTABLE object — here `o` is `val`-bound, so its `{x: 5}` is immutable — is
 // rejected: the write requires `o <: mut {x: number, ...}`, and an immutable object
-// cannot fill the mutable slot (the C2 gate's mutability rule).
+// cannot fill the mutable destination (the C2 gate's mutability rule).
 func TestInferAssignMemberTargetImmutable(t *testing.T) {
 	src := `val o = {x: 5}
 fn f() { o.x = 6 }`

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -164,7 +164,7 @@ func TestInferValMutConstructedAllowsFieldWrite(t *testing.T) {
 }
 
 // A constructed owned-mutable value can be borrowed `&mut`. The mutable cell fills
-// the mutable borrow slot, so `&mut q` checks where an owned-immutable q would fail
+// the mutable borrow destination, so `&mut q` checks where an owned-immutable q would fail
 // the mutability gate. This is the construction-side companion to
 // TestInferValMutBorrowFromOwnedMut, which sources owned-mutable from a parameter.
 func TestInferValMutConstructedBorrowsMut(t *testing.T) {
@@ -218,11 +218,11 @@ func TestInferValMutThawWidensLiteral(t *testing.T) {
 	require.Equal(t, "fn () -> mut {x: number}", values["f"])
 }
 
-// Freezing into a `var` binding widens the source's literal fields, since a `var` slot
+// Freezing into a `var` binding widens the source's literal fields, since a `var` binding
 // must admit any later reassignment of the field's primitive type. Freezing the
 // singleton `{x: 0}` into `var q` yields `{x: number}`. A plain `val q` keeps the
 // singleton, because an immutable, non-reassignable binding has no widening reason.
-// Both freeze the value immutably; only the `var` slot widens.
+// Both freeze the value immutably; only the `var` binding widens.
 func TestFreezeVarWidensLiteral(t *testing.T) {
 	t.Run("var_widens", func(t *testing.T) {
 		values, _, errs := inferSource(t, `fn f() {
@@ -256,7 +256,7 @@ func TestInferValAnnotatedOwnedImm(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number}) -> {x: number}", values["f"])
 }
 
-// `val q: &{x} = p` for an owned p auto-borrows p into the annotated borrow slot.
+// `val q: &{x} = p` for an owned p auto-borrows p into the annotated borrow destination.
 // The constrain rule's bare<:RefType arm wraps p as an immutable view.
 //
 // DISABLED until lifetime-bounds (M6.5) lands. The annotated borrow form has
@@ -292,9 +292,9 @@ func TestInferValAnnotatedBorrowMut(t *testing.T) {
 
 // --- Auto-borrow at call sites -------------------------------------------------
 
-// An owned-mutable argument auto-borrows into a `&mut` parameter slot. The
+// An owned-mutable argument auto-borrows into a `&mut` parameter. The
 // RefType<:RefType rule treats an owned source (Lt nil) as satisfying any borrow
-// slot, so the call type-checks without an explicit `&mut`.
+// destination, so the call type-checks without an explicit `&mut`.
 func TestInferAutoBorrowOwnedIntoMutParam(t *testing.T) {
 	src := `fn use(o: &mut {x: number}) -> number {
   return o.x
@@ -307,7 +307,7 @@ fn f(p: mut {x: number}) {
 	require.Equal(t, "fn (p: mut {x: number}) -> number", values["f"])
 }
 
-// An owned-immutable argument auto-borrows into a `&` parameter slot.
+// An owned-immutable argument auto-borrows into a `&` parameter.
 func TestInferAutoBorrowOwnedIntoImmParam(t *testing.T) {
 	src := `fn use(o: &{x: number}) -> number {
   return o.x
@@ -321,7 +321,7 @@ fn f(p: {x: number}) {
 }
 
 // An owned-immutable argument cannot auto-borrow into a `&mut` parameter: the
-// mutability check rejects an immutable source filling a mutable borrow slot.
+// mutability check rejects an immutable source filling a mutable borrow destination.
 func TestInferAutoBorrowImmIntoMutParamRejected(t *testing.T) {
 	src := `fn use(o: &mut {x: number}) -> number {
   return o.x

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -50,7 +50,7 @@ func TestInferFieldWriteThroughBorrowParam(t *testing.T) {
 }
 
 // Passing a borrow into a function whose parameter is an OWNED (bare) object is the
-// borrow-into-owned-slot escape: the RefType<:bare arm rejects because the source
+// borrow-into-owned destination escape: the RefType<:bare arm rejects because the source
 // carries a lifetime and the target owns its value. This is the only path that
 // exercises the escape guard D2 activated — before D2 every Lt was nil, so it never
 // fired.
@@ -70,7 +70,7 @@ fn f(p: &mut {x: number}) {
 // The companion to the escape case: passing the same borrow into a function
 // whose parameter is itself a `&mut` borrow checks. The RefType<:RefType arm
 // relates the two lifetimes via constrainLt instead of rejecting, so the borrow
-// slot admits the borrow.
+// destination admits the borrow.
 func TestInferBorrowIntoBorrowArg(t *testing.T) {
 	src := `fn use(o: &mut {x: number}) -> number {
   return o.x
@@ -102,7 +102,7 @@ func TestInferReadAfterWriteThroughBorrowParam(t *testing.T) {
 
 // Writing a field of a NON-`mut` owned object is rejected: the write lowers to the
 // mutable requirement `mut {x, ...}`, and an immutable owned object cannot fill a
-// mutable slot. This confirms the field-write requirement's fresh lifetime (D2) did
+// mutable destination. This confirms the field-write requirement's fresh lifetime (D2) did
 // not loosen the mutability gate — an owned-but-immutable receiver still fails.
 func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 	src := `fn g(o: {x: number}) {
@@ -266,7 +266,7 @@ func TestInferMixedBorrowAndOwnedReturnFallsBackToUnion(t *testing.T) {
 // stored value outlives every borrow region, so p's lifetime is forced `<: 'static`
 // and the parameter renders `&'static mut {x: number}` rather than under a borrow
 // lifetime `'l{id}`. The store itself checks. A 'static borrow is owned-forever, so
-// it fills the owned slot instead of tripping BorrowEscapeError.
+// it fills the owned destination instead of tripping BorrowEscapeError.
 func TestInferGlobalWriteEscapesBorrowToStatic(t *testing.T) {
 	src := `var sink = {x: 0}
 fn cache(p: &mut {x: number}) {
@@ -322,7 +322,7 @@ func TestInferImmutableBorrowAliasReturnedCarriesLifetime(t *testing.T) {
 	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a {x: number}", values["f"])
 }
 
-// Returning a local borrow into an OWNED return slot errors. The return
+// Returning a local borrow into an OWNED return destination errors. The return
 // annotation is owned, so the borrow flowing into it trips the escape guard. The
 // alias only relaxes the binding itself, not the function boundary.
 func TestInferBorrowAliasEscapingOwnedReturnRejected(t *testing.T) {
@@ -571,7 +571,7 @@ func TestInferExplicitMutBorrowOfMemberAcceptsMutReceiver(t *testing.T) {
 
 // An explicit `&mut obj.f` on an immutable receiver is rejected: the mut
 // requirement lowers to `mut {f: T, ...}`, and an immutable receiver cannot
-// fill the mutable slot. This is the same mutability gate inferMemberAssign
+// fill the mutable destination. This is the same mutability gate inferMemberAssign
 // imposes for a field write `obj.f = v`, surfacing here at the explicit mut
 // borrow.
 func TestInferExplicitMutBorrowOfMemberOnImmutableRejected(t *testing.T) {

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -120,7 +120,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 			}
 		} else {
 			// Freeze: take the source's immutable skeleton, so a later write through
-			// `q` is rejected. A `var` slot still widens so a reassignment can store
+			// `q` is rejected. A `var` binding still widens so a reassignment can store
 			// another value of the widened shape.
 			initT = stripOwnedMut(initT)
 			if d.Kind == ast.VarKind {
@@ -154,7 +154,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// (`var a = 5; val z = a` ⇒ z: number). A literal that arrives through a
 		// REFERENCE (`var y = x`) is a type variable here, which widen passes
 		// through unchanged. The binding var's Widenable flag widens that at coalesce
-		// time. That covers display, the reassignment slot, and the binding's own
+		// time. That covers display, the reassignment target, and the binding's own
 		// rendered type. A `val` keeps its literal singleton; only a mutable cell
 		// widens.
 		initT = widen(initT)
@@ -190,7 +190,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 //
 // 2. A bare owned annotation whose initializer is a borrow is a borrow-into-owned
 // escape. A `val` binding consumes an owned source, so a borrowed `p` flowing into a
-// bare owned slot, as in `val q: {x} = p`, does not alias `p`. The constraint takes the
+// bare owned destination, as in `val q: {x} = p`, does not alias `p`. The constraint takes the
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
@@ -539,7 +539,7 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	// mints; a body-level binding has none — it generalizes the initializer
 	// directly — so wrap the initializer in a fresh widenable var (initType <: v)
 	// and generalize that. The flag rides v through coalescing, so the recorded
-	// display type, the reassignment slot, and any read of the binding all widen
+	// display type, the reassignment target, and any read of the binding all widen
 	// consistently. An annotated `var` adopts its annotation and needs no widening.
 	//
 	// Skip the wrap when the initializer recovered to the ErrorType sentinel: it
@@ -574,8 +574,8 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 // bindPattern.
 //
 // The leaves are MONOMORPHIC projections of the initializer, not independently
-// generalized bindings. A destructured name reads a slot of the initializer, so
-// it shares that slot's type rather than quantifying over it. Top-level
+// generalized bindings. A destructured name reads a component of the initializer, so
+// it shares that component's type rather than quantifying over it. Top-level
 // destructuring at module scope still defers. It needs the SCC driver to bind
 // several names from one decl, so this path is body-level only and inferDeclDef
 // reports a top-level destructuring decl as unsupported.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -261,7 +261,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 			// A pattern-less param is not reachable from the real parser, which
 			// synthesizes a placeholder. Blame the enclosing function rather than a nil
 			// Span(), honoring the "never a panic" guarantee. Bind a synthetic name so
-			// the param slot still types.
+			// the parameter still types.
 			c.reportUnsupported(node)
 			name := fmt.Sprintf("arg%d", i)
 			fnScope.defineValue(name, ValueBinding{Schemes: []TypeScheme{monoScheme(pt)}})
@@ -592,7 +592,7 @@ func (c *checker) paramType(p *ast.Param, lvl int) soltype.Type {
 // RefType over the operand's carrier, carrying a fresh inferred lifetime. The
 // operand is constrained against the wrapper so the existing RefType<:RefType
 // and bare<:RefType rules enforce the rest. An immutable operand fails the
-// mutability check against `&mut`, and an owned operand satisfies a borrow slot
+// mutability check against `&mut`, and an owned operand satisfies a borrow destination
 // the same way a call-site argument does.
 //
 // The inner is taken directly from the operand rather than a fresh variable, so
@@ -877,7 +877,7 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// (len(fn.Params)) so the EXACT synth's accept-set gate does NOT also report
 	// arity (the lint owns the single, uniform message; the constraint does pure
 	// type-flow on the supplied args). Too-many truncates to the prefix; too-few pads
-	// the missing slots with fresh vars, which impose no constraint on absent args.
+	// the missing parameters with fresh vars, which impose no constraint on absent args.
 	fn, resolved := resolveFunc(callee)
 	demand := args
 	switch {
@@ -1023,12 +1023,12 @@ func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 //
 // On success the source is constrained `<: target` (the binding's coalesced type),
 // the new-solver form of the old checker's `Unify(rightType, leftType)`: the value
-// being stored must be a subtype of the slot. Reassigning an annotated `var a:
+// being stored must be a subtype of the binding's type. Reassigning an annotated `var a:
 // number = 5` with `a = 6` checks; an un-annotated `var a = 5` now widens its
 // binding to `number` (M4 B3), so `a = 6` checks there too.
 //
 // The assignment EXPRESSION evaluates to the value just stored, so its type is the
-// target binding's slot type — `val b = (a = 6)` for `var a: number` yields
+// target binding's type — `val b = (a = 6)` for `var a: number` yields
 // `b: number`. On an error path (invalid / immutable / unknown target) no value is
 // stored, so it recovers to `void`.
 func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.Type {
@@ -1098,7 +1098,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	// fresh instantiation: instantiating a generalized binding yields a var carrying
 	// only its LOWER bounds (the read/covariant face), so `a = "x"` for `var a:
 	// number` would merely add another lower bound and wrongly succeed. The coalesced
-	// type is the concrete slot type — `number` for an annotated var, and (since M4
+	// type is the concrete binding type — `number` for an annotated var, and (since M4
 	// B3) the widened `number` for an un-annotated `var a = 5`, so `a = 6` ⇒
 	// `6 <: number` checks.
 	//
@@ -1129,7 +1129,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		//
 		// The value-compatibility check runs against the source's CARRIER, not the
 		// borrow itself. A borrow forced to 'static is owned-forever, so it satisfies an
-		// owned slot. Comparing the whole borrow would instead trip the
+		// owned destination. Comparing the whole borrow would instead trip the
 		// borrow-into-owned BorrowEscapeError, the rule that rejects a borrow which does
 		// NOT escape. CarrierOf is the identity on a non-borrow source, so an ordinary
 		// global write such as `n = 5` is unaffected. The peel only looks through a
@@ -1148,15 +1148,15 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
 		}
 		if len(c.errs) == errsBefore {
-			// The store aliases the source into a permanent module-level slot. If the
-			// source's mutability differs from the slot's and the source stays live at
+			// The store aliases the source into a permanent module-level storage location. If the
+			// source's mutability differs from that location's and the source stays live at
 			// the conflicting mutability, that is a mut↔immutable transition the local
 			// reassignment path cannot see, since the global target is not a tracked
 			// local. Check it before forcing the escape so the source's own escape is
 			// not double-counted as a prior permanent alias.
 			c.checkGlobalWriteTransition(target, e.Right, bindingType(b), assignStmt)
 			c.constrainEscape(sourceT)
-			// The store transfers the value into a permanent 'static slot, so it consumes
+			// The store transfers the value into a permanent 'static storage location, so it consumes
 			// the source binding. A later use of the source is then a use-after-move, the
 			// affine rule that closes the leak the global write otherwise allowed.
 			// checkGlobalWriteTransition above skips the source's own self-conflict,
@@ -1191,7 +1191,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// the same top-level Mut from either, so the alias mutability is unchanged.
 		c.trackAliasesForAssignment(target, e.Right, bindingType(b), assignStmt)
 		// A non-module reassignment that moves its source consumes it. The global-write
-		// branch above runs its own consume, so this covers only the local-slot
+		// branch above runs its own consume, so this covers only the local-binding
 		// reassignment.
 		if !b.ModuleLevel && c.movesSourceInto(e.Right, bindingType(b)) {
 			if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
@@ -1226,7 +1226,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 //
 // The write requirement carries a fresh lifetime (D2): a mut-borrow receiver of
 // any lifetime is accepted (the fresh var imposes no obligation), and an owned
-// receiver satisfies the borrow slot by the RefType rule.
+// receiver satisfies the borrow destination by the RefType rule.
 //
 // A write has no result borrow to construct, so it needs no counterpart to the
 // read path's fieldReadBorrow. That helper builds the value a read yields: a
@@ -1281,7 +1281,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		// A fresh lifetime imposes no obligation on the receiver (D2): constrainLt
 		// gives the new variable an upper bound and constrains nothing back, so a
 		// mut-borrow receiver of ANY lifetime satisfies the write requirement. A
-		// nil slot lifetime would instead reject a borrow receiver as an escape.
+		// nil lifetime would instead reject a borrow receiver as an escape.
 		Lt: c.ctx.freshLifetime(lvl),
 		Inner: &soltype.ObjectType{
 			Elems:   []soltype.ObjTypeElem{&soltype.PropertyElem{Name: m.Prop.Name, Type: w}},
@@ -1717,7 +1717,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	//   - Reading a field through a `mut`/`'a` borrow is always legal and yields
 	//     the field's value, not the borrow.
 	//   - It keeps the requirement off the RefType, so the RefType<:bare escape
-	//     guard fires only when the borrow flows into an owned slot, not on a read.
+	//     guard fires only when the borrow flows into an owned destination, not on a read.
 	//   - A non-borrow receiver is returned unchanged, leaving plain vars untouched.
 	recvCarrier := soltype.CarrierOf(recv)
 	fieldVar := c.freshAt(lvl)

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -152,7 +152,7 @@ func TestInferFuncExprNilParamPatternNoPanic(t *testing.T) {
 }
 
 // A destructuring parameter binds its leaves and renders its pattern (M4 E1). The
-// leaves below go unused, so each slot coalesces to `unknown`. The point is that
+// leaves below go unused, so each element coalesces to `unknown`. The point is that
 // the param is accepted and rendered, not reported as unsupported.
 func TestInferFuncExprDestructuringParam(t *testing.T) {
 	c := newChecker()

--- a/internal/solver/infer_move_test.go
+++ b/internal/solver/infer_move_test.go
@@ -246,7 +246,7 @@ func TestMoveSemantics(t *testing.T) {
 				"2:13-2:29: borrowed value mut object does not live long enough to satisfy object",
 			},
 		},
-		// Moving one field out of an owned object consumes only that field's slot. The
+		// Moving one field out of an owned object consumes only that field. The
 		// sibling stays usable and a later read of the moved field is a use-after-move
 		// naming the field place (PR 7).
 		"PartialMoveConsumesFieldKeepsSibling": {
@@ -340,8 +340,8 @@ func TestMoveSemantics(t *testing.T) {
 			want: []string{"9:6-9:15: use of moved value 'pair.a'"},
 		},
 		// Tracking reaches nested field paths. Moving `pair.a.inner` consumes only that
-		// deep slot, so the sibling `pair.a.keep` stays usable and a read of the moved
-		// slot is a use-after-move naming the full path.
+		// deep field, so the sibling `pair.a.keep` stays usable and a read of the moved
+		// field is a use-after-move naming the full path.
 		"NestedFieldPartialMove": {
 			src: `
 				fn store(p: {id: number}) {}

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -49,8 +49,8 @@ func TestInferValObjectPatternMissingField(t *testing.T) {
 	require.Equal(t, "2:11-2:22: object is missing property: z", msgWithSpan(errs[0]))
 }
 
-// A tuple pattern binds per slot at the slot's element type. Reordering the bound
-// names in the result confirms each slot bound the right element.
+// A tuple pattern binds per element at the element's type. Reordering the bound
+// names in the result confirms each position bound the right element.
 func TestInferValTuplePatternBinds(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn h(t: [number, string]) {
@@ -62,7 +62,7 @@ func TestInferValTuplePatternBinds(t *testing.T) {
 	require.Equal(t, "fn (t: [number, string]) -> [string, number]", values["h"])
 }
 
-// A tuple pattern is exact in arity: binding more (or fewer) slots than the
+// A tuple pattern is exact in arity: binding more or fewer elements than the
 // scrutinee has is a TupleLengthMismatchError.
 func TestInferValTuplePatternWrongArity(t *testing.T) {
 	_, _, errs := inferSource(t, `
@@ -112,7 +112,7 @@ func TestInferNestedObjectPattern(t *testing.T) {
 	require.Equal(t, "fn (p: {pt: {x: number, y: string}}) -> [number, string]", values["f"])
 }
 
-// A wildcard slot in a tuple pattern matches without binding a name.
+// A wildcard element in a tuple pattern matches without binding a name.
 func TestInferTuplePatternWildcard(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(t: [number, string]) {
@@ -164,7 +164,7 @@ func TestInferObjectPatternLeafDefault(t *testing.T) {
 }
 
 // A trailing rest element relaxes the tuple requirement to an inexact prefix, so
-// the fixed slots bind without a spurious arity error. The rest element itself is
+// the fixed elements bind without a spurious arity error. The rest element itself is
 // reported unsupported, since typed rest tuples are M9.
 func TestInferTuplePatternRestPrefix(t *testing.T) {
 	values, _, errs := inferSource(t, `
@@ -280,7 +280,7 @@ func TestInferMatchParamUsageObject(t *testing.T) {
 }
 
 // The same usage inference applies through a tuple pattern: the scrutinee infers a
-// tuple whose arity is the pattern's and whose unused slot lands as `unknown`.
+// tuple whose arity is the pattern's and whose unused element lands as `unknown`.
 func TestInferMatchParamUsageTuple(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p) {
@@ -461,7 +461,7 @@ func TestInferMatchArmBindingScopedInDepGraph(t *testing.T) {
 }
 
 // Patterns nest across kinds: an object pattern whose field is a tuple pattern
-// binds the inner slots at the nested element types.
+// binds the inner elements at the nested element types.
 func TestInferObjectContainingTuplePattern(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(o: {pt: [number, string]}) {

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -42,7 +42,7 @@ func (c *checker) inferBlock(scope *Scope, lvl int, b *ast.Block) (soltype.Type,
 // operand). Body-level declarations are VarDecl-only: a DeclStmt wrapping any
 // other decl kind is a permanent BodyDeclNotAllowedError (§3.2), not the
 // temporary subset gate. Each val/var introduces a fresh, independent binding
-// and overwrites the name's slot in the current scope, so redeclaration rebinds
+// and overwrites the name's binding in the current scope, so redeclaration rebinds
 // without constraining the old and new types together.
 func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 	// M4 G1: record the enclosing statement so a reassignment in expression position
@@ -58,7 +58,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		// A return contributes both as the block's tail value (consumed only by
 		// value-position blocks; inferFunc discards the tail) AND as one of the
 		// enclosing function's return points. Bare `return` contributes Void in
-		// both slots.
+		// both roles.
 		var t soltype.Type = &soltype.Void{}
 		if s.Expr != nil {
 			t = c.inferExpr(scope, lvl, s.Expr)
@@ -103,7 +103,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is
-		// allowed and overwrites the name's slot (§3.2). inferVarDecl reports a
+		// allowed and overwrites the name's binding (§3.2). inferVarDecl reports a
 		// missing initializer itself and returns ok=false; bind only when it
 		// produced a type.
 		if b, ok := c.inferVarDecl(scope, lvl, vd); ok {

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -535,7 +535,7 @@ func litKindOrder(l soltype.Lit) int {
 }
 
 // compareLifetime orders the lifetime forms a RefType.Lt can take. A nil
-// slot, which marks an owned value, sorts first. Then 'static. Then
+// lifetime, which marks an owned value, sorts first. Then 'static. Then
 // LifetimeVar, ordered by ID. Then LifetimeUnion, ordered by length first
 // and members second.
 func compareLifetime(a, b soltype.Lifetime) int {

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -400,7 +400,7 @@ func (c *checker) recordMemberUse(e ast.Expr) {
 // given program point, blaming moveNode for the consume. The source must be a place —
 // a binding or a field path such as `pair.a` — whose value is owned-movable. A borrow,
 // value type, fresh literal, or non-place expression consumes nothing here. A field
-// path consumes only that field's slot, the partial move from PR 7.
+// path consumes only that field, the partial move from PR 7.
 //
 // It does NOT force the moved value's borrows to 'static. A return or local store
 // flows the value out at the call's own lifetime, not 'static, so forcing here would

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -129,7 +129,7 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		// A literal pattern asserts the literal is an admissible value of the
 		// scrutinee, so the literal flows INTO the scrutinee. `5 <: number` checks.
 		// The check is exact against a concrete scrutinee such as a top-level `match`
-		// arm. For a NESTED slot the scrutinee here is the field's covariant result
+		// arm. For a NESTED field the scrutinee here is the field's covariant result
 		// var, which carries no upper bound. So a kind mismatch like `{x: "hi"}`
 		// against `{x: number}` is not yet rejected. The refutable literal-pattern
 		// check lands with E2's `match`, which this path is laid out to extend. A
@@ -242,16 +242,16 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 
 // applyLeafExtras resolves a destructured leaf's optional type annotation
 // (`{x :: T}`, `[a :: T]`) and default value (`{x = d}`, `[a = d]`) against its
-// slot type, returning the type to bind. An annotation constrains the slot to
-// satisfy it and is then adopted as the leaf's type, mirroring how an annotated
+// leaf type, returning the type to bind. An annotation constrains the leaf type
+// to satisfy it and is then adopted as the leaf's type, mirroring how an annotated
 // `val` adopts its annotation. A default is required to satisfy that bound type
 // and flows into it, so a leaf bound from an absent-but-defaulted field reads the
 // default's type rather than `never`.
-func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot soltype.Type, typeAnn ast.TypeAnn, def ast.Expr) soltype.Type {
-	bound := slot
+func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, leafType soltype.Type, typeAnn ast.TypeAnn, def ast.Expr) soltype.Type {
+	bound := leafType
 	if typeAnn != nil {
 		if annT, ok := c.resolveTypeAnn(typeAnn, lvl); ok {
-			c.constrain(node, slot, annT)
+			c.constrain(node, leafType, annT)
 			bound = annT
 		}
 	}
@@ -262,11 +262,11 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 	return bound
 }
 
-// applyBindMode wraps a destructured leaf's slot type according to the scrutinee's
+// applyBindMode wraps a destructured leaf's leaf type according to the scrutinee's
 // binding mode and the leaf's own `mut` marker. It returns the type the leaf binds at.
 //
 //   - Owned scrutinee: the leaf is moved out. A `mut` leaf thaws into an owned-mutable
-//     cell, so a later write through it succeeds. A plain leaf keeps the slot's
+//     cell, so a later write through it succeeds. A plain leaf keeps the leaf's
 //     immutable type.
 //   - `&` scrutinee: the leaf is a shared borrow bounded by the scrutinee's lifetime.
 //     A `mut` leaf is rejected and recovers as the shared borrow. Mutable access cannot
@@ -279,35 +279,35 @@ func (c *checker) applyLeafExtras(scope *Scope, lvl int, node ast.Node, slot sol
 // returned unchanged. A leaf whose element shape is not statically known has a nil
 // concrete and is also returned unchanged. This is the same conservative choice
 // fieldReadBorrow makes for an unknown receiver.
-func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete soltype.Type, scrutineeMode bindMode) soltype.Type {
+func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, leafType, concrete soltype.Type, scrutineeMode bindMode) soltype.Type {
 	switch scrutineeMode.borrow {
 	case bmImm:
 		if mut {
 			c.report(&MutLeafThroughSharedBorrowError{Node: node})
 		}
-		if ri, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
+		if ri, ok := leafType.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
 			return soltype.NewRef(false, scrutineeMode.lt, ri)
 		}
-		return slot
+		return leafType
 	case bmMut:
-		if _, ok := slot.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
+		if _, ok := leafType.(soltype.RefInner); ok && soltype.BorrowableType(concrete) {
 			// Route the projection through a fresh variable rather than wrapping the
-			// slot directly. A tuple or object pattern pins each leaf's slot to the
-			// scrutinee's concrete element as an upper bound. That makes the slot
+			// leaf type directly. A tuple or object pattern pins each leaf type to the
+			// scrutinee's concrete element as an upper bound. That makes the leaf type
 			// invariantly exact under the `&mut` wrapper, so an inexact write
 			// requirement `mut {y, ...}` would clash with the exact element. The fresh
-			// variable takes the slot only as a lower bound. Its shape stays free to
+			// variable takes the leaf type only as a lower bound. Its shape stays free to
 			// absorb the write requirement.
 			v := c.freshAt(lvl)
-			c.constrain(node, slot, v)
+			c.constrain(node, leafType, v)
 			return soltype.NewRef(true, scrutineeMode.lt, v)
 		}
-		return slot
+		return leafType
 	default: // bmOwned
 		if mut {
-			return c.thawOwnedLeaf(lvl, node, slot, concrete)
+			return c.thawOwnedLeaf(lvl, node, leafType, concrete)
 		}
-		return slot
+		return leafType
 	}
 }
 
@@ -319,19 +319,19 @@ func (c *checker) applyBindMode(lvl int, node ast.Node, mut bool, slot, concrete
 // checks against the concrete shape, exactly as the IdentPat thaw does.
 //
 // When the projected type is not statically known, concrete is nil. The thaw then
-// routes the projection variable through a fresh widenable variable. The slot flows in
-// as a lower bound, and widening at coalesce time turns a literal field into its
-// primitive. The cell carries a variable rather than a concrete object. That is less
-// precise to render but still admits the write.
-func (c *checker) thawOwnedLeaf(lvl int, node ast.Node, slot, concrete soltype.Type) soltype.Type {
+// routes the projection variable through a fresh widenable variable. The leaf type
+// flows in as a lower bound, and widening at coalesce time turns a literal field into
+// its primitive. The cell carries a variable rather than a concrete object. That is
+// less precise to render but still admits the write.
+func (c *checker) thawOwnedLeaf(lvl int, node ast.Node, leafType, concrete soltype.Type) soltype.Type {
 	if concrete != nil {
 		widened := widen(stripOwnedMut(concrete))
 		inner, ok := widened.(soltype.RefInner)
 		if !ok {
 			// A primitive or function leaf is not borrowable, so `mut` is a no-op. It
-			// keeps its slot type, mirroring `val mut a = 1` keeping the primitive. Only
+			// keeps its leaf type, mirroring `val mut a = 1` keeping the primitive. Only
 			// an object or tuple leaf thaws into a mutable cell.
-			return slot
+			return leafType
 		}
 		ref := soltype.NewRef(true, nil, inner)
 		c.recordProv(ref, node, OwnedMutConstruction)
@@ -339,7 +339,7 @@ func (c *checker) thawOwnedLeaf(lvl int, node ast.Node, slot, concrete soltype.T
 	}
 	v := c.freshAt(lvl)
 	v.Widenable = true
-	c.constrain(node, slot, v)
+	c.constrain(node, leafType, v)
 	ref := soltype.NewRef(true, nil, v)
 	c.recordProv(ref, node, OwnedMutConstruction)
 	return ref

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -202,7 +202,7 @@ func (f *freshener) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { 
 // coalesced Union/Intersection nodes whose LevelOf is 0 (which freshenAbove's
 // LevelOf prune would skip) — and freshens vars wherever they occur.
 //
-// inferAssign uses it on a binding's coalesced slot type: coalesceScheme RETAINS
+// inferAssign uses it on a binding's coalesced type: coalesceScheme RETAINS
 // type-parameter vars by pointer, so constraining the source against that type would
 // mutate the binding's own vars and poison a reassigned polymorphic var for every
 // later use. Freshening first makes the constraint mutate throwaway copies instead.
@@ -275,7 +275,7 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // inside lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
 // lvl and freshens its bounds, so each use gets its own lifetime and constraining
 // one site does not perturb another. A LifetimeVar at lim or outside it, 'static,
-// and a nil slot are shared. The freshener passes its own lim; allFreshener passes
+// and a nil lifetime are shared. The freshener passes its own lim; allFreshener passes
 // math.MinInt so every lifetime is freshened.
 //
 // The cache is allocated lazily, so a borrow-free rewrite pays no allocation. It is

--- a/internal/solver/scope.go
+++ b/internal/solver/scope.go
@@ -85,7 +85,7 @@ type Namespace struct {
 // a parent link for lexical lookup.
 //
 // Why namespaces are stored by pointer while values/types are stored by value:
-// the distinction is by *kind*, not by slot. A Namespace is a shared, mutable,
+// the distinction is by *kind*, not by which scope map holds it. A Namespace is a shared, mutable,
 // recursive container — keyed by its qualified dep_graph BindingKey, referenced
 // from several scopes/files (so a pointer gives it one identity), populated
 // incrementally after insertion (a struct value in a map can't be field-mutated

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -165,7 +165,7 @@ func TestScriptEmpty(t *testing.T) {
 }
 
 // TestScriptRedeclaration checks that a script allows a name to be redeclared, the
-// function-body rule rather than the module rule. inferStmt overwrites the name's slot
+// function-body rule rather than the module rule. inferStmt overwrites the name's binding
 // on a body-level `val`/`var`, so a second declaration rebinds without constraining
 // the old and new types together. A later reference sees the new type. The identical
 // source as a module is rejected, because the dep-graph driver reports a duplicate
@@ -191,7 +191,7 @@ func TestScriptRedeclaration(t *testing.T) {
 // (inferAssign), distinct from the declaration-aliasing path the other parity cases
 // drive. inferAssign reads the enclosing statement from c.fn.currentStmt to find its
 // CFG StmtRef, which only exists because InferScript installs a funcCtx and runs the
-// liveness pre-pass over the script body. Reassigning an owned value into an owned slot
+// liveness pre-pass over the script body. Reassigning an owned value into an owned destination
 // moves it, so the later use of the source is a use-after-move. Mutating it before the
 // reassignment makes it dead, and the move stays silent.
 func TestScriptReassignTransition(t *testing.T) {

--- a/internal/solver/simplify_test.go
+++ b/internal/solver/simplify_test.go
@@ -37,7 +37,7 @@ func TestCoalesceSchemeMergesCoOccurring(t *testing.T) {
 }
 
 // Variables that do NOT co-occur stay distinct: two independent parameters each
-// flowing to its own tuple slot share no union/intersection group, so each remains
+// flowing to its own tuple element share no union/intersection group, so each remains
 // its own type parameter.
 func TestCoalesceSchemeKeepsDistinctParams(t *testing.T) {
 	a := &soltype.TypeVarType{ID: 1, Level: 1}

--- a/internal/solver/transition_test.go
+++ b/internal/solver/transition_test.go
@@ -29,7 +29,7 @@ import (
 //   - The G2 static-escape cases (TestStaticEscapeTransition) isolate the lifetime
 //     query, its polarity, the transitive-member reach, and the target-dead early
 //     return. From source those are confounded by the global-write store error and the
-//     borrow-into-owned-slot escape, or are not constructible at all. The feature's
+//     borrow-into-owned destination escape, or are not constructible at all. The feature's
 //     end-to-end coverage is TestStaticEscapeTransitionFromSource.
 
 func numT() *soltype.PrimType { return &soltype.PrimType{Prim: soltype.NumPrim} }
@@ -245,7 +245,7 @@ func TestStaticEscapeTransition(t *testing.T) {
 
 // TestStaticEscapeTransitionFromSource is the end-to-end move-engine counterpart.
 // Storing the borrow `p` into the module-level `sink` consumes p: the store transfers
-// it into the permanent 'static slot, so the later `val snap: &{x: number} = p` reads a
+// it into the permanent 'static storage location, so the later `val snap: &{x: number} = p` reads a
 // moved value and is a use-after-move. The global-write exclusivity check skips the
 // consumed source's self-conflict, so the single UseAfterMoveError is the only
 // diagnostic.
@@ -270,7 +270,7 @@ func TestStaticEscapeTransitionFromSource(t *testing.T) {
 // stored into an immutable global (see the dead-source case below).
 func TestGlobalWriteMutTransition(t *testing.T) {
 	// Storing an owned-mutable value into the global `sink` moves it: the store
-	// transfers ownership into the permanent slot, so the later `p.x = 5` is a
+	// transfers ownership into the permanent storage location, so the later `p.x = 5` is a
 	// use-after-move. This is the motivating `leak` example — the move consumes p, so
 	// the mutation that would let `sink` observe a later write is rejected.
 	t.Run("mut_into_immutable_global_then_mutate_error", func(t *testing.T) {
@@ -708,7 +708,7 @@ func TestMutabilityTransitionsFromSource(t *testing.T) {
 }
 
 // TestRule2TransitionFromSource covers binding an immutable value into an owned `mut`
-// slot while the source stays live afterward. The bind takes the immutable→mutable
+// destination while the source stays live afterward. The bind takes the immutable→mutable
 // upgrade — config is a uniquely-owned place, so granting mutableConfig the mutable type
 // aliases nothing live — and the move consumes config, so the later `config.x` read is a
 // use-after-move. Owned-into-owned is a move under the affine rule, so the move governs
@@ -734,7 +734,7 @@ func TestRule2TransitionFromSource(t *testing.T) {
 // the owned-mutable source these cases reassign from.
 func TestMutabilityTransitionReassignFromSource(t *testing.T) {
 	t.Run("source_live_error", func(t *testing.T) {
-		// Reassigning the owned `items` into the owned `snap` slot moves it: snap drops
+		// Reassigning the owned `items` into the owned `snap` destination moves it: snap drops
 		// its old value and takes ownership of items, so the later `items.x = 2` is a
 		// use-after-move.
 		_, _, errs := inferSource(t, `

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -294,7 +294,7 @@ func bindingType(b ValueBinding) soltype.Type {
 //	Rule 3: multiple mutable aliases are always allowed (mut → mut is not a transition).
 //
 // targetAlwaysLive marks a target that outlives the function, the permanent
-// module-level slot checkGlobalWriteTransition passes. Such a target has no liveness
+// module-level storage location checkGlobalWriteTransition passes. Such a target has no liveness
 // window, so the dead-target early return below is skipped for it.
 func (c *checker) checkMutabilityTransition(
 	sourceVarID liveness.VarID,
@@ -584,7 +584,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 	aliasMut := aliasMutability(targetMut)
 	c.recordVarIDType(targetVarID, targetType)
 
-	// A reassignment that MOVES its source — `q = p` for an owned p into an owned slot
+	// A reassignment that MOVES its source — `q = p` for an owned p into an owned destination
 	// — drops the previous value of q and takes ownership of p's value, so q becomes a
 	// fresh owner and p is consumed. Reassign to no source rather than aliasing, and let
 	// the move engine govern a later use of p; inferAssign records the consume through
@@ -627,7 +627,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 // source holds. Storing a mutable borrow into an immutable global, or an immutable one
 // into a mutable global, is therefore a mut↔immutable transition against a permanent,
 // always-live target. It conflicts when the source stays live at the conflicting
-// mutability after the store, WITHIN this body. slotType is the global binding's own
+// mutability after the store, WITHIN this body. targetType is the global binding's own
 // type, whose mutability is the target side of the transition.
 //
 // This is an in-body check only. It does NOT make a store into a global sound: a borrow
@@ -639,7 +639,7 @@ func (c *checker) trackAliasesForAssignment(target *ast.IdentExpr, rhs ast.Expr,
 //
 // Run BEFORE constrainEscape so the source's own about-to-happen escape is not
 // double-counted by the G2 escape query as a prior permanent alias.
-func (c *checker) checkGlobalWriteTransition(target *ast.IdentExpr, rhs ast.Expr, slotType soltype.Type, enclosingStmt ast.Stmt) {
+func (c *checker) checkGlobalWriteTransition(target *ast.IdentExpr, rhs ast.Expr, targetType soltype.Type, enclosingStmt ast.Stmt) {
 	if c.fn == nil || c.fn.aliases == nil {
 		return
 	}
@@ -650,7 +650,7 @@ func (c *checker) checkGlobalWriteTransition(target *ast.IdentExpr, rhs ast.Expr
 	source := liveness.DetermineAliasSource(rhs)
 	switch source.RootKind() {
 	case liveness.AliasSourceVariable, liveness.AliasSourceMultiple:
-		targetMut := isMutableType(slotType)
+		targetMut := isMutableType(targetType)
 		for _, sourceVarID := range source.UniqueVarIDs() {
 			c.checkMutabilityTransition(
 				sourceVarID, 0,

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -299,7 +299,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	return t, true
 }
 
-// resolveLifetimeAnn resolves the lifetime slot of a borrow annotation. A nil node is
+// resolveLifetimeAnn resolves the lifetime of a borrow annotation. A nil node is
 // an inferred borrow and mints a fresh lifetime. A named `'a` resolves to the variable
 // that name denotes. A `('a | 'b)` union resolves each member and joins them in a
 // LifetimeUnion.

--- a/internal/solver/widen_test.go
+++ b/internal/solver/widen_test.go
@@ -172,7 +172,7 @@ fn f() { y = 6 }`)
 		require.Equal(t, "number", values["y"])
 	})
 	// Reference widening rides the Widenable flag at coalesce time (display, the
-	// reassignment slot, the binding's own type), but the literal still flows into
+	// reassignment target, the binding's own type), but the literal still flows into
 	// the bound graph unwidened, so a read of the reference-widened var into a new
 	// binding keeps the precise literal: `val z = y` ⇒ z: 5. A direct literal
 	// widens at the constraint level instead, so ITS reads widen (see
@@ -221,7 +221,7 @@ func TestInferVarWideningBodyLevel(t *testing.T) {
 		require.Equal(t, "fn () -> number", values["f"])
 	})
 	// A body-level `var` initialized from a REFERENCE widens via the wrapper var's
-	// Widenable flag, so the reassignment slot is the primitive and `y = 6` checks
+	// Widenable flag, so the reassignment target is the primitive and `y = 6` checks
 	// — the body-level twin of TestInferVarWideningThroughReference.
 	t.Run("reference widens and reassigns", func(t *testing.T) {
 		_, _, errs := inferSource(t, `fn f() { val x = 5


### PR DESCRIPTION
Replace imprecise uses of "slot" in comments and documentation with more specific terminology that accurately describes what is being discussed.

The term "slot" was used ambiguously across the codebase to refer to several distinct concepts:
- Function parameters in callback/function subtyping contexts
- Object properties in structural subtyping
- Binding targets in variable declarations and assignments
- Borrow destinations in reference type constraints
- Tuple elements in pattern matching

Changes made:
- In function subtyping contexts: "slot" → "parameter" or "callback parameter" (e.g., "fn(x, y) slot" becomes "fn(x, y) callback parameter")
- In object subtyping: "slot" → "property" (e.g., "required target slot" becomes "required target property")
- In variable/assignment contexts: "slot" → "binding" or "type" (e.g., "var slot" becomes "var binding")
- In borrow/reference contexts: "slot" → "destination" or "target" (e.g., "mutable slot" becomes "mutable target")
- In tuple patterns: "slot" → "element" (e.g., "tuple slot" becomes "tuple element")

This improves clarity in comments throughout the solver, type checking, pattern matching, and error reporting code, making it easier to understand the specific constraint being discussed without requiring context about which domain the comment appears in.

https://claude.ai/code/session_01BosjfYR2NZjJrQtu1x4wQw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified terminology across solver comments and tests for consistency and readability.
  * Reworded references to bindings, destinations, properties, elements, and lifetimes in explanatory text.

* **Refactor**
  * Renamed a few local identifiers in comments and tests to better match the updated terminology.

* **Style**
  * Adjusted line wrapping and wording throughout comments without changing behavior or test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->