### PR TITLE
Support lifetime parameters in function type annotations

### DIFF
--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -94,64 +94,78 @@ func TestInferThrowsFuncAnnotationReportsUnsupported(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", values["f"])
 }
 
-// A lifetime parameter that names no borrow is inert. `'a` binds no borrow, so the
-// resolved annotation renders with the lifetime elided and reports no error.
-func TestInferLifetimeFuncAnnotationUnusedLifetime(t *testing.T) {
-	values, _, errs := inferSource(t, `val f: fn<'a>(x: number) -> number = fn (x) { return x }`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (x: number) -> number", values["f"])
-}
-
-// A lifetime parameter naming a borrow that reaches the output resolves to one
-// shared lifetime across the parameter and return, so the annotation round-trips
-// with `'a` quantified on both.
-func TestInferLifetimeFuncAnnotationNamedBorrowShares(t *testing.T) {
-	values, _, errs := inferSource(t, `val f: fn<'a>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
-}
-
-// A declared `'a: 'static` bound lowers to constrainLt('a, 'static). 'static is the
-// bottom of the outlives lattice and absorbs the meet, so 'a resolves to 'static. Both
-// the parameter and the return borrow then render `&'static` rather than under the
-// quantified name `'a`. Without the lowering 'a would stay a plain param lifetime, so
-// this is the direct evidence that a declared bound participates in solving.
-func TestInferLifetimeFuncAnnotationStaticBoundForcesStatic(t *testing.T) {
-	values, _, errs := inferSource(t, `val f: fn<'a: 'static>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (p: &'static {x: number}) -> &'static {x: number}", values["f"])
-}
-
-// A declared `'b: 'a` bound relates the two lifetimes, so eliding either would drop a
-// declared relationship. Only p is returned, so `'b` reaches no output on its own, yet
-// the bound keeps it named. The un-bounded twin below elides `'b` to a bare `&`, so
-// the difference isolates the bound's effect. The bound itself is not yet rendered in
-// the quantifier prefix, which is the render track's job.
-func TestInferLifetimeFuncAnnotationOutlivesBoundKeepsLifetime(t *testing.T) {
-	bounded := `val f: fn<'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`
-	values, _, errs := inferSource(t, bounded)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}", values["f"])
-
-	unbounded := `val f: fn<'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`
-	values, _, errs = inferSource(t, unbounded)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a {x: number}, q: &{x: number}) -> &'a {x: number}", values["f"])
-}
-
-// A function type annotation is its own lifetime scope, so a nested annotation's
-// declared bound stays local. Here the inner `g` annotation declares `'a: 'static`,
-// which would force `'a` to 'static, but `outer` also names a borrow lifetime `'a`.
-// The two must not share a variable: `outer`'s parameter stays a plain borrow
-// lifetime rather than being pinned to 'static by the inner bound.
-func TestInferLifetimeFuncAnnotationScopeIsLocal(t *testing.T) {
-	src := `fn outer(p: &'a {x: number}) {
+// A lifetime parameter in a function type annotation resolves against its declared
+// bounds, which lower into constrainLt so they solve like bounds a body infers. Each
+// case renders the binding named by `binding` and reports no error.
+func TestInferLifetimeFuncAnnotation(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		binding string
+		want    string
+	}{
+		// A lifetime that names no borrow is inert, so it renders elided.
+		{
+			name:    "unused lifetime",
+			src:     `val f: fn<'a>(x: number) -> number = fn (x) { return x }`,
+			binding: "f",
+			want:    "fn (x: number) -> number",
+		},
+		// A lifetime naming a borrow that reaches the output resolves to one shared
+		// lifetime across the parameter and return, so it quantifies as `'a` on both.
+		{
+			name:    "named borrow shares one lifetime",
+			src:     `val f: fn<'a>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`,
+			binding: "f",
+			want:    "fn <'a>(p: &'a {x: number}) -> &'a {x: number}",
+		},
+		// A declared `'a: 'static` bound lowers to constrainLt('a, 'static). 'static is
+		// the bottom of the outlives lattice and absorbs the meet, so 'a resolves to
+		// 'static and both borrows render `&'static`. Without the lowering 'a would stay
+		// a plain param lifetime, so this is the direct evidence a declared bound solves.
+		{
+			name:    "static bound forces static",
+			src:     `val f: fn<'a: 'static>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`,
+			binding: "f",
+			want:    "fn (p: &'static {x: number}) -> &'static {x: number}",
+		},
+		// A declared `'b: 'a` bound relates the two lifetimes. Only p is returned, so `'b`
+		// reaches no output on its own, yet the bound keeps it named. The un-bounded twin
+		// below elides `'b` to a bare `&`, isolating the bound's effect. The bound itself
+		// is not yet rendered in the prefix, which is the render track's job.
+		{
+			name:    "outlives bound keeps connected lifetime",
+			src:     `val f: fn<'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`,
+			binding: "f",
+			want:    "fn <'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}",
+		},
+		{
+			name:    "no bound elides unconnected lifetime",
+			src:     `val f: fn<'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`,
+			binding: "f",
+			want:    "fn <'a>(p: &'a {x: number}, q: &{x: number}) -> &'a {x: number}",
+		},
+		// A function type annotation is its own lifetime scope, so a nested annotation's
+		// declared bound stays local. The inner `g` declares `'a: 'static`, which would
+		// force `'a` to 'static, but `outer` also names a borrow lifetime `'a`. The two
+		// must not share a variable, so `outer`'s parameter stays a plain borrow lifetime.
+		{
+			name: "nested annotation scope is local",
+			src: `fn outer(p: &'a {x: number}) {
   val g: fn<'a: 'static>(q: &'a {y: number}) -> &'a {y: number} = fn (q) { return q }
   return p
-}`
-	values, _, errs := inferSource(t, src)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["outer"])
+}`,
+			binding: "outer",
+			want:    "fn <'a>(p: &'a {x: number}) -> &'a {x: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values[tt.binding])
+		})
+	}
 }
 
 // A destructuring parameter pattern is preserved in the resolved function type, so

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -94,14 +94,64 @@ func TestInferThrowsFuncAnnotationReportsUnsupported(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", values["f"])
 }
 
-// A lifetime-param'd function annotation reports the documented unsupported
-// feature and recovers function-shaped.
-func TestInferLifetimeFuncAnnotationReportsUnsupported(t *testing.T) {
+// A lifetime parameter that names no borrow is inert. `'a` binds no borrow, so the
+// resolved annotation renders with the lifetime elided and reports no error.
+func TestInferLifetimeFuncAnnotationUnusedLifetime(t *testing.T) {
 	values, _, errs := inferSource(t, `val f: fn<'a>(x: number) -> number = fn (x) { return x }`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "1:8-1:35: Unsupported: lifetime parameters in function type annotation", msgWithSpan(errs[0]))
+	require.Empty(t, errs)
 	require.Equal(t, "fn (x: number) -> number", values["f"])
+}
+
+// A lifetime parameter naming a borrow that reaches the output resolves to one
+// shared lifetime across the parameter and return, so the annotation round-trips
+// with `'a` quantified on both.
+func TestInferLifetimeFuncAnnotationNamedBorrowShares(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn<'a>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A declared `'a: 'static` bound lowers to constrainLt('a, 'static). 'static is the
+// bottom of the outlives lattice and absorbs the meet, so 'a resolves to 'static. Both
+// the parameter and the return borrow then render `&'static` rather than under the
+// quantified name `'a`. Without the lowering 'a would stay a plain param lifetime, so
+// this is the direct evidence that a declared bound participates in solving.
+func TestInferLifetimeFuncAnnotationStaticBoundForcesStatic(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn<'a: 'static>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: &'static {x: number}) -> &'static {x: number}", values["f"])
+}
+
+// A declared `'b: 'a` bound relates the two lifetimes, so eliding either would drop a
+// declared relationship. Only p is returned, so `'b` reaches no output on its own, yet
+// the bound keeps it named. The un-bounded twin below elides `'b` to a bare `&`, so
+// the difference isolates the bound's effect. The bound itself is not yet rendered in
+// the quantifier prefix, which is the render track's job.
+func TestInferLifetimeFuncAnnotationOutlivesBoundKeepsLifetime(t *testing.T) {
+	bounded := `val f: fn<'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`
+	values, _, errs := inferSource(t, bounded)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}", values["f"])
+
+	unbounded := `val f: fn<'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`
+	values, _, errs = inferSource(t, unbounded)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}, q: &{x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A function type annotation is its own lifetime scope, so a nested annotation's
+// declared bound stays local. Here the inner `g` annotation declares `'a: 'static`,
+// which would force `'a` to 'static, but `outer` also names a borrow lifetime `'a`.
+// The two must not share a variable: `outer`'s parameter stays a plain borrow
+// lifetime rather than being pinned to 'static by the inner bound.
+func TestInferLifetimeFuncAnnotationScopeIsLocal(t *testing.T) {
+	src := `fn outer(p: &'a {x: number}) {
+  val g: fn<'a: 'static>(q: &'a {y: number}) -> &'a {y: number} = fn (q) { return q }
+  return p
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["outer"])
 }
 
 // A destructuring parameter pattern is preserved in the resolved function type, so

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -454,19 +454,11 @@ func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.
 	}
 }
 
-// lowerLifetimeParamBounds asserts each declared outlives bound in a `<…>` quantifier
-// list as a constrainLt, so a bound written in a signature participates in solving like
-// one a body infers. A binder `'a: 'b` reads "'a outlives 'b", which is 'a <: 'b in the
-// outlives lattice, so it lowers to constrainLt('a, 'b). Each name resolves through
-// namedLifetime, which interns one LifetimeVar per written name in the current
-// signature, so a bound and a borrow that write the same name share a lifetime. A
-// 'static on the right resolves to soltype.Static, the bottom of the outlives lattice.
-// That forces the bound lifetime to 'static, the same escape-to-static constraint an
-// escaping borrow emits.
-//
-// A 'static on the left is not a bindable parameter, which the parser already rejects.
-// The binder is still built with that name, so skip it here rather than interning a
-// bogus "static" variable.
+// lowerLifetimeParamBounds lowers each declared `'a: 'b` bound ("'a outlives 'b") to
+// constrainLt('a, 'b), so a signature's bound solves like one a body infers. Names
+// resolve through namedLifetime, so a bound and a borrow writing the same name share a
+// lifetime. A 'static right-hand side forces the lifetime to 'static; a 'static
+// left-hand side is skipped, since the parser already rejects it as a binder.
 func (c *checker) lowerLifetimeParamBounds(params []*ast.LifetimeParam, lvl int) {
 	for _, p := range params {
 		if len(p.Bounds) == 0 || p.Name == "static" {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -232,8 +232,9 @@ func (c *checker) resolveIntersectionTypeAnn(ta *ast.IntersectionTypeAnn, lvl in
 // `fn(p: A, ...) -> R` into a soltype.FuncType, mapping ta.Inexact to
 // FuncType.Inexact. An unsupported part recovers to a fresh var so the function
 // shape survives, cascade-safe like the Promise/object/tuple arms. Generic, throws,
-// lifetime-param'd, and rest-param annotations report an unsupported feature and
-// recover as a monomorphic function.
+// and rest-param annotations report an unsupported feature and recover as a
+// monomorphic function. A lifetime parameter is supported. Its declared outlives
+// bounds lower into constrainLt so the annotation's borrows solve against them.
 func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
 	if len(ta.TypeParams) > 0 {
 		c.reportUnsupportedFeature(ta, "generic function type annotation")
@@ -241,9 +242,15 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 	if ta.Throws != nil {
 		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")
 	}
-	if len(ta.LifetimeParams) > 0 {
-		c.reportUnsupportedFeature(ta, "lifetime parameters in function type annotation")
-	}
+	// A function type annotation is its own quantifier scope, so give it its own
+	// named-lifetime map the way inferFunc does for a function body. Without this a
+	// nested `fn<'a: 'static>(…)` annotation would resolve `'a` to the enclosing
+	// function's `'a` and its declared bound would force that outer lifetime, so an
+	// unrelated borrow parameter of the enclosing function would be pinned to 'static.
+	savedNamedLts := c.namedLifetimes
+	c.namedLifetimes = nil
+	defer func() { c.namedLifetimes = savedNamedLts }()
+	c.lowerLifetimeParamBounds(ta.LifetimeParams, lvl)
 
 	params := make([]*soltype.FuncParam, len(ta.Params))
 	for i, p := range ta.Params {
@@ -447,10 +454,46 @@ func (c *checker) resolveLifetimeAnn(node ast.LifetimeAnnNode, lvl int) soltype.
 	}
 }
 
+// lowerLifetimeParamBounds asserts each declared outlives bound in a `<…>` quantifier
+// list as a constrainLt, so a bound written in a signature participates in solving like
+// one a body infers. A binder `'a: 'b` reads "'a outlives 'b", which is 'a <: 'b in the
+// outlives lattice, so it lowers to constrainLt('a, 'b). Each name resolves through
+// namedLifetime, which interns one LifetimeVar per written name in the current
+// signature, so a bound and a borrow that write the same name share a lifetime. A
+// 'static on the right resolves to soltype.Static, the bottom of the outlives lattice.
+// That forces the bound lifetime to 'static, the same escape-to-static constraint an
+// escaping borrow emits.
+//
+// A 'static on the left is not a bindable parameter, which the parser already rejects.
+// The binder is still built with that name, so skip it here rather than interning a
+// bogus "static" variable.
+func (c *checker) lowerLifetimeParamBounds(params []*ast.LifetimeParam, lvl int) {
+	for _, p := range params {
+		if len(p.Bounds) == 0 || p.Name == "static" {
+			continue
+		}
+		sub := c.namedLifetime(p.Name, lvl)
+		for _, b := range p.Bounds {
+			c.ctx.constrainLt(sub, c.boundLifetime(b.Name, lvl))
+		}
+	}
+}
+
+// boundLifetime resolves a lifetime name on the right of an outlives bound. A 'static
+// resolves to soltype.Static, the bottom of the outlives lattice. Any other name interns
+// through namedLifetime, sharing the variable a borrow writing that name uses.
+func (c *checker) boundLifetime(name string, lvl int) soltype.Lifetime {
+	if name == "static" {
+		return soltype.Static
+	}
+	return c.namedLifetime(name, lvl)
+}
+
 // namedLifetime resolves a written lifetime name to its variable, minting one on first
 // appearance so every `&'a` in one function shares a single lifetime. The map is reset
-// per function by inferFunc and per top-level binding by inferComponent, so the same
-// name in two such scopes denotes distinct lifetimes.
+// per function by inferFunc, per function type annotation by resolveFuncTypeAnn, and
+// per top-level binding by inferComponent, so the same name in two such scopes denotes
+// distinct lifetimes.
 func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 	if c.namedLifetimes == nil {
 		c.namedLifetimes = map[string]*soltype.LifetimeVar{}


### PR DESCRIPTION
Lifetime parameters in function type annotations are now supported. Previously they were rejected as an unsupported feature. The checker now lowers declared outlives bounds into constraints so they participate in lifetime solving, and each annotation gets its own named-lifetime scope to avoid cross-contamination with enclosing function scopes.

Key changes:

- Removed the unsupported-feature error for lifetime parameters in `resolveFuncTypeAnn`. Function type annotations now process lifetime parameters like function bodies do.
- Added `lowerLifetimeParamBounds` to convert declared outlives bounds (e.g., `'a: 'static`) into `constrainLt` constraints that affect solving. A bound `'a: 'b` lowers to `constrainLt('a, 'b)`, and `'static` on the right resolves to `soltype.Static`.
- Added `boundLifetime` to resolve lifetime names on the right side of outlives bounds, treating `'static` as the bottom of the outlives lattice.
- Each function type annotation now gets its own `namedLifetimes` map, scoped like function bodies. This prevents a nested annotation's declared bounds from affecting unrelated lifetimes in the enclosing function.
- Updated test suite to verify the new behavior: unused lifetimes are elided, shared lifetimes round-trip in the annotation, `'static` bounds force resolution to static, outlives bounds keep lifetimes named even when unreachable, and annotation scopes remain local.

https://claude.ai/code/session_01VdncqC115WfYKDWghrktam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function type annotations now support lifetime parameters, including shared borrows, outlives bounds, and nested annotation scoping.
  * Unused lifetime parameters are handled gracefully and no longer trigger errors.

* **Bug Fixes**
  * Lifetime relationships in annotated function types now render more accurately, including cases involving explicit static lifetimes and named lifetime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->