### PR TITLE
Add lifetime parameters to functions and classes

### DIFF
--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -86,7 +86,7 @@ func TestAcceptFuncSelfParamCopyOnWrite(t *testing.T) {
 	str := &PrimType{Prim: StrPrim}
 	a := &TypeVarType{ID: 1}
 	fn := &FuncType{
-		SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}),
+		SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{a}}),
 		Params:    []*FuncParam{identP("x", numP())},
 		Ret:       numP(),
 	}
@@ -94,7 +94,7 @@ func TestAcceptFuncSelfParamCopyOnWrite(t *testing.T) {
 	got := fn.Accept(&replaceVar{target: a, repl: str}, Positive).(*FuncType)
 
 	require.NotSame(t, fn, got, "a changed receiver forces a new FuncType")
-	require.Same(t, str, got.SelfParam.Type.(*ClassType).Args[0], "the receiver argument took the replacement")
+	require.Same(t, str, got.SelfParam.Type.(*ClassType).TypeArgs[0], "the receiver argument took the replacement")
 	require.Same(t, fn.Params[0], got.Params[0], "an unchanged param keeps its pointer")
 }
 
@@ -113,7 +113,7 @@ func TestAcceptFuncSelfParamContravariant(t *testing.T) {
 // LevelOf includes a method's self receiver, so a receiver-only variable lifts the
 // method's level.
 func TestLevelOfSelfParam(t *testing.T) {
-	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{&TypeVarType{ID: 1, Level: 6}}}), Ret: numP()}
+	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{&TypeVarType{ID: 1, Level: 6}}}), Ret: numP()}
 	require.Equal(t, 6, LevelOf(fn))
 }
 
@@ -121,7 +121,7 @@ func TestLevelOfSelfParam(t *testing.T) {
 // receiver type is named as a quantified parameter.
 func TestFreeTypeVarsSelfParam(t *testing.T) {
 	a := &TypeVarType{ID: 1, Level: 1}
-	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Ret: a}
+	fn := &FuncType{SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{a}}), Ret: a}
 	require.Equal(t, "fn <T0>(self) -> T0", PrintAsScheme(fn))
 }
 
@@ -183,20 +183,20 @@ func TestAcceptGetterSetterReceiverContravariant(t *testing.T) {
 func TestAcceptSetterSelfParamCopyOnWrite(t *testing.T) {
 	str := &PrimType{Prim: StrPrim}
 	a := &TypeVarType{ID: 1}
-	setter := &SetterElem{Name: "s", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Param: numP()}
+	setter := &SetterElem{Name: "s", SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{a}}), Param: numP()}
 	obj := &ObjectType{Elems: []ObjTypeElem{setter}}
 
 	got := obj.Accept(&replaceVar{target: a, repl: str}, Positive).(*ObjectType)
 
 	gotSetter := got.Elems[0].(*SetterElem)
 	require.NotSame(t, setter, gotSetter, "a changed receiver forces a new setter")
-	require.Same(t, str, gotSetter.SelfParam.Type.(*ClassType).Args[0], "the receiver argument took the replacement")
+	require.Same(t, str, gotSetter.SelfParam.Type.(*ClassType).TypeArgs[0], "the receiver argument took the replacement")
 }
 
 // LevelOf descends an instance getter's receiver.
 func TestLevelOfGetterReceiver(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{&TypeVarType{ID: 1, Level: 8}}}), Type: numP()},
+		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{&TypeVarType{ID: 1, Level: 8}}}), Type: numP()},
 	}}
 	require.Equal(t, 8, LevelOf(obj))
 }
