### PR TITLE
B5: Add definite-assignment analysis for constructor initialization

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -732,6 +732,8 @@ func (*SubclassConstructorRequiredError) isSolverError()  {}
 func (*WriteOnlyPropertyError) isSolverError()            {}
 func (*SetterArityError) isSolverError()                  {}
 func (*RecursiveMethodAnnotationError) isSolverError()    {}
+func (*FieldNotInitializedError) isSolverError()          {}
+func (*ReadBeforeInitError) isSolverError()               {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -832,6 +834,46 @@ func (e *RecursiveMethodAnnotationError) Span() ast.Span      { return e.Elem.Sp
 func (e *RecursiveMethodAnnotationError) Related() []ast.Span { return nil }
 func (e *RecursiveMethodAnnotationError) Message() string {
 	return "Mutually recursive method '" + e.Name + "' must declare a return type; the cycle " + strings.Join(e.Group, ", ") + " has no annotated return to ground it."
+}
+
+// FieldNotInitializedError fires when a constructor body has a reachable exit on
+// which one or more required instance fields are still uninitialized. FieldNames
+// lists the missing fields in sorted order, so the message is deterministic.
+type FieldNotInitializedError struct {
+	FieldNames []string
+	Ctor       *ast.ConstructorElem
+}
+
+func (e *FieldNotInitializedError) Span() ast.Span      { return e.Ctor.Fn.Body.Span }
+func (e *FieldNotInitializedError) Related() []ast.Span { return nil }
+func (e *FieldNotInitializedError) Message() string {
+	if len(e.FieldNames) == 1 {
+		return "Field '" + e.FieldNames[0] + "' is not initialized on every path through the constructor."
+	}
+	return "Fields " + quoteJoin(e.FieldNames) + " are not initialized on every path through the constructor."
+}
+
+// ReadBeforeInitError fires when a constructor reads `self.f` on a path where field
+// `f` has not yet been assigned. It blames the read.
+type ReadBeforeInitError struct {
+	FieldName string
+	Read      ast.Node
+}
+
+func (e *ReadBeforeInitError) Span() ast.Span      { return e.Read.Span() }
+func (e *ReadBeforeInitError) Related() []ast.Span { return nil }
+func (e *ReadBeforeInitError) Message() string {
+	return "Field 'self." + e.FieldName + "' is read before it has been initialized."
+}
+
+// quoteJoin renders names as a comma-separated list, each single-quoted, for a
+// multi-field diagnostic.
+func quoteJoin(names []string) string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = "'" + n + "'"
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -734,6 +734,7 @@ func (*SetterArityError) isSolverError()                  {}
 func (*RecursiveMethodAnnotationError) isSolverError()    {}
 func (*FieldNotInitializedError) isSolverError()          {}
 func (*ReadBeforeInitError) isSolverError()               {}
+func (*MethodCallBeforeInitError) isSolverError()         {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -864,6 +865,21 @@ func (e *ReadBeforeInitError) Span() ast.Span      { return e.Read.Span() }
 func (e *ReadBeforeInitError) Related() []ast.Span { return nil }
 func (e *ReadBeforeInitError) Message() string {
 	return "Field 'self." + e.FieldName + "' is read before it has been initialized."
+}
+
+// MethodCallBeforeInitError fires when a constructor calls a method on `self` on a
+// path where one or more required fields are not yet assigned. The called method may
+// read any field, so every required field must be initialized first. MissingFields
+// lists the still-unassigned fields in sorted order.
+type MethodCallBeforeInitError struct {
+	MissingFields []string
+	Call          ast.Node
+}
+
+func (e *MethodCallBeforeInitError) Span() ast.Span      { return e.Call.Span() }
+func (e *MethodCallBeforeInitError) Related() []ast.Span { return nil }
+func (e *MethodCallBeforeInitError) Message() string {
+	return "Cannot call a method on `self` before all required fields are initialized; missing " + quoteJoin(e.MissingFields) + "."
 }
 
 // quoteJoin renders names as a comma-separated list, each single-quoted, for a

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -1,7 +1,11 @@
 package solver
 
 import (
+	"slices"
+
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/liveness"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -46,9 +50,9 @@ func (c *checker) synthesizeConstructor(self *soltype.ClassType, body *soltype.O
 // write machinery, and returns a callable signature: the constructor's value
 // parameters — the params after the leading `mut self` — returning the instance.
 //
-// It does not check definite assignment. A required field left unassigned on some path,
-// or a field read before it is assigned, is not yet reported. PR B5 adds that check
-// (planning/simple_sub/m5-implementation-plan.md).
+// After the body is walked it runs definite-assignment analysis so a required field
+// left unassigned on some path is a FieldNotInitializedError and a `self.f` read before
+// its assignment is a ReadBeforeInitError.
 func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.ClassType, body *soltype.ObjectType, ctor *ast.ConstructorElem) soltype.Type {
 	// The parser materializes `mut self` as Fn.Params[0]; the callable signature is
 	// the params after it.
@@ -65,7 +69,173 @@ func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.Class
 	c.bindSelf(ctorScope, &ast.MethodReceiver{Mut: true}, body)
 
 	ft := c.inferFunc(ctorScope, lvl, bodySig, ctor.Fn.Body, ctor)
+	c.checkConstructorInit(body, ctor)
 	// A constructor returns a fresh instance, not the void its statement body falls off
 	// to, so override the inferred return with the instance type.
 	return &soltype.FuncType{Params: ft.Params, Ret: self, Inexact: ft.Inexact}
+}
+
+// checkConstructorInit runs definite-assignment analysis over an explicit
+// constructor's body. It reports a FieldNotInitializedError for any required instance
+// field left unassigned on some path that reaches a normal exit, and a
+// ReadBeforeInitError for a `self.f` read on a path where f is not yet assigned.
+//
+// The analysis reuses the CFG and the forward move-state dataflow rather than a fresh
+// tree traversal, so a `for` loop back edge inside the constructor is handled by the
+// same machinery moves and borrows already rely on. Field assignment is modeled as a
+// "move" of a synthetic per-field id: a field whose move-state is Moved at a point is
+// assigned on every path reaching it, so a required field that is not Moved at the
+// exit is uninitialized on some path, and a `self.f` read where f is not Moved reads it
+// before initialization.
+//
+// A `throw` is exempt: it assigns every required field synthetically, so a path that
+// throws before initializing the instance vacuously satisfies the requirement and does
+// not pollute the join at the exit.
+func (c *checker) checkConstructorInit(body *soltype.ObjectType, ctor *ast.ConstructorElem) {
+	if ctor.Fn == nil || ctor.Fn.Body == nil {
+		return
+	}
+
+	// Each required (non-optional) instance field gets a synthetic id the move-state
+	// dataflow keys on. Optional fields are exempt: they may stay unset.
+	fieldIDs := map[string]liveness.VarID{}
+	next := liveness.VarID(1)
+	for _, e := range body.Elems {
+		prop, ok := e.(*soltype.PropertyElem)
+		if !ok || prop.Optional {
+			continue
+		}
+		fieldIDs[prop.Name] = next
+		next++
+	}
+	if len(fieldIDs) == 0 {
+		return
+	}
+
+	cfg := liveness.BuildCFG(*ctor.Fn.Body)
+	col := &initCollector{
+		fieldIDs: fieldIDs,
+		gens:     map[liveness.StmtRef]set.Set[liveness.VarID]{},
+	}
+	// Walk each CFG block's statements. The builder has already flattened control flow
+	// into blocks and wrapped each branch condition as its own statement, so the per-
+	// statement scan attributes every `self.f` write and read to the right program point
+	// without re-deriving the branch structure.
+	for _, block := range cfg.Blocks {
+		for idx, stmt := range block.Stmts {
+			col.currentRef = liveness.StmtRef{BlockID: block.ID, StmtIdx: idx}
+			stmt.Accept(col)
+		}
+	}
+
+	info := liveness.AnalyzeMoves(cfg, col.gens)
+
+	// A required field not Moved at the exit join is unassigned on some path reaching a
+	// normal exit. StmtIdx -1 reads the exit block's entry state, the join over every
+	// predecessor.
+	exitRef := liveness.StmtRef{BlockID: cfg.Exit.ID, StmtIdx: -1}
+	var missing []string
+	for name, id := range fieldIDs {
+		if info.StateBefore(exitRef, id) != liveness.Moved {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		c.report(&FieldNotInitializedError{FieldNames: missing, Ctor: ctor})
+	}
+
+	for _, r := range col.reads {
+		if info.StateBefore(r.ref, fieldIDs[r.field]) != liveness.Moved {
+			c.report(&ReadBeforeInitError{FieldName: r.field, Read: r.node})
+		}
+	}
+}
+
+// initRead is one `self.f` read the collector recorded: the field name, the CFG point
+// of the read, and the node to blame.
+type initRead struct {
+	field string
+	ref   liveness.StmtRef
+	node  ast.Node
+}
+
+// initCollector walks a constructor body statement by statement, recording each
+// `self.f` assignment as a "gen" of field f at the current program point and each
+// `self.f` read as an initRead. currentRef is set by the driver before each statement,
+// so a write or read nested in that statement's expression is attributed to it.
+type initCollector struct {
+	ast.DefaultVisitor
+	currentRef liveness.StmtRef
+	fieldIDs   map[string]liveness.VarID
+	gens       map[liveness.StmtRef]set.Set[liveness.VarID]
+	reads      []initRead
+}
+
+// gen records that field is assigned at the current statement. A field absent from
+// fieldIDs is optional or unknown and is not tracked.
+func (col *initCollector) gen(field string) {
+	id, ok := col.fieldIDs[field]
+	if !ok {
+		return
+	}
+	at := col.gens[col.currentRef]
+	if at == nil {
+		at = set.NewSet[liveness.VarID]()
+		col.gens[col.currentRef] = at
+	}
+	at.Add(id)
+}
+
+func (col *initCollector) EnterExpr(e ast.Expr) bool {
+	switch e := e.(type) {
+	case *ast.FuncExpr:
+		// A nested closure has its own body and CFG. Its reads of `self.f` are not part
+		// of the constructor's straight-line flow, so do not descend into it.
+		return false
+	case *ast.BinaryExpr:
+		if e.Op == ast.Assign {
+			if name, ok := selfFieldName(e.Left); ok {
+				// The right side runs before the field is assigned, so scan it for reads
+				// first — `self.x = self.x` reads x before init — then mark x assigned.
+				// The write target itself is not a read, so the left side is not walked.
+				e.Right.Accept(col)
+				col.gen(name)
+				return false
+			}
+		}
+	case *ast.ThrowExpr:
+		// A throwing path never completes construction, so it is exempt: mark every
+		// required field assigned so the throw does not lower the init state at the join.
+		// The thrown value is still scanned for reads.
+		for name := range col.fieldIDs {
+			col.gen(name)
+		}
+		if e.Arg != nil {
+			e.Arg.Accept(col)
+		}
+		return false
+	case *ast.MemberExpr:
+		if name, ok := selfFieldName(e); ok {
+			col.reads = append(col.reads, initRead{field: name, ref: col.currentRef, node: e})
+			return false
+		}
+	}
+	return true
+}
+
+// selfFieldName returns the field name of a `self.f` member access — the property of a
+// non-optional-chain member whose object is the `self` identifier. ok is false for any
+// other expression, including `self[k]`, `other.f`, and a deeper path like `self.a.b`
+// whose object is `self.a` rather than `self`.
+func selfFieldName(e ast.Expr) (string, bool) {
+	m, ok := e.(*ast.MemberExpr)
+	if !ok || m.OptChain || m.Prop == nil {
+		return "", false
+	}
+	id, ok := m.Object.(*ast.IdentExpr)
+	if !ok || id.Name != "self" {
+		return "", false
+	}
+	return m.Prop.Name, true
 }

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -267,10 +267,18 @@ func (col *initCollector) EnterExpr(e ast.Expr) bool {
 	return true
 }
 
-// selfFieldName returns the field name of a `self.f` member access — the property of a
-// non-optional-chain member whose object is the `self` identifier. ok is false for any
-// other expression, including `self[k]`, `other.f`, and a deeper path like `self.a.b`
-// whose object is `self.a` rather than `self`.
+// selfFieldName returns the field name of a `self.f` member access: the property of a
+// non-optional-chain member whose object is the `self` identifier. It matches only the
+// dot form of *ast.MemberExpr. ok is false for `other.f`, whose object is not `self`,
+// and for a deeper path like `self.a.b`, whose object is `self.a` rather than `self`.
+//
+// An index form such as `self[k]` or `self["x"]` is an *ast.IndexExpr, not a MemberExpr,
+// so it returns false and this pass tracks no field for it. That is sound today because
+// index assignment `self[...] = v` is unsupported until M7, so no valid program
+// initializes a field through a bracket. When M7 adds it, a constant-string index
+// `self["x"]` will name a field the way constStringKey already resolves it for the move
+// engine, and this pass must recognize that form to avoid a spurious
+// FieldNotInitializedError.
 func selfFieldName(e ast.Expr) (string, bool) {
 	m, ok := e.(*ast.MemberExpr)
 	if !ok || m.OptChain || m.Prop == nil {

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -274,11 +274,11 @@ func (col *initCollector) EnterExpr(e ast.Expr) bool {
 //
 // An index form such as `self[k]` or `self["x"]` is an *ast.IndexExpr, not a MemberExpr,
 // so it returns false and this pass tracks no field for it. That is sound today because
-// index assignment `self[...] = v` is unsupported until M7, so no valid program
-// initializes a field through a bracket. When M7 adds it, a constant-string index
-// `self["x"]` will name a field the way constStringKey already resolves it for the move
-// engine, and this pass must recognize that form to avoid a spurious
-// FieldNotInitializedError.
+// index assignment `self[...] = v` is unsupported: inferAssign rejects an index target
+// pending the Array and index types M7 brings, so no valid program initializes a field
+// through a bracket. If a constant-string index like `self["x"]` later becomes a
+// supported field write, this pass must recognize it — the way constStringKey resolves a
+// constant key for the move engine — to avoid a spurious FieldNotInitializedError.
 func selfFieldName(e ast.Expr) (string, bool) {
 	m, ok := e.(*ast.MemberExpr)
 	if !ok || m.OptChain || m.Prop == nil {

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -77,16 +77,19 @@ func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.Class
 
 // checkConstructorInit runs definite-assignment analysis over an explicit
 // constructor's body. It reports a FieldNotInitializedError for any required instance
-// field left unassigned on some path that reaches a normal exit, and a
-// ReadBeforeInitError for a `self.f` read on a path where f is not yet assigned.
+// field left unassigned on some path that reaches a normal exit, a ReadBeforeInitError
+// for a `self.f` read on a path where f is not yet assigned, and a
+// MethodCallBeforeInitError for a `self.method(...)` call on a path where some required
+// field is not yet assigned, since the callee may read any field.
 //
 // The analysis reuses the CFG and the forward move-state dataflow rather than a fresh
 // tree traversal, so a `for` loop back edge inside the constructor is handled by the
 // same machinery moves and borrows already rely on. Field assignment is modeled as a
 // "move" of a synthetic per-field id: a field whose move-state is Moved at a point is
 // assigned on every path reaching it, so a required field that is not Moved at the
-// exit is uninitialized on some path, and a `self.f` read where f is not Moved reads it
-// before initialization.
+// exit is uninitialized on some path, a `self.f` read where f is not Moved reads it
+// before initialization, and a `self.method(...)` call where some field is not Moved
+// happens before the instance is fully built.
 //
 // A `throw` is exempt: it assigns every required field synthetically, so a path that
 // throws before initializing the instance vacuously satisfies the requirement and does
@@ -150,6 +153,21 @@ func (c *checker) checkConstructorInit(body *soltype.ObjectType, ctor *ast.Const
 			c.report(&ReadBeforeInitError{FieldName: r.field, Read: r.node})
 		}
 	}
+
+	// A method call on `self` may read any field, so it requires every required field
+	// assigned at the call site. Report the ones still unassigned on some reaching path.
+	for _, call := range col.calls {
+		var callMissing []string
+		for name, id := range fieldIDs {
+			if info.StateBefore(call.ref, id) != liveness.Moved {
+				callMissing = append(callMissing, name)
+			}
+		}
+		if len(callMissing) > 0 {
+			slices.Sort(callMissing)
+			c.report(&MethodCallBeforeInitError{MissingFields: callMissing, Call: call.node})
+		}
+	}
 }
 
 // initRead is one `self.f` read the collector recorded: the field name, the CFG point
@@ -160,16 +178,25 @@ type initRead struct {
 	node  ast.Node
 }
 
+// initCall is one `self.method(...)` call the collector recorded: the CFG point of the
+// call and the node to blame.
+type initCall struct {
+	ref  liveness.StmtRef
+	node ast.Node
+}
+
 // initCollector walks a constructor body statement by statement, recording each
-// `self.f` assignment as a "gen" of field f at the current program point and each
-// `self.f` read as an initRead. currentRef is set by the driver before each statement,
-// so a write or read nested in that statement's expression is attributed to it.
+// `self.f` assignment as a "gen" of field f at the current program point, each `self.f`
+// read as an initRead, and each `self.method(...)` call as an initCall. currentRef is
+// set by the driver before each statement, so a write, read, or call nested in that
+// statement's expression is attributed to it.
 type initCollector struct {
 	ast.DefaultVisitor
 	currentRef liveness.StmtRef
 	fieldIDs   map[string]liveness.VarID
 	gens       map[liveness.StmtRef]set.Set[liveness.VarID]
 	reads      []initRead
+	calls      []initCall
 }
 
 // gen records that field is assigned at the current statement. A field absent from
@@ -215,9 +242,25 @@ func (col *initCollector) EnterExpr(e ast.Expr) bool {
 			e.Arg.Accept(col)
 		}
 		return false
+	case *ast.CallExpr:
+		// A call whose callee is `self.x(...)` needs every required field initialized,
+		// since the callee may read any of them. Record the call site and scan the
+		// arguments for reads, but not the `self.x` callee — it is a method reference,
+		// not a field read.
+		if _, ok := selfFieldName(e.Callee); ok {
+			col.calls = append(col.calls, initCall{ref: col.currentRef, node: e})
+			for _, arg := range e.Args {
+				arg.Accept(col)
+			}
+			return false
+		}
 	case *ast.MemberExpr:
 		if name, ok := selfFieldName(e); ok {
-			col.reads = append(col.reads, initRead{field: name, ref: col.currentRef, node: e})
+			// Only a required field is tracked. A read of a method, getter, or optional
+			// field names no required field, so it is not a read-before-init.
+			if _, tracked := col.fieldIDs[name]; tracked {
+				col.reads = append(col.reads, initRead{field: name, ref: col.currentRef, node: e})
+			}
 			return false
 		}
 	}

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -710,6 +710,34 @@ func TestConstructorInitClean(t *testing.T) {
 				}
 			`,
 		},
+		{
+			// A method may be called once every required field is assigned.
+			name: "MethodCallAfterInit",
+			src: `
+				class C {
+					x: number,
+					log(self) -> number { return self.x },
+					constructor(mut self, x: number) {
+						self.x = x
+						val r = self.log()
+					},
+				}
+			`,
+		},
+		{
+			// Referencing a method member of self before init reads no field, so it is not
+			// a read-before-init.
+			name: "MethodReferenceBeforeInit",
+			src: `
+				class C {
+					x: number,
+					log(self) -> number { return self.x },
+					constructor(mut self, x: number) {
+						self.x = x
+					},
+				}
+			`,
+		},
 	}
 
 	for _, test := range tests {
@@ -721,8 +749,9 @@ func TestConstructorInitClean(t *testing.T) {
 }
 
 // TestConstructorInitErrors covers the definite-assignment diagnostics: a required
-// field left unassigned on some path is a FieldNotInitializedError, and a `self.f` read
-// before its assignment is a ReadBeforeInitError.
+// field left unassigned on some path is a FieldNotInitializedError, a `self.f` read
+// before its assignment is a ReadBeforeInitError, and a `self.method(...)` call before
+// every required field is assigned is a MethodCallBeforeInitError.
 func TestConstructorInitErrors(t *testing.T) {
 	tests := []struct {
 		name string
@@ -780,6 +809,36 @@ func TestConstructorInitErrors(t *testing.T) {
 				}
 			`,
 			want: "Field 'self.x' is read before it has been initialized.",
+		},
+		{
+			name: "MethodCallBeforeInit",
+			src: `
+				class C {
+					x: number,
+					log(self) -> number { return self.x },
+					constructor(mut self, x: number) {
+						val r = self.log()
+						self.x = x
+					},
+				}
+			`,
+			want: "Cannot call a method on `self` before all required fields are initialized; missing 'x'.",
+		},
+		{
+			name: "MethodCallMissingMultiple",
+			src: `
+				class C {
+					x: number,
+					y: number,
+					log(self) -> number { return self.x },
+					constructor(mut self) {
+						val r = self.log()
+						self.x = 1
+						self.y = 2
+					},
+				}
+			`,
+			want: "Cannot call a method on `self` before all required fields are initialized; missing 'x', 'y'.",
 		},
 	}
 

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -648,3 +648,146 @@ func TestInferClassErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestConstructorInitClean covers constructors whose definite-assignment analysis is
+// satisfied: every required field is assigned on every path, an optional field may be
+// left unassigned, and both branches of an `if` that each assign a field count.
+func TestConstructorInitClean(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "AllFieldsAssigned",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+					constructor(mut self, x: number, y: number) {
+						self.x = x
+						self.y = y
+					},
+				}
+			`,
+		},
+		{
+			name: "OptionalFieldUnassigned",
+			src: `
+				class C {
+					x: number,
+					y?: number,
+					constructor(mut self, x: number) {
+						self.x = x
+					},
+				}
+			`,
+		},
+		{
+			name: "BothBranchesAssign",
+			src: `
+				class C {
+					x: number,
+					constructor(mut self, cond: boolean) {
+						if cond {
+							self.x = 1
+						} else {
+							self.x = 2
+						}
+					},
+				}
+			`,
+		},
+		{
+			name: "AssignThenRead",
+			src: `
+				class C {
+					x: number,
+					y: number,
+					constructor(mut self, x: number) {
+						self.x = x
+						self.y = self.x
+					},
+				}
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Empty(t, errs)
+		})
+	}
+}
+
+// TestConstructorInitErrors covers the definite-assignment diagnostics: a required
+// field left unassigned on some path is a FieldNotInitializedError, and a `self.f` read
+// before its assignment is a ReadBeforeInitError.
+func TestConstructorInitErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "FieldNeverAssigned",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+					constructor(mut self, x: number) {
+						self.x = x
+					},
+				}
+			`,
+			want: "Field 'y' is not initialized on every path through the constructor.",
+		},
+		{
+			name: "MultipleFieldsUnassigned",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+					constructor(mut self) { },
+				}
+			`,
+			want: "Fields 'x', 'y' are not initialized on every path through the constructor.",
+		},
+		{
+			name: "AssignedOnOnlyOnePath",
+			src: `
+				class C {
+					x: number,
+					constructor(mut self, cond: boolean) {
+						if cond {
+							self.x = 1
+						}
+					},
+				}
+			`,
+			want: "Field 'x' is not initialized on every path through the constructor.",
+		},
+		{
+			name: "ReadBeforeInit",
+			src: `
+				class C {
+					x: number,
+					y: number,
+					constructor(mut self, x: number) {
+						self.y = self.x
+						self.x = x
+					},
+				}
+			`,
+			want: "Field 'self.x' is read before it has been initialized.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, test.want, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -733,6 +733,7 @@ func TestConstructorInitClean(t *testing.T) {
 					x: number,
 					log(self) -> number { return self.x },
 					constructor(mut self, x: number) {
+						val f = self.log
 						self.x = x
 					},
 				}


