### PR TITLE
Subsume inferred types at finalization

### DIFF
--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -299,3 +299,13 @@ func (s *typeVarSeeker) EnterType(t Type, _ Polarity) EnterResult {
 
 func (s *typeVarSeeker) ExitType(t Type, _ Polarity) Type { return t }
 
+// HasLifetimeVar reports whether t contains any LifetimeVar in a borrow's
+// lifetime slot, the lifetime-sort twin of HasTypeVar. It reuses
+// freeLifetimeVars so the rule for which lifetime forms hold a free variable —
+// a bare LifetimeVar or a LifetimeUnion member — lives in one place. A member
+// that still carries a free lifetime variable is not fully ground, so
+// subsumption leaves it in place rather than collapsing two borrows that
+// differ only in lifetime.
+func HasLifetimeVar(t Type) bool {
+	return len(freeLifetimeVars(t)) > 0
+}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -300,12 +300,7 @@ func (s *typeVarSeeker) EnterType(t Type, _ Polarity) EnterResult {
 func (s *typeVarSeeker) ExitType(t Type, _ Polarity) Type { return t }
 
 // HasLifetimeVar reports whether t contains any LifetimeVar in a borrow's
-// lifetime slot, the lifetime-sort twin of HasTypeVar. It reuses
-// freeLifetimeVars so the rule for which lifetime forms hold a free variable —
-// a bare LifetimeVar or a LifetimeUnion member — lives in one place. A member
-// that still carries a free lifetime variable is not fully ground, so
-// subsumption leaves it in place rather than collapsing two borrows that
-// differ only in lifetime.
+// lifetime slot, the lifetime-sort twin of HasTypeVar. It reuses freeLifetimeVars.
 func HasLifetimeVar(t Type) bool {
 	return len(freeLifetimeVars(t)) > 0
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -288,22 +288,40 @@ func TestAcceptRefCopyOnWrite(t *testing.T) {
 // depth, and reports false for a borrow whose lifetime is a non-variable form.
 func TestHasLifetimeVar(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
-
-	t.Run("bare lifetime var", func(t *testing.T) {
-		require.True(t, HasLifetimeVar(&RefType{Mut: true, Lt: &LifetimeVar{ID: 0}, Inner: obj}))
-	})
-	t.Run("lifetime var in a union member", func(t *testing.T) {
-		lt := &LifetimeUnion{Lifetimes: []Lifetime{&StaticLifetime{}, &LifetimeVar{ID: 1}}}
-		require.True(t, HasLifetimeVar(&RefType{Mut: true, Lt: lt, Inner: obj}))
-	})
-	t.Run("nested inside a tuple", func(t *testing.T) {
-		ref := &RefType{Mut: true, Lt: &LifetimeVar{ID: 2}, Inner: obj}
-		require.True(t, HasLifetimeVar(&TupleType{Elems: []Type{ref}}))
-	})
-	t.Run("static lifetime is not a var", func(t *testing.T) {
-		require.False(t, HasLifetimeVar(&RefType{Mut: true, Lt: &StaticLifetime{}, Inner: obj}))
-	})
-	t.Run("no borrow at all", func(t *testing.T) {
-		require.False(t, HasLifetimeVar(obj))
-	})
+	tests := []struct {
+		name string
+		in   Type
+		want bool
+	}{
+		{
+			name: "bare lifetime var",
+			in:   &RefType{Mut: true, Lt: &LifetimeVar{ID: 0}, Inner: obj},
+			want: true,
+		},
+		{
+			name: "lifetime var in a union member",
+			in:   &RefType{Mut: true, Lt: &LifetimeUnion{Lifetimes: []Lifetime{&StaticLifetime{}, &LifetimeVar{ID: 1}}}, Inner: obj},
+			want: true,
+		},
+		{
+			name: "nested inside a tuple",
+			in:   &TupleType{Elems: []Type{&RefType{Mut: true, Lt: &LifetimeVar{ID: 2}, Inner: obj}}},
+			want: true,
+		},
+		{
+			name: "static lifetime is not a var",
+			in:   &RefType{Mut: true, Lt: &StaticLifetime{}, Inner: obj},
+			want: false,
+		},
+		{
+			name: "no borrow at all",
+			in:   obj,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, HasLifetimeVar(tt.in))
+		})
+	}
 }

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -283,3 +283,27 @@ func TestAcceptRefCopyOnWrite(t *testing.T) {
 	require.NotSame(t, inner, gotInner, "the changed inner is a fresh object")
 	require.Same(t, str, gotInner.Elems[0].(*PropertyElem).Type, "the variable took the replacement")
 }
+
+// HasLifetimeVar finds a LifetimeVar in a borrow's lifetime slot, nested at any
+// depth, and reports false for a borrow whose lifetime is a non-variable form.
+func TestHasLifetimeVar(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: &PrimType{Prim: NumPrim}}}}
+
+	t.Run("bare lifetime var", func(t *testing.T) {
+		require.True(t, HasLifetimeVar(&RefType{Mut: true, Lt: &LifetimeVar{ID: 0}, Inner: obj}))
+	})
+	t.Run("lifetime var in a union member", func(t *testing.T) {
+		lt := &LifetimeUnion{Lifetimes: []Lifetime{&StaticLifetime{}, &LifetimeVar{ID: 1}}}
+		require.True(t, HasLifetimeVar(&RefType{Mut: true, Lt: lt, Inner: obj}))
+	})
+	t.Run("nested inside a tuple", func(t *testing.T) {
+		ref := &RefType{Mut: true, Lt: &LifetimeVar{ID: 2}, Inner: obj}
+		require.True(t, HasLifetimeVar(&TupleType{Elems: []Type{ref}}))
+	})
+	t.Run("static lifetime is not a var", func(t *testing.T) {
+		require.False(t, HasLifetimeVar(&RefType{Mut: true, Lt: &StaticLifetime{}, Inner: obj}))
+	})
+	t.Run("no borrow at all", func(t *testing.T) {
+		require.False(t, HasLifetimeVar(obj))
+	})
+}

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -339,6 +339,9 @@ func TestInferMatchInexactNeedsCatchAll(t *testing.T) {
 }
 
 // An inexact-object scrutinee with an unguarded catch-all arm is exhaustive.
