### PR TITLE
B2: Pre-bind mutually-recursive classes before body inference

### DIFF
--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -6,12 +6,17 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferClassDecl types a non-recursive class declaration (M5 B1). It returns the
-// class's constructor as a raw FuncType for the SCC driver to constrain into the
-// value binding var and generalize, along with the decl's provenance. It has two side
-// effects. It registers the instance TypeBinding in scope, so the class name resolves as
-// a type. It registers the ClassDef in the nominal registry, so member lookup and the
-// nominal constrain rule can read the projected body.
+// inferClassDecl types a class declaration (M5 B1). It returns the class's constructor
+// as a raw FuncType for the SCC driver to constrain into the value binding var and
+// generalize, along with the decl's provenance. It has two side effects. It registers
+// the instance TypeBinding in scope, so the class name resolves as a type. It registers
+// the ClassDef in the nominal registry, so member lookup and the nominal constrain rule
+// can read the projected body.
+//
+// A class in a mutually-recursive group reuses the nominal token and ClassDef shell the
+// SCC driver pre-bound for the group through classShell (M5 B2), so a forward reference
+// to a sibling defined later in the group resolves before its body is inferred. A class
+// reached without a pre-bound shell mints and registers the pair here.
 //
 // Fields are built first, then each method, getter, and setter is inferred eagerly.
 // `self` carries the fields only, so a method that calls another method of the same
