### PR TITLE
Add lifetime bounds graph analysis for constraint solving

### DIFF
--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -9,6 +9,11 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
+// outlivesRelation is a single "'from outlives 'to" assertion in raw lifetime-ID
+// space, the coordinate system implies and subsumes both speak. from and to are raw
+// IDs, not representatives; implies maps them into a set's own representative space.
+type outlivesRelation struct{ from, to int }
+
 // ltBoundSet is a directed outlives graph over lifetime-variable IDs, condensed over
 // outlives-equivalent lifetimes and then transitively reduced. An edge a -> b reads
 // "'a outlives 'b", written 'a: 'b. That is the direction constrainLt records as a in
@@ -21,7 +26,7 @@ import (
 type ltBoundSet struct {
 	edges      map[int]set.Set[int]         // rep -> reps it outlives, condensed then reduced
 	rep        map[int]int                  // lifetime ID -> its SCC representative ID
-	components map[int][]int                // rep -> member IDs, only for multi-member SCCs
+	equalities []outlivesRelation           // both directions of each mutual-outlives equality a component condensed away
 	vars       map[int]*soltype.LifetimeVar // representative ID -> a member var, for rendering
 	static     set.Set[int]                 // representative IDs forced to 'static, the absorbing bottom
 }
@@ -128,24 +133,28 @@ func buildLtBoundSet(occ map[*soltype.LifetimeVar]occPolarity) *ltBoundSet {
 		}
 	}
 
-	// Record each multi-member component's members under its representative. A
-	// multi-member SCC is a set of mutually-outliving, hence equal, lifetimes whose
-	// intra-component edges the condensation dropped. components is where those
-	// equalities are kept so subsumes can recover them. A singleton SCC asserts no
-	// equality, so it is omitted.
+	// Recover the mutual-outlives equalities the condensation dropped. A multi-member
+	// SCC is a set of lifetimes that outlive each other, hence are equal; its
+	// intra-component edges were collapsed, so record both directions of each member
+	// against its representative. subsumes replays these. reduce never touches rep, so
+	// these pairs stay valid after it runs. A singleton SCC asserts no equality.
 	grouped := map[int][]int{}
 	for id, r := range rep {
 		grouped[r] = append(grouped[r], id)
 	}
