### PR TITLE
M6.5 implementation plan: PR-by-PR breakdown (Route 3)

### DIFF
--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -468,11 +468,41 @@ point of the render and declare tracks.
 
 **Axis:** check (consumers). **Depends on:** PR1, PR3.
 
-`equalType`'s `RefType` arm, scheme dedup, and overload-arm comparison currently have
-no notion of bound-set equality, so two schemes that differ only in bound order or in a
-transitively-redundant edge compare unequal. Route each through
-`ltBoundSet.subsumes` in both directions over the canonical edges. Independent of the
-declare track, so it runs in parallel with PR5/PR6 once PR3 has landed.
+`equalType`'s `RefType` arm keys a lifetime by pointer identity today —
+`ltEqual` bottoms out in `a == b` ([coalesce.go](../../internal/solver/coalesce.go)) —
+which is deliberately strict so dedup never silently drops a lifetime the solver
+computed. That works while every comparison is within one coalesce, where the vars are
+shared pointers. It breaks at the cross-scheme sites — scheme/alias dedup and
+overload-arm comparison — where the two sides carry independent `LifetimeVar` identities,
+so pointer equality always reports unequal. PR3 makes this pervasive: a kept join now
+renders as a named lifetime with bounds instead of a `LifetimeUnion`, so nearly every
+borrow carries an identity-significant var. Without PR7, that fragments the dedup PR3's
+precision depends on — duplicate schemes miss their cache slot, and two semantically
+identical overloads read as distinct arms. PR3 and PR7 therefore move as a pair.
+
+Upgrade lifetime equality from pointer identity to **bound-set equivalence**, but note
+that equivalence is not a raw `subsumes`. Two schemes are equal when they are
+alpha-equivalent over their quantifier *and* their bounds agree, so the comparison has
+three steps:
+
+1. **Match lifetimes by canonical position.** Pair each scheme's lifetime parameters in
+   the printer's first-appearance `'a, 'b, …` order, the same order `canonicalEdges`
+   already imposes. This bijection is what makes `'a`-in-A correspond to `'a`-in-B; a
+   raw `subsumes` without it would over-merge structurally different borrows, dropping a
+   computed distinction — the exact failure the pointer check guards against.
+2. **Compare structure with lifetimes matched by that pairing**, not by pointer.
+3. **Compare the canonical reduced edge sets under the pairing** — a set comparison,
+   since PR1 already reduced and canonicalized both, not a closure-based `subsumes` on
+   what is a `coalesce`/lattice hot path. Mutual `subsumes` is the fallback only if an
+   input is not known-canonical.
+
+Independence must survive the upgrade: within one scheme, two param lifetimes with no
+bound between them stay unequal. Route `equalType`'s `RefType` arm, scheme dedup, and
+overload-arm comparison ([overload.go](../../internal/solver/overload.go)) through this.
+`ltEqual` keeps its `LifetimeUnion` arm until PR9 deletes the type. Because
+overload-arm ranking (`moreSpecific`) consumes `equalType`, borrow-typed overload
+selection can shift, so cover it with tests beyond the equality unit tests. Independent
+of the declare track, so it runs in parallel with PR5/PR6 once PR3 has landed.
 
 ### PR8 — Declared bounds at no-body sites
 
@@ -575,7 +605,9 @@ implicit:
 - **Which bounds to keep** — PR2, as directed reachability to an output, the
   lifetime-sort analogue of the single-polarity elimination
   [simplify.go](../../internal/solver/simplify.go) does for types.
-- **Bound-set subsumption and equality** — PR1 (`subsumes`), consumed by PR6 and PR7.
+- **Bound-set subsumption and equality** — PR1 (`subsumes`), consumed by PR6 as
+  one-directional subsumption and by PR7 as alpha-equivalence, a canonical-position
+  matching plus canonical-edge comparison, not a raw two-way `subsumes`.
 - **Removal of `LifetimeUnion`** — PR3 removes the join-rendering mint, PR9 removes the
   `('a | 'b)` annotation mint and deletes the type. Bounds supersede the union on both
   sides, so it is deleted outright, not kept alongside.

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -2,9 +2,10 @@
 
 This plan covers **M6.5 — Lifetime bounds** as listed in
 [01-milestones.md](01-milestones.md). It records the design routes considered, the
