### PR TITLE
Move PR11 (enclosing-function lifetimes) to backlog

### DIFF
--- a/planning/simple_sub/m6.5-implementation-plan.md
+++ b/planning/simple_sub/m6.5-implementation-plan.md
@@ -591,6 +591,8 @@ binder — so it can ride along in this PR or land as a short follow-up.
 
 ### PR11 — Enclosing-function lifetimes visible in a nested function
 
+**Moved to the backlog:** [escalier-lang/escalier#840](https://github.com/escalier-lang/escalier/issues/840).
+
 **Axis:** declare (front-end). **Depends on:** PR10.
 
 `inferFunc` gives every function a fresh lifetime scope. It saves the enclosing


### PR DESCRIPTION
Move the implementation of enclosing-function lifetimes visible in nested functions to the backlog, tracked in escalier-lang/escalier#840.

This feature was planned as PR11 in the m6.5 implementation plan but is being deferred to focus on higher-priority work.

https://claude.ai/code/session_01PEf7zX8BixFhB5ffXbVQjv