@@ -206,7 +206,7 @@ func TestLevelOfGetterReceiver(t *testing.T) {
 func TestFreeTypeVarsGetterReceiver(t *testing.T) {
 	a := &TypeVarType{ID: 1, Level: 1}
 	obj := &ObjectType{Elems: []ObjTypeElem{
-		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", Args: []Type{a}}), Type: numP()},
+		&GetterElem{Name: "g", SelfParam: selfRecv(&ClassType{Name: "Box", TypeArgs: []Type{a}}), Type: numP()},
 	}}
 	require.Equal(t, "<T0> {get g(self) -> number}", PrintAsScheme(obj))
 }
@@ -222,10 +222,10 @@ func TestPrintClassType(t *testing.T) {
 		want string
 	}{
 		{"monomorphic instance", &ClassType{Name: "Point"}, "Point"},
-		{"generic instance", &ClassType{Name: "Box", Args: []Type{numP()}}, "Box<number>"},
+		{"generic instance", &ClassType{Name: "Box", TypeArgs: []Type{numP()}}, "Box<number>"},
 		{
 			"two type arguments",
-			&ClassType{Name: "Map", Args: []Type{strP(), numP()}},
+			&ClassType{Name: "Map", TypeArgs: []Type{strP(), numP()}},
 			"Map<string, number>",
 		},
 		{
@@ -253,7 +253,7 @@ func TestPrintClassType(t *testing.T) {
 		},
 		{
 			"owned-mutable instance renders bare mut",
-			&RefType{Mut: true, Inner: &ClassType{Name: "Box", Args: []Type{numP()}}},
+			&RefType{Mut: true, Inner: &ClassType{Name: "Box", TypeArgs: []Type{numP()}}},
 			"mut Box<number>",
 		},
 	}
@@ -319,7 +319,7 @@ func TestPrintObjectMembers(t *testing.T) {
 
 // A no-op rewrite over a ClassType allocates nothing and keeps its pointer.
 func TestAcceptClassIdentityPreservation(t *testing.T) {
-	cls := &ClassType{Name: "Box", Args: []Type{numP()}, Final: true}
+	cls := &ClassType{Name: "Box", TypeArgs: []Type{numP()}, Final: true}
 	require.Same(t, cls, cls.Accept(identityVisitor{}, Positive), "an unchanged ClassType keeps its pointer")
 }
 
@@ -329,7 +329,7 @@ func TestAcceptClassCopyOnWrite(t *testing.T) {
 	str := &PrimType{Prim: StrPrim}
 	a := &TypeVarType{ID: 1}
 	lt := &StaticLifetime{}
-	cls := &ClassType{Name: "Box", Args: []Type{a}, Lt: lt, Final: true}
+	cls := &ClassType{Name: "Box", TypeArgs: []Type{a}, Lt: lt, Final: true}
 
 	got := cls.Accept(&replaceVar{target: a, repl: str}, Positive).(*ClassType)
 
@@ -337,14 +337,14 @@ func TestAcceptClassCopyOnWrite(t *testing.T) {
 	require.Equal(t, "Box", got.Name, "the name carries through")
 	require.True(t, got.Final, "the Final flag carries through")
 	require.Same(t, lt, got.Lt, "the lifetime carries through unchanged")
-	require.Same(t, str, got.Args[0], "the changed argument took the replacement")
+	require.Same(t, str, got.TypeArgs[0], "the changed argument took the replacement")
 }
 
 // Type arguments are covariant: a ClassType's argument is visited in the same
 // polarity the ClassType is.
 func TestAcceptClassArgsCovariant(t *testing.T) {
 	a := &TypeVarType{ID: 1}
-	cls := &ClassType{Name: "Box", Args: []Type{a}}
+	cls := &ClassType{Name: "Box", TypeArgs: []Type{a}}
 
 	r := &recorder{seen: map[Type]Polarity{}}
 	cls.Accept(r, Negative)
@@ -410,7 +410,7 @@ func TestAcceptObjectSetterCopyOnWrite(t *testing.T) {
 // Final identity carry no variables.
 func TestLevelOfClassType(t *testing.T) {
 	require.Equal(t, 0, LevelOf(&ClassType{Name: "Point"}), "no arguments ⇒ level 0")
-	cls := &ClassType{Name: "Box", Args: []Type{
+	cls := &ClassType{Name: "Box", TypeArgs: []Type{
 		&TypeVarType{ID: 1, Level: 2},
 		&TypeVarType{ID: 2, Level: 5},
 	}}
@@ -436,7 +436,7 @@ func TestLevelOfObjectMembers(t *testing.T) {
 func TestFreeTypeVarsClassType(t *testing.T) {
 	a := &TypeVarType{ID: 1, Level: 1}
 	b := &TypeVarType{ID: 2, Level: 1}
-	cls := &ClassType{Name: "Map", Args: []Type{a, b}}
+	cls := &ClassType{Name: "Map", TypeArgs: []Type{a, b}}
 	require.Equal(t, "Map<T0, T1>", PrintAsScheme(cls))
 }
 

--- a/internal/soltype/lifetime_param_test.go
+++ b/internal/soltype/lifetime_param_test.go
@@ -63,7 +63,7 @@ func TestPrintFuncLifetimeParam(t *testing.T) {
 // names the free lifetime argument 'a.
 func TestPrintClassLifetimeArgs(t *testing.T) {
 	lx := &LifetimeVar{ID: 0, Level: 1}
-	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{numP()}}
+	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, TypeArgs: []Type{numP()}}
 	require.Equal(t, "Ref<'a, number>", PrintAsScheme(ref))
 }
 
@@ -79,7 +79,7 @@ func TestPrintFuncLifetimeParamNoNameCollision(t *testing.T) {
 	fn := &FuncType{
 		LifetimeParams: []*LifetimeParam{{Name: "'a", Var: own}},
 		SelfParam:      selfRecv(&RefType{Lt: own, Inner: counterCls()}),
-		Ret:            &ClassType{Name: "Box", LifetimeArgs: []Lifetime{free}, Args: []Type{numP()}},
+		Ret:            &ClassType{Name: "Box", LifetimeArgs: []Lifetime{free}, TypeArgs: []Type{numP()}},
 	}
 	require.Equal(t, "fn <'a, 'b>(&'a self) -> Box<'b, number>", PrintAsScheme(fn))
 }
@@ -102,13 +102,13 @@ func TestAcceptClassLifetimeArgsCopyOnWrite(t *testing.T) {
 	str := &PrimType{Prim: StrPrim}
 	a := &TypeVarType{ID: 1}
 	lx := &LifetimeVar{ID: 0, Level: 1}
-	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{a}}
+	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, TypeArgs: []Type{a}}
 
 	got := ref.Accept(&replaceVar{target: a, repl: str}, Positive).(*ClassType)
 
 	require.NotSame(t, ref, got, "a changed type argument forces a new ClassType")
 	require.Same(t, lx, got.LifetimeArgs[0], "the lifetime argument carries through unchanged")
-	require.Same(t, str, got.Args[0], "the type argument took the replacement")
+	require.Same(t, str, got.TypeArgs[0], "the type argument took the replacement")
 }
 
 // freeLifetimeVars excludes a function's own lifetime parameter — it is bound, not free —
@@ -126,7 +126,7 @@ func TestFreeLifetimeVarsBoundLifetimeParam(t *testing.T) {
 
 	t.Run("a class reference's lifetime argument is collected", func(t *testing.T) {
 		lx := &LifetimeVar{ID: 0, Level: 1}
-		ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{numP()}}
+		ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, TypeArgs: []Type{numP()}}
 		require.Equal(t, []*LifetimeVar{lx}, freeLifetimeVars(ref))
 	})
 
@@ -148,7 +148,7 @@ func TestLevelOfClassLifetimeArgs(t *testing.T) {
 	ref := &ClassType{
 		Name:         "Ref",
 		LifetimeArgs: []Lifetime{&LifetimeVar{ID: 0, Level: 7}},
-		Args:         []Type{&TypeVarType{ID: 1, Level: 3}},
+		TypeArgs:     []Type{&TypeVarType{ID: 1, Level: 3}},
 	}
 	require.Equal(t, 7, LevelOf(ref), "the level is the max over the lifetime and type arguments")
 }

--- a/internal/soltype/lifetime_param_test.go
+++ b/internal/soltype/lifetime_param_test.go
@@ -1,0 +1,154 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// counterCls builds a fresh monomorphic Counter instance for the tests.
+func counterCls() *ClassType { return &ClassType{Name: "Counter"} }
+
+// A function's own lifetime parameter renders as a `<'a>` binder before the receiver
+// and params, and every `&'a` use inside renders under that name. A borrowing method
+// `fn get<'a>(&'a self) -> &'a Counter` names 'a once and reuses it in the receiver and
+// the return.
+func TestPrintFuncLifetimeParam(t *testing.T) {
+	tests := []struct {
+		name string
+		in   func() Type
+		want string
+	}{
+		{
+			name: "borrowing method",
+			in: func() Type {
+				la := &LifetimeVar{ID: 0, Level: 1}
+				return &FuncType{
+					LifetimeParams: []*LifetimeParam{{Name: "'a", Var: la}},
+					SelfParam:      selfRecv(&RefType{Lt: la, Inner: counterCls()}),
+					Ret:            &RefType{Lt: la, Inner: counterCls()},
+				}
+			},
+			want: "fn <'a>(&'a self) -> &'a Counter",
+		},
+		{
+			name: "outlives bound",
+			in: func() Type {
+				la := &LifetimeVar{ID: 0, Level: 1}
+				lb := &LifetimeVar{ID: 1, Level: 1}
+				return &FuncType{
+					LifetimeParams: []*LifetimeParam{
+						{Name: "'a", Var: la},
+						{Name: "'b", Var: lb, Bounds: []Lifetime{la}},
+					},
+					Params: []*FuncParam{
+						identP("x", &RefType{Lt: la, Inner: counterCls()}),
+						identP("y", &RefType{Lt: lb, Inner: counterCls()}),
+					},
+					Ret: &Void{},
+				}
+			},
+			want: "fn <'a, 'b: 'a>(x: &'a Counter, y: &'b Counter) -> void",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, Print(tt.in()))
+		})
+	}
+}
+
+// A class reference supplies both sorts of arguments: the lifetime argument 'x renders
+// before the type argument, so `Ref<'x, number>` shows its lifetime first. PrintAsScheme
+// names the free lifetime argument 'a.
+func TestPrintClassLifetimeArgs(t *testing.T) {
+	lx := &LifetimeVar{ID: 0, Level: 1}
+	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{numP()}}
+	require.Equal(t, "Ref<'a, number>", PrintAsScheme(ref))
+}
+
+// When a function captures a free scheme lifetime and also declares its own lifetime
+// parameter, the generated name for the captured lifetime skips the parameter's source
+// name, so the two render distinctly rather than both as 'a. Here the method declares 'a
+// and captures a free lifetime carried by a Box<'x, T> return. The own parameter renders
+// first under its source name 'a, and the captured lifetime skips 'a to take 'b, so the
+// prefix reads `<'a, 'b>` with no collision.
+func TestPrintFuncLifetimeParamNoNameCollision(t *testing.T) {
+	own := &LifetimeVar{ID: 0, Level: 1}
+	free := &LifetimeVar{ID: 1, Level: 1}
+	fn := &FuncType{
+		LifetimeParams: []*LifetimeParam{{Name: "'a", Var: own}},
+		SelfParam:      selfRecv(&RefType{Lt: own, Inner: counterCls()}),
+		Ret:            &ClassType{Name: "Box", LifetimeArgs: []Lifetime{free}, Args: []Type{numP()}},
+	}
+	require.Equal(t, "fn <'a, 'b>(&'a self) -> Box<'b, number>", PrintAsScheme(fn))
+}
+
+// A no-op rewrite over a FuncType carrying its own lifetime parameter keeps its pointer,
+// since Accept never allocates when nothing changed.
+func TestAcceptFuncLifetimeParamIdentity(t *testing.T) {
+	la := &LifetimeVar{ID: 0, Level: 1}
+	fn := &FuncType{
+		LifetimeParams: []*LifetimeParam{{Name: "'a", Var: la}},
+		SelfParam:      selfRecv(&RefType{Lt: la, Inner: counterCls()}),
+		Ret:            &RefType{Lt: la, Inner: counterCls()},
+	}
+	require.Same(t, fn, fn.Accept(identityVisitor{}, Positive), "an unchanged FuncType keeps its pointer")
+}
+
+// Rewriting a type argument inside a class reference rebuilds the ClassType, carries the
+// lifetime argument through unchanged, and replaces the type argument.
+func TestAcceptClassLifetimeArgsCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	lx := &LifetimeVar{ID: 0, Level: 1}
+	ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{a}}
+
+	got := ref.Accept(&replaceVar{target: a, repl: str}, Positive).(*ClassType)
+
+	require.NotSame(t, ref, got, "a changed type argument forces a new ClassType")
+	require.Same(t, lx, got.LifetimeArgs[0], "the lifetime argument carries through unchanged")
+	require.Same(t, str, got.Args[0], "the type argument took the replacement")
+}
+
+// freeLifetimeVars excludes a function's own lifetime parameter — it is bound, not free —
+// while still collecting a class reference's lifetime argument.
+func TestFreeLifetimeVarsBoundLifetimeParam(t *testing.T) {
+	t.Run("bound 'a is omitted", func(t *testing.T) {
+		la := &LifetimeVar{ID: 0, Level: 1}
+		fn := &FuncType{
+			LifetimeParams: []*LifetimeParam{{Name: "'a", Var: la}},
+			SelfParam:      selfRecv(&RefType{Lt: la, Inner: counterCls()}),
+			Ret:            &RefType{Lt: la, Inner: counterCls()},
+		}
+		require.Empty(t, freeLifetimeVars(fn))
+	})
+
+	t.Run("a class reference's lifetime argument is collected", func(t *testing.T) {
+		lx := &LifetimeVar{ID: 0, Level: 1}
+		ref := &ClassType{Name: "Ref", LifetimeArgs: []Lifetime{lx}, Args: []Type{numP()}}
+		require.Equal(t, []*LifetimeVar{lx}, freeLifetimeVars(ref))
+	})
+
+	t.Run("an outer lifetime reached only through a bound is collected", func(t *testing.T) {
+		outer := &LifetimeVar{ID: 0, Level: 1}
+		lb := &LifetimeVar{ID: 1, Level: 1}
+		fn := &FuncType{
+			LifetimeParams: []*LifetimeParam{{Name: "'b", Var: lb, Bounds: []Lifetime{outer}}},
+			Params:         []*FuncParam{identP("x", &RefType{Lt: lb, Inner: counterCls()})},
+			Ret:            &Void{},
+		}
+		require.Equal(t, []*LifetimeVar{outer}, freeLifetimeVars(fn))
+	})
+}
+
+// LevelOf folds a class reference's lifetime argument into its level, so a free lifetime
+// argument lifts the level the same way a type argument does.
+func TestLevelOfClassLifetimeArgs(t *testing.T) {
+	ref := &ClassType{
+		Name:         "Ref",
+		LifetimeArgs: []Lifetime{&LifetimeVar{ID: 0, Level: 7}},
+		Args:         []Type{&TypeVarType{ID: 1, Level: 3}},
+	}
+	require.Equal(t, 7, LevelOf(ref), "the level is the max over the lifetime and type arguments")
+}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -282,6 +282,7 @@ func (c *ltVarCollector) EnterType(t Type, _ Polarity) EnterResult {
 		// return. An outlives bound may reference an outer free lifetime, collected
 		// after the binders are marked so the bound's own parameter lifetimes stay
 		// excluded, mirroring freeTypeVars' treatment of a type parameter's constraint.
+		// c.add skips lifetime if it's already in c.seen.
 		for _, lp := range t.LifetimeParams {
 			c.seen.Add(lp.Var)
 		}
@@ -372,7 +373,7 @@ func freeTypeVars(t Type) []*TypeVarType {
 				}
 			}
 		case *ClassType:
-			for _, a := range t.Args {
+			for _, a := range t.TypeArgs {
 				walk(a)
 			}
 		case *PromiseType:
@@ -520,14 +521,14 @@ func (p *namedPrinter) printType(t Type) string {
 		// namespace prefix for registry keying, stripped here for display. Lt and the
 		// `mut` borrow forms come from a RefType wrapper, not this arm.
 		name := classDisplayName(t.Name)
-		if len(t.Args) == 0 && len(t.LifetimeArgs) == 0 {
+		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
 		}
-		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.Args))
+		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.TypeArgs))
 		for _, la := range t.LifetimeArgs {
 			parts = append(parts, p.printLifetime(la))
 		}
