### PR TITLE
Field-granular borrow-edge tracking for escape checking

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -164,18 +164,21 @@ type funcCtx struct {
 	// once the whole body, loop back edges included, has been walked, so a use that
 	// some reaching path moved is caught even when the move is textually later.
 	useSites []moveUse
-	// borrowEdges records, per binding root VarID, the function-local binding roots
-	// whose data it borrows through an explicit `&`/`&mut` in its initializer. The
-	// initializer `val a = {peer: &mut b}` records the edge a → b. The escape check
-	// follows these edges from a binding flowing out of the frame to find a borrow of a
-	// local that cannot outlive it. A parameter root is never recorded, since a borrow
-	// of a parameter carries a caller lifetime that already outlives the frame.
+	// borrowEdges records, per binding root VarID, the function-locals it borrows through
+	// an explicit `&`/`&mut`, each tagged with the field path holding the borrow. The
+	// initializer `val a = {peer: &mut b}` records the edge a → b at path [peer]. The
+	// escape check follows these edges from a value flowing out of the frame to find a
+	// borrow of a local that cannot outlive it, discriminating a field return `return
+	// a.peer` from the disjoint `return a.data`. A parameter root is never recorded, since
+	// a borrow of a parameter carries a caller lifetime that already outlives the frame.
 	//
-	// Only initializer borrows are recorded. A borrow introduced by reassigning a `var`,
-	// such as `a = &mut b`, is not tracked, so a later flow-out of that var under-checks.
-	// The graph is accumulate-only, so tracking reassignments soundly needs flow-sensitive
-	// edges that clear on reassignment, deferred to PR 11.
-	borrowEdges map[liveness.VarID]set.Set[liveness.VarID]
+	// Edges are recorded at a `val`/`var` initializer, a `var` reassignment, and a
+	// destructuring leaf. The graph is accumulate-only, so a reassignment adds edges
+	// without clearing the binding's earlier ones — the conservative direction that
+	// over-reports a replaced borrow but never misses a real escape. Clearing on
+	// reassignment soundly needs CFG-merge-joined edges, which the connected-component
+	// move builds.
+	borrowEdges map[liveness.VarID][]fieldBorrow
 	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
 	// parameter outlives the frame, so the escape check skips a referent in this set.
 	paramVarIDs set.Set[liveness.VarID]

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -647,10 +647,61 @@ func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 	}
 	c.bindPattern(scope, lvl, d.Pattern, initType, nil)
 	c.trackDestructureLeaves(scope, d.Pattern)
-	// A borrow projected into a destructuring leaf records no borrow edge, so a return
-	// of such a leaf is not yet caught as an escape. Tracking it precisely needs the
-	// per-leaf correspondence the field-granular move work introduces; a whole-binding
-	// approximation would over-report a disjoint leaf.
+	// Record each leaf's borrow edges from the initializer sub-expression it binds, so a
+	// return of a leaf that projects a borrow of a local is caught. `val {peer} = {peer:
+	// &mut b}` records peer → b. The correspondence is structural, so it tracks a leaf
+	// only when the initializer's shape mirrors the pattern's.
+	if c.fn != nil && c.fn.borrowEdges != nil && d.Init != nil {
+		c.recordDestructureBorrowEdges(d.Pattern, d.Init)
+	}
+}
+
+// recordDestructureBorrowEdges records the borrow edges of each destructuring leaf by
+// matching the pattern against the initializer expression structurally. An identifier leaf
+// records edges from the sub-expression bound to it. An object pattern matches each element
+// to the initializer property of the same name, and a tuple pattern matches by position. A
+// leaf whose initializer sub-expression is not statically present, such as a property
+// supplied by a spread, records nothing.
+func (c *checker) recordDestructureBorrowEdges(pat ast.Pat, init ast.Expr) {
+	switch pat := pat.(type) {
+	case *ast.IdentPat:
+		c.recordBorrowEdges(pat.VarID, init)
+	case *ast.ObjectPat:
+		obj, ok := init.(*ast.ObjectExpr)
+		if !ok {
+			return
+		}
+		props := map[string]ast.Expr{}
+		for _, elem := range obj.Elems {
+			if p, ok := elem.(*ast.PropertyExpr); ok && p.Value != nil {
+				if name, ok := objKeyName(p.Name); ok {
+					props[name] = p.Value
+				}
+			}
+		}
+		for _, elem := range pat.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjShorthandPat:
+				if v, ok := props[e.Key.Name]; ok {
+					c.recordBorrowEdges(e.VarID, v)
+				}
+			case *ast.ObjKeyValuePat:
+				if v, ok := props[e.Key.Name]; ok {
+					c.recordDestructureBorrowEdges(e.Value, v)
+				}
+			}
+		}
+	case *ast.TuplePat:
+		tup, ok := init.(*ast.TupleExpr)
+		if !ok {
+			return
+		}
+		for i, elem := range pat.Elems {
+			if i < len(tup.Elems) {
+				c.recordDestructureBorrowEdges(elem, tup.Elems[i])
+			}
+		}
+	}
 }
 
 // varName returns the bound name of a VarDecl whose pattern is an IdentPat, with

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -657,12 +657,18 @@ func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 }
 
 // recordDestructureBorrowEdges records the borrow edges of each destructuring leaf by
-// matching the pattern against the initializer expression structurally. An identifier leaf
-// records edges from the sub-expression bound to it. An object pattern matches each element
-// to the initializer property of the same name, and a tuple pattern matches by position. A
-// leaf whose initializer sub-expression is not statically present, such as a property
-// supplied by a spread, records nothing.
+// matching the pattern against the initializer structurally. When the initializer is a
+// place, recordPatternPlaceEdges projects the pattern over it, so `val {peer} = a` carries
+// a's edges into peer. Otherwise an identifier leaf records edges from the sub-expression
+// bound to it, an object pattern matches each element to the initializer property of the
+// same name, and a tuple pattern matches by position. A leaf whose initializer
+// sub-expression is not statically present, such as a property supplied by a spread,
+// records nothing.
 func (c *checker) recordDestructureBorrowEdges(pat ast.Pat, init ast.Expr) {
+	if p, ok := exprPlace(init); ok && p.root > 0 {
+		c.recordPatternPlaceEdges(pat, p)
+		return
+	}
 	switch pat := pat.(type) {
 	case *ast.IdentPat:
 		c.recordBorrowEdges(pat.VarID, init)
@@ -684,6 +690,10 @@ func (c *checker) recordDestructureBorrowEdges(pat ast.Pat, init ast.Expr) {
 			case *ast.ObjShorthandPat:
 				if v, ok := props[e.Key.Name]; ok {
 					c.recordBorrowEdges(e.VarID, v)
+				} else if e.Default != nil {
+					// The property is absent from the initializer, so the leaf takes the
+					// shorthand default, such as `val {peer = &mut b} = obj`.
+					c.recordBorrowEdges(e.VarID, e.Default)
 				}
 			case *ast.ObjKeyValuePat:
 				if v, ok := props[e.Key.Name]; ok {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1357,6 +1357,13 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 				c.consumeOwned(e.Right, c.info.TypeOf(e.Right), e.Right, ref)
 			}
 		}
+		// Record any borrow of a local the reassigned value introduces, so a later
+		// flow-out of the target finds it. `a = &mut b` records a → b. The edge graph
+		// accumulates, so this adds to the target's earlier edges rather than replacing
+		// them.
+		if !b.ModuleLevel {
+			c.recordBorrowEdges(target.VarID, e.Right)
+		}
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
 	// reading the target (inferIdent), so `val b = (a = 6)` ⇒ `b: number`. Use

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -35,9 +35,10 @@ import (
 // An edge carries the field path within the binding that holds the borrow. `val a = {peer:
 // &mut b}` records the edge a → b at path [peer], so a return discriminates by field. A
 // whole-binding return `return a` follows every edge under a, since the returned value
-// exposes all its fields. A field return `return a.peer` follows only the edges at [peer]
-// or beneath it, so it catches the escaping borrow of b. The disjoint field return `return
-// a.data` follows the edges at [data], finds none, and is sound with no false positive.
+// exposes all its fields. A field return `return a.peer` follows the edges on the [peer]
+// path — at [peer], beneath it, or above it where `val a = &mut b` borrows all of b — so it
+// catches the escaping borrow of b. The disjoint field return `return a.data` follows the
+// edges on the [data] path, finds none, and is sound with no false positive.
 //
 // Edges are recorded at three sites: a `val`/`var` initializer, a `var` reassignment, and a
 // destructuring leaf. The graph is accumulate-only and not flow-sensitive, so a
@@ -72,6 +73,39 @@ type fieldBorrow struct {
 	referent liveness.VarID
 }
 
+// borrowCollector gathers the BorrowExprs an expression carries by value, riding the
+// shared AST visitor so it reaches a borrow nested in an object or tuple literal, a spread,
+// or a control-flow carrier such as an if/else branch. It stops at a call or
+// nested-function boundary, where a borrow is not part of the value the scanned expression
+// yields.
+type borrowCollector struct {
+	*ast.DefaultVisitor
+	out *[]*ast.BorrowExpr
+}
+
+func (v *borrowCollector) EnterExpr(e ast.Expr) bool {
+	switch e := e.(type) {
+	case *ast.BorrowExpr:
+		*v.out = append(*v.out, e)
+	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
+		// A borrow written as a call argument is consumed or borrowed by that call, not
+		// carried out by its result, so `store(read(&mut b))` does not carry b. A borrow
+		// inside a nested function belongs to that function's scope. A borrow a result or
+		// closure genuinely captures is governed by the deferred closure-capture work.
+		return false
+	}
+	return true
+}
+
+// borrowsIn returns every BorrowExpr the expression e carries by value, descending through
+// object and tuple literals, spreads, and control-flow carriers but stopping at call and
+// nested-function boundaries.
+func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
+	var found []*ast.BorrowExpr
+	e.Accept(&borrowCollector{DefaultVisitor: &ast.DefaultVisitor{}, out: &found})
+	return found
+}
+
 // isLocalReferent reports whether the borrow operand names a function-local place, one
 // rooted at a real binding that is not a parameter. A parameter referent is exempt, and a
 // non-place operand names no tracked binding.
@@ -86,58 +120,35 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 	return p.root, true
 }
 
-// escapingLocalsOf returns the function-locals whose data e carries by value. A borrow of
-// a local written directly in e contributes its referent, such as the `&mut b` in
-// `{peer: &mut b}`. When e names a place — a whole binding `a` or a field `a.peer` — the
-// edges under that place contribute the locals they transitively reach. The walk descends
-// object and tuple literals but stops at call and nested-function boundaries, where a
-// borrow is not part of the value e yields.
+// escapingLocalsOf returns the function-locals whose data e carries by value. Two sources
+// contribute. First, a borrow of a local written anywhere in e, such as the `&mut b` in
+// `{peer: &mut b}` or in an if/else branch, contributes its referent. borrowsIn finds these,
+// descending carriers and stopping at call and nested-function boundaries. Second, when e
+// names a place — a whole binding `a` or a field `a.peer` — the edges under that place
+// contribute the locals they transitively reach, filtered to the place's field path so a
+// field return follows only that field's edges.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
 		return out
 	}
