### PR TITLE
PR9: unions and intersections as RefInner with ownership checks

### DIFF
--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -297,6 +297,47 @@ func TestPrintLazyDeepMutVerbatim(t *testing.T) {
 	}
 }
 
+// A borrow over a union or intersection prints with the pointee parenthesized. The
+// inner renders at precPrefix, looser than precUnion and precIntersection, so
+// `&(A | B)` and `&mut (A & B)` round-trip to surface syntax. The wrapper is outer
+// and shared: one `&`, one lifetime, one mutability for the whole pointee, never
+// `&A | &B`.
+func TestPrintBorrowOverLatticePointee(t *testing.T) {
+	objX := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}
+	objY := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "y", Type: strP()}}}
+	cases := []struct {
+		name string
+		ty   Type
+		want string
+	}{
+		{
+			name: "immutable borrow over a union",
+			ty:   &RefType{Lt: &StaticLifetime{}, Inner: &UnionType{Types: []Type{objX, objY}}},
+			want: "&'static ({x: number} | {y: string})",
+		},
+		{
+			name: "mutable borrow over a union",
+			ty:   &RefType{Mut: true, Lt: Anon, Inner: &UnionType{Types: []Type{objX, objY}}},
+			want: "&mut ({x: number} | {y: string})",
+		},
+		{
+			name: "owned-mutable union prints with mut and parens",
+			ty:   &RefType{Mut: true, Inner: &UnionType{Types: []Type{objX, objY}}},
+			want: "mut ({x: number} | {y: string})",
+		},
+		{
+			name: "immutable borrow over an intersection",
+			ty:   &RefType{Lt: Anon, Inner: &IntersectionType{Types: []Type{objX, objY}}},
+			want: "&({x: number} & {y: string})",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, Print(tc.ty))
+		})
+	}
+}
+
 // AnonLifetime renders as bare `&` / `&mut`, keeping a borrow distinguishable
 // from an owned value when its lifetime is elided.
 func TestPrintAnonLifetime(t *testing.T) {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -298,10 +298,10 @@ func TestPrintLazyDeepMutVerbatim(t *testing.T) {
 }
 
 // A borrow over a union or intersection prints with the pointee parenthesized. The
-// inner renders at precPrefix, looser than precUnion and precIntersection, so
-// `&(A | B)` and `&mut (A & B)` round-trip to surface syntax. The wrapper is outer
-// and shared: one `&`, one lifetime, one mutability for the whole pointee, never
-// `&A | &B`.
+// borrow prefix binds at precPrefix, tighter than precUnion and precIntersection, so
+// the looser inner is parenthesized to render `&(A | B)` and `&mut (A & B)`. The
+// wrapper is outer and shared: one `&`, one lifetime, one mutability for the whole
+// pointee, never `&A | &B`.
 func TestPrintBorrowOverLatticePointee(t *testing.T) {
 	objX := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "x", Type: numP()}}}
 	objY := &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "y", Type: strP()}}}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -301,17 +301,23 @@ type RefType struct {
 //
 // M4 admits ObjectType / TupleType / TypeVarType. The TypeVarType arm covers a
 // borrow whose content is still an inference variable; the content invariant — that
-// it resolves to a borrowable type — is checked at constrain time. UnionType /
-// IntersectionType (M6 inputs), AliasType (M7), and ClassType (M5) add their
-// isRefInner arms with those milestones.
+// it resolves to a borrowable type — is checked at constrain time. UnionType and
+// IntersectionType join as RefInner so `&(A | B)` is one borrow over a union
+// pointee, with a single lifetime and mutability for the whole value rather than
+// `&A | &B` with independent lifetimes. A union or intersection must have uniform
+// ownership. A borrowed member beside an owned one has no single owned-or-borrowed
+// verdict and is rejected at the inference join where it forms. AliasType (M7) and
+// ClassType (M5) add their isRefInner arms with those milestones.
 type RefInner interface {
 	Type
 	isRefInner()
 }
 
-func (*ObjectType) isRefInner()  {}
-func (*TupleType) isRefInner()   {}
-func (*TypeVarType) isRefInner() {}
+func (*ObjectType) isRefInner()       {}
+func (*TupleType) isRefInner()        {}
+func (*TypeVarType) isRefInner()      {}
+func (*UnionType) isRefInner()        {}
+func (*IntersectionType) isRefInner() {}
 
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -306,8 +306,8 @@ type RefType struct {
 // pointee, with a single lifetime and mutability for the whole value rather than
 // `&A | &B` with independent lifetimes. A union or intersection must have uniform
 // ownership. A borrowed member beside an owned one has no single owned-or-borrowed
-// verdict and is rejected at the inference join where it forms. AliasType (M7) and
-// ClassType (M5) add their isRefInner arms with those milestones.
+// verdict and is rejected at the inference join where it forms. AliasType and
+// ClassType add their isRefInner arms when those types are introduced.
 type RefInner interface {
 	Type
 	isRefInner()

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -696,6 +696,18 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
+// MixedOwnershipError fires when an inferred union or intersection has members that
+// disagree on ownership, a borrowed member beside an owned one such as
+// `{x: number} | &{y: number}`. Ownership is the outer wrapper shared by the whole
+// value, so a mix has no single owned-or-borrowed verdict. It forms where inference
+// joins branches of different ownership: an if/else, a `match` arm set, or several
+// return points. It self-blames that join node through Span and carries no related
+// node. The fix is to make ownership uniform before the join: clone the borrowed
+// member to own it, or borrow the owned member.
+type MixedOwnershipError struct {
+	Node ast.Node
+}
+
 func (*UnknownIdentifierError) isSolverError()            {}
 func (*NamespaceUsedAsValueError) isSolverError()         {}
 func (*UnknownNamespaceMemberError) isSolverError()       {}
@@ -716,7 +728,14 @@ func (*AwaitOutsideAsyncError) isSolverError()            {}
 func (*ReturnOutsideFunctionError) isSolverError()        {}
 func (*AsyncReturnNotPromiseError) isSolverError()        {}
 func (*NonExhaustiveMatchError) isSolverError()           {}
+func (*MixedOwnershipError) isSolverError()               {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()   {}
+
+func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }
+func (e *MixedOwnershipError) Related() []ast.Span { return nil }
+func (e *MixedOwnershipError) Message() string {
+	return "union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member"
+}
 
 func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }
 func (e *NonExhaustiveMatchError) Related() []ast.Span { return nil }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -729,7 +729,7 @@ func (*MutLeafThroughSharedBorrowError) isSolverError()   {}
 func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }
 func (e *MixedOwnershipError) Related() []ast.Span { return nil }
 func (e *MixedOwnershipError) Message() string {
-	return "union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member"
+	return "a union or intersection mixes owned and borrowed members. Make ownership uniform first. Clone the borrowed member to own it, or borrow the owned member."
 }
 
 func (e *NonExhaustiveMatchError) Span() ast.Span      { return e.Match.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -696,14 +696,9 @@ type NonExhaustiveMatchError struct {
 	Match *ast.MatchExpr
 }
 
-// MixedOwnershipError fires when an inferred union or intersection has members that
-// disagree on ownership, a borrowed member beside an owned one such as
-// `{x: number} | &{y: number}`. Ownership is the outer wrapper shared by the whole
-// value, so a mix has no single owned-or-borrowed verdict. It forms where inference
-// joins branches of different ownership: an if/else, a `match` arm set, or several
-// return points. It self-blames that join node through Span and carries no related
-// node. The fix is to make ownership uniform before the join: clone the borrowed
-// member to own it, or borrow the owned member.
+// MixedOwnershipError fires when an inferred union or intersection has a borrowed
+// member beside an owned one, such as `{x: number} | &{y: number}`, which has no
+// single owned-or-borrowed verdict. It blames the inference join where it forms.
 type MixedOwnershipError struct {
 	Node ast.Node
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -383,16 +383,9 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 	}
 }
 
-// collectBranchOwnership classifies how a branch result type participates in the
-// owned-or-borrowed ownership axis, recursing through union and intersection members
-// so a branch that is itself a union is judged by its members:
-//   - sawBorrowed becomes true for a borrow, a RefType carrying a lifetime.
-//   - sawOwned becomes true for an owned reference: a bare object or tuple, or an
-//     owned-mutable RefType whose lifetime is nil.
-//
-// A value type such as a primitive, literal, function, or promise carries no
-// ownership and touches neither flag, as do inference variables and the lattice
-// bounds, which have no settled ownership to judge.
+// collectBranchOwnership sets sawBorrowed for a borrow and sawOwned for an owned
+// object, tuple, or owned-mutable RefType, recursing through union and intersection
+// members. Value types and inference variables carry no ownership and set neither.
 func collectBranchOwnership(t soltype.Type, sawOwned, sawBorrowed *bool) {
 	switch t := t.(type) {
 	case *soltype.RefType:
@@ -414,13 +407,9 @@ func collectBranchOwnership(t soltype.Type, sawOwned, sawBorrowed *bool) {
 	}
 }
 
-// checkUniformOwnership reports a MixedOwnershipError when the branch types a join is
-// about to union disagree on ownership, some owned and some borrowed. The union the
-// join would form then has no single owned-or-borrowed verdict, since ownership is the
-// outer wrapper shared by the whole value. Each branch is coalesced first so an
-// inference variable resolves to the shape that flowed into it. A branch that stays a
-// variable, or is a value type, contributes no ownership and is skipped. node is the
-// join expression the error blames.
+// checkUniformOwnership reports a MixedOwnershipError against node when the branches a
+// join is about to union are some owned and some borrowed. Each branch is coalesced
+// first so an inference variable resolves to the shape that flowed into it.
 func (c *checker) checkUniformOwnership(node ast.Node, branches []soltype.Type) {
 	sawOwned, sawBorrowed := false, false
 	for _, b := range branches {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -373,12 +373,61 @@ func (c *checker) joinReturnPoints(node ast.Node, lvl int, collected []soltype.T
 		if joined, ok := c.joinBorrows(node, lvl, collected); ok {
 			return joined
 		}
+		c.checkUniformOwnership(node, collected)
 		joinVar := c.freshAt(lvl)
 		c.recordProv(joinVar, node, ReturnJoin)
 		for _, rt := range collected {
 			c.constrain(node, rt, joinVar)
 		}
 		return joinVar
+	}
+}
+
+// collectBranchOwnership classifies how a branch result type participates in the
+// owned-or-borrowed ownership axis, recursing through union and intersection members
+// so a branch that is itself a union is judged by its members:
+//   - sawBorrowed becomes true for a borrow, a RefType carrying a lifetime.
+//   - sawOwned becomes true for an owned reference: a bare object or tuple, or an
+//     owned-mutable RefType whose lifetime is nil.
+//
+// A value type such as a primitive, literal, function, or promise carries no
+// ownership and touches neither flag, as do inference variables and the lattice
+// bounds, which have no settled ownership to judge.
+func collectBranchOwnership(t soltype.Type, sawOwned, sawBorrowed *bool) {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if t.Lt != nil {
+			*sawBorrowed = true
+		} else {
+			*sawOwned = true
+		}
+	case *soltype.UnionType:
+		for _, m := range t.Types {
+			collectBranchOwnership(m, sawOwned, sawBorrowed)
+		}
+	case *soltype.IntersectionType:
+		for _, m := range t.Types {
+			collectBranchOwnership(m, sawOwned, sawBorrowed)
+		}
+	case *soltype.ObjectType, *soltype.TupleType:
+		*sawOwned = true
+	}
+}
+
+// checkUniformOwnership reports a MixedOwnershipError when the branch types a join is
+// about to union disagree on ownership, some owned and some borrowed. The union the
+// join would form then has no single owned-or-borrowed verdict, since ownership is the
+// outer wrapper shared by the whole value. Each branch is coalesced first so an
+// inference variable resolves to the shape that flowed into it. A branch that stays a
+// variable, or is a value type, contributes no ownership and is skipped. node is the
+// join expression the error blames.
+func (c *checker) checkUniformOwnership(node ast.Node, branches []soltype.Type) {
+	sawOwned, sawBorrowed := false, false
+	for _, b := range branches {
+		collectBranchOwnership(coalesce(b, soltype.Positive), &sawOwned, &sawBorrowed)
+	}
+	if sawOwned && sawBorrowed {
+		c.report(&MixedOwnershipError{Node: node})
 	}
 }
 
@@ -2077,12 +2126,16 @@ func (c *checker) inferIfElse(scope *Scope, lvl int, e *ast.IfElseExpr) soltype.
 	// above (reporting branch-local errors and collecting its `return` as a function
 	// return point); only its block-tail VALUE is dropped here. When both branches
 	// diverge, res keeps no lower bounds and coalesces to `never`.
+	var branches []soltype.Type
 	if !consDiverges {
 		c.constrain(e, consT, res)
+		branches = append(branches, consT)
 	}
 	if !altDiverges {
 		c.constrain(e, altT, res)
+		branches = append(branches, altT)
 	}
+	c.checkUniformOwnership(e, branches)
 	c.recordType(e, res)
 	return res
 }
@@ -2107,6 +2160,7 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 	}
 	res := c.freshAt(lvl)
 	c.recordProv(res, e, MatchBranch)
