### PR TITLE
Support generic functions with type parameters

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -147,10 +147,18 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 	for i, lv := range ltVars {
 		ltLabels[i] = p.lifetimeBinder(lv, ltBounds[lv], ltIndex)
 	}
-	prefix := "<" + strings.Join(append(labels, ltLabels...), ", ") + ">"
 	if ft, ok := t.(*FuncType); ok {
-		return "fn " + prefix + p.printFuncTail(ft)
+		// Merge the scheme's free variables, the function's OWN type parameters, and the
+		// lifetimes into one ordered prefix, so a generic method that also captures a
+		// scheme variable renders `fn <T0, U, 'a>(...)` rather than two adjacent groups.
+		// printFuncBody omits the type-param prefix so the own parameters are not repeated.
+		p.nameTypeParams(ft.TypeParams)
+		binders := append([]string{}, labels...)
+		binders = append(binders, p.typeParamBinders(ft.TypeParams)...)
+		binders = append(binders, ltLabels...)
+		return "fn <" + strings.Join(binders, ", ") + ">" + p.printFuncBody(ft)
 	}
+	prefix := "<" + strings.Join(append(labels, ltLabels...), ", ") + ">"
 	return prefix + " " + p.printType(t)
 }
 
@@ -596,7 +604,15 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 // syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	p.nameTypeParams(t.TypeParams)
-	tps := p.printTypeParams(t.TypeParams)
+	return p.printTypeParams(t.TypeParams) + p.printFuncBody(t)
+}
+
+// printFuncBody renders the "(receiver, params) -> ret" portion with NO quantifier
+// prefix, so a caller that emits its own combined prefix — PrintAsSchemeWith merging
+// scheme-bound variables with the function's own type parameters — does not render the
+// type parameters twice. The body may reference the type parameters, so a caller must
+// register their names with nameTypeParams first.
+func (p *namedPrinter) printFuncBody(t *FuncType) string {
 	ps := make([]string, 0, len(t.Params)+2)
 	if t.SelfParam != nil {
 		ps = append(ps, p.printSelfReceiver(t.SelfParam))
@@ -615,7 +631,7 @@ func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	if t.Inexact {
 		ps = append(ps, "...")
 	}
-	return tps + "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
+	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
 }
 
 // nameTypeParams registers each type parameter's binding variable under its source name
@@ -637,17 +653,15 @@ func (p *namedPrinter) nameTypeParams(tps []*TypeParam) {
 	}
 }
 
