### PR TITLE
PR 15: escape forcing at returns, stores, and consuming arguments

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -170,6 +170,11 @@ type funcCtx struct {
 	// follows these edges from a binding flowing out of the frame to find a borrow of a
 	// local that cannot outlive it. A parameter root is never recorded, since a borrow
 	// of a parameter carries a caller lifetime that already outlives the frame.
+	//
+	// Only initializer borrows are recorded. A borrow introduced by reassigning a `var`,
+	// such as `a = &mut b`, is not tracked, so a later flow-out of that var under-checks.
+	// The graph is accumulate-only, so tracking reassignments soundly needs flow-sensitive
+	// edges that clear on reassignment, deferred to PR 11.
 	borrowEdges map[liveness.VarID]set.Set[liveness.VarID]
 	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
 	// parameter outlives the frame, so the escape check skips a referent in this set.

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -164,6 +164,16 @@ type funcCtx struct {
 	// once the whole body, loop back edges included, has been walked, so a use that
 	// some reaching path moved is caught even when the move is textually later.
 	useSites []moveUse
+	// borrowEdges records, per binding root VarID, the function-local binding roots
+	// whose data it borrows through an explicit `&`/`&mut` in its initializer. The
+	// initializer `val a = {peer: &mut b}` records the edge a → b. The return-escape
+	// check (PR 15) follows these edges from a returned binding to find a borrow of a
+	// local that cannot outlive the frame. A parameter root is never recorded, since a
+	// borrow of a parameter carries a caller lifetime that already outlives the return.
+	borrowEdges map[liveness.VarID]set.Set[liveness.VarID]
+	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
+	// parameter is returnable, so the return-escape check skips a referent in this set.
+	paramVarIDs set.Set[liveness.VarID]
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in
 	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -166,13 +166,13 @@ type funcCtx struct {
 	useSites []moveUse
 	// borrowEdges records, per binding root VarID, the function-local binding roots
 	// whose data it borrows through an explicit `&`/`&mut` in its initializer. The
-	// initializer `val a = {peer: &mut b}` records the edge a → b. The return-escape
-	// check (PR 15) follows these edges from a returned binding to find a borrow of a
-	// local that cannot outlive the frame. A parameter root is never recorded, since a
-	// borrow of a parameter carries a caller lifetime that already outlives the return.
+	// initializer `val a = {peer: &mut b}` records the edge a → b. The escape check
+	// follows these edges from a binding flowing out of the frame to find a borrow of a
+	// local that cannot outlive it. A parameter root is never recorded, since a borrow
+	// of a parameter carries a caller lifetime that already outlives the frame.
 	borrowEdges map[liveness.VarID]set.Set[liveness.VarID]
 	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
-	// parameter is returnable, so the return-escape check skips a referent in this set.
+	// parameter outlives the frame, so the escape check skips a referent in this set.
 	paramVarIDs set.Set[liveness.VarID]
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -163,12 +163,10 @@ func TestInferValMutConstructedAllowsFieldWrite(t *testing.T) {
 	require.Equal(t, "fn () -> mut {x: number}", values["f"])
 }
 
-// A constructed owned-mutable value can be borrowed `&mut`. The mutable cell fills
-// the mutable borrow destination, so `&mut q` checks where an owned-immutable q would fail
-// the mutability gate. This is the construction-side companion to
-// TestInferValMutBorrowFromOwnedMut, which sources owned-mutable from a parameter. The
-// borrow checks, but returning it escapes the local q, which dies at the frame end, so
-// PR 15's return-escape rule rejects the return while leaving the borrow itself legal.
+// A constructed owned-mutable value can be borrowed `&mut`. The mutable cell fills the
+// mutable borrow destination, so `&mut q` checks where an owned-immutable q would fail the
+// mutability gate. The borrow itself is legal, but returning it escapes the local q, which
+// dies at the frame end, so the return is rejected while the borrow stands.
 func TestInferValMutConstructedBorrowsMut(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f() {
   val mut q = {x: 0}

--- a/internal/solver/infer_borrow_expr_test.go
+++ b/internal/solver/infer_borrow_expr_test.go
@@ -166,15 +166,18 @@ func TestInferValMutConstructedAllowsFieldWrite(t *testing.T) {
 // A constructed owned-mutable value can be borrowed `&mut`. The mutable cell fills
 // the mutable borrow destination, so `&mut q` checks where an owned-immutable q would fail
 // the mutability gate. This is the construction-side companion to
-// TestInferValMutBorrowFromOwnedMut, which sources owned-mutable from a parameter.
+// TestInferValMutBorrowFromOwnedMut, which sources owned-mutable from a parameter. The
+// borrow checks, but returning it escapes the local q, which dies at the frame end, so
+// PR 15's return-escape rule rejects the return while leaving the borrow itself legal.
 func TestInferValMutConstructedBorrowsMut(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f() {
+	_, _, errs := inferSource(t, `fn f() {
   val mut q = {x: 0}
   val r = &mut q
   return r
 }`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn () -> &mut {x: number}", values["f"])
+	require.Equal(t, []string{
+		"4:10-4:11: borrowed value 'q' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
 }
 
 // A `mut` binding of a primitive is unchanged: a primitive is a value type with no

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -647,6 +647,10 @@ func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 	}
 	c.bindPattern(scope, lvl, d.Pattern, initType, nil)
 	c.trackDestructureLeaves(scope, d.Pattern)
+	// A borrow projected into a destructuring leaf records no borrow edge, so a return
+	// of such a leaf is not yet caught as an escape. Tracking it precisely needs the
+	// per-leaf correspondence the field-granular move work introduces; a whole-binding
+	// approximation would over-report a disjoint leaf.
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1466,7 +1466,7 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		// Storing a value that borrows a local into a parameter's field escapes, since the
 		// parameter's object outlives the frame and the stored local would dangle in the
 		// caller. checkStoreEscape applies only when the receiver is a parameter.
-		c.checkStoreEscape(m.Object, e.Right)
+		c.checkParamFieldStoreEscape(m.Object, e.Right)
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1116,6 +1116,10 @@ func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liv
 			continue
 		}
 		c.consumeOwned(arg, c.info.TypeOf(arg), arg, ref)
+		// PR 15: a consuming argument carries its value out of the frame into the callee,
+		// so a borrow of a local it carries escapes. A `&`/`&mut` parameter borrows
+		// instead of consuming and is skipped by the isConcreteOwned gate above.
+		c.reportEscapingLocals(c.escapingLocalsOf(arg), arg)
 	}
 }
 
@@ -1458,6 +1462,9 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 			c.consumeOwned(e.Right, source, e.Right, ref)
 		}
+		// PR 15: storing a value that borrows a local into a parameter's field escapes,
+		// since the parameter's object outlives the frame.
+		c.checkStoreEscape(m.Object, e.Right)
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1116,9 +1116,10 @@ func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liv
 			continue
 		}
 		c.consumeOwned(arg, c.info.TypeOf(arg), arg, ref)
-		// PR 15: a consuming argument carries its value out of the frame into the callee,
-		// so a borrow of a local it carries escapes. A `&`/`&mut` parameter borrows
-		// instead of consuming and is skipped by the isConcreteOwned gate above.
+		// A consuming argument carries its value out of the frame into the callee, so a
+		// borrow of a local the argument carries escapes. reportEscapingLocals flags each
+		// local escapingLocalsOf finds in the argument. A `&`/`&mut` parameter borrows
+		// instead of consuming, so the isConcreteOwned gate above skips it.
 		c.reportEscapingLocals(c.escapingLocalsOf(arg), arg)
 	}
 }
@@ -1462,8 +1463,9 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 			c.consumeOwned(e.Right, source, e.Right, ref)
 		}
-		// PR 15: storing a value that borrows a local into a parameter's field escapes,
-		// since the parameter's object outlives the frame.
+		// Storing a value that borrows a local into a parameter's field escapes, since the
+		// parameter's object outlives the frame and the stored local would dangle in the
+		// caller. checkStoreEscape applies only when the receiver is a parameter.
 		c.checkStoreEscape(m.Object, e.Right)
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -73,6 +73,9 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.consumeOwned(s.Expr, t, s.Expr, ref)
 				}
+				// PR 15: a value flowing out of the frame must not borrow a function-local,
+				// which dies when the frame returns. Reject a returned borrow of a local.
+				c.checkReturnEscape(s.Expr)
 			}
 		} else {
 			// A `return` reached outside any function body — e.g. inside an `if` that
@@ -126,6 +129,10 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			if c.fn != nil {
 				c.trackAliasesForVarDecl(scope, vd, bindingType(b), s)
 				c.consumeBindingInit(vd, bindingType(b), s)
+				// PR 15: record which function-locals this binding's initializer
+				// borrows, so a later return of the binding can find a borrow of a
+				// local that would escape the frame.
+				c.recordBorrowEdges(b.VarID, vd.Init)
 			}
 		}
 		return &soltype.Void{}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -73,8 +73,9 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.consumeOwned(s.Expr, t, s.Expr, ref)
 				}
-				// PR 15: a value flowing out of the frame must not borrow a function-local,
-				// which dies when the frame returns. Reject a returned borrow of a local.
+				// A returned value must not borrow a function-local, which dies when the
+				// frame returns and would leave the borrow dangling. checkReturnEscape
+				// reports a returned borrow of a local.
 				c.checkReturnEscape(s.Expr)
 			}
 		} else {
@@ -129,9 +130,9 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			if c.fn != nil {
 				c.trackAliasesForVarDecl(scope, vd, bindingType(b), s)
 				c.consumeBindingInit(vd, bindingType(b), s)
-				// PR 15: record which function-locals this binding's initializer
-				// borrows, so a later return of the binding can find a borrow of a
-				// local that would escape the frame.
+				// Record which function-locals this binding's initializer borrows, so a
+				// later flow-out of the binding can find a borrow of a local that would
+				// escape the frame.
 				c.recordBorrowEdges(b.VarID, vd.Init)
 			}
 		}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -9,35 +9,32 @@ import (
 	"github.com/escalier-lang/escalier/internal/set"
 )
 
-// Escape forcing (PR 15). A value flowing out of the function frame must not carry a
-// borrow of a function-local binding, since a local dies when the frame returns and the
-// borrow would dangle. The move engine consumes the flowed-out source but does not check
-// the borrows it carries, so a value that borrows a local escapes with no error. This
+// Escape forcing. A value flowing out of the function frame must not carry a borrow of a
+// function-local binding, since a local dies when the frame returns and the borrow would
+// dangle. The move engine consumes the flowed-out source but does not check the borrows
+// it carries, so a value that borrows a local would otherwise escape with no error. This
 // pass reports it at the three non-global value-flow-out sites:
 //
 //   - a `return`, where the value flows out to the caller;
 //   - a field store into a parameter, where it flows into the caller's object;
 //   - a consuming argument, where it flows into the callee.
 //
-// The check works over the move engine's own state rather than the lifetime sort, which
-// is why it does not depend on the directional lifetime bounds slated for M6.5. A
+// The check works over the move engine's borrow tracking rather than the lifetime sort. A
 // per-binding borrow-edge graph drives it. As each binding is walked, recordBorrowEdges
 // records which function-locals it borrows: an explicit `&`/`&mut` of a local in its
 // initializer, and the edges of a whole-binding move that carries a borrow forward. At
 // each flow-out site, escapingLocalsOf follows those edges and scans for direct borrows
-// to find the locals the outgoing value carries. Extending the graph through a field
-// store into a local receiver is left to PR 11, which builds the connected-component
-// graph through field mutations.
+// to find the locals the outgoing value carries.
 //
 // A borrow of a parameter is exempt. It carries a caller-supplied lifetime that already
 // outlives the frame, so `fn (p: &mut {x}) -> &mut {x} { return p }` still checks.
 // recordBorrowEdges drops a parameter referent, so a local that only borrows a parameter
 // records no edge and a flow-out through it raises no escape.
 //
