### PR TITLE
Implement union match exhaustiveness checking

### DIFF
--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -381,6 +381,7 @@ func (t *TupleTypeAnn) Accept(v Visitor) {
 
 type UnionTypeAnn struct {
 	Types        []TypeAnn
+	Inexact      bool // trailing `...` marker: `A | B | ...` tolerates an unknown tail
 	span         Span
 	inferredType Type
 }

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -51,6 +51,15 @@ func TestParseInexactMarker(t *testing.T) {
 		require.True(t, fn.Inexact)
 		require.Empty(t, fn.Params)
 	})
+
+	t.Run("union type annotation", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, "number | string | ...")
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.True(t, u.Inexact)
+		require.Len(t, u.Types, 2) // the `...` does not become a member
+	})
 }
 
 // A bare function (no trailing `...`) is exact, and a `...rest` is an ordinary rest
@@ -73,5 +82,13 @@ func TestParseExactAndRestAreNotInexact(t *testing.T) {
 		require.Len(t, fd.Params, 2) // x and the rest param
 		_, isRest := fd.Params[1].Pattern.(*ast.RestPat)
 		require.True(t, isRest)
+	})
+
+	t.Run("bare union is exact", func(t *testing.T) {
+		ta, errs := ParseTypeAnn(ctx, "number | string")
+		require.Empty(t, errs)
+		u, ok := ta.(*ast.UnionTypeAnn)
+		require.True(t, ok)
+		require.False(t, u.Inexact)
 	})
 }

--- a/internal/parser/inexact_test.go
+++ b/internal/parser/inexact_test.go
@@ -62,6 +62,19 @@ func TestParseInexactMarker(t *testing.T) {
 	})
 }
 
+// A trailing `...` is only meaningful on a union of two or more members. After a
+// single member, or after a higher-precedence operator that leaves a non-union at
+// the top, no UnionTypeAnn carries the flag, so the parser reports an error rather
+// than silently dropping the marker and reducing the annotation to the bare member.
+func TestParseInexactUnionMarkerRequiresUnion(t *testing.T) {
+	ctx := context.Background()
+	for _, src := range []string{"number | ...", "number & string | ..."} {
+		_, errs := ParseTypeAnn(ctx, src)
+		require.Len(t, errs, 1, "input %q", src)
+		require.Equal(t, "a trailing `...` must follow two or more union members, as in `A | B | ...`", errs[0].Message)
+	}
+}
+
 // A bare function (no trailing `...`) is exact, and a `...rest` is an ordinary rest
 // param — NOT the inexact marker. The lookahead in parseFuncParams must keep these
 // distinct.

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -43,6 +43,7 @@ func (p *Parser) typeAnn() ast.TypeAnn {
 	typeAnns := NewStack[ast.TypeAnn]()
 	ops := NewStack[*TypeAnnOp]()
 	unionInexact := false
+	var unionInexactSpan ast.Span
 
 	token := p.lexer.peek()
 	//nolint: exhaustive
@@ -100,8 +101,9 @@ loop:
 		// holds at least the members listed, plus an unknown-typed tail. The
 		// marker ends the operand loop, so the operator stack drains over the
 		// members already collected. The flag is applied to the popped top-level
-		// union below.
+		// union below, or reported as an error when no union was built.
 		if nextOp.Kind == Union && p.lexer.peek().Type == DotDotDot {
+			unionInexactSpan = p.lexer.peek().Span
 			p.lexer.consume()
 			unionInexact = true
 			break loop
@@ -190,6 +192,11 @@ loop:
 	if unionInexact {
 		if u, ok := result.(*ast.UnionTypeAnn); ok {
 			u.Inexact = true
+		} else {
+			// The `...` followed a single member or a non-union top operator, so
+			// no UnionTypeAnn was built to carry the flag. A trailing `...` is
+			// only meaningful on a union of two or more members.
+			p.reportError(unionInexactSpan, "a trailing `...` must follow two or more union members, as in `A | B | ...`")
 		}
 	}
 	return result

--- a/internal/parser/type_ann.go
+++ b/internal/parser/type_ann.go
@@ -42,6 +42,7 @@ func (p *Parser) typeAnnRequired() ast.TypeAnn {
 func (p *Parser) typeAnn() ast.TypeAnn {
 	typeAnns := NewStack[ast.TypeAnn]()
 	ops := NewStack[*TypeAnnOp]()
+	unionInexact := false
 
 	token := p.lexer.peek()
 	//nolint: exhaustive
@@ -94,6 +95,18 @@ loop:
 		}
 
 		p.lexer.consume()
+
+		// A trailing `...` after a `|` marks the union inexact. An inexact union
+		// holds at least the members listed, plus an unknown-typed tail. The
+		// marker ends the operand loop, so the operator stack drains over the
+		// members already collected. The flag is applied to the popped top-level
+		// union below.
+		if nextOp.Kind == Union && p.lexer.peek().Type == DotDotDot {
+			p.lexer.consume()
+			unionInexact = true
+			break loop
+		}
+
 		skipOp := false
 
 		if !ops.IsEmpty() {
@@ -173,7 +186,13 @@ loop:
 		p.reportError(span, "internal error: type annotation stack invariant violated")
 		return ast.NewErrorTypeAnn(span)
 	}
-	return typeAnns.Pop()
+	result := typeAnns.Pop()
+	if unionInexact {
+		if u, ok := result.(*ast.UnionTypeAnn); ok {
+			u.Inexact = true
+		}
+	}
+	return result
 }
 
 func (p *Parser) primaryTypeAnn() ast.TypeAnn {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2040,9 +2040,10 @@ func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type)
 }
 
 // unionMatchExhaustive reports whether the unguarded arms cover a union scrutinee.
-// An inexact union needs a catch-all. An exact one is flagged only when a literal
-// member is provably uncovered. Structural-object and nominal members defer to M5,
-// so an exact union carrying them is left unchecked rather than falsely flagged.
+// An inexact union needs a catch-all. An exact one is flagged non-exhaustive only
+// when a literal member is provably uncovered. A non-literal member needs the
+// structural or nominal coverage M5 adds, so its arms are reported unsupported
+// rather than silently accepted or falsely flagged non-exhaustive.
 func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) bool {
 	for _, arm := range e.Cases {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2052,12 +2053,39 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 	if u.Inexact {
 		return false
 	}
+	hasNonLiteralMember := false
 	for _, member := range u.Types {
-		if lit, ok := member.(*soltype.LitType); ok && !c.litMemberCovered(lit, e.Cases) {
+		lit, ok := member.(*soltype.LitType)
+		if !ok {
+			hasNonLiteralMember = true
+			continue
+		}
+		if !c.litMemberCovered(lit, e.Cases) {
 			return false
 		}
 	}
+	if hasNonLiteralMember {
+		c.reportUnsupportedUnionArms(e)
+	}
 	return true
+}
+
+// reportUnsupportedUnionArms flags each unguarded arm whose pattern the union
+// coverage engine cannot yet evaluate. Only a literal pattern or a catch-all
+// covers a union member today, so an object, tuple, or other structural pattern
+// over a union with a non-literal member is reported as an unsupported feature
+// until M5 adds per-member structural and nominal coverage. Reporting it keeps the
+// unchecked coverage visible instead of passing the match silently.
+func (c *checker) reportUnsupportedUnionArms(e *ast.MatchExpr) {
+	for _, arm := range e.Cases {
+		if arm.Guard != nil || isCatchAll(arm.Pattern) {
+			continue
+		}
+		if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
+			continue
+		}
+		c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
+	}
 }
 
 // litMemberCovered reports whether some unguarded arm is a literal pattern equal to

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2064,28 +2064,22 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 			return false
 		}
 	}
