### PR TITLE
Implement read-until-narrowed unions for incompatible borrow joins

### DIFF
--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -204,18 +204,13 @@ fn use(a: &mut {x: number}, b: &mut {x: number}) {
 		values["use"])
 }
 
-// Joining borrows that share a field NAME but disagree on its TYPE is rejected. A mut
-// object's fields are observable in both directions, so the join pins each shared
-// field invariant, and `number` vs `string` for `x` fails that pin in both
-// directions. This locks in that the soundness constraint actually fires rather than
-// silently unifying incompatible borrows (M4 D3).
-//
-// FUTURE (M6): this error is the conservative M4 default. M6 may relax it to a
-// read-until-narrowed union — `(&'a mut {x: number}) | (&'b mut {x: string})`, readable
-// always and writable only after narrowing — to match TypeScript. See 01-milestones.md
-// M6, "Permissive mut-borrow joins". When that lands, this test changes from asserting
-// an error to asserting the union.
-func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
+// Joining borrows that share a field NAME but disagree on its TYPE degrades to the
+// read-until-narrowed union of the distinct borrows rather than erroring (M6,
+// "Permissive mut-borrow joins"). A single mut carrier would have to pin `x`
+// invariant across the inputs, and `number` vs `string` fails that pin, so the join
+// falls back to the type-level union, readable everywhere and writable at `x` only
+// after narrowing.
+func TestInferIncompatibleBorrowJoinReturnsUnion(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
   if true {
     return p
@@ -223,10 +218,76 @@ func TestInferIncompatibleBorrowJoinErrors(t *testing.T) {
     return q
   }
 }`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: string}) -> &'a mut {x: number} | &'b mut {x: string}",
+		values["f"])
+}
+
+// A read of a conflicting field off an incompatible-borrow union yields the
+// covariant union of the field types. `r.x` over `&'a mut {x: number} | &'b mut {x:
+// string}` reads `number | string` via the union read rule, the read-until-narrowed
+// view the permissive join enables.
+func TestInferIncompatibleBorrowUnionFieldReads(t *testing.T) {
+	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
+  val r = if true {
+    p
+  } else {
+    q
+  }
+  return r.x
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: &mut {x: number}, q: &mut {x: string}) -> number | string",
+		values["f"])
+}
+
+// An incompatible join over THREE borrows keeps every distinct lifetime in the
+// union, even when two members share a field set and differ only in lifetime. The
+// pin fails on `r`'s `string` field, so the union path runs over all three borrows.
+// `p` and `q` are both `&mut {x: number}` and would mutually subsume by a discardable
+// lifetime constraint, so the union is built with no subsumption to keep `'a` and
+// `'b` separate rather than collapsing one borrow into the other.
+func TestInferIncompatibleBorrowJoinKeepsDistinctLifetimes(t *testing.T) {
+	src := `fn f(p: &mut {x: number}, q: &mut {x: number}, r: &mut {x: string}) {
+  if true {
+    return p
+  } else {
+    if true {
+      return q
+    } else {
+      return r
+    }
+  }
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: string}) -> &'a mut {x: number} | &'b mut {x: number} | &'c mut {x: string}",
+		values["f"])
+}
+
+// A write to a conflicting field through an un-narrowed incompatible-borrow union is
+// rejected. The union of mutable objects is read-only at `x`, since `x` is `number`
+// in one branch and `string` in the other, so writing `5` must satisfy both and
+// fails the invariant pin in each direction. The read-until-narrowed contract is
+// sound only because this write is rejected. To write, narrow to one branch first.
+func TestInferIncompatibleBorrowUnionWriteRejected(t *testing.T) {
+	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
+  val r = if true {
+    p
+  } else {
+    q
+  }
+  r.x = 5
+}`
 	_, _, errs := inferSource(t, src)
 	require.Equal(t, []string{
-		"1:18-1:24: cannot constrain number <: string",
-		"1:39-1:45: cannot constrain string <: number",
+		"7:3-7:10: cannot constrain string <: number",
+		"7:3-7:10: cannot constrain number <: string",
 	}, messagesWithSpan(errs))
 }
 

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -205,11 +205,10 @@ fn use(a: &mut {x: number}, b: &mut {x: number}) {
 }
 
 // Joining borrows that share a field NAME but disagree on its TYPE degrades to the