-// Edges and the flow-out checks are whole-binding granular. A borrow held in a field
-// that is moved or returned on its own, such as `return a.peer`, is not tracked, since
-// the edge graph is keyed by root binding rather than by field place. That field-level
-// precision is left to PR 11, which builds on PR 7's per-field tracking.
+// Edges and the flow-out checks are whole-binding granular. A borrow held in a field that
+// is moved or returned on its own, such as `return a.peer`, is not tracked, and neither
+// is a borrow stored into a local receiver's field. The edge graph is keyed by root
+// binding rather than by field place.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
 // function-local binding, which cannot outlive the frame. It blames the outgoing
@@ -176,7 +173,7 @@ func (c *checker) checkReturnEscape(retExpr ast.Expr) {
 // checkStoreEscape handles a field store `recv.f = source`. Storing a value that borrows
 // a local into a parameter's field escapes. The parameter's object outlives the frame,
 // so the stored local would dangle in the caller. A store into a local receiver does not
-// escape here. Extending the borrow graph through such a store is left to PR 11.
+// escape here, and the borrow graph is not extended through such a store.
 func (c *checker) checkStoreEscape(recv, source ast.Expr) {
 	if c.fn == nil || c.fn.borrowEdges == nil {
 		return

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -10,11 +10,21 @@ import (
 )
 
 // Escape forcing. A value flowing out of the function frame must not carry a borrow of a
-// function-local, since the local dies when the frame returns. This pass reports such an
+// function-local, since the local does not outlive the frame. This pass reports such an
 // escape at three sites: a `return`, a field store into a parameter, and a consuming
 // argument.
 //
-// A per-binding borrow-edge graph drives it, over the move engine's borrow tracking
+// The rejection is conservative. The runtime is garbage-collected, so a returned value
+// that references a local keeps it reachable rather than dangling. Returning a
+// self-contained graph is therefore sound. A graph is self-contained when an owned value's
+// internal `&mut` edges reach only locals that nothing outside the graph references. The
+// connected-component move (PR 11) will allow that case by co-moving and consuming those
+// locals, so the returned value's owner anchors them and exclusivity holds. Until it lands,
+// any borrow of a local flowing out is rejected here. A bare `return &mut b` has no owned
+// carrier and stays rejected even then, since the move re-anchors a graph's internal edges,
+// not a borrow that is itself the returned value.
+//
+// A per-binding borrow-edge graph drives the check, over the move engine's borrow tracking
 // rather than the lifetime sort. recordBorrowEdges records which locals each binding
 // borrows. At each site, escapingLocalsOf follows those edges and scans for direct borrows
 // to find the locals the outgoing value carries.

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -1,0 +1,183 @@
+package solver
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// Return-escape forcing (PR 15). A value flowing out of the function frame must not
+// carry a borrow of a function-local binding, since a local dies when the frame
+// returns and the borrow would dangle. The move engine consumes the returned source
+// but does not check the borrows the returned value carries, so returning a binding
+// that borrows a local escapes that local with no error. This pass reports it.
+//
+// The check works over the move engine's own state rather than the lifetime sort,
+// which is why it does not depend on the directional lifetime bounds slated for M6.5.
+// Two pieces drive it:
+//
+//   - recordBorrowEdges records, as each binding is walked, which function-local
+//     bindings its initializer borrows through an explicit `&`/`&mut`. `val a = {peer:
+//     &mut b}` records the edge a → b.
+//   - checkReturnEscape, at each return, follows those edges from the returned binding
+//     and scans the returned expression for direct borrows, reporting an escape for any
+//     borrow of a non-parameter local it reaches.
+//
+// A borrow of a parameter is exempt. It carries a caller-supplied lifetime that already
+// outlives the return, so `fn (p: &mut {x}) -> &mut {x} { return p }` still checks.
+// recordBorrowEdges drops a parameter referent, so a local that only borrows a
+// parameter records no edge and a return through it raises no escape.
+
+// ReturnEscapeError fires when a returned value carries a borrow of a function-local
+// binding, which cannot outlive the frame. It blames the returned expression and names
+// the escaping local.
+type ReturnEscapeError struct {
+	// LocalName is the borrowed local's source name, for the message.
+	LocalName string
+	// node is the returned expression, blamed for the escape.
+	node ast.Node
+}
+
+func (*ReturnEscapeError) isSolverError()        {}
+func (e *ReturnEscapeError) Span() ast.Span      { return e.node.Span() }
+func (e *ReturnEscapeError) Related() []ast.Span { return nil }
+func (e *ReturnEscapeError) Message() string {
+	return fmt.Sprintf("borrowed value '%s' does not live long enough to escape the function", e.LocalName)
+}
+
+// borrowCollector gathers every BorrowExpr in an expression subtree. It rides the
+// shared AST visitor so it reaches a borrow nested in an object or tuple literal — the
+// `&mut b` inside `{peer: &mut b}` — without a hand-rolled walk.
+type borrowCollector struct {
+	*ast.DefaultVisitor
+	out *[]*ast.BorrowExpr
+}
+
+func (v *borrowCollector) EnterExpr(e ast.Expr) bool {
+	if b, ok := e.(*ast.BorrowExpr); ok {
+		*v.out = append(*v.out, b)
+	}
+	return true
+}
+
+// borrowsIn returns every BorrowExpr reachable in e, including those nested in object
+// or tuple literals.
+func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
+	var found []*ast.BorrowExpr
+	e.Accept(&borrowCollector{DefaultVisitor: &ast.DefaultVisitor{}, out: &found})
+	return found
+}
+
+// isLocalReferent reports whether the borrow operand names a function-local binding's
+// place: a place whose root is a real binding that is not a parameter. A parameter
+// referent is exempt, since its lifetime outlives the return. A non-place operand, such
+// as a borrow of a call result, names no tracked binding and is dropped.
+func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
+	p, ok := exprPlace(arg)
+	if !ok || p.root <= 0 {
+		return 0, false
+	}
+	if c.fn.paramVarIDs.Contains(p.root) {
+		return 0, false
+	}
+	return p.root, true
+}
+
+// recordBorrowEdges records, for the binding destVarID, which function-local bindings it
+// borrows. Two initializer shapes contribute an edge:
+//
+//   - An explicit `&`/`&mut` of a local. `val a = {peer: &mut b}` records a → b, so a
+//     later `return a` can find that it carries a borrow of the local b. A borrow of a
+//     parameter records no edge, per isLocalReferent.
+//   - A whole-binding move of a carrier. `val a2 = a` moves a's value into a2, so a2
+//     inherits a's borrow edges and `return a2` escapes the same local a would.
+//
+// Both are tracked at whole-binding granularity. A borrow held in a field that is then
+// moved on its own, such as `val a2 = a.peer`, is not inherited, since the edge graph is
+// keyed by root binding rather than by field place. That field-level precision is left
+// to the field-granular tracking PR 11 builds on PR 7.
+func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
+	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
+		return
+	}
+	destRoot := liveness.VarID(destVarID)
+	for _, b := range borrowsIn(init) {
+		if referent, ok := c.isLocalReferent(b.Arg); ok && referent != destRoot {
+			c.addBorrowEdge(destRoot, referent)
+		}
+	}
+	// A whole-binding move `val a2 = a` carries a's borrows into a2. Inherit only from a
+	// whole-binding source, since a field move is not tracked at this granularity.
+	if src, ok := exprPlace(init); ok && len(src.path) == 0 && src.root != destRoot {
+		for _, referent := range c.fn.borrowEdges[src.root].ToSlice() {
+			c.addBorrowEdge(destRoot, referent)
+		}
+	}
+}
+
+// addBorrowEdge records that the binding destRoot borrows the function-local referent,
+// allocating the destination's edge set on first use.
+func (c *checker) addBorrowEdge(destRoot, referent liveness.VarID) {
+	edges := c.fn.borrowEdges[destRoot]
+	if edges == nil {
+		edges = set.NewSet[liveness.VarID]()
+		c.fn.borrowEdges[destRoot] = edges
+	}
+	edges.Add(referent)
+}
+
+// checkReturnEscape reports a ReturnEscapeError for each function-local binding a
+// returned value borrows. It combines two sources of escaping referents: a borrow
+// written directly in the returned expression, such as `return &mut b` or `return
+// {peer: &mut b}`, and the borrow edges recorded for a returned binding, such as the a →
+// b edge behind `return a`. The escaping locals are reported in VarID order so the
+// diagnostics are deterministic.
+//
+// The edge graph is keyed by root binding, so the edges are followed only when the
+// whole binding is returned, `return a`, not a single field, `return a.peer`. Following
+// a root edge for a field return would over-report: a disjoint field `return a.other`
+// shares a's root but carries none of its borrows. Field-granular return escape is left
+// to PR 11, which tracks borrows per field place.
+func (c *checker) checkReturnEscape(retExpr ast.Expr) {
+	if c.fn == nil || c.fn.borrowEdges == nil || retExpr == nil {
+		return
+	}
+	escaping := set.NewSet[liveness.VarID]()
+	for _, b := range borrowsIn(retExpr) {
+		if referent, ok := c.isLocalReferent(b.Arg); ok {
+			escaping.Add(referent)
+		}
+	}
+	if p, ok := exprPlace(retExpr); ok && p.root > 0 && len(p.path) == 0 {
+		c.collectBorrowedLocals(p.root, escaping)
+	}
+	ids := escaping.ToSlice()
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		c.report(&ReturnEscapeError{LocalName: c.varIDToName(id), node: retExpr})
+	}
+}
+
+// collectBorrowedLocals adds to out every function-local binding reachable from root
+// through borrow edges. A returned binding does not itself escape, since it moves out,
+// so root is only the starting point and is never added to out. Only the locals it
+// transitively borrows are collected. The seen set terminates the cyclic case, where
+// two locals borrow each other.
+func (c *checker) collectBorrowedLocals(root liveness.VarID, out set.Set[liveness.VarID]) {
+	seen := set.NewSet[liveness.VarID]()
+	var walk func(liveness.VarID)
+	walk = func(node liveness.VarID) {
+		if seen.Contains(node) {
+			return
+		}
+		seen.Add(node)
+		for _, referent := range c.fn.borrowEdges[node].ToSlice() {
+			out.Add(referent)
+			walk(referent)
+		}
+	}
+	walk(root)
+}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -32,9 +32,14 @@ import (
 // A borrow of a parameter is exempt. Its lifetime outlives the frame, so
 // `fn (p: &mut {x}) -> &mut {x} { return p }` checks.
 //
-// Edges and the checks are whole-binding granular. A borrow held in a field returned on
-// its own, such as `return a.peer`, is not tracked, since the graph is keyed by root
-// binding, not field place.
+// Edges and the checks are whole-binding granular. An edge is keyed by root binding, so it
+// records that `a` borrows `b` without recording which field holds the borrow. The check
+// follows edges only from a whole-binding return like `return a`, never a field return
+// like `return a.peer`. Skipping field returns avoids a false positive. Following a root
+// edge for the disjoint owned field in `return a.data` would wrongly flag `b`, which
+// `a.data` does not borrow. The cost is a false negative. `return a.peer` returns the
+// borrow field itself, and the check does not catch it. Resolving a field return to its
+// own edge needs the per-field tracking deferred to PR 11.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
 // function-local. It blames the outgoing expression and names the escaping local.

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -113,11 +113,14 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
 		return out
 	}
+	// Borrows of locals written directly in e, such as the `&mut b` in `{peer: &mut b}`.
 	for _, b := range borrowsIn(e) {
 		if referent, ok := c.isLocalReferent(b.Arg); ok {
 			out.Add(referent)
 		}
 	}
+	// When e names a whole binding, the locals that binding transitively borrows. A field
+	// place is skipped by the len(p.path) == 0 guard.
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
 		c.collectBorrowedLocals(p.root, out)
 	}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -9,62 +9,83 @@ import (
 	"github.com/escalier-lang/escalier/internal/set"
 )
 
