### PR TITLE
B3: Implement two-phase member walk for class method recursion

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -150,6 +150,19 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 // path's MissingPropertyError. Only a method, getter, or setter member — which only a
 // class body carries — is intercepted, since the structural object arm reads only
 // properties and panics on those kinds.
+//
+// Unlike projectedMember, this deliberately does NOT project the class's type parameters.
+// `self` is an instance at the class's OWN arguments — the class-parameter vars themselves —
+// so a member referencing `T` keeps `T` symbolic, and it is the same shared var the calling
+// method resolves `T` to, since both members were walked in one class scope. Substituting,
+// the way external access does for a concrete receiver like `Box<5>`, would be wrong here.
+//
+// Per-method type parameters are a separate story that neither access path handles yet: a
+// method carrying its own `FuncType.TypeParams` must be wrapped in a scheme and instantiated
+// per call so each call freshens them, and that wrap belongs in memberValue, shared with
+// projectedMember, not here. Until it lands, a method whose return is a class or method type
+// parameter round-trips as `never` through a call — the same limitation external access has,
+// since an unannotated field read mints an intermediate var that projection cannot rewrite.
 func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
 	obj, ok := carrier.(*soltype.ObjectType)
 	if !ok {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -142,6 +142,29 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	return c.memberValue(lvl, blame, c.projectClassMember(def, ct, member)), true
 }
 