+	var armBodies []soltype.Type
 	for _, arm := range e.Cases {
 		// Each arm binds its pattern's leaves in a fresh child scope so a name bound
 		// by one arm is invisible to the next. bindPattern peels the scrutinee's borrow
@@ -2126,8 +2180,10 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 		bodyT, diverges := c.inferBlockOrExpr(armScope, lvl, &arm.Body)
 		if !diverges {
 			c.constrain(e, bodyT, res)
+			armBodies = append(armBodies, bodyT)
 		}
 	}
+	c.checkUniformOwnership(e, armBodies)
 	c.checkMatchExhaustive(e, matchShape)
 	c.recordType(e, res)
 	return res

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -9,7 +9,7 @@ import (
 
 // mixedOwnershipMsg is the MixedOwnershipError message, asserted with a span prefix
 // in the mixed-ownership rows below.
-const mixedOwnershipMsg = "union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member"
+const mixedOwnershipMsg = "a union or intersection mixes owned and borrowed members. Make ownership uniform first. Clone the borrowed member to own it, or borrow the owned member."
 
 // TestInferRefUnion pins binding `f`'s rendered type when wantErrs is nil, else asserts the exact diagnostics.
 func TestInferRefUnion(t *testing.T) {

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -11,10 +11,7 @@ import (
 // in the mixed-ownership rows below.
 const mixedOwnershipMsg = "union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member"
 
-// TestInferRefUnion exercises R9 end to end through the inference pipeline: a borrow
-// over a union or intersection pointee, mixed-ownership rejection at the inference
-// join sites, and nested-borrow normalization. Each row either pins the rendered type
-// of binding `f` when wantErrs is nil, or asserts the exact diagnostics when it is set.
+// TestInferRefUnion pins binding `f`'s rendered type when wantErrs is nil, else asserts the exact diagnostics.
 func TestInferRefUnion(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -23,10 +20,6 @@ func TestInferRefUnion(t *testing.T) {
 		wantErrs []string // exact diagnostics; nil means the source must check cleanly
 	}{
 		// --- unions/intersections as RefInner ---
-		//
-		// The borrow wrapper is outer and shared: `&(A | B)` is one borrow over a union
-		// pointee, with a single lifetime and mutability for the whole value, never
-		// `&A | &B` with independent lifetimes.
 		{
 			name: "immutable borrow over a union",
 			src:  `fn f(p: &({a: number} | {b: number})) { return p }`,
@@ -51,11 +44,6 @@ func TestInferRefUnion(t *testing.T) {
 		},
 
 		// --- mixed-ownership rejection at join sites ---
-		//
-		// A union or intersection must have uniform ownership. Inference joins branches
-		// of different ownership at an if/else, a match arm set, or several return
-		// points. A borrowed member beside an owned one there has no single
-		// owned-or-borrowed verdict and is rejected.
 		{
 			name: "mixed ownership in an if/else value",
 			src: `fn f(p: &mut {x: number}) {

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -1,0 +1,192 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- R9: unions/intersections as RefInner ---
+//
+// The borrow wrapper is outer and shared: `&(A | B)` is one borrow over a union
+// pointee, with a single lifetime and mutability for the whole value, never
+// `&A | &B` with independent lifetimes. A union or intersection joins RefInner so
+// these lower and render.
+
+// `&(A | B)` lowers to one borrow whose inner is a union, and round-trips through
+// the printer with the pointee parenthesized.
+func TestInferBorrowOverUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &({a: number} | {b: number})) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a ({a: number} | {b: number})) -> &'a ({a: number} | {b: number})",
+		values["f"])
+}
+
+// `&mut (A | B)` is the mutable borrow over a union pointee.
+func TestInferMutBorrowOverUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &mut ({a: number} | {b: number})) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a mut ({a: number} | {b: number})) -> &'a mut ({a: number} | {b: number})",
+		values["f"])
+}
+
+// An owned-mutable union `mut (A | B)` is accepted: the union joins RefInner, so the
+// `mut` wrapper has a borrowable pointee to wrap rather than reporting an unsupported
+// feature.
+func TestInferOwnedMutUnionAccepted(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: mut ({a: number} | {b: number})) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn (p: mut ({a: number} | {b: number})) -> mut ({a: number} | {b: number})",
+		values["f"])
+}
+
+// `&(A & B)` borrows an intersection pointee the same way.
+func TestInferBorrowOverIntersection(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &({a: number} & {b: number})) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a ({a: number} & {b: number})) -> &'a ({a: number} & {b: number})",
+		values["f"])
+}
+
+// A mutable borrow over a union is invariant in its pointee, so `mut A` does not
+// satisfy `mut (A | B)`: writing a `B` through the wider target would corrupt the
+// caller's `A`-typed storage. The reverse residual write view the RefType rule adds
+// for a mutable target drives the rejection.
+func TestConstrainMutUnionPointeeInvariant(t *testing.T) {
+	c := &Context{}
+	mutA := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
+	mutUnion := &soltype.RefType{Mut: true, Inner: &soltype.UnionType{
+		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
+	}}
+	require.NotEmpty(t, c.Constrain(mutA, mutUnion))
+}
+
+// An immutable borrow reads only, so `&(A | B)` factors by subtyping: `&A` is usable
+// where `&(A | B)` is wanted. No residual write view fires for an immutable target,
+// so the covariant inner read `A <: (A | B)` succeeds.
+func TestConstrainImmutableBorrowUnionFactors(t *testing.T) {
+	c := &Context{}
+	immA := &soltype.RefType{Lt: c.freshLifetime(0), Inner: exactObj(propElem("x", num()))}
+	immUnion := &soltype.RefType{Lt: c.freshLifetime(0), Inner: &soltype.UnionType{
+		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
+	}}
+	require.Empty(t, c.Constrain(immA, immUnion))
+}
+
+// A bare owned union satisfies a borrow destination: the bare<:RefType arm wraps the
+// borrowable owned source as an immutable view, so `(A | B)` auto-borrows into
+// `&(A | B)`.
+func TestConstrainBareUnionIntoBorrow(t *testing.T) {
+	c := &Context{}
+	bareUnion := &soltype.UnionType{
+		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
+	}
+	borrowUnion := &soltype.RefType{Lt: c.freshLifetime(0), Inner: &soltype.UnionType{
+		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
+	}}
+	require.Empty(t, c.Constrain(bareUnion, borrowUnion))
+}
+
+// --- R9: mixed-ownership rejection at join sites ---
+//
+// A union or intersection must have uniform ownership. Inference joins branches of
+// different ownership at an if/else, a match arm set, or several return points. A
+// borrowed member beside an owned one there has no single owned-or-borrowed verdict
+// and is rejected.
+
+// An if/else whose value is a borrow on one branch and an owned object on the other
+// forms a mixed-ownership union and is rejected, blaming the if/else expression.
+func TestInferMixedOwnershipIfElse(t *testing.T) {
+	src := `fn f(p: &mut {x: number}) {
+  val q = if true { p } else { {x: 5} }
+  return q
+}`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"2:10-2:40: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
+	}, messagesWithSpan(errs))
+}
+
+// Two return points, one a borrow and one an owned object, join into a mixed union
+// and are rejected at the function's return join.
+func TestInferMixedOwnershipReturns(t *testing.T) {
+	src := `fn f(p: &mut {x: number}) {
+  if true { return p } else { return {x: 5} }
+}`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"1:1-3:2: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
+	}, messagesWithSpan(errs))
+}
+
+// A match whose arms disagree on ownership is rejected at the match expression.
+func TestInferMixedOwnershipMatch(t *testing.T) {
+	src := `fn f(p: &mut {x: number}) {
+  val r = match 1 {
+    1 => p,
+    _ => ({x: 5}),
+  }
+  return r
+}`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{
+		"2:11-5:4: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
+	}, messagesWithSpan(errs))
+}
+
+// A union of two owned objects has uniform ownership and is accepted.
+func TestInferUniformOwnedUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  if true { return {x: 5} } else { return {x: 6} }
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> {x: 5} | {x: 6}", values["f"])
+}
+
+// A union of value types carries no ownership and is accepted.
+func TestInferUniformValueUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f() {
+  if true { return 5 } else { return "x" }
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn () -> 5 | "x"`, values["f"])
+}
+
+// Two borrows that differ only in lifetime join into one borrow rather than a mixed
+// union, so the uniform-ownership check leaves them alone.
+func TestInferUniformBorrowUnion(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}, q: &mut {x: number}) {
+  if true { return p } else { return q }
+}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		values["f"])
+}
+
+// --- R9: nested-borrow normalization ---
+//
+// A borrow whose pointee is itself a borrow collapses to depth one, since the JS
+// target compiles every borrow to the same bare object reference.
+
+// An immutable nested borrow `&(&{x})` collapses to a single `&{x}` at the outer
+// lifetime.
+func TestInferNestedImmutableBorrowCollapses(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f(p: &(&{x: number})) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A mutable nested borrow `&mut (&mut {x})` is uninhabitable: it would have to repoint
+// the inner borrow, which needs a storage cell the JS target cannot express.
+func TestInferNestedMutableBorrowRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f(p: &mut (&mut {x: number})) { return p }`)
+	require.Equal(t, []string{
+		"1:9-1:31: Unsupported: mutable borrow of a borrow is uninhabitable",
+	}, messagesWithSpan(errs))
+}

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -141,10 +141,7 @@ func TestConstrainRefUnion(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			// Writing a `B` through the wider `mut (A | B)` target would corrupt the
-			// caller's `A`-typed storage, so `mut A` does not satisfy `mut (A | B)`. The
-			// residual reverse write view the RefType rule adds for a mutable target
-			// drives the rejection.
+			// mut A </: mut (A | B): a mutable borrow is invariant in its pointee.
 			name: "mutable borrow pointee is invariant",
 			build: func(c *Context) (soltype.Type, soltype.Type) {
 				sub := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
@@ -154,9 +151,7 @@ func TestConstrainRefUnion(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// An immutable borrow reads only, so `&A` is usable where `&(A | B)` is
-			// wanted. No write view fires for an immutable target, so the covariant inner
-			// read `A <: (A | B)` succeeds.
+			// &A <: &(A | B): an immutable borrow is covariant in its pointee.
 			name: "immutable borrow pointee factors",
 			build: func(c *Context) (soltype.Type, soltype.Type) {
 				sub := &soltype.RefType{Lt: c.freshLifetime(0), Inner: exactObj(propElem("x", num()))}
@@ -166,8 +161,7 @@ func TestConstrainRefUnion(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// The bare<:RefType arm wraps a borrowable owned source as an immutable view,
-			// so a bare `(A | B)` auto-borrows into `&(A | B)`.
+			// (A | B) <: &(A | B): a bare owned union auto-borrows into a borrow.
 			name: "bare owned union auto-borrows into a borrow",
 			build: func(c *Context) (soltype.Type, soltype.Type) {
 				return unionXY(), &soltype.RefType{Lt: c.freshLifetime(0), Inner: unionXY()}

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -7,186 +7,196 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- R9: unions/intersections as RefInner ---
-//
-// The borrow wrapper is outer and shared: `&(A | B)` is one borrow over a union
-// pointee, with a single lifetime and mutability for the whole value, never
-// `&A | &B` with independent lifetimes. A union or intersection joins RefInner so
-// these lower and render.
+// mixedOwnershipMsg is the MixedOwnershipError message, asserted with a span prefix
+// in the mixed-ownership rows below.
+const mixedOwnershipMsg = "union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member"
 
-// `&(A | B)` lowers to one borrow whose inner is a union, and round-trips through
-// the printer with the pointee parenthesized.
-func TestInferBorrowOverUnion(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &({a: number} | {b: number})) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(p: &'a ({a: number} | {b: number})) -> &'a ({a: number} | {b: number})",
-		values["f"])
-}
+// TestInferRefUnion exercises R9 end to end through the inference pipeline: a borrow
+// over a union or intersection pointee, mixed-ownership rejection at the inference
+// join sites, and nested-borrow normalization. Each row either pins the rendered type
+// of binding `f` when wantErrs is nil, or asserts the exact diagnostics when it is set.
+func TestInferRefUnion(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		want     string   // rendered type of values["f"] when wantErrs is nil
+		wantErrs []string // exact diagnostics; nil means the source must check cleanly
+	}{
+		// --- unions/intersections as RefInner ---
+		//
+		// The borrow wrapper is outer and shared: `&(A | B)` is one borrow over a union
+		// pointee, with a single lifetime and mutability for the whole value, never
+		// `&A | &B` with independent lifetimes.
+		{
+			name: "immutable borrow over a union",
+			src:  `fn f(p: &({a: number} | {b: number})) { return p }`,
+			want: "fn <'a>(p: &'a ({a: number} | {b: number})) -> &'a ({a: number} | {b: number})",
+		},
+		{
+			name: "mutable borrow over a union",
+			src:  `fn f(p: &mut ({a: number} | {b: number})) { return p }`,
+			want: "fn <'a>(p: &'a mut ({a: number} | {b: number})) -> &'a mut ({a: number} | {b: number})",
+		},
+		{
+			// The union joins RefInner, so the `mut` wrapper has a borrowable pointee to
+			// wrap rather than reporting an unsupported feature.
+			name: "owned-mutable union accepted",
+			src:  `fn f(p: mut ({a: number} | {b: number})) { return p }`,
+			want: "fn (p: mut ({a: number} | {b: number})) -> mut ({a: number} | {b: number})",
+		},
+		{
+			name: "immutable borrow over an intersection",
+			src:  `fn f(p: &({a: number} & {b: number})) { return p }`,
+			want: "fn <'a>(p: &'a ({a: number} & {b: number})) -> &'a ({a: number} & {b: number})",
+		},
 
-// `&mut (A | B)` is the mutable borrow over a union pointee.
-func TestInferMutBorrowOverUnion(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &mut ({a: number} | {b: number})) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(p: &'a mut ({a: number} | {b: number})) -> &'a mut ({a: number} | {b: number})",
-		values["f"])
-}
-
-// An owned-mutable union `mut (A | B)` is accepted: the union joins RefInner, so the
-// `mut` wrapper has a borrowable pointee to wrap rather than reporting an unsupported
-// feature.
-func TestInferOwnedMutUnionAccepted(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: mut ({a: number} | {b: number})) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn (p: mut ({a: number} | {b: number})) -> mut ({a: number} | {b: number})",
-		values["f"])
-}
-
-// `&(A & B)` borrows an intersection pointee the same way.
-func TestInferBorrowOverIntersection(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &({a: number} & {b: number})) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(p: &'a ({a: number} & {b: number})) -> &'a ({a: number} & {b: number})",
-		values["f"])
-}
-
-// A mutable borrow over a union is invariant in its pointee, so `mut A` does not
-// satisfy `mut (A | B)`: writing a `B` through the wider target would corrupt the
-// caller's `A`-typed storage. The reverse residual write view the RefType rule adds
-// for a mutable target drives the rejection.
-func TestConstrainMutUnionPointeeInvariant(t *testing.T) {
-	c := &Context{}
-	mutA := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
-	mutUnion := &soltype.RefType{Mut: true, Inner: &soltype.UnionType{
-		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
-	}}
-	require.NotEmpty(t, c.Constrain(mutA, mutUnion))
-}
-
-// An immutable borrow reads only, so `&(A | B)` factors by subtyping: `&A` is usable
-// where `&(A | B)` is wanted. No residual write view fires for an immutable target,
-// so the covariant inner read `A <: (A | B)` succeeds.
-func TestConstrainImmutableBorrowUnionFactors(t *testing.T) {
-	c := &Context{}
-	immA := &soltype.RefType{Lt: c.freshLifetime(0), Inner: exactObj(propElem("x", num()))}
-	immUnion := &soltype.RefType{Lt: c.freshLifetime(0), Inner: &soltype.UnionType{
-		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
-	}}
-	require.Empty(t, c.Constrain(immA, immUnion))
-}
-
-// A bare owned union satisfies a borrow destination: the bare<:RefType arm wraps the
-// borrowable owned source as an immutable view, so `(A | B)` auto-borrows into
-// `&(A | B)`.
-func TestConstrainBareUnionIntoBorrow(t *testing.T) {
-	c := &Context{}
-	bareUnion := &soltype.UnionType{
-		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
-	}
-	borrowUnion := &soltype.RefType{Lt: c.freshLifetime(0), Inner: &soltype.UnionType{
-		Types: []soltype.Type{exactObj(propElem("x", num())), exactObj(propElem("y", str()))},
-	}}
-	require.Empty(t, c.Constrain(bareUnion, borrowUnion))
-}
-
-// --- R9: mixed-ownership rejection at join sites ---
-//
-// A union or intersection must have uniform ownership. Inference joins branches of
-// different ownership at an if/else, a match arm set, or several return points. A
-// borrowed member beside an owned one there has no single owned-or-borrowed verdict
-// and is rejected.
-
-// An if/else whose value is a borrow on one branch and an owned object on the other
-// forms a mixed-ownership union and is rejected, blaming the if/else expression.
-func TestInferMixedOwnershipIfElse(t *testing.T) {
-	src := `fn f(p: &mut {x: number}) {
+		// --- mixed-ownership rejection at join sites ---
+		//
+		// A union or intersection must have uniform ownership. Inference joins branches
+		// of different ownership at an if/else, a match arm set, or several return
+		// points. A borrowed member beside an owned one there has no single
+		// owned-or-borrowed verdict and is rejected.
+		{
+			name: "mixed ownership in an if/else value",
+			src: `fn f(p: &mut {x: number}) {
   val q = if true { p } else { {x: 5} }
   return q
-}`
-	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{
-		"2:10-2:40: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
-	}, messagesWithSpan(errs))
-}
-
-// Two return points, one a borrow and one an owned object, join into a mixed union
-// and are rejected at the function's return join.
-func TestInferMixedOwnershipReturns(t *testing.T) {
-	src := `fn f(p: &mut {x: number}) {
+}`,
+			wantErrs: []string{"2:10-2:40: " + mixedOwnershipMsg},
+		},
+		{
+			name: "mixed ownership across return points",
+			src: `fn f(p: &mut {x: number}) {
   if true { return p } else { return {x: 5} }
-}`
-	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{
-		"1:1-3:2: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
-	}, messagesWithSpan(errs))
-}
-
-// A match whose arms disagree on ownership is rejected at the match expression.
-func TestInferMixedOwnershipMatch(t *testing.T) {
-	src := `fn f(p: &mut {x: number}) {
+}`,
+			wantErrs: []string{"1:1-3:2: " + mixedOwnershipMsg},
+		},
+		{
+			name: "mixed ownership across match arms",
+			src: `fn f(p: &mut {x: number}) {
   val r = match 1 {
     1 => p,
     _ => ({x: 5}),
   }
   return r
-}`
-	_, _, errs := inferSource(t, src)
-	require.Equal(t, []string{
-		"2:11-5:4: union or intersection mixes owned and borrowed members; make ownership uniform — clone the borrowed member to own it, or borrow the owned member",
-	}, messagesWithSpan(errs))
-}
-
-// A union of two owned objects has uniform ownership and is accepted.
-func TestInferUniformOwnedUnion(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() {
+}`,
+			wantErrs: []string{"2:11-5:4: " + mixedOwnershipMsg},
+		},
+		{
+			name: "uniform owned union",
+			src: `fn f() {
   if true { return {x: 5} } else { return {x: 6} }
-}`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn () -> {x: 5} | {x: 6}", values["f"])
-}
-
-// A union of value types carries no ownership and is accepted.
-func TestInferUniformValueUnion(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() {
+}`,
+			want: "fn () -> {x: 5} | {x: 6}",
+		},
+		{
+			// Value types carry no ownership, so a union of them never trips the check.
+			name: "uniform value union",
+			src: `fn f() {
   if true { return 5 } else { return "x" }
-}`)
-	require.Empty(t, errs)
-	require.Equal(t, `fn () -> 5 | "x"`, values["f"])
-}
-
-// Two borrows that differ only in lifetime join into one borrow rather than a mixed
-// union, so the uniform-ownership check leaves them alone.
-func TestInferUniformBorrowUnion(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &mut {x: number}, q: &mut {x: number}) {
+}`,
+			want: `fn () -> 5 | "x"`,
+		},
+		{
+			// Two borrows that differ only in lifetime join into one borrow rather than a
+			// mixed union, so the uniform-ownership check leaves them alone.
+			name: "uniform borrow union",
+			src: `fn f(p: &mut {x: number}, q: &mut {x: number}) {
   if true { return p } else { return q }
-}`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
-		values["f"])
+}`,
+			want: "fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		},
+
+		// --- nested-borrow normalization ---
+		//
+		// A borrow whose pointee is itself a borrow collapses to depth one, since the JS
+		// target compiles every borrow to the same bare object reference.
+		{
+			name: "immutable nested borrow collapses to depth one",
+			src:  `fn f(p: &(&{x: number})) { return p }`,
+			want: "fn <'a>(p: &'a {x: number}) -> &'a {x: number}",
+		},
+		{
+			// `&mut (&mut {x})` would have to repoint the inner borrow, which needs a
+			// storage cell the JS target cannot express, so it is uninhabitable.
+			name:     "mutable nested borrow rejected",
+			src:      `fn f(p: &mut (&mut {x: number})) { return p }`,
+			wantErrs: []string{"1:9-1:31: Unsupported: mutable borrow of a borrow is uninhabitable"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			if tc.wantErrs != nil {
+				require.Equal(t, tc.wantErrs, messagesWithSpan(errs))
+				return
+			}
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values["f"])
+		})
+	}
 }
 