@@ -22,8 +27,6 @@ import (
 // lookup reads concrete member types. A generic body keeps its parameter vars symbolic
 // for per-instance projection.
 func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (soltype.Type, provenance.Provenance, bool) {
-	name := decl.Name.Name
-
 	// Resolve the class's type parameters into a child scope so the body resolves the
 	// class's T to one shared var, quantified at the class boundary and freshened per
 	// construction. A non-generic class reuses the enclosing scope.
@@ -34,27 +37,20 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
 
-	// The instance's nominal identity, carrying the class's own type-parameter vars as
-	// its arguments. B1 uses the bare local name as the qualified key, correct for the
-	// top-level default namespace; namespace-qualified keys ride the namespace work.
-	self := &soltype.ClassType{Name: name, TypeArgs: typeParamVars(typeParams)}
-
-	body := &soltype.ObjectType{}
-	static := &soltype.ObjectType{}
-	def := &ClassDef{
-		Body:       body,
-		Static:     static,
-		Level:      lvl - 1,
-		TypeParams: typeParams,
-		Variance:   make([]Variance, len(typeParams)),
-	}
-	c.ctx.registerClass(name, def)
-	// Register the type binding early so a self-referential type in the body resolves
-	// to this class rather than falling through as unknown.
-	scope.defineType(name, TypeBinding{
-		Type:    self,
-		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
-	})
+	// The instance's nominal identity and its heavy ClassDef, reusing the pair the SCC
+	// driver pre-bound for this class's recursive group (B2) so a sibling that already
+	// captured this class as a forward reference sees the finished body through the same
+	// token. A class reached without a pre-bound shell mints and registers the pair here.
+	// The token carries the class's own type-parameter vars as its arguments. B1 uses the
+	// bare local name as the qualified key, correct for the top-level default namespace;
+	// namespace-qualified keys ride the namespace work.
+	self, def := c.classShell(scope, decl)
+	self.TypeArgs = typeParamVars(typeParams)
+	def.Level = lvl - 1
+	def.TypeParams = typeParams
+	def.Variance = make([]Variance, len(typeParams))
+	body := def.Body
+	static := def.Static
 	c.recordType(decl.Name, self)
 
 	// Resolve the declared extends edge and implements interfaces so C1 can walk and
@@ -81,6 +77,47 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	}
 
 	return ctorType, &ast.NodeProvenance{Node: decl}, true
+}
+
+// classShell returns the nominal ClassType token and ClassDef a class binds to. It
+// reuses the pair the SCC driver pre-bound for a recursive group (preregisterClass) or,
+// when the class was reached without one, mints a fresh pair and registers the type
+// binding and registry entry. Either way the class name resolves to the returned token
+// and def before the body is walked, so a self- or sibling-reference in the body reaches
+// them. inferClassDecl then fills the def in place, so a sibling that captured the token
+// as a forward reference sees the finished body through the same object.
+func (c *checker) classShell(scope *Scope, decl *ast.ClassDecl) (*soltype.ClassType, *ClassDef) {
+	name := decl.Name.Name
+	if def, ok := c.ctx.classDef(name); ok {
+		if b, found := scope.GetType(name); found {
+			if self, ok := b.Type.(*soltype.ClassType); ok && self.Name == name {
+				return self, def
+			}
+		}
+	}
+	self := &soltype.ClassType{Name: name}
+	def := &ClassDef{Body: &soltype.ObjectType{}, Static: &soltype.ObjectType{}}
+	c.ctx.registerClass(name, def)
+	// Register the type binding so a self-referential type in the body resolves to this
+	// class rather than falling through as unknown.
+	scope.defineType(name, TypeBinding{
+		Type:    self,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	return self, def
+}
+
+// preregisterClass binds a class's nominal identity before any body in its
+// recursive group is walked (B2). The SCC driver runs it over each class in a
+// type-key component — the group of mutually-recursive classes the dep graph
+// condensed together — so every class in the group has a resolved type binding and
+// a ClassDef shell before the first value key infers a body. A sibling class defined
+// later in the group then resolves a forward reference — a field, method parameter,
+// or return typed by a peer — to the shared token. inferClassDecl fills the same
+// token and shell in place at the class's value key, so no placeholder-patch phase is
+// needed: the token a sibling captured is the one that carries the finished body.
+func (c *checker) preregisterClass(scope *Scope, decl *ast.ClassDecl) {
+	c.classShell(scope, decl)
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -37,14 +37,19 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
 
-	// The instance's nominal identity and its heavy ClassDef, reusing the pair the SCC
-	// driver pre-bound for this class's recursive group (B2) so a sibling that already
-	// captured this class as a forward reference sees the finished body through the same
-	// token. A class reached without a pre-bound pair mints and registers one here.
-	// The token carries the class's own type-parameter vars as its arguments. B1 uses the
+	// The instance's nominal identity and its heavy ClassDef. getOrCreateClass returns
+	// the pair the SCC pre-pass registered for this class — an empty shell it minted
+	// before any type params were resolved, so that a sibling in the same recursive group
+	// resolves a forward reference to this class through the shared token (B2). A class
+	// reached without a pre-registered shell mints and registers one here. B1 uses the
 	// bare local name as the qualified key, correct for the top-level default namespace;
 	// namespace-qualified keys ride the namespace work.
 	self, def := c.getOrCreateClass(scope, decl)
+	// Populate the type-param-derived fields the pre-pass left empty. This is the second
+	// phase: the pre-pass registers a bare identity so forward references resolve, and
+	// this call — running once every sibling is registered, so a bound like `<T: Sibling>`
+	// resolves — fills in the resolved type params. The token carries the class's own
+	// type-parameter vars as its arguments.
 	self.TypeArgs = typeParamVars(typeParams)
 	def.Level = lvl - 1
 	def.TypeParams = typeParams

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -13,10 +13,10 @@ import (
 // the ClassDef in the nominal registry, so member lookup and the nominal constrain rule
 // can read the projected body.
 //
-// A class in a mutually-recursive group reuses the nominal token and ClassDef shell the
-// SCC driver pre-bound for the group through classShell (M5 B2), so a forward reference
-// to a sibling defined later in the group resolves before its body is inferred. A class
-// reached without a pre-bound shell mints and registers the pair here.
+// A class in a mutually-recursive group reuses the nominal token and empty ClassDef the
+// SCC driver pre-bound for the group through getOrCreateClass (M5 B2), so a forward
+// reference to a sibling defined later in the group resolves before its body is inferred.
+// A class reached without a pre-bound pair mints and registers one here.
 //
 // Fields are built first, then each method, getter, and setter is inferred eagerly.
 // `self` carries the fields only, so a method that calls another method of the same
@@ -40,11 +40,11 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	// The instance's nominal identity and its heavy ClassDef, reusing the pair the SCC
 	// driver pre-bound for this class's recursive group (B2) so a sibling that already
 	// captured this class as a forward reference sees the finished body through the same
-	// token. A class reached without a pre-bound shell mints and registers the pair here.
+	// token. A class reached without a pre-bound pair mints and registers one here.
 	// The token carries the class's own type-parameter vars as its arguments. B1 uses the
 	// bare local name as the qualified key, correct for the top-level default namespace;
 	// namespace-qualified keys ride the namespace work.
-	self, def := c.classShell(scope, decl)
+	self, def := c.getOrCreateClass(scope, decl)
 	self.TypeArgs = typeParamVars(typeParams)
 	def.Level = lvl - 1
 	def.TypeParams = typeParams
@@ -79,14 +79,20 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	return ctorType, &ast.NodeProvenance{Node: decl}, true
 }
 
-// classShell returns the nominal ClassType token and ClassDef a class binds to. It
-// reuses the pair the SCC driver pre-bound for a recursive group (preregisterClass) or,
-// when the class was reached without one, mints a fresh pair and registers the type
-// binding and registry entry. Either way the class name resolves to the returned token
-// and def before the body is walked, so a self- or sibling-reference in the body reaches
-// them. inferClassDecl then fills the def in place, so a sibling that captured the token
-// as a forward reference sees the finished body through the same object.
-func (c *checker) classShell(scope *Scope, decl *ast.ClassDecl) (*soltype.ClassType, *ClassDef) {
+// getOrCreateClass returns the nominal ClassType token and ClassDef a class binds to,
+// reusing the pair already registered for the class or minting and registering a fresh
+// one when none exists. Either way the class name resolves to the returned token and def
+// before the body is walked, so a self- or sibling-reference in the body reaches them.
+// inferClassDecl then fills the def in place, so a sibling that captured the token as a
+// forward reference sees the finished body through the same object.
+//
+// The SCC driver calls it as a pre-pass over each class in a type-key component — the
+// group of mutually-recursive classes the dep graph condensed together — so every class
+// in the group has a resolved type binding and an empty ClassDef before the first value
+// key infers a body (M5 B2). That pre-pass discards the return; only inferClassDecl reads
+// it. No placeholder-patch phase is needed: the token a sibling captured is the one that
+// carries the finished body.
+func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl) (*soltype.ClassType, *ClassDef) {
 	name := decl.Name.Name
 	if def, ok := c.ctx.classDef(name); ok {
 		if b, found := scope.GetType(name); found {
@@ -105,19 +111,6 @@ func (c *checker) classShell(scope *Scope, decl *ast.ClassDecl) (*soltype.ClassT
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
 	})
 	return self, def
-}
-
-// preregisterClass binds a class's nominal identity before any body in its
-// recursive group is walked (B2). The SCC driver runs it over each class in a
-// type-key component — the group of mutually-recursive classes the dep graph
-// condensed together — so every class in the group has a resolved type binding and
-// a ClassDef shell before the first value key infers a body. A sibling class defined
-// later in the group then resolves a forward reference — a field, method parameter,
-// or return typed by a peer — to the shared token. inferClassDecl fills the same
-// token and shell in place at the class's value key, so no placeholder-patch phase is
-// needed: the token a sibling captured is the one that carries the finished body.
-func (c *checker) preregisterClass(scope *Scope, decl *ast.ClassDecl) {
-	c.classShell(scope, decl)
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -268,6 +268,84 @@ func TestInferClassJoinMemberAccess(t *testing.T) {
 }
 */
 
+// TestInferClassMutualRecursion covers classes that reference each other, or
+// themselves, through the SCC path (M5 B2). The dep graph condenses a mutually
+// recursive group into one type-key component ordered before every class's value key,
+// so pre-binding each class's nominal identity there lets a sibling defined later in the
+// group resolve a forward reference. Each constructor and type binding renders the peer's
+// class name with no placeholder leak.
+func TestInferClassMutualRecursion(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			// A forward reference: A's field is typed by B, declared later.
+			name: "MutualFields",
+			src: `
+				class A { b: B }
+				class B { a: A }
+			`,
+			wantValues: map[string]string{
+				"A": "fn (b: B) -> A",
+				"B": "fn (a: A) -> B",
+			},
+			wantTypes: map[string]string{"A": "A", "B": "B"},
+		},
+		{
+			// A self-referential field resolves to the class being declared.
+			name:       "SelfReferentialField",
+			src:        `class Node { next: Node }`,
+			wantValues: map[string]string{"Node": "fn (next: Node) -> Node"},
+			wantTypes:  map[string]string{"Node": "Node"},
+		},
+		{
+			// A method on A returns B and a method on B returns A, each inferred from a
+			// field read, so the return type is the sibling class.
+			name: "MutualMethodReturns",
+			src: `
+				class A {
+					b: B,
+					getB(self) { return self.b },
+				}
+				class B {
+					a: A,
+					getA(self) { return self.a },
+				}
+			`,
+			wantValues: map[string]string{
+				"A": "fn (b: B) -> A",
+				"B": "fn (a: A) -> B",
+			},
+			wantTypes: map[string]string{"A": "A", "B": "B"},
+		},
+		{
+			// A three-class cycle A -> B -> C -> A lands in one type-key component; every
+			// forward reference still resolves.
+			name: "ThreeClassCycle",
+			src: `
+				class A { b: B }
+				class B { c: C }
+				class C { a: A }
+			`,
+			wantValues: map[string]string{
+				"A": "fn (b: B) -> A",
+				"B": "fn (c: C) -> B",
+				"C": "fn (a: A) -> C",
+			},
+			wantTypes: map[string]string{"A": "A", "B": "B", "C": "C"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classValues(t, test.src, test.wantValues, test.wantTypes)
+		})
+	}
+}
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -342,7 +342,15 @@ func (c *checker) inferComponent(
 			if handled.Contains(d) {
 				continue
 			}
-			if _, ok := d.(*ast.ClassDecl); ok {
+			if cd, ok := d.(*ast.ClassDecl); ok {
+				// Pre-bind the class's nominal identity before any body in its recursive
+				// group is walked (M5 B2). A type-key component is the SCC condensation of
+				// a group of mutually-recursive classes, so registering every class's type
+				// binding and ClassDef shell here lets a sibling defined later in the group
+				// resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
+				// The value key infers the body and marks the decl handled; leave it
+				// unhandled here so the reconciliation pass finds it through that key.
+				c.preregisterClass(scope, cd)
 				continue
 			}
 			handled.Add(d)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -346,11 +346,12 @@ func (c *checker) inferComponent(
 				// Pre-bind the class's nominal identity before any body in its recursive
 				// group is walked (M5 B2). A type-key component is the SCC condensation of
 				// a group of mutually-recursive classes, so registering every class's type
-				// binding and ClassDef shell here lets a sibling defined later in the group
+				// binding and empty ClassDef here lets a sibling defined later in the group
 				// resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
 				// The value key infers the body and marks the decl handled; leave it
-				// unhandled here so the reconciliation pass finds it through that key.
-				c.preregisterClass(scope, cd)
+				// unhandled here so the reconciliation pass finds it through that key. The
+				// returned token and def are discarded here; inferClassDecl reuses them.
+				c.getOrCreateClass(scope, cd)
 				continue
 			}
 			handled.Add(d)

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -1032,11 +1032,13 @@ corruption of `freshenAbove`.
     `solver/constrain.go` (the object arm's `ConstructorElem` case),
     `solver/infer_class_test.go`.
   - **Structures:**
-    - add `soltype.ConstructorElem{Sig *FuncType}`, a new `ObjTypeElem` arm carrying
-      the class's constructor call signature — the standing-rule sweep every former
-      addition runs (`isObjTypeElem`, `acceptObjElems` with `Sig` covariant like a
-      method signature, `printType`, `equalType`, `freeTypeVars`, and every
-      `Member`/`AsProperty` switch site).
+    - add `soltype.ConstructorElem{Fn *FuncType}`, a new `ObjTypeElem` arm carrying
+      the class's constructor call signature — the field name matches the old
+      checker's `type_system.ConstructorElem` ([types.go:1052](../../internal/type_system/types.go)),
+      the port source. Adding it is the standing-rule sweep every former addition runs
+      (`isObjTypeElem`, `acceptObjElems` with `Fn` covariant like a method signature,
+      `printType`, `equalType`, `freeTypeVars`, and every `Member`/`AsProperty` switch
+      site).
     - the class VALUE binding becomes `ValueBinding{Schemes: [ctor-plus-static
       ObjectType]}` — one `ConstructorElem` for the callable side plus the
       `ClassDef.Static` elems (fields, methods, getters, setters) — replacing B1's raw
@@ -1046,7 +1048,7 @@ corruption of `freshenAbove`.
     SCC driver to constrain into the value var; B6 wraps that signature in a
     `ConstructorElem`, appends the frozen `ClassDef.Static` elems, and returns the
     resulting `ObjectType` as the raw value type instead. `resolveFunc` gains a case
-    that, given such an object, hands back the `ConstructorElem.Sig`, so a direct call
+    that, given such an object, hands back the `ConstructorElem.Fn`, so a direct call
     `Point(1, 2)` resolves through the call signature exactly as a bare `FuncType` did.
     Static member access `Point.origin` then rides the existing `valueProp` object-property
     path — reading a static off the same object needs no new access path. The object
@@ -1072,7 +1074,7 @@ corruption of `freshenAbove`.
     already in flight, **sequence B6 after B3 and B5 land** and rebase its value-side
     assembly onto their final `infer_class.go`, rather than running it parallel to them —
     landing it concurrently would re-churn the same value-binding assembly twice.
-  - **Accept:** a `class Point { x: number, y: number, static origin(self) -> Point {…} }`
+  - **Accept:** a `class Point { x: number, y: number, static origin() -> Point {…} }`
     binds a callable object value — `Point(1, 2)` still constructs a `Point`, `Point.origin`
     resolves the static method, and the value renders as the ctor-plus-static object; a
     `static count: number = 0` field is read through the value binding as `number`; two
@@ -1344,7 +1346,7 @@ two tracks is D2 (patterns × enums × M6's union exhaustiveness).
   instance's own borrow lifetime).
 - `soltype.MethodElem`/`GetterElem`/`SetterElem` — new `ObjTypeElem` arms
   (methods hold overload arms as an ordered `[]*FuncType`).
-- `soltype.ConstructorElem{Sig *FuncType}` (B6) — the call-signature `ObjTypeElem`
+- `soltype.ConstructorElem{Fn *FuncType}` (B6) — the call-signature `ObjTypeElem`
   arm that makes a class VALUE binding a callable object: one `ConstructorElem` plus
   the static members, so `Point(1, 2)` and `Point.origin` both resolve off one type.
   Bounded to the class-value carrier so the "callable in the lattice" exception stays

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -733,7 +733,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-14 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+15 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -1010,6 +1010,76 @@ corruption of `freshenAbove`.
     every required field checks clean; a `self.f` read before its assignment reports
     `ReadBeforeInitError`; an optional field left unassigned is accepted.
 
+- **B6 — Callable class value: constructor `ObjTypeElem` + ctor-plus-static object
+  binding** (~230). **← the static-member side of the dual binding B1 descoped.**
+  - **Problem:** B1 registers a class's VALUE binding as a bare constructor
+    `FuncType` and parks the static members on `ClassDef.Static`, which nothing reads
+    ([classes.go:49-51](../../internal/solver/classes.go)). So `Point(1, 2)` resolves
+    but `Point.origin` — a static field or method access on the class value — has no
+    binding to read, and the class value renders as a plain `fn (…) -> Point` rather
+    than the callable object carrying its statics. The old checker, the port source,
+    builds the value as one `ObjectType` holding a `ConstructorElem` call signature
+    plus the merged static elems
+    ([infer_class_decl.go:334-338](../../internal/checker/infer_class_decl.go)); the
+    solver has no such representation because `soltype.ObjectType`'s element set is
+    Property/Method/Getter/Setter with **no call-signature arm**.
+  - **Files:** `soltype/type.go` (the new `ConstructorElem` arm + `Member`/`AsProperty`
+    discipline), `soltype/visitor.go` (`acceptObjElems`), `soltype/print.go`
+    (`typePrec`/`printType`/`freeTypeVars`), `solver/coalesce.go` (`equalType` +
+    `freezeClassBody`'s static-side coalesce), `solver/infer_class.go` (assemble the
+    ctor-plus-static value `ObjectType` in place of the bare ctor `FuncType`),
+    `solver/infer_expr.go` (`resolveFunc` look-through, [infer_expr.go:1260](../../internal/solver/infer_expr.go)),
+    `solver/constrain.go` (the object arm's `ConstructorElem` case),
+    `solver/infer_class_test.go`.
+  - **Structures:**
+    - add `soltype.ConstructorElem{Sig *FuncType}`, a new `ObjTypeElem` arm carrying
+      the class's constructor call signature — the standing-rule sweep every former
+      addition runs (`isObjTypeElem`, `acceptObjElems` with `Sig` covariant like a
+      method signature, `printType`, `equalType`, `freeTypeVars`, and every
+      `Member`/`AsProperty` switch site).
+    - the class VALUE binding becomes `ValueBinding{Schemes: [ctor-plus-static
+      ObjectType]}` — one `ConstructorElem` for the callable side plus the
+      `ClassDef.Static` elems (fields, methods, getters, setters) — replacing B1's raw
+      ctor `FuncType`. `ClassDef.Static` is already partitioned and populated in B1, so
+      B6 only wraps it, it does not re-walk the body.
+  - **Algorithm:** `inferClassDecl` currently returns the raw ctor `FuncType` for the
+    SCC driver to constrain into the value var; B6 wraps that signature in a
+    `ConstructorElem`, appends the frozen `ClassDef.Static` elems, and returns the
+    resulting `ObjectType` as the raw value type instead. `resolveFunc` gains a case
+    that, given such an object, hands back the `ConstructorElem.Sig`, so a direct call
+    `Point(1, 2)` resolves through the call signature exactly as a bare `FuncType` did.
+    Static member access `Point.origin` then rides the existing `valueProp` object-property
+    path — reading a static off the same object needs no new access path. The object
+    arm in `constrain` gains a `ConstructorElem` case so a class value flows
+    structurally where an object with a matching call signature is expected.
+  - **Design note — the bounded lattice exception.** doc.go §"M3 (PR6)" deliberately
+    keeps "callable in several ways" OUT of the structural subtype lattice: FREE-function
+    overloads resolve through the separate `resolveOverload`/`Schemes` phase, never a
+    call-signature embedded in an object
+    ([doc.go:53-62](../../internal/solver/doc.go)). B6 reintroduces a callable element,
+    so scope it tightly — ONE `ConstructorElem` per class value, NOT a general
+    call-signature-in-any-object feature and NOT the overload disjunction. A class with
+    overloaded constructors or static methods still resolves its arms through E1's
+    `resolveOverload`; the `ConstructorElem` carries a single (post-merge) signature.
+    This keeps the lattice exception bounded to the class-value carrier.
+  - **Note:** the B1 sketch registers the dual binding as `ValueBinding{Schemes:
+    [ctor+static ObjectType]}` (§"Class declaration inference"); shipped B1 descoped it
+    to a bare ctor `FuncType`. B6 lands the sketched binding — the static-side analogue
+    of B3 pulling recursive methods out of B1 and B5 pulling definite-assignment out of B1.
+  - **Depends on:** B1. Overlaps `infer_class.go` with **B3** (member/static partition
+    rework) and `infer_class_ctor.go`'s signature assembly with **B5**, and its
+    `ClassType`/element sweep touches the same `soltype` sites as A1. Since B2–B5 are
+    already in flight, **sequence B6 after B3 and B5 land** and rebase its value-side
+    assembly onto their final `infer_class.go`, rather than running it parallel to them —
+    landing it concurrently would re-churn the same value-binding assembly twice.
+  - **Accept:** a `class Point { x: number, y: number, static origin(self) -> Point {…} }`
+    binds a callable object value — `Point(1, 2)` still constructs a `Point`, `Point.origin`
+    resolves the static method, and the value renders as the ctor-plus-static object; a
+    `static count: number = 0` field is read through the value binding as `number`; two
+    signatures for the class value differing only in var id compare equal under
+    `equalType`; a free-function overload set still resolves through `resolveOverload`
+    with no callable-in-lattice regression.
+
 ### Phase C — Nominal subtyping + variance
 
 - **C1 — The declared-subtype graph + the nominal constrain rule + `final`
@@ -1170,6 +1240,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► B3 (intra-class method recursion, two-phase walk)  ── parallel with B2
       ├─► B4 (cross-param type-param bounds, shared resolver) ── parallel with B2
       ├─► B5 (constructor definite-assignment)               ── parallel with B2
+      ├─► B6 (callable class value: ctor+static object binding) ── after B3 & B5 (shared infer_class.go)
       ├─► C1 (declared-subtype graph + nominal rule + final)
       │    ├─► C2 (variance inference + in/out modifiers)
       │    └─► F1 (iteration protocol + back-edge validation)
@@ -1192,6 +1263,7 @@ graph TD
     B3["B3 (intra-class method recursion, two-phase walk)"]
     B4["B4 (cross-param type-param bounds, shared resolver)"]
     B5["B5 (constructor definite-assignment)"]
+    B6["B6 (callable class value: ctor+static object binding)"]
     C1["C1 (declared-subtype graph + nominal rule + final)"]
     C2["C2 (variance inference + in/out modifiers)"]
     F1["F1 (iteration protocol + back-edge validation)"]
@@ -1219,6 +1291,9 @@ graph TD
     DEnum --> D2
     M6 -.-> DEnum
     M6 -.-> D2
+    B1 --> B6
+    B3 -.-> B6
+    B5 -.-> B6
 
     classDef crit fill:#ffe0b2,stroke:#e65100,stroke-width:2px,color:#000;
     classDef landed fill:#eceff1,stroke:#90a4ae,stroke-dasharray:4 3,color:#000;
@@ -1242,6 +1317,10 @@ they land before B1. Everything else is off the critical path.
   helper, independent of the recursion and subtyping work.
 - **B5** (constructor definite-assignment) — a CFG dataflow over the constructor
   body, reusing the move machinery, independent of the other Phase-B work.
+- **B6** (callable class value) — the ctor-plus-static object binding + a
+  `ConstructorElem` soltype arm. Depends on B1 but **is NOT parallel with B3/B5**: it
+  rebuilds the same value-side assembly in `infer_class.go` those PRs restructure, so
+  it lands AFTER B3 and B5 and rebases onto their final code.
 - **C1** (nominal subtyping) — `constrain`/`classes.go`.
 - **D1** (nominal patterns) — `pattern.go`, uses member lookup, **not** the C1
   subtyping rule, so it does not wait on C1.
@@ -1265,6 +1344,11 @@ two tracks is D2 (patterns × enums × M6's union exhaustiveness).
   instance's own borrow lifetime).
 - `soltype.MethodElem`/`GetterElem`/`SetterElem` — new `ObjTypeElem` arms
   (methods hold overload arms as an ordered `[]*FuncType`).
+- `soltype.ConstructorElem{Sig *FuncType}` (B6) — the call-signature `ObjTypeElem`
+  arm that makes a class VALUE binding a callable object: one `ConstructorElem` plus
+  the static members, so `Point(1, 2)` and `Point.origin` both resolve off one type.
+  Bounded to the class-value carrier so the "callable in the lattice" exception stays
+  narrow (free-function overloads still ride `resolveOverload`).
 - `soltype.TypeParam{Name, Var, Default}` — one quantified type parameter, shared
   by functions and classes. Constraint is `Var`'s upper bound; `Default` is the
   omitted-argument fallback (nil ⇒ required); `Name` is for display.

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -496,6 +496,10 @@ name — the analogue of the old checker's `TypeRefType.Name` being a `QualIdent
 plain string. The printer strips the namespace prefix for display, which is why
 the `printType` arm still renders the bare `Point` / `Box<number>`.
 
+Shipped B1 descoped this: `classShell` keys `classes` and `ClassType.Name` off the
+bare local name, correct only for the root namespace. **B7** lands the qualified
+keying described here.
+
 **Assumption (M5 solver path only) — classes are top-level, so the registry is
 insert/overwrite, never remove.** This is a property of the M5 `internal/solver`
 path, not a repo-wide invariant. In that path every `ClassDef` comes from a module-
@@ -1082,6 +1086,53 @@ corruption of `freshenAbove`.
     `equalType`; a free-function overload set still resolves through `resolveOverload`
     with no callable-in-lattice regression.
 
+- **B7 — Namespace-qualified class registry + `ClassType` keys** (~140).
+  **← finishes the qualified-key design B1 descoped.**
+  - **Problem:** `classShell` keys the flat `classes` registry and the class's
+    scope type binding off the bare `decl.Name.Name` — `Point`, not
+    `Geometry.Point` ([infer_class.go:90-107](../../internal/solver/infer_class.go)) —
+    and `inferClassDecl` mints the `ClassType` with the same bare `Name`
+    ([infer_class.go:47-54](../../internal/solver/infer_class.go)). That is correct
+    only while every class sits in the root namespace. Two sibling `class Point`
+    declarations under different directory-derived namespaces collide on
+    `classes["Point"]`, even though `dep_graph` keeps their binding keys distinct
+    (`Geometry.Point` vs `Shape.Point`) and each `Namespace` holds its own `Types`
+    map ([scope.go:76-81](../../internal/solver/scope.go)). This is the gap the
+    §"Qualified keys" design specifies but shipped B1 left open, the surface flagged
+    at [infer_class.go:44-46](../../internal/solver/infer_class.go).
+  - **Files:** `solver/infer_class.go` (`classShell` / `inferClassDecl` qualified-name
+    derivation), `solver/infer_decl.go` (thread the component's namespace into the
+    class dispatch), `solver/module.go` (`inferComponent` reads the component key's
+    `g.GetNamespace(key)` and passes it down), `solver/infer_class_test.go`, plus a
+    directory-namespaced fixture under `fixtures/`.
+  - **Algorithm:** derive the qualified name once — `ns + "." + decl.Name.Name` when
+    `ns := g.GetNamespace(key)` is non-empty, else the bare name. This is the same
+    `CurrentNamespace + "." + name` rule `dep_graph` forms binding keys with
+    ([dep_graph.go:331](../../internal/dep_graph/dep_graph.go)) and the inverse of
+    `leafName`'s prefix strip ([module.go:599-605](../../internal/solver/module.go)).
+    Key `registerClass` / `classDef` and `ClassType.Name` off that qualified string,
+    and record the class's type binding into the owning `Namespace.Types` under its
+    bare name, so an intra-namespace reference resolves `Point` and a cross-namespace
+    one resolves `Geometry.Point`. The printer already strips the namespace prefix,
+    so a `Geometry.Point` token still renders as the bare `Point` with no printer
+    change (§"Qualified keys").
+  - **Note:** the §"Qualified keys" section describes both `ClassType.Name` and the
+    `classes` key as the `dep_graph`-qualified name; shipped B1 descoped that to the
+    bare local name for the root namespace. B7 lands the qualified keying — the
+    namespace-side analogue of B3, B5, and B6 each pulling a descoped B1 slice into
+    its own PR.
+  - **Depends on:** B1. Touches `classShell` / `inferClassDecl`, which B2 also
+    modified, so rebase onto B2 (landed) rather than run parallel to it. Independent
+    of C/D/E — pure keying work with no overlap with subtyping, patterns, or
+    overloads.
+  - **Accept:** a `Geometry.Point { x: number }` and a `Shape.Point { label: string }`
+    under different directory namespaces infer as distinct `classes` entries with
+    distinct `ClassType.Name`; member access on an instance of each resolves its own
+    body (`x: number` vs `label: string`) with no cross-namespace collision; a
+    cross-namespace reference to `Geometry.Point` resolves to the right class; both
+    still render as the bare `Point`; a single root-namespace `class Point` is
+    unchanged.
+
 ### Phase C — Nominal subtyping + variance
 
 - **C1 — The declared-subtype graph + the nominal constrain rule + `final`
@@ -1243,6 +1294,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► B4 (cross-param type-param bounds, shared resolver) ── parallel with B2
       ├─► B5 (constructor definite-assignment)               ── parallel with B2
       ├─► B6 (callable class value: ctor+static object binding) ── after B3 & B5 (shared infer_class.go)
+      ├─► B7 (namespace-qualified class registry + ClassType keys) ── after B2 (shared classShell), ∥ C/D/E
       ├─► C1 (declared-subtype graph + nominal rule + final)
       │    ├─► C2 (variance inference + in/out modifiers)
       │    └─► F1 (iteration protocol + back-edge validation)
@@ -1266,6 +1318,7 @@ graph TD
     B4["B4 (cross-param type-param bounds, shared resolver)"]
     B5["B5 (constructor definite-assignment)"]
     B6["B6 (callable class value: ctor+static object binding)"]
+    B7["B7 (namespace-qualified class registry + ClassType keys)"]
     C1["C1 (declared-subtype graph + nominal rule + final)"]
     C2["C2 (variance inference + in/out modifiers)"]
     F1["F1 (iteration protocol + back-edge validation)"]
@@ -1296,6 +1349,8 @@ graph TD
     B1 --> B6
     B3 -.-> B6
     B5 -.-> B6
+    B1 --> B7
+    B2 -.-> B7
 
     classDef crit fill:#ffe0b2,stroke:#e65100,stroke-width:2px,color:#000;
     classDef landed fill:#eceff1,stroke:#90a4ae,stroke-dasharray:4 3,color:#000;
@@ -1323,6 +1378,10 @@ they land before B1. Everything else is off the critical path.
   `ConstructorElem` soltype arm. Depends on B1 but **is NOT parallel with B3/B5**: it
   rebuilds the same value-side assembly in `infer_class.go` those PRs restructure, so
   it lands AFTER B3 and B5 and rebases onto their final code.
+- **B7** (namespace-qualified class keys) — keys `classes` and `ClassType.Name` off
+  the `dep_graph`-qualified name so same-named classes in different namespaces stay
+  distinct. Depends on B1; touches the `classShell` B2 also modified, so it lands
+  after B2 and rebases onto it. Independent of subtyping, patterns, and overloads.
 - **C1** (nominal subtyping) — `constrain`/`classes.go`.
 - **D1** (nominal patterns) — `pattern.go`, uses member lookup, **not** the C1
   subtyping rule, so it does not wait on C1.


### PR DESCRIPTION
Refactor class declaration inference to support mutually-recursive class groups. When classes reference each other (e.g., `class A { b: B }` / `class B { a: A }`), the SCC driver now pre-binds each class's nominal identity and ClassDef shell before any body is walked, allowing forward references to resolve correctly.

**Key changes:**

- Extract class shell creation into a new `classShell` method that either reuses a pre-bound pair (from the SCC driver) or mints and registers a fresh one. This ensures a class name resolves to the same token before and after its body is inferred.

- Add `preregisterClass` method called by the SCC driver over each type-key component (the condensed group of mutually-recursive classes). It pre-binds the nominal identity and ClassDef shell so a sibling defined later in the group can resolve a forward reference to the shared token.

- Refactor `inferClassDecl` to use `classShell` instead of inline registration, removing the `name` variable and simplifying the initialization of `self` and `def`. The method now fills in the pre-bound shell's fields (TypeArgs, Level, TypeParams, Variance) rather than creating them from scratch.

- Update `module.go` to call `preregisterClass` during the type-key component walk, before any value-key inference runs.

- Add test cases covering mutual field references, self-referential fields, mutual method returns, and three-class cycles, all verifying that forward references resolve without placeholder leaks.

**Implementation detail:** The nominal token and ClassDef are now a stable pair shared across the entire recursive group. A sibling that captures the token as a forward reference sees the finished body through the same object once `inferClassDecl` fills it in, eliminating the need for a placeholder-patch phase.

https://claude.ai/code/session_01GDE5Tv6tkh6YRJDsGGiwm3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for mutually recursive classes, including forward references, self-referential fields, and cyclic method relationships.
  * Class references now resolve to the correct class names instead of temporary placeholders.

* **Documentation**
  * Updated the implementation plan to include callable class values and their dependency sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->