+// classBodyMember resolves a method, getter, or setter read off a class-body ObjectType —
+// the object `self` binds to inside a method or constructor body (M5 B3). It returns
+// ok=false for a property read, so a field keeps the structural field-requirement path
+// that threads the borrow and read-after-write rules a direct lookup would drop, and for a
+// non-object receiver or a missing member, so an unknown member reports through that
+// path's MissingPropertyError. Only a method, getter, or setter member — which only a
+// class body carries — is intercepted, since the structural object arm reads only
+// properties and panics on those kinds.
+func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+	obj, ok := carrier.(*soltype.ObjectType)
+	if !ok {
+		return pathResult{}, false
+	}
+	member, found := obj.Member(name)
+	if !found {
+		return pathResult{}, false
+	}
+	if _, isProp := member.(*soltype.PropertyElem); isProp {
+		return pathResult{}, false
+	}
+	return c.memberValue(lvl, blame, member), true
+}
+
 // projectClassMember rewrites one class-body member's type-parameter and
 // lifetime-parameter vars to the arguments of one instance, the single-member analogue
 // of projectClassBody. A non-generic class, whose body holds no such vars, returns the

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -117,7 +117,14 @@ func (b *mutBubbler) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type
 		anyMut := false
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
 		for i, e := range t.Elems {
-			p := soltype.AsProperty(e)
+			// Only a property can hold an owned-mut cell to bubble. A method, getter, or
+			// setter — carried by the object a class-body `self` binds to — has no field
+			// cell, so it passes through unchanged (M5 B3).
+			p, ok := e.(*soltype.PropertyElem)
+			if !ok {
+				elems[i] = e
+				continue
+			}
 			ft := p.Type
 			if inner, isMut, lt := soltype.UnwrapRef(ft); isMut && lt == nil {
 				anyMut = true

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -825,7 +825,7 @@ func (e *SetterArityError) Message() string {
 type RecursiveMethodAnnotationError struct {
 	Name  string
 	Elem  *ast.MethodElem
-	Group []string // the mutually recursive method names, in declaration order
+	Group []string // the mutually recursive method names, sorted lexicographically for a stable message
 }
 
 func (e *RecursiveMethodAnnotationError) Span() ast.Span      { return e.Elem.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -731,6 +731,7 @@ func (*FieldInitializerNotAllowedError) isSolverError()   {}
 func (*SubclassConstructorRequiredError) isSolverError()  {}
 func (*WriteOnlyPropertyError) isSolverError()            {}
 func (*SetterArityError) isSolverError()                  {}
+func (*RecursiveMethodAnnotationError) isSolverError()    {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -812,6 +813,25 @@ func (e *SetterArityError) Span() ast.Span      { return e.Elem.Span() }
 func (e *SetterArityError) Related() []ast.Span { return nil }
 func (e *SetterArityError) Message() string {
 	return "Setter '" + e.Name + "' must declare exactly one value parameter; found " + strconv.Itoa(e.Count) + "."
+}
+
+// RecursiveMethodAnnotationError fires when a group of mutually recursive methods
+// in one class has no return-type annotation anywhere in the cycle. A method's
+// signature is pre-declared before its body is walked so a sibling call resolves,
+// but an un-annotated return in a cycle stays an inference variable that the cycle
+// cannot ground on its own. An annotation on any member of the cycle breaks it, so
+// every member reports until one is annotated. This mirrors the recursion gate
+// top-level overloaded functions use (UnannotatedRecursiveOverloadError).
+type RecursiveMethodAnnotationError struct {
+	Name  string
+	Elem  *ast.MethodElem
+	Group []string // the mutually recursive method names, in declaration order
+}
+
+func (e *RecursiveMethodAnnotationError) Span() ast.Span      { return e.Elem.Span() }
+func (e *RecursiveMethodAnnotationError) Related() []ast.Span { return nil }
+func (e *RecursiveMethodAnnotationError) Message() string {
+	return "Mutually recursive method '" + e.Name + "' must declare a return type; the cycle " + strings.Join(e.Group, ", ") + " has no annotated return to ground it."
 }
 
 func (e *MixedOwnershipError) Span() ast.Span      { return spanOfNode(e.Node) }

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -538,42 +538,61 @@ func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype
 // `never` rather than a useful type. An annotation on any member of the cycle breaks it.
 // This mirrors the recursion gate top-level overloaded functions use.
 //
-// The check builds the call graph over methods with bodies — an edge from a method to
-// each sibling method its body reads through `self` — and inspects each strongly
-// connected component. A component of two or more methods is a mutual-recursion cycle; a
-// self-recursive method forms a single-method cycle that infers `never` the way a
-// self-recursive top-level function does, so it is not gated. A gated cycle reports every
-// member, since annotating any one of them resolves it.
+// The check builds the call graph over instance methods with bodies — an edge from a
+// method arm to each sibling method its body reads through `self` — and inspects each
+// strongly connected component. Only instance methods are nodes: a static method has no
+// `self` receiver to reach a sibling through, so it cannot join a self-recursion cycle.
+// Each overload arm is its own node keyed by its position, so two same-named arms are not
+// collapsed and every arm keeps its own annotation state and blame span. A `self.m`
+// reference edges to every arm named `m`, since overload resolution may reach any of them.
+// A component of two or more arms is a mutual-recursion cycle; a self-recursive method
+// forms a single-arm component that infers `never` the way a self-recursive top-level
+// function does, so it is not gated. A gated cycle reports every arm, since annotating any
+// one of them resolves it.
 func (c *checker) checkMethodRecursionAnnotations(decl *ast.ClassDecl) {
-	methods := map[string]*ast.MethodElem{}
-	var names []string
+	type methodArm struct {
+		name string
+		elem *ast.MethodElem
+	}
+	var arms []methodArm
+	byName := map[string][]int{} // method name → indices into arms sharing it
 	for _, elem := range decl.Body {
 		m, ok := elem.(*ast.MethodElem)
-		if !ok || m.Fn.Body == nil {
+		if !ok || m.Static || m.Fn.Body == nil {
 			continue
 		}
 		name, ok := objKeyName(m.Name)
 		if !ok {
 			continue
 		}
-		if _, seen := methods[name]; !seen {
-			names = append(names, name)
-		}
-		methods[name] = m
+		byName[name] = append(byName[name], len(arms))
+		arms = append(arms, methodArm{name: name, elem: m})
 	}
-	if len(names) < 2 {
+	if len(arms) < 2 {
 		return
 	}
-	successors := func(name string) []string {
-		return selfMethodRefs(methods[name].Fn.Body, methods)
+	names := set.NewSet[string]()
+	for name := range byName {
+		names.Add(name)
 	}
-	for _, component := range graph.StronglyConnectedComponents(names, successors) {
+	nodes := make([]int, len(arms))
+	for i := range arms {
+		nodes[i] = i
+	}
+	successors := func(i int) []int {
+		var out []int
+		for _, name := range selfMethodRefs(arms[i].elem.Fn.Body, names) {
+			out = append(out, byName[name]...)
+		}
+		return out
+	}
+	for _, component := range graph.StronglyConnectedComponents(nodes, successors) {
 		if len(component) < 2 {
 			continue
 		}
 		annotated := false
-		for _, name := range component {
-			if methods[name].Fn.FuncSig.Return != nil {
+		for _, i := range component {
+			if arms[i].elem.Fn.FuncSig.Return != nil {
 				annotated = true
 				break
 			}
@@ -581,22 +600,27 @@ func (c *checker) checkMethodRecursionAnnotations(decl *ast.ClassDecl) {
 		if annotated {
 			continue
 		}
-		// Sort the group so the diagnostic reads the same regardless of the order the SCC
-		// walk yields the component's members.
-		group := append([]string(nil), component...)
+		// Sort the deduped names so the diagnostic reads the same regardless of the order
+		// the SCC walk yields the component's arms, and so two arms of one name read once.
+		groupSet := set.NewSet[string]()
+		for _, i := range component {
+			groupSet.Add(arms[i].name)
+		}
+		group := groupSet.ToSlice()
 		sort.Strings(group)
-		for _, name := range component {
-			c.report(&RecursiveMethodAnnotationError{Name: name, Elem: methods[name], Group: group})
+		for _, i := range component {
+			c.report(&RecursiveMethodAnnotationError{Name: arms[i].name, Elem: arms[i].elem, Group: group})
 		}
 	}
 }
 
 // selfMethodRefs returns the names of the sibling methods a method body reads through
-// `self`, keyed against the class's method set so a `self.field` read or a call to a
-// non-method member does not count as a call-graph edge. Both a call `self.m()` and a bare
-// reference `self.m` count, since either makes the body depend on the sibling's signature.
-func selfMethodRefs(body *ast.Block, methods map[string]*ast.MethodElem) []string {
-	v := &selfMethodVisitor{methods: methods, found: set.NewSet[string]()}
+// `self`, keyed against the class's instance-method names so a `self.field` read or a call
+// to a non-method member does not count as a call-graph edge. Both a call `self.m()` and a
+// bare reference `self.m` count, since either makes the body depend on the sibling's
+// signature.
+func selfMethodRefs(body *ast.Block, names set.Set[string]) []string {
+	v := &selfMethodVisitor{names: names, found: set.NewSet[string]()}
 	body.Accept(v)
 	return v.found.ToSlice()
 }
@@ -604,8 +628,8 @@ func selfMethodRefs(body *ast.Block, methods map[string]*ast.MethodElem) []strin
 // selfMethodVisitor collects `self.<method>` references while walking a method body.
 type selfMethodVisitor struct {
 	ast.DefaultVisitor
-	methods map[string]*ast.MethodElem
-	found   set.Set[string]
+	names set.Set[string]
+	found set.Set[string]
 }
 
 func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
@@ -617,7 +641,7 @@ func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
 	if !ok || ident.Name != "self" {
 		return true
 	}
-	if _, isMethod := v.methods[member.Prop.Name]; isMethod {
+	if v.names.Contains(member.Prop.Name) {
 		v.found.Add(member.Prop.Name)
 	}
 	return true

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -1,8 +1,13 @@
 package solver
 
 import (
+	"fmt"
+	"sort"
+
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/graph"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -18,10 +23,11 @@ import (
 // reference to a sibling defined later in the group resolves before its body is inferred.
 // A class reached without a pre-bound pair mints and registers one here.
 //
-// Fields are built first, then each method, getter, and setter is inferred eagerly.
-// `self` carries the fields only, so a method that calls another method of the same
-// class is not handled here, whether self-recursive, mutually recursive, or a plain
-// sibling call. PR B3 addresses this (planning/simple_sub/m5-implementation-plan.md).
+// The member walk is two-phase: every field, method, getter, and setter signature is
+// appended to the body first, then each body is walked with `self` bound to the full
+// body. So a method calling another method of the same class resolves through the
+// pre-declared sibling signature, whether self-recursive, mutually recursive, or a
+// forward call to a member declared later.
 //
 // Once every body has refined the field vars, a non-generic body is coalesced so member
 // lookup reads concrete member types. A generic body keeps its parameter vars symbolic
@@ -63,13 +69,20 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	def.Supers = c.resolveClassSupers(declScope, decl)
 	def.Implements = c.resolveClassImplements(declScope, decl)
 
-	// Build every field first so a method body may read any field through `self`. Then
-	// infer each method, getter, and setter fully, so each body refines its own
-	// signature, appending it to the body as it goes. Calls between methods of the same
-	// class are not resolved here. The function doc explains why and what will fix it.
+	// Two-phase member walk (B3). Phase 1 appends a signature element for every field,
+	// method, getter, and setter to the instance or static body before any body is
+	// inferred. Phase 2 then walks each method, getter, setter, and the constructor body
+	// with `self` bound to the full body, so a call between two methods of the same class
+	// resolves through the pre-declared sibling signature — self-recursive, mutually
+	// recursive, or a forward call to a member declared later.
 	ctors := c.collectConstructors(decl)
 	c.buildFieldSigs(declScope, lvl, decl, body, static)
-	c.inferMembers(declScope, lvl, decl, self, body, static)
+	pending := c.buildMemberSigs(declScope, lvl, decl, self, body, static)
+	// A mutually recursive method group with no annotated return cannot ground its own
+	// return types, so it is reported before any body runs. Reporting here, not during
+	// body inference, keeps the diagnostic off the inferred-never recovery.
+	c.checkMethodRecursionAnnotations(decl)
+	c.inferMemberBodies(declScope, lvl, body, pending)
 	ctorType := c.inferConstructor(declScope, lvl, decl, self, body, ctors)
 
 	// A generic class keeps its member types symbolic — a field typed `T` stays the
@@ -276,18 +289,35 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 	}
 }
 
-// inferMembers infers each method, getter, and setter of a class fully — its body
-// refines its own signature through the shared inferFunc core — and appends the
-// resulting element to the instance or static body. An instance member missing its
-// `self` receiver is reported. Each member is appended before the next is inferred, so
-// a later member may reference an earlier one through `self`.
-func (c *checker) inferMembers(
+// pendingMember carries one method, getter, or setter from the signature phase to the
+// body phase. shell is the signature the phase-1 pass appended and every sibling call
+// resolves against; body carries the receiver, staticness, and function node its walk
+// needs. apply installs the fully-inferred body signature onto the stored element once
+// the body pass produces it.
+type pendingMember struct {
+	fn     *ast.FuncExpr
+	recv   *ast.MethodReceiver
+	static bool
+	shell  *soltype.FuncType
+	apply  func(bodyFt *soltype.FuncType)
+}
+
+// buildMemberSigs is phase 1 of the member walk. It appends one signature element per
+// method, getter, and setter to the instance or static body before any body is inferred,
+// so a call between two members of the same class resolves against the sibling's
+// pre-declared signature. Each signature is a shell: fresh vars for every value parameter
+// and the return, correct in arity but not yet refined by the body. The body pass links
+// the real inferred signature into these fresh vars and installs it onto the element, so
+// a sibling that read the shell before the body ran sees the refined type through the
+// bound graph. An instance member missing its `self` receiver is reported here.
+func (c *checker) buildMemberSigs(
 	scope *Scope,
 	lvl int,
 	decl *ast.ClassDecl,
 	self *soltype.ClassType,
 	body, static *soltype.ObjectType,
-) {
+) []pendingMember {
+	var pending []pendingMember
 	for _, elem := range decl.Body {
 		switch elem := elem.(type) {
 		case *ast.MethodElem:
@@ -296,42 +326,111 @@ func (c *checker) inferMembers(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
-			ft.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
-			appendMethodSig(targetBody(body, static, elem.Static), name, ft, elem.Static)
+			shell := c.memberSigShell(lvl, elem.Fn)
+			shell.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
+			method, arm := appendMethodSig(targetBody(body, static, elem.Static), name, shell, elem.Static)
+			pending = append(pending, pendingMember{
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				apply: func(bodyFt *soltype.FuncType) {
+					bodyFt.SelfParam = shell.SelfParam
+					method.Signatures[arm] = bodyFt
+				},
+			})
 		case *ast.GetterElem:
 			name, ok := objKeyName(elem.Name)
 			if !ok {
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
-			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: ft.Ret}
+			shell := c.memberSigShell(lvl, elem.Fn)
+			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: shell.Ret}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
+			pending = append(pending, pendingMember{
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				apply: func(bodyFt *soltype.FuncType) { getter.Type = bodyFt.Ret },
+			})
 		case *ast.SetterElem:
 			name, ok := objKeyName(elem.Name)
 			if !ok {
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			ft := c.inferMemberFunc(scope, lvl, elem.Fn, elem.Receiver, elem.Static, self, body)
 			// A well-formed setter declares exactly one value parameter beyond `self` — the
 			// value being assigned. Report a paramless or multi-parameter setter, then still
 			// build the elem from the first value parameter, or `unknown` when there is none,
 			// so member access recovers.
-			if len(ft.Params) != 1 {
-				c.report(&SetterArityError{Name: name, Elem: elem, Count: len(ft.Params)})
+			if len(elem.Fn.Params) != 1 {
+				c.report(&SetterArityError{Name: name, Elem: elem, Count: len(elem.Fn.Params)})
 			}
+			shell := c.memberSigShell(lvl, elem.Fn)
 			var param soltype.Type = &soltype.UnknownType{}
-			if len(ft.Params) > 0 {
-				param = ft.Params[0].Type
+			if len(shell.Params) > 0 {
+				param = shell.Params[0].Type
 			}
 			setter := &soltype.SetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Param: param}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, setter)
+			pending = append(pending, pendingMember{
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				apply: func(bodyFt *soltype.FuncType) {
+					if len(bodyFt.Params) > 0 {
+						setter.Param = bodyFt.Params[0].Type
+					}
+				},
+			})
 		}
 	}
+	return pending
+}
+
+// inferMemberBodies is phase 2 of the member walk. It walks each method, getter, and
+// setter body against the signature phase 1 appended. It links the inferred body
+// signature into the shell's fresh vars — `bodyFt <: shell`, the same "inferred type <:
+// pre-bound var" relation the module SCC driver uses for recursive functions — so a
+// sibling that already read the shell resolves through the bound graph, then installs the
+// fully-inferred signature onto the stored element so member access and class-vs-object
+// subtyping read the real member type.
+func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectType, pending []pendingMember) {
+	for _, m := range pending {
+		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, body)
+		c.linkMemberSig(m.fn, bodyFt, m.shell)
+		m.apply(bodyFt)
+	}
+}
+
+// linkMemberSig constrains a member's inferred body signature into the shell the
+// signature phase pre-declared. Only the callable parts — parameters and return — are
+// related, since the shell's SelfParam is stored on the element, not compared here. The
+// single `bodyFt <: shell` direction suffices: parameters are contravariant, so a
+// sibling call's argument flows shell parameter → body parameter, and the return is
+// covariant, so the body's inferred return flows body return → shell return, exactly the
+// grounding the recursive reference needs.
+func (c *checker) linkMemberSig(node ast.Node, bodyFt, shell *soltype.FuncType) {
+	callable := func(ft *soltype.FuncType) *soltype.FuncType {
+		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Inexact: ft.Inexact}
+	}
+	c.constrain(node, callable(bodyFt), callable(shell))
+}
+
+// memberSigShell builds a member's signature shell: one fresh var per value parameter,
+// preserving arity, parameter names, and optionality, plus a fresh return var. The body
+// pass refines these vars, so the shell only needs to be callable at the right arity for
+// a sibling call to resolve before the body runs.
+func (c *checker) memberSigShell(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
+	params := make([]*soltype.FuncParam, len(fn.Params))
+	for i, p := range fn.Params {
+		name, ok := identPatName(p.Pattern)
+		if !ok {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		params[i] = &soltype.FuncParam{
+			Pattern:  &soltype.IdentPat{Name: name},
+			Type:     c.freshAt(lvl),
+			Optional: p.Optional,
+		}
+	}
+	return &soltype.FuncType{Params: params, Ret: c.freshAt(lvl), Inexact: fn.FuncSig.Inexact}
 }
 
 // targetBody selects the static or instance body for a member.
@@ -351,16 +450,16 @@ func (c *checker) checkSelfReceiver(name string, elem ast.ClassElem, static bool
 }
 
 // inferMemberFunc infers one member body via the shared inferFunc core, binding `self`
-// to the instance body — owned-mutable for a `mut self` receiver — so field reads and
-// writes inside the body resolve through the record machinery. It returns the inferred
-// FuncType, whose params and return the caller installs on the member element.
+// to the full instance body — owned-mutable for a `mut self` receiver — so field reads
+// and writes resolve through the record machinery and a sibling call resolves through the
+// pre-declared member signature. It returns the inferred FuncType, whose params and
+// return the caller links into the member's signature shell.
 func (c *checker) inferMemberFunc(
 	scope *Scope,
 	lvl int,
 	fn *ast.FuncExpr,
 	recv *ast.MethodReceiver,
 	static bool,
-	self *soltype.ClassType, // unused until B3 binds `self` to the full instance
 	body *soltype.ObjectType,
 ) *soltype.FuncType {
 	memberScope := scope.Child()
@@ -371,15 +470,19 @@ func (c *checker) inferMemberFunc(
 }
 
 // appendMethodSig installs a method signature under name, merging it into an existing
-// same-named MethodElem as an overload arm rather than adding a second element.
-func appendMethodSig(obj *soltype.ObjectType, name string, sig *soltype.FuncType, static bool) {
+// same-named MethodElem as an overload arm rather than adding a second element. It
+// returns the MethodElem and the index of the appended arm, so the body pass can install
+// the fully-inferred signature onto that exact arm after overload merging.
+func appendMethodSig(obj *soltype.ObjectType, name string, sig *soltype.FuncType, static bool) (*soltype.MethodElem, int) {
 	for _, e := range obj.Elems {
 		if m, ok := e.(*soltype.MethodElem); ok && m.Name == name {
 			m.Signatures = append(m.Signatures, sig)
-			return
+			return m, len(m.Signatures) - 1
 		}
 	}
-	obj.Elems = append(obj.Elems, &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}, Static: static})
+	m := &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{sig}, Static: static}
+	obj.Elems = append(obj.Elems, m)
+	return m, 0
 }
 
 // selfParam builds the SelfParam a member's signature carries, or nil for a static
@@ -401,48 +504,130 @@ func (c *checker) selfType(recv *ast.MethodReceiver, self soltype.Type) soltype.
 	return self
 }
 
-// bindSelf binds the `self` identifier in a member body scope to the instance's fields.
-// It builds a field-only view of the class body, keeping the PropertyElems and dropping
-// every method, getter, and setter. The view shares each PropertyElem pointer with
-// the body, so a write such as `self.x = v` refines the same field-type var the
-// projected body later reads for external access. A `mut self` receiver wraps the view
-// in an owned-mutable borrow so field writes type-check. A plain `self` binds the bare
-// view.
+// bindSelf binds the `self` identifier in a member or constructor body scope to the full
+// instance body — fields and every method, getter, and setter. The view snapshots the
+// body's element slice while sharing each element pointer, so a field write such as
+// `self.x = v` refines the same field-type var the projected body reads, and a sibling
+// call `self.m()` resolves against the member signature the phase-1 pass installed on the
+// shared element. A `mut self` receiver wraps the view in an owned-mutable borrow so
+// field writes type-check; a plain `self` binds the bare view.
 //
-// `self` is field-only by design, not because method subtyping is unimplemented. A
-// `self.field` read or write flows through the record subtyping machinery, whose object
-// arm threads the borrow and mutability rules field access needs: read-through-borrow,
-// read-after-write, and the contravariant write view under `mut`. That arm reads only
-// properties and panics on a method member, per AsProperty, and methods need none of
-// those field rules, so they stay off this path.
-//
-// Methods are reached elsewhere, not dropped. External access resolves method, getter,
-// and setter members through the projected class body, and a sibling call through `self`
-// lands in B3. A method's own receiver ownership is checked separately at the call site
-// as a `receiver <: SelfParam` constraint, not by this binding. A `mut self` call, for
-// example, needs a mutable receiver.
+// A `self.field` read or write dispatches through the record subtyping machinery, whose
+// object arm threads the borrow and mutability rules field access needs: read-through-
+// borrow, read-after-write, and the contravariant write view under `mut`. A `self.method`
+// read cannot take that path, since the object arm reads only properties and panics on a
+// method member; valueProp intercepts it and resolves through member lookup instead. A
+// method's own receiver ownership is checked separately at the call site as a `receiver
+// <: SelfParam` constraint, not by this binding.
 func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype.ObjectType) {
-	// Keep only the PropertyElems, dropping every method, getter, and setter, and share
-	// each pointer so a write through `self` refines the same field-type var the
-	// projected body reads.
-	fields := &soltype.ObjectType{}
-	for _, e := range body.Elems {
-		if _, ok := e.(*soltype.PropertyElem); ok {
-			fields.Elems = append(fields.Elems, e)
-		}
-	}
-	var selfBody soltype.Type = fields
+	// Snapshot the element slice, sharing each element pointer so a write through `self`
+	// refines the same field-type var the projected body reads and a sibling signature
+	// installed by the body pass shows through the shared pointer.
+	view := &soltype.ObjectType{Elems: append([]soltype.ObjTypeElem(nil), body.Elems...)}
+	var selfBody soltype.Type = view
 	if recv != nil && recv.Mut {
-		selfBody = soltype.NewRef(true, nil, fields)
+		selfBody = soltype.NewRef(true, nil, view)
 	}
 	scope.defineValue("self", ValueBinding{Schemes: []TypeScheme{monoScheme(selfBody)}})
+}
+
+// checkMethodRecursionAnnotations reports a group of mutually recursive methods that has
+// no return-type annotation anywhere in the cycle. A method signature is pre-declared
+// before its body is walked so a sibling call resolves, but an un-annotated return in a
+// cycle stays an inference variable the cycle cannot ground on its own, so it collapses to
+// `never` rather than a useful type. An annotation on any member of the cycle breaks it.
+// This mirrors the recursion gate top-level overloaded functions use.
+//
+// The check builds the call graph over methods with bodies — an edge from a method to
+// each sibling method its body reads through `self` — and inspects each strongly
+// connected component. A component of two or more methods is a mutual-recursion cycle; a
+// self-recursive method forms a single-method cycle that infers `never` the way a
+// self-recursive top-level function does, so it is not gated. A gated cycle reports every
+// member, since annotating any one of them resolves it.
+func (c *checker) checkMethodRecursionAnnotations(decl *ast.ClassDecl) {
+	methods := map[string]*ast.MethodElem{}
+	var names []string
+	for _, elem := range decl.Body {
+		m, ok := elem.(*ast.MethodElem)
+		if !ok || m.Fn.Body == nil {
+			continue
+		}
+		name, ok := objKeyName(m.Name)
+		if !ok {
+			continue
+		}
+		if _, seen := methods[name]; !seen {
+			names = append(names, name)
+		}
+		methods[name] = m
+	}
+	if len(names) < 2 {
+		return
+	}
+	successors := func(name string) []string {
+		return selfMethodRefs(methods[name].Fn.Body, methods)
+	}
+	for _, component := range graph.StronglyConnectedComponents(names, successors) {
+		if len(component) < 2 {
+			continue
+		}
+		annotated := false
+		for _, name := range component {
+			if methods[name].Fn.FuncSig.Return != nil {
+				annotated = true
+				break
+			}
+		}
+		if annotated {
+			continue
+		}
+		// Sort the group so the diagnostic reads the same regardless of the order the SCC
+		// walk yields the component's members.
+		group := append([]string(nil), component...)
+		sort.Strings(group)
+		for _, name := range component {
+			c.report(&RecursiveMethodAnnotationError{Name: name, Elem: methods[name], Group: group})
+		}
+	}
+}
+
+// selfMethodRefs returns the names of the sibling methods a method body reads through
+// `self`, keyed against the class's method set so a `self.field` read or a call to a
+// non-method member does not count as a call-graph edge. Both a call `self.m()` and a bare
+// reference `self.m` count, since either makes the body depend on the sibling's signature.
+func selfMethodRefs(body *ast.Block, methods map[string]*ast.MethodElem) []string {
+	v := &selfMethodVisitor{methods: methods, found: set.NewSet[string]()}
+	body.Accept(v)
+	return v.found.ToSlice()
+}
+
+// selfMethodVisitor collects `self.<method>` references while walking a method body.
+type selfMethodVisitor struct {
+	ast.DefaultVisitor
+	methods map[string]*ast.MethodElem
+	found   set.Set[string]
+}
+
+func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
+	member, ok := e.(*ast.MemberExpr)
+	if !ok || member.Prop == nil {
+		return true
+	}
+	ident, ok := member.Object.(*ast.IdentExpr)
+	if !ok || ident.Name != "self" {
+		return true
+	}
+	if _, isMethod := v.methods[member.Prop.Name]; isMethod {
+		v.found.Add(member.Prop.Name)
+	}
+	return true
 }
 
 // freezeClassBody coalesces each member's type in place so member lookup and the
 // class-vs-object rule read concrete member types rather than the fresh vars a field
 // held before a constructor assignment refined it. Each member is coalesced
-// individually rather than the whole object at once, since the object's owned-mut
-// bubbling pass reads only PropertyElems and would panic on a method member.
+// individually rather than the whole object at once, since coalesce's object-merge pass
+// reads every element as a property and panics on a method, getter, or setter member.
 func (c *checker) freezeClassBody(obj *soltype.ObjectType) {
 	for i, e := range obj.Elems {
 		switch e := e.(type) {

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -290,7 +290,7 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 }
 
 // pendingMember carries one method, getter, or setter from the signature phase to the
-// body phase. shell is the signature the phase-1 pass appended and every sibling call
+// body phase. stub is the signature the phase-1 pass appended and every sibling call
 // resolves against; body carries the receiver, staticness, and function node its walk
 // needs. apply installs the fully-inferred body signature onto the stored element once
 // the body pass produces it.
@@ -298,17 +298,17 @@ type pendingMember struct {
 	fn     *ast.FuncExpr
 	recv   *ast.MethodReceiver
 	static bool
-	shell  *soltype.FuncType
+	stub   *soltype.FuncType
 	apply  func(bodyFt *soltype.FuncType)
 }
 
 // buildMemberSigs is phase 1 of the member walk. It appends one signature element per
 // method, getter, and setter to the instance or static body before any body is inferred,
 // so a call between two members of the same class resolves against the sibling's
-// pre-declared signature. Each signature is a shell: fresh vars for every value parameter
+// pre-declared signature. Each signature is a stub: fresh vars for every value parameter
 // and the return, correct in arity but not yet refined by the body. The body pass links
 // the real inferred signature into these fresh vars and installs it onto the element, so
-// a sibling that read the shell before the body ran sees the refined type through the
+// a sibling that read the stub before the body ran sees the refined type through the
 // bound graph. An instance member missing its `self` receiver is reported here.
 func (c *checker) buildMemberSigs(
 	scope *Scope,
@@ -326,13 +326,13 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			shell := c.memberSigShell(lvl, elem.Fn)
-			shell.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
-			method, arm := appendMethodSig(targetBody(body, static, elem.Static), name, shell, elem.Static)
+			stub := c.memberSigStub(lvl, elem.Fn)
+			stub.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
+			method, arm := appendMethodSig(targetBody(body, static, elem.Static), name, stub, elem.Static)
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
-					bodyFt.SelfParam = shell.SelfParam
+					bodyFt.SelfParam = stub.SelfParam
 					method.Signatures[arm] = bodyFt
 				},
 			})
@@ -342,12 +342,12 @@ func (c *checker) buildMemberSigs(
 				continue
 			}
 			c.checkSelfReceiver(name, elem, elem.Static, elem.Receiver)
-			shell := c.memberSigShell(lvl, elem.Fn)
-			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: shell.Ret}
+			stub := c.memberSigStub(lvl, elem.Fn)
+			getter := &soltype.GetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Type: stub.Ret}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, getter)
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) { getter.Type = bodyFt.Ret },
 			})
 		case *ast.SetterElem:
@@ -363,16 +363,16 @@ func (c *checker) buildMemberSigs(
 			if len(elem.Fn.Params) != 1 {
 				c.report(&SetterArityError{Name: name, Elem: elem, Count: len(elem.Fn.Params)})
 			}
-			shell := c.memberSigShell(lvl, elem.Fn)
+			stub := c.memberSigStub(lvl, elem.Fn)
 			var param soltype.Type = &soltype.UnknownType{}
-			if len(shell.Params) > 0 {
-				param = shell.Params[0].Type
+			if len(stub.Params) > 0 {
+				param = stub.Params[0].Type
 			}
 			setter := &soltype.SetterElem{Name: name, SelfParam: c.selfParam(elem.Receiver, elem.Static, self), Param: param}
 			target := targetBody(body, static, elem.Static)
 			target.Elems = append(target.Elems, setter)
 			pending = append(pending, pendingMember{
-				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, shell: shell,
+				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
 					if len(bodyFt.Params) > 0 {
 						setter.Param = bodyFt.Params[0].Type
@@ -386,38 +386,38 @@ func (c *checker) buildMemberSigs(
 
 // inferMemberBodies is phase 2 of the member walk. It walks each method, getter, and
 // setter body against the signature phase 1 appended. It links the inferred body
-// signature into the shell's fresh vars — `bodyFt <: shell`, the same "inferred type <:
+// signature into the stub's fresh vars — `bodyFt <: stub`, the same "inferred type <:
 // pre-bound var" relation the module SCC driver uses for recursive functions — so a
-// sibling that already read the shell resolves through the bound graph, then installs the
+// sibling that already read the stub resolves through the bound graph, then installs the
 // fully-inferred signature onto the stored element so member access and class-vs-object
 // subtyping read the real member type.
 func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectType, pending []pendingMember) {
 	for _, m := range pending {
 		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, body)
-		c.linkMemberSig(m.fn, bodyFt, m.shell)
+		c.linkMemberSig(m.fn, bodyFt, m.stub)
 		m.apply(bodyFt)
 	}
 }
 
-// linkMemberSig constrains a member's inferred body signature into the shell the
+// linkMemberSig constrains a member's inferred body signature into the stub the
 // signature phase pre-declared. Only the callable parts — parameters and return — are
-// related, since the shell's SelfParam is stored on the element, not compared here. The
-// single `bodyFt <: shell` direction suffices: parameters are contravariant, so a
-// sibling call's argument flows shell parameter → body parameter, and the return is
-// covariant, so the body's inferred return flows body return → shell return, exactly the
+// related, since the stub's SelfParam is stored on the element, not compared here. The
+// single `bodyFt <: stub` direction suffices: parameters are contravariant, so a
+// sibling call's argument flows stub parameter → body parameter, and the return is
+// covariant, so the body's inferred return flows body return → stub return, exactly the
 // grounding the recursive reference needs.
-func (c *checker) linkMemberSig(node ast.Node, bodyFt, shell *soltype.FuncType) {
+func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Inexact: ft.Inexact}
 	}
-	c.constrain(node, callable(bodyFt), callable(shell))
+	c.constrain(node, callable(bodyFt), callable(stub))
 }
 
-// memberSigShell builds a member's signature shell: one fresh var per value parameter,
+// memberSigStub builds a member's signature stub: one fresh var per value parameter,
 // preserving arity, parameter names, and optionality, plus a fresh return var. The body
-// pass refines these vars, so the shell only needs to be callable at the right arity for
+// pass refines these vars, so the stub only needs to be callable at the right arity for
 // a sibling call to resolve before the body runs.
-func (c *checker) memberSigShell(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
+func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
 		name, ok := identPatName(p.Pattern)
@@ -453,7 +453,7 @@ func (c *checker) checkSelfReceiver(name string, elem ast.ClassElem, static bool
 // to the full instance body — owned-mutable for a `mut self` receiver — so field reads
 // and writes resolve through the record machinery and a sibling call resolves through the
 // pre-declared member signature. It returns the inferred FuncType, whose params and
-// return the caller links into the member's signature shell.
+// return the caller links into the member's signature stub.
 func (c *checker) inferMemberFunc(
 	scope *Scope,
 	lvl int,

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -289,11 +289,8 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 	}
 }
 
-// pendingMember carries one method, getter, or setter from the signature phase to the
-// body phase. stub is the signature the phase-1 pass appended and every sibling call
-// resolves against; body carries the receiver, staticness, and function node its walk
-// needs. apply installs the fully-inferred body signature onto the stored element once
-// the body pass produces it.
+// pendingMember carries one method, getter, or setter from the signature phase to the body
+// phase; apply installs the fully-inferred signature onto the stored element.
 type pendingMember struct {
 	fn     *ast.FuncExpr
 	recv   *ast.MethodReceiver
@@ -302,14 +299,10 @@ type pendingMember struct {
 	apply  func(bodyFt *soltype.FuncType)
 }
 
-// buildMemberSigs is phase 1 of the member walk. It appends one signature element per
-// method, getter, and setter to the instance or static body before any body is inferred,
-// so a call between two members of the same class resolves against the sibling's
-// pre-declared signature. Each signature is a stub: fresh vars for every value parameter
-// and the return, correct in arity but not yet refined by the body. The body pass links
-// the real inferred signature into these fresh vars and installs it onto the element, so
-// a sibling that read the stub before the body ran sees the refined type through the
-// bound graph. An instance member missing its `self` receiver is reported here.
+// buildMemberSigs is phase 1 of the member walk: it appends a signature stub — fresh vars
+// for each parameter and the return, correct in arity but not yet refined — for every
+// method, getter, and setter, so a sibling call resolves before any body is walked. A
+// non-static instance member missing its `self` receiver is reported here.
 func (c *checker) buildMemberSigs(
 	scope *Scope,
 	lvl int,
@@ -384,13 +377,9 @@ func (c *checker) buildMemberSigs(
 	return pending
 }
 
-// inferMemberBodies is phase 2 of the member walk. It walks each method, getter, and
-// setter body against the signature phase 1 appended. It links the inferred body
-// signature into the stub's fresh vars — `bodyFt <: stub`, the same "inferred type <:
-// pre-bound var" relation the module SCC driver uses for recursive functions — so a
-// sibling that already read the stub resolves through the bound graph, then installs the
-// fully-inferred signature onto the stored element so member access and class-vs-object
-// subtyping read the real member type.
+// inferMemberBodies is phase 2 of the member walk: it walks each member body, links the
+// inferred signature into its stub so a sibling that read the stub grounds through the
+// bound graph, then installs the real signature onto the stored element.
 func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectType, pending []pendingMember) {
 	for _, m := range pending {
 		bodyFt := c.inferMemberFunc(scope, lvl, m.fn, m.recv, m.static, body)
@@ -399,13 +388,10 @@ func (c *checker) inferMemberBodies(scope *Scope, lvl int, body *soltype.ObjectT
 	}
 }
 
-// linkMemberSig constrains a member's inferred body signature into the stub the
-// signature phase pre-declared. Only the callable parts — parameters and return — are
-// related, since the stub's SelfParam is stored on the element, not compared here. The
-// single `bodyFt <: stub` direction suffices: parameters are contravariant, so a
-// sibling call's argument flows stub parameter → body parameter, and the return is
-// covariant, so the body's inferred return flows body return → stub return, exactly the
-// grounding the recursive reference needs.
+// linkMemberSig constrains a member's inferred signature into its stub. The single
+// `bodyFt <: stub` direction grounds both parameters (contravariant, so a sibling call's
+// argument flows stub → body) and the return (covariant, so the body's return flows body →
+// stub); SelfParam lives on the element and is not compared here.
 func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 	callable := func(ft *soltype.FuncType) *soltype.FuncType {
 		return &soltype.FuncType{Params: ft.Params, Ret: ft.Ret, Inexact: ft.Inexact}
@@ -414,12 +400,13 @@ func (c *checker) linkMemberSig(node ast.Node, bodyFt, stub *soltype.FuncType) {
 }
 
 // memberSigStub builds a member's signature stub: one fresh var per value parameter,
-// preserving arity, parameter names, and optionality, plus a fresh return var. The body
-// pass refines these vars, so the stub only needs to be callable at the right arity for
-// a sibling call to resolve before the body runs.
+// preserving arity, parameter names, and optionality, plus a fresh return var.
 func (c *checker) memberSigStub(lvl int, fn *ast.FuncExpr) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(fn.Params))
 	for i, p := range fn.Params {
+		// A destructuring parameter has no single name, so the stub uses a positional
+		// placeholder. It never surfaces: the stub carries arity and fresh-var types only,
+		// and the body pass installs the real signature, whose inferFunc binds the pattern.
 		name, ok := identPatName(p.Pattern)
 		if !ok {
 			name = fmt.Sprintf("arg%d", i)
@@ -549,6 +536,10 @@ func (c *checker) bindSelf(scope *Scope, recv *ast.MethodReceiver, body *soltype
 // forms a single-arm component that infers `never` the way a self-recursive top-level
 // function does, so it is not gated. A gated cycle reports every arm, since annotating any
 // one of them resolves it.
+//
+// The check is syntactic: it follows only a direct `self.m` reference. A call through an
+// aliased receiver such as `val s = self` or a cycle that spans two classes is not gated;
+// it falls back to `never` inference, the same as an ungrounded top-level cycle.
 func (c *checker) checkMethodRecursionAnnotations(decl *ast.ClassDecl) {
 	type methodArm struct {
 		name string

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -528,6 +528,37 @@ func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 }
 */
 
+// TestInferClassGenericMethodReturnsTypeParam pins the gap where a method whose return is a
+// class type parameter round-trips as `never` through a call — both a `self.method()` call
+// and external access. `read` returns the field typed `T`, so `b.read()` for `b : Box<5>`
+// should project `T` to `5`, and `alias` calling `self.read()` should reach the same value.
+//
+// DISABLED until B1's member-access projection is completed. B1's §"Member access" wires a
+// resolved method through the projected ClassDef.Body, wrapping a method's own TypeParams in
+// a PolyScheme and projecting the class arguments, so class-level args are substituted while
+// the method's own params freshen per call. The shipped B1 slice descoped the generic case:
+// member access returns the method's raw FuncType, and an unannotated field read mints an
+// intermediate var that class-argument projection cannot rewrite, so the return collapses to
+// `never`. Neither classBodyMember (self access) nor projectedMember (external access) needs
+// its own fix — the wrap belongs in the shared memberValue.
+/*
+func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> {
+			v: T,
+			read(self) { return self.v },
+			alias(self) { return self.read() },
+		}
+		val b = Box(5)
+		val x = b.read()
+		val y = b.alias()
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["x"])
+	require.Equal(t, "5", values["y"])
+}
+*/
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -441,6 +441,21 @@ func TestInferClassMethodRecursion(t *testing.T) {
 			wantValues: map[string]string{"C": "fn (n: number) -> C"},
 		},
 		{
+			// A destructuring method parameter is handled: the stub carries arity only, so
+			// the body pass installs the real signature that binds the pattern.
+			name: "DestructuredParam",
+			src: `
+				class C {
+					n: number,
+					f(self, {a, b}: {a: number, b: number}) -> number { return self.g(a) },
+					g(self, x: number) -> number { return x },
+				}
+				val c = C(1)
+				val r = c.f({a: 1, b: 2})
+			`,
+			wantValues: map[string]string{"r": "number"},
+		},
+		{
 			// A constructor body calls a method of the class; self binds to the full body
 			// in the constructor too, so the call resolves.
 			name: "ConstructorCallsMethod",

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -502,6 +502,32 @@ func TestInferClassMutualRecursionRequiresAnnotation(t *testing.T) {
 	}, msgs)
 }
 
+// TestInferClassMutMethodFromImmutMethod asserts that an immutable-`self` method calling a
+// `mut self` method of the same class is rejected: the mutable method needs a mutable
+// receiver, but `self` is immutable in the caller.
+//
+// DISABLED until E1. B3 resolves the call — `self.bump()` finds bump's signature — but does
+// not yet constrain the receiver against the method's SelfParam, so today the call
+// type-checks with no error. That `receiver <: SelfParam` check lands with E1's method-call
+// path through valueProp (receiver-dependent dispatch), and the same gap holds for an
+// external `mut` call on an immutable binding. The asserted message is the expected form
+// from the mutability machinery, which today reports `cannot constrain immutable object <:
+// mutable object` for the analogous immutable-value-into-`mut`-parameter case; E1 finalizes
+// the exact rendering for a class receiver.
+/*
+func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			bump(mut self) -> number { return self.n },
+			peek(self) -> number { return self.bump() },
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain immutable C <: mutable C", errs[0].Message())
+}
+*/
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -346,6 +346,147 @@ func TestInferClassMutualRecursion(t *testing.T) {
 	}
 }
 
+// TestInferClassMethodRecursion covers the two-phase member walk (B3): a method body
+// resolves a call to another method of the same class through the pre-declared sibling
+// signature, whether self-recursive, mutually recursive, a forward call to a member
+// declared later, or a call from a constructor. It also confirms a getter read and a
+// `mut self` receiver work alongside the new `self.method()` path.
+func TestInferClassMethodRecursion(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+	}{
+		{
+			// double() calls getN() twice through self; both resolve to the sibling's
+			// number-returning signature.
+			name: "SelfMethodCall",
+			src: `
+				class Counter {
+					n: number,
+					getN(self) -> number { return self.n },
+					double(self) -> number { return self.getN() },
+				}
+				val c = Counter(5)
+				val d = c.double()
+			`,
+			wantValues: map[string]string{"d": "number"},
+		},
+		{
+			// a() calls b(), which is declared later in the class body; the forward call
+			// resolves because every signature exists before any body is walked.
+			name: "ForwardSiblingCall",
+			src: `
+				class C {
+					n: number,
+					a(self) -> number { return self.b() },
+					b(self) -> number { return self.n },
+				}
+				val c = C(1)
+				val r = c.a()
+			`,
+			wantValues: map[string]string{"r": "number"},
+		},
+		{
+			// A self-recursive method with an annotated return type-checks; the recursive
+			// call resolves against the method's own pre-declared signature.
+			name: "SelfRecursionAnnotated",
+			src: `
+				class C {
+					n: number,
+					loop(self, k: number) -> number { return self.loop(k) },
+				}
+			`,
+			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+		},
+		{
+			// A mutually recursive pair with annotated returns type-checks; each call
+			// resolves against the sibling's annotated signature.
+			name: "MutualRecursionAnnotated",
+			src: `
+				class C {
+					n: number,
+					ping(self, k: number) -> number { return self.pong(k) },
+					pong(self, k: number) -> number { return self.ping(k) },
+				}
+			`,
+			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+		},
+		{
+			// A method reads a getter of the same class through self; the getter's value
+			// resolves through member lookup, not the structural field path.
+			name: "MethodReadsGetter",
+			src: `
+				class Box {
+					v: number,
+					get value(self) -> number { return self.v },
+					twice(self) -> number { return self.value },
+				}
+				val b = Box(3)
+				val x = b.twice()
+			`,
+			wantValues: map[string]string{"x": "number"},
+		},
+		{
+			// A `mut self` method calls an immutable-self sibling; the call resolves and
+			// the field write path still type-checks alongside it.
+			name: "MutSelfCallsMethod",
+			src: `
+				class C {
+					n: number,
+					helper(self) -> number { return self.n },
+					update(mut self) -> number { return self.helper() },
+				}
+			`,
+			wantValues: map[string]string{"C": "fn (n: number) -> C"},
+		},
+		{
+			// A constructor body calls a method of the class; self binds to the full body
+			// in the constructor too, so the call resolves.
+			name: "ConstructorCallsMethod",
+			src: `
+				class C {
+					n: number,
+					constructor(mut self, x: number) {
+						self.n = x
+					},
+					getN(self) -> number { return self.n },
+				}
+				val c = C(4)
+				val g = c.getN()
+			`,
+			wantValues: map[string]string{"g": "number"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			classValues(t, test.src, test.wantValues, nil)
+		})
+	}
+}
+
+// TestInferClassMutualRecursionRequiresAnnotation pins the annotation gate: a pair of
+// mutually recursive methods with no annotated return anywhere in the cycle cannot ground
+// its own return types, so every member of the cycle is reported. Annotating either
+// member breaks the cycle, which the positive test above covers.
+func TestInferClassMutualRecursionRequiresAnnotation(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			ping(self, k: number) { return self.pong(k) },
+			pong(self, k: number) { return self.ping(k) },
+		}
+	`)
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Message()
+	}
+	require.ElementsMatch(t, []string{
+		"Mutually recursive method 'ping' must declare a return type; the cycle ping, pong has no annotated return to ground it.",
+		"Mutually recursive method 'pong' must declare a return type; the cycle ping, pong has no annotated return to ground it.",
+	}, msgs)
+}
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -533,15 +533,15 @@ func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 // and external access. `read` returns the field typed `T`, so `b.read()` for `b : Box<5>`
 // should project `T` to `5`, and `alias` calling `self.read()` should reach the same value.
 //
-// DISABLED — no PR in the M5 plan is scheduled to close this. B1's §"Member access" owned it
-// (wire a resolved method through the projected ClassDef.Body, wrapping the method's own
-// TypeParams in a PolyScheme and substituting the class arguments), but the shipped B1 slice
-// descoped the generic case and no later PR picks it up; the per-method-generic half is
-// deferred to the generic-function work outside this plan. Today member access returns the
+// DISABLED until B8 (planning/simple_sub/m5-implementation-plan.md §"Phase B"). B1's
+// §"Member access" owned this — wire a resolved method through the projected ClassDef.Body,
+// wrapping the method's own TypeParams in a PolyScheme and substituting the class arguments —
+// but the shipped B1 slice descoped the generic case. Today member access returns the
 // method's raw FuncType, and an unannotated field read mints an intermediate var that
 // class-argument projection cannot rewrite, so the return collapses to `never`. Neither
 // classBodyMember (self access) nor projectedMember (external access) needs its own fix — the
-// wrap belongs in the shared memberValue. Re-enable when a follow-up lands it.
+// selective generic-body coalesce and the wrap belong in the shared member-access path. B8
+// lands it; re-enable then.
 /*
 func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
 	values, _, errs := inferSource(t, `

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -533,14 +533,15 @@ func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 // and external access. `read` returns the field typed `T`, so `b.read()` for `b : Box<5>`
 // should project `T` to `5`, and `alias` calling `self.read()` should reach the same value.
 //
-// DISABLED until B1's member-access projection is completed. B1's §"Member access" wires a
-// resolved method through the projected ClassDef.Body, wrapping a method's own TypeParams in
-// a PolyScheme and projecting the class arguments, so class-level args are substituted while
-// the method's own params freshen per call. The shipped B1 slice descoped the generic case:
-// member access returns the method's raw FuncType, and an unannotated field read mints an
-// intermediate var that class-argument projection cannot rewrite, so the return collapses to
-// `never`. Neither classBodyMember (self access) nor projectedMember (external access) needs
-// its own fix — the wrap belongs in the shared memberValue.
+// DISABLED — no PR in the M5 plan is scheduled to close this. B1's §"Member access" owned it
+// (wire a resolved method through the projected ClassDef.Body, wrapping the method's own
+// TypeParams in a PolyScheme and substituting the class arguments), but the shipped B1 slice
+// descoped the generic case and no later PR picks it up; the per-method-generic half is
+// deferred to the generic-function work outside this plan. Today member access returns the
+// method's raw FuncType, and an unannotated field read mints an intermediate var that
+// class-argument projection cannot rewrite, so the return collapses to `never`. Neither
+// classBodyMember (self access) nor projectedMember (external access) needs its own fix — the
+// wrap belongs in the shared memberValue. Re-enable when a follow-up lands it.
 /*
 func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
 	values, _, errs := inferSource(t, `

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1967,6 +1967,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	if res, ok := c.projectedMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
+	// A `self` receiver inside a class body binds to the full instance object, which
+	// carries method, getter, and setter members alongside fields. A read of such a
+	// member resolves through member lookup here, since the structural field-requirement
+	// path below reads only properties and panics on a non-property member (M5 B3).
+	if res, ok := c.classBodyMember(lvl, blame, name, recvCarrier); ok {
+		return res
+	}
 	fieldVar := c.freshAt(lvl)
 	// The member-requirement record {prop: fieldVar} is deliberately NOT recorded —
 	// MissingPropertyError blames this inner fieldVar, so the record would be a dead

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -737,7 +737,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-15 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+16 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -1133,6 +1133,62 @@ corruption of `freshenAbove`.
     still render as the bare `Point`; a single root-namespace `class Point` is
     unchanged.
 
+- **B8 — Generic member-access projection: type parameters through a method's
+  return** (~200). **← finishes the member-access projection B1 descoped.**
+  - **Problem:** a member whose type is derived from a class type parameter through an
+    inferred intermediate var round-trips as `never` through member access — external
+    and through `self`. For `class Box<T> { v: T, read(self) { return self.v } }`,
+    `b.read()` on `b : Box<5>` yields `never`, not `5`, while the direct field `b.v`
+    yields `5`. `read`'s inferred return is an intermediate inference var whose only
+    lower bound is the class parameter `T` — an un-annotated field read mints a fresh
+    var and constrains the field into it rather than returning `T` directly. Two things
+    then compound: `projectClassMember`'s Accept-based `classSubst` rewrites `T` where it
+    appears directly but NOT inside a var's bounds
+    ([classes.go:228-287](../../internal/solver/classes.go)), and a generic class body is
+    never coalesced — B1 skips `freezeClassBody` for a generic class to keep `T` symbolic
+    ([infer_class.go:92-95](../../internal/solver/infer_class.go)) — so the intermediate
+    var reaches the access site un-substituted and coalesces to `never`. Per-method type
+    parameters have the parallel gap: `memberValue` returns the method's raw `FuncType`
+    with no `PolyScheme` wrap ([classes.go:206-218](../../internal/solver/classes.go)), so
+    a call does not freshen the method's own `<U>` per use.
+  - **Files:** `solver/infer_class.go` (a generic-body member coalesce that preserves the
+    class's and each method's own quantified vars), `solver/classes.go`
+    (`memberValue`/`projectClassMember` and the shared member-access path),
+    `solver/poly.go` (the `PolyScheme` wrap + `instantiate` at access), `solver/errors.go`
+    (`MissingTypeArgError` if not already landed), `solver/infer_class_test.go`.
+  - **Algorithm:**
+    - **Class parameters.** Coalesce each generic class member at decl time in a mode that
+      collapses inference vars to their bounds but keeps the class's own `TypeParam.Var`s
+      (and a method's own `TypeParams` vars) symbolic. `coalesce(β, Positive)` for the
+      intermediate `β` whose lower bound is `T` yields `T`, so the stored member return
+      reads as `T` directly and `projectClassMember` then substitutes `T` → the instance's
+      argument. This is the generic analogue of `freezeClassBody`, which B1 skips wholesale
+      to avoid coalescing the still-unconstrained `T` to `never`; the selective coalesce
+      stops at the quantified vars so `T` survives.
+    - **Method parameters.** In the shared member-access path (`memberValue`, reached by
+      both `classBodyMember` for `self` access and `projectedMember` for external access),
+      wrap a resolved method carrying its own `FuncType.TypeParams` in a `PolyScheme` at the
+      class's generalize-level and `instantiate` at the access level, so each call freshens
+      the method's own params while class-level args stay shared or are substituted. A
+      non-generic method (`TypeParams` nil) skips the wrap and returns the projected
+      `FuncType` directly, unchanged.
+  - **Note:** B1's §"Member access" specifies the `PolyScheme` wrap and class-argument
+    projection through a resolved method; shipped B1 descoped the generic case — member
+    access returns the raw `FuncType` and the generic body is left un-coalesced. B8 lands
+    it, the member-return analogue of B3, B5, B6, and B7 each pulling a descoped B1 slice
+    into its own PR. The per-method `<U>` half is bounded to methods, consuming the shared
+    representation A2 landed; general `fn f<U>` *inference* stays with the generic-function
+    work outside this plan (§"Scope expansion this implies").
+  - **Depends on:** B1. Overlaps `infer_class.go`'s member walk with **B3** and the
+    member-access path (`memberValue`) with **B6**, so sequence B8 after B3 and B6 land and
+    rebase its coalesce/wrap onto their final code rather than running it parallel to them.
+  - **Accept:** re-enable `TestInferClassGenericMethodReturnsTypeParam` — `b.read()` and
+    `b.alias()` (calling `self.read()`) for `b : Box<5>` both infer `5`; a class parameter
+    used only through a field still projects (`b.v` = `5`, unchanged); a generic method
+    `fn first<U>(self, xs: Array<U>) -> U` instantiated at two call sites with different `U`
+    type-checks at each, confirming the method's own params freshen per call; a non-generic
+    method's access is unchanged.
+
 ### Phase C — Nominal subtyping + variance
 
 - **C1 — The declared-subtype graph + the nominal constrain rule + `final`
@@ -1295,6 +1351,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► B5 (constructor definite-assignment)               ── parallel with B2
       ├─► B6 (callable class value: ctor+static object binding) ── after B3 & B5 (shared infer_class.go)
       ├─► B7 (namespace-qualified class registry + ClassType keys) ── after B2 (shared classShell), ∥ C/D/E
+      ├─► B8 (generic member-access projection: type params through a method return) ── after B3 & B6
       ├─► C1 (declared-subtype graph + nominal rule + final)
       │    ├─► C2 (variance inference + in/out modifiers)
       │    └─► F1 (iteration protocol + back-edge validation)
@@ -1319,6 +1376,7 @@ graph TD
     B5["B5 (constructor definite-assignment)"]
     B6["B6 (callable class value: ctor+static object binding)"]
     B7["B7 (namespace-qualified class registry + ClassType keys)"]
+    B8["B8 (generic member-access projection: type params through a method return)"]
     C1["C1 (declared-subtype graph + nominal rule + final)"]
     C2["C2 (variance inference + in/out modifiers)"]
     F1["F1 (iteration protocol + back-edge validation)"]
@@ -1351,6 +1409,9 @@ graph TD
     B5 -.-> B6
     B1 --> B7
     B2 -.-> B7
+    B1 --> B8
+    B3 -.-> B8
+    B6 -.-> B8
 
     classDef crit fill:#ffe0b2,stroke:#e65100,stroke-width:2px,color:#000;
     classDef landed fill:#eceff1,stroke:#90a4ae,stroke-dasharray:4 3,color:#000;
@@ -1382,6 +1443,11 @@ they land before B1. Everything else is off the critical path.
   the `dep_graph`-qualified name so same-named classes in different namespaces stay
   distinct. Depends on B1; touches the `classShell` B2 also modified, so it lands
   after B2 and rebases onto it. Independent of subtyping, patterns, and overloads.
+- **B8** (generic member-access projection) — a selective generic-body coalesce plus
+  the `PolyScheme` wrap at member access, so a type parameter threads through a method's
+  return. Depends on B1 but **is NOT parallel with B3/B6**: it reworks the same member
+  walk in `infer_class.go` and the `memberValue` path B6 restructures, so it lands after
+  B3 and B6 and rebases onto their final code.
 - **C1** (nominal subtyping) — `constrain`/`classes.go`.
 - **D1** (nominal patterns) — `pattern.go`, uses member lookup, **not** the C1
   subtyping rule, so it does not wait on C1.


### PR DESCRIPTION
Implement the two-phase member walk (B3) so methods can call other methods of the same class, whether self-recursive, mutually recursive, or forward calls to members declared later.

**Summary**

Class methods previously could not call sibling methods because `self` bound only to fields. This change splits member inference into two phases: phase 1 appends a signature stub for every method, getter, and setter before any body is inferred, then phase 2 walks each body with `self` bound to the full instance object (fields and all members). A sibling call now resolves against the pre-declared signature, and the inferred body signature is linked into the stub's fresh vars so the sibling sees the refined type through the constraint graph.

**Key changes**

- Split `inferMembers` into `buildMemberSigs` (phase 1) and `inferMemberBodies` (phase 2), with a `pendingMember` struct carrying each method from phase 1 to phase 2.
- Add `memberSigStub` to build a callable signature with fresh vars for each parameter and return, preserving arity and parameter names but deferring refinement to the body pass.
- Add `linkMemberSig` to constrain the inferred body signature into the stub, using a single `bodyFt <: stub` direction that grounds both parameters (contravariant) and return (covariant).
- Update `bindSelf` to bind the full instance body (fields and members) instead of fields only, so a sibling call resolves through member lookup.
- Add `checkMethodRecursionAnnotations` to gate mutually recursive method groups without an annotated return anywhere in the cycle, mirroring the recursion gate for top-level overloaded functions. A self-recursive method is allowed (infers `never` like a self-recursive top-level function).
- Add `classBodyMember` to intercept method, getter, and setter reads off a class-body object in `valueProp`, since the structural field-requirement path reads only properties and panics on non-property members.
- Update `coalesce.go` to skip non-property elements when bubbling owned-mut cells, since methods, getters, and setters have no field cell.
- Add `RecursiveMethodAnnotationError` to report unannotated mutually recursive methods.
- Add comprehensive tests covering self-recursive, mutually recursive, forward calls, getter reads, `mut self` receivers, and constructor calls to methods.

**Implementation details**

The stub's fresh vars are shared with the element via closure captures in the `apply` function, so when the body pass links the inferred signature into the stub, a sibling that already read the stub sees the refined type through the constraint graph. This mirrors how the module SCC driver grounds recursive top-level functions.

The recursion check builds a call graph over methods with bodies (edges from a method to each sibling method its body reads through `self`) and inspects strongly connected components. Only components with two or more methods are gated; self-recursive methods are allowed.

https://claude.ai/code/session_01RXSpBmXaMcpYuirkQDoW7t



## Summary by CodeRabbit

* **New Features**
  * Class methods can now call themselves, call sibling methods—including forward references—and invoke methods from constructors.
  * Getter and setter access within class methods is supported more reliably.
  * Mutable-self methods can call immutable-self helpers.

* **Bug Fixes**
  * Improved class member resolution and handling of non-property members.

* **Diagnostics**
  * Added clearer errors when mutually recursive methods lack return-type annotations.