+	// A non-literal member needs the structural or nominal coverage M5 adds. Only a
+	// literal pattern or a catch-all covers a union member today, so flag each
+	// unguarded structural arm as unsupported rather than pass the match silently.
+	// The catch-all case has already returned above.
 	if hasNonLiteralMember {
-		c.reportUnsupportedUnionArms(e)
+		for _, arm := range e.Cases {
+			if arm.Guard != nil {
+				continue
+			}
+			if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
+				continue
+			}
+			c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
+		}
 	}
 	return true
-}
-
-// reportUnsupportedUnionArms flags each unguarded arm whose pattern the union
-// coverage engine cannot yet evaluate. Only a literal pattern or a catch-all
-// covers a union member today, so an object, tuple, or other structural pattern
-// over a union with a non-literal member is reported as an unsupported feature
-// until M5 adds per-member structural and nominal coverage. Reporting it keeps the
-// unchecked coverage visible instead of passing the match silently.
-func (c *checker) reportUnsupportedUnionArms(e *ast.MatchExpr) {
-	for _, arm := range e.Cases {
-		if arm.Guard != nil || isCatchAll(arm.Pattern) {
-			continue
-		}
-		if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
-			continue
-		}
-		c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
-	}
 }
 
 // litMemberCovered reports whether some unguarded arm is a literal pattern equal to

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2060,7 +2060,9 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 
 // unionMemberCovered reports whether some unguarded arm matches one union member via
 // a catch-all or an equal literal pattern. Other shapes read uncovered, so coverage
-// is sound but only complete for literal members.
+// is sound but only complete for literal members. Nominal members are covered
+// instead by M5's enum leg through constructor patterns; coverage of plain
+// structural-object members by object patterns is not yet handled.
 func (c *checker) unionMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
 	memberLit, memberIsLit := member.(*soltype.LitType)
 	for _, arm := range arms {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2040,7 +2040,9 @@ func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type)
 }
 
 // unionMatchExhaustive reports whether the unguarded arms cover a union scrutinee.
