### PR TITLE
Refine borrow escape error promotion to check lifetime necessity

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -217,12 +217,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					// into a closed super because that open tail can't be absorbed.
 					return nil
 				}
-				// Every concrete branch failed. When sub is a borrow whose peeled inner
-				// satisfies some union member, the lifetime is the genuine blocker, so
-				// promote a union-level BorrowEscapeError. The peel reruns the same
-				// union-super exists rule against sub's inner, so one matching branch is
-				// enough. Otherwise every branch is a shape mismatch and the lifetime is
-				// incidental, so emit the generic union-level error.
+				// Every concrete branch failed. Promote a BorrowEscapeError when sub's
+				// peeled inner still satisfies the union; else emit the generic error.
 				if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
 					if len(c.trialUnderProbe(ref.Inner, super)) == 0 {
 						return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
@@ -470,11 +466,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// its mutability.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if sub.Lt != nil {
-				// A borrow flows into an owned destination. Emit BorrowEscapeError only
-				// when the lifetime is the genuine blocker, that is, when peeling to the
-				// inner would have satisfied super. If the inner is itself a shape
-				// mismatch, surface that error instead so the diagnostic does not blame
-				// the lifetime for a mismatch extending it could never fix.
+				// Emit BorrowEscapeError only when the peeled inner satisfies super, so
+				// the lifetime is the blocker; otherwise surface the inner's mismatch.
 				if innerErrs := c.trialUnderProbe(sub.Inner, super); len(innerErrs) > 0 {
 					return innerErrs
 				}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -55,42 +55,6 @@ func acceptSet(f *soltype.FuncType) (lo, hi int) {
 	return lo, hi
 }
 
-// commonBorrowEscape returns a representative BorrowEscapeError when every
-// per-trial error is itself a BorrowEscapeError. That means sub is a borrow
-// with a lifetime and no super-union member could host it. The caller uses
-// the returned value to emit one union-level BorrowEscapeError so the
-// lifetime cause survives. Without this collapse the union-super exists
-// rule would shadow BorrowEscape with a generic CannotConstrain and the
-// actionable diagnostic would be lost.
-//
-// Example. With `&'a {x: number} <: (number | string)`:
-//   - trial `&'a {x: number} <: number`: BorrowEscapeError (the borrow can't fit a number destination)
-//   - trial `&'a {x: number} <: string`: BorrowEscapeError (same)
-//
-// Both trials returned the same shape, so commonBorrowEscape returns one of
-// them. The caller emits `BorrowEscapeError{Sub: borrow, Super: union}` and
-// the user sees "borrow does not live long enough" rather than the unhelpful
-// "cannot constrain mut object <: number | string".
-func commonBorrowEscape(trials [][]SolverError) *BorrowEscapeError {
-	if len(trials) == 0 {
-		return nil
-	}
-	var first *BorrowEscapeError
-	for _, errs := range trials {
-		if len(errs) != 1 {
-			return nil
-		}
-		esc, ok := errs[0].(*BorrowEscapeError)
-		if !ok {
-			return nil
-		}
-		if first == nil {
-			first = esc
-		}
-	}
-	return first
-}
-
 // constraintKey keys the coinductive seen-set by pointer identity (Go's
 // interface == on pointer-backed soltype concretes). Sufficient for M1: cycles
 // in subtype-checking can only form via TypeVarTypes, and TypeVarType pointers
@@ -238,7 +202,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
 			order := concreteSpecificityOrder(supU.Types)
 			if len(order) > 0 {
-				committed, trialErrs := c.trialAndCommit(order, func(idx int) []SolverError {
+				committed, _ := c.trialAndCommit(order, func(idx int) []SolverError {
 					// A cloned seen keeps each member's coinductive cache independent, so a
 					// failed member's entries can't wrongly short-circuit a later member.
 					return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
@@ -253,11 +217,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					// into a closed super because that open tail can't be absorbed.
 					return nil
 				}
-				// Every concrete branch failed. Promote a uniform BorrowEscape outcome
-				// so the lifetime cause survives; otherwise emit the generic union-level
-				// error.
-				if commonBorrowEscape(trialErrs) != nil {
-					return []SolverError{&BorrowEscapeError{Sub: sub.(*soltype.RefType), Super: super}}
+				// Every concrete branch failed. When sub is a borrow whose peeled inner
+				// satisfies some union member, the lifetime is the genuine blocker, so
+				// promote a union-level BorrowEscapeError. The peel reruns the same
+				// union-super exists rule against sub's inner, so one matching branch is
+				// enough. Otherwise every branch is a shape mismatch and the lifetime is
+				// incidental, so emit the generic union-level error.
+				if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
+					if len(c.trialUnderProbe(ref.Inner, super)) == 0 {
+						return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
+					}
 				}
 				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 			}
@@ -501,6 +470,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// its mutability.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if sub.Lt != nil {
+				// A borrow flows into an owned destination. Emit BorrowEscapeError only
+				// when the lifetime is the genuine blocker, that is, when peeling to the
+				// inner would have satisfied super. If the inner is itself a shape
+				// mismatch, surface that error instead so the diagnostic does not blame
+				// the lifetime for a mismatch extending it could never fix.
+				if innerErrs := c.trialUnderProbe(sub.Inner, super); len(innerErrs) > 0 {
+					return innerErrs
+				}
 				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
 			}
 			// Peeling an owned value into a bare destination is a covariant read; flag resets.

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -233,24 +233,87 @@ func TestConstrainInexactUnionIntoClosedRejects(t *testing.T) {
 	require.Equal(t, "cannot constrain string <: number", errs[1].Message())
 }
 
-// Regression: a borrow with a lifetime flowing into a union of owned types
-// must surface as a BorrowEscapeError rather than collapsing to a generic
-// union-level CannotConstrainError.
+// Regression: a borrow with a lifetime that would satisfy a union member once
+// its lifetime is stripped must surface as a union-level BorrowEscapeError
+// rather than collapsing to a generic CannotConstrainError. The shape here is
+// the meaningful one: branch 2 of the union matches the borrow's inner, so the
+// lifetime is the genuine blocker.
 //
-//	&'a {x: number} <: (number | string)    BorrowEscapeError, not CannotConstrain
+//	&'a {x: number} <: (number | {x: number})    BorrowEscapeError, not CannotConstrain
 //
-// Each per-member trial reports BorrowEscape internally. The union-super
-// exists rule promotes that to a single union-level BorrowEscape so the
-// lifetime cause survives.
+// The checker decides this by peeling the borrow's inner against the whole
+// union: one matching branch promotes a union-level BorrowEscape so the lifetime
+// cause survives. Contrast TestBorrowEscapePromotionByPeeledInner, where no
+// branch matches the inner, so the union error stays a shape mismatch.
 func TestConstrainUnionSuperPreservesBorrowEscape(t *testing.T) {
 	c := &Context{}
 	lt := c.freshLifetime(0)
 	borrow := &soltype.RefType{Mut: false, Lt: lt, Inner: exactObj(propElem("x", num()))}
-	super := newUnion(nil, []soltype.Type{num(), str()}, false)
+	super := newUnion(nil, []soltype.Type{num(), exactObj(propElem("x", num()))}, false)
 
 	errs := c.Constrain(borrow, super)
 	require.Len(t, errs, 1)
-	require.IsType(t, &BorrowEscapeError{}, errs[0])
+	require.Equal(t,
+		"borrowed value object does not live long enough to satisfy number | object",
+		errs[0].Message())
+}
+
+// TestBorrowEscapePromotionByPeeledInner pins the firing condition for both the
+// single-trial RefType arm and the union-level promotion. BorrowEscapeError is
+// emitted only when peeling the borrow's inner would have satisfied the
+// destination — when the lifetime is the genuine blocker. When the inner is
+// itself a shape mismatch, the clearer shape error surfaces instead, so
+// "does not live long enough" never blames the lifetime for a mismatch that
+// extending it could not fix.
+func TestBorrowEscapePromotionByPeeledInner(t *testing.T) {
+	// A fresh immutable borrow of `{x: number}` with a lifetime, rebuilt per
+	// case so trials never share bound state across the table.
+	borrow := func(c *Context) *soltype.RefType {
+		return &soltype.RefType{Mut: false, Lt: c.freshLifetime(0), Inner: exactObj(propElem("x", num()))}
+	}
+
+	tests := []struct {
+		name  string
+		super func() soltype.Type
+		want  string
+	}{
+		{
+			// Inner {x: number} <: number fails — shape, not lifetime. Surface the
+			// shape error rather than BorrowEscape.
+			name:  "non-union shape mismatch surfaces the shape error",
+			super: func() soltype.Type { return num() },
+			want:  "cannot constrain object <: number",
+		},
+		{
+			// Inner {x: number} <: {x: number} succeeds — the lifetime IS the blocker.
+			name:  "non-union shape match keeps BorrowEscape",
+			super: func() soltype.Type { return exactObj(propElem("x", num())) },
+			want:  "borrowed value object does not live long enough to satisfy object",
+		},
+		{
+			// Every union branch is a shape mismatch — the lifetime is incidental.
+			name:  "union with no matching branch surfaces the shape error",
+			super: func() soltype.Type { return newUnion(nil, []soltype.Type{num(), str()}, false) },
+			want:  "cannot constrain object <: number | string",
+		},
+		{
+			// Branch 2 matches the inner — the lifetime IS the blocker.
+			name:  "union with a matching branch keeps BorrowEscape",
+			super: func() soltype.Type {
+				return newUnion(nil, []soltype.Type{num(), exactObj(propElem("x", num()))}, false)
+			},
+			want: "borrowed value object does not live long enough to satisfy number | object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			errs := c.Constrain(borrow(c), tt.super())
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
 }
 
 // Regression: an inexact union flowing into a free inference variable must

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -301,20 +301,9 @@ func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 
 // subtypeUnderProbe trials sub <: super under a discard-only probe and
 // reports whether the trial succeeded. A successful trial means subsumption
-// holds. The probe is always Discarded so the bound mutations it would
-// otherwise leave behind never become visible.
-//
-// The probe push/pop runs directly on *Context. openProbe and closeProbe are
-// the checker-level path and additionally snapshot c.errs, which subsumption
-// does not need. (*Context).constrain returns its errors through the return
-// value and never appends to checker state.
+// holds.
 func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
-	p := newProbe(c.probe)
-	c.probe = p
-	errs := c.constrain(sub, super, set.NewSet[constraintKey](), false)
-	c.probe = p.parent
-	p.Discard()
-	return len(errs) == 0
+	return len(c.trialUnderProbe(sub, super)) == 0
 }
 
 // sortTypes orders parts in place under compareType. The sort is stable so a

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -288,7 +288,7 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 // unionDrops returns true when union member m should be dropped because the
 // sibling subsumes it. The check is m <: sibling.
 func unionDrops(c *Context, m, sibling soltype.Type) bool {
-	return subtypeUnderProbe(c, m, sibling)
+	return len(c.trialUnderProbe(m, sibling)) == 0
 }
 
 // intersectionDrops returns true when intersection member m should be
@@ -296,14 +296,7 @@ func unionDrops(c *Context, m, sibling soltype.Type) bool {
 // <: m. The sibling is narrower, so it already implies m, and m is the wider
 // one to discard.
 func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
-	return subtypeUnderProbe(c, sibling, m)
-}
-
-// subtypeUnderProbe trials sub <: super under a discard-only probe and
-// reports whether the trial succeeded. A successful trial means subsumption
-// holds.
-func subtypeUnderProbe(c *Context, sub, super soltype.Type) bool {
-	return len(c.trialUnderProbe(sub, super)) == 0
+	return len(c.trialUnderProbe(sibling, m)) == 0
 }
 
 // sortTypes orders parts in place under compareType. The sort is stable so a

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -285,17 +285,9 @@ func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError)
 }
 
 // trialUnderProbe trials `sub <: super` under a discard-only probe and returns
-// the trial's errors, keeping no bound it appended. An empty result means the
-// trial succeeded. The seen-set starts fresh so the trial is an honest,
-// self-contained subtype check that never inherits an in-progress coinductive
-// assumption from the surrounding walk; such an assumption could otherwise
-// short-circuit the check to a false success. The mut context starts at false:
-// every caller trials a covariant read view.
-//
-// The probe push/pop runs directly on *Context. openProbe and closeProbe are the
-// checker-level path and additionally snapshot c.errs, which a type-level trial
-// does not need, since (*Context).constrain returns its errors through the
-// return value and never appends to checker state.
+// the trial's errors, leaving no bound behind; an empty result means it
+// succeeded. The seen-set starts fresh and the mut context at false, so the
+// trial is a self-contained covariant read check.
 func (c *Context) trialUnderProbe(sub, super soltype.Type) []SolverError {
 	p := newProbe(c.probe)
 	c.probe = p

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -284,6 +284,27 @@ func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError)
 	return false, trialErrs
 }
 
+// trialUnderProbe trials `sub <: super` under a discard-only probe and returns
+// the trial's errors, keeping no bound it appended. An empty result means the
+// trial succeeded. The seen-set starts fresh so the trial is an honest,
+// self-contained subtype check that never inherits an in-progress coinductive
+// assumption from the surrounding walk; such an assumption could otherwise
+// short-circuit the check to a false success. The mut context starts at false:
+// every caller trials a covariant read view.
+//
+// The probe push/pop runs directly on *Context. openProbe and closeProbe are the
+// checker-level path and additionally snapshot c.errs, which a type-level trial
+// does not need, since (*Context).constrain returns its errors through the
+// return value and never appends to checker state.
+func (c *Context) trialUnderProbe(sub, super soltype.Type) []SolverError {
+	p := newProbe(c.probe)
+	c.probe = p
+	errs := c.constrain(sub, super, set.NewSet[constraintKey](), false)
+	c.probe = p.parent
+	p.Discard()
+	return errs
+}
+
 // snapshotMapEntry registers, under the active probe (else a no-op), a closure
 // that restores m[k] to its current value — or deletes the key if it is currently
 // absent — so a discarded trial leaves m exactly as it was. Shared by the Info


### PR DESCRIPTION
Improve the diagnostic for borrowed values constrained into union types by only promoting a `BorrowEscapeError` when the lifetime is the genuine blocker, not when the inner type is itself a shape mismatch.

Previously, when a borrow failed to satisfy any union member, the checker would promote a `BorrowEscapeError` if all trials returned that error type. This could surface a misleading "does not live long enough" message even when extending the lifetime would not fix the constraint — for example, when the borrow's inner type is incompatible with every union branch.

Now the checker peels the borrow's inner type against the union. If at least one branch matches the inner, the lifetime is the genuine blocker and a `BorrowEscapeError` surfaces. If no branch matches, the shape mismatch is the real problem and a `CannotConstrainError` surfaces instead, giving the user a clearer diagnostic.

Key changes:
- Removed `commonBorrowEscape` helper that promoted errors based on uniformity across trials
- Added `trialUnderProbe` method to run a self-contained subtype check under a fresh probe
- Updated union-super constraint logic to peel the borrow's inner and check if any branch matches
- Updated single-trial RefType constraint logic to apply the same peel-and-check pattern
- Refactored `subtypeUnderProbe` to use the new `trialUnderProbe` method
- Expanded test coverage with `TestBorrowEscapePromotionByPeeledInner` to pin the firing conditions for both union and non-union cases

The peel check reruns the same union-super exists rule against the inner type, so a matching branch is sufficient to confirm the lifetime is the blocker.

https://claude.ai/code/session_01Jt6w4AhVvqavg5DZcoCvfk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how type constraint failures are reported, especially around borrow/lifetime mismatches versus shape mismatches.
  * Refined union and reference handling so the most relevant error is shown when a borrow would escape.
  * Preserved more accurate failure messages for union cases with matching or non-matching branches.

* **Tests**
  * Updated existing regression coverage for borrow-escape behavior.
  * Added new tests covering multiple borrow promotion and mismatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->