### PR TITLE
Add ClassType and object member kinds (methods, getters, setters)

### DIFF
--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -11,6 +11,120 @@ func method(name string, sig *FuncType) *MethodElem {
 	return &MethodElem{Name: name, Signatures: []*FuncType{sig}}
 }
 
+// selfRecv builds a self receiver whose desugared type is recv.
+func selfRecv(recv Type) *FuncParam {
+	return &FuncParam{Pattern: &IdentPat{Name: "self"}, Type: recv}
+}
+
+// TestPrintMethodSelfReceiver renders a method's self receiver as the Rust-style
+// shorthand, read back from the desugared receiver type. Self renders `self`, mut
+// Self renders `mut self`, &Self renders `&self`, and &mut Self renders `&mut self`.
+// A method with no receiver is a static method and renders with no receiver.
+func TestPrintMethodSelfReceiver(t *testing.T) {
+	counter := func() Type { return &ClassType{Name: "Counter"} }
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		{
+			"owned immutable self",
+			&ObjectType{Elems: []ObjTypeElem{method("peek", &FuncType{SelfParam: selfRecv(counter()), Ret: numP()})}},
+			"{peek(self) -> number}",
+		},
+		{
+			"owned mutable mut self",
+			&ObjectType{Elems: []ObjTypeElem{method("inc", &FuncType{SelfParam: selfRecv(&RefType{Mut: true, Inner: &ClassType{Name: "Counter"}}), Ret: &Void{}})}},
+			"{inc(mut self) -> void}",
+		},
+		{
+			"immutable borrow &self",
+			&ObjectType{Elems: []ObjTypeElem{method("look", &FuncType{SelfParam: selfRecv(&RefType{Lt: Anon, Inner: &ClassType{Name: "Counter"}}), Ret: numP()})}},
+			"{look(&self) -> number}",
+		},
+		{
+			"mutable borrow &mut self",
+			&ObjectType{Elems: []ObjTypeElem{method("edit", &FuncType{SelfParam: selfRecv(&RefType{Mut: true, Lt: Anon, Inner: &ClassType{Name: "Counter"}}), Ret: &Void{}})}},
+			"{edit(&mut self) -> void}",
+		},
+		{
+			"self followed by ordinary params",
+			&ObjectType{Elems: []ObjTypeElem{method("add", &FuncType{SelfParam: selfRecv(counter()), Params: []*FuncParam{identP("x", numP())}, Ret: numP()})}},
+			"{add(self, x: number) -> number}",
+		},
+		{
+			"static method has no receiver",
+			&ObjectType{Elems: []ObjTypeElem{method("make", &FuncType{Ret: &ClassType{Name: "Counter"}})}},
+			"{make() -> Counter}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// A borrowing method's receiver lifetime flows through Accept, so the scheme printer
+// names it and renders the receiver as `&'a self`.
+func TestPrintMethodSelfReceiverNamedLifetime(t *testing.T) {
+	lv := &LifetimeVar{ID: 0, Level: 1}
+	fn := &FuncType{SelfParam: selfRecv(&RefType{Lt: lv, Inner: &ClassType{Name: "Counter"}}), Ret: numP()}
+	require.Equal(t, "fn <'a>(&'a self) -> number", PrintAsScheme(fn))
+}
+
+// A no-op rewrite over a method keeps its pointer, walking the self receiver yet
+// leaving it unchanged.
+func TestAcceptFuncSelfParamIdentity(t *testing.T) {
+	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Counter"}), Ret: numP()}
+	require.Same(t, fn, fn.Accept(identityVisitor{}, Positive), "an unchanged method keeps its pointer")
+}
+
+// Rewriting a variable inside the receiver type rebuilds the FuncType and its self
+// receiver while carrying the other fields through.
+func TestAcceptFuncSelfParamCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	fn := &FuncType{
+		SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}),
+		Params:    []*FuncParam{identP("x", numP())},
+		Ret:       numP(),
+	}
+
+	got := fn.Accept(&replaceVar{target: a, repl: str}, Positive).(*FuncType)
+
+	require.NotSame(t, fn, got, "a changed receiver forces a new FuncType")
+	require.Same(t, str, got.SelfParam.Type.(*ClassType).Args[0], "the receiver argument took the replacement")
+	require.Same(t, fn.Params[0], got.Params[0], "an unchanged param keeps its pointer")
+}
+
+// A method's self receiver is contravariant, like a parameter, so it is visited in
+// the flipped polarity.
+func TestAcceptFuncSelfParamContravariant(t *testing.T) {
+	recv := &TypeVarType{ID: 7}
+	fn := &FuncType{SelfParam: selfRecv(recv), Ret: numP()}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	fn.Accept(r, Positive)
+
+	require.Equal(t, Negative, r.seen[recv], "the receiver is contravariant")
+}
+
+// LevelOf includes a method's self receiver, so a receiver-only variable lifts the
+// method's level.
+func TestLevelOfSelfParam(t *testing.T) {
+	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{&TypeVarType{ID: 1, Level: 6}}}), Ret: numP()}
+	require.Equal(t, 6, LevelOf(fn))
+}
+
+// freeTypeVars descends a method's self receiver, so a variable appearing only in the
+// receiver type is named as a quantified parameter.
+func TestFreeTypeVarsSelfParam(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 1}
+	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Ret: a}
+	require.Equal(t, "fn <T0>(self) -> T0", PrintAsScheme(fn))
+}
+
 // TestPrintClassType renders a nominal instance under its display name, with a
 // `<...>` type-argument list when it has arguments. The qualified Name carries a
 // namespace prefix for registry keying, which the printer strips for display. The

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -125,6 +125,92 @@ func TestFreeTypeVarsSelfParam(t *testing.T) {
 	require.Equal(t, "fn <T0>(self) -> T0", PrintAsScheme(fn))
 }
 