+// The arms return `x`, a `number` field, and the literal `0`. The join is
+// `number | 0`, which the finalization subsumption pass collapses to `number`
+// since `0 <: number`.
 func TestInferMatchInexactWithCatchAll(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: {x: number, y: number, ...}) {
@@ -349,7 +352,7 @@ func TestInferMatchInexactWithCatchAll(t *testing.T) {
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: {x: number, y: number, ...}) -> number | 0", values["f"])
+	require.Equal(t, "fn (p: {x: number, y: number, ...}) -> number", values["f"])
 }
 
 // An exact union scrutinee whose arms cover every member needs no catch-all. An

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -260,6 +260,8 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	}
 	parts = append([]soltype.Type(nil), parts...)
 	sortTypes(parts)
+	// notGround[i] is true when member i still carries a free type or lifetime
+	// variable, so it is skipped by the concrete gate below.
 	notGround := make([]bool, len(parts))
 	for i, p := range parts {
 		notGround[i] = soltype.HasTypeVar(p) || soltype.HasLifetimeVar(p)

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -324,24 +324,29 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 	return soltype.EnterResult{}
 }
 
-// ExitType re-mints a lattice node, then returns the original when the re-mint is
-// equalType-equal to it. newUnion / newIntersection always allocate a fresh node,
-// so keeping the original when nothing was subsumed preserves pointer identity up
-// the spine. Both sides are canonical, so the equalType compare is positional.
+// ExitType subsumes a lattice node's members and rebuilds it only when a member
+// was dropped. The input is a coalesced display type, so it is already flattened,
+// pruned, deduped, and canonically ordered — newUnion's other normalization steps
+// would be no-ops here, so only subsumeMembers runs. subsumeMembers only ever
+// removes members, so a length drop is an O(1) signal that the node changed, which
+// avoids a structural re-comparison. When nothing dropped the original node is
+// returned, preserving pointer identity up the spine.
 func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	var got soltype.Type
 	switch t := t.(type) {
 	case *soltype.UnionType:
-		got = newUnion(s.ctx, t.Types, t.Inexact)
+		kept := subsumeMembers(s.ctx, t.Types, unionDrops)
+		if len(kept) == len(t.Types) {
+			return t
+		}
+		return collapseUnion(kept, t.Inexact, false)
 	case *soltype.IntersectionType:
-		got = newIntersection(s.ctx, t.Types)
-	default:
-		return t
+		kept := subsumeMembers(s.ctx, t.Types, intersectionDrops)
+		if len(kept) == len(t.Types) {
+			return t
+		}
+		return collapseIntersection(kept, false)
 	}
-	if equalType(got, t) {
-		return t
-	}
-	return got
+	return t
 }
 
 // sortTypes orders parts in place under compareType. The sort is stable so a

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -305,26 +305,10 @@ func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 	return len(c.trialUnderProbe(sibling, m)) == 0
 }
 
