### PR TITLE
Implement connected-component move for escape analysis

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -182,6 +182,13 @@ type funcCtx struct {
 	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
 	// parameter outlives the frame, so the escape check skips a referent in this set.
 	paramVarIDs set.Set[liveness.VarID]
+	// escapeSites records every value flowing out of the frame that might carry a borrow
+	// of a function-local: a return value, a value stored into a parameter's field, and a
+	// consuming argument. The decision is deferred to a post-pass, resolveComponentEscapes,
+	// which runs once the whole body is walked, so the borrow-edge graph is complete and
+	// the consumed lattice is available. A self-contained connected component re-anchors
+	// and co-moves; anything else reports an EscapingBorrowError.
+	escapeSites []escapeSite
 	// varIDTypes maps each tracked variable's VarID to its soltype. It is the bridge
 	// the transition checker uses to query the lifetime sort for a `'static` escape in
 	// M4 G2. It replaces the dropped HasStatic{Mut,Imm}Alias bits. A value whose borrow

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1117,10 +1117,11 @@ func (c *checker) consumeCallArgs(e *ast.CallExpr, fn *soltype.FuncType, ref liv
 		}
 		c.consumeOwned(arg, c.info.TypeOf(arg), arg, ref)
 		// A consuming argument carries its value out of the frame into the callee, so a
-		// borrow of a local the argument carries escapes. reportEscapingLocals flags each
-		// local escapingLocalsOf finds in the argument. A `&`/`&mut` parameter borrows
-		// instead of consuming, so the isConcreteOwned gate above skips it.
-		c.reportEscapingLocals(c.escapingLocalsOf(arg), arg)
+		// borrow of a local the argument carries escapes unless the argument owns a
+		// self-contained component the move re-anchors. recordEscapeSite records the
+		// argument for the post-pass to decide. A `&`/`&mut` parameter borrows instead of
+		// consuming, so the isConcreteOwned gate above skips it.
+		c.recordEscapeSite(arg, ref)
 	}
 }
 
@@ -1469,11 +1470,12 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 		// overwritten with an inner branch statement.
 		if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
 			c.consumeOwned(e.Right, source, e.Right, ref)
+			// Storing a value that borrows a local into a parameter's field escapes, since
+			// the parameter's object outlives the frame and the stored local would dangle in
+			// the caller. checkParamFieldStoreEscape applies only when the receiver is a
+			// parameter, and records the store for the post-pass to decide.
+			c.checkParamFieldStoreEscape(m.Object, e.Right, ref)
 		}
-		// Storing a value that borrows a local into a parameter's field escapes, since the
-		// parameter's object outlives the frame and the stored local would dangle in the
-		// caller. checkStoreEscape applies only when the receiver is a parameter.
-		c.checkParamFieldStoreEscape(m.Object, e.Right)
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the
 	// `void` recovery type inferAssign recorded on e before dispatching here.

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -72,11 +72,12 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			if s.Expr != nil {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.consumeOwned(s.Expr, t, s.Expr, ref)
+					// A returned value must not borrow a function-local, which dies when the
+					// frame returns and would leave the borrow dangling, unless it owns a
+					// self-contained component the move re-anchors. checkReturnEscape records
+					// the return for the post-pass to decide.
+					c.checkReturnEscape(s.Expr, ref)
 				}