-// --- R9: nested-borrow normalization ---
-//
-// A borrow whose pointee is itself a borrow collapses to depth one, since the JS
-// target compiles every borrow to the same bare object reference.
-
-// An immutable nested borrow `&(&{x})` collapses to a single `&{x}` at the outer
-// lifetime.
-func TestInferNestedImmutableBorrowCollapses(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &(&{x: number})) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
-}
-
-// A mutable nested borrow `&mut (&mut {x})` is uninhabitable: it would have to repoint
-// the inner borrow, which needs a storage cell the JS target cannot express.
-func TestInferNestedMutableBorrowRejected(t *testing.T) {
-	_, _, errs := inferSource(t, `fn f(p: &mut (&mut {x: number})) { return p }`)
-	require.Equal(t, []string{
-		"1:9-1:31: Unsupported: mutable borrow of a borrow is uninhabitable",
-	}, messagesWithSpan(errs))
+// TestConstrainRefUnion pins the variance of a borrow over a union pointee at the
+// constraint level. A mutable borrow is invariant in its pointee, an immutable borrow
+// factors covariantly, and a bare owned union auto-borrows into a borrow destination.
+func TestConstrainRefUnion(t *testing.T) {
+	unionXY := func() *soltype.UnionType {
+		return &soltype.UnionType{Types: []soltype.Type{
+			exactObj(propElem("x", num())),
+			exactObj(propElem("y", str())),
+		}}
+	}
+	cases := []struct {
+		name    string
+		build   func(c *Context) (sub, super soltype.Type)
+		wantErr bool
+	}{
+		{
+			// Writing a `B` through the wider `mut (A | B)` target would corrupt the
+			// caller's `A`-typed storage, so `mut A` does not satisfy `mut (A | B)`. The
+			// residual reverse write view the RefType rule adds for a mutable target
+			// drives the rejection.
+			name: "mutable borrow pointee is invariant",
+			build: func(c *Context) (soltype.Type, soltype.Type) {
+				sub := &soltype.RefType{Mut: true, Inner: exactObj(propElem("x", num()))}
+				super := &soltype.RefType{Mut: true, Inner: unionXY()}
+				return sub, super
+			},
+			wantErr: true,
+		},
+		{
+			// An immutable borrow reads only, so `&A` is usable where `&(A | B)` is
+			// wanted. No write view fires for an immutable target, so the covariant inner
+			// read `A <: (A | B)` succeeds.
+			name: "immutable borrow pointee factors",
+			build: func(c *Context) (soltype.Type, soltype.Type) {
+				sub := &soltype.RefType{Lt: c.freshLifetime(0), Inner: exactObj(propElem("x", num()))}
+				super := &soltype.RefType{Lt: c.freshLifetime(0), Inner: unionXY()}
+				return sub, super
+			},
+			wantErr: false,
+		},
+		{
+			// The bare<:RefType arm wraps a borrowable owned source as an immutable view,
+			// so a bare `(A | B)` auto-borrows into `&(A | B)`.
+			name: "bare owned union auto-borrows into a borrow",
+			build: func(c *Context) (soltype.Type, soltype.Type) {
+				return unionXY(), &soltype.RefType{Lt: c.freshLifetime(0), Inner: unionXY()}
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Context{}
+			sub, super := tc.build(c)
+			errs := c.Constrain(sub, super)
+			if tc.wantErr {
+				require.NotEmpty(t, errs)
+			} else {
+				require.Empty(t, errs)
+			}
+		})
+	}
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -389,14 +389,10 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	lt := c.resolveLifetimeAnn(ta.Lifetime, lvl)
 	inner, ok := c.resolveTypeAnn(ta.Inner, lvl)
 	if !ok {
-		// The inner annotation was unsupported and already reported its own error.
-		// Recover it to a fresh var so the borrow wrapper survives and the binding
-		// stays cascade-safe, matching the Promise/object/tuple recovery.
+		// Recover an unsupported inner to a fresh var so the borrow wrapper survives, cascade-safe.
 		inner = c.freshAt(lvl)
 	}
-	// Nested-borrow normalization (PR 9): a borrow whose pointee is itself a borrow
-	// collapses to depth one, since the JS target compiles every borrow to the same
-	// bare object reference and cannot represent a borrow of a borrow.
+	// A borrow whose pointee is itself a borrow collapses to depth one (PR 9).
 	if nested, isRef := inner.(*soltype.RefType); isRef {
 		return c.normalizeNestedBorrow(ta, lt, nested)
 	}
@@ -412,19 +408,13 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	return t, true
 }
 
-// normalizeNestedBorrow collapses a borrow whose pointee is itself a borrow to
-// depth one, the PR 9 rule for a nested borrow such as `&&Point`. Two cases:
+// normalizeNestedBorrow collapses a borrow whose pointee is itself a borrow to depth
+// one, the PR 9 rule for a nested borrow such as `&&Point`. Two cases:
 //
-//   - An immutable outer layer collapses. An immutable borrow is Copy, duplicating
-//     the reference and never the referenced data, so `&'a &'b Point` is just another
-//     immutable alias and reduces to `&'a Point`, the inner carrier at the outer,
-//     shorter lifetime. The inner lifetime must outlive the outer, so 'b outlives 'a.
-//     A `& &mut` collapses the same way, downgrading to an immutable view, since the
-//     read-only outer can never hand out the inner's mutable access.
-//   - A mutable outer layer is uninhabitable. `&mut &…` would mean "repoint the inner
-//     borrow," which needs a storage cell holding that reference. A borrow compiles to
-//     the bare object reference with no cell of its own, and JS offers no lvalue
-//     reference to a binding, so the form has no inhabitant and is rejected.
+//   - An immutable outer layer collapses, since an immutable borrow is Copy. `&'a &'b
+//     Point` reduces to `&'a Point` at the outer lifetime, with 'b outliving 'a.
+//   - A mutable outer layer is uninhabitable, since `&mut &…` would repoint the inner
+//     borrow, which needs a storage cell the JS target cannot express. It is rejected.
 func (c *checker) normalizeNestedBorrow(ta *ast.RefTypeAnn, outerLt soltype.Lifetime, inner *soltype.RefType) (soltype.Type, bool) {
 	if ta.Mut {
 		return c.reportUnsupportedFeature(ta, "mutable borrow of a borrow is uninhabitable"), false

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -358,8 +358,9 @@ func (c *checker) resolveMutableTypeAnn(ta *ast.MutableTypeAnn, lvl int) (soltyp
 	return t, true
 }
 
-// borrowInner resolves the pointee of a `mut` or `&` annotation to a RefInner, the
-// shared inner-resolution step of resolveMutableTypeAnn and resolveRefTypeAnn. An
+// borrowInner resolves the pointee of a `mut` annotation to a RefInner, the
+// inner-resolution step of resolveMutableTypeAnn. resolveRefTypeAnn resolves its own
+// inner directly so it can intercept a nested borrow before the RefInner cast. An
 // unsupported inner recovers to a fresh var, which IS a RefInner, so the wrapper is
 // preserved and the binding stays cascade-safe. ok=false means the inner resolved to a
 // concrete non-borrowable type such as a primitive, function, or promise. The caller
@@ -385,14 +386,53 @@ func (c *checker) borrowInner(ta ast.TypeAnn, lvl int) (soltype.RefInner, bool) 
 // connects nothing elides. Unlike resolveMutableTypeAnn, this arm always sets Lt, so the
 // result is a genuine borrow rather than an owned value.
 func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, bool) {
-	ri, ok := c.borrowInner(ta.Inner, lvl)
+	lt := c.resolveLifetimeAnn(ta.Lifetime, lvl)
+	inner, ok := c.resolveTypeAnn(ta.Inner, lvl)
 	if !ok {
+		// The inner annotation was unsupported and already reported its own error.
+		// Recover it to a fresh var so the borrow wrapper survives and the binding
+		// stays cascade-safe, matching the Promise/object/tuple recovery.
+		inner = c.freshAt(lvl)
+	}
+	// Nested-borrow normalization (PR 9): a borrow whose pointee is itself a borrow
+	// collapses to depth one, since the JS target compiles every borrow to the same
+	// bare object reference and cannot represent a borrow of a borrow.
+	if nested, isRef := inner.(*soltype.RefType); isRef {
+		return c.normalizeNestedBorrow(ta, lt, nested)
+	}
+	ri, isRI := inner.(soltype.RefInner)
+	if !isRI {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
 	// The lazy deep-mut form (PR 14) stores `&mut {a: {x}}` verbatim; the deep-mut
 	// rule is applied at access and constrain time rather than by rewriting the
 	// pointee's children here.
-	t := &soltype.RefType{Mut: ta.Mut, Lt: c.resolveLifetimeAnn(ta.Lifetime, lvl), Inner: ri}
+	t := &soltype.RefType{Mut: ta.Mut, Lt: lt, Inner: ri}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// normalizeNestedBorrow collapses a borrow whose pointee is itself a borrow to
+// depth one, the PR 9 rule for a nested borrow such as `&&Point`. Two cases:
+//
+//   - An immutable outer layer collapses. An immutable borrow is Copy, duplicating
+//     the reference and never the referenced data, so `&'a &'b Point` is just another
+//     immutable alias and reduces to `&'a Point`, the inner carrier at the outer,
+//     shorter lifetime. The inner lifetime must outlive the outer, so 'b outlives 'a.
+//     A `& &mut` collapses the same way, downgrading to an immutable view, since the
+//     read-only outer can never hand out the inner's mutable access.
+//   - A mutable outer layer is uninhabitable. `&mut &…` would mean "repoint the inner
+//     borrow," which needs a storage cell holding that reference. A borrow compiles to
+//     the bare object reference with no cell of its own, and JS offers no lvalue
+//     reference to a binding, so the form has no inhabitant and is rejected.
+func (c *checker) normalizeNestedBorrow(ta *ast.RefTypeAnn, outerLt soltype.Lifetime, inner *soltype.RefType) (soltype.Type, bool) {
+	if ta.Mut {
+		return c.reportUnsupportedFeature(ta, "mutable borrow of a borrow is uninhabitable"), false
+	}
+	if inner.Lt != nil && outerLt != nil {
+		c.ctx.constrainLt(inner.Lt, outerLt)
+	}
+	t := soltype.NewRef(false, outerLt, inner.Inner)
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -392,7 +392,7 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 		// Recover an unsupported inner to a fresh var so the borrow wrapper survives, cascade-safe.
 		inner = c.freshAt(lvl)
 	}
-	// A borrow whose pointee is itself a borrow collapses to depth one (PR 9).
+	// A borrow whose pointee is itself a borrow collapses to depth one.
 	if nested, isRef := inner.(*soltype.RefType); isRef {
 		return c.normalizeNestedBorrow(ta, lt, nested)
 	}
@@ -400,16 +400,16 @@ func (c *checker) resolveRefTypeAnn(ta *ast.RefTypeAnn, lvl int) (soltype.Type, 
 	if !isRI {
 		return c.reportUnsupportedFeature(ta, "borrow of a non-borrowable type"), false
 	}
-	// The lazy deep-mut form (PR 14) stores `&mut {a: {x}}` verbatim; the deep-mut
-	// rule is applied at access and constrain time rather than by rewriting the
-	// pointee's children here.
+	// The lazy deep-mut form stores `&mut {a: {x}}` verbatim. The deep-mut rule is
+	// applied at access and constrain time rather than by rewriting the pointee's
+	// children here.
 	t := &soltype.RefType{Mut: ta.Mut, Lt: lt, Inner: ri}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 
 // normalizeNestedBorrow collapses a borrow whose pointee is itself a borrow to depth
-// one, the PR 9 rule for a nested borrow such as `&&Point`. Two cases:
+// one, for a nested borrow such as `&&Point`. Two cases:
 //
 //   - An immutable outer layer collapses, since an immutable borrow is Copy. `&'a &'b
 //     Point` reduces to `&'a Point` at the outer lifetime, with 'b outliving 'a.

--- a/planning/simple_sub/m6-implementation-plan.md
+++ b/planning/simple_sub/m6-implementation-plan.md
@@ -141,8 +141,8 @@ and the *rules*.
 
 ## Sequencing rationale
 
-**Status.** PR1–PR6 and the two cleanups PR2.5/PR2.7 have landed; PR7 and PR8
-remain. Completed PRs are marked ✅ with their merged PR number; the rest are ⬜.
+**Status.** PR1–PR6, the two cleanups PR2.5/PR2.7, and PR8 have landed; only PR7
+remains. Completed PRs are marked ✅ with their merged PR number; the rest are ⬜.
 
 ```
 PR1 ✅ #774 (representation + normalization)
@@ -155,7 +155,7 @@ PR1 ✅ #774 (representation + normalization)
  │     └─► PR5 ✅ #804 (⊤/⊥ rules + Variation-B close — now testable end-to-end)
  ├─► PR6 ✅ #805 (permissive mut-borrow join)
  ├─► PR7 ⬜ (if-let / let-else — needs PR4 + PR5)
- └─► PR8 ⬜ (subsume inferred types at finalization — needs PR1 + PR2)
+ └─► PR8 ✅ #808 (subsume inferred types at finalization — needs PR1 + PR2)
 ```
 
 - **PR1 is first because every other PR mints or compares a union/intersection**,


### PR DESCRIPTION
Implement PR9 of the M6 plan: allow unions and intersections to serve as the pointee of a borrow, and enforce uniform ownership at join sites.

**Summary**

This PR makes unions and intersections valid `RefInner` types, so `&(A | B)` is one borrow over a union pointee with a single lifetime and mutability, rather than `&A | &B` with independent lifetimes. It also adds validation to reject mixed-ownership unions and intersections that form at inference join points (if/else, match arms, return points), where a borrowed member beside an owned one has no single owned-or-borrowed verdict.

**Key changes**

- **Type representation**: `UnionType` and `IntersectionType` now implement `RefInner`, allowing them to be wrapped by `RefType`.
- **Nested-borrow normalization**: Borrows whose pointee is itself a borrow collapse to depth one. An immutable outer layer reduces to a single borrow at the outer lifetime; a mutable outer layer is rejected as uninhabitable (would require repointable storage the JS target cannot express).
- **Ownership validation**: Added `checkUniformOwnership` to detect and reject unions and intersections with mixed owned and borrowed members at if/else, match, and return join sites. The check recurses through union and intersection members to classify each branch's ownership.
- **Printing**: Borrows over unions and intersections now render with the pointee parenthesized (e.g., `&(A | B)`, `&mut (A & B)`).
- **Error reporting**: New `MixedOwnershipError` type reports the join expression and guides the user to make ownership uniform by cloning or borrowing.

**Implementation details**

- `collectBranchOwnership` recursively walks union and intersection members to determine whether a branch participates in the owned-or-borrowed axis, skipping value types and unresolved variables.
- Nested-borrow collapse in `normalizeNestedBorrow` enforces the lifetime constraint that the inner borrow's lifetime must outlive the outer one.
- Ownership checks are inserted at all three join sites: `joinReturnPoints`, `inferIfElse`, and `inferMatch`, collecting branch types before the union is formed.

https://claude.ai/code/session_017FXrv4XvivqpaKtdBTTc6E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for borrowing over union and intersection types, including nested borrows and parenthesized composite pointees in output.
  * Improved type checking so conditional branches, matches, and return paths now require consistent ownership across combined results.

* **Bug Fixes**
  * Mixed owned/borrowed combinations are now rejected with a clear diagnostic.
  * Nested immutable borrows are normalized correctly, while unsupported mutable nested borrows are rejected.

* **Tests**
  * Added coverage for borrow formatting, ownership consistency, and union/intersection inference cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->