### PR TITLE
Check lifetime declarations against uses in signatures

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -813,6 +813,10 @@ func (e *UndeclaredLifetimeError) Message() string {
 		msg += "; add `<'" + e.Name + ">` to the enclosing function signature"
 	case len(e.Suggestions) > 0:
 		msg += "; did you mean '" + strings.Join(e.Suggestions, " or '") + "?"
+	default:
+		// A clause exists but no declared name is close enough to be a likely typo, so
+		// point at declaring the name rather than guessing a correction.
+		msg += "; add `<'" + e.Name + ">` to the signature's lifetime list"
 	}
 	return msg
 }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -776,6 +776,66 @@ func (e *LifetimeBoundNotSatisfiedError) Message() string {
 		e.Sub, e.Super, e.Sub, e.Super)
 }
 
+// UndeclaredLifetimeError fires when a signature uses a named lifetime that its own
+// `<…>` quantifier list does not bind. A `&'x` borrow or a bound's right-hand side
+// names `'x`, but no `<'x>` binder introduces it, so the name is a forgotten
+// declaration or a typo. Name is the used name without the leading `'`.
+//
+// Severity follows the signature's quantifier clause. With no `<…>` clause the author
+// almost certainly meant to declare the binder, so it is a hard error. With a clause
+// that binds other names the miss is most likely a typo, so it is a warning carrying
+// nearest-match Suggestions drawn from the declared siblings. Recovery mints a fresh
+// lifetime through namedLifetime either way, so the signature stays well-formed and
+// later checks proceed.
+//
+// SolverError carries no severity slot, so IsWarning lives on this concrete type and a
+// caller that needs the severity reads it through a type assertion.
+type UndeclaredLifetimeError struct {
+	Name        string
+	Suggestions []string // nearest declared siblings by edit distance; empty when none is close
+	hasClause   bool     // whether the signature carries any `<…>` binder at all
+	span        ast.Span
+}
+
+func (*UndeclaredLifetimeError) isSolverError()        {}
+func (e *UndeclaredLifetimeError) Span() ast.Span      { return e.span }
+func (e *UndeclaredLifetimeError) Related() []ast.Span { return nil }
+
+// IsWarning reports the typo case, where a `<…>` clause exists but does not bind the
+// name. With no clause at all the use is unambiguously a forgotten declaration and a
+// hard error.
+func (e *UndeclaredLifetimeError) IsWarning() bool { return e.hasClause }
+
+func (e *UndeclaredLifetimeError) Message() string {
+	msg := "lifetime '" + e.Name + " is used but not declared"
+	switch {
+	case !e.hasClause:
+		msg += "; add `<'" + e.Name + ">` to the enclosing function signature"
+	case len(e.Suggestions) > 0:
+		msg += "; did you mean '" + strings.Join(e.Suggestions, " or '") + "?"
+	}
+	return msg
+}
+
+// UnusedLifetimeParamError fires when a signature declares a `<'a>` binder that no
+// `&'a` borrow and no bound right-hand side references. The program is well-typed; the
+// binder is dead weight. Name is the declared name without the leading `'`. It is the
+// symmetric companion of UndeclaredLifetimeError — the same signature scan read the
+// other way, binders with no use rather than uses with no binder — and is always a
+// warning.
+type UnusedLifetimeParamError struct {
+	Name  string
+	Param *ast.LifetimeParam
+}
+
+func (*UnusedLifetimeParamError) isSolverError()        {}
+func (e *UnusedLifetimeParamError) Span() ast.Span      { return e.Param.Span() }
+func (e *UnusedLifetimeParamError) Related() []ast.Span { return nil }
+func (e *UnusedLifetimeParamError) IsWarning() bool     { return true }
+func (e *UnusedLifetimeParamError) Message() string {
+	return "lifetime parameter '" + e.Name + " is declared but never used"
+}
+
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
 func (e *UnknownIdentifierError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -262,23 +262,23 @@ type ReadonlyFieldSubtypeError struct {
 	site  ast.Node
 }
 
-func (*CannotConstrainError) isSolverError()      {}
-func (*MutFieldError) isSolverError()             {}
-func (*ReadonlyFieldError) isSolverError()        {}
-func (*ReadonlyFieldSubtypeError) isSolverError() {}
-func (*FuncArityMismatchError) isSolverError()    {}
-func (*TupleLengthMismatchError) isSolverError() {}
-func (*SpreadNotTupleError) isSolverError()      {}
-func (*InexactTupleSpreadError) isSolverError()  {}
-func (*MissingPropertyError) isSolverError()     {}
-func (*InexactIntoExactError) isSolverError()    {}
+func (*CannotConstrainError) isSolverError()       {}
+func (*MutFieldError) isSolverError()              {}
+func (*ReadonlyFieldError) isSolverError()         {}
+func (*ReadonlyFieldSubtypeError) isSolverError()  {}
+func (*FuncArityMismatchError) isSolverError()     {}
+func (*TupleLengthMismatchError) isSolverError()   {}
+func (*SpreadNotTupleError) isSolverError()        {}
+func (*InexactTupleSpreadError) isSolverError()    {}
+func (*MissingPropertyError) isSolverError()       {}
+func (*InexactIntoExactError) isSolverError()      {}
 func (*InexactTupleIntoExactError) isSolverError() {}
 func (*InexactUnionIntoExactError) isSolverError() {}
-func (*ExtraPropertyError) isSolverError()       {}
-func (*ExtraElementError) isSolverError()        {}
-func (*OptionalPropertyError) isSolverError()    {}
-func (*MutabilityMismatchError) isSolverError()  {}
-func (*BorrowEscapeError) isSolverError()        {}
+func (*ExtraPropertyError) isSolverError()         {}
+func (*ExtraElementError) isSolverError()          {}
+func (*OptionalPropertyError) isSolverError()      {}
+func (*MutabilityMismatchError) isSolverError()    {}
+func (*BorrowEscapeError) isSolverError()          {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -779,17 +779,14 @@ func (e *LifetimeBoundNotSatisfiedError) Message() string {
 // UndeclaredLifetimeError fires when a signature uses a named lifetime that its own
 // `<…>` quantifier list does not bind. A `&'x` borrow or a bound's right-hand side
 // names `'x`, but no `<'x>` binder introduces it, so the name is a forgotten
-// declaration or a typo. Name is the used name without the leading `'`.
+// declaration or a typo. Either way it is a hard error the author must resolve. Name is
+// the used name without the leading `'`.
 //
-// Severity follows the signature's quantifier clause. With no `<…>` clause the author
-// almost certainly meant to declare the binder, so it is a hard error. With a clause
-// that binds other names the miss is most likely a typo, so it is a warning carrying
-// nearest-match Suggestions drawn from the declared siblings. Recovery mints a fresh
-// lifetime through namedLifetime either way, so the signature stays well-formed and
-// later checks proceed.
-//
-// SolverError carries no severity slot, so IsWarning lives on this concrete type and a
-// caller that needs the severity reads it through a type assertion.
+// The clause shapes only the hint, not the severity. With no `<…>` clause the message
+// prompts adding one. With a clause that binds other names the message suggests the
+// nearest declared siblings by edit distance when one is close, since the miss is likely
+// a typo, and otherwise prompts declaring the name. Recovery mints a fresh lifetime
+// through namedLifetime so the signature stays well-formed and later checks proceed.
 type UndeclaredLifetimeError struct {
 	Name        string
 	Suggestions []string // nearest declared siblings by edit distance; empty when none is close
@@ -800,11 +797,6 @@ type UndeclaredLifetimeError struct {
 func (*UndeclaredLifetimeError) isSolverError()        {}
 func (e *UndeclaredLifetimeError) Span() ast.Span      { return e.span }
 func (e *UndeclaredLifetimeError) Related() []ast.Span { return nil }
-
-// IsWarning reports the typo case, where a `<…>` clause exists but does not bind the
-// name. With no clause at all the use is unambiguously a forgotten declaration and a
-// hard error.
-func (e *UndeclaredLifetimeError) IsWarning() bool { return e.hasClause }
 
 func (e *UndeclaredLifetimeError) Message() string {
 	msg := "lifetime '" + e.Name + " is used but not declared"
@@ -819,6 +811,24 @@ func (e *UndeclaredLifetimeError) Message() string {
 		msg += "; add `<'" + e.Name + ">` to the signature's lifetime list"
 	}
 	return msg
+}
+
+// DuplicateLifetimeParamError fires when a signature's `<…>` list binds the same
+// lifetime name more than once, as in `<'a, 'a>`. The repeat binds nothing new and is
+// almost certainly a typo, so it is a hard error. Name is the repeated name without the
+// leading `'`. Param is the redundant binder, the blame span; First is the kept binder,
+// surfaced through Related.
+type DuplicateLifetimeParamError struct {
+	Name  string
+	Param *ast.LifetimeParam
+	First *ast.LifetimeParam
+}
+
+func (*DuplicateLifetimeParamError) isSolverError()        {}
+func (e *DuplicateLifetimeParamError) Span() ast.Span      { return e.Param.Span() }
+func (e *DuplicateLifetimeParamError) Related() []ast.Span { return []ast.Span{e.First.Span()} }
+func (e *DuplicateLifetimeParamError) Message() string {
+	return "lifetime parameter '" + e.Name + " is declared more than once"
 }
 
 // UnusedLifetimeParamError fires when a signature declares a `<'a>` binder that no

--- a/internal/solver/infer_borrow_lifetime_test.go
+++ b/internal/solver/infer_borrow_lifetime_test.go
@@ -519,9 +519,10 @@ func TestInferBorrowAnnMutableParam(t *testing.T) {
 
 // A named `&'a` lifetime resolves to one lifetime variable shared by every occurrence in
 // the function, so two parameters annotated `&'a` borrow at the same lifetime. Returning
-// one makes that lifetime load-bearing, and the display names it `'a` on both params.
+// one makes that lifetime load-bearing, and the display names it `'a` on both params. The
+// `<'a>` binder is required: a `&'a` borrow whose name no clause declares is rejected.
 func TestInferNamedBorrowLifetimeShared(t *testing.T) {
-	values, _, errs := inferSource(t, `fn f(p: &'a {x: number}, q: &'a {x: number}) { return p }`)
+	values, _, errs := inferSource(t, `fn f<'a>(p: &'a {x: number}, q: &'a {x: number}) { return p }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <'a>(p: &'a {x: number}, q: &'a {x: number}) -> &'a {x: number}", values["f"])
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -194,6 +194,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	savedNamedLts := c.namedLifetimes
 	c.namedLifetimes = nil
 	defer func() { c.namedLifetimes = savedNamedLts }()
+	// Report any named lifetime the signature uses without binding it in its own `<…>`
+	// list, and the symmetric unused binder. Run before resolving the params so the scan
+	// reads the written names, not what namedLifetime has since interned.
+	c.checkLifetimeDeclarations(sig.LifetimeParams, sig.Params, sig.Return, sig.Throws)
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
 		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -99,17 +99,20 @@ func TestInferThrowsFuncAnnotationReportsUnsupported(t *testing.T) {
 // case renders the binding named by `binding` and reports no error.
 func TestInferLifetimeFuncAnnotation(t *testing.T) {
 	tests := []struct {
-		name    string
-		src     string
-		binding string
-		want    string
+		name     string
+		src      string
+		binding  string
+		want     string
+		wantErrs []string
 	}{
-		// A lifetime that names no borrow is inert, so it renders elided.
+		// A lifetime that names no borrow is inert, so it renders elided. Declaring it and
+		// then naming nothing is dead weight, so the unused-binder companion warns.
 		{
-			name:    "unused lifetime",
-			src:     `val f: fn<'a>(x: number) -> number = fn (x) { return x }`,
-			binding: "f",
-			want:    "fn (x: number) -> number",
+			name:     "unused lifetime",
+			src:      `val f: fn<'a>(x: number) -> number = fn (x) { return x }`,
+			binding:  "f",
+			want:     "fn (x: number) -> number",
+			wantErrs: []string{"lifetime parameter 'a is declared but never used"},
 		},
 		// A lifetime naming a borrow that reaches the output resolves to one shared
 		// lifetime across the parameter and return, so it quantifies as `'a` on both.
@@ -151,7 +154,7 @@ func TestInferLifetimeFuncAnnotation(t *testing.T) {
 		// must not share a variable, so `outer`'s parameter stays a plain borrow lifetime.
 		{
 			name: "nested annotation scope is local",
-			src: `fn outer(p: &'a {x: number}) {
+			src: `fn outer<'a>(p: &'a {x: number}) {
   val g: fn<'a: 'static>(q: &'a {y: number}) -> &'a {y: number} = fn (q) { return q }
   return p
 }`,
@@ -162,7 +165,7 @@ func TestInferLifetimeFuncAnnotation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
-			require.Empty(t, errs)
+			require.Equal(t, tt.wantErrs, Messages(errs))
 			require.Equal(t, tt.want, values[tt.binding])
 		})
 	}

--- a/internal/solver/infer_undeclared_lifetime_test.go
+++ b/internal/solver/infer_undeclared_lifetime_test.go
@@ -3,7 +3,6 @@ package solver
 import (
 	"testing"
 
-	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,23 +25,19 @@ func TestInferUndeclaredLifetimeNoClauseHardError(t *testing.T) {
 			"1:30-1:32: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
 		},
 		messagesWithSpan(errs))
-	require.False(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
-		"a use with no clause is a hard error")
 }
 
-// A used lifetime the clause does not bind is a typo warning, with the nearest declared
-// sibling suggested. 'a is declared and borrowed by p, so it is not unused; only the
-// stray 'b on q is undeclared, and 'a is one edit away.
-func TestInferUndeclaredLifetimeWithClauseWarns(t *testing.T) {
+// A used lifetime the clause does not bind is a hard error, with the nearest declared
+// sibling suggested since the miss is likely a typo. 'a is declared and borrowed by p, so
+// it is not unused; only the stray 'b on q is undeclared, and 'a is one edit away.
+func TestInferUndeclaredLifetimeWithClause(t *testing.T) {
 	_, _, errs := inferSource(t, `fn f<'a>(p: &'a {x: number}, q: &'b {x: number}) { return p }`)
 	require.Equal(t,
 		[]string{"1:34-1:36: lifetime 'b is used but not declared; did you mean 'a?"},
 		messagesWithSpan(errs))
-	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
-		"a use under an existing clause is a typo warning")
 }
 
-// A clause exists but no declared name is close enough to suggest, so the warning falls
+// A clause exists but no declared name is close enough to suggest, so the message falls
 // back to prompting the author to declare the name rather than offering a correction.
 // `'xyz` is three edits from the stray 'a, beyond the suggestion threshold.
 func TestInferUndeclaredLifetimeWithClauseNoCloseSuggestion(t *testing.T) {
@@ -51,20 +46,18 @@ func TestInferUndeclaredLifetimeWithClauseNoCloseSuggestion(t *testing.T) {
 	require.Equal(t,
 		[]string{"1:38-1:40: lifetime 'a is used but not declared; add `<'a>` to the signature's lifetime list"},
 		messagesWithSpan(errs))
-	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning())
 }
 
 // The right-hand side of a declared bound is a use, so an undeclared name there is
 // reported the same way. A function type annotation is a no-body site whose bounds lower
-// rather than being checked, so only the undeclared-lifetime warning fires. 'a is one
-// edit from the stray 'b.
+// rather than being checked, so only the undeclared-lifetime error fires. 'a is one edit
+// from the stray 'b.
 func TestInferUndeclaredLifetimeInBoundRHS(t *testing.T) {
 	_, _, errs := inferSource(t,
 		`val f: fn<'a: 'b>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
 	require.Equal(t,
 		[]string{"1:15-1:17: lifetime 'b is used but not declared; did you mean 'a?"},
 		messagesWithSpan(errs))
-	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning())
 }
 
 // 'static is the built-in bottom of the outlives lattice, so it is never undeclared. A
@@ -90,8 +83,6 @@ func TestInferUndeclaredLifetimeNestedJudgedByOwnClause(t *testing.T) {
 			"2:43-2:45: lifetime 'a is used but not declared; add `<'a>` to the enclosing function signature",
 		},
 		messagesWithSpan(errs))
-	require.False(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
-		"the inner function has no clause, so its use is a hard error")
 }
 
 // A declared binder that no borrow and no bound references is dead weight. `<'a>` is
@@ -104,22 +95,32 @@ func TestInferUnusedLifetimeParamWarns(t *testing.T) {
 	require.True(t, errs[0].(*UnusedLifetimeParamError).IsWarning())
 }
 
-// A name bound more than once warns unused only once, blaming its first binder. The
-// undeclared and unused directions agree on deduplication. The check runs directly on a
-// hand-built signature, since the parser does not produce a repeated binder.
-func TestCheckLifetimeDeclarationsDuplicateBinderWarnsOnce(t *testing.T) {
-	c := newChecker()
-	first := ast.NewLifetimeParam("a", nil, ast.Span{Start: ast.Location{Line: 1, Column: 6}, End: ast.Location{Line: 1, Column: 8}})
-	second := ast.NewLifetimeParam("a", nil, ast.Span{Start: ast.Location{Line: 1, Column: 10}, End: ast.Location{Line: 1, Column: 12}})
-	params := []*ast.LifetimeParam{first, second}
-
-	c.checkLifetimeDeclarations(params, nil, nil, nil)
-
-	require.Len(t, c.errs, 1, "a name bound twice warns unused once")
-	ue, ok := c.errs[0].(*UnusedLifetimeParamError)
+// A `<…>` list that binds the same name twice is a hard error. The repeat binds nothing
+// new, so it blames the second binder and relates the kept first binder. 'a is borrowed,
+// so it is used and no unused warning joins the duplicate error.
+func TestInferDuplicateLifetimeParam(t *testing.T) {
+	_, _, errs := inferSource(t,
+		`fn f<'a, 'a>(p: &'a {x: number}) -> &'a {x: number} { return p }`)
+	require.Equal(t,
+		[]string{"1:10-1:12: lifetime parameter 'a is declared more than once"},
+		messagesWithSpan(errs))
+	de, ok := errs[0].(*DuplicateLifetimeParamError)
 	require.True(t, ok)
-	require.Equal(t, "a", ue.Name)
-	require.Same(t, first, ue.Param, "the first binder is blamed")
+	require.Equal(t, "a", de.Name)
+	require.Equal(t, "1:6-1:8", de.Related()[0].String(), "the first binder is related")
+}
+
+// The duplicate and unused scans agree on deduplication. A repeated binder that nothing
+// uses reports the duplicate once and the unused warning once, both blaming the first
+// binder, rather than a warning per repeat.
+func TestInferDuplicateLifetimeParamUnusedReportedOnce(t *testing.T) {
+	_, _, errs := inferSource(t, `fn g<'a, 'a>(p: &{x: number}) { return p }`)
+	require.Equal(t,
+		[]string{
+			"1:10-1:12: lifetime parameter 'a is declared more than once",
+			"1:6-1:8: lifetime parameter 'a is declared but never used",
+		},
+		messagesWithSpan(errs))
 }
 
 // A binder used only as a bound right-hand side counts as used, so it does not warn as

--- a/internal/solver/infer_undeclared_lifetime_test.go
+++ b/internal/solver/infer_undeclared_lifetime_test.go
@@ -42,6 +42,18 @@ func TestInferUndeclaredLifetimeWithClauseWarns(t *testing.T) {
 		"a use under an existing clause is a typo warning")
 }
 
+// A clause exists but no declared name is close enough to suggest, so the warning falls
+// back to prompting the author to declare the name rather than offering a correction.
+// `'xyz` is three edits from the stray 'a, beyond the suggestion threshold.
+func TestInferUndeclaredLifetimeWithClauseNoCloseSuggestion(t *testing.T) {
+	_, _, errs := inferSource(t,
+		`fn f<'xyz>(p: &'xyz {x: number}, q: &'a {x: number}) { return p }`)
+	require.Equal(t,
+		[]string{"1:38-1:40: lifetime 'a is used but not declared; add `<'a>` to the signature's lifetime list"},
+		messagesWithSpan(errs))
+	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning())
+}
+
 // The right-hand side of a declared bound is a use, so an undeclared name there is
 // reported the same way. A function type annotation is a no-body site whose bounds lower
 // rather than being checked, so only the undeclared-lifetime warning fires. 'a is one

--- a/internal/solver/infer_undeclared_lifetime_test.go
+++ b/internal/solver/infer_undeclared_lifetime_test.go
@@ -1,0 +1,154 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6.5 PR10: error on a used-but-undeclared lifetime ---
+//
+// A named lifetime a signature uses must be bound by that signature's own `<…>` list.
+// A `&'x` borrow or a bound right-hand side names `'x`; when no `<'x>` binder introduces
+// it the name is a forgotten declaration or a typo. With no clause at all the use is a
+// hard error; with a clause that binds other names it is a typo warning carrying the
+// nearest declared siblings. The symmetric companion warns on a binder no use references.
+
+// A used lifetime with no `<…>` clause is a hard error blaming each occurrence, since the
+// author almost certainly meant to declare the binder. The borrow appears on both the
+// parameter and the return, so each names 'b and each is blamed.
+func TestInferUndeclaredLifetimeNoClauseHardError(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f(p: &'b {x: number}) -> &'b {x: number} { return p }`)
+	require.Equal(t,
+		[]string{
+			"1:10-1:12: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
+			"1:30-1:32: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
+		},
+		messagesWithSpan(errs))
+	require.False(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
+		"a use with no clause is a hard error")
+}
+
+// A used lifetime the clause does not bind is a typo warning, with the nearest declared
+// sibling suggested. 'a is declared and borrowed by p, so it is not unused; only the
+// stray 'b on q is undeclared, and 'a is one edit away.
+func TestInferUndeclaredLifetimeWithClauseWarns(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<'a>(p: &'a {x: number}, q: &'b {x: number}) { return p }`)
+	require.Equal(t,
+		[]string{"1:34-1:36: lifetime 'b is used but not declared; did you mean 'a?"},
+		messagesWithSpan(errs))
+	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
+		"a use under an existing clause is a typo warning")
+}
+
+// The right-hand side of a declared bound is a use, so an undeclared name there is
+// reported the same way. A function type annotation is a no-body site whose bounds lower
+// rather than being checked, so only the undeclared-lifetime warning fires. 'a is one
+// edit from the stray 'b.
+func TestInferUndeclaredLifetimeInBoundRHS(t *testing.T) {
+	_, _, errs := inferSource(t,
+		`val f: fn<'a: 'b>(p: &'a {x: number}) -> &'a {x: number} = fn (p) { return p }`)
+	require.Equal(t,
+		[]string{"1:15-1:17: lifetime 'b is used but not declared; did you mean 'a?"},
+		messagesWithSpan(errs))
+	require.True(t, errs[0].(*UndeclaredLifetimeError).IsWarning())
+}
+
+// 'static is the built-in bottom of the outlives lattice, so it is never undeclared. A
+// `&'static` borrow with no clause reports nothing.
+func TestInferStaticLifetimeNeverUndeclared(t *testing.T) {
+	_, _, errs := inferSource(t,
+		`fn f(p: &'static {x: number}) -> &'static {x: number} { return p }`)
+	require.Empty(t, errs)
+}
+
+// A nested function is judged by its own clause, not an enclosing one. The inner `relay`
+// declares no `<'a>`, so its `&'a` borrows are undeclared with no clause and are hard
+// errors, even though the outer function declares `<'a>`. An enclosing function's
+// lifetimes are not visible to a nested one.
+func TestInferUndeclaredLifetimeNestedJudgedByOwnClause(t *testing.T) {
+	_, _, errs := inferSource(t, `fn outer<'a>(p: &'a {x: number}) -> &'a {x: number} {
+  val relay = fn (q: &'a {x: number}) -> &'a {x: number} { return q }
+  return p
+}`)
+	require.Equal(t,
+		[]string{
+			"2:23-2:25: lifetime 'a is used but not declared; add `<'a>` to the enclosing function signature",
+			"2:43-2:45: lifetime 'a is used but not declared; add `<'a>` to the enclosing function signature",
+		},
+		messagesWithSpan(errs))
+	require.False(t, errs[0].(*UndeclaredLifetimeError).IsWarning(),
+		"the inner function has no clause, so its use is a hard error")
+}
+
+// A declared binder that no borrow and no bound references is dead weight. `<'a>` is
+// declared but p borrows at a fresh inferred lifetime, so 'a is unused and warns.
+func TestInferUnusedLifetimeParamWarns(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<'a>(p: &{x: number}) { return p }`)
+	require.Equal(t,
+		[]string{"1:6-1:8: lifetime parameter 'a is declared but never used"},
+		messagesWithSpan(errs))
+	require.True(t, errs[0].(*UnusedLifetimeParamError).IsWarning())
+}
+
+// A name bound more than once warns unused only once, blaming its first binder. The
+// undeclared and unused directions agree on deduplication. The check runs directly on a
+// hand-built signature, since the parser does not produce a repeated binder.
+func TestCheckLifetimeDeclarationsDuplicateBinderWarnsOnce(t *testing.T) {
+	c := newChecker()
+	first := ast.NewLifetimeParam("a", nil, ast.Span{Start: ast.Location{Line: 1, Column: 6}, End: ast.Location{Line: 1, Column: 8}})
+	second := ast.NewLifetimeParam("a", nil, ast.Span{Start: ast.Location{Line: 1, Column: 10}, End: ast.Location{Line: 1, Column: 12}})
+	params := []*ast.LifetimeParam{first, second}
+
+	c.checkLifetimeDeclarations(params, nil, nil, nil)
+
+	require.Len(t, c.errs, 1, "a name bound twice warns unused once")
+	ue, ok := c.errs[0].(*UnusedLifetimeParamError)
+	require.True(t, ok)
+	require.Equal(t, "a", ue.Name)
+	require.Same(t, first, ue.Param, "the first binder is blamed")
+}
+
+// A binder used only as a bound right-hand side counts as used, so it does not warn as
+// unused. `<'a: 'c, 'b: 'c, 'c>` declares 'c and references it from both bounds; 'c also
+// borrows nothing on its own, yet the bound uses keep it live.
+func TestInferBoundRHSCountsAsUse(t *testing.T) {
+	_, _, errs := inferSource(t, `fn pick<'a: 'c, 'b: 'c, 'c>(p: &'a mut {x: number}, q: &'b mut {x: number}) -> &'c mut {x: number} {
+		if true { return p } else { return q }
+	}`)
+	require.Empty(t, errs)
+}
+
+// A well-formed signature that declares and uses every lifetime reports nothing.
+func TestInferDeclaredAndUsedLifetimeNoDiagnostic(t *testing.T) {
+	_, _, errs := inferSource(t,
+		`fn f<'a>(p: &'a {x: number}) -> &'a {x: number} { return p }`)
+	require.Empty(t, errs)
+}
+
+// nearestLifetimes ranks declared siblings by edit distance and keeps only the closest
+// within the threshold, so a stray name points at its likeliest intended binder.
+func TestNearestLifetimes(t *testing.T) {
+	tests := []struct {
+		name     string
+		use      string
+		siblings []string
+		want     []string
+	}{
+		// Single-letter names are all one edit apart, so every sibling is an equally close
+		// suggestion, returned in declaration order.
+		{"all one edit", "c", []string{"a", "b"}, []string{"a", "b"}},
+		// Among mixed distances only the minimum-distance siblings are kept.
+		{"keeps closest only", "abd", []string{"abc", "xyz"}, []string{"abc"}},
+		// A sibling farther than the threshold is no suggestion at all.
+		{"beyond threshold", "a", []string{"xyz"}, nil},
+		// No declared siblings means no suggestion.
+		{"no siblings", "a", nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, nearestLifetimes(tt.use, tt.siblings))
+		})
+	}
+}

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -1,0 +1,198 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+)
+
+// checkLifetimeDeclarations reports the two directions in which a signature's named
+// lifetimes and its `<…>` binder list can disagree:
+//
+//   - A used-but-undeclared lifetime. A `&'x` borrow or a bound right-hand side names
+//     `'x` that no binder introduces, so `'x` is a forgotten declaration or a typo.
+//   - A declared-but-unused binder. A `<'a>` that no borrow and no bound references.
+//
+// A use is any named lifetime the signature mentions that is not itself a binder. It is
+// the lifetime of a `&'x` borrow and the right-hand side of a bound, since `'a: 'x` uses
+// `'x`. The left-hand side of a bound is a binder, not a use. `'static` is the built-in
+// bottom of the outlives lattice and is never undeclared, on either side.
+//
+// A nested `fn(…)` type is its own lifetime-quantifier scope. Its borrows are checked by
+// its own resolveFuncTypeAnn pass, so the scan treats a nested function annotation as an
+// opaque boundary and neither collects its inner borrows here nor counts them toward this
+// signature's binders. An enclosing function's lifetimes are not visible to a nested one,
+// so a nested function is judged only by its own clause.
+//
+// Recovery is left to namedLifetime, which mints a fresh lifetime for an undeclared name
+// so the signature stays well-formed. This scan only reports; it changes no resolution.
+func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam, params []*ast.Param, ret, throws ast.TypeAnn) {
+	// declared maps each binder name to its first binder node, the node the unused-binder
+	// scan blames. declaredOrder is the deduplicated first-appearance order, which drives
+	// deterministic suggestions and a single unused report per name even when a name is
+	// bound more than once.
+	declared := map[string]*ast.LifetimeParam{}
+	declaredOrder := []string{}
+	for _, p := range lifetimeParams {
+		// A 'static left-hand side is not a bindable parameter; the parser rejects it.
+		// This guard is defensive against a hand-built AST.
+		if p.Name == "static" {
+			continue
+		}
+		if _, seen := declared[p.Name]; !seen {
+			declaredOrder = append(declaredOrder, p.Name)
+			declared[p.Name] = p
+		}
+	}
+
+	// Collect every named-lifetime use in the signature's borrows and bound right-hand
+	// sides.
+	var col lifetimeUseCollector
+	for _, p := range params {
+		if p.TypeAnn != nil {
+			p.TypeAnn.Accept(&col)
+		}
+	}
+	if ret != nil {
+		ret.Accept(&col)
+	}
+	if throws != nil {
+		throws.Accept(&col)
+	}
+	for _, p := range lifetimeParams {
+		for _, b := range p.Bounds {
+			if b.Name != "static" {
+				col.uses = append(col.uses, lifetimeUse{name: b.Name, span: b.Span()})
+			}
+		}
+	}
+
+	// The signature's severity for an undeclared use follows whether it carries any
+	// binder at all: with no clause a use is a hard error, with a clause it is a typo
+	// warning.
+	hasClause := len(lifetimeParams) > 0
+	used := set.NewSet[string]()
+	for _, u := range col.uses {
+		used.Add(u.name)
+		if _, ok := declared[u.name]; ok {
+			continue
+		}
+		c.report(&UndeclaredLifetimeError{
+			Name:        u.name,
+			Suggestions: nearestLifetimes(u.name, declaredOrder),
+			hasClause:   hasClause,
+			span:        u.span,
+		})
+	}
+
+	// The symmetric companion: a binder no use references is dead weight. Iterating
+	// declaredOrder reports each unused name once and blames its first binder, even for a
+	// name bound more than once.
+	for _, name := range declaredOrder {
+		if !used.Contains(name) {
+			c.report(&UnusedLifetimeParamError{Name: name, Param: declared[name]})
+		}
+	}
+}
+
+// lifetimeUse is a named-lifetime occurrence in a signature, carrying the name written
+// without the leading `'` and the span of the occurrence for blame.
+type lifetimeUse struct {
+	name string
+	span ast.Span
+}
+
+// lifetimeUseCollector walks a signature's type annotations and records each `&'x`
+// borrow's lifetime as a use. It descends through nested borrows and object, tuple, and
+// union annotations, but stops at a nested function annotation, which owns its own
+// lifetime scope.
+//
+// The set of forms this records must match the forms resolveLifetimeAnn interns through
+// namedLifetime, since a use the scan misses is one namedLifetime still mints a fresh
+// recovery lifetime for. Today that is the `&'x` borrow alone; `'x` on a referenced type,
+// as `Foo<'x>` or `'x Point`, resolves as an unsupported feature and interns nothing. When
+// that form gains support, add it here and to addLifetime.
+type lifetimeUseCollector struct {
+	ast.DefaultVisitor
+	uses []lifetimeUse
+}
+
+func (v *lifetimeUseCollector) EnterTypeAnn(t ast.TypeAnn) bool {
+	switch n := t.(type) {
+	case *ast.RefTypeAnn:
+		v.addLifetime(n.Lifetime)
+		return true
+	case *ast.FuncTypeAnn:
+		// A nested function type is its own quantifier scope. Its inner borrows are not
+		// uses of this signature's clause, and its own pass checks them.
+		return false
+	default:
+		return true
+	}
+}
+
+// addLifetime records a borrow's lifetime as a use. A nil node is a bare `&` inferred
+// borrow that carries no name, so it is skipped. `'static` is the outlives bottom and is
+// never undeclared, so it is skipped too. A `('a | 'b)` union records each member.
+func (v *lifetimeUseCollector) addLifetime(node ast.LifetimeAnnNode) {
+	switch n := node.(type) {
+	case *ast.LifetimeAnn:
+		if n.Name != "static" {
+			v.uses = append(v.uses, lifetimeUse{name: n.Name, span: n.Span()})
+		}
+	case *ast.LifetimeUnionAnn:
+		for _, m := range n.Lifetimes {
+			if m.Name != "static" {
+				v.uses = append(v.uses, lifetimeUse{name: m.Name, span: m.Span()})
+			}
+		}
+	}
+}
+
+// nearestLifetimes returns the declared siblings closest to name by Levenshtein edit
+// distance, for an undeclared-lifetime typo suggestion. Only siblings within maxSuggest
+// edits qualify, and among those only the minimum-distance ones are returned, in the
+// siblings' first-appearance order. An empty result means no sibling is close enough to
+// suggest. Lifetime names are short, often a single letter, so a small threshold keeps a
+// `'c` typo pointing at `'a` or `'b` without suggesting an unrelated `'lifetime`.
+func nearestLifetimes(name string, siblings []string) []string {
+	const maxSuggest = 2
+	best := maxSuggest + 1
+	var out []string
+	for _, s := range siblings {
+		switch d := levenshtein(name, s); {
+		case d < best:
+			best = d
+			out = []string{s}
+		case d == best:
+			out = append(out, s)
+		}
+	}
+	if best > maxSuggest {
+		return nil
+	}
+	return out
+}
+
+// levenshtein returns the edit distance between a and b, the least number of single-
+// character insertions, deletions, or substitutions that turns one into the other. It
+// runs the standard two-row dynamic program, keeping only the previous and current rows.
+func levenshtein(a, b string) int {
+	ar, br := []rune(a), []rune(b)
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
+}

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -38,10 +38,14 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 		if p.Name == "static" {
 			continue
 		}
