### PR TITLE
Add alpha-equivalence for lifetime comparison across schemes

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -636,7 +636,57 @@ func dedup(parts []soltype.Type) []soltype.Type {
 // parameters as named references, so a generalized scheme's display type can carry
 // variables — compared here by pointer identity (the same var is one type
 // parameter), which is what lets dedup collapse `T0 & T0` to `T0`.
+//
+// Lifetimes compare by pointer identity too, which two borrows minted in one coalesce
+// share whenever they denote the same borrow. That identity keying is what dedup and the
+// lattice's canonical member order rely on, and it keeps two independent param lifetimes
+// with no bound between them distinct. alphaEqualTypes is the cross-scheme variant that
+// compares lifetimes up to renaming instead.
 func equalType(a, b soltype.Type) bool {
+	return equalTypeWith(a, b, nil)
+}
+
+// ltPairing is the bijection alphaEqualTypes discovers between the lifetime variables of
+// two types compared up to renaming. equalTypeWith fills it in as it walks: the first
+// time it matches a borrow on each side it binds their lifetime variables together, and
+// every later occurrence must respect that binding. aToB and bToA are the two directions
+// of the bijection, keyed by lifetime-variable ID. aVars and bVars list the bound
+// variables in binding order, so index i on each side names one paired lifetime.
+// sameOutlivesUnderPairing compares the outlives relation over those pairs. A nil
+// *ltPairing selects pointer-identity lifetime equality, the within-coalesce default
+// equalType uses.
+type ltPairing struct {
+	aToB  map[int]int
+	bToA  map[int]int
+	aVars []*soltype.LifetimeVar
+	bVars []*soltype.LifetimeVar
+}
+
+// pair records or rechecks that a and b are the same lifetime under the bijection. A
+// variable already bound to a different partner fails, which is what keeps a borrow that
+// shares one lifetime across two positions from matching a side that uses two distinct
+// lifetimes there. Because the walk matches structure in the same order on both sides,
+// binding a and b together the first time they are matched pairs corresponding lifetimes
+// regardless of the order the two types happen to list their object properties.
+func (p *ltPairing) pair(a, b *soltype.LifetimeVar) bool {
+	if j, ok := p.aToB[a.ID]; ok {
+		return j == b.ID
+	}
+	if _, ok := p.bToA[b.ID]; ok {
+		return false // b is already bound to a different left-side lifetime
+	}
+	p.aToB[a.ID] = b.ID
+	p.bToA[b.ID] = a.ID
+	p.aVars = append(p.aVars, a)
+	p.bVars = append(p.bVars, b)
+	return true
+}
+
+// equalTypeWith is equalType parameterized by an optional lifetime pairing. With a nil
+// pairing it is exactly equalType, keying lifetimes by pointer identity. With a pairing
+// it keys a borrow's lifetime by first-appearance index, so alphaEqualTypes can compare
+// borrows across schemes whose lifetime variables have independent identities.
+func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 	switch a := a.(type) {
 	case *soltype.TypeVarType:
 		b, ok := b.(*soltype.TypeVarType)
@@ -668,11 +718,11 @@ func equalType(a, b soltype.Type) bool {
 			return false
 		}
 		for i := range a.Params {
-			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalType(a.Params[i].Type, b.Params[i].Type) {
+			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalTypeWith(a.Params[i].Type, b.Params[i].Type, p) {
 				return false
 			}
 		}
-		return equalType(a.Ret, b.Ret)
+		return equalTypeWith(a.Ret, b.Ret, p)
 	case *soltype.TupleType:
 		b, ok := b.(*soltype.TupleType)
 		// Inexact flags must be equal — an open tuple never equals a closed one,
@@ -681,7 +731,7 @@ func equalType(a, b soltype.Type) bool {
 			return false
 		}
 		for i := range a.Elems {
-			if !equalType(a.Elems[i], b.Elems[i]) {
+			if !equalTypeWith(a.Elems[i], b.Elems[i], p) {
 				return false
 			}
 		}
@@ -702,35 +752,57 @@ func equalType(a, b soltype.Type) bool {
 		for _, ae := range a.Elems {
 			ap := soltype.AsProperty(ae)
 			bp, ok := b.Prop(ap.Name)
-			if !ok || ap.Optional != bp.Optional || ap.Readonly != bp.Readonly || !equalType(ap.Type, bp.Type) {
+			if !ok || ap.Optional != bp.Optional || ap.Readonly != bp.Readonly || !equalTypeWith(ap.Type, bp.Type, p) {
 				return false
 			}
 		}
 		return true
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
-		return ok && equalType(a.Inner, b.Inner)
+		return ok && equalTypeWith(a.Inner, b.Inner, p)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the
 		// lifetimes must match: D2 mints borrow lifetimes, so two borrows differing only
 		// in lifetime are NOT equal. Without the Lt check, dedup would collapse them and
-		// silently drop a lifetime the solver computed. ltEqual compares a LifetimeVar by
-		// pointer and 'static by value.
-		return ok && a.Mut == b.Mut && ltEqual(a.Lt, b.Lt) && equalType(a.Inner, b.Inner)
+		// silently drop a lifetime the solver computed. ltEqualWith compares a LifetimeVar
+		// by pointer under a nil pairing and by first-appearance index under one.
+		return ok && a.Mut == b.Mut && ltEqualWith(a.Lt, b.Lt, p) && equalTypeWith(a.Inner, b.Inner, p)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
 		// one. The M6 PR1 newUnion imposes canonical member order at
-		// construction, so the positional equalTypeSlice is order-stable and
+		// construction, so the positional equalTypeSliceWith is order-stable and
 		// two unions over the same member set are now equal whatever order
 		// their members were minted in.
-		return ok && a.Inexact == b.Inexact && equalTypeSlice(a.Types, b.Types)
+		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, p)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
-		return ok && equalTypeSlice(a.Types, b.Types)
+		return ok && equalTypeSliceWith(a.Types, b.Types, p)
 	}
 	return false
+}
+
+// ltEqualWith reports lifetime equality for equalTypeWith's RefType arm. Under a nil
+// pairing it is ltEqual, keying a LifetimeVar by pointer. Under a pairing it binds the
+// two variables together through the bijection, so two borrows minted in independent
+// schemes match when they occupy corresponding positions and a variable reused on one
+// side must be reused the same way on the other. A borrow whose lifetime is not a
+// variable — 'static, an owned-mutable nil, an anonymous marker, or a union — falls back
+// to ltEqual's by-value rule in both modes.
+func ltEqualWith(a, b soltype.Lifetime, p *ltPairing) bool {
+	if p == nil {
+		return ltEqual(a, b)
+	}
+	av, aok := a.(*soltype.LifetimeVar)
+	bv, bok := b.(*soltype.LifetimeVar)
+	if !aok && !bok {
+		return ltEqual(a, b)
+	}
+	if !aok || !bok {
+		return false // a variable never pairs with a non-variable lifetime
+	}
+	return p.pair(av, bv)
 }
 
 // ltEqual reports lifetime equality for equalType's RefType arm (D2). Each lifetime
@@ -772,12 +844,12 @@ func ltEqual(a, b soltype.Lifetime) bool {
 	return a == b
 }
 
-func equalTypeSlice(a, b []soltype.Type) bool {
+func equalTypeSliceWith(a, b []soltype.Type, p *ltPairing) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !equalType(a[i], b[i]) {
+		if !equalTypeWith(a[i], b[i], p) {
 			return false
 		}
 	}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -771,10 +771,9 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
-		// one. The M6 PR1 newUnion imposes canonical member order at
-		// construction, so the positional equalTypeSliceWith is order-stable and
-		// two unions over the same member set are now equal whatever order
-		// their members were minted in.
+		// one. newUnion imposes canonical member order at construction, so the
+		// positional equalTypeSliceWith is order-stable and two unions over the
+		// same member set compare equal whatever order their members were minted in.
 		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, p)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -62,6 +62,39 @@ func TestInferOverloadDuplicateParamTypesRejected(t *testing.T) {
 		msgWithSpan(errs[0]))
 }
 
+// Two borrow-parameter arms are inferred in independent schemes, so each `&mut {x}`
+// param carries its own lifetime variable. Their parameter types are indistinguishable
+// up to that renaming, so the duplicate-overload gate must reject them. The gate ranks
+// arms through equallySpecific, which compares lifetimes by alpha-equivalence, so the
+// two borrow params read as equal despite their distinct lifetime identities.
+func TestInferOverloadDuplicateBorrowParamsRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: &mut {x: number}) -> number { return 5 }
+		fn f(p: &mut {x: number}) -> string { return "a" }
+		val r = f
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"3:3-3:53: Overload arms must have distinguishable parameter types: f",
+		msgWithSpan(errs[0]))
+}
+
+// Alpha-equivalence over lifetimes must not over-merge borrows with different inner
+// shapes. Two arms taking `&mut {x: number}` and `&mut {y: number}` have distinguishable
+// parameter types — the borrowed objects differ — so the duplicate-overload gate accepts
+// the set and a call resolves against the matching arm.
+func TestInferOverloadDistinctBorrowParamsAllowed(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: &mut {x: number}) -> number { return 5 }
+		fn f(p: &mut {y: number}) -> string { return "a" }
+		val r = f
+	`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"(fn (p: &mut {x: number}) -> number) & (fn (p: &mut {y: number}) -> string)",
+		values["f"])
+}
+
 // Cross-file declaration order is pinned to SOURCE POSITION (file path alphabetically,
 // then line/column), NOT to the order the parser received the files. Two arms of f
 // live in separate files with DISTINCT parameter types (a.esc takes number, b.esc

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -23,7 +23,7 @@ import (
 // PR6 pass their checker's Context.
 //
 // Canonical member order keeps equalType positional and cheap. Two unions
-// over the same members hold them in the same order, so equalTypeSlice
+// over the same members hold them in the same order, so equalTypeSliceWith
 // already returns true. Canonical order also makes rendering deterministic,
 // so `number | string` and `string | number` print identically, and it lets
 // the canonical type serve as a stable key for caching.

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -360,6 +360,78 @@ func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
 	return true
 }
 
+// alphaEqualTypes reports whether a and b are equal up to a consistent renaming of their
+// lifetime variables — alpha-equivalence over the lifetime quantifier. Two borrows minted
+// in independent schemes carry distinct LifetimeVar identities, so the pointer-identity
+// equalType always reports them unequal even when they denote the same borrow. This is
+// the cross-scheme lifetime equality overload-arm comparison needs.
+//
+// It refines equalType only for borrows. A type with no lifetime variable compares
+// exactly as equalType does, so callers on the coalesce and lattice hot path keep pointer
+// identity and two independent param lifetimes stay distinct there. The comparison runs
+// in two steps:
+//
+//  1. Compare structure while equalTypeWith discovers the lifetime bijection, binding
+//     each matched borrow's lifetime on one side to the other's. Matching object
+//     properties by name means the bijection follows structure, not the order the two
+//     types happen to list their properties. A variable reused on one side must be reused
+//     the same way on the other, so two structurally-identical borrows whose
+//     lifetime-sharing patterns differ do not match.
+//  2. Compare the outlives relation among the paired lifetimes, so two signatures that
+//     agree structurally but differ in which lifetime outlives which are still unequal.
+//
+// overload-arm comparison calls this once per parameter through structuralSubtype, so a
+// lifetime shared across two parameters is not distinguished there. That is intended. A
+// borrow's lifetime is erased at codegen, which dispatches on parameter shape, so two arms
+// whose parameters are alpha-equal are indistinguishable however their lifetimes relate.
+func alphaEqualTypes(a, b soltype.Type) bool {
+	p := &ltPairing{aToB: map[int]int{}, bToA: map[int]int{}}
+	if !equalTypeWith(a, b, p) {
+		return false
+	}
+	if len(p.aVars) == 0 {
+		return true // no borrows: equalTypeWith settled it structurally
+	}
+	return sameOutlivesUnderPairing(p)
+}
+
+// sameOutlivesUnderPairing reports whether the two sides' paired lifetimes carry the same
+// outlives relation and the same 'static forcings. It builds each side's condensed
+// outlives graph over its paired variables, then for every ordered pair of paired
+// lifetimes checks that one side proves the outlives relation exactly when the other
+// does. implies folds in reachability, the mutual-outlives equality a condensed cycle
+// leaves behind, and 'static absorption, so a relation routed through an unpositioned
+// intermediary or realized as a cycle is compared correctly without a separate edge set.
+func sameOutlivesUnderPairing(p *ltPairing) bool {
+	absA := buildLtBoundSet(occOf(p.aVars))
+	absB := buildLtBoundSet(occOf(p.bVars))
+
+	for i := range p.aVars {
+		ai, bi := p.aVars[i].ID, p.bVars[i].ID
+		if absA.static.Contains(absA.repOf(ai)) != absB.static.Contains(absB.repOf(bi)) {
+			return false
+		}
+		for j := range p.aVars {
+			aj, bj := p.aVars[j].ID, p.bVars[j].ID
+			if absA.implies(ai, aj) != absB.implies(bi, bj) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// occOf seeds a bound-set walk from the given variables. The polarity is irrelevant to
+// the outlives graph, which lives in the variables' bound lists, so every variable is
+// recorded as occNeg.
+func occOf(vars []*soltype.LifetimeVar) map[*soltype.LifetimeVar]occPolarity {
+	occ := map[*soltype.LifetimeVar]occPolarity{}
+	for _, v := range vars {
+		occ[v] = occNeg
+	}
+	return occ
+}
+
 // canonicalEdges returns the condensed edges as (from, to) representative-ID pairs
 // sorted ascending, giving stable rendering and order-insensitive equality. This is the
 // lifetime-sort analogue of a canonical union member order.

--- a/internal/solver/lifetime_bounds_test.go
+++ b/internal/solver/lifetime_bounds_test.go
@@ -226,8 +226,9 @@ func TestLtBoundSetSubsumesChecksStaticForcing(t *testing.T) {
 
 // alphaEqualTypes equates two borrows minted in independent schemes when they denote
 // the same borrow up to lifetime renaming, where the pointer-identity equalType reports
-// them unequal. `fn(p: &'a mut {x}) -> &'a mut {x}` and the same signature over 'b are
-// alpha-equivalent. Each has one lifetime shared between its parameter and return.
+// them unequal. Both signatures render `fn <'a>(p: &'a mut {x}) -> &'a mut {x}`, each
+// sharing one lifetime between its parameter and return, but their lifetime variables are
+// distinct identities, so only alphaEqualTypes sees them as equal.
 func TestAlphaEqualTypesBorrowsAcrossSchemes(t *testing.T) {
 	c := newChecker()
 	a := c.ctx.freshLifetime(0)

--- a/internal/solver/lifetime_bounds_test.go
+++ b/internal/solver/lifetime_bounds_test.go
@@ -239,10 +239,10 @@ func TestAlphaEqualTypesBorrowsAcrossSchemes(t *testing.T) {
 	require.False(t, equalType(fnA, fnB),
 		"pointer-identity equality distinguishes the two independent lifetimes")
 	require.True(t, alphaEqualTypes(fnA, fnB),
-		"the two signatures are equal up to renaming 'a to 'b")
+		"the two signatures are equal up to lifetime renaming")
 }
 
