### PR TITLE
B4: Enable cross-parameter type-bound references via two-pass resolution

### DIFF
--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -83,37 +83,13 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	return ctorType, &ast.NodeProvenance{Node: decl}, true
 }
 
-// resolveClassTypeParams resolves a class's AST type parameters to soltype
-// TypeParams, minting one shared var per parameter, recording its constraint as the
-// var's upper bound and its resolved default, and declaring each into scope so the
-// class body resolves the parameter name to that var.
-//
-// Resolution runs in declaration order, so a bound may reference the parameter itself
-// or an earlier one, but not a later one. A forward or mutual reference such as
-// `<T: U, U>` does not resolve. PR B4 replaces this with a shared two-pass resolver
-// that declares every parameter before resolving any bound
-// (planning/simple_sub/m5-implementation-plan.md).
+// resolveClassTypeParams resolves a class's AST type parameters to soltype TypeParams,
+// declaring each into the class scope so the body resolves the parameter name to its var.
+// It delegates to the shared resolveTypeParams, whose two-pass body declares every
+// parameter before resolving any bound, so a class bound may reference any sibling —
+// forward, mutual, or F-bounded.
 func (c *checker) resolveClassTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
-	out := make([]*soltype.TypeParam, len(params))
-	for i, p := range params {
-		v := c.freshAt(lvl)
-		// Declare the parameter before resolving its own constraint and default so an
-		// F-bounded `<T: Foo<T>>` or a defaulting `<T, U = T>` reference resolves to it.
-		scope.defineType(p.Name, TypeBinding{Type: v})
-		if p.Constraint != nil {
-			if ct, ok := c.resolveClassTypeAnn(scope, p.Constraint, lvl); ok {
-				c.ctx.addUpperBound(v, ct)
-			}
-		}
-		var def soltype.Type
-		if p.Default != nil {
-			if dt, ok := c.resolveClassTypeAnn(scope, p.Default, lvl); ok {
-				def = dt
-			}
-		}
-		out[i] = &soltype.TypeParam{Name: p.Name, Var: v, Default: def}
-	}
-	return out
+	return c.resolveTypeParams(scope, lvl, params)
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own
@@ -175,15 +151,35 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltyp
 	return nil
 }
 
-// resolveClassTypeAnn resolves a type annotation appearing in a class body. It first
-// consults the type scope for a bare reference to a class or type parameter — the two
-// names resolveTypeAnn's general TypeRef resolution does not yet cover — and otherwise
+// resolveClassTypeAnn resolves a type annotation appearing in a class body or a
+// type-parameter bound. It first consults the type scope for a reference to a class or
+// type parameter — a bare `Point` or `T`, or a generic class instance `Box<number>` — the
+// names resolveTypeAnn's general TypeRef resolution does not yet cover, and otherwise
 // delegates to resolveTypeAnn for primitives and structural types.
 func (c *checker) resolveClassTypeAnn(scope *Scope, ann ast.TypeAnn, lvl int) (soltype.Type, bool) {
-	if ref, ok := ann.(*ast.TypeRefTypeAnn); ok && len(ref.TypeArgs) == 0 {
+	if ref, ok := ann.(*ast.TypeRefTypeAnn); ok {
 		name := ast.QualIdentToString(ref.Name)
 		if b, ok := scope.GetType(name); ok {
-			return b.Type, true
+			if len(ref.TypeArgs) == 0 {
+				return b.Type, true
+			}
+			// A generic class reference like `Cmp<U>` names a class and supplies its type
+			// arguments. Resolve each argument through the same class-scope path and mint a
+			// fresh instance token carrying them, so a type-parameter bound such as
+			// `<T: Cmp<U>>` resolves to `Cmp<U>` rather than falling through to general
+			// TypeRef resolution. An unresolved argument recovers to a fresh var so the
+			// reference keeps its arity, cascade-safe.
+			if ct, ok := b.Type.(*soltype.ClassType); ok {
+				args := make([]soltype.Type, len(ref.TypeArgs))
+				for i, arg := range ref.TypeArgs {
+					if at, ok := c.resolveClassTypeAnn(scope, arg, lvl); ok {
+						args[i] = at
+					} else {
+						args[i] = c.freshAt(lvl)
+					}
+				}
+				return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final}, true
+			}
 		}
 	}
 	return c.resolveTypeAnn(ann, lvl)

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -31,7 +31,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	var typeParams []*soltype.TypeParam
 	if len(decl.TypeParams) > 0 {
 		declScope = scope.Child()
-		typeParams = c.resolveClassTypeParams(declScope, lvl, decl.TypeParams)
+		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
 
 	// The instance's nominal identity, carrying the class's own type-parameter vars as
@@ -81,15 +81,6 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	}
 
 	return ctorType, &ast.NodeProvenance{Node: decl}, true
-}
-
-// resolveClassTypeParams resolves a class's AST type parameters to soltype TypeParams,
-// declaring each into the class scope so the body resolves the parameter name to its var.
-// It delegates to the shared resolveTypeParams, whose two-pass body declares every
-// parameter before resolving any bound, so a class bound may reference any sibling —
-// forward, mutual, or F-bounded.
-func (c *checker) resolveClassTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
-	return c.resolveTypeParams(scope, lvl, params)
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -180,6 +180,59 @@ func TestInferClassGeneric(t *testing.T) {
 	}
 }
 