-// An inexact union needs a catch-all. An exact one needs every member covered.
+// An inexact union needs a catch-all. An exact one is flagged only when a literal
+// member is provably uncovered. Structural-object and nominal members defer to M5,
+// so an exact union carrying them is left unchecked rather than falsely flagged.
 func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) bool {
 	for _, arm := range e.Cases {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2051,32 +2053,26 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 		return false
 	}
 	for _, member := range u.Types {
-		if !c.unionMemberCovered(member, e.Cases) {
+		if lit, ok := member.(*soltype.LitType); ok && !c.litMemberCovered(lit, e.Cases) {
 			return false
 		}
 	}
 	return true
 }
 
-// unionMemberCovered reports whether some unguarded arm matches one union member via
-// a catch-all or an equal literal pattern. Other shapes read uncovered, so coverage
-// is sound but only complete for literal members. Nominal members are covered
-// instead by M5's enum leg through constructor patterns; coverage of plain
-// structural-object members by object patterns is not yet handled.
-func (c *checker) unionMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
-	memberLit, memberIsLit := member.(*soltype.LitType)
+// litMemberCovered reports whether some unguarded arm is a literal pattern equal to
+// the given literal union member. The caller has already excluded an unguarded
+// catch-all, which would otherwise cover the member too.
+func (c *checker) litMemberCovered(member *soltype.LitType, arms []*ast.MatchCase) bool {
 	for _, arm := range arms {
 		if arm.Guard != nil {
 			continue
 		}
-		if isCatchAll(arm.Pattern) {
-			return true
-		}
 		armLit, ok := arm.Pattern.(*ast.LitPat)
-		if !ok || !memberIsLit {
+		if !ok {
 			continue
 		}
-		if lt, ok := c.litTypeOf(armLit.Lit); ok && memberLit.Equal(lt) {
+		if lt, ok := c.litTypeOf(armLit.Lit); ok && member.Equal(lt) {
 			return true
 		}
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1980,15 +1980,9 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 // Exhaustiveness is checked from structural exactness by checkMatchExhaustive.
 func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Type {
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
-	// Snapshot the scrutinee's shape for the exhaustiveness check before any arm
-	// binds. A literal pattern records its literal as a lower bound on a scrutinee
-	// variable, so reading the union after the arm loop would fold every arm
-	// literal into it. Over `x: "a" | "b"` the arm `"z" if guard => …` would then
-	// leak `"z"` as a phantom member and report a false non-exhaustive error.
-	// Coalescing a variable to its positive form here reads only the bounds
-	// established before the match, so an inferred union such as `"a" | "b"` from
-	// an if/else over two literals is checked while an annotated scrutinee, which
-	// is already concrete, is left untouched.
+	// Snapshot the scrutinee for the exhaustiveness check before any arm binds. A
+	// literal pattern adds its literal as a lower bound, which would otherwise leak
+	// a phantom member into the coalesced union read after the arm loop.
 	matchShape := scrutinee
 	if _, isVar := soltype.CarrierOf(scrutinee).(*soltype.TypeVarType); isVar {
 		matchShape = coalesce(scrutinee, soltype.Positive)
@@ -2022,14 +2016,7 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 }
 
 // checkMatchExhaustive reports a NonExhaustiveMatchError when no arm covers every
-// value the scrutinee can take. M4 drives the decision solely from the scrutinee's
-// structural exactness. An exact object or tuple has a fixed shape, so a structural
-// arm matching it covers every value. An inexact object or tuple carries an open
-// tail of unknown values, so only an unguarded catch-all covers it. A catch-all is
-// a wildcard `_` or an identifier pattern. A scrutinee that is neither an object nor
-// a tuple is not checked here. Enum-scrutinee exhaustiveness is M5 and extends
-// this same path. The caller passes the scrutinee already coalesced to its
-// pre-match shape, so an inferred union reaches here as a UnionType.
+// value the coalesced scrutinee can take, dispatching on its union or object/tuple shape.
 func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type) {
 	carrier := soltype.CarrierOf(scrutinee)
 	if u, ok := carrier.(*soltype.UnionType); ok {
@@ -2052,12 +2039,8 @@ func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type)
 	c.report(&NonExhaustiveMatchError{Match: e})
 }
 
-// unionMatchExhaustive reports whether the unguarded arms cover every value a
-// union scrutinee can take. An unguarded catch-all covers any union, exact or
-// inexact. An inexact union also carries an open tail of unknown values, so only
-// a catch-all covers it. An exact union is covered when the unguarded arms
-// collectively match every member. For example, a literal member `"a"` of
-// `"a" | "b"` is matched by an arm whose literal pattern is `"a"`.
+// unionMatchExhaustive reports whether the unguarded arms cover a union scrutinee.
+// An inexact union needs a catch-all. An exact one needs every member covered.
 func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) bool {
 	for _, arm := range e.Cases {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2075,12 +2058,9 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 	return true
 }
 
-// unionMemberCovered reports whether some unguarded arm matches a single union
-// member. A catch-all matches any member. A literal pattern matches a literal
-// member of equal value. Any other member or pattern shape is conservatively
-// treated as uncovered, so such a union still needs a catch-all to be
-// exhaustive. This is sound but not complete, which keeps the union leg scoped
-// to literal members until structural-member coverage lands.
+// unionMemberCovered reports whether some unguarded arm matches one union member via
+// a catch-all or an equal literal pattern. Other shapes read uncovered, so coverage
+// is sound but only complete for literal members.
 func (c *checker) unionMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
 	memberLit, memberIsLit := member.(*soltype.LitType)
 	for _, arm := range arms {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2064,21 +2064,25 @@ func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) b
 			return false
 		}
 	}
+
+	if !hasNonLiteralMember {
+		return true
+	}
+
 	// A non-literal member needs the structural or nominal coverage M5 adds. Only a
 	// literal pattern or a catch-all covers a union member today, so flag each
 	// unguarded structural arm as unsupported rather than pass the match silently.
 	// The catch-all case has already returned above.
-	if hasNonLiteralMember {
-		for _, arm := range e.Cases {
-			if arm.Guard != nil {
-				continue
-			}
-			if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
-				continue
-			}
-			c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
+	for _, arm := range e.Cases {
+		if arm.Guard != nil {
+			continue
 		}
+		if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
+			continue
+		}
+		c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
 	}
+
 	return true
 }
 

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1980,6 +1980,19 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 // Exhaustiveness is checked from structural exactness by checkMatchExhaustive.
 func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Type {
 	scrutinee := c.inferExpr(scope, lvl, e.Target)
+	// Snapshot the scrutinee's shape for the exhaustiveness check before any arm
+	// binds. A literal pattern records its literal as a lower bound on a scrutinee
+	// variable, so reading the union after the arm loop would fold every arm
+	// literal into it. Over `x: "a" | "b"` the arm `"z" if guard => …` would then
+	// leak `"z"` as a phantom member and report a false non-exhaustive error.
+	// Coalescing a variable to its positive form here reads only the bounds
+	// established before the match, so an inferred union such as `"a" | "b"` from
+	// an if/else over two literals is checked while an annotated scrutinee, which
+	// is already concrete, is left untouched.
+	matchShape := scrutinee
+	if _, isVar := soltype.CarrierOf(scrutinee).(*soltype.TypeVarType); isVar {
+		matchShape = coalesce(scrutinee, soltype.Positive)
+	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, MatchBranch)
 	for _, arm := range e.Cases {
@@ -2003,7 +2016,7 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 			c.constrain(e, bodyT, res)
 		}
 	}
-	c.checkMatchExhaustive(e, scrutinee)
+	c.checkMatchExhaustive(e, matchShape)
 	c.recordType(e, res)
 	return res
 }
@@ -2014,10 +2027,18 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 // arm matching it covers every value. An inexact object or tuple carries an open
 // tail of unknown values, so only an unguarded catch-all covers it. A catch-all is
 // a wildcard `_` or an identifier pattern. A scrutinee that is neither an object nor
-// a tuple is not checked here. Union-scrutinee exhaustiveness is M6 and enum
-// exhaustiveness is M5, and both extend this same path.
+// a tuple is not checked here. Enum-scrutinee exhaustiveness is M5 and extends
+// this same path. The caller passes the scrutinee already coalesced to its
+// pre-match shape, so an inferred union reaches here as a UnionType.
 func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type) {
-	inexact, isStructural := structuralInexact(soltype.CarrierOf(scrutinee))
+	carrier := soltype.CarrierOf(scrutinee)
+	if u, ok := carrier.(*soltype.UnionType); ok {
+		if !c.unionMatchExhaustive(e, u) {
+			c.report(&NonExhaustiveMatchError{Match: e})
+		}
+		return
+	}
+	inexact, isStructural := structuralInexact(carrier)
 	if !isStructural {
 		return
 	}
@@ -2029,6 +2050,55 @@ func (c *checker) checkMatchExhaustive(e *ast.MatchExpr, scrutinee soltype.Type)
 		}
 	}
 	c.report(&NonExhaustiveMatchError{Match: e})