-// The lifetime pairing is a bijection over first-appearance index, so which parameter a
+// The walk binds each matched borrow's lifetime into a bijection, so which parameter a
 // return borrows from is part of the comparison. Two signatures that both take two
 // borrows but return the FIRST versus the SECOND are not alpha-equivalent, even though
 // both carry exactly two lifetimes.
@@ -265,14 +265,15 @@ func TestAlphaEqualTypesPairingIsBijection(t *testing.T) {
 	}
 
 	require.True(t, alphaEqualTypes(fnRetFirst, fnRetFirst2),
-		"both return the borrow at first-appearance index 0")
+		"both return their first parameter's borrow")
 	require.False(t, alphaEqualTypes(fnRetFirst, fnRetSecond),
-		"returning index 0 versus index 1 is a different borrow relation")
+		"returning the first versus the second parameter's borrow is a different relation")
 }
 
 // Two independent param lifetimes with no bound between them stay distinct, so a
 // signature over two DISTINCT borrows is not alpha-equivalent to one that reuses a
-// single borrow for both parameters. The differing lifetime counts alone settle it.
+// single borrow for both parameters. The bijection refuses to bind the reused lifetime
+// to two different partners.
 func TestAlphaEqualTypesIndependenceWithinScheme(t *testing.T) {
 	c := newChecker()
 	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
@@ -352,6 +353,60 @@ func TestAlphaEqualTypesMutualOutlivesSharesLifetime(t *testing.T) {
 
 	require.True(t, alphaEqualTypes(mutual, mutual2),
 		"two signatures whose paired borrows are each mutually-outliving are alpha-equal")
+}
+
+// inferredValueType returns the coalesced display type of a top-level value binding, the
+// inferred type a hover would show. alphaEqualTypes compares two of these.
+func inferredValueType(t *testing.T, scope *Scope, name string) soltype.Type {
+	t.Helper()
+	b, ok := scope.GetValue(name)
+	require.True(t, ok, "no value binding for %q", name)
+	require.Len(t, b.Schemes, 1, "%q should be a single-scheme binding", name)
+	return schemeType(b.Schemes[0])
+}
+
+// Two source functions that declare their borrow lifetime with different names infer to
+// the same signature. Inference mints an independent lifetime variable per function, so
+// pointer-identity equalType reports them unequal, but alphaEqualTypes equates them up to
+// the renaming. A third function borrowing a differently-shaped object stays distinct.
+func TestAlphaEqualTypesInferredRenamedLifetimes(t *testing.T) {
+	scope, _, errs := InferModule(parseModule(t, `
+		fn f<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} { return p }
+		fn g<'b>(q: &'b mut {x: number}) -> &'b mut {x: number} { return q }
+		fn h<'c>(r: &'c mut {y: number}) -> &'c mut {y: number} { return r }
+	`))
+	require.Empty(t, errs)
+	f := inferredValueType(t, scope, "f")
+	g := inferredValueType(t, scope, "g")
+	h := inferredValueType(t, scope, "h")
+
+	require.False(t, equalType(f, g),
+		"inference minted independent lifetime variables, so pointer identity differs")
+	require.True(t, alphaEqualTypes(f, g),
+		"'a and 'b name the same borrow signature")
+	require.False(t, alphaEqualTypes(f, h),
+		"the borrowed object shapes differ, {x: number} versus {y: number}")
+}
+
+// Two source functions that each return the first of their two borrows are
+// alpha-equivalent under a lifetime renaming, even with differently-named lifetime
+// parameters. A third that returns its second borrow carries a different lifetime
+// relation and is not equivalent to them.
+func TestAlphaEqualTypesInferredReturnChoice(t *testing.T) {
+	scope, _, errs := InferModule(parseModule(t, `
+		fn pair1<'a, 'b>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'a mut {x: number} { return p }
+		fn pair2<'c, 'd>(r: &'c mut {x: number}, s: &'d mut {x: number}) -> &'c mut {x: number} { return r }
+		fn pair3<'e, 'f>(u: &'e mut {x: number}, v: &'f mut {x: number}) -> &'f mut {x: number} { return v }
+	`))
+	require.Empty(t, errs)
+	pair1 := inferredValueType(t, scope, "pair1")
+	pair2 := inferredValueType(t, scope, "pair2")
+	pair3 := inferredValueType(t, scope, "pair3")
+
+	require.True(t, alphaEqualTypes(pair1, pair2),
+		"both return the first of their two borrows")
+	require.False(t, alphaEqualTypes(pair1, pair3),
+		"returning the first versus the second borrow is a different lifetime relation")
 }
 
 // On a type with no lifetime variable, alphaEqualTypes reduces to equalType, so a caller

--- a/internal/solver/lifetime_bounds_test.go
+++ b/internal/solver/lifetime_bounds_test.go
@@ -223,3 +223,144 @@ func TestLtBoundSetSubsumesChecksStaticForcing(t *testing.T) {
 		"a non-'static '1 does not satisfy a declared '1: 'static")
 	require.True(t, declaredStatic.subsumes(declaredStatic))
 }