-// printTypeParams renders a function's own quantified type parameters as the prefix
-// `<U>`, `<U: T>` for a constraint, `<U = D>` for a default, or `<U: T = D>` for both,
-// joined by commas. An empty slice renders "", so a monomorphic function shows no
-// prefix. The constraint is the parameter variable's upper bound. A variable with
-// several upper bounds renders them joined by ` & `. nameTypeParams must run first so a
-// constraint or default that references another parameter renders under its name.
-func (p *namedPrinter) printTypeParams(tps []*TypeParam) string {
-	if len(tps) == 0 {
-		return ""
-	}
-	parts := make([]string, len(tps))
+// typeParamBinders renders each type parameter as a binder string — `U`, `U: T` for a
+// constraint, `U = D` for a default, or `U: T = D` for both — without the surrounding
+// `<>`. The constraint is the parameter variable's upper bound. A variable with several
+// upper bounds renders them joined by ` & `. nameTypeParams must run first so a binder
+// that references another parameter renders under its name. Callers that build a
+// combined quantifier prefix, such as PrintAsSchemeWith, join these with the scheme's
+// free variables and lifetimes into one list.
+func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
+	binders := make([]string, len(tps))
 	for i, tp := range tps {
 		s := p.printType(tp.Var) // the registered source name, else t{ID}
 		if bounds := tp.Var.UpperBounds; len(bounds) > 0 {
@@ -660,9 +674,20 @@ func (p *namedPrinter) printTypeParams(tps []*TypeParam) string {
 		if tp.Default != nil {
 			s += " = " + p.printType(tp.Default)
 		}
-		parts[i] = s
+		binders[i] = s
 	}
-	return "<" + strings.Join(parts, ", ") + ">"
+	return binders
+}
+
+// printTypeParams wraps a function's own type-parameter binders in a `<...>` prefix,
+// so a generic function renders `<U>`, `<U: T>`, `<U = D>`, or `<U: T = D>`. An empty
+// slice renders "", so a monomorphic function shows no prefix. nameTypeParams must run
+// first. See typeParamBinders for the per-parameter form.
+func (p *namedPrinter) printTypeParams(tps []*TypeParam) string {
+	if len(tps) == 0 {
+		return ""
+	}
+	return "<" + strings.Join(p.typeParamBinders(tps), ", ") + ">"
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -258,6 +258,22 @@ func freeTypeVars(t Type) []*TypeVarType {
 				out = append(out, t)
 			}
 		case *FuncType:
+			// A function's own type parameters are bound, not free, so mark their
+			// variables seen up front to exclude every use in the params, return,
+			// constraints, and defaults. Their constraints and defaults may still
+			// reference outer free variables, so walk those once the bound variables are
+			// seen.
+			for _, tp := range t.TypeParams {
+				seen.Add(tp.Var)
+			}
+			for _, tp := range t.TypeParams {
+				for _, b := range tp.Var.UpperBounds {
+					walk(b)
+				}
+				if tp.Default != nil {
+					walk(tp.Default)
+				}
+			}
 			if t.SelfParam != nil {
 				walk(t.SelfParam.Type)
 			}
@@ -579,6 +595,8 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 // entry (`fn (x: T, ...) -> R`) so the exactness it carries round-trips to surface
 // syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
+	p.nameTypeParams(t.TypeParams)
+	tps := p.printTypeParams(t.TypeParams)
 	ps := make([]string, 0, len(t.Params)+2)
 	if t.SelfParam != nil {
 		ps = append(ps, p.printSelfReceiver(t.SelfParam))
@@ -597,7 +615,54 @@ func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	if t.Inexact {
 		ps = append(ps, "...")
 	}
-	return "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
+	return tps + "(" + strings.Join(ps, ", ") + ") -> " + p.printType(t.Ret)
+}
+
+// nameTypeParams registers each type parameter's binding variable under its source name
+// in the printer's name map, so a use of the parameter inside the params, return,
+// constraints, or defaults renders as that name rather than the raw t{ID} debug form. It
+// allocates the map lazily, since plain Print starts with none. A parameter with no
+// source name is left unregistered and falls back to t{ID}.
+func (p *namedPrinter) nameTypeParams(tps []*TypeParam) {
+	if len(tps) == 0 {
+		return
+	}
+	if p.names == nil {
+		p.names = map[*TypeVarType]string{}
+	}
+	for _, tp := range tps {
+		if tp.Name != "" {
+			p.names[tp.Var] = tp.Name
+		}
+	}
+}
+
+// printTypeParams renders a function's own quantified type parameters as the prefix
+// `<U>`, `<U: T>` for a constraint, `<U = D>` for a default, or `<U: T = D>` for both,
+// joined by commas. An empty slice renders "", so a monomorphic function shows no
+// prefix. The constraint is the parameter variable's upper bound. A variable with
+// several upper bounds renders them joined by ` & `. nameTypeParams must run first so a
+// constraint or default that references another parameter renders under its name.
+func (p *namedPrinter) printTypeParams(tps []*TypeParam) string {
+	if len(tps) == 0 {
+		return ""
+	}
+	parts := make([]string, len(tps))
+	for i, tp := range tps {
+		s := p.printType(tp.Var) // the registered source name, else t{ID}
+		if bounds := tp.Var.UpperBounds; len(bounds) > 0 {
+			rendered := make([]string, len(bounds))
+			for j, b := range bounds {
+				rendered[j] = p.printType(b)
+			}
+			s += ": " + strings.Join(rendered, " & ")
+		}
+		if tp.Default != nil {
+			s += " = " + p.printType(tp.Default)
+		}
+		parts[i] = s
+	}
+	return "<" + strings.Join(parts, ", ") + ">"
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -577,6 +577,20 @@ func TestPrintScheme(t *testing.T) {
 		require.Equal(t, "fn <T0>(x: T0) -> T0", PrintAsScheme(ty))
 	})
 
+	t.Run("captured free var and own type param merge into one prefix", func(t *testing.T) {
+		u := &TypeVarType{ID: 10, Level: 2}    // the function's own type parameter
+		free := &TypeVarType{ID: 20, Level: 1} // a captured scheme variable
+		// fn <U>(x: U, y: free) -> [U, free]: the scheme names free as T0, the function
+		// contributes U, and the two merge into a single ordered `<T0, U>` prefix rather
+		// than the malformed `<T0><U>` two adjacent groups would produce.
+		ty := &FuncType{
+			TypeParams: []*TypeParam{{Name: "U", Var: u}},
+			Params:     []*FuncParam{identP("x", u), identP("y", free)},
+			Ret:        &TupleType{Elems: []Type{u, free}},
+		}
+		require.Equal(t, "fn <T0, U>(x: U, y: T0) -> [U, T0]", PrintAsScheme(ty))
+	})
+
 	t.Run("distinct vars are named by first appearance", func(t *testing.T) {
 		a := &TypeVarType{ID: 1, Level: 1}
 		b := &TypeVarType{ID: 2, Level: 1}

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -177,6 +177,125 @@ func TestPrintRoundTrips(t *testing.T) {
 	}
 }
 
+// A generic function renders its own quantified type parameters as a `<...>` prefix:
+// `<U>` bare, `<U: T>` for a constraint carried as the parameter variable's upper
+// bound, `<U = D>` for a default, and `<U: T = D>` for both. A use of the parameter in
+// the params or return renders under its source name rather than the raw t{ID} form.
+func TestPrintGenericFunc(t *testing.T) {
+	// tparam builds a type parameter and a fresh variable to stand for it, so each case
+	// constructs its own U without sharing state across the table.
+	tparam := func(name string, constraint, def Type) (*TypeParam, *TypeVarType) {
+		u := &TypeVarType{ID: 10, Level: 1}
+		if constraint != nil {
+			u.UpperBounds = []Type{constraint}
+		}
+		return &TypeParam{Name: name, Var: u, Default: def}, u
+	}
+	tests := []struct {
+		name string
+		in   func() Type
+		want string
+	}{
+		{
+			name: "bare type parameter",
+			in: func() Type {
+				tp, u := tparam("U", nil, nil)
+				return &FuncType{TypeParams: []*TypeParam{tp}, Params: []*FuncParam{identP("x", u)}, Ret: u}
+			},
+			want: "fn <U>(x: U) -> U",
+		},
+		{
+			name: "constrained type parameter",
+			in: func() Type {
+				tp, u := tparam("U", numP(), nil)
+				return &FuncType{TypeParams: []*TypeParam{tp}, Params: []*FuncParam{identP("x", u)}, Ret: u}
+			},
+			want: "fn <U: number>(x: U) -> U",
+		},
+		{
+			name: "defaulted type parameter",
+			in: func() Type {
+				tp, u := tparam("U", nil, strP())
+				return &FuncType{TypeParams: []*TypeParam{tp}, Params: []*FuncParam{identP("x", u)}, Ret: u}
+			},
+			want: "fn <U = string>(x: U) -> U",
+		},
+		{
+			name: "constrained and defaulted type parameter",
+			in: func() Type {
+				tp, u := tparam("U", numP(), strP())
+				return &FuncType{TypeParams: []*TypeParam{tp}, Params: []*FuncParam{identP("x", u)}, Ret: u}
+			},
+			want: "fn <U: number = string>(x: U) -> U",
+		},
+		{
+			// A generic higher-order signature: the parameter appears inside a nested
+			// function and the return, so its name must render at every use. A tuple
+			// stands in for Array<U>, which lands with ClassType in A1.
+			name: "map-shaped generic",
+			in: func() Type {
+				u := &TypeVarType{ID: 10, Level: 1}
+				return &FuncType{
+					TypeParams: []*TypeParam{{Name: "U", Var: u}},
+					Params:     []*FuncParam{identP("f", &FuncType{Params: []*FuncParam{identP("n", numP())}, Ret: u})},
+					Ret:        &TupleType{Elems: []Type{u}},
+				}
+			},
+			want: "fn <U>(f: fn (n: number) -> U) -> [U]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in()))
+		})
+	}
+}
+
+// A generic method renders its own type-parameter prefix through the shared method
+// element arm, so a `map<U>` member prints its `<U>` before the receiver and params.
+func TestPrintGenericMethod(t *testing.T) {
+	u := &TypeVarType{ID: 10, Level: 1}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&MethodElem{
+			Name: "map",
+			Signatures: []*FuncType{{
+				TypeParams: []*TypeParam{{Name: "U", Var: u}},
+				SelfParam:  &FuncParam{Pattern: &IdentPat{Name: "self"}, Type: &ClassType{Name: "Box"}},
+				Params:     []*FuncParam{identP("x", u)},
+				Ret:        u,
+			}},
+		},
+	}}
+	require.Equal(t, "{map<U>(self, x: U) -> U}", Print(obj))
+}
+
+// freeTypeVars excludes a function's own type parameters — they are bound, not free —
+// while still collecting an outer free variable, including one that appears only in a
+// parameter's constraint.
+func TestFreeTypeVarsBoundTypeParam(t *testing.T) {
+	t.Run("bound U is omitted, outer var kept", func(t *testing.T) {
+		u := &TypeVarType{ID: 10, Level: 1}
+		outer := &TypeVarType{ID: 20, Level: 1}
+		ft := &FuncType{
+			TypeParams: []*TypeParam{{Name: "U", Var: u}},
+			Params:     []*FuncParam{identP("x", u), identP("y", outer)},
+			Ret:        u,
+		}
+		require.Equal(t, []*TypeVarType{outer}, freeTypeVars(ft))
+	})
+
+	t.Run("an outer var reached only through a constraint is collected", func(t *testing.T) {
+		outer := &TypeVarType{ID: 20, Level: 1}
+		u := &TypeVarType{ID: 10, Level: 1, UpperBounds: []Type{outer}}
+		ft := &FuncType{
+			TypeParams: []*TypeParam{{Name: "U", Var: u}},
+			Params:     []*FuncParam{identP("x", u)},
+			Ret:        u,
+		}
+		require.Equal(t, []*TypeVarType{outer}, freeTypeVars(ft))
+	})
+}
+
 func TestIsIdent(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -203,6 +203,31 @@ type FuncType struct {
 	Params    []*FuncParam
 	Ret       Type
 	Inexact   bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
+	// TypeParams are the function's own quantified type parameters in declaration
+	// order. nil is monomorphic, the common case and the zero value. A generic
+	// method such as Array<T>.map<U> lists U here; a class-level parameter is captured
+	// from the enclosing class type rather than listed. LevelOf maxes over Params and
+	// Ret only. A TypeParam's Var is minted deeper than the function by
+	// construction, so folding it into the level would raise the function's level
+	// above its capture level.
+	TypeParams []*TypeParam
+}
+
+// TypeParam is one quantified type parameter, shared by FuncType.TypeParams for
+// function and method generics and by a class's own generics, so classes and functions
+// describe their generics the same way. Var is the quantified inference variable that
+// stands for the parameter. It is minted one level deeper than the enclosing binding
+// and freshened per use by freshenAbove, rather than a named parameter resolved by a
+// substitution pass. The declared constraint is Var's upper bound. `<U extends T>` sets
+// Var.UpperBounds to [T], so constrain and freshenAbove enforce and copy it with no new
+// machinery. Default is the type filled in when a type argument is omitted. It is nil
+// when the parameter is required. Type-argument resolution reads it, and constraint
+// solving ignores it. Name is the source name kept for display, since TypeVarType
+// carries none.
+type TypeParam struct {
+	Name    string
+	Var     *TypeVarType
+	Default Type // nil ⇒ required
 }
 
 // TupleType is a tuple type. Inexact follows the ObjectType/FuncType convention:

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -89,12 +89,13 @@ func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
+	tparams, tpChanged := acceptTypeParams(cur.TypeParams, v, pol)
 	self, selfChanged := acceptSelfParam(cur.SelfParam, v, pol) // receiver contravariant
 	params, changed := acceptParams(cur.Params, v, pol)         // params contravariant
-	ret := cur.Ret.Accept(v, pol)                              // return covariant
+	ret := cur.Ret.Accept(v, pol)                               // return covariant
 	out := cur
-	if selfChanged || changed || ret != cur.Ret {
-		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact}
+	if tpChanged || selfChanged || changed || ret != cur.Ret {
+		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact, TypeParams: tparams}
 	}
 	return v.ExitType(out, pol)
 }