+}
+
+// unionMatchExhaustive reports whether the unguarded arms cover every value a
+// union scrutinee can take. An unguarded catch-all covers any union, exact or
+// inexact. An inexact union also carries an open tail of unknown values, so only
+// a catch-all covers it. An exact union is covered when the unguarded arms
+// collectively match every member. For example, a literal member `"a"` of
+// `"a" | "b"` is matched by an arm whose literal pattern is `"a"`.
+func (c *checker) unionMatchExhaustive(e *ast.MatchExpr, u *soltype.UnionType) bool {
+	for _, arm := range e.Cases {
+		if arm.Guard == nil && isCatchAll(arm.Pattern) {
+			return true
+		}
+	}
+	if u.Inexact {
+		return false
+	}
+	for _, member := range u.Types {
+		if !c.unionMemberCovered(member, e.Cases) {
+			return false
+		}
+	}
+	return true
+}
+
+// unionMemberCovered reports whether some unguarded arm matches a single union
+// member. A catch-all matches any member. A literal pattern matches a literal
+// member of equal value. Any other member or pattern shape is conservatively
+// treated as uncovered, so such a union still needs a catch-all to be
+// exhaustive. This is sound but not complete, which keeps the union leg scoped
+// to literal members until structural-member coverage lands.
+func (c *checker) unionMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
+	memberLit, memberIsLit := member.(*soltype.LitType)
+	for _, arm := range arms {
+		if arm.Guard != nil {
+			continue
+		}
+		if isCatchAll(arm.Pattern) {
+			return true
+		}
+		armLit, ok := arm.Pattern.(*ast.LitPat)
+		if !ok || !memberIsLit {
+			continue
+		}
+		if lt, ok := c.litTypeOf(armLit.Lit); ok && memberLit.Equal(lt) {
+			return true
+		}
+	}
+	return false
 }
 
 // structuralInexact returns the Inexact flag of an object or tuple type and whether