-		if _, seen := declared[p.Name]; !seen {
-			declaredOrder = append(declaredOrder, p.Name)
-			declared[p.Name] = p
+		// A name bound twice binds nothing new. Report each repeat against the kept first
+		// binder and dedup so the undeclared and unused scans see the name once.
+		if first, seen := declared[p.Name]; seen {
+			c.report(&DuplicateLifetimeParamError{Name: p.Name, Param: p, First: first})
+			continue
 		}
+		declaredOrder = append(declaredOrder, p.Name)
+		declared[p.Name] = p
 	}
 
 	// Collect every named-lifetime use in the signature's borrows and bound right-hand
@@ -61,26 +65,25 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 	for _, p := range lifetimeParams {
 		for _, b := range p.Bounds {
 			if b.Name != "static" {
-				col.uses = append(col.uses, lifetimeUse{name: b.Name, span: b.Span()})
+				col.uses = append(col.uses, b)
 			}
 		}
 	}
 
-	// The signature's severity for an undeclared use follows whether it carries any
-	// binder at all: with no clause a use is a hard error, with a clause it is a typo
-	// warning.
+	// A use with no `<…>` clause at all prompts adding one; a use under a clause suggests
+	// the nearest declared name. Both are hard errors — hasClause shapes only the hint.
 	hasClause := len(lifetimeParams) > 0
 	used := set.NewSet[string]()
 	for _, u := range col.uses {
-		used.Add(u.name)
-		if _, ok := declared[u.name]; ok {
+		used.Add(u.Name)
+		if _, ok := declared[u.Name]; ok {
 			continue
 		}
 		c.report(&UndeclaredLifetimeError{
-			Name:        u.name,
-			Suggestions: nearestLifetimes(u.name, declaredOrder),
+			Name:        u.Name,
+			Suggestions: nearestLifetimes(u.Name, declaredOrder),
 			hasClause:   hasClause,
-			span:        u.span,
+			span:        u.Span(),
 		})
 	}
 
@@ -94,17 +97,11 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 	}
 }
 