@@ -280,6 +281,51 @@ func acceptParams(ps []*FuncParam, v TypeVisitor, pol Polarity) ([]*FuncParam, b
 		}
 	}
 	return out, changed
+}
+
+// acceptTypeParams rewrites each type parameter's binding variable and its default so a
+// rewriting visitor copies both. The main such visitor is freshenAbove. The binding
+// variable is visited as a Type and must stay a *TypeVarType. freshenAbove replaces it
+// with a fresh variable whose bounds it has already freshened, so the constraint carried
+// as the variable's upper bound rides along on the copy. The default is visited
+// covariantly and may reference the variable or an earlier parameter, which Accept
+// rewrites through the visitor's cache. Copy-on-write mirrors acceptParams. A changed
+// parameter gets a fresh *TypeParam and unchanged ones keep their pointer.
+func acceptTypeParams(tps []*TypeParam, v TypeVisitor, pol Polarity) ([]*TypeParam, bool) {
+	out := tps
+	changed := false
+	for i, tp := range tps {
+		nv := acceptTypeParamVar(tp.Var, v, pol)
+		def := tp.Default
+		if def != nil {
+			def = def.Accept(v, pol)
+		}
+		if nv != tp.Var || def != tp.Default {
+			if !changed {
+				out = append([]*TypeParam(nil), tps...)
+				changed = true
+			}
+			out[i] = &TypeParam{Name: tp.Name, Var: nv, Default: def}
+		}
+	}
+	return out, changed
+}
+
+// acceptTypeParamVar visits a type parameter's binding variable and requires the result
+// to stay a *TypeVarType, since the TypeParams slot can hold only a variable. freshenAbove
+// meets this contract: it rewrites a variable to a fresh variable. A visitor that instead
+// inlines a variable to a non-variable form, such as the display coalescer, must skip a
+// type parameter's binder before rewriting a generic function. Otherwise it trips this
+// guard, which fails loudly rather than desyncing the binder from its uses in the params
+// and return.
+func acceptTypeParamVar(tv *TypeVarType, v TypeVisitor, pol Polarity) *TypeVarType {
+	nt := tv.Accept(v, pol)
+	nv, ok := nt.(*TypeVarType)
+	if !ok {
+		panic(fmt.Sprintf("soltype.Accept: a FuncType type parameter rewrote to %T, "+
+			"not *TypeVarType; a bound parameter must stay a variable", nt))
+	}
+	return nv
 }
 
 // acceptObjElems walks each member, copy-on-write like acceptParams: a member