@@ -2054,11 +2124,24 @@ func structuralInexact(t soltype.Type) (inexact bool, ok bool) {
 // values the pattern cannot see, so it still needs a true catch-all. A literal
 // pattern is refutable and never covers.
 func armCoversShape(p ast.Pat, inexact bool) bool {
+	if isCatchAll(p) {
+		return true
+	}
+	switch p.(type) {
+	case *ast.ObjectPat, *ast.TuplePat:
+		return !inexact && irrefutablePat(p)
+	default:
+		return false
+	}
+}
+
+// isCatchAll reports whether a pattern matches every value unconditionally, so an
+// unguarded arm with it alone makes any match exhaustive. A wildcard or
+// identifier binds without testing the value. Every other pattern is refutable.
+func isCatchAll(p ast.Pat) bool {
 	switch p.(type) {
 	case *ast.WildcardPat, *ast.IdentPat:
 		return true
-	case *ast.ObjectPat, *ast.TuplePat:
-		return !inexact && irrefutablePat(p)
 	default:
 		return false
 	}

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -436,11 +436,11 @@ func TestInferMatchInexactUnionWithCatchAll(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// An exact union of structural members is left unchecked rather than falsely
-// flagged: covering structural-object and tuple members is M5 work, so the union
-// leg only flags a provably-uncovered literal member. A tuple-union match whose
-// single arm binds both members reports no non-exhaustive error.
-func TestInferMatchStructuralUnionNotFalselyFlagged(t *testing.T) {
+// Covering structural-object and tuple union members is M5 work, so the union leg
+// cannot yet evaluate a structural arm pattern against a union member. Rather than
+// falsely flag the match non-exhaustive or silently accept it, each unguarded
+// structural arm over a union with a non-literal member is reported unsupported.
+func TestInferMatchStructuralUnionArmUnsupported(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(b: boolean) {
 			val x = if b { [1, 2] } else { [3, 4] }
@@ -449,7 +449,8 @@ func TestInferMatchStructuralUnionNotFalselyFlagged(t *testing.T) {
 			}
 		}
 	`)
-	require.Empty(t, errs)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:5-5:11: Unsupported: non-literal match arm pattern over a union scrutinee", msgWithSpan(errs[0]))
 }
 
 // A guarded arm can always fail its guard, so it never makes a match exhaustive. An

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -352,6 +352,90 @@ func TestInferMatchInexactWithCatchAll(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number, y: number, ...}) -> number | 0", values["f"])
 }
 
+// An exact union scrutinee whose arms cover every member needs no catch-all. An
+// if/else over two string literals infers the exact union `"a" | "b"`, and the two
+// literal patterns match one member each, so the arms together are exhaustive.
+func TestInferMatchExactUnionCoversMembers(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { "a" } else { "b" }
+			return match x {
+				"a" => 1,
+				"b" => 2
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (b: boolean) -> 1 | 2`, values["f"])
+}
+
+// An exact union scrutinee with a member left uncovered is non-exhaustive. The
+// arms match `"a"` only, so `"b"` escapes and a catch-all is required.
+func TestInferMatchExactUnionMissingMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { "a" } else { "b" }
+			return match x {
+				"a" => 1
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// A guarded arm binds its pattern before its guard runs, so a literal pattern in a
+// guarded arm records its literal as a lower bound on the scrutinee. Exhaustiveness
+// reads the scrutinee's shape from before any arm binds, so a guarded arm's foreign
+// literal does not leak into the union as a phantom uncovered member. The two
+// unguarded arms cover `"a" | "b"`, so the match is exhaustive despite the guarded
+// `"z"` arm.
+func TestInferMatchExactUnionGuardedArmNoPhantomMember(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { "a" } else { "b" }
+			return match x {
+				"a" => 1,
+				"b" => 2,
+				"z" if b => 3
+			}
+		}
+	`)
+	require.Empty(t, errs)
+}
+
+// An inexact union scrutinee carries an open tail of unknown values, so covering
+// every listed member is not enough — only an unguarded catch-all makes it
+// exhaustive. The scrutinee is annotated inexact through a binding.
+func TestInferMatchInexactUnionNeedsCatchAll(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x: number | string | ... = if b { 1 } else { "b" }
+			return match x {
+				1 => 1,
+				"b" => 2
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:11-7:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// An inexact union scrutinee with an unguarded catch-all arm is exhaustive.
+func TestInferMatchInexactUnionWithCatchAll(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x: number | string | ... = if b { 1 } else { "b" }
+			return match x {
+				1 => 1,
+				"b" => 2,
+				_ => 0
+			}
+		}
+	`)
+	require.Empty(t, errs)
+}
+
 // A guarded arm can always fail its guard, so it never makes a match exhaustive. An
 // inexact scrutinee still needs a separate catch-all even when a guarded arm names
 // its whole shape.

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -436,6 +436,22 @@ func TestInferMatchInexactUnionWithCatchAll(t *testing.T) {
 	require.Empty(t, errs)
 }
 
+// An exact union of structural members is left unchecked rather than falsely
+// flagged: covering structural-object and tuple members is M5 work, so the union
+// leg only flags a provably-uncovered literal member. A tuple-union match whose
+// single arm binds both members reports no non-exhaustive error.
+func TestInferMatchStructuralUnionNotFalselyFlagged(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { [1, 2] } else { [3, 4] }
+			return match x {
+				[a, c] => a
+			}
+		}
+	`)
+	require.Empty(t, errs)
+}
+
 // A guarded arm can always fail its guard, so it never makes a match exhaustive. An
 // inexact scrutinee still needs a separate catch-all even when a guarded arm names
 // its whole shape.

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -192,8 +192,8 @@ func (c *checker) resolveTupleTypeAnn(ta *ast.TupleTypeAnn, lvl int) (soltype.Ty
 
 // resolveUnionTypeAnn lowers `A | B | …` through newUnion. An unsupported
 // member recovers to a fresh var so the union shape survives, mirroring the
-// Promise<bad> and object/tuple cascade-safe recovery. The Inexact flag and
-// its parser surface land in PR4.
+// Promise<bad> and object/tuple cascade-safe recovery. A trailing `...` in the
+// source sets ta.Inexact, which carries onto the resolved union.
 func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Type, bool) {
 	members := make([]soltype.Type, len(ta.Types))
 	for i, m := range ta.Types {
@@ -206,7 +206,7 @@ func (c *checker) resolveUnionTypeAnn(ta *ast.UnionTypeAnn, lvl int) (soltype.Ty
 			members[i] = c.freshAt(lvl)
 		}
 	}
-	t := newUnion(c.ctx, members, false)
+	t := newUnion(c.ctx, members, ta.Inexact)
 	// newUnion can collapse to an input member's pointer (single-member
 	// dedup, or subsumption). Re-recording Prov on a pointer that already
 	// carries it would overwrite the narrower child-annotation blame and

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -687,16 +687,16 @@ M4 substrate without retrofitting.
   target-dispatched rule above: an inexact object target admits a
   structurally-conforming class instance.
 - **Structural-object union exhaustiveness — the home for the case M6 left
-  open.** M6's union `match` leg checks only literal union members. It leaves an
-  exact union of structural objects such as `{x: number} | {y: string}` unchecked,
-  so a genuinely non-exhaustive structural union is not flagged. The per-member
-  coverage engine M5 builds for the enum leg extends to these members. An object
-  pattern covers a union member when that member carries every field the pattern
-  names, so the arms are exhaustive when they collectively cover each member. This
-  is the third coverage case after literal members in M6 and nominal variants in
-  M5's enum leg. It extends the member loop in `unionMatchExhaustive`
-  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), which M6
-  skips for non-literal members rather than risk a false non-exhaustive error.
+  open.** M6's union `match` leg checks only literal union members. For an exact
+  union of structural objects such as `{x: number} | {y: string}` it cannot yet
+  decide whether an object pattern covers a member, so it reports each unguarded
+  structural arm as an unsupported feature rather than guess. M5 replaces that
+  report with real coverage. An object pattern covers a union member when that
+  member carries every field the pattern names, so the arms are exhaustive when
+  they collectively cover each member. This is the third coverage case after
+  literal members in M6 and nominal variants in M5's enum leg. It extends the
+  member loop in `unionMatchExhaustive` and removes `reportUnsupportedUnionArms`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)).
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,
   exactly as SimpleSub already does for inference variables. A parameter that

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -695,7 +695,8 @@ M4 substrate without retrofitting.
   member carries every field the pattern names, so the arms are exhaustive when
   they collectively cover each member. This is the third coverage case after
   literal members in M6 and nominal variants in M5's enum leg. It extends the
-  member loop in `unionMatchExhaustive` and removes `reportUnsupportedUnionArms`
+  member loop in `unionMatchExhaustive`, replacing the unsupported-feature report
+  that loop emits today for a structural arm
   ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)).
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -687,16 +687,16 @@ M4 substrate without retrofitting.
   target-dispatched rule above: an inexact object target admits a
   structurally-conforming class instance.
 - **Structural-object union exhaustiveness — the home for the case M6 left
-  open.** M6's union `match` leg covers only literal union members, so an exact
-  union of structural objects such as `{x: number} | {y: string}` still demands a
-  catch-all even when the arms name every member. The per-member coverage engine
-  M5 builds for the enum leg extends to these members. An object pattern covers a
-  union member when that member carries every field the pattern names, so the arms
-  are exhaustive when they collectively cover each member. This is the third
-  coverage case after literal members in M6 and nominal variants in M5's enum leg.
-  It lands in `unionMemberCovered` and `armCoversShape`
-  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), which
-  M6's union leg deliberately scoped to literals.
+  open.** M6's union `match` leg checks only literal union members. It leaves an
+  exact union of structural objects such as `{x: number} | {y: string}` unchecked,
+  so a genuinely non-exhaustive structural union is not flagged. The per-member
+  coverage engine M5 builds for the enum leg extends to these members. An object
+  pattern covers a union member when that member carries every field the pattern
+  names, so the arms are exhaustive when they collectively cover each member. This
+  is the third coverage case after literal members in M6 and nominal variants in
+  M5's enum leg. It extends the member loop in `unionMatchExhaustive`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), which M6
+  skips for non-literal members rather than risk a false non-exhaustive error.
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,
   exactly as SimpleSub already does for inference variables. A parameter that

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -686,6 +686,17 @@ M4 substrate without retrofitting.
   `var foo: {x: number, y: number, ...} = Point(5, 10)` is **accepted** under the
   target-dispatched rule above: an inexact object target admits a
   structurally-conforming class instance.
+- **Structural-object union exhaustiveness — the home for the case M6 left
+  open.** M6's union `match` leg covers only literal union members, so an exact
+  union of structural objects such as `{x: number} | {y: string}` still demands a
+  catch-all even when the arms name every member. The per-member coverage engine
+  M5 builds for the enum leg extends to these members. An object pattern covers a
+  union member when that member carries every field the pattern names, so the arms
+  are exhaustive when they collectively cover each member. This is the third
+  coverage case after literal members in M6 and nominal variants in M5's enum leg.
+  It lands in `unionMemberCovered` and `armCoversShape`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)), which
+  M6's union leg deliberately scoped to literals.
 - **Per-type-parameter variance via polarity (Option 2).** Each class's type
   parameters get their variance inferred from how they appear in the class body,
   exactly as SimpleSub already does for inference variables. A parameter that

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -727,8 +727,9 @@ M6's reachable inexact source is the annotation; the borrow-join union (PR6) and
   per-member shape test rather than inventing a new coverage engine. The
   `NonExhaustiveMatchError` is unchanged; only its trigger condition widens. A
   union of structural-object members needs object-pattern-covers-member
-  discrimination, which M6 leaves to M5's coverage generalization
-  ([01-milestones.md](01-milestones.md) §M5, "Structural-object union
+  discrimination M6 does not implement, so a structural arm over such a union is
+  reported as an unsupported feature until M5's coverage generalization replaces
+  it ([01-milestones.md](01-milestones.md) §M5, "Structural-object union
   exhaustiveness").
 
 **Tests.** An exact-union `match` covering all members needs no default; an

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -670,50 +670,69 @@ recovers function-shaped.
 
 ---
 
-### PR4 — Union exactness flag end to end + `match` exhaustiveness (union leg)
+### PR4 — Union exactness flag: surface syntax + `match` exhaustiveness (union leg)
 
-Thread the flag from surface syntax to the exhaustiveness payoff.
+Thread the `Inexact` flag from surface syntax to the exhaustiveness payoff. The
+representation and the constrain rule already exist, so this PR is the missing
+two ends — the parser/AST marker that lets source write an inexact union, and the
+`match`-exhaustiveness leg that reads the flag.
+
+**Already landed — out of this PR's scope.** Three pieces the original PR4 listed
+shipped earlier:
+
+- `soltype.UnionType.Inexact`, its `Accept` flag-carry, and the printer's
+  trailing-`...` rendering landed in **PR1**
+  ([soltype/type.go:353](../../internal/soltype/type.go),
+  [print.go:413](../../internal/soltype/print.go)).
+- The one-way exactness rule in `constrain` landed in **PR2 (#776)**: a
+  `UnionType` sub decomposes for-all, and an **inexact** sub against a closed
+  super emits `InexactUnionIntoExactError`
+  ([constrain.go:159-175](../../internal/solver/constrain.go)). It already reads
+  the real flag, so there is no separate "activate against the flag" step.
 
 **AST + parser.** Add `Inexact bool` to `ast.UnionTypeAnn`
-([ast/type_ann.go:381](../../internal/ast/type_ann.go)) and teach the parser to
-set it on a trailing `...` in a union, mirroring the object/tuple/function
-inexact markers already parsed ([ast/type_ann.go:316](../../internal/ast/type_ann.go)
-and siblings). `IntersectionTypeAnn` gets no marker.
+([ast/type_ann.go:382](../../internal/ast/type_ann.go)) and teach `typeAnn`
+([parser/type_ann.go:42](../../internal/parser/type_ann.go)) to set it on a
+trailing `...` in a union, mirroring the object/tuple/function inexact markers
+already parsed. The union annotation is built by a shunting-yard operator parser,
+not `parseDelimSeqInexact`, so the marker is recognized inline: when the operator
+just consumed is a `|` and the next token is `...`, consume it, flag the union
+inexact, and stop the operand loop. The flag is set on the popped top-level
+`UnionTypeAnn` after the operator stack drains. `IntersectionTypeAnn` gets no
+marker.
 
-**Resolve and thread.** `resolveTypeAnn`'s union arm (PR2) passes
-`ta.Inexact` into `newUnion`. Coalesced **output** unions are **exact by
-default** — `combine` ([coalesce.go:295](../../internal/solver/coalesce.go)) mints
-`newUnion(parts, false)` — matching exact-by-default for inferred shapes. The
-flag must be **threaded by coalescing, not just stored**: where a union's
-exactness derives from a source former's exactness it is carried through. M6's
-reachable case is the annotation and the borrow-join union (PR6); `keyof` /
-tuple-element-union propagation is M9.
-
-**Constrain.** Activate the full one-way rule from PR2 against the real flag:
-exact `<:` inexact ok, inexact `<:` exact rejected, exact `<:` exact requires the
-member sets to match after normalization.
+**Resolve and thread.** `resolveUnionTypeAnn`
+([type_ann.go:197](../../internal/solver/type_ann.go)) passes `ta.Inexact` into
+`newUnion` instead of the hardcoded `false`. Coalesced **output** unions stay
+exact by default — `combine` ([coalesce.go:295](../../internal/solver/coalesce.go))
+mints `newUnion(..., false)` — matching exact-by-default for inferred shapes.
+M6's reachable inexact source is the annotation; the borrow-join union (PR6) and
+`keyof` / tuple-element-union propagation (M9) are separate.
 
 **`match` exhaustiveness — the union leg.** Extend the M4 path
-([infer_expr.go:1475](../../internal/solver/infer_expr.go) `checkMatchExhaustive`):
+([infer_expr.go:2019](../../internal/solver/infer_expr.go) `checkMatchExhaustive`):
 
-- `structuralInexact` ([infer_expr.go:1493](../../internal/solver/infer_expr.go))
+- `structuralInexact` ([infer_expr.go:2037](../../internal/solver/infer_expr.go))
   grows a `UnionType` arm returning its `Inexact` flag, so an **exact** union
   scrutinee with arms covering every member needs no catch-all, while an
   **inexact** union requires one — the third leg after structural (M4) and ahead
-  of enum (M5).
-- Covering "every member" for a union of literal/structural members extends
-  `armCoversShape` ([infer_expr.go:1512](../../internal/solver/infer_expr.go)): an
-  exact union is exhaustive when the arm patterns collectively match each member.
-  For an exact union of literals this is literal-pattern coverage of the member
-  set; reuse the per-member shape test rather than inventing a new coverage
-  engine. The `NonExhaustiveMatchError`
-  ([errors.go:622](../../internal/solver/errors.go)) is unchanged; only its
-  trigger condition widens.
+  of enum (M5). `checkMatchExhaustive` already peels the scrutinee through
+  `soltype.CarrierOf` ([ref.go:28](../../internal/soltype/ref.go)), the affine
+  borrow-unwrap added after the original PR4 draft, so a union behind a borrow
+  reaches the new arm already unwrapped — no extra handling needed.
+- Covering "every member" for a union of literal members extends `armCoversShape`
+  ([infer_expr.go:2056](../../internal/solver/infer_expr.go)): an exact union is
+  exhaustive when the arm patterns collectively match each member. For an exact
+  union of literals this is literal-pattern coverage of the member set; reuse the
+  per-member shape test rather than inventing a new coverage engine. The
+  `NonExhaustiveMatchError` is unchanged; only its trigger condition widens.
 
-**Tests.** An exact union `"a" | "b"` is assignable to inexact `"a" | "b" | ...`
-but not the reverse; an exact-union `match` covering all members needs no
-default; an inexact-union `match` requires a default; printer round-trip for the
-inexact marker.
+**Tests.** An exact-union `match` covering all members needs no default; an
+exact-union `match` missing a member is non-exhaustive; an inexact-union `match`
+requires a default; printer round-trip for the inexact marker; the parser sets
+`Inexact` on a trailing `...` and leaves a bare `A | B` exact. The exact-union
+scrutinee is built by inference, since a literal type annotation does not yet
+resolve.
 
 ---
 

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -725,7 +725,11 @@ M6's reachable inexact source is the annotation; the borrow-join union (PR6) and
   exhaustive when the arm patterns collectively match each member. For an exact
   union of literals this is literal-pattern coverage of the member set; reuse the
   per-member shape test rather than inventing a new coverage engine. The
-  `NonExhaustiveMatchError` is unchanged; only its trigger condition widens.
+  `NonExhaustiveMatchError` is unchanged; only its trigger condition widens. A
+  union of structural-object members needs object-pattern-covers-member
+  discrimination, which M6 leaves to M5's coverage generalization
+  ([01-milestones.md](01-milestones.md) §M5, "Structural-object union
+  exhaustiveness").
 
 **Tests.** An exact-union `match` covering all members needs no default; an
 exact-union `match` missing a member is non-exhaustive; an inexact-union `match`


### PR DESCRIPTION
Adds exhaustiveness checking for `match` expressions with union-type scrutinees, completing the union leg of M6's match exhaustiveness work.

**Summary**

Union scrutinees now report non-exhaustive matches when arms fail to cover all members of an exact union, or when an inexact union lacks an unguarded catch-all. The implementation reads the union's `Inexact` flag (added in PR1) and checks literal-pattern coverage of union members.

**Changes**

- **Parser and AST**: Added `Inexact` field to `ast.UnionTypeAnn` and taught the parser to recognize a trailing `...` after a `|` operator, marking the union inexact.

- **Type resolution**: `resolveUnionTypeAnn` now threads the `Inexact` flag from the AST into the resolved `soltype.UnionType`, replacing the hardcoded `false`.

- **Match exhaustiveness**: Extended `checkMatchExhaustive` to handle union scrutinees by checking the `Inexact` flag and verifying that unguarded arms cover every member of exact unions. Added `unionMatchExhaustive` and `unionMemberCovered` helpers to implement literal-pattern coverage checking.

- **Scrutinee shape snapshot**: Before processing match arms, the scrutinee is coalesced to its pre-match shape if it's a type variable. This prevents guarded arms from leaking their literal patterns into the union as phantom uncovered members, which would cause false non-exhaustive errors.

- **Refactoring**: Extracted `isCatchAll` helper to identify patterns that unconditionally match any value (wildcard or identifier), reducing duplication in exhaustiveness logic.

**Tests**

Added five test cases covering exact unions with complete and incomplete member coverage, inexact unions requiring catch-alls, and the phantom-member scenario with guarded arms.

https://claude.ai/code/session_01YUSH29FWbZT8gph5X8iBhZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking union type annotations as open-ended with a trailing `...`.
  * Match exhaustiveness now handles exact and inexact unions more accurately, including literal patterns and catch-all branches.

* **Bug Fixes**
  * Improved parser and type resolution so inexact union markers are preserved end-to-end.
  * Fixed exhaustiveness checks to avoid false positives when matching against guarded arms or inferred type variables.

* **Tests**
  * Added coverage for parsing inexact unions and match behavior across exact/inexact union cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->