### PR TITLE
Unify overload and lattice member ordering through specificity

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -231,40 +231,37 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each member under a probe;
-	// the first success commits, the losers roll back. Free TypeVar members
-	// are skipped to avoid speculatively pinning them to sub.
+	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each concrete member under a
+	// probe most-specific-first; the first success commits, the losers roll back.
+	// Free TypeVar members are skipped to avoid speculatively pinning them to sub.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
-			var trialErrs [][]SolverError
-			triedAny := false
-			for _, m := range supU.Types {
-				if _, isVar := m.(*soltype.TypeVarType); isVar {
-					continue
-				}
-				triedAny = true
-				p := newProbe(c.probe)
-				c.probe = p
-				errs := c.constrain(sub, m, seen.Clone(), mutCtx)
-				c.probe = p.parent
-				if len(errs) == 0 {
-					p.Commit()
+			order := concreteSpecificityOrder(supU.Types)
+			if len(order) > 0 {
+				committed, trialErrs := c.trialAndCommit(order, func(idx int) []SolverError {
+					// A cloned seen keeps each member's coinductive cache independent, so a
+					// failed member's entries can't wrongly short-circuit a later member.
+					return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
+				})
+				if committed {
 					return nil
 				}
-				p.Discard()
-				trialErrs = append(trialErrs, errs)
-			}
-			if !triedAny {
-				// Every member was a free var; fall through to the var arms.
-			} else {
-				// Every concrete branch failed. Promote a uniform
-				// BorrowEscape outcome so the lifetime cause survives;
-				// otherwise emit the generic union-level error.
+				if supU.Inexact {
+					// An inexact union super has an open, unknown-typed tail. A sub that
+					// matches no named member is subsumed by that tail, so accept it. This
+					// is the dual of the union-sub arm above, which rejects an inexact sub
+					// into a closed super because that open tail can't be absorbed.
+					return nil
+				}
+				// Every concrete branch failed. Promote a uniform BorrowEscape outcome
+				// so the lifetime cause survives; otherwise emit the generic union-level
+				// error.
 				if commonBorrowEscape(trialErrs) != nil {
 					return []SolverError{&BorrowEscapeError{Sub: sub.(*soltype.RefType), Super: super}}
 				}
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 			}
+			// Every member was a free var; fall through to the var arms.
 		}
 	}
 
@@ -529,31 +526,22 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		//     direct call would, in the same order.
 		//   - Annotation input (M6 PR2). `val x: A & B = e` resolves through
 		//     resolveTypeAnn into an IntersectionType and reaches here when the
-		//     binding flows into a constraint. specificityOrder ranks
-		//     non-function arms last in declaration order, so a non-function
-		//     intersection trials in declaration order without a separate code
-		//     path.
+		//     binding flows into a constraint. specificityOrder ranks general
+		//     types, so a non-function intersection trials its more-specific
+		//     members first; incomparable members keep declaration order.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
-			funcs := make([]*soltype.FuncType, len(sub.Types))
-			for i, m := range sub.Types {
-				funcs[i], _ = m.(*soltype.FuncType)
-			}
-			var lastErrs []SolverError
-			for _, idx := range specificityOrder(funcs) {
-				p := newProbe(c.probe)
-				c.probe = p
+			committed, trialErrs := c.trialAndCommit(specificityOrder(sub.Types), func(idx int) []SolverError {
 				// A cloned seen keeps each arm's coinductive cache independent, so a failed
 				// arm's entries can't wrongly short-circuit a later arm to success.
-				errs := c.constrain(sub.Types[idx], super, seen.Clone(), mutCtx)
-				c.probe = p.parent
-				if len(errs) == 0 {
-					p.Commit()
-					return nil
-				}
-				p.Discard()
-				lastErrs = errs
+				return c.constrain(sub.Types[idx], super, seen.Clone(), mutCtx)
+			})
+			if committed {
+				return nil
 			}
-			return lastErrs
+			if len(trialErrs) > 0 {
+				return trialErrs[len(trialErrs)-1] // no arm matched: surface the last arm's failure
+			}
+			return nil
 		}
 	}
 

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -160,6 +160,29 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 	})
 }
 
