### PR TITLE
Flow-sensitive borrow-edge tracking and return borrow-stripping

### DIFF
--- a/internal/solver/borrow_flow.go
+++ b/internal/solver/borrow_flow.go
@@ -42,9 +42,9 @@ import (
 //   - After the walk, analyzeBorrows folds borrowGens forward over the CFG to a fixed point,
 //     producing the per-program-point graph. Each assignment replaces a root's whole edge set,
 //     so a reassignment clears the prior referent.
-//   - At each escape/flow-out site, resolveComponentEscapes overwrites eagerBorrowGraph with that
-//     point's snapshot from the flow-sensitive result, so downstream escape checks that read
-//     eagerBorrowGraph see the flow-sensitive graph rather than the whole-body eager one.
+//   - At each escape/flow-out site, resolveComponentEscapes reads that point's snapshot from the
+//     flow-sensitive result and passes it to each escape helper, so they see the flow-sensitive
+//     graph rather than the whole-body eager one.
 //
 // Branch handling. The eager walk is a source-order AST traversal, so it is not branch-scoped.
 // inferIfElse and inferMatch walk each arm in order, and both arms mutate the one eagerBorrowGraph
@@ -65,7 +65,7 @@ import (
 //     through a loop back edge.
 //   - Straight-line-only reads. The eager map's cross-branch value is read only by copyPlaceEdges
 //     within straight-line code. At an escape or flow-out site the escape check reads the
-//     flow-sensitive snapshot resolveComponentEscapes swaps in, so a merge never relies on the
+//     flow-sensitive snapshot resolveComponentEscapes passes it, so a merge never relies on the
 //     last-writer-wins eager state.
 
 // borrowAssign is one statement's replacement of a binding's borrow edges: the binding root

--- a/internal/solver/borrow_flow.go
+++ b/internal/solver/borrow_flow.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/escalier-lang/escalier/internal/liveness"
@@ -12,31 +13,80 @@ import (
 // reassignment replaces the binding's referent or that a field store repoints one field, so
 // the graph is computed per CFG program point instead.
 //
-// The analysis has two halves that mirror the move engine's consumed lattice:
+// The dataflow layer models borrows with the classic gen/kill formulation. Each statement is
+// characterized by the facts it generates and the facts it kills, and the forward transfer
+// function is out = gen ∪ (in − kill). Here a fact is a borrow edge root → local. A statement
+// that re-points a binding generates the binding's new edge set and kills its prior one. The
+// kill is not tracked separately: analyzeBorrows replaces a root's whole edge set with the
+// generated one, so recording the new edges implicitly kills the old. Branch merges union the
+// incoming graphs per root, the meet for this may-borrow problem, so a borrow present on any
+// path reaches the merge.
 //
-//   - While the body is walked, each statement's borrow recording updates the eager
-//     borrowEdges map by strong subtree replacement and records the binding's new edge set
-//     into borrowGens, keyed by the statement's CFG position. The eager map holds the
-//     source-order-current state so copyPlaceEdges can project a source binding's edges.
-//   - After the walk, analyzeBorrows folds borrowGens forward over the CFG. Each assignment
-//     replaces a binding's whole edge set, so a reassignment clears the prior referent, and
-//     branch merges join edge sets by union, so a borrow set on one branch reaches the merge.
+// Two structures track the same borrows at different granularities and for different
+// consumers:
 //
-// The escape check then reads the edge set at each flow-out site's program point rather than
-// a single whole-body map.
+//   - eagerBorrowGraph (map[VarID][]fieldBorrow) is the eager, source-order-current graph, updated
+//     by strong subtree replacement as the body is walked. copyPlaceEdges reads it to project a
+//     source binding's edges, so it must hold the edge set as of the copy point. Being one
+//     whole-body map, it cannot express that different CFG paths reach a point with different
+//     borrow sets.
+//   - borrowGens (map[StmtRef][]borrowAssign) is the flow-sensitive input to the dataflow,
+//     recording per CFG statement position the new edge set the eager walk computed for each
+//     binding that statement re-points. It is the "gen" set of the analysis, the borrow
+//     counterpart of moveSites.
+//
+// How they relate:
+//
+//   - The eager walk maintains eagerBorrowGraph and, via flushBorrowDirty, snapshots each dirtied
+//     root's current edge set into borrowGens keyed by the statement's CFG position.
+//   - After the walk, analyzeBorrows folds borrowGens forward over the CFG to a fixed point,
+//     producing the per-program-point graph. Each assignment replaces a root's whole edge set,
+//     so a reassignment clears the prior referent.
+//   - At each escape/flow-out site, resolveComponentEscapes overwrites eagerBorrowGraph with that
+//     point's snapshot from the flow-sensitive result, so downstream escape checks that read
+//     eagerBorrowGraph see the flow-sensitive graph rather than the whole-body eager one.
+//
+// Branch handling. The eager walk is a source-order AST traversal, so it is not branch-scoped.
+// inferIfElse and inferMatch walk each arm in order, and both arms mutate the one eagerBorrowGraph
+// in place. The textually-later arm's strong update overwrites the earlier one, so after the
+// construct the eager map holds only the last arm's edges. It cannot represent a per-path borrow
+// set. For
+//
+//	if cond { a = &mut b } else { a = &mut c }
+//
+// the eager map ends holding a → c. Each arm's assignment was snapshotted into borrowGens at its
+// own CFG position, so analyzeBorrows unions them at the join block to the correct a → {b, c}.
+// Two things keep this sound:
+//
+//   - Unconditional kill. A reassignment to a non-borrow on one arm still marks its root dirty
+//     even though it pruned nothing, emitting an explicit kill at that point. In
+//     `if cond { a = seed } else { a = &mut c }` the then-arm's kill lets the join union "no edge"
+//     with the else-arm's a → c. The same rule covers a borrow that reaches a reassignment only
+//     through a loop back edge.
+//   - Straight-line-only reads. The eager map's cross-branch value is read only by copyPlaceEdges
+//     within straight-line code. At an escape or flow-out site the escape check reads the
+//     flow-sensitive snapshot resolveComponentEscapes swaps in, so a merge never relies on the
+//     last-writer-wins eager state.
 
 // borrowAssign is one statement's replacement of a binding's borrow edges: the binding root
 // and the full edge set the eager walk computed for it at that statement. The dataflow
 // replaces the root's whole edge set with these, so a repoint that leaves other fields
 // untouched still carries them, since the eager map already merged the retained fields into
-// the recorded set.
+// the recorded set. For
+//
+//	val recv = {a: &mut x, b: &mut y}   // recv borrows [a]→x, [b]→y
+//	recv.a = &mut z                     // repoints only field a
+//
+// the store's assignment carries {[a]→z, [b]→y}, not just the touched {[a]→z}: the eager map
+// cleared [a]→x, added [a]→z, and left [b]→y alone, so the recorded set already holds the
+// retained sibling. Replacing recv's whole set with it therefore keeps [b]→y.
 type borrowAssign struct {
-	root  liveness.VarID
-	edges []fieldBorrow
+	root         liveness.VarID
+	fieldBorrows []fieldBorrow
 }
 
-// markBorrowDirty flags root as having its eager edge set changed during the current
-// statement, so flushBorrowGens emits an assignment for it.
+// markBorrowDirty flags root as having its fieldBorrow set in the eagerBorrowGraph changed
+// during the current statement, so flushBorrowDirty emits an assignment for it.
 func (c *checker) markBorrowDirty(root liveness.VarID) {
 	if c.fn == nil || c.fn.borrowDirty == nil || root <= 0 {
 		return
@@ -48,11 +98,11 @@ func (c *checker) markBorrowDirty(root liveness.VarID) {
 // base, so a `var` reassignment clears the binding wholly with an empty base and a field store
 // clears only the stored field's subtree.
 //
-// A whole-binding reassignment (empty base) always marks root dirty, so it emits a kill even
-// when the eager map held no edge to prune. The eager map is filled in source order, so a
-// borrow that reaches the reassignment only through a CFG back edge is absent here; without an
-// unconditional kill the dataflow would carry that stale edge past `a = seed`. A whole-binding
-// reassignment replaces the binding's entire edge set, so killing it wholesale is sound.
+// A whole-binding reassignment (empty base) always marks root dirty, emitting a kill even when
+// the eager map held no edge to prune. That unconditional kill is what lets a reassignment clear
+// a referent reaching it only through a branch join or a loop back edge; the file docstring's
+// branch-handling notes give the examples. Killing wholesale is sound because the reassignment
+// replaces the binding's entire edge set.
 //
 // A field-store subtree update (non-empty base) marks root dirty only when it pruned an edge.
 // Its dataflow assignment replaces root's WHOLE edge set with the source-order eager set, so an
@@ -60,60 +110,64 @@ func (c *checker) markBorrowDirty(root liveness.VarID) {
 // escape. A store that adds a borrow is marked dirty separately by addBorrowEdge, and one that
 // prunes a prior borrow is caught by `removed`; a store that changes no borrow emits nothing.
 func (c *checker) clearEagerSubtree(root liveness.VarID, base []placeSeg) {
-	if c.fn == nil || c.fn.borrowEdges == nil || root <= 0 {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil || root <= 0 {
 		return
 	}
-	edges := c.fn.borrowEdges[root]
-	kept := edges[:0:0]
+	fieldBorrows := c.fn.eagerBorrowGraph[root]
+	var kept []fieldBorrow
 	removed := false
-	for _, e := range edges {
-		if pathHasPrefix(e.path, base) {
+	for _, fb := range fieldBorrows {
+		if pathHasPrefix(fb.path, base) {
 			removed = true
 			continue
 		}
-		kept = append(kept, e)
+		kept = append(kept, fb)
 	}
 	if len(kept) == 0 {
-		delete(c.fn.borrowEdges, root)
+		delete(c.fn.eagerBorrowGraph, root)
 	} else {
-		c.fn.borrowEdges[root] = kept
+		c.fn.eagerBorrowGraph[root] = kept
 	}
+	// Dirty when this pruned an edge, and unconditionally for a whole-binding
+	// reassignment so it emits a kill even when nothing was pruned. See the docstring.
 	if removed || len(base) == 0 {
 		c.markBorrowDirty(root)
 	}
 }
 
-// flushBorrowGens records, for every root dirtied while recording the statement at ref, an
-// assignment carrying that root's current eager edge set. It then resets the dirty set for
-// the next statement. A root cleared to no edges still emits an empty assignment, which the
-// dataflow applies as a kill of the prior referent.
-func (c *checker) flushBorrowGens(ref liveness.StmtRef) {
+// flushBorrowDirty appends to borrowGens[ref], for every root dirtied while recording the
+// statement at ref, an assignment carrying that root's current eager fieldBorrow set. It then
+// resets the dirty set for the next statement. A root cleared to no fieldBorrows still emits an
+// empty assignment, which the dataflow applies as a kill of the prior referent.
+func (c *checker) flushBorrowDirty(stmtRef liveness.StmtRef) {
 	if c.fn == nil || c.fn.borrowDirty == nil || c.fn.borrowGens == nil {
 		return
 	}
 	roots := c.fn.borrowDirty.ToSlice()
 	slices.Sort(roots)
 	for _, root := range roots {
-		edges := slices.Clone(c.fn.borrowEdges[root])
-		c.fn.borrowGens[ref] = append(c.fn.borrowGens[ref], borrowAssign{root: root, edges: edges})
+		fieldBorrows := slices.Clone(c.fn.eagerBorrowGraph[root])
+		c.fn.borrowGens[stmtRef] = append(
+			c.fn.borrowGens[stmtRef],
+			borrowAssign{root: root, fieldBorrows: fieldBorrows},
+		)
 	}
 	c.fn.borrowDirty = set.NewSet[liveness.VarID]()
 }
 
-// borrowInfo holds the per-program-point borrow-edge graph analyzeBorrows computed. before[b]
+// flowBorrowGraph holds the per-program-point borrow-edge graph analyzeBorrows computed. before[b]
 // [i] is the edge graph just before statement i of block b, joined across every path reaching
 // it; blockIn[b] is the graph on entry to block b, the answer for a StmtRef whose index is the
 // synthetic -1 entry position a decomposed decl points at.
-type borrowInfo struct {
+type flowBorrowGraph struct {
 	before  [][]map[liveness.VarID][]fieldBorrow
 	blockIn []map[liveness.VarID][]fieldBorrow
 }
 
-// analyzeBorrows folds borrowGens forward over the body's CFG to a fixed point, producing the
-// borrow-edge graph at every program point. Each statement's assignments replace their roots'
-// edge sets; branch merges union the incoming graphs per root. State only grows in the finite
-// per-root edge lattice within a fixed binding set, so the iteration terminates.
-func (c *checker) analyzeBorrows() *borrowInfo {
+// analyzeBorrows runs the forward fold described in the file docstring, producing the borrow-edge
+// graph at every program point. It terminates because state only grows in the finite per-root edge
+// lattice within a fixed binding set.
+func (c *checker) analyzeBorrows() *flowBorrowGraph {
 	cfg := c.fn.cfg
 	gens := c.fn.borrowGens
 	n := len(cfg.Blocks)
@@ -130,33 +184,40 @@ func (c *checker) analyzeBorrows() *borrowInfo {
 		changed = false
 		for _, block := range cfg.Blocks {
 			newIn := joinBorrowPreds(block, blockOut)
-			newOut := applyBlockBorrows(newIn, block, gens)
+			newOut := applyBlockBorrows(newIn, block, gens, nil)
 			if !borrowStateEqual(blockIn[block.ID], newIn) || !borrowStateEqual(blockOut[block.ID], newOut) {
-				changed = true
+				changed = true // keep looping until a fixed point is reached
 				blockIn[block.ID] = newIn
 				blockOut[block.ID] = newOut
 			}
 		}
 	}
 
+	// Once the fixed point is reached, replay each block's fold from its converged entry graph
+	// to recover the per-statement "before" graphs edgesBefore serves. The fixed-point loop
+	// above discards these intermediates and keeps only the exit graph, so the visit callback
+	// captures the graph ahead of each statement as the same fold walks past it.
 	before := make([][]map[liveness.VarID][]fieldBorrow, n)
 	for _, block := range cfg.Blocks {
-		m := len(block.Stmts)
-		before[block.ID] = make([]map[liveness.VarID][]fieldBorrow, m)
-		state := applyBorrowAssigns(blockIn[block.ID], borrowAssignsAt(gens, block.ID, -1))
-		for idx := range m {
-			before[block.ID][idx] = state
-			state = applyBorrowAssigns(state, borrowAssignsAt(gens, block.ID, idx))
-		}
+		stmtBefore := make([]map[liveness.VarID][]fieldBorrow, len(block.Stmts))
+		applyBlockBorrows(
+			blockIn[block.ID], block, gens,
+			func(idx int, g map[liveness.VarID][]fieldBorrow) {
+				stmtBefore[idx] = g
+			},
+		)
+		before[block.ID] = stmtBefore
 	}
 
-	return &borrowInfo{before: before, blockIn: blockIn}
+	return &flowBorrowGraph{before: before, blockIn: blockIn}
 }
 
-// edgesBefore returns the borrow-edge graph just before the statement at ref, joined across
+// fieldBorrowGraphBefore returns the borrow-edge graph just before the statement at ref, joined across
 // every path that reaches it. A StmtIdx of -1 reads the block's entry graph. An out-of-range
 // ref yields an empty graph.
-func (b *borrowInfo) edgesBefore(ref liveness.StmtRef) map[liveness.VarID][]fieldBorrow {
+func (b *flowBorrowGraph) fieldBorrowGraphBefore(
+	ref liveness.StmtRef,
+) map[liveness.VarID][]fieldBorrow {
 	if ref.BlockID < 0 || ref.BlockID >= len(b.before) {
 		return map[liveness.VarID][]fieldBorrow{}
 	}
@@ -171,9 +232,11 @@ func (b *borrowInfo) edgesBefore(ref liveness.StmtRef) map[liveness.VarID][]fiel
 }
 
 // joinBorrowPreds computes a block's entry graph as the per-root union of every predecessor's
-// exit graph. A borrow that reaches through only one predecessor is kept, the may-reach
-// direction that never drops a real escape.
-func joinBorrowPreds(block *liveness.BasicBlock, blockOut []map[liveness.VarID][]fieldBorrow) map[liveness.VarID][]fieldBorrow {
+// exit graph, keeping a borrow that reaches through even one predecessor.
+func joinBorrowPreds(
+	block *liveness.BasicBlock,
+	blockOut []map[liveness.VarID][]fieldBorrow,
+) map[liveness.VarID][]fieldBorrow {
 	in := map[liveness.VarID][]fieldBorrow{}
 	for _, pred := range block.Predecessors {
 		for root, edges := range blockOut[pred.ID] {
@@ -183,66 +246,66 @@ func joinBorrowPreds(block *liveness.BasicBlock, blockOut []map[liveness.VarID][
 	return in
 }
 
-// applyBlockBorrows folds every statement's assignments in the block, in order, over the entry
-// graph — the synthetic -1 entry position first, then each real statement.
-func applyBlockBorrows(in map[liveness.VarID][]fieldBorrow, block *liveness.BasicBlock, gens map[liveness.StmtRef][]borrowAssign) map[liveness.VarID][]fieldBorrow {
-	state := applyBorrowAssigns(in, borrowAssignsAt(gens, block.ID, -1))
+// applyBlockBorrows folds the block's assignments over in, in order — the synthetic -1 entry
+// position first, then each statement — and returns the block's exit graph. When visit is
+// non-nil it is called with the graph just before each statement idx, letting a caller capture
+// the per-statement "before" snapshots without recomputing the fold. It leaves in unmodified,
+// returning fresh graphs, since applyBorrowAssigns copies its input rather than mutating it.
+func applyBlockBorrows(
+	in map[liveness.VarID][]fieldBorrow,
+	block *liveness.BasicBlock,
+	gens map[liveness.StmtRef][]borrowAssign,
+	visit func(stmtIdx int, before map[liveness.VarID][]fieldBorrow),
+) map[liveness.VarID][]fieldBorrow {
+	state := applyBorrowAssigns(in, gens[liveness.StmtRef{BlockID: block.ID, StmtIdx: -1}])
 	for idx := range block.Stmts {
-		state = applyBorrowAssigns(state, borrowAssignsAt(gens, block.ID, idx))
+		if visit != nil {
+			visit(idx, state)
+		}
+		state = applyBorrowAssigns(state, gens[liveness.StmtRef{BlockID: block.ID, StmtIdx: idx}])
 	}
 	return state
 }
 
 // applyBorrowAssigns returns a copy of state with each assignment's root re-pointed to that
 // assignment's edge set, dropping the root's key when the new set is empty.
-func applyBorrowAssigns(state map[liveness.VarID][]fieldBorrow, assigns []borrowAssign) map[liveness.VarID][]fieldBorrow {
-	out := cloneBorrowState(state)
+func applyBorrowAssigns(
+	state map[liveness.VarID][]fieldBorrow,
+	assigns []borrowAssign,
+) map[liveness.VarID][]fieldBorrow {
+	// state is never nil. Block entry graphs start as empty maps and joinBorrowPreds returns a
+	// non-nil map, so maps.Clone yields a non-nil map that the assignment writes below require.
+	out := maps.Clone(state)
 	for _, a := range assigns {
-		if len(a.edges) == 0 {
+		if len(a.fieldBorrows) == 0 {
 			delete(out, a.root)
 			continue
 		}
-		out[a.root] = slices.Clone(a.edges)
+		out[a.root] = slices.Clone(a.fieldBorrows)
 	}
 	return out
-}
-
-// borrowAssignsAt returns the assignments recorded at one program point, or nil when the point
-// records none.
-func borrowAssignsAt(gens map[liveness.StmtRef][]borrowAssign, blockID, stmtIdx int) []borrowAssign {
-	return gens[liveness.StmtRef{BlockID: blockID, StmtIdx: stmtIdx}]
 }
 
 // unionEdges returns the edges in a or b with no duplicate path/referent pair, the join at a
 // CFG merge.
 func unionEdges(a, b []fieldBorrow) []fieldBorrow {
 	out := slices.Clone(a)
-	for _, e := range b {
-		if !containsEdge(out, e) {
-			out = append(out, e)
+	for _, fb := range b {
+		if !containsFieldBorrow(out, fb) {
+			out = append(out, fb)
 		}
 	}
 	return out
 }
 
-// containsEdge reports whether edges holds one with the same path and referent as e.
-func containsEdge(edges []fieldBorrow, e fieldBorrow) bool {
-	for _, x := range edges {
-		if x.referent == e.referent && slices.Equal(x.path, e.path) {
+// containsFieldBorrow reports whether edges holds one with the same path and referent as e.
+func containsFieldBorrow(fieldBorrows []fieldBorrow, fb fieldBorrow) bool {
+	for _, x := range fieldBorrows {
+		if x.referent == fb.referent && slices.Equal(x.path, fb.path) {
 			return true
 		}
 	}
 	return false
-}
-
-// cloneBorrowState copies the graph one level deep: a fresh outer map whose edge slices are
-// shared, since applyBorrowAssigns replaces a root's slice wholesale rather than mutating it.
-func cloneBorrowState(m map[liveness.VarID][]fieldBorrow) map[liveness.VarID][]fieldBorrow {
-	out := make(map[liveness.VarID][]fieldBorrow, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
 }
 
 // borrowStateEqual reports whether two graphs hold the same edge set for every root, the
@@ -253,21 +316,21 @@ func borrowStateEqual(a, b map[liveness.VarID][]fieldBorrow) bool {
 	}
 	for root, ae := range a {
 		be, ok := b[root]
-		if !ok || !edgeSetEqual(ae, be) {
+		if !ok || !fieldBorrowsEqual(ae, be) {
 			return false
 		}
 	}
 	return true
 }
 
-// edgeSetEqual reports whether two edge slices hold the same path/referent pairs regardless of
+// fieldBorrowsEqual reports whether two edge slices hold the same path/referent pairs regardless of
 // order.
-func edgeSetEqual(a, b []fieldBorrow) bool {
+func fieldBorrowsEqual(a, b []fieldBorrow) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for _, e := range a {
-		if !containsEdge(b, e) {
+		if !containsFieldBorrow(b, e) {
 			return false
 		}
 	}

--- a/internal/solver/borrow_flow.go
+++ b/internal/solver/borrow_flow.go
@@ -45,10 +45,20 @@ func (c *checker) markBorrowDirty(root liveness.VarID) {
 }
 
 // clearEagerSubtree removes from root's eager edge set every edge whose path lies at or below
-// base, so a `var` reassignment clears the binding wholly with a nil base and a field store
-// clears only the stored field's subtree. It marks root dirty when it removed an edge, so a
-// reassignment away from a borrow emits an assignment that kills the prior referent in the
-// dataflow, while a borrow-free binding that clears nothing emits no spurious assignment.
+// base, so a `var` reassignment clears the binding wholly with an empty base and a field store
+// clears only the stored field's subtree.
+//
+// A whole-binding reassignment (empty base) always marks root dirty, so it emits a kill even
+// when the eager map held no edge to prune. The eager map is filled in source order, so a
+// borrow that reaches the reassignment only through a CFG back edge is absent here; without an
+// unconditional kill the dataflow would carry that stale edge past `a = seed`. A whole-binding
+// reassignment replaces the binding's entire edge set, so killing it wholesale is sound.
+//
+// A field-store subtree update (non-empty base) marks root dirty only when it pruned an edge.
+// Its dataflow assignment replaces root's WHOLE edge set with the source-order eager set, so an
+// unconditional whole-root emit could drop a sibling field's back-edge borrow and miss a real
+// escape. A store that adds a borrow is marked dirty separately by addBorrowEdge, and one that
+// prunes a prior borrow is caught by `removed`; a store that changes no borrow emits nothing.
 func (c *checker) clearEagerSubtree(root liveness.VarID, base []placeSeg) {
 	if c.fn == nil || c.fn.borrowEdges == nil || root <= 0 {
 		return
@@ -68,7 +78,7 @@ func (c *checker) clearEagerSubtree(root liveness.VarID, base []placeSeg) {
 	} else {
 		c.fn.borrowEdges[root] = kept
 	}
-	if removed {
+	if removed || len(base) == 0 {
 		c.markBorrowDirty(root)
 	}
 }

--- a/internal/solver/borrow_flow.go
+++ b/internal/solver/borrow_flow.go
@@ -1,0 +1,265 @@
+package solver
+
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// Flow-sensitive borrow-edge tracking. The borrow-edge graph records which function-locals
+// each binding borrows. A single accumulate-only map cannot express that a `var`
+// reassignment replaces the binding's referent or that a field store repoints one field, so
+// the graph is computed per CFG program point instead.
+//
+// The analysis has two halves that mirror the move engine's consumed lattice:
+//
+//   - While the body is walked, each statement's borrow recording updates the eager
+//     borrowEdges map by strong subtree replacement and records the binding's new edge set
+//     into borrowGens, keyed by the statement's CFG position. The eager map holds the
+//     source-order-current state so copyPlaceEdges can project a source binding's edges.
+//   - After the walk, analyzeBorrows folds borrowGens forward over the CFG. Each assignment
+//     replaces a binding's whole edge set, so a reassignment clears the prior referent, and
+//     branch merges join edge sets by union, so a borrow set on one branch reaches the merge.
+//
+// The escape check then reads the edge set at each flow-out site's program point rather than
+// a single whole-body map.
+
+// borrowAssign is one statement's replacement of a binding's borrow edges: the binding root
+// and the full edge set the eager walk computed for it at that statement. The dataflow
+// replaces the root's whole edge set with these, so a repoint that leaves other fields
+// untouched still carries them, since the eager map already merged the retained fields into
+// the recorded set.
+type borrowAssign struct {
+	root  liveness.VarID
+	edges []fieldBorrow
+}
+
+// markBorrowDirty flags root as having its eager edge set changed during the current
+// statement, so flushBorrowGens emits an assignment for it.
+func (c *checker) markBorrowDirty(root liveness.VarID) {
+	if c.fn == nil || c.fn.borrowDirty == nil || root <= 0 {
+		return
+	}
+	c.fn.borrowDirty.Add(root)
+}
+
+// clearEagerSubtree removes from root's eager edge set every edge whose path lies at or below
+// base, so a `var` reassignment clears the binding wholly with a nil base and a field store
+// clears only the stored field's subtree. It marks root dirty when it removed an edge, so a
+// reassignment away from a borrow emits an assignment that kills the prior referent in the
+// dataflow, while a borrow-free binding that clears nothing emits no spurious assignment.
+func (c *checker) clearEagerSubtree(root liveness.VarID, base []placeSeg) {
+	if c.fn == nil || c.fn.borrowEdges == nil || root <= 0 {
+		return
+	}
+	edges := c.fn.borrowEdges[root]
+	kept := edges[:0:0]
+	removed := false
+	for _, e := range edges {
+		if pathHasPrefix(e.path, base) {
+			removed = true
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if len(kept) == 0 {
+		delete(c.fn.borrowEdges, root)
+	} else {
+		c.fn.borrowEdges[root] = kept
+	}
+	if removed {
+		c.markBorrowDirty(root)
+	}
+}
+
+// flushBorrowGens records, for every root dirtied while recording the statement at ref, an
+// assignment carrying that root's current eager edge set. It then resets the dirty set for
+// the next statement. A root cleared to no edges still emits an empty assignment, which the
+// dataflow applies as a kill of the prior referent.
+func (c *checker) flushBorrowGens(ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.borrowDirty == nil || c.fn.borrowGens == nil {
+		return
+	}
+	roots := c.fn.borrowDirty.ToSlice()
+	slices.Sort(roots)
+	for _, root := range roots {
+		edges := slices.Clone(c.fn.borrowEdges[root])
+		c.fn.borrowGens[ref] = append(c.fn.borrowGens[ref], borrowAssign{root: root, edges: edges})
+	}
+	c.fn.borrowDirty = set.NewSet[liveness.VarID]()
+}
+
+// borrowInfo holds the per-program-point borrow-edge graph analyzeBorrows computed. before[b]
+// [i] is the edge graph just before statement i of block b, joined across every path reaching
+// it; blockIn[b] is the graph on entry to block b, the answer for a StmtRef whose index is the
+// synthetic -1 entry position a decomposed decl points at.
+type borrowInfo struct {
+	before  [][]map[liveness.VarID][]fieldBorrow
+	blockIn []map[liveness.VarID][]fieldBorrow
+}
+
+// analyzeBorrows folds borrowGens forward over the body's CFG to a fixed point, producing the
+// borrow-edge graph at every program point. Each statement's assignments replace their roots'
+// edge sets; branch merges union the incoming graphs per root. State only grows in the finite
+// per-root edge lattice within a fixed binding set, so the iteration terminates.
+func (c *checker) analyzeBorrows() *borrowInfo {
+	cfg := c.fn.cfg
+	gens := c.fn.borrowGens
+	n := len(cfg.Blocks)
+
+	blockIn := make([]map[liveness.VarID][]fieldBorrow, n)
+	blockOut := make([]map[liveness.VarID][]fieldBorrow, n)
+	for i := range n {
+		blockIn[i] = map[liveness.VarID][]fieldBorrow{}
+		blockOut[i] = map[liveness.VarID][]fieldBorrow{}
+	}
+
+	changed := true
+	for changed {
+		changed = false
+		for _, block := range cfg.Blocks {
+			newIn := joinBorrowPreds(block, blockOut)
+			newOut := applyBlockBorrows(newIn, block, gens)
+			if !borrowStateEqual(blockIn[block.ID], newIn) || !borrowStateEqual(blockOut[block.ID], newOut) {
+				changed = true
+				blockIn[block.ID] = newIn
+				blockOut[block.ID] = newOut
+			}
+		}
+	}
+
+	before := make([][]map[liveness.VarID][]fieldBorrow, n)
+	for _, block := range cfg.Blocks {
+		m := len(block.Stmts)
+		before[block.ID] = make([]map[liveness.VarID][]fieldBorrow, m)
+		state := applyBorrowAssigns(blockIn[block.ID], borrowAssignsAt(gens, block.ID, -1))
+		for idx := range m {
+			before[block.ID][idx] = state
+			state = applyBorrowAssigns(state, borrowAssignsAt(gens, block.ID, idx))
+		}
+	}
+
+	return &borrowInfo{before: before, blockIn: blockIn}
+}
+
+// edgesBefore returns the borrow-edge graph just before the statement at ref, joined across
+// every path that reaches it. A StmtIdx of -1 reads the block's entry graph. An out-of-range
+// ref yields an empty graph.
+func (b *borrowInfo) edgesBefore(ref liveness.StmtRef) map[liveness.VarID][]fieldBorrow {
+	if ref.BlockID < 0 || ref.BlockID >= len(b.before) {
+		return map[liveness.VarID][]fieldBorrow{}
+	}
+	if ref.StmtIdx < 0 {
+		return b.blockIn[ref.BlockID]
+	}
+	block := b.before[ref.BlockID]
+	if ref.StmtIdx >= len(block) {
+		return map[liveness.VarID][]fieldBorrow{}
+	}
+	return block[ref.StmtIdx]
+}
+
+// joinBorrowPreds computes a block's entry graph as the per-root union of every predecessor's
+// exit graph. A borrow that reaches through only one predecessor is kept, the may-reach
+// direction that never drops a real escape.
+func joinBorrowPreds(block *liveness.BasicBlock, blockOut []map[liveness.VarID][]fieldBorrow) map[liveness.VarID][]fieldBorrow {
+	in := map[liveness.VarID][]fieldBorrow{}
+	for _, pred := range block.Predecessors {
+		for root, edges := range blockOut[pred.ID] {
+			in[root] = unionEdges(in[root], edges)
+		}
+	}
+	return in
+}
+
+// applyBlockBorrows folds every statement's assignments in the block, in order, over the entry
+// graph — the synthetic -1 entry position first, then each real statement.
+func applyBlockBorrows(in map[liveness.VarID][]fieldBorrow, block *liveness.BasicBlock, gens map[liveness.StmtRef][]borrowAssign) map[liveness.VarID][]fieldBorrow {
+	state := applyBorrowAssigns(in, borrowAssignsAt(gens, block.ID, -1))
+	for idx := range block.Stmts {
+		state = applyBorrowAssigns(state, borrowAssignsAt(gens, block.ID, idx))
+	}
+	return state
+}
+
+// applyBorrowAssigns returns a copy of state with each assignment's root re-pointed to that
+// assignment's edge set, dropping the root's key when the new set is empty.
+func applyBorrowAssigns(state map[liveness.VarID][]fieldBorrow, assigns []borrowAssign) map[liveness.VarID][]fieldBorrow {
+	out := cloneBorrowState(state)
+	for _, a := range assigns {
+		if len(a.edges) == 0 {
+			delete(out, a.root)
+			continue
+		}
+		out[a.root] = slices.Clone(a.edges)
+	}
+	return out
+}
+
+// borrowAssignsAt returns the assignments recorded at one program point, or nil when the point
+// records none.
+func borrowAssignsAt(gens map[liveness.StmtRef][]borrowAssign, blockID, stmtIdx int) []borrowAssign {
+	return gens[liveness.StmtRef{BlockID: blockID, StmtIdx: stmtIdx}]
+}
+
+// unionEdges returns the edges in a or b with no duplicate path/referent pair, the join at a
+// CFG merge.
+func unionEdges(a, b []fieldBorrow) []fieldBorrow {
+	out := slices.Clone(a)
+	for _, e := range b {
+		if !containsEdge(out, e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// containsEdge reports whether edges holds one with the same path and referent as e.
+func containsEdge(edges []fieldBorrow, e fieldBorrow) bool {
+	for _, x := range edges {
+		if x.referent == e.referent && slices.Equal(x.path, e.path) {
+			return true
+		}
+	}
+	return false
+}
+
+// cloneBorrowState copies the graph one level deep: a fresh outer map whose edge slices are
+// shared, since applyBorrowAssigns replaces a root's slice wholesale rather than mutating it.
+func cloneBorrowState(m map[liveness.VarID][]fieldBorrow) map[liveness.VarID][]fieldBorrow {
+	out := make(map[liveness.VarID][]fieldBorrow, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// borrowStateEqual reports whether two graphs hold the same edge set for every root, the
+// fixed-point convergence test.
+func borrowStateEqual(a, b map[liveness.VarID][]fieldBorrow) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for root, ae := range a {
+		be, ok := b[root]
+		if !ok || !edgeSetEqual(ae, be) {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeSetEqual reports whether two edge slices hold the same path/referent pairs regardless of
+// order.
+func edgeSetEqual(a, b []fieldBorrow) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, e := range a {
+		if !containsEdge(b, e) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/solver/flow_sensitive_borrow_test.go
+++ b/internal/solver/flow_sensitive_borrow_test.go
@@ -1,0 +1,208 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFlowSensitiveBorrowEdges covers the flow-sensitive borrow-edge graph: a binding's
+// borrow edges are set where a borrow flows in, cleared at a reassignment, and joined by
+// union at CFG branch merges. A reassignment away from a borrow drops the replaced referent,
+// so it no longer over-reports as escaping, while a borrow set on one branch still reaches the
+// merge.
+func TestFlowSensitiveBorrowEdges(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// Reassigning a `var`'s borrow clears the replaced edge: `a = &mut d` after `a = &mut
+		// c` leaves only a → d, so returning a escapes d alone. The stale c edge is cleared by
+		// the strong update, not carried forward, so it does not over-report as escaping.
+		"VarReassignClearsReplacedEdge": {
+			src: `
+				fn f() {
+					val mut c = {value: 1}
+					val mut d = {value: 0}
+					var a = &mut c
+					a = &mut d
+					return a
+				}
+			`,
+			want:  []string{"7:13-7:14: borrowed value 'd' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn () -> &mut {value: number}"},
+		},
+		// A borrow set on only one branch reaches the merge: `a = &mut d` runs only when cond
+		// holds, but the union at the merge keeps a → d, so returning a escapes d. The seed is
+		// a parameter, so the fall-through path carries no local edge and only d is reported.
+		"BorrowSetOnOneBranchReachesMerge": {
+			src: `
+				fn f(seed: &mut {value: number}, cond: boolean) {
+					var a = seed
+					val mut d = {value: 0}
+					if cond {
+						a = &mut d
+					}
+					return a
+				}
+			`,
+			want:  []string{"8:13-8:14: borrowed value 'd' does not live long enough to escape the function"},
+			types: map[string]string{"f": "fn <'a>(seed: &'a mut {value: number}, cond: boolean) -> &'a mut {value: number}"},
+		},
+		// Disagreeing branches union their referents: the then-branch repoints a to d and the
+		// else-branch back to c, so the merge carries both a → c and a → d, and returning a
+		// escapes both locals.
+		"BranchesUnionReferents": {
+			src: `
+				fn f(cond: boolean) {
+					val mut c = {value: 1}
+					val mut d = {value: 0}
+					var a = &mut c
+					if cond {
+						a = &mut d
+					} else {
+						a = &mut c
+					}
+					return a
+				}
+			`,
+			want: []string{
+				"11:13-11:14: borrowed value 'c' does not live long enough to escape the function",
+				"11:13-11:14: borrowed value 'd' does not live long enough to escape the function",
+			},
+			types: map[string]string{"f": "fn (cond: boolean) -> &mut {value: number}"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestFieldStoreBorrowEdges covers borrow edges recorded at a field store into a local
+// receiver: `b.peer = &mut d` records b → d at [peer], so a later flow-out of b finds the
+// borrow. The store is a strong update on the stored field's subtree, so a repoint replaces
+// the field's referent rather than accumulating a stale one.
+func TestFieldStoreBorrowEdges(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// Repointing a field to a local then returning the carrier carries the stored borrow
+		// out: `b.peer = &mut d` records b → d, so returning b is a component move of d, the
+		// falsified-lifetime case the field-store edge catches. The initial referent c is
+		// cleared by the strong update, so only d is co-moved, and stripping owns d in the
+		// returned tree.
+		"FieldStoreRepointThenReturn": {
+			src: `
+				fn f() {
+					val mut c = {x: 1}
+					val mut d = {x: 0}
+					val mut b = {peer: &mut c}
+					b.peer = &mut d
+					return b
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"f": "fn () -> mut {peer: {x: number}}"},
+		},
+		// A repoint replaces the field's edge: `b.peer = &mut e` clears the [peer] subtree
+		// before recording b → e, so returning b co-moves e and leaves the replaced d untouched.
+		"FieldStoreRepointReplacesEdge": {
+			src: `
+				fn f() {
+					val mut d = {x: 0}
+					val mut e = {x: 9}
+					val mut b = {peer: &mut d}
+					b.peer = &mut e
+					return b
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"f": "fn () -> mut {peer: {x: number}}"},
+		},
+		// Storing a local borrow into a field, then aliasing the carrier from a live binding
+		// outside the moved component, blocks the move and escapes: keep holds `&b` and is read
+		// after the store, so b's node is externally referenced when storing b tries to move it.
+		"FieldStoreEscapesWhenExternallyAliased": {
+			src: `
+				fn store(x: {peer: &mut {x: number}}) {}
+				fn f() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					val keep = &b
+					store(b)
+					val y = keep
+				}
+			`,
+			want: []string{"7:12-7:13: borrowed value 'd' does not live long enough to escape the function"},
+			types: map[string]string{
+				"store": "fn (x: {peer: &mut {x: number}}) -> void",
+				"f":     "fn () -> void",
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}
+
+// TestMutableGraphNode covers the borrow-field owned-mutable upgrade: an unannotated `val mut
+// b = {peer: &mut d}` builds the owned-mutable `mut {peer: &mut {x: number}}`, so b is
+// `&mut`-borrowable, its field is writable through, and its borrow field is repointable. This
+// is the natural way to construct a mutable graph node holding a borrow.
+func TestMutableGraphNode(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// The owned-mutable graph node is `&mut`-borrowable: passing `&mut b` to a parameter of
+		// type `&mut {peer: &mut {x: number}}` checks, which requires b to be owned-mutable with
+		// a `&mut` field.
+		"BorrowableAsMut": {
+			src: `
+				fn read(x: &mut {peer: &mut {x: number}}) {}
+				fn f() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					read(&mut b)
+				}
+			`,
+			want: nil,
+			types: map[string]string{
+				"read": "fn (x: &mut {peer: &mut {x: number}}) -> void",
+				"f":    "fn () -> void",
+			},
+		},
+		// The referent is writable through the node's borrow field: `b.peer.x = 5` mutates d
+		// through the `&mut` the field holds.
+		"WriteThroughBorrowField": {
+			src: `
+				fn f() {
+					val mut d = {x: 0}
+					val mut b = {peer: &mut d}
+					b.peer.x = 5
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"f": "fn () -> void"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}

--- a/internal/solver/flow_sensitive_borrow_test.go
+++ b/internal/solver/flow_sensitive_borrow_test.go
@@ -95,9 +95,9 @@ func TestFieldStoreBorrowEdges(t *testing.T) {
 	}{
 		// Repointing a field to a local then returning the carrier carries the stored borrow
 		// out: `b.peer = &mut d` records b → d, so returning b is a component move of d, the
-		// falsified-lifetime case the field-store edge catches. The initial referent c is
-		// cleared by the strong update, so only d is co-moved, and stripping owns d in the
-		// returned tree.
+		// falsified-lifetime case the field-store edge catches. The store is a strong update
+		// that clears the [peer] subtree before recording, so the replaced referent c is
+		// dropped and only d is co-moved, and stripping owns d in the returned tree.
 		"FieldStoreRepointThenReturn": {
 			src: `
 				fn f() {
@@ -105,21 +105,6 @@ func TestFieldStoreBorrowEdges(t *testing.T) {
 					val mut d = {x: 0}
 					val mut b = {peer: &mut c}
 					b.peer = &mut d
-					return b
-				}
-			`,
-			want:  nil,
-			types: map[string]string{"f": "fn () -> mut {peer: {x: number}}"},
-		},
-		// A repoint replaces the field's edge: `b.peer = &mut e` clears the [peer] subtree
-		// before recording b → e, so returning b co-moves e and leaves the replaced d untouched.
-		"FieldStoreRepointReplacesEdge": {
-			src: `
-				fn f() {
-					val mut d = {x: 0}
-					val mut e = {x: 9}
-					val mut b = {peer: &mut d}
-					b.peer = &mut e
 					return b
 				}
 			`,

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -178,8 +178,8 @@ type funcCtx struct {
 	// clears only the [f] subtree. copyPlaceEdges reads it to project a source binding's
 	// edges into a destructuring leaf, so it must reflect the state at the copy point. The
 	// per-program-point graph the escape check reads is the flow-sensitive one analyzeBorrows
-	// computes from borrowGens, not this eager map. After the body walk, resolveComponentEscapes
-	// overwrites this field with the per-point snapshot at each escape site.
+	// computes from borrowGens, not this eager map; resolveComponentEscapes passes that snapshot
+	// to each escape helper rather than storing it here.
 	eagerBorrowGraph map[liveness.VarID][]fieldBorrow
 	// borrowGens records, per CFG statement position, the borrow-edge assignments that
 	// statement makes: for each binding it re-points, the full new edge set the eager

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -172,13 +172,27 @@ type funcCtx struct {
 	// a.peer` from the disjoint `return a.data`. A parameter root is never recorded, since
 	// a borrow of a parameter carries a caller lifetime that already outlives the frame.
 	//
-	// Edges are recorded at a `val`/`var` initializer, a `var` reassignment, and a
-	// destructuring leaf. The graph is accumulate-only, so a reassignment adds edges
-	// without clearing the binding's earlier ones — the conservative direction that
-	// over-reports a replaced borrow but never misses a real escape. Clearing on
-	// reassignment soundly needs CFG-merge-joined edges, which the connected-component
-	// move builds.
+	// While the body is walked this map holds the source-order-current edge set for each
+	// binding, updated by strong subtree replacement: a `var` reassignment clears the
+	// binding's prior edges before recording its new ones, and a field store `recv.f = …`
+	// clears only the [f] subtree. copyPlaceEdges reads it to project a source binding's
+	// edges into a destructuring leaf, so it must reflect the state at the copy point. The
+	// per-program-point graph the escape check reads is the flow-sensitive one analyzeBorrows
+	// computes from borrowGens, not this eager map. After the body walk, resolveComponentEscapes
+	// overwrites this field with the per-point snapshot at each escape site.
 	borrowEdges map[liveness.VarID][]fieldBorrow
+	// borrowGens records, per CFG statement position, the borrow-edge assignments that
+	// statement makes: for each binding it re-points, the full new edge set the eager
+	// walk computed. analyzeBorrows folds these forward over the CFG, joining edge sets at
+	// branch merges by union so a borrow set on one branch reaches the merge, and replacing
+	// a binding's whole edge set at each assignment so a reassignment clears the prior
+	// referent. It is the flow-sensitive counterpart of moveSites.
+	borrowGens map[liveness.StmtRef][]borrowAssign
+	// borrowDirty accumulates the roots whose eager edge set changed while recording the
+	// current statement's borrows. The recording sites flush it into borrowGens once the
+	// statement's borrows are recorded, emitting one assignment per dirtied root. It is
+	// reset after each flush.
+	borrowDirty set.Set[liveness.VarID]
 	// paramVarIDs holds the VarID of every parameter leaf binding. A borrow of a
 	// parameter outlives the frame, so the escape check skips a referent in this set.
 	paramVarIDs set.Set[liveness.VarID]

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -164,7 +164,7 @@ type funcCtx struct {
 	// once the whole body, loop back edges included, has been walked, so a use that
 	// some reaching path moved is caught even when the move is textually later.
 	useSites []moveUse
-	// borrowEdges records, per binding root VarID, the function-locals it borrows through
+	// eagerBorrowGraph records, per binding root VarID, the function-locals it borrows through
 	// an explicit `&`/`&mut`, each tagged with the field path holding the borrow. The
 	// initializer `val a = {peer: &mut b}` records the edge a → b at path [peer]. The
 	// escape check follows these edges from a value flowing out of the frame to find a
@@ -180,7 +180,7 @@ type funcCtx struct {
 	// per-program-point graph the escape check reads is the flow-sensitive one analyzeBorrows
 	// computes from borrowGens, not this eager map. After the body walk, resolveComponentEscapes
 	// overwrites this field with the per-point snapshot at each escape site.
-	borrowEdges map[liveness.VarID][]fieldBorrow
+	eagerBorrowGraph map[liveness.VarID][]fieldBorrow
 	// borrowGens records, per CFG statement position, the borrow-edge assignments that
 	// statement makes: for each binding it re-points, the full new edge set the eager
 	// walk computed. analyzeBorrows folds these forward over the CFG, joining edge sets at

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -135,7 +135,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
-	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && c.constructsOwnedMut(d.Init):
+	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && freshLiteralShape(d.Init, c.acceptsBorrowLeaf):
 		// An unannotated `val mut q = {…}` / `var mut q = {…}` from a freshly
 		// constructed literal constructs an owned-mutable value. This mirrors the
 		// annotated `val q: mut {x} = {x: 1}` upgrade in
@@ -492,29 +492,6 @@ func containsOwnedMut(t soltype.Type) bool {
 func isMutableIdentPat(p ast.Pat) bool {
 	ip, ok := p.(*ast.IdentPat)
 	return ok && ip.Mutable
-}
-
-// isFreshlyConstructed reports whether e is a syntactically fresh, unaliased value: a
-// literal, or an object/tuple literal whose every element is itself freshly
-// constructed. Such a value captures no reference to an existing binding, so it is
-// uniquely owned. It is deliberately conservative and identifier-free: any IdentExpr,
-// call, member access, or spread disqualifies the whole expression, because a captured
-// variable could alias a value held immutably elsewhere. Being identifier-free also
-// makes it sound without VarIDs, so it holds at module top level where the liveness
-// pre-pass has not run. canUpgradeToOwnedMut is the richer judgment that also admits an
-// owned-place move; both run through freshLiteralShape and differ only at a non-literal
-// leaf, which this predicate always rejects.
-func isFreshlyConstructed(e ast.Expr) bool {
-	return freshLiteralShape(e, func(ast.Expr) bool { return false })
-}
-
-// constructsOwnedMut reports whether the unannotated initializer e builds an owned-mutable
-// value: a fresh literal, admitting a borrow leaf. It extends isFreshlyConstructed by accepting
-// a `&`/`&mut` leaf, so `val mut b = {peer: &mut d}` upgrades to owned-mutable `mut {peer: &mut
-// {…}}` the same way `val mut q = {x: 1}` does. The borrow leaf's soundness rests on the
-// escape tracking that runs inside a function body, so acceptsBorrowLeaf admits it only there.
-func (c *checker) constructsOwnedMut(e ast.Expr) bool {
-	return freshLiteralShape(e, c.acceptsBorrowLeaf)
 }
 
 // checkExcessLiteralMembers is the construction-site excess check (M4 A3): a

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -682,7 +682,7 @@ func (c *checker) inferDestructureDecl(scope *Scope, lvl int, d *ast.VarDecl) {
 	// return of a leaf that projects a borrow of a local is caught. `val {peer} = {peer:
 	// &mut b}` records peer → b. The correspondence is structural, so it tracks a leaf
 	// only when the initializer's shape mirrors the pattern's.
-	if c.fn != nil && c.fn.borrowEdges != nil && d.Init != nil {
+	if c.fn != nil && c.fn.eagerBorrowGraph != nil && d.Init != nil {
 		c.recordDestructureBorrowEdges(d.Pattern, d.Init)
 	}
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -135,7 +135,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 	}
 	initT := c.inferExpr(scope, lvl, d.Init)
 	switch {
-	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && isFreshlyConstructed(d.Init):
+	case d.TypeAnn == nil && isMutableIdentPat(d.Pattern) && c.constructsOwnedMut(d.Init):
 		// An unannotated `val mut q = {…}` / `var mut q = {…}` from a freshly
 		// constructed literal constructs an owned-mutable value. This mirrors the
 		// annotated `val q: mut {x} = {x: 1}` upgrade in
@@ -144,9 +144,11 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// type aliases nothing. The literal's fields widen, since a mutable cell
 		// admits any value of the field's primitive type. So `val mut q = {x: 1}`
 		// is `mut {x: number}`. A `mut {x: 1}` would reject the ordinary write
-		// `q.x = 2`. A primitive initializer is not borrowable and has no interior
-		// mutability to make mutable, so it falls back to the var-widening and
-		// val-keep behaviour below.
+		// `q.x = 2`. A borrow leaf is admitted too: `val mut b = {peer: &mut d}`
+		// builds the owned-mutable `mut {peer: &mut {…}}`, whose field is repointable
+		// and which is `&mut`-borrowable. A primitive initializer is not borrowable and
+		// has no interior mutability to make mutable, so it falls back to the
+		// var-widening and val-keep behaviour below.
 		widened := widen(initT)
 		if inner, ok := widened.(soltype.RefInner); ok {
 			ref := soltype.NewRef(true, nil, inner)
@@ -323,9 +325,29 @@ func (c *checker) tryUpgradeToOwnedMut(site ast.Node, src ast.Expr, srcT, target
 // no backing move.
 func (c *checker) canUpgradeToOwnedMut(src ast.Expr) bool {
 	return freshLiteralShape(src, func(leaf ast.Expr) bool {
+		if c.acceptsBorrowLeaf(leaf) {
+			return true
+		}
 		t := c.info.TypeOf(leaf)
 		return !containsOwnedMut(t) && movesOwnedPlace(leaf, t)
 	})
+}
+
+// acceptsBorrowLeaf reports whether leaf is a borrow expression `&e`/`&mut e` that may sit in
+// an owned-mutable literal — `val mut b = {peer: &mut d}` builds the owned-mutable `mut {peer:
+// &mut d}`, so `b` is `&mut`-borrowable and its field repointable. The container's mutability
+// lets the field be repointed but grants no write to the referent beyond what the borrow
+// already carries, and the borrow's pointee stays invariant through the C2 RefType arm, so the
+// covariant read-view constrain the upgrade runs does not widen the pointee. A borrow of a
+// function-local that this makes constructible is tracked by the borrow-edge graph, so a later
+// flow-out of the container is caught by the escape check. It is confined to a function body,
+// where that escape tracking runs.
+func (c *checker) acceptsBorrowLeaf(leaf ast.Expr) bool {
+	if c.fn == nil {
+		return false
+	}
+	_, ok := leaf.(*ast.BorrowExpr)
+	return ok
 }
 
 // freshLiteralShape reports whether e is a primitive literal, or an object/tuple literal
@@ -484,6 +506,15 @@ func isMutableIdentPat(p ast.Pat) bool {
 // leaf, which this predicate always rejects.
 func isFreshlyConstructed(e ast.Expr) bool {
 	return freshLiteralShape(e, func(ast.Expr) bool { return false })
+}
+
+// constructsOwnedMut reports whether the unannotated initializer e builds an owned-mutable
+// value: a fresh literal, admitting a borrow leaf. It extends isFreshlyConstructed by accepting
+// a `&`/`&mut` leaf, so `val mut b = {peer: &mut d}` upgrades to owned-mutable `mut {peer: &mut
+// {…}}` the same way `val mut q = {x: 1}` does. The borrow leaf's soundness rests on the
+// escape tracking that runs inside a function body, so acceptsBorrowLeaf admits it only there.
+func (c *checker) constructsOwnedMut(e ast.Expr) bool {
+	return freshLiteralShape(e, c.acceptsBorrowLeaf)
 }
 
 // checkExcessLiteralMembers is the construction-site excess check (M4 A3): a

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1359,11 +1359,15 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 			}
 		}
 		// Record any borrow of a local the reassigned value introduces, so a later
-		// flow-out of the target finds it. `a = &mut b` records a → b. The edge graph
-		// accumulates, so this adds to the target's earlier edges rather than replacing
-		// them.
+		// flow-out of the target finds it. `a = &mut b` records a → b. Recording strong-
+		// updates the binding, clearing its prior referent, and the flush lands the new
+		// edge set at this statement's CFG point so the flow-sensitive graph joins it at
+		// later merges.
 		if !b.ModuleLevel {
 			c.recordBorrowEdges(target.VarID, e.Right)
+			if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
+				c.flushBorrowGens(ref)
+			}
 		}
 	}
 	// The assignment evaluates to the value just stored — the SAME read face as
@@ -1475,6 +1479,10 @@ func (c *checker) inferMemberAssign(scope *Scope, lvl int, e *ast.BinaryExpr, m 
 			// the caller. checkParamFieldStoreEscape applies only when the receiver is a
 			// parameter, and records the store for the post-pass to decide.
 			c.checkParamFieldStoreEscape(m.Object, e.Right, ref)
+			// A store into a LOCAL receiver's field records a borrow edge instead, rooted at
+			// the field. It does not escape until the receiver itself flows out, at which
+			// point the recorded edge is followed. `b.peer = &mut d` records b → d at [peer].
+			c.recordFieldStoreEdges(m.Object, m.Prop.Name, e.Right, ref)
 		}
 	}
 	// The assignment evaluates to the value just stored. recordType overwrites the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1366,7 +1366,7 @@ func (c *checker) inferAssign(scope *Scope, lvl int, e *ast.BinaryExpr) soltype.
 		if !b.ModuleLevel {
 			c.recordBorrowEdges(target.VarID, e.Right)
 			if ref, ok := c.fn.stmtToRef[assignStmt]; ok {
-				c.flushBorrowGens(ref)
+				c.flushBorrowDirty(ref)
 			}
 		}
 	}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -113,6 +113,13 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			// Type the initializer, then bind the pattern's leaves against it as
 			// monomorphic projections.
 			c.inferDestructureDecl(scope, lvl, vd)
+			// Flush each leaf's recorded borrow edges into the flow-sensitive graph at
+			// this statement's CFG point.
+			if c.fn != nil {
+				if ref, ok := c.fn.stmtToRef[s]; ok {
+					c.flushBorrowGens(ref)
+				}
+			}
 			return &soltype.Void{}
 		}
 		// Unlike the module driver (inferComponent), a body-level redeclaration is
@@ -133,8 +140,12 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				c.consumeBindingInit(vd, bindingType(b), s)
 				// Record which function-locals this binding's initializer borrows, so a
 				// later flow-out of the binding can find a borrow of a local that would
-				// escape the frame.
+				// escape the frame. Flush the recorded edges into the flow-sensitive graph
+				// at this statement's CFG point.
 				c.recordBorrowEdges(b.VarID, vd.Init)
+				if ref, ok := c.fn.stmtToRef[s]; ok {
+					c.flushBorrowGens(ref)
+				}
 			}
 		}
 		return &soltype.Void{}

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -113,8 +113,6 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			// Type the initializer, then bind the pattern's leaves against it as
 			// monomorphic projections.
 			c.inferDestructureDecl(scope, lvl, vd)
-			// Flush each leaf's recorded borrow edges into the flow-sensitive graph at
-			// this statement's CFG point.
 			if c.fn != nil {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.flushBorrowDirty(ref)
@@ -140,8 +138,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				c.consumeBindingInit(vd, bindingType(b), s)
 				// Record which function-locals this binding's initializer borrows, so a
 				// later flow-out of the binding can find a borrow of a local that would
-				// escape the frame. Flush the recorded edges into the flow-sensitive graph
-				// at this statement's CFG point.
+				// escape the frame.
 				c.recordBorrowEdges(b.VarID, vd.Init)
 				if ref, ok := c.fn.stmtToRef[s]; ok {
 					c.flushBorrowDirty(ref)

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -117,7 +117,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 			// this statement's CFG point.
 			if c.fn != nil {
 				if ref, ok := c.fn.stmtToRef[s]; ok {
-					c.flushBorrowGens(ref)
+					c.flushBorrowDirty(ref)
 				}
 			}
 			return &soltype.Void{}
@@ -144,7 +144,7 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 				// at this statement's CFG point.
 				c.recordBorrowEdges(b.VarID, vd.Init)
 				if ref, ok := c.fn.stmtToRef[s]; ok {
-					c.flushBorrowGens(ref)
+					c.flushBorrowDirty(ref)
 				}
 			}
 		}

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -566,8 +566,8 @@ func (c *checker) checkUseAfterMoves() {
 	// graph, then fold any component-move consumes back into moveSites and recompute, so a
 	// use after a co-moved local is caught.
 	if len(c.fn.escapeSites) > 0 {
-		binfo := c.analyzeBorrows()
-		if c.resolveComponentEscapes(info, binfo) {
+		flowBorrowGraph := c.analyzeBorrows()
+		if c.resolveComponentEscapes(info, flowBorrowGraph) {
 			info = liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
 		}
 	}

--- a/internal/solver/moves.go
+++ b/internal/solver/moves.go
@@ -562,10 +562,14 @@ func (c *checker) checkUseAfterMoves() {
 		return
 	}
 	info := liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
-	// Decide deferred escapes against the lattice, then fold any component-move consumes
-	// back into moveSites and recompute, so a use after a co-moved local is caught.
-	if len(c.fn.escapeSites) > 0 && c.resolveComponentEscapes(info) {
-		info = liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
+	// Decide deferred escapes against the move lattice and the flow-sensitive borrow-edge
+	// graph, then fold any component-move consumes back into moveSites and recompute, so a
+	// use after a co-moved local is caught.
+	if len(c.fn.escapeSites) > 0 {
+		binfo := c.analyzeBorrows()
+		if c.resolveComponentEscapes(info, binfo) {
+			info = liveness.AnalyzeMoves(c.fn.cfg, c.fn.moveSites)
+		}
 	}
 	for _, u := range c.fn.useSites {
 		state, movedID := c.movedConflict(info, u)

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -44,14 +44,19 @@ import (
 //   - A disjoint field return `return a.data` follows the edges on the [data] path, finds
 //     none, and is sound with no false positive.
 //
-// Edges are recorded at four sites: a `val`/`var` initializer, a `var` reassignment, a field
-// store into a local receiver, and a destructuring leaf. The graph is flow-sensitive. Each
-// recording strong-updates the binding, clearing the replaced subtree before adding the new
-// edges, and analyzeBorrows folds the per-statement edge sets forward over the CFG, joining
-// them by union at branch merges. So a reassignment drops its prior referent, a repoint
-// replaces one field's edge, and a borrow set on one branch still reaches the merge. See
-// borrow_flow.go. resolveComponentEscapes reads the edge set at each flow-out site's program
-// point through this graph.
+// Edges are recorded at four sites:
+//
+//   - a `val`/`var` initializer,
+//   - a `var` reassignment,
+//   - a field store into a local receiver,
+//   - a destructuring leaf.
+//
+// The graph is flow-sensitive. Each recording strong-updates the binding, clearing the replaced
+// subtree before adding the new edges. analyzeBorrows folds the per-statement edge sets
+// forward over the CFG, joining them by union at branch merges. So a reassignment drops its prior
+// referent, a repoint replaces one field's edge, and a borrow set on one branch still reaches the
+// merge. See borrow_flow.go. resolveComponentEscapes reads the edge set at each flow-out site's
+// program point through this graph.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
 // function-local. It blames the outgoing expression and names the escaping local.
@@ -75,8 +80,8 @@ func (e *EscapingBorrowError) Message() string {
 // frame at. The expression doubles as the diagnostic blame and as the source whose carried
 // locals the post-pass computes.
 type escapeSite struct {
-	expr ast.Expr
-	ref  liveness.StmtRef
+	expr    ast.Expr
+	stmtRef liveness.StmtRef
 }
 
 // resolveComponentEscapes decides every recorded escape site once the body is fully walked,
@@ -85,19 +90,22 @@ type escapeSite struct {
 // connected-component move — allowed, co-moving and consuming the component's locals — or an
 // ordinary escape, reported. It returns true when it consumed any co-moved local, so the
 // caller knows to recompute the lattice before the use-after-move scan reads it.
-func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *flowBorrowGraph) bool {
+func (c *checker) resolveComponentEscapes(
+	info *liveness.MoveInfo,
+	flowBorrowGraph *flowBorrowGraph,
+) bool {
 	consumed := false
 	for _, es := range c.fn.escapeSites {
-		// Read the borrow-edge graph at this site's program point. The escape helpers all
-		// consult c.fn.eagerBorrowGraph, so swap in the flow-sensitive snapshot before running
-		// them: a borrow cleared by an earlier reassignment is gone here, and one set on a
-		// reaching branch is joined in.
-		c.fn.eagerBorrowGraph = binfo.fieldBorrowGraphBefore(es.ref)
-		escaping := c.escapingLocalsOf(es.expr)
+		// The flow-sensitive borrow-edge graph at this site's program point. A borrow cleared by an
+		// earlier reassignment is gone here, and one set on a reaching branch is joined in. Passed
+		// explicitly to each escape helper so they read this per-point snapshot rather than the
+		// whole-body eager graph.
+		fieldBorrowGraph := flowBorrowGraph.fieldBorrowGraphBefore(es.stmtRef)
+		escaping := c.escapingLocalsOf(es.expr, fieldBorrowGraph)
 		if escaping.Len() == 0 {
 			continue
 		}
-		if c.componentMoveCovers(es.expr, escaping, es.ref, info) {
+		if c.componentMoveCovers(es.expr, escaping, es.stmtRef, info, fieldBorrowGraph) {
 			// Co-move the component: consume every borrowed local, so a later use of any of
 			// them is a use-after-move. The escaping value's own root is consumed at the flow
 			// site already, so it is skipped here — a borrow cycle can route an edge back to
@@ -112,12 +120,12 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *flowBo
 				if id == rootID {
 					continue
 				}
-				c.recordMove(id, es.expr, es.ref)
+				c.recordMove(id, es.expr, es.stmtRef)
 			}
 			// When the moved graph is a tree — every borrowed local reached exactly once with
 			// no cycle — the return value is the sole owner of each node, so owning them in the
 			// type is honest. Strip the borrows from this return's type.
-			c.stripReturnBorrowsIfTree(es.expr)
+			c.stripReturnBorrowsIfTree(es.expr, fieldBorrowGraph)
 			consumed = true
 			continue
 		}
@@ -144,15 +152,20 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *flowBo
 // shared limitation the graph's three recording sites impose. Recording a container-method
 // borrow needs `Array` and method-call support the solver lacks today; it is tracked as a
 // post-M7 item under "Deferred and out of scope" in planning/affine_semantics/implementation_plan.md.
-func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarID], ref liveness.StmtRef, info *liveness.MoveInfo) bool {
-	if !c.escapesAsOwnedCarrier(e) {
+func (c *checker) componentMoveCovers(
+	e ast.Expr, escaping set.Set[liveness.VarID],
+	stmtRef liveness.StmtRef,
+	info *liveness.MoveInfo,
+	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
+) bool {
+	if !c.escapesAsOwnedCarrier(e, fieldBorrowGraph) {
 		return false
 	}
 	component := escaping.Clone()
 	if p, ok := exprPlace(e); ok && p.root > 0 {
 		component.Add(p.root)
 	}
-	for root, edges := range c.fn.eagerBorrowGraph {
+	for root, edges := range fieldBorrowGraph {
 		if component.Contains(root) {
 			continue
 		}
@@ -161,10 +174,10 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 		// moved before ref, or not live after it. At a return every local is dead — nothing
 		// runs after — so only a parameter or a longer-lived store can pin a returned
 		// component; a live external alias at a store or argument site still blocks the move.
-		if info.StateBefore(ref, root) == liveness.Moved {
+		if info.StateBefore(stmtRef, root) == liveness.Moved {
 			continue
 		}
-		if c.fn.liveness != nil && !c.fn.liveness.IsLiveAfter(ref, root) {
+		if c.fn.liveness != nil && !c.fn.liveness.IsLiveAfter(stmtRef, root) {
 			continue
 		}
 		for _, edge := range edges {
@@ -194,7 +207,10 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 //     a → b at [] reads a borrow-typed binding.
 //   - Any other carrier — an if/match, a call result — is conservatively a bare borrow, so an
 //     ambiguous outgoing value stays an escape rather than a speculative component move.
-func (c *checker) escapesAsOwnedCarrier(e ast.Expr) bool {
+func (c *checker) escapesAsOwnedCarrier(
+	e ast.Expr,
+	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
+) bool {
 	switch e.(type) {
 	case *ast.BorrowExpr:
 		return false
@@ -205,7 +221,7 @@ func (c *checker) escapesAsOwnedCarrier(e ast.Expr) bool {
 	if !ok || p.root <= 0 {
 		return false
 	}
-	for _, edge := range c.fn.eagerBorrowGraph[p.root] {
+	for _, edge := range fieldBorrowGraph[p.root] {
 		if pathHasPrefix(p.path, edge.path) {
 			return false
 		}
@@ -292,9 +308,12 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 //   - The edges under a place e names, a whole binding `a` or a field `a.peer`. They
 //     contribute the locals they transitively reach, filtered to the place's field path so a
 //     field return follows only that field's edges.
-func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
+func (c *checker) escapingLocalsOf(
+	e ast.Expr,
+	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
+) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
-	if c.fn == nil || c.fn.eagerBorrowGraph == nil || e == nil {
+	if c.fn == nil || fieldBorrowGraph == nil || e == nil {
 		return out
 	}
 	for _, b := range borrowsIn(e) {
@@ -303,7 +322,7 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 		}
 	}
 	if p, ok := exprPlace(e); ok && p.root > 0 {
-		c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID]())
+		c.collectBorrowedFrom(p.root, p.path, out, set.NewSet[liveness.VarID](), fieldBorrowGraph)
 	}
 	return out
 }
@@ -313,11 +332,11 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 // the same path and referent is ignored, so repeated walks keep one copy rather than
 // accumulating identical edges.
 func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
-	e := fieldBorrow{path: path, referent: referent}
-	if containsFieldBorrow(c.fn.eagerBorrowGraph[root], e) {
+	fb := fieldBorrow{path: path, referent: referent}
+	if containsFieldBorrow(c.fn.eagerBorrowGraph[root], fb) {
 		return
 	}
-	c.fn.eagerBorrowGraph[root] = append(c.fn.eagerBorrowGraph[root], e)
+	c.fn.eagerBorrowGraph[root] = append(c.fn.eagerBorrowGraph[root], fb)
 	c.markBorrowDirty(root)
 }
 
@@ -483,24 +502,24 @@ func (c *checker) reportEscapingLocals(escaping set.Set[liveness.VarID], blame a
 // post-pass, capturing the outgoing expression and the program point it flows out at. The
 // post-pass needs the complete borrow-edge graph and the consumed lattice, neither of which
 // is final mid-walk, so it cannot decide a self-contained component move inline.
-func (c *checker) recordEscapeSite(e ast.Expr, ref liveness.StmtRef) {
+func (c *checker) recordEscapeSite(e ast.Expr, stmtRef liveness.StmtRef) {
 	if c.fn == nil || e == nil {
 		return
 	}
-	c.fn.escapeSites = append(c.fn.escapeSites, escapeSite{expr: e, ref: ref})
+	c.fn.escapeSites = append(c.fn.escapeSites, escapeSite{expr: e, stmtRef: stmtRef})
 }
 
 // checkReturnEscape records the return value as an escape site. `return a` where a borrows
 // b, `return &mut b`, and `return {peer: &mut b}` all carry a borrow of b out of the frame;
 // resolveComponentEscapes later decides each as a component move or an escape.
-func (c *checker) checkReturnEscape(retExpr ast.Expr, ref liveness.StmtRef) {
-	c.recordEscapeSite(retExpr, ref)
+func (c *checker) checkReturnEscape(retExpr ast.Expr, stmtRef liveness.StmtRef) {
+	c.recordEscapeSite(retExpr, stmtRef)
 }
 
 // checkParamFieldStoreEscape handles a field store `recv.f = source`. Storing a value that
 // borrows a local into a parameter's field escapes, since the parameter's object outlives
 // the frame. A store into a local receiver does not escape and is not tracked.
-func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness.StmtRef) {
+func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, stmtRef liveness.StmtRef) {
 	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
@@ -508,7 +527,7 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness
 	if !ok || rp.root <= 0 || !c.fn.paramVarIDs.Contains(rp.root) {
 		return
 	}
-	c.recordEscapeSite(source, ref)
+	c.recordEscapeSite(source, stmtRef)
 }
 
 // recordFieldStoreEdges records a borrow edge for a field store `recv.f = source` into a
@@ -518,8 +537,13 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness
 // checkParamFieldStoreEscape reports at once. It is a strong update on the stored field's
 // subtree: it clears the [f] subtree before recording, so a repoint `b.peer = &mut e` after
 // `b.peer = &mut d` leaves only b → e at [peer] while a sibling edge b → x at [data] survives.
-// The caller flushes the dirtied root into borrowGens.
-func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.Expr, ref liveness.StmtRef) {
+// It then flushes the dirtied root into borrowGens at stmtRef.
+func (c *checker) recordFieldStoreEdges(
+	recv ast.Expr,
+	field string,
+	source ast.Expr,
+	stmtRef liveness.StmtRef,
+) {
 	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
@@ -530,7 +554,7 @@ func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.
 	base := appendSeg(rp.path, field)
 	c.clearEagerSubtree(rp.root, base)
 	c.recordBorrowSources(rp.root, base, source)
-	c.flushBorrowDirty(ref)
+	c.flushBorrowDirty(stmtRef)
 }
 
 // collectBorrowedFrom adds to out every function-local the read place rooted at root, with
@@ -549,13 +573,18 @@ func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.
 // root is the starting point, not itself collected, except when a borrow cycle reaches back
 // to it. Collecting it then is sound: a local that borrows root and itself escapes carries
 // root's data out too.
-func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, out, seen set.Set[liveness.VarID]) {
-	for _, edge := range c.fn.eagerBorrowGraph[root] {
+func (c *checker) collectBorrowedFrom(
+	root liveness.VarID,
+	filter []placeSeg,
+	out, seen set.Set[liveness.VarID],
+	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
+) {
+	for _, edge := range fieldBorrowGraph[root] {
 		if !pathPrefixRelated(edge.path, filter) {
 			continue
 		}
 		out.Add(edge.referent)
-		c.collectAllFrom(edge.referent, out, seen)
+		c.collectAllFrom(edge.referent, out, seen, fieldBorrowGraph)
 	}
 }
 
@@ -564,14 +593,18 @@ func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, ou
 // exposes all of it. For node a with edges a → b at [peer] and a → c at [data], it collects
 // both b and c, then walks each of their edges in turn. The seen set terminates borrow
 // cycles.
-func (c *checker) collectAllFrom(node liveness.VarID, out, seen set.Set[liveness.VarID]) {
+func (c *checker) collectAllFrom(
+	node liveness.VarID,
+	out, seen set.Set[liveness.VarID],
+	fieldBorrowGraph map[liveness.VarID][]fieldBorrow,
+) {
 	if seen.Contains(node) {
 		return
 	}
 	seen.Add(node)
-	for _, edge := range c.fn.eagerBorrowGraph[node] {
+	for _, edge := range fieldBorrowGraph[node] {
 		out.Add(edge.referent)
-		c.collectAllFrom(edge.referent, out, seen)
+		c.collectAllFrom(edge.referent, out, seen, fieldBorrowGraph)
 	}
 }
 

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -85,14 +85,14 @@ type escapeSite struct {
 // connected-component move — allowed, co-moving and consuming the component's locals — or an
 // ordinary escape, reported. It returns true when it consumed any co-moved local, so the
 // caller knows to recompute the lattice before the use-after-move scan reads it.
-func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *borrowInfo) bool {
+func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *flowBorrowGraph) bool {
 	consumed := false
 	for _, es := range c.fn.escapeSites {
 		// Read the borrow-edge graph at this site's program point. The escape helpers all
-		// consult c.fn.borrowEdges, so swap in the flow-sensitive snapshot before running
+		// consult c.fn.eagerBorrowGraph, so swap in the flow-sensitive snapshot before running
 		// them: a borrow cleared by an earlier reassignment is gone here, and one set on a
 		// reaching branch is joined in.
-		c.fn.borrowEdges = binfo.edgesBefore(es.ref)
+		c.fn.eagerBorrowGraph = binfo.fieldBorrowGraphBefore(es.ref)
 		escaping := c.escapingLocalsOf(es.expr)
 		if escaping.Len() == 0 {
 			continue
@@ -152,7 +152,7 @@ func (c *checker) componentMoveCovers(e ast.Expr, escaping set.Set[liveness.VarI
 	if p, ok := exprPlace(e); ok && p.root > 0 {
 		component.Add(p.root)
 	}
-	for root, edges := range c.fn.borrowEdges {
+	for root, edges := range c.fn.eagerBorrowGraph {
 		if component.Contains(root) {
 			continue
 		}
@@ -205,7 +205,7 @@ func (c *checker) escapesAsOwnedCarrier(e ast.Expr) bool {
 	if !ok || p.root <= 0 {
 		return false
 	}
-	for _, edge := range c.fn.borrowEdges[p.root] {
+	for _, edge := range c.fn.eagerBorrowGraph[p.root] {
 		if pathHasPrefix(p.path, edge.path) {
 			return false
 		}
@@ -294,7 +294,7 @@ func (c *checker) isLocalReferent(arg ast.Expr) (liveness.VarID, bool) {
 //     field return follows only that field's edges.
 func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 	out := set.NewSet[liveness.VarID]()
-	if c.fn == nil || c.fn.borrowEdges == nil || e == nil {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil || e == nil {
 		return out
 	}
 	for _, b := range borrowsIn(e) {
@@ -314,10 +314,10 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 // accumulating identical edges.
 func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
 	e := fieldBorrow{path: path, referent: referent}
-	if containsEdge(c.fn.borrowEdges[root], e) {
+	if containsFieldBorrow(c.fn.eagerBorrowGraph[root], e) {
 		return
 	}
-	c.fn.borrowEdges[root] = append(c.fn.borrowEdges[root], e)
+	c.fn.eagerBorrowGraph[root] = append(c.fn.eagerBorrowGraph[root], e)
 	c.markBorrowDirty(root)
 }
 
@@ -328,7 +328,7 @@ func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent l
 // &mut d` leaves only a → e. The caller flushes the dirtied roots into borrowGens once the
 // statement's borrows are recorded.
 func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
-	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil || destVarID <= 0 || init == nil {
 		return
 	}
 	root := liveness.VarID(destVarID)
@@ -415,7 +415,7 @@ func (c *checker) recordBorrowSources(root liveness.VarID, base []placeSeg, e as
 // whole binding, so the read projects entirely within it and the suffix is empty. It backs
 // both a place initializer `val c = a.peer` and a shorthand property `{peer}`.
 func (c *checker) copyPlaceEdges(root liveness.VarID, base []placeSeg, src movePlace) {
-	for _, edge := range c.fn.borrowEdges[src.root] {
+	for _, edge := range c.fn.eagerBorrowGraph[src.root] {
 		// Skip an edge off the read place's field path, and one pointing back at root. The
 		// self-edge guard matters because src's referent can be root: reassigning `b = a`
 		// where a holds a borrow of b would otherwise copy a → b into b as a b → b loop.
@@ -501,7 +501,7 @@ func (c *checker) checkReturnEscape(retExpr ast.Expr, ref liveness.StmtRef) {
 // borrows a local into a parameter's field escapes, since the parameter's object outlives
 // the frame. A store into a local receiver does not escape and is not tracked.
 func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness.StmtRef) {
-	if c.fn == nil || c.fn.borrowEdges == nil {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
 	rp, ok := exprPlace(recv)
@@ -520,7 +520,7 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness
 // `b.peer = &mut d` leaves only b → e at [peer] while a sibling edge b → x at [data] survives.
 // The caller flushes the dirtied root into borrowGens.
 func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.Expr, ref liveness.StmtRef) {
-	if c.fn == nil || c.fn.borrowEdges == nil {
+	if c.fn == nil || c.fn.eagerBorrowGraph == nil {
 		return
 	}
 	rp, ok := exprPlace(recv)
@@ -530,7 +530,7 @@ func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.
 	base := appendSeg(rp.path, field)
 	c.clearEagerSubtree(rp.root, base)
 	c.recordBorrowSources(rp.root, base, source)
-	c.flushBorrowGens(ref)
+	c.flushBorrowDirty(ref)
 }
 
 // collectBorrowedFrom adds to out every function-local the read place rooted at root, with
@@ -550,7 +550,7 @@ func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.
 // to it. Collecting it then is sound: a local that borrows root and itself escapes carries
 // root's data out too.
 func (c *checker) collectBorrowedFrom(root liveness.VarID, filter []placeSeg, out, seen set.Set[liveness.VarID]) {
-	for _, edge := range c.fn.borrowEdges[root] {
+	for _, edge := range c.fn.eagerBorrowGraph[root] {
 		if !pathPrefixRelated(edge.path, filter) {
 			continue
 		}
@@ -569,7 +569,7 @@ func (c *checker) collectAllFrom(node liveness.VarID, out, seen set.Set[liveness
 		return
 	}
 	seen.Add(node)
-	for _, edge := range c.fn.borrowEdges[node] {
+	for _, edge := range c.fn.eagerBorrowGraph[node] {
 		out.Add(edge.referent)
 		c.collectAllFrom(edge.referent, out, seen)
 	}

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -333,10 +333,10 @@ func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 	}
 	root := liveness.VarID(destVarID)
 	c.clearEagerSubtree(root, nil)
-	c.walkBorrowSources(root, nil, init)
+	c.recordBorrowSources(root, nil, init)
 }
 
-// walkBorrowSources records the borrow edges the expression e contributes to the binding
+// recordBorrowSources records the borrow edges the expression e contributes to the binding
 // root, at base, the field path reached so far:
 //
 //   - A direct `&mut b` of a local records an edge at base.
@@ -351,7 +351,7 @@ func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 //     through borrowsIn.
 //
 // The walk stops at a call or nested-function boundary.
-func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.Expr) {
+func (c *checker) recordBorrowSources(root liveness.VarID, base []placeSeg, e ast.Expr) {
 	switch e := e.(type) {
 	case *ast.BorrowExpr:
 		if referent, ok := c.isLocalReferent(e.Arg); ok && referent != root {
@@ -363,12 +363,12 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 			case *ast.PropertyExpr:
 				if el.Value != nil {
 					if name, ok := objKeyName(el.Name); ok {
-						c.walkBorrowSources(root, appendSeg(base, name), el.Value)
+						c.recordBorrowSources(root, appendSeg(base, name), el.Value)
 					} else {
 						// A computed key names no static field segment, so the borrow can't
 						// be addressed by a field path. Keep base, attributing the value to the
 						// enclosing object conservatively.
-						c.walkBorrowSources(root, base, el.Value)
+						c.recordBorrowSources(root, base, el.Value)
 					}
 				} else if ident, ok := el.Name.(*ast.IdentExpr); ok && ident.VarID > 0 {
 					// A shorthand property `{peer}` is `{peer: peer}`: the field peer holds
@@ -379,15 +379,15 @@ func (c *checker) walkBorrowSources(root liveness.VarID, base []placeSeg, e ast.
 					c.copyPlaceEdges(root, appendSeg(base, ident.Name), movePlace{root: liveness.VarID(ident.VarID)})
 				}
 			case *ast.ObjSpreadExpr:
-				c.walkBorrowSources(root, base, el.Value)
+				c.recordBorrowSources(root, base, el.Value)
 			}
 		}
 	case *ast.TupleExpr:
 		for _, el := range e.Elems {
-			c.walkBorrowSources(root, base, el)
+			c.recordBorrowSources(root, base, el)
 		}
 	case *ast.ArraySpreadExpr:
-		c.walkBorrowSources(root, base, e.Value)
+		c.recordBorrowSources(root, base, e.Value)
 	case *ast.CallExpr, *ast.TaggedTemplateLitExpr, *ast.FuncExpr:
 		return
 	default:
@@ -529,7 +529,7 @@ func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.
 	}
 	base := appendSeg(rp.path, field)
 	c.clearEagerSubtree(rp.root, base)
-	c.walkBorrowSources(rp.root, base, source)
+	c.recordBorrowSources(rp.root, base, source)
 	c.flushBorrowGens(ref)
 }
 

--- a/internal/solver/return_escape.go
+++ b/internal/solver/return_escape.go
@@ -44,12 +44,14 @@ import (
 //   - A disjoint field return `return a.data` follows the edges on the [data] path, finds
 //     none, and is sound with no false positive.
 //
-// Edges are recorded at three sites: a `val`/`var` initializer, a `var` reassignment, and a
-// destructuring leaf. The graph is accumulate-only and not flow-sensitive, so a
-// reassignment adds edges without clearing the binding's earlier ones. This over-reports a
-// borrow that a later reassignment replaced, the conservative direction that never misses a
-// real escape. Clearing on reassignment soundly needs CFG-merge-joined edges, which the
-// connected-component move builds.
+// Edges are recorded at four sites: a `val`/`var` initializer, a `var` reassignment, a field
+// store into a local receiver, and a destructuring leaf. The graph is flow-sensitive. Each
+// recording strong-updates the binding, clearing the replaced subtree before adding the new
+// edges, and analyzeBorrows folds the per-statement edge sets forward over the CFG, joining
+// them by union at branch merges. So a reassignment drops its prior referent, a repoint
+// replaces one field's edge, and a borrow set on one branch still reaches the merge. See
+// borrow_flow.go. resolveComponentEscapes reads the edge set at each flow-out site's program
+// point through this graph.
 
 // EscapingBorrowError fires when a value flowing out of the frame carries a borrow of a
 // function-local. It blames the outgoing expression and names the escaping local.
@@ -83,9 +85,14 @@ type escapeSite struct {
 // connected-component move — allowed, co-moving and consuming the component's locals — or an
 // ordinary escape, reported. It returns true when it consumed any co-moved local, so the
 // caller knows to recompute the lattice before the use-after-move scan reads it.
-func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
+func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo, binfo *borrowInfo) bool {
 	consumed := false
 	for _, es := range c.fn.escapeSites {
+		// Read the borrow-edge graph at this site's program point. The escape helpers all
+		// consult c.fn.borrowEdges, so swap in the flow-sensitive snapshot before running
+		// them: a borrow cleared by an earlier reassignment is gone here, and one set on a
+		// reaching branch is joined in.
+		c.fn.borrowEdges = binfo.edgesBefore(es.ref)
 		escaping := c.escapingLocalsOf(es.expr)
 		if escaping.Len() == 0 {
 			continue
@@ -107,6 +114,10 @@ func (c *checker) resolveComponentEscapes(info *liveness.MoveInfo) bool {
 				}
 				c.recordMove(id, es.expr, es.ref)
 			}
+			// When the moved graph is a tree — every borrowed local reached exactly once with
+			// no cycle — the return value is the sole owner of each node, so owning them in the
+			// type is honest. Strip the borrows from this return's type.
+			c.stripReturnBorrowsIfTree(es.expr)
 			consumed = true
 			continue
 		}
@@ -302,22 +313,27 @@ func (c *checker) escapingLocalsOf(e ast.Expr) set.Set[liveness.VarID] {
 // the same path and referent is ignored, so repeated walks keep one copy rather than
 // accumulating identical edges.
 func (c *checker) addBorrowEdge(root liveness.VarID, path []placeSeg, referent liveness.VarID) {
-	for _, e := range c.fn.borrowEdges[root] {
-		if e.referent == referent && slices.Equal(e.path, path) {
-			return
-		}
+	e := fieldBorrow{path: path, referent: referent}
+	if containsEdge(c.fn.borrowEdges[root], e) {
+		return
 	}
-	c.fn.borrowEdges[root] = append(c.fn.borrowEdges[root], fieldBorrow{path: path, referent: referent})
+	c.fn.borrowEdges[root] = append(c.fn.borrowEdges[root], e)
+	c.markBorrowDirty(root)
 }
 
 // recordBorrowEdges records which function-locals the binding destVarID borrows and at
 // which field. `val a = {peer: &mut b}` records a → b at path [peer], and a whole-binding
-// move `val a2 = a` carries a's edges into a2 at the same paths.
+// move `val a2 = a` carries a's edges into a2 at the same paths. A `var` reassignment reuses
+// the same VarID, so recording clears the binding's prior edges first: `a = &mut e` after `a =
+// &mut d` leaves only a → e. The caller flushes the dirtied roots into borrowGens once the
+// statement's borrows are recorded.
 func (c *checker) recordBorrowEdges(destVarID int, init ast.Expr) {
 	if c.fn == nil || c.fn.borrowEdges == nil || destVarID <= 0 || init == nil {
 		return
 	}
-	c.walkBorrowSources(liveness.VarID(destVarID), nil, init)
+	root := liveness.VarID(destVarID)
+	c.clearEagerSubtree(root, nil)
+	c.walkBorrowSources(root, nil, init)
 }
 
 // walkBorrowSources records the borrow edges the expression e contributes to the binding
@@ -493,6 +509,28 @@ func (c *checker) checkParamFieldStoreEscape(recv, source ast.Expr, ref liveness
 		return
 	}
 	c.recordEscapeSite(source, ref)
+}
+
+// recordFieldStoreEdges records a borrow edge for a field store `recv.f = source` into a
+// LOCAL receiver, rooted at recv's place extended by f. A store `b.peer = &mut d` records b →
+// d at [peer], so a later flow-out of b finds the borrow of d. The store into a local does
+// not escape until b itself flows out, unlike the store into a parameter's field, which
+// checkParamFieldStoreEscape reports at once. It is a strong update on the stored field's
+// subtree: it clears the [f] subtree before recording, so a repoint `b.peer = &mut e` after
+// `b.peer = &mut d` leaves only b → e at [peer] while a sibling edge b → x at [data] survives.
+// The caller flushes the dirtied root into borrowGens.
+func (c *checker) recordFieldStoreEdges(recv ast.Expr, field string, source ast.Expr, ref liveness.StmtRef) {
+	if c.fn == nil || c.fn.borrowEdges == nil {
+		return
+	}
+	rp, ok := exprPlace(recv)
+	if !ok || rp.root <= 0 || c.fn.paramVarIDs.Contains(rp.root) {
+		return
+	}
+	base := appendSeg(rp.path, field)
+	c.clearEagerSubtree(rp.root, base)
+	c.walkBorrowSources(rp.root, base, source)
+	c.flushBorrowGens(ref)
 }
 
 // collectBorrowedFrom adds to out every function-local the read place rooted at root, with

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -168,12 +168,10 @@ func TestReturnEscape(t *testing.T) {
 			types: map[string]string{"f": "fn <'a>(obj: {peer?: &'a mut {value: number}}) -> &'a mut {value: number}"},
 		},
 		// A borrow introduced by reassigning a `var` escapes: `a = &mut b` records the edge
-		// a → b, so returning a escapes the local b. The edge graph accumulates, so the
-		// reassignment adds the edge to a's earlier ones.
-		// PR 16: flow-sensitive set-and-clear replaces the accumulate-only edge, so the
-		// reassignment clears a's prior edges and sets a → b. The escape result is unchanged
-		// here, since a's prior referent was the parameter seed, which records no edge; the
-		// comment's "accumulates" narrative is what updates.
+		// a → b, so returning a escapes the local b. The flow-sensitive graph strong-updates a
+		// at the reassignment, clearing its prior edges and setting a → b. Here a's prior
+		// referent was the parameter seed, which records no edge, so the clear removes nothing
+		// and only a → b reaches the return.
 		"ReturnVarReassignedToBorrowEscapes": {
 			src: `
 				fn f(seed: &mut {value: number}) {
@@ -318,13 +316,11 @@ func TestEscapeAtStoreAndArgSites(t *testing.T) {
 // escape. When a node is also reachable from a live binding outside the component, the move
 // does not apply and the ordinary escape stands.
 //
-// Cases tagged `PR 16:` change when the flow-sensitivity work lands. Two behaviours move
-// them. Return borrow-stripping rewrites a returned `&`/`&mut` of a function-local reached
-// exactly once into an owned field, so a tree-shaped component move returns an owned type
-// while a diamond or cyclic graph keeps its borrows. The borrow-field owned-mutable upgrade
-// makes `&mut` graph carriers constructible, flipping the all-`&mut` diamond from a
-// construction error to a component move. See PR 16 in
-// planning/affine_semantics/implementation_plan.md.
+// Two behaviours shape the returned types here. Return borrow-stripping rewrites a returned
+// `&`/`&mut` of a function-local reached exactly once into an owned field, so a tree-shaped
+// component move returns an owned type while a diamond or cyclic graph keeps its borrows. The
+// borrow-field owned-mutable upgrade makes `&mut` graph carriers constructible, so an
+// all-`&mut` diamond is a component move rather than a construction error.
 func TestConnectedComponentMove(t *testing.T) {
 	tests := map[string]struct {
 		src   string
@@ -333,9 +329,8 @@ func TestConnectedComponentMove(t *testing.T) {
 	}{
 		// The canonical case: the owned binding a holds `&mut b`, and nothing outside the
 		// {a, b} component references either node, so returning a moves the whole component
-		// out. No escape, and a and b are both consumed.
-		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
-		// `{peer: {value: number}}`.
+		// out. No escape, and a and b are both consumed. b is reached once, so borrow-stripping
+		// rewrites the return to the owned `{peer: {value: number}}`.
 		"ReturnSelfContainedComponent": {
 			src: `
 				fn build() {
@@ -345,12 +340,12 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+			types: map[string]string{"build": "fn () -> {peer: {value: number}}"},
 		},
 		// A component with two borrowed locals moves as a unit just the same: both b and c
-		// are reachable only through a, so returning a co-moves all three.
-		// PR 16: b and c are each reached once, so borrow-stripping rewrites the return to the
-		// owned `{p: {x: number}, q: {x: number}}`.
+		// are reachable only through a, so returning a co-moves all three. b and c are each
+		// reached once, so borrow-stripping rewrites the return to the owned `{p: {x: number},
+		// q: {x: number}}`.
 		"ReturnComponentTwoLocals": {
 			src: `
 				fn build() {
@@ -361,12 +356,11 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {p: &mut {x: number}, q: &mut {x: number}}"},
+			types: map[string]string{"build": "fn () -> {p: {x: number}, q: {x: number}}"},
 		},
 		// The owned carrier may be a fresh literal with no intervening binding: the returned
-		// object owns the borrow of b, and b is reachable only through it.
-		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
-		// `{peer: {value: number}}`.
+		// object owns the borrow of b, and b is reachable only through it. b is reached once,
+		// so borrow-stripping rewrites the return to the owned `{peer: {value: number}}`.
 		"ReturnInlineLiteralComponent": {
 			src: `
 				fn build() {
@@ -375,13 +369,12 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+			types: map[string]string{"build": "fn () -> {peer: {value: number}}"},
 		},
 		// A whole-binding move carries the graph forward: `val a2 = a` moves a, borrow and
 		// all, into a2. The dead a is not a live external reference to b, so returning a2
-		// still moves the {a2, b} component out.
-		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
-		// `{peer: {value: number}}`.
+		// still moves the {a2, b} component out. b is reached once, so borrow-stripping
+		// rewrites the return to the owned `{peer: {value: number}}`.
 		"ReturnMovedCarrierComponent": {
 			src: `
 				fn build() {
@@ -392,12 +385,12 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &mut {value: number}}"},
+			types: map[string]string{"build": "fn () -> {peer: {value: number}}"},
 		},
 		// An acyclic shared graph moves out the same way: a holds `&b`, and b is reachable
-		// only through a.
-		// PR 16: b is reached once, so borrow-stripping rewrites the return to the owned
-		// `{peer: {value: number}}` — stripping covers shared `&` borrows as well as `&mut`.
+		// only through a. b is reached once, so borrow-stripping rewrites the return to the
+		// owned `{peer: {value: number}}` — stripping covers shared `&` borrows as well as
+		// `&mut`.
 		"ReturnSharedComponent": {
 			src: `
 				fn build() {
@@ -407,7 +400,7 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &{value: number}}"},
+			types: map[string]string{"build": "fn () -> {peer: {value: number}}"},
 		},
 		// A consuming argument moves the component into the callee, which now owns the graph.
 		"ConsumingArgComponentMove": {
@@ -446,9 +439,11 @@ func TestConnectedComponentMove(t *testing.T) {
 		},
 		// An escape through a consuming call inside a return is a component move at the
 		// argument: the literal owning `&mut b` moves into id, b reachable only through it.
-		// No escape is reported at either the argument or the enclosing return.
-		// PR 16: f's returned value borrows b once, so borrow-stripping rewrites f's return to
-		// the owned `{peer: {value: number}}`; id keeps its borrow-typed parameter and result.
+		// No escape is reported at either the argument or the enclosing return. f's return is
+		// the call result `id(…)`, which hides its borrow behind the call boundary, so
+		// borrow-stripping leaves f's return borrowed rather than rewriting it to owned.
+		// Stripping through a consuming call needs lifetime machinery that maps the callee's
+		// returned borrow back to the moved local, deferred past this work.
 		"ComponentMoveThroughConsumingCall": {
 			src: `
 				fn id(y: {peer: &mut {value: number}}) {
@@ -468,8 +463,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// A transitive chain moves as a unit: a borrows b, b borrows c, c borrows d, so the
 		// component reachable from a is {a, b, c, d}. Returning a co-moves all four. The
 		// chain uses shared borrows so the carriers nest without a mutable-view conflict.
-		// PR 16: every node is reached once, so borrow-stripping rewrites the return to the
-		// owned `{peer: {peer: {peer: {value: 4}}}}`.
+		// Every node is reached once, so borrow-stripping rewrites the return to the owned
+		// `{peer: {peer: {peer: {value: 4}}}}`.
 		"ReturnTransitiveChain": {
 			src: `
 				fn build() {
@@ -481,14 +476,14 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &{peer: &{peer: &{value: 4}}}}"},
+			types: map[string]string{"build": "fn () -> {peer: {peer: {peer: {value: 4}}}}"},
 		},
 		// A diamond shares a node: a borrows b and c, and both b and c borrow d, so d is
 		// reachable through two paths. The component is still {a, b, c, d} and moves out as a
-		// unit; reaching d twice is collapsed by the reachability walk's seen set.
-		// PR 16: d is reached through two paths, so borrow-stripping KEEPS the borrows — an
-		// owned tree cannot express the shared node — and this return type is unchanged. This
-		// is the multiplicity case that bounds stripping.
+		// unit; reaching d twice is collapsed by the reachability walk's seen set. d is reached
+		// through two paths, so borrow-stripping KEEPS the borrows — an owned tree cannot
+		// express the shared node — and this return type stays borrowed. A node reached more
+		// than once is what bounds stripping to tree-shaped graphs.
 		"ReturnDiamondSharedNode": {
 			src: `
 				fn build() {
@@ -502,19 +497,15 @@ func TestConnectedComponentMove(t *testing.T) {
 			want:  nil,
 			types: map[string]string{"build": "fn () -> {l: &{peer: &{x: 0}}, r: &{peer: &{x: 0}}}"},
 		},
-		// The mutable analog of the shared diamond does not form. Borrowing `&mut b` and
-		// `&mut c` where b and c are owned objects already holding a `&mut` borrow is rejected,
-		// since a `&mut` of a borrow-carrying local is not yet supported, so the carrier never
-		// builds. The aliasing question the shared diamond raises — d reached through two
-		// mutable paths — is therefore never reached here; the two-mutable-alias rejection is
-		// pinned separately by MutableAliasRejectsMove.
-		// PR 16: the borrow-field owned-mutable upgrade makes the `&mut` carriers
-		// constructible, so this flips from the two `cannot constrain` errors to a
-		// connected-component move with `want: nil`. d is reached through two paths, so
-		// borrow-stripping keeps the borrows and the moved type stays
-		// `{l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x: number}}}`. Rename to
-		// MutableDiamondMovesAsUnit when it lands.
-		"MutableDiamondRejected": {
+		// The mutable analog of the shared diamond moves as a unit. The borrow-field
+		// owned-mutable upgrade makes `val mut b = {peer: &mut d}` owned-mutable, so `&mut b`
+		// and `&mut c` build the carrier a. The component reachable from a is {a, b, c, d}, and
+		// nothing outside it references a node, so returning a co-moves the whole graph. d is
+		// reached through two mutable paths, so borrow-stripping keeps the borrows and the
+		// moved type stays `{l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x:
+		// number}}}`. The two mutable paths to d are both internal to the moved component, the
+		// same aliasing MutableAliasRejectsMove rejects when one path is left live outside it.
+		"MutableDiamondMovesAsUnit": {
 			src: `
 				fn build() {
 					val mut d = {x: 0}
@@ -524,10 +515,7 @@ func TestConnectedComponentMove(t *testing.T) {
 					return a
 				}
 			`,
-			want: []string{
-				"6:18-6:24: cannot constrain immutable object <: mutable object",
-				"6:29-6:35: cannot constrain immutable object <: mutable object",
-			},
+			want:  nil,
 			types: map[string]string{"build": "fn () -> {l: &mut {peer: &mut {x: number}}, r: &mut {peer: &mut {x: number}}}"},
 		},
 		// A node mutably aliased outside the moved component blocks the move: b and c each hold
@@ -561,12 +549,8 @@ func TestConnectedComponentMove(t *testing.T) {
 		// returning a re-anchors the whole graph — both internal mutable paths included — with
 		// no external observer. This is the mirror of MutableAliasRejectsMove: there the second
 		// `&mut d` was left outside the component and rejected; here a owns both, so it is not.
-		// The outer borrows are shared, so the carrier sidesteps the owned-mutable upgrade that
-		// blocks the all-`&mut` MutableDiamondRejected.
-		// PR 16: two changes meet here but cancel. The borrow-field upgrade no longer blocks
-		// the all-`&mut` MutableDiamondRejected, so that cross-reference goes stale. And d is
-		// reached through two paths, so borrow-stripping keeps the borrows — this return type
-		// is unchanged.
+		// d is reached through two paths, so borrow-stripping keeps the borrows and this return
+		// type stays borrowed.
 		"InternalMutableAliasMovesAsUnit": {
 			src: `
 				fn build() {
@@ -603,9 +587,9 @@ func TestConnectedComponentMove(t *testing.T) {
 			},
 		},
 		// A wider component with five borrowed locals moves out as one unit, the same as the
-		// two-local case, since every node is reachable only through a.
-		// PR 16: every node is reached once, so borrow-stripping rewrites the return to the
-		// owned `{b1: {x: number}, …}` with all five fields owned.
+		// two-local case, since every node is reachable only through a. Every node is reached
+		// once, so borrow-stripping rewrites the return to the owned `{b1: {x: number}, …}` with
+		// all five fields owned.
 		"ReturnLargeStar": {
 			src: `
 				fn build() {
@@ -620,7 +604,7 @@ func TestConnectedComponentMove(t *testing.T) {
 			`,
 			want: nil,
 			types: map[string]string{
-				"build": "fn () -> {b1: &mut {x: number}, c1: &mut {x: number}, d1: &mut {x: number}, e1: &mut {x: number}, g1: &mut {x: number}}",
+				"build": "fn () -> {b1: {x: number}, c1: {x: number}, d1: {x: number}, e1: {x: number}, g1: {x: number}}",
 			},
 		},
 		// The co-move reaches the deepest transitive node: storing the chain a → b → c → d
@@ -648,7 +632,9 @@ func TestConnectedComponentMove(t *testing.T) {
 		// component: keep holds `&b`, but it is never read after `return a`, and at a return
 		// every local is dead, so keep observes nothing once b is co-moved. The move applies
 		// and no escape is reported. Self-containment is about a LIVE external reference, so a
-		// stray unused borrow before a return is not one.
+		// stray unused borrow before a return is not one. The returned carrier a reaches b once,
+		// so borrow-stripping rewrites its return to the owned `{peer: {value: number}}`. keep's
+		// separate dead borrow is not part of a's reachable tree.
 		"DeadExternalRefAllowsMove": {
 			src: `
 				fn build() {
@@ -659,7 +645,7 @@ func TestConnectedComponentMove(t *testing.T) {
 				}
 			`,
 			want:  nil,
-			types: map[string]string{"build": "fn () -> {peer: &{value: number}}"},
+			types: map[string]string{"build": "fn () -> {peer: {value: number}}"},
 		},
 		// A node reachable from a LIVE binding outside the component is not self-contained: keep
 		// holds `&b` and is read after the store, so it is a live external reference to b when

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -733,7 +733,7 @@ func TestComponentEscapeCyclicGraph(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c := newChecker()
 			c.fn = &funcCtx{
-				borrowEdges: tc.edges,
+				eagerBorrowGraph: tc.edges,
 				paramVarIDs: set.NewSet[liveness.VarID](),
 			}
 			e := &ast.IdentExpr{Name: "root", VarID: int(tc.root)}

--- a/internal/solver/return_escape_test.go
+++ b/internal/solver/return_escape_test.go
@@ -733,11 +733,10 @@ func TestComponentEscapeCyclicGraph(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c := newChecker()
 			c.fn = &funcCtx{
-				eagerBorrowGraph: tc.edges,
 				paramVarIDs: set.NewSet[liveness.VarID](),
 			}
 			e := &ast.IdentExpr{Name: "root", VarID: int(tc.root)}
-			got := c.escapingLocalsOf(e).ToSlice()
+			got := c.escapingLocalsOf(e, tc.edges).ToSlice()
 			require.ElementsMatch(t, tc.want, got)
 		})
 	}

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -8,30 +8,30 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Return borrow-stripping. When a returned value owns a self-contained graph of borrowed
-// locals and that graph is a tree — every borrowed local reached exactly once from the return
-// with no cycle — the connected-component move has already re-anchored the nodes and consumed
-// the locals, so the return value is the sole owner of each node. Owning them in the type is
-// then honest, so the returned borrows are stripped to their owned pointees. `return a` over
-// `val a = {peer: &mut d}` returns `{peer: {value: number}}` rather than `{peer: &mut {value:
-// number}}`.
+// Return borrow-stripping rewrites a returned borrow of a self-contained local graph into the
+// owned pointee. The connected-component move has already re-anchored the nodes and consumed the
+// locals, so the return value is their sole owner, and owning them in the type is honest. `return
+// a` over `val a = {peer: &mut d}` then returns `{peer: {value: number}}` rather than `{peer:
+// &mut {value: number}}`.
 //
-// Stripping is withheld when a node is reached through two or more paths (a diamond) or sits on
-// a cycle. An owned type is a tree with no sharing, so it cannot represent a shared or cyclic
-// node without duplicating it, which is wrong since the paths are one object, or without
-// keeping the borrow that expresses the sharing. So a diamond or cyclic graph keeps its
-// borrows.
+// The reachable shape from the return decides whether a borrow is stripped:
 //
-// Only a direct place or object/tuple-literal carrier is stripped. A returned call result,
-// such as `return id(a)`, hides its borrows behind the call boundary, so its type is left
-// borrowed — sound, since the component move already keeps the nodes alive, just not stripped.
-// A borrow of a parameter carries no local edge and is never stripped.
+//   - Tree: every borrowed local is reached exactly once with no cycle. Strip every borrow to
+//     its owned pointee, since the return value uniquely owns each node.
+//   - Diamond or cycle: a node is reached through two or more paths, or sits on a cycle. Keep
+//     the borrows. An owned tree cannot represent a shared node without duplicating it, which
+//     would hide mutations across the shared paths.
+//
+// The carrier the return names decides whether stripping runs at all:
+//
+//   - A direct place or object/tuple literal is eligible.
+//   - A call result such as `return id(a)` is left borrowed, since its borrows are hidden behind
+//     the call boundary. This is sound. The component move already keeps the nodes alive.
+//   - A parameter borrow is never stripped, since it carries no local edge.
 
-// stripReturnBorrowsIfTree rewrites the return type of the return whose value is e to own the
-// data when e's reachable borrow graph is a tree. It is a no-op when e is not a return value,
-// when the carrier is not a direct place or literal, or when the graph is not a tree. The
-// borrow-edge graph read is c.fn.borrowEdges, which resolveComponentEscapes has set to the
-// snapshot at this return's program point.
+// stripReturnBorrowsIfTree rewrites the return whose value is e to own its borrowed locals when
+// e's reachable borrow graph is a tree. It is a no-op unless e is a return value with a
+// strippable carrier and a tree-shaped graph.
 func (c *checker) stripReturnBorrowsIfTree(e ast.Expr) {
 	idx := c.returnIndexOf(e)
 	if idx < 0 {
@@ -59,11 +59,9 @@ func (c *checker) returnIndexOf(e ast.Expr) int {
 	return -1
 }
 
-// carrierGraph returns the borrow-edge graph and the carrier root that describe the outgoing
-// value e's borrow fields. A whole-binding place `return a` uses a's VarID and the snapshot
-// graph directly. An object or tuple literal `return {peer: &mut b}` has no binding, so it is
-// walked into a private copy of the graph under a synthetic root. Any other carrier reports
-// ok=false, leaving its type unstripped.
+// carrierGraph returns the borrow-edge graph and the carrier root for e's borrow fields. A
+// whole-binding place uses its VarID and the snapshot graph; an object or tuple literal is walked
+// into a private copy under a synthetic root. Any other carrier reports ok=false.
 func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
 		return c.fn.borrowEdges, p.root, true
@@ -76,7 +74,7 @@ func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, li
 		c.fn.borrowEdges = cloneBorrowState(saved)
 		root := liveness.VarID(c.varIDCounter)
 		c.varIDCounter++
-		c.walkBorrowSources(root, nil, e)
+		c.recordBorrowSources(root, nil, e)
 		graph := c.fn.borrowEdges
 		c.fn.borrowEdges = saved
 		return graph, root, true
@@ -92,21 +90,19 @@ func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, li
 func isTreeReachable(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID) bool {
 	counts := map[liveness.VarID]int{}
 	tree := true
-	var walk func(node liveness.VarID)
-	reach := func(referent liveness.VarID) {
-		counts[referent]++
-		if counts[referent] == 1 {
-			walk(referent)
-		} else {
-			tree = false
-		}
-	}
-	walk = func(node liveness.VarID) {
+	var visit func(node liveness.VarID)
+	visit = func(node liveness.VarID) {
 		for _, e := range graph[node] {
-			reach(e.referent)
+			counts[e.referent]++
+			if counts[e.referent] == 1 {
+				visit(e.referent)
+			} else {
+				// A second reach — a shared node or a cycle's back edge — breaks the tree.
+				tree = false
+			}
 		}
 	}
-	walk(root)
+	visit(root)
 	return tree
 }
 

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -33,15 +33,15 @@ import (
 
 // stripReturnBorrowsIfTree rewrites the return type of the return whose value is e to own the
 // data when e's reachable borrow graph is a tree. It is a no-op when e is not a return value,
-// when the carrier is not a direct place or literal, or when the graph is not a tree. The
-// borrow-edge graph read is c.fn.eagerBorrowGraph, which resolveComponentEscapes has set to the
-// snapshot at this return's program point.
-func (c *checker) stripReturnBorrowsIfTree(e ast.Expr) {
+// when the carrier is not a direct place or literal, or when the graph is not a tree. snapshot is
+// the flow-sensitive borrow-edge graph at this return's program point, which resolveComponentEscapes
+// reads from the dataflow and passes in.
+func (c *checker) stripReturnBorrowsIfTree(e ast.Expr, snapshot map[liveness.VarID][]fieldBorrow) {
 	idx := c.returnIndexOf(e)
 	if idx < 0 {
 		return
 	}
-	graph, root, ok := c.carrierGraph(e)
+	graph, root, ok := c.carrierGraph(e, snapshot)
 	if !ok {
 		return
 	}
@@ -63,25 +63,25 @@ func (c *checker) returnIndexOf(e ast.Expr) int {
 	return -1
 }
 
-// carrierGraph returns the borrow-edge graph and the carrier root for e's borrow fields. A
-// whole-binding place is already a node in the graph, so it uses its own VarID as the root and
-// returns c.fn.eagerBorrowGraph directly. That graph is the snapshot resolveComponentEscapes
-// swapped in for this return's program point, so no cloning is needed. An object or tuple literal
-// has no binding node, so it is walked into a private copy under a synthetic root. Any other
-// carrier reports ok=false.
-func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
+// carrierGraph returns the borrow-edge graph and the carrier root for e's borrow fields, drawing
+// from snapshot, the per-program-point graph. A whole-binding place is already a node in snapshot,
+// so it returns snapshot and the binding's own VarID directly, no cloning needed. An object or
+// tuple literal has no binding node, so it is walked into a private clone of snapshot under a
+// synthetic root. Any other carrier reports ok=false.
+func (c *checker) carrierGraph(e ast.Expr, snapshot map[liveness.VarID][]fieldBorrow) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
-		return c.fn.eagerBorrowGraph, p.root, true
+		return snapshot, p.root, true
 	}
 	switch e.(type) {
 	case *ast.ObjectExpr, *ast.TupleExpr:
-		// Walk the literal into a private copy so the shared snapshot is not mutated, using a
-		// synthetic root drawn from the module-wide counter so it never collides with a binding.
+		// Walk the literal into a private clone of snapshot under a synthetic root drawn from the
+		// module-wide counter so it never collides with a binding. The clone goes through the
+		// eagerBorrowGraph field because recordBorrowSources and addBorrowEdge write there; the
+		// field is saved and restored so nothing outside sees the mutation. snapshot is non-nil
+		// (fieldBorrowGraphBefore returns a non-nil map), so the clone is non-nil and those writes
+		// cannot panic on a nil map.
 		saved := c.fn.eagerBorrowGraph
-		// saved is non-nil here. resolveComponentEscapes set eagerBorrowGraph to a non-nil
-		// snapshot before return-stripping runs, so this clone is non-nil and the
-		// recordBorrowSources writes below cannot panic on a nil map.
-		c.fn.eagerBorrowGraph = maps.Clone(saved)
+		c.fn.eagerBorrowGraph = maps.Clone(snapshot)
 		root := liveness.VarID(c.varIDCounter)
 		c.varIDCounter++
 		// The literal has no binding, so nothing in the graph describes its borrows. Record the

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -154,11 +154,14 @@ func stripBorrowTree(t soltype.Type, root liveness.VarID, path []placeSeg, graph
 		}
 		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
 	case *soltype.TupleType:
-		elems := make([]soltype.Type, len(t.Elems))
-		for i, e := range t.Elems {
-			elems[i] = stripBorrowTree(e, root, path, graph)
-		}
-		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+		// Keep a tuple's borrows unstripped. Every tuple element's borrow is recorded at the
+		// container path, since placeSeg has no tuple-index kind yet, so findReferentAt cannot
+		// tell which element a same-path edge belongs to. Recursing each element at the shared
+		// path would strip it with a sibling's referent and follow the wrong subgraph. Leaving
+		// the tuple borrowed is sound: the component move still consumes the borrowed locals,
+		// only the type is not rewritten to owned. Per-element stripping lands once a tuple
+		// index yields its own place segment.
+		return t
 	default:
 		return t
 	}

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -1,0 +1,177 @@
+package solver
+
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// Return borrow-stripping. When a returned value owns a self-contained graph of borrowed
+// locals and that graph is a tree — every borrowed local reached exactly once from the return
+// with no cycle — the connected-component move has already re-anchored the nodes and consumed
+// the locals, so the return value is the sole owner of each node. Owning them in the type is
+// then honest, so the returned borrows are stripped to their owned pointees. `return a` over
+// `val a = {peer: &mut d}` returns `{peer: {value: number}}` rather than `{peer: &mut {value:
+// number}}`.
+//
+// Stripping is withheld when a node is reached through two or more paths (a diamond) or sits on
+// a cycle. An owned type is a tree with no sharing, so it cannot represent a shared or cyclic
+// node without duplicating it, which is wrong since the paths are one object, or without
+// keeping the borrow that expresses the sharing. So a diamond or cyclic graph keeps its
+// borrows.
+//
+// Only a direct place or object/tuple-literal carrier is stripped. A returned call result,
+// such as `return id(a)`, hides its borrows behind the call boundary, so its type is left
+// borrowed — sound, since the component move already keeps the nodes alive, just not stripped.
+// A borrow of a parameter carries no local edge and is never stripped.
+
+// stripReturnBorrowsIfTree rewrites the return type of the return whose value is e to own the
+// data when e's reachable borrow graph is a tree. It is a no-op when e is not a return value,
+// when the carrier is not a direct place or literal, or when the graph is not a tree. The
+// borrow-edge graph read is c.fn.borrowEdges, which resolveComponentEscapes has set to the
+// snapshot at this return's program point.
+func (c *checker) stripReturnBorrowsIfTree(e ast.Expr) {
+	idx := c.returnIndexOf(e)
+	if idx < 0 {
+		return
+	}
+	graph, root, ok := c.carrierGraph(e)
+	if !ok {
+		return
+	}
+	if !isTreeReachable(graph, root) {
+		return
+	}
+	c.fn.returns[idx] = stripBorrowTree(c.fn.returns[idx], root, nil, graph)
+}
+
+// returnIndexOf returns the index of the return whose operand is e, or -1 when e is not a
+// recorded return value. The returns and returnExprs slices are parallel, so the index into
+// returnExprs selects the return type to rewrite.
+func (c *checker) returnIndexOf(e ast.Expr) int {
+	for i, re := range c.fn.returnExprs {
+		if re == e {
+			return i
+		}
+	}
+	return -1
+}
+
+// carrierGraph returns the borrow-edge graph and the carrier root that describe the outgoing
+// value e's borrow fields. A whole-binding place `return a` uses a's VarID and the snapshot
+// graph directly. An object or tuple literal `return {peer: &mut b}` has no binding, so it is
+// walked into a private copy of the graph under a synthetic root. Any other carrier reports
+// ok=false, leaving its type unstripped.
+func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
+	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
+		return c.fn.borrowEdges, p.root, true
+	}
+	switch e.(type) {
+	case *ast.ObjectExpr, *ast.TupleExpr:
+		// Walk the literal into a private copy so the shared snapshot is not mutated, using a
+		// synthetic root drawn from the module-wide counter so it never collides with a binding.
+		saved := c.fn.borrowEdges
+		c.fn.borrowEdges = cloneBorrowState(saved)
+		root := liveness.VarID(c.varIDCounter)
+		c.varIDCounter++
+		c.walkBorrowSources(root, nil, e)
+		graph := c.fn.borrowEdges
+		c.fn.borrowEdges = saved
+		return graph, root, true
+	}
+	return nil, 0, false
+}
+
+// isTreeReachable reports whether the borrow graph reachable from root is a tree: every reached
+// node is reached exactly once and no cycle routes back onto a reached node. It counts each
+// node's incoming reaches, recursing into a node the first time it is reached; a second reach —
+// a shared node or a cycle's back edge — sets the result false. The recursion terminates because
+// a node is descended only on its first reach.
+func isTreeReachable(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID) bool {
+	counts := map[liveness.VarID]int{}
+	tree := true
+	var walk func(node liveness.VarID)
+	reach := func(referent liveness.VarID) {
+		counts[referent]++
+		if counts[referent] == 1 {
+			walk(referent)
+		} else {
+			tree = false
+		}
+	}
+	walk = func(node liveness.VarID) {
+		for _, e := range graph[node] {
+			reach(e.referent)
+		}
+	}
+	walk(root)
+	return tree
+}
+
+// stripBorrowTree returns t with every borrow of a tracked local replaced by the borrow's
+// owned pointee, following the borrow-edge graph in parallel with the type. root is the
+// binding whose edges describe t's borrow fields, and path is the field path within root
+// reached so far.
+//
+//   - A borrow RefType at path whose referent the graph names is stripped: the result is its
+//     pointee, walked with root switched to the referent and the path reset, since the
+//     referent's own fields are keyed under it. A borrow with no local edge, such as a
+//     parameter borrow, is kept unchanged.
+//   - An owned-mutable cell is rebuilt around its walked inner at the same root and path.
+//   - An object descends each property at the path extended by the property name; a tuple
+//     descends each element at the same path, since a tuple index contributes no field segment.
+func stripBorrowTree(t soltype.Type, root liveness.VarID, path []placeSeg, graph map[liveness.VarID][]fieldBorrow) soltype.Type {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		if t.Lt != nil {
+			referent, ok := findReferentAt(graph, root, path)
+			if !ok {
+				return t
+			}
+			return stripBorrowTree(t.Inner, referent, nil, graph)
+		}
+		// An owned-mutable cell rebuilds around its walked inner. The inner is an object or
+		// tuple, so its strip stays a RefInner; keep the cell unchanged if that ever fails to
+		// hold rather than panicking.
+		inner, ok := stripBorrowTree(t.Inner, root, path, graph).(soltype.RefInner)
+		if !ok {
+			return t
+		}
+		return soltype.NewRef(t.Mut, nil, inner)
+	case *soltype.ObjectType:
+		elems := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, e := range t.Elems {
+			p := soltype.AsProperty(e)
+			var propPath []placeSeg
+			if isDotPlaceSegment(p.Name) {
+				propPath = appendSeg(path, p.Name)
+			} else {
+				propPath = path
+			}
+			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: stripBorrowTree(p.Type, root, propPath, graph), Optional: p.Optional, Readonly: p.Readonly}
+		}
+		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
+	case *soltype.TupleType:
+		elems := make([]soltype.Type, len(t.Elems))
+		for i, e := range t.Elems {
+			elems[i] = stripBorrowTree(e, root, path, graph)
+		}
+		return &soltype.TupleType{Elems: elems, Inexact: t.Inexact}
+	default:
+		return t
+	}
+}
+
+// findReferentAt returns the local root's edge exactly at path, the borrow that field holds.
+// A borrow field at path P records its edge at P, so the lookup is an exact path match. A path
+// with no edge names no tracked borrow, so it reports ok=false and the borrow is kept.
+func findReferentAt(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID, path []placeSeg) (liveness.VarID, bool) {
+	for _, e := range graph[root] {
+		if slices.Equal(e.path, path) {
+			return e.referent, true
+		}
+	}
+	return 0, false
+}

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/escalier-lang/escalier/internal/ast"
@@ -29,9 +30,11 @@ import (
 //     the call boundary. This is sound. The component move already keeps the nodes alive.
 //   - A parameter borrow is never stripped, since it carries no local edge.
 
-// stripReturnBorrowsIfTree rewrites the return whose value is e to own its borrowed locals when
-// e's reachable borrow graph is a tree. It is a no-op unless e is a return value with a
-// strippable carrier and a tree-shaped graph.
+// stripReturnBorrowsIfTree rewrites the return type of the return whose value is e to own the
+// data when e's reachable borrow graph is a tree. It is a no-op when e is not a return value,
+// when the carrier is not a direct place or literal, or when the graph is not a tree. The
+// borrow-edge graph read is c.fn.eagerBorrowGraph, which resolveComponentEscapes has set to the
+// snapshot at this return's program point.
 func (c *checker) stripReturnBorrowsIfTree(e ast.Expr) {
 	idx := c.returnIndexOf(e)
 	if idx < 0 {
@@ -64,19 +67,22 @@ func (c *checker) returnIndexOf(e ast.Expr) int {
 // into a private copy under a synthetic root. Any other carrier reports ok=false.
 func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
-		return c.fn.borrowEdges, p.root, true
+		return c.fn.eagerBorrowGraph, p.root, true
 	}
 	switch e.(type) {
 	case *ast.ObjectExpr, *ast.TupleExpr:
 		// Walk the literal into a private copy so the shared snapshot is not mutated, using a
 		// synthetic root drawn from the module-wide counter so it never collides with a binding.
-		saved := c.fn.borrowEdges
-		c.fn.borrowEdges = cloneBorrowState(saved)
+		saved := c.fn.eagerBorrowGraph
+		// saved is non-nil here. resolveComponentEscapes set eagerBorrowGraph to a non-nil
+		// snapshot before return-stripping runs, so this clone is non-nil and the
+		// walkBorrowSources writes below cannot panic on a nil map.
+		c.fn.eagerBorrowGraph = maps.Clone(saved)
 		root := liveness.VarID(c.varIDCounter)
 		c.varIDCounter++
 		c.recordBorrowSources(root, nil, e)
-		graph := c.fn.borrowEdges
-		c.fn.borrowEdges = saved
+		graph := c.fn.eagerBorrowGraph
+		c.fn.eagerBorrowGraph = saved
 		return graph, root, true
 	}
 	return nil, 0, false

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -63,8 +64,11 @@ func (c *checker) returnIndexOf(e ast.Expr) int {
 }
 
 // carrierGraph returns the borrow-edge graph and the carrier root for e's borrow fields. A
-// whole-binding place uses its VarID and the snapshot graph; an object or tuple literal is walked
-// into a private copy under a synthetic root. Any other carrier reports ok=false.
+// whole-binding place is already a node in the graph, so it uses its own VarID as the root and
+// returns c.fn.eagerBorrowGraph directly. That graph is the snapshot resolveComponentEscapes
+// swapped in for this return's program point, so no cloning is needed. An object or tuple literal
+// has no binding node, so it is walked into a private copy under a synthetic root. Any other
+// carrier reports ok=false.
 func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, liveness.VarID, bool) {
 	if p, ok := exprPlace(e); ok && p.root > 0 && len(p.path) == 0 {
 		return c.fn.eagerBorrowGraph, p.root, true
@@ -76,10 +80,13 @@ func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, li
 		saved := c.fn.eagerBorrowGraph
 		// saved is non-nil here. resolveComponentEscapes set eagerBorrowGraph to a non-nil
 		// snapshot before return-stripping runs, so this clone is non-nil and the
-		// walkBorrowSources writes below cannot panic on a nil map.
+		// recordBorrowSources writes below cannot panic on a nil map.
 		c.fn.eagerBorrowGraph = maps.Clone(saved)
 		root := liveness.VarID(c.varIDCounter)
 		c.varIDCounter++
+		// The literal has no binding, so nothing in the graph describes its borrows. Record the
+		// edges it carries under the synthetic root, so stripReturnBorrowsIfTree can treat it like
+		// a binding whose edges the eager walk had recorded.
 		c.recordBorrowSources(root, nil, e)
 		graph := c.fn.eagerBorrowGraph
 		c.fn.eagerBorrowGraph = saved
@@ -89,27 +96,28 @@ func (c *checker) carrierGraph(e ast.Expr) (map[liveness.VarID][]fieldBorrow, li
 }
 
 // isTreeReachable reports whether the borrow graph reachable from root is a tree: every reached
-// node is reached exactly once and no cycle routes back onto a reached node. It counts each
-// node's incoming reaches, recursing into a node the first time it is reached; a second reach —
-// a shared node or a cycle's back edge — sets the result false. The recursion terminates because
-// a node is descended only on its first reach.
+// node is reached exactly once and no cycle routes back onto a reached node. It records each node
+// it reaches in a seen set and recurses into it the first time. Reaching a node already seen — a
+// shared node or a cycle's back edge — means the graph is not a tree, so it returns false at once
+// without walking the rest. The recursion terminates because a node is descended only on its first
+// reach.
 func isTreeReachable(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID) bool {
-	counts := map[liveness.VarID]int{}
-	tree := true
-	var visit func(node liveness.VarID)
-	visit = func(node liveness.VarID) {
+	seen := set.NewSet[liveness.VarID]()
+	var visit func(node liveness.VarID) bool
+	visit = func(node liveness.VarID) bool {
 		for _, e := range graph[node] {
-			counts[e.referent]++
-			if counts[e.referent] == 1 {
-				visit(e.referent)
-			} else {
+			if seen.Contains(e.referent) {
 				// A second reach — a shared node or a cycle's back edge — breaks the tree.
-				tree = false
+				return false
+			}
+			seen.Add(e.referent)
+			if !visit(e.referent) {
+				return false
 			}
 		}
+		return true
 	}
-	visit(root)
-	return tree
+	return visit(root)
 }
 
 // stripBorrowTree returns t with every borrow of a tracked local replaced by the borrow's
@@ -124,7 +132,12 @@ func isTreeReachable(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID
 //   - An owned-mutable cell is rebuilt around its walked inner at the same root and path.
 //   - An object descends each property at the path extended by the property name; a tuple
 //     descends each element at the same path, since a tuple index contributes no field segment.
-func stripBorrowTree(t soltype.Type, root liveness.VarID, path []placeSeg, graph map[liveness.VarID][]fieldBorrow) soltype.Type {
+func stripBorrowTree(
+	t soltype.Type,
+	root liveness.VarID,
+	path []placeSeg,
+	graph map[liveness.VarID][]fieldBorrow,
+) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.RefType:
 		if t.Lt != nil {
@@ -152,7 +165,12 @@ func stripBorrowTree(t soltype.Type, root liveness.VarID, path []placeSeg, graph
 			} else {
 				propPath = path
 			}
-			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: stripBorrowTree(p.Type, root, propPath, graph), Optional: p.Optional, Readonly: p.Readonly}
+			elems[i] = &soltype.PropertyElem{
+				Name:     p.Name,
+				Type:     stripBorrowTree(p.Type, root, propPath, graph),
+				Optional: p.Optional,
+				Readonly: p.Readonly,
+			}
 		}
 		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}
 	case *soltype.TupleType:
@@ -172,6 +190,11 @@ func stripBorrowTree(t soltype.Type, root liveness.VarID, path []placeSeg, graph
 // findReferentAt returns the local root's edge exactly at path, the borrow that field holds.
 // A borrow field at path P records its edge at P, so the lookup is an exact path match. A path
 // with no edge names no tracked borrow, so it reports ok=false and the borrow is kept.
+//
+// A parameter borrow is the common ok=false case. For a parameter p, `return {peer: &mut p}`
+// leaves a RefType at [peer] in the return type, but recordBorrowSources added no edge there,
+// since isLocalReferent skips a borrow of a parameter. So findReferentAt reports ok=false and the
+// `&mut p` stays borrowed.
 func findReferentAt(graph map[liveness.VarID][]fieldBorrow, root liveness.VarID, path []placeSeg) (liveness.VarID, bool) {
 	for _, e := range graph[root] {
 		if slices.Equal(e.path, path) {

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -766,6 +766,8 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.placeIDs = map[string]liveness.VarID{}
 	c.fn.movePlaces = map[liveness.VarID]movePlace{}
 	c.fn.borrowEdges = map[liveness.VarID][]fieldBorrow{}
+	c.fn.borrowGens = map[liveness.StmtRef][]borrowAssign{}
+	c.fn.borrowDirty = set.NewSet[liveness.VarID]()
 	c.fn.paramVarIDs = collectParamVarIDs(astParams)
 }
 

--- a/internal/solver/transitions.go
+++ b/internal/solver/transitions.go
@@ -765,7 +765,7 @@ func (c *checker) runLivenessPrePass(scope *Scope, astParams []*ast.Param, param
 	c.fn.moveSites = map[liveness.StmtRef]set.Set[liveness.VarID]{}
 	c.fn.placeIDs = map[string]liveness.VarID{}
 	c.fn.movePlaces = map[liveness.VarID]movePlace{}
-	c.fn.borrowEdges = map[liveness.VarID][]fieldBorrow{}
+	c.fn.eagerBorrowGraph = map[liveness.VarID][]fieldBorrow{}
 	c.fn.borrowGens = map[liveness.StmtRef][]borrowAssign{}
 	c.fn.borrowDirty = set.NewSet[liveness.VarID]()
 	c.fn.paramVarIDs = collectParamVarIDs(astParams)

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -962,7 +962,7 @@ clearing. Field stores `recv.f = source` record **no** edges at all. PR 11 noted
 
 2. **Field-store edge recording.** Record an edge at `recv.f = source` when `recv` is a local
    and `source` borrows locals, rooted at `recv`'s place extended by `f` — the same
-   `walkBorrowSources` the initializer path uses, at base `[recv.path…, f]`. With clearing
+   `recordBorrowSources` the initializer path uses, at base `[recv.path…, f]`. With clearing
    from piece 1, a repoint `b.peer = &mut e` replaces `b → d at [peer]` rather than
    accumulating a stale edge. The store into a *parameter* field stays the immediate escape
    `checkParamFieldStoreEscape` already reports; this piece covers the store into a *local*,

--- a/planning/affine_semantics/implementation_plan.md
+++ b/planning/affine_semantics/implementation_plan.md
@@ -259,7 +259,7 @@ Status legend: ✅ done · 🚧 in progress · ⬜ not started.
 | 13 | Deep, uniform `mut` and `readonly` | 1, 2 | Medium | ✅ done (#777, #781) |
 | 14 | Lazy deep `mut`: store the surface form, push the rule to access and constrain | 13 | Large | ✅ done (#780) |
 | 15 | Escape forcing at returns, stores, and consuming arguments (deferred from PR 6) | 6 | Large | ✅ done (#814); element stores deferred to M7, field-granular escape to PR 11 |
-| 16 | CFG-merge-joined flow-sensitivity, field-store edges, mutable graph nodes, return borrow-stripping | 7, 11, 14 | Large | ⬜ not started |
+| 16 | CFG-merge-joined flow-sensitivity, field-store edges, mutable graph nodes, return borrow-stripping | 7, 11, 14 | Large | ✅ done; return borrow-stripping through a consuming call deferred |
 
 ### PR 1 — `&` grammar, `RefTypeAnn` node, printer
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1127,6 +1127,15 @@ now resolve to real `soltype` structures rather than opaque placeholders.
       `symbolSeg` kind keyed on the symbol's stable id. A non-singleton or otherwise
       non-constant key falls back to the container place, exactly as a dynamic index does
       now — sound, at worst over-conservative, never a missed use-after-move.
+      - **Number keys — decide `namedSeg` vs a distinct `indexSeg`.** Mapping a
+        singleton-number key to a `namedSeg` carrying the literal conflates `a[0]` with the
+        string key `a["0"]`, since a `namedSeg` is keyed by string text. The
+        "Tuple-index place segments" item in
+        [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)
+        instead calls for a distinct index-segment kind keyed by the integer, so `a[0]` and
+        `a["0"]` stay separate. Both are sound; the distinct kind is more precise and is what
+        tuple-element tracking needs. Pick one here and apply it uniformly to `constKey`,
+        `renderPlace`, and the tuple-literal walk.
     - **`soltype` prerequisite for the symbol case.** `soltype` has only the `symbol`
       primitive (`SymbolPrim`), no unique-symbol type carrying a stable id; the
       `UniqueSymbolType{Value int}` with that id lives in `internal/type_system`, the old

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -737,6 +737,22 @@ M4 substrate without retrofitting.
   the existing dispatch path." Depends on `Iterable<T>` / `Iterator<T>` /
   `AsyncIterable<T>` / `IteratorResult<T>` being available from the stdlib
   (M2 placeholder; real resolution lands in M7).
+  - **Back-edge validation for the borrow-edge dataflow.** A `for` loop is the
+    first inferable source that gives the CFG a back edge, so it is where the
+    affine flow-sensitive analyses first meet one from real code. The move
+    consumed-lattice (`AnalyzeMoves`) and the borrow-edge dataflow
+    (`analyzeBorrows`, `internal/solver/borrow_flow.go`) already join at CFG
+    merges and iterate to a fixed point, but that path is exercised only by
+    hand-built graphs today. When `for` lands, add loop tests for both. The
+    borrow-edge case has a known subtlety: a borrow can reach a reassignment
+    through the back edge that the source-order eager map does not yet hold, so
+    `clearEagerSubtree` emits an unconditional kill for a whole-binding
+    reassignment (`a = seed` clears `a`'s stale edge). Confirm that with a loop
+    test. A field-store subtree update keeps the prune-gated kill, since the
+    dataflow replaces a root's whole edge set and an unconditional whole-root
+    kill could drop a sibling field's back-edge borrow and miss an escape. That
+    field-store-across-a-back-edge case is the remaining imprecision to
+    re-examine here.
 - **`mut` and lifetimes ride on it free.** `Class` is borrowed the same way
   records and tuples are — wrapped in `Ref{mut, lt, inner: Class{...}}`. The
   M4 lifetime machinery applies unchanged (`mut 'a Point` is `Ref{mut: true,


### PR DESCRIPTION
Implement flow-sensitive borrow-edge tracking and return borrow-stripping to improve escape analysis and enable owned-mutable graph nodes.

## Summary

This change adds two major features to the borrow checker:

1. **Flow-sensitive borrow-edge graph** (`borrow_flow.go`): Replaces the accumulate-only edge tracking with a CFG-aware analysis that strong-updates bindings on reassignment and joins edges by union at branch merges. A `var` reassignment now clears the prior referent, a field store clears only the stored field's subtree, and a borrow set on one branch reaches the merge point.

2. **Return borrow-stripping** (`return_strip.go`): When a returned value owns a tree-shaped graph of borrowed locals (every local reached exactly once with no cycles), the return type is rewritten to own the data rather than borrow it. A diamond or cyclic graph keeps its borrows since an owned type cannot represent sharing.

## Key changes

- **`borrow_flow.go` (new)**: Implements `analyzeBorrows()` to fold per-statement edge assignments forward over the CFG to a fixed point, producing the borrow-edge graph at every program point. Helper functions manage eager edge updates during the walk (`markBorrowDirty`, `clearEagerSubtree`, `flushBorrowGens`) and dataflow operations (`joinBorrowPreds`, `applyBlockBorrows`, `unionEdges`).

- **`return_strip.go` (new)**: Implements `stripReturnBorrowsIfTree()` to rewrite return types when the borrow graph is a tree. `isTreeReachable()` detects trees by counting incoming reaches per node; `stripBorrowTree()` walks the type in parallel with the graph to replace borrows with owned pointees.

- **`return_escape.go`**: Updated to read the flow-sensitive borrow-edge graph at each escape site's program point via `binfo.edgesBefore()` rather than a single whole-body map. Calls `stripReturnBorrowsIfTree()` after confirming a component move.

- **`infer_decl.go`**: Extended `canUpgradeToOwnedMut()` to accept borrow leaves via `acceptsBorrowLeaf()`, enabling `val mut b = {peer: &mut d}` to construct an owned-mutable graph node.

- **`infer_expr.go`**: Updated reassignment recording to note that strong-updates clear prior edges and flush to the flow-sensitive graph.

- **`infer_stmt.go`**: Added `flushBorrowGens()` call after destructuring declarations to record leaf edges at the statement's CFG point.

- **`moves.go`**: Updated `checkUseAfterMoves()` to compute and pass the flow-sensitive borrow info to `resolveComponentEscapes()`.

- **`transitions.go`**: Initialized `borrowDirty` and `borrowGens` maps in the liveness pre-pass.

- **Test files**: Added `flow_sensitive_borrow_test.go` covering reassignment clears, branch merges, and field stores. Updated `return_escape_test.go` comments to reflect flow-sensitivity and added test cases for borrow-stripping in `TestConnectedComponentMove`.

## Implementation notes

The analysis mirrors the move engine's consumed lattice with two phases: an eager walk that updates `borrowEdges` by strong subtree replacement and records changes in `borrowGens` keyed by CFG position, followed by `analyzeBorrows()` that folds the per-statement assignments forward over the CFG. This separation allows `copyPlaceEdges` to read the source-order-current state during the walk while escape checks read the flow-sensitive snapshot at each site's program point.

https://claude.ai/code/session_01BRqq3eWEvbmwPQoMnune8y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flow-sensitive tracking for borrows across assignments, field stores, branches, and returns.
  * Improved handling of mutable local construction so borrow-containing literals can now be accepted in more cases.
  * Return values may now be simplified when their borrow graph forms a tree, often yielding more owned return types.

* **Bug Fixes**
  * Reassignment and field updates now correctly replace old borrow edges instead of accumulating stale ones.
  * Escape and move analysis now uses the borrow state at the exact program point, improving accuracy.
  * Added coverage for reassignment, merges, field stores, and mutable graph-node behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->