+// An instance getter or setter renders its self receiver first, through the same
+// shorthand as a method. A static getter or setter renders no receiver.
+func TestPrintGetterSetterSelfReceiver(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		{
+			"instance getter",
+			&ObjectType{Elems: []ObjTypeElem{&GetterElem{Name: "size", SelfParam: selfRecv(&ClassType{Name: "List"}), Type: numP()}}},
+			"{get size(self) -> number}",
+		},
+		{
+			"instance setter with mut self",
+			&ObjectType{Elems: []ObjTypeElem{&SetterElem{Name: "size", SelfParam: selfRecv(&RefType{Mut: true, Inner: &ClassType{Name: "List"}}), Param: numP()}}},
+			"{set size(mut self, value: number)}",
+		},
+		{
+			"static getter has no receiver",
+			&ObjectType{Elems: []ObjTypeElem{&GetterElem{Name: "size", Type: numP()}}},
+			"{get size() -> number}",
+		},
+		{
+			"static setter has no receiver",
+			&ObjectType{Elems: []ObjTypeElem{&SetterElem{Name: "size", Param: numP()}}},
+			"{set size(value: number)}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// A getter's and setter's self receiver is contravariant, visited in the flipped
+// polarity like a method receiver.
+func TestAcceptGetterSetterReceiverContravariant(t *testing.T) {
+	getterRecv := &TypeVarType{ID: 1}
+	setterRecv := &TypeVarType{ID: 2}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&GetterElem{Name: "g", SelfParam: selfRecv(getterRecv), Type: numP()},
+		&SetterElem{Name: "s", SelfParam: selfRecv(setterRecv), Param: numP()},
+	}}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	obj.Accept(r, Positive)
+
+	require.Equal(t, Negative, r.seen[getterRecv], "a getter's receiver is contravariant")
+	require.Equal(t, Negative, r.seen[setterRecv], "a setter's receiver is contravariant")
+}
+
+// Rewriting a variable inside an instance setter's receiver rebuilds the setter and
+// carries the receiver through.
+func TestAcceptSetterSelfParamCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	setter := &SetterElem{Name: "s", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Param: numP()}
+	obj := &ObjectType{Elems: []ObjTypeElem{setter}}
+
+	got := obj.Accept(&replaceVar{target: a, repl: str}, Positive).(*ObjectType)
+
+	gotSetter := got.Elems[0].(*SetterElem)
+	require.NotSame(t, setter, gotSetter, "a changed receiver forces a new setter")
+	require.Same(t, str, gotSetter.SelfParam.Type.(*ClassType).Args[0], "the receiver argument took the replacement")
+}
+
+// LevelOf descends an instance getter's receiver.
+func TestLevelOfGetterReceiver(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{&TypeVarType{ID: 1, Level: 8}}}), Type: numP()},
+	}}
+	require.Equal(t, 8, LevelOf(obj))
+}
+
+// freeTypeVars descends an instance getter's receiver, so a variable appearing only
+// there is named as a quantified parameter even though the receiver prints as `self`.
+func TestFreeTypeVarsGetterReceiver(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 1}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Type: numP()},
+	}}
+	require.Equal(t, "<T0> {get g(self) -> number}", PrintAsScheme(obj))
+}
+
 // TestPrintClassType renders a nominal instance under its display name, with a
 // `<...>` type-argument list when it has arguments. The qualified Name carries a
 // namespace prefix for registry keying, which the printer strips for display. The

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -1,0 +1,288 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// method builds a single-signature MethodElem for the tests.
+func method(name string, sig *FuncType) *MethodElem {
+	return &MethodElem{Name: name, Signatures: []*FuncType{sig}}
+}
+
+// TestPrintClassType renders a nominal instance under its display name, with a
+// `<...>` type-argument list when it has arguments. The qualified Name carries a
+// namespace prefix for registry keying, which the printer strips for display. The
+// Final flag does not change the rendering.
+func TestPrintClassType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		{"monomorphic instance", &ClassType{Name: "Point"}, "Point"},
+		{"generic instance", &ClassType{Name: "Box", Args: []Type{numP()}}, "Box<number>"},
+		{
+			"two type arguments",
+			&ClassType{Name: "Map", Args: []Type{strP(), numP()}},
+			"Map<string, number>",
+		},
+		{
+			"qualified name strips the namespace prefix",
+			&ClassType{Name: "Geometry.Point"},
+			"Point",
+		},
+		{
+			"final class renders the same as a non-final one",
+			&ClassType{Name: "Point", Final: true},
+			"Point",
+		},
+		{
+			// A ClassType is an atom, so it needs no parens inside a union.
+			"instance in a union needs no parens",
+			&UnionType{Types: []Type{&ClassType{Name: "Point"}, strP()}},
+			"Point | string",
+		},
+		{
+			// A `mut 'static Point` borrow wraps the ClassType in a RefType, which
+			// carries the `&`/`mut` prefix. The ClassType arm itself renders no lifetime.
+			"borrowed instance renders via the RefType wrapper",
+			&RefType{Mut: true, Lt: &StaticLifetime{}, Inner: &ClassType{Name: "Point"}},
+			"&'static mut Point",
+		},
+		{
+			"owned-mutable instance renders bare mut",
+			&RefType{Mut: true, Inner: &ClassType{Name: "Box", Args: []Type{numP()}}},
+			"mut Box<number>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// TestPrintObjectMembers renders the method, getter, and setter members an object
+// carries once M5 adds them to the element set. A method renders one entry per
+// overload arm, arms joined by "; ".
+func TestPrintObjectMembers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Type
+		want string
+	}{
+		{
+			"monomorphic method",
+			&ObjectType{Elems: []ObjTypeElem{
+				method("foo", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}),
+			}},
+			"{foo(x: number) -> string}",
+		},
+		{
+			"getter",
+			&ObjectType{Elems: []ObjTypeElem{&GetterElem{Name: "x", Type: numP()}}},
+			"{get x() -> number}",
+		},
+		{
+			"setter",
+			&ObjectType{Elems: []ObjTypeElem{&SetterElem{Name: "x", Param: numP()}}},
+			"{set x(value: number)}",
+		},
+		{
+			"method, getter, and setter together",
+			&ObjectType{Elems: []ObjTypeElem{
+				method("greet", &FuncType{Ret: strP()}),
+				&GetterElem{Name: "size", Type: numP()},
+				&SetterElem{Name: "size", Param: numP()},
+			}},
+			"{greet() -> string, get size() -> number, set size(value: number)}",
+		},
+		{
+			// An overloaded method renders each arm, joined by "; " so the arm boundary
+			// stays distinct from the ", " between sibling members.
+			"overloaded method joins arms with a semicolon",
+			&ObjectType{Elems: []ObjTypeElem{&MethodElem{Name: "f", Signatures: []*FuncType{
+				{Params: []*FuncParam{identP("x", numP())}, Ret: numP()},
+				{Params: []*FuncParam{identP("x", strP())}, Ret: strP()},
+			}}}},
+			"{f(x: number) -> number; f(x: string) -> string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in))
+		})
+	}
+}
+
+// A no-op rewrite over a ClassType keeps its pointer (copy-on-write).
+func TestAcceptClassIdentityPreservation(t *testing.T) {
+	cls := &ClassType{Name: "Box", Args: []Type{numP()}, Final: true}
+	require.Same(t, cls, cls.Accept(identityVisitor{}, Positive), "an unchanged ClassType keeps its pointer")
+}
+
+// Rewriting a type argument rebuilds the ClassType, carries the Name/Final/Lt
+// identity through, and walks the arguments covariantly.
+func TestAcceptClassCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	lt := &StaticLifetime{}
+	cls := &ClassType{Name: "Box", Args: []Type{a}, Lt: lt, Final: true}
+
+	got := cls.Accept(&replaceVar{target: a, repl: str}, Positive).(*ClassType)
+
+	require.NotSame(t, cls, got, "a changed argument forces a new ClassType")
+	require.Equal(t, "Box", got.Name, "the name carries through")
+	require.True(t, got.Final, "the Final flag carries through")
+	require.Same(t, lt, got.Lt, "the lifetime carries through unchanged")
+	require.Same(t, str, got.Args[0], "the changed argument took the replacement")
+}
+
+// Type arguments are covariant: a ClassType's argument is visited in the same
+// polarity the ClassType is.
+func TestAcceptClassArgsCovariant(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	cls := &ClassType{Name: "Box", Args: []Type{a}}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	cls.Accept(r, Negative)
+
+	require.Equal(t, Negative, r.seen[cls], "the ClassType keeps the start polarity")
+	require.Equal(t, Negative, r.seen[a], "a type argument is covariant")
+}
+
+// A no-op rewrite over an object carrying a method, getter, and setter keeps every
+// pointer (copy-on-write): a method's signature, the getter's type, and the
+// setter's param are all walked, yet nothing changes.
+func TestAcceptObjectMembersIdentityPreservation(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		method("f", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}),
+		&GetterElem{Name: "g", Type: numP()},
+		&SetterElem{Name: "s", Param: numP()},
+	}}
+	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive), "an unchanged object keeps its pointer")
+}
+
+// A setter's param is in write position, so it is visited in the FLIPPED polarity,
+// while a getter's type and a property's type are read covariantly. A method's
+// signature threads through FuncType.Accept, which flips its own parameters.
+func TestAcceptObjectMemberVariance(t *testing.T) {
+	getterT := &TypeVarType{ID: 1}
+	setterT := &TypeVarType{ID: 2}
+	methodParamT := &TypeVarType{ID: 3}
+	methodRetT := &TypeVarType{ID: 4}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&GetterElem{Name: "g", Type: getterT},
+		&SetterElem{Name: "s", Param: setterT},
+		method("m", &FuncType{Params: []*FuncParam{identP("x", methodParamT)}, Ret: methodRetT}),
+	}}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	obj.Accept(r, Positive)
+
+	require.Equal(t, Positive, r.seen[getterT], "a getter's type is covariant")
+	require.Equal(t, Negative, r.seen[setterT], "a setter's param is contravariant")
+	require.Equal(t, Negative, r.seen[methodParamT], "a method parameter is contravariant")
+	require.Equal(t, Positive, r.seen[methodRetT], "a method return is covariant")
+}
+
+// Rewriting a variable inside a setter rebuilds only that element, leaving the
+// object's other members untouched (copy-on-write).
+func TestAcceptObjectSetterCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	prop := &PropertyElem{Name: "p", Type: numP()}
+	setter := &SetterElem{Name: "s", Param: a}
+	obj := &ObjectType{Elems: []ObjTypeElem{prop, setter}}
+
+	got := obj.Accept(&replaceVar{target: a, repl: str}, Positive).(*ObjectType)
+
+	require.NotSame(t, obj, got, "a changed member forces a new object")
+	require.Same(t, prop, got.Elems[0], "the unchanged property keeps its pointer")
+	gotSetter := got.Elems[1].(*SetterElem)
+	require.NotSame(t, setter, gotSetter, "the changed setter is a fresh element")
+	require.Same(t, str, gotSetter.Param, "the setter param took the replacement")
+}
+
+// LevelOf on a ClassType is the max level over its type arguments; the Name and
+// Final identity carry no variables.
+func TestLevelOfClassType(t *testing.T) {
+	require.Equal(t, 0, LevelOf(&ClassType{Name: "Point"}), "no arguments ⇒ level 0")
+	cls := &ClassType{Name: "Box", Args: []Type{
+		&TypeVarType{ID: 1, Level: 2},
+		&TypeVarType{ID: 2, Level: 5},
+	}}
+	require.Equal(t, 5, LevelOf(cls), "the level is the max over the type arguments")
+}
+
+// LevelOf on an object descends into every member kind: a method's signatures, a
+// getter's type, and a setter's param.
+func TestLevelOfObjectMembers(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		method("m", &FuncType{Params: []*FuncParam{identP("x", &TypeVarType{ID: 1, Level: 3})}, Ret: numP()}),
+		&GetterElem{Name: "g", Type: &TypeVarType{ID: 2, Level: 7}},
+		&SetterElem{Name: "s", Param: &TypeVarType{ID: 3, Level: 4}},
+	}}
+	require.Equal(t, 7, LevelOf(obj), "the level is the max over all member types")
+}
+
+// freeTypeVars descends a ClassType's arguments, so a generic instance's arguments
+// are named as quantified parameters by the scheme printer.
+func TestFreeTypeVarsClassType(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 1}
+	b := &TypeVarType{ID: 2, Level: 1}
+	cls := &ClassType{Name: "Map", Args: []Type{a, b}}
+	require.Equal(t, "<T0, T1> Map<T0, T1>", PrintAsScheme(cls))
+}
+
+// freeTypeVars descends every object member kind, so a method parameter, a getter
+// type, and a setter param are each named as quantified parameters.
+func TestFreeTypeVarsObjectMembers(t *testing.T) {
+	a := &TypeVarType{ID: 1, Level: 1}
+	b := &TypeVarType{ID: 2, Level: 1}
+	c := &TypeVarType{ID: 3, Level: 1}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		method("m", &FuncType{Params: []*FuncParam{identP("x", a)}, Ret: numP()}),
+		&GetterElem{Name: "g", Type: b},
+		&SetterElem{Name: "s", Param: c},
+	}}
+	require.Equal(t, "<T0, T1, T2> {m(x: T0) -> number, get g() -> T1, set s(value: T2)}", PrintAsScheme(obj))
+}
+
+// Member generalizes Prop across all element kinds, returning the element of any
+// kind by name and reporting absence.
+func TestObjectMember(t *testing.T) {
+	m := method("m", &FuncType{Ret: numP()})
+	g := &GetterElem{Name: "g", Type: numP()}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&PropertyElem{Name: "p", Type: numP()},
+		m,
+		g,
+	}}
+
+	gotProp, ok := obj.Member("p")
+	require.True(t, ok)
+	_, isProp := gotProp.(*PropertyElem)
+	require.True(t, isProp, "Member returns the property element")
+
+	gotMethod, ok := obj.Member("m")
+	require.True(t, ok)
+	require.Same(t, m, gotMethod, "Member returns the method element")
+
+	gotGetter, ok := obj.Member("g")
+	require.True(t, ok)
+	require.Same(t, g, gotGetter, "Member returns the getter element")
+
+	_, ok = obj.Member("missing")
+	require.False(t, ok, "an absent name reports not present")
+}
+
+// ObjElemName reads the name off any element kind.
+func TestObjElemName(t *testing.T) {
+	require.Equal(t, "p", ObjElemName(&PropertyElem{Name: "p"}))
+	require.Equal(t, "m", ObjElemName(method("m", &FuncType{Ret: numP()})))
+	require.Equal(t, "g", ObjElemName(&GetterElem{Name: "g"}))
+	require.Equal(t, "s", ObjElemName(&SetterElem{Name: "s"}))
+}

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -117,7 +117,7 @@ func TestPrintObjectMembers(t *testing.T) {
 	}
 }
 