-	c.collectEscaping(e, out)
+	for _, b := range borrowsIn(e) {
+		if referent, ok := c.isLocalReferent(b.Arg); ok {
+			out.Add(referent)
+		}
+	}
+	if p, ok := exprPlace(e); ok && p.root > 0 {
+		c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID]())
+	}
 	return out
 }
 
-// collectEscaping adds to out every function-local the expression e carries by value. A
-// direct `&mut b` of a local contributes b. An object or tuple literal contributes the
-// locals its elements carry. A place expression contributes the locals its edges reach,
-// filtered to the place's field path. The walk stops at a call or nested-function
-// boundary, where a borrow is consumed by the callee or belongs to the inner scope rather
-// than flowing out through e.
-func (c *checker) collectEscaping(e ast.Expr, out set.Set[liveness.VarID]) {
-	switch e := e.(type) {
-	case *ast.BorrowExpr:
-		if referent, ok := c.isLocalReferent(e.Arg); ok {
-			out.Add(referent)
-		}
-	case *ast.ObjectExpr:
-		for _, elem := range e.Elems {
-			if prop, ok := elem.(*ast.PropertyExpr); ok && prop.Value != nil {
-				c.collectEscaping(prop.Value, out)
-			}
-		}
-	case *ast.TupleExpr:
-		for _, el := range e.Elems {
-			c.collectEscaping(el, out)
-		}
-	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
-		return
-	default:
-		if p, ok := exprPlace(e); ok && p.root > 0 {
-			c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID]())
-		}
-	}
-}
-
 // addBorrowEdge records that the binding root borrows the function-local referent at the
-// given field path, allocating the root's edge list on first use. A duplicate edge — the
-// same path and referent — is dropped, so repeated walks do not accumulate copies.
+// given field path, allocating the root's edge list on first use. A duplicate edge with
+// the same path and referent is dropped, so repeated walks do not accumulate copies.
 func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
 	for _, e := range c.fn.borrowEdges[root] {
-		if e.referent == referent && equalPath(e.path, path) {
+		if e.referent == referent && slices.Equal(e.path, path) {
 			return
 		}
 	}
@@ -155,11 +166,12 @@ func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 }
 
 // walkBorrowSources records the borrow edges the expression e contributes to the binding
