### PR TITLE
Refactor lifetime coalescing to use condensed SCC graph

### DIFF
--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -225,6 +225,47 @@ func condenseSCCs(nodeIDs []int, edges map[int]set.Set[int]) map[int]int {
 	return rep
 }
 
+// weakComponents labels each representative with its weakly-connected component,
+// treating every condensed outlives edge as undirected, and returns a map from
+// representative ID to the smallest representative ID in its component. That
+// smallest-ID leader mirrors the representative rule condenseSCCs uses. An
+// instantiation links a join to the argument lifetime it feeds through a shared
+// intermediary that outlives both, with no directed edge between the two, so
+// connectivity — not directed reachability — is what gathers a join's members.
+func (s *ltBoundSet) weakComponents() map[int]int {
+	adj := map[int][]int{}
+	for from, tos := range s.edges {
+		for to := range tos {
+			adj[from] = append(adj[from], to)
+			adj[to] = append(adj[to], from)
+		}
+	}
+
+	comp := map[int]int{}
+	visited := set.NewSet[int]()
+	for _, start := range slices.Sorted(maps.Keys(s.vars)) {
+		if visited.Contains(start) {
+			continue
+		}
+		// BFS the whole component from start, then key every member to the min ID.
+		members := []int{start}
+		visited.Add(start)
+		for i := 0; i < len(members); i++ {
+			for _, nbr := range adj[members[i]] {
+				if !visited.Contains(nbr) {
+					visited.Add(nbr)
+					members = append(members, nbr)
+				}
+			}
+		}
+		leader := slices.Min(members)
+		for _, m := range members {
+			comp[m] = leader
+		}
+	}
+	return comp
+}
+
 // repOf maps a raw lifetime ID to its component representative, or to itself when the
 // ID is not in this set.
 func (s *ltBoundSet) repOf(id int) int {

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -16,8 +16,11 @@ import (
 // their display form, the lifetime-sort analogue of how the var arms resolve a type
 // variable.
 //
-// It has three jobs, all keyed off a single occurrence analysis plus a
-// connected-component grouping of the lifetime bound graph:
+// It has three jobs, all keyed off a single occurrence analysis plus a grouping of
+// the lifetime bound graph built by buildLtBoundSet. That builder condenses each
+// mutual-outlives cycle to one strongly-connected-component representative, so the
+// grouping is over a DAG rather than the raw graph constrainLt records. The three
+// jobs group by connectivity in that condensed graph:
 //
 //  1. Naming. A borrow originates at a parameter, so a lifetime occurring in a
 //     NEGATIVE position is a "param lifetime". It is the only kind named in the
@@ -25,10 +28,10 @@ import (
 //     in the type.
 //
 //  2. Elision. A param lifetime whose borrow never reaches an output connects
-//     nothing. It occurs in no positive position, and its bound-graph component
-//     holds no output lifetime, so it is dropped. This is the lifetime-sort analogue
-//     of single-polarity type-variable elimination. The drop branches on the
-//     borrow's Mut flag:
+//     nothing. It occurs in no positive position, and its connected component in the
+//     condensed graph holds no output lifetime, so it is dropped. This is the
+//     lifetime-sort analogue of single-polarity type-variable elimination. The drop
+//     branches on the borrow's Mut flag:
 //     - A mutable borrow becomes owned-mutable, RefType{Mut: true, Lt: nil}.
 //     - An immutable borrow drops the RefType wrapper entirely and returns its
 //     bare inner, because RefType{Mut: false, Lt: nil} is the forbidden
@@ -37,17 +40,16 @@ import (
 //  3. Join expansion. A non-param lifetime is not itself nameable. It is either a
 //     join variable minted at a return or branch, or a lifetime freshened when a
 //     borrow-passing function was instantiated. It expands to the union of the param
-//     lifetimes it shares a bound-graph component with, so a return uniting two
-//     borrows coalesces to ('a | 'b). The expansion follows the UNDIRECTED bound
-//     graph. Instantiation interposes intermediary variables between a call's
-//     argument lifetime and the callee's freshened parameter lifetime, related only
-//     by a mix of upper and lower bounds, so reachability cannot be confined to one
-//     bound direction. A lifetime forced to 'static renders 'static and absorbs.
-//     FUTURE (M6.5, lifetime bounds): this undirected grouping is a D4
-//     approximation, sound only because independent param lifetimes never share a
-//     bound-graph component. M6.5 replaces it with directional reasoning over the
-//     LowerBounds/UpperBounds edges, rendering a join as precise where-clauses like
-//     `where 'a: 'c, 'b: 'c` rather than collapsing it to the union ('a | 'b).
+//     lifetimes sharing its connected component in the condensed graph, so a return
+//     uniting two borrows coalesces to ('a | 'b). The grouping is by connectivity
+//     because instantiation interposes an intermediary between a call's argument
+//     lifetime and the join it feeds. That intermediary outlives both the caller's
+//     param lifetime and the join, so the param and the join are joined only through
+//     it, with no direct outlives edge either way. A lifetime forced to 'static
+//     renders 'static and absorbs. The union is a conservative rendering of the
+//     directional bound set the condensed graph carries. A later change keeps the
+//     join lifetime named and renders each kept param's outlives edges as `'a: 'c`
+//     bounds instead of collapsing to the union ('a | 'b).
 //
 // coalesceLifetimes resolves the borrow lifetimes left raw by the structural
 // coalescers. pol is the root polarity the type was coalesced at, threaded through
@@ -87,76 +89,46 @@ func (v *ltOccVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.E
 func (v *ltOccVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // ltAnalysis is the precomputed input the rewriter reads: per-variable structural
-// occurrence, the connected-component grouping of the lifetime bound graph, and the
-// set of component roots that hold a positive output lifetime.
+// occurrence, the condensed outlives graph the grouping is built from, the
+// connected-component leader of each representative, and the set of component leaders
+// that hold a positive output lifetime.
 type ltAnalysis struct {
 	occ      map[*soltype.LifetimeVar]occPolarity
-	uf       *unionFind                   // components over lifetime bound edges; find(ID) is the component's representative ID
-	vars     map[int]*soltype.LifetimeVar // every lifetime var reachable, by ID
-	posRoots set.Set[int]                 // representative IDs (uf.find results) of components reaching a positive occurrence
+	bs       *ltBoundSet  // condensed outlives graph; rep IDs collapse mutual-outlives cycles
+	comp     map[int]int  // representative ID -> connected-component leader ID in bs
+	posComps set.Set[int] // component leaders reaching a positive occurrence
 }
 
-// newLtAnalysis builds the bound-graph components from the structurally-occurring
-// lifetime variables. It walks each occurring variable's bounds transitively in
-// BOTH directions, unioning a variable with every lifetime variable it is bounded
-// by or bounds, so an instantiation intermediary ends up in the same component as
-// the argument and parameter lifetimes it bridges. A component root is marked
-// positive when any structurally-positive lifetime falls in it; that is what keeps
-// a connected param lifetime from being elided.
+// newLtAnalysis builds the grouping from the structurally-occurring lifetime
+// variables. buildLtBoundSet walks each occurring variable's bounds in both
+// directions and condenses every mutual-outlives cycle to one representative, so the
+// grouping runs over a DAG. bs.weakComponents then labels each representative with its
+// connected component. A component leader is marked positive when any
+// structurally-positive lifetime falls in it; that is what keeps a connected param
+// lifetime from being elided.
 //
-// INVARIANT: this grouping is UNDIRECTED, so it conflates outlives direction. It is
-// correct only while two distinct param lifetimes share a component ONLY when they
-// genuinely co-flow, meaning a join unites them or one is borrowed from the other.
-// Every lifetime origin today obeys this. Each borrow site mints an independent
-// var. resolveLifetimeAnn mints one for an `&` annotation, and inferBorrow mints
-// one for an `&p` expression. The only cross-links are joins from joinBorrows and
-// instantiation copies from the freshener and extruder, both of which connect
-// lifetimes that really do flow together. A future origin that bound-links two
-// independent param borrows through a shared intermediary would break it. The two
-// would be unioned and both kept, rendering a spurious `('a | 'b)`. Distinguishing
-// that case needs directional reasoning, or first-class lifetime bounds, which the
-// union rendering deliberately does not yet model. M6.5 (lifetime bounds) is the
-// milestone that retires this undirected grouping, replacing it with directional
-// reasoning over the LowerBounds/UpperBounds edges. See the join-expansion note above.
+// The grouping is by connectivity rather than directed reachability because a
+// borrow-passing function's instantiation interposes an intermediary between a call's
+// argument lifetime and the join it feeds. The intermediary outlives both the
+// argument lifetime and the join, so the two sit in one component yet neither reaches
+// the other along outlives edges. Condensing mutual-outlives cycles to one
+// representative first is what leaves a DAG for reduce and for the directional bound
+// rendering that layers on top.
 func newLtAnalysis(occ map[*soltype.LifetimeVar]occPolarity) *ltAnalysis {
-	uf := newUnionFind()
-	vars := map[int]*soltype.LifetimeVar{}
-	var visit func(v *soltype.LifetimeVar)
-	visitBound := func(v *soltype.LifetimeVar, b soltype.Lifetime) {
-		bv, ok := b.(*soltype.LifetimeVar)
-		if !ok {
-			return
-		}
-		uf.union(v.ID, bv.ID)
-		visit(bv)
-	}
-	visit = func(v *soltype.LifetimeVar) {
-		if _, seen := vars[v.ID]; seen {
-			return
-		}
-		vars[v.ID] = v
-		for _, b := range v.LowerBounds {
-			visitBound(v, b)
-		}
-		for _, b := range v.UpperBounds {
-			visitBound(v, b)
-		}
-	}
-	for v := range occ {
-		visit(v)
-	}
+	bs := buildLtBoundSet(occ)
+	comp := bs.weakComponents()
 
-	posRoots := set.NewSet[int]()
+	posComps := set.NewSet[int]()
 	for v, pols := range occ {
 		// pols is a bitset of the polarities v occurred in. `&occPos != 0` tests
 		// whether the positive flag is set, tolerating a co-set occNeg bit, so a
 		// both-polarity v still counts. A v that occurs positively reaches an output,
-		// so mark its component root positive — kept reads this to gate elision.
+		// so mark its component leader positive — kept reads this to gate elision.
 		if pols&occPos != 0 {
-			posRoots.Add(uf.find(v.ID))
+			posComps.Add(comp[bs.repOf(v.ID)])
 		}
 	}
-	return &ltAnalysis{occ: occ, uf: uf, vars: vars, posRoots: posRoots}
+	return &ltAnalysis{occ: occ, bs: bs, comp: comp, posComps: posComps}
 }
 
 // isParam reports whether v is a param lifetime: one that originates at a borrow
@@ -165,31 +137,51 @@ func (a *ltAnalysis) isParam(v *soltype.LifetimeVar) bool {
 	return a.occ[v]&occNeg != 0
 }
 
-// kept reports whether a param lifetime survives elision: its bound-graph component
+// leaderOf maps a lifetime variable to its connected-component leader in the condensed
+// graph, mapping through the variable's representative first.
+func (a *ltAnalysis) leaderOf(v *soltype.LifetimeVar) int {
+	return a.comp[a.bs.repOf(v.ID)]
+}
+
+// kept reports whether a param lifetime survives elision: its connected component
 // reaches an output, so the borrow flows somewhere observable. A param occurring
 // only on its parameter, connected to no output, is elided.
 func (a *ltAnalysis) kept(v *soltype.LifetimeVar) bool {
-	return a.posRoots.Contains(a.uf.find(v.ID))
+	return a.posComps.Contains(a.leaderOf(v))
 }
 
-// componentParams returns the kept param lifetimes sharing v's component, sorted by
-// ID. Sorting yields a canonical union member order, so a join expanded here renders
-// the same ('a | 'b) regardless of bound-list order, and ltEqual's positional member
-// compare stays order-insensitive. This closes the order gap noted in coalesce.go.
+// componentParams returns the kept param lifetimes sharing v's connected component,
+// sorted by variable ID. Sorting yields a canonical union member order, so a join
+// expanded here renders the same ('a | 'b) regardless of bound-list order, and
+// ltEqual's positional member compare stays order-insensitive. Members are keyed by
+// SCC representative so two mutually-outliving params list once, but the emitted
+// member is a param var, not bs.vars[rep]: the representative can be a non-param
+// bridge var that surfaces in no parameter slot, and resolveLt names a kept param
+// under its own var, so the union member must be a param var to name the same
+// lifetime the parameter slot does. The smallest-ID param per representative is kept
+// for a deterministic choice across map-iteration order.
 func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime {
-	root := a.uf.find(v.ID)
-	var ids []int
-	for id, lv := range a.vars {
-		if a.uf.find(id) != root || !a.isParam(lv) || !a.kept(lv) {
+	leader := a.leaderOf(v)
+	byRep := map[int]*soltype.LifetimeVar{}
+	for p := range a.occ {
+		if !a.isParam(p) || !a.kept(p) {
 			continue
 		}
-		ids = append(ids, id)
+		pr := a.bs.repOf(p.ID)
+		if a.comp[pr] != leader {
+			continue
+		}
+		if cur, ok := byRep[pr]; !ok || p.ID < cur.ID {
+			byRep[pr] = p
+		}
 	}
-	sort.Ints(ids)
-	members := make([]soltype.Lifetime, len(ids))
-	for i, id := range ids {
-		members[i] = a.vars[id]
+	members := make([]soltype.Lifetime, 0, len(byRep))
+	for _, p := range byRep {
+		members = append(members, p)
 	}
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].(*soltype.LifetimeVar).ID < members[j].(*soltype.LifetimeVar).ID
+	})
 	return members
 }
 

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -150,16 +150,10 @@ func (a *ltAnalysis) kept(v *soltype.LifetimeVar) bool {
 	return a.posComps.Contains(a.leaderOf(v))
 }
 
-// componentParams returns the kept param lifetimes sharing v's connected component,
-// sorted by variable ID. Sorting yields a canonical union member order, so a join
-// expanded here renders the same ('a | 'b) regardless of bound-list order, and
-// ltEqual's positional member compare stays order-insensitive. Members are keyed by
-// SCC representative so two mutually-outliving params list once, but the emitted
-// member is a param var, not bs.vars[rep]: the representative can be a non-param
-// bridge var that surfaces in no parameter slot, and resolveLt names a kept param
-// under its own var, so the union member must be a param var to name the same
-// lifetime the parameter slot does. The smallest-ID param per representative is kept
-// for a deterministic choice across map-iteration order.
+// componentParams returns the kept param lifetimes in v's connected component, sorted
+// by variable ID for a canonical union member order. Members are keyed by SCC
+// representative so mutually-outliving params list once, but emit a param var, since
+// the representative itself can be a non-param bridge var named in no parameter slot.
 func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime {
 	leader := a.leaderOf(v)
 	byRep := map[int]*soltype.LifetimeVar{}

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -291,8 +291,16 @@ func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
 // component condenses to the non-param representative. The join must still render
 // under the parameter's name, so componentParams emits the param var `p` rather than
 // the representative `m`, and the return renders `&'a` rather than a fresh name bound
-// to no input. Minting the join `m` first gives it the smaller ID, as a freshener or
-// extruder can.
+// to no input.
+//
+// This guards an ID ordering ordinary source does not produce, so the graph is built
+// directly rather than through inference. Mutual-outlives cycles do arise from source:
+// `bag.item = it` stores a borrow into a mutable field, whose invariant lifetime forces
+// the field and `it` to be equal. But both members of a source-level cycle are param
+// lifetimes, and a param is always minted before any join or instantiation intermediary,
+// so the param carries the smaller ID and wins the representative slot. The reverse — a
+// non-param representative — needs the non-param minted first, which a freshener or
+// extruder can do but top-level inference cannot, so `m` is minted before `p` here.
 func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
 	c := newChecker()
 	m := c.ctx.freshJoinLifetime(0) // non-param, minted first so it holds the smaller ID

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -267,6 +267,53 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
+// Two param lifetimes that mutually outlive are EQUAL, so a join over both collapses
+// to one member rather than a two-element union. constrainLt(a, b) with
+// constrainLt(b, a) closes an outlives cycle, and buildLtBoundSet condenses that
+// strongly connected component to a single representative. componentParams then keys
+// the join's members by representative, so 'a and 'b contribute one member and the
+// return renders `&'a` instead of `&('a | 'b)`. The params keep their own names 'a
+// and 'b, named from the borrows they originate on; only the join lifetime resolves
+// to the representative.
+func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	join := c.ctx.freshJoinLifetime(0)
+	c.ctx.constrainLt(a, b) // a outlives b
+	c.ctx.constrainLt(b, a) // b outlives a — the cycle makes a and b equal
+	c.ctx.constrainLt(a, join)
+	c.ctx.constrainLt(b, join)
+	fn := borrowFn(mutPointRef(join), a, b)
+
+	require.Equal(t,
+		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'a mut {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+}
+
+// When a param lifetime mutually outlives a NON-param lifetime that carries a smaller
+// ID, the strongly connected component condenses to the non-param representative,
+// since the representative is the smallest ID in the component. The join over that
+// component must still render under the PARAMETER's name, so its member is the param
+// var rather than the representative. Here the join `m` is minted first, so it holds
+// the smaller ID; `p`'s lifetime and `m` mutually outlive. componentParams keys the
+// member by representative `m` but emits the param var `p`, so the return renders
+// `&'a`, the same name the parameter slot carries, instead of a fresh name bound to no
+// input. Minting the join before the param is what a freshener or extruder can do, so
+// this orders the ids the way that path would.
+func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
+	c := newChecker()
+	m := c.ctx.freshJoinLifetime(0) // non-param, minted first so it holds the smaller ID
+	p := c.ctx.freshLifetime(0)     // param lifetime, larger ID
+	c.ctx.constrainLt(p, m)         // p outlives m
+	c.ctx.constrainLt(m, p)         // m outlives p — the cycle makes p and m equal, rep = m
+	fn := borrowFn(mutPointRef(m), p)
+
+	require.Equal(t,
+		"fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+}
+
 // ltEqual compares a LifetimeUnion structurally. A LifetimeUnion is the union form a
 // join variable coalesces to. Two unions are equal iff their members are pairwise
 // equal in order, so two RefTypes with the same coalesced union dedup during

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -294,13 +294,20 @@ func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
 // to no input.
 //
 // This guards an ID ordering ordinary source does not produce, so the graph is built
-// directly rather than through inference. Mutual-outlives cycles do arise from source:
-// `bag.item = it` stores a borrow into a mutable field, whose invariant lifetime forces
-// the field and `it` to be equal. But both members of a source-level cycle are param
-// lifetimes, and a param is always minted before any join or instantiation intermediary,
-// so the param carries the smaller ID and wins the representative slot. The reverse — a
-// non-param representative — needs the non-param minted first, which a freshener or
-// extruder can do but top-level inference cannot, so `m` is minted before `p` here.
+// directly rather than through inference. Mutual-outlives cycles do arise from source —
+// storing a borrow into a mutable field makes the field and the stored borrow equal,
+// since a mutable field's lifetime is invariant:
+//
+//	fn f(bag: &mut {item: &mut {x: number}}, it: &mut {x: number}) {
+//	  bag.item = it
+//	  return it
+//	}
+//
+// But both members of a source-level cycle are param lifetimes, and a param is always
+// minted before any join or instantiation intermediary, so the param carries the smaller
+// ID and wins the representative slot. The reverse — a non-param representative — needs
+// the non-param minted first, which a freshener or extruder can do but top-level
+// inference cannot, so `m` is minted before `p` here.
 func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
 	c := newChecker()
 	m := c.ctx.freshJoinLifetime(0) // non-param, minted first so it holds the smaller ID

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -267,14 +267,10 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// Two param lifetimes that mutually outlive are EQUAL, so a join over both collapses
-// to one member rather than a two-element union. constrainLt(a, b) with
-// constrainLt(b, a) closes an outlives cycle, and buildLtBoundSet condenses that
-// strongly connected component to a single representative. componentParams then keys
-// the join's members by representative, so 'a and 'b contribute one member and the
-// return renders `&'a` instead of `&('a | 'b)`. The params keep their own names 'a
-// and 'b, named from the borrows they originate on; only the join lifetime resolves
-// to the representative.
+// Two param lifetimes that mutually outlive are EQUAL, so buildLtBoundSet condenses
+// them to one representative and a join over both renders `&'a` instead of the union
+// `&('a | 'b)`. The params keep their own names 'a and 'b from the borrows they
+// originate on; only the join lifetime resolves to the representative.
 func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)
@@ -291,16 +287,12 @@ func TestJoinOverMutualOutlivesCollapsesToOne(t *testing.T) {
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// When a param lifetime mutually outlives a NON-param lifetime that carries a smaller
-// ID, the strongly connected component condenses to the non-param representative,
-// since the representative is the smallest ID in the component. The join over that
-// component must still render under the PARAMETER's name, so its member is the param
-// var rather than the representative. Here the join `m` is minted first, so it holds
-// the smaller ID; `p`'s lifetime and `m` mutually outlive. componentParams keys the
-// member by representative `m` but emits the param var `p`, so the return renders
-// `&'a`, the same name the parameter slot carries, instead of a fresh name bound to no
-// input. Minting the join before the param is what a freshener or extruder can do, so
-// this orders the ids the way that path would.
+// When a param lifetime mutually outlives a NON-param lifetime with a smaller ID, the
+// component condenses to the non-param representative. The join must still render
+// under the parameter's name, so componentParams emits the param var `p` rather than
+// the representative `m`, and the return renders `&'a` rather than a fresh name bound
+// to no input. Minting the join `m` first gives it the smaller ID, as a freshener or
+// extruder can.
 func TestJoinRepresentativeIsNonParamRendersParamName(t *testing.T) {
 	c := newChecker()
 	m := c.ctx.freshJoinLifetime(0) // non-param, minted first so it holds the smaller ID


### PR DESCRIPTION
Replace the undirected union-find grouping in lifetime coalescing with a directed approach that first condenses strongly-connected components (mutual-outlives cycles) to single representatives, then groups by weak connectivity over the resulting DAG.

**Key changes:**

- `ltAnalysis` now uses `ltBoundSet` (the condensed outlives graph) and `weakComponents()` to build component groupings, replacing the previous undirected union-find traversal.
- Add `weakComponents()` method to `ltBoundSet` that treats condensed edges as undirected and returns a map from representative ID to the smallest representative ID in its component.
- Add `leaderOf()` helper to map a lifetime variable to its connected-component leader, routing through the variable's SCC representative first.
- Update `componentParams()` to key union members by SCC representative, ensuring mutually-outliving params contribute only one member to a join. When the representative is a non-param bridge variable, emit the smallest-ID param var from that component so the union renders under a parameter's name rather than a fresh one.
- Simplify the component-root tracking by iterating only over structurally-occurring variables rather than all reachable variables.
- Update comments to reflect the DAG-based grouping and clarify why weak connectivity (not directed reachability) is needed: instantiation interposes an intermediary between a call's argument lifetime and the join it feeds, linking them through the intermediary with no direct outlives edge either way.

**Tests:**

- Add `TestJoinOverMutualOutlivesCollapsesToOne` to verify that two param lifetimes in a mutual-outlives cycle collapse to one union member.
- Add `TestJoinRepresentativeIsNonParamRendersParamName` to verify that when the SCC representative is a non-param lifetime with a smaller ID, the union still renders under the parameter's name.

https://claude.ai/code/session_01CA4LDcs9S9QK3pyWi9T8CT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime rendering so mutually related lifetimes are shown as a single named lifetime instead of an unnecessary union.
  * Fixed lifetime name selection in join outputs to prefer the expected parameter name, even when internal representatives differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->