### PR TITLE
Update implementation plan with merged PR numbers and status

### DIFF
--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -141,18 +141,21 @@ and the *rules*.
 
 ## Sequencing rationale
 
+**Status.** PR1–PR6 and the two cleanups PR2.5/PR2.7 have landed; PR7 and PR8
+remain. Completed PRs are marked ✅ with their merged PR number; the rest are ⬜.
+
 ```
-PR1 (representation + normalization)
- ├─► PR2 (constrain lattice rules + union/intersection annotation input)
- │     ├─► PR2.5 (trial-and-commit cleanup: shared helper, specificity order,
- │     │          delete constrainAssign)
- │     ├─► PR2.7 (tighter BorrowEscape promotion: lifetime-blocker check)
- │     └─► PR4 (union exactness flag + match exhaustiveness leg)
- ├─► PR3 (monomorphic function-type annotations)
- │     └─► PR5 (⊤/⊥ rules + Variation-B close — now testable end-to-end)
- ├─► PR6 (permissive mut-borrow join)
- ├─► PR7 (if-let / let-else — needs PR4 + PR5)
- └─► PR8 (subsume inferred types at finalization — needs PR1 + PR2)
+PR1 ✅ #774 (representation + normalization)
+ ├─► PR2 ✅ #776 (constrain lattice rules + union/intersection annotation input)
+ │     ├─► PR2.5 ✅ #800 (trial-and-commit cleanup: shared helper, specificity
+ │     │          order, delete constrainAssign)
+ │     ├─► PR2.7 ✅ #801 (tighter BorrowEscape promotion: lifetime-blocker check)
+ │     └─► PR4 ✅ #803 (union exactness flag + match exhaustiveness leg)
+ ├─► PR3 ✅ #802 (monomorphic function-type annotations)
+ │     └─► PR5 ✅ #804 (⊤/⊥ rules + Variation-B close — now testable end-to-end)
+ ├─► PR6 ✅ #805 (permissive mut-borrow join)
+ ├─► PR7 ⬜ (if-let / let-else — needs PR4 + PR5)
+ └─► PR8 ⬜ (subsume inferred types at finalization — needs PR1 + PR2)
 ```
 
 - **PR1 is first because every other PR mints or compares a union/intersection**,


### PR DESCRIPTION
Update the sequencing rationale section to reflect the current state of the implementation plan. Six PRs have now landed (PR1, PR2, PR2.5, PR2.7, PR3, PR4, PR5, PR6), with PR7 and PR8 remaining.

Changes made:
- Add a status line indicating which PRs have merged and which are pending
- Mark completed PRs with ✅ and their merged PR numbers (#774, #776, #800, #801, #802, #803, #804, #805)
- Mark pending PRs (PR7, PR8) with ⬜
- Reformat the dependency tree to show PR numbers alongside descriptions for clarity

https://claude.ai/code/session_01Ao7DUvr1Zzq4LJMfzBnQKU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sequencing diagram to show which pull requests are already merged and which are still pending.
  * Clarified the current progress in the planned sequence by adding completion markers and merged PR references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->