+// TestInferClassCrossParamBounds covers B4: a type-parameter bound or default may
+// reference any sibling parameter — forward, mutual, or through a generic class — because
+// the shared resolveTypeParams declares every parameter in scope before resolving any
+// bound. A single declare-and-resolve pass leaves a later-declared sibling undeclared when
+// its bound is read, so the reference falls through to general type-ref resolution and
+// reports `Unsupported: TypeRefTypeAnn`. None of these should report that error now.
+func TestInferClassCrossParamBounds(t *testing.T) {
+	srcs := map[string]string{
+		"ForwardConstraint": `class C<T: U, U> { value: T }`,
+		"MutualConstraint":  `class C<T: U, U: T> { value: T }`,
+		"ForwardDefault":    `class C<T = U, U> { value: T }`,
+		"MutualDefault":     `class C<T = U, U = T> { value: T }`,
+		// The referenced class Cmp is declared before Foo so its instance type is in scope
+		// when Foo's bounds resolve. Resolving `Cmp<U>` / `Cmp<T>` combines the two-pass
+		// sibling visibility with generic-class-reference resolution. Robust ordering
+		// regardless of declaration order rides the B2 recursive-class SCC path
+		// (planning/simple_sub/m5-implementation-plan.md).
+		"MutualFBound": `
+			class Cmp<X> { value: X }
+			class Foo<T: Cmp<U>, U: Cmp<T>> { value: T }
+		`,
+	}
+	for name, src := range srcs {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, src)
+			require.Empty(t, errs)
+		})
+	}
+}
+
+// TestInferClassForwardBoundEnforced shows a forward reference resolves to a real bound,
+// not just a parsed placeholder. `<T: U, U: number>` chains T's bound through the
+// later-declared U to number, so a construction whose argument violates it is rejected and
+// one that satisfies it checks clean and infers the argument at both positions.
+func TestInferClassForwardBoundEnforced(t *testing.T) {
+	t.Run("Violated", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Box<T: U, U: number> { value: T }
+			val b = Box("hi")
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+	})
+	t.Run("Satisfied", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Box<T: U, U: number> { value: T }
+			val b = Box(5)
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "Box<5, 5>", values["b"])
+	})
+}
+
 // A join of the same class at two different type arguments — the value of
 // `if c { Box(5) } else { Box("hello") }` — leaves the binding a union of both
 // instantiations, Box<5> | Box<"hello">. That union is the shape classCarrier sees as two

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -181,11 +181,10 @@ func TestInferClassGeneric(t *testing.T) {
 }
 
 // TestInferClassCrossParamBounds covers B4: a type-parameter bound or default may