-// subsumeFinal runs the Context-gated subsumed-member elimination over a
-// finalized display type t and returns the canonicalized result. combine and
-// coalesceScheme build lattice nodes without a Context, so a coalesced
-// `1 | number` keeps both members. This pass re-mints every UnionType and
-// IntersectionType node in t through newUnion / newIntersection with the
-// ambient Context, so each node drops a member that a concrete sibling
-// subsumes. An inferred `1 | number` becomes `number` and an inferred
-// `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.
-//
-// It runs once per finalized type at generalization, off the constrain and
-// coalesce inner loops, so it cannot reenter coalescing. The walk re-mints
-// bottom-up in ExitType, so a nested union is already subsumed when its parent
-// re-mints. The concrete gate in subsumeMembers leaves a member carrying a
-// free type variable untouched, so a scheme whose union is not yet ground is
-// unchanged.
-//
-// The reduction is sound in any variance position: a union and its subsumed
-// form denote the same set, since the dropped member is a subtype of the
-// survivor, and likewise an intersection equals its narrowest member. So
-// neither soundness nor assignability changes.
+// subsumeFinal re-mints every UnionType and IntersectionType node in a finalized
+// display type through newUnion / newIntersection with the ambient Context, so a
+// member a concrete sibling subsumes is dropped. An inferred `1 | number` becomes
+// `number`; an inferred `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.
 func (c *checker) subsumeFinal(t soltype.Type) soltype.Type {
 	return t.Accept(&finalSubsumer{ctx: c.ctx}, soltype.Positive)
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -260,19 +260,19 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	}
 	parts = append([]soltype.Type(nil), parts...)
 	sortTypes(parts)
-	// notGround[i] is true when member i still carries a free type or lifetime
+	// hasVar[i] is true when member i still carries a free type or lifetime
 	// variable, so it is skipped by the concrete gate below.