--- a/internal/soltype/visitor_test.go
+++ b/internal/soltype/visitor_test.go
@@ -284,6 +284,56 @@ func TestAcceptRefCopyOnWrite(t *testing.T) {
 	require.Same(t, str, gotInner.Elems[0].(*PropertyElem).Type, "the variable took the replacement")
 }
 
+// A no-op rewrite over a generic FuncType keeps its pointer, type parameters and all
+// (copy-on-write): the TypeParams slot allocates nothing when nothing under it changed.
+func TestAcceptGenericFuncIdentityPreservation(t *testing.T) {
+	u := &TypeVarType{ID: 10, Level: 1, UpperBounds: []Type{&PrimType{Prim: NumPrim}}}
+	fn := &FuncType{
+		TypeParams: []*TypeParam{{Name: "U", Var: u, Default: &PrimType{Prim: StrPrim}}},
+		Params:     []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: u}},
+		Ret:        u,
+	}
+	require.Same(t, fn, fn.Accept(identityVisitor{}, Positive), "an unchanged generic FuncType keeps its pointer")
+}
+
+// Rewriting a type parameter's binding variable rebuilds the FuncType, swaps the
+// variable in the TypeParams slot and its default, and keeps every use in the params
+// and return pointing at the replacement.
+func TestAcceptGenericFuncRewritesTypeParamVar(t *testing.T) {
+	u := &TypeVarType{ID: 10, Level: 1}
+	v := &TypeVarType{ID: 11, Level: 1}
+	fn := &FuncType{
+		TypeParams: []*TypeParam{{Name: "U", Var: u, Default: u}},
+		Params:     []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: u}},
+		Ret:        u,
+	}
+	got := fn.Accept(&replaceVar{target: u, repl: v}, Positive).(*FuncType)
+
+	require.NotSame(t, fn, got, "a changed type parameter forces a new FuncType")
+	require.Same(t, v, got.TypeParams[0].Var, "the type parameter's binding var took the replacement")
+	require.Same(t, v, got.TypeParams[0].Default, "the type parameter's default took the replacement")
+	require.Same(t, v, got.Params[0].Type, "the parameter use took the replacement")
+	require.Same(t, v, got.Ret, "the return use took the replacement")
+	require.Equal(t, "U", got.TypeParams[0].Name, "the source name is carried through")
+}
+
+// A type parameter that rewrites to a non-variable is a visitor contract violation:
+// acceptTypeParamVar panics with a clear message rather than a bare type-assertion
+// fault. A bound parameter must stay a variable through any rewrite.
+func TestAcceptTypeParamVarNonVarPanics(t *testing.T) {
+	u := &TypeVarType{ID: 10, Level: 1}
+	fn := &FuncType{
+		TypeParams: []*TypeParam{{Name: "U", Var: u}},
+		Params:     []*FuncParam{{Pattern: &IdentPat{Name: "x"}, Type: u}},
+		Ret:        u,
+	}
+	v := &replaceVar{target: u, repl: &PrimType{Prim: NumPrim}}
+	require.PanicsWithValue(t,
+		"soltype.Accept: a FuncType type parameter rewrote to *soltype.PrimType, "+
+			"not *TypeVarType; a bound parameter must stay a variable",
+		func() { fn.Accept(v, Positive) })
+}
+
 // HasLifetimeVar finds a LifetimeVar in a borrow's lifetime slot, nested at any
 // depth, and reports false for a borrow whose lifetime is a non-variable form.
 func TestHasLifetimeVar(t *testing.T) {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -643,7 +643,50 @@ func dedup(parts []soltype.Type) []soltype.Type {
 // with no bound between them distinct. alphaEqualTypes is the cross-scheme variant that
 // compares lifetimes up to renaming instead.
 func equalType(a, b soltype.Type) bool {
-	return equalTypeWith(a, b, nil)
+	return equalTypeWith(a, b, &alphaCtx{})
+}
+
+// alphaCtx carries the bijections equalTypeWith uses to compare two types up to a
+// consistent renaming of their bound variables. tvAToB and tvBToA pair the positional
+// type parameters of two generic FuncTypes, bound at each function boundary so a
+// parameter's identity is its position rather than its variable id. lt pairs borrow
+// lifetimes for alphaEqualTypes. A nil lt selects pointer-identity lifetime equality,
+// the within-coalesce default equalType uses. The type-parameter maps start nil and are
+// allocated on the first binding, so the monomorphic common case allocates nothing.
+type alphaCtx struct {
+	lt     *ltPairing
+	tvAToB map[int]int
+	tvBToA map[int]int
+}
+
+// bindTypeParams pairs two generic FuncTypes' type parameters positionally, so every
+// later occurrence of one side's parameter must match the other's bound partner. The
+// bindings persist for the rest of the walk. Type-variable ids are unique across the
+// comparison, so a parameter bound here is never confused with one from another
+// function.
+func (ctx *alphaCtx) bindTypeParams(as, bs []*soltype.TypeParam) {
+	if ctx.tvAToB == nil {
+		ctx.tvAToB = map[int]int{}
+		ctx.tvBToA = map[int]int{}
+	}
+	for i := range as {
+		ctx.tvAToB[as[i].Var.ID] = bs[i].Var.ID
+		ctx.tvBToA[bs[i].Var.ID] = as[i].Var.ID
+	}
+}
+
+// sameTypeVar reports whether two type variables are equal under the type-parameter
+// bijection. A variable bound as one side's parameter must map to the other's partner. A
+// variable bound on neither side is a shared or free variable and compares by pointer
+// identity, the rule the rest of equalType keys variables by.
+func (ctx *alphaCtx) sameTypeVar(a, b *soltype.TypeVarType) bool {
+	if j, ok := ctx.tvAToB[a.ID]; ok {
+		return j == b.ID
+	}
+	if _, ok := ctx.tvBToA[b.ID]; ok {
+		return false // b is a bound parameter, a is not — mismatch
+	}
+	return a == b
 }
 
 // ltPairing is the bijection alphaEqualTypes discovers between the lifetime variables of
@@ -652,9 +695,9 @@ func equalType(a, b soltype.Type) bool {
 // every later occurrence must respect that binding. aToB and bToA are the two directions
 // of the bijection, keyed by lifetime-variable ID. aVars and bVars list the bound
 // variables in binding order, so index i on each side names one paired lifetime.
-// sameOutlivesUnderPairing compares the outlives relation over those pairs. A nil
-// *ltPairing selects pointer-identity lifetime equality, the within-coalesce default
-// equalType uses.
+// sameOutlivesUnderPairing compares the outlives relation over those pairs. The pairing
+// sits on alphaCtx.lt. A nil lt selects pointer-identity lifetime equality, the
+// within-coalesce default equalType uses.
 type ltPairing struct {
 	aToB  map[int]int
 	bToA  map[int]int
@@ -682,15 +725,17 @@ func (p *ltPairing) pair(a, b *soltype.LifetimeVar) bool {
 	return true
 }
 
-// equalTypeWith is equalType parameterized by an optional lifetime pairing. With a nil
-// pairing it is exactly equalType, keying lifetimes by pointer identity. With a pairing
-// it keys a borrow's lifetime by first-appearance index, so alphaEqualTypes can compare
-// borrows across schemes whose lifetime variables have independent identities.
-func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
+// equalTypeWith is equalType threading an alphaCtx. Its lt pairing keys a borrow's
+// lifetime by first-appearance index when set, so alphaEqualTypes can compare borrows
+// across schemes whose lifetime variables have independent identities. With a nil lt it
+// keys lifetimes by pointer. Its type-parameter bijection compares two generic
+// FuncTypes up to alpha-renaming of their positional TypeParams, so a parameter's
+// identity is its position rather than its variable id.
+func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	switch a := a.(type) {
 	case *soltype.TypeVarType:
 		b, ok := b.(*soltype.TypeVarType)
-		return ok && a == b
+		return ok && ctx.sameTypeVar(a, b)
 	case *soltype.PrimType:
 		b, ok := b.(*soltype.PrimType)
 		return ok && a.Prim == b.Prim
@@ -714,21 +759,40 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		return ok
 	case *soltype.FuncType:
 		b, ok := b.(*soltype.FuncType)
-		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact {
+		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact || len(a.TypeParams) != len(b.TypeParams) {
 			return false
+		}
+		if len(a.TypeParams) > 0 {
+			// Bind the two functions' type parameters positionally, then compare each
+			// one's constraint (its variable's upper bounds) and default under that
+			// binding. Binding all of them first lets a later parameter's constraint or
+			// default reference an earlier one.
+			ctx.bindTypeParams(a.TypeParams, b.TypeParams)
+			for i := range a.TypeParams {
+				at, bt := a.TypeParams[i], b.TypeParams[i]
+				if !equalTypeSliceWith(at.Var.UpperBounds, bt.Var.UpperBounds, ctx) {
+					return false
+				}
+				if (at.Default == nil) != (bt.Default == nil) {
+					return false
+				}
+				if at.Default != nil && !equalTypeWith(at.Default, bt.Default, ctx) {
+					return false
+				}
+			}
 		}
 		// Receiver presence distinguishes an instance method from a static one, and the
 		// receiver type carries its mutability and borrow, so `(self) -> T`, `(mut self)
 		// -> T`, and `() -> T` are all distinct.
-		if !equalSelfParam(a.SelfParam, b.SelfParam, p) {
+		if !equalSelfParam(a.SelfParam, b.SelfParam, ctx) {
 			return false
 		}
 		for i := range a.Params {
-			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalTypeWith(a.Params[i].Type, b.Params[i].Type, p) {
+			if a.Params[i].Optional != b.Params[i].Optional || a.Params[i].Rest != b.Params[i].Rest || !equalTypeWith(a.Params[i].Type, b.Params[i].Type, ctx) {
 				return false
 			}
 		}
-		return equalTypeWith(a.Ret, b.Ret, p)
+		return equalTypeWith(a.Ret, b.Ret, ctx)
 	case *soltype.TupleType:
 		b, ok := b.(*soltype.TupleType)
 		// Inexact flags must be equal — an open tuple never equals a closed one,
@@ -737,7 +801,7 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 			return false
 		}
 		for i := range a.Elems {
-			if !equalTypeWith(a.Elems[i], b.Elems[i], p) {
+			if !equalTypeWith(a.Elems[i], b.Elems[i], ctx) {
 				return false
 			}
 		}
@@ -758,7 +822,7 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 			name := soltype.ObjElemName(ae)
 			found := false
 			for _, be := range b.Elems {
-				if soltype.ObjElemName(be) == name && equalObjElem(ae, be, p) {
+				if soltype.ObjElemName(be) == name && equalObjElem(ae, be, ctx) {
 					found = true
 					break
 				}
@@ -776,10 +840,10 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		if !ok || a.Name != b.Name || a.Final != b.Final {
 			return false
 		}
-		return equalTypeSliceWith(a.Args, b.Args, p)
+		return equalTypeSliceWith(a.Args, b.Args, ctx)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
-		return ok && equalTypeWith(a.Inner, b.Inner, p)
+		return ok && equalTypeWith(a.Inner, b.Inner, ctx)
 	case *soltype.RefType:
 		b, ok := b.(*soltype.RefType)
 		// Mut must match — a mutable borrow never equals an immutable one — and the
@@ -787,17 +851,17 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 		// in lifetime are NOT equal. Without the Lt check, dedup would collapse them and
 		// silently drop a lifetime the solver computed. ltEqualWith compares a LifetimeVar
 		// by pointer under a nil pairing and by first-appearance index under one.
-		return ok && a.Mut == b.Mut && ltEqualWith(a.Lt, b.Lt, p) && equalTypeWith(a.Inner, b.Inner, p)
+		return ok && a.Mut == b.Mut && ltEqualWith(a.Lt, b.Lt, ctx.lt) && equalTypeWith(a.Inner, b.Inner, ctx)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
 		// one. newUnion imposes canonical member order at construction, so the
 		// positional equalTypeSliceWith is order-stable and two unions over the
 		// same member set compare equal whatever order their members were minted in.
-		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, p)
+		return ok && a.Inexact == b.Inexact && equalTypeSliceWith(a.Types, b.Types, ctx)
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
-		return ok && equalTypeSliceWith(a.Types, b.Types, p)
+		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)
 	}
 	return false
 }
@@ -813,28 +877,28 @@ func equalTypeWith(a, b soltype.Type, p *ltPairing) bool {
 //   - a setter compares its parameter type.
 //
 // It panics on an unknown element kind, matching AsProperty.
-func equalObjElem(a, b soltype.ObjTypeElem, p *ltPairing) bool {
+func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	switch a := a.(type) {
 	case *soltype.PropertyElem:
 		b, ok := b.(*soltype.PropertyElem)
-		return ok && a.Optional == b.Optional && a.Readonly == b.Readonly && equalTypeWith(a.Type, b.Type, p)
+		return ok && a.Optional == b.Optional && a.Readonly == b.Readonly && equalTypeWith(a.Type, b.Type, ctx)
 	case *soltype.MethodElem:
 		b, ok := b.(*soltype.MethodElem)
 		if !ok || a.Static != b.Static || len(a.Signatures) != len(b.Signatures) {
 			return false
 		}
 		for i := range a.Signatures {
-			if !equalTypeWith(a.Signatures[i], b.Signatures[i], p) {
+			if !equalTypeWith(a.Signatures[i], b.Signatures[i], ctx) {
 				return false
 			}
 		}
 		return true
 	case *soltype.GetterElem:
 		b, ok := b.(*soltype.GetterElem)
-		return ok && equalSelfParam(a.SelfParam, b.SelfParam, p) && equalTypeWith(a.Type, b.Type, p)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Type, b.Type, ctx)
 	case *soltype.SetterElem:
 		b, ok := b.(*soltype.SetterElem)
-		return ok && equalSelfParam(a.SelfParam, b.SelfParam, p) && equalTypeWith(a.Param, b.Param, p)
+		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Param, b.Param, ctx)
 	}
 	panic(fmt.Sprintf("equalObjElem: unhandled ObjTypeElem %T", a))
 }
@@ -842,14 +906,14 @@ func equalObjElem(a, b soltype.ObjTypeElem, p *ltPairing) bool {
 // equalSelfParam reports whether two receivers match. Presence must agree, so an
 // instance member never equals a static one, and when both are present their receiver
 // types must be equal. It is shared by the method, getter, and setter comparisons.
-func equalSelfParam(a, b *soltype.FuncParam, p *ltPairing) bool {
+func equalSelfParam(a, b *soltype.FuncParam, ctx *alphaCtx) bool {
 	if (a == nil) != (b == nil) {
 		return false
 	}
 	if a == nil {
 		return true
 	}
-	return equalTypeWith(a.Type, b.Type, p)
+	return equalTypeWith(a.Type, b.Type, ctx)
 }
 
 // ltEqualWith reports lifetime equality for equalTypeWith's RefType arm. Under a nil
@@ -898,12 +962,12 @@ func ltEqual(a, b soltype.Lifetime) bool {
 	return a == b
 }
 
-func equalTypeSliceWith(a, b []soltype.Type, p *ltPairing) bool {
+func equalTypeSliceWith(a, b []soltype.Type, ctx *alphaCtx) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !equalTypeWith(a[i], b[i], p) {
+		if !equalTypeWith(a[i], b[i], ctx) {
 			return false
 		}
 	}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -508,9 +508,11 @@ func TestEqualTypeGenericFunc(t *testing.T) {
 			want: false,
 		},
 		{
+			// Params match, so this reaches the TypeParams-length check rather than
+			// short-circuiting on the earlier Params-length comparison.
 			name: "type parameter arity differs",
 			a:    identityFn(10, nil, nil),
-			b:    &soltype.FuncType{Ret: num()}, // no type parameters
+			b:    &soltype.FuncType{Params: []*soltype.FuncParam{ident("x", num())}, Ret: num()},
 			want: false,
 		},
 		{

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -429,6 +429,113 @@ func TestEqualTypeClass(t *testing.T) {
 	}
 }
 
+// equalType compares two generic FuncTypes up to alpha-renaming of their positional
+// type parameters: a parameter's identity is its position, not its variable id, so two
+// signatures differing only in variable id compare equal, while a constraint, default,
+// arity, or positional-use difference makes them unequal. A free variable is still keyed
+// by pointer, so a bound parameter does not leak into the free-variable comparison.
+func TestEqualTypeGenericFunc(t *testing.T) {
+	// tv builds a fresh type variable at a quantifiable level.
+	tv := func(id int) *soltype.TypeVarType { return &soltype.TypeVarType{ID: id, Level: 1} }
+	// ident wraps a type as a named parameter.
+	ident := func(name string, ty soltype.Type) *soltype.FuncParam {
+		return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: name}, Type: ty}
+	}
+	// identityFn is `fn <U>(x: U) -> U` with U carrying the given id, constraint, and
+	// default, so the table can vary one facet at a time.
+	identityFn := func(id int, constraint, def soltype.Type) *soltype.FuncType {
+		u := tv(id)
+		if constraint != nil {
+			u.UpperBounds = []soltype.Type{constraint}
+		}
+		return &soltype.FuncType{
+			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u, Default: def}},
+			Params:     []*soltype.FuncParam{ident("x", u)},
+			Ret:        u,
+		}
+	}
+	// freeFn builds `fn <U>(x: U, y: free) -> U`, threading one U pointer through so
+	// each side reuses its parameter variable the way real solver output does. The free
+	// variable is passed in, so two sides can share it or differ.
+	freeFn := func(u, free *soltype.TypeVarType) *soltype.FuncType {
+		return &soltype.FuncType{
+			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u}},
+			Params:     []*soltype.FuncParam{ident("x", u), ident("y", free)},
+			Ret:        u,
+		}
+	}
+	sharedFree := tv(99)
+
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "differ only in parameter var id",
+			a:    identityFn(10, nil, nil),
+			b:    identityFn(20, nil, nil),
+			want: true,
+		},
+		{
+			name: "same constraint, different var id",
+			a:    identityFn(10, num(), nil),
+			b:    identityFn(20, num(), nil),
+			want: true,
+		},
+		{
+			name: "constraint differs",
+			a:    identityFn(10, num(), nil),
+			b:    identityFn(20, str(), nil),
+			want: false,
+		},
+		{
+			name: "one constrained, one not",
+			a:    identityFn(10, num(), nil),
+			b:    identityFn(20, nil, nil),
+			want: false,
+		},
+		{
+			name: "default differs",
+			a:    identityFn(10, nil, num()),
+			b:    identityFn(20, nil, str()),
+			want: false,
+		},
+		{
+			name: "one defaulted, one not",
+			a:    identityFn(10, nil, num()),
+			b:    identityFn(20, nil, nil),
+			want: false,
+		},
+		{
+			name: "type parameter arity differs",
+			a:    identityFn(10, nil, nil),
+			b:    &soltype.FuncType{Ret: num()}, // no type parameters
+			want: false,
+		},
+		{
+			// The same free-var pointer beside an alpha-renamed parameter still matches.
+			name: "same free var pointer matches",
+			a:    freeFn(tv(10), sharedFree),
+			b:    freeFn(tv(20), sharedFree),
+			want: true,
+		},
+		{
+			// A bound parameter does not leak into the free-var comparison: two distinct
+			// free-var pointers stay unequal even though the parameters alpha-match.
+			name: "different free var pointers do not match",
+			a:    freeFn(tv(10), tv(98)),
+			b:    freeFn(tv(20), tv(97)),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
 // equalType distinguishes methods by their receiver: presence marks an instance
 // versus a static method, and the receiver type carries mutability, so (self),
 // (mut self), and () are all distinct.
@@ -581,6 +688,35 @@ func TestEqualTypeObjectMembers(t *testing.T) {
 			require.Equal(t, tt.want, equalType(tt.a, tt.b))
 		})
 	}
+}
+
+// A parameter's identity is its position: two two-parameter signatures that use their
+// parameters in swapped positions are unequal even though each is well-formed.
+func TestEqualTypeGenericFuncPositional(t *testing.T) {
+	// mk builds `fn <U, V>(x: U, y: V) -> [retFirst, retSecond]`, choosing which
+	// parameter each return element uses, so a swap changes only the body's positions.
+	mk := func(idU, idV int, retFirst, retSecond int) *soltype.FuncType {
+		u := &soltype.TypeVarType{ID: idU, Level: 1}
+		v := &soltype.TypeVarType{ID: idV, Level: 1}
+		pick := func(id int) *soltype.TypeVarType {
+			if id == idU {
+				return u
+			}
+			return v
+		}
+		return &soltype.FuncType{
+			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u}, {Name: "V", Var: v}},
+			Params: []*soltype.FuncParam{
+				{Pattern: &soltype.IdentPat{Name: "x"}, Type: u},
+				{Pattern: &soltype.IdentPat{Name: "y"}, Type: v},
+			},
+			Ret: &soltype.TupleType{Elems: []soltype.Type{pick(retFirst), pick(retSecond)}},
+		}
+	}
+	// Both return [first param, second param]: alpha-equal despite distinct var ids.
+	require.True(t, equalType(mk(10, 11, 10, 11), mk(20, 21, 20, 21)))
+	// The second swaps the return to [second param, first param]: positions differ.
+	require.False(t, equalType(mk(10, 11, 10, 11), mk(20, 21, 21, 20)))
 }
 
 // equalType on ObjectType must discriminate on the Inexact flag and on each