+// TestConstrainInexactUnionSuperAcceptsViaTail covers the union-super exists rule for
+// an INEXACT super. The open tail is unknown-typed, so a concrete sub that matches no
+// named member is still subsumed by the tail and accepted, rather than reported as a
+// union-level CannotConstrainError.
+//
+//	boolean <: (number | string | ...)    accepted via the open tail
+//
+// This is the dual of TestConstrainInexactUnionIntoClosedRejects, where an inexact SUB
+// into a closed super is rejected because that tail can't be absorbed. The parser surface
+// for `A | B | ...` lands in PR4, so until then the rule fires only against an
+// internally-built inexact union, minted directly through the smart constructor.
+func TestConstrainInexactUnionSuperAcceptsViaTail(t *testing.T) {
+	c := &Context{}
+	t.Run("non-member accepted via the open tail", func(t *testing.T) {
+		super := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
+		require.Empty(t, c.Constrain(boolT(), super))
+	})
+	t.Run("a named member still commits its branch", func(t *testing.T) {
+		super := &soltype.UnionType{Types: parseTypes(t, "number", "string"), Inexact: true}
+		require.Empty(t, c.Constrain(num(), super))
+	})
+}
+
 // TestConstrainUnionPrecedesRefArm proves the pre-switch placement: a
 // borrow flowing into a union of borrows must match a member, NOT hit the
 // RefType arm's "non-variable super" path that treats a union super as a

--- a/internal/solver/infer_assign_test.go
+++ b/internal/solver/infer_assign_test.go
@@ -159,9 +159,9 @@ func TestInferAssignTopLevelBrokenBindingNoCascade(t *testing.T) {
 	require.Equal(t, "error", values["a"]) // recovered as the sentinel, not never
 }
 