-chosen route, and the sequencing rationale. It is a routes-and-decision document,
-not yet a PR-by-PR breakdown. The PR breakdown is written once the route is
-committed and M6 has settled the join semantics this builds on.
+chosen route, the sequencing rationale, and the PR-by-PR breakdown for the chosen
+route. The routes-and-decision material comes first; the
+[PR-by-PR breakdown](#pr-by-pr-breakdown-route-3) follows. The breakdown assumes M6
+has settled the join semantics it builds on, as its prerequisite note records.
 
 A **lifetime bound** is a declared or rendered outlives relation between two named
 lifetimes in a signature. Rust spells it `'a: 'b`, read "`'a` outlives `'b`".
@@ -328,11 +329,27 @@ a bound. A lifetime bound rides in the `<…>` list as `<'a, 'b: 'a>`, mirroring
 type-param bound `<T: U>`, so the binder needs a bounds slot the way `ast.TypeParam`
 has `Constraint`.
 
+**Multiple bounds use `&`, the same token as a type-param bound.** A type param
+expresses several bounds with the intersection type `<T: A & B>`, since its constraint
+is one type annotation and `T <: A & B` unfolds to `T <: A` and `T <: B`. A lifetime
+outliving several others is the exact lattice twin — `'a` outlives both `'b` and `'c`
+iff `'a <: ('b ⊓ 'c)`, below the *meet* of the two — so the same `&` spells it:
+`<'a: 'b & 'c>`. The parse is unambiguous because a bound's right-hand side holds only
+lifetimes, so a `&` there is always the meet separator and a `&mut T` / `&'x T` borrow
+after it is a type-in-lifetime-position error. `&` reused as both the borrow sigil and
+the bound-meet is a readability cost accepted for parity with type-param bounds and for
+naming the actual lattice operation, rather than introducing a `+` that corresponds to
+no operator elsewhere in the language. Multiple bounds on one lifetime are the
+secondary case anyway; the common join renders as several lifetimes each with a single
+bound, `<'a: 'c, 'b: 'c, 'c>`.
+
 ```go
 // LifetimeParam is a lifetime binder in a <…> quantifier list. Bounds are the
 // lifetimes this one must outlive: <'a, 'b: 'a> gives 'b the bound {'a}, read
-// "'b outlives 'a". A bare <'a> has no bounds. Mirrors ast.TypeParam's Name +
-// Constraint shape so one quantifier list carries both sorts.
+// "'b outlives 'a". Several bounds are written with &, the meet, as a type-param
+// bound writes an intersection: <'a: 'b & 'c> gives 'a the bounds {'b, 'c}. A bare
+// <'a> has no bounds. Mirrors ast.TypeParam's Name + Constraint shape so one
+// quantifier list carries both sorts.
 type LifetimeParam struct {
     Name   string
     Bounds []*LifetimeAnn
@@ -397,11 +414,29 @@ milestone is visible in output.
 
 Introduce `ast.LifetimeParam` and migrate every `LifetimeParams` field to it. Extend
 `maybeLifetimeAndTypeParams` ([decl.go](../../internal/parser/decl.go)) to parse an
-optional `: 'a` — and a comma-free bound list `: 'a` after a lifetime name, mirroring
-`typeParam`'s constraint parse. The printer round-trips `<'a, 'b: 'a>`. No solver
+optional `: 'b` after a lifetime name, and `: 'b & 'c` for several bounds, mirroring
+`typeParam`'s `: Constraint` parse. The `&`-separated form reads a `'lifetime` after
+each `&` and rejects a non-lifetime there, since only lifetimes are legal in a bound's
+right-hand side. The printer round-trips `<'a, 'b: 'a>` and `<'a: 'b & 'c>`. No solver
 semantics yet: a declared bound is parsed and, for this PR, ignored by inference. This
 PR is purely syntactic surface, which is what lets it run in parallel with the render
 track.
+
+**Two disambiguations the surface must settle here.**
+
+- **`:` means different relations per sort, by design.** `<T: U>` is subtyping —
+  `T <: U`. `<'a: 'b>` is outliving — `'a` lives at least as long as `'b`. The token is
+  the same and the two never mix on one binder, since a binder is a lifetime *or* a
+  type, so the checker picks the relation from the binder's sort. Call this out in the
+  `LifetimeParam` and `TypeParam` doc comments so the shared `:` is not read as one
+  relation.
+- **`'static` is a legal bound RHS.** `<'a: 'static>` parses like any other bound. It
+  says `'a` outlives `'static`, and since `'static` is the bottom of the outlives
+  lattice — it outlives everything — the only lifetime that outlives it is `'static`
+  itself, so the bound forces `'a = 'static`. PR5 lowers it to `constrainLt('a,
+  'static)`, the same escape-to-static constraint an escaping borrow already emits, so
+  no special case is needed. `'static` on the *left* of a binder (`<'static: 'a>`) is
+  rejected: `'static` is not a bindable parameter name.
 
 ### PR5 — Lower declared bounds into `constrainLt`
 

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -219,3 +219,258 @@ lifetimes, using the undirected connected-component grouping documented in
 `newLtAnalysis`. M6.5 promotes that pass from "union approximation" to "directional
 bound set", and is the natural home for swapping the undirected grouping for the
 directional reasoning D4 deliberately deferred.
+
+---
+
+# PR-by-PR breakdown (Route 3)
+
+Route 3 is committed above, so this section turns it into single-PR chunks. Each PR
+is independently reviewable, keeps `go test ./...` green, and moves along exactly one
+of the three capability axes — render, declare, check — or lays the shared data
+structure they all read. The wording of every referenced type and function matches
+the code as it stands on this branch.
+
+**Prerequisite — M6.** M6.5's canonical bound set is built on M6's join
+representation. M6 relaxes the incompatible mut-borrow join to a read-until-narrowed
+union and adds canonical union/intersection member order
+([01-milestones.md](01-milestones.md) M6). Building the bound set before that
+representation settles means reworking it afterward, so PR2 onward assume M6 has
+landed. PR1 and PR4 touch neither join code nor union members, so they can start
+against the current tree ahead of M6.
+
+## New data structures and algorithms
+
+Three things are added; everything else is a wiring change to code that already
+exists.
+
+### 1. `ltBoundSet` — the canonical directional bound set (solver)
+
+The single representation both inference and annotation produce and consume. It sits
+in `internal/solver/` beside `ltAnalysis`, since it is a display-and-checking
+artifact over the solved graph, not a constraint input. `soltype` keeps owning the
+raw `LifetimeVar.LowerBounds`/`UpperBounds` edges; `ltBoundSet` is the reduced,
+canonical view built from them.
+
+```go
+// ltBoundSet is a directed outlives graph over lifetime-variable IDs, canonical
+// and transitively reduced. An edge a -> b reads "'a outlives 'b" ('a: 'b), the
+// same direction constrainLt records as a in b.LowerBounds / b in a.UpperBounds.
+type ltBoundSet struct {
+    edges map[int]set.Set[int]           // a -> {b : 'a: 'b}, after reduction
+    vars  map[int]*soltype.LifetimeVar   // ID -> var, for rendering and naming
+    static set.Set[int]                  // IDs forced to 'static (absorbing)
+}
+```
+
+Operations, each unit-tested in isolation before any of it is wired in:
+
+- **`buildLtBoundSet(occ)`** — walk the occurring lifetime vars' `LowerBounds`/
+  `UpperBounds` directionally, recording an edge per real outlives relation instead
+  of `uf.union`'s symmetric merge. This is the directed twin of `newLtAnalysis`'s
+  walk.
+- **`reduce()`** — transitive reduction over the DAG, so `'a: 'b, 'b: 'c, 'a: 'c`
+  keeps only `'a: 'b` and `'b: 'c`. Standard reduction: drop `a -> c` when a longer
+  path `a -> … -> c` exists. `'static` is the absorbing bottom, so an edge into a
+  `'static`-forced node drops.
+- **`implies(a, b)`** — reachability in the transitive closure: does this set prove
+  `'a: 'b`. The primitive for subsumption.
+- **`subsumes(other)`** — for every edge in `other`, `implies` holds here. This is
+  "the inferred bound set satisfies the declared one" and "these two schemes carry
+  the same bounds", the check PR6 and PR7 both need.
+- **`canonicalEdges()`** — edges sorted by `(from ID, to ID)` for stable rendering
+  and order-insensitive equality, the lifetime-sort analogue of the canonical
+  union member order M6 gives the type sort.
+
+### 2. Directional analysis replacing the undirected grouping (solver)
+
+`newLtAnalysis` today builds `uf *unionFind` over the bound graph and marks a
+component root positive when any positive-position lifetime falls in it
+([lifetime_coalesce.go](../../internal/solver/lifetime_coalesce.go)). That undirected
+grouping is sound only under the invariant that file documents — independent param
+lifetimes never share a component. M6.5 replaces `uf` with `ltBoundSet` and recomputes
+`kept`/elision as **directed reachability to an output**: a param lifetime is kept
+when it reaches, along outlives edges, a lifetime that occurs positively. This retires
+the invariant rather than resting on it.
+
+### 3. `ast.LifetimeParam` — a lifetime binder that carries bounds (ast/parser/printer)
+
+`FuncSig.LifetimeParams` is `[]*ast.LifetimeAnn` today, a bare name with no place for
+a bound. A lifetime bound rides in the `<…>` list as `<'a, 'b: 'a>`, mirroring a
+type-param bound `<T: U>`, so the binder needs a bounds slot the way `ast.TypeParam`
+has `Constraint`.
+
+```go
+// LifetimeParam is a lifetime binder in a <…> quantifier list. Bounds are the
+// lifetimes this one must outlive: <'a, 'b: 'a> gives 'b the bound {'a}, read
+// "'b outlives 'a". A bare <'a> has no bounds. Mirrors ast.TypeParam's Name +
+// Constraint shape so one quantifier list carries both sorts.
+type LifetimeParam struct {
+    Name   string
+    Bounds []*LifetimeAnn
+    span   Span
+}
+```
+
+Every `LifetimeParams []*ast.LifetimeAnn` field — `FuncSig`, `FuncTypeAnn`,
+`InterfaceDecl`, and the method/class carriers in [decl.go](../../internal/ast/decl.go)
+— migrates to `[]*ast.LifetimeParam`. That fan-out is why the syntax lands as its own
+PR (PR4) rather than riding along with the semantics.
+
+## The PRs
+
+### PR1 — `ltBoundSet` core: representation, reduction, subsumption
+
+**Axis:** foundation. **Depends on:** nothing (can precede M6).
+
+Add the `ltBoundSet` type and its five operations above to `internal/solver/`, with a
+dedicated `lifetime_bounds.go` and `lifetime_bounds_test.go`. Pure data structure and
+algorithms — nothing reads it yet, so there is no behavior change and no snapshot
+churn. Tests assert reduction on the `'a: 'b: 'c` diamond, `implies` reachability
+including the `'static` absorbing case, `subsumes` in both directions, and canonical
+edge order under shuffled input.
+
+### PR2 — Directional grouping in `coalesceLifetimes` (analysis swap, output held)
+
+**Axis:** render (internal). **Depends on:** PR1, M6.
+
+Replace `newLtAnalysis`'s `unionFind` with a `ltBoundSet` and recompute `kept` as
+directed reachability to a positive occurrence. Hold the rendered output unchanged:
+`resolveLt` still expands a join var to the `LifetimeUnion` of its reachable kept
+params, so existing snapshots do not move. This isolates the risky analysis swap from
+the visible display change, and it retires the undirected-grouping invariant on its
+own. The `componentParams` sort folds into `canonicalEdges`. This is the "cheap down
+payment" the routes section flags — a strict subset of Route 3, throwaway-free.
+
+### PR3 — Render inferred bounds in the quantifier prefix
+
+**Axis:** render. **Depends on:** PR2.
+
+Flip the display. `resolveLt` keeps the join lifetime named instead of expanding it to
+a union, and `PrintAsSchemeWith` / `namedPrinter`
+([print.go](../../internal/soltype/print.go)) emit each kept lifetime's outlives edges
+as `'a: 'c` bounds in the prefix it already builds. A multi-source join renders
+`fn <'a: 'c, 'b: 'c, 'c>(p: mut 'a {…}, q: mut 'b {…}) -> mut 'c {…}` instead of
+`('a | 'b)`. `LifetimeUnion` stays only for the cases a directed bound set cannot form.
+Bulk snapshot update; this is the first PR whose accept-criteria line in the milestone
+is visible in output.
+
+### PR4 — AST + parser + printer for in-list lifetime bounds
+
+**Axis:** declare (front-end). **Depends on:** nothing (can precede M6, parallel to PR1–PR3).
+
+Introduce `ast.LifetimeParam` and migrate every `LifetimeParams` field to it. Extend
+`maybeLifetimeAndTypeParams` ([decl.go](../../internal/parser/decl.go)) to parse an
+optional `: 'a` — and a comma-free bound list `: 'a` after a lifetime name, mirroring
+`typeParam`'s constraint parse. The printer round-trips `<'a, 'b: 'a>`. No solver
+semantics yet: a declared bound is parsed and, for this PR, ignored by inference. This
+PR is purely syntactic surface, which is what lets it run in parallel with the render
+track.
+
+### PR5 — Lower declared bounds into `constrainLt`
+
+**Axis:** declare (semantics). **Depends on:** PR4.
+
+During signature resolution, emit `constrainLt` for each declared `'a: 'b` so a
+declared bound participates in solving exactly like an inferred one. The names resolve
+through `namedLifetime` ([type_ann.go](../../internal/solver/type_ann.go)), which
+already interns a written lifetime name to one `LifetimeVar` per function. Remove the
+`"lifetime parameters in function type annotation"` `reportUnsupportedFeature` guard in
+`resolveFuncTypeAnn` for the bound-carrying case. After this PR a declared bound is
+indistinguishable from an inferred one in the graph, so PR3's renderer already displays
+it correctly.
+
+### PR6 — Check inferred bounds against declared
+
+**Axis:** check. **Depends on:** PR1, PR3, PR5.
+
+An annotated function's inferred bound set must satisfy its declared one. Build the
+inferred `ltBoundSet` from the solved graph, build the declared one from the
+`LifetimeParam` bounds, and require `inferred.subsumes(declared)`. A declared bound the
+inference does not imply is a `LifetimeBoundNotSatisfiedError` — a new sealed
+`SolverError` kind in [errors.go](../../internal/solver/errors.go) carrying the two
+lifetimes and rendering the full outlives message. A redundant declared bound implied
+by transitivity is dropped from the rendered set via `reduce`. This PR is the join
+point of the render and declare tracks.
+
+### PR7 — Bound-set equality in `equalType`, scheme dedup, overload arms
+
+**Axis:** check (consumers). **Depends on:** PR1, PR3.
+
+`equalType`'s `RefType` arm, scheme dedup, and overload-arm comparison currently have
+no notion of bound-set equality, so two schemes that differ only in bound order or in a
+transitively-redundant edge compare unequal. Route each through
+`ltBoundSet.subsumes` in both directions over the canonical edges. Independent of the
+declare track, so it runs in parallel with PR5/PR6 once PR3 has landed.
+
+### PR8 — Declared bounds at no-body sites
+
+**Axis:** declare (reach). **Depends on:** PR5, PR6.
+
+Extend the PR5 lowering to the sites that have no body to infer from and therefore
+*require* declaration: `declare` function signatures, abstract interface methods, and
+type aliases over borrows. These are the configurations the routes section names as the
+hard trigger, and they are what M7 library imports consume — an imported
+borrow-relating function cannot be represented without its declared bounds. Landing this
+before M7 is what makes M6.5 "with or just before M7" rather than after it.
+
+## Dependency graph
+
+```mermaid
+graph TD
+    M6[M6 — join semantics settled] --> PR2
+    PR1[PR1 — ltBoundSet core] --> PR2[PR2 — directional grouping]
+    PR2 --> PR3[PR3 — render inferred bounds]
+    PR4[PR4 — AST/parser bound syntax] --> PR5[PR5 — lower into constrainLt]
+    PR1 --> PR6
+    PR3 --> PR6[PR6 — check inferred vs declared]
+    PR5 --> PR6
+    PR1 --> PR7[PR7 — bound-set equality consumers]
+    PR3 --> PR7
+    PR5 --> PR8[PR8 — no-body sites]
+    PR6 --> PR8
+    PR8 --> M7[M7 — library imports]
+```
+
+ASCII, with each edge read "left must land before right":
+
+```
+PR1 ──▶ PR2 ──▶ PR3 ──┬──▶ PR6 ──▶ PR8 ──▶ (M7)
+ │                    │           ▲
+ ├──────────────▶ PR7 │           │
+ │                    │           │
+ └───────────────────▶ PR6        │
+PR4 ──▶ PR5 ──────────┴───────────┘
+```
+
+## Parallel groups
+
+Two independent tracks run from the start — the **render track** (PR1 → PR2 → PR3)
+and the **declare front-end** (PR4 → PR5) — and they only meet at PR6.
+
+- **Wave 1 (parallel):** PR1 and PR4. Foundation data structure and front-end syntax
+  touch disjoint code — `solver/lifetime_bounds.go` versus `ast`/`parser`/`printer` —
+  and neither needs M6. Start both together.
+- **Wave 2 (parallel):** PR2 (needs PR1 and M6) and PR5 (needs PR4). The render
+  analysis swap and the declared-bound lowering are independent.
+- **Wave 3:** PR3 (needs PR2). PR5 may still be in flight alongside it.
+- **Wave 4 (parallel):** PR6 (needs PR1, PR3, PR5) and PR7 (needs PR1, PR3). PR7 is a
+  pure consumer change and does not touch the declare track, so it runs beside PR6.
+- **Wave 5:** PR8 (needs PR5, PR6). This is the hand-off to M7.
+
+The critical path is PR1 → PR2 → PR3 → PR6 → PR8, five PRs. PR4/PR5 and PR7 fill the
+slack beside it, so the milestone is not serialized end to end despite the single
+join point at PR6.
+
+## Hard-parts coverage
+
+The four hard parts the routes section lists above map onto the PRs so none is left
+implicit:
+
+- **Canonicalization and transitive reduction** — PR1 (`reduce`, `canonicalEdges`).
+- **Which bounds to keep** — PR2, as directed reachability to an output, the
+  lifetime-sort analogue of the single-polarity elimination
+  [simplify.go](../../internal/solver/simplify.go) does for types.
+- **Bound-set subsumption and equality** — PR1 (`subsumes`), consumed by PR6 and PR7.
+- **Coexistence with `LifetimeUnion`** — PR3 decides it: bounds supersede the union
+  rendering wherever a directed set forms, and `LifetimeUnion` is retained only for
+  the residual cases that cannot.

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -251,14 +251,28 @@ artifact over the solved graph, not a constraint input. `soltype` keeps owning t
 raw `LifetimeVar.LowerBounds`/`UpperBounds` edges; `ltBoundSet` is the reduced,
 canonical view built from them.
 
+**The raw graph is not a DAG.** `constrainLt` records an edge for each direction of
+a var-to-var constraint, so `'a: 'b` together with `'b: 'a` puts each lifetime in the
+other's bound lists and forms a cycle — the case `TestConstrainLtCycleTerminates`
+already exercises for termination. A cycle in the outlives relation means those
+lifetimes are mutually outliving, so they are **equal** as lifetimes. Transitive
+reduction is only defined on a DAG, so `ltBoundSet` first condenses each strongly
+connected component to a single representative — the canonical form for a set of
+outlives-equivalent lifetimes — and every edge, query, and rendering is over that
+condensed DAG, never the raw graph.
+
 ```go
-// ltBoundSet is a directed outlives graph over lifetime-variable IDs, canonical
-// and transitively reduced. An edge a -> b reads "'a outlives 'b" ('a: 'b), the
-// same direction constrainLt records as a in b.LowerBounds / b in a.UpperBounds.
+// ltBoundSet is a directed outlives graph over lifetime-variable IDs, condensed
+// over outlives-equivalent lifetimes and then transitively reduced. An edge a -> b
+// reads "'a outlives 'b" ('a: 'b), the same direction constrainLt records as a in
+// b.LowerBounds / b in a.UpperBounds. Cyclic constraints (mutual 'a: 'b, 'b: 'a)
+// collapse into one SCC representative, so edges and vars are keyed by
+// representative ID, not raw lifetime ID.
 type ltBoundSet struct {
-    edges map[int]set.Set[int]           // a -> {b : 'a: 'b}, after reduction
-    vars  map[int]*soltype.LifetimeVar   // ID -> var, for rendering and naming
-    static set.Set[int]                  // IDs forced to 'static (absorbing)
+    edges map[int]set.Set[int]           // rep -> {rep : 'a: 'b}, condensed then reduced
+    rep   map[int]int                    // lifetime ID -> its SCC representative ID
+    vars  map[int]*soltype.LifetimeVar   // representative ID -> a member var, for rendering
+    static set.Set[int]                  // representative IDs forced to 'static (absorbing)
 }
 ```
 
@@ -266,20 +280,28 @@ Operations, each unit-tested in isolation before any of it is wired in:
 
 - **`buildLtBoundSet(occ)`** — walk the occurring lifetime vars' `LowerBounds`/
   `UpperBounds` directionally, recording an edge per real outlives relation instead
-  of `uf.union`'s symmetric merge. This is the directed twin of `newLtAnalysis`'s
-  walk.
-- **`reduce()`** — transitive reduction over the DAG, so `'a: 'b, 'b: 'c, 'a: 'c`
-  keeps only `'a: 'b` and `'b: 'c`. Standard reduction: drop `a -> c` when a longer
-  path `a -> … -> c` exists. `'static` is the absorbing bottom, so an edge into a
-  `'static`-forced node drops.
-- **`implies(a, b)`** — reachability in the transitive closure: does this set prove
-  `'a: 'b`. The primitive for subsumption.
+  of `uf.union`'s symmetric merge. Then find the strongly connected components of
+  that directed graph — Tarjan or Kosaraju over the same edges — and condense each to
+  a representative in `rep`, collapsing a mutual-outlives cycle to one node. The
+  smaller lifetime ID is the stable representative, mirroring `unionFind`'s
+  smaller-id rule. This is the directed twin of `newLtAnalysis`'s walk, plus the SCC
+  condensation the undirected union-find got for free by never distinguishing
+  direction.
+- **`reduce()`** — transitive reduction over the **condensed DAG**, so
+  `'a: 'b, 'b: 'c, 'a: 'c` keeps only `'a: 'b` and `'b: 'c`. Standard reduction: drop
+  `a -> c` when a longer path `a -> … -> c` exists. Well-defined only because the SCC
+  condensation in `buildLtBoundSet` already removed every cycle. `'static` is the
+  absorbing bottom, so an edge into a `'static`-forced node drops.
+- **`implies(a, b)`** — map `a` and `b` to their representatives, then test
+  reachability in the transitive closure: does this set prove `'a: 'b`. Two
+  outlives-equivalent lifetimes share a representative, so `implies` reports the
+  cycle as equality in both directions. The primitive for subsumption.
 - **`subsumes(other)`** — for every edge in `other`, `implies` holds here. This is
   "the inferred bound set satisfies the declared one" and "these two schemes carry
   the same bounds", the check PR6 and PR7 both need.
-- **`canonicalEdges()`** — edges sorted by `(from ID, to ID)` for stable rendering
-  and order-insensitive equality, the lifetime-sort analogue of the canonical
-  union member order M6 gives the type sort.
+- **`canonicalEdges()`** — condensed edges sorted by `(from rep, to rep)` for stable
+  rendering and order-insensitive equality, the lifetime-sort analogue of the
+  canonical union member order M6 gives the type sort.
 
 ### 2. Directional analysis replacing the undirected grouping (solver)
 
@@ -327,7 +349,10 @@ dedicated `lifetime_bounds.go` and `lifetime_bounds_test.go`. Pure data structur
 algorithms — nothing reads it yet, so there is no behavior change and no snapshot
 churn. Tests assert reduction on the `'a: 'b: 'c` diamond, `implies` reachability
 including the `'static` absorbing case, `subsumes` in both directions, and canonical
-edge order under shuffled input.
+edge order under shuffled input. The load-bearing case is a **mutual-outlives cycle**
+(`'a: 'b, 'b: 'a`): `buildLtBoundSet` must condense it to one representative so
+`reduce` sees a DAG, `implies` reports it as equality in both directions, and a
+three-node cycle folded to one node reduces without looping.
 
 ### PR2 — Directional grouping in `coalesceLifetimes` (analysis swap, output held)
 
@@ -467,7 +492,8 @@ join point at PR6.
 The four hard parts the routes section lists above map onto the PRs so none is left
 implicit:
 
-- **Canonicalization and transitive reduction** — PR1 (`reduce`, `canonicalEdges`).
+- **SCC condensation, canonicalization, and transitive reduction** — PR1
+  (`buildLtBoundSet` condenses cycles, `reduce`, `canonicalEdges`).
 - **Which bounds to keep** — PR2, as directed reachability to an output, the
   lifetime-sort analogue of the single-polarity elimination
   [simplify.go](../../internal/solver/simplify.go) does for types.

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -431,15 +431,16 @@ graph TD
     PR8 --> M7[M7 — library imports]
 ```
 
-ASCII, with each edge read "left must land before right":
+ASCII, with each edge read "left must land before right". The critical path is
+the top line; the remaining edges are listed below it as `source ─── target`
+pairs, since the fan-in to PR6 and PR7 crosses too many lanes to draw inline
+cleanly.
 
 ```
-PR1 ──▶ PR2 ──▶ PR3 ──┬──▶ PR6 ──▶ PR8 ──▶ (M7)
- │                    │           ▲
- ├──────────────▶ PR7 │           │
- │                    │           │
- └───────────────────▶ PR6        │
-PR4 ──▶ PR5 ──────────┴───────────┘
+critical path:   PR1 ─── PR2 ─── PR3 ─── PR6 ─── PR8 ─── M7
+
+remaining edges: PR4 ─── PR5     PR1 ─── PR6     PR1 ─── PR7
+                 PR5 ─── PR6     PR3 ─── PR7     PR5 ─── PR8
 ```
 
 ## Parallel groups

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -208,8 +208,15 @@ is a strict subset of Route 3.
   overload arms, and annotation-checking all need "does the inferred bound set imply
   the declared one". `constrainLt` gives the primitive. The set-level comparison is
   new.
-- **Coexistence with `LifetimeUnion`.** Decide whether bounds supersede the union
-  rendering M4 D4 produces or sit alongside it.
+- **Removal of `LifetimeUnion`.** Bounds supersede the union on both sides, so
+  `soltype.LifetimeUnion` is deleted outright rather than kept alongside them. It has
+  two mint sites today and a named lifetime with directional bounds is strictly more
+  precise than either. The join-rendering mint
+  ([lifetime_coalesce.go](../../internal/solver/lifetime_coalesce.go)) is replaced by
+  the bounded form in PR3. The annotation-input mint
+  ([type_ann.go](../../internal/solver/type_ann.go), lowering a written `('a | 'b) T`)
+  is retired with the `('a | 'b)` surface syntax it lowers, since `<'a: 'b>` bounds
+  express the same relation. See PR3 and PR9 for the removal split.
 
 ## Relationship to M4 D4
 
@@ -226,9 +233,9 @@ directional reasoning D4 deliberately deferred.
 
 Route 3 is committed above, so this section turns it into single-PR chunks. Each PR
 is independently reviewable, keeps `go test ./...` green, and moves along exactly one
-of the three capability axes — render, declare, check — or lays the shared data
-structure they all read. The wording of every referenced type and function matches
-the code as it stands on this branch.
+of the three capability axes — render, declare, check — lays the shared data structure
+they all read, or does the final cleanup deletion. The wording of every referenced
+type and function matches the code as it stands on this branch.
 
 **Prerequisite — M6.** M6.5's canonical bound set is built on M6's join
 representation. M6 relaxes the incompatible mut-borrow join to a read-until-narrowed
@@ -375,9 +382,14 @@ a union, and `PrintAsSchemeWith` / `namedPrinter`
 ([print.go](../../internal/soltype/print.go)) emit each kept lifetime's outlives edges
 as `'a: 'c` bounds in the prefix it already builds. A multi-source join renders
 `fn <'a: 'c, 'b: 'c, 'c>(p: mut 'a {…}, q: mut 'b {…}) -> mut 'c {…}` instead of
-`('a | 'b)`. `LifetimeUnion` stays only for the cases a directed bound set cannot form.
-Bulk snapshot update; this is the first PR whose accept-criteria line in the milestone
-is visible in output.
+`('a | 'b)`. A named lifetime with directional bounds is strictly more precise than
+the union approximation, and a directed bound set forms for every join, so this
+**removes the join-rendering mint of `LifetimeUnion`** at
+[lifetime_coalesce.go:217](../../internal/solver/lifetime_coalesce.go) rather than
+leaving a residual case. The `soltype.LifetimeUnion` type itself is not deleted until
+PR9, because its second mint — the `('a | 'b)` annotation input — is still live until
+then. Bulk snapshot update; this is the first PR whose accept-criteria line in the
+milestone is visible in output.
 
 ### PR4 — AST + parser + printer for in-list lifetime bounds
 
@@ -438,6 +450,31 @@ hard trigger, and they are what M7 library imports consume — an imported
 borrow-relating function cannot be represented without its declared bounds. Landing this
 before M7 is what makes M6.5 "with or just before M7" rather than after it.
 
+### PR9 — Retire the `('a | 'b)` annotation syntax and delete `LifetimeUnion`
+
+**Axis:** cleanup. **Depends on:** PR3, PR8.
+
+`<'a: 'b>` bounds express every relation the `('a | 'b)` type-position annotation did,
+and PR8 has by now given every no-body site the bound form, so the union annotation is
+redundant surface. Retire it and delete the type:
+
+- Drop the `('a | 'b)` parse in [type_ann.go](../../internal/parser/type_ann.go) and
+  the `ast.LifetimeUnionAnn` node, plus its printer arm. A written `('a | 'b) T` now
+  parses as an error directing the author to a named lifetime with bounds.
+- Delete the annotation-input mint at
+  [type_ann.go:438](../../internal/solver/type_ann.go), the second and last live
+  producer of `soltype.LifetimeUnion`.
+- With both mints gone — the join-rendering one removed in PR3, this one here — delete
+  `soltype.LifetimeUnion` itself and its now-dead arms: the print arms in
+  [print.go](../../internal/soltype/print.go), the `ltEqual` arms in
+  [lattice.go](../../internal/solver/lattice.go), and the coalesce-equality arm in
+  [coalesce.go](../../internal/solver/coalesce.go). The `soltype.Lifetime` sort narrows
+  to `LifetimeVar`, `StaticLifetime`, and `AnonLifetime`.
+
+This is a pure deletion once bounds carry every case, which is why it lands last and
+depends on both the render flip (PR3) and the no-body reach (PR8). It is separate from
+PR3 so the risky rendering change and the surface-syntax removal are reviewed apart.
+
 ## Dependency graph
 
 ```mermaid
@@ -453,7 +490,10 @@ graph TD
     PR3 --> PR7
     PR5 --> PR8[PR8 — no-body sites]
     PR6 --> PR8
+    PR3 --> PR9[PR9 — retire union syntax, delete LifetimeUnion]
+    PR8 --> PR9
     PR8 --> M7[M7 — library imports]
+    PR9 --> M7
 ```
 
 ASCII, with each edge read "left must land before right". The critical path is
@@ -462,10 +502,11 @@ pairs, since the fan-in to PR6 and PR7 crosses too many lanes to draw inline
 cleanly.
 
 ```
-critical path:   PR1 ─── PR2 ─── PR3 ─── PR6 ─── PR8 ─── M7
+critical path:   PR1 ─── PR2 ─── PR3 ─── PR6 ─── PR8 ─── PR9 ─── M7
 
 remaining edges: PR4 ─── PR5     PR1 ─── PR6     PR1 ─── PR7
                  PR5 ─── PR6     PR3 ─── PR7     PR5 ─── PR8
+                 PR3 ─── PR9
 ```
 
 ## Parallel groups
@@ -481,10 +522,12 @@ and the **declare front-end** (PR4 → PR5) — and they only meet at PR6.
 - **Wave 3:** PR3 (needs PR2). PR5 may still be in flight alongside it.
 - **Wave 4 (parallel):** PR6 (needs PR1, PR3, PR5) and PR7 (needs PR1, PR3). PR7 is a
   pure consumer change and does not touch the declare track, so it runs beside PR6.
-- **Wave 5:** PR8 (needs PR5, PR6). This is the hand-off to M7.
+- **Wave 5:** PR8 (needs PR5, PR6). The no-body-site declaration lowering.
+- **Wave 6:** PR9 (needs PR3, PR8). The cleanup deletion, the hand-off to M7 alongside
+  PR8.
 
-The critical path is PR1 → PR2 → PR3 → PR6 → PR8, five PRs. PR4/PR5 and PR7 fill the
-slack beside it, so the milestone is not serialized end to end despite the single
+The critical path is PR1 → PR2 → PR3 → PR6 → PR8 → PR9, six PRs. PR4/PR5 and PR7 fill
+the slack beside it, so the milestone is not serialized end to end despite the single
 join point at PR6.
 
 ## Hard-parts coverage
@@ -498,6 +541,6 @@ implicit:
   lifetime-sort analogue of the single-polarity elimination
   [simplify.go](../../internal/solver/simplify.go) does for types.
 - **Bound-set subsumption and equality** — PR1 (`subsumes`), consumed by PR6 and PR7.
-- **Coexistence with `LifetimeUnion`** — PR3 decides it: bounds supersede the union
-  rendering wherever a directed set forms, and `LifetimeUnion` is retained only for
-  the residual cases that cannot.
+- **Removal of `LifetimeUnion`** — PR3 removes the join-rendering mint, PR9 removes the
+  `('a | 'b)` annotation mint and deletes the type. Bounds supersede the union on both
+  sides, so it is deleted outright, not kept alongside.


### PR DESCRIPTION
Add a detailed PR-by-PR breakdown of Route 3 for M6.5 (directional lifetime bounds), turning the high-level implementation strategy into independently reviewable chunks.

The new section documents:

- **Three new data structures and algorithms** that form the foundation: `ltBoundSet` (canonical directional bound set), directional analysis replacing undirected grouping in `coalesceLifetimes`, and `ast.LifetimeParam` (lifetime binder with bounds).

- **Eight PRs** organized by capability axis (render, declare, check) with clear dependencies, each keeping `go test ./...` green and moving along exactly one axis or laying shared infrastructure.

- **Dependency graph and parallel groups** showing the critical path (PR1 → PR2 → PR3 → PR6 → PR8) and identifying where independent tracks can run in parallel to avoid serialization.

- **Hard-parts coverage** mapping the four identified hard problems (canonicalization, which bounds to keep, subsumption/equality, coexistence with `LifetimeUnion`) to specific PRs so none is left implicit.

The breakdown assumes M6 has landed (join representation settled) and identifies which PRs can start before it (PR1, PR4) versus which depend on it (PR2 onward).

https://claude.ai/code/session_01UfWFecKHEPjFTQgk4ncJTu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed PR-by-PR implementation breakdown for the next release.
  * Clarified the plan to remove the legacy `LifetimeUnion` approach in favor of directional lifetime bound handling.
  * Introduced `ltBoundSet` as the canonical representation, including canonical ordering and how reachability drives implies/subsumes.
  * Documented updated inferred-vs-declared bound checking behavior, including stricter requirements at declaration-only sites.
  * Added/updated design notes for lifetime bounds syntax in parameter lists (`<...>` with meet forms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->