-	notGround := make([]bool, len(parts))
+	hasVar := make([]bool, len(parts))
 	for i, p := range parts {
-		notGround[i] = soltype.HasTypeVar(p) || soltype.HasLifetimeVar(p)
+		hasVar[i] = soltype.HasTypeVar(p) || soltype.HasLifetimeVar(p)
 	}
 	dropped := set.NewSet[int]()
 	for i, a := range parts {
-		if dropped.Contains(i) || notGround[i] {
+		if dropped.Contains(i) || hasVar[i] {
 			continue
 		}
 		for j, b := range parts {
-			if i == j || dropped.Contains(j) || notGround[j] {
+			if i == j || dropped.Contains(j) || hasVar[j] {
 				continue
 			}
 			if drops(c, a, b) {

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -243,6 +243,12 @@ func collapseIntersection(pruned []soltype.Type, hadError bool) soltype.Type {
 // variable could pin it speculatively. The trial uses a discard-only probe
 // so a successful trial leaves no bound mutation behind.
 //
+// A free lifetime variable disqualifies a member the same way. Two borrows
+// that differ only in lifetime, such as `&'a mut {x: number}` and
+// `&'b mut {x: number}`, mutually subsume by a discardable lifetime
+// constraint, so dropping one would silently lose a distinct lifetime the
+// signature quantifies over. Gating on the lifetime sort keeps both borrows.
+//
 // When two members mutually subsume, the survivor must be deterministic. The
 // pass pre-sorts the input by compareType, so the iteration order is
 // canonical and newUnion([A, B]) and newUnion([B, A]) drop the same member
@@ -254,17 +260,17 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 	}
 	parts = append([]soltype.Type(nil), parts...)
 	sortTypes(parts)
-	hasVar := make([]bool, len(parts))
+	notGround := make([]bool, len(parts))
 	for i, p := range parts {
-		hasVar[i] = soltype.HasTypeVar(p)
+		notGround[i] = soltype.HasTypeVar(p) || soltype.HasLifetimeVar(p)
 	}
 	dropped := set.NewSet[int]()
 	for i, a := range parts {
-		if dropped.Contains(i) || hasVar[i] {
+		if dropped.Contains(i) || notGround[i] {
 			continue
 		}
 		for j, b := range parts {
-			if i == j || dropped.Contains(j) || hasVar[j] {
+			if i == j || dropped.Contains(j) || notGround[j] {
 				continue
 			}
 			if drops(c, a, b) {
@@ -297,6 +303,49 @@ func unionDrops(c *Context, m, sibling soltype.Type) bool {
 // one to discard.
 func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
 	return len(c.trialUnderProbe(sibling, m)) == 0
+}
+
+// subsumeFinal runs the Context-gated subsumed-member elimination over a
+// finalized display type t and returns the canonicalized result. combine and
+// coalesceScheme build lattice nodes without a Context, so a coalesced
+// `1 | number` keeps both members. This pass re-mints every UnionType and
+// IntersectionType node in t through newUnion / newIntersection with the
+// ambient Context, so each node drops a member that a concrete sibling
+// subsumes. An inferred `1 | number` becomes `number` and an inferred
+// `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.
+//
+// It runs once per finalized type at generalization, off the constrain and
+// coalesce inner loops, so it cannot reenter coalescing. The walk re-mints
+// bottom-up in ExitType, so a nested union is already subsumed when its parent
+// re-mints. The concrete gate in subsumeMembers leaves a member carrying a
+// free type variable untouched, so a scheme whose union is not yet ground is
+// unchanged.
+//
+// The reduction is sound in any variance position: a union and its subsumed
+// form denote the same set, since the dropped member is a subtype of the
+// survivor, and likewise an intersection equals its narrowest member. So
+// neither soundness nor assignability changes.
+func (c *checker) subsumeFinal(t soltype.Type) soltype.Type {
+	return t.Accept(&finalSubsumer{ctx: c.ctx}, soltype.Positive)
+}
+
+// finalSubsumer is the rewriting visitor behind subsumeFinal. It re-mints a
+// lattice node in ExitType, after its children, so each member is itself
+// already subsumed before the enclosing node runs its own subsumption.
+type finalSubsumer struct{ ctx *Context }
+
+func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	return soltype.EnterResult{}
+}
+
+func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.UnionType:
+		return newUnion(s.ctx, t.Types, t.Inexact)
+	case *soltype.IntersectionType:
+		return newIntersection(s.ctx, t.Types)
+	}
+	return t
 }
 
 // sortTypes orders parts in place under compareType. The sort is stable so a

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -324,14 +324,24 @@ func (s *finalSubsumer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.
 	return soltype.EnterResult{}
 }
 
+// ExitType re-mints a lattice node, then returns the original when the re-mint is
+// equalType-equal to it. newUnion / newIntersection always allocate a fresh node,
+// so keeping the original when nothing was subsumed preserves pointer identity up
+// the spine. Both sides are canonical, so the equalType compare is positional.
 func (s *finalSubsumer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	var got soltype.Type
 	switch t := t.(type) {
 	case *soltype.UnionType:
-		return newUnion(s.ctx, t.Types, t.Inexact)
+		got = newUnion(s.ctx, t.Types, t.Inexact)
 	case *soltype.IntersectionType:
-		return newIntersection(s.ctx, t.Types)
+		got = newIntersection(s.ctx, t.Types)
+	default:
+		return t
 	}
-	return t
+	if equalType(got, t) {
+		return t
+	}
+	return got
 }
 
 // sortTypes orders parts in place under compareType. The sort is stable so a

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -303,6 +303,22 @@ func TestNewUnionSubsumptionSkipsVar(t *testing.T) {
 	require.Len(t, u.Types, 2)
 }
 
+// TestNewUnionSubsumptionSkipsLifetimeVar pins the lifetime half of the concrete
+// gate. Two mut borrows over the same inner that differ only in lifetime variable
+// mutually subsume by a discardable lifetime constraint, so an ungated pass would
+// drop one and lose a distinct lifetime. The gate keeps both. The lifetimes have
+// no surface form parseType can author, so the borrows are built directly.
+func TestNewUnionSubsumptionSkipsLifetimeVar(t *testing.T) {
+	c := &Context{}
+	a := &soltype.RefType{Mut: true, Lt: &soltype.LifetimeVar{ID: 0}, Inner: exactObj(propElem("x", num()))}
+	b := &soltype.RefType{Mut: true, Lt: &soltype.LifetimeVar{ID: 1}, Inner: exactObj(propElem("x", num()))}
+	require.Empty(t, c.Constrain(a, b), "precondition: a <: b")
+	require.Empty(t, c.Constrain(b, a), "precondition: b <: a")
+	got := newUnion(c, []soltype.Type{a, b}, false)
+	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
+	require.Len(t, got.(*soltype.UnionType).Types, 2)
+}
+
 // TestVoidAndNullSortLast pins the convention that the absence markers
 // NullType and Void appear after data members in canonical order, with
 // NullType before Void. A mixed union such as `number | null | void`

--- a/internal/solver/lattice_test.go
+++ b/internal/solver/lattice_test.go
@@ -304,10 +304,7 @@ func TestNewUnionSubsumptionSkipsVar(t *testing.T) {
 }
 
 // TestNewUnionSubsumptionSkipsLifetimeVar pins the lifetime half of the concrete
-// gate. Two mut borrows over the same inner that differ only in lifetime variable
-// mutually subsume by a discardable lifetime constraint, so an ungated pass would
-// drop one and lose a distinct lifetime. The gate keeps both. The lifetimes have
-// no surface form parseType can author, so the borrows are built directly.
+// gate: two mut borrows differing only in lifetime variable both survive.
 func TestNewUnionSubsumptionSkipsLifetimeVar(t *testing.T) {
 	c := &Context{}
 	a := &soltype.RefType{Mut: true, Lt: &soltype.LifetimeVar{ID: 0}, Inner: exactObj(propElem("x", num()))}

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -366,7 +366,15 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 // OPERATIVE body, so callers cannot pass extra fields (Policy A / B2). See its doc.
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
 	c.sealUsageObjects(t, lvl)
-	return &PolyScheme{Level: lvl, Body: t}
+	sc := &PolyScheme{Level: lvl, Body: t}
+	// Subsume the display type now, while the ambient Context is available.
+	// display() computes and caches the coalesced form, which combine builds
+	// Context-free and so leaves un-subsumed. Overwriting the cache with the
+	// subsumed form seals it once at generalization, so every later read —
+	// schemeType for Info and renderScheme for the printed string — sees the
+	// canonical type. An inferred `1 | number` thus renders `number`.
+	sc.coalesced = c.subsumeFinal(sc.display())
+	return sc
 }
 
 // sealUsageObjects is the operative half of Policy A (B2). Body inference records a

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -367,12 +367,8 @@ func (f *freshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 func (c *checker) generalize(t soltype.Type, lvl int) TypeScheme {
 	c.sealUsageObjects(t, lvl)
 	sc := &PolyScheme{Level: lvl, Body: t}
-	// Subsume the display type now, while the ambient Context is available.
-	// display() computes and caches the coalesced form, which combine builds
-	// Context-free and so leaves un-subsumed. Overwriting the cache with the
-	// subsumed form seals it once at generalization, so every later read —
-	// schemeType for Info and renderScheme for the printed string — sees the
-	// canonical type. An inferred `1 | number` thus renders `number`.
+	// Seal the subsumed display now, while the ambient Context is available, so
+	// every later read sees the canonical type and an inferred `1 | number` renders `number`.
 	sc.coalesced = c.subsumeFinal(sc.display())
 	return sc
 }

--- a/internal/solver/subsume_test.go
+++ b/internal/solver/subsume_test.go
@@ -1,0 +1,115 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6 PR8: subsume inferred types at finalization ---
+
+// subsumeFinal collapses a coalesced `number | 1` to `number`, since `1 <: number`.
+// combine builds the union Context-free, so the redundant literal survives until
+// the finalization pass re-mints it with the ambient Context.
+func TestSubsumeFinalUnionLiteralIntoPrimitive(t *testing.T) {
+	c := newChecker()
+	in := newUnion(nil, parseTypes(t, "number", "1"), false)
+	require.IsType(t, &soltype.UnionType{}, in, "precondition: combine leaves both members")
+	got := c.subsumeFinal(in)
+	require.True(t, equalType(parseType(t, "number"), got), "got %s", soltype.Print(got))
+}
+
+// The meet twin: `{x, ...} & {x, y, ...}` collapses to `{x, y, ...}`, since the
+// wider object is a subtype of the narrower one under inexact width subtyping, so
+// the narrower member already constrains the value.
+func TestSubsumeFinalIntersectionObjects(t *testing.T) {
+	c := newChecker()
+	in := newIntersection(nil, parseTypes(t,
+		"{x: number, ...}",
+		"{x: number, y: string, ...}",
+	))
+	require.IsType(t, &soltype.IntersectionType{}, in, "precondition: combine leaves both members")
+	got := c.subsumeFinal(in)
+	require.True(t, equalType(parseType(t, "{x: number, y: string, ...}"), got), "got %s", soltype.Print(got))
+}
+
+// A member that still carries a free type variable is left in place. The pass is
+// concrete-gated, so a scheme whose union is not yet ground is unchanged.
+func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
+	c := newChecker()
+	v := c.ctx.freshVar(0)
+	got := c.subsumeFinal(newUnion(nil, []soltype.Type{parseType(t, "number"), v}, false))
+	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
+	require.Len(t, got.(*soltype.UnionType).Types, 2)
+}
+
+// The walk re-mints bottom-up, so a union nested inside another type is subsumed
+// too. A tuple `[number | 1]` finalizes to `[number]`.
+func TestSubsumeFinalNestedUnion(t *testing.T) {
+	c := newChecker()
+	nested := newUnion(nil, parseTypes(t, "number", "1"), false)
+	in := &soltype.TupleType{Elems: []soltype.Type{nested}}
+	got := c.subsumeFinal(in)
+	require.True(t, equalType(parseType(t, "[number]"), got), "got %s", soltype.Print(got))
+}
+
+// An inferred `1 | number` renders `number` end to end. The two return points are
+// the literal `1` and the `number` param `n`, so the join is `1 | number`, which
+// the generalization-time subsumption collapses to `number`.
+func TestInferSubsumesUnionToPrimitive(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(b: boolean, n: number) {
+			return if b { 1 } else { n }
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (b: boolean, n: number) -> number", values["f"])
+}
+
+// The finalized inferred type is equalType-equal to the annotated form, so caching
+// and annotation round-trip agree. The body infers `1 | number`; the annotation
+// resolves to `number`; after subsumption the two are equalType-equal.
+func TestInferSubsumedTypeEqualsAnnotation(t *testing.T) {
+	scope, _, errs := InferModule(parseModule(t, `
+		fn inferred(b: boolean, n: number) {
+			return if b { 1 } else { n }
+		}
+		val annotated: number = 0
+	`))
+	require.Empty(t, errs)
+
+	inferredFn := schemeType(scope.values["inferred"].Schemes[0]).(*soltype.FuncType)
+	annotated := schemeType(scope.values["annotated"].Schemes[0])
+	require.True(t, equalType(annotated, inferredFn.Ret),
+		"inferred return %s should equal annotated %s",
+		soltype.Print(inferredFn.Ret), soltype.Print(annotated))
+}
+
+// Subsumption is display-only: the scheme's operative body keeps `1 | number`,
+// so assignability is unchanged. A `number` sink accepts the value and a `string`
+// sink rejects it, with the rejection decomposing the union for-all exactly as it
+// would against the un-subsumed form.
+func TestInferSubsumedTypePreservesAssignability(t *testing.T) {
+	t.Run("number accepted", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(b: boolean, n: number) {
+				val r = if b { 1 } else { n }
+				val s: number = r
+			}
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("string rejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			fn f(b: boolean, n: number) {
+				val r = if b { 1 } else { n }
+				val s: string = r
+			}
+		`)
+		require.Equal(t, []string{
+			"4:21-4:22: cannot constrain 1 <: string",
+			"4:21-4:22: cannot constrain number <: string",
+		}, messagesWithSpan(errs))
+	})
+}

--- a/internal/solver/subsume_test.go
+++ b/internal/solver/subsume_test.go
@@ -156,3 +156,13 @@ func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
 	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
 	require.Len(t, got.(*soltype.UnionType).Types, 2)
 }
+
+// When nothing is subsumed the original node is returned, so pointer identity is
+// preserved up the spine rather than reallocating an equal node. `1 | 2` has no
+// subsumable member, so subsumeFinal returns the same union pointer.
+func TestSubsumeFinalPreservesIdentityWhenUnchanged(t *testing.T) {
+	c := newChecker()
+	in := newUnion(nil, parseTypes(t, "1", "2"), false)
+	require.IsType(t, &soltype.UnionType{}, in)
+	require.Same(t, in, c.subsumeFinal(in))
+}

--- a/internal/solver/subsume_test.go
+++ b/internal/solver/subsume_test.go
@@ -9,62 +9,69 @@ import (
 
 // --- M6 PR8: subsume inferred types at finalization ---
 
-// subsumeFinal collapses a coalesced `number | 1` to `number`, since `1 <: number`.
-// combine builds the union Context-free, so the redundant literal survives until
-// the finalization pass re-mints it with the ambient Context.
-func TestSubsumeFinalUnionLiteralIntoPrimitive(t *testing.T) {
-	c := newChecker()
-	in := newUnion(nil, parseTypes(t, "number", "1"), false)
-	require.IsType(t, &soltype.UnionType{}, in, "precondition: combine leaves both members")
-	got := c.subsumeFinal(in)
-	require.True(t, equalType(parseType(t, "number"), got), "got %s", soltype.Print(got))
-}
-
-// The meet twin: `{x, ...} & {x, y, ...}` collapses to `{x, y, ...}`, since the
-// wider object is a subtype of the narrower one under inexact width subtyping, so
-// the narrower member already constrains the value.
-func TestSubsumeFinalIntersectionObjects(t *testing.T) {
-	c := newChecker()
-	in := newIntersection(nil, parseTypes(t,
-		"{x: number, ...}",
-		"{x: number, y: string, ...}",
-	))
-	require.IsType(t, &soltype.IntersectionType{}, in, "precondition: combine leaves both members")
-	got := c.subsumeFinal(in)
-	require.True(t, equalType(parseType(t, "{x: number, y: string, ...}"), got), "got %s", soltype.Print(got))
-}
-
-// A member that still carries a free type variable is left in place. The pass is
-// concrete-gated, so a scheme whose union is not yet ground is unchanged.
-func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
-	c := newChecker()
-	v := c.ctx.freshVar(0)
-	got := c.subsumeFinal(newUnion(nil, []soltype.Type{parseType(t, "number"), v}, false))
-	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
-	require.Len(t, got.(*soltype.UnionType).Types, 2)
-}
-
-// The walk re-mints bottom-up, so a union nested inside another type is subsumed
-// too. A tuple `[number | 1]` finalizes to `[number]`.
-func TestSubsumeFinalNestedUnion(t *testing.T) {
-	c := newChecker()
-	nested := newUnion(nil, parseTypes(t, "number", "1"), false)
-	in := &soltype.TupleType{Elems: []soltype.Type{nested}}
-	got := c.subsumeFinal(in)
-	require.True(t, equalType(parseType(t, "[number]"), got), "got %s", soltype.Print(got))
-}
-
-// An inferred `1 | number` renders `number` end to end. The two return points are
-// the literal `1` and the `number` param `n`, so the join is `1 | number`, which
-// the generalization-time subsumption collapses to `number`.
-func TestInferSubsumesUnionToPrimitive(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		fn f(b: boolean, n: number) {
-			return if b { 1 } else { n }
-		}
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (b: boolean, n: number) -> number", values["f"])
+// An inferred union whose member a concrete sibling subsumes collapses to that
+// sibling at generalization. Each case joins an if/else into a union, which
+// combine builds Context-free, and the finalization pass subsumes it. Distinct
+// literals that nothing subsumes are left intact.
+func TestInferSubsumesInferredUnion(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "literal into primitive",
+			src: `
+				fn f(b: boolean, n: number) {
+					return if b { 1 } else { n }
+				}
+			`,
+			want: "fn (b: boolean, n: number) -> number",
+		},
+		{
+			name: "several literals into primitive",
+			src: `
+				fn f(b: boolean, n: number) {
+					return if b { 1 } else { if b { 2 } else { n } }
+				}
+			`,
+			want: "fn (b: boolean, n: number) -> number",
+		},
+		{
+			name: "string literal into string",
+			src: `
+				fn f(b: boolean, s: string) {
+					return if b { "a" } else { s }
+				}
+			`,
+			want: "fn (b: boolean, s: string) -> string",
+		},
+		{
+			name: "union nested in a tuple",
+			src: `
+				fn f(b: boolean, n: number) {
+					return [if b { 1 } else { n }]
+				}
+			`,
+			want: "fn (b: boolean, n: number) -> [number]",
+		},
+		{
+			name: "distinct literals are not subsumed",
+			src: `
+				fn f(b: boolean) {
+					return if b { 1 } else { 2 }
+				}
+			`,
+			want: "fn (b: boolean) -> 1 | 2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
 }
 
 // The finalized inferred type is equalType-equal to the annotated form, so caching
@@ -86,30 +93,69 @@ func TestInferSubsumedTypeEqualsAnnotation(t *testing.T) {
 		soltype.Print(inferredFn.Ret), soltype.Print(annotated))
 }
 
-// Subsumption is display-only: the scheme's operative body keeps `1 | number`,
-// so assignability is unchanged. A `number` sink accepts the value and a `string`
-// sink rejects it, with the rejection decomposing the union for-all exactly as it
-// would against the un-subsumed form.
+// Subsumption is display-only: the scheme's operative body keeps `1 | number`, so
+// assignability is unchanged. A `number` sink accepts the value and a `string`
+// sink rejects it, the rejection decomposing the union for-all exactly as it would
+// against the un-subsumed form. Both sink keywords are six characters, so `r` sits
+// at the same column and the rejection spans match.
 func TestInferSubsumedTypePreservesAssignability(t *testing.T) {
-	t.Run("number accepted", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn f(b: boolean, n: number) {
-				val r = if b { 1 } else { n }
-				val s: number = r
-			}
-		`)
-		require.Empty(t, errs)
-	})
-	t.Run("string rejected", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			fn f(b: boolean, n: number) {
-				val r = if b { 1 } else { n }
-				val s: string = r
-			}
-		`)
-		require.Equal(t, []string{
-			"4:21-4:22: cannot constrain 1 <: string",
-			"4:21-4:22: cannot constrain number <: string",
-		}, messagesWithSpan(errs))
-	})
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "number sink accepts",
+			src: `
+				fn f(b: boolean, n: number) {
+					val r = if b { 1 } else { n }
+					val s: number = r
+				}
+			`,
+			want: nil,
+		},
+		{
+			name: "string sink rejects both union members",
+			src: `
+				fn f(b: boolean, n: number) {
+					val r = if b { 1 } else { n }
+					val s: string = r
+				}
+			`,
+			want: []string{
+				"4:22-4:23: cannot constrain 1 <: string",
+				"4:22-4:23: cannot constrain number <: string",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Equal(t, tt.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// An inferred intersection of inexact objects collapses to its narrowest member.
+// `{x, ...} & {x, y, ...}` reduces to `{x, y, ...}`, since the wider object is a
+// subtype of the narrower under inexact width subtyping. An inferred intersection
+// has no if/else source form that survives combine's usage-object fold, so the
+// type is built directly and run through subsumeFinal.
+func TestSubsumeFinalIntersectionObjects(t *testing.T) {
+	c := newChecker()
+	in := newIntersection(nil, parseTypes(t, "{x: number, ...}", "{x: number, y: string, ...}"))
+	require.IsType(t, &soltype.IntersectionType{}, in, "precondition: combine leaves both members")
+	got := c.subsumeFinal(in)
+	require.True(t, equalType(parseType(t, "{x: number, y: string, ...}"), got), "got %s", soltype.Print(got))
+}
+
+// A member that still carries a free type variable is left in place. The concrete
+// gate skips it, so a scheme whose union is not yet ground is unchanged. The free
+// var has no surface form parseType can author, so the union is built directly.
+func TestSubsumeFinalLeavesFreeVar(t *testing.T) {
+	c := newChecker()
+	v := c.ctx.freshVar(0)
+	got := c.subsumeFinal(newUnion(nil, []soltype.Type{parseType(t, "number"), v}, false))
+	require.IsType(t, &soltype.UnionType{}, got, "got %s", soltype.Print(got))
+	require.Len(t, got.(*soltype.UnionType).Types, 2)
 }

--- a/internal/solver/subsume_test.go
+++ b/internal/solver/subsume_test.go
@@ -136,11 +136,8 @@ func TestInferSubsumedTypePreservesAssignability(t *testing.T) {
 	}
 }
 
-// An inferred intersection of inexact objects collapses to its narrowest member.
-// `{x, ...} & {x, y, ...}` reduces to `{x, y, ...}`, since the wider object is a
-// subtype of the narrower under inexact width subtyping. An inferred intersection
-// has no if/else source form that survives combine's usage-object fold, so the
-// type is built directly and run through subsumeFinal.
+// An inferred intersection collapses to its narrowest member: `{x, ...} & {x, y, ...}`
+// reduces to `{x, y, ...}`. It has no source form that survives combine's fold, so it is built directly.
 func TestSubsumeFinalIntersectionObjects(t *testing.T) {
 	c := newChecker()
 	in := newIntersection(nil, parseTypes(t, "{x: number, ...}", "{x: number, y: string, ...}"))


### PR DESCRIPTION
Adds a finalization pass that collapses redundant union and intersection members after type inference completes. This makes inferred types display more intuitively while preserving their operative semantics for assignability checking.

## Summary

When the type inference engine combines types from multiple code paths, it builds unions and intersections without a type-checking context. This can leave redundant members in place—for example, `1 | number` where the literal is subsumed by the primitive. This PR adds `subsumeFinal`, a post-inference pass that re-mints lattice nodes with the ambient context to drop subsumed members.

## Key changes

- **New `subsumeFinal` method and `finalSubsumer` visitor** in `lattice.go`: Walks a finalized type bottom-up and re-mints each union and intersection through `newUnion` and `newIntersection`, which apply the concrete-gated subsumption logic. A union like `1 | number` becomes `number`, and an intersection like `{x, ...} & {x, y, ...}` becomes `{x, y, ...}`.

- **Lifetime variable gating** in `subsumeMembers`: Extended the concrete-gate check to also skip subsumption when a member carries a free lifetime variable. Two borrows differing only in lifetime (e.g., `&'a mut {x: number}` and `&'b mut {x: number}`) mutually subsume by a discardable lifetime constraint, so dropping one would silently lose a distinct lifetime the signature quantifies over.

- **New `HasLifetimeVar` function** in `visitor.go`: Mirrors `HasTypeVar` for the lifetime sort, reusing the existing `freeLifetimeVars` logic to detect free lifetime variables in a type.

- **Integration into `generalize`** in `poly.go`: Calls `subsumeFinal` on the display type at generalization time, before caching. This ensures every printed type and cached scheme sees the canonical subsumed form.

- **Test coverage**: Comprehensive tests for subsumption of unions into primitives, intersections of objects, nested unions, and preservation of free variables. Integration tests verify that inferred types match their annotated equivalents and that assignability is unchanged.

## Implementation notes

The pass is sound in any variance position because a union and its subsumed form denote the same set—the dropped member is a subtype of the survivor. The operative body of the scheme keeps the original un-subsumed form, so assignability checking remains unchanged; subsumption is display-only. The concrete gate ensures a scheme whose union is not yet ground (carrying a free type or lifetime variable) is left unchanged.

https://claude.ai/code/session_01HMMHzV2uGjLXr8zK2pHq2e