-// Reassigning a union-typed var applies the union-target rule: a member assigns, a
-// non-member is rejected once. (Union subtyping in general is M6; inferAssign trials
-// the members under a probe so a legal member assignment isn't wrongly rejected.)
+// Reassigning a union-typed var applies the union-super exists rule in constrain: a
+// member assigns, a non-member is rejected once. constrain trials each member under a
+// probe so a legal member assignment isn't wrongly rejected.
 func TestInferAssignUnionTarget(t *testing.T) {
 	t.Run("member assigns", func(t *testing.T) {
 		_, _, errs := inferSource(t, `
@@ -183,17 +183,12 @@ func TestInferAssignUnionTarget(t *testing.T) {
 	})
 }
 
-// KNOWN GAP (M6): assigning an inference-variable source into a union target
-// over-narrows the variable. `a = x` for an un-annotated param `x` and `a: 1 | 2`
-// commits the first matching member (`x <: 1`), so `x` infers as `1` rather than
-// the sound `1 | 2`. This is INCOMPLETE, not unsound (the committed bound is always
-// stronger than required, so no invalid program is accepted), and it is not fixable
-// in constrainAssign — falling through to constrain(source, union) injects the
-// coalesced union node into source's bound list and panics the coalescer. The correct
-// fix is M6's first-class union subtyping with inference variables. This pins the
-// interim behavior so the M6 change is visible: when it lands, `x` becomes `1 | 2`
-// and this assertion must be updated. See constrainAssign's KNOWN GAP note.
-func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
+// Assigning an inference-variable source into a union target records the WHOLE union as
+// the variable's upper bound rather than committing to one member. `a = x` for an
+// un-annotated param `x` and `a: 1 | 2` defers, because the union-super exists rule is
+// gated to a concrete sub. The variable falls through to the subVar arm, which records
+// the whole union, so `x` coalesces as the sound and complete `1 | 2`.
+func TestInferAssignUnionTargetVarRHSWidensToUnion(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(c: boolean, x) {
 			var a = if c { 1 } else { 2 }
@@ -201,8 +196,7 @@ func TestInferAssignUnionTargetVarRHSOverNarrows(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	// M6 target: "fn (c: boolean, x: 1 | 2) -> void".
-	require.Equal(t, "fn (c: boolean, x: 1) -> void", values["f"])
+	require.Equal(t, "fn (c: boolean, x: 1 | 2) -> void", values["f"])
 }
 
 // A namespace name as an assignment target reports NamespaceUsedAsValue, mirroring

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1145,7 +1145,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		// type-checks. The carrier feeds the upgrade for the same reason it feeds the
 		// strict check below: a borrow forced to 'static satisfies the owned global.
 		if !c.tryUpgradeToOwnedMut(e, e.Right, soltype.CarrierOf(sourceT), targetT) {
-			c.constrainAssign(e, soltype.CarrierOf(sourceT), targetT)
+			c.constrain(e, soltype.CarrierOf(sourceT), targetT)
 		}
 		if len(c.errs) == errsBefore {
 			// The store aliases the source into a permanent module-level storage location. If the
@@ -1179,9 +1179,9 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 	} else if !c.tryUpgradeToOwnedMut(e, e.Right, sourceT, targetT) {
 		// A uniquely-owned source reassigned into an owned-mutable `var` takes the
 		// immutable→mutable upgrade, the same grant the annotated declaration makes. The
-		// upgrade fires only for a RefType target, so a union target still routes through
-		// constrainAssign's per-member trial below.
-		c.constrainAssign(e, sourceT, targetT)
+		// upgrade fires only for a RefType target, so a union target instead routes through
+		// constrain's union-super exists rule, which trials each member under a probe.
+		c.constrain(e, sourceT, targetT)
 	}
 	if c.fn != nil && len(c.errs) == assignErrsBefore && target.VarID > 0 {
 		// Track against the binding's own type, not the freshened targetT. The G2
@@ -1400,49 +1400,6 @@ func (c *checker) recordWritten(recv soltype.Type, name string, t soltype.Type) 
 	if v, ok := recv.(*soltype.TypeVarType); ok {
 		c.fn.written[fieldKey{recvID: v.ID, field: name}] = t
 	}
-}
-
-// constrainAssign asserts `source <: target` for a reassignment. For a UNION target
-// it applies the union-target rule — X <: (A | B) iff X <: A or X <: B — by trying
-// each member speculatively under a probe, committing the first that holds. constrain
-// itself has no UnionType-super rule until M6, so without this a legal assignment of a
-// union member (`var a = if c { 1 } else { 2 }; a = 1`) would be wrongly rejected.
-// A non-union target takes the ordinary single-constraint path.
-//
-// KNOWN GAP (M6): when `source` is (or contains) an inference variable, committing the
-// first matching member over-narrows it. `var a = 1 | 2; a = x` for an un-annotated
-// param `x` commits `x <: 1` and infers `x: 1` instead of the sound `x: 1 | 2`,
-// which can wrongly reject a later use of `x` that needs `2`. This is INCOMPLETE,
-// not unsound — the committed bound is always stronger than required, so no invalid
-// program is accepted. It is not fixable here: the obvious "don't commit, fall
-// through to constrain(source, target)" injects the COALESCED union node into source's
-// bound list and panics the coalescer (coalesced output must never re-enter the
-// graph). A correct fix needs first-class union subtyping with inference variables
-// — M6's deferred union/intersection rules in constrain. Pinned by
-// TestInferAssignUnionTargetVarRHSOverNarrows.
-func (c *checker) constrainAssign(n ast.Node, source, target soltype.Type) {
-	union, ok := target.(*soltype.UnionType)
-	if !ok {
-		c.constrain(n, source, target)
-		return
-	}
-	for _, member := range union.Types {
-		p := c.openProbe()
-		errs := c.ctx.Constrain(source, member)
-		c.closeProbe(p, len(errs) == 0) // commit the first member that holds; else roll back
-		if len(errs) == 0 {
-			return
-		}
-	}
-	if union.Inexact {
-		// An inexact union target has an open tail of unknown type, so a
-		// value that does not match any named member still satisfies the
-		// tail. Skip the failure report. The tail accepts everything.
-		return
-	}
-	// No member matched: report once against the whole union (CannotConstrainError),
-	// blaming the assignment.
-	c.constrain(n, source, target)
 }
 
 // bindingDecl returns the AST node of the binding's introducing declaration — the

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -109,53 +109,59 @@ func (c *checker) overloadOrder(schemes []TypeScheme, args []soltype.Type) []int
 		}
 		return order // an unconstrained arg can't rank arms, so try in declaration order
 	}
-	funcs := make([]*soltype.FuncType, len(schemes))
+	cands := make([]soltype.Type, len(schemes))
 	for i, s := range schemes {
-		funcs[i] = schemeFunc(s)
+		// A non-function arm's body is not a FuncType, so leave its slot a nil
+		// interface. specificityOrder ranks a nil candidate last. Boxing a typed
+		// nil *FuncType here would instead pass typeSpecificity a non-nil interface
+		// over a nil pointer and panic on the param access.
+		if ft := schemeFunc(s); ft != nil {
+			cands[i] = ft
+		}
 	}
-	return specificityOrder(funcs)
+	return specificityOrder(cands)
 }
 
-// specificityOrder returns funcs' indices most-specific-first, with declaration order
-// breaking ties. It ranks each arm by its DOMINATION COUNT — the number of other arms
-// strictly more specific than it, i.e. that "dominate" it — and sorts ascending on that
-// count, so an arm dominated by nobody comes first and the generic catch-all that every
-// other arm beats comes last.
+// specificityOrder returns cands' indices most-specific-first, with declaration order
+// breaking ties. It ranks each candidate by its DOMINATION COUNT — the number of other
+// candidates strictly more specific than it, i.e. that "dominate" it — and sorts ascending
+// on that count, so a candidate dominated by nobody comes first and the generic catch-all
+// that every other candidate beats comes last.
 //
-// For example, given arms (x: number), (x: T), and (x: string): each concrete arm is
-// dominated by nobody (number and string are incomparable), so both get count 0; the
-// generic (x: T) is dominated by both, count 2. Ascending order is therefore number,
-// string, T — the concretes first (their tie kept in declaration order), the generic last.
+// For example, given candidates number, T, and string: each concrete candidate is
+// dominated by nobody, since number and string are incomparable, so both get count 0; the
+// variable T is dominated by both, count 2. Ascending order is therefore number, string,
+// T — the concretes first with their tie kept in declaration order, the variable last.
 //
-// The domination count exists to dodge a partial-order sort hazard. The moreSpecific
-// relation is only a partial order: some arm pairs are incomparable (the tie cases —
-// different literal tags, disjoint shapes, different arities), and incomparability is not
-// transitive (A incomparable to B and B to C does not make A incomparable to C). Feeding
-// moreSpecific straight to sort.SliceStable would therefore violate the strict-weak-ordering
-// contract and yield undefined results. Projecting each arm onto its integer domination
-// count yields a TOTAL order on integers, so the sort is well-defined. An arm dominated by
-// none gets count 0 and sorts first; equal counts keep declaration order through the
-// stable sort.
+// The domination count exists to dodge a partial-order sort hazard. The typeSpecificity
+// relation is only a partial order: some pairs are incomparable, the tie cases such as
+// different literal tags, disjoint shapes, or different function arities, and
+// incomparability is not transitive, so A incomparable to B and B to C does not make A
+// incomparable to C. Feeding typeSpecificity straight to sort.SliceStable would therefore
+// violate the strict-weak-ordering contract and yield undefined results. Projecting each
+// candidate onto its integer domination count yields a TOTAL order on integers, so the
+// sort is well-defined. A candidate dominated by none gets count 0 and sorts first; equal
+// counts keep declaration order through the stable sort.
 //
-// overloadOrder uses this for direct calls and constrain's IntersectionType arm uses it
-// for value-position calls, so both resolve in the same order. A nil entry is a
-// non-function arm and sorts last.
-func specificityOrder(funcs []*soltype.FuncType) []int {
-	order := make([]int, len(funcs))
+// overloadOrder uses this for direct calls, and constrain's IntersectionType-sub and
+// UnionType-super exists arms use it for their member trials, so every trial site resolves
+// in the same order. A nil candidate is a non-function overload arm and sorts last.
+func specificityOrder(cands []soltype.Type) []int {
+	order := make([]int, len(cands))
 	for i := range order {
 		order[i] = i
 	}
-	dominators := make([]int, len(funcs))
-	for i := range funcs {
-		if funcs[i] == nil {
-			dominators[i] = len(funcs) + 1 // non-function arms sort last
+	dominators := make([]int, len(cands))
+	for i := range cands {
+		if cands[i] == nil {
+			dominators[i] = len(cands) + 1 // a non-rankable candidate sorts last
 			continue
 		}
-		for j := range funcs {
-			if i == j || funcs[j] == nil {
+		for j := range cands {
+			if i == j || cands[j] == nil {
 				continue
 			}
-			if moreSpecific(funcs[j], funcs[i]) < 0 {
+			if typeSpecificity(cands[j], cands[i]) < 0 {
 				dominators[i]++
 			}
 		}
@@ -163,6 +169,56 @@ func specificityOrder(funcs []*soltype.FuncType) []int {
 	sort.SliceStable(order, func(a, b int) bool {
 		return dominators[order[a]] < dominators[order[b]]
 	})
+	return order
+}
+
+// typeSpecificity compares two trial candidates by specificity. It returns -1 when a is
+// strictly more specific than b, +1 when b is, and 0 when the two are incomparable or
+// equally specific.
+//
+// Two functions compare parameter-wise through moreSpecific, so a concrete (x: number)
+// still outranks a generic (x: T). Any other pair compares through structuralSubtype: a
+// is more specific when it is a structural subtype of b and b is not a structural subtype
+// of a. So a literal outranks its primitive, 1 before number, and a concrete type outranks
+// a bare variable. structuralSubtype ranks disjoint shapes as incomparable, which yields a
+// 0 tie that the stable sort resolves in declaration order.
+func typeSpecificity(a, b soltype.Type) int {
+	if fa, ok := a.(*soltype.FuncType); ok {
+		if fb, ok := b.(*soltype.FuncType); ok {
+			return moreSpecific(fa, fb)
+		}
+	}
+	aSubB := structuralSubtype(a, b)
+	bSubA := structuralSubtype(b, a)
+	switch {
+	case aSubB && !bSubA:
+		return -1
+	case bSubA && !aSubB:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// concreteSpecificityOrder returns the indices of types' concrete members in
+// most-specific-first order, skipping any member that is a free type variable. The
+// union-super exists rule trials these. The skip keeps the trial from speculatively
+// pinning a variable member to sub, and the specificity order keeps a less-specific
+// member from changing which branch commits.
+func concreteSpecificityOrder(types []soltype.Type) []int {
+	var concrete []soltype.Type
+	var origIdx []int
+	for i, m := range types {
+		if _, isVar := m.(*soltype.TypeVarType); isVar {
+			continue
+		}
+		concrete = append(concrete, m)
+		origIdx = append(origIdx, i)
+	}
+	order := make([]int, len(concrete))
+	for k, pos := range specificityOrder(concrete) {
+		order[k] = origIdx[pos]
+	}
 	return order
 }
 

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -254,6 +254,34 @@ func (c *checker) openProbe() *Probe {
 	return p
 }
 
+// trialAndCommit trials each index in order under a fresh child probe, returning at the
+// first trial whose body reports no errors. That winning trial's bound mutations commit,
+// and every losing trial rolls back so it leaves no bound behind. The boolean reports
+// whether a trial committed. When none does, the per-trial error lists are returned in
+// trial order so the caller can promote a shared failure, such as the union-super rule's
+// uniform BorrowEscapeError, or surface the last trial's diagnostics.
+//
+// It is the one mint path for the speculative member trials the lattice arms run.
+// constrain's IntersectionType-sub exists rule and UnionType-super exists rule both route
+// through it, so the probe push/pop discipline lives in one place. The trial body owns its
+// own coinductive seen clone, since only the caller holds the constraint key.
+func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (bool, [][]SolverError) {
+	var trialErrs [][]SolverError
+	for _, idx := range order {
+		p := newProbe(c.probe)
+		c.probe = p
+		errs := trial(idx)
+		c.probe = p.parent
+		if len(errs) == 0 {
+			p.Commit()
+			return true, nil
+		}
+		p.Discard()
+		trialErrs = append(trialErrs, errs)
+	}
+	return false, trialErrs
+}
+
 // snapshotMapEntry registers, under the active probe (else a no-op), a closure
 // that restores m[k] to its current value — or deletes the key if it is currently
 // absent — so a discarded trial leaves m exactly as it was. Shared by the Info

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -254,17 +254,19 @@ func (c *checker) openProbe() *Probe {
 	return p
 }
 
-// trialAndCommit trials each index in order under a fresh child probe, returning at the
-// first trial whose body reports no errors. That winning trial's bound mutations commit,
-// and every losing trial rolls back so it leaves no bound behind. The boolean reports
-// whether a trial committed. When none does, the per-trial error lists are returned in
-// trial order so the caller can promote a shared failure, such as the union-super rule's
-// uniform BorrowEscapeError, or surface the last trial's diagnostics.
+// trialAndCommit tries each index in order, running its trial under a fresh child probe.
+// The first trial whose body reports no errors wins. Its bound mutations commit, and the
+// method returns (true, nil). Every losing trial rolls back, so it leaves no bound behind.
 //
-// It is the one mint path for the speculative member trials the lattice arms run.
-// constrain's IntersectionType-sub exists rule and UnionType-super exists rule both route
-// through it, so the probe push/pop discipline lives in one place. The trial body owns its
-// own coinductive seen clone, since only the caller holds the constraint key.
+// When no trial wins, the method returns false with each trial's errors in trial order.
+// The caller decides what to do with them. It can promote a shared failure or report the
+// last trial's diagnostics. The union-super rule, for example, promotes a uniform
+// BorrowEscapeError when every trial reports one.
+//
+// This is the single path for the speculative member trials the lattice arms run. Both
+// constrain's IntersectionType-sub exists rule and its UnionType-super exists rule route
+// through it, so the probe push-and-pop discipline lives in one place. Each trial body
+// owns its own coinductive seen clone, since only the caller holds the constraint key.
 func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (bool, [][]SolverError) {
 	var trialErrs [][]SolverError
 	for _, idx := range order {

--- a/internal/solver/specificity_test.go
+++ b/internal/solver/specificity_test.go
@@ -1,0 +1,79 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6 PR2.5: shared specificity ordering for the trial-and-commit sites ---
+//
+// The overload resolver (overloadOrder), the IntersectionType-sub exists arm, and the
+// UnionType-super exists arm all order their candidate members through specificityOrder,
+// so most-specific-first is the one ordering rule every trial site shares. These tests
+// pin the ordering primitive directly, independent of any single trial site. The
+// observable end-to-end payoff at the overload site lives in infer_overload_test.go
+// (TestInferOverloadSpecificityBeatsDeclarationOrder and TestInferOverloadThreeArmSpecificity).
+
+// typeSpecificity ranks a literal below its primitive, a concrete type below a variable,
+// and two functions parameter-wise; disjoint shapes and equal types tie.
+func TestTypeSpecificity(t *testing.T) {
+	v := &soltype.TypeVarType{}
+	fnLit := &soltype.FuncType{Params: []*soltype.FuncParam{{Type: numLit(1)}}, Ret: num()}
+	fnPrim := &soltype.FuncType{Params: []*soltype.FuncParam{{Type: num()}}, Ret: num()}
+
+	tests := []struct {
+		name     string
+		a, b     soltype.Type
+		expected int
+	}{
+		{"literal more specific than its primitive", numLit(1), num(), -1},
+		{"primitive less specific than its literal", num(), numLit(1), 1},
+		{"concrete more specific than a variable", num(), v, -1},
+		{"variable less specific than a concrete", v, num(), 1},
+		{"disjoint primitives tie", num(), str(), 0},
+		{"equal types tie", num(), num(), 0},
+		{"function with a literal param outranks one with the primitive", fnLit, fnPrim, -1},
+		{"function with the primitive param is outranked", fnPrim, fnLit, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, typeSpecificity(tt.a, tt.b))
+		})
+	}
+}
+
+// specificityOrder lists candidates most-specific-first, and adding a less-specific
+// candidate does not change which candidate ranks first. This is the property the
+// trial-and-commit sites rely on: a new, less-specific union member or overload arm never
+// steals the win from a more-specific one.
+func TestSpecificityOrderStability(t *testing.T) {
+	// Most-specific-first: the literal outranks its primitive whatever the input order.
+	require.Equal(t, []int{1, 0}, specificityOrder([]soltype.Type{num(), numLit(1)}))
+	require.Equal(t, []int{0, 1}, specificityOrder([]soltype.Type{numLit(1), num()}))
+
+	// Adding a variable, which every concrete candidate outranks, leaves the literal first
+	// and the primitive second; the variable sorts last. The literal's win is unchanged.
+	v := &soltype.TypeVarType{}
+	require.Equal(t, []int{1, 0, 2}, specificityOrder([]soltype.Type{num(), numLit(1), v}))
+
+	// A nil candidate, a non-function overload arm, sorts last without disturbing the rest.
+	require.Equal(t, []int{1, 0, 2}, specificityOrder([]soltype.Type{num(), numLit(1), nil}))
+}
+
+// concreteSpecificityOrder skips free type-variable members and orders the rest
+// most-specific-first, returning original indices. The union-super exists rule consults
+// it, so a variable member is never trialled and the concrete members trial
+// most-specific-first.
+func TestConcreteSpecificityOrder(t *testing.T) {
+	v := &soltype.TypeVarType{}
+
+	// Members number(0), α(1), 1(2). The variable is skipped; the literal outranks the
+	// primitive, so the trial order over original indices is [2, 0].
+	require.Equal(t, []int{2, 0}, concreteSpecificityOrder([]soltype.Type{num(), v, numLit(1)}))
+
+	// All-variable members yield an empty order, the signal the union-super rule reads to
+	// fall through to the var arms.
+	require.Empty(t, concreteSpecificityOrder([]soltype.Type{v, &soltype.TypeVarType{}}))
+}


### PR DESCRIPTION
Refactor the overload resolver and constraint system to use a shared specificity-based ordering for all trial-and-commit sites. This ensures that overload resolution, intersection-type subtyping, and union-type supertyping all rank their candidate members consistently.

**Key changes:**

- Extract `typeSpecificity` as a general-purpose type comparison function that ranks literals below their primitives, concrete types below variables, and functions parameter-wise. This replaces the function-only `moreSpecific` for non-function comparisons.

- Generalize `specificityOrder` to accept `[]soltype.Type` instead of `[]*soltype.FuncType`, handling nil entries (non-function overload arms) that sort last. Update its documentation to describe candidates rather than functions.

- Add `concreteSpecificityOrder` to filter out free type variables and return the remaining members in specificity order. The union-super exists rule uses this to skip variable members and avoid speculatively pinning them to the subtype.

- Introduce `trialAndCommit` in the constraint context as the single mint path for speculative member trials. Both the intersection-sub and union-super exists rules now route through it, centralizing the probe push/pop discipline.

- Refactor `constrain`'s union-super exists rule to use `concreteSpecificityOrder` and `trialAndCommit`, replacing the previous inline trial loop. This ensures union members are trialled most-specific-first and handles inexact unions correctly (accepting non-members via the open tail).

- Refactor `constrain`'s intersection-sub exists rule to use `specificityOrder` and `trialAndCommit`, replacing the previous inline trial loop. Non-function members now trial in specificity order rather than declaration order.

- Remove `constrainAssign` from `infer_expr.go`. Its union-target rule is now subsumed by the union-super exists rule in `constrain`, which applies to all constraint sites including assignments.

- Add `specificity_test.go` with tests for `typeSpecificity`, `specificityOrder` stability, and `concreteSpecificityOrder` behavior.

- Update `infer_assign_test.go` to reflect the new behavior: assigning an inference-variable source into a union target now records the whole union as the variable's upper bound (sound and complete) rather than committing to the first matching member (incomplete).

The change ensures that most-specific-first is the one ordering rule every trial site shares, making the resolver behavior predictable and consistent across all contexts.

https://claude.ai/code/session_01WcEoMyXA3kuY49C21ubWGk