--- a/internal/solver/lifetime_bounds.go
+++ b/internal/solver/lifetime_bounds.go
@@ -385,14 +385,14 @@ func (s *ltBoundSet) subsumes(other *ltBoundSet) bool {
 // borrow's lifetime is erased at codegen, which dispatches on parameter shape, so two arms
 // whose parameters are alpha-equal are indistinguishable however their lifetimes relate.
 func alphaEqualTypes(a, b soltype.Type) bool {
-	p := &ltPairing{aToB: map[int]int{}, bToA: map[int]int{}}
-	if !equalTypeWith(a, b, p) {
+	lt := &ltPairing{aToB: map[int]int{}, bToA: map[int]int{}}
+	if !equalTypeWith(a, b, &alphaCtx{lt: lt}) {
 		return false
 	}
-	if len(p.aVars) == 0 {
+	if len(lt.aVars) == 0 {
 		return true // no borrows: equalTypeWith settled it structurally
 	}
-	return sameOutlivesUnderPairing(p)
+	return sameOutlivesUnderPairing(lt)
 }
 
 // sameOutlivesUnderPairing reports whether the two sides' paired lifetimes carry the same

--- a/internal/solver/poly_test.go
+++ b/internal/solver/poly_test.go
@@ -76,6 +76,31 @@ func TestFreshenAboveFreshensBoundsAndHandlesCycles(t *testing.T) {
 	})
 }
 
+// freshenAbove copies a generic FuncType's own type parameter: the parameter's binding
+// variable is replaced by a fresh variable, its constraint is copied onto that fresh
+// variable, and every use across the params and return shares the one fresh variable, so
+// each instantiation of the generic gets its own U. This is the per-method
+// generalization the FuncType.TypeParams field exists to carry.
+func TestFreshenAboveGenericFunc(t *testing.T) {
+	c := newChecker()
+	u := c.freshAt(2) // deeper than the limit 1, so it is a quantified parameter
+	u.UpperBounds = []soltype.Type{&soltype.PrimType{Prim: soltype.NumPrim}}
+	fn := &soltype.FuncType{
+		TypeParams: []*soltype.TypeParam{{Name: "U", Var: u}},
+		Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: u}},
+		Ret:        u,
+	}
+
+	got := c.freshenAbove(1, fn, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{}).(*soltype.FuncType)
+
+	fresh := got.TypeParams[0].Var
+	require.NotSame(t, u, fresh, "the type parameter var is freshened")
+	require.Same(t, fresh, got.Params[0].Type, "the param use shares the fresh var")
+	require.Same(t, fresh, got.Ret, "the return use shares the fresh var")
+	require.Len(t, fresh.UpperBounds, 1)
+	require.Equal(t, &soltype.PrimType{Prim: soltype.NumPrim}, fresh.UpperBounds[0], "the constraint is copied onto the fresh var")
+}
+
 // instantiate records a FromInstantiation provenance edge for each freshened
 // variable, pointing back at the variable it was copied from — the first interior
 // Origin (M3, PR1). A MonoScheme instantiation records nothing (it freshens no


