### PR TITLE
Add lifetime parameter bounds syntax

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -4,7 +4,7 @@ import "github.com/escalier-lang/escalier/internal/provenance"
 
 type ClassDecl struct {
 	Name           *Ident
-	LifetimeParams []*LifetimeAnn    // generic lifetime parameters (e.g. <'a>)
+	LifetimeParams []*LifetimeParam  // generic lifetime parameters (e.g. <'a>)
 	TypeParams     []*TypeParam      // generic type parameters
 	Extends        *TypeRefTypeAnn   // optional superclass (can be a simple identifier or a generic type reference)
 	Implements     []*TypeRefTypeAnn // interfaces this class implements (may be nil/empty)
@@ -47,7 +47,7 @@ type MethodReceiver struct {
 func (r *MethodReceiver) Span() Span { return r.Span_ }
 
 // Exported constructor for use in parser
-func NewClassDecl(name *Ident, lifetimeParams []*LifetimeAnn, typeParams []*TypeParam, extends *TypeRefTypeAnn, implements []*TypeRefTypeAnn, body []ClassElem, export, declare bool, span Span) *ClassDecl {
+func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*TypeParam, extends *TypeRefTypeAnn, implements []*TypeRefTypeAnn, body []ClassElem, export, declare bool, span Span) *ClassDecl {
 	return &ClassDecl{
 		Name:           name,
 		LifetimeParams: lifetimeParams,

--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -134,7 +134,7 @@ type FuncDecl struct {
 
 func NewFuncDecl(
 	name *Ident,
-	lifetimeParams []*LifetimeAnn,
+	lifetimeParams []*LifetimeParam,
 	typeParams []*TypeParam,
 	params []*Param,
 	returnType TypeAnn, // optional
@@ -237,7 +237,7 @@ func (d *TypeDecl) SetProvenance(p provenance.Provenance) {
 
 type InterfaceDecl struct {
 	Name           *Ident
-	LifetimeParams []*LifetimeAnn
+	LifetimeParams []*LifetimeParam
 	TypeParams     []*TypeParam
 	Extends        []*TypeRefTypeAnn
 	TypeAnn        *ObjectTypeAnn
@@ -248,7 +248,7 @@ type InterfaceDecl struct {
 	provenance     provenance.Provenance
 }
 
-func NewInterfaceDecl(name *Ident, lifetimeParams []*LifetimeAnn, typeParams []*TypeParam, extends []*TypeRefTypeAnn, typeAnn *ObjectTypeAnn, export, declare bool, span Span) *InterfaceDecl {
+func NewInterfaceDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*TypeParam, extends []*TypeRefTypeAnn, typeAnn *ObjectTypeAnn, export, declare bool, span Span) *InterfaceDecl {
 	return &InterfaceDecl{
 		Name:           name,
 		LifetimeParams: lifetimeParams,

--- a/internal/ast/expr.go
+++ b/internal/ast/expr.go
@@ -338,6 +338,11 @@ func (e *IdentExpr) Accept(v Visitor) {
 	v.ExitExpr(e)
 }
 
+// TypeParam is a type binder in a <…> quantifier list. Constraint is the bound
+// the type must satisfy. In <T: U>, T <: U, read "T is a subtype of U". The ':'
+// here means subtyping, not the outliving ':' of a LifetimeParam bound. A
+// binder is a type or a lifetime, never both, so the two never mix on one
+// binder and the checker picks the relation from the binder's sort.
 type TypeParam struct {
 	Name       string
 	Constraint TypeAnn
@@ -349,7 +354,7 @@ func NewTypeParam(name string, constraint, defaultType TypeAnn) TypeParam {
 }
 
 type FuncSig struct {
-	LifetimeParams []*LifetimeAnn // optional, e.g. ['a, 'b]
+	LifetimeParams []*LifetimeParam // optional, e.g. <'a, 'b: 'a>
 	TypeParams     []*TypeParam
 	Params         []*Param
 	Return         TypeAnn // optional
@@ -366,7 +371,7 @@ type FuncExpr struct {
 }
 
 func NewFuncExpr(
-	lifetimeParams []*LifetimeAnn,
+	lifetimeParams []*LifetimeParam,
 	typeParams []*TypeParam,
 	params []*Param,
 	ret TypeAnn, // optional

--- a/internal/ast/lifetime.go
+++ b/internal/ast/lifetime.go
@@ -23,6 +23,27 @@ func NewLifetimeAnn(name string, span Span) *LifetimeAnn {
 func (l *LifetimeAnn) Span() Span         { return l.span }
 func (*LifetimeAnn) isLifetimeAnnNode() {}
 
+// LifetimeParam is a lifetime binder in a <…> quantifier list. Bounds are the
+// lifetimes this one must outlive. In <'a, 'b: 'a>, 'b has the bound {'a}, read
+// "'b outlives 'a". Several bounds are written with &, the lattice meet, the
+// way a type-param bound writes an intersection. In <'a: 'b & 'c>, 'a has the
+// bounds {'b, 'c}. A bare <'a> has no bounds. Mirrors TypeParam's Name +
+// Constraint shape so one quantifier list carries both sorts.
+//
+// The ':' here means outliving, not the subtyping ':' of a TypeParam bound. A
+// binder is a lifetime or a type, never both, so the two never mix on one
+// binder and the checker picks the relation from the binder's sort.
+type LifetimeParam struct {
+	Name   string
+	Bounds []*LifetimeAnn
+	span   Span
+}
+
+func NewLifetimeParam(name string, bounds []*LifetimeAnn, span Span) *LifetimeParam {
+	return &LifetimeParam{Name: name, Bounds: bounds, span: span}
+}
+func (l *LifetimeParam) Span() Span { return l.span }
+
 // LifetimeUnionAnn represents multiple lifetimes on a single type
 // (e.g. ('a | 'b) in `('a | 'b) Point`). Used when a value may carry one
 // of several lifetimes — typically the return type of a function whose

--- a/internal/ast/type_ann.go
+++ b/internal/ast/type_ann.go
@@ -438,8 +438,8 @@ func (t *TypeRefTypeAnn) Accept(v Visitor) {
 }
 
 type FuncTypeAnn struct {
-	LifetimeParams []*LifetimeAnn // optional, e.g. ['a, 'b]
-	TypeParams     []*TypeParam   // optional
+	LifetimeParams []*LifetimeParam // optional, e.g. <'a, 'b: 'a>
+	TypeParams     []*TypeParam     // optional
 	Params         []*Param
 	Return         TypeAnn
 	Throws         TypeAnn // optionanl
@@ -449,7 +449,7 @@ type FuncTypeAnn struct {
 }
 
 func NewFuncTypeAnn(
-	lifetimeParams []*LifetimeAnn,
+	lifetimeParams []*LifetimeParam,
 	typeParams []*TypeParam,
 	params []*Param,
 	ret TypeAnn,

--- a/internal/checker/diag_lifetime.go
+++ b/internal/checker/diag_lifetime.go
@@ -126,7 +126,7 @@ func (e LifetimeArgCountMismatchError) Message() string {
 // receiver is not present in `Params` at signature-inference time.
 func reportUnusedLifetimeParams(
 	fnType *type_system.FuncType,
-	astParams []*ast.LifetimeAnn,
+	astParams []*ast.LifetimeParam,
 	fallbackSpan ast.Span,
 ) []Error {
 	if len(fnType.LifetimeParams) == 0 {

--- a/internal/checker/infer_lifetime_ann.go
+++ b/internal/checker/infer_lifetime_ann.go
@@ -24,10 +24,10 @@ func (c *Checker) declareLifetimeParams(
 		return nil
 	}
 	out := make([]*type_system.LifetimeVar, len(astParams))
-	for i, ann := range astParams {
-		lv := c.FreshLifetimeVar(ann.Name)
+	for i, lp := range astParams {
+		lv := c.FreshLifetimeVar(lp.Name)
 		out[i] = lv
-		scope.SetLifetimeVar(ann.Name, lv)
+		scope.SetLifetimeVar(lp.Name, lv)
 	}
 	return out
 }

--- a/internal/checker/infer_lifetime_ann.go
+++ b/internal/checker/infer_lifetime_ann.go
@@ -18,7 +18,7 @@ import (
 // how duplicate type parameters are handled.
 func (c *Checker) declareLifetimeParams(
 	scope *Scope,
-	astParams []*ast.LifetimeAnn,
+	astParams []*ast.LifetimeParam,
 ) []*type_system.LifetimeVar {
 	if len(astParams) == 0 {
 		return nil

--- a/internal/parser/__snapshots__/lifetime_test.snap
+++ b/internal/parser/__snapshots__/lifetime_test.snap
@@ -127,8 +127,8 @@
             span: 1:5-1:6,
         },
         TypeAnn: &ast.FuncTypeAnn{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:11-1:13,
                 },
@@ -183,8 +183,8 @@
             span: 1:4-1:12,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:13-1:15,
                 },
@@ -257,8 +257,8 @@
             span: 1:4-1:7,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:8-1:10,
                 },
@@ -320,12 +320,12 @@
             span: 1:4-1:9,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:10-1:12,
                 },
-                &ast.LifetimeAnn{
+                &ast.LifetimeParam{
                     Name: "b",
                     span: 1:14-1:16,
                 },
@@ -413,8 +413,8 @@
             span: 1:4-1:12,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:13-1:15,
                 },
@@ -482,12 +482,12 @@
             span: 1:4-1:8,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:9-1:11,
                 },
-                &ast.LifetimeAnn{
+                &ast.LifetimeParam{
                     Name: "b",
                     span: 1:13-1:15,
                 },
@@ -591,8 +591,8 @@
                         span: 1:22-1:28,
                     },
                     Fn: &ast.FuncTypeAnn{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:29-1:31,
                             },
@@ -657,8 +657,8 @@
                 },
                 Fn: &ast.FuncExpr{
                     FuncSig: ast.FuncSig{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:20-1:22,
                             },
@@ -727,8 +727,8 @@
             Name: "Container",
             span: 1:7-1:16,
         },
-        LifetimeParams: []*ast.LifetimeAnn{
-            &ast.LifetimeAnn{
+        LifetimeParams: []*ast.LifetimeParam{
+            &ast.LifetimeParam{
                 Name: "a",
                 span: 1:17-1:19,
             },
@@ -766,8 +766,8 @@
             Name: "Holder",
             span: 1:11-1:17,
         },
-        LifetimeParams: []*ast.LifetimeAnn{
-            &ast.LifetimeAnn{
+        LifetimeParams: []*ast.LifetimeParam{
+            &ast.LifetimeParam{
                 Name: "a",
                 span: 1:18-1:20,
             },
@@ -837,8 +837,8 @@
             Name: "Forwarder",
             span: 1:7-1:16,
         },
-        LifetimeParams: []*ast.LifetimeAnn{
-            &ast.LifetimeAnn{
+        LifetimeParams: []*ast.LifetimeParam{
+            &ast.LifetimeParam{
                 Name: "a",
                 span: 1:17-1:19,
             },
@@ -961,8 +961,8 @@
             span: 1:4-1:10,
         },
         FuncSig: ast.FuncSig{
-            LifetimeParams: []*ast.LifetimeAnn{
-                &ast.LifetimeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
                     Name: "a",
                     span: 1:11-1:13,
                 },
@@ -1127,8 +1127,8 @@
                 },
                 Fn: &ast.FuncExpr{
                     FuncSig: ast.FuncSig{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:19-1:21,
                             },
@@ -1197,8 +1197,8 @@
                         span: 1:20-1:24,
                     },
                     Fn: &ast.FuncTypeAnn{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:25-1:27,
                             },
@@ -1248,8 +1248,8 @@
                         span: 1:21-1:28,
                     },
                     Fn: &ast.FuncTypeAnn{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:29-1:31,
                             },
@@ -1314,8 +1314,8 @@
                 },
                 Fn: &ast.FuncExpr{
                     FuncSig: ast.FuncSig{
-                        LifetimeParams: []*ast.LifetimeAnn{
-                            &ast.LifetimeAnn{
+                        LifetimeParams: []*ast.LifetimeParam{
+                            &ast.LifetimeParam{
                                 Name: "a",
                                 span: 1:27-1:29,
                             },
@@ -1365,5 +1365,349 @@
         span: 1:1-1:74,
     },
     span: 1:1-1:74,
+}
+---
+
+[TestParseLifetimeAnnotations/FnLifetimeParamMultiBound - 1]
+&ast.DeclStmt{
+    Decl: &ast.FuncDecl{
+        Name: &ast.Ident{
+            Name: "pick",
+            span: 1:4-1:8,
+        },
+        FuncSig: ast.FuncSig{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
+                    Name: "a",
+                    Bounds: []*ast.LifetimeAnn{
+                        &ast.LifetimeAnn{
+                            Name: "b",
+                            span: 1:13-1:15,
+                        },
+                        &ast.LifetimeAnn{
+                            Name: "c",
+                            span: 1:18-1:20,
+                        },
+                    },
+                    span: 1:9-1:20,
+                },
+                &ast.LifetimeParam{
+                    Name: "b",
+                    span: 1:22-1:24,
+                },
+                &ast.LifetimeParam{
+                    Name: "c",
+                    span: 1:26-1:28,
+                },
+            },
+            Params: []*ast.Param{
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "a",
+                        span: 1:30-1:31,
+                    },
+                    TypeAnn: &ast.MutableTypeAnn{
+                        Target: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "Point",
+                                span: 1:40-1:45,
+                            },
+                            Lifetime: &ast.LifetimeAnn{
+                                Name: "a",
+                                span: 1:37-1:39,
+                            },
+                            span: 1:40-1:45,
+                        },
+                        span: 1:40-1:45,
+                    },
+                },
+            },
+            Return: &ast.MutableTypeAnn{
+                Target: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:57-1:62,
+                    },
+                    Lifetime: &ast.LifetimeAnn{
+                        Name: "a",
+                        span: 1:54-1:56,
+                    },
+                    span: 1:57-1:62,
+                },
+                span: 1:57-1:62,
+            },
+        },
+        Body: &ast.Block{
+            Stmts: []ast.Stmt{
+                &ast.ReturnStmt{
+                    Expr: &ast.IdentExpr{
+                        Name: "a",
+                        span: 1:72-1:73,
+                    },
+                    span: 1:65-1:73,
+                },
+            },
+            Span: 1:63-1:75,
+        },
+        span: 1:1-1:75,
+    },
+    span: 1:1-1:75,
+}
+---
+
+[TestParseLifetimeAnnotations/FnLifetimeParamSingleBound - 1]
+&ast.DeclStmt{
+    Decl: &ast.FuncDecl{
+        Name: &ast.Ident{
+            Name: "pick",
+            span: 1:4-1:8,
+        },
+        FuncSig: ast.FuncSig{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
+                    Name: "a",
+                    span: 1:9-1:11,
+                },
+                &ast.LifetimeParam{
+                    Name: "b",
+                    Bounds: []*ast.LifetimeAnn{
+                        &ast.LifetimeAnn{
+                            Name: "a",
+                            span: 1:17-1:19,
+                        },
+                    },
+                    span: 1:13-1:19,
+                },
+            },
+            Params: []*ast.Param{
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "a",
+                        span: 1:21-1:22,
+                    },
+                    TypeAnn: &ast.MutableTypeAnn{
+                        Target: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "Point",
+                                span: 1:31-1:36,
+                            },
+                            Lifetime: &ast.LifetimeAnn{
+                                Name: "a",
+                                span: 1:28-1:30,
+                            },
+                            span: 1:31-1:36,
+                        },
+                        span: 1:31-1:36,
+                    },
+                },
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "b",
+                        span: 1:38-1:39,
+                    },
+                    TypeAnn: &ast.MutableTypeAnn{
+                        Target: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "Point",
+                                span: 1:48-1:53,
+                            },
+                            Lifetime: &ast.LifetimeAnn{
+                                Name: "b",
+                                span: 1:45-1:47,
+                            },
+                            span: 1:48-1:53,
+                        },
+                        span: 1:48-1:53,
+                    },
+                },
+            },
+            Return: &ast.MutableTypeAnn{
+                Target: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:65-1:70,
+                    },
+                    Lifetime: &ast.LifetimeAnn{
+                        Name: "b",
+                        span: 1:62-1:64,
+                    },
+                    span: 1:65-1:70,
+                },
+                span: 1:65-1:70,
+            },
+        },
+        Body: &ast.Block{
+            Stmts: []ast.Stmt{
+                &ast.ReturnStmt{
+                    Expr: &ast.IdentExpr{
+                        Name: "b",
+                        span: 1:80-1:81,
+                    },
+                    span: 1:73-1:81,
+                },
+            },
+            Span: 1:71-1:83,
+        },
+        span: 1:1-1:83,
+    },
+    span: 1:1-1:83,
+}
+---
+
+[TestParseLifetimeAnnotations/FnTypeAnnLifetimeParamBound - 1]
+&ast.DeclStmt{
+    Decl: &ast.VarDecl{
+        Pattern: &ast.IdentPat{
+            Name: "f",
+            span: 1:5-1:6,
+        },
+        TypeAnn: &ast.FuncTypeAnn{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
+                    Name: "a",
+                    span: 1:11-1:13,
+                },
+                &ast.LifetimeParam{
+                    Name: "b",
+                    Bounds: []*ast.LifetimeAnn{
+                        &ast.LifetimeAnn{
+                            Name: "a",
+                            span: 1:19-1:21,
+                        },
+                    },
+                    span: 1:15-1:21,
+                },
+            },
+            Params: []*ast.Param{
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "a",
+                        span: 1:23-1:24,
+                    },
+                    TypeAnn: &ast.TypeRefTypeAnn{
+                        Name: &ast.Ident{
+                            Name: "Point",
+                            span: 1:29-1:34,
+                        },
+                        Lifetime: &ast.LifetimeAnn{
+                            Name: "a",
+                            span: 1:26-1:28,
+                        },
+                        span: 1:29-1:34,
+                    },
+                },
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "b",
+                        span: 1:36-1:37,
+                    },
+                    TypeAnn: &ast.TypeRefTypeAnn{
+                        Name: &ast.Ident{
+                            Name: "Point",
+                            span: 1:42-1:47,
+                        },
+                        Lifetime: &ast.LifetimeAnn{
+                            Name: "b",
+                            span: 1:39-1:41,
+                        },
+                        span: 1:42-1:47,
+                    },
+                },
+            },
+            Return: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "Point",
+                    span: 1:55-1:60,
+                },
+                Lifetime: &ast.LifetimeAnn{
+                    Name: "b",
+                    span: 1:52-1:54,
+                },
+                span: 1:55-1:60,
+            },
+            span: 1:8-1:60,
+        },
+        Init: &ast.IdentExpr{
+            Name: "pick",
+            span: 1:63-1:67,
+        },
+        span: 1:1-1:67,
+    },
+    span: 1:1-1:67,
+}
+---
+
+[TestParseLifetimeAnnotations/FnLifetimeParamStaticBound - 1]
+&ast.DeclStmt{
+    Decl: &ast.FuncDecl{
+        Name: &ast.Ident{
+            Name: "keep",
+            span: 1:4-1:8,
+        },
+        FuncSig: ast.FuncSig{
+            LifetimeParams: []*ast.LifetimeParam{
+                &ast.LifetimeParam{
+                    Name: "a",
+                    Bounds: []*ast.LifetimeAnn{
+                        &ast.LifetimeAnn{
+                            Name: "static",
+                            span: 1:13-1:20,
+                        },
+                    },
+                    span: 1:9-1:20,
+                },
+            },
+            Params: []*ast.Param{
+                &ast.Param{
+                    Pattern: &ast.IdentPat{
+                        Name: "p",
+                        span: 1:22-1:23,
+                    },
+                    TypeAnn: &ast.MutableTypeAnn{
+                        Target: &ast.TypeRefTypeAnn{
+                            Name: &ast.Ident{
+                                Name: "Point",
+                                span: 1:32-1:37,
+                            },
+                            Lifetime: &ast.LifetimeAnn{
+                                Name: "a",
+                                span: 1:29-1:31,
+                            },
+                            span: 1:32-1:37,
+                        },
+                        span: 1:32-1:37,
+                    },
+                },
+            },
+            Return: &ast.MutableTypeAnn{
+                Target: &ast.TypeRefTypeAnn{
+                    Name: &ast.Ident{
+                        Name: "Point",
+                        span: 1:49-1:54,
+                    },
+                    Lifetime: &ast.LifetimeAnn{
+                        Name: "a",
+                        span: 1:46-1:48,
+                    },
+                    span: 1:49-1:54,
+                },
+                span: 1:49-1:54,
+            },
+        },
+        Body: &ast.Block{
+            Stmts: []ast.Stmt{
+                &ast.ReturnStmt{
+                    Expr: &ast.IdentExpr{
+                        Name: "p",
+                        span: 1:64-1:65,
+                    },
+                    span: 1:57-1:65,
+                },
+            },
+            Span: 1:55-1:67,
+        },
+        span: 1:1-1:67,
+    },
+    span: 1:1-1:67,
 }
 ---

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -92,8 +92,8 @@ func (p *Parser) lifetimeAnn() *ast.LifetimeAnn {
 // include both lifetime parameters ('a) and type parameters (T). Lifetime
 // parameters must precede type parameters by convention, but this parser
 // accepts them in any order and sorts them out by token kind.
-func (p *Parser) maybeLifetimeAndTypeParams() ([]*ast.LifetimeAnn, []*ast.TypeParam) {
-	var lifetimeParams []*ast.LifetimeAnn
+func (p *Parser) maybeLifetimeAndTypeParams() ([]*ast.LifetimeParam, []*ast.TypeParam) {
+	var lifetimeParams []*ast.LifetimeParam
 	var typeParams []*ast.TypeParam
 	token := p.lexer.peek()
 	if token.Type != LessThan {
@@ -111,8 +111,7 @@ func (p *Parser) maybeLifetimeAndTypeParams() ([]*ast.LifetimeAnn, []*ast.TypePa
 			break
 		}
 		if token.Type == Lifetime {
-			p.lexer.consume()
-			lifetimeParams = append(lifetimeParams, ast.NewLifetimeAnn(token.Value, token.Span))
+			lifetimeParams = append(lifetimeParams, p.lifetimeParam(token))
 		} else {
 			tp := p.typeParam()
 			if tp == nil {
@@ -129,6 +128,56 @@ func (p *Parser) maybeLifetimeAndTypeParams() ([]*ast.LifetimeAnn, []*ast.TypePa
 	}
 	p.expect(GreaterThan, AlwaysConsume)
 	return lifetimeParams, typeParams
+}
+
+// lifetimeParam parses one lifetime binder in a <…> list. A binder is a bare
+// `'a`, a single-bound `'b: 'a`, or a multi-bound `'a: 'b & 'c`. The bound's
+// right-hand side holds only lifetimes, so each `&`-separated entry reads a
+// `'lifetime` and a non-lifetime there is an error. `nameTok` is the
+// already-peeked lifetime name token, still on the lexer. This consumes it.
+// Mirrors typeParam's `: Constraint` parse, but `:` here means outliving
+// rather than subtyping.
+func (p *Parser) lifetimeParam(nameTok *Token) *ast.LifetimeParam {
+	p.lexer.consume() // consume the lifetime name
+	// `'static` is the bottom of the outlives lattice, not a bindable
+	// parameter name, so it cannot be introduced on the left of a binder.
+	if nameTok.Value == "static" {
+		p.reportError(nameTok.Span,
+			"'static is not a bindable lifetime parameter name")
+	}
+	start := nameTok.Span.Start
+	end := nameTok.Span.End
+
+	var bounds []*ast.LifetimeAnn
+	if p.lexer.peek().Type == Colon {
+		p.lexer.consume() // consume ':'
+		for {
+			bt := p.lexer.peek()
+			if bt.Type != Lifetime {
+				p.reportError(bt.Span, "expected a lifetime in a lifetime bound")
+				// Consume a stray non-delimiter so the enclosing <…> parse
+				// still recovers to the next ',' or '>'. A delimiter is left
+				// in place so that loop can close the list cleanly.
+				// nolint: exhaustive
+				switch bt.Type {
+				case GreaterThan, Comma, CloseParen, EndOfFile:
+				default:
+					p.lexer.consume()
+				}
+				break
+			}
+			p.lexer.consume()
+			bounds = append(bounds, ast.NewLifetimeAnn(bt.Value, bt.Span))
+			end = bt.Span.End
+			if p.lexer.peek().Type != Ampersand {
+				break
+			}
+			p.lexer.consume() // consume '&' separating several bounds
+		}
+	}
+
+	span := ast.NewSpan(start, end, p.lexer.source.ID)
+	return ast.NewLifetimeParam(nameTok.Value, bounds, span)
 }
 
 // Decl = decorator* 'export'? 'override'? 'declare'? 'async'? (varDecl | fnDecl | ...)

--- a/internal/parser/lifetime_test.go
+++ b/internal/parser/lifetime_test.go
@@ -53,6 +53,18 @@ func TestParseLifetimeAnnotations(t *testing.T) {
 		"FnReturnLifetimeUnion": {
 			input: `fn pick<'a, 'b>(a: 'a Point, b: 'b Point, cond: boolean) -> ('a | 'b) Point { return a }`,
 		},
+		"FnLifetimeParamSingleBound": {
+			input: `fn pick<'a, 'b: 'a>(a: mut 'a Point, b: mut 'b Point) -> mut 'b Point { return b }`,
+		},
+		"FnLifetimeParamMultiBound": {
+			input: `fn pick<'a: 'b & 'c, 'b, 'c>(a: mut 'a Point) -> mut 'a Point { return a }`,
+		},
+		"FnLifetimeParamStaticBound": {
+			input: `fn keep<'a: 'static>(p: mut 'a Point) -> mut 'a Point { return p }`,
+		},
+		"FnTypeAnnLifetimeParamBound": {
+			input: `val f: fn<'a, 'b: 'a>(a: 'a Point, b: 'b Point) -> 'b Point = pick`,
+		},
 		"FnImmutableLifetimeOnRef": {
 			input: `fn ref<'a>(p: 'a Point) -> 'a Point { return p }`,
 		},
@@ -155,6 +167,51 @@ func TestParseLifetimeInUnsupportedContextErrors(t *testing.T) {
 			if assert.Len(t, errors, 1,
 				"expected exactly one parse error for lifetime in unsupported context: %#v", errors) {
 				assert.Equal(t, expected, errors[0].Message)
+			}
+		})
+	}
+}
+
+// TestParseLifetimeBoundErrors verifies the disambiguations the bound syntax
+// settles: 'static cannot bind on the left of a binder, and a bound's right-
+// hand side accepts only lifetimes, so a non-lifetime after ':' or '&' is
+// rejected. Each input recovers to exactly one diagnostic.
+func TestParseLifetimeBoundErrors(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		message string
+	}{
+		"StaticOnLeftOfBinder": {
+			input:   `fn f<'static>(p: Point) -> Point { return p }`,
+			message: "'static is not a bindable lifetime parameter name",
+		},
+		"NonLifetimeAfterColon": {
+			input:   `fn f<'a: T>(p: 'a Point) -> 'a Point { return p }`,
+			message: "expected a lifetime in a lifetime bound",
+		},
+		"NonLifetimeAfterAmpersand": {
+			input:   `fn f<'a: 'b & T>(p: 'a Point) -> 'a Point { return p }`,
+			message: "expected a lifetime in a lifetime bound",
+		},
+		"MissingLifetimeAfterColon": {
+			input:   `fn f<'a:>(p: 'a Point) -> 'a Point { return p }`,
+			message: "expected a lifetime in a lifetime bound",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			source := &ast.Source{ID: 0, Path: "input.esc", Contents: test.input}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			parser := NewParser(ctx, source)
+			_, errors := parser.ParseScript()
+
+			if assert.Len(t, errors, 1,
+				"expected exactly one parse error: %#v", errors) {
+				assert.Equal(t, test.message, errors[0].Message)
 			}
 		})
 	}

--- a/internal/parser/lifetime_test.go
+++ b/internal/parser/lifetime_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/snapshot"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLexLifetimeTokens snapshots the token stream for inputs that
@@ -209,10 +210,9 @@ func TestParseLifetimeBoundErrors(t *testing.T) {
 			parser := NewParser(ctx, source)
 			_, errors := parser.ParseScript()
 
-			if assert.Len(t, errors, 1,
-				"expected exactly one parse error: %#v", errors) {
-				assert.Equal(t, test.message, errors[0].Message)
-			}
+			require.Len(t, errors, 1,
+				"expected exactly one parse error: %#v", errors)
+			require.Equal(t, test.message, errors[0].Message)
 		})
 	}
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -231,9 +231,7 @@ func (p *Printer) printClassDecl(decl *ast.ClassDecl) {
 	p.writeString("class ")
 	p.writeString(decl.Name.Name)
 
-	if len(decl.TypeParams) > 0 {
-		p.printTypeParams(decl.TypeParams)
-	}
+	p.printGenericParams(decl.LifetimeParams, decl.TypeParams)
 
 	if decl.Extends != nil {
 		p.writeString(" extends ")
@@ -398,9 +396,7 @@ func (p *Printer) printClassElem(elem ast.ClassElem) {
 // to printFuncSig but injects the receiver as the first parameter
 // inside the parentheses so the round-trip preserves it.
 func (p *Printer) printMethodSig(sig *ast.FuncSig, recv *ast.MethodReceiver) {
-	if len(sig.TypeParams) > 0 {
-		p.printTypeParams(sig.TypeParams)
-	}
+	p.printGenericParams(sig.LifetimeParams, sig.TypeParams)
 	p.writeString("(")
 	first := true
 	params := sig.Params
@@ -556,9 +552,7 @@ func (p *Printer) printInterfaceDecl(decl *ast.InterfaceDecl) {
 	p.writeString("interface ")
 	p.writeString(decl.Name.Name)
 
-	if len(decl.TypeParams) > 0 {
-		p.printTypeParams(decl.TypeParams)
-	}
+	p.printGenericParams(decl.LifetimeParams, decl.TypeParams)
 
 	p.space()
 	p.printTypeAnn(decl.TypeAnn)
@@ -1020,9 +1014,7 @@ func (p *Printer) printFuncExpr(expr *ast.FuncExpr) {
 }
 
 func (p *Printer) printFuncSig(sig *ast.FuncSig) {
-	if len(sig.TypeParams) > 0 {
-		p.printTypeParams(sig.TypeParams)
-	}
+	p.printGenericParams(sig.LifetimeParams, sig.TypeParams)
 
 	p.writeString("(")
 	for i, param := range sig.Params {
@@ -1319,9 +1311,7 @@ func (p *Printer) printObjTypeAnnElem(elem ast.ObjTypeAnnElem) {
 		p.printFuncTypeAnn(e.Fn)
 	case *ast.MethodTypeAnn:
 		p.printObjKey(e.Name)
-		if len(e.Fn.TypeParams) > 0 {
-			p.printTypeParams(e.Fn.TypeParams)
-		}
+		p.printGenericParams(e.Fn.LifetimeParams, e.Fn.TypeParams)
 		p.writeString("(")
 		for i, param := range e.Fn.Params {
 			p.printPattern(param.Pattern)
@@ -1541,11 +1531,9 @@ func (p *Printer) printLifetimeAnn(lt ast.LifetimeAnnNode) {
 }
 
 func (p *Printer) printFuncTypeAnn(typ *ast.FuncTypeAnn) {
-	if len(typ.TypeParams) > 0 {
-		p.printTypeParams(typ.TypeParams)
-	}
-
-	p.writeString("fn (")
+	p.writeString("fn")
+	p.printGenericParams(typ.LifetimeParams, typ.TypeParams)
+	p.writeString(" (")
 	for i, param := range typ.Params {
 		p.printPattern(param.Pattern)
 		if param.Optional {
@@ -1655,6 +1643,51 @@ func (p *Printer) printTypeParams(params []*ast.TypeParam) {
 			p.printTypeAnn(param.Default)
 		}
 		if i < len(params)-1 {
+			p.writeString(", ")
+		}
+	}
+	p.writeString(">")
+}
+
+// printGenericParams renders the combined lifetime and type quantifier list
+// `<'a, 'b: 'a, T>`, lifetime binders first then type binders. It writes
+// nothing when both lists are empty. A lifetime binder's outlives bounds are
+// joined with ` & `, so 'a bounded by 'b and 'c renders as `'a: 'b & 'c`.
+func (p *Printer) printGenericParams(lifetimeParams []*ast.LifetimeParam, typeParams []*ast.TypeParam) {
+	if len(lifetimeParams) == 0 {
+		if len(typeParams) > 0 {
+			p.printTypeParams(typeParams)
+		}
+		return
+	}
+	p.writeString("<")
+	for i, lp := range lifetimeParams {
+		p.writeString("'")
+		p.writeString(lp.Name)
+		for j, bound := range lp.Bounds {
+			if j == 0 {
+				p.writeString(": ")
+			} else {
+				p.writeString(" & ")
+			}
+			p.writeString("'")
+			p.writeString(bound.Name)
+		}
+		if i < len(lifetimeParams)-1 || len(typeParams) > 0 {
+			p.writeString(", ")
+		}
+	}
+	for i, tp := range typeParams {
+		p.writeString(tp.Name)
+		if tp.Constraint != nil {
+			p.writeString(": ")
+			p.printTypeAnn(tp.Constraint)
+		}
+		if tp.Default != nil {
+			p.writeString(" = ")
+			p.printTypeAnn(tp.Default)
+		}
+		if i < len(typeParams)-1 {
 			p.writeString(", ")
 		}
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -819,35 +819,65 @@ func TestPrintBorrowTypeAnnotations(t *testing.T) {
 // 'a: 'b & 'c, and the 'static bound RHS are all preserved. The clause sits
 // after the declaration keyword and name, lifetime binders before type binders.
 //
-// The assertions target the printed generic clause. They don't cover lifetime
-// prefixes in type positions like `'a Point`, which the printer drops
-// independently of the quantifier list.
+// Each case asserts the full printed declaration equals `expected`, then re-
+// parses that output and prints it again to confirm the printer reaches a
+// stable fixed point. Parameter and field types stay plain, since the printer
+// drops lifetime prefixes in type positions like `'a Point` for reasons
+// unrelated to the quantifier list.
 func TestPrintLifetimeParams(t *testing.T) {
 	tests := []struct {
-		name string
-		// input parses to one declaration.
-		input string
-		// clause is the exact substring the printed declaration must contain,
-		// i.e. the rendered quantifier list.
-		clause string
+		name     string
+		input    string
+		expected string
 	}{
-		{"fn single lifetime param", `declare fn ref<'a>(p: 'a Point) -> 'a Point`, `ref<'a>(`},
-		{"fn single bound", `declare fn pick<'a, 'b: 'a>(a: 'a Point) -> 'a Point`, `pick<'a, 'b: 'a>(`},
-		{"fn multiple bounds", `declare fn narrow<'a: 'b & 'c, 'b, 'c>(a: 'a Point) -> 'a Point`, `narrow<'a: 'b & 'c, 'b, 'c>(`},
-		{"fn static bound", `declare fn keep<'a: 'static>(p: 'a Point) -> 'a Point`, `keep<'a: 'static>(`},
-		{"fn lifetime before type param", `declare fn id<'a, T>(p: 'a T) -> 'a T`, `id<'a, T>(`},
-		{"interface lifetime param", `interface Holder<'a> { p: 'a Point }`, `Holder<'a> {`},
-		{"class lifetime param", `class Container<'a> { p: 'a Point }`, `Container<'a> {`},
-		{"fn type annotation bound", `declare val f: fn<'a, 'b: 'a>(a: 'a Point) -> 'a Point`, `fn<'a, 'b: 'a> (`},
+		{
+			"fn single bound",
+			`fn pick<'a, 'b: 'a>(x: Point) -> Point { return x }`,
+			"fn pick<'a, 'b: 'a>(x: Point) -> Point {\n    return x\n}",
+		},
+		{
+			"fn multiple bounds",
+			`fn narrow<'a: 'b & 'c, 'b, 'c>(x: Point) -> Point { return x }`,
+			"fn narrow<'a: 'b & 'c, 'b, 'c>(x: Point) -> Point {\n    return x\n}",
+		},
+		{
+			"fn static bound",
+			`fn keep<'a: 'static>(x: Point) -> Point { return x }`,
+			"fn keep<'a: 'static>(x: Point) -> Point {\n    return x\n}",
+		},
+		{
+			"fn lifetime before type param",
+			`fn id<'a, T>(x: T) -> T { return x }`,
+			"fn id<'a, T>(x: T) -> T {\n    return x\n}",
+		},
+		{
+			"interface lifetime param",
+			`interface Holder<'a> { p: Point }`,
+			"interface Holder<'a> {\n    p: Point\n}",
+		},
+		{
+			"class lifetime param",
+			`class Container<'a> { p: Point }`,
+			"class Container<'a> {\n    p: Point\n}",
+		},
+		{
+			"fn type annotation bound",
+			`val f: fn<'a, 'b: 'a>(a: Point, b: Point) -> Point = pick`,
+			"val f: fn<'a, 'b: 'a> (a: Point, b: Point) -> Point = pick",
+		},
 	}
 
 	opts := DefaultOptions()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			decl := parseDecl(t, tt.input)
-			result, err := Print(decl, opts)
+			result, err := Print(parseDecl(t, tt.input), opts)
 			require.NoError(t, err)
-			require.Contains(t, result, tt.clause)
+			require.Equal(t, tt.expected, result)
+
+			// Re-parse and re-print; a faithful printer reproduces its output.
+			roundTripped, err := Print(parseDecl(t, result), opts)
+			require.NoError(t, err)
+			require.Equal(t, result, roundTripped)
 		})
 	}
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -813,6 +813,45 @@ func TestPrintBorrowTypeAnnotations(t *testing.T) {
 	}
 }
 
+// TestPrintLifetimeParams verifies that a lifetime quantifier list, including
+// outlives bounds written with ':' and multiple bounds joined with '&', round-
+// trips through the printer. A bare 'a, a single-bound 'b: 'a, a multi-bound
+// 'a: 'b & 'c, and the 'static bound RHS are all preserved. The clause sits
+// after the declaration keyword and name, lifetime binders before type binders.
+//
+// The assertions target the printed generic clause. They don't cover lifetime
+// prefixes in type positions like `'a Point`, which the printer drops
+// independently of the quantifier list.
+func TestPrintLifetimeParams(t *testing.T) {
+	tests := []struct {
+		name string
+		// input parses to one declaration.
+		input string
+		// clause is the exact substring the printed declaration must contain,
+		// i.e. the rendered quantifier list.
+		clause string
+	}{
+		{"fn single lifetime param", `declare fn ref<'a>(p: 'a Point) -> 'a Point`, `ref<'a>(`},
+		{"fn single bound", `declare fn pick<'a, 'b: 'a>(a: 'a Point) -> 'a Point`, `pick<'a, 'b: 'a>(`},
+		{"fn multiple bounds", `declare fn narrow<'a: 'b & 'c, 'b, 'c>(a: 'a Point) -> 'a Point`, `narrow<'a: 'b & 'c, 'b, 'c>(`},
+		{"fn static bound", `declare fn keep<'a: 'static>(p: 'a Point) -> 'a Point`, `keep<'a: 'static>(`},
+		{"fn lifetime before type param", `declare fn id<'a, T>(p: 'a T) -> 'a T`, `id<'a, T>(`},
+		{"interface lifetime param", `interface Holder<'a> { p: 'a Point }`, `Holder<'a> {`},
+		{"class lifetime param", `class Container<'a> { p: 'a Point }`, `Container<'a> {`},
+		{"fn type annotation bound", `declare val f: fn<'a, 'b: 'a>(a: 'a Point) -> 'a Point`, `fn<'a, 'b: 'a> (`},
+	}
+
+	opts := DefaultOptions()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decl := parseDecl(t, tt.input)
+			result, err := Print(decl, opts)
+			require.NoError(t, err)
+			require.Contains(t, result, tt.clause)
+		})
+	}
+}
+
 func TestPrintScript(t *testing.T) {
 	input := `val x = 5
 val y = 10


### PR DESCRIPTION
Introduce support for lifetime parameter bounds in the parser, AST, and printer. Lifetime parameters can now declare outlives constraints using the syntax `'a: 'b` (single bound) or `'a: 'b & 'c` (multiple bounds), mirroring the constraint syntax for type parameters.

**Key changes:**

- Add `LifetimeParam` AST node to represent a lifetime binder with optional bounds, distinct from `LifetimeAnn` which represents a lifetime reference. `LifetimeParam` holds a name, a list of `LifetimeAnn` bounds, and a span.
- Update all AST nodes that carry lifetime parameters (`FuncDecl`, `FuncSig`, `FuncTypeAnn`, `ClassDecl`, `InterfaceDecl`) to use `[]*LifetimeParam` instead of `[]*LifetimeAnn`.
- Implement `lifetimeParam()` parser to handle the bound syntax. Bounds are parsed after a `:` token and separated by `&`. The parser rejects `'static` on the left side of a binder and requires only lifetimes (not types) in the bound list.
- Add `printGenericParams()` printer function to render combined lifetime and type quantifier lists. Lifetime binders precede type binders; multiple bounds are joined with ` & `.
- Update checker and printer call sites to use the new `LifetimeParam` type.
- Add test cases for single-bound, multi-bound, and `'static`-bound lifetime parameters in function declarations and type annotations.
- Add error recovery tests for invalid bound syntax (`'static` as a binder name, non-lifetime tokens in bounds).

The `:` in a lifetime bound means outliving (the lattice meet), distinct from the subtyping `:` in type parameter constraints. A binder is either a lifetime or a type, never both, so the two relations never mix on a single binder.

https://claude.ai/code/session_01Qrb3sMYYh8yNkAzwdUUiK4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lifetime parameters in generic declarations and function signatures, including lifetime bounds and multiple bounds joined with `&`.
  * Updated formatting so lifetime parameters print consistently alongside type parameters across declarations, methods, and function types.

* **Bug Fixes**
  * Improved parsing and error reporting for invalid lifetime parameter syntax, including reserved names and missing or invalid bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->