### PR TITLE
Support monomorphic function type annotations

### DIFF
--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -1,0 +1,117 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6 PR3: monomorphic function type annotations ---
+
+// A monomorphic function type annotation resolves to a FuncType and an annotated
+// binding adopts it, so the rendered binding type is the annotation.
+func TestInferFuncAnnotationAdopted(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn(x: number) -> string = fn (x) { return "a" }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: number) -> string", values["f"])
+}
+
+// A body whose return type does not satisfy the annotated return is rejected,
+// constrained body <: declared return.
+func TestInferFuncAnnotationRejectsMismatchedBody(t *testing.T) {
+	_, _, errs := inferSource(t, `val f: fn(x: number) -> string = fn (x) { return 5 }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:50-1:51: cannot constrain 5 <: string", msgWithSpan(errs[0]))
+}
+
+// An inexact function annotation resolves its trailing `...` onto FuncType.Inexact
+// and round-trips through the printer. The value is itself inexact so its
+// accept-set [1, ∞] fills the inexact slot's [1, ∞].
+func TestInferInexactFuncAnnotation(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn(x: number, ...) -> string = fn (x, ...) { return "a" }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (x: number, ...) -> string", values["f"])
+}
+
+// A function annotation resolves as a union member, composing with PR2's union
+// annotation input.
+func TestInferFuncAnnotationUnionMember(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: (fn() -> number) | (fn() -> string) = fn () { return 5 }`)
+	require.Empty(t, errs)
+	require.Equal(t, "(fn () -> number) | (fn () -> string)", values["f"])
+}
+
+// The M3 accept-set callback-slot rule is now expressible in source. Reading the
+// annotation as a callback slot `fn(x: number, y: number) -> number`, an inexact
+// value `fn (x, ...)` is accepted: its accept-set [1, ∞] covers the slot's [2, 2].
+func TestInferFuncAnnotationAcceptSetInexactValueAccepted(t *testing.T) {
+	_, _, errs := inferSource(t, `val cb: fn(x: number, y: number) -> number = fn (x, ...) { return 1 }`)
+	require.Empty(t, errs)
+}
+
+// A nullary inexact value `fn (...)` is likewise accepted into the two-param slot:
+// its accept-set [0, ∞] covers [2, 2].
+func TestInferFuncAnnotationAcceptSetNullaryInexactValueAccepted(t *testing.T) {
+	_, _, errs := inferSource(t, `val cb: fn(x: number, y: number) -> number = fn (...) { return 1 }`)
+	require.Empty(t, errs)
+}
+
+// An exact value with too few params is rejected: `fn (x)` has accept-set [1, 1],
+// which does not cover the slot's [2, 2] at the upper bound.
+func TestInferFuncAnnotationAcceptSetTooFewParamsRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `val cb: fn(x: number, y: number) -> number = fn (x) { return 1 }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &FuncArityMismatchError{}, errs[0])
+}
+
+// An exact value with too many params is rejected: `fn (x, y, z)` has accept-set
+// [3, 3], which demands more arguments than the slot's [2, 2] supplies.
+func TestInferFuncAnnotationAcceptSetTooManyParamsRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `val cb: fn(x: number, y: number) -> number = fn (x, y, z) { return 1 }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &FuncArityMismatchError{}, errs[0])
+}
+
+// A generic function annotation reports the documented unsupported feature and
+// recovers function-shaped, so the binding still resolves as a function rather
+// than collapsing to an unconstrained var.
+func TestInferGenericFuncAnnotationReportsUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn<T>(x: number) -> number = fn (x) { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "1:8-1:34: Unsupported: generic function type annotation", msgWithSpan(errs[0]))
+	require.Equal(t, "fn (x: number) -> number", values["f"])
+}
+
+// A throws clause reports the documented unsupported feature and recovers
+// function-shaped.
+func TestInferThrowsFuncAnnotationReportsUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn(x: number) -> number throws boolean = fn (x) { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "1:8-1:46: Unsupported: throws clause in function type annotation", msgWithSpan(errs[0]))
+	require.Equal(t, "fn (x: number) -> number", values["f"])
+}
+
+// A lifetime-param'd function annotation reports the documented unsupported
+// feature and recovers function-shaped.
+func TestInferLifetimeFuncAnnotationReportsUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn<'a>(x: number) -> number = fn (x) { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "1:8-1:35: Unsupported: lifetime parameters in function type annotation", msgWithSpan(errs[0]))
+	require.Equal(t, "fn (x: number) -> number", values["f"])
+}
+
+// A rest parameter reports the documented unsupported feature and recovers as a
+// normal positional param, so it never sets FuncParam.Rest. acceptSet / hasRest /
+// requiredCount assume a rest param is last, and the parser does not enforce that
+// for a non-last `...x`, so a silently-set Rest could corrupt the accept-set.
+func TestInferRestParamFuncAnnotationReportsUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn(...xs: number) -> number = fn (x) { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "1:11-1:16: Unsupported: rest parameter in function type annotation", msgWithSpan(errs[0]))
+	require.Equal(t, "fn (xs: number) -> number", values["f"])
+}

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -104,6 +104,15 @@ func TestInferLifetimeFuncAnnotationReportsUnsupported(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", values["f"])
 }
 
