### PR TITLE
Render join lifetimes with outlives bounds instead of unions

### DIFF
--- a/internal/soltype/lifetime.go
+++ b/internal/soltype/lifetime.go
@@ -40,13 +40,12 @@ type LifetimeVar struct {
 
 	// Join marks an internal lifetime minted at a multi-source join site (M4 D3).
 	// A join site is a return or branch that unites several borrows with distinct
-	// lifetimes. A join variable is NOT a borrow origin, so it is never named in
-	// the output. It renders as the union of the param lifetimes it reaches through
-	// its bounds, e.g. returning one of two borrows coalesces to `('a | 'b)`. The
-	// default is a param lifetime, Join false, which originates at a borrow
-	// parameter and renders under its own name. The distinction governs
-	// coalesceLifetime. A param variable is kept whole, a join variable is expanded
-	// to its reachable members.
+	// lifetimes. A join variable is not a borrow origin. When it reaches one param
+	// lifetime it renders under that param's name; when it reaches two or more it
+	// takes its own name and the source params carry outlives bounds to it, so
+	// returning one of two borrows renders `<'a: 'c, 'b: 'c, 'c>`. The default is a
+	// param lifetime, Join false, which originates at a borrow parameter and renders
+	// under its own name. The distinction governs coalesceLifetime.
 	Join bool
 }
 
@@ -76,12 +75,11 @@ type StaticLifetime struct{}
 // determined unobservable.
 type AnonLifetime struct{}
 
-// LifetimeUnion is a coalescing-output-only lifetime. It is the union of the param
-// lifetimes a join variable reaches, e.g. returning one of two borrows renders as
-// `('a | 'b)`. It never appears as a constraint input, since constrainLt relates
-// LifetimeVars and 'static only. It is minted solely by coalesceLifetime when a
-// join variable expands to more than one member. A single-member expansion yields
-// the member directly, so a LifetimeUnion always carries at least two lifetimes.
+// LifetimeUnion is the union of several named lifetimes, e.g. `('a | 'b)`. It never
+// appears as a constraint input, since constrainLt relates LifetimeVars and 'static
+// only. Its sole mint is the `('a | 'b) T` annotation lowering in type_ann.go, which
+// interns each named member and unions them. A union always carries at least two
+// lifetimes, since a single member lowers to that member directly.
 type LifetimeUnion struct {
 	Lifetimes []Lifetime
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -2,6 +2,7 @@ package soltype
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -82,8 +83,14 @@ func Print(t Type) string {
 // that trusts its input is a fully-generalized type. The solver's renderScheme
 // uses PrintAsSchemeWith to restrict naming to the variables generalization
 // actually quantified, so a stray variable is not disguised as a parameter.
+//
+// PrintAsScheme passes no lifetime bounds, so a quantified lifetime renders as a bare
+// name with no outlives bound. A join lifetime then shows as `<'a, 'b, 'c>` with no
+// `'a: 'c` linkage. To render those bounds a caller must supply them through
+// PrintAsSchemeWith, which the solver's renderScheme does. Use renderScheme, not
+// PrintAsScheme, to display a solver scheme that may carry borrow lifetimes.
 func PrintAsScheme(t Type) string {
-	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true })
+	return PrintAsSchemeWith(t, func(*TypeVarType) bool { return true }, nil)
 }
 
 // PrintAsSchemeWith renders a generalized type, naming ONLY the free variables