### PR DESCRIPTION
Add support for generic functions with quantified type parameters, constraints, and defaults. This enables function signatures like `fn <U>(x: U) -> U` and `fn <U: number>(x: U) -> U = string`.

**Key changes:**

- Add `TypeParam` struct to represent quantified type parameters with a binding variable, optional constraint (upper bounds), and optional default type.
- Extend `FuncType` with a `TypeParams` field to hold the function's own generic parameters in declaration order.
- Update type equality checking (`equalType`) to compare generic functions up to alpha-renaming of their positional type parameters. A parameter's identity is its position, not its variable ID, so two signatures differing only in variable ID compare equal. Constraints, defaults, arity, and positional uses must match exactly.
- Implement `alphaCtx` to thread type-parameter bijections through equality checking, pairing parameters positionally and validating that bound parameters map consistently while free variables compare by pointer identity.
- Update the type visitor to handle type parameters: `acceptTypeParams` rewrites binding variables and defaults through the visitor, and `acceptTypeParamVar` enforces that a bound parameter stays a `TypeVarType` after rewriting.
- Add printing support: `nameTypeParams` registers each parameter's source name in the printer, and `printTypeParams` renders the `<...>` prefix with constraints and defaults.
- Update `freeTypeVars` to exclude a function's own type parameters (they are bound, not free) while still collecting outer free variables reachable through constraints and defaults.
- Add comprehensive tests covering parameter identity by position, constraint and default matching, arity differences, free-variable pointer identity, and positional use differences.

**Implementation details:**

Type parameters are minted one level deeper than the enclosing function by construction, so they don't affect the function's level calculation. The constraint is stored as the parameter variable's upper bounds, reusing existing constraint machinery. Freshening a generic function copies its type parameters, replacing each binding variable with a fresh variable and copying its constraint onto that fresh variable, so each instantiation gets its own parameter variable.

https://claude.ai/code/session_01SjgBxUZ8Vdo2TZTH456CSf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generic function type parameters in type printing, including constraints and default types.
  * Improved type comparison to recognize equivalent generic functions even when type parameter names differ.

* **Bug Fixes**
  * Fixed handling of function-scoped type parameters so they are treated correctly during type analysis and rewriting.
  * Improved freshness and substitution behavior for generic function types to keep parameter references consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->