+// A destructuring parameter pattern is preserved in the resolved function type, so
+// an object or tuple pattern renders and round-trips rather than degrading to a
+// positional name.
+func TestInferFuncAnnotationPreservesDestructuringPattern(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn({x, y}: {x: number, y: number}, [a, b]: [number, string]) -> number = fn (p, q) { return 1 }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn ({x, y}: {x: number, y: number}, [a, b]: [number, string]) -> number", values["f"])
+}
+
 // A rest parameter reports the documented unsupported feature and recovers as a
 // normal positional param, so it never sets FuncParam.Rest. acceptSet / hasRest /
 // requiredCount assume a rest param is last, and the parser does not enforce that

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -283,11 +283,7 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 }
 
 // mirrorParamPat structurally mirrors a function-type-annotation parameter pattern
-// into its soltype.Pat for rendering and round-tripping. A function type annotation
-// binds no values, so this carries the pattern shape only, with no scope binding or
-// constraint, unlike bindPattern. A sub-pattern with no soltype counterpart, an
-// ObjRestPat or a bare RestPat, is dropped, and an entirely unmappable pattern
-// yields nil, which the printer renders as a positional name such as arg0.
+// into its soltype.Pat for rendering. A shape with no soltype counterpart is dropped.
 func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
 	switch p := pat.(type) {
 	case *ast.IdentPat:

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -5,15 +5,16 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// resolveTypeAnn converts an M2-supported type annotation into a soltype.Type,
-// returning ok=false when the annotation is outside the supported set. M2 needs
-// only the primitive annotations that annotated params and return types use
-// (number/string/boolean); everything richer — type references, generics,
-// object/tuple/function annotations, unions — is represented by types later
-// milestones add (M3/M4/M6) and resolves to an UnsupportedNodeError here, with
-// ok=false and a `never` placeholder so a caller can recover by keeping the type
-// it already inferred (rather than constraining against / adopting `never`, which
-// would cascade a spurious `<: never` error and poison the binding). It takes the
+// resolveTypeAnn converts a supported type annotation into a soltype.Type,
+// returning ok=false when the annotation is outside the supported set. The
+// supported set has grown across milestones: primitives, Promise, objects, tuples,
+// borrows, unions, intersections, and the monomorphic function type. What still
+// reports an UnsupportedNodeError is the general type reference (M7), the operator
+// type forms such as keyof and conditional types, and the deferred function
+// features the function arm names. An unsupported annotation returns ok=false and a
+// `never` placeholder so a caller can recover by keeping the type it already
+// inferred. Adopting `never` instead would cascade a spurious `<: never` error and
+// poison the binding. It takes the
 // current inference level `lvl` so a supported generic with an UNSUPPORTED inner (a
 // malformed `Promise<…>`) can recover its inner to a fresh var at the right level
 // while keeping the wrapper; the primitive arms ignore lvl. Full name resolution
@@ -85,6 +86,8 @@ func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 		return c.resolveUnionTypeAnn(ta, lvl)
 	case *ast.IntersectionTypeAnn:
 		return c.resolveIntersectionTypeAnn(ta, lvl)
+	case *ast.FuncTypeAnn:
+		return c.resolveFuncTypeAnn(ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -231,6 +234,81 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 	if !c.hasProv(t) {
 		c.recordProv(t, ta, AnnotationType)
 	}
+	return t, true
+}
+
+// resolveFuncTypeAnn lowers a monomorphic function type annotation
+// `fn(p1: A, p2: B) -> R` and the inexact `fn(p1: A, ...) -> R` into a
+// soltype.FuncType, so a function type is writable as a binding annotation, a
+// parameter or return annotation, and a union/intersection member. Each
+// parameter's value annotation resolves through resolveTypeAnn. ta.Inexact maps to
+// FuncType.Inexact so the accept-set rule and the printer see the trailing `...`.
+//
+// An unsupported part recovers to a fresh var and the function shape survives. This
+// is cascade-safe like the Promise<bad>, object, and tuple arms. A `fn(x: Bad) -> R`
+// stays function-shaped so `f(x)` and the rendered signature still read as a
+// function rather than collapsing the binding to an unconstrained var.
+//
+// Generic, throws, and lifetime-param'd function annotations report an unsupported
+// feature and recover the rest as a monomorphic function. A written type parameter
+// `T` needs the type-name scope M7 adds, `throws` is M9, and lifetime parameters
+// ride the lifetime-annotation surface (M6.5).
+func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
+	if len(ta.TypeParams) > 0 {
+		c.reportUnsupportedFeature(ta, "generic function type annotation")
+	}
+	if ta.Throws != nil {
+		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")
+	}
+	if len(ta.LifetimeParams) > 0 {
+		c.reportUnsupportedFeature(ta, "lifetime parameters in function type annotation")
+	}
+
+	params := make([]*soltype.FuncParam, len(ta.Params))
+	for i, p := range ta.Params {
+		pat := p.Pattern
+		// A rest param is reported unsupported and recovered as a normal positional
+		// param. The value-function path also rejects RestPat. acceptSet, hasRest,
+		// and requiredCount all assume a rest param is the last one. The parser does
+		// not enforce that for a non-last `...x`, so setting Rest here could corrupt
+		// the accept-set. Modeling the rest arity effect rides M4/M9 with rest
+		// element-type checking.
+		if rp, ok := pat.(*ast.RestPat); ok {
+			c.reportUnsupportedFeature(rp, "rest parameter in function type annotation")
+			pat = rp.Pattern
+		}
+		// A missing or unsupported parameter annotation recovers to a fresh var so
+		// the function keeps its arity and shape, cascade-safe like Promise<bad>.
+		var pt soltype.Type = c.freshAt(lvl)
+		if p.TypeAnn != nil {
+			if t, ok := c.resolveTypeAnn(p.TypeAnn, lvl); ok {
+				pt = t
+			}
+		}
+		// A function type annotation binds no values, so the parameter name is
+		// carried for rendering only. There is no scope binding or constraint, unlike
+		// bindPattern. An IdentPat mirrors by name. Any other shape leaves the
+		// pattern nil, which the printer renders as a positional name such as arg0,
+		// without affecting the parameter's type.
+		var mirror soltype.Pat
+		if name, ok := identPatName(pat); ok {
+			mirror = &soltype.IdentPat{Name: name}
+		}
+		params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}
+	}
+
+	// The parser requires `-> R`, so ta.Return is normally non-nil. Guard
+	// defensively and recover an unsupported or absent return to a fresh var,
+	// keeping the function shape.
+	var ret soltype.Type = c.freshAt(lvl)
+	if ta.Return != nil {
+		if t, ok := c.resolveTypeAnn(ta.Return, lvl); ok {
+			ret = t
+		}
+	}
+
+	t := &soltype.FuncType{Params: params, Ret: ret, Inexact: ta.Inexact}
+	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -248,12 +248,8 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 	params := make([]*soltype.FuncParam, len(ta.Params))
 	for i, p := range ta.Params {
 		pat := p.Pattern
-		// A rest param is reported unsupported and recovered as a normal positional
-		// param. The value-function path also rejects RestPat. acceptSet, hasRest,
-		// and requiredCount all assume a rest param is the last one. The parser does
-		// not enforce that for a non-last `...x`, so setting Rest here could corrupt
-		// the accept-set. Modeling the rest arity effect rides M4/M9 with rest
-		// element-type checking.
+		// A rest param recovers to a normal positional param. acceptSet/hasRest assume
+		// a rest param is last, which the parser does not enforce, so Rest is unset.
 		if rp, ok := pat.(*ast.RestPat); ok {
 			c.reportUnsupportedFeature(rp, "rest parameter in function type annotation")
 			pat = rp.Pattern
@@ -266,11 +262,8 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 				pt = t
 			}
 		}