-// read-until-narrowed union of the distinct borrows rather than erroring (M6,
-// "Permissive mut-borrow joins"). A single mut carrier would have to pin `x`
-// invariant across the inputs, and `number` vs `string` fails that pin, so the join
-// falls back to the type-level union, readable everywhere and writable at `x` only
-// after narrowing.
+// read-until-narrowed union of the distinct borrows rather than erroring. A single
+// mut carrier would have to pin `x` invariant across the inputs, and `number` vs
+// `string` fails that pin, so the join falls back to the type-level union, readable
+// everywhere and writable at `x` only after narrowing.
 func TestInferIncompatibleBorrowJoinReturnsUnion(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
   if true {

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -275,6 +275,12 @@ func TestInferIncompatibleBorrowJoinKeepsDistinctLifetimes(t *testing.T) {
 // in one branch and `string` in the other, so writing `5` must satisfy both and
 // fails the invariant pin in each direction. The read-until-narrowed contract is
 // sound only because this write is rejected. To write, narrow to one branch first.
+//
+// The write reports two messages for the one mistake: the `string` member's `x` is
+// pinned invariant against the `number` write requirement, so both the read view
+// (`string <: number`) and the write view (`number <: string`) fail. Collapsing this
+// to a single diagnostic is tracked in escalier-lang/escalier#806; update this
+// assertion when that lands.
 func TestInferIncompatibleBorrowUnionWriteRejected(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: string}) {
   val r = if true {

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -244,6 +244,28 @@ func TestInferIncompatibleBorrowUnionFieldReads(t *testing.T) {
 		values["f"])
 }
 
+// Reading a conflicting field that is ITSELF a borrow keeps each branch's borrowed
+// field result. `r.a` over `&mut {a: &'a mut {x: number}} | &mut {a: &'b mut {x:
+// string}}` reads `&'a mut {x: number} | &'b mut {x: string}`, each member's field
+// borrow at its own lifetime. The field-read result var coalesces to the union of the
+// member field types rather than collapsing to a single lifetime, so the per-branch
+// borrows survive the read.
+func TestInferIncompatibleBorrowUnionReadsBorrowedField(t *testing.T) {
+	src := `fn f(p: &mut {a: &mut {x: number}}, q: &mut {a: &mut {x: string}}) {
+  val r = if true {
+    p
+  } else {
+    q
+  }
+  return r.a
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b>(p: &mut {a: &'a mut {x: number}}, q: &mut {a: &'b mut {x: string}}) -> &'a mut {x: number} | &'b mut {x: string}",
+		values["f"])
+}
+
 // An incompatible join over THREE borrows keeps every distinct lifetime in the
 // union, even when two members share a field set and differ only in lifetime. The
 // pin fails on `r`'s `string` field, so the union path runs over all three borrows.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -416,10 +416,10 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 	return true
 }
 
-// joinBorrows joins several mutable borrows of objects (M4 D3). It applies only when
-// EVERY input is a mutable borrow of an object, all sharing the same field-name set
-// with each carrying a lifetime, and returns ok=false otherwise so the caller falls
-// back to its generic union path. The result depends on whether the shared fields
+// joinBorrows joins several mutable borrows of objects. It applies only when EVERY
+// input is a mutable borrow of an object, all sharing the same field-name set with
+// each carrying a lifetime, and returns ok=false otherwise so the caller falls back
+// to its generic union path. The result depends on whether the shared fields
 // reconcile:
 //
 //   - Reconcilable: one mutable borrow `&('a | 'b) mut {…}` whose lifetime is a fresh
@@ -428,9 +428,9 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 //   - Conflicting: the read-until-narrowed union of the distinct borrows,
 //     `&'a mut {x: number} | &'b mut {x: string}`, rather than erroring on the pin.
 //
-// The pin runs under a discard-only probe, so the union path leaves no trace: a
-// successful pin commits the single carrier, a failed pin rolls back its bounds and
-// error and yields the union instead.
+// The pin runs under a probe. A successful pin commits the single carrier. A failed
+// pin discards its bounds and error and yields the union instead, so the union path
+// leaves no trace.
 //
 // The union is governed by a read-until-narrowed contract: it is readable everywhere
 // but writable at its conflicting fields only after narrowing. A read off the union
@@ -458,9 +458,10 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 		objs[i] = obj
 	}
 
-	// Pin each shared field invariant across the inputs under a discard-only probe. A
-	// mut object's fields are read AND written through the single carrier, so it is
-	// sound only when they agree. The probe lets the union path leave no trace.
+	// Pin each shared field invariant across the inputs under a probe. A mut object's
+	// fields are read AND written through the single carrier, so it is sound only when
+	// they agree. Committing on success and discarding on failure lets the union path
+	// leave no trace.
 	errsBefore := len(c.errs)
 	p := c.openProbe()
 	for _, e := range objs[0].Elems {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -432,10 +432,12 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 // successful pin commits the single carrier, a failed pin rolls back its bounds and
 // error and yields the union instead.
 //
-// Read-until-narrowed contract. A read off the union yields the covariant union of
-// the conflicting fields via the union read rule. A write to a conflicting field is
-// rejected, which keeps the union sound: it is read-only at its conflicting fields,
-// and a rejected write never changes its type. To write, narrow to one branch with
+// The union is governed by a read-until-narrowed contract: it is readable everywhere
+// but writable at its conflicting fields only after narrowing. A read off the union
+// yields the covariant union of the conflicting fields via the union read rule. A
+// write to a conflicting field is rejected, which keeps the union sound: it is
+// read-only at its conflicting fields, and a rejected write never changes its type.
+// To write, narrow to one branch with
 // `if let r2: mut {x: number} = r` and write through the fresh mutable view.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
 	refs := make([]*soltype.RefType, len(types))
@@ -475,10 +477,17 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 	if !reconciled {
 		// The fields conflict. Discarding the probe rolled back the failed pin and
 		// its error, so each borrow keeps its own lifetime. Build the
-		// read-until-narrowed union of the original borrows. Pass no Context, so
-		// subsumption does not run. Two borrows differing only in lifetime would
-		// otherwise mutually subsume through a lifetime constraint the subtype trial
-		// discards, unsoundly collapsing the distinct lifetimes the union must keep.
+		// read-until-narrowed union of the original borrows.
+		//
+		// Pass no Context, so subsumption does not run. Each union member is a
+		// distinct borrow the value can take at runtime, with its own lifetime.
+		// Subsumption would trial one member <: another and drop the "subtype",
+		// but two borrows differing only in lifetime each subtype the other
+		// through a lifetime constraint the trial then discards. Dropping either
+		// would retype a value that may be the shorter-lived borrow as the
+		// longer-lived one, so a later read could outlive the borrowed data. The
+		// distinct lifetimes must survive into the union for the borrow check to
+		// stay sound.
 		return newUnion(nil, types, false), true
 	}
 	// Reconcilable fields: unite the input lifetimes under one fresh join lifetime,
@@ -535,11 +544,19 @@ func (escapeVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
 // lower bounds — the shape a `val`-bound or call-result borrow takes — would
 // otherwise propagate un-peeled into the requirement and escape-error, so the
 // variable case peels its lower bounds, the same look-through resolveFunc uses to
-// find a concrete callee behind a binding var.
+// find a concrete callee behind a binding var. For example, in
 //
-// A variable with no borrow lower bound is returned unchanged, so an inferred-param
-// read (`fn f(p) { p.x }`) keeps recording its requirement against the variable and
-// coalesces to an owned object rather than a borrow.
+//	val r = if c { p } else { q }   // p, q are &mut borrows
+//	r.x                             // recv is r's variable, lower-bounded by both borrows
+//
+// the read peels the two borrow lower bounds to `{x: …} | {x: …}` rather than
+// constraining the borrows against the field requirement directly.
+//
+// The peel keys off the receiver variable's lower bounds, not the kind of read. A
+// variable with no borrow lower bound is returned unchanged. A parameter read like
+// `fn f(p) { p.x }` is one such case: nothing flows into p inside the body, so p's
+// variable has no lower bound, only the upper-bound field requirement the read adds,
+// and it coalesces to an owned object rather than a borrow.
 func readCarrier(recv soltype.Type) soltype.Type {
 	v, ok := recv.(*soltype.TypeVarType)
 	if !ok {
@@ -552,7 +569,11 @@ func readCarrier(recv soltype.Type) soltype.Type {
 	sawBorrow := false
 	for _, lb := range v.LowerBounds {
 		if lb == soltype.Type(v) {
-			continue // a self-edge would point the read back at the receiver variable
+			// A nested mut write such as `obj.p.x = 5` can leave the receiver
+			// variable with a vacuous `v <: v` self-edge among its bounds, the same
+			// case withoutSelf drops in coalesce. It constrains nothing, so skip it
+			// rather than point the read back at the receiver variable.
+			continue
 		}
 		if hasBorrowShape(lb) {
 			sawBorrow = true

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -416,19 +416,39 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 	return true
 }
 
-// joinBorrows synthesizes the join of several borrowed objects that differ only in
-// lifetime (M4 D3). It applies only when EVERY input is a mutable borrow of an
-// object, all sharing the same field-name set with each carrying a lifetime. The
-// result is one mutable borrow whose lifetime is a fresh JOIN variable bounded below
-// by each input's lifetime, so a positive-position result coalesces to `('a | 'b)`.
-// The shared fields are constrained invariant across the inputs. A mut object's
-// fields are observable in both directions, so a sound join pins them equal. Uniting
-// differing field sets returns ok=false, because it would invent writable fields
-// absent from one input.
+// joinBorrows synthesizes the join of several borrowed objects (M4 D3). It applies
+// only when EVERY input is a mutable borrow of an object, all sharing the same
+// field-name set with each carrying a lifetime. Two outcomes are possible depending
+// on whether the shared fields reconcile:
 //
-// ok=false leaves the caller on its generic union path. A usage-inferred borrow is a
-// type variable here, not a concrete RefType, so it returns ok=false. This matches
-// the spike, which joins only concrete mut records.
+//   - Reconcilable fields join to one mutable borrow whose lifetime is a fresh JOIN
+//     variable bounded below by each input's lifetime, so a positive-position result
+//     coalesces to `&('a | 'b) mut {…}`. The shared fields are pinned invariant
+//     across the inputs, since a mut object's fields are read AND written through
+//     the join and a sound single carrier needs them to agree.
+//   - Conflicting fields degrade to the type-level union of the distinct borrows,
+//     `&'a mut {x: number} | &'b mut {x: string}`, instead of erroring on the pin.
+//     This is the read-until-narrowed treatment of a union of mutable objects.
+//
+// The reconcile attempt runs under a discard-only probe so it leaves no trace on the
+// union path. When the pin reports no error the probe commits the single carrier;
+// when it reports an error the probe discards both the pinned bounds and the error,
+// and the union of the original borrows is returned.
+//
+// Read-until-narrowed contract. A read off the un-narrowed union yields the
+// covariant union of the conflicting fields, `number | string`, via the union read
+// rule. A WRITE to a conflicting field through the un-narrowed union is rejected,
+// which is sound: an un-narrowed union of mutable objects is read-only at its
+// conflicting fields, and a rejected write never changes the union's type. To write,
+// narrow to one branch with an `if let r2: mut {x: number} = r` and write through the
+// fresh mutable view. The un-narrowed binding stays read-only at its conflicting
+// fields for its whole scope by design, not as a deferral.
+//
+// Uniting differing field-NAME sets returns ok=false, because the single-carrier
+// shape would invent writable fields absent from one input and the value-level union
+// is the caller's generic-union job. ok=false leaves the caller on its generic union
+// path. A usage-inferred borrow is a type variable here, not a concrete RefType, so
+// it returns ok=false.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
 	refs := make([]*soltype.RefType, len(types))
 	objs := make([]*soltype.ObjectType, len(types))
@@ -448,12 +468,11 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 		objs[i] = obj
 	}
 
-	joinLt := c.ctx.freshJoinLifetime(lvl)
-	for _, r := range refs {
-		c.ctx.constrainLt(r.Lt, joinLt)
-	}
-	// Pin each shared field invariant across the inputs: a mut object's fields are
-	// read AND written through the join, so the join is sound only when they agree.
+	// Pin each shared field invariant across the inputs under a discard-only probe. A
+	// mut object's fields are read AND written through the single carrier, so it is
+	// sound only when they agree. The probe lets the union path leave no trace.
+	errsBefore := len(c.errs)
+	p := c.openProbe()
 	for _, e := range objs[0].Elems {
 		name := soltype.AsProperty(e).Name
 		first, _ := objs[0].Prop(name)
@@ -462,6 +481,24 @@ func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (sol
 			c.constrain(node, first.Type, other.Type)
 			c.constrain(node, other.Type, first.Type)
 		}
+	}
+	reconciled := len(c.errs) == errsBefore
+	c.closeProbe(p, reconciled)
+	if !reconciled {
+		// The fields conflict. Discarding the probe rolled back the failed pin and
+		// its error, so each borrow keeps its own lifetime. Build the
+		// read-until-narrowed union of the original borrows. Pass no Context, so
+		// subsumption does not run. Two borrows differing only in lifetime would
+		// otherwise mutually subsume through a lifetime constraint the subtype trial
+		// discards, unsoundly collapsing the distinct lifetimes the union must keep.
+		return newUnion(nil, types, false), true
+	}
+	// Reconcilable fields: unite the input lifetimes under one fresh join lifetime,
+	// bounded below by each, and return the single mutable carrier. Allocating the
+	// join lifetime only here keeps the union path from minting a dead lifetime.
+	joinLt := c.ctx.freshJoinLifetime(lvl)
+	for _, r := range refs {
+		c.ctx.constrainLt(r.Lt, joinLt)
 	}
 	return &soltype.RefType{Mut: true, Lt: joinLt, Inner: objs[0]}, true
 }
@@ -503,6 +540,87 @@ func (v escapeVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Ent
 }
 
 func (escapeVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// readCarrier peels the borrow wrapper for a field-read requirement so the
+// borrow-escape guard does not fire on a read. Reading a field through a borrow is
+// always legal and yields the field's value, so the requirement is built against the
+// peeled carrier rather than the borrow. The receiver reaches valueProp in three
+// shapes:
+//
+//   - A concrete RefType peels to its inner carrier.
+//   - A union peels each member, so a read off a union of borrows reads each member
+//     through the union for-all rule and the field coalesces to their union.
+//   - A join variable holding borrow lower bounds peels each such bound. A
+//     `val`-bound or call-result borrow reaches valueProp as the join variable
+//     holding the borrow, not the concrete RefType, so a read off it would otherwise
+//     propagate the un-peeled borrow into the requirement and escape-error. The peel
+//     looks through the variable's lower bounds, the same technique resolveFunc uses
+//     to find a concrete callee behind a binding var.
+//
+// A variable with no borrow lower bound is left unchanged, so an inferred-param read
+// (`fn f(p) { p.x }`) still records its inexact upper-bound requirement against the
+// variable, keeping its coalesced shape an owned object rather than a borrow. A join
+// over non-borrow objects likewise stays on the variable so each object lower bound
+// propagates as before.
+func readCarrier(recv soltype.Type) soltype.Type {
+	v, ok := recv.(*soltype.TypeVarType)
+	if !ok {
+		return peelBorrows(recv)
+	}
+	// Peel each lower bound, the same look-through resolveFunc uses to find a concrete
+	// callee behind a binding var. Divert to the peeled carriers only when a borrow is
+	// actually present, so a non-borrow variable read keeps the variable-direct path.
+	members := make([]soltype.Type, 0, len(v.LowerBounds))
+	sawBorrow := false
+	for _, lb := range v.LowerBounds {
+		if lb == soltype.Type(v) {
+			continue // a self-edge would point the read back at the receiver variable
+		}
+		if hasBorrowShape(lb) {
+			sawBorrow = true
+		}
+		members = append(members, peelBorrows(lb))
+	}
+	if !sawBorrow {
+		return v
+	}
+	return newUnion(nil, members, false)
+}
+
+// peelBorrows strips the borrow wrapper off a concrete carrier, distributing through
+// a union so a union of borrows peels each member. A type variable is left as a leaf,
+// since recursing into its bounds could loop on a cyclic bound, and constrain handles
+// a bare variable on the sub side anyway.
+func peelBorrows(t soltype.Type) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		return t.Inner
+	case *soltype.UnionType:
+		members := make([]soltype.Type, len(t.Types))
+		for i, m := range t.Types {
+			members[i] = peelBorrows(m)
+		}
+		return newUnion(nil, members, t.Inexact)
+	}
+	return t
+}
+
+// hasBorrowShape reports whether t is a borrow or a union with a borrow member. It
+// gates readCarrier's look-through so only a variable actually holding a borrow
+// diverts to the peeled-bound read path.
+func hasBorrowShape(t soltype.Type) bool {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		return true
+	case *soltype.UnionType:
+		for _, m := range t.Types {
+			if hasBorrowShape(m) {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // sameObjectKeys reports whether two objects carry exactly the same set of property
 // names — the join's precondition, since a mut object's field set is invariant.
@@ -1674,7 +1792,9 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	//   - It keeps the requirement off the RefType, so the RefType<:bare escape
 	//     guard fires only when the borrow flows into an owned destination, not on a read.
 	//   - A non-borrow receiver is returned unchanged, leaving plain vars untouched.
-	recvCarrier := soltype.CarrierOf(recv)
+	//   - A union receiver peels each member's borrow, so a read off a union of
+	//     borrows reads each member through the union for-all rule.
+	recvCarrier := readCarrier(recv)
 	fieldVar := c.freshAt(lvl)
 	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner fieldVar, so the record would be a dead

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -416,39 +416,27 @@ func (c *checker) allReturnsUpgradable(retExprs []ast.Expr) bool {
 	return true
 }
 
-// joinBorrows synthesizes the join of several borrowed objects (M4 D3). It applies
-// only when EVERY input is a mutable borrow of an object, all sharing the same
-// field-name set with each carrying a lifetime. Two outcomes are possible depending
-// on whether the shared fields reconcile:
+// joinBorrows joins several mutable borrows of objects (M4 D3). It applies only when
+// EVERY input is a mutable borrow of an object, all sharing the same field-name set
+// with each carrying a lifetime, and returns ok=false otherwise so the caller falls
+// back to its generic union path. The result depends on whether the shared fields
+// reconcile:
 //
-//   - Reconcilable fields join to one mutable borrow whose lifetime is a fresh JOIN
-//     variable bounded below by each input's lifetime, so a positive-position result
-//     coalesces to `&('a | 'b) mut {…}`. The shared fields are pinned invariant
-//     across the inputs, since a mut object's fields are read AND written through
-//     the join and a sound single carrier needs them to agree.
-//   - Conflicting fields degrade to the type-level union of the distinct borrows,
-//     `&'a mut {x: number} | &'b mut {x: string}`, instead of erroring on the pin.
-//     This is the read-until-narrowed treatment of a union of mutable objects.
+//   - Reconcilable: one mutable borrow `&('a | 'b) mut {…}` whose lifetime is a fresh
+//     join variable bounded below by each input's. The shared fields are pinned
+//     invariant, since a mut field is read AND written through the single carrier.
+//   - Conflicting: the read-until-narrowed union of the distinct borrows,
+//     `&'a mut {x: number} | &'b mut {x: string}`, rather than erroring on the pin.
 //
-// The reconcile attempt runs under a discard-only probe so it leaves no trace on the
-// union path. When the pin reports no error the probe commits the single carrier;
-// when it reports an error the probe discards both the pinned bounds and the error,
-// and the union of the original borrows is returned.
+// The pin runs under a discard-only probe, so the union path leaves no trace: a
+// successful pin commits the single carrier, a failed pin rolls back its bounds and
+// error and yields the union instead.
 //
-// Read-until-narrowed contract. A read off the un-narrowed union yields the
-// covariant union of the conflicting fields, `number | string`, via the union read
-// rule. A WRITE to a conflicting field through the un-narrowed union is rejected,
-// which is sound: an un-narrowed union of mutable objects is read-only at its
-// conflicting fields, and a rejected write never changes the union's type. To write,
-// narrow to one branch with an `if let r2: mut {x: number} = r` and write through the
-// fresh mutable view. The un-narrowed binding stays read-only at its conflicting
-// fields for its whole scope by design, not as a deferral.
-//
-// Uniting differing field-NAME sets returns ok=false, because the single-carrier
-// shape would invent writable fields absent from one input and the value-level union
-// is the caller's generic-union job. ok=false leaves the caller on its generic union
-// path. A usage-inferred borrow is a type variable here, not a concrete RefType, so
-// it returns ok=false.
+// Read-until-narrowed contract. A read off the union yields the covariant union of
+// the conflicting fields via the union read rule. A write to a conflicting field is
+// rejected, which keeps the union sound: it is read-only at its conflicting fields,
+// and a rejected write never changes its type. To write, narrow to one branch with
+// `if let r2: mut {x: number} = r` and write through the fresh mutable view.
 func (c *checker) joinBorrows(node ast.Node, lvl int, types []soltype.Type) (soltype.Type, bool) {
 	refs := make([]*soltype.RefType, len(types))
 	objs := make([]*soltype.ObjectType, len(types))
@@ -542,26 +530,16 @@ func (v escapeVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Ent
 func (escapeVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // readCarrier peels the borrow wrapper for a field-read requirement so the
-// borrow-escape guard does not fire on a read. Reading a field through a borrow is
-// always legal and yields the field's value, so the requirement is built against the
-// peeled carrier rather than the borrow. The receiver reaches valueProp in three
-// shapes:
+// borrow-escape guard does not fire on a read, which is always legal. A concrete
+// RefType or a union of borrows peels directly. A borrow held in a join variable's
+// lower bounds — the shape a `val`-bound or call-result borrow takes — would
+// otherwise propagate un-peeled into the requirement and escape-error, so the
+// variable case peels its lower bounds, the same look-through resolveFunc uses to
+// find a concrete callee behind a binding var.
 //
-//   - A concrete RefType peels to its inner carrier.
-//   - A union peels each member, so a read off a union of borrows reads each member
-//     through the union for-all rule and the field coalesces to their union.
-//   - A join variable holding borrow lower bounds peels each such bound. A
-//     `val`-bound or call-result borrow reaches valueProp as the join variable
-//     holding the borrow, not the concrete RefType, so a read off it would otherwise
-//     propagate the un-peeled borrow into the requirement and escape-error. The peel
-//     looks through the variable's lower bounds, the same technique resolveFunc uses
-//     to find a concrete callee behind a binding var.
-//
-// A variable with no borrow lower bound is left unchanged, so an inferred-param read
-// (`fn f(p) { p.x }`) still records its inexact upper-bound requirement against the
-// variable, keeping its coalesced shape an owned object rather than a borrow. A join
-// over non-borrow objects likewise stays on the variable so each object lower bound
-// propagates as before.
+// A variable with no borrow lower bound is returned unchanged, so an inferred-param
+// read (`fn f(p) { p.x }`) keeps recording its requirement against the variable and
+// coalesces to an owned object rather than a borrow.
 func readCarrier(recv soltype.Type) soltype.Type {
 	v, ok := recv.(*soltype.TypeVarType)
 	if !ok {


### PR DESCRIPTION
Implement the M6 "Permissive mut-borrow joins" feature, allowing incompatible borrow joins to degrade gracefully to read-until-narrowed unions instead of erroring.

When joining multiple mutable borrows that share field names but disagree on field types, the join now:
- Attempts to pin shared fields invariant under a discard-only probe
- If the pin succeeds, returns a single mutable carrier with a fresh join lifetime
- If the pin fails, discards the probe and returns the type-level union of the original borrows

The union of incompatible borrows is readable everywhere (reads coalesce to the union of field types via the union read rule) but writable only after narrowing to a single branch. This matches TypeScript's behavior and is sound because writes to conflicting fields are rejected by the invariant pin.

Key changes:
- `joinBorrows` now uses a discard-only probe to test field reconciliation, falling back to a union on conflict instead of propagating errors
- Added `readCarrier`, `peelBorrows`, and `hasBorrowShape` helpers to handle field reads through unions of borrows by peeling the borrow wrapper and distributing through union members
- Updated `valueProp` to use `readCarrier` instead of `CarrierOf`, enabling reads off unions of borrows to yield the covariant union of field types
- Expanded the `joinBorrows` comment to document the read-until-narrowed contract and the probe-based reconciliation strategy
- Updated tests to assert the union result and verify that reads work while writes to conflicting fields are rejected

https://claude.ai/code/session_0183KWGKkgp3nySqqCvw5hHy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Borrowed objects with incompatible branches now infer as a union instead of failing outright, preserving distinct lifetimes.
  * Field reads from these unions now work and return a combined field type when the branches differ.

* **Bug Fixes**
  * Improved handling of conflicting borrowed fields so compatible reads succeed while direct writes to conflicting fields are still rejected.
  * Better support for multi-branch borrow joins, keeping each branch’s lifetime separate when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->