### PR TITLE
Support inherited lifetimes in nested functions

### DIFF
--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -61,10 +61,34 @@ type checker struct {
 
 	// namedLifetimes resolves a written lifetime name `'a` to its lifetime variable so
 	// every `&'a` in one scope shares one variable. inferFunc saves and clears it on
-	// entry and restores it on exit, so each function has its own named-lifetime scope,
-	// nested functions included. inferComponent clears it per top-level binding for the
-	// same reason. The map is allocated lazily by namedLifetime on first use.
+	// entry and restores it on exit, so each function has its own named-lifetime scope.
+	// inferComponent clears it per top-level binding for the same reason. The map is
+	// allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
+
+	// enclosingLifetimes chains the named-lifetime scopes of the functions this one nests
+	// in, outermost last. namedLifetime resolves a name the current function does not bind
+	// up this chain, so a closure that writes an outer `'a` shares the enclosing lifetime.
+	// It is nil at a top-level binding, which has no enclosing function.
+	enclosingLifetimes *lifetimeScope
+
+	// lifetimeBinders holds the names the current function declares in its own `<…>` list.
+	// A name in this set shadows an enclosing lifetime of the same name, so namedLifetime
+	// mints a fresh variable for it rather than inheriting.
+	lifetimeBinders set.Set[string]
+
+	// enclosingBinders is the union of the `<…>` binder names of every enclosing function.
+	// A used lifetime in this set is declared on the chain, so checkLifetimeDeclarations
+	// does not report it as undeclared even when the current function does not bind it.
+	enclosingBinders set.Set[string]
+}
+
+// lifetimeScope is one enclosing function's named-lifetime environment, linked outward
+// through parent. names holds the variable each written lifetime name resolved to in that
+// function. A nested function walks the chain to inherit an enclosing lifetime by name.
+type lifetimeScope struct {
+	names  map[string]*soltype.LifetimeVar
+	parent *lifetimeScope
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -187,17 +187,22 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // return-annotation constraint failure.
 func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
 	// Give this function its own named-lifetime scope so a `&'a` in its signature
-	// resolves consistently across its params and return, without sharing the name
-	// with an enclosing or sibling function. Restored on exit so a nested function
-	// does not clobber the outer scope's names. namedLifetime allocates the map on
-	// first use, so a body with no `&'a` annotation pays no allocation.
-	savedNamedLts := c.namedLifetimes
-	c.namedLifetimes = nil
-	defer func() { c.namedLifetimes = savedNamedLts }()
+	// resolves consistently across its params and return, without sharing the name with
+	// a sibling function. The enclosing function's scope is chained, so a name this
+	// function does not bind resolves to an enclosing lifetime, while a name it binds in
+	// its own `<…>` list shadows. A function with no lifetime binders and no `&'a`
+	// annotation never allocates the map.
+	defer c.pushLifetimeScope(lifetimeParamNames(sig.LifetimeParams))()
 	// Report any named lifetime the signature uses without binding it in its own `<…>`
-	// list, and the symmetric unused binder. Run before resolving the params so the scan
-	// reads the written names, not what namedLifetime has since interned.
-	c.checkLifetimeDeclarations(sig.LifetimeParams, sig.Params, sig.Return, sig.Throws)
+	// list or inheriting it from an enclosing one, and the symmetric unused binder. Run
+	// before resolving the params so the scan reads the written names, not what
+	// namedLifetime has since interned.
+	c.checkLifetimeDeclarations(sig.LifetimeParams, sig.Params, sig.Return, sig.Throws, c.enclosingBinders)
+	// Intern this function's own binders so each is visible to a nested closure that names
+	// it, before the body or a return annotation first mentions the name. A closure whose
+	// borrow writes `'a` then resolves to this function's lifetime regardless of whether a
+	// parameter, the return, or only the closure writes `'a` first.
+	c.internLifetimeBinders(sig.LifetimeParams, lvl)
 	if len(sig.TypeParams) > 0 {
 		// Generic functions (fn <T>(...)) need type schemes / generalization,
 		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the

--- a/internal/solver/infer_nested_lifetime_test.go
+++ b/internal/solver/infer_nested_lifetime_test.go
@@ -13,102 +13,123 @@ import (
 // means what it reads and PR10 does not flag the name as undeclared. A name the nested
 // function binds in its own `<…>` list still shadows, minting a fresh lifetime. This is a
 // naming change, not an inference one, so the computed types do not move.
-
-// A closure names the enclosing `'a` in its own signature. `relay` borrows the same region
-// as `outer`'s parameter, so no `<'a>` on `relay` is needed and no undeclared-lifetime
-// error fires. Returning `relay(p)` escapes the inherited borrow out of `outer` at `'a`.
-// Inference ties the two through the `relay(p)` call, so `outer` types as though `relay`
-// were written inline.
-func TestInferNestedLifetimeInherited(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+//
+// Each case infers a top-level `outer` and asserts its rendered type. An inherited name
+// renders as one shared lifetime across the whole signature; a shadowed name renders as a
+// distinct lifetime. No case reports an error, so a stray diagnostic fails the case.
+func TestInferNestedLifetime(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		// A closure names the enclosing `'a` in its own signature. `relay` borrows the same
+		// region as `outer`'s parameter, so no `<'a>` on `relay` is needed and no undeclared-
+		// lifetime error fires. Returning `relay(p)` escapes the inherited borrow out of
+		// `outer` at `'a`. Inference ties the two through the `relay(p)` call, so `outer`
+		// types as though `relay` were written inline.
+		{
+			name: "inherited",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
   val relay = fn (q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
   return relay(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
-}
+}`,
+			want: "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// An inherited lifetime keeps the enclosing function's level, so generalizing the closure
-// at its deeper level leaves the lifetime free rather than quantifying it. Returning the
-// closure surfaces its type: the closure renders `fn (q: &'a mut {…}) -> &'a mut {…}` with
-// no `<'a>` prefix of its own, so `'a` is `outer`'s quantified lifetime, not a fresh one
-// bound by the closure.
-func TestInferNestedLifetimeStaysFree(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> fn(q: &'a mut {x: number}) -> &'a mut {x: number} {
+		// An inherited lifetime keeps the enclosing function's level, so generalizing the
+		// closure at its deeper level leaves the lifetime free rather than quantifying it.
+		// Returning the closure surfaces its type: the closure renders `fn (q: &'a mut {…}) ->
+		// &'a mut {…}` with no `<'a>` prefix of its own, so `'a` is `outer`'s quantified
+		// lifetime, not a fresh one bound by the closure.
+		{
+			name: "inherited lifetime stays free",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}) -> fn(q: &'a mut {x: number}) -> &'a mut {x: number} {
   val relay = fn (q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
   return relay
-}`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(p: &'a mut {x: number}) -> fn (q: &'a mut {x: number}) -> &'a mut {x: number}",
-		values["outer"])
-}
+}`,
+			want: "fn <'a>(p: &'a mut {x: number}) -> fn (q: &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// A name the closure binds in its own `<…>` list shadows the enclosing lifetime, minting a
-// fresh one. `relay`'s `<'a>` is a new lifetime unrelated to `outer`'s, so the closure is
-// polymorphic in its own `'a` and the `relay(p)` call instantiates it to `outer`'s. The
-// signature still type-checks and reports nothing.
-func TestInferNestedLifetimeShadowed(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+		// A name the closure binds in its own `<…>` list shadows the enclosing lifetime,
+		// minting a fresh one. `relay`'s `<'a>` is a new lifetime unrelated to `outer`'s, so
+		// the closure is polymorphic in its own `'a` and the `relay(p)` call instantiates it
+		// to `outer`'s. The signature still type-checks and reports nothing.
+		{
+			name: "shadowed by inner clause",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
   val relay = fn <'a>(q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
   return relay(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
-}
+}`,
+			want: "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// Inheritance chains through more than one enclosing function. `inner` names `'a`, which
-// `outer` binds two levels up; `mid` neither binds nor shadows it, so the name resolves
-// past `mid` to `outer`. Every level borrows the same region and nothing is undeclared.
-func TestInferNestedLifetimeChainsTwoLevels(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+		// Inheritance chains through more than one enclosing function. `inner` names `'a`,
+		// which `outer` binds two levels up; `mid` neither binds nor shadows it, so the name
+		// resolves past `mid` to `outer`. Every level borrows the same region and nothing is
+		// undeclared.
+		{
+			name: "chains two levels",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
   val mid = fn (q: &'a mut {x: number}) -> &'a mut {x: number} {
     val inner = fn (r: &'a mut {x: number}) -> &'a mut {x: number} { return r }
     return inner(q)
   }
   return mid(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
-}
+}`,
+			want: "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// The chain also reaches a nested `fn(…)` type annotation, resolved by resolveFuncTypeAnn
-// rather than inferFunc. The callback parameter's type names `'a`, which resolves to
-// `outer`'s lifetime, so the whole signature shares one `'a` and nothing is undeclared.
-func TestInferNestedLifetimeInFuncTypeAnn(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}, cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
+		// The chain also reaches a nested `fn(…)` type annotation, resolved by
+		// resolveFuncTypeAnn rather than inferFunc. The callback parameter's type names `'a`,
+		// which resolves to `outer`'s lifetime, so the whole signature shares one `'a` and
+		// nothing is undeclared.
+		{
+			name: "inherited in fn type annotation",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}, cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
   return cb(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(p: &'a mut {x: number}, cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number}",
-		values["outer"])
-}
+}`,
+			want: "fn <'a>(p: &'a mut {x: number}, cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// Inheritance does not depend on the order the enclosing signature first writes the name.
-// Here the callback annotation names `'a` before any parameter or the return does, yet it
-// still resolves to `outer`'s `'a` rather than splitting off a separate lifetime. The whole
-// signature shares one `'a`, the same as when a plain parameter is written first.
-func TestInferNestedLifetimeInheritedRegardlessOfOrder(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number} {
+		// Inheritance does not depend on the order the enclosing signature first writes the
+		// name. Here the callback annotation names `'a` before any parameter or the return
+		// does, yet it still resolves to `outer`'s `'a` rather than splitting off a separate
+		// lifetime. The whole signature shares one `'a`, the same as when a plain parameter is
+		// written first.
+		{
+			name: "inherited regardless of write order",
+			src: `
+fn outer<'a>(cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number} {
   return cb(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a>(cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number}",
-		values["outer"])
-}
+}`,
+			want: "fn <'a>(cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number}",
+		},
 
-// A nested `fn<'a>(…)` type annotation binds `'a` itself, shadowing `outer`'s. The
-// callback's `'a` is a fresh lifetime, so the rendered scheme names it distinctly: `outer`
-// keeps `'a` on its own borrows and the callback carries the separate `'b`. This is the
-// signature-level view of the shadow a closure's `<'a>` makes internally.
-func TestInferNestedLifetimeShadowedInFuncTypeAnn(t *testing.T) {
-	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}, cb: fn<'a>(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
+		// A nested `fn<'a>(…)` type annotation binds `'a` itself, shadowing `outer`'s. The
+		// callback's `'a` is a fresh lifetime, so the rendered scheme names it distinctly:
+		// `outer` keeps `'a` on its own borrows and the callback carries the separate `'b`.
+		// This is the signature-level view of the shadow a closure's `<'a>` makes internally.
+		{
+			name: "shadowed in fn type annotation",
+			src: `
+fn outer<'a>(p: &'a mut {x: number}, cb: fn<'a>(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
   return cb(p)
-}`)
-	require.Empty(t, errs)
-	require.Equal(t,
-		"fn <'a, 'b>(p: &'a mut {x: number}, cb: fn (q: &'b mut {x: number}) -> &'b mut {x: number}) -> &'a mut {x: number}",
-		values["outer"])
+}`,
+			want: "fn <'a, 'b>(p: &'a mut {x: number}, cb: fn (q: &'b mut {x: number}) -> &'b mut {x: number}) -> &'a mut {x: number}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["outer"])
+		})
+	}
 }

--- a/internal/solver/infer_nested_lifetime_test.go
+++ b/internal/solver/infer_nested_lifetime_test.go
@@ -1,0 +1,114 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M6.5 PR11: enclosing-function lifetimes visible in a nested function ---
+//
+// A nested function reads an enclosing function's declared lifetimes by name. A closure
+// that writes an outer `'a` resolves to that same lifetime variable, so the annotation
+// means what it reads and PR10 does not flag the name as undeclared. A name the nested
+// function binds in its own `<…>` list still shadows, minting a fresh lifetime. This is a
+// naming change, not an inference one, so the computed types do not move.
+
+// A closure names the enclosing `'a` in its own signature. `relay` borrows the same region
+// as `outer`'s parameter, so no `<'a>` on `relay` is needed and no undeclared-lifetime
+// error fires. Returning `relay(p)` escapes the inherited borrow out of `outer` at `'a`.
+// Inference ties the two through the `relay(p)` call, so `outer` types as though `relay`
+// were written inline.
+func TestInferNestedLifetimeInherited(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+  val relay = fn (q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
+  return relay(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
+}
+
+// An inherited lifetime keeps the enclosing function's level, so generalizing the closure
+// at its deeper level leaves the lifetime free rather than quantifying it. Returning the
+// closure surfaces its type: the closure renders `fn (q: &'a mut {…}) -> &'a mut {…}` with
+// no `<'a>` prefix of its own, so `'a` is `outer`'s quantified lifetime, not a fresh one
+// bound by the closure.
+func TestInferNestedLifetimeStaysFree(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> fn(q: &'a mut {x: number}) -> &'a mut {x: number} {
+  val relay = fn (q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
+  return relay
+}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a mut {x: number}) -> fn (q: &'a mut {x: number}) -> &'a mut {x: number}",
+		values["outer"])
+}
+
+// A name the closure binds in its own `<…>` list shadows the enclosing lifetime, minting a
+// fresh one. `relay`'s `<'a>` is a new lifetime unrelated to `outer`'s, so the closure is
+// polymorphic in its own `'a` and the `relay(p)` call instantiates it to `outer`'s. The
+// signature still type-checks and reports nothing.
+func TestInferNestedLifetimeShadowed(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+  val relay = fn <'a>(q: &'a mut {x: number}) -> &'a mut {x: number} { return q }
+  return relay(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
+}
+
+// Inheritance chains through more than one enclosing function. `inner` names `'a`, which
+// `outer` binds two levels up; `mid` neither binds nor shadows it, so the name resolves
+// past `mid` to `outer`. Every level borrows the same region and nothing is undeclared.
+func TestInferNestedLifetimeChainsTwoLevels(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}) -> &'a mut {x: number} {
+  val mid = fn (q: &'a mut {x: number}) -> &'a mut {x: number} {
+    val inner = fn (r: &'a mut {x: number}) -> &'a mut {x: number} { return r }
+    return inner(q)
+  }
+  return mid(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a mut {x: number}) -> &'a mut {x: number}", values["outer"])
+}
+
+// The chain also reaches a nested `fn(…)` type annotation, resolved by resolveFuncTypeAnn
+// rather than inferFunc. The callback parameter's type names `'a`, which resolves to
+// `outer`'s lifetime, so the whole signature shares one `'a` and nothing is undeclared.
+func TestInferNestedLifetimeInFuncTypeAnn(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}, cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
+  return cb(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(p: &'a mut {x: number}, cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number}",
+		values["outer"])
+}
+
+// Inheritance does not depend on the order the enclosing signature first writes the name.
+// Here the callback annotation names `'a` before any parameter or the return does, yet it
+// still resolves to `outer`'s `'a` rather than splitting off a separate lifetime. The whole
+// signature shares one `'a`, the same as when a plain parameter is written first.
+func TestInferNestedLifetimeInheritedRegardlessOfOrder(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(cb: fn(q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number} {
+  return cb(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a>(cb: fn (q: &'a mut {x: number}) -> &'a mut {x: number}, p: &'a mut {x: number}) -> &'a mut {x: number}",
+		values["outer"])
+}
+
+// A nested `fn<'a>(…)` type annotation binds `'a` itself, shadowing `outer`'s. The
+// callback's `'a` is a fresh lifetime, so the rendered scheme names it distinctly: `outer`
+// keeps `'a` on its own borrows and the callback carries the separate `'b`. This is the
+// signature-level view of the shadow a closure's `<'a>` makes internally.
+func TestInferNestedLifetimeShadowedInFuncTypeAnn(t *testing.T) {
+	values, _, errs := inferSource(t, `fn outer<'a>(p: &'a mut {x: number}, cb: fn<'a>(q: &'a mut {x: number}) -> &'a mut {x: number}) -> &'a mut {x: number} {
+  return cb(p)
+}`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b>(p: &'a mut {x: number}, cb: fn (q: &'b mut {x: number}) -> &'b mut {x: number}) -> &'a mut {x: number}",
+		values["outer"])
+}

--- a/internal/solver/infer_undeclared_lifetime_test.go
+++ b/internal/solver/infer_undeclared_lifetime_test.go
@@ -68,19 +68,19 @@ func TestInferStaticLifetimeNeverUndeclared(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// A nested function is judged by its own clause, not an enclosing one. The inner `relay`
-// declares no `<'a>`, so its `&'a` borrows are undeclared with no clause and are hard
-// errors, even though the outer function declares `<'a>`. An enclosing function's
-// lifetimes are not visible to a nested one.
-func TestInferUndeclaredLifetimeNestedJudgedByOwnClause(t *testing.T) {
+// A nested function is judged by its own clause or an enclosing one. The inner `relay`
+// declares no `<'b>`, and no enclosing function binds 'b, so its `&'b` borrows are
+// undeclared with no clause and are hard errors. The outer `<'a>` binds a different name,
+// which does not cover 'b.
+func TestInferUndeclaredLifetimeNestedBoundNowhere(t *testing.T) {
 	_, _, errs := inferSource(t, `fn outer<'a>(p: &'a {x: number}) -> &'a {x: number} {
-  val relay = fn (q: &'a {x: number}) -> &'a {x: number} { return q }
+  val relay = fn (q: &'b {x: number}) -> &'b {x: number} { return q }
   return p
 }`)
 	require.Equal(t,
 		[]string{
-			"2:23-2:25: lifetime 'a is used but not declared; add `<'a>` to the enclosing function signature",
-			"2:43-2:45: lifetime 'a is used but not declared; add `<'a>` to the enclosing function signature",
+			"2:23-2:25: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
+			"2:43-2:45: lifetime 'b is used but not declared; add `<'b>` to the enclosing function signature",
 		},
 		messagesWithSpan(errs))
 }

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -20,12 +20,16 @@ import (
 // A nested `fn(…)` type is its own lifetime-quantifier scope. Its borrows are checked by
 // its own resolveFuncTypeAnn pass, so the scan treats a nested function annotation as an
 // opaque boundary and neither collects its inner borrows here nor counts them toward this
-// signature's binders. An enclosing function's lifetimes are not visible to a nested one,
-// so a nested function is judged only by its own clause.
+// signature's binders.
+//
+// enclosing holds the `<…>` binder names of every enclosing function. A used name in it is
+// declared on the chain and resolves to the enclosing lifetime, so it is not undeclared
+// even when this signature does not bind it. A name bound nowhere on the chain is the hard
+// error.
 //
 // Recovery is left to namedLifetime, which mints a fresh lifetime for an undeclared name
 // so the signature stays well-formed. This scan only reports; it changes no resolution.
-func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam, params []*ast.Param, ret, throws ast.TypeAnn) {
+func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam, params []*ast.Param, ret, throws ast.TypeAnn, enclosing set.Set[string]) {
 	// declared maps each binder name to its first binder node, the node the unused-binder
 	// scan blames. declaredOrder is the deduplicated first-appearance order, which drives
 	// deterministic suggestions and a single unused report per name even when a name is
@@ -77,6 +81,11 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 	for _, u := range col.uses {
 		used.Add(u.Name)
 		if _, ok := declared[u.Name]; ok {
+			continue
+		}
+		// A name an enclosing function binds is inherited, not undeclared. namedLifetime
+		// resolves it to the enclosing lifetime, so the borrow ties to that region.
+		if enclosing.Contains(u.Name) {
 			continue
 		}
 		c.report(&UndeclaredLifetimeError{

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -152,6 +152,16 @@ func (c *checker) inferComponent(
 ) {
 	inner := lvl + 1
 
+	// Clear the lifetime-name scope at the component boundary so phase-1 signature
+	// inference starts clean. A previous component that ended in a top-level `val x: &'a T`
+	// leaves namedLifetimes populated, and pushLifetimeScope would otherwise link that
+	// stale map as a fake enclosing chain for this component's functions. Phase 2 clears it
+	// again per binding for independence between siblings.
+	c.namedLifetimes = nil
+	c.enclosingLifetimes = nil
+	c.lifetimeBinders = nil
+	c.enclosingBinders = nil
+
 	// Recursion gate (PR6): an overloaded function in a mutually-recursive component
 	// (more than one binding) must have fully-annotated arms, since the overload set
 	// has to be ground before bodies are inferred — fixed-point iteration over
@@ -210,7 +220,12 @@ func (c *checker) inferComponent(
 		// Each top-level binding is its own named-lifetime scope, mirroring inferFunc.
 		// Two declarations that both write `&'a` get independent lifetimes rather than
 		// sharing one through a stale map. A function decl re-clears this inside inferFunc.
+		// A top-level binding has no enclosing function, so clear the chain and binder sets
+		// too, leaving no stale link from a previous component.
 		c.namedLifetimes = nil
+		c.enclosingLifetimes = nil
+		c.lifetimeBinders = nil
+		c.enclosingBinders = nil
 		b, isValue := bindings[key]
 		if !isValue {
 			continue // non-value keys handled below

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -243,16 +244,20 @@ func (c *checker) resolveFuncTypeAnn(ta *ast.FuncTypeAnn, lvl int) (soltype.Type
 		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")
 	}
 	// A function type annotation is its own quantifier scope, so give it its own
-	// named-lifetime map the way inferFunc does for a function body. Without this a
-	// nested `fn<'a: 'static>(…)` annotation would resolve `'a` to the enclosing
-	// function's `'a` and its declared bound would force that outer lifetime, so an
-	// unrelated borrow parameter of the enclosing function would be pinned to 'static.
-	savedNamedLts := c.namedLifetimes
-	c.namedLifetimes = nil
-	defer func() { c.namedLifetimes = savedNamedLts }()
+	// named-lifetime map the way inferFunc does for a function body. A name it binds in
+	// its own `<…>` list shadows an enclosing lifetime. Without the fresh scope a nested
+	// `fn<'a: 'static>(…)` annotation would resolve `'a` to the enclosing function's `'a`
+	// and its declared bound would force that outer lifetime, pinning an unrelated borrow
+	// parameter of the enclosing function to 'static. A name the annotation only uses
+	// still resolves up the chain, so a nested `fn(q: &'a …)` inherits the enclosing `'a`.
+	defer c.pushLifetimeScope(lifetimeParamNames(ta.LifetimeParams))()
 	// Report any named lifetime this annotation uses without binding it in its own `<…>`
-	// list, and the symmetric unused binder, before lowering its bounds interns the names.
-	c.checkLifetimeDeclarations(ta.LifetimeParams, ta.Params, ta.Return, ta.Throws)
+	// list or inheriting it from an enclosing one, and the symmetric unused binder, before
+	// lowering its bounds interns the names.
+	c.checkLifetimeDeclarations(ta.LifetimeParams, ta.Params, ta.Return, ta.Throws, c.enclosingBinders)
+	// Intern this annotation's own binders so each is visible to a nested function that
+	// names it, before resolving the params where a nested `fn(…)` may first mention one.
+	c.internLifetimeBinders(ta.LifetimeParams, lvl)
 	c.lowerLifetimeParamBounds(ta.LifetimeParams, lvl)
 
 	params := make([]*soltype.FuncParam, len(ta.Params))
@@ -489,6 +494,11 @@ func (c *checker) boundLifetime(name string, lvl int) soltype.Lifetime {
 // per function by inferFunc, per function type annotation by resolveFuncTypeAnn, and
 // per top-level binding by inferComponent, so the same name in two such scopes denotes
 // distinct lifetimes.
+//
+// A name the current function does not bind in its own `<…>` list resolves up the
+// enclosing-function chain, so a closure that writes an outer `'a` borrows the same
+// region as the enclosing function. A name the function binds shadows, minting a fresh
+// lifetime unrelated to any enclosing one.
 func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 	if c.namedLifetimes == nil {
 		c.namedLifetimes = map[string]*soltype.LifetimeVar{}
@@ -496,9 +506,73 @@ func (c *checker) namedLifetime(name string, lvl int) *soltype.LifetimeVar {
 	if lt, ok := c.namedLifetimes[name]; ok {
 		return lt
 	}
+	if !c.lifetimeBinders.Contains(name) {
+		for s := c.enclosingLifetimes; s != nil; s = s.parent {
+			if lt, ok := s.names[name]; ok {
+				c.namedLifetimes[name] = lt
+				return lt
+			}
+		}
+	}
 	lt := c.ctx.freshLifetime(lvl)
 	c.namedLifetimes[name] = lt
 	return lt
+}
+
+// pushLifetimeScope opens a fresh named-lifetime scope for a function body or a function
+// type annotation and links the scope it nests in as the enclosing chain, so namedLifetime
+// can resolve a name the entered scope does not bind up to an enclosing function. binders
+// are the names the entered scope declares in its own `<…>` list. A name it binds shadows
+// an enclosing lifetime. A name it only uses inherits. The returned closure restores the
+// enclosing scope and must be deferred by the caller.
+func (c *checker) pushLifetimeScope(binders set.Set[string]) func() {
+	savedNames := c.namedLifetimes
+	savedParent := c.enclosingLifetimes
+	savedBinders := c.lifetimeBinders
+	savedEnclosingBinders := c.enclosingBinders
+	// A scope that interned no names contributes nothing to the chain, so keep its own
+	// parent as the enclosing chain rather than linking an empty map.
+	if savedNames != nil {
+		c.enclosingLifetimes = &lifetimeScope{names: savedNames, parent: savedParent}
+	}
+	c.enclosingBinders = savedEnclosingBinders.Union(savedBinders)
+	c.namedLifetimes = nil
+	c.lifetimeBinders = binders
+	return func() {
+		c.namedLifetimes = savedNames
+		c.enclosingLifetimes = savedParent
+		c.lifetimeBinders = savedBinders
+		c.enclosingBinders = savedEnclosingBinders
+	}
+}
+
+// lifetimeParamNames collects the names a `<…>` list binds. A 'static left-hand side is
+// skipped. The parser rejects it as a binder, so the skip is only defensive against a
+// hand-built AST.
+func lifetimeParamNames(params []*ast.LifetimeParam) set.Set[string] {
+	names := set.NewSet[string]()
+	for _, p := range params {
+		if p.Name != "static" {
+			names.Add(p.Name)
+		}
+	}
+	return names
+}
+
+// internLifetimeBinders mints a lifetime variable for each name a `<…>` list binds and
+// records it in the current scope's map. A binder name is in lifetimeBinders, so
+// namedLifetime mints a fresh variable rather than inheriting one, which is the shadow a
+// binder introduces. Interning every binder up front makes it visible to a nested function
+// that names it, whatever order the enclosing signature first writes the name in. Without
+// this a name a nested scope mentions before the enclosing signature writes it would
+// resolve to a fresh, decoupled lifetime, since namedLifetime interns lazily in written
+// order and the chain walk would find the enclosing map still empty.
+func (c *checker) internLifetimeBinders(params []*ast.LifetimeParam, lvl int) {
+	for _, p := range params {
+		if p.Name != "static" {
+			c.namedLifetime(p.Name, lvl)
+		}
+	}
 }
 
 // annPrim mints a FRESH PrimType for an annotation and records it against the


### PR DESCRIPTION
Enable nested functions and function type annotations to inherit lifetime names from enclosing functions, so a closure that writes `&'a` can refer to the enclosing function's `'a` rather than requiring its own declaration.

**Key changes:**

- Add `enclosingLifetimes` chain to track named-lifetime scopes of enclosing functions, allowing `namedLifetime` to resolve names up the chain when the current function doesn't bind them.
- Add `lifetimeBinders` and `enclosingBinders` sets to distinguish between declared lifetimes (which shadow) and inherited ones (which resolve to the enclosing scope).
- Introduce `pushLifetimeScope` helper to manage scope entry/exit, linking the current scope into the enclosing chain and restoring state on exit.
- Add `internLifetimeBinders` to mint lifetime variables for all declared binders up front, making them visible to nested functions regardless of mention order in the signature.
- Update `checkLifetimeDeclarations` to accept `enclosingBinders` and skip undeclared-lifetime errors for names bound on the enclosing chain.
- Clear lifetime state at component boundaries in `inferComponent` to prevent stale maps from leaking between top-level bindings.
- Update `inferFunc` and `resolveFuncTypeAnn` to use the new scope-management helpers and pass enclosing binders to the declaration checker.

**Implementation notes:**

A nested function's `<'a>` list shadows an enclosing `'a`, minting a fresh lifetime. A name the nested function only uses (not declared in its own `<…>`) resolves to the enclosing function's lifetime of that name. The chain walk in `namedLifetime` skips enclosing scopes if the name is in `lifetimeBinders`, implementing the shadow. Interning binders before resolving the signature ensures a nested mention of a name sees the binder even if the enclosing signature writes that name later.

https://claude.ai/code/session_01C2zBrQJydsH7ZJWmBGhiGV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifetime handling for nested functions and function-type annotations, including correct inheritance, shadowing, and isolation between sibling scopes.
  * Fixed undeclared-lifetime diagnostics so names inherited from enclosing scopes are no longer reported incorrectly.
  * Prevented lifetime state from leaking between unrelated inference paths.

* **Tests**
  * Added coverage for nested lifetime inheritance, shadowing, multi-level nesting, and undeclared lifetime reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->