-		// A function type annotation binds no values, so the parameter name is
-		// carried for rendering only. There is no scope binding or constraint, unlike
-		// bindPattern. An IdentPat mirrors by name. Any other shape leaves the
-		// pattern nil, which the printer renders as a positional name such as arg0,
-		// without affecting the parameter's type.
+		// The parameter name is carried for rendering only, with no scope binding. A
+		// non-IdentPat leaves the pattern nil, which the printer renders as arg0, arg1.
 		var mirror soltype.Pat
 		if name, ok := identPatName(pat); ok {
 			mirror = &soltype.IdentPat{Name: name}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -6,19 +6,10 @@ import (
 )
 
 // resolveTypeAnn converts a supported type annotation into a soltype.Type,
-// returning ok=false when the annotation is outside the supported set. The
-// supported set has grown across milestones: primitives, Promise, objects, tuples,
-// borrows, unions, intersections, and the monomorphic function type. What still
-// reports an UnsupportedNodeError is the general type reference (M7), the operator
-// type forms such as keyof and conditional types, and the deferred function
-// features the function arm names. An unsupported annotation returns ok=false and a
-// `never` placeholder so a caller can recover by keeping the type it already
-// inferred. Adopting `never` instead would cascade a spurious `<: never` error and
-// poison the binding. It takes the
-// current inference level `lvl` so a supported generic with an UNSUPPORTED inner (a
-// malformed `Promise<…>`) can recover its inner to a fresh var at the right level
-// while keeping the wrapper; the primitive arms ignore lvl. Full name resolution
-// against the type scope still arrives with TypeRef support (M7).
+// returning ok=false with a `never` placeholder when the annotation is unsupported
+// so a caller can recover by keeping the type it already inferred. The level `lvl`
+// lets a supported wrapper with an unsupported inner recover that inner to a fresh
+// var at the right level.
 func (c *checker) resolveTypeAnn(ta ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	switch ta := ta.(type) {
 	case *ast.NumberTypeAnn:
@@ -238,21 +229,11 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 }
 
 // resolveFuncTypeAnn lowers a monomorphic function type annotation
-// `fn(p1: A, p2: B) -> R` and the inexact `fn(p1: A, ...) -> R` into a
-// soltype.FuncType, so a function type is writable as a binding annotation, a
-// parameter or return annotation, and a union/intersection member. Each
-// parameter's value annotation resolves through resolveTypeAnn. ta.Inexact maps to
-// FuncType.Inexact so the accept-set rule and the printer see the trailing `...`.
-//
-// An unsupported part recovers to a fresh var and the function shape survives. This
-// is cascade-safe like the Promise<bad>, object, and tuple arms. A `fn(x: Bad) -> R`
-// stays function-shaped so `f(x)` and the rendered signature still read as a
-// function rather than collapsing the binding to an unconstrained var.
-//
-// Generic, throws, and lifetime-param'd function annotations report an unsupported
-// feature and recover the rest as a monomorphic function. A written type parameter
-// `T` needs the type-name scope M7 adds, `throws` is M9, and lifetime parameters
-// ride the lifetime-annotation surface (M6.5).
+// `fn(p: A, ...) -> R` into a soltype.FuncType, mapping ta.Inexact to
+// FuncType.Inexact. An unsupported part recovers to a fresh var so the function
+// shape survives, cascade-safe like the Promise/object/tuple arms. Generic, throws,
+// lifetime-param'd, and rest-param annotations report an unsupported feature and
+// recover as a monomorphic function.
 func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
 	if len(ta.TypeParams) > 0 {
 		c.reportUnsupportedFeature(ta, "generic function type annotation")

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -262,13 +262,9 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 				pt = t
 			}
 		}
-		// The parameter name is carried for rendering only, with no scope binding. A
-		// non-IdentPat leaves the pattern nil, which the printer renders as arg0, arg1.
-		var mirror soltype.Pat
-		if name, ok := identPatName(pat); ok {
-			mirror = &soltype.IdentPat{Name: name}
-		}
-		params[i] = &soltype.FuncParam{Pattern: mirror, Type: pt, Optional: p.Optional}
+		// The pattern is carried for rendering and round-tripping only, with no scope
+		// binding. mirrorParamPat preserves its full shape.
+		params[i] = &soltype.FuncParam{Pattern: c.mirrorParamPat(pat), Type: pt, Optional: p.Optional}
 	}
 
 	// The parser requires `-> R`, so ta.Return is normally non-nil. Guard