-// root at base, the field path reached so far. A direct `&mut b` of a local records an
-// edge at base. An object literal property descends with base extended by the property
-// name, and a tuple element descends at base unchanged, since a tuple index has no field
-// segment. A place expression copies that place's edges, re-rooted under root at base. The
-// walk stops at a call or nested-function boundary.
+// root, at base, the field path reached so far. A direct `&mut b` of a local records an
+// edge at base. An object property descends with base extended by the property name, while
+// a tuple element and a spread descend at base unchanged, since neither refines the field
+// path. A place expression copies that place's edges, re-rooted under root at base. Any
+// other carrier, such as an if/else branch, contributes its inline borrows at base through
+// borrowsIn. The walk stops at a call or nested-function boundary.
 func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.Expr) {
 	switch e := e.(type) {
 	case *ast.BorrowExpr:
@@ -168,36 +180,53 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 		}
 	case *ast.ObjectExpr:
 		for _, elem := range e.Elems {
-			prop, ok := elem.(*ast.PropertyExpr)
-			if !ok || prop.Value == nil {
-				continue
-			}
-			if name, ok := objKeyName(prop.Name); ok {
-				c.walkBorrowSources(root, appendSeg(base, name), prop.Value)
+			switch el := elem.(type) {
+			case *ast.PropertyExpr:
+				if el.Value == nil {
+					continue
+				}
+				if name, ok := objKeyName(el.Name); ok {
+					c.walkBorrowSources(root, appendSeg(base, name), el.Value)
+				} else {
+					c.walkBorrowSources(root, base, el.Value)
+				}
+			case *ast.ObjSpreadExpr:
+				c.walkBorrowSources(root, base, el.Value)
 			}
 		}
 	case *ast.TupleExpr:
 		for _, el := range e.Elems {
 			c.walkBorrowSources(root, base, el)
 		}
+	case *ast.ArraySpreadExpr:
+		c.walkBorrowSources(root, base, e.Value)
 	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
 		return
 	default:
-		// A place names another binding whose value e copies. Each of that binding's
-		// edges whose path lies at or beneath the read place transfers to root, re-rooted
-		// at base plus the part of the edge path below the read place.
-		p, ok := exprPlace(e)
-		if !ok || p.root <= 0 {
+		// A place names another binding whose value e copies. Each of that binding's edges
+		// on the read place's field path transfers to root, re-rooted at base plus the part
+		// of the edge path below the read place. An edge is on the path when it sits at the
+		// read place, beneath it, or above it. An edge above the read place reaches the
+		// whole binding, so the read projects entirely within it and the suffix is empty.
+		if p, ok := exprPlace(e); ok && p.root > 0 {
+			for _, edge := range c.fn.borrowEdges[p.root] {
+				if !pathPrefixRelated(edge.path, p.path) || edge.referent == root {
+					continue
+				}
+				var suffix []placeSeg
+				if len(edge.path) > len(p.path) {
+					suffix = edge.path[len(p.path):]
+				}
+				c.addBorrowEdge(root, appendPath(base, suffix), edge.referent)
+			}
 			return
 		}
-		for _, edge := range c.fn.borrowEdges[p.root] {
-			if !pathHasPrefix(edge.path, p.path) {
-				continue
+		// Any other carrier expression contributes its inline borrows of locals at base,
+		// descending through it but stopping at call and nested-function boundaries.
+		for _, b := range borrowsIn(e) {
+			if referent, ok := c.isLocalReferent(b.Arg); ok && referent != root {
+				c.addBorrowEdge(root, base, referent)
 			}
-			if edge.referent == root {
-				continue
-			}
-			c.addBorrowEdge(root, appendPath(base, edge.path[len(p.path):]), edge.referent)
 		}
 	}
 }
@@ -232,52 +261,37 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
 	c.reportEscapingLocals(c.escapingLocalsOf(source), source)
 }
 
-// collectBorrowedFrom adds to out every function-local reachable from the place rooted at
-// root through borrow edges. filter restricts the first hop to edges at or beneath the
-// read place's field path, so a field read `a.peer` follows only the edges under [peer].
-// Each borrowed local is then followed in full — a borrow exposes the whole referent — so
-// deeper hops pass a nil filter. root is the carrier binding, the starting point, and is
-// never added to out. The seen set terminates borrow cycles.
+// collectBorrowedFrom adds to out every function-local the read place rooted at root, with
+// field path filter, exposes through borrow edges. The first hop keeps only edges on the
+// filter path: an edge at [peer], beneath it at [peer, …], or above it at [] where a wholly
+// borrows b. So a field read `a.peer` follows a → b on any of those but not a disjoint a → c
+// at [data]. Each local the first hop reaches is then followed in full through
+// collectAllFrom, since a borrow exposes the whole referent. root is the carrier binding,
+// the starting point for the first hop. It is added to out only when a borrow cycle reaches
+// back to it, which is sound: a local that borrows root, and itself escapes, carries root's
+// data out too.
 func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, out, seen set.Set[liveness.VarID]) {
-	if seen.Contains(root) {
-		return
-	}
-	seen.Add(root)
 	for _, edge := range c.fn.borrowEdges[root] {
-		if filter != nil && !pathHasPrefix(edge.path, filter) {
+		if !pathPrefixRelated(edge.path, filter) {
 			continue
 		}
 		out.Add(edge.referent)
-		c.collectBorrowedFrom(edge.referent, nil, out, seen)
+		c.collectAllFrom(edge.referent, out, seen)
 	}
 }
 
-// pathHasPrefix reports whether prefix is a prefix of path: every segment of prefix equals
-// the segment at the same position in path. An empty prefix matches every path, so a
-// whole-binding read follows every edge under the binding.
-func pathHasPrefix(path, prefix []placeSeg) bool {
-	if len(prefix) > len(path) {
-		return false
+// collectAllFrom adds to out every function-local reachable from node through borrow edges,
+// following every edge regardless of field path, since reaching a binding through a borrow
+// exposes all of it. The seen set terminates borrow cycles.
+func (c *checker) collectAllFrom(node liveness.VarID, out, seen set.Set[liveness.VarID]) {
+	if seen.Contains(node) {
+		return
 	}
-	for i := range prefix {
-		if path[i] != prefix[i] {
-			return false
-		}
+	seen.Add(node)
+	for _, edge := range c.fn.borrowEdges[node] {
+		out.Add(edge.referent)
+		c.collectAllFrom(edge.referent, out, seen)
 	}
-	return true
-}
-
-// equalPath reports whether two field paths are identical, segment for segment.
-func equalPath(a, b []placeSeg) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // appendSeg returns base with one more named field segment appended, copying the path so

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -24,22 +24,27 @@ import (
 // carrier and stays rejected even then, since the move re-anchors a graph's internal edges,
 // not a borrow that is itself the returned value.
 //
-// A per-binding borrow-edge graph drives the check, over the move engine's borrow tracking
-// rather than the lifetime sort. recordBorrowEdges records which locals each binding
-// borrows. At each site, escapingLocalsOf follows those edges and scans for direct borrows
-// to find the locals the outgoing value carries.
+// A field-granular borrow-edge graph drives the check, over the move engine's borrow
+// tracking rather than the lifetime sort. recordBorrowEdges records which locals each
+// binding borrows, and at which field. At each site, escapingLocalsOf follows those edges
+// and scans for direct borrows to find the locals the outgoing value carries.
 //
 // A borrow of a parameter is exempt. Its lifetime outlives the frame, so
 // `fn (p: &mut {x}) -> &mut {x} { return p }` checks.
 //
-// Edges and the checks are whole-binding granular. An edge is keyed by root binding, so it
-// records that `a` borrows `b` without recording which field holds the borrow. The check
-// follows edges only from a whole-binding return like `return a`, never a field return
-// like `return a.peer`. Skipping field returns avoids a false positive. Following a root
-// edge for the disjoint owned field in `return a.data` would wrongly flag `b`, which
-// `a.data` does not borrow. The cost is a false negative. `return a.peer` returns the
-// borrow field itself, and the check does not catch it. Resolving a field return to its
-// own edge needs the per-field tracking deferred to PR 11.
+// An edge carries the field path within the binding that holds the borrow. `val a = {peer:
+// &mut b}` records the edge a → b at path [peer], so a return discriminates by field. A
+// whole-binding return `return a` follows every edge under a, since the returned value
+// exposes all its fields. A field return `return a.peer` follows only the edges at [peer]
+// or beneath it, so it catches the escaping borrow of b. The disjoint field return `return
+// a.data` follows the edges at [data], finds none, and is sound with no false positive.
+//
+// Edges are recorded at three sites: a `val`/`var` initializer, a `var` reassignment, and a
+// destructuring leaf. The graph is accumulate-only and not flow-sensitive, so a
+// reassignment adds edges without clearing the binding's earlier ones. This over-reports a
+// borrow that a later reassignment replaced, the conservative direction that never misses a
+// real escape. Clearing on reassignment soundly needs CFG-merge-joined edges, which the
+// connected-component move builds.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
 // function-local. It blames the outgoing expression and names the escaping local.
@@ -58,35 +63,13 @@ func (e *EscapingBorrowError) Message() string {
 	return fmt.Sprintf("borrowed value '%s' does not live long enough to escape the function", e.LocalName)
 }
 
-// borrowCollector gathers the BorrowExprs an expression carries by value, riding the
-// shared AST visitor so it reaches a borrow nested in an object or tuple literal. It stops
-// at a call or nested-function boundary, where a borrow is not part of the value the
-// scanned expression yields.
-type borrowCollector struct {
-	*ast.DefaultVisitor
-	out *[]*ast.BorrowExpr
-}
-
-func (v *borrowCollector) EnterExpr(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.BorrowExpr:
-		*v.out = append(*v.out, e)
-	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
-		// A borrow written as a call argument is consumed or borrowed by that call, not
-		// carried out by its result, so `store(read(&mut b))` does not carry b. A borrow
-		// inside a nested function belongs to that function's scope. A borrow a result or
-		// closure genuinely captures is governed by the deferred closure-capture work.
-		return false
-	}
-	return true
-}
-
-// borrowsIn returns every BorrowExpr the expression e carries by value, descending through
-// object and tuple literals but stopping at call and nested-function boundaries.
-func borrowsIn(e ast.Expr) []*ast.BorrowExpr {
-	var found []*ast.BorrowExpr
-	e.Accept(&borrowCollector{DefaultVisitor: &ast.DefaultVisitor{}, out: &found})
-	return found
+// fieldBorrow is one borrow edge under a binding: the field path within the binding that
+// holds the borrow, and the function-local the borrow refers to. The path is empty when
+// the whole binding is the borrow, as in `var a = &mut b`, and names the field chain when
+// a field holds it, as in `val a = {peer: &mut b}` recording path [peer].
+type fieldBorrow struct {
+	path     []placeSeg
+	referent liveness.VarID
 }
 
 // isLocalReferent reports whether the borrow operand names a function-local place, one
@@ -105,27 +88,118 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 
 // escapingLocalsOf returns the function-locals whose data e carries by value. A borrow of
 // a local written directly in e contributes its referent, such as the `&mut b` in
-// `{peer: &mut b}`. When e names a whole binding, the binding's borrow edges contribute the
-// locals they reach. A field place is not followed, since the edge graph is keyed by root
-// binding.
+// `{peer: &mut b}`. When e names a place — a whole binding `a` or a field `a.peer` — the
+// edges under that place contribute the locals they transitively reach. The walk descends
+// object and tuple literals but stops at call and nested-function boundaries, where a
+// borrow is not part of the value e yields.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
 		return out
 	}
-	// Borrows of locals written directly in e, such as the `&mut b` in `{peer: &mut b}`.
-	for _, b := range borrowsIn(e) {
-		if referent, ok := c.isLocalReferent(b.Arg); ok {
+	c.collectEscaping(e, out)
+	return out
+}
+
+// collectEscaping adds to out every function-local the expression e carries by value. A
+// direct `&mut b` of a local contributes b. An object or tuple literal contributes the
+// locals its elements carry. A place expression contributes the locals its edges reach,
+// filtered to the place's field path. The walk stops at a call or nested-function
+// boundary, where a borrow is consumed by the callee or belongs to the inner scope rather
+// than flowing out through e.
+func (c *checker) collectEscaping(e ast.Expr, out set.Set[liveness.VarID]) {
+	switch e := e.(type) {
+	case *ast.BorrowExpr:
+		if referent, ok := c.isLocalReferent(e.Arg); ok {
 			out.Add(referent)
 		}
+	case *ast.ObjectExpr:
+		for _, elem := range e.Elems {
+			if prop, ok := elem.(*ast.PropertyExpr); ok && prop.Value != nil {
+				c.collectEscaping(prop.Value, out)
+			}
+		}
+	case *ast.TupleExpr:
+		for _, el := range e.Elems {
+			c.collectEscaping(el, out)
+		}
+	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
+		return
+	default:
+		if p, ok := exprPlace(e); ok && p.root > 0 {
+			c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID]())
+		}
 	}
-	// When e names a whole binding, the locals that binding transitively borrows. For `a`
-	// bound by `val a = {peer: &mut b}`, this follows the a → b edge. A field place is
-	// skipped by the len(p.path) == 0 guard, so `a.peer` follows nothing.
-	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
-		c.collectBorrowedLocals(p.root, out)
+}
+
+// addBorrowEdge records that the binding root borrows the function-local referent at the
+// given field path, allocating the root's edge list on first use. A duplicate edge — the
+// same path and referent — is dropped, so repeated walks do not accumulate copies.
+func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
+	for _, e := range c.fn.borrowEdges[root] {
+		if e.referent == referent && equalPath(e.path, path) {
+			return
+		}
 	}
-	return out
+	c.fn.borrowEdges[root] = append(c.fn.borrowEdges[root], fieldBorrow{path: path, referent: referent})
+}
+
+// recordBorrowEdges records which function-locals the binding destVarID borrows and at
+// which field. `val a = {peer: &mut b}` records a → b at path [peer], and a whole-binding
+// move `val a2 = a` carries a's edges into a2 at the same paths.
+func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
+	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
+		return
+	}
+	c.walkBorrowSources(liveness.VarID(destVarID), nil, init)
+}
+
+// walkBorrowSources records the borrow edges the expression e contributes to the binding
+// root at base, the field path reached so far. A direct `&mut b` of a local records an
+// edge at base. An object literal property descends with base extended by the property
+// name, and a tuple element descends at base unchanged, since a tuple index has no field
+// segment. A place expression copies that place's edges, re-rooted under root at base. The
+// walk stops at a call or nested-function boundary.
+func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.Expr) {
+	switch e := e.(type) {
+	case *ast.BorrowExpr:
+		if referent, ok := c.isLocalReferent(e.Arg); ok && referent != root {
+			c.addBorrowEdge(root, base, referent)
+		}
+	case *ast.ObjectExpr:
+		for _, elem := range e.Elems {
+			prop, ok := elem.(*ast.PropertyExpr)
+			if !ok || prop.Value == nil {
+				continue
+			}
+			if name, ok := objKeyName(prop.Name); ok {
+				c.walkBorrowSources(root, appendSeg(base, name), prop.Value)
+			}
+		}
+	case *ast.TupleExpr:
+		for _, el := range e.Elems {
+			c.walkBorrowSources(root, base, el)
+		}
+	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
+		return
+	default:
+		// A place names another binding whose value e copies. Each of that binding's
+		// edges whose path lies at or beneath the read place transfers to root, re-rooted
+		// at base plus the part of the edge path below the read place.
+		p, ok := exprPlace(e)
+		if !ok || p.root <= 0 {
+			return
+		}
+		for _, edge := range c.fn.borrowEdges[p.root] {
+			if !pathHasPrefix(edge.path, p.path) {
+				continue
+			}
+			if edge.referent == root {
+				continue
+			}
+			c.addBorrowEdge(root, appendPath(base, edge.path[len(p.path):]), edge.referent)
+		}
+	}
 }
 
 // reportEscapingLocals reports an EscapingBorrowError for each escaping local, blaming the