-// Return-escape forcing (PR 15). A value flowing out of the function frame must not
-// carry a borrow of a function-local binding, since a local dies when the frame
-// returns and the borrow would dangle. The move engine consumes the returned source
-// but does not check the borrows the returned value carries, so returning a binding
-// that borrows a local escapes that local with no error. This pass reports it.
+// Escape forcing (PR 15). A value flowing out of the function frame must not carry a
+// borrow of a function-local binding, since a local dies when the frame returns and the
+// borrow would dangle. The move engine consumes the flowed-out source but does not check
+// the borrows it carries, so a value that borrows a local escapes with no error. This
+// pass reports it at the three non-global value-flow-out sites:
 //
-// The check works over the move engine's own state rather than the lifetime sort,
-// which is why it does not depend on the directional lifetime bounds slated for M6.5.
-// Two pieces drive it:
+//   - a `return`, where the value flows out to the caller;
+//   - a field store into a parameter, where it flows into the caller's object;
+//   - a consuming argument, where it flows into the callee.
 //
-//   - recordBorrowEdges records, as each binding is walked, which function-local
-//     bindings its initializer borrows through an explicit `&`/`&mut`. `val a = {peer:
-//     &mut b}` records the edge a → b.
-//   - checkReturnEscape, at each return, follows those edges from the returned binding
-//     and scans the returned expression for direct borrows, reporting an escape for any
-//     borrow of a non-parameter local it reaches.
+// The check works over the move engine's own state rather than the lifetime sort, which
+// is why it does not depend on the directional lifetime bounds slated for M6.5. A
+// per-binding borrow-edge graph drives it. As each binding is walked, recordBorrowEdges
+// records which function-locals it borrows: an explicit `&`/`&mut` of a local in its
+// initializer, and the edges of a whole-binding move that carries a borrow forward. At
+// each flow-out site, escapingLocalsOf follows those edges and scans for direct borrows
+// to find the locals the outgoing value carries. Extending the graph through a field
+// store into a local receiver is left to PR 11, which builds the connected-component
+// graph through field mutations.
 //
 // A borrow of a parameter is exempt. It carries a caller-supplied lifetime that already
-// outlives the return, so `fn (p: &mut {x}) -> &mut {x} { return p }` still checks.
-// recordBorrowEdges drops a parameter referent, so a local that only borrows a
-// parameter records no edge and a return through it raises no escape.
+// outlives the frame, so `fn (p: &mut {x}) -> &mut {x} { return p }` still checks.
+// recordBorrowEdges drops a parameter referent, so a local that only borrows a parameter
+// records no edge and a flow-out through it raises no escape.
+//
+// Edges and the flow-out checks are whole-binding granular. A borrow held in a field
+// that is moved or returned on its own, such as `return a.peer`, is not tracked, since
+// the edge graph is keyed by root binding rather than by field place. That field-level
+// precision is left to PR 11, which builds on PR 7's per-field tracking.
 
-// ReturnEscapeError fires when a returned value carries a borrow of a function-local
-// binding, which cannot outlive the frame. It blames the returned expression and names
-// the escaping local.
-type ReturnEscapeError struct {
+// EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
+// function-local binding, which cannot outlive the frame. It blames the outgoing
+// expression and names the escaping local.
+type EscapingBorrowError struct {
 	// LocalName is the borrowed local's source name, for the message.
 	LocalName string
-	// node is the returned expression, blamed for the escape.
+	// node is the outgoing expression — the returned value, stored value, or argument —
+	// blamed for the escape.
 	node ast.Node
 }
 
-func (*ReturnEscapeError) isSolverError()        {}
-func (e *ReturnEscapeError) Span() ast.Span      { return e.node.Span() }
-func (e *ReturnEscapeError) Related() []ast.Span { return nil }
-func (e *ReturnEscapeError) Message() string {
+func (*EscapingBorrowError) isSolverError()        {}
+func (e *EscapingBorrowError) Span() ast.Span      { return e.node.Span() }
+func (e *EscapingBorrowError) Related() []ast.Span { return nil }
+func (e *EscapingBorrowError) Message() string {
 	return fmt.Sprintf("borrowed value '%s' does not live long enough to escape the function", e.LocalName)
 }
 
-// borrowCollector gathers every BorrowExpr in an expression subtree. It rides the
+// borrowCollector gathers the BorrowExprs an expression carries by value. It rides the
 // shared AST visitor so it reaches a borrow nested in an object or tuple literal — the
-// `&mut b` inside `{peer: &mut b}` — without a hand-rolled walk.
+// `&mut b` inside `{peer: &mut b}` — without a hand-rolled walk. It stops at a call or
+// nested function boundary, since a borrow there is not part of the value the scanned
+// expression yields.
 type borrowCollector struct {
 	*ast.DefaultVisitor
 	out *[]*ast.BorrowExpr
 }
 
 func (v *borrowCollector) EnterExpr(e ast.Expr) bool {
-	if b, ok := e.(*ast.BorrowExpr); ok {
-		*v.out = append(*v.out, b)
+	switch e := e.(type) {
+	case *ast.BorrowExpr:
+		*v.out = append(*v.out, e)
+	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
+		// Do not descend into a call or a nested function. A borrow written as a call
+		// argument is consumed or borrowed by that call, not carried out by the value the
+		// call yields, so `store(read(&mut b))` does not carry b. A borrow inside a nested
+		// function body belongs to that function's scope, not this frame's, so resolving
+		// it against this frame's bindings would be wrong. A borrow the call result or
+		// closure genuinely captures is governed by the escaping-closure-capture work,
+		// which is deferred.
+		return false
 	}
 	return true
 }
 
-// borrowsIn returns every BorrowExpr reachable in e, including those nested in object
-// or tuple literals.
+// borrowsIn returns every BorrowExpr the expression e carries by value, descending
+// through object and tuple literals but stopping at call and nested-function boundaries.
 func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
 	var found []*ast.BorrowExpr
 	e.Accept(&borrowCollector{DefaultVisitor: &ast.DefaultVisitor{}, out: &found})
@@ -73,7 +94,7 @@ func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
 
 // isLocalReferent reports whether the borrow operand names a function-local binding's
 // place: a place whose root is a real binding that is not a parameter. A parameter
-// referent is exempt, since its lifetime outlives the return. A non-place operand, such
+// referent is exempt, since its lifetime outlives the frame. A non-place operand, such
 // as a borrow of a call result, names no tracked binding and is dropped.
 func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	p, ok := exprPlace(arg)
@@ -86,35 +107,35 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	return p.root, true
 }
 
-// recordBorrowEdges records, for the binding destVarID, which function-local bindings it
-// borrows. Two initializer shapes contribute an edge:
-//
-//   - An explicit `&`/`&mut` of a local. `val a = {peer: &mut b}` records a → b, so a
-//     later `return a` can find that it carries a borrow of the local b. A borrow of a
-//     parameter records no edge, per isLocalReferent.
-//   - A whole-binding move of a carrier. `val a2 = a` moves a's value into a2, so a2
-//     inherits a's borrow edges and `return a2` escapes the same local a would.
-//
-// Both are tracked at whole-binding granularity. A borrow held in a field that is then
-// moved on its own, such as `val a2 = a.peer`, is not inherited, since the edge graph is
-// keyed by root binding rather than by field place. That field-level precision is left
-// to the field-granular tracking PR 11 builds on PR 7.
-func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
-	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
-		return
+// escapingLocalsOf returns the function-local bindings whose data the expression e
+// carries by value. Two shapes contribute: a borrow of a local written directly in e,
+// such as the `&mut b` in `{peer: &mut b}`, and the borrow edges of a whole-binding
+// place e names, such as the a → b edge behind `a`. A field place is not followed, since
+// the edge graph is keyed by root binding. See the package doc.
+func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
+	out := set.NewSet[liveness.VarID]()
+	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
+		return out
 	}
-	destRoot := liveness.VarID(destVarID)
-	for _, b := range borrowsIn(init) {
-		if referent, ok := c.isLocalReferent(b.Arg); ok && referent != destRoot {
-			c.addBorrowEdge(destRoot, referent)
+	for _, b := range borrowsIn(e) {
+		if referent, ok := c.isLocalReferent(b.Arg); ok {
+			out.Add(referent)
 		}
 	}
-	// A whole-binding move `val a2 = a` carries a's borrows into a2. Inherit only from a
-	// whole-binding source, since a field move is not tracked at this granularity.
-	if src, ok := exprPlace(init); ok && len(src.path) == 0 && src.root != destRoot {
-		for _, referent := range c.fn.borrowEdges[src.root].ToSlice() {
-			c.addBorrowEdge(destRoot, referent)
-		}
+	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
+		c.collectBorrowedLocals(p.root, out)
+	}
+	return out
+}
+
+// reportEscapingLocals reports an EscapingBorrowError for each escaping local, blaming
+// the outgoing expression. The locals are reported in VarID order so the diagnostics are
+// deterministic across the unordered set iteration.
+func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame ast.Node) {
+	ids := escaping.ToSlice()
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		c.report(&EscapingBorrowError{LocalName: c.varIDToName(id), node: blame})
 	}
 }
 
@@ -129,40 +150,46 @@ func (c *checker) addBorrowEdge(destRoot, referent liveness.VarID) {
 	edges.Add(referent)
 }
 
-// checkReturnEscape reports a ReturnEscapeError for each function-local binding a
-// returned value borrows. It combines two sources of escaping referents: a borrow
-// written directly in the returned expression, such as `return &mut b` or `return
-// {peer: &mut b}`, and the borrow edges recorded for a returned binding, such as the a →
-// b edge behind `return a`. The escaping locals are reported in VarID order so the
-// diagnostics are deterministic.
-//
-// The edge graph is keyed by root binding, so the edges are followed only when the
-// whole binding is returned, `return a`, not a single field, `return a.peer`. Following
-// a root edge for a field return would over-report: a disjoint field `return a.other`
-// shares a's root but carries none of its borrows. Field-granular return escape is left
-// to PR 11, which tracks borrows per field place.
-func (c *checker) checkReturnEscape(retExpr ast.Expr) {
-	if c.fn == nil || c.fn.borrowEdges == nil || retExpr == nil {
+// recordBorrowEdges records, for the binding destVarID, which function-locals its
+// initializer borrows. `val a = {peer: &mut b}` records a → b, and a whole-binding move
+// `val a2 = a` carries a's edges into a2, so a later `return a` or `return a2` can find
+// it borrows the local b.
+func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
+	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
 		return
 	}
-	escaping := set.NewSet[liveness.VarID]()
-	for _, b := range borrowsIn(retExpr) {
-		if referent, ok := c.isLocalReferent(b.Arg); ok {
-			escaping.Add(referent)
+	destRoot := liveness.VarID(destVarID)
+	for _, referent := range c.escapingLocalsOf(init).ToSlice() {
+		if referent != destRoot {
+			c.addBorrowEdge(destRoot, referent)
 		}
-	}
-	if p, ok := exprPlace(retExpr); ok && p.root > 0 && len(p.path) == 0 {
-		c.collectBorrowedLocals(p.root, escaping)
-	}
-	ids := escaping.ToSlice()
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	for _, id := range ids {
-		c.report(&ReturnEscapeError{LocalName: c.varIDToName(id), node: retExpr})
 	}
 }
 
+// checkReturnEscape reports an escape for each function-local a returned value borrows.
+// It is the return flow-out site: `return a` for an a that borrows local b, `return &mut
+// b`, and `return {peer: &mut b}` all escape b.
+func (c *checker) checkReturnEscape(retExpr ast.Expr) {
+	c.reportEscapingLocals(c.escapingLocalsOf(retExpr), retExpr)
+}
+
+// checkStoreEscape handles a field store `recv.f = source`. Storing a value that borrows
+// a local into a parameter's field escapes. The parameter's object outlives the frame,
+// so the stored local would dangle in the caller. A store into a local receiver does not
+// escape here. Extending the borrow graph through such a store is left to PR 11.
+func (c *checker) checkStoreEscape(recv, source ast.Expr) {
+	if c.fn == nil || c.fn.borrowEdges == nil {
+		return
+	}
+	rp, ok := exprPlace(recv)
+	if !ok || rp.root <= 0 || !c.fn.paramVarIDs.Contains(rp.root) {
+		return
+	}
+	c.reportEscapingLocals(c.escapingLocalsOf(source), source)
+}
+
 // collectBorrowedLocals adds to out every function-local binding reachable from root
-// through borrow edges. A returned binding does not itself escape, since it moves out,
+// through borrow edges. The carrier binding does not itself escape, since it moves out,
 // so root is only the starting point and is never added to out. Only the locals it
 // transitively borrows are collected. The seen set terminates the cyclic case, where
 // two locals borrow each other.

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -103,9 +103,11 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	return p.root, true
 }
 
-// escapingLocalsOf returns the function-locals whose data e carries by value: a borrow of
-// a local written directly in e, and the borrow edges of a whole-binding place e names. A
-// field place is not followed, since the edge graph is keyed by root binding.
+// escapingLocalsOf returns the function-locals whose data e carries by value. A borrow of
+// a local written directly in e contributes its referent, such as the `&mut b` in
+// `{peer: &mut b}`. When e names a whole binding, the binding's borrow edges contribute the
+// locals they reach. A field place is not followed, since the edge graph is keyed by root
+// binding.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -119,8 +119,9 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 			out.Add(referent)
 		}
 	}
