### PR TITLE
Implement class type inference and member resolution (M5 B1)

### DIFF
--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -342,7 +342,7 @@ func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeEle
 	out := es
 	changed := false
 	for i, e := range es {
-		ne := acceptObjElem(e, v, pol)
+		ne := AcceptObjElem(e, v, pol)
 		if ne != e {
 			if !changed {
 				out = append([]ObjTypeElem(nil), es...)
@@ -354,9 +354,12 @@ func acceptObjElems(es []ObjTypeElem, v TypeVisitor, pol Polarity) ([]ObjTypeEle
 	return out, changed
 }
 
-// acceptObjElem rewrites one object member, returning the original pointer when no
-// child changed. It panics on an unknown element kind, matching AsProperty.
-func acceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
+// AcceptObjElem rewrites one object member through the visitor, returning the original
+// pointer when no child changed and threading polarity by the member's variance, as
+// acceptObjElems does for a whole member list. It is exported so a caller projecting a
+// single member can reuse this logic without wrapping the member in an ObjectType. It
+// panics on an unknown element kind, matching AsProperty.
+func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 	switch e := e.(type) {
 	case *PropertyElem:
 		pt := e.Type.Accept(v, pol) // covariant read
@@ -385,7 +388,7 @@ func acceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 		}
 		return &MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
 	}
-	panic(fmt.Sprintf("acceptObjElem: unhandled ObjTypeElem %T", e))
+	panic(fmt.Sprintf("AcceptObjElem: unhandled ObjTypeElem %T", e))
 }
 
 // acceptSignatures walks each signature of a method's overload set through

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"fmt"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -76,10 +78,15 @@ func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, 
 	}
 	subst := newClassSubst(def, ct)
 	projected := def.Body.Accept(subst, soltype.Positive)
-	if obj, ok := projected.(*soltype.ObjectType); ok {
-		return obj, true
+	obj, ok := projected.(*soltype.ObjectType)
+	if !ok {
+		// Substitution replaces only vars and lifetimes, so an ObjectType body always
+		// projects to an ObjectType; a different kind means the substitution corrupted
+		// the body. Fail loudly rather than return the unsubstituted body, matching the
+		// AsProperty discipline.
+		panic(fmt.Sprintf("projectClassBody: %s projected to non-ObjectType %T", ct.Name, projected))
 	}
-	return def.Body, true
+	return obj, true
 }
 
 // projectedMember resolves a member access against a class instance or against a
@@ -117,11 +124,12 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 // instance flows through the bound graph as a variable with a ClassType lower bound
 // rather than a bare ClassType.
 //