-		for _, a := range t.Args {
+		for _, a := range t.TypeArgs {
 			parts = append(parts, p.printType(a))
 		}
 		return name + "<" + strings.Join(parts, ", ") + ">"

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -125,8 +125,21 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 	ltVars := freeLifetimeVars(t)
 	ltNames := map[*LifetimeVar]string{}
 	ltIndex := map[*LifetimeVar]int{}
+	// A function's own lifetime parameters keep their source names in the prefix, and a
+	// free lifetime gets a generated name from the same 'a, 'b, … alphabet, so a generated
+	// name must skip any source name a parameter already claims. Without this a captured
+	// 'a and a declared 'a would both render as 'a. The type-parameter path never collides
+	// because generated T0, T1 and source names like U are disjoint alphabets.
+	reserved := ownLifetimeParamNames(t)
+	next := 0
 	for i, lv := range ltVars {
-		ltNames[lv] = lifetimeParamName(i)
+		name := lifetimeParamName(next)
+		for reserved.Contains(name) {
+			next++
+			name = lifetimeParamName(next)
+		}
+		next++
+		ltNames[lv] = name
 		ltIndex[lv] = i
 	}
 	if len(labels) == 0 && len(ltVars) == 0 {
@@ -148,13 +161,17 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 		ltLabels[i] = p.lifetimeBinder(lv, ltBounds[lv], ltIndex)
 	}
 	if ft, ok := t.(*FuncType); ok {
-		// Merge the scheme's free variables, the function's OWN type parameters, and the
-		// lifetimes into one ordered prefix, so a generic method that also captures a
-		// scheme variable renders `fn <T0, U, 'a>(...)` rather than two adjacent groups.
-		// printFuncBody omits the type-param prefix so the own parameters are not repeated.
+		// Merge the scheme's free variables, the function's OWN type and lifetime
+		// parameters, and the free scheme lifetimes into one ordered prefix, so a generic
+		// method that also captures a scheme variable renders `fn <T0, U, 'a>(...)` rather
+		// than adjacent groups. A function's own lifetime params are excluded from ltLabels
+		// by freeLifetimeVars, so they are named and rendered here from their declared
+		// bounds. printFuncBody omits the prefix so the own parameters are not repeated.
 		p.nameTypeParams(ft.TypeParams)
+		p.nameLifetimeParams(ft.LifetimeParams)
 		binders := append([]string{}, labels...)
 		binders = append(binders, p.typeParamBinders(ft.TypeParams)...)
+		binders = append(binders, p.lifetimeParamBinders(ft.LifetimeParams)...)
 		binders = append(binders, ltLabels...)
 		return "fn <" + strings.Join(binders, ", ") + ">" + p.printFuncBody(ft)
 	}
@@ -195,6 +212,22 @@ func typeParamName(i int) string {
 	return "T" + strconv.Itoa(i)
 }
 
+// ownLifetimeParamNames returns the source names a function's own lifetime parameters
+// claim in the quantifier prefix, so the free-lifetime naming can avoid colliding with
+// them. It is non-empty only for a FuncType that declares lifetime parameters; every
+// other type reserves nothing.
+func ownLifetimeParamNames(t Type) set.Set[string] {
+	names := set.NewSet[string]()
+	if ft, ok := t.(*FuncType); ok {
+		for _, lp := range ft.LifetimeParams {
+			if lp.Name != "" {
+				names.Add(lp.Name)
+			}
+		}
+	}
+	return names
+}
+
 // lifetimeParamName is the surface name for the i-th quantified lifetime parameter:
 // 'a, 'b, …, 'z, 'aa, 'ab, … in Excel-style base-26, so a borrow renders as
 // `fn <'a>(p: &'a mut {x}) -> &'a mut {x}`.
@@ -232,16 +265,40 @@ type ltVarCollector struct {
 }
 
 func (c *ltVarCollector) EnterType(t Type, _ Polarity) EnterResult {
-	if r, ok := t.(*RefType); ok {
-		c.add(r.Lt)
+	switch t := t.(type) {
+	case *RefType:
+		c.add(t.Lt)
+	case *ClassType:
+		// A nominal instance's lifetime arguments and its own borrow lifetime are free
+		// lifetimes reached here, so `Ref<'x, T>` collects 'x. They precede any lifetime
+		// nested inside the type arguments, matching print order.
+		for _, la := range t.LifetimeArgs {
+			c.add(la)
+		}
+		c.add(t.Lt)
+	case *FuncType:
+		// A function's own lifetime parameters are bound, not free, so mark their
+		// variables seen up front to exclude every use in the receiver, params, and
+		// return. An outlives bound may reference an outer free lifetime, collected
+		// after the binders are marked so the bound's own parameter lifetimes stay
+		// excluded, mirroring freeTypeVars' treatment of a type parameter's constraint.
+		for _, lp := range t.LifetimeParams {
+			c.seen.Add(lp.Var)
+		}
+		for _, lp := range t.LifetimeParams {
+			for _, b := range lp.Bounds {
+				c.add(b)
+			}
+		}
 	}
 	return EnterResult{}
 }
 
 func (c *ltVarCollector) ExitType(t Type, _ Polarity) Type { return t }
 
-// add records a borrow's lifetime when it is a LifetimeVar, deduped by identity.
-// 'static and an anonymous display lifetime carry no variable and are skipped.
+// add records a lifetime when it is a LifetimeVar, deduped by identity. 'static and an
+// anonymous display lifetime carry no variable and are skipped. A variable already
+// marked seen, such as a function's own bound lifetime parameter, is skipped too.
 func (c *ltVarCollector) add(lt Lifetime) {
 	if lv, ok := lt.(*LifetimeVar); ok && !c.seen.Contains(lv) {
 		c.seen.Add(lv)
@@ -456,19 +513,24 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		return "{" + strings.Join(elems, ", ") + "}"
 	case *ClassType:
-		// A ClassType renders under its bare display name, with a `<...>` type-argument
-		// list when it has arguments: `Point`, `Box<number>`. The qualified Name carries
-		// a namespace prefix for registry keying, stripped here for display. Lt and the
+		// A ClassType renders under its bare display name, with a `<...>` argument list
+		// when it has arguments: `Point`, `Box<number>`, `Ref<'x, number>`. Lifetime
+		// arguments render first, then type arguments, so a class holding borrowed data
+		// shows its lifetime before its element type. The qualified Name carries a
+		// namespace prefix for registry keying, stripped here for display. Lt and the
 		// `mut` borrow forms come from a RefType wrapper, not this arm.
 		name := classDisplayName(t.Name)
-		if len(t.Args) == 0 {
+		if len(t.Args) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
 		}
-		args := make([]string, len(t.Args))
-		for i, a := range t.Args {
-			args[i] = p.printType(a)
+		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.Args))
+		for _, la := range t.LifetimeArgs {
+			parts = append(parts, p.printLifetime(la))
 		}
-		return name + "<" + strings.Join(args, ", ") + ">"
+		for _, a := range t.Args {
+			parts = append(parts, p.printType(a))
+		}
+		return name + "<" + strings.Join(parts, ", ") + ">"
 	case *FuncType:
 		return "fn " + p.printFuncTail(t)
 	case *PromiseType:
@@ -604,7 +666,13 @@ func (p *namedPrinter) printSelfReceiver(sp *FuncParam) string {
 // syntax. An exact function with no receiver renders with no marker.
 func (p *namedPrinter) printFuncTail(t *FuncType) string {
 	p.nameTypeParams(t.TypeParams)
-	return p.printTypeParams(t.TypeParams) + p.printFuncBody(t)
+	p.nameLifetimeParams(t.LifetimeParams)
+	binders := append(p.typeParamBinders(t.TypeParams), p.lifetimeParamBinders(t.LifetimeParams)...)
+	prefix := ""
+	if len(binders) > 0 {
+		prefix = "<" + strings.Join(binders, ", ") + ">"
+	}
+	return prefix + p.printFuncBody(t)
 }
 
 // printFuncBody renders the "(receiver, params) -> ret" portion with NO quantifier
@@ -679,15 +747,45 @@ func (p *namedPrinter) typeParamBinders(tps []*TypeParam) []string {
 	return binders
 }
 
-// printTypeParams wraps a function's own type-parameter binders in a `<...>` prefix,
-// so a generic function renders `<U>`, `<U: T>`, `<U = D>`, or `<U: T = D>`. An empty
-// slice renders "", so a monomorphic function shows no prefix. nameTypeParams must run
-// first. See typeParamBinders for the per-parameter form.
-func (p *namedPrinter) printTypeParams(tps []*TypeParam) string {
-	if len(tps) == 0 {
-		return ""
+// nameLifetimeParams registers each lifetime parameter's variable under its source name
+// in the printer's ltNames map, so a use of the parameter inside the receiver, params,
+// return, or another parameter's bound renders as that name rather than the raw `'l{ID}`
+// debug form. It allocates the map lazily, since plain Print starts with none. It is the
+// lifetime-sort twin of nameTypeParams.
+func (p *namedPrinter) nameLifetimeParams(lps []*LifetimeParam) {
+	if len(lps) == 0 {
+		return
 	}
-	return "<" + strings.Join(p.typeParamBinders(tps), ", ") + ">"
+	if p.ltNames == nil {
+		p.ltNames = map[*LifetimeVar]string{}
+	}
+	for _, lp := range lps {
+		if lp.Name != "" {
+			p.ltNames[lp.Var] = lp.Name
+		}
+	}
+}
+
+// lifetimeParamBinders renders each lifetime parameter as a binder string — `'a`, or
+// `'b: 'a` for an outlives bound and `'b: 'a & 'c` for several — without the surrounding
+// `<>`. The bound is the parameter's declared outlives list. nameLifetimeParams must run
+// first so a binder that references another parameter renders under its name. It is the
+// lifetime-sort twin of typeParamBinders, joined into the same combined quantifier
+// prefix so a method renders `fn <U, 'a>(...)`.
+func (p *namedPrinter) lifetimeParamBinders(lps []*LifetimeParam) []string {
+	binders := make([]string, len(lps))
+	for i, lp := range lps {
+		s := p.printLifetime(lp.Var) // the registered source name, else 'l{ID}
+		if len(lp.Bounds) > 0 {
+			rendered := make([]string, len(lp.Bounds))
+			for j, b := range lp.Bounds {
+				rendered[j] = p.printLifetime(b)
+			}
+			s += ": " + strings.Join(rendered, " & ")
+		}
+		binders[i] = s
+	}
+	return binders
 }
 
 // paramName renders p.Pattern. M1's only Pat concrete is IdentPat; a nil or

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -211,6 +211,14 @@ type FuncType struct {
 	// construction, so folding it into the level would raise the function's level
 	// above its capture level.
 	TypeParams []*TypeParam
+	// LifetimeParams are the function's own quantified lifetime parameters in
+	// declaration order, the lifetime-sort twin of TypeParams. nil means the function
+	// declares no lifetime params, the common case and the zero value. A borrowing
+	// method such as `fn get<'a>(&'a self) -> &'a T` lists 'a here. A class-level
+	// lifetime param is captured from the enclosing class type rather than listed. Like
+	// TypeParams these are minted deeper than the function, so LevelOf does not fold
+	// them in. A lifetime used in the body still counts through its RefType.
+	LifetimeParams []*LifetimeParam
 }
 
 // TypeParam is one quantified type parameter, shared by FuncType.TypeParams for
@@ -228,6 +236,24 @@ type TypeParam struct {
 	Name    string
 	Var     *TypeVarType
 	Default Type // nil ⇒ required
+}
+
+// LifetimeParam is one quantified lifetime parameter, the lifetime-sort analogue of
+// TypeParam. It is shared by FuncType.LifetimeParams for a method's or function's own
+// lifetime params, such as `fn get<'a>(&'a self) -> &'a T`, and by a class's own
+// lifetime params, such as `class Ref<'a, T>`, so both describe their lifetime generics
+// the same way. Var is the quantified lifetime variable that stands for the parameter.
+// It is minted one level deeper than the enclosing binding and freshened per use by the
+// ltFreshener, the lifetime counterpart of freshenAbove. Bounds are the declared
+// outlives constraints. A `<'b: 'a>` declaration gives 'b's Bounds the single entry 'a,
+// meaning 'b outlives 'a. The class-decl walk also records these as bounds on Var so
+// constrainLt enforces them. Lifetimes carry no default, since an omitted lifetime argument is
+// elided to a fresh lifetime rather than filled from a fallback. Name is the source name
+// (`'a`) kept for display, since LifetimeVar carries none.
+type LifetimeParam struct {
+	Name   string
+	Var    *LifetimeVar
+	Bounds []Lifetime // outlives constraints; nil ⇒ unconstrained
 }
 
 // TupleType is a tuple type. Inexact follows the ObjectType/FuncType convention:
@@ -500,6 +526,11 @@ type ClassType struct {
 	// Args are the type arguments, one per class type parameter, checked per position
 	// by the variance the class registry records for that parameter.
 	Args []Type
+	// LifetimeArgs are the lifetime arguments, one per class lifetime parameter, so a
+	// reference `Ref<'x, T>` supplies both the lifetime arg 'x and the type arg T. They
+	// name the lifetime of borrowed data the instance holds. This is distinct from Lt,
+	// which is how long the caller holds the instance itself.
+	LifetimeArgs []Lifetime
 	// Lt is the instance's own borrow lifetime, nil for an owned value. A `mut 'b
 	// Point` wraps a ClassType in a RefType rather than setting Lt directly, so no
 	// site sets Lt today and it is always nil.
@@ -555,14 +586,19 @@ func LevelOf(t Type) int {
 		}
 		return m
 	case *ClassType:
-		// A nominal instance's level is the max level over its type arguments. The Name
-		// and Final identity carry no variables. Lt is always nil today, so it
-		// contributes nothing here.
+		// A nominal instance's level is the max level over its type and lifetime
+		// arguments and its own borrow lifetime. The Name and Final identity carry no
+		// variables. A free lifetime arg such as the 'x in Ref<'x, T> must lift the
+		// level so the freshener/extruder prune descends to freshen it, the same reason
+		// the RefType arm folds in its lifetime.
 		m := 0
 		for _, a := range t.Args {
 			m = max(m, LevelOf(a))
 		}
-		return m
+		for _, la := range t.LifetimeArgs {
+			m = max(m, LevelOfLifetime(la))
+		}
+		return max(m, LevelOfLifetime(t.Lt))
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -203,21 +203,11 @@ type FuncType struct {
 	Params    []*FuncParam
 	Ret       Type
 	Inexact   bool // PR4: trailing `...` ⇒ true; bare fn(...) ⇒ false (the exact zero value)
-	// TypeParams are the function's own quantified type parameters in declaration
-	// order. nil is monomorphic, the common case and the zero value. A generic
-	// method such as Array<T>.map<U> lists U here; a class-level parameter is captured
-	// from the enclosing class type rather than listed. LevelOf maxes over Params and
-	// Ret only. A TypeParam's Var is minted deeper than the function by
-	// construction, so folding it into the level would raise the function's level
-	// above its capture level.
+	// TypeParams are the function's own quantified type parameters; nil is monomorphic and
+	// a class-level parameter is captured, not listed. LevelOf skips them, being minted deeper.
 	TypeParams []*TypeParam
-	// LifetimeParams are the function's own quantified lifetime parameters in
-	// declaration order, the lifetime-sort twin of TypeParams. nil means the function
-	// declares no lifetime params, the common case and the zero value. A borrowing
-	// method such as `fn get<'a>(&'a self) -> &'a T` lists 'a here. A class-level
-	// lifetime param is captured from the enclosing class type rather than listed. Like
-	// TypeParams these are minted deeper than the function, so LevelOf does not fold
-	// them in. A lifetime used in the body still counts through its RefType.
+	// LifetimeParams are the function's quantified lifetime parameters, the twin of TypeParams;
+	// LevelOf skips them too, though a body lifetime still counts through its RefType.
 	LifetimeParams []*LifetimeParam
 }
 
@@ -238,18 +228,10 @@ type TypeParam struct {
 	Default Type // nil ⇒ required
 }
 
-// LifetimeParam is one quantified lifetime parameter, the lifetime-sort analogue of
-// TypeParam. It is shared by FuncType.LifetimeParams for a method's or function's own
-// lifetime params, such as `fn get<'a>(&'a self) -> &'a T`, and by a class's own
-// lifetime params, such as `class Ref<'a, T>`, so both describe their lifetime generics
-// the same way. Var is the quantified lifetime variable that stands for the parameter.
-// It is minted one level deeper than the enclosing binding and freshened per use by the
-// ltFreshener, the lifetime counterpart of freshenAbove. Bounds are the declared
-// outlives constraints. A `<'b: 'a>` declaration gives 'b's Bounds the single entry 'a,
-// meaning 'b outlives 'a. The class-decl walk also records these as bounds on Var so
-// constrainLt enforces them. Lifetimes carry no default, since an omitted lifetime argument is
-// elided to a fresh lifetime rather than filled from a fallback. Name is the source name
-// (`'a`) kept for display, since LifetimeVar carries none.
+// LifetimeParam is one quantified lifetime parameter, the lifetime-sort analogue of TypeParam,
+// shared by a function's or class's own lifetime params such as `fn get<'a>` and `class Ref<'a, T>`.
+// Var is minted one level deeper and freshened per use; Bounds are the outlives constraints, where
+// `<'b: 'a>` gives 'b the single bound 'a. Name keeps the source name for display.
 type LifetimeParam struct {
 	Name   string
 	Var    *LifetimeVar
@@ -523,13 +505,11 @@ type ClassType struct {
 	// local identifier, so two classes named Point in different namespaces stay
 	// distinct. It also keys the registry holding the heavy per-class data.
 	Name string
-	// Args are the type arguments, one per class type parameter, checked per position
+	// TypeArgs are the type arguments, one per class type parameter, checked per position
 	// by the variance the class registry records for that parameter.
-	Args []Type
-	// LifetimeArgs are the lifetime arguments, one per class lifetime parameter, so a
-	// reference `Ref<'x, T>` supplies both the lifetime arg 'x and the type arg T. They
-	// name the lifetime of borrowed data the instance holds. This is distinct from Lt,
-	// which is how long the caller holds the instance itself.
+	TypeArgs []Type
+	// LifetimeArgs are the lifetime arguments, one per class lifetime parameter, so `Ref<'x, T>`
+	// supplies arg 'x. They name the lifetime of borrowed data the instance holds, distinct from Lt.
 	LifetimeArgs []Lifetime
 	// Lt is the instance's own borrow lifetime, nil for an owned value. A `mut 'b
 	// Point` wraps a ClassType in a RefType rather than setting Lt directly, so no
@@ -588,13 +568,14 @@ func LevelOf(t Type) int {
 	case *ClassType:
 		// A nominal instance's level is the max level over its type and lifetime
 		// arguments and its own borrow lifetime. The Name and Final identity carry no
-		// variables. A free lifetime arg such as the 'x in Ref<'x, T> must lift the
-		// level so the freshener/extruder prune descends to freshen it, the same reason
-		// the RefType arm folds in its lifetime.
+		// variables.
 		m := 0
-		for _, a := range t.Args {
+		for _, a := range t.TypeArgs {
 			m = max(m, LevelOf(a))
 		}
+		// A free lifetime arg such as the 'x in Ref<'x, T> must lift the level so the
+		// freshener/extruder prune descends to freshen it, the same reason the RefType
+		// arm folds in its lifetime.
 		for _, la := range t.LifetimeArgs {
 			m = max(m, LevelOfLifetime(la))
 		}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -239,14 +239,14 @@ func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	args, changed := acceptTypes(cur.Args, v, pol) // type arguments covariant
+	args, changed := acceptTypes(cur.TypeArgs, v, pol) // type arguments covariant
 	out := cur
 	if changed {
 		// Name and Final are the nominal identity, carried through unchanged.
 		// LifetimeArgs and Lt are lifetimes, not Types, so Accept never walks them; a
 		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
 		// ClassType before this rebuild, so cur already holds the freshened lifetimes.
-		out = &ClassType{Name: cur.Name, Args: args, LifetimeArgs: cur.LifetimeArgs, Lt: cur.Lt, Final: cur.Final}
+		out = &ClassType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs, Lt: cur.Lt, Final: cur.Final}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -95,7 +95,11 @@ func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	ret := cur.Ret.Accept(v, pol)                               // return covariant
 	out := cur
 	if tpChanged || selfChanged || changed || ret != cur.Ret {
-		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact, TypeParams: tparams}
+		// LifetimeParams carry through unchanged here, because Accept never walks a
+		// lifetime. A lifetime-aware visitor freshens them in its EnterType, replacing
+		// the whole FuncType before this rebuild, so cur already holds the freshened
+		// params.
+		out = &FuncType{SelfParam: self, Params: params, Ret: ret, Inexact: cur.Inexact, TypeParams: tparams, LifetimeParams: cur.LifetimeParams}
 	}
 	return v.ExitType(out, pol)
 }
@@ -238,10 +242,11 @@ func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
 	args, changed := acceptTypes(cur.Args, v, pol) // type arguments covariant
 	out := cur
 	if changed {
-		// Name, Final, and Lt are the nominal identity, carried through unchanged. Lt
-		// is a Lifetime, not a Type, so Accept never walks it. Only lifetime-aware
-		// passes touch a lifetime.
-		out = &ClassType{Name: cur.Name, Args: args, Lt: cur.Lt, Final: cur.Final}
+		// Name and Final are the nominal identity, carried through unchanged.
+		// LifetimeArgs and Lt are lifetimes, not Types, so Accept never walks them; a
+		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
+		// ClassType before this rebuild, so cur already holds the freshened lifetimes.
+		out = &ClassType{Name: cur.Name, Args: args, LifetimeArgs: cur.LifetimeArgs, Lt: cur.Lt, Final: cur.Final}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -902,7 +902,7 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, ctx) {
 			return false
 		}
-		return equalTypeSliceWith(a.Args, b.Args, ctx)
+		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
 		return ok && equalTypeWith(a.Inner, b.Inner, ctx)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -657,6 +657,15 @@ type alphaCtx struct {
 	lt     *ltPairing
 	tvAToB map[int]int
 	tvBToA map[int]int
+	// ltpAToB and ltpBToA pair the positional lifetime parameters of two generic
+	// FuncTypes, the lifetime-sort twin of tvAToB/tvBToA. They are bound at each
+	// function boundary so a lifetime parameter's identity is its position rather than
+	// its variable id. They are separate from lt. lt discovers a bijection over borrow
+	// lifetimes for alphaEqualTypes, while these are declared bindings over a function's
+	// own quantified lifetime params. They start nil and allocate on first binding, so
+	// the common lifetime-param-free case allocates nothing.
+	ltpAToB map[int]int
+	ltpBToA map[int]int
 }
 
 // bindTypeParams pairs two generic FuncTypes' type parameters positionally, so every
@@ -687,6 +696,44 @@ func (ctx *alphaCtx) sameTypeVar(a, b *soltype.TypeVarType) bool {
 		return false // b is a bound parameter, a is not — mismatch
 	}
 	return a == b
+}
+
+// bindLifetimeParams pairs two generic FuncTypes' lifetime parameters positionally, the
+// lifetime-sort twin of bindTypeParams, so every later occurrence of one side's lifetime
+// parameter must match the other's bound partner. The bindings persist for the rest of
+// the walk. Lifetime-variable ids are unique across the comparison, so a parameter bound
+// here is never confused with one from another function.
+func (ctx *alphaCtx) bindLifetimeParams(as, bs []*soltype.LifetimeParam) {
+	if ctx.ltpAToB == nil {
+		ctx.ltpAToB = map[int]int{}
+		ctx.ltpBToA = map[int]int{}
+	}
+	for i := range as {
+		ctx.ltpAToB[as[i].Var.ID] = bs[i].Var.ID
+		ctx.ltpBToA[bs[i].Var.ID] = as[i].Var.ID
+	}
+}
+
+// sameLifetime reports lifetime equality under the alpha context. A lifetime bound as
+// one side's parameter must map to the other's partner through the lifetime-parameter
+// bijection, so two borrowing methods differing only in lifetime-variable id compare
+// equal. A lifetime bound on neither side falls back to ltEqualWith, which keys a
+// LifetimeVar by pointer under a nil borrow pairing and by first-appearance index under
+// one.
+func (ctx *alphaCtx) sameLifetime(a, b soltype.Lifetime) bool {
+	av, aok := a.(*soltype.LifetimeVar)
+	bv, bok := b.(*soltype.LifetimeVar)
+	if aok {
+		if j, ok := ctx.ltpAToB[av.ID]; ok {
+			return bok && j == bv.ID
+		}
+	}
+	if bok {
+		if _, ok := ctx.ltpBToA[bv.ID]; ok {
+			return false // b is a bound lifetime parameter, a is not — mismatch
+		}
+	}
+	return ltEqualWith(a, b, ctx.lt)
 }
 
 // ltPairing is the bijection alphaEqualTypes discovers between the lifetime variables of
@@ -759,7 +806,7 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return ok
 	case *soltype.FuncType:
 		b, ok := b.(*soltype.FuncType)
-		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact || len(a.TypeParams) != len(b.TypeParams) {
+		if !ok || len(a.Params) != len(b.Params) || a.Inexact != b.Inexact || len(a.TypeParams) != len(b.TypeParams) || len(a.LifetimeParams) != len(b.LifetimeParams) {
 			return false
 		}
 		if len(a.TypeParams) > 0 {
@@ -777,6 +824,18 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 					return false
 				}
 				if at.Default != nil && !equalTypeWith(at.Default, bt.Default, ctx) {
+					return false
+				}
+			}
+		}
+		if len(a.LifetimeParams) > 0 {
+			// Bind the two functions' lifetime parameters positionally, then compare each
+			// one's outlives bounds under that binding, so two borrowing methods differing
+			// only in lifetime-variable id compare equal. Binding all of them first lets a
+			// later parameter's `'b: 'a` bound reference an earlier one.
+			ctx.bindLifetimeParams(a.LifetimeParams, b.LifetimeParams)
+			for i := range a.LifetimeParams {
+				if !sameLifetimeSlice(a.LifetimeParams[i].Bounds, b.LifetimeParams[i].Bounds, ctx) {
 					return false
 				}
 			}
@@ -834,10 +893,13 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return true
 	case *soltype.ClassType:
 		b, ok := b.(*soltype.ClassType)
-		// Nominal identity is the qualified name plus the Final exactness flag. The type
-		// arguments then compare positionally. A ClassType's Lt is always nil today, so
-		// it is not compared.
+		// Nominal identity is the qualified name plus the Final exactness flag. The
+		// lifetime arguments then compare positionally, then the type arguments. A
+		// ClassType's Lt is always nil today, so it is not compared.
 		if !ok || a.Name != b.Name || a.Final != b.Final {
+			return false
+		}
+		if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, ctx) {
 			return false
 		}
 		return equalTypeSliceWith(a.Args, b.Args, ctx)
@@ -851,7 +913,7 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// in lifetime are NOT equal. Without the Lt check, dedup would collapse them and
 		// silently drop a lifetime the solver computed. ltEqualWith compares a LifetimeVar
 		// by pointer under a nil pairing and by first-appearance index under one.
-		return ok && a.Mut == b.Mut && ltEqualWith(a.Lt, b.Lt, ctx.lt) && equalTypeWith(a.Inner, b.Inner, ctx)
+		return ok && a.Mut == b.Mut && ctx.sameLifetime(a.Lt, b.Lt) && equalTypeWith(a.Inner, b.Inner, ctx)
 	case *soltype.UnionType:
 		b, ok := b.(*soltype.UnionType)
 		// Inexact flags must match, since an open union never equals a closed
@@ -968,6 +1030,22 @@ func equalTypeSliceWith(a, b []soltype.Type, ctx *alphaCtx) bool {
 	}
 	for i := range a {
 		if !equalTypeWith(a[i], b[i], ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+// sameLifetimeSlice compares two lifetime slices positionally under the alpha context,
+// so a class's lifetime arguments and a lifetime parameter's outlives bounds compare up
+// to the lifetime-parameter bijection. It is the lifetime-sort twin of
+// equalTypeSliceWith.
+func sameLifetimeSlice(a, b []soltype.Lifetime, ctx *alphaCtx) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !ctx.sameLifetime(a[i], b[i]) {
 			return false
 		}
 	}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -772,3 +772,143 @@ func TestEqualTypeObject(t *testing.T) {
 		})
 	}
 }
+
+// equalType compares two generic FuncTypes up to alpha-renaming of their own lifetime
+// parameters, so two borrowing methods that differ only in lifetime-variable id are
+// equal, while a difference in the outlives bound or the arity is not. This is the
+// lifetime-sort twin of TestEqualTypeGenericFunc's type-parameter alpha-equivalence.
+func TestEqualTypeLifetimeParams(t *testing.T) {
+	// lv builds a fresh lifetime variable at a quantifiable level.
+	lv := func(id int) *soltype.LifetimeVar { return &soltype.LifetimeVar{ID: id, Level: 1} }
+	// borrowCounter wraps Counter in an immutable borrow with the given lifetime.
+	borrowCounter := func(lt soltype.Lifetime) *soltype.RefType {
+		return &soltype.RefType{Lt: lt, Inner: &soltype.ClassType{Name: "Counter"}}
+	}
+	// getFn is `fn <'a>(x: &'a Counter) -> &'a Counter`, threading one lifetime through
+	// so each side reuses its parameter lifetime the way real solver output does.
+	getFn := func(id int) *soltype.FuncType {
+		la := lv(id)
+		return &soltype.FuncType{
+			LifetimeParams: []*soltype.LifetimeParam{{Name: "'a", Var: la}},
+			Params:         []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: borrowCounter(la)}},
+			Ret:            borrowCounter(la),
+		}
+	}
+	// boundedFn is `fn <'a, 'b: 'a>(x: &'a Counter, y: &'b Counter) -> void`.
+	boundedFn := func(idA, idB int) *soltype.FuncType {
+		la, lb := lv(idA), lv(idB)
+		return &soltype.FuncType{
+			LifetimeParams: []*soltype.LifetimeParam{
+				{Name: "'a", Var: la},
+				{Name: "'b", Var: lb, Bounds: []soltype.Lifetime{la}},
+			},
+			Params: []*soltype.FuncParam{
+				{Pattern: &soltype.IdentPat{Name: "x"}, Type: borrowCounter(la)},
+				{Pattern: &soltype.IdentPat{Name: "y"}, Type: borrowCounter(lb)},
+			},
+			Ret: &soltype.Void{},
+		}
+	}
+
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "differ only in lifetime-parameter var id",
+			a:    getFn(10),
+			b:    getFn(20),
+			want: true,
+		},
+		{
+			name: "same outlives bound, different var ids",
+			a:    boundedFn(10, 11),
+			b:    boundedFn(20, 21),
+			want: true,
+		},
+		{
+			// The bijection follows structure: a's y uses 'b but b's y uses 'a, so the
+			// paired lifetimes disagree and the two are not equal.
+			name: "body lifetime-sharing pattern differs",
+			a:    boundedFn(10, 11),
+			b: func() *soltype.FuncType {
+				la, lb := lv(20), lv(21)
+				return &soltype.FuncType{
+					LifetimeParams: []*soltype.LifetimeParam{
+						{Name: "'a", Var: la},
+						{Name: "'b", Var: lb, Bounds: []soltype.Lifetime{la}},
+					},
+					Params: []*soltype.FuncParam{
+						{Pattern: &soltype.IdentPat{Name: "x"}, Type: borrowCounter(la)},
+						{Pattern: &soltype.IdentPat{Name: "y"}, Type: borrowCounter(la)},
+					},
+					Ret: &soltype.Void{},
+				}
+			}(),
+			want: false,
+		},
+		{
+			name: "lifetime-parameter arity differs",
+			a:    getFn(10),
+			b: &soltype.FuncType{
+				Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: borrowCounter(&soltype.StaticLifetime{})}},
+				Ret:    &soltype.RefType{Lt: &soltype.StaticLifetime{}, Inner: &soltype.ClassType{Name: "Counter"}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}
+
+// equalType compares a class reference's lifetime arguments positionally, keying a
+// LifetimeVar by pointer within a single coalesce the way it keys a borrow's lifetime, so
+// two references sharing a lifetime argument are equal and two with distinct lifetime
+// variables or differing arity are not.
+func TestEqualTypeClassLifetimeArgs(t *testing.T) {
+	lx := &soltype.LifetimeVar{ID: 0, Level: 1}
+	ly := &soltype.LifetimeVar{ID: 1, Level: 1}
+	ref := func(lts []soltype.Lifetime, args []soltype.Type) *soltype.ClassType {
+		return &soltype.ClassType{Name: "Ref", LifetimeArgs: lts, Args: args}
+	}
+
+	tests := []struct {
+		name string
+		a, b soltype.Type
+		want bool
+	}{
+		{
+			name: "same lifetime argument pointer",
+			a:    ref([]soltype.Lifetime{lx}, []soltype.Type{num()}),
+			b:    ref([]soltype.Lifetime{lx}, []soltype.Type{num()}),
+			want: true,
+		},
+		{
+			name: "distinct lifetime argument variables",
+			a:    ref([]soltype.Lifetime{lx}, []soltype.Type{num()}),
+			b:    ref([]soltype.Lifetime{ly}, []soltype.Type{num()}),
+			want: false,
+		},
+		{
+			name: "lifetime argument arity differs",
+			a:    ref([]soltype.Lifetime{lx}, []soltype.Type{num()}),
+			b:    ref(nil, []soltype.Type{num()}),
+			want: false,
+		},
+		{
+			name: "type argument differs under equal lifetime arguments",
+			a:    ref([]soltype.Lifetime{lx}, []soltype.Type{num()}),
+			b:    ref([]soltype.Lifetime{lx}, []soltype.Type{str()}),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, equalType(tt.a, tt.b))
+		})
+	}
+}

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -387,20 +387,20 @@ func TestEqualTypeClass(t *testing.T) {
 	}{
 		{
 			name: "same name and arguments",
-			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
-			b:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			a:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{num()}},
 			want: true,
 		},
 		{
 			name: "name differs",
-			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
-			b:    &soltype.ClassType{Name: "Bag", Args: []soltype.Type{num()}},
+			a:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Bag", TypeArgs: []soltype.Type{num()}},
 			want: false,
 		},
 		{
 			name: "type argument differs",
-			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
-			b:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{str()}},
+			a:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{num()}},
+			b:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{str()}},
 			want: false,
 		},
 		{
@@ -411,7 +411,7 @@ func TestEqualTypeClass(t *testing.T) {
 		},
 		{
 			name: "argument count differs",
-			a:    &soltype.ClassType{Name: "Box", Args: []soltype.Type{num()}},
+			a:    &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{num()}},
 			b:    &soltype.ClassType{Name: "Box"},
 			want: false,
 		},