-	// When e names a whole binding, the locals that binding transitively borrows. A field
-	// place is skipped by the len(p.path) == 0 guard.
+	// When e names a whole binding, the locals that binding transitively borrows. For `a`
+	// bound by `val a = {peer: &mut b}`, this follows the a → b edge. A field place is
+	// skipped by the len(p.path) == 0 guard, so `a.peer` follows nothing.
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
 		c.collectBorrowedLocals(p.root, out)
 	}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -10,40 +10,29 @@ import (
 )
 
 // Escape forcing. A value flowing out of the function frame must not carry a borrow of a
-// function-local binding, since a local dies when the frame returns and the borrow would
-// dangle. The move engine consumes the flowed-out source but does not check the borrows
-// it carries, so a value that borrows a local would otherwise escape with no error. This
-// pass reports it at the three non-global value-flow-out sites:
+// function-local, since the local dies when the frame returns. This pass reports such an
+// escape at three sites: a `return`, a field store into a parameter, and a consuming
+// argument.
 //
-//   - a `return`, where the value flows out to the caller;
-//   - a field store into a parameter, where it flows into the caller's object;
-//   - a consuming argument, where it flows into the callee.
-//
-// The check works over the move engine's borrow tracking rather than the lifetime sort. A
-// per-binding borrow-edge graph drives it. As each binding is walked, recordBorrowEdges
-// records which function-locals it borrows: an explicit `&`/`&mut` of a local in its
-// initializer, and the edges of a whole-binding move that carries a borrow forward. At
-// each flow-out site, escapingLocalsOf follows those edges and scans for direct borrows
+// A per-binding borrow-edge graph drives it, over the move engine's borrow tracking
+// rather than the lifetime sort. recordBorrowEdges records which locals each binding
+// borrows. At each site, escapingLocalsOf follows those edges and scans for direct borrows
 // to find the locals the outgoing value carries.
 //
-// A borrow of a parameter is exempt. It carries a caller-supplied lifetime that already
-// outlives the frame, so `fn (p: &mut {x}) -> &mut {x} { return p }` still checks.
-// recordBorrowEdges drops a parameter referent, so a local that only borrows a parameter
-// records no edge and a flow-out through it raises no escape.
+// A borrow of a parameter is exempt. Its lifetime outlives the frame, so
+// `fn (p: &mut {x}) -> &mut {x} { return p }` checks.
 //
-// Edges and the flow-out checks are whole-binding granular. A borrow held in a field that
-// is moved or returned on its own, such as `return a.peer`, is not tracked, and neither
-// is a borrow stored into a local receiver's field. The edge graph is keyed by root
-// binding rather than by field place.
+// Edges and the checks are whole-binding granular. A borrow held in a field returned on
+// its own, such as `return a.peer`, is not tracked, since the graph is keyed by root
+// binding, not field place.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
-// function-local binding, which cannot outlive the frame. It blames the outgoing
-// expression and names the escaping local.
+// function-local. It blames the outgoing expression and names the escaping local.
 type EscapingBorrowError struct {
-	// LocalName is the borrowed local's source name, for the message.
+	// LocalName is the borrowed local's name, for the message.
 	LocalName string
-	// node is the outgoing expression — the returned value, stored value, or argument —
-	// blamed for the escape.
+	// node is the outgoing expression blamed for the escape: a return value, stored value,
+	// or argument.
 	node ast.Node
 }
 
@@ -54,11 +43,10 @@ func (e *EscapingBorrowError) Message() string {
 	return fmt.Sprintf("borrowed value '%s' does not live long enough to escape the function", e.LocalName)
 }
 
-// borrowCollector gathers the BorrowExprs an expression carries by value. It rides the
-// shared AST visitor so it reaches a borrow nested in an object or tuple literal — the
-// `&mut b` inside `{peer: &mut b}` — without a hand-rolled walk. It stops at a call or
-// nested function boundary, since a borrow there is not part of the value the scanned
-// expression yields.
+// borrowCollector gathers the BorrowExprs an expression carries by value, riding the
+// shared AST visitor so it reaches a borrow nested in an object or tuple literal. It stops
+// at a call or nested-function boundary, where a borrow is not part of the value the
+// scanned expression yields.
 type borrowCollector struct {
 	*ast.DefaultVisitor
 	out *[]*ast.BorrowExpr
@@ -69,30 +57,26 @@ func (v *borrowCollector) EnterExpr(e ast.Expr) bool {
 	case *ast.BorrowExpr:
 		*v.out = append(*v.out, e)
 	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
-		// Do not descend into a call or a nested function. A borrow written as a call
-		// argument is consumed or borrowed by that call, not carried out by the value the
-		// call yields, so `store(read(&mut b))` does not carry b. A borrow inside a nested
-		// function body belongs to that function's scope, not this frame's, so resolving
-		// it against this frame's bindings would be wrong. A borrow the call result or
-		// closure genuinely captures is governed by the escaping-closure-capture work,
-		// which is deferred.
+		// A borrow written as a call argument is consumed or borrowed by that call, not
+		// carried out by its result, so `store(read(&mut b))` does not carry b. A borrow
+		// inside a nested function belongs to that function's scope. A borrow a result or
+		// closure genuinely captures is governed by the deferred closure-capture work.
 		return false
 	}
 	return true
 }
 
-// borrowsIn returns every BorrowExpr the expression e carries by value, descending
-// through object and tuple literals but stopping at call and nested-function boundaries.
+// borrowsIn returns every BorrowExpr the expression e carries by value, descending through
+// object and tuple literals but stopping at call and nested-function boundaries.
 func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
 	var found []*ast.BorrowExpr
 	e.Accept(&borrowCollector{DefaultVisitor: &ast.DefaultVisitor{}, out: &found})
 	return found
 }
 
-// isLocalReferent reports whether the borrow operand names a function-local binding's
-// place: a place whose root is a real binding that is not a parameter. A parameter
-// referent is exempt, since its lifetime outlives the frame. A non-place operand, such
-// as a borrow of a call result, names no tracked binding and is dropped.
+// isLocalReferent reports whether the borrow operand names a function-local place, one
+// rooted at a real binding that is not a parameter. A parameter referent is exempt, and a
+// non-place operand names no tracked binding.
 func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	p, ok := exprPlace(arg)
 	if !ok || p.root <= 0 {
@@ -104,11 +88,9 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	return p.root, true
 }
 
-// escapingLocalsOf returns the function-local bindings whose data the expression e
-// carries by value. Two shapes contribute: a borrow of a local written directly in e,
-// such as the `&mut b` in `{peer: &mut b}`, and the borrow edges of a whole-binding
-// place e names, such as the a → b edge behind `a`. A field place is not followed, since
-// the edge graph is keyed by root binding. See the package doc.
+// escapingLocalsOf returns the function-locals whose data e carries by value: a borrow of
+// a local written directly in e, and the borrow edges of a whole-binding place e names. A
+// field place is not followed, since the edge graph is keyed by root binding.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
@@ -125,9 +107,8 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	return out
 }
 
-// reportEscapingLocals reports an EscapingBorrowError for each escaping local, blaming
-// the outgoing expression. The locals are reported in VarID order so the diagnostics are
-// deterministic across the unordered set iteration.
+// reportEscapingLocals reports an EscapingBorrowError for each escaping local, blaming the
+// outgoing expression. Locals are reported in VarID order for deterministic diagnostics.
 func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame ast.Node) {
 	ids := escaping.ToSlice()
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
@@ -147,10 +128,9 @@ func (c *checker) addBorrowEdge(destRoot, referent liveness.VarID) {
 	edges.Add(referent)
 }
 
-// recordBorrowEdges records, for the binding destVarID, which function-locals its
-// initializer borrows. `val a = {peer: &mut b}` records a → b, and a whole-binding move
-// `val a2 = a` carries a's edges into a2, so a later `return a` or `return a2` can find
-// it borrows the local b.
+// recordBorrowEdges records which function-locals the binding destVarID borrows. `val a =
+// {peer: &mut b}` records a → b, and a whole-binding move `val a2 = a` carries a's edges
+// into a2.
 func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
 		return
@@ -164,16 +144,14 @@ func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 }
 
 // checkReturnEscape reports an escape for each function-local a returned value borrows.
-// It is the return flow-out site: `return a` for an a that borrows local b, `return &mut
-// b`, and `return {peer: &mut b}` all escape b.
+// `return a` where a borrows b, `return &mut b`, and `return {peer: &mut b}` all escape b.
 func (c *checker) checkReturnEscape(retExpr ast.Expr) {
 	c.reportEscapingLocals(c.escapingLocalsOf(retExpr), retExpr)
 }
 