### PR DESCRIPTION
Adds definite-assignment checking to constructor bodies so that required instance fields must be assigned on every path to a normal exit, and reads of `self.f` before assignment are caught.

The implementation reuses the existing CFG and move-state dataflow analysis. Each required (non-optional) field gets a synthetic variable ID, and field assignments are modeled as "moves" of that ID. A `throw` statement exempts its path from the requirement by marking all fields as assigned, since a throwing path never completes construction. Optional fields are not tracked.

Key changes:
- `checkConstructorInit` runs the analysis after type-checking the constructor body, reporting `FieldNotInitializedError` for uninitialized required fields at the exit and `ReadBeforeInitError` for reads before assignment.
- `initCollector` walks the constructor body statement-by-statement, recording field assignments as gens and field reads as `initRead` records. It handles assignment expressions specially to detect reads on the right side before the field is marked assigned (e.g., `self.x = self.x`).
- `selfFieldName` extracts the field name from a `self.f` member access, excluding optional chaining, deeper paths, and non-self objects.
- Error types `FieldNotInitializedError` and `ReadBeforeInitError` report the missing fields or the read site respectively.
- Tests cover both clean constructors (all fields assigned, optional fields unassigned, conditional branches) and error cases (missing fields, reads before init).

https://claude.ai/code/session_01SQ2qhKwukHp63o7CscBoj6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constructor definite-assignment validation to ensure all required instance fields are initialized on every successful exit path.
  * Introduced clearer diagnostics for three failure modes: missing required fields, reading an instance field before initialization, and calling `self` methods before all required fields are initialized.

* **Tests**
  * Added table-driven test suites covering valid initialization patterns (including branching and optional fields) and exact error-message assertions for each failure scenario.

* **Documentation**
  * Improved user-facing messaging clarity by deterministically listing missing fields and pointing to the relevant code span.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->