-				// A returned value must not borrow a function-local, which dies when the
-				// frame returns and would leave the borrow dangling. checkReturnEscape
-				// reports a returned borrow of a local.
-				c.checkReturnEscape(s.Expr)
 			}
 		} else {
 			// A `return` reached outside any function body — e.g. inside an `if` that

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -558,10 +558,15 @@ func (c *checker) checkUseAfterMoves() {
 	if c.fn == nil || c.fn.cfg == nil {
 		return
 	}
-	if len(c.fn.useSites) == 0 && len(c.fn.moveSites) == 0 && len(c.fn.pendingTransitions) == 0 {
+	if len(c.fn.useSites) == 0 && len(c.fn.moveSites) == 0 && len(c.fn.pendingTransitions) == 0 && len(c.fn.escapeSites) == 0 {
 		return
 	}
 	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
+	// Decide deferred escapes against the lattice, then fold any component-move consumes
+	// back into moveSites and recompute, so a use after a co-moved local is caught.
+	if len(c.fn.escapeSites) > 0 && c.resolveComponentEscapes(info) {
+		info = liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
+	}
 	for _, u := range c.fn.useSites {
 		state, movedID := c.movedConflict(info, u)
 		if state == liveness.NotMoved {

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -119,18 +119,12 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
 // componentMoveCovers reports whether the escape of e is a self-contained connected-component
 // move rather than an ordinary escape. It holds when two conditions are met:
 //
-//   - e is an owned carrier, not a bare borrow. Only an owned value re-anchors its internal
-//     graph; a borrow that is itself the outgoing value — `return &mut b`, a borrowed field,
-//     a borrow-typed binding — has no graph to re-anchor and stays an escape.
+//   - e is an owned carrier, not a bare borrow. A borrow that is itself the outgoing value —
+//     `return &mut b`, a borrowed field, a borrow-typed binding — has no graph to re-anchor.
 //   - The component is self-contained: no live binding outside it borrows a node inside it.
-//     The component is e's root binding together with every local it transitively borrows.
-//     A binding that is dead at ref does not count as an external reference — a moved binding's
-//     value is gone, and a binding not live after ref is never read again, so neither can
-//     observe the re-anchoring. So a carrier consumed into the escaping value, as in `val a2 =
-//     a; return a2`, is not a false external alias, and a stray borrow left unused before a
-//     return does not block the move. At a return every local is dead, so only a parameter or
-//     a longer-lived store can pin a returned component; a live external alias at a store or
-//     argument site still blocks the move.
+//     The component is e's root together with every local it transitively borrows. A binding
+//     dead at ref does not count as an external reference, so a stray unused borrow before a
+//     return does not block the move. The loop below explains what "dead" covers.
 //
 // The external-reference scan reads the same borrow-edge graph the escape check is built on,
 // so it sees the aliases recorded at a `val`/`var` initializer, a `var` reassignment, and a
@@ -161,6 +155,9 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 			continue
 		}
 		for _, edge := range edges {
+			// This live outside binding borrows a node inside the component, so the component
+			// is not self-contained: some node is referenced from outside. The move cannot
+			// apply, and the value escapes normally.
 			if component.Contains(edge.referent) {
 				return false
 			}
@@ -169,12 +166,12 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 	return true
 }
 
-// escapesAsOwnedCarrier reports whether the outgoing value e is an owned aggregate that
-// merely contains borrows of locals, as opposed to a value that is itself a borrow. Only an
-// owned carrier re-anchors an internal graph; a bare borrow has no graph to re-anchor and
-// stays an escape. The recorded type of e cannot make this call: a field read auto-derefs a
-// borrow field to its owned inner, so a borrow read back reads as owned. The borrow-edge
-// graph drives the decision instead.
+// escapesAsOwnedCarrier reports whether the outgoing value e is an owned aggregate holding
+// borrows of locals in its fields, rather than being a borrow itself. Only an owned carrier
+// re-anchors an internal graph. When e is itself a borrow — `&mut b`, a borrow-typed binding,
+// a borrowed field — there is no graph to re-anchor and it stays an escape. The recorded type
+// of e cannot make this call: a field read auto-derefs a borrow field to its owned inner, so
+// a borrow read back reads as owned. The borrow-edge graph drives the decision instead.
 //
 //   - A `&mut b` / `&b` expression is the borrow itself.
 //   - A fresh object or tuple literal is an owned carrier; its borrows are nested fields.

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -18,11 +18,12 @@ import (
 // that references a local keeps it reachable rather than dangling. Returning a
 // self-contained graph is therefore sound. A graph is self-contained when an owned value's
 // internal `&mut` edges reach only locals that nothing outside the graph references. The
-// connected-component move (PR 11) will allow that case by co-moving and consuming those
-// locals, so the returned value's owner anchors them and exclusivity holds. Until it lands,
-// any borrow of a local flowing out is rejected here. A bare `return &mut b` has no owned
-// carrier and stays rejected even then, since the move re-anchors a graph's internal edges,
-// not a borrow that is itself the returned value.
+// connected-component move re-anchors that case: when the flowed-out value owns a graph
+// whose borrowed locals are reachable only through the graph, the escape becomes a move of
+// the whole component — every binding in it is consumed, and a later use of any of them is
+// a use-after-move. A bare `return &mut b` has no owned carrier and stays rejected, since
+// the move re-anchors a graph's internal edges, not a borrow that is itself the returned
+// value. See resolveComponentEscapes.
 //
 // A field-granular borrow-edge graph drives the check, over the move engine's borrow
 // tracking rather than the lifetime sort. recordBorrowEdges records which locals each
@@ -65,6 +66,137 @@ func (e *EscapingBorrowError) Span() ast.Span      { return e.node.Span() }
 func (e *EscapingBorrowError) Related() []ast.Span { return nil }
 func (e *EscapingBorrowError) Message() string {
 	return fmt.Sprintf("borrowed value '%s' does not live long enough to escape the function", e.LocalName)
+}
+
+// escapeSite is one value flowing out of the frame whose escape decision is deferred to
+// resolveComponentEscapes. It holds the outgoing expression and the CFG point it leaves the
+// frame at. The expression doubles as the diagnostic blame and as the source whose carried
+// locals the post-pass computes.
+type escapeSite struct {
+	expr ast.Expr
+	ref  liveness.StmtRef
+}
+
+// resolveComponentEscapes decides every recorded escape site once the body is fully walked,
+// so the borrow-edge graph is complete and the consumed lattice `info` is known. A site
+// whose outgoing value carries borrows of function-locals is either a self-contained
+// connected-component move — allowed, co-moving and consuming the component's locals — or an
+// ordinary escape, reported. It returns true when it consumed any co-moved local, so the
+// caller knows to recompute the lattice before the use-after-move scan reads it.
+func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
+	consumed := false
+	for _, es := range c.fn.escapeSites {
+		escaping := c.escapingLocalsOf(es.expr)
+		if escaping.Len() == 0 {
+			continue
+		}
+		if c.componentMoveCovers(es.expr, escaping, es.ref, info) {
+			// Co-move the component: consume every borrowed local, so a later use of any of
+			// them is a use-after-move. The escaping value's own root is consumed at the flow
+			// site already, so it is skipped here — a borrow cycle can route an edge back to
+			// the root, and consuming it twice at one program point is a spurious double-move.
+			var rootID liveness.VarID
+			if p, ok := exprPlace(es.expr); ok {
+				rootID = p.root
+			}
+			ids := escaping.ToSlice()
+			slices.Sort(ids)
+			for _, id := range ids {
+				if id == rootID {
+					continue
+				}
+				c.recordMove(id, es.expr, es.ref)
+			}
+			consumed = true
+			continue
+		}
+		c.reportEscapingLocals(escaping, es.expr)
+	}
+	c.fn.escapeSites = nil
+	return consumed
+}
+
+// componentMoveCovers reports whether the escape of e is a self-contained connected-component
+// move rather than an ordinary escape. It holds when two conditions are met:
+//
+//   - e is an owned carrier, not a bare borrow. Only an owned value re-anchors its internal
+//     graph; a borrow that is itself the outgoing value — `return &mut b`, a borrowed field,
+//     a borrow-typed binding — has no graph to re-anchor and stays an escape.
+//   - The component is self-contained: no live binding outside it borrows a node inside it.
+//     The component is e's root binding together with every local it transitively borrows.
+//     A binding already moved is dead and does not count as an external reference, so a
+//     carrier consumed into the escaping value, as in `val a2 = a; return a2`, is not a false
+//     external alias of the component a2 now owns.
+func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarID], ref liveness.StmtRef, info *liveness.MoveInfo) bool {
+	if !c.escapesAsOwnedCarrier(e) {
+		return false
+	}
+	component := escaping.Clone()
+	if p, ok := exprPlace(e); ok && p.root > 0 {
+		component.Add(p.root)
+	}
+	for root, edges := range c.fn.borrowEdges {
+		if component.Contains(root) {
+			continue
+		}
+		if info.StateBefore(ref, root) == liveness.Moved {
+			continue
+		}
+		for _, edge := range edges {
+			if component.Contains(edge.referent) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// escapesAsOwnedCarrier reports whether the outgoing value e is an owned aggregate that
+// merely contains borrows of locals, as opposed to a value that is itself a borrow. Only an
+// owned carrier re-anchors an internal graph; a bare borrow has no graph to re-anchor and
+// stays an escape. The recorded type of e cannot make this call: a field read auto-derefs a
+// borrow field to its owned inner, so a borrow read back reads as owned. The borrow-edge
+// graph drives the decision instead.
+//
+//   - A `&mut b` / `&b` expression is the borrow itself.
+//   - A fresh object or tuple literal is an owned carrier; its borrows are nested fields.
+//   - A place is an owned carrier unless a borrow edge sits at or above the read place, which
+//     makes the read project onto a borrow. `return a` over a → b at [peer] reads the owned
+//     object a, while `return a.peer` over the same edge reads the borrow, and `return a` over
+//     a → b at [] reads a borrow-typed binding.
+//   - Any other carrier — an if/match, a call result — is conservatively a bare borrow, so an
+//     ambiguous outgoing value stays an escape rather than a speculative component move.
+func (c *checker) escapesAsOwnedCarrier(e ast.Expr) bool {
+	switch e.(type) {
+	case *ast.BorrowExpr:
+		return false
+	case *ast.ObjectExpr, *ast.TupleExpr:
+		return true
+	}
+	p, ok := exprPlace(e)
+	if !ok || p.root <= 0 {
+		return false
+	}
+	for _, edge := range c.fn.borrowEdges[p.root] {
+		if pathHasPrefix(p.path, edge.path) {
+			return false
+		}
+	}
+	return true
+}
+
+// pathHasPrefix reports whether prefix is a prefix of full: every segment of prefix matches
+// full at the same index, so an empty prefix matches any path and equal paths match.
+func pathHasPrefix(full, prefix []placeSeg) bool {
+	if len(prefix) > len(full) {
+		return false
+	}
+	for i := range prefix {
+		if prefix[i] != full[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // fieldBorrow is one borrow edge under a binding: the field path within the binding that
@@ -314,16 +446,28 @@ func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame a
 	}
 }
 
-// checkReturnEscape reports an escape for each function-local a returned value borrows.
-// `return a` where a borrows b, `return &mut b`, and `return {peer: &mut b}` all escape b.
-func (c *checker) checkReturnEscape(retExpr ast.Expr) {
-	c.reportEscapingLocals(c.escapingLocalsOf(retExpr), retExpr)
+// recordEscapeSite defers the escape decision for a value flowing out of the frame to the
+// post-pass, capturing the outgoing expression and the program point it flows out at. The
+// post-pass needs the complete borrow-edge graph and the consumed lattice, neither of which
+// is final mid-walk, so it cannot decide a self-contained component move inline.
+func (c *checker) recordEscapeSite(e ast.Expr, ref liveness.StmtRef) {
+	if c.fn == nil || e == nil {
+		return
+	}
+	c.fn.escapeSites = append(c.fn.escapeSites, escapeSite{expr: e, ref: ref})
 }
 
-// checkParamFieldStoreEscape handles a field store `recv.f = source`. Storing a value that borrows a
-// local into a parameter's field escapes, since the parameter's object outlives the frame.
-// A store into a local receiver does not escape and is not tracked.
-func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
+// checkReturnEscape records the return value as an escape site. `return a` where a borrows
+// b, `return &mut b`, and `return {peer: &mut b}` all carry a borrow of b out of the frame;
+// resolveComponentEscapes later decides each as a component move or an escape.
+func (c *checker) checkReturnEscape(retExpr ast.Expr, ref liveness.StmtRef) {
+	c.recordEscapeSite(retExpr, ref)
+}
+
+// checkParamFieldStoreEscape handles a field store `recv.f = source`. Storing a value that
+// borrows a local into a parameter's field escapes, since the parameter's object outlives
+// the frame. A store into a local receiver does not escape and is not tracked.
+func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness.StmtRef) {
 	if c.fn == nil || c.fn.borrowEdges == nil {
 		return
 	}
@@ -331,7 +475,7 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr) {
 	if !ok || rp.root <= 0 || !c.fn.paramVarIDs.Contains(rp.root) {
 		return
 	}
-	c.reportEscapingLocals(c.escapingLocalsOf(source), source)
+	c.recordEscapeSite(source, ref)
 }
 
 // collectBorrowedFrom adds to out every function-local the read place rooted at root, with

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -127,6 +127,12 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
 //     A binding already moved is dead and does not count as an external reference, so a
 //     carrier consumed into the escaping value, as in `val a2 = a; return a2`, is not a false
 //     external alias of the component a2 now owns.
+//
+// The external-reference scan reads the same borrow-edge graph the escape check is built on,
+// so it sees the aliases recorded at a `val`/`var` initializer, a `var` reassignment, and a
+// destructuring leaf. An alias formed by a path the graph does not record, such as a `.push`
+// of a borrow into a container, is invisible here exactly as it is to the escape check, the
+// shared limitation the graph's three recording sites impose.
 func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarID], ref liveness.StmtRef, info *liveness.MoveInfo) bool {
 	if !c.escapesAsOwnedCarrier(e) {
 		return false

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -130,7 +130,9 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
 // so it sees the aliases recorded at a `val`/`var` initializer, a `var` reassignment, and a
 // destructuring leaf. An alias formed by a path the graph does not record, such as a `.push`
 // of a borrow into a container, is invisible here exactly as it is to the escape check, the
-// shared limitation the graph's three recording sites impose.
+// shared limitation the graph's three recording sites impose. Recording a container-method
+// borrow needs `Array` and method-call support the solver lacks today; it is tracked as a
+// post-M7 item under "Deferred and out of scope" in planning/affine_semantics/implementation_plan.md.
 func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarID], ref liveness.StmtRef, info *liveness.MoveInfo) bool {
 	if !c.escapesAsOwnedCarrier(e) {
 		return false

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -124,9 +124,13 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
 //     a borrow-typed binding — has no graph to re-anchor and stays an escape.
 //   - The component is self-contained: no live binding outside it borrows a node inside it.
 //     The component is e's root binding together with every local it transitively borrows.
-//     A binding already moved is dead and does not count as an external reference, so a
-//     carrier consumed into the escaping value, as in `val a2 = a; return a2`, is not a false
-//     external alias of the component a2 now owns.
+//     A binding that is dead at ref does not count as an external reference — a moved binding's
+//     value is gone, and a binding not live after ref is never read again, so neither can
+//     observe the re-anchoring. So a carrier consumed into the escaping value, as in `val a2 =
+//     a; return a2`, is not a false external alias, and a stray borrow left unused before a
+//     return does not block the move. At a return every local is dead, so only a parameter or
+//     a longer-lived store can pin a returned component; a live external alias at a store or
+//     argument site still blocks the move.
 //
 // The external-reference scan reads the same borrow-edge graph the escape check is built on,
 // so it sees the aliases recorded at a `val`/`var` initializer, a `var` reassignment, and a
@@ -145,7 +149,15 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 		if component.Contains(root) {
 			continue
 		}
+		// A binding that is dead at ref does not pin the component: its borrow of a component
+		// node is never dereferenced again, so co-moving the node observes nothing. Dead means
+		// moved before ref, or not live after it. At a return every local is dead — nothing
+		// runs after — so only a parameter or a longer-lived store can pin a returned
+		// component; a live external alias at a store or argument site still blocks the move.
 		if info.StateBefore(ref, root) == liveness.Moved {
+			continue
+		}
+		if c.fn.liveness != nil && !c.fn.liveness.IsLiveAfter(ref, root) {
 			continue
 		}
 		for _, edge := range edges {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -230,6 +230,24 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 			want:  nil,
 			types: map[string]string{"f": "fn (p: mut {peer: &mut {value: number}}, q: &mut {value: number}) -> void"},
 		},
+		// Storing an owned carrier that holds a local borrow into a parameter's field is a
+		// connected-component move, not an escape: the stored `{peer: &mut b}` owns a
+		// self-contained graph whose only borrowed local b is reached just through it, so the
+		// store re-anchors the component to the parameter's region and consumes b. No escape
+		// fires, and reading b afterward is a use-after-move. This is the owned-carrier twin of
+		// StoreLocalBorrowIntoParamField, where the bare borrow `&mut b` had no graph to
+		// re-anchor and escaped.
+		"StoreCarrierIntoParamFieldMovesComponent": {
+			src: `
+				fn f(p: mut {node: {peer: &mut {value: number}}}) {
+					val mut b = {value: 0}
+					p.node = {peer: &mut b}
+					val y = b
+				}
+			`,
+			want:  []string{"5:14-5:15: use of moved value 'b'"},
+			types: map[string]string{"f": "fn (p: mut {node: {peer: &mut {value: number}}}) -> void"},
+		},
 		// Auto-borrowing a local into a `&mut` parameter is sound: the parameter borrows
 		// for the call rather than consuming, so the local outlives the borrow.
 		"BorrowArgToRefParamOk": {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -493,6 +493,50 @@ func TestConnectedComponentMove(t *testing.T) {
 			want:  []string{"6:13-6:14: borrowed value 'd' does not live long enough to escape the function"},
 			types: map[string]string{"build": "fn () -> {peer: &mut {x: number}}"},
 		},
+		// Two mutable aliases of one node are fine when both live inside the moved component.
+		// b and c each hold `&mut d`, and a holds shared borrows of both, so the component
+		// reachable from a is {a, b, c, d} and both `&mut d` paths are internal to it. The
+		// model permits several `&mut` borrows live at once, so this is a legal value, and
+		// returning a re-anchors the whole graph — both internal mutable paths included — with
+		// no external observer. This is the mirror of MutableAliasRejectsMove: there the second
+		// `&mut d` was left outside the component and rejected; here a owns both, so it is not.
+		// The outer borrows are shared, so the carrier sidesteps the owned-mutable upgrade that
+		// blocks the all-`&mut` MutableDiamondRejected.
+		"InternalMutableAliasMovesAsUnit": {
+			src: `
+				fn build() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					val mut c = {peer: &mut d}
+					val a = {l: &b, r: &c}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {l: &{peer: &mut {x: number}}, r: &{peer: &mut {x: number}}}"},
+		},
+		// The co-move consumes the shared node exactly once despite the two internal mutable
+		// paths to it: storing the graph into a callee consumes d, so reading it afterward is a
+		// single use-after-move, with no spurious double-move from reaching d through both b
+		// and c.
+		"InternalMutableAliasConsumesSharedNode": {
+			src: `
+				fn store(x: {l: &{peer: &mut {x: number}}, r: &{peer: &mut {x: number}}}) {}
+				fn f() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					val mut c = {peer: &mut d}
+					val a = {l: &b, r: &c}
+					store(a)
+					val y = d
+				}
+			`,
+			want: []string{"9:14-9:15: use of moved value 'd'"},
+			types: map[string]string{
+				"store": "fn (x: {l: &{peer: &mut {x: number}}, r: &{peer: &mut {x: number}}}) -> void",
+				"f":     "fn () -> void",
+			},
+		},
 		// A wider component with five borrowed locals moves out as one unit, the same as the
 		// two-local case, since every node is reachable only through a.
 		"ReturnLargeStar": {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -531,20 +531,28 @@ func TestConnectedComponentMove(t *testing.T) {
 			types: map[string]string{"build": "fn () -> {l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x: number}}}"},
 		},
 		// A node mutably aliased outside the moved component blocks the move: b and c each hold
-		// `&mut d`, so returning b cannot move d out while c is a live second mutable path to
-		// it. This is the same external-reference rejection as the shared case, and it is what
-		// keeps a mutable same-graph alias from being co-moved out from under a live writer.
+		// `&mut d`, and c is read after the store, so it is a live second mutable path to d when
+		// storing b tries to move it out. This is the same external-reference rejection as the
+		// shared case, and it is what keeps a mutable same-graph alias from being co-moved out
+		// from under a live writer. The escape is demonstrated at a store site, not a return,
+		// because at a return every local is dead — see DeadExternalRefAllowsMove — so a live
+		// external alias only exists where it is used after the escape.
 		"MutableAliasRejectsMove": {
 			src: `
-				fn build() {
+				fn store(x: {peer: &mut {x: number}}) {}
+				fn f() {
 					val mut d = {x: 0}
 					val b = {peer: &mut d}
 					val c = {peer: &mut d}
-					return b
+					store(b)
+					val y = c
 				}
 			`,
-			want:  []string{"6:13-6:14: borrowed value 'd' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn () -> {peer: &mut {x: number}}"},
+			want: []string{"7:12-7:13: borrowed value 'd' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &mut {x: number}}) -> void",
+				"f":     "fn () -> void",
+			},
 		},
 		// Two mutable aliases of one node are fine when both live inside the moved component.
 		// b and c each hold `&mut d`, and a holds shared borrows of both, so the component
@@ -636,10 +644,12 @@ func TestConnectedComponentMove(t *testing.T) {
 				"f":     "fn () -> void",
 			},
 		},
-		// A node also reachable from a live binding outside the component is not self-
-		// contained: keep holds a second borrow of b, so the move does not apply and
-		// returning a reports the ordinary escape.
-		"RetainedNodeRejectsMove": {
+		// A second borrow of a node that is dead by the escape point does not pin the
+		// component: keep holds `&b`, but it is never read after `return a`, and at a return
+		// every local is dead, so keep observes nothing once b is co-moved. The move applies
+		// and no escape is reported. Self-containment is about a LIVE external reference, so a
+		// stray unused borrow before a return is not one.
+		"DeadExternalRefAllowsMove": {
 			src: `
 				fn build() {
 					val mut b = {value: 2}
@@ -648,8 +658,30 @@ func TestConnectedComponentMove(t *testing.T) {
 					return a
 				}
 			`,
-			want:  []string{"6:13-6:14: borrowed value 'b' does not live long enough to escape the function"},
+			want:  nil,
 			types: map[string]string{"build": "fn () -> {peer: &{value: number}}"},
+		},
+		// A node reachable from a LIVE binding outside the component is not self-contained: keep
+		// holds `&b` and is read after the store, so it is a live external reference to b when
+		// storing a tries to move the {a, b} component out. The move does not apply and the
+		// ordinary escape stands. Contrast DeadExternalRefAllowsMove, where the same borrow was
+		// dead at a return.
+		"LiveExternalRefRejectsMove": {
+			src: `
+				fn store(x: {peer: &{value: number}}) {}
+				fn f() {
+					val mut b = {value: 2}
+					val a = {peer: &b}
+					val keep = &b
+					store(a)
+					val y = keep
+				}
+			`,
+			want: []string{"7:12-7:13: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &{value: number}}) -> void",
+				"f":     "fn () -> void",
+			},
 		},
 	}
 	for name, tc := range tests {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -170,6 +170,10 @@ func TestReturnEscape(t *testing.T) {
 		// A borrow introduced by reassigning a `var` escapes: `a = &mut b` records the edge
 		// a → b, so returning a escapes the local b. The edge graph accumulates, so the
 		// reassignment adds the edge to a's earlier ones.
+		// PR 16: flow-sensitive set-and-clear replaces the accumulate-only edge, so the
+		// reassignment clears a's prior edges and sets a → b. The escape result is unchanged
+		// here, since a's prior referent was the parameter seed, which records no edge; the
+		// comment's "accumulates" narrative is what updates.
 		"ReturnVarReassignedToBorrowEscapes": {
 			src: `
 				fn f(seed: &mut {value: number}) {
@@ -295,6 +299,14 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 // destination region and consumes every binding in the component, rather than reporting an
 // escape. When a node is also reachable from a live binding outside the component, the move
 // does not apply and the ordinary escape stands.
+//
+// Cases tagged `PR 16:` change when the flow-sensitivity work lands. Two behaviours move
+// them. Return borrow-stripping rewrites a returned `&`/`&mut` of a function-local reached
+// exactly once into an owned field, so a tree-shaped component move returns an owned type
+// while a diamond or cyclic graph keeps its borrows. The borrow-field owned-mutable upgrade
+// makes `&mut` graph carriers constructible, flipping the all-`&mut` diamond from a
+// construction error to a component move. See PR 16 in
+// planning/affine_semantics/implementation_plan.md.
 func TestConnectedComponentMove(t *testing.T) {
 	tests := map[string]struct {
 		src   string
@@ -304,6 +316,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// The canonical case: the owned binding a holds `&mut b`, and nothing outside the
 		// {a, b} component references either node, so returning a moves the whole component
 		// out. No escape, and a and b are both consumed.
+		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
+		// `{peer: {value: number}}`.
 		"ReturnSelfContainedComponent": {
 			src: `
 				fn build() {
@@ -317,6 +331,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		},
 		// A component with two borrowed locals moves as a unit just the same: both b and c
 		// are reachable only through a, so returning a co-moves all three.
+		// PR 16: b and c are each reached once, so borrow-stripping rewrites the return to the
+		// owned `{p: {x: number}, q: {x: number}}`.
 		"ReturnComponentTwoLocals": {
 			src: `
 				fn build() {
@@ -331,6 +347,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		},
 		// The owned carrier may be a fresh literal with no intervening binding: the returned
 		// object owns the borrow of b, and b is reachable only through it.
+		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
+		// `{peer: {value: number}}`.
 		"ReturnInlineLiteralComponent": {
 			src: `
 				fn build() {
@@ -344,6 +362,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// A whole-binding move carries the graph forward: `val a2 = a` moves a, borrow and
 		// all, into a2. The dead a is not a live external reference to b, so returning a2
 		// still moves the {a2, b} component out.
+		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
+		// `{peer: {value: number}}`.
 		"ReturnMovedCarrierComponent": {
 			src: `
 				fn build() {
@@ -358,6 +378,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		},
 		// An acyclic shared graph moves out the same way: a holds `&b`, and b is reachable
 		// only through a.
+		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
+		// `{peer: {value: number}}` — stripping covers shared `&` borrows as well as `&mut`.
 		"ReturnSharedComponent": {
 			src: `
 				fn build() {
@@ -407,6 +429,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// An escape through a consuming call inside a return is a component move at the
 		// argument: the literal owning `&mut b` moves into id, b reachable only through it.
 		// No escape is reported at either the argument or the enclosing return.
+		// PR 16: f's returned value borrows b once, so borrow-stripping rewrites f's return to
+		// the owned `{peer: {value: number}}`; id keeps its borrow-typed parameter and result.
 		"ComponentMoveThroughConsumingCall": {
 			src: `
 				fn id(y: {peer: &mut {value: number}}) {
@@ -426,6 +450,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// A transitive chain moves as a unit: a borrows b, b borrows c, c borrows d, so the
 		// component reachable from a is {a, b, c, d}. Returning a co-moves all four. The
 		// chain uses shared borrows so the carriers nest without a mutable-view conflict.
+		// PR 16: every node is reached once, so borrow-stripping rewrites the return to the
+		// owned `{peer: {peer: {peer: {value: 4}}}}`.
 		"ReturnTransitiveChain": {
 			src: `
 				fn build() {
@@ -442,6 +468,9 @@ func TestConnectedComponentMove(t *testing.T) {
 		// A diamond shares a node: a borrows b and c, and both b and c borrow d, so d is
 		// reachable through two paths. The component is still {a, b, c, d} and moves out as a
 		// unit; reaching d twice is collapsed by the reachability walk's seen set.
+		// PR 16: d is reached through two paths, so borrow-stripping KEEPS the borrows — an
+		// owned tree cannot express the shared node — and this return type is unchanged. This
+		// is the multiplicity case that bounds stripping.
 		"ReturnDiamondSharedNode": {
 			src: `
 				fn build() {
@@ -461,6 +490,12 @@ func TestConnectedComponentMove(t *testing.T) {
 		// builds. The aliasing question the shared diamond raises — d reached through two
 		// mutable paths — is therefore never reached here; the two-mutable-alias rejection is
 		// pinned separately by MutableAliasRejectsMove.
+		// PR 16: the borrow-field owned-mutable upgrade makes the `&mut` carriers
+		// constructible, so this flips from the two `cannot constrain` errors to a
+		// connected-component move with `want: nil`. d is reached through two paths, so
+		// borrow-stripping keeps the borrows and the moved type stays
+		// `{l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x: number}}}`. Rename to
+		// MutableDiamondMovesAsUnit when it lands.
 		"MutableDiamondRejected": {
 			src: `
 				fn build() {
@@ -502,6 +537,10 @@ func TestConnectedComponentMove(t *testing.T) {
 		// `&mut d` was left outside the component and rejected; here a owns both, so it is not.
 		// The outer borrows are shared, so the carrier sidesteps the owned-mutable upgrade that
 		// blocks the all-`&mut` MutableDiamondRejected.
+		// PR 16: two changes meet here but cancel. The borrow-field upgrade no longer blocks
+		// the all-`&mut` MutableDiamondRejected, so that cross-reference goes stale. And d is
+		// reached through two paths, so borrow-stripping keeps the borrows — this return type
+		// is unchanged.
 		"InternalMutableAliasMovesAsUnit": {
 			src: `
 				fn build() {
@@ -539,6 +578,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		},
 		// A wider component with five borrowed locals moves out as one unit, the same as the
 		// two-local case, since every node is reachable only through a.
+		// PR 16: every node is reached once, so borrow-stripping rewrites the return to the
+		// owned `{b1: {x: number}, …}` with all five fields owned.
 		"ReturnLargeStar": {
 			src: `
 				fn build() {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -455,6 +455,44 @@ func TestConnectedComponentMove(t *testing.T) {
 			want:  nil,
 			types: map[string]string{"build": "fn () -> {l: &{peer: &{x: 0}}, r: &{peer: &{x: 0}}}"},
 		},
+		// The mutable analog of the shared diamond does not form. Borrowing `&mut b` and
+		// `&mut c` where b and c are owned objects already holding a `&mut` borrow is rejected,
+		// since a `&mut` of a borrow-carrying local is not yet supported, so the carrier never
+		// builds. The aliasing question the shared diamond raises — d reached through two
+		// mutable paths — is therefore never reached here; the two-mutable-alias rejection is
+		// pinned separately by MutableAliasRejectsMove.
+		"MutableDiamondRejected": {
+			src: `
+				fn build() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					val mut c = {peer: &mut d}
+					val a = {l: &mut b, r: &mut c}
+					return a
+				}
+			`,
+			want: []string{
+				"6:18-6:24: cannot constrain immutable object <: mutable object",
+				"6:29-6:35: cannot constrain immutable object <: mutable object",
+			},
+			types: map[string]string{"build": "fn () -> {l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x: number}}}"},
+		},
+		// A node mutably aliased outside the moved component blocks the move: b and c each hold
+		// `&mut d`, so returning b cannot move d out while c is a live second mutable path to
+		// it. This is the same external-reference rejection as the shared case, and it is what
+		// keeps a mutable same-graph alias from being co-moved out from under a live writer.
+		"MutableAliasRejectsMove": {
+			src: `
+				fn build() {
+					val mut d = {x: 0}
+					val b = {peer: &mut d}
+					val c = {peer: &mut d}
+					return b
+				}
+			`,
+			want:  []string{"6:13-6:14: borrowed value 'd' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> {peer: &mut {x: number}}"},
+		},
 		// A wider component with five borrowed locals moves out as one unit, the same as the
 		// two-local case, since every node is reachable only through a.
 		"ReturnLargeStar": {

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -3,6 +3,9 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/stretchr/testify/require"
 )
 
@@ -420,6 +423,78 @@ func TestConnectedComponentMove(t *testing.T) {
 				"f":  "fn () -> {peer: &mut {value: number}}",
 			},
 		},
+		// A transitive chain moves as a unit: a borrows b, b borrows c, c borrows d, so the
+		// component reachable from a is {a, b, c, d}. Returning a co-moves all four. The
+		// chain uses shared borrows so the carriers nest without a mutable-view conflict.
+		"ReturnTransitiveChain": {
+			src: `
+				fn build() {
+					val d = {value: 4}
+					val c = {peer: &d}
+					val b = {peer: &c}
+					val a = {peer: &b}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {peer: &{peer: &{peer: &{value: 4}}}}"},
+		},
+		// A diamond shares a node: a borrows b and c, and both b and c borrow d, so d is
+		// reachable through two paths. The component is still {a, b, c, d} and moves out as a
+		// unit; reaching d twice is collapsed by the reachability walk's seen set.
+		"ReturnDiamondSharedNode": {
+			src: `
+				fn build() {
+					val d = {x: 0}
+					val b = {peer: &d}
+					val c = {peer: &d}
+					val a = {l: &b, r: &c}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {l: &{peer: &{x: 0}}, r: &{peer: &{x: 0}}}"},
+		},
+		// A wider component with five borrowed locals moves out as one unit, the same as the
+		// two-local case, since every node is reachable only through a.
+		"ReturnLargeStar": {
+			src: `
+				fn build() {
+					val mut b = {x: 1}
+					val mut c = {x: 2}
+					val mut d = {x: 3}
+					val mut e = {x: 4}
+					val mut g = {x: 5}
+					val a = {b1: &mut b, c1: &mut c, d1: &mut d, e1: &mut e, g1: &mut g}
+					return a
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"build": "fn () -> {b1: &mut {x: number}, c1: &mut {x: number}, d1: &mut {x: number}, e1: &mut {x: number}, g1: &mut {x: number}}",
+			},
+		},
+		// The co-move reaches the deepest transitive node: storing the chain a → b → c → d
+		// into a callee consumes d, so reading it afterward is a use-after-move even though d
+		// is three borrows away from the moved binding.
+		"ChainMoveConsumesDeepestNode": {
+			src: `
+				fn store(x: {peer: &{peer: &{peer: &{value: number}}}}) {}
+				fn f() {
+					val d = {value: 4}
+					val c = {peer: &d}
+					val b = {peer: &c}
+					val a = {peer: &b}
+					store(a)
+					val y = d
+				}
+			`,
+			want: []string{"9:14-9:15: use of moved value 'd'"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &{peer: &{peer: &{value: number}}}}) -> void",
+				"f":     "fn () -> void",
+			},
+		},
 		// A node also reachable from a live binding outside the component is not self-
 		// contained: keep holds a second borrow of b, so the move does not apply and
 		// returning a reports the ordinary escape.
@@ -441,6 +516,70 @@ func TestConnectedComponentMove(t *testing.T) {
 			values, _, errs := inferSource(t, tc.src)
 			require.Equal(t, tc.want, messagesWithSpan(errs))
 			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestComponentEscapeCyclicGraph drives the component reachability walk over a cyclic
+// borrow-edge graph. A genuine cycle — a borrows b and b borrows a — is not expressible in
+// source today, since it needs a recursive type alias (M7) for the mutually-referential
+// carriers, and the `.push` form the requirements' cyclic `build()` uses does not record
+// borrow edges. So the cycle handling is exercised by building the edge graph directly and
+// asserting escapingLocalsOf terminates and returns every node, the root included.
+//
+// escapingLocalsOf reaching the root back through the cycle is the case resolveComponentEscapes
+// guards when it skips the root while consuming co-moved locals, so a cyclic component does
+// not double-move its own root.
+func TestComponentEscapeCyclicGraph(t *testing.T) {
+	edge := func(referent liveness.VarID) fieldBorrow {
+		return fieldBorrow{path: nil, referent: referent}
+	}
+	tests := map[string]struct {
+		edges map[liveness.VarID][]fieldBorrow
+		root  liveness.VarID
+		want  []liveness.VarID
+	}{
+		// A two-node cycle: a ⇄ b. Reaching b follows b's edge back to a, so the escaping
+		// set closes over both nodes and includes the root a.
+		"TwoNodeCycle": {
+			edges: map[liveness.VarID][]fieldBorrow{
+				1: {edge(2)},
+				2: {edge(1)},
+			},
+			root: 1,
+			want: []liveness.VarID{1, 2},
+		},
+		// A three-node cycle: a → b → c → a. Every node is reachable, and the walk's seen set
+		// terminates the loop at the third hop rather than recurring forever.
+		"ThreeNodeCycle": {
+			edges: map[liveness.VarID][]fieldBorrow{
+				1: {edge(2)},
+				2: {edge(3)},
+				3: {edge(1)},
+			},
+			root: 1,
+			want: []liveness.VarID{1, 2, 3},
+		},
+		// A node with a self-loop plus an onward edge: a → a and a → b. The self-edge is
+		// followed once and collapsed by the seen set, and b is still reached.
+		"SelfLoopAndOnward": {
+			edges: map[liveness.VarID][]fieldBorrow{
+				1: {edge(1), edge(2)},
+			},
+			root: 1,
+			want: []liveness.VarID{1, 2},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := newChecker()
+			c.fn = &funcCtx{
+				borrowEdges: tc.edges,
+				paramVarIDs: set.NewSet[liveness.VarID](),
+			}
+			e := &ast.IdentExpr{Name: "root", VarID: int(tc.root)}
+			got := c.escapingLocalsOf(e).ToSlice()
+			require.ElementsMatch(t, tc.want, got)
 		})
 	}
 }

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -11,38 +11,17 @@ import (
 // of a parameter is exempt, because its lifetime is supplied by the caller and already
 // outlives the return. Each case also pins the function's inferred type, since the escape
 // is reported alongside ordinary inference rather than replacing it.
+//
+// Every case here is a bare borrow flowing out: the outgoing value IS a borrow, so it has
+// no owned graph to re-anchor and stays an escape. An owned value carrying a self-contained
+// graph of borrowed locals is a connected-component move instead, covered by
+// TestConnectedComponentMove.
 func TestReturnEscape(t *testing.T) {
 	tests := map[string]struct {
 		src   string
 		want  []string
 		types map[string]string
 	}{
-		// Returning a binding that borrows a local escapes the local it borrows. The
-		// binding a holds `&mut b`, so returning a would leave a's edge dangling at b,
-		// which dies with the frame.
-		"ReturnBindingBorrowingLocal": {
-			src: `
-				fn build() {
-					val mut b = {value: 2}
-					val a = {peer: &mut b}
-					return a
-				}
-			`,
-			want:  []string{"5:13-5:14: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
-		},
-		// A borrow of a local written directly into the returned literal escapes the same
-		// way, with no intervening binding.
-		"ReturnInlineBorrowOfLocal": {
-			src: `
-				fn build() {
-					val mut b = {value: 2}
-					return {peer: &mut b}
-				}
-			`,
-			want:  []string{"4:13-4:27: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
-		},
 		// Returning the borrow itself, `return &mut b`, escapes the local b.
 		"ReturnDirectBorrowOfLocal": {
 			src: `
@@ -53,36 +32,6 @@ func TestReturnEscape(t *testing.T) {
 			`,
 			want:  []string{"4:13-4:19: borrowed value 'b' does not live long enough to escape the function"},
 			types: map[string]string{"build": "fn () -> &mut {value: number}"},
-		},
-		// A binding that borrows two locals escapes both, reported in source order.
-		"ReturnBindingBorrowingTwoLocals": {
-			src: `
-				fn build() {
-					val mut b = {x: 0}
-					val mut c = {x: 1}
-					val a = {p: &mut b, q: &mut c}
-					return a
-				}
-			`,
-			want: []string{
-				"6:13-6:14: borrowed value 'b' does not live long enough to escape the function",
-				"6:13-6:14: borrowed value 'c' does not live long enough to escape the function",
-			},
-			types: map[string]string{"build": "fn () -> {p: &mut {x: number}, q: &mut {x: number}}"},
-		},
-		// A whole-binding move carries the borrow forward: `val a2 = a` moves a's value,
-		// borrow and all, into a2, so returning a2 escapes the same local a would.
-		"ReturnMovedCarrierEscapes": {
-			src: `
-				fn build() {
-					val mut b = {value: 2}
-					val a = {peer: &mut b}
-					val a2 = a
-					return a2
-				}
-			`,
-			want:  []string{"6:13-6:15: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
 		},
 		// Returning the borrow field itself escapes the local it holds: `a.peer` is the
 		// `&mut b` borrow, so returning it leaves b dangling. The field-granular edge at
@@ -274,23 +223,6 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 			want:  nil,
 			types: map[string]string{"f": "fn (p: mut {peer: &mut {value: number}}, q: &mut {value: number}) -> void"},
 		},
-		// Passing a value that borrows a local as a consuming argument escapes: the callee
-		// takes ownership of the value and could retain it past the frame.
-		"ConsumingArgCarriesLocalBorrow": {
-			src: `
-				fn store(x: {peer: &mut {value: number}}) {}
-				fn f() {
-					val mut b = {value: 0}
-					val a = {peer: &mut b}
-					store(a)
-				}
-			`,
-			want: []string{"6:12-6:13: borrowed value 'b' does not live long enough to escape the function"},
-			types: map[string]string{
-				"store": "fn (x: {peer: &mut {value: number}}) -> void",
-				"f":     "fn () -> void",
-			},
-		},
 		// Auto-borrowing a local into a `&mut` parameter is sound: the parameter borrows
 		// for the call rather than consuming, so the local outlives the borrow.
 		"BorrowArgToRefParamOk": {
@@ -344,10 +276,135 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 				"f":     "fn () -> void",
 			},
 		},
-		// A single escape through a consuming call inside a return is reported once, at the
-		// argument where the local borrow flows into the callee, not a second time at the
-		// enclosing return.
-		"EscapeThroughConsumingCallReportedOnce": {
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestConnectedComponentMove covers the connected-component move: an owned value carrying a
+// self-contained graph of borrowed locals flows out of the frame as a unit. The borrowed
+// locals are reachable only through the graph, so the move re-anchors them to the
+// destination region and consumes every binding in the component, rather than reporting an
+// escape. When a node is also reachable from a live binding outside the component, the move
+// does not apply and the ordinary escape stands.
+func TestConnectedComponentMove(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The canonical case: the owned binding a holds `&mut b`, and nothing outside the
+		// {a, b} component references either node, so returning a moves the whole component
+		// out. No escape, and a and b are both consumed.
+		"ReturnSelfContainedComponent": {
+			src: `
+				fn build() {
+					val mut b = {value: 2}
+					val a = {peer: &mut b}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+		},
+		// A component with two borrowed locals moves as a unit just the same: both b and c
+		// are reachable only through a, so returning a co-moves all three.
+		"ReturnComponentTwoLocals": {
+			src: `
+				fn build() {
+					val mut b = {x: 0}
+					val mut c = {x: 1}
+					val a = {p: &mut b, q: &mut c}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {p: &mut {x: number}, q: &mut {x: number}}"},
+		},
+		// The owned carrier may be a fresh literal with no intervening binding: the returned
+		// object owns the borrow of b, and b is reachable only through it.
+		"ReturnInlineLiteralComponent": {
+			src: `
+				fn build() {
+					val mut b = {value: 2}
+					return {peer: &mut b}
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+		},
+		// A whole-binding move carries the graph forward: `val a2 = a` moves a, borrow and
+		// all, into a2. The dead a is not a live external reference to b, so returning a2
+		// still moves the {a2, b} component out.
+		"ReturnMovedCarrierComponent": {
+			src: `
+				fn build() {
+					val mut b = {value: 2}
+					val a = {peer: &mut b}
+					val a2 = a
+					return a2
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+		},
+		// An acyclic shared graph moves out the same way: a holds `&b`, and b is reachable
+		// only through a.
+		"ReturnSharedComponent": {
+			src: `
+				fn build() {
+					val mut b = {value: 2}
+					val a = {peer: &b}
+					return a
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"build": "fn () -> {peer: &{value: number}}"},
+		},
+		// A consuming argument moves the component into the callee, which now owns the graph.
+		"ConsumingArgComponentMove": {
+			src: `
+				fn store(x: {peer: &mut {value: number}}) {}
+				fn f() {
+					val mut b = {value: 0}
+					val a = {peer: &mut b}
+					store(a)
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"store": "fn (x: {peer: &mut {value: number}}) -> void",
+				"f":     "fn () -> void",
+			},
+		},
+		// The component move consumes the borrowed local, not just the carrier: after the
+		// graph moves into store, reading b is a use-after-move even though b was never the
+		// argument. The carrier a is consumed by the ordinary argument move.
+		"ComponentMoveConsumesBorrowedLocal": {
+			src: `
+				fn store(x: {peer: &mut {value: number}}) {}
+				fn f() {
+					val mut b = {value: 0}
+					val a = {peer: &mut b}
+					store(a)
+					val y = b
+				}
+			`,
+			want: []string{"7:14-7:15: use of moved value 'b'"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &mut {value: number}}) -> void",
+				"f":     "fn () -> void",
+			},
+		},
+		// An escape through a consuming call inside a return is a component move at the
+		// argument: the literal owning `&mut b` moves into id, b reachable only through it.
+		// No escape is reported at either the argument or the enclosing return.
+		"ComponentMoveThroughConsumingCall": {
 			src: `
 				fn id(y: {peer: &mut {value: number}}) {
 					return y
@@ -357,11 +414,26 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 					return id({peer: &mut b})
 				}
 			`,
-			want: []string{"7:16-7:30: borrowed value 'b' does not live long enough to escape the function"},
+			want: nil,
 			types: map[string]string{
 				"id": "fn <'a>(y: {peer: &'a mut {value: number}}) -> {peer: &'a mut {value: number}}",
 				"f":  "fn () -> {peer: &mut {value: number}}",
 			},
+		},
+		// A node also reachable from a live binding outside the component is not self-
+		// contained: keep holds a second borrow of b, so the move does not apply and
+		// returning a reports the ordinary escape.
+		"RetainedNodeRejectsMove": {
+			src: `
+				fn build() {
+					val mut b = {value: 2}
+					val a = {peer: &b}
+					val keep = &b
+					return a
+				}
+			`,
+			want:  []string{"6:13-6:14: borrowed value 'b' does not live long enough to escape the function"},
+			types: map[string]string{"build": "fn () -> {peer: &{value: number}}"},
 		},
 	}
 	for name, tc := range tests {

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -254,7 +254,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 8 | Immutable→mutable thaw move and borrow-phase framing | 6 | Medium | ✅ done |
 | 9 | Unions/intersections as `RefInner`, mixed-ownership rejection, nested-borrow normalization | 3, M6 | Medium | ✅ done (#811) |
 | 10 | Mutable narrowed binding with pinned discriminant | 8, 9, M6 | Medium | ⬜ not started |
-| 11 | Connected-component moves for graphs | 6, 7, 15 | Large | ⬜ not started |
+| 11 | Connected-component moves for graphs | 6, 7, 15 | Large | ✅ done; field-granular borrow-edge graph landed in #818, connected-component move follows |
 | 12 | ~~`Freeze`/`Thaw` utility types~~ — retired; subsumed by uniform deep `mut` + the freeze/thaw moves (PR 8, 11) | — | — | ❌ retired |
 | 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
@@ -762,16 +762,33 @@ binding in the component is consumed.
 
 - Compute the connected component reachable from an escaping value through its
   borrow edges, over the move/borrow state the engine already tracks on `funcCtx`
-  (PRs 5–7).
+  (PRs 5–7). **Landed.** The escape decision is deferred to a post-pass,
+  `resolveComponentEscapes`, run from `checkUseAfterMoves` once the body is fully
+  walked, so the borrow-edge graph is complete and the consumed lattice is available.
+  The component is the escaping value's root binding together with every local
+  `escapingLocalsOf` transitively reaches.
 - Establish the precondition that no node in the component is reachable from any
   binding or store outside it, reusing the alias and liveness state and the
-  per-path tracking from PR 7.
+  per-path tracking from PR 7. **Landed.** `componentMoveCovers` rejects the move when
+  any live binding outside the component holds a borrow edge into it. A binding the
+  lattice reads as `Moved` at the escape point is dead and does not count, so a
+  carrier consumed into the escaping value, `val a2 = a; return a2`, is not a false
+  external alias of the component `a2` now owns.
 - When it holds, treat the escape as a component move: re-anchor the internal borrow
-  lifetimes to the destination region — unify the mutual lifetimes into the
-  destination rather than failing the borrow-escape check — and consume every local
-  binding in the component, so any later use of any of them is a use-after-move.
+  lifetimes to the destination region and consume every local binding in the
+  component, so any later use of any of them is a use-after-move. **Landed.** The
+  re-anchoring needs no explicit lifetime work: an owned carrier returning its
+  internal graph already infers a clean type through the lifetime sort, so only the
+  escape error is relaxed. The post-pass records a move of each borrowed local;
+  the carrier root is consumed at the flow site already and is skipped, so a borrow
+  cycle routing an edge back to the root does not double-move it.
+- The move applies only to an owned carrier, not a bare borrow. `return &mut b`, a
+  borrowed field, or a borrow-typed binding is itself the outgoing value, with no
+  graph to re-anchor, so it stays an escape. `escapesAsOwnedCarrier` reads this off
+  the borrow-edge graph rather than the recorded type, since a field read auto-derefs
+  a borrow field to its owned inner and so a borrow reads back as owned.
 - When it fails — some node is externally aliased — fall back to the ordinary
-  borrow-escape error or phase conflict.
+  borrow-escape error or phase conflict. **Landed.**
 - Soundness rests on the GC keeping co-moved nodes alive and on there being no
   external observer, so the phase rules are unchanged; this is the requirements'
   "Moving a graph" argument.

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -259,6 +259,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
 | 15 | Escape forcing at returns, stores, and consuming arguments (deferred from PR 6) | 6 | Large | ✅ done (#814); element stores deferred to M7, field-granular escape to PR 11 |
+| 16 | CFG-merge-joined flow-sensitivity, field-store edges, mutable graph nodes, return borrow-stripping | 7, 11, 14 | Large | ⬜ not started |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 
@@ -801,8 +802,9 @@ binding in the component is consumed.
   a.data`, and a field read through a whole-binding borrow `val a = &mut b; return a.peer`
   still escapes b. The reassignment and destructuring cases that the formerly-disabled tests
   pin are re-enabled. The graph stays accumulate-only, so a reassignment adds edges without
-  clearing earlier ones; the full set-and-clear joined at CFG merges, which the component
-  move builds on, is the remaining flow-sensitivity work.
+  clearing earlier ones; the full set-and-clear joined at CFG merges is the remaining
+  flow-sensitivity work, deferred to PR 16 along with field-store edges and the mutable
+  graph nodes and return borrow-stripping they unblock.
 
 Tests: the cyclic `build()` returns `a` with both `a` and `b` consumed; an acyclic
 shared graph returned the same way; a graph where a node is also held by a retained
@@ -930,6 +932,106 @@ Acceptance: deep-mut semantics is preserved end to end with no representational
 deepening. The stored type matches the surface annotation, the printer is unchanged,
 and the constrain pipeline carries the deep-mut rule through a context flag rather
 than through the field types.
+
+---
+
+### PR 16 — CFG-merge-joined flow-sensitivity, field-store edges, mutable graph nodes, return borrow-stripping
+
+Goal: make the borrow-edge graph flow-sensitive, record edges at field stores, and land the
+two behaviours that soundness gates on that precision — constructing mutable graph nodes that
+hold borrow fields, and stripping a returned function-local borrow to ownership for the
+tree case. These four pieces are bundled because the two user-facing behaviours are unsound
+without the two infrastructure pieces, as the #819 review confirmed.
+
+**Where PR 11 left the graph.** The field-granular borrow-edge graph (PR 11, #818) is
+**accumulate-only**: edges recorded at a `val`/`var` initializer, a `var` reassignment, and a
+destructuring leaf are never cleared. A reassignment adds edges without removing the ones it
+replaced, which over-reports a replaced borrow — conservative-sound but unable to support
+clearing. Field stores `recv.f = source` record **no** edges at all. PR 11 noted both gaps as
+"the remaining flow-sensitivity work."
+
+**The infrastructure delta.**
+
+1. **Set-and-clear flow-sensitive edges.** Compute the borrow-edge set per CFG point: set a
+   binding's edges where a borrow flows in, clear them on a reassignment or repoint, and join
+   the sets at branch merges. This mirrors the consumed lattice the move engine already builds
+   over the same CFG (`AnalyzeMoves` in [internal/liveness](../../internal/liveness)), so the
+   borrow-edge graph stops being a single accumulate-only map and becomes a per-point lattice
+   read at the escape and component-move sites. Reassigning `a = &mut e` after `a = &mut d`
+   then leaves only `a → e`, not both.
+
+2. **Field-store edge recording.** Record an edge at `recv.f = source` when `recv` is a local
+   and `source` borrows locals, rooted at `recv`'s place extended by `f` — the same
+   `walkBorrowSources` the initializer path uses, at base `[recv.path…, f]`. With clearing
+   from piece 1, a repoint `b.peer = &mut e` replaces `b → d at [peer]` rather than
+   accumulating a stale edge. The store into a *parameter* field stays the immediate escape
+   `checkParamFieldStoreEscape` already reports; this piece covers the store into a *local*,
+   which does not escape until that local later flows out.
+
+**What the infrastructure unblocks.**
+
+3. **Mutable graph nodes that hold borrow fields.** Admit a borrow leaf in the fresh-literal
+   owned-mutable upgrade — `canUpgradeToOwnedMut` and the unannotated `val mut q = {…}` path
+   in [infer_decl.go](../../internal/solver/infer_decl.go) — so `val mut b = {peer: &mut d}` is
+   owned-mutable `mut {peer: &mut d}` and `b` is `&mut`-borrowable. This is the natural way to
+   build the `Node` graph the requirements' "Moving a graph" example writes. It is **sound
+   only with pieces 1 and 2**: without field-store edges, the repoint-then-return
+
+   ```esc
+   fn f(p: &mut {x: number}) {
+       val mut d = {x: 0}
+       val mut b = {peer: p}
+       b.peer = &mut d        // repoint b's field to the local d
+       return b               // returns mut {peer: &'a mut {x}} — 'a is falsified
+   }
+   ```
+
+   carries a borrow of the local `d` out under the parameter's lifetime `'a`, and no escape
+   fires, because the field store records no edge. The construction and connected-component
+   cases are sound on their own; this repoint-then-escape case is exactly what the
+   flow-sensitive field-store edges catch. The borrow-leaf upgrade's own soundness — the
+   container's mutability lets the field be repointed but grants no write to the referent
+   beyond what the borrow already carries, and the borrow's pointee stays invariant through
+   the C2 RefType arm — was validated in the #819 review; only the escape-tracking gap blocks
+   it.
+
+4. **Return borrow-stripping for the tree case.** When a returned value borrows
+   function-locals and each local is reached **exactly once** from the return with **no
+   cycle**, strip the `&`/`&mut` wrapper and let the return value own the data. This is the
+   type-level reflection of the connected-component move: the move already re-anchors the
+   nodes at the value level and consumes the locals, so a uniquely-reached node has no owner
+   but the return value, and owning it in the type is honest. It removes the falsified-lifetime
+   class of return type that piece 3 would otherwise expose — a stripped field carries no
+   lifetime to falsify. **Keep the borrow** when a node is reached through two or more paths
+   (the diamond) or sits on a cycle: an owned type is a tree with no sharing, so it cannot
+   represent a shared or cyclic node without either duplicating it — wrong, since the paths are
+   one object whose mutation must be observable through both — or keeping the borrow that
+   expresses the sharing. The multiplicity test extends the component reachability walk's
+   `seen` set from "have I reached this node" to "have I reached it twice," and reuses the
+   self-containment precondition the component move already checks.
+
+**Tests.**
+
+- Flow-sensitivity: reassigning a `var`'s borrow clears the replaced edge, so a stale referent
+  no longer over-reports as escaping; a borrow set on only one branch joins to MaybeBorrowed at
+  the merge.
+- Field-store edges: `b.peer = &mut d; return b` reports the escape or component-moves d
+  rather than silently returning a falsified-lifetime borrow; a repoint replaces the edge.
+- Mutable graph nodes: `val mut b = {peer: &mut d}` is `mut {peer: &mut {x: number}}`,
+  `&mut b` checks, `b.peer = &mut e` repoints, `b.peer.x = 5` writes through; the all-`&mut`
+  diamond becomes a connected-component move.
+- Return borrow-stripping: a tree-shaped component move returns an owned type — `return a`
+  over `a = {peer: &mut d}` returns `{peer: {value: number}}`, not `{peer: &mut {value:
+  number}}` — while a diamond or a cyclic graph keeps its borrows; a node also aliased outside
+  the component still errors.
+
+**Acceptance.** The borrow-edge graph is flow-sensitive; mutable graph nodes that hold borrow
+fields are constructible and `&mut`-borrowable with no falsified-lifetime escape; a returned
+tree of function-local borrows is owned by the return value while a shared or cyclic graph
+keeps its borrows.
+
+**Depends on:** PR 11 (the borrow-edge graph and connected-component move), PR 7 (field-level
+places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rides on).
 
 ---
 

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -1068,6 +1068,23 @@ places), PR 14 (the C2 mut-context flag the borrow-leaf upgrade's invariance rid
   rides the M7 computed-key/index-segment work
   ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7);
   pull it forward if tuple-heavy code makes the imprecision bite.
+- **Borrow tracking through container methods.** The borrow-edge graph records an alias only
+  at a `val`/`var` initializer, a `var` reassignment, and a destructuring leaf, so a borrow
+  stored into a container through a method call — `a.peers.push(&mut b)` — is invisible to the
+  escape check and the connected-component move
+  ([internal/solver/return_escape.go](../../internal/solver/return_escape.go)). This is what
+  keeps the requirements' canonical cyclic `build()` from being expressible as written: the
+  `.push` edges that wire the graph are never recorded, so the escape check sees no borrows to
+  co-move. This is NOT part of PR 16, whose scope is the flow-sensitivity of the existing three
+  recording sites. It needs two things the affine PRs do not provide. First, `Array<T>` and its
+  method surface: `internal/solver` has no `Array` type and no array/tuple method calls today,
+  and both arrive with the M7 stdlib ingestion
+  ([planning/simple_sub/01-milestones.md](../simple_sub/01-milestones.md) §M7). Second, a
+  lifetime annotation on a container method that expresses "the argument-borrow is stored into
+  the receiver," which the edge recorder reads at the call site to record a `receiver →
+  referent` edge — the same call-effect modeling a `&mut Holder` write needs. So it lands after
+  M7 as an extension of the borrow-edge recorder to model a call that stores a borrow into its
+  receiver, gated on the container-method lifetime annotations that supply the effect.
 
 ## Testing approach
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1243,6 +1243,20 @@ user. Land them once that happens:
   Roughly doubles the work for ambiguous unions, which matches the cost
   of the original failure mode. Worth landing once user reports of
   confusion start coming in.
+- **Unblocks (not owned here): affine borrow tracking through container methods.** The affine
+  connected-component move records a borrow alias only at a binding initializer, a `var`
+  reassignment, and a destructuring leaf, so a borrow stored into a container by a method
+  call — `a.peers.push(&mut b)` — is invisible to its escape check
+  ([internal/solver/return_escape.go](../../internal/solver/return_escape.go)). That is why the
+  affine requirements' canonical cyclic `build()`, which wires the graph with `.push`, is not
+  yet expressible. This milestone is the prerequisite: it resolves `Array<T>` and its method
+  surface (`push`, …), which `internal/solver` has no representation for today — there is no
+  `Array` type and no array/tuple method call. The fix itself — teaching the borrow-edge
+  recorder to model a call that stores an argument-borrow into its receiver, gated on a
+  container-method lifetime annotation that expresses that effect — is affine work that lands
+  after this milestone, tracked under "Deferred and out of scope" in
+  [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
+  Recorded here so the dependency is visible from the milestone that unblocks it.
 
 **Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
 `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves


### PR DESCRIPTION
Implement the connected-component move for escape analysis, allowing owned values carrying self-contained graphs of borrowed locals to flow out of the frame without reporting an escape.

When a value owns a graph of borrowed locals that are reachable only through that value, the escape becomes a move of the entire component: every binding in the component is consumed, and later uses of any of them are use-after-move errors. This applies to returns, consuming arguments, and stores into parameter fields.

The implementation defers escape decisions to a post-pass (`resolveComponentEscapes`) run after the function body is fully walked, so the borrow-edge graph is complete and the consumed lattice is available. The component is identified as the escaping value's root binding plus every local reachable through borrow edges. The move applies only when no live binding outside the component holds a borrow edge into it—a binding already moved is dead and does not count as an external reference.

Key changes:
- Add `escapeSites` field to `funcCtx` to record values flowing out of the frame (returns, consuming arguments, parameter field stores)
- Implement `resolveComponentEscapes` to decide each escape site once the body is walked
- Implement `componentMoveCovers` to check whether an escape is a self-contained component move
- Implement `escapesAsOwnedCarrier` to distinguish owned carriers from bare borrows; only owned carriers re-anchor their internal graphs
- Update `checkReturnEscape`, `checkParamFieldStoreEscape`, and consuming argument handling to record escape sites instead of immediately reporting
- Integrate the post-pass into `checkUseAfterMoves` and recompute the move lattice if any component-move consumes are recorded
- Update test cases: move tests expecting escapes from `TestReturnEscape` and `TestEscapeAtStoreAndArgSites` to new `TestConnectedComponentMove` test function, which now expects no errors for self-contained components
- Update implementation plan to mark item 11 as done

The move applies only to owned carriers, not bare borrows. `return &mut b`, a borrowed field, or a borrow-typed binding stays an escape since they have no owned graph to re-anchor.

https://claude.ai/code/session_01Kdq3q3r225uZCfNobpt4Tg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of borrows that move together as a connected component, allowing some previously rejected patterns to be accepted.

* **Bug Fixes**
  * Reduced false escape errors for returns, field stores, and consuming arguments.
  * Improved use-after-move reporting after escape handling is resolved, making diagnostics more accurate.

* **Tests**
  * Expanded coverage for connected-component move scenarios and updated existing escape/borrow cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->