-// checkStoreEscape handles a field store `recv.f = source`. Storing a value that borrows
-// a local into a parameter's field escapes. The parameter's object outlives the frame,
-// so the stored local would dangle in the caller. A store into a local receiver does not
-// escape here, and the borrow graph is not extended through such a store.
+// checkStoreEscape handles a field store `recv.f = source`. Storing a value that borrows a
+// local into a parameter's field escapes, since the parameter's object outlives the frame.
+// A store into a local receiver does not escape and is not tracked.
 func (c *checker) checkStoreEscape(recv, source ast.Expr) {
 	if c.fn == nil || c.fn.borrowEdges == nil {
 		return
@@ -185,11 +163,9 @@ func (c *checker) checkStoreEscape(recv, source ast.Expr) {
 	c.reportEscapingLocals(c.escapingLocalsOf(source), source)
 }
 
-// collectBorrowedLocals adds to out every function-local binding reachable from root
-// through borrow edges. The carrier binding does not itself escape, since it moves out,
-// so root is only the starting point and is never added to out. Only the locals it
-// transitively borrows are collected. The seen set terminates the cyclic case, where
-// two locals borrow each other.
+// collectBorrowedLocals adds to out every function-local reachable from root through
+// borrow edges. root is the carrier binding, which moves out rather than escaping, so it
+// is the starting point but never added to out. The seen set terminates borrow cycles.
 func (c *checker) collectBorrowedLocals(root liveness.VarID, out set.Set[liveness.VarID]) {
 	seen := set.NewSet[liveness.VarID]()
 	var walk func(liveness.VarID)

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -2,7 +2,7 @@ package solver
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
@@ -132,7 +132,7 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 // outgoing expression. Locals are reported in VarID order for deterministic diagnostics.
 func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame ast.Node) {
 	ids := escaping.ToSlice()
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	slices.Sort(ids)
 	for _, id := range ids {
 		c.report(&EscapingBorrowError{LocalName: c.varIDToName(id), node: blame})
 	}
@@ -170,10 +170,10 @@ func (c *checker) checkReturnEscape(retExpr ast.Expr) {
 	c.reportEscapingLocals(c.escapingLocalsOf(retExpr), retExpr)
 }
 
-// checkStoreEscape handles a field store `recv.f = source`. Storing a value that borrows a
+// checkParamFieldStoreEscape handles a field store `recv.f = source`. Storing a value that borrows a
 // local into a parameter's field escapes, since the parameter's object outlives the frame.
 // A store into a local receiver does not escape and is not tracked.
-func (c *checker) checkStoreEscape(recv, source ast.Expr) {
+func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
 	if c.fn == nil || c.fn.borrowEdges == nil {
 		return
 	}

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -1,0 +1,130 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReturnEscape covers PR 15's return-escape rule: a value flowing out of the frame
+// may not borrow a function-local, since the local dies when the frame returns. A borrow
+// of a parameter is exempt, because its lifetime is supplied by the caller and already
+// outlives the return.
+func TestReturnEscape(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Returning a binding that borrows a local escapes the local it borrows. The
+		// binding a holds `&mut b`, so returning a would leave a's edge dangling at b,
+		// which dies with the frame.
+		"ReturnBindingBorrowingLocal": {
+			src: `
+				fn build() -> {peer: &mut {value: number}} {
+					val mut b = {value: 2}
+					val a = {peer: &mut b}
+					return a
+				}
+			`,
+			want: []string{"5:13-5:14: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// A borrow of a local written directly into the returned literal escapes the same
+		// way, with no intervening binding.
+		"ReturnInlineBorrowOfLocal": {
+			src: `
+				fn build() -> {peer: &mut {value: number}} {
+					val mut b = {value: 2}
+					return {peer: &mut b}
+				}
+			`,
+			want: []string{"4:13-4:27: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// Returning the borrow itself, `return &mut b`, escapes the local b.
+		"ReturnDirectBorrowOfLocal": {
+			src: `
+				fn build() -> &mut {value: number} {
+					val mut b = {value: 2}
+					return &mut b
+				}
+			`,
+			want: []string{"4:13-4:19: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// A binding that borrows two locals escapes both, reported in source order.
+		"ReturnBindingBorrowingTwoLocals": {
+			src: `
+				fn build() -> {p: &mut {x: number}, q: &mut {x: number}} {
+					val mut b = {x: 0}
+					val mut c = {x: 1}
+					val a = {p: &mut b, q: &mut c}
+					return a
+				}
+			`,
+			want: []string{
+				"6:13-6:14: borrowed value 'b' does not live long enough to escape the function",
+				"6:13-6:14: borrowed value 'c' does not live long enough to escape the function",
+			},
+		},
+		// A whole-binding move carries the borrow forward: `val a2 = a` moves a's value,
+		// borrow and all, into a2, so returning a2 escapes the same local a would.
+		"ReturnMovedCarrierEscapes": {
+			src: `
+				fn build() -> {peer: &mut {value: number}} {
+					val mut b = {value: 2}
+					val a = {peer: &mut b}
+					val a2 = a
+					return a2
+				}
+			`,
+			want: []string{"6:13-6:15: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// Returning a disjoint owned field of a binding that also has a borrow field does
+		// not escape: `a.data` carries none of a's borrow of b. The whole-binding edge is
+		// not followed for a field return, so no spurious escape is reported.
+		"ReturnDisjointFieldOk": {
+			src: `
+				fn build() -> {value: number} {
+					val mut b = {value: 2}
+					val a = {peer: &mut b, data: {value: 7}}
+					return a.data
+				}
+			`,
+			want: nil,
+		},
+		// Returning a parameter borrow is sound: the borrow carries the caller's lifetime,
+		// which outlives the call.
+		"ReturnParamBorrowOk": {
+			src: `
+				fn pass(p: &mut {x: number}) -> &mut {x: number} {
+					return p
+				}
+			`,
+			want: nil,
+		},
+		// Borrowing a parameter and returning the borrow is sound for the same reason.
+		"ReturnBorrowOfParamOk": {
+			src: `
+				fn pass(p: mut {x: number}) {
+					return &mut p
+				}
+			`,
+			want: nil,
+		},
+		// A local that only borrows a parameter is returnable: the edge to the parameter
+		// is never recorded, so returning the local raises no escape.
+		"LocalBorrowsParamThenReturnOk": {
+			src: `
+				fn pass(p: &mut {x: number}) -> {peer: &mut {x: number}} {
+					val a = {peer: p}
+					return a
+				}
+			`,
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -128,3 +128,110 @@ func TestReturnEscape(t *testing.T) {
 		})
 	}
 }
+
+// TestEscapeAtStoreAndArgSites covers PR 15's other two flow-out sites: a field store
+// into a parameter, where the value flows into the caller's object, and a consuming
+// argument, where it flows into the callee. A borrow of a local that flows out either
+// way escapes, while a parameter borrow and a plain owned value do not.
+func TestEscapeAtStoreAndArgSites(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Storing a borrow of a local into a parameter's field escapes: the parameter's
+		// object outlives the frame, so the stored local would dangle in the caller.
+		"StoreLocalBorrowIntoParamField": {
+			src: `
+				fn f(p: mut {peer: &mut {value: number}}) {
+					val mut b = {value: 0}
+					p.peer = &mut b
+				}
+			`,
+			want: []string{"4:15-4:21: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// Storing a parameter borrow into a parameter's field is sound: the stored borrow
+		// carries the caller's lifetime, which outlives the frame.
+		"StoreParamBorrowIntoParamFieldOk": {
+			src: `
+				fn f(p: mut {peer: &mut {value: number}}, q: &mut {value: number}) {
+					p.peer = q
+				}
+			`,
+			want: nil,
+		},
+		// Passing a value that borrows a local as a consuming argument escapes: the callee
+		// takes ownership of the value and could retain it past the frame.
+		"ConsumingArgCarriesLocalBorrow": {
+			src: `
+				fn store(x: {peer: &mut {value: number}}) {}
+				fn f() {
+					val mut b = {value: 0}
+					val a = {peer: &mut b}
+					store(a)
+				}
+			`,
+			want: []string{"6:12-6:13: borrowed value 'b' does not live long enough to escape the function"},
+		},
+		// Auto-borrowing a local into a `&mut` parameter is sound: the parameter borrows
+		// for the call rather than consuming, so the local outlives the borrow.
+		"BorrowArgToRefParamOk": {
+			src: `
+				fn read(x: &mut {value: number}) {}
+				fn f() {
+					val mut b = {value: 0}
+					read(&mut b)
+				}
+			`,
+			want: nil,
+		},
+		// A consuming argument that is a plain owned value carries no borrow, so it moves
+		// into the callee with no escape.
+		"ConsumingArgOwnedValueOk": {
+			src: `
+				fn store(x: {value: number}) {}
+				fn f() {
+					val a = {value: 0}
+					store(a)
+				}
+			`,
+			want: nil,
+		},
+		// A borrow passed to an inner call is consumed by that call, not carried out by
+		// the owned value the call yields. Wrapping the call in a consuming call does not
+		// escape the local, so the scan must stop at the inner call boundary.
+		"BorrowConsumedByInnerCallDoesNotEscape": {
+			src: `
+				fn read(x: &mut {value: number}) -> {value: number} {
+					return {value: 1}
+				}
+				fn store(y: {value: number}) {}
+				fn f() {
+					val mut b = {value: 0}
+					store(read(&mut b))
+				}
+			`,
+			want: nil,
+		},
+		// A single escape through a consuming call inside a return is reported once, at the
+		// argument where the local borrow flows into the callee, not a second time at the
+		// enclosing return.
+		"EscapeThroughConsumingCallReportedOnce": {
+			src: `
+				fn id(y: {peer: &mut {value: number}}) -> {peer: &mut {value: number}} {
+					return y
+				}
+				fn f() -> {peer: &mut {value: number}} {
+					val mut b = {value: 0}
+					return id({peer: &mut b})
+				}
+			`,
+			want: []string{"7:16-7:30: borrowed value 'b' does not live long enough to escape the function"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -297,3 +297,28 @@ func TestDestructuredBorrowLeafEscapes(t *testing.T) {
 		}, messagesWithSpan(errs))
 	*/
 }
+
+// TestVarReassignBorrowEscapes pins a known under-check: recordBorrowEdges runs only at a
+// binding's initializer, so a borrow introduced by reassigning a `var`, such as the `a =
+// &mut b` below, records no edge. Returning the var then escapes the local with no error.
+// Tracking it soundly needs flow-sensitive borrow edges that clear on reassignment, since
+// the graph is accumulate-only.
+//
+// DISABLED until flow-sensitive borrow tracking lands: when reassignment records edges,
+// `return a` below escapes the local `b` and this assertion holds. Re-enable by removing
+// the `/* */` wrapper around the body.
+func TestVarReassignBorrowEscapes(t *testing.T) {
+	/*
+		_, _, errs := inferSource(t, `
+			fn f(seed: &mut {value: number}) {
+				var a = seed
+				val mut b = {value: 0}
+				a = &mut b
+				return a
+			}
+		`)
+		require.Equal(t, []string{
+			"6:12-6:13: borrowed value 'b' does not live long enough to escape the function",
+		}, messagesWithSpan(errs))
+	*/
+}

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -9,11 +9,13 @@ import (
 // TestReturnEscape covers the return-escape rule: a value flowing out of the frame
 // may not borrow a function-local, since the local dies when the frame returns. A borrow
 // of a parameter is exempt, because its lifetime is supplied by the caller and already
-// outlives the return.
+// outlives the return. Each case also pins the function's inferred type, since the escape
+// is reported alongside ordinary inference rather than replacing it.
 func TestReturnEscape(t *testing.T) {
 	tests := map[string]struct {
-		src  string
-		want []string
+		src   string
+		want  []string
+		types map[string]string
 	}{
 		// Returning a binding that borrows a local escapes the local it borrows. The
 		// binding a holds `&mut b`, so returning a would leave a's edge dangling at b,
@@ -26,7 +28,8 @@ func TestReturnEscape(t *testing.T) {
 					return a
 				}
 			`,
-			want: []string{"5:13-5:14: borrowed value 'b' does not live long enough to escape the function"},
+			want:  []string{"5:13-5:14: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
 		},
 		// A borrow of a local written directly into the returned literal escapes the same
 		// way, with no intervening binding.
@@ -37,7 +40,8 @@ func TestReturnEscape(t *testing.T) {
 					return {peer: &mut b}
 				}
 			`,
-			want: []string{"4:13-4:27: borrowed value 'b' does not live long enough to escape the function"},
+			want:  []string{"4:13-4:27: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
 		},
 		// Returning the borrow itself, `return &mut b`, escapes the local b.
 		"ReturnDirectBorrowOfLocal": {
@@ -47,7 +51,8 @@ func TestReturnEscape(t *testing.T) {
 					return &mut b
 				}
 			`,
-			want: []string{"4:13-4:19: borrowed value 'b' does not live long enough to escape the function"},
+			want:  []string{"4:13-4:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> &mut {value: number}"},
 		},
 		// A binding that borrows two locals escapes both, reported in source order.
 		"ReturnBindingBorrowingTwoLocals": {
@@ -63,6 +68,7 @@ func TestReturnEscape(t *testing.T) {
 				"6:13-6:14: borrowed value 'b' does not live long enough to escape the function",
 				"6:13-6:14: borrowed value 'c' does not live long enough to escape the function",
 			},
+			types: map[string]string{"build": "fn () -> {p: &mut {x: number}, q: &mut {x: number}}"},
 		},
 		// A whole-binding move carries the borrow forward: `val a2 = a` moves a's value,
 		// borrow and all, into a2, so returning a2 escapes the same local a would.
@@ -75,7 +81,8 @@ func TestReturnEscape(t *testing.T) {
 					return a2
 				}
 			`,
-			want: []string{"6:13-6:15: borrowed value 'b' does not live long enough to escape the function"},
+			want:  []string{"6:13-6:15: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
 		},
 		// Returning a disjoint owned field of a binding that also has a borrow field does
 		// not escape: `a.data` carries none of a's borrow of b. The whole-binding edge is
@@ -88,7 +95,8 @@ func TestReturnEscape(t *testing.T) {
 					return a.data
 				}
 			`,
-			want: nil,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {value: number}"},
 		},
 		// Returning a parameter borrow is sound: the borrow carries the caller's lifetime,
 		// which outlives the call.
@@ -98,7 +106,8 @@ func TestReturnEscape(t *testing.T) {
 					return p
 				}
 			`,
-			want: nil,
+			want:  nil,
+			types: map[string]string{"pass": "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}"},
 		},
 		// Borrowing a parameter and returning the borrow is sound for the same reason.
 		"ReturnBorrowOfParamOk": {
@@ -107,7 +116,8 @@ func TestReturnEscape(t *testing.T) {
 					return &mut p
 				}
 			`,
-			want: nil,
+			want:  nil,
+			types: map[string]string{"pass": "fn (p: mut {x: number}) -> &mut {x: number}"},
 		},
 		// A local that only borrows a parameter is returnable: the edge to the parameter
 		// is never recorded, so returning the local raises no escape.
@@ -118,13 +128,15 @@ func TestReturnEscape(t *testing.T) {
 					return a
 				}
 			`,
-			want: nil,
+			want:  nil,
+			types: map[string]string{"pass": "fn <'a>(p: &'a mut {x: number}) -> {peer: &'a mut {x: number}}"},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, tc.src)
+			values, _, errs := inferSource(t, tc.src)
 			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
 		})
 	}
 }
@@ -132,11 +144,13 @@ func TestReturnEscape(t *testing.T) {
 // TestEscapeAtStoreAndArgSites covers the other two flow-out sites: a field store
 // into a parameter, where the value flows into the caller's object, and a consuming
 // argument, where it flows into the callee. A borrow of a local that flows out either
-// way escapes, while a parameter borrow and a plain owned value do not.
+// way escapes, while a parameter borrow and a plain owned value do not. Each case also
+// pins the inferred type of every function it declares.
 func TestEscapeAtStoreAndArgSites(t *testing.T) {
 	tests := map[string]struct {
-		src  string
-		want []string
+		src   string
+		want  []string
+		types map[string]string
 	}{
 		// Storing a borrow of a local into a parameter's field escapes: the parameter's
 		// object outlives the frame, so the stored local would dangle in the caller.
@@ -147,7 +161,8 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 					p.peer = &mut b
 				}
 			`,
-			want: []string{"4:15-4:21: borrowed value 'b' does not live long enough to escape the function"},
+			want:  []string{"4:15-4:21: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn (p: mut {peer: &mut {value: number}}) -> void"},
 		},
 		// Storing a parameter borrow into a parameter's field is sound: the stored borrow
 		// carries the caller's lifetime, which outlives the frame.
@@ -157,7 +172,8 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 					p.peer = q
 				}
 			`,
-			want: nil,
+			want:  nil,
+			types: map[string]string{"f": "fn (p: mut {peer: &mut {value: number}}, q: &mut {value: number}) -> void"},
 		},
 		// Passing a value that borrows a local as a consuming argument escapes: the callee
 		// takes ownership of the value and could retain it past the frame.
@@ -171,6 +187,10 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				}
 			`,
 			want: []string{"6:12-6:13: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &mut {value: number}}) -> void",
+				"f":     "fn () -> void",
+			},
 		},
 		// Auto-borrowing a local into a `&mut` parameter is sound: the parameter borrows
 		// for the call rather than consuming, so the local outlives the borrow.
@@ -183,6 +203,10 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				}
 			`,
 			want: nil,
+			types: map[string]string{
+				"read": "fn (x: &mut {value: number}) -> void",
+				"f":    "fn () -> void",
+			},
 		},
 		// A consuming argument that is a plain owned value carries no borrow, so it moves
 		// into the callee with no escape.
@@ -195,6 +219,10 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				}
 			`,
 			want: nil,
+			types: map[string]string{
+				"store": "fn (x: {value: number}) -> void",
+				"f":     "fn () -> void",
+			},
 		},
 		// A borrow passed to an inner call is consumed by that call, not carried out by
 		// the owned value the call yields. Wrapping the call in a consuming call does not
@@ -211,6 +239,11 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				}
 			`,
 			want: nil,
+			types: map[string]string{
+				"read":  "fn (x: &mut {value: number}) -> {value: number}",
+				"store": "fn (y: {value: number}) -> void",
+				"f":     "fn () -> void",
+			},
 		},
 		// A single escape through a consuming call inside a return is reported once, at the
 		// argument where the local borrow flows into the callee, not a second time at the
@@ -226,12 +259,17 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				}
 			`,
 			want: []string{"7:16-7:30: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"id": "fn <'a>(y: {peer: &'a mut {value: number}}) -> {peer: &'a mut {value: number}}",
+				"f":  "fn () -> {peer: &mut {value: number}}",
+			},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, _, errs := inferSource(t, tc.src)
+			values, _, errs := inferSource(t, tc.src)
 			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
 		})
 	}
 }

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestReturnEscape covers PR 15's return-escape rule: a value flowing out of the frame
+// TestReturnEscape covers the return-escape rule: a value flowing out of the frame
 // may not borrow a function-local, since the local dies when the frame returns. A borrow
 // of a parameter is exempt, because its lifetime is supplied by the caller and already
 // outlives the return.
@@ -129,7 +129,7 @@ func TestReturnEscape(t *testing.T) {
 	}
 }
 
-// TestEscapeAtStoreAndArgSites covers PR 15's other two flow-out sites: a field store
+// TestEscapeAtStoreAndArgSites covers the other two flow-out sites: a field store
 // into a parameter, where the value flows into the caller's object, and a consuming
 // argument, where it flows into the callee. A borrow of a local that flows out either
 // way escapes, while a parameter borrow and a plain owned value do not.
@@ -234,4 +234,28 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 			require.Equal(t, tc.want, messagesWithSpan(errs))
 		})
 	}
+}
+
+// TestDestructuredBorrowLeafEscapes pins a known under-check: a borrow projected into a
+// destructuring leaf records no borrow edge, so returning the leaf escapes the local
+// with no error. recordBorrowEdges runs only for a named `val`/`var` binding. Catching
+// the leaf case needs the per-leaf pattern correspondence the field-granular move work
+// introduces.
+//
+// DISABLED until field-granular move tracking lands: when a destructuring leaf tracks
+// its borrow, `return peer` below escapes the local `b` and this assertion holds.
+// Re-enable by removing the `/* */` wrapper around the body.
+func TestDestructuredBorrowLeafEscapes(t *testing.T) {
+	/*
+		_, _, errs := inferSource(t, `
+			fn f() -> &mut {value: number} {
+				val mut b = {value: 0}
+				val {peer} = {peer: &mut b}
+				return peer
+			}
+		`)
+		require.Equal(t, []string{
+			"5:12-5:16: borrowed value 'b' does not live long enough to escape the function",
+		}, messagesWithSpan(errs))
+	*/
 }

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -22,7 +22,7 @@ func TestReturnEscape(t *testing.T) {
 		// which dies with the frame.
 		"ReturnBindingBorrowingLocal": {
 			src: `
-				fn build() -> {peer: &mut {value: number}} {
+				fn build() {
 					val mut b = {value: 2}
 					val a = {peer: &mut b}
 					return a
@@ -35,7 +35,7 @@ func TestReturnEscape(t *testing.T) {
 		// way, with no intervening binding.
 		"ReturnInlineBorrowOfLocal": {
 			src: `
-				fn build() -> {peer: &mut {value: number}} {
+				fn build() {
 					val mut b = {value: 2}
 					return {peer: &mut b}
 				}
@@ -46,7 +46,7 @@ func TestReturnEscape(t *testing.T) {
 		// Returning the borrow itself, `return &mut b`, escapes the local b.
 		"ReturnDirectBorrowOfLocal": {
 			src: `
-				fn build() -> &mut {value: number} {
+				fn build() {
 					val mut b = {value: 2}
 					return &mut b
 				}
@@ -57,7 +57,7 @@ func TestReturnEscape(t *testing.T) {
 		// A binding that borrows two locals escapes both, reported in source order.
 		"ReturnBindingBorrowingTwoLocals": {
 			src: `
-				fn build() -> {p: &mut {x: number}, q: &mut {x: number}} {
+				fn build() {
 					val mut b = {x: 0}
 					val mut c = {x: 1}
 					val a = {p: &mut b, q: &mut c}
@@ -74,7 +74,7 @@ func TestReturnEscape(t *testing.T) {
 		// borrow and all, into a2, so returning a2 escapes the same local a would.
 		"ReturnMovedCarrierEscapes": {
 			src: `
-				fn build() -> {peer: &mut {value: number}} {
+				fn build() {
 					val mut b = {value: 2}
 					val a = {peer: &mut b}
 					val a2 = a
@@ -102,7 +102,7 @@ func TestReturnEscape(t *testing.T) {
 		// which outlives the call.
 		"ReturnParamBorrowOk": {
 			src: `
-				fn pass(p: &mut {x: number}) -> &mut {x: number} {
+				fn pass(p: &mut {x: number}) {
 					return p
 				}
 			`,
@@ -123,7 +123,7 @@ func TestReturnEscape(t *testing.T) {
 		// is never recorded, so returning the local raises no escape.
 		"LocalBorrowsParamThenReturnOk": {
 			src: `
-				fn pass(p: &mut {x: number}) -> {peer: &mut {x: number}} {
+				fn pass(p: &mut {x: number}) {
 					val a = {peer: p}
 					return a
 				}
@@ -250,10 +250,10 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 		// enclosing return.
 		"EscapeThroughConsumingCallReportedOnce": {
 			src: `
-				fn id(y: {peer: &mut {value: number}}) -> {peer: &mut {value: number}} {
+				fn id(y: {peer: &mut {value: number}}) {
 					return y
 				}
-				fn f() -> {peer: &mut {value: number}} {
+				fn f() {
 					val mut b = {value: 0}
 					return id({peer: &mut b})
 				}

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -769,10 +769,9 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.paramVarIDs = collectParamVarIDs(astParams)
 }
 
-// collectParamVarIDs returns the VarID of every parameter leaf binding. The
-// return-escape check (PR 15) consults it to tell a returnable borrow of a parameter
-// from an escaping borrow of a function-local: a parameter borrow carries a
-// caller-supplied lifetime that already outlives the return, so it is exempt.
+// collectParamVarIDs returns the VarID of every parameter leaf binding. The escape check
+// consults it to exempt a borrow of a parameter, which carries a caller-supplied lifetime
+// that already outlives the frame, from an escaping borrow of a function-local.
 func collectParamVarIDs(astParams []*ast.Param) set.Set[liveness.VarID] {
 	ids := set.NewSet[liveness.VarID]()
 	for _, param := range astParams {

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -765,6 +765,24 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
 	c.fn.placeIDs = map[string]liveness.VarID{}
 	c.fn.movePlaces = map[liveness.VarID]movePlace{}
+	c.fn.borrowEdges = map[liveness.VarID]set.Set[liveness.VarID]{}
+	c.fn.paramVarIDs = collectParamVarIDs(astParams)
+}
+
+// collectParamVarIDs returns the VarID of every parameter leaf binding. The
+// return-escape check (PR 15) consults it to tell a returnable borrow of a parameter
+// from an escaping borrow of a function-local: a parameter borrow carries a
+// caller-supplied lifetime that already outlives the return, so it is exempt.
+func collectParamVarIDs(astParams []*ast.Param) set.Set[liveness.VarID] {
+	ids := set.NewSet[liveness.VarID]()
+	for _, param := range astParams {
+		ast.ForEachLeafBinding(param.Pattern, func(_ string, varID int) {
+			if varID > 0 {
+				ids.Add(liveness.VarID(varID))
+			}
+		})
+	}
+	return ids
 }
 
 // seedParamLeafAliases walks each parameter pattern recursively and seeds the alias

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -695,6 +695,15 @@ stored value that borrows a function-local binding is silently accepted today. T
 makes that case the escape error it should be, which is the baseline PR 11 then relaxes
 for a self-contained component.
 
+Status: the return, parameter-field-store, and consuming-argument sites have landed in
+[internal/solver/return_escape.go](../../internal/solver/return_escape.go), built over a
+per-binding borrow-edge graph on `funcCtx` rather than the lifetime sort, so the check
+does not wait on M6.5. Deferred: element stores `xs[i] = …` need index-assignment support
+from M7; extending the borrow graph through a field store into a *local* receiver is left
+to PR 11, since storing a borrow into a borrow-typed field is itself rejected by the type
+system today; field-granular escape such as `return a.peer` waits on PR 11's per-field
+tracking; escaping-closure-capture escape stays deferred with PR 6's closure-capture work.
+
 This is the forcing half of PR 5's first bullet, deferred through PR 6 to here. PR 5
 landed the consumed lattice and the `borrowEscapedToStatic` detection-gap closure; PR 6
 landed the consume at every flow site. Only the `constrainEscape` forcing at the

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -471,13 +471,14 @@ PR 6 reads the state at each use, passing `NotMoved` and rejecting `Moved` and
 Tests: unit tests that the consumed lattice merges correctly across if/else, match,
 and loops; unit tests that `borrowEscapedToStatic` sees a borrow nested in a field or
 tuple element and one reachable only through a usage-inferred type variable. The tests
-that escape fires at returns, stores, arguments, and captures move to PR 15 with the
-`constrainEscape` forcing they exercise.
+that escape fires at returns, stores, and arguments move to PR 15, which forces escape
+over the move engine's borrow tracking at those sites. Escaping-closure-capture escape
+stays deferred.
 
 Acceptance: the consumed lattice reports correct per-path state, and the escape query
 sees every borrow in a recorded type, including nested and type-variable positions. The
-"escape forced at every value-flow-out site" criterion moves to PR 15 with the deferred
-`constrainEscape` generalization. No user-facing errors yet.
+"escape forced at the value-flow-out sites" criterion moves to PR 15, which covers
+returns, parameter-field stores, and consuming arguments. No user-facing errors yet.
 
 ### PR 6 — Consume and use-after-move at every flow site, conditional moves
 
@@ -711,36 +712,34 @@ non-global sites remained, since today only the module-level global write runs i
 ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
 `b.ModuleLevel` store).
 
-- Force escape at returns, field and element stores, and owned-parameter arguments, the
-  three non-global value-flow-out sites. A returned or stored value flows out at the
-  call's own region, not `'static`, so the forcing is **not** the `'static` pin
-  `consumeAtGlobalWrite` applies. The constraint is that each borrow the flowed-out
-  value carries must outlive the destination region: the caller's region for a return,
-  the receiver's region for a field or element store, the callee's region for a
-  consuming argument.
+- Force escape at the non-global value-flow-out sites: a `return`, a field store into a
+  parameter, and a consuming argument. A flowed-out value travels at the call's own
+  region, not `'static`, so the forcing is **not** the `'static` pin
+  `consumeAtGlobalWrite` applies. Each borrow the value carries must outlive its
+  destination: the caller's region for a return, the receiver's region for a field
+  store, the callee's region for a consuming argument.
 - Distinguish a function-local borrow from a parameter borrow. A borrow of a parameter
-  carries a caller-supplied lifetime that already outlives the call, so returning it is
-  sound — `fn (p: &'a {x}) -> &'a {x}` returns `p` at `'a`, not `'static`, and must keep
-  checking. A borrow of a function-local binding carries a body-region lifetime that
-  cannot outlive the frame, so flowing it out is a `BorrowEscapeError`. The lifetime
-  sort already separates the two: a param lifetime occurs in a negative position
-  (`isParam` in [internal/solver/lifetime_coalesce.go](../../internal/solver/lifetime_coalesce.go)),
-  and the level invariant places a body-minted lifetime deeper than the signature.
-- Generalize the existing `escapeVisitor`
-  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) so it reaches a
-  borrow in any structural position — object property, tuple element, union member —
-  rather than only the top-level `RefType`, mirroring the nested-escape closure PR 5
-  landed for `borrowEscapedToStatic`. The visitor already descends through the shared
-  soltype walk; the new caller points it at the return and store sites.
+  carries a caller-supplied lifetime that already outlives the call, so flowing it out is
+  sound — `fn (p: &'a {x}) -> &'a {x}` returns `p` at `'a` and keeps checking. A borrow
+  of a function-local cannot outlive the frame, so flowing it out is an
+  `EscapingBorrowError`. `collectParamVarIDs` records the parameter leaf VarIDs on
+  `funcCtx`, and `isLocalReferent` exempts a referent in that set.
+- Detect the carried borrows over the move engine's borrow tracking rather than the
+  lifetime sort, so the check does not wait on M6.5. A per-binding borrow-edge graph on
+  `funcCtx` records which function-locals each binding borrows, populated by
+  `recordBorrowEdges` at `val`/`var` bindings. At each flow-out site, `escapingLocalsOf`
+  scans the outgoing expression for direct `&`/`&mut` borrows with `borrowCollector` and
+  follows the edges of a whole-binding place with `collectBorrowedLocals`.
 - Files: the return site in
-  [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go) where each
-  `ReturnStmt` is collected and the source is consumed, the field and element store
-  sites and the consuming-argument site in
-  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
+  [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go); the field-store
+  and consuming-argument sites in
+  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go); the borrow-edge
+  graph, the detection, and `EscapingBorrowError` in
+  [internal/solver/return_escape.go](../../internal/solver/return_escape.go).
 
-Tests: returning a borrow of a function-local is a `BorrowEscapeError`; returning a
-parameter borrow `fn (p: &'a {x}) -> &'a {x}` still checks; storing a local borrow into
-a receiver field escapes; passing a local borrow as a consuming argument escapes; the
+Tests: returning a borrow of a function-local is an `EscapingBorrowError`; returning a
+parameter borrow `fn (p: &'a {x}) -> &'a {x}` still checks; storing a local borrow into a
+parameter's field escapes; passing a local borrow as a consuming argument escapes; the
 existing global-write escape tests are unchanged.
 
 Acceptance: a borrow flowing out through a return, a store, or a consuming argument is

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -146,10 +146,10 @@ stores, owned-parameter arguments, and escaping closure captures. The nested and
 type-variable escape gap is closed as part of this work, since a move that misses a
 nested escape is unsound. This is why the move engine is split across PR 5 and PR 6.
 PR 5 landed the consumed lattice and the `borrowEscapedToStatic` detection-gap
-closure (#786, #787). The `constrainEscape` forcing at the non-global flow sites was
-deferred from PR 5 to PR 6, where it rides alongside the consume over the same sites
-rather than running as a separate earlier pass; see "Deferred from PR 5" under PR 6.
-The consume and use-after-move behaviour is PR 6's own scope.
+closure (#786, #787). PR 6 landed the consume at every flow site. The `constrainEscape`
+forcing at the non-global flow sites was deferred past both, to PR 15, since the consume
+and the forcing target different destination regions and were cleaner as separate
+changes; see PR 15. The consume and use-after-move behaviour is PR 6's own scope.
 
 ### Narrowing comes from M6, not this plan
 
@@ -248,16 +248,17 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 2 | Solver lowering of `&`, soltype `&` rendering, snapshot migration | 1 | Medium | ✅ done (#770) |
 | 3 | Annotation-literal ownership, owned/borrow params, auto-borrow | 2 | Medium | ✅ done (#771) |
 | 4 | Member reads borrow the receiver | 3 | Medium | ✅ done (#773) |
-| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 6 |
-| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ✅ done; escaping-closure-capture moves and the return/argument `constrainEscape` forcing deferred |
+| 5 | Move engine substrate: generalize escape detection, build the consumed lattice | 4 | Large | ✅ done (#786, #787); constrainEscape generalization deferred to PR 15 |
+| 6 | Consume and use-after-move at every flow site, conditional moves | 5 | Large | ✅ done; escaping-closure-capture moves deferred; return/argument `constrainEscape` forcing moved to PR 15 |
 | 7 | Partial moves and field-level ownership | 6 | Medium | ✅ done (#791) |
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ✅ done |
-| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ⬜ not started |
+| 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ✅ done (#811) |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium | ⬜ not started |
-| 11 | Connected-component moves for graphs | 6, 7 | Large | ⬜ not started |
+| 11 | Connected-component moves for graphs | 6, 7, 15 | Large | ⬜ not started |
 | 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — | ❌ retired |
 | 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
+| 15 | Escape forcing at returns, stores, and consuming arguments (deferred from PR 6) | 6 | Large | 🚧 in progress |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -417,17 +418,16 @@ queried" above.
 
 Status: done. PR 5's scope is the consumed lattice and the `borrowEscapedToStatic`
 detection-gap closure, both of which landed. The `constrainEscape` generalization to
-the non-global flow sites, the forcing half of the first bullet below, was deferred to
-PR 6, where the same sites are revisited for the consume; see "Deferred from PR 5"
-under PR 6.
+the non-global flow sites, the forcing half of the first bullet below, was deferred past
+PR 6 to PR 15; see PR 15.
 
 - Generalize escape detection beyond the single module-level write site. Two halves:
-  - Run `constrainEscape` at returns, field and element stores, owned-parameter
-    arguments, and escaping closure captures. **Deferred to PR 6** — today only the
-    module-level global write forces escape
+  - Force a borrow flowing out at returns, field and element stores, owned-parameter
+    arguments, and escaping closure captures to outlive its destination. **Deferred to
+    PR 15** — today only the module-level global write forces escape
     ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
-    `b.ModuleLevel` store). This forcing is folded into PR 6's consume bullet so the
-    escape forcing and the consume land together over one pass of these sites.
+    `b.ModuleLevel` store), and that site forces `<: 'static`, while the non-global
+    sites force a borrow to outlive the caller, receiver, or callee region instead.
   - Close the top-level-only gap in `borrowEscapedToStatic` so a borrow nested in a
     field, or reached through a usage-inferred type variable, is seen. **Done** — the
     nested field/element case landed in #786, and the usage-inferred `TypeVarType`
@@ -471,12 +471,12 @@ PR 6 reads the state at each use, passing `NotMoved` and rejecting `Moved` and
 Tests: unit tests that the consumed lattice merges correctly across if/else, match,
 and loops; unit tests that `borrowEscapedToStatic` sees a borrow nested in a field or
 tuple element and one reachable only through a usage-inferred type variable. The tests
-that escape fires at returns, stores, arguments, and captures move to PR 6 with the
+that escape fires at returns, stores, arguments, and captures move to PR 15 with the
 `constrainEscape` forcing they exercise.
 
 Acceptance: the consumed lattice reports correct per-path state, and the escape query
 sees every borrow in a recorded type, including nested and type-variable positions. The
-"escape forced at every value-flow-out site" criterion moves to PR 6 with the deferred
+"escape forced at every value-flow-out site" criterion moves to PR 15 with the deferred
 `constrainEscape` generalization. No user-facing errors yet.
 
 ### PR 6 — Consume and use-after-move at every flow site, conditional moves
@@ -485,28 +485,24 @@ Goal: turn the PR 5 substrate into the affine rule. When an owned value escapes 
 source region, ownership moves, the source is consumed, and a later use is an error.
 
 Deferred from PR 5: the `constrainEscape` generalization to the non-global flow sites
-lands here, not in PR 5. PR 5 was scoped to the consumed lattice and the
+was slated to land here. PR 6 landed the consume at each flow site, but the escape
+forcing was deferred again, to PR 15, so PR 6 ships the consume and PR 15 ships the
+forcing over the same sites. PR 5 was scoped to the consumed lattice and the
 `borrowEscapedToStatic` detection-gap closure, both of which landed (#786 escape
-nesting, #787 the usage-inferred `TypeVarType` case). What did not land in PR 5 is the
-forcing half of its first bullet: today only the module-level global write runs
-`constrainEscape` ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)
-at the `b.ModuleLevel` store), so a borrow that flows out through a return, a field or
-element store, an owned-parameter argument, or an escaping closure capture is not yet
-forced `<: 'static`. That generalization is folded into the consume bullet below,
-because PR 6 already revisits exactly these sites to consume the source, so the escape
-forcing and the consume are wired in together rather than in two passes over the same
-sites. Files for the deferred forcing:
-[internal/solver/infer_expr.go](../../internal/solver/infer_expr.go),
-[internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go).
+nesting, #787 the usage-inferred `TypeVarType` case). The forcing half of PR 5's first
+bullet is that today only the module-level global write runs `constrainEscape`
+([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
+`b.ModuleLevel` store), so a borrow that flows out through a return, a field or element
+store, an owned-parameter argument, or an escaping closure capture is not yet forced to
+outlive its destination. PR 15 closes that, since the consume and the forcing turned out
+to need different region targets and were cleaner as separate changes than as one wiring.
 
 - Consume the source at each flow site: `val`/`var` binding, reassignment that drops
   the previous owner, `return`, field and element stores, owned-parameter arguments,
   and escaping closure captures. The global-write site stops dropping mutability and
   instead consumes, per "Move subsumes the escape-site logic." This is also where a
-  bare owned parameter finally consumes its argument, the behaviour PR 3 deferred. At
-  each of these same sites, run the `constrainEscape` forcing deferred from PR 5 so a
-  borrow flowing out is pinned `<: 'static` before the source is consumed, closing the
-  forcing gap left after PR 5.
+  bare owned parameter finally consumes its argument, the behaviour PR 3 deferred. The
+  matching `constrainEscape` forcing at these same sites lands in PR 15.
 - Conditional moves are path-sensitive through the consumed lattice: a value moved
   on one branch and untouched on another is consumed only on the moving paths, and a
   later use is an error only if some reaching path moved it.
@@ -546,10 +542,9 @@ capture by an escaping closure; an if/else where only one branch moves; a
 `val q: {x} = p_borrow` that was silently accepted under G3 is now rejected.
 
 Acceptance: every flow site moves or borrows correctly, including per-branch
-behaviour, and use-after-move names both sites. A borrow flowing out is forced
-`<: 'static` at every value-flow-out site, the `constrainEscape` generalization
-deferred from PR 5. A borrowed source flowing into a bare owned annotation is
-rejected, with the explicit `&` form preserved as the opt-in for an alias.
+behaviour, and use-after-move names both sites. Forcing a borrow flowing out to outlive
+its destination is PR 15, not this PR. A borrowed source flowing into a bare owned
+annotation is rejected, with the explicit `&` form preserved as the opt-in for an alias.
 
 ### PR 7 — Partial moves and field-level ownership
 
@@ -691,12 +686,71 @@ un-narrowed alias rejected by the pin.
 
 Acceptance: mutable narrowing works with the discriminant pinned for the arm.
 
+### PR 15 — Escape forcing at returns, stores, and consuming arguments
+
+Goal: force a borrow flowing out of the function frame to outlive its destination
+region, at the value-flow-out sites PR 6 left unforced. PR 6 consumes the source at
+these sites but never pins the borrows the flowed-out value carries, so a returned or
+stored value that borrows a function-local binding is silently accepted today. This PR
+makes that case the escape error it should be, which is the baseline PR 11 then relaxes
+for a self-contained component.
+
+This is the forcing half of PR 5's first bullet, deferred through PR 6 to here. PR 5
+landed the consumed lattice and the `borrowEscapedToStatic` detection-gap closure; PR 6
+landed the consume at every flow site. Only the `constrainEscape` forcing at the
+non-global sites remained, since today only the module-level global write runs it
+([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go) at the
+`b.ModuleLevel` store).
+
+- Force escape at returns, field and element stores, and owned-parameter arguments, the
+  three non-global value-flow-out sites. A returned or stored value flows out at the
+  call's own region, not `'static`, so the forcing is **not** the `'static` pin
+  `consumeAtGlobalWrite` applies. The constraint is that each borrow the flowed-out
+  value carries must outlive the destination region: the caller's region for a return,
+  the receiver's region for a field or element store, the callee's region for a
+  consuming argument.
+- Distinguish a function-local borrow from a parameter borrow. A borrow of a parameter
+  carries a caller-supplied lifetime that already outlives the call, so returning it is
+  sound — `fn (p: &'a {x}) -> &'a {x}` returns `p` at `'a`, not `'static`, and must keep
+  checking. A borrow of a function-local binding carries a body-region lifetime that
+  cannot outlive the frame, so flowing it out is a `BorrowEscapeError`. The lifetime
+  sort already separates the two: a param lifetime occurs in a negative position
+  (`isParam` in [internal/solver/lifetime_coalesce.go](../../internal/solver/lifetime_coalesce.go)),
+  and the level invariant places a body-minted lifetime deeper than the signature.
+- Generalize the existing `escapeVisitor`
+  ([internal/solver/infer_expr.go](../../internal/solver/infer_expr.go)) so it reaches a
+  borrow in any structural position — object property, tuple element, union member —
+  rather than only the top-level `RefType`, mirroring the nested-escape closure PR 5
+  landed for `borrowEscapedToStatic`. The visitor already descends through the shared
+  soltype walk; the new caller points it at the return and store sites.
+- Files: the return site in
+  [internal/solver/infer_stmt.go](../../internal/solver/infer_stmt.go) where each
+  `ReturnStmt` is collected and the source is consumed, the field and element store
+  sites and the consuming-argument site in
+  [internal/solver/infer_expr.go](../../internal/solver/infer_expr.go).
+
+Tests: returning a borrow of a function-local is a `BorrowEscapeError`; returning a
+parameter borrow `fn (p: &'a {x}) -> &'a {x}` still checks; storing a local borrow into
+a receiver field escapes; passing a local borrow as a consuming argument escapes; the
+existing global-write escape tests are unchanged.
+
+Acceptance: a borrow flowing out through a return, a store, or a consuming argument is
+forced to outlive its destination and errors when it borrows a function-local, while a
+parameter borrow flowing out at its own lifetime still checks. This is the
+"escape forced at every value-flow-out site" criterion PR 5 and PR 6 deferred.
+
 ### PR 11 — Connected-component moves for graphs
 
 Goal: move a self-contained cyclic or acyclic graph out of a function — returned or
 stored — when no node is referenced from outside the graph. See "Moving a graph" in
-the requirements. This logically extends the move engine (PRs 5–7); it's numbered
-later only because its dependencies are 6 and 7.
+the requirements. This logically extends the move engine (PRs 5–7) and the escape
+forcing (PR 15); it's numbered later only because its dependencies are 6, 7, and 15.
+
+PR 15 makes a returned or stored borrow of a function-local an escape error. PR 11
+relaxes exactly that error for a self-contained component: when the flowed-out value's
+borrow edges reach only local bindings that nothing outside the component references,
+the escape is re-anchored to the destination region instead of rejected, and every
+binding in the component is consumed.
 
 - Compute the connected component reachable from an escaping value through its
   borrow edges, over the move/borrow state the engine already tracks on `funcCtx`

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -775,6 +775,16 @@ binding in the component is consumed.
 - Soundness rests on the GC keeping co-moved nodes alive and on there being no
   external observer, so the phase rules are unchanged; this is the requirements'
   "Moving a graph" argument.
+- Extend the borrow-edge graph beyond what PR 15 records. PR 15 records an edge only at a
+  binding's initializer and keys it on the root binding, so three cases under-check: a
+  borrow introduced by reassigning a `var` such as `a = &mut b`, a borrow projected into a
+  destructuring leaf such as `val {peer} = {peer: &mut b}`, and a borrow held in one field
+  returned on its own such as `return a.peer`. Closing them needs flow-sensitive,
+  field-granular edges — set-and-clear per assignment joined at CFG merges, keyed by field
+  place rather than root binding — which the component analysis here builds on anyway. The
+  reassignment and destructuring cases are pinned by the disabled
+  `TestVarReassignBorrowEscapes` and `TestDestructuredBorrowLeafEscapes`; the field-return
+  miss is noted in [internal/solver/return_escape.go](../../internal/solver/return_escape.go).
 
 Tests: the cyclic `build()` returns `a` with both `a` and `b` consumed; an acyclic
 shared graph returned the same way; a graph where a node is also held by a retained


### PR DESCRIPTION
## Summary

Implements **PR 15** of the move/affine-semantics plan: force a borrow flowing out of the function frame to outlive its destination, at the three value-flow-out sites PR 6 left unforced. A value that carries a borrow of a function-local binding now reports an `EscapingBorrowError` when it flows out, since a local dies when the frame returns and the borrow would dangle.

This is the deferred forcing half of PR 5's first bullet, and it is the baseline PR 11 (connected-component moves) relaxes for a self-contained graph. It also adds PR 15 to the plan and wires PR 11 to depend on it.

## Why a new PR

While picking up PR 11, the return/store/argument escape forcing turned out to never have landed — it was deferred out of PR 6. The clean lifetime-sort route to rejecting a dangling local borrow depends on directional lifetime bounds (M6.5), which isn't landed. So the check is built over the move engine's own state instead: a per-binding **borrow-edge graph** on `funcCtx` records which function-locals a binding borrows, and at each flow-out site `escapingLocalsOf` follows those edges and scans for direct borrows. This sidesteps M6.5 and is the infrastructure PR 11 needs anyway.

## Sites covered

- **Return** — `return a` for an `a` that borrows local `b`, `return &mut b`, and `return {peer: &mut b}` all escape `b`. A parameter borrow `fn (p: &mut {x}) -> &mut {x} { return p }` stays legal.
- **Field store into a parameter** — `p.peer = &mut b` escapes, since the parameter's object outlives the frame. Storing a parameter borrow into the field is fine.
- **Consuming argument** — passing a value that borrows a local to a concrete-owned parameter escapes. A `&mut` auto-borrow param and a plain owned value do not.

The borrow scan stops at call and nested-function boundaries: a borrow handed to an inner call is consumed by that call rather than carried out by its result, and a borrow inside a nested function body belongs to that function's scope.

## Deferred (documented in code and the plan)

- Element stores `xs[i] = …` — need index-assignment support from M7.
- Extending the borrow graph through a field store into a *local* receiver — left to PR 11; storing a borrow into a borrow-typed field is itself type-rejected today.
- Field-granular escape such as `return a.peer` — waits on PR 11's per-field tracking.
- Escaping-closure-capture escape — stays deferred with PR 6's closure-capture work.

## Tests

Full `internal/solver` suite is green (`go test ./internal/solver/ -count=1`), with new table-driven coverage for all three sites, the parameter-borrow exemptions, the disjoint-field and moved-carrier cases, and regression tests for the over-report and double-report bugs caught in review. One existing test that asserted the under-checked dangling-borrow behavior (`return &mut <local>`) is updated in place to assert the new escape.

## Review

Reviewed at high effort. Two confirmed correctness bugs were fixed before this PR: a false positive on returning a disjoint field of a borrow-carrying binding, and a false negative when a whole-binding move (`val a2 = a`) carried the borrow forward. A second review of the store/argument extension found and fixed an over-report on `store(read(&mut b))` and a double-report through a consuming call inside a return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F89vid6gePW3xiLGjgUfSx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter borrow checks for returns, stored values, and consuming arguments.
  * Improved diagnostics to point to the exact local value that escapes its valid lifetime.
* **Bug Fixes**
  * Returning a borrow of a function-local value is now rejected.
  * Storing a borrowed local into an outliving field is now detected.
  * Passing borrowed locals to consuming calls now reports escape issues reliably.
* **Tests**
  * Expanded coverage for return-escape and other flow-out cases, including allowed parameter-based borrows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->