-	components := map[int][]int{}
-	for r, members := range grouped {
-		if len(members) > 1 {
-			slices.Sort(members)
-			components[r] = members
+	var equalities []outlivesRelation
+	for _, r := range slices.Sorted(maps.Keys(grouped)) {
+		members := grouped[r]
+		slices.Sort(members)
+		for _, m := range members {
+			if m == r {
+				continue
+			}
+			equalities = append(equalities, outlivesRelation{m, r}, outlivesRelation{r, m})
 		}
 	}
 
-	return &ltBoundSet{edges: edges, rep: rep, components: components, vars: repVars, static: static}
+	return &ltBoundSet{edges: edges, rep: rep, equalities: equalities, vars: repVars, static: static}
 }
 
 // condenseSCCs finds the strongly connected components of the directed graph given by
@@ -314,36 +323,23 @@ func (s *ltBoundSet) implies(a, b int) bool {
 	return s.reaches(ra, rb)
 }
 
-// outlivesRelation is a single "'from outlives 'to" assertion in raw lifetime-ID
-// space, the coordinate system implies and subsumes both speak. from and to are raw
-// IDs, not representatives; implies maps them into a set's own representative space.
-type outlivesRelation struct{ from, to int }
-
 // assertedOutlives returns every outlives relation this set asserts, as raw-ID pairs.
 // Two kinds contribute:
 //
 //   - each kept edge, keyed by representative;
 //   - both directions of every mutual-outlives equality a multi-member component
-//     condensed away, recovered from components.
+//     condensed away, precomputed into equalities.
 //
 // 'static forcings are not returned, since a forcing is not a pairwise outlives
 // relation; subsumes checks those against static directly.
 func (s *ltBoundSet) assertedOutlives() []outlivesRelation {
-	var rels []outlivesRelation
+	rels := make([]outlivesRelation, 0, len(s.equalities))
 	for from, tos := range s.edges {
 		for to := range tos {
 			rels = append(rels, outlivesRelation{from, to})
 		}
 	}
-	for rep, members := range s.components {
-		for _, m := range members {
-			if m == rep {
-				continue
-			}
-			rels = append(rels, outlivesRelation{m, rep}, outlivesRelation{rep, m})
-		}
-	}
-	return rels
+	return append(rels, s.equalities...)
 }
 
 // subsumes reports whether this set proves every relation the other set asserts, so

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"maps"
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -73,11 +75,7 @@ func buildLtBoundSet(occ map[*soltype.LifetimeVar]occPolarity) *ltBoundSet {
 		visit(v)
 	}
 
-	ids := make([]int, 0, len(vars))
-	for id := range vars {
-		ids = append(ids, id)
-	}
-	rep := condenseSCCs(ids, rawEdges)
+	rep := condenseSCCs(slices.Sorted(maps.Keys(vars)), rawEdges)
 
 	edges := map[int]set.Set[int]{}
 	for from, tos := range rawEdges {

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -19,10 +19,11 @@ import (
 // representative. Every edge, query, and rendering is keyed by representative ID, not
 // raw lifetime ID.
 type ltBoundSet struct {
-	edges  map[int]set.Set[int]         // rep -> reps it outlives, condensed then reduced
-	rep    map[int]int                  // lifetime ID -> its SCC representative ID
-	vars   map[int]*soltype.LifetimeVar // representative ID -> a member var, for rendering
-	static set.Set[int]                 // representative IDs forced to 'static, the absorbing bottom
+	edges      map[int]set.Set[int]         // rep -> reps it outlives, condensed then reduced
+	rep        map[int]int                  // lifetime ID -> its SCC representative ID
+	components map[int][]int                // rep -> member IDs, only for multi-member SCCs
+	vars       map[int]*soltype.LifetimeVar // representative ID -> a member var, for rendering
+	static     set.Set[int]                 // representative IDs forced to 'static, the absorbing bottom
 }
 
 // buildLtBoundSet walks the occurring lifetime variables' bound lists directionally
@@ -127,7 +128,24 @@ func buildLtBoundSet(occ map[*soltype.LifetimeVar]occPolarity) *ltBoundSet {
 		}
 	}
 
-	return &ltBoundSet{edges: edges, rep: rep, vars: repVars, static: static}
+	// Record each multi-member component's members under its representative. A
+	// multi-member SCC is a set of mutually-outliving, hence equal, lifetimes whose
+	// intra-component edges the condensation dropped. components is where those
+	// equalities are kept so subsumes can recover them. A singleton SCC asserts no
+	// equality, so it is omitted.
+	grouped := map[int][]int{}
+	for id, r := range rep {
+		grouped[r] = append(grouped[r], id)
+	}
+	components := map[int][]int{}
+	for r, members := range grouped {
+		if len(members) > 1 {
+			slices.Sort(members)
+			components[r] = members
+		}
+	}
+
+	return &ltBoundSet{edges: edges, rep: rep, components: components, vars: repVars, static: static}
 }
 
 // condenseSCCs finds the strongly connected components of the directed graph given by
@@ -296,37 +314,51 @@ func (s *ltBoundSet) implies(a, b int) bool {
 	return s.reaches(ra, rb)
 }
 
-// subsumes reports whether this set proves every outlives relation the other set
-// asserts, so "the inferred bound set satisfies the declared one" is
-// inferred.subsumes(declared). Three kinds of relation must each hold here via implies:
+// outlivesRelation is a single "'from outlives 'to" assertion in raw lifetime-ID
+// space, the coordinate system implies and subsumes both speak. from and to are raw
+// IDs, not representatives; implies maps them into a set's own representative space.
+type outlivesRelation struct{ from, to int }
+
+// assertedOutlives returns every outlives relation this set asserts, as raw-ID pairs.
+// Two kinds contribute:
 //
-//   - every outlives edge other keeps;
-//   - every mutual-outlives equality other condensed into a component;
-//   - every 'static forcing other records.
+//   - each kept edge, keyed by representative;
+//   - both directions of every mutual-outlives equality a multi-member component
+//     condensed away, recovered from components.
 //
-// The equalities and 'static forcings are checked explicitly because neither survives
-// as an edge in other.edges.
-func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
-	for from, tos := range other.edges {
+// 'static forcings are not returned, since a forcing is not a pairwise outlives
+// relation; subsumes checks those against static directly.
+func (s *ltBoundSet) assertedOutlives() []outlivesRelation {
+	var rels []outlivesRelation
+	for from, tos := range s.edges {
 		for to := range tos {
-			if !s.implies(from, to) {
-				return false
-			}
+			rels = append(rels, outlivesRelation{from, to})
 		}
 	}
-	// A component with more than one member records the mutual outlives that collapsed
-	// it. other.edges dropped those, so recover them from other.rep and require both
-	// directions here.
-	for id, rep := range other.rep {
-		if id == rep {
-			continue
+	for rep, members := range s.components {
+		for _, m := range members {
+			if m == rep {
+				continue
+			}
+			rels = append(rels, outlivesRelation{m, rep}, outlivesRelation{rep, m})
 		}
-		if !s.implies(id, rep) || !s.implies(rep, id) {
+	}
+	return rels
+}
+
+// subsumes reports whether this set proves every relation the other set asserts, so
+// "the inferred bound set satisfies the declared one" is inferred.subsumes(declared).
+// other.assertedOutlives enumerates the outlives relations — kept edges plus the
+// mutual-outlives equalities its components condensed away — and each must hold here
+// via implies. A 'static forcing is the one kind that is not a pairwise outlives
+// relation, so it is checked separately: this set must force to 'static every lifetime
+// other does.
+func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
+	for _, r := range other.assertedOutlives() {
+		if !s.implies(r.from, r.to) {
 			return false
 		}
 	}
-	// A 'static forcing declares that the node outlives everything, so this set must
-	// force it to 'static too.
 	for id := range other.static {
 		if !s.static.Contains(s.repOf(id)) {
 			return false

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -299,9 +299,13 @@ func (s *ltBoundSet) implies(a, b int) bool {
 // subsumes reports whether this set proves every outlives relation the other set
 // asserts, so "the inferred bound set satisfies the declared one" is
 // inferred.subsumes(declared). Three kinds of relation must each hold here via implies:
-// every outlives edge other keeps, every mutual-outlives equality other condensed into
-// a component, and every 'static forcing other records. The equalities and 'static
-// forcings are checked explicitly because neither survives as an edge in other.edges.
+//
+//   - every outlives edge other keeps;
+//   - every mutual-outlives equality other condensed into a component;
+//   - every 'static forcing other records.
+//
+// The equalities and 'static forcings are checked explicitly because neither survives
+// as an edge in other.edges.
 func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
 	for from, tos := range other.edges {
 		for to := range tos {

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -1,0 +1,353 @@
+package solver
+
+import (
+	"sort"
+
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// ltBoundSet is a directed outlives graph over lifetime-variable IDs, condensed over
+// outlives-equivalent lifetimes and then transitively reduced. An edge a -> b reads
+// "'a outlives 'b", written 'a: 'b. That is the direction constrainLt records as a in
+// b.LowerBounds and b in a.UpperBounds.
+//
+// A mutual constraint 'a: 'b together with 'b: 'a makes the two lifetimes outlive each
+// other, so they are equal. Such a cycle collapses into one strongly-connected-component
+// representative. Every edge, query, and rendering is keyed by representative ID, not
+// raw lifetime ID.
+type ltBoundSet struct {
+	edges  map[int]set.Set[int]         // rep -> reps it outlives, condensed then reduced
+	rep    map[int]int                  // lifetime ID -> its SCC representative ID
+	vars   map[int]*soltype.LifetimeVar // representative ID -> a member var, for rendering
+	static set.Set[int]                 // representative IDs forced to 'static, the absorbing bottom
+}
+
+// buildLtBoundSet walks the occurring lifetime variables' bound lists directionally
+// and returns the condensed outlives graph over them. It records an edge per real
+// outlives relation rather than the symmetric merge newLtAnalysis's union-find does,
+// then condenses each strongly connected component to one representative so the result
+// is a DAG that reduce can act on.
+//
+// The occurrence map's keys seed the walk. The polarity values are unused here, since
+// the outlives edges live entirely in the bound lists. The result is not yet reduced;
+// call reduce for the transitively-reduced canonical form.
+func buildLtBoundSet(occ map[*soltype.LifetimeVar]occPolarity) *ltBoundSet {
+	vars := map[int]*soltype.LifetimeVar{}
+	rawEdges := map[int]set.Set[int]{}
+
+	addEdge := func(from, to int) {
+		s, ok := rawEdges[from]
+		if !ok {
+			s = set.NewSet[int]()
+			rawEdges[from] = s
+		}
+		s.Add(to)
+	}
+
+	var visit func(v *soltype.LifetimeVar)
+	visit = func(v *soltype.LifetimeVar) {
+		if _, seen := vars[v.ID]; seen {
+			return
+		}
+		vars[v.ID] = v
+		// v outlives each of its upper bounds, so record an edge v -> ub. Each of v's
+		// lower bounds outlives v, so record lb -> v. constrainLt writes both directions
+		// of a var-to-var relation, so reading either list alone would suffice for the
+		// edges. Walking both is what discovers a variable reachable only through a
+		// lower-bound link.
+		for _, b := range v.UpperBounds {
+			if bv, ok := b.(*soltype.LifetimeVar); ok {
+				addEdge(v.ID, bv.ID)
+				visit(bv)
+			}
+		}
+		for _, b := range v.LowerBounds {
+			if bv, ok := b.(*soltype.LifetimeVar); ok {
+				addEdge(bv.ID, v.ID)
+				visit(bv)
+			}
+		}
+	}
+	for v := range occ {
+		visit(v)
+	}
+
+	ids := make([]int, 0, len(vars))
+	for id := range vars {
+		ids = append(ids, id)
+	}
+	rep := condenseSCCs(ids, rawEdges)
+
+	edges := map[int]set.Set[int]{}
+	for from, tos := range rawEdges {
+		rf := rep[from]
+		for to := range tos {
+			rt := rep[to]
+			if rf == rt {
+				continue // an intra-component edge is collapsed away
+			}
+			s, ok := edges[rf]
+			if !ok {
+				s = set.NewSet[int]()
+				edges[rf] = s
+			}
+			s.Add(rt)
+		}
+	}
+
+	// A variable is forced to 'static only by an UPPER-bound 'static, the escape
+	// constraint v <: 'static. A lower-bound 'static means 'static outlives v, which is
+	// trivially true and forces nothing, so forcedToStatic, which reads both directions,
+	// must not be used here.
+	static := set.NewSet[int]()
+	for id, v := range vars {
+		if soltype.ContainsLifetime(v.UpperBounds, soltype.Static) {
+			static.Add(rep[id])
+		}
+	}
+	// Propagate 'static backward along outlives edges. A lifetime that outlives a
+	// 'static-forced lifetime is itself 'static, since only 'static outlives 'static.
+	// This closure keeps the static set correct even when the caller has not already
+	// propagated the escape constraint through the graph.
+	work := static.ToSlice()
+	for len(work) > 0 {
+		cur := work[len(work)-1]
+		work = work[:len(work)-1]
+		for from, tos := range edges {
+			if !static.Contains(from) && tos.Contains(cur) {
+				static.Add(from)
+				work = append(work, from)
+			}
+		}
+	}
+
+	repVars := map[int]*soltype.LifetimeVar{}
+	for id, v := range vars {
+		if rep[id] == id {
+			repVars[id] = v
+		}
+	}
+
+	return &ltBoundSet{edges: edges, rep: rep, vars: repVars, static: static}
+}
+
+// condenseSCCs finds the strongly connected components of the directed graph given by
+// adjacency edges over the node IDs, and returns a map from every node ID to its
+// component representative, the smallest ID in the component. A cycle in the outlives
+// relation means mutually-outliving, hence equal, lifetimes, so folding each component
+// to one representative turns the raw graph into a DAG. Uses Tarjan's algorithm.
+func condenseSCCs(nodeIDs []int, edges map[int]set.Set[int]) map[int]int {
+	index := map[int]int{}
+	lowlink := map[int]int{}
+	onStack := set.NewSet[int]()
+	var stack []int
+	next := 0
+	rep := map[int]int{}
+
+	var strongconnect func(v int)
+	strongconnect = func(v int) {
+		index[v] = next
+		lowlink[v] = next
+		next++
+		stack = append(stack, v)
+		onStack.Add(v)
+
+		for w := range edges[v] {
+			if _, seen := index[w]; !seen {
+				strongconnect(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onStack.Contains(w) {
+				if index[w] < lowlink[v] {
+					lowlink[v] = index[w]
+				}
+			}
+		}
+
+		if lowlink[v] != index[v] {
+			return // v is not a component root, so its members stay on the stack
+		}
+		// v roots a component. Pop the stack down to v and key every member to the
+		// smallest ID among them, mirroring unionFind's smaller-id representative rule.
+		r := v
+		start := len(stack)
+		for {
+			start--
+			if stack[start] < r {
+				r = stack[start]
+			}
+			if stack[start] == v {
+				break
+			}
+		}
+		for _, w := range stack[start:] {
+			onStack.Remove(w)
+			rep[w] = r
+		}
+		stack = stack[:start]
+	}
+
+	// Seed the traversal in ascending ID order so a run is reproducible.
+	sorted := append([]int(nil), nodeIDs...)
+	sort.Ints(sorted)
+	for _, id := range sorted {
+		if _, seen := index[id]; !seen {
+			strongconnect(id)
+		}
+	}
+	return rep
+}
+
+// repOf maps a raw lifetime ID to its component representative, or to itself when the
+// ID is not in this set.
+func (s *ltBoundSet) repOf(id int) int {
+	if r, ok := s.rep[id]; ok {
+		return r
+	}
+	return id
+}
+
+// reduce transitively reduces the condensed graph in place, so 'a: 'b, 'b: 'c, 'a: 'c
+// keeps only 'a: 'b and 'b: 'c. An edge a -> c drops when a longer path a -> … -> c
+// already proves the same reachability. The reduction is well-defined only because
+// buildLtBoundSet condensed every cycle, leaving a DAG.
+//
+// Every edge incident to a 'static-forced node is dropped first. 'static is the
+// absorbing bottom of the outlives order. An edge into such a node is subsumed by the
+// node's own staticness, and an edge out of one is trivially true, so neither is a
+// bound worth rendering or comparing.
+func (s *ltBoundSet) reduce() {
+	for from, tos := range s.edges {
+		if s.static.Contains(from) {
+			delete(s.edges, from)
+			continue
+		}
+		for to := range tos {
+			if s.static.Contains(to) {
+				tos.Remove(to)
+			}
+		}
+		if tos.Len() == 0 {
+			delete(s.edges, from)
+		}
+	}
+
+	type edge struct{ from, to int }
+	var redundant []edge
+	for from, tos := range s.edges {
+		for to := range tos {
+			// from -> to is redundant when some other successor of from already reaches
+			// to. Reachability is read from the pre-reduction graph. On a DAG, dropping a
+			// shortcut edge never removes the longer path that made it redundant, so
+			// collecting first and deleting after is safe.
+			for mid := range tos {
+				if mid != to && s.reaches(mid, to) {
+					redundant = append(redundant, edge{from, to})
+					break
+				}
+			}
+		}
+	}
+	for _, e := range redundant {
+		s.edges[e.from].Remove(e.to)
+		if s.edges[e.from].Len() == 0 {
+			delete(s.edges, e.from)
+		}
+	}
+}
+
+// reaches reports whether to is reachable from from over the condensed edges.
+func (s *ltBoundSet) reaches(from, to int) bool {
+	if from == to {
+		return true
+	}
+	visited := set.NewSet[int]()
+	stack := []int{from}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if visited.Contains(n) {
+			continue
+		}
+		visited.Add(n)
+		for nbr := range s.edges[n] {
+			if nbr == to {
+				return true
+			}
+			stack = append(stack, nbr)
+		}
+	}
+	return false
+}
+
+// implies reports whether this set proves 'a: 'b, that a outlives b. Both IDs map to
+// their representatives first, so two outlives-equivalent lifetimes share a
+// representative and implies reports the cycle as equality in both directions. A
+// 'static-forced source outlives everything, so it implies every target. Otherwise the
+// answer is reachability from a's representative to b's.
+func (s *ltBoundSet) implies(a, b int) bool {
+	ra, rb := s.repOf(a), s.repOf(b)
+	if ra == rb {
+		return true
+	}
+	if s.static.Contains(ra) {
+		return true
+	}
+	return s.reaches(ra, rb)
+}
+
+// subsumes reports whether this set proves every outlives relation the other set
+// asserts, so "the inferred bound set satisfies the declared one" is
+// inferred.subsumes(declared). Three kinds of relation must each hold here via implies:
+// every outlives edge other keeps, every mutual-outlives equality other condensed into
+// a component, and every 'static forcing other records. The equalities and 'static
+// forcings are checked explicitly because neither survives as an edge in other.edges.
+func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
+	for from, tos := range other.edges {
+		for to := range tos {
+			if !s.implies(from, to) {
+				return false
+			}
+		}
+	}
+	// A component with more than one member records the mutual outlives that collapsed
+	// it. other.edges dropped those, so recover them from other.rep and require both
+	// directions here.
+	for id, rep := range other.rep {
+		if id == rep {
+			continue
+		}
+		if !s.implies(id, rep) || !s.implies(rep, id) {
+			return false
+		}
+	}
+	// A 'static forcing declares that the node outlives everything, so this set must
+	// force it to 'static too.
+	for id := range other.static {
+		if !s.static.Contains(s.repOf(id)) {
+			return false
+		}
+	}
+	return true
+}
+
+// canonicalEdges returns the condensed edges as (from, to) representative-ID pairs
+// sorted ascending, giving stable rendering and order-insensitive equality. This is the
+// lifetime-sort analogue of a canonical union member order.
+func (s *ltBoundSet) canonicalEdges() [][2]int {
+	var out [][2]int
+	for from, tos := range s.edges {
+		for to := range tos {
+			out = append(out, [2]int{from, to})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
+	return out
+}

--- a/internal/solver/lifetime_bounds_test.go
+++ b/internal/solver/lifetime_bounds_test.go
@@ -1,0 +1,225 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// ltVarsFromEdges builds one LifetimeVar per ID mentioned in edges or staticIDs and
+// records each edge (x, y) as "'x outlives 'y" the way constrainLt does: y joins
+// x.UpperBounds and x joins y.LowerBounds. Each ID in staticIDs gains 'static as an
+// upper bound, the escape constraint that forces it to 'static. It returns the
+// occurrence map buildLtBoundSet consumes; the polarity value is irrelevant to graph
+// construction, so every variable is recorded as occNeg.
+func ltVarsFromEdges(edges [][2]int, staticIDs ...int) map[*soltype.LifetimeVar]occPolarity {
+	vars := map[int]*soltype.LifetimeVar{}
+	get := func(id int) *soltype.LifetimeVar {
+		v, ok := vars[id]
+		if !ok {
+			v = &soltype.LifetimeVar{ID: id}
+			vars[id] = v
+		}
+		return v
+	}
+	for _, e := range edges {
+		x, y := get(e[0]), get(e[1])
+		x.UpperBounds = append(x.UpperBounds, y)
+		y.LowerBounds = append(y.LowerBounds, x)
+	}
+	for _, id := range staticIDs {
+		get(id).UpperBounds = append(get(id).UpperBounds, soltype.Static)
+	}
+	occ := map[*soltype.LifetimeVar]occPolarity{}
+	for _, v := range vars {
+		occ[v] = occNeg
+	}
+	return occ
+}
+
+// buildReduced builds a bound set from edges plus 'static-forced IDs and reduces it.
+func buildReduced(edges [][2]int, staticIDs ...int) *ltBoundSet {
+	s := buildLtBoundSet(ltVarsFromEdges(edges, staticIDs...))
+	s.reduce()
+	return s
+}
+
+// Transitive reduction and 'static edge removal both collapse the edge set to its
+// non-redundant, meaningful bounds.
+func TestLtBoundSetReduce(t *testing.T) {
+	tests := []struct {
+		name      string
+		edges     [][2]int
+		staticIDs []int
+		want      [][2]int
+	}{
+		{
+			// '1: '2, '2: '3, '1: '3 — the shortcut '1: '3 drops.
+			name:  "transitive shortcut drops",
+			edges: [][2]int{{1, 2}, {2, 3}, {1, 3}},
+			want:  [][2]int{{1, 2}, {2, 3}},
+		},
+		{
+			// A diamond keeps its four rim edges and drops only the '1: '4 shortcut.
+			name:  "diamond keeps rim, drops shortcut",
+			edges: [][2]int{{1, 2}, {1, 3}, {2, 4}, {3, 4}, {1, 4}},
+			want:  [][2]int{{1, 2}, {1, 3}, {2, 4}, {3, 4}},
+		},
+		{
+			// The multi-source join '1: '3, '2: '3 keeps '1 and '2 independent.
+			name:  "independent join sources stay unrelated",
+			edges: [][2]int{{1, 3}, {2, 3}},
+			want:  [][2]int{{1, 3}, {2, 3}},
+		},
+		{
+			// An edge into a 'static-forced node drops.
+			name:      "edge into static drops",
+			edges:     [][2]int{{1, 2}},
+			staticIDs: []int{2},
+			want:      nil,
+		},
+		{
+			// An edge out of a 'static-forced node is trivially true and drops.
+			name:      "edge out of static drops",
+			edges:     [][2]int{{1, 2}},
+			staticIDs: []int{1},
+			want:      nil,
+		},
+		{
+			// A mutual-outlives cycle condenses to one node, so no edge survives.
+			name:  "two-node cycle collapses",
+			edges: [][2]int{{1, 2}, {2, 1}},
+			want:  nil,
+		},
+		{
+			// A three-node cycle likewise folds to one node.
+			name:  "three-node cycle collapses",
+			edges: [][2]int{{1, 2}, {2, 3}, {3, 1}},
+			want:  nil,
+		},
+		{
+			// A cycle that also outlives an outside lifetime keeps the one condensed edge.
+			name:  "cycle with outgoing edge",
+			edges: [][2]int{{1, 2}, {2, 1}, {2, 3}},
+			want:  [][2]int{{1, 3}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, buildReduced(tt.edges, tt.staticIDs...).canonicalEdges())
+		})
+	}
+}
+
+// canonicalEdges sorts by (from, to), so the edge order is the same no matter the order
+// the bounds were recorded in.
+func TestLtBoundSetCanonicalEdgeOrderShuffleInvariant(t *testing.T) {
+	want := [][2]int{{1, 2}, {1, 4}, {2, 3}}
+	require.Equal(t, want, buildReduced([][2]int{{1, 2}, {2, 3}, {1, 4}}).canonicalEdges())
+	require.Equal(t, want, buildReduced([][2]int{{1, 4}, {2, 3}, {1, 2}}).canonicalEdges())
+}
+
+// A mutual-outlives cycle condenses to its smallest-ID representative, so both members
+// share one representative and implies reports the equality in both directions.
+func TestLtBoundSetMutualOutlivesIsEquality(t *testing.T) {
+	s := buildReduced([][2]int{{1, 2}, {2, 1}})
+
+	require.Equal(t, 1, s.repOf(1), "the smaller ID is the representative")
+	require.Equal(t, 1, s.repOf(2))
+	require.True(t, s.implies(1, 2), "equal lifetimes outlive each other")
+	require.True(t, s.implies(2, 1))
+}
+
+// A three-node cycle folds to one node and reduce terminates on it rather than looping
+// over the collapsed cycle. Every member inherits the component's outgoing relations.
+func TestLtBoundSetThreeNodeCycleReducesWithoutLooping(t *testing.T) {
+	s := buildLtBoundSet(ltVarsFromEdges([][2]int{{1, 2}, {2, 3}, {3, 1}, {3, 4}}))
+	require.NotPanics(t, func() { s.reduce() })
+
+	require.Equal(t, 1, s.repOf(1))
+	require.Equal(t, 1, s.repOf(2))
+	require.Equal(t, 1, s.repOf(3))
+	require.True(t, s.implies(2, 4), "'2 shares the cycle's component, so it outlives '4")
+}
+
+// implies answers reachability over the reduced graph, including reflexivity and the
+// transitive relation the reduction elided from the edge set.
+func TestLtBoundSetImpliesReachability(t *testing.T) {
+	s := buildReduced([][2]int{{1, 2}, {2, 3}})
+
+	require.True(t, s.implies(1, 2), "'1: '2 is a direct edge")
+	require.True(t, s.implies(2, 3), "'2: '3 is a direct edge")
+	require.True(t, s.implies(1, 3), "'1: '3 holds transitively though the edge was reduced away")
+	require.True(t, s.implies(1, 1), "outlives is reflexive")
+	require.False(t, s.implies(3, 1), "'3 does not outlive '1")
+	require.False(t, s.implies(2, 1), "'2 does not outlive '1")
+}
+
+// A 'static-forced lifetime outlives every other lifetime, so it implies every target
+// regardless of the edges.
+func TestLtBoundSetImpliesStaticAbsorbs(t *testing.T) {
+	s := buildReduced([][2]int{{2, 3}}, 1)
+
+	require.True(t, s.static.Contains(s.repOf(1)), "'1 is forced to 'static")
+	require.True(t, s.implies(1, 2), "'static outlives '2")
+	require.True(t, s.implies(1, 3), "'static outlives '3")
+	require.False(t, s.implies(2, 1), "'2 does not outlive the 'static lifetime")
+}
+
+// 'static forcing propagates backward: a lifetime that outlives a 'static-forced
+// lifetime is itself forced to 'static, since only 'static outlives 'static.
+func TestLtBoundSetStaticPropagatesBackward(t *testing.T) {
+	// '1: '2, '2: 'static forces '1 to 'static too.
+	s := buildReduced([][2]int{{1, 2}}, 2)
+
+	require.True(t, s.static.Contains(s.repOf(1)), "'1 outlives the 'static '2, so '1 is 'static")
+	require.True(t, s.implies(1, 3), "the now-'static '1 outlives an unrelated '3")
+}
+
+// A lower-bound 'static is 'static outliving the variable, which is trivially true and
+// forces nothing. The variable must not be treated as absorbing.
+func TestLtBoundSetLowerBoundStaticDoesNotForce(t *testing.T) {
+	v := &soltype.LifetimeVar{ID: 1, LowerBounds: []soltype.Lifetime{soltype.Static}}
+	other := &soltype.LifetimeVar{ID: 2}
+	s := buildLtBoundSet(map[*soltype.LifetimeVar]occPolarity{v: occNeg, other: occNeg})
+	s.reduce()
+
+	require.False(t, s.static.Contains(s.repOf(1)), "a lower-bound 'static is not an escape")
+	require.False(t, s.implies(1, 2), "'1 does not outlive an unrelated '2")
+}
+
+// subsumes requires this set to prove every relation the other set asserts: kept edges,
+// mutual-outlives equalities condensed away, and 'static forcings.
+func TestLtBoundSetSubsumes(t *testing.T) {
+	chain := buildReduced([][2]int{{1, 2}, {2, 3}})
+
+	require.True(t, chain.subsumes(buildReduced([][2]int{{1, 3}})),
+		"the chain proves the transitively-implied '1: '3")
+	require.False(t, buildReduced([][2]int{{1, 3}}).subsumes(chain),
+		"the lone edge proves neither '1: '2 nor '2: '3")
+	require.False(t, chain.subsumes(buildReduced([][2]int{{3, 1}})),
+		"the chain does not prove the reversed '3: '1")
+}
+
+// A declared mutual-outlives bound is not satisfied vacuously: the collapsed equality
+// must actually hold in the subsuming set, even though it survives as no edge.
+func TestLtBoundSetSubsumesChecksCondensedEqualities(t *testing.T) {
+	declaredEqual := buildReduced([][2]int{{1, 2}, {2, 1}}) // '1 and '2 must be equal
+
+	require.False(t, buildReduced([][2]int{{1, 2}}).subsumes(declaredEqual),
+		"proving only '1: '2 does not prove the required '2: '1")
+	require.True(t, declaredEqual.subsumes(declaredEqual),
+		"an equal-lifetime set proves its own equality")
+}
+
+// A declared 'static forcing is not satisfied vacuously: it survives as no edge, so a
+// set that does not force the same lifetime to 'static must fail to subsume it.
+func TestLtBoundSetSubsumesChecksStaticForcing(t *testing.T) {
+	declaredStatic := buildReduced(nil, 1)      // '1: 'static
+	notStatic := buildReduced([][2]int{{1, 2}}) // '1 relates to '2 but is not 'static
+
+	require.False(t, notStatic.subsumes(declaredStatic),
+		"a non-'static '1 does not satisfy a declared '1: 'static")
+	require.True(t, declaredStatic.subsumes(declaredStatic))
+}


### PR DESCRIPTION
Adds a directed outlives graph representation and analysis for lifetime variables in the constraint solver. This enables checking whether inferred lifetime bounds satisfy declared bounds.

The new `ltBoundSet` type represents the outlives relation as a condensed, transitively-reduced DAG:
- Builds a directed graph from lifetime variable bounds, where an edge `a -> b` means `'a outlives 'b`
- Condenses strongly connected components (mutual outlives relations) into single representatives using Tarjan's algorithm, since cycles represent equal lifetimes
- Transitively reduces the resulting DAG to remove redundant edges
- Handles `'static` as an absorbing bottom: lifetimes forced to `'static` outlive everything, and this constraint propagates backward through the graph

Key methods:
- `buildLtBoundSet` walks occurrence maps and constructs the raw graph
- `condenseSCCs` finds strongly connected components and assigns representatives
- `reduce` removes transitive shortcuts and edges incident to `'static` nodes
- `implies` checks whether the graph proves one lifetime outlives another
- `subsumes` verifies that inferred bounds satisfy declared bounds by checking all edges, equalities, and `'static` forcings

The implementation includes comprehensive tests covering transitive reduction, cycle collapsing, `'static` propagation, and subsumption checking.

https://claude.ai/code/session_011LLd6qvxk7HGTQiSB5YgLc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of lifetime relationships, including mutual dependencies, transitive inference, and `'static` propagation.
  * Fixed edge cases where lifetime constraints could be reduced incorrectly or behave inconsistently.
  * Added coverage to ensure lifetime bound checks remain stable and consistent across varied inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->