@@ -135,32 +209,6 @@ func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame a
 	slices.Sort(ids)
 	for _, id := range ids {
 		c.report(&EscapingBorrowError{LocalName: c.varIDToName(id), node: blame})
-	}
-}
-
-// addBorrowEdge records that the binding destRoot borrows the function-local referent,
-// allocating the destination's edge set on first use.
-func (c *checker) addBorrowEdge(destRoot, referent liveness.VarID) {
-	edges := c.fn.borrowEdges[destRoot]
-	if edges == nil {
-		edges = set.NewSet[liveness.VarID]()
-		c.fn.borrowEdges[destRoot] = edges
-	}
-	edges.Add(referent)
-}
-
-// recordBorrowEdges records which function-locals the binding destVarID borrows. `val a =
-// {peer: &mut b}` records a → b, and a whole-binding move `val a2 = a` carries a's edges
-// into a2.
-func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
-	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
-		return
-	}
-	destRoot := liveness.VarID(destVarID)
-	for _, referent := range c.escapingLocalsOf(init).ToSlice() {
-		if referent != destRoot {
-			c.addBorrowEdge(destRoot, referent)
-		}
 	}
 }
 
@@ -184,21 +232,69 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
 	c.reportEscapingLocals(c.escapingLocalsOf(source), source)
 }
 