@@ -284,6 +280,60 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 	t := &soltype.FuncType{Params: params, Ret: ret, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// mirrorParamPat structurally mirrors a function-type-annotation parameter pattern
+// into its soltype.Pat for rendering and round-tripping. A function type annotation
+// binds no values, so this carries the pattern shape only, with no scope binding or
+// constraint, unlike bindPattern. A sub-pattern with no soltype counterpart, an
+// ObjRestPat or a bare RestPat, is dropped, and an entirely unmappable pattern
+// yields nil, which the printer renders as a positional name such as arg0.
+func (c *checker) mirrorParamPat(pat ast.Pat) soltype.Pat {
+	switch p := pat.(type) {
+	case *ast.IdentPat:
+		return &soltype.IdentPat{Name: p.Name}
+	case *ast.WildcardPat:
+		return &soltype.WildcardPat{}
+	case *ast.LitPat:
+		if lt, ok := c.litTypeOf(p.Lit); ok {
+			return &soltype.LitPat{Lit: lt.Lit}
+		}
+		return nil
+	case *ast.TuplePat:
+		elems := make([]soltype.Pat, 0, len(p.Elems))
+		for _, e := range p.Elems {
+			// soltype.TuplePat has no rest element, so a `...rest` is dropped.
+			if _, isRest := e.(*ast.RestPat); isRest {
+				continue
+			}
+			elems = append(elems, c.mirrorParamPat(e))
+		}
+		return &soltype.TuplePat{Elems: elems}
+	case *ast.ObjectPat:
+		fields := make([]*soltype.ObjectPatField, 0, len(p.Elems))
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjShorthandPat:
+				// A bare `{x}` mirrors to a field whose value is the IdentPat `x`.
+				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: &soltype.IdentPat{Name: e.Key.Name}})
+			case *ast.ObjKeyValuePat:
+				fields = append(fields, &soltype.ObjectPatField{Name: e.Key.Name, Value: c.mirrorParamPat(e.Value)})
+			}
+			// ObjRestPat has no soltype counterpart and is dropped.
+		}
+		return &soltype.ObjectPat{Fields: fields}
+	case *ast.ExtractorPat:
+		args := make([]soltype.Pat, len(p.Args))
+		for i, a := range p.Args {
+			args[i] = c.mirrorParamPat(a)
+		}
+		return &soltype.ExtractorPat{Name: ast.QualIdentToString(p.Name), Args: args}
+	case *ast.InstancePat:
+		obj, _ := c.mirrorParamPat(p.Object).(*soltype.ObjectPat)
+		return &soltype.InstancePat{ClassName: ast.QualIdentToString(p.ClassName), Object: obj}
+	default:
+		return nil
+	}
 }
 
 // resolveMutableTypeAnn lowers a `mut T` annotation to an owned-mutable borrow,