-// lifetimeUse is a named-lifetime occurrence in a signature, carrying the name written
-// without the leading `'` and the span of the occurrence for blame.
-type lifetimeUse struct {
-	name string
-	span ast.Span
-}
-
 // lifetimeUseCollector walks a signature's type annotations and records each `&'x`
-// borrow's lifetime as a use. It descends through nested borrows and object, tuple, and
-// union annotations, but stops at a nested function annotation, which owns its own
-// lifetime scope.
+// borrow's lifetime as a use, keeping the LifetimeAnn node so the check reads its name
+// and blames its span. It descends through nested borrows and object, tuple, and union
+// annotations, but stops at a nested function annotation, which owns its own lifetime
+// scope.
 //
 // The set of forms this records must match the forms resolveLifetimeAnn interns through
 // namedLifetime, since a use the scan misses is one namedLifetime still mints a fresh
@@ -113,7 +110,7 @@ type lifetimeUse struct {
 // that form gains support, add it here and to addLifetime.
 type lifetimeUseCollector struct {
 	ast.DefaultVisitor
-	uses []lifetimeUse
+	uses []*ast.LifetimeAnn
 }
 
 func (v *lifetimeUseCollector) EnterTypeAnn(t ast.TypeAnn) bool {
@@ -137,12 +134,12 @@ func (v *lifetimeUseCollector) addLifetime(node ast.LifetimeAnnNode) {
 	switch n := node.(type) {
 	case *ast.LifetimeAnn:
 		if n.Name != "static" {
-			v.uses = append(v.uses, lifetimeUse{name: n.Name, span: n.Span()})
+			v.uses = append(v.uses, n)
 		}
 	case *ast.LifetimeUnionAnn:
 		for _, m := range n.Lifetimes {
 			if m.Name != "static" {
-				v.uses = append(v.uses, lifetimeUse{name: m.Name, span: m.Span()})
+				v.uses = append(v.uses, m)
 			}
 		}
 	}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -250,6 +250,9 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 	savedNamedLts := c.namedLifetimes
 	c.namedLifetimes = nil
 	defer func() { c.namedLifetimes = savedNamedLts }()
+	// Report any named lifetime this annotation uses without binding it in its own `<…>`
+	// list, and the symmetric unused binder, before lowering its bounds interns the names.
+	c.checkLifetimeDeclarations(ta.LifetimeParams, ta.Params, ta.Return, ta.Throws)
 	c.lowerLifetimeParamBounds(ta.LifetimeParams, lvl)
 
 	params := make([]*soltype.FuncParam, len(ta.Params))


### PR DESCRIPTION
Add validation that named lifetimes in function signatures are properly declared and used. A signature's `<…>` quantifier list must bind every named lifetime that appears in its borrows and bounds, and conversely should not bind lifetimes that go unused.

**Changes:**

- Add `checkLifetimeDeclarations` to scan a signature's lifetime parameters, borrow annotations, and bounds, reporting two classes of issues:
  - **Undeclared lifetime use**: A `&'x` borrow or bound right-hand side names `'x` but no `<'x>` binder introduces it. Severity depends on whether the signature carries any `<…>` clause at all. With no clause it is a hard error (the author almost certainly meant to declare the binder). With a clause that binds other names it is a typo warning, with suggestions drawn from declared siblings by Levenshtein edit distance.
  - **Unused lifetime parameter**: A `<'a>` binder that no borrow and no bound right-hand side references. Always a warning.

- Add `UndeclaredLifetimeError` and `UnusedLifetimeParamError` error types to report these issues with appropriate messages and suggestions.

- Add `lifetimeUseCollector` visitor to walk type annotations and collect named-lifetime uses from `&'x` borrows and bound right-hand sides, stopping at nested function annotations (which own their own lifetime scope).

- Add `nearestLifetimes` and `levenshtein` helpers to compute edit distance and suggest the closest declared siblings within a threshold.

- Call `checkLifetimeDeclarations` from `inferFunc` and `resolveFuncTypeAnn` before resolving parameter types, so the scan runs on the original signature before recovery lifetimes are minted.

- Update existing tests to expect the new diagnostics where signatures declare unused lifetimes.

A nested function is judged only by its own clause; enclosing lifetimes are not visible to it. Recovery is left to `namedLifetime`, which mints a fresh lifetime for undeclared names so the signature stays well-formed.

https://claude.ai/code/session_015btXwJeB4nUHY61Ah5ZuPb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifetime diagnostics for function signatures and type annotations, including clearer messages when a lifetime is used without being declared.
  * Suggestions are now shown for likely lifetime name typos.

* **Bug Fixes**
  * Lifetime binders that are declared but never used are now reported.
  * Nested function signatures are checked independently, reducing false positives from outer scopes.
  * Lifetime references inside bounds are now handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->