### PR TITLE
Check declared lifetime bounds against inferred relations

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -752,6 +752,30 @@ func (e *MutLeafThroughSharedBorrowError) Message() string {
 	return "cannot bind a `mut` leaf through an immutable borrow; the scrutinee must be owned or a `&mut` borrow"
 }
 
+// LifetimeBoundNotSatisfiedError fires when a function body does not establish an
+// outlives relation its signature declares. A declared `<'a: 'b>` asserts 'a outlives
+// 'b, and the body must prove that from its borrows, joins, and stores. When the
+// inferred lifetime graph does not prove it, the declared bound is unfounded and
+// rejected here. Sub and Super are the two lifetime names written without the leading
+// `'`, so `<'a: 'b>` gives Sub "a" and Super "b".
+//
+// It is a BRIDGE error: born in inferFunc with the LifetimeParam binder in hand, so it
+// self-blames the `'a: 'b` binder through Span and carries no related node.
+type LifetimeBoundNotSatisfiedError struct {
+	Sub   string
+	Super string
+	Param *ast.LifetimeParam
+}
+
+func (*LifetimeBoundNotSatisfiedError) isSolverError()        {}
+func (e *LifetimeBoundNotSatisfiedError) Span() ast.Span      { return e.Param.Span() }
+func (e *LifetimeBoundNotSatisfiedError) Related() []ast.Span { return nil }
+func (e *LifetimeBoundNotSatisfiedError) Message() string {
+	return fmt.Sprintf(
+		"declared lifetime bound '%s: '%s is not satisfied; the body does not make '%s outlive '%s",
+		e.Sub, e.Super, e.Sub, e.Super)
+}
+
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
 func (e *UnknownIdentifierError) Message() string {

--- a/internal/solver/infer_declared_lifetime_bound_test.go
+++ b/internal/solver/infer_declared_lifetime_bound_test.go
@@ -133,7 +133,7 @@ func TestInferNoDeclaredBoundStillRendersInferred(t *testing.T) {
 // under the single 'a.
 func TestInferDeclaredTransitiveBoundSatisfied(t *testing.T) {
 	values, _, errs := inferSource(t, `
-		fn f<'c: 'a>(p: &'a &'b &'c {x: number}) -> &'a {x: number} { return p }`)
+		fn f<'a, 'b, 'c: 'a>(p: &'a &'b &'c {x: number}) -> &'a {x: number} { return p }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
 }

--- a/internal/solver/infer_declared_lifetime_bound_test.go
+++ b/internal/solver/infer_declared_lifetime_bound_test.go
@@ -1,0 +1,177 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6.5 PR6: check inferred lifetime bounds against declared ones ---
+//
+// A body-carrying function must prove every outlives relation its signature declares.
+// A declared `<'a: 'b>` asserts 'a outlives 'b; the body's borrows, joins, and stores
+// must make it hold. The inferred relation is read the same way the printer renders it,
+// so a bound the signature declares and the printer would render are accepted together.
+// A declared bound the inference does not prove is a LifetimeBoundNotSatisfiedError.
+
+// firstBoundError returns the first LifetimeBoundNotSatisfiedError among errs, or nil.
+func firstBoundError(errs []SolverError) *LifetimeBoundNotSatisfiedError {
+	for _, e := range errs {
+		if be, ok := e.(*LifetimeBoundNotSatisfiedError); ok {
+			return be
+		}
+	}
+	return nil
+}
+
+// A multi-source join declared with the bounds inference produces round-trips: each
+// source outlives the join, so `<'a: 'c, 'b: 'c, 'c>` is exactly what the body proves.
+// No LifetimeBoundNotSatisfiedError fires and the signature renders as written.
+func TestInferDeclaredJoinBoundSatisfied(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn pick<'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
+			if true { return p } else { return q }
+		}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
+		values["pick"])
+}
+
+// A declared bound whose left lifetime borrows a parameter the body never relates is
+// unfounded. `q` connects nothing, so the body proves nothing about 'b, and the declared
+// 'a: 'b cannot hold.
+func TestInferDeclaredBoundUnusedParamUnsatisfied(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f<'a: 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'a mut {x: number} {
+			return p
+		}`)
+	be := firstBoundError(errs)
+	require.NotNil(t, be, "expected a LifetimeBoundNotSatisfiedError; got %v", errs)
+	require.Equal(t, "a", be.Sub)
+	require.Equal(t, "b", be.Super)
+	require.Equal(t,
+		"declared lifetime bound 'a: 'b is not satisfied; the body does not make 'a outlive 'b",
+		be.Message())
+}
+
+// A join relates each source to the join, not the reverse. Declaring the reversed bounds
+// `<'c: 'a, 'c: 'b>` claims the join outlives its sources, which the body does not prove,
+// so one error fires per reversed bound.
+func TestInferDeclaredJoinBoundReversedUnsatisfied(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn pick<'c: 'a, 'c: 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
+			if true { return p } else { return q }
+		}`)
+	var messages []string
+	for _, e := range errs {
+		if _, ok := e.(*LifetimeBoundNotSatisfiedError); ok {
+			messages = append(messages, e.Message())
+		}
+	}
+	require.Equal(t,
+		[]string{
+			"declared lifetime bound 'c: 'a is not satisfied; the body does not make 'c outlive 'a",
+			"declared lifetime bound 'c: 'b is not satisfied; the body does not make 'c outlive 'b",
+		},
+		messages)
+}
+
+// A lifetime trivially outlives itself, so a self-bound `<'a: 'a>` always holds and
+// fires no error.
+func TestInferDeclaredSelfBoundSatisfied(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f<'a: 'a>(p: &'a mut {x: number}) -> &'a mut {x: number} { return p }`)
+	require.Empty(t, errs)
+}
+
+// `<'a: 'static>` forces 'a to 'static, and only a 'static-forced lifetime outlives
+// 'static. An ordinary borrow parameter is not forced to 'static, so the bound is
+// unsatisfied.
+func TestInferDeclaredStaticBoundUnsatisfied(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f<'a: 'static>(p: &'a mut {x: number}) -> &'a mut {x: number} { return p }`)
+	be := firstBoundError(errs)
+	require.NotNil(t, be, "expected a LifetimeBoundNotSatisfiedError; got %v", errs)
+	require.Equal(t, "a", be.Sub)
+	require.Equal(t, "static", be.Super)
+	require.Equal(t,
+		"declared lifetime bound 'a: 'static is not satisfied; the body does not make 'a outlive 'static",
+		be.Message())
+}
+
+// A borrow stored into module-level storage escapes its region, forcing its lifetime to
+// 'static. The body then proves the declared `<'a: 'static>`, so no error fires and the
+// parameter renders under 'static.
+func TestInferDeclaredStaticBoundSatisfiedByEscape(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		var sink = {x: 0}
+		fn cache<'a: 'static>(p: &'a mut {x: number}) { sink = p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: &'static mut {x: number}) -> void", values["cache"])
+}
+
+// A bare `<'a, 'b>` declares no bounds, so the check does nothing and the inferred join
+// still renders its bounds. This guards the common inferred-render path from a spurious
+// bound error.
+func TestInferNoDeclaredBoundStillRendersInferred(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn pick<'a, 'b, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
+			if true { return p } else { return q }
+		}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number}",
+		values["pick"])
+}
+
+// A nested borrow `&'a &'b &'c` collapses to `&'a` with 'c outliving 'b outliving 'a, so
+// the graph proves 'c: 'a transitively even though 'b and 'c are elided from the render.
+// A declared 'c: 'a is redundant and accepted, and the reduced signature still renders
+// under the single 'a.
+func TestInferDeclaredTransitiveBoundSatisfied(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f<'c: 'a>(p: &'a &'b &'c {x: number}) -> &'a {x: number} { return p }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a {x: number}) -> &'a {x: number}", values["f"])
+}
+
+// A lifetime with only a lower-bound 'static is not forced to 'static. A lower-bound
+// 'static reads "'static outlives 'a", which is trivially true and proves nothing, so it
+// must not satisfy a bound on 'a. Only an upper-bound 'static, the escape constraint 'a
+// <: 'static, forces 'a to 'static. The check reads the escape set the bound set records
+// from upper bounds, not forcedToStatic which reads both directions.
+//
+// The check runs directly because current surface syntax does not put a lower-bound
+// 'static on a parameter lifetime. The store paths that would are deferred to M7.
+func TestCheckDeclaredBoundLowerBoundStaticNotForced(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	c.namedLifetimes = map[string]*soltype.LifetimeVar{"a": a, "b": b}
+	// constrainLt('static, 'a) records 'static as a lower bound of 'a, forcing nothing.
+	c.ctx.constrainLt(soltype.Static, a)
+
+	ft := &soltype.FuncType{
+		Params: []*soltype.FuncParam{
+			{Pattern: &soltype.IdentPat{Name: "p"}, Type: &soltype.RefType{Mut: true, Lt: a, Inner: c.freshAt(0)}},
+			{Pattern: &soltype.IdentPat{Name: "q"}, Type: &soltype.RefType{Mut: true, Lt: b, Inner: c.freshAt(0)}},
+		},
+		Ret: &soltype.Void{},
+	}
+	// <'a: 'b>: nothing relates 'a to 'b, so the bound is unfounded.
+	params := []*ast.LifetimeParam{
+		ast.NewLifetimeParam("a", []*ast.LifetimeAnn{ast.NewLifetimeAnn("b", ast.Span{})}, ast.Span{}),
+		ast.NewLifetimeParam("b", nil, ast.Span{}),
+	}
+
+	c.checkDeclaredLifetimeBounds(params, ft)
+
+	require.Len(t, c.errs, 1, "a lower-bound 'static must not satisfy an unfounded bound")
+	be, ok := c.errs[0].(*LifetimeBoundNotSatisfiedError)
+	require.True(t, ok)
+	require.Equal(t, "a", be.Sub)
+	require.Equal(t, "b", be.Super)
+}