-// collectBorrowedLocals adds to out every function-local reachable from root through
-// borrow edges. root is the carrier binding, which moves out rather than escaping, so it
-// is the starting point but never added to out. The seen set terminates borrow cycles.
-func (c *checker) collectBorrowedLocals(root liveness.VarID, out set.Set[liveness.VarID]) {
-	seen := set.NewSet[liveness.VarID]()
-	var walk func(liveness.VarID)
-	walk = func(node liveness.VarID) {
-		if seen.Contains(node) {
-			return
+// collectBorrowedFrom adds to out every function-local reachable from the place rooted at
+// root through borrow edges. filter restricts the first hop to edges at or beneath the
+// read place's field path, so a field read `a.peer` follows only the edges under [peer].
+// Each borrowed local is then followed in full — a borrow exposes the whole referent — so
+// deeper hops pass a nil filter. root is the carrier binding, the starting point, and is
+// never added to out. The seen set terminates borrow cycles.
+func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, out, seen set.Set[liveness.VarID]) {
+	if seen.Contains(root) {
+		return
+	}
+	seen.Add(root)
+	for _, edge := range c.fn.borrowEdges[root] {
+		if filter != nil && !pathHasPrefix(edge.path, filter) {
+			continue
 		}
-		seen.Add(node)
-		for _, referent := range c.fn.borrowEdges[node].ToSlice() {
-			out.Add(referent)
-			walk(referent)
+		out.Add(edge.referent)
+		c.collectBorrowedFrom(edge.referent, nil, out, seen)
+	}
+}
+
+// pathHasPrefix reports whether prefix is a prefix of path: every segment of prefix equals
+// the segment at the same position in path. An empty prefix matches every path, so a
+// whole-binding read follows every edge under the binding.
+func pathHasPrefix(path, prefix []placeSeg) bool {
+	if len(prefix) > len(path) {
+		return false
+	}
+	for i := range prefix {
+		if path[i] != prefix[i] {
+			return false
 		}
 	}
-	walk(root)
+	return true
 }
+
+// equalPath reports whether two field paths are identical, segment for segment.
+func equalPath(a, b []placeSeg) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// appendSeg returns base with one more named field segment appended, copying the path so
+// sibling places built from the same base never share backing storage.
+func appendSeg(base []placeSeg, name string) []placeSeg {
+	out := make([]placeSeg, len(base)+1)
+	copy(out, base)
+	out[len(base)] = placeSeg{kind: namedSeg, name: name}
+	return out
+}
+
+// appendPath returns base with the segments of suffix appended, copying so the result
+// shares no backing storage with either input.
+func appendPath(base, suffix []placeSeg) []placeSeg {
+	out := make([]placeSeg, len(base)+len(suffix))
+	copy(out, base)
+	copy(out[len(base):], suffix)
+	return out
+}
+

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -182,13 +182,17 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 		for _, elem := range e.Elems {
 			switch el := elem.(type) {
 			case *ast.PropertyExpr:
-				if el.Value == nil {
-					continue
-				}
-				if name, ok := objKeyName(el.Name); ok {
-					c.walkBorrowSources(root, appendSeg(base, name), el.Value)
-				} else {
-					c.walkBorrowSources(root, base, el.Value)
+				if el.Value != nil {
+					if name, ok := objKeyName(el.Name); ok {
+						c.walkBorrowSources(root, appendSeg(base, name), el.Value)
+					} else {
+						c.walkBorrowSources(root, base, el.Value)
+					}
+				} else if ident, ok := el.Name.(*ast.IdentExpr); ok && ident.VarID > 0 {
+					// A shorthand property `{peer}` is `{peer: peer}`, so the field peer
+					// holds the value of the binding peer. Copy that binding's edges at the
+					// peer field.
+					c.copyPlaceEdges(root, appendSeg(base, ident.Name), movePlace{root: liveness.VarID(ident.VarID)})
 				}
 			case *ast.ObjSpreadExpr:
 				c.walkBorrowSources(root, base, el.Value)
@@ -203,22 +207,10 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
 		return
 	default:
-		// A place names another binding whose value e copies. Each of that binding's edges
-		// on the read place's field path transfers to root, re-rooted at base plus the part
-		// of the edge path below the read place. An edge is on the path when it sits at the
-		// read place, beneath it, or above it. An edge above the read place reaches the
-		// whole binding, so the read projects entirely within it and the suffix is empty.
+		// A place names another binding whose value e copies. copyPlaceEdges transfers that
+		// binding's edges to root, re-rooted at base.
 		if p, ok := exprPlace(e); ok && p.root > 0 {
-			for _, edge := range c.fn.borrowEdges[p.root] {
-				if !pathPrefixRelated(edge.path, p.path) || edge.referent == root {
-					continue
-				}
-				var suffix []placeSeg
-				if len(edge.path) > len(p.path) {
-					suffix = edge.path[len(p.path):]
-				}
-				c.addBorrowEdge(root, appendPath(base, suffix), edge.referent)
-			}
+			c.copyPlaceEdges(root, base, p)
 			return
 		}
 		// Any other carrier expression contributes its inline borrows of locals at base,
@@ -227,6 +219,60 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 			if referent, ok := c.isLocalReferent(b.Arg); ok && referent != root {
 				c.addBorrowEdge(root, base, referent)
 			}
+		}
+	}
+}
+
+// copyPlaceEdges transfers to the binding root the borrow edges of the source place src,
+// re-rooted at base. Each of src's edges on src's field path — at it, beneath it, or above
+// it where the source binding wholly borrows a local — transfers, re-rooted at base plus
+// the part of the edge path below the read place. An edge above the read place reaches the
+// whole binding, so the read projects entirely within it and the suffix is empty. It backs
+// both a place initializer `val c = a.peer` and a shorthand property `{peer}`.
+func (c *checker) copyPlaceEdges(root liveness.VarID, base []placeSeg, src movePlace) {
+	for _, edge := range c.fn.borrowEdges[src.root] {
+		if !pathPrefixRelated(edge.path, src.path) || edge.referent == root {
+			continue
+		}
+		var suffix []placeSeg
+		if len(edge.path) > len(src.path) {
+			suffix = edge.path[len(src.path):]
+		}
+		c.addBorrowEdge(root, appendPath(base, suffix), edge.referent)
+	}
+}
+
+// recordPatternPlaceEdges records borrow edges for a destructuring whose initializer is a
+// place, projecting the pattern over that place. `val {peer} = a` binds peer to a.peer, so
+// peer inherits a's edges on the [peer] path. An identifier pattern inherits the whole
+// place's edges; an object element extends the place by its key; a tuple element keeps the
+// place, since a tuple index has no field segment and the read approximates to the
+// container.
+func (c *checker) recordPatternPlaceEdges(pat ast.Pat, src movePlace) {
+	switch pat := pat.(type) {
+	case *ast.IdentPat:
+		if pat.VarID > 0 {
+			c.copyPlaceEdges(liveness.VarID(pat.VarID), nil, src)
+		}
+	case *ast.ObjectPat:
+		for _, elem := range pat.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjShorthandPat:
+				if e.VarID > 0 {
+					c.copyPlaceEdges(liveness.VarID(e.VarID), nil, extendPlace(src, e.Key.Name))
+				}
+				if e.Default != nil {
+					// The property may be absent, so the leaf can take the shorthand
+					// default, such as `val {peer = &mut b} = obj`.
+					c.recordBorrowEdges(e.VarID, e.Default)
+				}
+			case *ast.ObjKeyValuePat:
+				c.recordPatternPlaceEdges(e.Value, extendPlace(src, e.Key.Name))
+			}
+		}
+	case *ast.TuplePat:
+		for _, elem := range pat.Elems {
+			c.recordPatternPlaceEdges(elem, src)
 		}
 	}
 }

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -33,12 +33,15 @@ import (
 // `fn (p: &mut {x}) -> &mut {x} { return p }` checks.
 //
 // An edge carries the field path within the binding that holds the borrow. `val a = {peer:
-// &mut b}` records the edge a → b at path [peer], so a return discriminates by field. A
-// whole-binding return `return a` follows every edge under a, since the returned value
-// exposes all its fields. A field return `return a.peer` follows the edges on the [peer]
-// path — at [peer], beneath it, or above it where `val a = &mut b` borrows all of b — so it
-// catches the escaping borrow of b. The disjoint field return `return a.data` follows the
-// edges on the [data] path, finds none, and is sound with no false positive.
+// &mut b}` records the edge a → b at path [peer], so a return discriminates by field:
+//
+//   - A whole-binding return `return a` follows every edge under a, since the returned value
+//     exposes all of a's fields.
+//   - A field return `return a.peer` follows the edges on the [peer] path. That covers an
+//     edge at [peer], beneath it, or above it where `val a = &mut b` borrows all of b. So it
+//     catches the escaping borrow of b.
+//   - A disjoint field return `return a.data` follows the edges on the [data] path, finds
+//     none, and is sound with no false positive.
 //
 // Edges are recorded at three sites: a `val`/`var` initializer, a `var` reassignment, and a
 // destructuring leaf. The graph is accumulate-only and not flow-sensitive, so a
@@ -121,12 +124,14 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 }
 
 // escapingLocalsOf returns the function-locals whose data e carries by value. Two sources
-// contribute. First, a borrow of a local written anywhere in e, such as the `&mut b` in
-// `{peer: &mut b}` or in an if/else branch, contributes its referent. borrowsIn finds these,
-// descending carriers and stopping at call and nested-function boundaries. Second, when e
-// names a place — a whole binding `a` or a field `a.peer` — the edges under that place
-// contribute the locals they transitively reach, filtered to the place's field path so a
-// field return follows only that field's edges.
+// contribute:
+//
+//   - A borrow of a local written anywhere in e, such as the `&mut b` in `{peer: &mut b}` or
+//     in an if/else branch. borrowsIn finds these, descending carriers and stopping at call
+//     and nested-function boundaries.
+//   - The edges under a place e names, a whole binding `a` or a field `a.peer`. They
+//     contribute the locals they transitively reach, filtered to the place's field path so a
+//     field return follows only that field's edges.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
 	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
@@ -145,7 +150,8 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 
 // addBorrowEdge records that the binding root borrows the function-local referent at the
 // given field path, allocating the root's edge list on first use. A duplicate edge with
-// the same path and referent is dropped, so repeated walks do not accumulate copies.
+// the same path and referent is ignored, so repeated walks keep one copy rather than
+// accumulating identical edges.
 func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
 	for _, e := range c.fn.borrowEdges[root] {
 		if e.referent == referent && slices.Equal(e.path, path) {
@@ -166,12 +172,20 @@ func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 }
 
 // walkBorrowSources records the borrow edges the expression e contributes to the binding
-// root, at base, the field path reached so far. A direct `&mut b` of a local records an
-// edge at base. An object property descends with base extended by the property name, while
-// a tuple element and a spread descend at base unchanged, since neither refines the field
-// path. A place expression copies that place's edges, re-rooted under root at base. Any
-// other carrier, such as an if/else branch, contributes its inline borrows at base through
-// borrowsIn. The walk stops at a call or nested-function boundary.
+// root, at base, the field path reached so far:
+//
+//   - A direct `&mut b` of a local records an edge at base.
+//   - An object property descends with base extended by the property name.
+//   - A tuple element and a spread descend at base unchanged. A field path is a chain of
+//     named segments, and neither a tuple index nor a spread contributes one: a tuple index
+//     is a number, not a field name, and a spread merges its source's fields without naming
+//     them. The place model approximates a read of either to its container, so the borrow
+//     stays attributed to base.
+//   - A place expression copies that place's edges, re-rooted under root at base.
+//   - Any other carrier, such as an if/else branch, contributes its inline borrows at base
+//     through borrowsIn.
+//
+// The walk stops at a call or nested-function boundary.
 func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.Expr) {
 	switch e := e.(type) {
 	case *ast.BorrowExpr:
@@ -186,12 +200,17 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 					if name, ok := objKeyName(el.Name); ok {
 						c.walkBorrowSources(root, appendSeg(base, name), el.Value)
 					} else {
+						// A computed key names no static field segment, so the borrow can't
+						// be addressed by a field path. Keep base, attributing the value to the
+						// enclosing object conservatively.
 						c.walkBorrowSources(root, base, el.Value)
 					}
 				} else if ident, ok := el.Name.(*ast.IdentExpr); ok && ident.VarID > 0 {
-					// A shorthand property `{peer}` is `{peer: peer}`, so the field peer
-					// holds the value of the binding peer. Copy that binding's edges at the
-					// peer field.
+					// A shorthand property `{peer}` is `{peer: peer}`: the field peer holds
+					// the value of the binding peer. objKeyName would give the field name,
+					// but the value's edges are reached through the binding's VarID, so read
+					// both the name and the VarID from the IdentExpr directly. A shorthand
+					// key is always an identifier, never a computed or string key.
 					c.copyPlaceEdges(root, appendSeg(base, ident.Name), movePlace{root: liveness.VarID(ident.VarID)})
 				}
 			case *ast.ObjSpreadExpr:
@@ -207,14 +226,15 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
 		return
 	default:
-		// A place names another binding whose value e copies. copyPlaceEdges transfers that
-		// binding's edges to root, re-rooted at base.
+		// A place names another binding whose value e copies, as in `val a2 = a` or `val c =
+		// a.peer`. copyPlaceEdges transfers that binding's edges to root, re-rooted at base.
 		if p, ok := exprPlace(e); ok && p.root > 0 {
 			c.copyPlaceEdges(root, base, p)
 			return
 		}
-		// Any other carrier expression contributes its inline borrows of locals at base,
-		// descending through it but stopping at call and nested-function boundaries.
+		// Any other carrier expression contributes its inline borrows of locals at base, as
+		// in the `if cond { &mut b } else { … }` of `val a = if cond { &mut b } else { … }`.
+		// The walk descends through it but stops at call and nested-function boundaries.
 		for _, b := range borrowsIn(e) {
 			if referent, ok := c.isLocalReferent(b.Arg); ok && referent != root {
 				c.addBorrowEdge(root, base, referent)
@@ -231,6 +251,9 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 // both a place initializer `val c = a.peer` and a shorthand property `{peer}`.
 func (c *checker) copyPlaceEdges(root liveness.VarID, base []placeSeg, src movePlace) {
 	for _, edge := range c.fn.borrowEdges[src.root] {
+		// Skip an edge off the read place's field path, and one pointing back at root. The
+		// self-edge guard matters because src's referent can be root: reassigning `b = a`
+		// where a holds a borrow of b would otherwise copy a → b into b as a b → b loop.
 		if !pathPrefixRelated(edge.path, src.path) || edge.referent == root {
 			continue
 		}
@@ -248,6 +271,10 @@ func (c *checker) copyPlaceEdges(root liveness.VarID, base []placeSeg, src moveP
 // place's edges; an object element extends the place by its key; a tuple element keeps the
 // place, since a tuple index has no field segment and the read approximates to the
 // container.
+//
+// It covers the destructuring patterns that bind a sub-place of the initializer. A rest
+// pattern and an extractor pattern record nothing today; projecting them would extend this
+// switch once they need borrow tracking.
 func (c *checker) recordPatternPlaceEdges(pat ast.Pat, src movePlace) {
 	switch pat := pat.(type) {
 	case *ast.IdentPat:
@@ -308,14 +335,21 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
 }
 
 // collectBorrowedFrom adds to out every function-local the read place rooted at root, with
-// field path filter, exposes through borrow edges. The first hop keeps only edges on the
-// filter path: an edge at [peer], beneath it at [peer, …], or above it at [] where a wholly
-// borrows b. So a field read `a.peer` follows a → b on any of those but not a disjoint a → c
-// at [data]. Each local the first hop reaches is then followed in full through
-// collectAllFrom, since a borrow exposes the whole referent. root is the carrier binding,
-// the starting point for the first hop. It is added to out only when a borrow cycle reaches
-// back to it, which is sound: a local that borrows root, and itself escapes, carries root's
-// data out too.
+// field path filter, exposes through borrow edges.
+//
+// The first hop keeps only edges on the filter path:
+//
+//   - at the filter, such as a → b at [peer] for a read of a.peer;
+//   - beneath it, at [peer, …];
+//   - above it, at [] where a wholly borrows b.
+//
+// So a read of a.peer follows a → b on any of those, but not a disjoint a → c at [data].
+// Each local the first hop reaches is then followed in full through collectAllFrom, since a
+// borrow exposes the whole referent.
+//
+// root is the starting point, not itself collected, except when a borrow cycle reaches back
+// to it. Collecting it then is sound: a local that borrows root and itself escapes carries
+// root's data out too.
 func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, out, seen set.Set[liveness.VarID]) {
 	for _, edge := range c.fn.borrowEdges[root] {
 		if !pathPrefixRelated(edge.path, filter) {
@@ -328,7 +362,9 @@ func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, ou
 
 // collectAllFrom adds to out every function-local reachable from node through borrow edges,
 // following every edge regardless of field path, since reaching a binding through a borrow
-// exposes all of it. The seen set terminates borrow cycles.
+// exposes all of it. For node a with edges a → b at [peer] and a → c at [data], it collects
+// both b and c, then walks each of their edges in turn. The seen set terminates borrow
+// cycles.
 func (c *checker) collectAllFrom(node liveness.VarID, out, seen set.Set[liveness.VarID]) {
 	if seen.Contains(node) {
 		return
@@ -357,4 +393,3 @@ func appendPath(base, suffix []placeSeg) []placeSeg {
 	copy(out[len(base):], suffix)
 	return out
 }
-

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -98,6 +98,33 @@ func TestReturnEscape(t *testing.T) {
 			want:  []string{"5:13-5:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{"build": "fn () -> &mut {value: number}"},
 		},
+		// Reading a field through a whole-binding borrow escapes the borrowed local: `a`
+		// borrows all of b, so `a.peer` projects into b and returning it leaves b dangling.
+		// The edge a → b sits at path [], above the read path [peer], so the field return
+		// still follows it.
+		"ReturnFieldThroughWholeBorrowEscapes": {
+			src: `
+				fn build() -> &mut {value: number} {
+					val mut b = {peer: {value: 0}}
+					val a = &mut b
+					return a.peer
+				}
+			`,
+			want:  []string{"5:13-5:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> &mut {value: number}"},
+		},
+		// A borrow of a local written inside a control-flow carrier escapes the same as one
+		// written directly: the scan descends the if/else branches to find the `&mut b`.
+		"ReturnBorrowInIfBranchEscapes": {
+			src: `
+				fn build() -> &mut {value: number} {
+					val mut b = {value: 0}
+					return if true { &mut b } else { &mut b }
+				}
+			`,
+			want:  []string{"4:12-4:47: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> &mut {value: number}"},
+		},
 		// Returning a disjoint owned field of a binding that also has a borrow field does
 		// not escape: `a.data` carries none of a's borrow of b. The field return follows
 		// only the edges at [data], finds none, and reports no spurious escape.

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -172,6 +172,64 @@ func TestReturnEscape(t *testing.T) {
 			want:  nil,
 			types: map[string]string{"pass": "fn <'a>(p: &'a mut {x: number}) -> {peer: &'a mut {x: number}}"},
 		},
+		// A borrow projected into a destructuring leaf escapes: `val {peer} = {peer: &mut
+		// b}` binds peer to the borrow of the local b, so returning peer escapes b. The
+		// pattern leaf is matched to its initializer property and its edge recorded.
+		"ReturnDestructuredBorrowLeafEscapes": {
+			src: `
+				fn f() -> &mut {value: number} {
+					val mut b = {value: 0}
+					val {peer} = {peer: &mut b}
+					return peer
+				}
+			`,
+			want:  []string{"5:13-5:17: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn () -> &mut {value: number}"},
+		},
+		// Destructuring from a place carries the place's field edges into the leaf: `val
+		// {peer} = a` binds peer to a.peer, so peer inherits a's borrow of b at [peer] and
+		// returning peer escapes b.
+		"ReturnDestructuredFromPlaceEscapes": {
+			src: `
+				fn build() -> &mut {value: number} {
+					val mut b = {value: 0}
+					val a = {peer: &mut b}
+					val {peer} = a
+					return peer
+				}
+			`,
+			want:  []string{"6:13-6:17: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> &mut {value: number}"},
+		},
+		// A shorthand destructuring default escapes: when `obj` may lack peer, `val {peer =
+		// &mut b} = obj` binds peer to the default `&mut b` on the absent-property path, so
+		// returning peer escapes the local b.
+		"ReturnShorthandDefaultEscapes": {
+			src: `
+				fn f(obj: {peer?: &mut {value: number}}) -> &mut {value: number} {
+					val mut b = {value: 0}
+					val {peer = &mut b} = obj
+					return peer
+				}
+			`,
+			want:  []string{"5:13-5:17: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn <'a>(obj: {peer?: &'a mut {value: number}}) -> &'a mut {value: number}"},
+		},
+		// A borrow introduced by reassigning a `var` escapes: `a = &mut b` records the edge
+		// a → b, so returning a escapes the local b. The edge graph accumulates, so the
+		// reassignment adds the edge to a's earlier ones.
+		"ReturnVarReassignedToBorrowEscapes": {
+			src: `
+				fn f(seed: &mut {value: number}) {
+					var a = seed
+					val mut b = {value: 0}
+					a = &mut b
+					return a
+				}
+			`,
+			want:  []string{"6:13-6:14: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn <'a>(seed: &'a mut {value: number}) -> &'a mut {value: number}"},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -313,38 +371,4 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 			require.Equal(t, tc.types, values)
 		})
 	}
-}
-
-// TestDestructuredBorrowLeafEscapes covers a borrow projected into a destructuring leaf:
-// `val {peer} = {peer: &mut b}` binds peer to the borrow of the local b, so returning peer
-// escapes b. recordDestructureBorrowEdges matches the pattern leaf to its initializer
-// property and records the leaf's edge.
-func TestDestructuredBorrowLeafEscapes(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f() -> &mut {value: number} {
-			val mut b = {value: 0}
-			val {peer} = {peer: &mut b}
-			return peer
-		}
-	`)
-	require.Equal(t, []string{
-		"5:11-5:15: borrowed value 'b' does not live long enough to escape the function",
-	}, messagesWithSpan(errs))
-}
-
-// TestVarReassignBorrowEscapes covers a borrow introduced by reassigning a `var`: `a =
-// &mut b` records the edge a → b, so returning a escapes the local b. The edge graph
-// accumulates, so the reassignment adds the edge to a's earlier ones.
-func TestVarReassignBorrowEscapes(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		fn f(seed: &mut {value: number}) {
-			var a = seed
-			val mut b = {value: 0}
-			a = &mut b
-			return a
-		}
-	`)
-	require.Equal(t, []string{
-		"6:11-6:12: borrowed value 'b' does not live long enough to escape the function",
-	}, messagesWithSpan(errs))
 }

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -84,9 +84,23 @@ func TestReturnEscape(t *testing.T) {
 			want:  []string{"6:13-6:15: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
 		},
+		// Returning the borrow field itself escapes the local it holds: `a.peer` is the
+		// `&mut b` borrow, so returning it leaves b dangling. The field-granular edge at
+		// [peer] is followed for the field return.
+		"ReturnBorrowFieldEscapes": {
+			src: `
+				fn build() -> &mut {value: number} {
+					val mut b = {value: 2}
+					val a = {peer: &mut b, data: {value: 7}}
+					return a.peer
+				}
+			`,
+			want:  []string{"5:13-5:19: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> &mut {value: number}"},
+		},
 		// Returning a disjoint owned field of a binding that also has a borrow field does
-		// not escape: `a.data` carries none of a's borrow of b. The whole-binding edge is
-		// not followed for a field return, so no spurious escape is reported.
+		// not escape: `a.data` carries none of a's borrow of b. The field return follows
+		// only the edges at [data], finds none, and reports no spurious escape.
 		"ReturnDisjointFieldOk": {
 			src: `
 				fn build() -> {value: number} {
@@ -274,51 +288,36 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 	}
 }
 
-// TestDestructuredBorrowLeafEscapes pins a known under-check: a borrow projected into a
-// destructuring leaf records no borrow edge, so returning the leaf escapes the local
-// with no error. recordBorrowEdges runs only for a named `val`/`var` binding. Catching
-// the leaf case needs the per-leaf pattern correspondence the field-granular move work
-// introduces.
-//
-// DISABLED until field-granular move tracking lands: when a destructuring leaf tracks
-// its borrow, `return peer` below escapes the local `b` and this assertion holds.
-// Re-enable by removing the `/* */` wrapper around the body.
+// TestDestructuredBorrowLeafEscapes covers a borrow projected into a destructuring leaf:
+// `val {peer} = {peer: &mut b}` binds peer to the borrow of the local b, so returning peer
+// escapes b. recordDestructureBorrowEdges matches the pattern leaf to its initializer
+// property and records the leaf's edge.
 func TestDestructuredBorrowLeafEscapes(t *testing.T) {
-	/*
-		_, _, errs := inferSource(t, `
-			fn f() -> &mut {value: number} {
-				val mut b = {value: 0}
-				val {peer} = {peer: &mut b}
-				return peer
-			}
-		`)
-		require.Equal(t, []string{
-			"5:12-5:16: borrowed value 'b' does not live long enough to escape the function",
-		}, messagesWithSpan(errs))
-	*/
+	_, _, errs := inferSource(t, `
+		fn f() -> &mut {value: number} {
+			val mut b = {value: 0}
+			val {peer} = {peer: &mut b}
+			return peer
+		}
+	`)
+	require.Equal(t, []string{
+		"5:11-5:15: borrowed value 'b' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
 }
 
-// TestVarReassignBorrowEscapes pins a known under-check: recordBorrowEdges runs only at a
-// binding's initializer, so a borrow introduced by reassigning a `var`, such as the `a =
-// &mut b` below, records no edge. Returning the var then escapes the local with no error.
-// Tracking it soundly needs flow-sensitive borrow edges that clear on reassignment, since
-// the graph is accumulate-only.
-//
-// DISABLED until flow-sensitive borrow tracking lands: when reassignment records edges,
-// `return a` below escapes the local `b` and this assertion holds. Re-enable by removing
-// the `/* */` wrapper around the body.
+// TestVarReassignBorrowEscapes covers a borrow introduced by reassigning a `var`: `a =
+// &mut b` records the edge a → b, so returning a escapes the local b. The edge graph
+// accumulates, so the reassignment adds the edge to a's earlier ones.
 func TestVarReassignBorrowEscapes(t *testing.T) {
-	/*
-		_, _, errs := inferSource(t, `
-			fn f(seed: &mut {value: number}) {
-				var a = seed
-				val mut b = {value: 0}
-				a = &mut b
-				return a
-			}
-		`)
-		require.Equal(t, []string{
-			"6:12-6:13: borrowed value 'b' does not live long enough to escape the function",
-		}, messagesWithSpan(errs))
-	*/
+	_, _, errs := inferSource(t, `
+		fn f(seed: &mut {value: number}) {
+			var a = seed
+			val mut b = {value: 0}
+			a = &mut b
+			return a
+		}
+	`)
+	require.Equal(t, []string{
+		"6:11-6:12: borrowed value 'b' does not live long enough to escape the function",
+	}, messagesWithSpan(errs))
 }

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -765,7 +765,7 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
 	c.fn.placeIDs = map[string]liveness.VarID{}
 	c.fn.movePlaces = map[liveness.VarID]movePlace{}
-	c.fn.borrowEdges = map[liveness.VarID]set.Set[liveness.VarID]{}
+	c.fn.borrowEdges = map[liveness.VarID][]fieldBorrow{}
 	c.fn.paramVarIDs = collectParamVarIDs(astParams)
 }
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -258,7 +258,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — | ❌ retired |
 | 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
-| 15 | Escape forcing at returns, stores, and consuming arguments (deferred from PR 6) | 6 | Large | 🚧 in progress |
+| 15 | Escape forcing at returns, stores, and consuming arguments (deferred from PR 6) | 6 | Large | ✅ done (#814); element stores deferred to M7, field-granular escape to PR 11 |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -696,7 +696,7 @@ stored value that borrows a function-local binding is silently accepted today. T
 makes that case the escape error it should be, which is the baseline PR 11 then relaxes
 for a self-contained component.
 
-Status: the return, parameter-field-store, and consuming-argument sites have landed in
+Status: done (#814). The return, parameter-field-store, and consuming-argument sites landed in
 [internal/solver/return_escape.go](../../internal/solver/return_escape.go), built over a
 per-binding borrow-edge graph on `funcCtx` rather than the lifetime sort, so the check
 does not wait on M6.5. Deferred: element stores `xs[i] = …` need index-assignment support

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -931,6 +931,24 @@ than through the field types.
 - **Diagnostic wording.** Each PR ships a working diagnostic; final wording and
   blame spans for use-after-move and move-on-escape are tuned as the engine
   settles.
+- **Tuple-index place segments.** The move/escape place model
+  ([internal/solver/moves.go](../../internal/solver/moves.go), `placeSeg`) keys a
+  field path by named segments only. A numeric tuple index `t[0]` has no name, so
+  `exprPlace` collapses it to the container `t`, and the borrow-edge walk records a
+  tuple element's borrow at the whole binding. This is conservative-sound but
+  imprecise in two places. The escape check over-reports: `val a = [&mut b, {x: 1}];
+  return a[1]` flags b even though `a[1]` carries none of the borrow. Partial moves
+  (PR 7) over-consume: moving `t[0]` consumes all of `t`, so a later read of `t[1]`
+  is a spurious use-after-move. Both gain object-field precision once a tuple index
+  yields its own place segment. The fix is small and already anticipated: `placeSeg`
+  carries a `kind` tag so a non-name segment can be added without conflating `t[0]`
+  with the string key `t["0"]`. It needs a distinct index-segment kind keyed by the
+  integer, `exprPlace` recognizing a `NumLit` index, `renderPlace` printing the
+  index, and the tuple-literal walk extending the path by the element index. A
+  dynamic `t[i]` still falls back to the container, as `arr[i]` does today. This
+  rides the M7 computed-key/index-segment work
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7);
+  pull it forward if tuple-heavy code makes the imprecision bite.
 
 ## Testing approach
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -775,16 +775,16 @@ binding in the component is consumed.
 - Soundness rests on the GC keeping co-moved nodes alive and on there being no
   external observer, so the phase rules are unchanged; this is the requirements'
   "Moving a graph" argument.
-- Extend the borrow-edge graph beyond what PR 15 records. PR 15 records an edge only at a
-  binding's initializer and keys it on the root binding, so three cases under-check: a
-  borrow introduced by reassigning a `var` such as `a = &mut b`, a borrow projected into a
-  destructuring leaf such as `val {peer} = {peer: &mut b}`, and a borrow held in one field
-  returned on its own such as `return a.peer`. Closing them needs flow-sensitive,
-  field-granular edges — set-and-clear per assignment joined at CFG merges, keyed by field
-  place rather than root binding — which the component analysis here builds on anyway. The
-  reassignment and destructuring cases are pinned by the disabled
-  `TestVarReassignBorrowEscapes` and `TestDestructuredBorrowLeafEscapes`; the field-return
-  miss is noted in [internal/solver/return_escape.go](../../internal/solver/return_escape.go).
+- Extend the borrow-edge graph beyond what PR 15 records. **Landed.** The graph now keys
+  edges by field place rather than root binding, tagging each edge with the field path that
+  holds the borrow, and records edges at three sites: a `val`/`var` initializer, a `var`
+  reassignment such as `a = &mut b`, and a destructuring leaf such as `val {peer} = {peer:
+  &mut b}`. Following discriminates a field return `return a.peer` from the disjoint `return
+  a.data`, and a field read through a whole-binding borrow `val a = &mut b; return a.peer`
+  still escapes b. The reassignment and destructuring cases that `TestVarReassignBorrowEscapes`
+  and `TestDestructuredBorrowLeafEscapes` pin are re-enabled. The graph stays accumulate-only,
+  so a reassignment adds edges without clearing earlier ones; the full set-and-clear joined
+  at CFG merges, which the component move builds on, is the remaining flow-sensitivity work.
 
 Tests: the cyclic `build()` returns `a` with both `a` and `b` consumed; an acyclic
 shared graph returned the same way; a graph where a node is also held by a retained

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -775,16 +775,17 @@ binding in the component is consumed.
 - Soundness rests on the GC keeping co-moved nodes alive and on there being no
   external observer, so the phase rules are unchanged; this is the requirements'
   "Moving a graph" argument.
-- Extend the borrow-edge graph beyond what PR 15 records. **Landed.** The graph now keys
-  edges by field place rather than root binding, tagging each edge with the field path that
-  holds the borrow, and records edges at three sites: a `val`/`var` initializer, a `var`
+- Extend the borrow-edge graph beyond what PR 15 records. **Landed.** The graph stays keyed
+  by root binding VarID, a `map[VarID][]fieldBorrow`, but each `fieldBorrow` entry now
+  carries the field path within the binding that holds the borrow rather than only the
+  borrowed local. Edges are recorded at three sites: a `val`/`var` initializer, a `var`
   reassignment such as `a = &mut b`, and a destructuring leaf such as `val {peer} = {peer:
   &mut b}`. Following discriminates a field return `return a.peer` from the disjoint `return
   a.data`, and a field read through a whole-binding borrow `val a = &mut b; return a.peer`
-  still escapes b. The reassignment and destructuring cases that `TestVarReassignBorrowEscapes`
-  and `TestDestructuredBorrowLeafEscapes` pin are re-enabled. The graph stays accumulate-only,
-  so a reassignment adds edges without clearing earlier ones; the full set-and-clear joined
-  at CFG merges, which the component move builds on, is the remaining flow-sensitivity work.
+  still escapes b. The reassignment and destructuring cases that the formerly-disabled tests
+  pin are re-enabled. The graph stays accumulate-only, so a reassignment adds edges without
+  clearing earlier ones; the full set-and-clear joined at CFG merges, which the component
+  move builds on, is the remaining flow-sensitivity work.
 
 Tests: the cyclic `build()` returns `a` with both `a` and `b` consumed; an acyclic
 shared graph returned the same way; a graph where a node is also held by a retained


### PR DESCRIPTION
Extend the borrow-edge graph to track the field path within each binding that holds a borrow, enabling the escape check to discriminate field returns from whole-binding returns and catch more cases without false positives.

**Summary**

The escape checker now records borrow edges at field granularity. Instead of tracking only that binding `a` borrows local `b`, it tracks the specific field path where the borrow sits — for example, `val a = {peer: &mut b}` records the edge `a → b` at path `[peer]`. This allows the checker to correctly handle field returns: `return a.peer` follows only edges on the `[peer]` path and catches the escaping borrow, while `return a.data` follows only the `[data]` path, finds no edges, and avoids a false positive.

**Key changes**

- Add `fieldBorrow` struct to pair each borrow edge with its field path within the binding.
- Replace `borrowEdges` map value type from `set.Set[liveness.VarID]` to `[]fieldBorrow` to store path information alongside each referent.
- Rewrite `walkBorrowSources` to descend through object properties, tuple elements, spreads, and control-flow carriers (if/else branches), building up the field path as it walks. Direct `&mut` borrows record edges at the current path. Place expressions copy edges from the source binding, re-rooted under the destination and adjusted for the field path difference.
- Split borrow collection into two phases: `collectBorrowedFrom` filters edges by the read place's field path for the first hop, then `collectAllFrom` follows all edges from each reached local, since reaching a binding through a borrow exposes all of it.
- Add `recordDestructureBorrowEdges` to match destructuring patterns against initializer expressions structurally and record borrow edges for each leaf, catching cases like `val {peer} = {peer: &mut b}`.
- Record borrow edges at `var` reassignments in `inferAssign`, so `a = &mut b` adds the edge to `a`'s earlier ones. The graph is accumulate-only, over-reporting a replaced borrow but never missing a real escape.
- Update comments throughout to reflect field-granular tracking and clarify the three recording sites: initializer, reassignment, and destructuring leaf.

**Notable details**

- `pathPrefixRelated` checks whether an edge path is on, above, or below a read place's path, so a field return correctly follows edges that sit at the field, beneath it, or above it (whole-binding borrows).
- `appendSeg` and `appendPath` copy path slices to prevent sibling places from sharing backing storage.
- The escape check now descends into control-flow carriers like if/else branches to find inline borrows, improving coverage without requiring flow-sensitive tracking.
- Two previously disabled tests (`TestDestructuredBorrowLeafEscapes` and `TestVarReassignBorrowEscapes`) are re-enabled and now pass.
- Three new test cases cover field returns, whole-binding borrows read through a field, and borrows in control-flow carriers.

https://claude.ai/code/session_013xgXnykg8QkcDhK196BLbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escape checking now tracks borrows more precisely through fields, destructuring leaves, and variable reassignment.
  * Returning nested borrows like a field or destructured value is now detected more accurately.

* **Bug Fixes**
  * Fixed cases where escaping borrows were missed when passed through whole values, `if` branches, or reassigned locals.
  * Improved reporting for field-specific return escapes.

* **Documentation**
  * Updated implementation notes to reflect the completed escape-analysis work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->