-// It resolves only an unambiguous class: a variable whose lower bounds name two
-// different classes, as a join of `Foo(…)` and `Bar(…)` does, is not resolved, so
-// member access falls to the structural path rather than silently projecting whichever
-// class appears first. Member access on such a union rides the nominal-vs-structural
-// rule in C1.
+// It resolves only an unambiguous class: a variable whose lower bounds carry two
+// different instantiations is not resolved, so member access falls to the structural
+// path rather than silently projecting whichever appears first. This covers a join of
+// distinct classes such as `Foo(…)` and `Bar(…)`, and a join of the same class at
+// different arguments such as `Box(1)` and `Box("s")`, whose members differ by
+// argument. Member access on such a union rides the nominal-vs-structural rule in C1.
 func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
 	switch t := t.(type) {
 	case *soltype.ClassType:
@@ -133,7 +141,7 @@ func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
 			if !ok {
 				continue
 			}
-			if found != nil && found.Name != ct.Name {
+			if found != nil && !equalType(found, ct) {
 				return nil, false
 			}
 			found = ct
@@ -148,8 +156,9 @@ func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
 // memberValue produces the value a member access yields: a property's or getter's
 // type directly, or a method's callable signature with the receiver applied — the
 // signature with its SelfParam stripped, since `p.m` binds the receiver and returns a
-// function of the remaining parameters. An overloaded method resolves its arm at the
-// call site (E1); B1 hands back the first signature.
+// function of the remaining parameters. Reading a setter-only member is a write-only
+// access and is reported. An overloaded method resolves its arm at the call site (E1);
+// B1 hands back the first signature.
 func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeElem) pathResult {
 	var out soltype.Type
 	switch m := member.(type) {
@@ -170,6 +179,8 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 			TypeParams:     sig.TypeParams,
 			LifetimeParams: sig.LifetimeParams,
 		}
+	case *soltype.SetterElem:
+		out = c.report(&WriteOnlyPropertyError{Name: m.Name, Site: blame})
 	default:
 		out = &soltype.ErrorType{}
 	}

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -10,7 +10,8 @@ import (
 // ClassDef is the heavy per-class data the nominal token soltype.ClassType points
 // at. inferClassDecl builds one per class declaration and registers it on the
 // Context under the class's dep_graph-qualified name; member lookup reads the
-// projected Body, and the nominal constrain rule (C1) reads Supers and Variance.
+// projected Body, and the nominal constrain rule (C1) reads Supers, Implements, and
+// Variance.
 // Keeping this data out of soltype.ClassType lets the token stay a small, cheap-to-
 // compare identity.
 type ClassDef struct {
@@ -18,25 +19,37 @@ type ClassDef struct {
 	// each carrying its constraint as its Var's upper bound and its resolved default.
 	// nil for a non-generic class.
 	TypeParams []*soltype.TypeParam
+
 	// LifetimeParams are the class's quantified lifetime parameters (A3), the lifetime
 	// twin of TypeParams. nil for a class that holds no borrowed data.
 	LifetimeParams []*soltype.LifetimeParam
+
 	// Variance records one entry per TypeParam, dispatched per position by the nominal
 	// constrain rule. B1 leaves every entry Invariant, the conservative default;
 	// variance inference (C2) overwrites it.
 	Variance []Variance
-	// Supers holds the resolved `extends` superclass followed by each resolved
-	// `implements` interface — the declared subtype-graph edges. The rule that walks
-	// them transitively is C1; B1 only records them.
+
+	// Supers holds the resolved `extends` superclass — the declared nominal
+	// subtype-graph edge. A class has at most one, so this holds zero or one element.
+	// The rule that walks it transitively is C1; B1 only records it.
 	Supers []*soltype.ClassType
+
+	// Implements holds each resolved `implements` interface. `implements` is a
+	// conformance-only assertion, so these are kept out of Supers: the nominal subtype
+	// walk skips them and the structural conformance check reads them. Both the check
+	// and the walk land in C1; B1 only records the targets.
+	Implements []*soltype.ClassType
+
 	// Body is the instance member view a class projects: one element per field,
 	// method, getter, and setter. Member access and the class-vs-object constrain
 	// rule read it.
 	Body *soltype.ObjectType
+
 	// Static is the constructor-plus-static-member view — the value side of the dual
 	// binding. B1 stores static members here for later phases; the callable
 	// constructor itself is the value binding's FuncType.
 	Static *soltype.ObjectType
+
 	// Level is the class binding's generalize level. A generic method's own type
 	// parameters live deeper than this, so member access wraps a resolved method in a
 	// scheme quantified at this level and instantiates it per access.
@@ -52,11 +65,14 @@ const (
 	// until inference runs, the conservative choice a sound constrain rule can always
 	// fall back to.
 	Invariant Variance = iota
+
 	// Covariant lets a subtype argument make a subtype instance, as a read-only field
 	// of that type would.
 	Covariant
+
 	// Contravariant flips the direction, as a write-only or parameter position would.
 	Contravariant
+
 	// Bivariant imposes no constraint — a phantom parameter that appears nowhere in
 	// the body.
 	Bivariant
@@ -66,8 +82,9 @@ const (
 // registered Body with each class type parameter replaced by the instance's
 // corresponding type argument and each lifetime parameter by its lifetime argument.
 // A non-generic instance, or one whose class is unregistered, projects the stored
-// Body unchanged. It is the single path member lookup and the class-vs-object
-// constrain rule use to read a class instance structurally.
+// Body unchanged. The class-vs-object constrain rule reads the whole projected body;
+// a single member access projects just that member through projectClassMember, so it
+// pays only for the member it reads rather than rebuilding every member.
 func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, bool) {
 	def, ok := c.ctx.classDef(ct.Name)
 	if !ok || def.Body == nil {
@@ -89,11 +106,12 @@ func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, 
 	return obj, true
 }
 
-// projectedMember resolves a member access against a class instance or against a
-// class body's method/getter member by direct lookup through the projected body,
-// returning ok=false when the receiver is neither — a plain object property, or a type
-// variable — so the caller falls back to the structural field-requirement path. A
-// class instance whose class has no such member reports the miss here.
+// projectedMember resolves a member access against a class instance by looking the
+// member up on the registered class body and projecting just that member to the
+// instance's arguments, returning ok=false when the receiver is not a class instance —
+// a plain object property, or a type variable — so the caller falls back to the
+// structural field-requirement path. A class instance whose class has no such member
+// reports the miss here.
 //
 // Only a class receiver is intercepted. A plain object keeps the structural
 // field-requirement path, which threads the read-through-borrow and read-after-write
@@ -104,18 +122,37 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	if !ok {
 		return pathResult{}, false
 	}
-	obj, ok := c.projectClassBody(ct)
-	if !ok {
+	def, ok := c.ctx.classDef(ct.Name)
+	if !ok || def.Body == nil {
 		return pathResult{}, false
 	}
-	member, found := obj.Member(name)
+	// Member names are invariant under substitution, so look the member up on the
+	// unprojected body and project only the one accessed, rather than rebuilding the
+	// whole body per access.
+	member, found := def.Body.Member(name)
 	if !found {
+		// The miss is rare, so project the whole body here to render the diagnostic at
+		// the instance's arguments rather than the declared type parameters.
+		obj, _ := c.projectClassBody(ct)
 		err := &MissingPropertyError{Sub: obj, Super: propReq(name, &soltype.UnknownType{}, false), Name: name}
 		err.prov, err.site = c.prov, blame
 		c.errs = append(c.errs, err)
 		return pathResult{value: &soltype.ErrorType{}}, true
 	}
-	return c.memberValue(lvl, blame, member), true
+	return c.memberValue(lvl, blame, c.projectClassMember(def, ct, member)), true
+}
+
+// projectClassMember rewrites one class-body member's type-parameter and
+// lifetime-parameter vars to the arguments of one instance, the single-member analogue
+// of projectClassBody. A non-generic class, whose body holds no such vars, returns the
+// member unchanged. It runs the same classSubst walk projectClassBody runs over the
+// whole body, through the shared per-member entry point, so a member reads exactly as it
+// would there.
+func (c *checker) projectClassMember(def *ClassDef, ct *soltype.ClassType, member soltype.ObjTypeElem) soltype.ObjTypeElem {
+	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
+		return member
+	}
+	return soltype.AcceptObjElem(member, newClassSubst(def, ct), soltype.Positive)
 }
 
 // classCarrier resolves a receiver to the class instance it reads as: a ClassType
@@ -198,6 +235,9 @@ type classSubst struct {
 	lifetimes map[*soltype.LifetimeVar]soltype.Lifetime
 }
 
+// newClassSubst builds the substitution for one class instance. ct is that instance's
+// type, such as Box<5>, so its TypeArgs and LifetimeArgs are the concrete arguments each
+// of def's parameter vars maps to.
 func newClassSubst(def *ClassDef, ct *soltype.ClassType) *classSubst {
 	s := &classSubst{
 		types:     map[*soltype.TypeVarType]soltype.Type{},

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -1,0 +1,236 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// ClassDef is the heavy per-class data the nominal token soltype.ClassType points
+// at. inferClassDecl builds one per class declaration and registers it on the
+// Context under the class's dep_graph-qualified name; member lookup reads the
+// projected Body, and the nominal constrain rule (C1) reads Supers and Variance.
+// Keeping this data out of soltype.ClassType lets the token stay a small, cheap-to-
+// compare identity.
+type ClassDef struct {
+	// TypeParams are the class's own quantified type parameters in declaration order,
+	// each carrying its constraint as its Var's upper bound and its resolved default.
+	// nil for a non-generic class.
+	TypeParams []*soltype.TypeParam
+	// LifetimeParams are the class's quantified lifetime parameters (A3), the lifetime
+	// twin of TypeParams. nil for a class that holds no borrowed data.
+	LifetimeParams []*soltype.LifetimeParam
+	// Variance records one entry per TypeParam, dispatched per position by the nominal
+	// constrain rule. B1 leaves every entry Invariant, the conservative default;
+	// variance inference (C2) overwrites it.
+	Variance []Variance
+	// Supers holds the resolved `extends` superclass followed by each resolved
+	// `implements` interface — the declared subtype-graph edges. The rule that walks
+	// them transitively is C1; B1 only records them.
+	Supers []*soltype.ClassType
+	// Body is the instance member view a class projects: one element per field,
+	// method, getter, and setter. Member access and the class-vs-object constrain
+	// rule read it.
+	Body *soltype.ObjectType
+	// Static is the constructor-plus-static-member view — the value side of the dual
+	// binding. B1 stores static members here for later phases; the callable
+	// constructor itself is the value binding's FuncType.
+	Static *soltype.ObjectType
+	// Level is the class binding's generalize level. A generic method's own type
+	// parameters live deeper than this, so member access wraps a resolved method in a
+	// scheme quantified at this level and instantiates it per access.
+	Level int
+}
+
+// Variance is a type parameter's variance — how the subtype relation on a class
+// instance depends on that parameter's argument.
+type Variance int
+
+const (
+	// Invariant requires the argument to match in both directions. It is the default
+	// until inference runs, the conservative choice a sound constrain rule can always
+	// fall back to.
+	Invariant Variance = iota
+	// Covariant lets a subtype argument make a subtype instance, as a read-only field
+	// of that type would.
+	Covariant
+	// Contravariant flips the direction, as a write-only or parameter position would.
+	Contravariant
+	// Bivariant imposes no constraint — a phantom parameter that appears nowhere in
+	// the body.
+	Bivariant
+)
+
+// projectClassBody returns the instance member view of a class instance: the
+// registered Body with each class type parameter replaced by the instance's
+// corresponding type argument and each lifetime parameter by its lifetime argument.
+// A non-generic instance, or one whose class is unregistered, projects the stored
+// Body unchanged. It is the single path member lookup and the class-vs-object
+// constrain rule use to read a class instance structurally.
+func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, bool) {
+	def, ok := c.ctx.classDef(ct.Name)
+	if !ok || def.Body == nil {
+		return nil, false
+	}
+	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
+		return def.Body, true
+	}
+	subst := newClassSubst(def, ct)
+	projected := def.Body.Accept(subst, soltype.Positive)
+	if obj, ok := projected.(*soltype.ObjectType); ok {
+		return obj, true
+	}
+	return def.Body, true
+}
+
+// projectedMember resolves a member access against a class instance or against a
+// class body's method/getter member by direct lookup through the projected body,
+// returning ok=false when the receiver is neither — a plain object property, or a type
+// variable — so the caller falls back to the structural field-requirement path. A
+// class instance whose class has no such member reports the miss here.
+//
+// Only a class receiver is intercepted. A plain object keeps the structural
+// field-requirement path, which threads the read-through-borrow and read-after-write
+// rules a direct lookup would drop; a method or getter member reaches valueProp only
+// through a class instance, since class bodies are the only source of those elements.
+func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+	ct, ok := classCarrier(carrier)
+	if !ok {
+		return pathResult{}, false
+	}
+	obj, ok := c.projectClassBody(ct)
+	if !ok {
+		return pathResult{}, false
+	}
+	member, found := obj.Member(name)
+	if !found {
+		err := &MissingPropertyError{Sub: obj, Super: propReq(name, &soltype.UnknownType{}, false), Name: name}
+		err.prov, err.site = c.prov, blame
+		c.errs = append(c.errs, err)
+		return pathResult{value: &soltype.ErrorType{}}, true
+	}
+	return c.memberValue(lvl, blame, member), true
+}
+
+// classCarrier resolves a receiver to the class instance it reads as: a ClassType
+// directly, or a type variable whose lower bounds carry one — the same look-through
+// resolveFunc uses to find a concrete callee behind a binding var, since a class
+// instance flows through the bound graph as a variable with a ClassType lower bound
+// rather than a bare ClassType.
+//
+// It resolves only an unambiguous class: a variable whose lower bounds name two
+// different classes, as a join of `Foo(…)` and `Bar(…)` does, is not resolved, so
+// member access falls to the structural path rather than silently projecting whichever
+// class appears first. Member access on such a union rides the nominal-vs-structural
+// rule in C1.
+func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
+	switch t := t.(type) {
+	case *soltype.ClassType:
+		return t, true
+	case *soltype.TypeVarType:
+		var found *soltype.ClassType
+		for _, lb := range t.LowerBounds {
+			ct, ok := lb.(*soltype.ClassType)
+			if !ok {
+				continue
+			}
+			if found != nil && found.Name != ct.Name {
+				return nil, false
+			}
+			found = ct
+		}
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// memberValue produces the value a member access yields: a property's or getter's
+// type directly, or a method's callable signature with the receiver applied — the
+// signature with its SelfParam stripped, since `p.m` binds the receiver and returns a
+// function of the remaining parameters. An overloaded method resolves its arm at the
+// call site (E1); B1 hands back the first signature.
+func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeElem) pathResult {
+	var out soltype.Type
+	switch m := member.(type) {
+	case *soltype.PropertyElem:
+		out = m.Type
+	case *soltype.GetterElem:
+		out = m.Type
+	case *soltype.MethodElem:
+		if len(m.Signatures) == 0 {
+			out = &soltype.ErrorType{}
+			break
+		}
+		sig := m.Signatures[0]
+		out = &soltype.FuncType{
+			Params:         sig.Params,
+			Ret:            sig.Ret,
+			Inexact:        sig.Inexact,
+			TypeParams:     sig.TypeParams,
+			LifetimeParams: sig.LifetimeParams,
+		}
+	default:
+		out = &soltype.ErrorType{}
+	}
+	c.recordType(blame, out)
+	return pathResult{value: out}
+}
+
+// classSubst rewrites a class body's type-parameter and lifetime-parameter vars to
+// the arguments of one instance. It maps each TypeParam.Var to the instance's
+// positional TypeArg and each LifetimeParam.Var to its positional LifetimeArg, so a
+// generic member's type reads at the instance's arguments rather than the declared
+// parameters.
+type classSubst struct {
+	types     map[*soltype.TypeVarType]soltype.Type
+	lifetimes map[*soltype.LifetimeVar]soltype.Lifetime
+}
+
+func newClassSubst(def *ClassDef, ct *soltype.ClassType) *classSubst {
+	s := &classSubst{
+		types:     map[*soltype.TypeVarType]soltype.Type{},
+		lifetimes: map[*soltype.LifetimeVar]soltype.Lifetime{},
+	}
+	for i, tp := range def.TypeParams {
+		if i < len(ct.TypeArgs) {
+			s.types[tp.Var] = ct.TypeArgs[i]
+		}
+	}
+	for i, lp := range def.LifetimeParams {
+		if i < len(ct.LifetimeArgs) {
+			s.lifetimes[lp.Var] = ct.LifetimeArgs[i]
+		}
+	}
+	return s
+}
+
+func (s *classSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	// A borrow's lifetime and a nested ClassType's lifetime arguments are a separate
+	// sort Accept does not walk, so rewrite them here on the way down through the
+	// shared lifetime-rewrite helpers and let Accept rebuild the type's children.
+	switch t := t.(type) {
+	case *soltype.RefType:
+		return rewriteRefLifetime(t, s.lifetime(t.Lt))
+	case *soltype.ClassType:
+		return rewriteClassLifetimes(t, s.lifetime)
+	case *soltype.TypeVarType:
+		if rep, ok := s.types[t]; ok {
+			return soltype.EnterResult{Type: rep, SkipChildren: true}
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *classSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+func (s *classSubst) lifetime(lt soltype.Lifetime) soltype.Lifetime {
+	lv, ok := lt.(*soltype.LifetimeVar)
+	if !ok {
+		return lt
+	}
+	if rep, ok := s.lifetimes[lv]; ok {
+		return rep
+	}
+	return lt
+}

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -38,6 +38,31 @@ type Context struct {
 	// removed from its bound list is simply never matched, since findLtProxy scans
 	// only bounds currently present.
 	ltProxyOrigin map[*soltype.LifetimeVar]soltype.Lifetime
+
+	// classes is the nominal registry (M5): each class's heavy data — the projected
+	// instance body, the resolved supers, and the per-parameter variance — keyed by
+	// the class's dep_graph-qualified name, the same string stored in
+	// soltype.ClassType.Name. inferClassDecl writes an entry per class decl; member
+	// lookup and the nominal constrain rule read it. Every ClassDef comes from a
+	// top-level decl and lives for the whole inference run, so an entry is inserted or
+	// overwritten but never removed for scope exit.
+	classes map[string]*ClassDef
+}
+
+// classDef returns the registered ClassDef for a qualified class name, or ok=false
+// when no class of that name has been registered on this Context.
+func (c *Context) classDef(name string) (*ClassDef, bool) {
+	def, ok := c.classes[name]
+	return def, ok
+}
+
+// registerClass inserts def under a qualified class name, allocating the registry
+// map on first use.
+func (c *Context) registerClass(name string, def *ClassDef) {
+	if c.classes == nil {
+		c.classes = map[string]*ClassDef{}
+	}
+	c.classes[name] = def
 }
 
 // freshVar allocates a new inference variable at the given level, assigning it

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -729,6 +729,7 @@ func (*MissingSelfReceiverError) isSolverError()          {}
 func (*MultipleConstructorsError) isSolverError()         {}
 func (*FieldInitializerNotAllowedError) isSolverError()   {}
 func (*SubclassConstructorRequiredError) isSolverError()  {}
+func (*WriteOnlyPropertyError) isSolverError()            {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -741,7 +742,21 @@ type MissingSelfReceiverError struct {
 func (e *MissingSelfReceiverError) Span() ast.Span      { return e.Elem.Span() }
 func (e *MissingSelfReceiverError) Related() []ast.Span { return nil }
 func (e *MissingSelfReceiverError) Message() string {
-	return "Instance methods, getters, and setters must declare a `self` receiver as their first parameter."
+	return "Instance member '" + e.Name + "' must declare a `self` receiver as its first parameter."
+}
+
+// WriteOnlyPropertyError fires when a setter-only member is read, as in `val v =
+// c.value` where `value` is declared only with `set value(...)`. A setter defines a
+// write, not a readable value.
+type WriteOnlyPropertyError struct {
+	Name string
+	Site ast.Node
+}
+
+func (e *WriteOnlyPropertyError) Span() ast.Span      { return e.Site.Span() }
+func (e *WriteOnlyPropertyError) Related() []ast.Span { return nil }
+func (e *WriteOnlyPropertyError) Message() string {
+	return "Property '" + e.Name + "' is write-only; it has a setter but no getter or field to read."
 }
 
 // MultipleConstructorsError fires on the second and any later `constructor` block in

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -730,6 +730,7 @@ func (*MultipleConstructorsError) isSolverError()         {}
 func (*FieldInitializerNotAllowedError) isSolverError()   {}
 func (*SubclassConstructorRequiredError) isSolverError()  {}
 func (*WriteOnlyPropertyError) isSolverError()            {}
+func (*SetterArityError) isSolverError()                  {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -796,6 +797,21 @@ func (e *SubclassConstructorRequiredError) Span() ast.Span      { return e.Decl.
 func (e *SubclassConstructorRequiredError) Related() []ast.Span { return nil }
 func (e *SubclassConstructorRequiredError) Message() string {
 	return "Subclasses must declare an explicit `constructor` block; constructor synthesis is not supported for classes with an `extends` clause."
+}
+
+// SetterArityError fires when a setter declares other than exactly one value parameter
+// beyond its `self` receiver. A setter's single parameter is the value being assigned,
+// so `set x(self)` and `set x(self, a, b)` are both malformed.
+type SetterArityError struct {
+	Name  string
+	Elem  *ast.SetterElem
+	Count int // value parameters declared, excluding `self`
+}
+
+func (e *SetterArityError) Span() ast.Span      { return e.Elem.Span() }
+func (e *SetterArityError) Related() []ast.Span { return nil }
+func (e *SetterArityError) Message() string {
+	return "Setter '" + e.Name + "' must declare exactly one value parameter; found " + strconv.Itoa(e.Count) + "."
 }
 
 func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -725,6 +725,63 @@ func (*AsyncReturnNotPromiseError) isSolverError()        {}
 func (*NonExhaustiveMatchError) isSolverError()           {}
 func (*MixedOwnershipError) isSolverError()               {}
 func (*MutLeafThroughSharedBorrowError) isSolverError()   {}
+func (*MissingSelfReceiverError) isSolverError()          {}
+func (*MultipleConstructorsError) isSolverError()         {}
+func (*FieldInitializerNotAllowedError) isSolverError()   {}
+func (*SubclassConstructorRequiredError) isSolverError()  {}
+
+// MissingSelfReceiverError fires when a non-static instance method, getter, or
+// setter omits its `self` receiver. Such a member cannot read the instance, so the
+// receiver is required.
+type MissingSelfReceiverError struct {
+	Name string
+	Elem ast.ClassElem
+}
+
+func (e *MissingSelfReceiverError) Span() ast.Span      { return e.Elem.Span() }
+func (e *MissingSelfReceiverError) Related() []ast.Span { return nil }
+func (e *MissingSelfReceiverError) Message() string {
+	return "Instance methods, getters, and setters must declare a `self` receiver as their first parameter."
+}
+
+// MultipleConstructorsError fires on the second and any later `constructor` block in
+// one class; a class declares at most one.
+type MultipleConstructorsError struct {
+	Ctor *ast.ConstructorElem
+}
+
+func (e *MultipleConstructorsError) Span() ast.Span      { return e.Ctor.Span() }
+func (e *MultipleConstructorsError) Related() []ast.Span { return nil }
+func (e *MultipleConstructorsError) Message() string {
+	return "Multiple constructors per class are not yet supported."
+}
+
+// FieldInitializerNotAllowedError fires when an instance field declares a `= expr`
+// initializer. Instance fields are assigned in the constructor body; only static
+// fields may use the initializer form.
+type FieldInitializerNotAllowedError struct {
+	Field *ast.FieldElem
+}
+
+func (e *FieldInitializerNotAllowedError) Span() ast.Span      { return e.Field.Span() }
+func (e *FieldInitializerNotAllowedError) Related() []ast.Span { return nil }
+func (e *FieldInitializerNotAllowedError) Message() string {
+	name, _ := objKeyName(e.Field.Name)
+	return "Field '" + name + "' cannot have a `= expr` initializer; only static fields may use this form. Initialize instance fields in the constructor body."
+}
+
+// SubclassConstructorRequiredError fires when a class with an `extends` clause
+// declares no `constructor` block. Synthesizing one would silently skip the required
+// `super(...)` call, so the constructor must be written explicitly.
+type SubclassConstructorRequiredError struct {
+	Decl *ast.ClassDecl
+}
+
+func (e *SubclassConstructorRequiredError) Span() ast.Span      { return e.Decl.Name.Span() }
+func (e *SubclassConstructorRequiredError) Related() []ast.Span { return nil }
+func (e *SubclassConstructorRequiredError) Message() string {
+	return "Subclasses must declare an explicit `constructor` block; constructor synthesis is not supported for classes with an `extends` clause."
+}
 
 func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }
 func (e *MixedOwnershipError) Related() []ast.Span { return nil }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -1,0 +1,397 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferClassDecl types a non-recursive class declaration (M5 B1). It returns the
+// class's constructor as a raw FuncType for the SCC driver to constrain into the
+// value binding var and generalize, along with the decl's provenance. As side
+// effects it registers the instance TypeBinding in scope and the ClassDef in the
+// nominal registry, so the class name resolves as a type and member lookup and the
+// nominal constrain rule can read the projected body.
+//
+// Every field is built first, so a method body may read any field through `self`.
+// Each method, getter, and setter is then inferred fully and appended to the shared
+// instance Body, so a later member may reference an earlier one through `self`. Once
+// every body has refined the field vars, a non-generic body is coalesced so member
+// lookup reads concrete member types; a generic body keeps its parameter vars
+// symbolic for per-instance projection.
+func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (soltype.Type, provenance.Provenance, bool) {
+	name := decl.Name.Name
+
+	// Resolve the class's type parameters into a child scope so the body resolves the
+	// class's T to one shared var, quantified at the class boundary and freshened per
+	// construction. A non-generic class reuses the enclosing scope.
+	declScope := scope
+	var typeParams []*soltype.TypeParam
+	if len(decl.TypeParams) > 0 {
+		declScope = scope.Child()
+		typeParams = c.resolveClassTypeParams(declScope, lvl, decl.TypeParams)
+	}
+
+	// The instance's nominal identity, carrying the class's own type-parameter vars as
+	// its arguments. B1 uses the bare local name as the qualified key, correct for the
+	// top-level default namespace; namespace-qualified keys ride the namespace work.
+	self := &soltype.ClassType{Name: name, TypeArgs: typeParamVars(typeParams)}
+
+	body := &soltype.ObjectType{}
+	static := &soltype.ObjectType{}
+	def := &ClassDef{
+		Body:       body,
+		Static:     static,
+		Level:      lvl - 1,
+		TypeParams: typeParams,
+		Variance:   make([]Variance, len(typeParams)),
+	}
+	c.ctx.registerClass(name, def)
+	// Register the type binding early so a self-referential type in the body resolves
+	// to this class rather than falling through as unknown.
+	scope.defineType(name, TypeBinding{
+		Type:    self,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	c.recordType(decl.Name, self)
+
+	// Resolve the declared supers so C1 can walk them; B1 records the edges only.
+	def.Supers = c.resolveClassSupers(declScope, lvl, decl)
+
+	// Build every field first so a method body may read any field through `self`,
+	// then infer each method, getter, and setter — each fully, so its body refines its
+	// own signature — appending it to the body as it goes, so a later member may
+	// reference an earlier one through `self`. Intra-class forward references to a
+	// later member are out of B1's scope.
+	ctors := c.collectConstructors(decl)
+	c.buildFieldSigs(declScope, lvl, decl, body, static)
+	c.inferMembers(declScope, lvl, decl, self, body, static)
+	ctorType := c.inferConstructor(declScope, lvl, decl, self, body, ctors)
+
+	// A generic class keeps its member types symbolic — a field typed `T` stays the
+	// class type-parameter var so member lookup can substitute an instance's argument
+	// for it. Freezing would coalesce that unconstrained var to `never`. A non-generic
+	// class has no such vars, so its body is coalesced to concrete member types.
+	if len(typeParams) == 0 {
+		c.freezeClassBody(body)
+		c.freezeClassBody(static)
+	}
+
+	return ctorType, &ast.NodeProvenance{Node: decl}, true
+}
+
+// resolveClassTypeParams resolves a class's AST type parameters to soltype
+// TypeParams, minting one shared var per parameter, recording its constraint as the
+// var's upper bound and its resolved default, and declaring each into scope so the
+// class body resolves the parameter name to that var.
+func (c *checker) resolveClassTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
+	out := make([]*soltype.TypeParam, len(params))
+	for i, p := range params {
+		v := c.freshAt(lvl)
+		// Declare the parameter before resolving its own constraint and default so an
+		// F-bounded `<T: Foo<T>>` or a defaulting `<T, U = T>` reference resolves to it.
+		scope.defineType(p.Name, TypeBinding{Type: v})
+		if p.Constraint != nil {
+			if ct, ok := c.resolveClassTypeAnn(scope, p.Constraint, lvl); ok {
+				c.ctx.addUpperBound(v, ct)
+			}
+		}
+		var def soltype.Type
+		if p.Default != nil {
+			if dt, ok := c.resolveClassTypeAnn(scope, p.Default, lvl); ok {
+				def = dt
+			}
+		}
+		out[i] = &soltype.TypeParam{Name: p.Name, Var: v, Default: def}
+	}
+	return out
+}
+
+// typeParamVars returns each type parameter's var, the arguments a class's own
+// instance carries — the Self reference `Box<T>` fills its TypeArgs with the T vars.
+func typeParamVars(params []*soltype.TypeParam) []soltype.Type {
+	if len(params) == 0 {
+		return nil
+	}
+	args := make([]soltype.Type, len(params))
+	for i, p := range params {
+		args[i] = p.Var
+	}
+	return args
+}
+
+// resolveClassSupers resolves a class's `extends` superclass and `implements`
+// interfaces to their ClassTypes, in that order, dropping any that do not resolve to
+// a class. B1 records these edges on ClassDef.Supers; the transitive subtype walk and
+// the structural implements check land in C1.
+func (c *checker) resolveClassSupers(scope *Scope, lvl int, decl *ast.ClassDecl) []*soltype.ClassType {
+	var supers []*soltype.ClassType
+	add := func(ref *ast.TypeRefTypeAnn) {
+		if ref == nil {
+			return
+		}
+		if ct := c.resolveClassRef(scope, ref); ct != nil {
+			supers = append(supers, ct)
+		}
+	}
+	add(decl.Extends)
+	for _, impl := range decl.Implements {
+		add(impl)
+	}
+	return supers
+}
+
+// resolveClassRef resolves a type reference that names a class to its ClassType, or
+// nil when the name is not a registered class. B1 consults the type scope directly
+// rather than routing through resolveTypeAnn, whose general TypeRef resolution lands
+// with the alias work.
+func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltype.ClassType {
+	name := ast.QualIdentToString(ref.Name)
+	if b, ok := scope.GetType(name); ok {
+		if ct, ok := b.Type.(*soltype.ClassType); ok {
+			return ct
+		}
+	}
+	return nil
+}
+
+// resolveClassTypeAnn resolves a type annotation appearing in a class body. It first
+// consults the type scope for a bare reference to a class or type parameter — the two
+// names resolveTypeAnn's general TypeRef resolution does not yet cover — and otherwise
+// delegates to resolveTypeAnn for primitives and structural types.
+func (c *checker) resolveClassTypeAnn(scope *Scope, ann ast.TypeAnn, lvl int) (soltype.Type, bool) {
+	if ref, ok := ann.(*ast.TypeRefTypeAnn); ok && len(ref.TypeArgs) == 0 {
+		name := ast.QualIdentToString(ref.Name)
+		if b, ok := scope.GetType(name); ok {
+			return b.Type, true
+		}
+	}
+	return c.resolveTypeAnn(ann, lvl)
+}
+
+// collectConstructors returns the explicit constructor elements of a class, reporting
+// each one past the first as a duplicate. A well-formed class has zero or one.
+func (c *checker) collectConstructors(decl *ast.ClassDecl) []*ast.ConstructorElem {
+	var ctors []*ast.ConstructorElem
+	for _, elem := range decl.Body {
+		if ctor, ok := elem.(*ast.ConstructorElem); ok {
+			if len(ctors) >= 1 {
+				c.report(&MultipleConstructorsError{Ctor: ctor})
+				continue
+			}
+			ctors = append(ctors, ctor)
+		}
+	}
+	return ctors
+}
+
+// buildFieldSigs adds one PropertyElem per field to the instance or static body,
+// resolving each field's annotation or minting a fresh var when it is unannotated. An
+// instance field carrying an initializer is rejected — instance fields are set in the
+// constructor — while a static field's initializer is inferred and checked against the
+// field's declared type.
+func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, body, static *soltype.ObjectType) {
+	for _, elem := range decl.Body {
+		field, ok := elem.(*ast.FieldElem)
+		if !ok {
+			continue
+		}
+		fieldName, ok := objKeyName(field.Name)
+		if !ok {
+			continue
+		}
+		var fieldType soltype.Type
+		if field.Type != nil {
+			if t, ok := c.resolveClassTypeAnn(scope, field.Type, lvl); ok {
+				fieldType = t
+			} else {
+				fieldType = c.freshAt(lvl)
+			}
+		} else {
+			fieldType = c.freshAt(lvl)
+		}
+		if field.Value != nil {
+			if field.Static {
+				// A static field's initializer must fit its declared type, so
+				// `static x: number = "hi"` is rejected.
+				initType := c.inferExpr(scope, lvl, field.Value)
+				c.constrain(field.Value, initType, fieldType)
+			} else {
+				c.report(&FieldInitializerNotAllowedError{Field: field})
+			}
+		}
+		prop := &soltype.PropertyElem{
+			Name:     fieldName,
+			Type:     fieldType,
+			Optional: field.Optional,
+			Readonly: field.Readonly,
+		}
+		if field.Static {
+			static.Elems = append(static.Elems, prop)
+		} else {
+			body.Elems = append(body.Elems, prop)
+		}
+	}
+}
+
+// inferMembers infers each method, getter, and setter of a class fully — its body
+// refines its own signature through the shared inferFunc core — and appends the
+// resulting element to the instance or static body. An instance member missing its
+// `self` receiver is reported. Each member is appended before the next is inferred, so
+// a later member may reference an earlier one through `self`.
+func (c *checker) inferMembers(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body, static *soltype.ObjectType) {
+	for _, elem := range decl.Body {
+		switch elem := elem.(type) {
+		case *ast.MethodElem:
+			name, ok := objKeyName(elem.Name)
+			if !ok {
+				continue
+			}
+			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
+			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
+			ft.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
+			appendMethodSig(targetBody(body, static, elem.Static), name, ft, elem.Static)
+		case *ast.GetterElem:
+			name, ok := objKeyName(elem.Name)
+			if !ok {
+				continue
+			}
+			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
+			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
+			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: ft.Ret}
+			target := targetBody(body, static, elem.Static)
+			target.Elems = append(target.Elems, getter)
+		case *ast.SetterElem:
+			name, ok := objKeyName(elem.Name)
+			if !ok {
+				continue
+			}
+			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
+			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
+			var param soltype.Type = &soltype.UnknownType{}
+			if len(ft.Params) > 0 {
+				param = ft.Params[0].Type
+			}
+			setter := &soltype.SetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Param: param}
+			target := targetBody(body, static, elem.Static)
+			target.Elems = append(target.Elems, setter)
+		}
+	}
+}
+
+// targetBody selects the static or instance body for a member.
+func targetBody(body, static *soltype.ObjectType, isStatic bool) *soltype.ObjectType {
+	if isStatic {
+		return static
+	}
+	return body
+}
+
+// checkSelfReceiver reports a non-static instance member that omits its `self`
+// receiver.
+func (c *checker) checkSelfReceiver(name string, elem ast.ClassElem, static bool, recv *ast.MethodReceiver) {
+	if !static && recv == nil {
+		c.report(&MissingSelfReceiverError{Name: name, Elem: elem})
+	}
+}
+
+// inferMemberFunc infers one member body via the shared inferFunc core, binding `self`
+// to the instance body — owned-mutable for a `mut self` receiver — so field reads and
+// writes inside the body resolve through the record machinery. It returns the inferred
+// FuncType, whose params and return the caller installs on the member element.
+func (c *checker) inferMemberFunc(scope *Scope, lvl int, fn *ast.FuncExpr, recv *ast.MethodReceiver, static bool, self *soltype.ClassType, body *soltype.ObjectType) *soltype.FuncType {
+	memberScope := scope.Child()
+	if !static {
+		c.bindSelf(memberScope, recv, body)
+	}
+	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn)
+}
+
+// appendMethodSig installs a method signature under name, merging it into an existing
+// same-named MethodElem as an overload arm rather than adding a second element.
+func appendMethodSig(obj *soltype.ObjectType, name string, sig *soltype.FuncType, static bool) {
+	for _, e := range obj.Elems {
+		if m, ok := e.(*soltype.MethodElem); ok && m.Name == name {
+			m.Signatures = append(m.Signatures, sig)
+			return
+		}
+	}
+	obj.Elems = append(obj.Elems, &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}, Static: static})
+}
+
+// selfParam builds the SelfParam a member's signature carries, or nil for a static
+// member. A `mut self` receiver wraps the instance in an owned-mutable borrow; a plain
+// `self` carries the bare instance.
+func (c *checker) selfParam(recv *ast.MethodReceiver, static bool, self *soltype.ClassType) *soltype.FuncParam {
+	if static || recv == nil {
+		return nil
+	}
+	return &soltype.FuncParam{Pattern: &soltype.IdentPat{Name: "self"}, Type: c.selfType(recv, self)}
+}
+
+// selfType returns the type the `self` binding takes in a member body: an
+// owned-mutable borrow of the instance for `mut self`, the bare instance otherwise.
+func (c *checker) selfType(recv *ast.MethodReceiver, self soltype.Type) soltype.Type {
+	if recv != nil && recv.Mut {
+		return soltype.NewRef(true, nil, self.(soltype.RefInner))
+	}
+	return self
+}
+
+// bindSelf binds the `self` identifier in a member body scope to the instance's
+// fields, wrapped owned-mutable for a `mut self` receiver so field writes type-check.
+//
+// `self` carries only the field members, not the methods: field reads and writes flow
+// through the record subtyping machinery, whose object arm reads only properties and
+// would panic on a method member. A field-only `self` therefore keeps that path sound.
+// A method calling a sibling method through `self` is out of B1's scope; external
+// member access still reaches every member through the projected class body.
+func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype.ObjectType) {
+	fields := &soltype.ObjectType{Elems: fieldElems(body)}
+	var selfBody soltype.Type = fields
+	if recv != nil && recv.Mut {
+		selfBody = soltype.NewRef(true, nil, fields)
+	}
+	scope.defineValue("self", ValueBinding{Schemes: []TypeScheme{monoScheme(selfBody)}})
+}
+
+// fieldElems returns the property members of a class body, sharing each PropertyElem
+// pointer so a write through `self` refines the same field type the projected body
+// reads.
+func fieldElems(body *soltype.ObjectType) []soltype.ObjTypeElem {
+	var fields []soltype.ObjTypeElem
+	for _, e := range body.Elems {
+		if _, ok := e.(*soltype.PropertyElem); ok {
+			fields = append(fields, e)
+		}
+	}
+	return fields
+}
+
+// freezeClassBody coalesces each member's type in place so member lookup and the
+// class-vs-object rule read concrete member types rather than the fresh vars a field
+// held before a constructor assignment refined it. Each member is coalesced
+// individually rather than the whole object at once, since the object's owned-mut
+// bubbling pass reads only PropertyElems and would panic on a method member.
+func (c *checker) freezeClassBody(obj *soltype.ObjectType) {
+	for i, e := range obj.Elems {
+		switch e := e.(type) {
+		case *soltype.PropertyElem:
+			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesce(e.Type, soltype.Positive), Optional: e.Optional, Readonly: e.Readonly}
+		case *soltype.GetterElem:
+			obj.Elems[i] = &soltype.GetterElem{Name: e.Name, SelfParam: e.SelfParam, Type: coalesce(e.Type, soltype.Positive)}
+		case *soltype.SetterElem:
+			obj.Elems[i] = &soltype.SetterElem{Name: e.Name, SelfParam: e.SelfParam, Param: coalesce(e.Param, soltype.Negative)}
+		case *soltype.MethodElem:
+			sigs := make([]*soltype.FuncType, len(e.Signatures))
+			for j, sig := range e.Signatures {
+				if cs, ok := coalesce(sig, soltype.Positive).(*soltype.FuncType); ok {
+					sigs[j] = cs
+				} else {
+					sigs[j] = sig
+				}
+			}
+			obj.Elems[i] = &soltype.MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
+		}
+	}
+}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -8,17 +8,19 @@ import (
 
 // inferClassDecl types a non-recursive class declaration (M5 B1). It returns the
 // class's constructor as a raw FuncType for the SCC driver to constrain into the
-// value binding var and generalize, along with the decl's provenance. As side
-// effects it registers the instance TypeBinding in scope and the ClassDef in the
-// nominal registry, so the class name resolves as a type and member lookup and the
+// value binding var and generalize, along with the decl's provenance. It has two side
+// effects. It registers the instance TypeBinding in scope, so the class name resolves as
+// a type. It registers the ClassDef in the nominal registry, so member lookup and the
 // nominal constrain rule can read the projected body.
 //
-// Every field is built first, so a method body may read any field through `self`.
-// Each method, getter, and setter is then inferred fully and appended to the shared
-// instance Body, so a later member may reference an earlier one through `self`. Once
-// every body has refined the field vars, a non-generic body is coalesced so member
-// lookup reads concrete member types; a generic body keeps its parameter vars
-// symbolic for per-instance projection.
+// Fields are built first, then each method, getter, and setter is inferred eagerly.
+// `self` carries the fields only, so a method that calls another method of the same
+// class is not handled here, whether self-recursive, mutually recursive, or a plain
+// sibling call. PR B3 addresses this (planning/simple_sub/m5-implementation-plan.md).
+//
+// Once every body has refined the field vars, a non-generic body is coalesced so member
+// lookup reads concrete member types. A generic body keeps its parameter vars symbolic
+// for per-instance projection.
 func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (soltype.Type, provenance.Provenance, bool) {
 	name := decl.Name.Name
 
@@ -55,14 +57,15 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	})
 	c.recordType(decl.Name, self)
 
-	// Resolve the declared supers so C1 can walk them; B1 records the edges only.
-	def.Supers = c.resolveClassSupers(declScope, lvl, decl)
+	// Resolve the declared extends edge and implements interfaces so C1 can walk and
+	// check them; B1 records them only.
+	def.Supers = c.resolveClassSupers(declScope, decl)
+	def.Implements = c.resolveClassImplements(declScope, decl)
 
-	// Build every field first so a method body may read any field through `self`,
-	// then infer each method, getter, and setter — each fully, so its body refines its
-	// own signature — appending it to the body as it goes, so a later member may
-	// reference an earlier one through `self`. Intra-class forward references to a
-	// later member are out of B1's scope.
+	// Build every field first so a method body may read any field through `self`. Then
+	// infer each method, getter, and setter fully, so each body refines its own
+	// signature, appending it to the body as it goes. Calls between methods of the same
+	// class are not resolved here. The function doc explains why and what will fix it.
 	ctors := c.collectConstructors(decl)
 	c.buildFieldSigs(declScope, lvl, decl, body, static)
 	c.inferMembers(declScope, lvl, decl, self, body, static)
@@ -84,6 +87,12 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 // TypeParams, minting one shared var per parameter, recording its constraint as the
 // var's upper bound and its resolved default, and declaring each into scope so the
 // class body resolves the parameter name to that var.
+//
+// Resolution runs in declaration order, so a bound may reference the parameter itself
+// or an earlier one, but not a later one. A forward or mutual reference such as
+// `<T: U, U>` does not resolve. PR B4 replaces this with a shared two-pass resolver
+// that declares every parameter before resolving any bound
+// (planning/simple_sub/m5-implementation-plan.md).
 func (c *checker) resolveClassTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
 	out := make([]*soltype.TypeParam, len(params))
 	for i, p := range params {
@@ -120,31 +129,42 @@ func typeParamVars(params []*soltype.TypeParam) []soltype.Type {
 	return args
 }
 
-// resolveClassSupers resolves a class's `extends` superclass and `implements`
-// interfaces to their ClassTypes, in that order, dropping any that do not resolve to
-// a class. B1 records these edges on ClassDef.Supers; the transitive subtype walk and
-// the structural implements check land in C1.
-func (c *checker) resolveClassSupers(scope *Scope, lvl int, decl *ast.ClassDecl) []*soltype.ClassType {
-	var supers []*soltype.ClassType
-	add := func(ref *ast.TypeRefTypeAnn) {
-		if ref == nil {
-			return
-		}
-		if ct := c.resolveClassRef(scope, ref); ct != nil {
-			supers = append(supers, ct)
-		}
+// resolveClassSupers resolves a class's `extends` superclass to its ClassType,
+// returning a single-element slice or nil when the class has no superclass or it does
+// not resolve to a class. B1 records this edge on ClassDef.Supers; the transitive
+// nominal subtype walk lands in C1.
+func (c *checker) resolveClassSupers(scope *Scope, decl *ast.ClassDecl) []*soltype.ClassType {
+	if decl.Extends == nil {
+		return nil
 	}
-	add(decl.Extends)
+	if ct := c.resolveClassRef(scope, decl.Extends); ct != nil {
+		return []*soltype.ClassType{ct}
+	}
+	return nil
+}
+
+// resolveClassImplements resolves a class's `implements` interfaces to their
+// ClassTypes, dropping any that do not resolve to a class. `implements` is a
+// conformance-only assertion the nominal subtype walk skips, so B1 records these on
+// ClassDef.Implements apart from Supers; the structural conformance check lands in C1.
+func (c *checker) resolveClassImplements(scope *Scope, decl *ast.ClassDecl) []*soltype.ClassType {
+	var ifaces []*soltype.ClassType
 	for _, impl := range decl.Implements {
-		add(impl)
+		if ct := c.resolveClassRef(scope, impl); ct != nil {
+			ifaces = append(ifaces, ct)
+		}
 	}
-	return supers
+	return ifaces
 }
 
 // resolveClassRef resolves a type reference that names a class to its ClassType, or
 // nil when the name is not a registered class. B1 consults the type scope directly
 // rather than routing through resolveTypeAnn, whose general TypeRef resolution lands
 // with the alias work.
+//
+// A nil result is currently dropped by the callers with no diagnostic. C1 reports the
+// non-class case as NonClassSuperError, and M7's general TypeRef resolution reports an
+// unbound name (planning/simple_sub/m5-implementation-plan.md).
 func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltype.ClassType {
 	name := ast.QualIdentToString(ref.Name)
 	if b, ok := scope.GetType(name); ok {
@@ -239,7 +259,13 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 // resulting element to the instance or static body. An instance member missing its
 // `self` receiver is reported. Each member is appended before the next is inferred, so
 // a later member may reference an earlier one through `self`.
-func (c *checker) inferMembers(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body, static *soltype.ObjectType) {
+func (c *checker) inferMembers(
+	scope *Scope,
+	lvl int,
+	decl *ast.ClassDecl,
+	self *soltype.ClassType,
+	body, static *soltype.ObjectType,
+) {
 	for _, elem := range decl.Body {
 		switch elem := elem.(type) {
 		case *ast.MethodElem:
@@ -268,6 +294,13 @@ func (c *checker) inferMembers(scope *Scope, lvl int, decl *ast.ClassDecl, self 
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
 			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
+			// A well-formed setter declares exactly one value parameter beyond `self` — the
+			// value being assigned. Report a paramless or multi-parameter setter, then still
+			// build the elem from the first value parameter, or `unknown` when there is none,
+			// so member access recovers.
+			if len(ft.Params) != 1 {
+				c.report(&SetterArityError{Name: name, Elem: elem, Count: len(ft.Params)})
+			}
 			var param soltype.Type = &soltype.UnknownType{}
 			if len(ft.Params) > 0 {
 				param = ft.Params[0].Type
@@ -299,7 +332,15 @@ func (c *checker) checkSelfReceiver(name string, elem ast.ClassElem, static bool
 // to the instance body — owned-mutable for a `mut self` receiver — so field reads and
 // writes inside the body resolve through the record machinery. It returns the inferred
 // FuncType, whose params and return the caller installs on the member element.
-func (c *checker) inferMemberFunc(scope *Scope, lvl int, fn *ast.FuncExpr, recv *ast.MethodReceiver, static bool, self *soltype.ClassType, body *soltype.ObjectType) *soltype.FuncType {
+func (c *checker) inferMemberFunc(
+	scope *Scope,
+	lvl int,
+	fn *ast.FuncExpr,
+	recv *ast.MethodReceiver,
+	static bool,
+	self *soltype.ClassType, // unused until B3 binds `self` to the full instance
+	body *soltype.ObjectType,
+) *soltype.FuncType {
 	memberScope := scope.Child()
 	if !static {
 		c.bindSelf(memberScope, recv, body)
@@ -338,34 +379,41 @@ func (c *checker) selfType(recv *ast.MethodReceiver, self soltype.Type) soltype.
 	return self
 }
 
-// bindSelf binds the `self` identifier in a member body scope to the instance's
-// fields, wrapped owned-mutable for a `mut self` receiver so field writes type-check.
+// bindSelf binds the `self` identifier in a member body scope to the instance's fields.
+// It builds a field-only view of the class body, keeping the PropertyElems and dropping
+// every method, getter, and setter. The view shares each PropertyElem pointer with
+// the body, so a write such as `self.x = v` refines the same field-type var the
+// projected body later reads for external access. A `mut self` receiver wraps the view
+// in an owned-mutable borrow so field writes type-check. A plain `self` binds the bare
+// view.
 //
-// `self` carries only the field members, not the methods: field reads and writes flow
-// through the record subtyping machinery, whose object arm reads only properties and
-// would panic on a method member. A field-only `self` therefore keeps that path sound.
-// A method calling a sibling method through `self` is out of B1's scope; external
-// member access still reaches every member through the projected class body.
+// `self` is field-only by design, not because method subtyping is unimplemented. A
+// `self.field` read or write flows through the record subtyping machinery, whose object
+// arm threads the borrow and mutability rules field access needs: read-through-borrow,
+// read-after-write, and the contravariant write view under `mut`. That arm reads only
+// properties and panics on a method member, per AsProperty, and methods need none of
+// those field rules, so they stay off this path.
+//
+// Methods are reached elsewhere, not dropped. External access resolves method, getter,
+// and setter members through the projected class body, and a sibling call through `self`
+// lands in B3. A method's own receiver ownership is checked separately at the call site
+// as a `receiver <: SelfParam` constraint, not by this binding. A `mut self` call, for
+// example, needs a mutable receiver.
 func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype.ObjectType) {
-	fields := &soltype.ObjectType{Elems: fieldElems(body)}
+	// Keep only the PropertyElems, dropping every method, getter, and setter, and share
+	// each pointer so a write through `self` refines the same field-type var the
+	// projected body reads.
+	fields := &soltype.ObjectType{}
+	for _, e := range body.Elems {
+		if _, ok := e.(*soltype.PropertyElem); ok {
+			fields.Elems = append(fields.Elems, e)
+		}
+	}
 	var selfBody soltype.Type = fields
 	if recv != nil && recv.Mut {
 		selfBody = soltype.NewRef(true, nil, fields)
 	}
 	scope.defineValue("self", ValueBinding{Schemes: []TypeScheme{monoScheme(selfBody)}})
-}
-
-// fieldElems returns the property members of a class body, sharing each PropertyElem
-// pointer so a write through `self` refines the same field type the projected body
-// reads.
-func fieldElems(body *soltype.ObjectType) []soltype.ObjTypeElem {
-	var fields []soltype.ObjTypeElem
-	for _, e := range body.Elems {
-		if _, ok := e.(*soltype.PropertyElem); ok {
-			fields = append(fields, e)
-		}
-	}
-	return fields
 }
 
 // freezeClassBody coalesces each member's type in place so member lookup and the

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -1,0 +1,67 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferConstructor produces a class's constructor as a FuncType returning the
+// instance. With an explicit constructor it walks the constructor body so field
+// assignments refine the instance fields, then builds a callable signature from the
+// value parameters. With none it synthesizes one from the instance fields, unless the
+// class extends a superclass — a subclass must declare its own constructor to call
+// `super`, so a missing one is reported and a field-based constructor is synthesized
+// for recovery.
+func (c *checker) inferConstructor(scope *Scope, lvl int, decl *ast.ClassDecl, self *soltype.ClassType, body *soltype.ObjectType, ctors []*ast.ConstructorElem) soltype.Type {
+	if len(ctors) == 0 {
+		if decl.Extends != nil {
+			c.report(&SubclassConstructorRequiredError{Decl: decl})
+		}
+		return c.synthesizeConstructor(self, body)
+	}
+	return c.walkConstructorBody(scope, lvl, self, body, ctors[0])
+}
+
+// synthesizeConstructor builds the implicit constructor of a class with no explicit
+// one: a function taking one parameter per required instance field, in declaration
+// order, and returning the instance. An optional field is omitted, matching its
+// omission from the required set.
+func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.ObjectType) soltype.Type {
+	var params []*soltype.FuncParam
+	for _, e := range body.Elems {
+		prop, ok := e.(*soltype.PropertyElem)
+		if !ok || prop.Optional {
+			continue
+		}
+		params = append(params, &soltype.FuncParam{
+			Pattern: &soltype.IdentPat{Name: prop.Name},
+			Type:    prop.Type,
+		})
+	}
+	return &soltype.FuncType{Params: params, Ret: self}
+}
+
+// walkConstructorBody walks an explicit constructor's body with `self` bound to the
+// owned-mutable instance body, so `self.x = value` refines field x through the record
+// write machinery, and returns a callable signature: the constructor's value
+// parameters — the params after the leading `mut self` — returning the instance.
+func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.ClassType, body *soltype.ObjectType, ctor *ast.ConstructorElem) soltype.Type {
+	// The parser materializes `mut self` as Fn.Params[0]; the callable signature is
+	// the params after it.
+	valueParams := ctor.Fn.Params
+	if ctor.Receiver != nil && len(valueParams) > 0 {
+		valueParams = valueParams[1:]
+	}
+	bodySig := ctor.Fn.FuncSig
+	bodySig.Params = valueParams
+
+	ctorScope := scope.Child()
+	// A constructor's `self` is always owned-mutable so its body can assign fields,
+	// regardless of the class's default mutability.
+	c.bindSelf(ctorScope, &ast.MethodReceiver{Mut: true}, body)
+
+	ft := c.inferFunc(ctorScope, lvl, bodySig, ctor.Fn.Body, ctor)
+	// A constructor returns a fresh instance, not the void its statement body falls off
+	// to, so override the inferred return with the instance type.
+	return &soltype.FuncType{Params: ft.Params, Ret: self, Inexact: ft.Inexact}
+}

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -45,6 +45,10 @@ func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.O
 // owned-mutable instance body, so `self.x = value` refines field x through the record
 // write machinery, and returns a callable signature: the constructor's value
 // parameters — the params after the leading `mut self` — returning the instance.
+//
+// It does not check definite assignment. A required field left unassigned on some path,
+// or a field read before it is assigned, is not yet reported. PR B5 adds that check
+// (planning/simple_sub/m5-implementation-plan.md).
 func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.ClassType, body *soltype.ObjectType, ctor *ast.ConstructorElem) soltype.Type {
 	// The parser materializes `mut self` as Fn.Params[0]; the callable signature is
 	// the params after it.

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -180,6 +180,42 @@ func TestInferClassGeneric(t *testing.T) {
 	}
 }
 
+// A join of the same class at two different type arguments — the value of
+// `if c { Box(5) } else { Box("hello") }` — leaves the binding a union of both
+// instantiations, Box<5> | Box<"hello">. That union is the shape classCarrier sees as two
+// distinct class instances on one variable's lower bounds, so a member access on it cannot
+// take the fast projected-member path and rides the nominal-vs-structural rule instead.
+func TestInferClassJoinDistinctArgs(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> { value: T }
+		val c = true
+		val b = if c { Box(5) } else { Box("hello") }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `Box<5> | Box<"hello">`, values["b"])
+}
+
+// Reading a member off that union — `b.value` for b : Box<5> | Box<"hello"> — distributes
+// over the union and joins each arm's `value` field into 5 | "hello".
+//
+// DISABLED until C1 lands. classCarrier resolves only an unambiguous class, so a variable
+// whose lower bounds carry two different instantiations falls to the structural
+// field-requirement path. That path has no class-vs-object rule yet, so each Box<…> arm
+// fails `cannot constrain ? <: object` and v coalesces to never. C1 adds the
+// nominal-vs-structural rule; re-enable then and assert v : 5 | "hello" with no errors.
+/*
+func TestInferClassJoinMemberAccess(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> { value: T }
+		val c = true
+		val b = if c { Box(5) } else { Box("hello") }
+		val v = b.value
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `5 | "hello"`, values["v"])
+}
+*/
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {
@@ -203,6 +239,26 @@ func TestInferClassErrors(t *testing.T) {
 				val r = c.value
 			`,
 			want: "Property 'value' is write-only; it has a setter but no getter or field to read.",
+		},
+		{
+			name: "SetterNoParams",
+			src: `
+				class C {
+					v: number,
+					set value(mut self) { },
+				}
+			`,
+			want: "Setter 'value' must declare exactly one value parameter; found 0.",
+		},
+		{
+			name: "SetterTooManyParams",
+			src: `
+				class C {
+					v: number,
+					set value(mut self, a: number, b: number) { },
+				}
+			`,
+			want: "Setter 'value' must declare exactly one value parameter; found 2.",
 		},
 		{
 			name: "MultipleConstructors",

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1,0 +1,238 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// classValues is the value/type-binding assertion shared by the class tests: it
+// infers src, requires no errors, and checks each expected value and type binding.
+func classValues(t *testing.T, src string, wantValues, wantTypes map[string]string) {
+	t.Helper()
+	values, types, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	for name, want := range wantValues {
+		require.Equal(t, want, values[name], "value binding %q", name)
+	}
+	for name, want := range wantTypes {
+		require.Equal(t, want, types[name], "type binding %q", name)
+	}
+}
+
+// TestInferClassBasic covers a non-generic class end to end: the type binding
+// renders under the class name, the value binding is the constructor signature,
+// construction yields an instance, and fields and methods resolve through the
+// projected body.
+func TestInferClassBasic(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			name: "SynthesizedConstructor",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+				}
+			`,
+			wantValues: map[string]string{"Point": "fn (x: number, y: number) -> Point"},
+			wantTypes:  map[string]string{"Point": "Point"},
+		},
+		{
+			name: "ConstructAndReadField",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+				}
+				val p = Point(1, 2)
+				val px = p.x
+			`,
+			wantValues: map[string]string{
+				"Point": "fn (x: number, y: number) -> Point",
+				"p":     "Point",
+				"px":    "number",
+			},
+		},
+		{
+			name: "MethodCall",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+					getX(self) -> number { return self.x },
+				}
+				val p = Point(1, 2)
+				val d = p.getX()
+			`,
+			wantValues: map[string]string{"p": "Point", "d": "number"},
+		},
+		{
+			name: "ExplicitConstructor",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+					constructor(mut self, x: number, y: number) {
+						self.x = x
+						self.y = y
+					},
+				}
+				val p = Point(1, 2)
+				val px = p.x
+			`,
+			wantValues: map[string]string{
+				"Point": "fn (x: number, y: number) -> Point",
+				"p":     "Point",
+				"px":    "number",
+			},
+		},
+		{
+			name: "MutSelfMethod",
+			src: `
+				class Counter {
+					count: number,
+					constructor(mut self, count: number) { self.count = count },
+					increment(mut self) -> number { return self.count },
+				}
+				val c = Counter(0)
+				val n = c.increment()
+			`,
+			wantValues: map[string]string{"c": "Counter", "n": "number"},
+		},
+		{
+			name: "Getter",
+			src: `
+				class Box {
+					v: number,
+					get value(self) -> number { return self.v },
+				}
+				val b = Box(3)
+				val x = b.value
+			`,
+			wantValues: map[string]string{"b": "Box", "x": "number"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classValues(t, test.src, test.wantValues, test.wantTypes)
+		})
+	}
+}
+
+// TestInferClassGeneric covers a generic class: the constructor is generalized over
+// its type parameters, construction infers the type arguments, member access
+// projects the instance's argument into a field typed by a parameter, and a
+// declared constraint is enforced as the parameter's bound.
+func TestInferClassGeneric(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+	}{
+		{
+			name: "GenericFieldProjection",
+			src: `
+				class Box<T> { value: T }
+				val b = Box(5)
+				val v = b.value
+			`,
+			wantValues: map[string]string{
+				"Box": "fn <T0>(value: T0) -> Box<T0>",
+				"b":   "Box<5>",
+				"v":   "5",
+			},
+		},
+		{
+			name: "TwoTypeParams",
+			src: `
+				class Pair<A, B> { first: A, second: B }
+				val p = Pair(1, "x")
+				val a = p.first
+				val b = p.second
+			`,
+			wantValues: map[string]string{
+				"p": `Pair<1, "x">`,
+				"a": "1",
+				"b": `"x"`,
+			},
+		},
+		{
+			name: "ConstraintSatisfied",
+			src: `
+				class Box<T: number> { value: T }
+				val b = Box(5)
+				val v = b.value
+			`,
+			wantValues: map[string]string{"b": "Box<5>", "v": "5"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classValues(t, test.src, test.wantValues, nil)
+		})
+	}
+}
+
+// TestInferClassErrors asserts the full diagnostic for each rejected class shape.
+func TestInferClassErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "MissingSelfReceiver",
+			src:  `class C { foo() -> number { return 1 } }`,
+			want: "Instance methods, getters, and setters must declare a `self` receiver as their first parameter.",
+		},
+		{
+			name: "MultipleConstructors",
+			src: `class C {
+				constructor(mut self) {},
+				constructor(mut self) {},
+			}`,
+			want: "Multiple constructors per class are not yet supported.",
+		},
+		{
+			name: "FieldInitializerNotAllowed",
+			src:  `class C { x: number = 5 }`,
+			want: "Field 'x' cannot have a `= expr` initializer; only static fields may use this form. Initialize instance fields in the constructor body.",
+		},
+		{
+			name: "SubclassConstructorRequired",
+			src: `
+				class A { x: number }
+				class B extends A { }
+			`,
+			want: "Subclasses must declare an explicit `constructor` block; constructor synthesis is not supported for classes with an `extends` clause.",
+		},
+		{
+			name: "ConstraintViolated",
+			src: `
+				class Box<T: number> { value: T }
+				val b = Box("hi")
+			`,
+			want: `cannot constrain "hi" <: number`,
+		},
+		{
+			name: "StaticFieldInitializerMismatch",
+			src:  `class C { static x: number = "hi" }`,
+			want: `cannot constrain "hi" <: number`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, test.want, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -190,7 +190,19 @@ func TestInferClassErrors(t *testing.T) {
 		{
 			name: "MissingSelfReceiver",
 			src:  `class C { foo() -> number { return 1 } }`,
-			want: "Instance methods, getters, and setters must declare a `self` receiver as their first parameter.",
+			want: "Instance member 'foo' must declare a `self` receiver as its first parameter.",
+		},
+		{
+			name: "WriteOnlySetterRead",
+			src: `
+				class C {
+					v: number,
+					set value(mut self, x: number) { self.v = x },
+				}
+				val c = C(0)
+				val r = c.value
+			`,
+			want: "Property 'value' is write-only; it has a setter but no getter or field to read.",
 		},
 		{
 			name: "MultipleConstructors",

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -59,6 +59,11 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 		// binding's Sources slice.
 		t, src := c.inferFuncDecl(scope, lvl, d)
 		return t, src, true
+	case *ast.ClassDecl:
+		// inferClassDecl returns the RAW constructor func type for the SCC driver to
+		// constrain into the value binding var and generalize, and registers the
+		// instance type binding plus the nominal ClassDef as side effects.
+		return c.inferClassDecl(scope, lvl, d)
 	default:
 		c.reportUnsupported(d)
 		return nil, nil, false

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1960,6 +1960,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	//   - A union receiver peels each member's borrow, so a read off a union of
 	//     borrows reads each member through the union for-all rule.
 	recvCarrier := readCarrier(recv)
+	// A class instance, and any member that is a method or getter rather than a plain
+	// field, resolves through the projected class body by direct member lookup rather
+	// than the structural field-requirement below — the constraint path reads only
+	// PropertyElems and cannot see a method or getter (M5 B1).
+	if res, ok := c.projectedMember(lvl, blame, name, recvCarrier); ok {
+		return res
+	}
 	fieldVar := c.freshAt(lvl)
 	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner fieldVar, so the record would be a dead

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -322,9 +322,10 @@ func (c *checker) inferComponent(
 		}
 	}
 
-	// Non-value keys (type aliases, …) are outside the M2 subset. Report each
-	// contributing decl once, skipping any already handled by a value key (a
-	// class/enum contributes both a value and a type key for the same decl).
+	// Non-value keys such as type aliases are outside the M2 subset. Report each
+	// contributing decl once, skipping any already handled by a value key. A class or
+	// enum contributes both a value and a type key for the same decl, so its type key
+	// is skipped here.
 	//
 	// A class's type key is left to its value key, which infers the class and
 	// registers both the instance type and the constructor together (M5 B1). The two

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -322,15 +322,26 @@ func (c *checker) inferComponent(
 		}
 	}
 
-	// Non-value keys (type aliases, classes, …) are outside the M2 subset. Report
-	// each contributing decl once, skipping any already handled by a value key (a
+	// Non-value keys (type aliases, …) are outside the M2 subset. Report each
+	// contributing decl once, skipping any already handled by a value key (a
 	// class/enum contributes both a value and a type key for the same decl).
+	//
+	// A class's type key is left to its value key, which infers the class and
+	// registers both the instance type and the constructor together (M5 B1). The two
+	// keys land in separate components, and the type key's component is ordered first,
+	// so reporting it here would both mis-report the class as unsupported and mark the
+	// decl handled — blocking the value key. Skip such a decl without marking it
+	// handled; its value key infers it and the reconciliation pass then finds it
+	// handled.
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
 		}
 		for _, d := range g.GetDecls(key) {
 			if handled.Contains(d) {
+				continue
+			}
+			if _, ok := d.(*ast.ClassDecl); ok {
 				continue
 			}
 			handled.Add(d)

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -163,8 +163,12 @@ In (per the milestone):
    `GetterElem`/`SetterElem` object elements; all standing sites.
 2. `ClassDecl` inference: instance body + constructor/static type, dual
    type/value binding, `Self` substitution, constructor synthesis/validation,
-   static/instance partition. Non-recursive first, then mutually-recursive via
-   the SCC path.
+   static/instance partition. Non-recursive first, then intra-class method
+   recursion via a two-phase member walk, then mutually-recursive classes via the
+   SCC path. Type parameters resolve through a shared resolver whose bounds may
+   reference any sibling parameter — forward, mutual, or F-bounded. A constructor's
+   body is checked for definite assignment: every required field initialized on
+   every path, and no field read before it is assigned.
 3. The declared-subtype graph + the nominal `constrain` rule (name identity +
    transitive `extends`/`implements`), target-dispatched against structural
    object targets by exactness; `final` ⇒ exact instance.
@@ -729,7 +733,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-11 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+14 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -873,7 +877,10 @@ corruption of `freshenAbove`.
     projected `FuncType` directly.
   - **Errors (ported names):** `MultipleConstructorsError`,
     `SubclassConstructorRequiredError`, `MissingSelfReceiverError`,
-    plus constructor-return / field-init errors.
+    `SetterArityError`, plus constructor-return / field-init errors.
+    `SetterArityError` fires when a setter declares other than one value parameter
+    beyond `self`; the member walk still builds the elem from the first value
+    parameter, or `unknown` when there is none, so member access recovers.
   - **Accept:** a single `class Point { x: number; y: number; fn dist(self) ->
     number {...} }` infers; `Point(5, 10)` constructs an instance; `p.x` and
     `p.dist()` resolve through the body; a class with an explicit constructor and
@@ -902,6 +909,107 @@ corruption of `freshenAbove`.
     a method on `A` returning `B` and vice versa type-check; no placeholder leak
     in the rendered types.
 
+- **B3 — Intra-class method recursion (two-phase member signature/body walk)**
+  (~260).
+  - **Files:** `solver/infer_class.go` (split member inference into a signature
+    pass and a body pass; widen `bindSelf`), `solver/infer_expr.go` /
+    `solver/classes.go` (route a `self.method` read through projected-member
+    lookup), `solver/infer_class_test.go`.
+  - **Algorithm:** widen B1's field-first ordering from fields to every member.
+    Phase 1 appends a signature element for each method, getter, and setter to the
+    instance or static Body **before** any body is inferred — fresh vars for
+    un-annotated params and returns, the method analogue of `buildFieldSigs`. Bind
+    `self` to the full Body (fields + methods), not the field-only object B1 builds,
+    so a body reaches its siblings through `self`; a `self.method` read routes
+    through the projected-member path, since the structural object arm reads only
+    properties and panics on a method member. Phase 2 infers each body against its
+    pre-declared signature, so a `self.m()` call resolves to that signature's var.
+    Every signature exists before any body runs, so a self-recursive call, a
+    mutually recursive method pair, and a forward sibling call all resolve. Coalesce
+    / generalize once every body is inferred, unchanged from B1.
+  - **Annotation gate:** an unannotated mutually recursive method pair hits the same
+    mutual-recursion-needs-annotation rule top-level functions use
+    ([poly.go](../../internal/solver/poly.go)): a member cannot generalize
+    mid-cycle, so a cycle with no annotated return reports the annotation-required
+    error rather than inferring through it.
+  - **Depends on:** B1. Parallel with B2 — B2 pre-binds whole classes at the module
+    SCC level while B3 pre-binds members within one class, so the two are
+    orthogonal.
+  - **Accept:** a self-recursive method — `fn countdown(self, n: number) -> number`
+    whose body calls `self.countdown(n - 1)` — type-checks; a mutually recursive
+    `isEven` / `isOdd` pair with annotated returns type-checks, and the same pair
+    unannotated reports the annotation-required error; a method that calls a sibling
+    declared later in the class body resolves; `self.field` reads keep working
+    alongside the new `self.method()` calls.
+
+- **B4 — Cross-parameter references in type-param bounds (shared resolver)**
+  (~170).
+  - **Files:** `solver/type_params.go` (new — the shared `resolveTypeParams`
+    helper), `solver/infer_class.go` (`resolveClassTypeParams` → thin caller),
+    `solver/infer_class_test.go`.
+  - **Problem:** `resolveClassTypeParams` resolves each parameter's constraint and
+    default in the same pass that declares it, so a bound sees only the parameter
+    itself (an F-bound `<T: Foo<T>>`) or an earlier one (`<U, T: U>`). A forward or
+    mutual reference — `<T: U, U>` or `<T: U, U: T>` — leaves the sibling undeclared,
+    so it falls through to general type-ref resolution and reports
+    `Unsupported: TypeRefTypeAnn`. Functions and methods resolve no bounds at all:
+    `inferFunc` reports the whole `<…>` list unsupported
+    ([infer_expr.go:207](../../internal/solver/infer_expr.go)).
+  - **Algorithm:** one shared `resolveTypeParams(scope, lvl, params)` with a
+    two-pass body. Pass 1 mints a fresh var per parameter and declares each name in
+    the scope. Pass 2 resolves every constraint into the var's upper bound and every
+    default. Every sibling name is in scope before any bound is read, so a bound may
+    reference any other parameter — earlier, later, itself, or mutually. This
+    supersedes the old checker's approach — `ast.SortTypeParamsTopologically` plus a
+    split `inferTypeParams` (module-level) and `inferFuncTypeParams`
+    (function-level) — with no sort and a single resolver, and it admits a true
+    mutual cycle such as `<T: Cmp<U>, U: Cmp<T>>` that a topological sort cannot
+    order. `resolveClassTypeParams` becomes a thin caller.
+  - **Boundary:** this PR resolves the parameter *bounds* and declares the
+    parameters in scope. It does NOT build a generic function/method scheme or
+    generalize — that is the M3 generic-function work and the generic-method
+    `PolyScheme` wrap B1 sketches. Because function/method generic inference is not
+    implemented in the solver yet, those bounds are not independently testable here;
+    the deliverable is the shared helper plus the class fix. The mandate is that the
+    generic-function (M3) and generic-method paths resolve their `<…>` lists through
+    `resolveTypeParams` rather than re-deriving bound resolution, so the logic never
+    forks the way the old checker's two helpers did.
+  - **Depends on:** B1 (class type-param resolution to fold in) + A2
+    (`FuncType.TypeParams`). Parallel with B2 / B3.
+  - **Accept:** a class `<T: U, U>`, `<T: U, U: T>`, `<T = U, U>`, and
+    `<T = U, U = T>` resolve their bounds instead of reporting
+    `Unsupported: TypeRefTypeAnn`; a mutual F-bound `<T: Cmp<U>, U: Cmp<T>>`
+    resolves; the resulting `[]*TypeParam` stays in declaration order so
+    instantiation substitutes positionally.
+
+- **B5 — Constructor definite-assignment (`FieldNotInitializedError` +
+  `ReadBeforeInitError`)** (~200).
+  - **Files:** `solver/infer_class_ctor.go` (the definite-assignment pass in
+    `walkConstructorBody`), `solver/errors.go` (the two errors),
+    `solver/borrow_flow.go` (reuse the CFG), `solver/infer_class_test.go`.
+  - **Problem:** `walkConstructorBody` walks the body so `self.x = v` refines field
+    `x`, but never checks that every required field is assigned on all reachable
+    exits, nor that a field is not read before assignment. A `class Point { x, y }`
+    whose constructor assigns only `x` compiles clean, and `self.x = self.x` reads
+    `x` before it is initialized with no error.
+  - **Algorithm:** a definite-assignment dataflow over the constructor body's CFG,
+    ported from the old checker's `init_check.go`. Track the set of assigned instance
+    fields per program point. At each reachable exit, a required (non-optional) field
+    not in the assigned set is a `FieldNotInitializedError` naming the missing
+    fields. A `self.f` read before `f` joins the assigned set is a
+    `ReadBeforeInitError`. Reuse the solver's CFG / move machinery
+    ([borrow_flow.go](../../internal/solver/borrow_flow.go), `AnalyzeMoves`) rather
+    than a fresh traversal, since a `for` loop back edge already exercises that CFG.
+    Optional fields are exempt, mirroring `synthesizeConstructor`'s optional skip.
+  - **Note:** the B1 plan lists "check constructor field-init completeness" in
+    Phase 2; this initial B1 slice descoped it and B5 implements it, the constructor
+    analogue of B3 pulling recursive methods out of B1.
+  - **Depends on:** B1. Parallel with B2 / B3 / B4.
+  - **Accept:** a constructor that leaves a required field unassigned on some path
+    reports `FieldNotInitializedError` naming the field; a constructor that assigns
+    every required field checks clean; a `self.f` read before its assignment reports
+    `ReadBeforeInitError`; an optional field left unassigned is accepted.
+
 ### Phase C — Nominal subtyping + variance
 
 - **C1 — The declared-subtype graph + the nominal constrain rule + `final`
@@ -919,14 +1027,27 @@ corruption of `freshenAbove`.
       `final class Point` rejects extra members against an exact target and
       `keyof` is an exact union, while a non-`final` instance behaves like an
       open object. This is one line at `projectClassBody`, reading `sub.Final`.
-  - **Errors:** `ClassIntoExactObjectError`, `StructuralIntoClassError`, and the
-    nominal-mismatch `CannotConstrainError` path.
+  - **`extends`/`implements` must name a class:** B1's `resolveClassRef` returns
+    nil when a super reference resolves to a non-class or an unbound name, and
+    `resolveClassSupers`/`resolveClassImplements` drop it silently — the one
+    type-reference position in the pipeline that reports nothing, where every other
+    position at least surfaces `Unsupported: TypeRefTypeAnn`. C1 stops the silent
+    drop, so those resolvers report at the drop site or retain the unresolved ref for
+    C1 to flag. A reference that resolves to a non-class — a type parameter, say —
+    reports `NonClassSuperError`. The unbound-name half rides M7's general TypeRef
+    resolution, which reports an undefined name centrally; until M7 lands an unbound
+    super stays silent.
+  - **Errors:** `ClassIntoExactObjectError`, `StructuralIntoClassError`, the
+    nominal-mismatch `CannotConstrainError` path, and `NonClassSuperError` (an
+    `extends` or `implements` reference that resolves to a non-class).
   - **Accept:** `class B extends A` yields `B <: A` via the graph and A's methods
     dispatch on a `B` when not overridden; a bare `{x: number}` is rejected
     against `Point` and vice versa; `var foo: {x, y, ...} = Point(5,10)` is
     accepted (inexact target) while `var foo: {x, y} = Point(5,10)` and
     `var bar: Point = {x, y}` reject; a `final` instance is exact (extra members
-    reject), a non-`final` instance is inexact.
+    reject), a non-`final` instance is inexact; a `class B extends P` / `class C
+    implements P` where `P` resolves to a non-class reports `NonClassSuperError`
+    rather than dropping the edge.
 
 - **C2 — Per-type-parameter variance inference + `in`/`out` modifiers** (~220).
   - **Files:** `solver/classes.go` (`inferVariance`), `solver/constrain.go`
@@ -1040,12 +1161,15 @@ corruption of `freshenAbove`.
 ## Dependency graph
 
 ```
-A1 (ClassType + method/getter/setter elems)  ──┐
+A1 (ClassType + method/getter/setter elems)  ───┐
 A2 (TypeParam + FuncType.TypeParams)          ──┤   ── A2 ∥ A1 (needs only FuncType)
 A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's ClassType, else ∥ A2
                                                 ▼
  └─► B1 (non-recursive ClassDecl + dual binding + member access)
       ├─► B2 (mutually-recursive classes, SCC path)          ── parallel with C/D/E after B1
+      ├─► B3 (intra-class method recursion, two-phase walk)  ── parallel with B2
+      ├─► B4 (cross-param type-param bounds, shared resolver) ── parallel with B2
+      ├─► B5 (constructor definite-assignment)               ── parallel with B2
       ├─► C1 (declared-subtype graph + nominal rule + final)
       │    ├─► C2 (variance inference + in/out modifiers)
       │    └─► F1 (iteration protocol + back-edge validation)
@@ -1065,6 +1189,9 @@ graph TD
     A3["A3 (LifetimeParam + FuncType.LifetimeParams)"]
     B1["B1 (non-recursive ClassDecl + dual binding + member access)"]
     B2["B2 (mutually-recursive classes, SCC path)"]
+    B3["B3 (intra-class method recursion, two-phase walk)"]
+    B4["B4 (cross-param type-param bounds, shared resolver)"]
+    B5["B5 (constructor definite-assignment)"]
     C1["C1 (declared-subtype graph + nominal rule + final)"]
     C2["C2 (variance inference + in/out modifiers)"]
     F1["F1 (iteration protocol + back-edge validation)"]
@@ -1079,6 +1206,9 @@ graph TD
     A2 --> B1
     A3 --> B1
     B1 --> B2
+    B1 --> B3
+    B1 --> B4
+    B1 --> B5
     B1 --> C1
     B1 --> D1
     B1 --> DEnum
@@ -1094,7 +1224,7 @@ graph TD
     classDef landed fill:#eceff1,stroke:#90a4ae,stroke-dasharray:4 3,color:#000;
     class A1,B1,C1,C2 crit;
     class M6 landed;
-    linkStyle 0,5,9 stroke:#e65100,stroke-width:2px;
+    linkStyle 0,8,12 stroke:#e65100,stroke-width:2px;
 ```
 
 **Critical path:** A1 → B1 → C1 → C2 (variance is the milestone's headline
@@ -1106,6 +1236,12 @@ they land before B1. Everything else is off the critical path.
 **Parallelizable once B1 lands** (all depend only on B1, mutually independent):
 
 - **B2** (recursive classes) — pure SCC-path work, no overlap with subtyping.
+- **B3** (intra-class method recursion) — a two-phase member walk in
+  `infer_class.go`, orthogonal to B2's SCC-path work.
+- **B4** (cross-param type-param bounds) — a shared two-pass `resolveTypeParams`
+  helper, independent of the recursion and subtyping work.
+- **B5** (constructor definite-assignment) — a CFG dataflow over the constructor
+  body, reusing the move machinery, independent of the other Phase-B work.
 - **C1** (nominal subtyping) — `constrain`/`classes.go`.
 - **D1** (nominal patterns) — `pattern.go`, uses member lookup, **not** the C1
   subtyping rule, so it does not wait on C1.


### PR DESCRIPTION
Adds class declaration type inference and member access resolution for non-generic and generic classes. This implements the M5 B1 milestone, enabling class definitions with fields, methods, getters, setters, and constructors.

**Key changes:**

- `infer_class.go`: Core class inference logic. Resolves type parameters into a child scope, registers the class in the nominal registry, builds field signatures, infers member bodies, and synthesizes or walks explicit constructors. Generic classes preserve symbolic type-parameter vars in their body; non-generic classes coalesce to concrete types.

- `infer_class_ctor.go`: Constructor handling. Synthesizes implicit constructors from required fields or walks explicit constructor bodies with `self` bound as owned-mutable so field assignments refine instance types.

- `classes.go`: Nominal registry and member projection. Defines `ClassDef` to hold per-class metadata (type parameters, supers, instance/static bodies, variance). Implements `projectClassBody` to substitute type arguments into a generic class's body and `projectedMember` to resolve member access through the projected body.

- `errors.go`: Four new error types for class-specific violations: missing `self` receiver on instance members, multiple constructors, instance field initializers, and missing constructors on subclasses.

- `context.go`: Adds `classes` registry map and `classDef`/`registerClass` methods to store and retrieve class definitions by qualified name.

- `infer_decl.go`: Routes `ClassDecl` to `inferClassDecl`.

- `infer_expr.go`: Integrates `projectedMember` into member access resolution so class instances resolve members through their projected body before falling back to structural lookup.

- `module.go`: Clarifies that class type keys are handled by their value keys (constructor inference registers both bindings together).

**Tests:** `infer_class_test.go` covers non-generic classes (synthesized and explicit constructors, methods, getters), generic classes (type parameter projection, constraints), and error cases (missing receiver, multiple constructors, field initializers, subclass constructor requirement, constraint violations).

https://claude.ai/code/session_016ySfLzvF6d47F8D137ZCJu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for class declarations, including constructors, fields, methods, getters, and inheritance.
  * Class member access now resolves through the class instance view, including generic type substitution.

* **Bug Fixes**
  * Improved error reporting for invalid class definitions and member usage.
  * Enforced clearer rules for constructors, instance field initializers, and inherited classes.

* **Tests**
  * Added coverage for class behavior, generics, member access, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->