### PR TITLE
Extract Tarjan SCC algorithm to shared graph package

### DIFF
--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -157,8 +157,8 @@ func extractPseudoPackageImports(ctx context.Context, path string) ([]string, er
 }
 
 // tarjanSCCs runs the shared strongly-connected-components pass over
-// the adjacency list `edges`. Nodes referenced only as targets (not
-// present as keys) are included as singletons. Returns one slice per
+// the adjacency list `edges`. A node referenced only as a target, never
+// present as a key, is included as a singleton. Returns one slice per
 // SCC.
 func tarjanSCCs(edges map[string][]string) [][]string {
 	// Gather all nodes (sources + targets) so isolated importees are

--- a/internal/checker/infer_stdlib_scc.go
+++ b/internal/checker/infer_stdlib_scc.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/type_system"
@@ -155,22 +156,11 @@ func extractPseudoPackageImports(ctx context.Context, path string) ([]string, er
 	return out, nil
 }
 
-// tarjanSCCs runs Tarjan's strongly-connected-components algorithm
-// over the adjacency list `edges`. Nodes referenced only as targets
-// (not present as keys) are included as singletons. Returns one slice
-// per SCC.
-//
-// The DFS is implemented recursively; Go grows goroutine stacks
-// dynamically (8KB → many MB), so depth is bounded only by available
-// memory and is far beyond any realistic stdlib graph size.
+// tarjanSCCs runs the shared strongly-connected-components pass over
+// the adjacency list `edges`. Nodes referenced only as targets (not
+// present as keys) are included as singletons. Returns one slice per
+// SCC.
 func tarjanSCCs(edges map[string][]string) [][]string {
-	index := 0
-	indices := map[string]int{}
-	lowlink := map[string]int{}
-	onStack := set.NewSet[string]()
-	stack := []string{}
-	var sccs [][]string
-
 	// Gather all nodes (sources + targets) so isolated importees are
 	// represented even if they have no outgoing edges.
 	nodeSet := set.NewSet[string]()
@@ -183,48 +173,9 @@ func tarjanSCCs(edges map[string][]string) [][]string {
 	nodes := nodeSet.ToSlice()
 	sort.Strings(nodes) // deterministic traversal
 
-	var strongconnect func(v string)
-	strongconnect = func(v string) {
-		indices[v] = index
-		lowlink[v] = index
-		index++
-		stack = append(stack, v)
-		onStack.Add(v)
-
-		for _, w := range edges[v] {
-			if _, seen := indices[w]; !seen {
-				strongconnect(w)
-				if lowlink[w] < lowlink[v] {
-					lowlink[v] = lowlink[w]
-				}
-			} else if onStack.Contains(w) {
-				if indices[w] < lowlink[v] {
-					lowlink[v] = indices[w]
-				}
-			}
-		}
-
-		if lowlink[v] == indices[v] {
-			var scc []string
-			for {
-				w := stack[len(stack)-1]
-				stack = stack[:len(stack)-1]
-				onStack.Remove(w)
-				scc = append(scc, w)
-				if w == v {
-					break
-				}
-			}
-			sccs = append(sccs, scc)
-		}
-	}
-
-	for _, n := range nodes {
-		if _, seen := indices[n]; !seen {
-			strongconnect(n)
-		}
-	}
-	return sccs
+	return graph.StronglyConnectedComponents(nodes, func(v string) []string {
+		return edges[v]
+	})
 }
 
 // loadStdlibSCC parses and infers every URI in sccURIs as a single

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	graphalg "github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/tidwall/btree"
 )
@@ -843,65 +844,26 @@ func FindDeclDependencies(key BindingKey, graph *DepGraph) btree.Set[BindingKey]
 // component to be reported. If a component has size equal to threshold, it is
 // reported only if it contains a self-reference.
 func (g *DepGraph) FindStronglyConnectedComponents(threshold int) [][]BindingKey {
-	index := 0
-	stack := make([]BindingKey, 0)
-	indices := make(map[BindingKey]int)
-	lowlinks := make(map[BindingKey]int)
-	onStack := set.NewSet[BindingKey]()
-	sccs := make([][]BindingKey, 0)
-
-	var strongConnect func(BindingKey)
-	strongConnect = func(v BindingKey) {
-		indices[v] = index
-		lowlinks[v] = index
-		index++
-		stack = append(stack, v)
-		onStack.Add(v)
-
-		// Consider successors of v
+	// Read each binding's out-neighbours from its btree dep set, in the set's
+	// own sorted order, so the shared pass seeds and traverses deterministically.
+	successors := func(v BindingKey) []BindingKey {
 		deps := g.GetDeps(v)
+		out := make([]BindingKey, 0, deps.Len())
 		iter := deps.Iter()
 		for ok := iter.First(); ok; ok = iter.Next() {
-			w := iter.Key()
-			if _, exists := indices[w]; !exists {
-				// Successor w has not yet been visited; recurse on it
-				strongConnect(w)
-				if lowlinks[w] < lowlinks[v] {
-					lowlinks[v] = lowlinks[w]
-				}
-			} else if onStack.Contains(w) {
-				// Successor w is in stack and hence in the current SCC
-				if indices[w] < lowlinks[v] {
-					lowlinks[v] = indices[w]
-				}
-			}
+			out = append(out, iter.Key())
 		}
-
-		// If v is a root node, pop the stack and create an SCC
-		if lowlinks[v] == indices[v] {
-			var scc []BindingKey
-			for {
-				w := stack[len(stack)-1]
-				stack = stack[:len(stack)-1]
-				onStack.Remove(w)
-				scc = append(scc, w)
-				if w == v {
-					break
-				}
-			}
-			// Report cycles: either multiple bindings OR a self-reference
-			deps := g.GetDeps(scc[0])
-			if len(scc) > threshold || (len(scc) == threshold && deps.Contains(scc[0])) {
-				sccs = append(sccs, scc)
-			}
-		}
+		return out
 	}
 
-	// Run the algorithm for all unvisited binding keys
-	allKeys := g.AllBindings()
-	for _, key := range allKeys {
-		if _, exists := indices[key]; !exists {
-			strongConnect(key)
+	sccs := make([][]BindingKey, 0)
+	for _, scc := range graphalg.StronglyConnectedComponents(g.AllBindings(), successors) {
+		// Report cycles: either more members than the threshold, or exactly the
+		// threshold with a self-reference. scc[0] is the first member popped;
+		// for the size-1 self-loop case it is the sole member.
+		deps := g.GetDeps(scc[0])
+		if len(scc) > threshold || (len(scc) == threshold && deps.Contains(scc[0])) {
+			sccs = append(sccs, scc)
 		}
 	}
 

--- a/internal/graph/scc.go
+++ b/internal/graph/scc.go
@@ -1,0 +1,85 @@
+// Package graph holds small, reusable directed-graph algorithms shared across
+// the compiler. Its first member is a generic Tarjan strongly-connected-
+// components pass that the solver, checker, and dep_graph each wrap.
+package graph
+
+import "github.com/escalier-lang/escalier/internal/set"
+
+// StronglyConnectedComponents returns the strongly connected components of the
+// directed graph whose vertices are nodes and whose edges are given by
+// successors: successors(v) yields the out-neighbours of v. It runs Tarjan's
+// algorithm.
+//
+// Components come back in reverse topological order. A component is emitted only
+// after every component reachable from it, so if some vertex in A has an edge
+// into B, then B appears before A. Within a component the members are in the
+// order Tarjan pops them off its stack. Callers that need a canonical member
+// order sort or reduce each component themselves.
+//
+// Determinism is the caller's contract. The traversal is seeded in the order
+// nodes is given and visits each vertex's out-neighbours in the order
+// successors returns them. A caller that wants a reproducible result passes both
+// pre-sorted. The helper imposes no ordering on T, which is what lets it serve
+// int, string, and other comparable keys from one body.
+//
+// A vertex reached through successors but absent from nodes is still traversed
+// and placed in a component, but it is never used as a DFS seed. A caller that
+// wants an isolated vertex represented as its own singleton must include it in
+// nodes.
+//
+// The DFS recurses, so a pathologically deep graph can overflow the goroutine
+// stack. Go grows goroutine stacks dynamically, so the practical bound is
+// available memory, far beyond any graph the compiler builds today.
+func StronglyConnectedComponents[T comparable](nodes []T, successors func(T) []T) [][]T {
+	index := 0
+	indices := map[T]int{}
+	lowlink := map[T]int{}
+	onStack := set.NewSet[T]()
+	var stack []T
+	var sccs [][]T
+
+	var strongconnect func(v T)
+	strongconnect = func(v T) {
+		indices[v] = index
+		lowlink[v] = index
+		index++
+		stack = append(stack, v)
+		onStack.Add(v)
+
+		for _, w := range successors(v) {
+			if _, seen := indices[w]; !seen {
+				strongconnect(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onStack.Contains(w) {
+				if indices[w] < lowlink[v] {
+					lowlink[v] = indices[w]
+				}
+			}
+		}
+
+		if lowlink[v] != indices[v] {
+			return // v is not a component root, so its members stay on the stack
+		}
+		// v roots a component. Pop the stack down to and including v.
+		var scc []T
+		for {
+			w := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			onStack.Remove(w)
+			scc = append(scc, w)
+			if w == v {
+				break
+			}
+		}
+		sccs = append(sccs, scc)
+	}
+
+	for _, n := range nodes {
+		if _, seen := indices[n]; !seen {
+			strongconnect(n)
+		}
+	}
+	return sccs
+}

--- a/internal/graph/scc_test.go
+++ b/internal/graph/scc_test.go
@@ -1,0 +1,130 @@
+package graph
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// adjSuccessors adapts an adjacency map to the successors function shape.
+func adjSuccessors[T comparable](edges map[T][]T) func(T) []T {
+	return func(v T) []T { return edges[v] }
+}
+
+// normalize sorts each component and then the outer list by first member so
+// assertions don't depend on Tarjan's visit order for membership tests.
+func normalize(sccs [][]int) [][]int {
+	out := make([][]int, len(sccs))
+	for i, scc := range sccs {
+		s := append([]int(nil), scc...)
+		sort.Ints(s)
+		out[i] = s
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
+	return out
+}
+
+func TestStronglyConnectedComponents(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []int
+		edges map[int][]int
+		want  [][]int
+	}{
+		{
+			name:  "empty graph",
+			nodes: nil,
+			edges: nil,
+			want:  [][]int{},
+		},
+		{
+			name:  "single node no edges",
+			nodes: []int{1},
+			edges: map[int][]int{},
+			want:  [][]int{{1}},
+		},
+		{
+			name:  "self loop is its own component",
+			nodes: []int{1},
+			edges: map[int][]int{1: {1}},
+			want:  [][]int{{1}},
+		},
+		{
+			name:  "two-node cycle collapses to one component",
+			nodes: []int{1, 2},
+			edges: map[int][]int{1: {2}, 2: {1}},
+			want:  [][]int{{1, 2}},
+		},
+		{
+			name:  "acyclic chain yields three singletons",
+			nodes: []int{1, 2, 3},
+			edges: map[int][]int{1: {2}, 2: {3}},
+			want:  [][]int{{1}, {2}, {3}},
+		},
+		{
+			name:  "two disjoint cycles",
+			nodes: []int{1, 2, 3, 4},
+			edges: map[int][]int{1: {2}, 2: {1}, 3: {4}, 4: {3}},
+			want:  [][]int{{1, 2}, {3, 4}},
+		},
+		{
+			name:  "one-way importer of a cycle stays a singleton",
+			nodes: []int{1, 2, 3},
+			edges: map[int][]int{1: {2}, 2: {3}, 3: {2}},
+			want:  [][]int{{1}, {2, 3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StronglyConnectedComponents(tt.nodes, adjSuccessors(tt.edges))
+			require.Equal(t, tt.want, normalize(got))
+		})
+	}
+}
+
+// TestStronglyConnectedComponents_ReverseTopologicalOrder pins the ordering
+// contract: a component is emitted only after every component reachable from it.
+// The graph 1 → 2 → {3 ↔ 4} must emit {3,4}, then {2}, then {1}.
+func TestStronglyConnectedComponents_ReverseTopologicalOrder(t *testing.T) {
+	edges := map[int][]int{1: {2}, 2: {3}, 3: {4}, 4: {3}}
+	got := StronglyConnectedComponents([]int{1, 2, 3, 4}, adjSuccessors(edges))
+
+	require.Len(t, got, 3)
+	// {3,4} finishes first, then the singletons 2 and 1 in that order.
+	first := append([]int(nil), got[0]...)
+	sort.Ints(first)
+	require.Equal(t, []int{3, 4}, first)
+	require.Equal(t, []int{2}, got[1])
+	require.Equal(t, []int{1}, got[2])
+}
+
+// TestStronglyConnectedComponents_TargetNotSeeded verifies a vertex reached only
+// through successors but absent from nodes is still placed in a component. Here
+// 2 is a successor of 1 but not in the seed list, yet both come back.
+func TestStronglyConnectedComponents_TargetNotSeeded(t *testing.T) {
+	edges := map[int][]int{1: {2}}
+	got := StronglyConnectedComponents([]int{1}, adjSuccessors(edges))
+	require.Equal(t, [][]int{{2}, {1}}, got)
+}
+
+// TestStronglyConnectedComponents_Strings exercises the helper on a non-int key
+// type, matching the checker's string-URI usage.
+func TestStronglyConnectedComponents_Strings(t *testing.T) {
+	edges := map[string][]string{
+		"a": {"b"},
+		"b": {"a"},
+		"c": {"a"},
+	}
+	got := StronglyConnectedComponents([]string{"a", "b", "c"}, adjSuccessors(edges))
+
+	out := make([][]string, len(got))
+	for i, scc := range got {
+		s := append([]string(nil), scc...)
+		sort.Strings(s)
+		out[i] = s
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
+	require.Equal(t, [][]string{{"a", "b"}, {"c"}}, out)
+}

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -161,65 +162,20 @@ func buildLtBoundSet(occ map[*soltype.LifetimeVar]occPolarity) *ltBoundSet {
 // adjacency edges over the node IDs, and returns a map from every node ID to its
 // component representative, the smallest ID in the component. A cycle in the outlives
 // relation means mutually-outliving, hence equal, lifetimes, so folding each component
-// to one representative turns the raw graph into a DAG. Uses Tarjan's algorithm.
+// to one representative turns the raw graph into a DAG. The shared Tarjan pass finds the
+// components; the smallest-ID representative mirrors unionFind's smaller-id rule.
 func condenseSCCs(nodeIDs []int, edges map[int]set.Set[int]) map[int]int {
-	index := map[int]int{}
-	lowlink := map[int]int{}
-	onStack := set.NewSet[int]()
-	var stack []int
-	next := 0
-	rep := map[int]int{}
-
-	var strongconnect func(v int)
-	strongconnect = func(v int) {
-		index[v] = next
-		lowlink[v] = next
-		next++
-		stack = append(stack, v)
-		onStack.Add(v)
-
-		for w := range edges[v] {
-			if _, seen := index[w]; !seen {
-				strongconnect(w)
-				if lowlink[w] < lowlink[v] {
-					lowlink[v] = lowlink[w]
-				}
-			} else if onStack.Contains(w) {
-				if index[w] < lowlink[v] {
-					lowlink[v] = index[w]
-				}
-			}
-		}
-
-		if lowlink[v] != index[v] {
-			return // v is not a component root, so its members stay on the stack
-		}
-		// v roots a component. Pop the stack down to v and key every member to the
-		// smallest ID among them, mirroring unionFind's smaller-id representative rule.
-		r := v
-		start := len(stack)
-		for {
-			start--
-			if stack[start] < r {
-				r = stack[start]
-			}
-			if stack[start] == v {
-				break
-			}
-		}
-		for _, w := range stack[start:] {
-			onStack.Remove(w)
-			rep[w] = r
-		}
-		stack = stack[:start]
-	}
-
 	// Seed the traversal in ascending ID order so a run is reproducible.
 	sorted := append([]int(nil), nodeIDs...)
 	sort.Ints(sorted)
-	for _, id := range sorted {
-		if _, seen := index[id]; !seen {
-			strongconnect(id)
+
+	rep := map[int]int{}
+	for _, scc := range graph.StronglyConnectedComponents(sorted, func(v int) []int {
+		return edges[v].ToSlice()
+	}) {
+		r := slices.Min(scc)
+		for _, w := range scc {
+			rep[w] = r
 		}
 	}
 	return rep


### PR DESCRIPTION
Consolidates three independent implementations of Tarjan's strongly-connected-components algorithm into a single generic helper in a new `internal/graph` package. This eliminates code duplication across the dep_graph, solver, and checker modules while maintaining the same behavior and performance characteristics.

**Key changes:**

- Added `internal/graph/scc.go` with a generic `StronglyConnectedComponents` function that works over any comparable type and accepts a caller-provided successor function for flexibility.
- Added comprehensive test coverage in `internal/graph/scc_test.go` including edge cases (empty graphs, self-loops, disjoint cycles) and verification of reverse topological ordering.
- Refactored `internal/dep_graph/dep_graph.go` to call the shared pass instead of its own Tarjan implementation.
- Refactored `internal/solver/lifetime_bounds.go` to use the shared pass and simplified component representative selection with `slices.Min`.
- Refactored `internal/checker/infer_stdlib_scc.go` to use the shared pass, reducing the function from ~50 lines to ~5.

**Implementation notes:**

The shared algorithm preserves the original behavior: components are emitted in reverse topological order, vertices reached only through successors are included even if absent from the seed list, and determinism is the caller's responsibility (both the node list and successor order must be stable). The generic design imposes no ordering constraint on the type parameter, allowing it to serve int, string, and other comparable keys from a single implementation.

https://claude.ai/code/session_01Me5G93V1EDbEqn2PpuzJTK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified component-detection logic across the system, improving consistency and maintainability.
  * Preserved existing behavior while making results deterministic and keeping component ordering stable.

* **Tests**
  * Added coverage for multiple graph scenarios, including cycles, self-loops, empty graphs, and non-integer values.
  * Verified component ordering and handling of nodes discovered through relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->