@@ -92,7 +99,13 @@ func PrintAsScheme(t Type) string {
 // preserves the leak anchor: a variable coalescing failed to inline (a captured
 // var that escaped, a stray inference var) shows as `t{ID}` rather than a spurious
 // `<Tn>` that would make a malformed signature look valid.
-func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
+//
+// ltBounds carries the transitively-reduced outlives relation among the type's named
+// lifetime variables: ltBounds[lv] is the lifetimes lv outlives. A join lifetime
+// bounded below by two borrows renders as `<'a: 'c, 'b: 'c, 'c>`, where 'a and 'b
+// each carry the bound {'c}. A nil map draws no bounds, so a caller that does not
+// solve lifetime bounds renders bare names.
+func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*LifetimeVar][]*LifetimeVar) string {
 	names := map[*TypeVarType]string{}
 	var labels []string
 	for _, v := range freeTypeVars(t) {
@@ -104,27 +117,58 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool) string {
 		labels = append(labels, name)
 	}
 	// Borrow lifetimes left in the coalesced type by D4's coalesceLifetimes are all
-	// nameable param lifetimes. A connect-nothing one was already elided, and a join
-	// expanded to a union of these. Name each 'a, 'b, … in first-appearance order and
-	// add it to the quantifier prefix after the type parameters.
+	// nameable. A connect-nothing one was already elided; a param lifetime and a kept
+	// join lifetime both survive here. Name each 'a, 'b, … in first-appearance order
+	// and add it to the quantifier prefix after the type parameters.
+	ltVars := freeLifetimeVars(t)
 	ltNames := map[*LifetimeVar]string{}
-	var ltLabels []string
-	for _, lv := range freeLifetimeVars(t) {
-		name := lifetimeParamName(len(ltLabels))
-		ltNames[lv] = name
-		ltLabels = append(ltLabels, name)
+	ltIndex := map[*LifetimeVar]int{}
+	for i, lv := range ltVars {
+		ltNames[lv] = lifetimeParamName(i)
+		ltIndex[lv] = i
 	}
-	if len(labels) == 0 && len(ltLabels) == 0 {
+	if len(labels) == 0 && len(ltVars) == 0 {
 		// No quantified parameters: render as a plain (possibly raw-var) type, which
 		// keeps a leaked variable visible as t{ID}.
 		return Print(t)
 	}
 	p := &namedPrinter{names: names, ltNames: ltNames}
+	ltLabels := make([]string, len(ltVars))
+	for i, lv := range ltVars {
+		ltLabels[i] = p.lifetimeBinder(lv, ltBounds[lv], ltIndex)
+	}
 	prefix := "<" + strings.Join(append(labels, ltLabels...), ", ") + ">"
 	if ft, ok := t.(*FuncType); ok {
 		return "fn " + prefix + p.printFuncTail(ft)
 	}
 	return prefix + " " + p.printType(t)
+}
+
+// lifetimeBinder renders one lifetime binder in the quantifier prefix: the bare name
+// `'a`, or `'a: 'b & 'c` when lv outlives 'b and 'c. The bound lifetimes are ordered
+// by first appearance via ltIndex, the same order the prefix names them, so the output
+// is stable. A bound lifetime absent from ltIndex is skipped rather than rendered as an
+// out-of-band name. The solver never produces such a bound, so this is only a guard.
+func (p *namedPrinter) lifetimeBinder(lv *LifetimeVar, bounds []*LifetimeVar, ltIndex map[*LifetimeVar]int) string {
+	name := p.ltNames[lv]
+	if len(bounds) == 0 {
+		return name
+	}
+	targets := make([]*LifetimeVar, 0, len(bounds))
+	for _, b := range bounds {
+		if _, ok := ltIndex[b]; ok {
+			targets = append(targets, b)
+		}
+	}
+	if len(targets) == 0 {
+		return name
+	}
+	sort.Slice(targets, func(i, j int) bool { return ltIndex[targets[i]] < ltIndex[targets[j]] })
+	parts := make([]string, len(targets))
+	for i, b := range targets {
+		parts[i] = p.ltNames[b]
+	}
+	return name + ": " + strings.Join(parts, " & ")
 }
 
 // typeParamName is the surface name for the i-th quantified type parameter: T0,
@@ -274,9 +318,9 @@ func (p *namedPrinter) printLifetime(lt Lifetime) string {
 		}
 		return "'l" + strconv.Itoa(lt.ID)
 	case *LifetimeUnion:
-		// The union form a join lifetime coalesces to. It is the union of the param
-		// lifetimes it reaches, parenthesized so the `mut`/borrow prefix binds the
-		// whole union, giving `mut ('a | 'b) {…}` rather than `mut 'a | 'b {…}`.
+		// A written `('a | 'b)` annotation, parenthesized so the `mut`/borrow prefix
+		// binds the whole union, giving `mut ('a | 'b) {…}` rather than
+		// `mut 'a | 'b {…}`.
 		parts := make([]string, len(lt.Lifetimes))
 		for i, m := range lt.Lifetimes {
 			parts[i] = p.printLifetime(m)

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -530,6 +530,6 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 		Params: []*FuncParam{identP("x", param)},
 		Ret:    &TupleType{Elems: []Type{param, leaked}},
 	}
-	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 })
+	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil)
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -32,7 +32,7 @@ import (
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
-	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
+	c = bubbleOwnedMut(c)            // #779: lift an owned-mut cell out of an immutable container
 	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
@@ -339,11 +339,14 @@ func schemeType(s TypeScheme) soltype.Type {
 func renderScheme(s TypeScheme) string {
 	switch sc := s.(type) {
 	case *MonoScheme:
-		return soltype.PrintAsScheme(coalesce(sc.Ty, soltype.Positive))
+		t := coalesce(sc.Ty, soltype.Positive)
+		return soltype.PrintAsSchemeWith(t, func(*soltype.TypeVarType) bool { return true },
+			displayLtBounds(t, soltype.Positive))
 	case *PolyScheme:
-		return soltype.PrintAsSchemeWith(sc.display(), func(v *soltype.TypeVarType) bool {
+		t := sc.display()
+		return soltype.PrintAsSchemeWith(t, func(v *soltype.TypeVarType) bool {
 			return v.Level > sc.Level
-		})
+		}, displayLtBounds(t, soltype.Positive))
 	}
 	panic(fmt.Sprintf("renderScheme: unknown TypeScheme %T", s))
 }

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -115,11 +115,11 @@ func TestInferFieldWriteToImmutableObjectRejected(t *testing.T) {
 }
 
 // Returning one of two borrows with DISTINCT lifetimes joins them into a single
-// borrow whose lifetime is the union of theirs. This is the ConditionalUnionReturn
-// acceptance (M4 D3). The return-point join mints a fresh join lifetime bounded
-// below by 'l0 and 'l1, which coalesces to `('l0 | 'l1)` in the positive return
-// position. The param lifetimes 'l0/'l1 stay named on the borrows they originate.
-// D4 renders them `'a`/`'b` and the union `('a | 'b)`.
+// borrow whose lifetime is bounded below by both. This is the ConditionalUnionReturn
+// acceptance (M4 D3). The return-point join mints a fresh join lifetime bounded below
+// by 'l0 and 'l1, which stays named as 'c in the positive return position. The param
+// lifetimes 'l0/'l1 stay named on the borrows they originate, and each outlives 'c, so
+// the quantifier prefix carries the bounds `'a: 'c, 'b: 'c`.
 func TestInferConditionalUnionReturn(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: number}) {
   if true {
@@ -131,7 +131,7 @@ func TestInferConditionalUnionReturn(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		"fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
 		values["f"])
 }
 
@@ -155,9 +155,10 @@ func TestInferMismatchedBorrowsFallBackToUnion(t *testing.T) {
 		values["f"])
 }
 
-// A join over THREE borrows unites all their lifetimes. The fresh join lifetime is
-// bounded below by each, coalescing to `('l0 | 'l1 | 'l2)` in the return position.
-// This confirms the join generalizes past the two-branch case to an n-ary return set.
+// A join over THREE borrows relates all their lifetimes to one return lifetime. The
+// fresh join lifetime 'd is bounded below by each, so each param lifetime carries the
+// bound `: 'd` in the prefix. This confirms the join generalizes past the two-branch
+// case to an n-ary return set.
 func TestInferThreeWayBorrowJoin(t *testing.T) {
 	src := `fn f(p: &mut {x: number}, q: &mut {x: number}, r: &mut {x: number}) {
   if true {
@@ -173,20 +174,21 @@ func TestInferThreeWayBorrowJoin(t *testing.T) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &('a | 'b | 'c) mut {x: number}",
+		"fn <'a: 'd, 'b: 'd, 'c: 'd, 'd>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &'d mut {x: number}",
 		values["f"])
 }
 
-// A GENERALIZED joined-borrow function keeps its lifetime union after instantiation.
-// A caller that passes two of its own borrows still sees a two-lifetime union, not a
-// single name. This is the only end-to-end exercise of the Join flag riding through
-// freshenAbove/extrude (D2.5). If the flag were dropped on the freshened join
-// lifetime, the instantiated return would coalesce to one lifetime instead of a
-// union. `pick` renders `mut ('a | 'b) {…}` over its two param lifetimes.
-// Instantiating it inside `use` freshens the join and its two members to use-level
-// lifetimes. D4's component-based expansion resolves those intermediaries back to
-// `use`'s own param lifetimes, so `use` renders the same clean `mut ('a | 'b) {…}`
-// over `a` and `b` rather than the raw freshened ids.
+// A GENERALIZED joined-borrow function keeps its bounded return lifetime after
+// instantiation. A caller that passes two of its own borrows still sees both
+// lifetimes bounding the return, not a single name. This is the only end-to-end
+// exercise of the Join flag riding through freshenAbove/extrude (D2.5). If the flag
+// were dropped on the freshened join lifetime, the instantiated return would coalesce
+// to one lifetime instead of a bounded join. `pick` renders `<'a: 'c, 'b: 'c, 'c>`
+// over its two param lifetimes and the return lifetime they outlive. Instantiating it
+// inside `use` freshens the join and its two members to use-level lifetimes. The
+// component-based analysis resolves those intermediaries back to `use`'s own param
+// lifetimes, so `use` renders the same clean bounded form over `a` and `b` rather than
+// the raw freshened ids.
 func TestInferInstantiatedJoinReturnsUnion(t *testing.T) {
 	src := `fn pick(p: &mut {x: number}, q: &mut {x: number}) {
   if true { return p } else { return q }
@@ -197,10 +199,10 @@ fn use(a: &mut {x: number}, b: &mut {x: number}) {
 	values, _, errs := inferSource(t, src)
 	require.Empty(t, errs)
 	require.Equal(t,
-		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		"fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
 		values["pick"])
 	require.Equal(t,
-		"fn <'a, 'b>(a: &'a mut {x: number}, b: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		"fn <'a: 'c, 'b: 'c, 'c>(a: &'a mut {x: number}, b: &'b mut {x: number}) -> &'c mut {x: number}",
 		values["use"])
 }
 

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -619,8 +619,9 @@ func (c *checker) inferVarDecl(scope *Scope, lvl int, d *ast.VarDecl) (ValueBind
 	}
 	scheme := c.generalize(bound, lvl)
 	// The recorded display type retains any quantified type-parameter vars (it is
-	// not var-free), so Info consumers must render it with soltype.PrintAsScheme, not
-	// plain soltype.Print — same contract as the top-level path (see module.go).
+	// not var-free), so Info consumers must render it with renderScheme, which threads
+	// lifetime bounds. Plain soltype.Print drops the var names and plain PrintAsScheme
+	// drops the lifetime bounds. Same contract as the top-level path (see module.go).
 	c.recordType(d.Pattern, schemeType(scheme))
 	// PR8: carry the introducing decl's kind so inferAssign can gate reassignment —
 	// only a `var` is reassignable, a `val` is not.

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -131,13 +131,13 @@ func TestInferLifetimeFuncAnnotation(t *testing.T) {
 		},
 		// A declared `'b: 'a` bound relates the two lifetimes. Only p is returned, so `'b`
 		// reaches no output on its own, yet the bound keeps it named. The un-bounded twin
-		// below elides `'b` to a bare `&`, isolating the bound's effect. The bound itself
-		// is not yet rendered in the prefix, which is the render track's job.
+		// below elides `'b` to a bare `&`, isolating the bound's effect. The bound renders
+		// back in the prefix as `'b: 'a`, since 'b outlives 'a.
 		{
 			name:    "outlives bound keeps connected lifetime",
 			src:     `val f: fn<'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number} = fn (p, q) { return p }`,
 			binding: "f",
-			want:    "fn <'a, 'b>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}",
+			want:    "fn <'a, 'b: 'a>(p: &'a {x: number}, q: &'b {x: number}) -> &'a {x: number}",
 		},
 		{
 			name:    "no bound elides unconnected lifetime",

--- a/internal/solver/infer_ref_union_test.go
+++ b/internal/solver/infer_ref_union_test.go
@@ -87,12 +87,13 @@ func TestInferRefUnion(t *testing.T) {
 		},
 		{
 			// Two borrows that differ only in lifetime join into one borrow rather than a
-			// mixed union, so the uniform-ownership check leaves them alone.
+			// mixed union, so the uniform-ownership check leaves them alone. The join
+			// lifetime 'c stays named, with each source lifetime bounded above it.
 			name: "uniform borrow union",
 			src: `fn f(p: &mut {x: number}, q: &mut {x: number}) {
   if true { return p } else { return q }
 }`,
-			want: "fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+			want: "fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
 		},
 
 		// --- nested-borrow normalization ---

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -222,12 +222,14 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 // occur. pol is the polarity t was coalesced at, threaded so the occurrence walk starts
 // from the same root.
 //
-// The relation has two sources. A directed edge the solved graph records, read by
-// implies, covers a declared or inferred bound between two named lifetimes, such as
-// `'b: 'a`. A source lifetime feeding a multi-source join covers the join case. An
-// instantiation interposes an intermediary that outlives both the source and the join,
-// so no directed edge links them, yet each source outlives the join. componentParams
-// recovers those sources from the join's connected component.
+// The relation draws on two sources of outlives facts:
+//
+//   - A directed edge the solved graph records, read by implies. This covers a
+//     declared or inferred bound between two named lifetimes, such as `'b: 'a`.
+//   - A source lifetime feeding a multi-source join, recovered by componentParams from
+//     the join's connected component. An instantiation interposes an intermediary that
+//     outlives both the source and the join, so no directed edge links them, yet each
+//     source outlives the join.
 //
 // The reduction reads its own edge relation, the implies-or-feedsJoin union, rather
 // than ltBoundSet.reduce's raw edge graph, so it is computed here rather than reused.

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"maps"
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -244,10 +246,7 @@ func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.Lifetime
 	a := newLtAnalysis(occ)
 	bs := a.bs
 
-	survivors := make([]*soltype.LifetimeVar, 0, len(occ))
-	for v := range occ {
-		survivors = append(survivors, v)
-	}
+	survivors := slices.Collect(maps.Keys(occ))
 	sort.Slice(survivors, func(i, j int) bool { return survivors[i].ID < survivors[j].ID })
 
 	// joinSources maps each multi-source join survivor to the SCC representatives of the

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -37,19 +37,18 @@ import (
 //     bare inner, because RefType{Mut: false, Lt: nil} is the forbidden
 //     degenerate cell NewRef rejects.
 //
-//  3. Join expansion. A non-param lifetime is not itself nameable. It is either a
-//     join variable minted at a return or branch, or a lifetime freshened when a
-//     borrow-passing function was instantiated. It expands to the union of the param
-//     lifetimes sharing its connected component in the condensed graph, so a return
-//     uniting two borrows coalesces to ('a | 'b). The grouping is by connectivity
-//     because instantiation interposes an intermediary between a call's argument
-//     lifetime and the join it feeds. That intermediary outlives both the caller's
-//     param lifetime and the join, so the param and the join are joined only through
-//     it, with no direct outlives edge either way. A lifetime forced to 'static
-//     renders 'static and absorbs. The union is a conservative rendering of the
-//     directional bound set the condensed graph carries. A later change keeps the
-//     join lifetime named and renders each kept param's outlives edges as `'a: 'c`
-//     bounds instead of collapsing to the union ('a | 'b).
+//  3. Join naming. A non-param lifetime is a join variable minted at a return or
+//     branch, or a lifetime freshened when a borrow-passing function was instantiated.
+//     It resolves to the param lifetimes sharing its connected component in the
+//     condensed graph. A join reaching one param renders under that param's name. A
+//     join reaching two or more keeps its own name, and displayLtBounds renders each
+//     source param's outlives edge as an `'a: 'c` bound, so a return uniting two
+//     borrows renders `<'a: 'c, 'b: 'c, 'c>`. The grouping is by connectivity because
+//     instantiation interposes an intermediary between a call's argument lifetime and
+//     the join it feeds. That intermediary outlives both the caller's param lifetime
+//     and the join, so the param and the join are joined only through it, with no
+//     direct outlives edge either way. A lifetime forced to 'static renders 'static
+//     and absorbs.
 //
 // coalesceLifetimes resolves the borrow lifetimes left raw by the structural
 // coalescers. pol is the root polarity the type was coalesced at, threaded through
@@ -150,15 +149,22 @@ func (a *ltAnalysis) kept(v *soltype.LifetimeVar) bool {
 	return a.posComps.Contains(a.leaderOf(v))
 }
 
-// componentParams returns the kept param lifetimes in v's connected component, sorted
-// by variable ID for a canonical union member order. Members are keyed by SCC
-// representative so mutually-outliving params list once, but emit a param var, since
-// the representative itself can be a non-param bridge var named in no parameter slot.
-func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime {
+// componentParams returns the kept param lifetimes in v's connected component, keyed
+// by SCC representative so mutually-outliving params list once. Each entry emits a
+// param var, since the representative itself can be a non-param bridge var named in no
+// parameter slot. The result is sorted by variable ID. resolveLt reads only the count:
+// one member means v reborrows a single source and renders under that source's name,
+// while two or more means v is a genuine multi-source join.
+//
+// A 'static-forced param renders as 'static rather than a name, so it is not a named
+// source and is excluded. This keeps the count of named sources consistent with what
+// survives in the resolved type, so a join whose only other source escaped to 'static
+// collapses to its single remaining name rather than taking a fresh one.
+func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []*soltype.LifetimeVar {
 	leader := a.leaderOf(v)
 	byRep := map[int]*soltype.LifetimeVar{}
 	for p := range a.occ {
-		if !a.isParam(p) || !a.kept(p) {
+		if !a.isParam(p) || !a.kept(p) || forcedToStatic(p) {
 			continue
 		}
 		pr := a.bs.repOf(p.ID)
@@ -169,13 +175,11 @@ func (a *ltAnalysis) componentParams(v *soltype.LifetimeVar) []soltype.Lifetime 
 			byRep[pr] = p
 		}
 	}
-	members := make([]soltype.Lifetime, 0, len(byRep))
+	members := make([]*soltype.LifetimeVar, 0, len(byRep))
 	for _, p := range byRep {
 		members = append(members, p)
 	}
-	sort.Slice(members, func(i, j int) bool {
-		return members[i].(*soltype.LifetimeVar).ID < members[j].(*soltype.LifetimeVar).ID
-	})
+	sort.Slice(members, func(i, j int) bool { return members[i].ID < members[j].ID })
 	return members
 }
 
@@ -191,17 +195,144 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 		}
 		return nil, true // connect-nothing param: elide
 	}
-	// A non-param lifetime is a join variable or an instantiation intermediary. It is
-	// not nameable, so it expands to the union of the param lifetimes in its component.
+	// A non-param lifetime is a join variable minted at a return or branch, or an
+	// instantiation intermediary. It resolves to the param lifetimes it reaches.
 	members := a.componentParams(v)
 	switch len(members) {
 	case 0:
-		return nil, true
+		return nil, true // reaches no param: elide
 	case 1:
+		// A single reached param means v reborrows one source, so it renders under that
+		// source's name rather than a fresh one. Mutually-outliving params condense to
+		// one member here, so a join over equal borrows also lands in this arm.
 		return members[0], false
 	default:
-		return &soltype.LifetimeUnion{Lifetimes: members}, false
+		// A genuine multi-source join keeps its own name. The param lifetimes that
+		// outlive it render as `'a: 'c` bounds in the quantifier prefix, computed by
+		// displayLtBounds.
+		return v, false
 	}
+}
+
+// displayLtBounds computes the transitively-reduced outlives relation among the named
+// lifetime variables surviving in a coalesced display type, keyed by variable for the
+// printer's `'a: 'c` prefix. bounds[u] lists the survivors u directly outlives. t is
+// the type coalesceLifetimes produced, so its RefType lifetimes are exactly the named
+// survivors. An elided or 'static-forced lifetime is not a LifetimeVar and so does not
+// occur. pol is the polarity t was coalesced at, threaded so the occurrence walk starts
+// from the same root.
+//
+// The relation has two sources. A directed edge the solved graph records, read by
+// implies, covers a declared or inferred bound between two named lifetimes, such as
+// `'b: 'a`. A source lifetime feeding a multi-source join covers the join case. An
+// instantiation interposes an intermediary that outlives both the source and the join,
+// so no directed edge links them, yet each source outlives the join. componentParams
+// recovers those sources from the join's connected component.
+//
+// The reduction reads its own edge relation, the implies-or-feedsJoin union, rather
+// than ltBoundSet.reduce's raw edge graph, so it is computed here rather than reused.
+// The union relation is materialized once into edges before the reduction, so
+// feedsJoin's occ scan runs per survivor pair, not per reduction step.
+func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.LifetimeVar][]*soltype.LifetimeVar {
+	occ := map[*soltype.LifetimeVar]occPolarity{}
+	t.Accept(&ltOccVisitor{occ: occ}, pol)
+	if len(occ) == 0 {
+		return nil
+	}
+	a := newLtAnalysis(occ)
+	bs := a.bs
+
+	survivors := make([]*soltype.LifetimeVar, 0, len(occ))
+	for v := range occ {
+		survivors = append(survivors, v)
+	}
+	sort.Slice(survivors, func(i, j int) bool { return survivors[i].ID < survivors[j].ID })
+
+	// joinSources maps each multi-source join survivor to the SCC representatives of the
+	// params feeding it. An instantiation interposes an intermediary that outlives both a
+	// source param and the join, so implies does not link them; componentParams recovers
+	// the sources from the join's connected component. Precomputed once so the outlives
+	// relation below reads it instead of rescanning occ per pair.
+	joinSources := map[*soltype.LifetimeVar]set.Set[int]{}
+	for _, w := range survivors {
+		if a.isParam(w) {
+			continue
+		}
+		members := a.componentParams(w)
+		if len(members) < 2 {
+			continue
+		}
+		reps := set.NewSet[int]()
+		for _, m := range members {
+			reps.Add(bs.repOf(m.ID))
+		}
+		joinSources[w] = reps
+	}
+
+	// outlives holds when u and w condense to different representatives and either the
+	// bound set proves 'u: 'w or u feeds the join w. Two survivors sharing a
+	// representative are equal lifetimes, so no bound is drawn between them.
+	outlives := func(u, w *soltype.LifetimeVar) bool {
+		if bs.repOf(u.ID) == bs.repOf(w.ID) {
+			return false
+		}
+		if bs.implies(u.ID, w.ID) {
+			return true
+		}
+		reps, ok := joinSources[w]
+		return ok && reps.Contains(bs.repOf(u.ID))
+	}
+
+	// edges materializes the full outlives relation among survivors once, so the
+	// transitive reduction below reads it rather than recomputing outlives.
+	edges := map[*soltype.LifetimeVar]set.Set[*soltype.LifetimeVar]{}
+	for _, u := range survivors {
+		targets := set.NewSet[*soltype.LifetimeVar]()
+		for _, v := range survivors {
+			if outlives(u, v) {
+				targets.Add(v)
+			}
+		}
+		edges[u] = targets
+	}
+
+	bounds := map[*soltype.LifetimeVar][]*soltype.LifetimeVar{}
+	for _, u := range survivors {
+		var direct []*soltype.LifetimeVar
+		seenRep := set.NewSet[int]()
+		for _, v := range survivors {
+			if !edges[u].Contains(v) {
+				continue
+			}
+			// Drop u -> v when a survivor w sits between them, so 'a: 'b, 'b: 'c renders
+			// without the redundant 'a: 'c. w must condense away from both endpoints, or
+			// it is not a genuine intermediate.
+			redundant := false
+			for _, w := range survivors {
+				if bs.repOf(w.ID) == bs.repOf(u.ID) || bs.repOf(w.ID) == bs.repOf(v.ID) {
+					continue
+				}
+				if edges[u].Contains(w) && edges[w].Contains(v) {
+					redundant = true
+					break
+				}
+			}
+			if redundant {
+				continue
+			}
+			// Two survivors sharing a representative name one lifetime, so keep only the
+			// first to reach it.
+			if seenRep.Contains(bs.repOf(v.ID)) {
+				continue
+			}
+			seenRep.Add(bs.repOf(v.ID))
+			direct = append(direct, v)
+		}
+		if len(direct) > 0 {
+			bounds[u] = direct
+		}
+	}
+	return bounds
 }
 
 // ltRewriter applies the analysis to a coalesced type, resolving each RefType's

--- a/internal/solver/lifetime_test.go
+++ b/internal/solver/lifetime_test.go
@@ -188,10 +188,10 @@ func borrowFn(ret soltype.Type, paramLts ...soltype.Lifetime) *soltype.FuncType 
 }
 
 // Escaping a JOINED borrow forces every param lifetime the join reaches to outlive
-// 'static, so the whole `('a | 'b)` union collapses to a single 'static. This is the
+// 'static, so the whole bounded join collapses to a single 'static. This is the
 // join↔escape interaction (M4 D3). constrainEscape constrains the join lifetime
 // `<: 'static`, which propagates through its lower bounds to each member, and
-// coalesceLifetimes then absorbs the union to 'static rather than expanding it.
+// coalesceLifetimes then absorbs every member to 'static rather than naming it.
 func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)
