### PR TITLE
Convert SCC algorithm from recursive to iterative

### DIFF
--- a/internal/graph/scc.go
+++ b/internal/graph/scc.go
@@ -27,9 +27,9 @@ import "github.com/escalier-lang/escalier/internal/set"
 // wants an isolated vertex represented as its own singleton must include it in
 // nodes.
 //
-// The DFS recurses, so a pathologically deep graph can overflow the goroutine
-// stack. Go grows goroutine stacks dynamically, so the practical bound is
-// available memory, far beyond any graph the compiler builds today.
+// The DFS runs on an explicit work stack rather than the goroutine call stack,
+// so a pathologically deep graph cannot overflow it. The bound is available
+// memory, far beyond any graph the compiler builds today.
 func StronglyConnectedComponents[T comparable](nodes []T, successors func(T) []T) [][]T {
 	index := 0
 	indices := map[T]int{}
@@ -38,48 +38,78 @@ func StronglyConnectedComponents[T comparable](nodes []T, successors func(T) []T
 	var stack []T
 	var sccs [][]T
 
-	var strongconnect func(v T)
-	strongconnect = func(v T) {
+	// visit assigns v its DFS index, pushes it onto the Tarjan stack, and returns
+	// the work frame that drives iteration over its out-neighbours.
+	visit := func(v T) frame[T] {
 		indices[v] = index
 		lowlink[v] = index
 		index++
 		stack = append(stack, v)
 		onStack.Add(v)
-
-		for _, w := range successors(v) {
-			if _, seen := indices[w]; !seen {
-				strongconnect(w)
-				if lowlink[w] < lowlink[v] {
-					lowlink[v] = lowlink[w]
-				}
-			} else if onStack.Contains(w) {
-				if indices[w] < lowlink[v] {
-					lowlink[v] = indices[w]
-				}
-			}
-		}
-
-		if lowlink[v] != indices[v] {
-			return // v is not a component root, so its members stay on the stack
-		}
-		// v roots a component. Pop the stack down to and including v.
-		var scc []T
-		for {
-			w := stack[len(stack)-1]
-			stack = stack[:len(stack)-1]
-			onStack.Remove(w)
-			scc = append(scc, w)
-			if w == v {
-				break
-			}
-		}
-		sccs = append(sccs, scc)
+		return frame[T]{v: v, succ: successors(v)}
 	}
 
 	for _, n := range nodes {
-		if _, seen := indices[n]; !seen {
-			strongconnect(n)
+		if _, seen := indices[n]; seen {
+			continue
+		}
+
+		// work is the explicit recursion stack. Each frame tracks a vertex and how
+		// far we have advanced through its out-neighbours, so we can resume where a
+		// simulated recursive call left off.
+		work := []frame[T]{visit(n)}
+		for len(work) > 0 {
+			f := &work[len(work)-1]
+			if f.i < len(f.succ) {
+				w := f.succ[f.i]
+				f.i++
+				if _, seen := indices[w]; !seen {
+					// Descend into w. Its lowlink folds back into f.v when its frame
+					// pops, matching the post-recursion update in the recursive form.
+					work = append(work, visit(w))
+				} else if onStack.Contains(w) {
+					if indices[w] < lowlink[f.v] {
+						lowlink[f.v] = indices[w]
+					}
+				}
+				continue
+			}
+
+			// v's out-neighbours are exhausted, so its recursive call would return here.
+			v := f.v
+			if lowlink[v] == indices[v] {
+				// v roots a component. Pop the stack down to and including v.
+				var scc []T
+				for {
+					w := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					onStack.Remove(w)
+					scc = append(scc, w)
+					if w == v {
+						break
+					}
+				}
+				sccs = append(sccs, scc)
+			}
+
+			work = work[:len(work)-1]
+			if len(work) > 0 {
+				// Fold v's lowlink into its parent, the caller in the recursive form.
+				parent := &work[len(work)-1]
+				if lowlink[v] < lowlink[parent.v] {
+					lowlink[parent.v] = lowlink[v]
+				}
+			}
 		}
 	}
 	return sccs
+}
+
+// frame is one entry on the explicit DFS stack: the vertex v under expansion,
+// its cached out-neighbours succ, and i, the index of the next out-neighbour to
+// visit.
+type frame[T comparable] struct {
+	v    T
+	succ []T
+	i    int
 }


### PR DESCRIPTION
Replace the recursive implementation of Tarjan's strongly connected components algorithm with an iterative one using an explicit work stack. This eliminates the risk of goroutine stack overflow on pathologically deep graphs.

The algorithm's logic remains unchanged. The key changes are:

- Introduce a `frame` type to track each vertex under expansion, its cached out-neighbours, and the index of the next neighbour to visit. This allows resuming iteration after a simulated recursive call.
- Replace the nested `strongconnect` function with a loop that processes frames from the work stack. When descending into an unvisited neighbour, push a new frame onto the stack. When a frame's neighbours are exhausted, pop it and fold its lowlink value back into its parent, matching the post-recursion update in the recursive form.
- Update comments to reflect the iterative approach and remove the note about goroutine stack growth.

The bound on graph depth is now available memory rather than goroutine stack size, which is far beyond any graph the compiler builds today.

https://claude.ai/code/session_01VayvBHs6GWfrdm2CnHCfZR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph component detection to handle very deep or large graphs more reliably.
  * Reduced the risk of stack overflows during complex graph processing.
  * Preserved the same results while making the operation safer and more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->