### PR TITLE
Preload TypeScript prelude in LSP server test setup

### DIFF
--- a/cmd/lsp-server/testmain_test.go
+++ b/cmd/lsp-server/testmain_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/checker"
 	"github.com/escalier-lang/escalier/internal/interop"
 )
 
@@ -13,5 +15,14 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	// Load and type-check the TypeScript prelude once, without a deadline, so
+	// its cost is paid here rather than inside a per-test timeout. checker.Prelude
+	// caches the global scope package-wide, so the completion helpers'
+	// subsequent calls hit the cache and only clone it. Their 1s deadlines then
+	// cover just the small user snippet, not the heavy prelude load, which is
+	// what made those tests flake on a slow runner.
+	checker.Prelude(checker.NewChecker(context.Background()))
+
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Move the cost of loading and type-checking the TypeScript prelude outside the per-test timeout window. The prelude is now loaded once during `TestMain` setup rather than on first use within each test, which prevents flaky timeouts on slow runners.

The checker caches the global scope package-wide, so subsequent test calls hit the cache and only clone it. This allows the 1-second test deadlines to cover just the user snippet, not the heavy prelude load.

Changes:
- Import `context` and `checker` packages in the test file
- Call `checker.Prelude(checker.NewChecker(context.Background()))` in `TestMain` before running tests
- Add explanatory comment describing the caching behavior and timeout strategy

https://claude.ai/code/session_015Qfyu399koNz2dk7514RoB