@@ -873,7 +873,7 @@ func TestEqualTypeClassLifetimeArgs(t *testing.T) {
 	lx := &soltype.LifetimeVar{ID: 0, Level: 1}
 	ly := &soltype.LifetimeVar{ID: 1, Level: 1}
 	ref := func(lts []soltype.Lifetime, args []soltype.Type) *soltype.ClassType {
-		return &soltype.ClassType{Name: "Ref", LifetimeArgs: lts, Args: args}
+		return &soltype.ClassType{Name: "Ref", LifetimeArgs: lts, TypeArgs: args}
 	}
 
 	tests := []struct {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -757,14 +757,14 @@ func (e *extruder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Enter
 	}
 	if r, ok := t.(*soltype.RefType); ok {
 		// A borrow's lifetime is covariant on the wrapper and never walked by Accept, so
-		// extrude it here in the wrapper's polarity (M4 D2.5). refLifetimeResult then
+		// extrude it here in the wrapper's polarity (M4 D2.5). rewriteRefLifetime then
 		// hands back a RefType carrying the fresh lifetime for the descend path to
 		// rebuild Inner around, or signals an ordinary rebuild when no extrusion was
 		// needed. The cache is allocated on first use so a borrow-free pass pays nothing.
 		if e.ltCache == nil {
 			e.ltCache = map[ltExtrudeKey]*soltype.LifetimeVar{}
 		}
-		return refLifetimeResult(r, e.c.extrudeLt(r.Lt, pol, e.lvl, e.ltCache))
+		return rewriteRefLifetime(r, e.c.extrudeLt(r.Lt, pol, e.lvl, e.ltCache))
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {

--- a/internal/solver/lifetime_generalization_test.go
+++ b/internal/solver/lifetime_generalization_test.go
@@ -169,6 +169,87 @@ fn f(a: mut {x: number}, b: mut {x: number}) {
 	require.Empty(t, errs)
 }
 
+// --- M5 A3: a function's own quantified lifetime parameters ---
+//
+// A borrowing method such as `fn get<'a>(&'a self) -> &'a T` records 'a in
+// FuncType.LifetimeParams. Accept never walks a lifetime, so the freshener freshens the
+// parameter's binder through the same ltFreshener cache the body's uses reach. The binder
+// and every `&'a` use then land on one fresh lifetime per instantiation.
+
+// getRefScheme is `fn <'a>(&'a self) -> &'a mut {x}` — a borrowing method whose own
+// lifetime parameter 'a appears in FuncType.LifetimeParams, the receiver, and the return,
+// all on one lifetime pointer.
+func getRefScheme(lt *soltype.LifetimeVar) *soltype.FuncType {
+	return &soltype.FuncType{
+		LifetimeParams: []*soltype.LifetimeParam{{Name: "'a", Var: lt}},
+		SelfParam:      &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: mutObjAt(lt)},
+		Ret:            mutObjAt(lt),
+	}
+}
+
+// freshenAbove freshens a function's own lifetime parameter: the binder in
+// LifetimeParams, the receiver's `&'a`, and the return's `&'a` all land on one fresh
+// lifetime, so the binder never desyncs from its uses. This is the per-instantiation
+// freshening the LifetimeParams field exists to carry, the lifetime-sort twin of
+// TestFreshenAboveGenericFunc.
+func TestFreshenAboveFuncLifetimeParam(t *testing.T) {
+	c := newChecker()
+	la := c.ctx.freshLifetime(1) // above the generalize-level (lim = 0)
+
+	out := c.freshenAbove(0, getRefScheme(la), 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	fn := out.(*soltype.FuncType)
+	binder := fn.LifetimeParams[0].Var
+	recvLt := fn.SelfParam.Type.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+	retLt := fn.Ret.(*soltype.RefType).Lt.(*soltype.LifetimeVar)
+
+	require.NotSame(t, la, binder, "the lifetime parameter's binder is freshened")
+	require.Same(t, binder, recvLt, "the receiver use shares the fresh binder lifetime")
+	require.Same(t, binder, retLt, "the return use shares the fresh binder lifetime")
+}
+
+// Two instantiations of a scheme carrying a lifetime parameter get DISTINCT binder
+// lifetimes, so a method's `<'a>` is fresh per call — the same non-contamination the
+// ordinary borrow-passing case relies on, here for an explicit lifetime parameter.
+func TestFreshenFuncLifetimeParamDistinctPerInstantiation(t *testing.T) {
+	c := newChecker()
+	la := c.ctx.freshLifetime(1)
+	body := getRefScheme(la)
+
+	out1 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+	out2 := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+
+	b1 := out1.(*soltype.FuncType).LifetimeParams[0].Var
+	b2 := out2.(*soltype.FuncType).LifetimeParams[0].Var
+	require.NotSame(t, b1, b2, "two call sites instantiate two distinct binder lifetimes")
+}
+
+// A freshened lifetime parameter carries its declared outlives bound onto the fresh
+// binder, and a `<'b: 'a>` bound resolves to the fresh 'a of the same instantiation, so
+// the outlives relation survives the copy intact.
+func TestFreshenFuncLifetimeParamBound(t *testing.T) {
+	c := newChecker()
+	la := c.ctx.freshLifetime(1)
+	lb := c.ctx.freshLifetime(1)
+	body := &soltype.FuncType{
+		LifetimeParams: []*soltype.LifetimeParam{
+			{Name: "'a", Var: la},
+			{Name: "'b", Var: lb, Bounds: []soltype.Lifetime{la}},
+		},
+		Params: []*soltype.FuncParam{{Type: mutObjAt(la)}, {Type: mutObjAt(lb)}},
+		Ret:    &soltype.Void{},
+	}
+
+	out := c.freshenAbove(0, body, 1, map[*soltype.TypeVarType]*soltype.TypeVarType{}).(*soltype.FuncType)
+
+	freshA := out.LifetimeParams[0].Var
+	freshB := out.LifetimeParams[1]
+	require.NotSame(t, la, freshA, "'a is freshened")
+	require.NotSame(t, lb, freshB.Var, "'b is freshened")
+	require.Equal(t, []soltype.Lifetime{soltype.Lifetime(freshA)}, freshB.Bounds,
+		"'b's outlives bound resolves to the fresh 'a of the same instantiation")
+}
+
 // --- extruder lifetime arm ---
 //
 // extrude copies a type so a variable above the target level is replaced by a

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -153,14 +153,8 @@ func (f *freshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterR
 	if soltype.LevelOf(t) <= f.lim {
 		return soltype.EnterResult{Type: t, SkipChildren: true}
 	}
-	if r, ok := t.(*soltype.RefType); ok {
-		// A borrow's lifetime is not a Type, so Accept carries it through unchanged and
-		// neither the structural rebuild below nor the var arm would ever freshen it
-		// (M4 D2.5). ltFreshener.fresh replaces a quantified param lifetime
-		// (Level > lim) and shares a captured, 'static, or nil one; refLifetimeResult
-		// then either hands back a RefType carrying the fresh lifetime or signals an
-		// ordinary descent so Accept rebuilds Inner.
-		return refLifetimeResult(r, f.lt.fresh(r.Lt))
+	if res, ok := freshenLifetimeFormer(t, &f.lt); ok {
+		return res
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
@@ -235,8 +229,8 @@ type allFreshener struct {
 }
 
 func (f *allFreshener) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
-	if r, ok := t.(*soltype.RefType); ok {
-		return refLifetimeResult(r, f.lt.fresh(r.Lt))
+	if res, ok := freshenLifetimeFormer(t, &f.lt); ok {
+		return res
 	}
 	v, ok := t.(*soltype.TypeVarType)
 	if !ok {
@@ -335,6 +329,115 @@ func refLifetimeResult(r *soltype.RefType, lt soltype.Lifetime) soltype.EnterRes
 		return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
 	}
 	return soltype.EnterResult{}
+}
+
+// freshenLifetimeFormer freshens the lifetimes a former carries that Accept never walks:
+// a borrow's Lt, a function's own lifetime parameters, and a class's lifetime arguments
+// and borrow lifetime. All go through the shared ltFreshener lf, so a lifetime reached
+// from more than one former lands on one fresh copy per instantiation. It returns the
+// EnterType result and whether t was a lifetime-bearing former; a non-former returns
+// (_, false) so the caller falls through to its own variable arm. The freshener and
+// allFreshener share it because both hold an ltFreshener and both must freshen these
+// lifetimes; the extruder does not, since its per-polarity cache needs a different call
+// shape and B1 owns the extrude semantics for a bound lifetime parameter.
+func freshenLifetimeFormer(t soltype.Type, lf *ltFreshener) (soltype.EnterResult, bool) {
+	switch t := t.(type) {
+	case *soltype.RefType:
+		// A borrow's lifetime is not a Type, so ltFreshener.fresh replaces a quantified
+		// param lifetime (Level > lim) and shares a captured, 'static, or nil one, then
+		// refLifetimeResult hands back a RefType carrying it or signals an ordinary descent.
+		return refLifetimeResult(t, lf.fresh(t.Lt)), true
+	case *soltype.FuncType:
+		// A function's own lifetime parameters are freshened through the same cache the
+		// body's uses reach through the RefType arm, so a method's `'a` is freshened once
+		// and the binder and every `&'a` use land on one fresh lifetime per instantiation.
+		return funcLifetimeResult(t, lf.fresh), true
+	case *soltype.ClassType:
+		return classLifetimeResult(t, lf.fresh), true
+	}
+	return soltype.EnterResult{}, false
+}
+
+// funcLifetimeResult builds the EnterType result for a FuncType whose own lifetime
+// parameters a visitor rewrites through xform, applied to each parameter's Var and
+// outlives Bounds. Accept never walks a lifetime, so a lifetime-aware visitor rewrites
+// the parameters here and then descends: the body's uses of a parameter reach xform
+// through the RefType arm, which shares xform's cache, so the rebuilt binder and its uses
+// stay one lifetime. When no parameter changed it signals an ordinary descent. A
+// parameter's Var stays a variable, since xform maps a variable to a variable.
+func funcLifetimeResult(t *soltype.FuncType, xform func(soltype.Lifetime) soltype.Lifetime) soltype.EnterResult {
+	if len(t.LifetimeParams) == 0 {
+		return soltype.EnterResult{}
+	}
+	nlps, changed := rewriteLtParams(t.LifetimeParams, xform)
+	if !changed {
+		return soltype.EnterResult{}
+	}
+	repl := *t
+	repl.LifetimeParams = nlps
+	return soltype.EnterResult{Type: &repl}
+}
+
+// classLifetimeResult builds the EnterType result for a ClassType whose lifetime
+// arguments and own borrow lifetime a visitor rewrites through xform. Like
+// funcLifetimeResult it rewrites the non-Type lifetimes here and then descends so the
+// type arguments still walk, sharing xform's cache with any borrow the arguments carry.
+// When no lifetime changed it signals an ordinary descent.
+func classLifetimeResult(t *soltype.ClassType, xform func(soltype.Lifetime) soltype.Lifetime) soltype.EnterResult {
+	if len(t.LifetimeArgs) == 0 && t.Lt == nil {
+		return soltype.EnterResult{}
+	}
+	nargs, argsChanged := rewriteLtSlice(t.LifetimeArgs, xform)
+	nlt := xform(t.Lt)
+	if !argsChanged && nlt == t.Lt {
+		return soltype.EnterResult{}
+	}
+	repl := *t
+	repl.LifetimeArgs = nargs
+	repl.Lt = nlt
+	return soltype.EnterResult{Type: &repl}
+}
+
+// rewriteLtParams applies xform to each lifetime parameter's Var and outlives Bounds,
+// returning the rewritten slice and whether anything changed, so a caller shares the
+// original slice when nothing moved. xform maps a LifetimeVar to a LifetimeVar, so a
+// bound parameter stays a variable. It is copy-on-write, mirroring acceptTypeParams.
+func rewriteLtParams(lps []*soltype.LifetimeParam, xform func(soltype.Lifetime) soltype.Lifetime) ([]*soltype.LifetimeParam, bool) {
+	out := lps
+	changed := false
+	for i, lp := range lps {
+		nv := xform(lp.Var).(*soltype.LifetimeVar)
+		nb, boundsChanged := rewriteLtSlice(lp.Bounds, xform)
+		if nv != lp.Var || boundsChanged {
+			if !changed {
+				out = append([]*soltype.LifetimeParam(nil), lps...)
+				changed = true
+			}
+			out[i] = &soltype.LifetimeParam{Name: lp.Name, Var: nv, Bounds: nb}
+		}
+	}
+	return out, changed
+}
+
+// rewriteLtSlice applies xform to each lifetime in a slice, copy-on-write like
+// rewriteLtParams, preserving the nil-for-empty shape.
+func rewriteLtSlice(lts []soltype.Lifetime, xform func(soltype.Lifetime) soltype.Lifetime) ([]soltype.Lifetime, bool) {
+	if len(lts) == 0 {
+		return nil, false
+	}
+	out := lts
+	changed := false
+	for i, lt := range lts {
+		nl := xform(lt)
+		if nl != lt {
+			if !changed {
+				out = append([]soltype.Lifetime(nil), lts...)
+				changed = true
+			}
+			out[i] = nl
+		}
+	}
+	return out, changed
 }
 
 // freshenBounds freshens a var's bound list, preserving the nil-for-empty shape.

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -265,7 +265,7 @@ func (f *allFreshener) freshenBounds(bounds []soltype.Type) []soltype.Type {
 
 // ltFreshener freshens lifetime variables for the rewriting visitors (M4 D2.5).
 // Accept never walks a RefType's lifetime, because a Lifetime is not a Type, so each
-// lifetime-aware visitor delegates here through refLifetimeResult. A LifetimeVar
+// lifetime-aware visitor delegates here through rewriteRefLifetime. A LifetimeVar
 // inside lim is a quantified lifetime: fresh replaces it with a fresh lifetime at
 // lvl and freshens its bounds, so each use gets its own lifetime and constraining
 // one site does not perturb another. A LifetimeVar at lim or outside it, 'static,
@@ -317,59 +317,48 @@ func (lf *ltFreshener) freshBounds(bounds []soltype.Lifetime) []soltype.Lifetime
 	return out
 }
 
-// refLifetimeResult builds the EnterType result for a RefType whose lifetime a
-// visitor has transformed to lt. It is the single place every lifetime-aware
-// rewriting visitor handles a borrow's non-Type lifetime: when lt changed it hands
-// back a RefType carrying it so the descend path rebuilds Inner around the new
-// lifetime; otherwise it signals an ordinary descent so Accept rebuilds Inner with
-// the lifetime shared. Sharing this keeps freshener, allFreshener, and the extruder
-// from each re-deriving the rebuild-or-descend boilerplate.
-func refLifetimeResult(r *soltype.RefType, lt soltype.Lifetime) soltype.EnterResult {
+// rewriteRefLifetime builds the EnterType result for a RefType whose lifetime a visitor
+// transformed to lt: a changed lt yields a RefType carrying it, otherwise an ordinary descent.
+func rewriteRefLifetime(r *soltype.RefType, lt soltype.Lifetime) soltype.EnterResult {
 	if lt != r.Lt {
 		return soltype.EnterResult{Type: &soltype.RefType{Mut: r.Mut, Lt: lt, Inner: r.Inner}}
 	}
 	return soltype.EnterResult{}
 }
 
-// freshenLifetimeFormer freshens the lifetimes a former carries that Accept never walks:
-// a borrow's Lt, a function's own lifetime parameters, and a class's lifetime arguments
-// and borrow lifetime. All go through the shared ltFreshener lf, so a lifetime reached
-// from more than one former lands on one fresh copy per instantiation. It returns the
-// EnterType result and whether t was a lifetime-bearing former; a non-former returns
-// (_, false) so the caller falls through to its own variable arm. The freshener and
-// allFreshener share it because both hold an ltFreshener and both must freshen these
-// lifetimes; the extruder does not, since its per-polarity cache needs a different call
-// shape and B1 owns the extrude semantics for a bound lifetime parameter.
+// freshenLifetimeFormer freshens the lifetimes Accept never walks: a borrow's Lt, a
+// function's lifetime parameters, and a class's lifetime arguments and borrow lifetime.
+// All share ltFreshener lf, so a lifetime reached from two formers lands on one fresh copy.
+// The bool reports whether t was a lifetime-bearing former; false falls through to the var arm.
 func freshenLifetimeFormer(t soltype.Type, lf *ltFreshener) (soltype.EnterResult, bool) {
 	switch t := t.(type) {
 	case *soltype.RefType:
 		// A borrow's lifetime is not a Type, so ltFreshener.fresh replaces a quantified
 		// param lifetime (Level > lim) and shares a captured, 'static, or nil one, then
-		// refLifetimeResult hands back a RefType carrying it or signals an ordinary descent.
-		return refLifetimeResult(t, lf.fresh(t.Lt)), true
+		// rewriteRefLifetime hands back a RefType carrying it or signals an ordinary descent.
+		return rewriteRefLifetime(t, lf.fresh(t.Lt)), true
 	case *soltype.FuncType:
 		// A function's own lifetime parameters are freshened through the same cache the
 		// body's uses reach through the RefType arm, so a method's `'a` is freshened once
 		// and the binder and every `&'a` use land on one fresh lifetime per instantiation.
-		return funcLifetimeResult(t, lf.fresh), true
+		return rewriteFuncLifetimes(t, lf.fresh), true
 	case *soltype.ClassType:
-		return classLifetimeResult(t, lf.fresh), true
+		return rewriteClassLifetimes(t, lf.fresh), true
 	}
 	return soltype.EnterResult{}, false
 }
 
-// funcLifetimeResult builds the EnterType result for a FuncType whose own lifetime
-// parameters a visitor rewrites through xform, applied to each parameter's Var and
-// outlives Bounds. Accept never walks a lifetime, so a lifetime-aware visitor rewrites
-// the parameters here and then descends: the body's uses of a parameter reach xform
-// through the RefType arm, which shares xform's cache, so the rebuilt binder and its uses
-// stay one lifetime. When no parameter changed it signals an ordinary descent. A
-// parameter's Var stays a variable, since xform maps a variable to a variable.
-func funcLifetimeResult(t *soltype.FuncType, xform func(soltype.Lifetime) soltype.Lifetime) soltype.EnterResult {
+// rewriteFuncLifetimes rewrites a FuncType's own lifetime parameters through tf,
+// which Accept never walks. It shares tf's cache with the body's uses, so a
+// rebuilt binder and its `&'a` uses stay one lifetime. No change signals an ordinary descent.
+func rewriteFuncLifetimes(
+	t *soltype.FuncType,
+	tf func(soltype.Lifetime) soltype.Lifetime,
+) soltype.EnterResult {
 	if len(t.LifetimeParams) == 0 {
 		return soltype.EnterResult{}
 	}
-	nlps, changed := rewriteLtParams(t.LifetimeParams, xform)
+	nlps, changed := rewriteLtParams(t.LifetimeParams, tf)
 	if !changed {
 		return soltype.EnterResult{}
 	}
@@ -378,17 +367,18 @@ func funcLifetimeResult(t *soltype.FuncType, xform func(soltype.Lifetime) soltyp
 	return soltype.EnterResult{Type: &repl}
 }
 
-// classLifetimeResult builds the EnterType result for a ClassType whose lifetime
-// arguments and own borrow lifetime a visitor rewrites through xform. Like
-// funcLifetimeResult it rewrites the non-Type lifetimes here and then descends so the
-// type arguments still walk, sharing xform's cache with any borrow the arguments carry.
-// When no lifetime changed it signals an ordinary descent.
-func classLifetimeResult(t *soltype.ClassType, xform func(soltype.Lifetime) soltype.Lifetime) soltype.EnterResult {
+// rewriteClassLifetimes rewrites a ClassType's lifetime arguments and own borrow lifetime
+// through tf, the non-Type lifetimes Accept never walks. The type arguments still
+// descend, sharing tf's cache. No change signals an ordinary descent.
+func rewriteClassLifetimes(
+	t *soltype.ClassType,
+	tf func(soltype.Lifetime) soltype.Lifetime,
+) soltype.EnterResult {
 	if len(t.LifetimeArgs) == 0 && t.Lt == nil {
 		return soltype.EnterResult{}
 	}
-	nargs, argsChanged := rewriteLtSlice(t.LifetimeArgs, xform)
-	nlt := xform(t.Lt)
+	nargs, argsChanged := rewriteLtSlice(t.LifetimeArgs, tf)
+	nlt := tf(t.Lt)
 	if !argsChanged && nlt == t.Lt {
 		return soltype.EnterResult{}
 	}
@@ -398,16 +388,18 @@ func classLifetimeResult(t *soltype.ClassType, xform func(soltype.Lifetime) solt
 	return soltype.EnterResult{Type: &repl}
 }
 
-// rewriteLtParams applies xform to each lifetime parameter's Var and outlives Bounds,
-// returning the rewritten slice and whether anything changed, so a caller shares the
-// original slice when nothing moved. xform maps a LifetimeVar to a LifetimeVar, so a
-// bound parameter stays a variable. It is copy-on-write, mirroring acceptTypeParams.
-func rewriteLtParams(lps []*soltype.LifetimeParam, xform func(soltype.Lifetime) soltype.Lifetime) ([]*soltype.LifetimeParam, bool) {
+// rewriteLtParams applies tf to each lifetime parameter's Var and outlives Bounds,
+// returning the rewritten slice and whether anything changed. It is copy-on-write, mirroring
+// acceptTypeParams, and tf maps a LifetimeVar to a LifetimeVar so a bound param stays a variable.
+func rewriteLtParams(
+	lps []*soltype.LifetimeParam,
+	tf func(soltype.Lifetime) soltype.Lifetime,
+) ([]*soltype.LifetimeParam, bool) {
 	out := lps
 	changed := false
 	for i, lp := range lps {
-		nv := xform(lp.Var).(*soltype.LifetimeVar)
-		nb, boundsChanged := rewriteLtSlice(lp.Bounds, xform)
+		nv := tf(lp.Var).(*soltype.LifetimeVar)
+		nb, boundsChanged := rewriteLtSlice(lp.Bounds, tf)
 		if nv != lp.Var || boundsChanged {
 			if !changed {
 				out = append([]*soltype.LifetimeParam(nil), lps...)
@@ -419,16 +411,19 @@ func rewriteLtParams(lps []*soltype.LifetimeParam, xform func(soltype.Lifetime) 
 	return out, changed
 }
 
-// rewriteLtSlice applies xform to each lifetime in a slice, copy-on-write like
+// rewriteLtSlice applies tf to each lifetime in a slice, copy-on-write like
 // rewriteLtParams, preserving the nil-for-empty shape.
-func rewriteLtSlice(lts []soltype.Lifetime, xform func(soltype.Lifetime) soltype.Lifetime) ([]soltype.Lifetime, bool) {
+func rewriteLtSlice(
+	lts []soltype.Lifetime,
+	tf func(soltype.Lifetime) soltype.Lifetime,
+) ([]soltype.Lifetime, bool) {
 	if len(lts) == 0 {
 		return nil, false
 	}
 	out := lts
 	changed := false
 	for i, lt := range lts {
-		nl := xform(lt)
+		nl := tf(lt)
 		if nl != lt {
 			if !changed {
 				out = append([]soltype.Lifetime(nil), lts...)


### PR DESCRIPTION
Implement support for quantified lifetime parameters on functions and classes, enabling borrowing methods like `fn get<'a>(&'a self) -> &'a T` to declare and use their own lifetime parameters.

**Key changes:**

- Add `LifetimeParams` field to `FuncType` and `ClassType` to hold declared lifetime parameters in order
- Add `LifetimeParam` struct to represent a single quantified lifetime with its source name, variable, and outlives bounds
- Add `LifetimeArgs` field to `ClassType` to hold lifetime arguments supplied at instantiation
- Extend the type visitor to freshen lifetime parameters through the same `ltFreshener` cache as borrow lifetimes, ensuring a function's `<'a>` binder and all `&'a` uses land on one fresh lifetime per instantiation
- Update `Print` and `PrintAsScheme` to render lifetime parameters in function quantifier prefixes and lifetime arguments in class references, with collision avoidance when a function captures a free lifetime that would shadow a declared parameter name
- Extend type equality checking to compare lifetime parameters positionally under alpha-renaming, so two borrowing methods differing only in lifetime-variable IDs compare equal
- Update `freeLifetimeVars` to exclude a function's own bound lifetime parameters while collecting free lifetimes from class references and outlives bounds
- Add comprehensive tests for printing, freshening, equality, and level computation of lifetime parameters and arguments

The implementation mirrors the existing type-parameter machinery, treating lifetime parameters as bound variables that are freshened per instantiation and compared structurally under alpha-equivalence.

https://claude.ai/code/session_01FVw5apXTFER3MWabtFEnCU