--- a/internal/solver/infer_declared_lifetime_bound_test.go
+++ b/internal/solver/infer_declared_lifetime_bound_test.go
@@ -57,12 +57,12 @@ func TestInferDeclaredBoundUnusedParamUnsatisfied(t *testing.T) {
 		be.Message())
 }
 
-// A join relates each source to the join, not the reverse. Declaring the reversed bounds
-// `<'c: 'a, 'c: 'b>` claims the join outlives its sources, which the body does not prove,
-// so one error fires per reversed bound.
+// A join relates each source to the join, not the reverse. The meet bound `<'c: 'a & 'b>`
+// claims the join outlives both its sources, which the body does not prove, so one error
+// fires per source the reversed bound names.
 func TestInferDeclaredJoinBoundReversedUnsatisfied(t *testing.T) {
 	_, _, errs := inferSource(t, `
-		fn pick<'c: 'a, 'c: 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
+		fn pick<'a, 'b, 'c: 'a & 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
 			if true { return p } else { return q }
 		}`)
 	var messages []string

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -8,7 +8,6 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
-	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -347,8 +346,8 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// callees; M3's FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
 	// A body-carrying function must prove every lifetime bound its signature declares.
-	// A no-body site has nothing to prove against and instead lowers its bounds (PR8),
-	// so the check is gated on hasBody.
+	// A no-body site has nothing to prove against and instead lowers its bounds, so the
+	// check is gated on hasBody.
 	if hasBody {
 		c.checkDeclaredLifetimeBounds(sig.LifetimeParams, ft)
 	}
@@ -379,7 +378,7 @@ func (c *checker) checkDeclaredLifetimeBounds(params []*ast.LifetimeParam, ft *s
 		return
 	}
 
-	a, survivors, outlives := ltOutlivesRelation(ft, soltype.Positive)
+	a, _, outlives := ltOutlivesRelation(ft, soltype.Positive)
 
 	lookup := func(name string) (*soltype.LifetimeVar, bool) {
 		if c.namedLifetimes == nil {
@@ -402,34 +401,12 @@ func (c *checker) checkDeclaredLifetimeBounds(params []*ast.LifetimeParam, ft *s
 	staticForced := func(v *soltype.LifetimeVar) bool {
 		return a != nil && a.bs.static.Contains(a.bs.repOf(v.ID))
 	}
-	// reachable reports whether 'from outlives 'to through the survivor relation, directly
-	// or across intermediate survivors. outlives already folds in the graph's transitive
-	// reachability. The walk adds transitivity across the join-feeding edges it does not
-	// close over.
-	reachable := func(from, to *soltype.LifetimeVar) bool {
-		if outlives == nil {
-			return false
-		}
-		visited := set.NewSet[int]()
-		stack := []*soltype.LifetimeVar{from}
-		for len(stack) > 0 {
-			n := stack[len(stack)-1]
-			stack = stack[:len(stack)-1]
-			if visited.Contains(n.ID) {
-				continue
-			}
-			visited.Add(n.ID)
-			for _, s := range survivors {
-				if !outlives(n, s) {
-					continue
-				}
-				if sameLt(s, to) {
-					return true
-				}
-				stack = append(stack, s)
-			}
-		}
-		return false
+	// proves reports whether the inferred relation proves 'sub outlives 'super. outlives is
+	// already transitive, so no further walk is needed here. implies reads reachability over
+	// the whole condensed graph, and componentParams gathers every param in a join's
+	// connected component, so a param outlives a join it feeds through any number of hops.
+	proves := func(sub, super *soltype.LifetimeVar) bool {
+		return sameLt(sub, super) || (outlives != nil && outlives(sub, super))
 	}
 
 	for _, p := range params {
@@ -456,7 +433,7 @@ func (c *checker) checkDeclaredLifetimeBounds(params []*ast.LifetimeParam, ft *s
 				satisfied = false
 			default:
 				super, superOk := lookup(b.Name)
-				satisfied = superOk && (sameLt(sub, super) || reachable(sub, super))
+				satisfied = superOk && proves(sub, super)
 			}
 			if !satisfied {
 				c.report(&LifetimeBoundNotSatisfiedError{Sub: p.Name, Super: b.Name, Param: p})

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -345,7 +346,123 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// re-minted by coalescing at binding time, so the entry is exact for inline
 	// callees; M3's FromInstantiation makes named-callee blame precise.)
 	c.recordProv(ft, node, FuncInference)
+	// A body-carrying function must prove every lifetime bound its signature declares.
+	// A no-body site has nothing to prove against and instead lowers its bounds (PR8),
+	// so the check is gated on hasBody.
+	if hasBody {
+		c.checkDeclaredLifetimeBounds(sig.LifetimeParams, ft)
+	}
 	return ft
+}
+
+// checkDeclaredLifetimeBounds verifies that the function body establishes every outlives
+// relation the signature declares. A declared `<'a: 'b>` asserts 'a outlives 'b, and the
+// body must prove it. The inferred outlives relation is read through ltOutlivesRelation,
+// the same relation the printer renders, so a bound the signature declares and the
+// printer would render are accepted together. A declared bound the inference does not
+// prove is reported as a LifetimeBoundNotSatisfiedError blaming its binder.
+//
+// Declared bounds are NOT lowered into the graph for a body-carrying function. The body
+// must prove each relation on its own, so lowering would make every declared bound
+// trivially self-satisfying. The names resolve through the function's namedLifetimes
+// map, which inferFunc has already populated from the signature's borrows, so a declared
+// `'a` and the `&'a` borrow writing it share one variable.
+func (c *checker) checkDeclaredLifetimeBounds(params []*ast.LifetimeParam, ft *soltype.FuncType) {
+	hasBound := false
+	for _, p := range params {
+		if len(p.Bounds) > 0 {
+			hasBound = true
+			break
+		}
+	}
+	if !hasBound {
+		return
+	}
+
+	a, survivors, outlives := ltOutlivesRelation(ft, soltype.Positive)
+
+	lookup := func(name string) (*soltype.LifetimeVar, bool) {
+		if c.namedLifetimes == nil {
+			return nil, false
+		}
+		v, ok := c.namedLifetimes[name]
+		return v, ok
+	}
+	// sameLt reports whether two named lifetimes are one lifetime. They are one when they
+	// are the same variable, or when the solved graph proved them mutually outliving so
+	// they share an SCC representative.
+	sameLt := func(x, y *soltype.LifetimeVar) bool {
+		return a != nil && a.bs.repOf(x.ID) == a.bs.repOf(y.ID)
+	}
+	// staticForced reports whether the solved graph forces v to 'static, the escape
+	// constraint v <: 'static that records 'static as an upper bound. A lower-bound
+	// 'static is trivially true and forces nothing, so forcedToStatic reads the wrong
+	// direction for this test. The bound set's static set reads upper bounds only, the
+	// same set implies consults.
+	staticForced := func(v *soltype.LifetimeVar) bool {
+		return a != nil && a.bs.static.Contains(a.bs.repOf(v.ID))
+	}
+	// reachable reports whether 'from outlives 'to through the survivor relation, directly
+	// or across intermediate survivors. outlives already folds in the graph's transitive
+	// reachability. The walk adds transitivity across the join-feeding edges it does not
+	// close over.
+	reachable := func(from, to *soltype.LifetimeVar) bool {
+		if outlives == nil {
+			return false
+		}
+		visited := set.NewSet[int]()
+		stack := []*soltype.LifetimeVar{from}
+		for len(stack) > 0 {
+			n := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if visited.Contains(n.ID) {
+				continue
+			}
+			visited.Add(n.ID)
+			for _, s := range survivors {
+				if !outlives(n, s) {
+					continue
+				}
+				if sameLt(s, to) {
+					return true
+				}
+				stack = append(stack, s)
+			}
+		}
+		return false
+	}
+
+	for _, p := range params {
+		// A 'static left-hand side is not a bindable parameter. The parser rejects it, so
+		// no binder named "static" reaches here. This guard is defensive against a
+		// hand-built AST.
+		if p.Name == "static" {
+			continue
+		}
+		sub, subOk := lookup(p.Name)
+		for _, b := range p.Bounds {
+			satisfied := false
+			switch {
+			case !subOk:
+				// The bound's left lifetime borrows nothing, so the body proves nothing
+				// about it and the bound cannot hold.
+				satisfied = false
+			case staticForced(sub):
+				// A 'static-forced lifetime outlives everything, so every bound on it holds.
+				satisfied = true
+			case b.Name == "static":
+				// Only a 'static-forced left lifetime outlives 'static, and that case is
+				// already satisfied above, so any other left lifetime fails the bound.
+				satisfied = false
+			default:
+				super, superOk := lookup(b.Name)
+				satisfied = superOk && (sameLt(sub, super) || reachable(sub, super))
+			}
+			if !satisfied {
+				c.report(&LifetimeBoundNotSatisfiedError{Sub: p.Name, Super: b.Name, Param: p})
+			}
+		}
+	}
 }
 
 // joinReturnPoints builds a function's return type from the ReturnStmt types

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -216,13 +216,10 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 	}
 }
 
-// displayLtBounds computes the transitively-reduced outlives relation among the named
-// lifetime variables surviving in a coalesced display type, keyed by variable for the
-// printer's `'a: 'c` prefix. bounds[u] lists the survivors u directly outlives. t is
-// the type coalesceLifetimes produced, so its RefType lifetimes are exactly the named
-// survivors. An elided or 'static-forced lifetime is not a LifetimeVar and so does not
-// occur. pol is the polarity t was coalesced at, threaded so the occurrence walk starts
-// from the same root.
+// ltOutlivesRelation builds the outlives relation among the named lifetime variables
+// occurring in a display type, as both the printer and the declared-bound check read
+// it. It returns the analysis, the survivors sorted by ID, and a predicate outlives(u,
+// w) that holds when u outlives w. A nil predicate means t carries no lifetime variable.
 //
 // The relation draws on two sources of outlives facts:
 //
@@ -233,15 +230,14 @@ func (a *ltAnalysis) resolveLt(v *soltype.LifetimeVar) (lt soltype.Lifetime, eli
 //     outlives both the source and the join, so no directed edge links them, yet each
 //     source outlives the join.
 //
-// The reduction reads its own edge relation, the implies-or-feedsJoin union, rather
-// than ltBoundSet.reduce's raw edge graph, so it is computed here rather than reused.
-// The union relation is materialized once into edges before the reduction, so
-// feedsJoin's occ scan runs per survivor pair, not per reduction step.
-func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.LifetimeVar][]*soltype.LifetimeVar {
+// Two survivors sharing a representative are equal lifetimes, so outlives reports no
+// relation between them. pol is the polarity t was built at, threaded so the occurrence
+// walk starts from the same root.
+func ltOutlivesRelation(t soltype.Type, pol soltype.Polarity) (*ltAnalysis, []*soltype.LifetimeVar, func(u, w *soltype.LifetimeVar) bool) {
 	occ := map[*soltype.LifetimeVar]occPolarity{}
 	t.Accept(&ltOccVisitor{occ: occ}, pol)
 	if len(occ) == 0 {
-		return nil
+		return nil, nil, nil
 	}
 	a := newLtAnalysis(occ)
 	bs := a.bs
@@ -270,9 +266,6 @@ func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.Lifetime
 		joinSources[w] = reps
 	}
 
-	// outlives holds when u and w condense to different representatives and either the
-	// bound set proves 'u: 'w or u feeds the join w. Two survivors sharing a
-	// representative are equal lifetimes, so no bound is drawn between them.
 	outlives := func(u, w *soltype.LifetimeVar) bool {
 		if bs.repOf(u.ID) == bs.repOf(w.ID) {
 			return false
@@ -283,6 +276,27 @@ func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.Lifetime
 		reps, ok := joinSources[w]
 		return ok && reps.Contains(bs.repOf(u.ID))
 	}
+	return a, survivors, outlives
+}
+
+// displayLtBounds computes the transitively-reduced outlives relation among the named
+// lifetime variables surviving in a coalesced display type, keyed by variable for the
+// printer's `'a: 'c` prefix. bounds[u] lists the survivors u directly outlives. t is
+// the type coalesceLifetimes produced, so its RefType lifetimes are exactly the named
+// survivors. An elided or 'static-forced lifetime is not a LifetimeVar and so does not
+// occur. pol is the polarity t was coalesced at, threaded so the occurrence walk starts
+// from the same root.
+//
+// The reduction reads the implies-or-feedsJoin relation ltOutlivesRelation returns,
+// rather than ltBoundSet.reduce's raw edge graph, so it is computed over that relation
+// here. The relation is materialized once into edges before the reduction, so the
+// per-pair predicate runs once per survivor pair, not per reduction step.
+func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.LifetimeVar][]*soltype.LifetimeVar {
+	a, survivors, outlives := ltOutlivesRelation(t, pol)
+	if outlives == nil {
+		return nil
+	}
+	bs := a.bs
 
 	// edges materializes the full outlives relation among survivors once, so the
 	// transitive reduction below reads it rather than recomputing outlives.

--- a/internal/solver/lifetime_coalesce.go
+++ b/internal/solver/lifetime_coalesce.go
@@ -279,18 +279,10 @@ func ltOutlivesRelation(t soltype.Type, pol soltype.Polarity) (*ltAnalysis, []*s
 	return a, survivors, outlives
 }
 
-// displayLtBounds computes the transitively-reduced outlives relation among the named
-// lifetime variables surviving in a coalesced display type, keyed by variable for the
-// printer's `'a: 'c` prefix. bounds[u] lists the survivors u directly outlives. t is
-// the type coalesceLifetimes produced, so its RefType lifetimes are exactly the named
-// survivors. An elided or 'static-forced lifetime is not a LifetimeVar and so does not
-// occur. pol is the polarity t was coalesced at, threaded so the occurrence walk starts
-// from the same root.
-//
-// The reduction reads the implies-or-feedsJoin relation ltOutlivesRelation returns,
-// rather than ltBoundSet.reduce's raw edge graph, so it is computed over that relation
-// here. The relation is materialized once into edges before the reduction, so the
-// per-pair predicate runs once per survivor pair, not per reduction step.
+// displayLtBounds returns the transitively-reduced outlives relation among the named
+// lifetime survivors of a coalesced display type, keyed by variable for the printer's
+// `'a: 'c` prefix. bounds[u] lists the survivors u directly outlives. The relation comes
+// from ltOutlivesRelation, materialized into edges once before the reduction reads it.
 func displayLtBounds(t soltype.Type, pol soltype.Polarity) map[*soltype.LifetimeVar][]*soltype.LifetimeVar {
 	a, survivors, outlives := ltOutlivesRelation(t, pol)
 	if outlives == nil {

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -570,7 +570,8 @@ Severity follows the function's own quantifier clause, mirroring the retired
   declared; add `<'b>` to the enclosing function signature". The author almost certainly
   meant to declare the binder. A nested function is judged by its own clause, not an
   ancestor's, so an inner `fn` with no clause is a hard error even inside an outer
-  `fn<'a>`.
+  `fn<'a>`. PR11 revisits this rule when it makes an enclosing function's lifetimes
+  visible to a nested one.
 - **A `<…>` clause exists but does not bind the name.** A warning with edit-distance
   suggestions drawn from the declared siblings, since a near-miss is most likely a typo:
   "lifetime 'b is used but not declared; did you mean 'a?". Recovery mints a fresh
@@ -588,6 +589,58 @@ or bound references is §9.7 class 1, `lifetime parameter 'a is declared but nev
 It is the same scan read the other way — binders with no use rather than uses with no
 binder — so it can ride along in this PR or land as a short follow-up.
 
+### PR11 — Enclosing-function lifetimes visible in a nested function
+
+**Axis:** declare (front-end). **Depends on:** PR10.
+
+`inferFunc` gives every function a fresh lifetime scope. It saves the enclosing
+`namedLifetimes` map, clears it, and restores it on exit
+([infer_expr.go](../../internal/solver/infer_expr.go)). So an inner function's `'a` is a
+distinct lifetime from an outer `<'a>`, and a nested function cannot name an enclosing
+lifetime in its own annotations. This PR lets a nested function read an enclosing
+function's declared lifetimes by name.
+
+**This is a naming gap, not an inference one.** A captured borrow's `LifetimeVar` already
+flows into a nested function through the captured value's type, so inference of a captured
+borrow works today. What is missing is writing the enclosing `'a` in the inner signature
+and having it resolve to that same variable. The change adds name resolution, not a new
+inference path, so the computed types do not move.
+
+**The soundness rests on levels, which already exist.** A lifetime carries a `Level` (M4
+D2.5), and generalization quantifies only a variable with `Level > genLevel`
+([poly.go](../../internal/solver/poly.go), [coalesce.go](../../internal/solver/coalesce.go)).
+An inherited outer lifetime keeps its outer, lower level, so a nested function inferred at
+a deeper level leaves it free rather than quantifying it, the same treatment a captured
+outer type variable already gets. The work confirms this holds rather than building it.
+
+The change is three coupled edits:
+
+- **Chain the name lookup.** Resolve a lifetime name up the enclosing functions for a use,
+  while a name in the inner's own `<…>` list mints a fresh, shadowing variable.
+  `namedLifetime` interns lazily today with no notion of a declared-binder set, so it gains
+  the inner's binder set to decide shadow versus inherit. The same chaining applies to a
+  nested `fn(…)` type annotation in `resolveFuncTypeAnn`.
+- **Consult the chain in the PR10 check.** A name declared in an enclosing function is no
+  longer undeclared in the inner, so PR10's "judged by its own clause" rule relaxes to
+  "judged by its own clause or an enclosing one". The hard-error case narrows to a name
+  bound nowhere on the chain.
+- **Cover it with tests.** A closure that names and borrows an enclosing lifetime; a
+  shadowing inner `<'a>`; generalization leaving an inherited lifetime free; escape of a
+  closure-returned inherited borrow.
+
+**The gating decision is the capture rule, not the code.** Rust splits it by function kind.
+A nested `fn` item does not capture the enclosing lifetimes, while a closure does. The
+solver routes both a function declaration and a function expression through `inferFunc`, so
+the rule that separates them is part of this PR. A nested `fn` declaration is rejected
+outright today, since a function body admits only a `VarDecl`
+([errors.go](../../internal/solver/errors.go), `BodyDeclNotAllowedError`), so the reachable
+surface is the `fn` expression closure alone.
+
+This is the lowest-priority PR in the milestone. It is an ergonomic convenience over
+working inference, its only consumer is a borrowing closure, and that pattern may not
+appear before M7. It depends on PR10 for the check it relaxes and can land any time after,
+off the critical path.
+
 ## Dependency graph
 
 ```mermaid
@@ -597,6 +650,7 @@ graph TD
     PR2 --> PR3[PR3 — render inferred bounds]
     PR4[PR4 — AST/parser bound syntax] --> PR5[PR5 — lower into constrainLt]
     PR4 --> PR10[PR10 — undeclared-lifetime error]
+    PR10 --> PR11[PR11 — enclosing lifetimes in nested fns]
     PR1 --> PR6
     PR3 --> PR6[PR6 — check inferred vs declared]
     PR5 --> PR6
@@ -620,11 +674,12 @@ critical path:   PR1 ─── PR2 ─── PR3 ─── PR6 ─── PR8 ─
 
 remaining edges: PR4 ─── PR5     PR1 ─── PR6     PR1 ─── PR7
                  PR5 ─── PR6     PR3 ─── PR7     PR5 ─── PR8
-                 PR3 ─── PR9     PR4 ─── PR10
+                 PR3 ─── PR9     PR4 ─── PR10    PR10 ─── PR11
 ```
 
 PR10 hangs off PR4 on the declare track and is on no critical path, so it fills slack
-beside PR5 rather than lengthening the six-PR spine.
+beside PR5 rather than lengthening the six-PR spine. PR11 hangs off PR10 as the
+lowest-priority tail of that track, also off the critical path.
 
 ## Parallel groups
 
@@ -642,10 +697,11 @@ and the **declare front-end** (PR4 → PR5) — and they only meet at PR6.
   pure consumer change and does not touch the declare track, so it runs beside PR6.
 - **Wave 5:** PR8 (needs PR5, PR6). The no-body-site declaration lowering.
 - **Wave 6:** PR9 (needs PR3, PR8). The cleanup deletion, the hand-off to M7 alongside
-  PR8.
+  PR8. PR11 (needs PR10) also lands here or later, the lowest-priority tail of the declare
+  track.
 
-The critical path is PR1 → PR2 → PR3 → PR6 → PR8 → PR9, six PRs. PR4/PR5, PR7, and PR10
-fill the slack beside it, so the milestone is not serialized end to end despite the
+The critical path is PR1 → PR2 → PR3 → PR6 → PR8 → PR9, six PRs. PR4/PR5, PR7, PR10, and
+PR11 fill the slack beside it, so the milestone is not serialized end to end despite the
 single join point at PR6.
 
 ## Hard-parts coverage

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -600,6 +600,26 @@ distinct lifetime from an outer `<'a>`, and a nested function cannot name an enc
 lifetime in its own annotations. This PR lets a nested function read an enclosing
 function's declared lifetimes by name.
 
+The affected code is a closure that names an enclosing lifetime:
+
+```
+fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+  // relay names 'a to say its argument borrows the same region as p.
+  val relay = fn(q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
+  return relay(p)
+}
+```
+
+By the time `inferFunc` resolves `relay`, it has cleared the name scope, so the `'a` inside
+`relay` is a fresh lifetime unrelated to `outer`'s. Under PR10 that becomes a used-but-
+undeclared hard error, since `relay` declares no `<'a>` of its own, and the author must
+fall back to a bare `&`, which drops the written tie to `outer`'s region, or write
+`fn<'a>(…)`, which declares a new `'a` that misleadingly shares the spelling. PR11 makes the
+`'a` inside `relay` resolve to `outer`'s lifetime, so the annotation means what it reads.
+Inference already ties the two through the `relay(p)` call, so only the annotation changes,
+not the inferred types. Writing `<'a>` on `relay` still shadows, minting a fresh lifetime as
+it does today.
+
 **This is a naming gap, not an inference one.** A captured borrow's `LifetimeVar` already
 flows into a nested function through the captured value's type, so inference of a captured
 borrow works today. What is missing is writing the enclosing `'a` in the inner signature

--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -540,6 +540,54 @@ This is a pure deletion once bounds carry every case, which is why it lands last
 depends on both the render flip (PR3) and the no-body reach (PR8). It is separate from
 PR3 so the risky rendering change and the surface-syntax removal are reviewed apart.
 
+### PR10 — Error on a used-but-undeclared lifetime
+
+**Axis:** declare (front-end). **Depends on:** PR4.
+
+A named lifetime that appears in a signature must be bound by that signature's `<…>`
+list. `fn f<'a>(p: &'a {…})` declares `'a`. A `&'b` with no `<'b>` binder is a forgotten
+declaration or a typo, not a fresh lifetime to invent. The solver interns every written
+`'x` through `namedLifetime` ([type_ann.go](../../internal/solver/type_ann.go)) whether
+or not a binder introduced it, so `fn f<'a>(p: &'b {…})` silently renames `'b` to `'a` in
+the display and no diagnostic fires. This PR rejects the undeclared use.
+
+The rule reads the two lifetime forms the surface already has. A bare `&T` / `&mut T` is
+the inferred borrow: it mints a fresh lifetime and carries no name, so it is never
+undeclared. A named `&'x T` is an explicit reference to a binder, so `'x` must appear in
+the enclosing `<…>` list. This keeps the inference-first ergonomics — the common borrow
+writes no lifetime and declares nothing — while making a written name mean what it says.
+
+A **use** is any named lifetime in the signature that is not itself a binder. It is the
+lifetime of a `&'x` borrow, and the right-hand side of a bound, since `'a: 'x` uses `'x`.
+The left-hand side of a bound is a binder, not a use. `'static` is the built-in bottom of
+the outlives lattice and is never undeclared, on either side.
+
+Severity follows the function's own quantifier clause, mirroring the retired
+`internal/checker`'s §9.7 class 2 diagnostic
+([diag_lifetime.go](../../internal/checker/diag_lifetime.go)):
+
+- **The function has no `<…>` clause.** A hard error: "lifetime 'b is used but not
+  declared; add `<'b>` to the enclosing function signature". The author almost certainly
+  meant to declare the binder. A nested function is judged by its own clause, not an
+  ancestor's, so an inner `fn` with no clause is a hard error even inside an outer
+  `fn<'a>`.
+- **A `<…>` clause exists but does not bind the name.** A warning with edit-distance
+  suggestions drawn from the declared siblings, since a near-miss is most likely a typo:
+  "lifetime 'b is used but not declared; did you mean 'a?". Recovery mints a fresh
+  lifetime so the signature stays well-formed and later checks proceed.
+
+The check reads the binder set the `LifetimeParam` list carries (PR4) and the named uses
+the borrow and bound resolution already visit, so it is a scan over data both halves of
+the declare track already build. It runs at signature resolution, in `resolveFuncTypeAnn`
+and the `inferFunc` signature pass, before `namedLifetime` interns an unbacked name. It is
+independent of the render track (PR1–PR3), the bound check (PR6), and the PR9 cleanup, so
+it can land any time after PR4, in parallel with PR5.
+
+**The symmetric companion is the unused-binder warning.** A declared `<'a>` that no borrow
+or bound references is §9.7 class 1, `lifetime parameter 'a is declared but never used`.
+It is the same scan read the other way — binders with no use rather than uses with no
+binder — so it can ride along in this PR or land as a short follow-up.
+
 ## Dependency graph
 
 ```mermaid
@@ -548,6 +596,7 @@ graph TD
     PR1[PR1 — ltBoundSet core] --> PR2[PR2 — directional grouping]
     PR2 --> PR3[PR3 — render inferred bounds]
     PR4[PR4 — AST/parser bound syntax] --> PR5[PR5 — lower into constrainLt]
+    PR4 --> PR10[PR10 — undeclared-lifetime error]
     PR1 --> PR6
     PR3 --> PR6[PR6 — check inferred vs declared]
     PR5 --> PR6
@@ -571,8 +620,11 @@ critical path:   PR1 ─── PR2 ─── PR3 ─── PR6 ─── PR8 ─
 
 remaining edges: PR4 ─── PR5     PR1 ─── PR6     PR1 ─── PR7
                  PR5 ─── PR6     PR3 ─── PR7     PR5 ─── PR8
-                 PR3 ─── PR9
+                 PR3 ─── PR9     PR4 ─── PR10
 ```
+
+PR10 hangs off PR4 on the declare track and is on no critical path, so it fills slack
+beside PR5 rather than lengthening the six-PR spine.
 
 ## Parallel groups
 
@@ -582,18 +634,19 @@ and the **declare front-end** (PR4 → PR5) — and they only meet at PR6.
 - **Wave 1 (parallel):** PR1 and PR4. Foundation data structure and front-end syntax
   touch disjoint code — `solver/lifetime_bounds.go` versus `ast`/`parser`/`printer` —
   and neither needs M6. Start both together.
-- **Wave 2 (parallel):** PR2 (needs PR1 and M6) and PR5 (needs PR4). The render
-  analysis swap and the declared-bound lowering are independent.
-- **Wave 3:** PR3 (needs PR2). PR5 may still be in flight alongside it.
+- **Wave 2 (parallel):** PR2 (needs PR1 and M6), PR5 (needs PR4), and PR10 (needs PR4).
+  The render analysis swap, the declared-bound lowering, and the undeclared-lifetime
+  diagnostic are independent.
+- **Wave 3:** PR3 (needs PR2). PR5 and PR10 may still be in flight alongside it.
 - **Wave 4 (parallel):** PR6 (needs PR1, PR3, PR5) and PR7 (needs PR1, PR3). PR7 is a
   pure consumer change and does not touch the declare track, so it runs beside PR6.
 - **Wave 5:** PR8 (needs PR5, PR6). The no-body-site declaration lowering.
 - **Wave 6:** PR9 (needs PR3, PR8). The cleanup deletion, the hand-off to M7 alongside
   PR8.
 
-The critical path is PR1 → PR2 → PR3 → PR6 → PR8 → PR9, six PRs. PR4/PR5 and PR7 fill
-the slack beside it, so the milestone is not serialized end to end despite the single
-join point at PR6.
+The critical path is PR1 → PR2 → PR3 → PR6 → PR8 → PR9, six PRs. PR4/PR5, PR7, and PR10
+fill the slack beside it, so the milestone is not serialized end to end despite the
+single join point at PR6.
 
 ## Hard-parts coverage
 


### PR DESCRIPTION
A function body must establish every outlives relation its signature declares. This PR adds validation that declared lifetime bounds like `<'a: 'b>` are satisfied by the inferred lifetime graph.

**Key changes:**

- Added `checkDeclaredLifetimeBounds` to verify each declared bound holds in the inferred graph. A declared `'a: 'b` is satisfied when the body proves `'a` outlives `'b` through borrows, joins, and stores, or when `'a` is forced to `'static`.

- Extracted `ltOutlivesRelation` from `displayLtBounds` to compute the outlives relation among named lifetimes. This relation is read the same way the printer renders bounds, so a bound the signature declares and the printer would render are accepted together.

- Added `LifetimeBoundNotSatisfiedError` to report unsatisfied declared bounds, blaming the lifetime parameter binder.

- The check runs only for body-carrying functions; no-body sites have nothing to prove and will lower bounds in a later milestone.

**Implementation details:**

The check reads the escape set (upper bounds) to determine if a lifetime is forced to `'static`, not the bidirectional `forcedToStatic` predicate, since a lower-bound `'static` is trivially true and forces nothing. Transitive reachability across join-feeding edges is computed via a walk over the survivor relation, extending the direct outlives facts the bound set provides.

https://claude.ai/code/session_01EfCXQi5e9ZXGRT1C7bsrF1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for declared lifetime bounds in function signatures, so the solver now checks whether the function body actually satisfies them.
  * Improved lifetime-bound handling for transitive relations, joins, and special `'static` cases.

* **Bug Fixes**
  * Added a clearer error when a declared lifetime bound is not proven by the function body.
  * Improved detection of redundant or unsatisfied lifetime constraints in nested and inferred lifetime scenarios.

* **Tests**
  * Added coverage for satisfied, unsatisfied, and edge-case lifetime-bound checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->