@@ -203,9 +203,9 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	ret := mutPointRef(join)
 	fn := borrowFn(ret, a, b)
 
-	// Before escape the join expands to the union of its members.
+	// Before escape the join stays named as 'c, bounded below by each source lifetime.
 	require.Equal(t,
-		"fn <'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &('a | 'b) mut {x: number}",
+		"fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 
 	c.constrainEscape(ret)
@@ -215,6 +215,27 @@ func TestEscapingJoinedBorrowCollapsesToStatic(t *testing.T) {
 	require.Equal(t, []soltype.Lifetime{soltype.Static}, join.UpperBounds)
 	require.Equal(t,
 		"fn (p: &'static mut {x: number}, q: &'static mut {x: number}) -> &'static mut {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+}
+
+// When one of a join's two sources escapes to 'static, the join has a single remaining
+// NAMED source, so it collapses to that source's name rather than taking a fresh one.
+// 'a escapes, rendering `&'static`; the join is left with only 'b, so componentParams
+// counts one named member and the return renders `&'b` under the same name as q, not a
+// distinct bounded lifetime. Without excluding the 'static-forced source, the join
+// would keep its own name and render the weaker `<'b: 'c, 'c>`.
+func TestJoinWithOneStaticSourceCollapsesToRemaining(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	join := c.ctx.freshJoinLifetime(0)
+	c.ctx.constrainLt(a, soltype.Static) // 'a escapes to 'static
+	c.ctx.constrainLt(a, join)
+	c.ctx.constrainLt(b, join)
+	fn := borrowFn(mutPointRef(join), a, b)
+
+	require.Equal(t,
+		"fn <'a>(p: &'static mut {x: number}, q: &'a mut {x: number}) -> &'a mut {x: number}",
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 
@@ -240,12 +261,11 @@ func TestImmutableConnectNothingBorrowKeepsRef(t *testing.T) {
 	require.Equal(t, "fn (p: &{x: number}) -> number", renderScheme(&MonoScheme{Ty: fn}))
 }
 
-// A nested join reaching one param lifetime through two distinct sub-joins lists
-// that lifetime once in the rendered union, not twice. The top join's lower bounds
-// are the two sub-joins, and both reach 'a. componentParams gathers the join's
-// component param lifetimes into an ID-keyed, sorted set, so a lifetime reached
-// through two sub-joins appears once. Without that dedup this rendered
-// `('a | 'b | 'a | 'c)`.
+// A nested join reaching one param lifetime through two distinct sub-joins draws that
+// lifetime's bound to the top join once, not twice. The top join's lower bounds are
+// the two sub-joins, and both reach 'a. displayLtBounds keys each survivor's targets
+// by SCC representative, so a lifetime reaching the top join through two sub-joins
+// yields one `'a: 'd` bound. Without that dedup 'a would carry the bound twice.
 func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)
@@ -263,7 +283,32 @@ func TestNestedJoinDedupsSharedLifetime(t *testing.T) {
 	fn := borrowFn(mutPointRef(top), a, b, d)
 
 	require.Equal(t,
-		"fn <'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &('a | 'b | 'c) mut {x: number}",
+		"fn <'a: 'd, 'b: 'd, 'c: 'd, 'd>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> &'d mut {x: number}",
+		renderScheme(&MonoScheme{Ty: fn}))
+}
+
+// A lifetime bounded above two distinct joins renders both bounds joined with `&`, the
+// meet. Two joins sharing a source param sit in one connected component, so the
+// grouping bounds every param in that component to both joins: 'a feeds j1 and j2
+// directly, while 'b and 'c reach the second join only through the shared component.
+// Each param therefore carries `: 'd & 'e`. This is the same connectivity grouping the
+// union rendering used, where both tuple slots read `('a | 'b | 'c)`.
+func TestParamFeedingTwoJoinsRendersMeetBound(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	d := c.ctx.freshLifetime(0)
+	j1 := c.ctx.freshJoinLifetime(0)
+	j2 := c.ctx.freshJoinLifetime(0)
+	c.ctx.constrainLt(a, j1) // 'a feeds both joins
+	c.ctx.constrainLt(b, j1)
+	c.ctx.constrainLt(a, j2)
+	c.ctx.constrainLt(d, j2)
+	ret := &soltype.TupleType{Elems: []soltype.Type{mutPointRef(j1), mutPointRef(j2)}}
+	fn := borrowFn(ret, a, b, d)
+
+	require.Equal(t,
+		"fn <'a: 'd & 'e, 'b: 'd & 'e, 'c: 'd & 'e, 'd, 'e>(p: &'a mut {x: number}, q: &'b mut {x: number}, r: &'c mut {x: number}) -> [&'d mut {x: number}, &'e mut {x: number}]",
 		renderScheme(&MonoScheme{Ty: fn}))
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -441,8 +441,10 @@ func (c *checker) inferComponent(
 		//
 		// NOTE: for a GENERALIZED binding this display type RETAINS its quantified
 		// type-parameter variables (it is not var-free), so consumers must render it
-		// with soltype.PrintAsScheme — plain soltype.Print renders those vars as the
-		// raw `t{ID}` debug form. (renderScheme is the canonical renderer.)
+		// with renderScheme, the canonical renderer. renderScheme threads the lifetime
+		// outlives bounds through soltype.PrintAsSchemeWith. Plain soltype.Print renders
+		// the retained vars as the raw `t{ID}` debug form, and plain soltype.PrintAsScheme
+		// omits the lifetime bounds, so a join lifetime would lose its `'a: 'c` linkage.
 		display := schemeType(scheme)
 		if b.infoNode != nil {
 			c.recordType(b.infoNode, display)


### PR DESCRIPTION
Changes how multi-source join lifetimes display in inferred function signatures. Instead of rendering as a union like `&('a | 'b) mut T`, they now render as a named lifetime with outlives bounds: `&'c mut T` where the quantifier prefix carries `'a: 'c, 'b: 'c, 'c`.

**Key changes:**

- `componentParams` now returns `[]*soltype.LifetimeVar` instead of `[]soltype.Lifetime`, and excludes 'static-forced params so the count reflects only named sources. A join reaching one param collapses to that param's name; two or more keeps its own name.

- `resolveLt` returns the join variable itself when it reaches multiple params, rather than constructing a `LifetimeUnion`. Single-param joins still resolve to that param's name.

- New `displayLtBounds` function computes the transitively-reduced outlives relation among named lifetime variables in a coalesced type. It reads both the solved bound graph and the join-feeding relation (recovered from connected components) to emit `'a: 'c` bounds in the quantifier prefix.

- `PrintAsSchemeWith` now accepts an `ltBounds` parameter mapping each lifetime variable to the lifetimes it outlives. `lifetimeBinder` renders each lifetime with its bounds as `'a: 'b & 'c`.

- `renderScheme` threads `displayLtBounds` output through `PrintAsSchemeWith` so rendered schemes carry the bounds.

- Updated comments and docstrings to describe the new naming strategy and remove references to union expansion.

**Implementation notes:**

The join-to-sources relation is recovered from the condensed graph's connected components rather than stored separately. An instantiation interposes an intermediary that outlives both a source param and the join, so no direct edge links them; `componentParams` groups by SCC representative to recover the sources. The transitive reduction in `displayLtBounds` deduplicates by representative so a param reaching a join through multiple sub-joins yields one bound, not multiple.

https://claude.ai/code/session_01J5AsjWtoRJteFaGnv3g5nG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displayed inferred lifetimes now keep join lifetimes named and show outlives bounds in type schemes.
  * Function and type rendering now preserves quantified lifetime relationships more clearly, including combined bounds.

* **Bug Fixes**
  * Improved lifetime display for joined borrows, especially when multiple sources, nested joins, or instantiation are involved.
  * Escaping joins now render more consistently, including cases that collapse to `'static` or a remaining source lifetime.

* **Tests**
  * Updated and expanded coverage for lifetime rendering and join behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->