-// reference any sibling parameter — forward, mutual, or through a generic class — because
-// the shared resolveTypeParams declares every parameter in scope before resolving any
-// bound. A single declare-and-resolve pass leaves a later-declared sibling undeclared when
-// its bound is read, so the reference falls through to general type-ref resolution and
-// reports `Unsupported: TypeRefTypeAnn`. None of these should report that error now.
+// reference any sibling parameter — forward, mutual, or through a generic class. Each case
+// resolves its cross-parameter references without reporting `Unsupported: TypeRefTypeAnn`,
+// because the shared resolveTypeParams declares every parameter in scope before resolving
+// any bound, so a bound reading a later-declared sibling finds it already in scope.
 func TestInferClassCrossParamBounds(t *testing.T) {
 	srcs := map[string]string{
 		"ForwardConstraint": `class C<T: U, U> { value: T }`,

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -1,0 +1,49 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// resolveTypeParams resolves a `<…>` type-parameter list to soltype TypeParams in two
+// passes, so a bound or default may reference any sibling parameter regardless of order.
+// Pass 1 mints one fresh var per parameter and declares its name in scope. Pass 2 resolves
+// each parameter's constraint into its var's upper bound and its default, reading names
+// against the scope that now holds every sibling.
+//
+// Declaring every parameter before reading any bound is what lets a forward reference
+// `<T: U, U>`, a mutual cycle `<T: U, U: T>`, an F-bound `<T: Foo<T>>`, a mutual F-bound
+// `<T: Cmp<U>, U: Cmp<T>>`, and a defaulting reference `<T = U, U>` all resolve. A single
+// declare-and-resolve pass leaves a later-declared sibling undeclared when its bound is
+// read, so the reference falls through to general type-ref resolution and reports
+// `Unsupported: TypeRefTypeAnn`. Because every sibling is in scope up front, a true mutual
+// cycle resolves that a topological sort of the parameters cannot order.
+//
+// The result stays in declaration order, so instantiation substitutes type arguments
+// positionally. The class and, once generic-function inference lands, the function and
+// method paths both route their `<…>` lists through here so bound resolution never forks.
+func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypeParam) []*soltype.TypeParam {
+	out := make([]*soltype.TypeParam, len(params))
+	// Pass 1: mint each parameter's var and declare its name, so a bound in pass 2 may
+	// reference any sibling — earlier, later, itself, or mutually.
+	for i, p := range params {
+		v := c.freshAt(lvl)
+		scope.defineType(p.Name, TypeBinding{Type: v})
+		out[i] = &soltype.TypeParam{Name: p.Name, Var: v}
+	}
+	// Pass 2: resolve each constraint into its var's upper bound and each default, now that
+	// every sibling name is in scope.
+	for i, p := range params {
+		if p.Constraint != nil {
+			if ct, ok := c.resolveClassTypeAnn(scope, p.Constraint, lvl); ok {
+				c.ctx.addUpperBound(out[i].Var, ct)
+			}
+		}
+		if p.Default != nil {
+			if dt, ok := c.resolveClassTypeAnn(scope, p.Default, lvl); ok {
+				out[i].Default = dt
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Implement B4: allow type-parameter bounds and defaults to reference any sibling parameter — forward, mutual, or F-bounded — by resolving type parameters in two passes instead of one.

**Summary**

Type parameters can now reference later-declared siblings in their bounds and defaults. `<T: U, U>`, `<T: U, U: T>`, and `<T: Cmp<U>, U: Cmp<T>>` all resolve correctly instead of falling through to general type-ref resolution and reporting unsupported errors.

**Changes**

- Extract type-parameter resolution into a shared `resolveTypeParams` function in new `type_params.go` that declares all parameters in scope before resolving any bound, enabling sibling visibility regardless of declaration order.
- Simplify `resolveClassTypeParams` to delegate to the shared resolver.
- Extend `resolveClassTypeAnn` to handle generic class references like `Cmp<U>` in bounds by resolving type arguments through the class-scope path and minting a fresh instance token, so bounds chain through generic classes correctly.
- Add test coverage for forward constraints, mutual constraints, forward defaults, mutual defaults, and mutual F-bounds, plus enforcement tests showing forward bounds are real constraints, not placeholders.

https://claude.ai/code/session_01VAJaKvNQbw6xAfQ9UR4wbA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generic class type-parameter resolution, including forward references, mutual constraints, and defaults.
  - Class type annotations now resolve generic arguments more reliably.
  - Added enforcement for bounds that reference later type parameters.
  - Improved type inference and diagnostics for valid and invalid generic class constructions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->