### PR DESCRIPTION
Add support for writing function types as binding, parameter, and return annotations. This enables the M6 milestone feature of monomorphic function type annotations.

**Changes:**

- Add `resolveFuncTypeAnn` to lower `fn(p1: A, p2: B) -> R` and inexact `fn(p1: A, ...) -> R` annotations into `soltype.FuncType`. Each parameter annotation resolves through the existing `resolveTypeAnn` path, and `ta.Inexact` maps to `FuncType.Inexact` so the accept-set rule and printer see the trailing `...`.

- Unsupported function annotation features report errors and recover gracefully:
  - Generic function annotations (`fn<T>(...)`) report unsupported and recover as monomorphic
  - Throws clauses report unsupported and recover
  - Lifetime parameters report unsupported and recover
  - Rest parameters in annotations report unsupported and recover as normal positional params (to avoid corrupting the accept-set, which assumes rest params are last)

- Unsupported or missing parameter/return annotations recover to fresh type variables, keeping the function shape intact so bindings don't collapse to unconstrained vars.

- Add comprehensive test coverage in `infer_func_ann_test.go` for annotation adoption, body type checking, inexact functions, union members, accept-set validation (inexact values accepted into exact slots, exact values with wrong arity rejected), and all unsupported features.

https://claude.ai/code/session_01SmreChCgVwP3CtEenE4Jpo