-// A no-op rewrite over a ClassType keeps its pointer (copy-on-write).
+// A no-op rewrite over a ClassType allocates nothing and keeps its pointer.
 func TestAcceptClassIdentityPreservation(t *testing.T) {
 	cls := &ClassType{Name: "Box", Args: []Type{numP()}, Final: true}
 	require.Same(t, cls, cls.Accept(identityVisitor{}, Positive), "an unchanged ClassType keeps its pointer")
@@ -153,9 +153,9 @@ func TestAcceptClassArgsCovariant(t *testing.T) {
 	require.Equal(t, Negative, r.seen[a], "a type argument is covariant")
 }
 
-// A no-op rewrite over an object carrying a method, getter, and setter keeps every
-// pointer (copy-on-write): a method's signature, the getter's type, and the
-// setter's param are all walked, yet nothing changes.
+// A no-op rewrite over an object carrying a method, getter, and setter walks the
+// method's signature, the getter's type, and the setter's param, yet nothing
+// changes, so it keeps every pointer.
 func TestAcceptObjectMembersIdentityPreservation(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{
 		method("f", &FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()}),
@@ -188,8 +188,8 @@ func TestAcceptObjectMemberVariance(t *testing.T) {
 	require.Equal(t, Positive, r.seen[methodRetT], "a method return is covariant")
 }
 
-// Rewriting a variable inside a setter rebuilds only that element, leaving the
-// object's other members untouched (copy-on-write).
+// Rewriting a variable inside a setter rebuilds only that element and reuses the
+// pointers of the object's other members.
 func TestAcceptObjectSetterCopyOnWrite(t *testing.T) {
 	str := &PrimType{Prim: StrPrim}
 	a := &TypeVarType{ID: 1}

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -229,12 +229,15 @@ func TestLevelOfObjectMembers(t *testing.T) {
 }
 
 // freeTypeVars descends a ClassType's arguments, so a generic instance's arguments
-// are named as quantified parameters by the scheme printer.
+// are named as quantified parameters by the scheme printer. The instance shows those
+// parameters inline in its `<...>` argument list, so the scheme printer adds no
+// separate quantifier prefix: Map<K, V> renders as Map<T0, T1>, not
+// <T0, T1> Map<T0, T1>.
 func TestFreeTypeVarsClassType(t *testing.T) {
 	a := &TypeVarType{ID: 1, Level: 1}
 	b := &TypeVarType{ID: 2, Level: 1}
 	cls := &ClassType{Name: "Map", Args: []Type{a, b}}
-	require.Equal(t, "<T0, T1> Map<T0, T1>", PrintAsScheme(cls))
+	require.Equal(t, "Map<T0, T1>", PrintAsScheme(cls))
 }
 
 // freeTypeVars descends every object member kind, so a method parameter, a getter
@@ -277,6 +280,24 @@ func TestObjectMember(t *testing.T) {
 
 	_, ok = obj.Member("missing")
 	require.False(t, ok, "an absent name reports not present")
+}
+
+// A getter and a setter may legitimately share a name. Member returns the first in
+// declaration order and cannot reach the second, so it is insufficient on its own to
+// resolve read-versus-write member access, where obj.x reads the getter and obj.x = v
+// writes the setter. A caller that needs both sides scans Elems by name AND kind
+// rather than relying on Member. This pins the first-declared-wins behavior.
+func TestObjectMemberGetterSetterSameName(t *testing.T) {
+	getter := &GetterElem{Name: "x", Type: numP()}
+	setter := &SetterElem{Name: "x", Param: strP()}
+
+	got, ok := (&ObjectType{Elems: []ObjTypeElem{getter, setter}}).Member("x")
+	require.True(t, ok)
+	require.Same(t, getter, got, "the getter is declared first, so Member returns it")
+
+	got, ok = (&ObjectType{Elems: []ObjTypeElem{setter, getter}}).Member("x")
+	require.True(t, ok)
+	require.Same(t, setter, got, "declaration order decides which of the two Member returns")
 }
 
 // ObjElemName reads the name off any element kind.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -475,10 +475,11 @@ func (p *namedPrinter) printType(t Type) string {
 //   - a property renders `name: T` with the `readonly` and `?` markers;
 //   - a method renders `name(params) -> ret` per overload arm, arms joined by "; "
 //     so the arm boundary stays distinct from the outer ", " between members;
-//   - a getter renders `get name() -> T`;
-//   - a setter renders `set name(value: T)`.
+//   - a getter renders `get name(self) -> T`, or `get name() -> T` when static;
+//   - a setter renders `set name(self, value: T)`, or `set name(value: T)` when static.
 //
-// It panics on an unknown element kind, matching AsProperty.
+// A getter's or setter's self receiver renders through the same shorthand as a
+// method's. It panics on an unknown element kind, matching AsProperty.
 func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 	switch e := e.(type) {
 	case *PropertyElem:
@@ -498,9 +499,17 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		}
 		return strings.Join(arms, "; ")
 	case *GetterElem:
-		return "get " + printObjectKeyName(e.Name) + "() -> " + p.printType(e.Type)
+		recv := ""
+		if e.SelfParam != nil {
+			recv = p.printSelfReceiver(e.SelfParam)
+		}
+		return "get " + printObjectKeyName(e.Name) + "(" + recv + ") -> " + p.printType(e.Type)
 	case *SetterElem:
-		return "set " + printObjectKeyName(e.Name) + "(value: " + p.printType(e.Param) + ")"
+		recv := ""
+		if e.SelfParam != nil {
+			recv = p.printSelfReceiver(e.SelfParam) + ", "
+		}
+		return "set " + printObjectKeyName(e.Name) + "(" + recv + "value: " + p.printType(e.Param) + ")"
 	}
 	panic(fmt.Sprintf("printObjElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -258,6 +258,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 				out = append(out, t)
 			}
 		case *FuncType:
+			if t.SelfParam != nil {
+				walk(t.SelfParam.Type)
+			}
 			for _, p := range t.Params {
 				walk(p.Type)
 			}
@@ -443,17 +446,7 @@ func (p *namedPrinter) printType(t Type) string {
 		// The inner prints at precPrefix so a looser inner such as a union or function
 		// gets parenthesized. Under the lazy deep-mut form (PR 14) the inner is the
 		// bare shape the user wrote, so it prints verbatim with no elision pass.
-		prefix := ""
-		if t.Lt != nil {
-			prefix = "&"
-			if name := p.borrowLifetimeName(t.Lt); name != "" {
-				prefix += name + " "
-			}
-		}
-		if t.Mut {
-			prefix += "mut "
-		}
-		return prefix + p.printTypeMinPrec(t.Inner, precPrefix)
+		return p.refBorrowPrefix(t) + p.printTypeMinPrec(t.Inner, precPrefix)
 	case *UnionType:
 		// An inexact union renders a trailing `...` entry, so a union typed
 		// `A | B | ...` round-trips to surface syntax. The inexact tuple,
@@ -522,16 +515,50 @@ func classDisplayName(qname string) string {
 	return qname
 }
 
+// refBorrowPrefix renders the ownership and borrow prefix of a RefType: "" for an
+// owned-immutable cell, "mut " for owned-mutable, "&" or "&'a " for an immutable
+// borrow, and "&mut " or "&'a mut " for a mutable borrow. The RefType arm and the
+// method self-receiver share it so a borrow renders the same in both places.
+func (p *namedPrinter) refBorrowPrefix(t *RefType) string {
+	prefix := ""
+	if t.Lt != nil {
+		prefix = "&"
+		if name := p.borrowLifetimeName(t.Lt); name != "" {
+			prefix += name + " "
+		}
+	}
+	if t.Mut {
+		prefix += "mut "
+	}
+	return prefix
+}
+
+// printSelfReceiver renders a method's receiver as the Rust-style shorthand, reading
+// it back from the desugared receiver type. An owned receiver `Self` renders `self`.
+// The `mut Self`, `&Self`, and `&mut Self` receivers render `mut self`, `&self`, and
+// `&mut self` through the shared borrow prefix, so a named borrow lifetime renders
+// `&'a self`.
+func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
+	if ref, ok := sp.Type.(*RefType); ok {
+		return p.refBorrowPrefix(ref) + "self"
+	}
+	return "self"
+}
+
 // printFuncTail renders the "(params) -> ret" portion of a function, without the
 // leading "fn" keyword. Kept as a separate helper so PrintAsScheme can compose it
 // with a <...> quantifier prefix without byte-slicing the "fn " back off.
 //
-// PR4 markers: an optional parameter renders as `x?: T`, and an INEXACT function
-// renders a trailing `...` entry (`fn (x: T, ...) -> R`) so the exactness it
-// carries round-trips to surface syntax. An exact function (the common case)
-// renders with no marker.
+// A method's self receiver renders first as its shorthand, so an instance method
+// reads `(self, x: T) -> R` or `(mut self) -> R`. PR4 markers follow: an optional
+// parameter renders as `x?: T`, and an INEXACT function renders a trailing `...`
+// entry (`fn (x: T, ...) -> R`) so the exactness it carries round-trips to surface
+// syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
-	ps := make([]string, 0, len(t.Params)+1)
+	ps := make([]string, 0, len(t.Params)+2)
+	if t.SelfParam != nil {
+		ps = append(ps, p.printSelfReceiver(t.SelfParam))
+	}
 	for i, param := range t.Params {
 		rest := ""
 		if param.Rest {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -34,10 +34,12 @@ func typePrec(t Type) int {
 	case *RefType:
 		return precPrefix
 	default:
-		// PrimType, LitType, TupleType, ObjectType, Void, NeverType, UnknownType —
-		// atoms (ObjectType is brace-delimited, so it never needs parens). A
-		// raw TypeVarType (which appears only when printing an un-coalesced type,
-		// see printType) is also an atom (rendered as `t{ID}`), so it lands here.
+		// PrimType, LitType, TupleType, ObjectType, ClassType, Void, NeverType,
+		// UnknownType — atoms. ObjectType is brace-delimited and ClassType renders as
+		// a bare name or `Name<args>`, so neither needs parens. A raw TypeVarType
+		// appears only when printing an un-coalesced type, see printType; it is also an
+		// atom rendered as `t{ID}`, so it lands here. A `mut 'a Point` borrow wraps the
+		// ClassType in a RefType, which carries the looser precPrefix precedence.
 		return precAtom
 	}
 }
@@ -258,7 +260,13 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *ObjectType:
 			for _, e := range t.Elems {
-				walk(AsProperty(e).Type)
+				for _, ct := range ObjElemTypes(e) {
+					walk(ct)
+				}
+			}
+		case *ClassType:
+			for _, a := range t.Args {
+				walk(a)
 			}
 		case *PromiseType:
 			walk(t.Inner)
@@ -391,21 +399,26 @@ func (p *namedPrinter) printType(t Type) string {
 	case *ObjectType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
-			prop := AsProperty(e)
-			opt := ""
-			if prop.Optional {
-				opt = "?"
-			}
-			ro := ""
-			if prop.Readonly {
-				ro = "readonly "
-			}
-			elems = append(elems, ro+printObjectKeyName(prop.Name)+opt+": "+p.printType(prop.Type))
+			elems = append(elems, p.printObjElem(e))
 		}
 		if t.Inexact {
 			elems = append(elems, "...")
 		}
 		return "{" + strings.Join(elems, ", ") + "}"
+	case *ClassType:
+		// A ClassType renders under its bare display name, with a `<...>` type-argument
+		// list when it has arguments: `Point`, `Box<number>`. The qualified Name carries
+		// a namespace prefix for registry keying, stripped here for display. Lt and the
+		// `mut` borrow forms come from a RefType wrapper, not this arm.
+		name := classDisplayName(t.Name)
+		if len(t.Args) == 0 {
+			return name
+		}
+		args := make([]string, len(t.Args))
+		for i, a := range t.Args {
+			args[i] = p.printType(a)
+		}
+		return name + "<" + strings.Join(args, ", ") + ">"
 	case *FuncType:
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
@@ -453,6 +466,52 @@ func (p *namedPrinter) printType(t Type) string {
 		return strings.Join(parts, " & ")
 	}
 	panic(fmt.Sprintf("printType: unhandled %T", t))
+}
+
+// printObjElem renders one object member in Escalier surface syntax. Each kind has
+// its own form:
+//
+//   - a property renders `name: T` with the `readonly` and `?` markers;
+//   - a method renders `name(params) -> ret` per overload arm, arms joined by "; "
+//     so the arm boundary stays distinct from the outer ", " between members;
+//   - a getter renders `get name() -> T`;
+//   - a setter renders `set name(value: T)`.
+//
+// It panics on an unknown element kind, matching AsProperty.
+func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
+	switch e := e.(type) {
+	case *PropertyElem:
+		opt := ""
+		if e.Optional {
+			opt = "?"
+		}
+		ro := ""
+		if e.Readonly {
+			ro = "readonly "
+		}
+		return ro + printObjectKeyName(e.Name) + opt + ": " + p.printType(e.Type)
+	case *MethodElem:
+		arms := make([]string, len(e.Signatures))
+		for i, sig := range e.Signatures {
+			arms[i] = printObjectKeyName(e.Name) + p.printFuncTail(sig)
+		}
+		return strings.Join(arms, "; ")
+	case *GetterElem:
+		return "get " + printObjectKeyName(e.Name) + "() -> " + p.printType(e.Type)
+	case *SetterElem:
+		return "set " + printObjectKeyName(e.Name) + "(value: " + p.printType(e.Param) + ")"
+	}
+	panic(fmt.Sprintf("printObjElem: unhandled ObjTypeElem %T", e))
+}
+
+// classDisplayName strips the dep_graph namespace prefix off a qualified class
+// name for display, so "Geometry.Point" renders as "Point". A bare name with no
+// dot is returned unchanged.
+func classDisplayName(qname string) string {
+	if i := strings.LastIndex(qname, "."); i >= 0 {
+		return qname[i+1:]
+	}
+	return qname
 }
 
 // printFuncTail renders the "(params) -> ret" portion of a function, without the

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -271,8 +271,23 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *ObjectType:
 			for _, e := range t.Elems {
-				for _, ct := range ObjElemTypes(e) {
-					walk(ct)
+				switch e := e.(type) {
+				case *PropertyElem:
+					walk(e.Type)
+				case *MethodElem:
+					for _, sig := range e.Signatures {
+						walk(sig)
+					}
+				case *GetterElem:
+					if e.SelfParam != nil {
+						walk(e.SelfParam.Type)
+					}
+					walk(e.Type)
+				case *SetterElem:
+					if e.SelfParam != nil {
+						walk(e.SelfParam.Type)
+					}
+					walk(e.Param)
 				}
 			}
 		case *ClassType:

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -135,6 +135,14 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 		return Print(t)
 	}
 	p := &namedPrinter{names: names, ltNames: ltNames}
+	if _, ok := t.(*ClassType); ok {
+		// A class instance already displays its type parameters inline in its `<...>`
+		// argument list, so it needs no separate quantifier prefix. A generalized
+		// Map<K, V> renders as Map<T0, T1>, not <T0, T1> Map<T0, T1>. A ClassType's only
+		// free-variable children are its arguments, so every quantified variable is
+		// shown inline and none is lost by dropping the prefix.
+		return p.printType(t)
+	}
 	ltLabels := make([]string, len(ltVars))
 	for i, lv := range ltVars {
 		ltLabels[i] = p.lifetimeBinder(lv, ltBounds[lv], ltIndex)

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -238,6 +238,54 @@ type PropertyElem struct {
 
 func (*PropertyElem) isObjTypeElem() {}
 
+// MethodElem is one named method of an ObjectType. Its signature is a FuncType
+// whose first parameter is the `self` receiver, so member lookup and subtyping
+// reuse the FuncType machinery with no method-specific path. An overloaded method
+// holds its arms in Signatures, ordered most-specific-first the way the solver
+// resolves an overload set. A plain method has exactly one signature. Static marks
+// a static method, which lives on the constructor value rather than the instance.
+type MethodElem struct {
+	Name       string
+	Signatures []*FuncType // len 1 = ordinary; >1 = overload set (most-specific-first)
+	Static     bool
+}
+
+// GetterElem is a computed read property `get x() -> T`. Type is the value the
+// getter returns, read covariantly like a PropertyElem's Type.
+type GetterElem struct {
+	Name string
+	Type Type
+}
+
+// SetterElem is a computed write property `set x(v: T)`. Param is the value the
+// setter accepts, in write position, so it is read contravariantly.
+type SetterElem struct {
+	Name  string
+	Param Type
+}
+
+func (*MethodElem) isObjTypeElem() {}
+func (*GetterElem) isObjTypeElem() {}
+func (*SetterElem) isObjTypeElem() {}
+
+// ObjElemName returns the member name of any ObjTypeElem kind. It is the shared
+// name accessor for member lookup and structural equality, so those sites need no
+// per-kind type switch of their own. It panics on an unknown element kind,
+// matching the loud-fail discipline of AsProperty.
+func ObjElemName(e ObjTypeElem) string {
+	switch e := e.(type) {
+	case *PropertyElem:
+		return e.Name
+	case *MethodElem:
+		return e.Name
+	case *GetterElem:
+		return e.Name
+	case *SetterElem:
+		return e.Name
+	}
+	panic(fmt.Sprintf("ObjElemName: unhandled ObjTypeElem %T", e))
+}
+
 // Prop returns the named property and whether it is present. Property names are
 // unique in a well-formed ObjectType — the constraint solver dedups duplicate
 // keys (last value wins) when it builds an object from a literal — so the first
@@ -254,15 +302,30 @@ func (o *ObjectType) Prop(name string) (*PropertyElem, bool) {
 	return nil, false
 }
 
-// AsProperty narrows an ObjTypeElem to its *PropertyElem. M4 ships PropertyElem
-// as the only ObjTypeElem kind, so any other element is a bug: a later member
-// kind (method/getter/setter in M5, index signature or object rest/spread in M9)
-// wired up without extending the call site that processes every element. It
-// panics rather than silently skipping, matching type_system's unknown-element
-// convention (print_type.go panics on an unhandled ObjTypeElem) and the M4 plan's
-// standing rule that a missed element kind must fail loudly, not vanish from
-// subtyping, equality, or rendering. Use it at sites that must visit EVERY
-// element; name lookups like Prop legitimately skip non-matching kinds instead.
+// Member returns the named member of any kind and whether it is present. It
+// generalizes Prop across property, method, getter, and setter elements, so member
+// access and nominal subtyping look a name up through one call regardless of its
+// kind. When a name is carried by both a getter and a setter it returns the first
+// in declaration order. A caller that must distinguish the two inspects the returned
+// element's concrete kind.
+func (o *ObjectType) Member(name string) (ObjTypeElem, bool) {
+	for _, e := range o.Elems {
+		if ObjElemName(e) == name {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+// AsProperty narrows an ObjTypeElem to its *PropertyElem. It is used at sites that
+// handle only properties and do not yet process the method, getter, and setter
+// kinds, so any other element reaching one is a wiring bug: a member kind added
+// without extending that call site. It panics rather than silently skipping, so a
+// missed element kind fails loudly instead of vanishing from subtyping, equality,
+// or rendering. This matches type_system's convention, where print_type.go panics
+// on an unhandled ObjTypeElem. Use it only at property-only sites. A site that must
+// visit every element kind switches on the kind or reads ObjElemTypes; name lookups
+// like Prop legitimately skip non-matching kinds instead.
 func AsProperty(e ObjTypeElem) *PropertyElem {
 	p, ok := e.(*PropertyElem)
 	if !ok {
@@ -306,8 +369,9 @@ type RefType struct {
 // pointee, with a single lifetime and mutability for the whole value rather than
 // `&A | &B` with independent lifetimes. A union or intersection must have uniform
 // ownership. A borrowed member beside an owned one has no single owned-or-borrowed
-// verdict and is rejected at the inference join where it forms. AliasType and
-// ClassType add their isRefInner arms when those types are introduced.
+// verdict and is rejected at the inference join where it forms. ClassType is a
+// RefInner too, so a `mut 'a Point` borrows a class instance. AliasType adds its
+// isRefInner arm when that type is introduced.
 type RefInner interface {
 	Type
 	isRefInner()
@@ -318,6 +382,7 @@ func (*TupleType) isRefInner()        {}
 func (*TypeVarType) isRefInner()      {}
 func (*UnionType) isRefInner()        {}
 func (*IntersectionType) isRefInner() {}
+func (*ClassType) isRefInner()        {}
 
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
@@ -382,6 +447,31 @@ type IntersectionType struct{ Types []Type }
 // diagnostics/debug only.
 type ErrorType struct{} // ⊤⊥ absorbing sentinel; see PR8
 
+// ClassType is a nominal lattice element — the identity token for a class. Two
+// ClassTypes are the same nominal type when their Name matches. The Args are the
+// type arguments, checked per position by the variance the class registry records
+// for that parameter. Name is the dep_graph-qualified name such as
+// "Geometry.Point", not the bare local identifier, so two classes named Point in
+// different namespaces stay distinct. The heavy per-class data — the projected
+// member body, the resolved supers, and the inferred variance — lives in a side
+// registry keyed by Name, so this token stays small and cheap to compare and
+// rewrite.
+//
+// A final class's subclasses cannot add members, so Final marks its instance type
+// as closed the way an exact object is (exact-types §2.6). The zero value false is
+// inexact, matching a non-final class whose subclasses may widen it.
+//
+// Lt is the instance's own borrow lifetime, nil for an owned value. A `mut 'b Point`
+// wraps a ClassType in a RefType rather than setting Lt directly, so no site sets Lt
+// today and it is always nil. Lifetime arguments filling the class's declared
+// lifetime params have no field yet.
+type ClassType struct {
+	Name  string // dep_graph-qualified name, e.g. "Geometry.Point"
+	Args  []Type // type arguments, one per class type parameter
+	Lt    Lifetime
+	Final bool // final ⇒ exact instance
+}
+
 func (*TypeVarType) isType()      {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -397,6 +487,7 @@ func (*UnknownType) isType()      {}
 func (*UnionType) isType()        {}
 func (*IntersectionType) isType() {}
 func (*ErrorType) isType()        {}
+func (*ClassType) isType()        {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).
@@ -419,7 +510,16 @@ func LevelOf(t Type) int {
 	case *ObjectType:
 		m := 0
 		for _, e := range t.Elems {
-			m = max(m, LevelOf(AsProperty(e).Type))
+			m = max(m, levelOfElem(e))
+		}
+		return m
+	case *ClassType:
+		// A nominal instance's level is the max level over its type arguments. The Name
+		// and Final identity carry no variables. Lt is always nil today, so it
+		// contributes nothing here.
+		m := 0
+		for _, a := range t.Args {
+			m = max(m, LevelOf(a))
 		}
 		return m
 	case *PromiseType:
@@ -454,6 +554,40 @@ func LevelOf(t Type) int {
 		// childless leaves. ErrorType is a sentinel at level 0.
 		return 0
 	}
+}
+
+// ObjElemTypes returns the child types an object member carries: a property's
+// value type, each of a method's overload signatures, a getter's return type, or a
+// setter's parameter type. It is the single place that enumerates a member's child
+// types, so a walk over the element set reads its children here rather than
+// re-switching on the kind. It panics on an unknown element kind, matching
+// AsProperty.
+func ObjElemTypes(e ObjTypeElem) []Type {
+	switch e := e.(type) {
+	case *PropertyElem:
+		return []Type{e.Type}
+	case *MethodElem:
+		out := make([]Type, len(e.Signatures))
+		for i, sig := range e.Signatures {
+			out[i] = sig
+		}
+		return out
+	case *GetterElem:
+		return []Type{e.Type}
+	case *SetterElem:
+		return []Type{e.Param}
+	}
+	panic(fmt.Sprintf("ObjElemTypes: unhandled ObjTypeElem %T", e))
+}
+
+// levelOfElem returns the max TypeVarType level across an object member's child
+// types, the per-element generalization of LevelOf's property case.
+func levelOfElem(e ObjTypeElem) int {
+	m := 0
+	for _, ct := range ObjElemTypes(e) {
+		m = max(m, LevelOf(ct))
+	}
+	return m
 }
 
 // maxMemberLevel returns the highest LevelOf across a Union/Intersection's members,

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -259,18 +259,24 @@ type MethodElem struct {
 	Static     bool
 }
 
-// GetterElem is a computed read property `get x() -> T`. Type is the value the
-// getter returns, read covariantly like a PropertyElem's Type.
+// GetterElem is a computed read property `get x(self) -> T`. Type is the value the
+// getter returns, read covariantly like a PropertyElem's Type. SelfParam is the
+// receiver of an instance getter and nil for a static getter, mirroring
+// FuncType.SelfParam.
 type GetterElem struct {
-	Name string
-	Type Type
+	Name      string
+	SelfParam *FuncParam // nil ⇒ static getter; non-nil ⇒ instance getter
+	Type      Type
 }
 
-// SetterElem is a computed write property `set x(v: T)`. Param is the value the
-// setter accepts, in write position, so it is read contravariantly.
+// SetterElem is a computed write property `set x(self, v: T)`. Param is the value the
+// setter accepts, in write position, so it is read contravariantly. SelfParam is the
+// receiver of an instance setter and nil for a static setter, mirroring
+// FuncType.SelfParam.
 type SetterElem struct {
-	Name  string
-	Param Type
+	Name      string
+	SelfParam *FuncParam // nil ⇒ static setter; non-nil ⇒ instance setter
+	Param     Type
 }
 
 func (*MethodElem) isObjTypeElem() {}
@@ -568,12 +574,13 @@ func LevelOf(t Type) int {
 	}
 }
 
-// ObjElemTypes returns the child types an object member carries: a property's
-// value type, each of a method's overload signatures, a getter's return type, or a
-// setter's parameter type. It is the single place that enumerates a member's child
-// types, so a walk over the element set reads its children here rather than
-// re-switching on the kind. It panics on an unknown element kind, matching
-// AsProperty.
+// ObjElemTypes returns the child types an object member carries in print order: a
+// property's value type; each of a method's overload signatures, whose FuncType
+// already carries the receiver; a getter's receiver then its return type; a setter's
+// receiver then its parameter type. A static getter or setter has no receiver. It is
+// the single place that enumerates a member's child types, so a walk over the element
+// set reads its children here rather than re-switching on the kind. It panics on an
+// unknown element kind, matching AsProperty.
 func ObjElemTypes(e ObjTypeElem) []Type {
 	switch e := e.(type) {
 	case *PropertyElem:
@@ -585,11 +592,20 @@ func ObjElemTypes(e ObjTypeElem) []Type {
 		}
 		return out
 	case *GetterElem:
-		return []Type{e.Type}
+		return selfThen(e.SelfParam, e.Type)
 	case *SetterElem:
-		return []Type{e.Param}
+		return selfThen(e.SelfParam, e.Param)
 	}
 	panic(fmt.Sprintf("ObjElemTypes: unhandled ObjTypeElem %T", e))
+}
+
+// selfThen prepends a receiver type to rest when the receiver is present, so a walk
+// visits an instance getter's or setter's receiver before its value in print order.
+func selfThen(self *FuncParam, rest Type) []Type {
+	if self == nil {
+		return []Type{rest}
+	}
+	return []Type{self.Type, rest}
 }
 
 // levelOfElem returns the max TypeVarType level across an object member's child

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -339,8 +339,8 @@ func (o *ObjectType) Member(name string) (ObjTypeElem, bool) {
 // missed element kind fails loudly instead of vanishing from subtyping, equality,
 // or rendering. This matches type_system's convention, where print_type.go panics
 // on an unhandled ObjTypeElem. Use it only at property-only sites. A site that must
-// visit every element kind switches on the kind or reads ObjElemTypes; name lookups
-// like Prop legitimately skip non-matching kinds instead.
+// visit every element kind switches on the kind instead. Name lookups like Prop
+// legitimately skip non-matching kinds.
 func AsProperty(e ObjTypeElem) *PropertyElem {
 	p, ok := e.(*PropertyElem)
 	if !ok {
@@ -572,48 +572,36 @@ func LevelOf(t Type) int {
 	}
 }
 
-// ObjElemTypes returns the child types an object member carries in print order: a
-// property's value type; each of a method's overload signatures, whose FuncType
-// already carries the receiver; a getter's receiver then its return type; a setter's
-// receiver then its parameter type. A static getter or setter has no receiver. It is
-// the single place that enumerates a member's child types, so a walk over the element
-// set reads its children here rather than re-switching on the kind. It panics on an
-// unknown element kind, matching AsProperty.
-func ObjElemTypes(e ObjTypeElem) []Type {
+// levelOfElem returns the max TypeVarType level across an object member's types, the
+// per-element generalization of LevelOf's property case. A method's receiver rides
+// inside each signature FuncType; a getter or setter carries its receiver directly,
+// present only for an instance member. It panics on an unknown element kind, matching
+// AsProperty.
+func levelOfElem(e ObjTypeElem) int {
 	switch e := e.(type) {
 	case *PropertyElem:
-		return []Type{e.Type}
+		return LevelOf(e.Type)
 	case *MethodElem:
-		out := make([]Type, len(e.Signatures))
-		for i, sig := range e.Signatures {
-			out[i] = sig
+		m := 0
+		for _, sig := range e.Signatures {
+			m = max(m, LevelOf(sig))
 		}
-		return out
+		return m
 	case *GetterElem:
-		return selfThen(e.SelfParam, e.Type)
+		return max(selfLevel(e.SelfParam), LevelOf(e.Type))
 	case *SetterElem:
-		return selfThen(e.SelfParam, e.Param)
+		return max(selfLevel(e.SelfParam), LevelOf(e.Param))
 	}
-	panic(fmt.Sprintf("ObjElemTypes: unhandled ObjTypeElem %T", e))
+	panic(fmt.Sprintf("levelOfElem: unhandled ObjTypeElem %T", e))
 }
 
-// selfThen prepends a receiver type to rest when the receiver is present, so a walk
-// visits an instance getter's or setter's receiver before its value in print order.
-func selfThen(self *FuncParam, rest Type) []Type {
+// selfLevel returns the level of a getter's or setter's receiver type, 0 for a static
+// member whose receiver is nil.
+func selfLevel(self *FuncParam) int {
 	if self == nil {
-		return []Type{rest}
+		return 0
 	}
-	return []Type{self.Type, rest}
-}
-
-// levelOfElem returns the max TypeVarType level across an object member's child
-// types, the per-element generalization of LevelOf's property case.
-func levelOfElem(e ObjTypeElem) int {
-	m := 0
-	for _, ct := range ObjElemTypes(e) {
-		m = max(m, LevelOf(ct))
-	}
-	return m
+	return LevelOf(self.Type)
 }
 
 // maxMemberLevel returns the highest LevelOf across a Union/Intersection's members,

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -463,28 +463,26 @@ type IntersectionType struct{ Types []Type }
 type ErrorType struct{} // ⊤⊥ absorbing sentinel; see PR8
 
 // ClassType is a nominal lattice element — the identity token for a class. Two
-// ClassTypes are the same nominal type when their Name matches. The Args are the
-// type arguments, checked per position by the variance the class registry records
-// for that parameter. Name is the dep_graph-qualified name such as
-// "Geometry.Point", not the bare local identifier, so two classes named Point in
-// different namespaces stay distinct. The heavy per-class data — the projected
-// member body, the resolved supers, and the inferred variance — lives in a side
-// registry keyed by Name, so this token stays small and cheap to compare and
-// rewrite.
-//
-// A final class's subclasses cannot add members, so Final marks its instance type
-// as closed the way an exact object is (exact-types §2.6). The zero value false is
-// inexact, matching a non-final class whose subclasses may widen it.
-//
-// Lt is the instance's own borrow lifetime, nil for an owned value. A `mut 'b Point`
-// wraps a ClassType in a RefType rather than setting Lt directly, so no site sets Lt
-// today and it is always nil. Lifetime arguments filling the class's declared
-// lifetime params have no field yet.
+// ClassTypes are the same nominal type when their Name matches. The heavy per-class
+// data — the projected member body, the resolved supers, and the inferred variance —
+// lives in a side registry keyed by Name, so this token stays small and cheap to
+// compare and rewrite.
 type ClassType struct {
-	Name  string // dep_graph-qualified name, e.g. "Geometry.Point"
-	Args  []Type // type arguments, one per class type parameter
-	Lt    Lifetime
-	Final bool // final ⇒ exact instance
+	// Name is the dep_graph-qualified name such as "Geometry.Point", not the bare
+	// local identifier, so two classes named Point in different namespaces stay
+	// distinct. It also keys the registry holding the heavy per-class data.
+	Name string
+	// Args are the type arguments, one per class type parameter, checked per position
+	// by the variance the class registry records for that parameter.
+	Args []Type
+	// Lt is the instance's own borrow lifetime, nil for an owned value. A `mut 'b
+	// Point` wraps a ClassType in a RefType rather than setting Lt directly, so no
+	// site sets Lt today and it is always nil.
+	Lt Lifetime
+	// Final marks a class whose subclasses cannot add members, so its instance type is
+	// closed the way an exact object is (exact-types §2.6). The zero value false is
+	// inexact, matching a non-final class whose subclasses may widen it.
+	Final bool
 }
 
 func (*TypeVarType) isType()      {}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -190,10 +190,19 @@ type FuncParam struct {
 // exact-by-default semantics: a function minted without thinking about exactness is
 // correctly exact, and the structural rewriters (coalesce, extrude, freshenAbove)
 // carry the flag through unchanged. Only the parser's `...` marker sets it.
+// SelfParam carries the implicit `self` receiver of a method, so a method's
+// FuncType records its receiver distinctly from its ordinary parameters. Its
+// presence marks an instance method and its absence a static method or a plain
+// function. Type is the receiver type after desugaring the Rust-style shorthand:
+// `self` is `Self`, `mut self` is `mut Self`, `&self` is `&Self`, and `&mut self`
+// is `&mut Self`. The printer reads that shape back to the shorthand, and the
+// receiver's borrow and lifetime flow through the visitor the same way a
+// parameter's do. Pattern names the receiver, always the `self` identifier.
 type FuncType struct {
-	Params  []*FuncParam
-	Ret     Type
-	Inexact bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
+	SelfParam *FuncParam // nil ⇒ static method or plain function; non-nil ⇒ instance method
+	Params    []*FuncParam
+	Ret       Type
+	Inexact   bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
 }
 
 // TupleType is a tuple type. Inexact follows the ObjectType/FuncType convention:
@@ -497,6 +506,9 @@ func LevelOf(t Type) int {
 		return t.Level
 	case *FuncType:
 		m := 0
+		if t.SelfParam != nil {
+			m = LevelOf(t.SelfParam.Type)
+		}
 		for _, p := range t.Params {
 			m = max(m, LevelOf(p.Type))
 		}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -213,6 +213,23 @@ func (t *IntersectionType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	args, changed := acceptTypes(cur.Args, v, pol) // type arguments covariant
+	out := cur
+	if changed {
+		// Name, Final, and Lt are the nominal identity, carried through unchanged. Lt
+		// is a Lifetime, not a Type, so Accept never walks it. Only lifetime-aware
+		// passes touch a lifetime.
+		out = &ClassType{Name: cur.Name, Args: args, Lt: cur.Lt, Final: cur.Final}
+	}
+	return v.ExitType(out, pol)
+}
+
 // acceptTypes walks each element covariantly, returning (originalSlice, false)
 // when nothing changed and (copy-on-write slice, true) otherwise.
 func acceptTypes(ts []Type, v TypeVisitor, pol Polarity) ([]Type, bool) {
@@ -250,22 +267,80 @@ func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, b
 	return out, changed
 }
 
-// acceptObjElems walks each property's type covariantly, copy-on-write like
-// acceptParams. M4's elements are all PropertyElem; later member kinds add their
-// own variance treatment here.
+// acceptObjElems walks each member, copy-on-write like acceptParams: a member
+// whose type changed gets a fresh element, unchanged members keep their pointer.
+// Each kind threads polarity by its variance — a property or getter reads
+// covariantly, a setter writes contravariantly, and a method delegates to
+// FuncType.Accept, which flips polarity on its own parameters.
 func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeElem, bool) {
 	out := es
 	changed := false
 	for i, e := range es {
-		p := AsProperty(e)
-		pt := p.Type.Accept(v, pol)
-		if pt != p.Type {
+		ne := acceptObjElem(e, v, pol)
+		if ne != e {
 			if !changed {
 				out = append([]ObjTypeElem(nil), es...)
 				changed = true
 			}
-			out[i] = &PropertyElem{Name: p.Name, Type: pt, Optional: p.Optional, Readonly: p.Readonly}
+			out[i] = ne
 		}
+	}
+	return out, changed
+}
+
+// acceptObjElem rewrites one object member, returning the original pointer when no
+// child changed. It panics on an unknown element kind, matching AsProperty.
+func acceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
+	switch e := e.(type) {
+	case *PropertyElem:
+		pt := e.Type.Accept(v, pol) // covariant read
+		if pt == e.Type {
+			return e
+		}
+		return &PropertyElem{Name: e.Name, Type: pt, Optional: e.Optional, Readonly: e.Readonly}
+	case *GetterElem:
+		rt := e.Type.Accept(v, pol) // covariant read
+		if rt == e.Type {
+			return e
+		}
+		return &GetterElem{Name: e.Name, Type: rt}
+	case *SetterElem:
+		pt := e.Param.Accept(v, pol.Flip()) // contravariant write
+		if pt == e.Param {
+			return e
+		}
+		return &SetterElem{Name: e.Name, Param: pt}
+	case *MethodElem:
+		sigs, changed := acceptSignatures(e.Signatures, v, pol)
+		if !changed {
+			return e
+		}
+		return &MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
+	}
+	panic(fmt.Sprintf("acceptObjElem: unhandled ObjTypeElem %T", e))
+}
+
+// acceptSignatures walks each signature of a method's overload set through
+// FuncType.Accept, copy-on-write like acceptObjElems. A signature is always a
+// FuncType and FuncType.Accept rewrites it to a FuncType, so a non-FuncType result
+// is a visitor-contract violation and panics with a clear message.
+func acceptSignatures(sigs []*FuncType, v TypeVisitor, pol Polarity) ([]*FuncType, bool) {
+	out := sigs
+	changed := false
+	for i, sig := range sigs {
+		ns := sig.Accept(v, pol)
+		if ns == sig {
+			continue
+		}
+		nf, ok := ns.(*FuncType)
+		if !ok {
+			panic(fmt.Sprintf("acceptSignatures: method signature rewrote to non-FuncType %T", ns))
+		}
+		if !changed {
+			out = append([]*FuncType(nil), sigs...)
+			changed = true
+		}
+		out[i] = nf
 	}
 	return out, changed
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -314,17 +314,19 @@ func acceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 		}
 		return &PropertyElem{Name: e.Name, Type: pt, Optional: e.Optional, Readonly: e.Readonly}
 	case *GetterElem:
-		rt := e.Type.Accept(v, pol) // covariant read
-		if rt == e.Type {
+		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
+		rt := e.Type.Accept(v, pol)                               // covariant read
+		if !selfChanged && rt == e.Type {
 			return e
 		}
-		return &GetterElem{Name: e.Name, Type: rt}
+		return &GetterElem{Name: e.Name, SelfParam: self, Type: rt}
 	case *SetterElem:
-		pt := e.Param.Accept(v, pol.Flip()) // contravariant write
-		if pt == e.Param {
+		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
+		pt := e.Param.Accept(v, pol.Flip())                       // contravariant write
+		if !selfChanged && pt == e.Param {
 			return e
 		}
-		return &SetterElem{Name: e.Name, Param: pt}
+		return &SetterElem{Name: e.Name, SelfParam: self, Param: pt}
 	case *MethodElem:
 		sigs, changed := acceptSignatures(e.Signatures, v, pol)
 		if !changed {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -89,13 +89,28 @@ func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	params, changed := acceptParams(cur.Params, v, pol) // params contravariant
-	ret := cur.Ret.Accept(v, pol)                       // return covariant
+	self, selfChanged := acceptSelfParam(cur.SelfParam, v, pol) // receiver contravariant
+	params, changed := acceptParams(cur.Params, v, pol)         // params contravariant
+	ret := cur.Ret.Accept(v, pol)                              // return covariant
 	out := cur
-	if changed || ret != cur.Ret {
-		out = &FuncType{Params: params, Ret: ret, Inexact: cur.Inexact}
+	if selfChanged || changed || ret != cur.Ret {
+		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact}
 	}
 	return v.ExitType(out, pol)
+}
+
+// acceptSelfParam walks a method's receiver type contravariantly, like an ordinary
+// parameter, and returns the original *FuncParam when its type did not change. A nil
+// receiver passes through unchanged, since a static method or plain function has none.
+func acceptSelfParam(sp *FuncParam, v TypeVisitor, pol Polarity) (*FuncParam, bool) {
+	if sp == nil {
+		return nil, false
+	}
+	pt := sp.Type.Accept(v, pol.Flip())
+	if pt == sp.Type {
+		return sp, false
+	}
+	return &FuncParam{Pattern: sp.Pattern, Type: pt, Optional: sp.Optional, Rest: sp.Rest}, true
 }
 
 func (t *TupleType) Accept(v TypeVisitor, pol Polarity) Type {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -720,10 +720,7 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		// Receiver presence distinguishes an instance method from a static one, and the
 		// receiver type carries its mutability and borrow, so `(self) -> T`, `(mut self)
 		// -> T`, and `() -> T` are all distinct.
-		if (a.SelfParam == nil) != (b.SelfParam == nil) {
-			return false
-		}
-		if a.SelfParam != nil && !equalTypeWith(a.SelfParam.Type, b.SelfParam.Type, p) {
+		if !equalSelfParam(a.SelfParam, b.SelfParam, p) {
 			return false
 		}
 		for i := range a.Params {
@@ -834,12 +831,25 @@ func equalObjElem(a, b soltype.ObjTypeElem, p *ltPairing) bool {
 		return true
 	case *soltype.GetterElem:
 		b, ok := b.(*soltype.GetterElem)
-		return ok && equalTypeWith(a.Type, b.Type, p)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, p) && equalTypeWith(a.Type, b.Type, p)
 	case *soltype.SetterElem:
 		b, ok := b.(*soltype.SetterElem)
-		return ok && equalTypeWith(a.Param, b.Param, p)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, p) && equalTypeWith(a.Param, b.Param, p)
 	}
 	panic(fmt.Sprintf("equalObjElem: unhandled ObjTypeElem %T", a))
+}
+
+// equalSelfParam reports whether two receivers match. Presence must agree, so an
+// instance member never equals a static one, and when both are present their receiver
+// types must be equal. It is shared by the method, getter, and setter comparisons.
+func equalSelfParam(a, b *soltype.FuncParam, p *ltPairing) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return equalTypeWith(a.Type, b.Type, p)
 }
 
 // ltEqualWith reports lifetime equality for equalTypeWith's RefType arm. Under a nil

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -743,20 +743,34 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
-		// Objects are equal up to property order, so match each property by name
-		// via ObjectType.Prop rather than by position. The solver dedups property
-		// names on construction, so names are unique. Equal lengths plus every
-		// a-property matching a b-property by name, type, and optionality is then a
-		// full structural match. Optional mirrors the FuncType arm's param-Optional
-		// discriminator.
+		// Objects are equal up to member order, so each a-member must find a b-member
+		// that shares its name and equals it kind-for-kind. Equal lengths plus that
+		// match on every a-member is a full structural match. Comparing against every
+		// same-named b-member, rather than the first, disambiguates a getter and setter
+		// that share a name.
 		for _, ae := range a.Elems {
-			ap := soltype.AsProperty(ae)
-			bp, ok := b.Prop(ap.Name)
-			if !ok || ap.Optional != bp.Optional || ap.Readonly != bp.Readonly || !equalTypeWith(ap.Type, bp.Type, p) {
+			name := soltype.ObjElemName(ae)
+			found := false
+			for _, be := range b.Elems {
+				if soltype.ObjElemName(be) == name && equalObjElem(ae, be, p) {
+					found = true
+					break
+				}
+			}
+			if !found {
 				return false
 			}
 		}
 		return true
+	case *soltype.ClassType:
+		b, ok := b.(*soltype.ClassType)
+		// Nominal identity is the qualified name plus the Final exactness flag. The type
+		// arguments then compare positionally. A ClassType's Lt is always nil today, so
+		// it is not compared.
+		if !ok || a.Name != b.Name || a.Final != b.Final {
+			return false
+		}
+		return equalTypeSliceWith(a.Args, b.Args, p)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
 		return ok && equalTypeWith(a.Inner, b.Inner, p)
@@ -780,6 +794,43 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		return ok && equalTypeSliceWith(a.Types, b.Types, p)
 	}
 	return false
+}
+
+// equalObjElem reports structural equality of two object members. It returns false
+// on a kind mismatch, so the caller matches a-members to b-members by name and kind
+// together. Each kind compares its own payload:
+//
+//   - a property compares its type, optionality, and readonly flag;
+//   - a method compares its static flag and each overload signature positionally,
+//     since arm order is significant;
+//   - a getter compares its return type;
+//   - a setter compares its parameter type.
+//
+// It panics on an unknown element kind, matching AsProperty.
+func equalObjElem(a, b soltype.ObjTypeElem, p *ltPairing) bool {
+	switch a := a.(type) {
+	case *soltype.PropertyElem:
+		b, ok := b.(*soltype.PropertyElem)
+		return ok && a.Optional == b.Optional && a.Readonly == b.Readonly && equalTypeWith(a.Type, b.Type, p)
+	case *soltype.MethodElem:
+		b, ok := b.(*soltype.MethodElem)
+		if !ok || a.Static != b.Static || len(a.Signatures) != len(b.Signatures) {
+			return false
+		}
+		for i := range a.Signatures {
+			if !equalTypeWith(a.Signatures[i], b.Signatures[i], p) {
+				return false
+			}
+		}
+		return true
+	case *soltype.GetterElem:
+		b, ok := b.(*soltype.GetterElem)
+		return ok && equalTypeWith(a.Type, b.Type, p)
+	case *soltype.SetterElem:
+		b, ok := b.(*soltype.SetterElem)
+		return ok && equalTypeWith(a.Param, b.Param, p)
+	}
+	panic(fmt.Sprintf("equalObjElem: unhandled ObjTypeElem %T", a))
 }
 
 // ltEqualWith reports lifetime equality for equalTypeWith's RefType arm. Under a nil

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -717,6 +717,15 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact {
 			return false
 		}
+		// Receiver presence distinguishes an instance method from a static one, and the
+		// receiver type carries its mutability and borrow, so `(self) -> T`, `(mut self)
+		// -> T`, and `() -> T` are all distinct.
+		if (a.SelfParam == nil) != (b.SelfParam == nil) {
+			return false
+		}
+		if a.SelfParam != nil && !equalTypeWith(a.SelfParam.Type, b.SelfParam.Type, p) {
+			return false
+		}
 		for i := range a.Params {
 			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalTypeWith(a.Params[i].Type, b.Params[i].Type, p) {
 				return false

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -429,6 +429,54 @@ func TestEqualTypeClass(t *testing.T) {
 	}
 }
 
+// equalType distinguishes methods by their receiver: presence marks an instance
+// versus a static method, and the receiver type carries mutability, so (self),
+// (mut self), and () are all distinct.
+func TestEqualTypeFuncSelfParam(t *testing.T) {
+	selfRecv := func(recv soltype.Type) *soltype.FuncParam {
+		return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: recv}
+	}
+	owned := func() soltype.Type { return &soltype.ClassType{Name: "Counter"} }
+	mutSelf := func() soltype.Type {
+		return &soltype.RefType{Mut: true, Inner: &soltype.ClassType{Name: "Counter"}}
+	}
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "same receiver",
+			a:    &soltype.FuncType{SelfParam: selfRecv(owned()), Ret: num()},
+			b:    &soltype.FuncType{SelfParam: selfRecv(owned()), Ret: num()},
+			want: true,
+		},
+		{
+			name: "receiver mutability differs",
+			a:    &soltype.FuncType{SelfParam: selfRecv(owned()), Ret: num()},
+			b:    &soltype.FuncType{SelfParam: selfRecv(mutSelf()), Ret: num()},
+			want: false,
+		},
+		{
+			name: "instance versus static",
+			a:    &soltype.FuncType{SelfParam: selfRecv(owned()), Ret: num()},
+			b:    &soltype.FuncType{Ret: num()},
+			want: false,
+		},
+		{
+			name: "both static",
+			a:    &soltype.FuncType{Ret: num()},
+			b:    &soltype.FuncType{Ret: num()},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType over an object carrying method, getter, and setter members compares
 // each member kind-for-kind and stays order-independent. A getter and a setter that
 // share a name are disambiguated by kind, so a getter never matches a setter.

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -477,6 +477,47 @@ func TestEqualTypeFuncSelfParam(t *testing.T) {
 	}
 }
 
+// equalType distinguishes an instance getter or setter from a static one by receiver
+// presence, and by receiver type.
+func TestEqualTypeGetterSetterSelfParam(t *testing.T) {
+	selfRecv := func(recv soltype.Type) *soltype.FuncParam {
+		return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: recv}
+	}
+	owned := func() soltype.Type { return &soltype.ClassType{Name: "List"} }
+	mutSelf := func() soltype.Type {
+		return &soltype.RefType{Mut: true, Inner: &soltype.ClassType{Name: "List"}}
+	}
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "instance getter versus static getter",
+			a:    exactObj(&soltype.GetterElem{Name: "g", SelfParam: selfRecv(owned()), Type: num()}),
+			b:    exactObj(&soltype.GetterElem{Name: "g", Type: num()}),
+			want: false,
+		},
+		{
+			name: "same instance getter",
+			a:    exactObj(&soltype.GetterElem{Name: "g", SelfParam: selfRecv(owned()), Type: num()}),
+			b:    exactObj(&soltype.GetterElem{Name: "g", SelfParam: selfRecv(owned()), Type: num()}),
+			want: true,
+		},
+		{
+			name: "setter receiver mutability differs",
+			a:    exactObj(&soltype.SetterElem{Name: "s", SelfParam: selfRecv(owned()), Param: num()}),
+			b:    exactObj(&soltype.SetterElem{Name: "s", SelfParam: selfRecv(mutSelf()), Param: num()}),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType over an object carrying method, getter, and setter members compares
 // each member kind-for-kind and stays order-independent. A getter and a setter that
 // share a name are disambiguated by kind, so a getter never matches a setter.

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -376,6 +376,124 @@ func TestEqualTypeRef(t *testing.T) {
 	}
 }
 
+// equalType on a ClassType is nominal: it compares the qualified Name and the Final
+// exactness flag, then the type arguments positionally. Two instances of different
+// classes, or of the same class with different arguments or exactness, are not equal.
+func TestEqualTypeClass(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "same name and arguments",
+			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			want: true,
+		},
+		{
+			name: "name differs",
+			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Bag", Args: []soltype.Type{num()}},
+			want: false,
+		},
+		{
+			name: "type argument differs",
+			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{str()}},
+			want: false,
+		},
+		{
+			name: "Final differs",
+			a:    &soltype.ClassType{Name: "Box", Final: true},
+			b:    &soltype.ClassType{Name: "Box", Final: false},
+			want: false,
+		},
+		{
+			name: "argument count differs",
+			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Box"},
+			want: false,
+		},
+		{
+			name: "a class is not its bare projected object",
+			a:    &soltype.ClassType{Name: "Box"},
+			b:    exactObj(),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
+// equalType over an object carrying method, getter, and setter members compares
+// each member kind-for-kind and stays order-independent. A getter and a setter that
+// share a name are disambiguated by kind, so a getter never matches a setter.
+func TestEqualTypeObjectMembers(t *testing.T) {
+	method := func(name string, sig *soltype.FuncType) *soltype.MethodElem {
+		return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}}
+	}
+	fn := func(param, ret soltype.Type) *soltype.FuncType {
+		return &soltype.FuncType{Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: param}}, Ret: ret}
+	}
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "equal up to member order",
+			a: exactObj(
+				method("m", fn(num(), str())),
+				&soltype.GetterElem{Name: "g", Type: num()},
+			),
+			b: exactObj(
+				&soltype.GetterElem{Name: "g", Type: num()},
+				method("m", fn(num(), str())),
+			),
+			want: true,
+		},
+		{
+			name: "method signature differs",
+			a:    exactObj(method("m", fn(num(), str()))),
+			b:    exactObj(method("m", fn(num(), num()))),
+			want: false,
+		},
+		{
+			name: "getter and setter with the same name stay distinct",
+			a:    exactObj(&soltype.GetterElem{Name: "x", Type: num()}),
+			b:    exactObj(&soltype.SetterElem{Name: "x", Param: num()}),
+			want: false,
+		},
+		{
+			name: "setter param differs",
+			a:    exactObj(&soltype.SetterElem{Name: "s", Param: num()}),
+			b:    exactObj(&soltype.SetterElem{Name: "s", Param: str()}),
+			want: false,
+		},
+		{
+			name: "matching getter and setter sharing a name",
+			a: exactObj(
+				&soltype.GetterElem{Name: "x", Type: num()},
+				&soltype.SetterElem{Name: "x", Param: num()},
+			),
+			b: exactObj(
+				&soltype.SetterElem{Name: "x", Param: num()},
+				&soltype.GetterElem{Name: "x", Type: num()},
+			),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType on ObjectType must discriminate on the Inexact flag and on each
 // property's Optional marker (mirroring the FuncType arm's Inexact / param-Optional
 // checks), and must be order-independent. Without the Optional check (M4 A1 review


### PR DESCRIPTION
Introduces nominal class types and extends object types to support methods, getters, and setters alongside properties.

**Changes:**

- Add `ClassType` as a nominal lattice element representing class instances. A `ClassType` carries a qualified name, type arguments (checked per position by class variance), and a `Final` flag marking exact instances. The heavy per-class data lives in a side registry keyed by name, keeping the token small and cheap to compare.

- Extend `ObjectType` members beyond properties to include `MethodElem` (with overload signatures), `GetterElem` (computed read property), and `SetterElem` (computed write property). Each kind carries its own variance: properties and getters read covariantly, setters write contravariantly, and methods delegate to `FuncType.Accept` which flips polarity on parameters.

- Add `ObjElemName` and `ObjElemTypes` helpers to enumerate member names and child types across all element kinds, eliminating per-kind type switches at call sites.

- Generalize `ObjectType.Prop` to `ObjectType.Member`, which looks up any member kind by name and returns the first match (disambiguating getters and setters that share a name by kind).

- Update `ClassType` to be a `RefInner`, allowing borrows like `&'static mut Point`.

- Extend type visitors (`Accept`), equality (`equalType`), level computation (`LevelOf`), and free variable collection (`freeTypeVars`) to handle the new types and member kinds.

- Add comprehensive tests for `ClassType` rendering, member printing, visitor behavior, variance, copy-on-write semantics, and equality.

https://claude.ai/code/session_01UQnWQ9pm19i3AHFbZkTa9J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for richer class and object type display, including class names, type arguments, and more member kinds.
  * Improved type traversal and comparison so class and object types behave more consistently across nested structures.

* **Bug Fixes**
  * Fixed object member handling for methods, getters, setters, and overloaded methods.
  * Improved equality checks so member order and member kind are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->