+
+// alphaEqualTypes equates two borrows minted in independent schemes when they denote
+// the same borrow up to lifetime renaming, where the pointer-identity equalType reports
+// them unequal. `fn(p: &'a mut {x}) -> &'a mut {x}` and the same signature over 'b are
+// alpha-equivalent. Each has one lifetime shared between its parameter and return.
+func TestAlphaEqualTypesBorrowsAcrossSchemes(t *testing.T) {
+	c := newChecker()
+	a := c.ctx.freshLifetime(0)
+	b := c.ctx.freshLifetime(0)
+	fnA := borrowFn(mutPointRef(a), a)
+	fnB := borrowFn(mutPointRef(b), b)
+
+	require.False(t, equalType(fnA, fnB),
+		"pointer-identity equality distinguishes the two independent lifetimes")
+	require.True(t, alphaEqualTypes(fnA, fnB),
+		"the two signatures are equal up to renaming 'a to 'b")
+}
+
+// The lifetime pairing is a bijection over first-appearance index, so which parameter a
+// return borrows from is part of the comparison. Two signatures that both take two
+// borrows but return the FIRST versus the SECOND are not alpha-equivalent, even though
+// both carry exactly two lifetimes.
+func TestAlphaEqualTypesPairingIsBijection(t *testing.T) {
+	c := newChecker()
+	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	fnRetFirst := &soltype.FuncType{
+		Params: borrowFn(num(), a, b).Params, // p: &'a mut {x}, q: &'b mut {x}
+		Ret:    mutPointRef(a),               // returns the first borrow
+	}
+	cc, d := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	fnRetFirst2 := &soltype.FuncType{
+		Params: borrowFn(num(), cc, d).Params,
+		Ret:    mutPointRef(cc), // also returns its first borrow
+	}
+	e, f := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	fnRetSecond := &soltype.FuncType{
+		Params: borrowFn(num(), e, f).Params,
+		Ret:    mutPointRef(f), // returns its SECOND borrow
+	}
+
+	require.True(t, alphaEqualTypes(fnRetFirst, fnRetFirst2),
+		"both return the borrow at first-appearance index 0")
+	require.False(t, alphaEqualTypes(fnRetFirst, fnRetSecond),
+		"returning index 0 versus index 1 is a different borrow relation")
+}
+
+// Two independent param lifetimes with no bound between them stay distinct, so a
+// signature over two DISTINCT borrows is not alpha-equivalent to one that reuses a
+// single borrow for both parameters. The differing lifetime counts alone settle it.
+func TestAlphaEqualTypesIndependenceWithinScheme(t *testing.T) {
+	c := newChecker()
+	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	distinct := borrowFn(num(), a, b) // two independent borrows
+	shared := borrowFn(num(), a, a)   // one borrow used for both parameters
+
+	require.False(t, alphaEqualTypes(distinct, shared),
+		"two independent lifetimes do not collapse to one")
+}
+
+// The reduced outlives relation is part of the comparison. Two structurally identical
+// two-borrow signatures are alpha-equivalent only when they carry the same outlives
+// bound; adding `'a: 'b` to one side breaks the equality.
+func TestAlphaEqualTypesComparesOutlivesRelation(t *testing.T) {
+	c := newChecker()
+	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	c.ctx.constrainLt(a, b) // 'a outlives 'b
+	bound := borrowFn(num(), a, b)
+
+	e, f := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	c.ctx.constrainLt(e, f)
+	bound2 := borrowFn(num(), e, f)
+
+	g, h := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	free := borrowFn(num(), g, h) // same shape, no bound between the two lifetimes
+
+	require.True(t, alphaEqualTypes(bound, bound2),
+		"two signatures with the same 'a: 'b bound are alpha-equivalent")
+	require.False(t, alphaEqualTypes(bound, free),
+		"a signature with 'a: 'b differs from one with no bound")
+}
+
+// The lifetime bijection follows structure, so matching two objects with the same
+// borrow-typed properties in different declaration order still pairs the properties by
+// name. equalType already treats objects as equal up to property order, and
+// alpha-equivalence must not regress that for borrow-typed fields.
+func TestAlphaEqualTypesObjectPropertyOrderInsensitive(t *testing.T) {
+	c := newChecker()
+	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	objMN := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{
+		&soltype.PropertyElem{Name: "m", Type: mutPointRef(a)},
+		&soltype.PropertyElem{Name: "n", Type: mutPointRef(b)},
+	}}
+	cc, d := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	objNM := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{ // same fields, swapped order
+		&soltype.PropertyElem{Name: "n", Type: mutPointRef(d)},
+		&soltype.PropertyElem{Name: "m", Type: mutPointRef(cc)},
+	}}
+	fnA := &soltype.FuncType{Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: objMN}}, Ret: num()}
+	fnB := &soltype.FuncType{Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "p"}, Type: objNM}}, Ret: num()}
+
+	require.True(t, alphaEqualTypes(fnA, fnB),
+		"borrow-typed object properties pair by name, not by declaration order")
+}
+
+// Two lifetimes that mutually outlive each other are equal, so a signature whose two
+// borrows are mutually-outliving shares one lifetime and is not alpha-equivalent to one
+// with two independent borrows. The outlives comparison reads this equality through
+// implies, which reports a condensed cycle as equality in both directions.
+func TestAlphaEqualTypesMutualOutlivesSharesLifetime(t *testing.T) {
+	c := newChecker()
+	a, b := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	c.ctx.constrainLt(a, b)
+	c.ctx.constrainLt(b, a) // 'a and 'b mutually outlive, hence are equal
+	mutual := borrowFn(num(), a, b)
+
+	e, f := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	independent := borrowFn(num(), e, f) // two distinct lifetimes, unrelated
+
+	require.False(t, alphaEqualTypes(mutual, independent),
+		"one shared borrow does not equal two independent ones")
+
+	g, h := c.ctx.freshLifetime(0), c.ctx.freshLifetime(0)
+	c.ctx.constrainLt(g, h)
+	c.ctx.constrainLt(h, g)
+	mutual2 := borrowFn(num(), g, h)
+
+	require.True(t, alphaEqualTypes(mutual, mutual2),
+		"two signatures whose paired borrows are each mutually-outliving are alpha-equal")
+}
+
+// On a type with no lifetime variable, alphaEqualTypes reduces to equalType, so a caller
+// gains lifetime alpha-equivalence for borrows without changing equality anywhere else.
+func TestAlphaEqualTypesReducesToEqualTypeWithoutBorrows(t *testing.T) {
+	obj := exactObj(propElem("x", num()))
+	obj2 := exactObj(propElem("x", num()))
+
+	require.True(t, alphaEqualTypes(obj, obj2))
+	require.True(t, alphaEqualTypes(num(), num()))
+	require.False(t, alphaEqualTypes(num(), str()))
+	require.False(t, alphaEqualTypes(num(), obj))
+}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -324,6 +324,12 @@ func equallySpecific(a, b *soltype.FuncType) bool {
 // equality plus a literal under its primitive. Anything richer ranks as incomparable and
 // returns false, deferring to declaration order.
 //
+// Two overload arms come from independent schemes, so a borrow parameter of one carries
+// a LifetimeVar distinct from the matching borrow of the other. Structural equality here
+// is therefore alpha-equivalence over lifetimes, not pointer identity, so two arms whose
+// borrow parameters differ only in lifetime identity rank as equally specific rather than
+// as two incomparable arms.
+//
 // It is deliberately NOT the full subtype relation. Resolution correctness comes from
 // the constrain trial in tryOverloadArm, not from this comparator.
 func structuralSubtype(a, b soltype.Type) bool {
@@ -333,7 +339,7 @@ func structuralSubtype(a, b soltype.Type) bool {
 	if _, ok := a.(*soltype.TypeVarType); ok {
 		return false
 	}
-	if equalType(a, b) {
+	if alphaEqualTypes(a, b) {
 		return true
 	}
 	if l, ok := a.(*soltype.LitType); ok {


### PR DESCRIPTION
Adds `alphaEqualTypes` to compare types up to consistent renaming of lifetime variables, enabling cross-scheme borrow-parameter comparison in overload resolution.

Within a single coalesce, `equalType` keys lifetimes by pointer identity, keeping independent param lifetimes distinct. Across schemes (as in overload arms), each borrow carries its own `LifetimeVar` with an independent identity, so pointer-identity comparison always reports them unequal even when they denote the same borrow. This breaks overload-arm deduplication: two arms with identical borrow parameters should rank as equally specific and trigger a duplicate-overload error, but pointer identity made them appear different.

**Key changes:**

- Add `ltPairing` to track the bijection between lifetime variables as types are compared structurally. The bijection follows structure (matching object properties by name), so a variable reused on one side must be reused the same way on the other.
- Refactor `equalType` to `equalTypeWith(a, b, pairing)`, parameterized by an optional lifetime pairing. With `nil`, it behaves exactly as before (pointer-identity keying). With a pairing, it keys borrows by first-appearance index.
- Add `ltEqualWith` to compare lifetimes under a pairing, binding variables together as they are first matched.
- Add `alphaEqualTypes` for cross-scheme comparison. It discovers the lifetime bijection via `equalTypeWith`, then calls `sameOutlivesUnderPairing` to verify the two sides carry the same outlives relation and 'static forcings.
- Add `sameOutlivesUnderPairing` to compare the condensed outlives graph over paired lifetimes using `implies`, which folds in reachability and mutual-outlives equality.
- Update `structuralSubtype` in overload resolution to use `alphaEqualTypes` instead of `equalType`, so borrow parameters differing only in lifetime identity rank as equally specific.
- Add comprehensive test coverage for alpha-equivalence: borrows across schemes, bijection as a function (which parameter a return borrows from matters), independence within a scheme, outlives-relation comparison, object property order insensitivity, mutual-outlives cycles, and reduction to `equalType` for types without borrows.
- Add integration tests in `infer_overload_test.go` verifying that duplicate borrow-parameter arms are rejected and distinct borrow-parameter arms are allowed.

https://claude.ai/code/session_01UtsxzahRhXbXsL9pM4vTrr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overload handling so borrow-based signatures are compared more intelligently, reducing false duplicate detections and better preserving valid overload sets.
  * Made overload specificity ranking more consistent when borrow lifetimes differ but the types are otherwise equivalent.
  * Refined type comparison to treat borrow lifetimes and related constraints more accurately across complex types, including functions, tuples, objects, unions, and intersections.

* **Tests**
  * Added regression coverage for borrow and lifetime equivalence in overload inference and type comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->