### PR TITLE
M5 B6: Support static members on class values

### DIFF
--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -406,6 +406,36 @@ func TestAcceptObjectSetterCopyOnWrite(t *testing.T) {
 	require.Same(t, str, gotSetter.Param, "the setter param took the replacement")
 }
 
+// A constructor's parameter is in write position, so Accept visits it in the FLIPPED
+// polarity, mirroring an ordinary parameter, while its return is covariant. A changed
+// variable rebuilds the ConstructorElem and the enclosing object copy-on-write (M5 B6).
+func TestAcceptConstructorElem(t *testing.T) {
+	paramT := &TypeVarType{ID: 1}
+	retT := &TypeVarType{ID: 2}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", paramT)}, Ret: retT}},
+	}}
+
+	r := &recorder{seen: map[Type]Polarity{}}
+	obj.Accept(r, Positive)
+	require.Equal(t, Negative, r.seen[paramT], "a constructor parameter is contravariant")
+	require.Equal(t, Positive, r.seen[retT], "a constructor return is covariant")
+
+	str := &PrimType{Prim: StrPrim}
+	got := obj.Accept(&replaceVar{target: paramT, repl: str}, Positive).(*ObjectType)
+	require.NotSame(t, obj, got, "a changed constructor forces a new object")
+	gotCtor := got.Elems[0].(*ConstructorElem)
+	require.Same(t, str, gotCtor.Fn.Params[0].Type, "the constructor param took the replacement")
+}
+
+// LevelOf on an object descends into a constructor's signature.
+func TestLevelOfConstructorElem(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", &TypeVarType{ID: 1, Level: 6})}, Ret: numP()}},
+	}}
+	require.Equal(t, 6, LevelOf(obj), "the level is the max over the constructor signature")
+}
+
 // LevelOf on a ClassType is the max level over its type arguments; the Name and
 // Final identity carry no variables.
 func TestLevelOfClassType(t *testing.T) {

--- a/internal/soltype/class_test.go
+++ b/internal/soltype/class_test.go
@@ -408,7 +408,7 @@ func TestAcceptObjectSetterCopyOnWrite(t *testing.T) {
 
 // A constructor's parameter is in write position, so Accept visits it in the FLIPPED
 // polarity, mirroring an ordinary parameter, while its return is covariant. A changed
-// variable rebuilds the ConstructorElem and the enclosing object copy-on-write (M5 B6).
+// variable rebuilds the ConstructorElem and the enclosing object copy-on-write.
 func TestAcceptConstructorElem(t *testing.T) {
 	paramT := &TypeVarType{ID: 1}
 	retT := &TypeVarType{ID: 2}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -617,8 +617,8 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		}
 		return "set " + printObjectKeyName(e.Name) + "(" + recv + "value: " + p.printType(e.Param) + ")"
 	case *ConstructorElem:
-		// A class value's constructor renders `new (params) -> ret`, matching the
-		// old checker's ConstructorElem form.
+		// A class value's constructor renders as the unnamed call signature
+		// `new (params) -> ret`.
 		return "new " + p.printFuncTail(e.Fn)
 	}
 	panic(fmt.Sprintf("printObjElem: unhandled ObjTypeElem %T", e))

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -370,6 +370,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 						walk(e.SelfParam.Type)
 					}
 					walk(e.Param)
+				case *ConstructorElem:
+					walk(e.Fn)
 				}
 			}
 		case *ClassType:
@@ -578,7 +580,9 @@ func (p *namedPrinter) printType(t Type) string {
 //   - a method renders `name(params) -> ret` per overload arm, arms joined by "; "
 //     so the arm boundary stays distinct from the outer ", " between members;
 //   - a getter renders `get name(self) -> T`, or `get name() -> T` when static;
-//   - a setter renders `set name(self, value: T)`, or `set name(value: T)` when static.
+//   - a setter renders `set name(self, value: T)`, or `set name(value: T)` when static;
+//   - a constructor renders `new (params) -> ret`, the unnamed call signature of a
+//     class value.
 //
 // A getter's or setter's self receiver renders through the same shorthand as a
 // method's. It panics on an unknown element kind, matching AsProperty.
@@ -612,6 +616,10 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 			recv = p.printSelfReceiver(e.SelfParam) + ", "
 		}
 		return "set " + printObjectKeyName(e.Name) + "(" + recv + "value: " + p.printType(e.Param) + ")"
+	case *ConstructorElem:
+		// A class value's constructor renders `new (params) -> ret`, matching the
+		// old checker's ConstructorElem form.
+		return "new " + p.printFuncTail(e.Fn)
 	}
 	panic(fmt.Sprintf("printObjElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -269,6 +269,33 @@ func TestPrintGenericMethod(t *testing.T) {
 	require.Equal(t, "{map<U>(self, x: U) -> U}", Print(obj))
 }
 
+// A class value renders as an object holding its constructor as `new (params) -> ret`
+// alongside its static members, and round-trips through Accept unchanged (M5 B6).
+func TestPrintConstructorElem(t *testing.T) {
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&ConstructorElem{Fn: &FuncType{
+			Params: []*FuncParam{identP("x", numP()), identP("y", numP())},
+			Ret:    &ClassType{Name: "Point"},
+		}},
+		&PropertyElem{Name: "count", Type: numP()},
+		&MethodElem{Name: "zero", Signatures: []*FuncType{{Ret: numP()}}, Static: true},
+	}}
+	require.Equal(t, "{new (x: number, y: number) -> Point, count: number, zero() -> number}", Print(obj))
+	// Accept with an identity visitor preserves the node, so a constructor member
+	// survives every rewriting pass built on Accept.
+	require.Same(t, obj, obj.Accept(identityVisitor{}, Positive))
+}
+
+// freeTypeVars descends a constructor's signature, so a variable reachable only through
+// a class value's constructor parameter is collected.
+func TestFreeTypeVarsConstructorElem(t *testing.T) {
+	v := &TypeVarType{ID: 7, Level: 1}
+	obj := &ObjectType{Elems: []ObjTypeElem{
+		&ConstructorElem{Fn: &FuncType{Params: []*FuncParam{identP("x", v)}, Ret: &ClassType{Name: "Box"}}},
+	}}
+	require.Equal(t, []*TypeVarType{v}, freeTypeVars(obj))
+}
+
 // freeTypeVars excludes a function's own type parameters — they are bound, not free —
 // while still collecting an outer free variable, including one that appears only in a
 // parameter's constraint.

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -270,7 +270,7 @@ func TestPrintGenericMethod(t *testing.T) {
 }
 
 // A class value renders as an object holding its constructor as `new (params) -> ret`
-// alongside its static members, and round-trips through Accept unchanged (M5 B6).
+// alongside its static members, and round-trips through Accept unchanged.
 func TestPrintConstructorElem(t *testing.T) {
 	obj := &ObjectType{Elems: []ObjTypeElem{
 		&ConstructorElem{Fn: &FuncType{

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -312,14 +312,25 @@ type SetterElem struct {
 	Param     Type
 }
 
-func (*MethodElem) isObjTypeElem() {}
-func (*GetterElem) isObjTypeElem() {}
-func (*SetterElem) isObjTypeElem() {}
+// ConstructorElem is the call signature a class value carries. It is the constructor a
+// class name resolves to as a value, so `Point(1, 2)` calls Fn. A class value holds
+// exactly one, unnamed, alongside the class's static members. It is the single callable
+// element the structural lattice admits, scoped to the class-value carrier rather than a
+// general call-signature-in-any-object feature.
+type ConstructorElem struct{ Fn *FuncType }
+
+func (*MethodElem) isObjTypeElem()      {}
+func (*GetterElem) isObjTypeElem()      {}
+func (*SetterElem) isObjTypeElem()      {}
+func (*ConstructorElem) isObjTypeElem() {}
 
 // ObjElemName returns the member name of any ObjTypeElem kind. It is the shared
 // name accessor for member lookup and structural equality, so those sites need no
-// per-kind type switch of their own. It panics on an unknown element kind,
-// matching the loud-fail discipline of AsProperty.
+// per-kind type switch of their own. A ConstructorElem is unnamed, so it returns the
+// empty string. No source-derived member carries that name, so a name lookup never
+// matches a constructor. Two constructors still pair up under the shared empty key when
+// their objects are compared. It panics on an unknown element kind, matching the
+// loud-fail discipline of AsProperty.
 func ObjElemName(e ObjTypeElem) string {
 	switch e := e.(type) {
 	case *PropertyElem:
@@ -330,6 +341,8 @@ func ObjElemName(e ObjTypeElem) string {
 		return e.Name
 	case *SetterElem:
 		return e.Name
+	case *ConstructorElem:
+		return ""
 	}
 	panic(fmt.Sprintf("ObjElemName: unhandled ObjTypeElem %T", e))
 }
@@ -360,6 +373,19 @@ func (o *ObjectType) Member(name string) (ObjTypeElem, bool) {
 	for _, e := range o.Elems {
 		if ObjElemName(e) == name {
 			return e, true
+		}
+	}
+	return nil, false
+}
+
+// Constructor returns the object's constructor call signature and whether it carries
+// one. A class value carries exactly one ConstructorElem, so this is the lookup a call
+// site and the nominal-value constrain rule use to reach the constructor without a
+// type switch of their own.
+func (o *ObjectType) Constructor() (*ConstructorElem, bool) {
+	for _, e := range o.Elems {
+		if ctor, ok := e.(*ConstructorElem); ok {
+			return ctor, true
 		}
 	}
 	return nil, false
@@ -633,6 +659,8 @@ func levelOfElem(e ObjTypeElem) int {
 		return max(selfLevel(e.SelfParam), LevelOf(e.Type))
 	case *SetterElem:
 		return max(selfLevel(e.SelfParam), LevelOf(e.Param))
+	case *ConstructorElem:
+		return LevelOf(e.Fn)
 	}
 	panic(fmt.Sprintf("levelOfElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -387,6 +387,15 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 			return e
 		}
 		return &MethodElem{Name: e.Name, Signatures: sigs, Static: e.Static}
+	case *ConstructorElem:
+		nf, ok := e.Fn.Accept(v, pol).(*FuncType) // params contravariant, via FuncType.Accept
+		if !ok {
+			panic(fmt.Sprintf("AcceptObjElem: constructor signature rewrote to non-FuncType %T", e.Fn))
+		}
+		if nf == e.Fn {
+			return e
+		}
+		return &ConstructorElem{Fn: nf}
 	}
 	panic(fmt.Sprintf("AcceptObjElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -382,6 +382,61 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	return pathResult{value: out}
 }
 
+// classValueMember resolves a static member read off a class value, such as
+// `Point.origin` or `Point.count` — a field, method, getter, or setter access on the
+// class name itself. The class value is an object carrying its constructor plus its
+// static members, so the member is looked up on that object and its type produced
+// through the shared memberValue helper. It returns ok=false in two cases. When the
+// receiver is not a class value, an ordinary object receiver keeps the structural
+// field-requirement path. When the class value carries no such member, a genuinely
+// missing static reports through that path's MissingPropertyError.
+func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+	obj, ok := classValueCarrier(carrier)
+	if !ok {
+		return pathResult{}, false
+	}
+	member, found := obj.Member(name)
+	if !found {
+		return pathResult{}, false
+	}
+	return c.memberValue(lvl, blame, member), true
+}
+
+// classValueCarrier resolves a receiver to the class-value object it reads as: an object
+// carrying a ConstructorElem directly, or a binding var whose lower bounds carry one —
+// the same look-through classCarrier uses for a class instance, since a class value
+// flows through the bound graph as a variable with the object as a lower bound rather
+// than a bare object. It resolves only an unambiguous class value: a variable whose lower
+// bounds carry two different class-value objects is left to the structural path rather
+// than silently reading whichever appears first.
+func classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
+	switch t := t.(type) {
+	case *soltype.ObjectType:
+		if _, ok := t.Constructor(); ok {
+			return t, true
+		}
+	case *soltype.TypeVarType:
+		var found *soltype.ObjectType
+		for _, lb := range t.LowerBounds {
+			obj, ok := lb.(*soltype.ObjectType)
+			if !ok {
+				continue
+			}
+			if _, hasCtor := obj.Constructor(); !hasCtor {
+				continue
+			}
+			if found != nil && !equalType(found, obj) {
+				return nil, false
+			}
+			found = obj
+		}
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
 // classSubst rewrites a class body's type-parameter and lifetime-parameter vars to
 // the arguments of one instance. It maps each TypeParam.Var to the instance's
 // positional TypeArg and each LifetimeParam.Var to its positional LifetimeArg, so a

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -383,13 +383,9 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 }
 
 // classValueMember resolves a static member read off a class value, such as
-// `Point.origin` or `Point.count` — a field, method, getter, or setter access on the
-// class name itself. The class value is an object carrying its constructor plus its
-// static members, so the member is looked up on that object and its type produced
-// through the shared memberValue helper. It returns ok=false in two cases. When the
-// receiver is not a class value, an ordinary object receiver keeps the structural
-// field-requirement path. When the class value carries no such member, a genuinely
-// missing static reports through that path's MissingPropertyError.
+// `Point.origin`, by looking the member up on the value object and producing its type via
+// memberValue. It returns ok=false when the receiver is not a class value or carries no
+// such member, leaving both cases to the structural field-requirement path.
 func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
 	obj, ok := classValueCarrier(carrier)
 	if !ok {
@@ -403,12 +399,9 @@ func (c *checker) classValueMember(lvl int, blame ast.Node, name string, carrier
 }
 
 // classValueCarrier resolves a receiver to the class-value object it reads as: an object
-// carrying a ConstructorElem directly, or a binding var whose lower bounds carry one —
-// the same look-through classCarrier uses for a class instance, since a class value
-// flows through the bound graph as a variable with the object as a lower bound rather
-// than a bare object. It resolves only an unambiguous class value: a variable whose lower
-// bounds carry two different class-value objects is left to the structural path rather
-// than silently reading whichever appears first.
+// carrying a ConstructorElem directly, or a binding var whose lower bounds carry one, the
+// same look-through classCarrier uses for an instance. A var with two different class-value
+// lower bounds is ambiguous and left to the structural path.
 func classValueCarrier(t soltype.Type) (*soltype.ObjectType, bool) {
 	switch t := t.(type) {
 	case *soltype.ObjectType:

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -943,7 +943,8 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 //   - a method compares its static flag and each overload signature positionally,
 //     since arm order is significant;
 //   - a getter compares its return type;
-//   - a setter compares its parameter type.
+//   - a setter compares its parameter type;
+//   - a constructor compares its call signature.
 //
 // It panics on an unknown element kind, matching AsProperty.
 func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
@@ -968,6 +969,9 @@ func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	case *soltype.SetterElem:
 		b, ok := b.(*soltype.SetterElem)
 		return ok && equalSelfParam(a.SelfParam, b.SelfParam, ctx) && equalTypeWith(a.Param, b.Param, ctx)
+	case *soltype.ConstructorElem:
+		b, ok := b.(*soltype.ConstructorElem)
+		return ok && equalTypeWith(a.Fn, b.Fn, ctx)
 	}
 	panic(fmt.Sprintf("equalObjElem: unhandled ObjTypeElem %T", a))
 }

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -692,6 +692,43 @@ func TestEqualTypeObjectMembers(t *testing.T) {
 	}
 }
 
+// A class value's constructor is compared through its ConstructorElem, threading the
+// alpha context equalObjElem already uses for methods. Two class-value objects whose
+// generic constructors differ only in the var id of a bound type parameter are equal, and
+// two whose constructor signatures differ structurally are not. This is the equality
+// dedup relies on when it folds equal class-value bounds (M5 B6).
+func TestEqualTypeConstructorElem(t *testing.T) {
+	// value builds `{new <U>(x: U) -> U, count: number}`, whose constructor parameter is
+	// the bound type parameter U, so two values differing only in U's var id are
+	// alpha-equal. A parameter's identity is its position, not its var id.
+	value := func(id int) *soltype.ObjectType {
+		u := &soltype.TypeVarType{ID: id, Level: 1}
+		ctor := &soltype.FuncType{
+			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u}},
+			Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: u}},
+			Ret:        u,
+		}
+		return exactObj(
+			&soltype.ConstructorElem{Fn: ctor},
+			&soltype.PropertyElem{Name: "count", Type: num()},
+		)
+	}
+	// Same structure, distinct var ids on the bound parameter: alpha-equal.
+	require.True(t, equalType(value(10), value(20)))
+	// A constructor whose parameter type differs structurally is not equal.
+	strCtor := exactObj(&soltype.ConstructorElem{Fn: &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: str()}},
+		Ret:    &soltype.ClassType{Name: "Point"},
+	}})
+	numCtor := exactObj(&soltype.ConstructorElem{Fn: &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: num()}},
+		Ret:    &soltype.ClassType{Name: "Point"},
+	}})
+	require.False(t, equalType(numCtor, strCtor))
+	// An object carrying a constructor never equals one without it.
+	require.False(t, equalType(numCtor, exactObj(&soltype.PropertyElem{Name: "count", Type: num()})))
+}
+
 // A parameter's identity is its position: two two-parameter signatures that use their
 // parameters in swapped positions are unequal even though each is well-formed.
 func TestEqualTypeGenericFuncPositional(t *testing.T) {

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -696,7 +696,7 @@ func TestEqualTypeObjectMembers(t *testing.T) {
 // alpha context equalObjElem already uses for methods. Two class-value objects whose
 // generic constructors differ only in the var id of a bound type parameter are equal, and
 // two whose constructor signatures differ structurally are not. This is the equality
-// dedup relies on when it folds equal class-value bounds (M5 B6).
+// dedup relies on when it folds equal class-value bounds.
 func TestEqualTypeConstructorElem(t *testing.T) {
 	// value builds `{new <U>(x: U) -> U, count: number}`, whose constructor parameter is
 	// the bound type parameter U, so two values differing only in U's var id are

--- a/internal/solver/coalesce_test.go
+++ b/internal/solver/coalesce_test.go
@@ -693,18 +693,22 @@ func TestEqualTypeObjectMembers(t *testing.T) {
 }
 
 // A class value's constructor is compared through its ConstructorElem, threading the
-// alpha context equalObjElem already uses for methods. Two class-value objects whose
-// generic constructors differ only in the var id of a bound type parameter are equal, and
-// two whose constructor signatures differ structurally are not. This is the equality
-// dedup relies on when it folds equal class-value bounds.
+// alpha context equalObjElem already uses for methods. Since that delegates to the full
+// FuncType comparison, two generic constructors are equal only up to alpha-renaming of a
+// bound type parameter whose constraint AND default also match; differing var ids are
+// equal, but a differing parameter type, constraint, or default is not. This is the
+// equality dedup relies on when it folds equal class-value bounds.
 func TestEqualTypeConstructorElem(t *testing.T) {
-	// value builds `{new <U>(x: U) -> U, count: number}`, whose constructor parameter is
-	// the bound type parameter U, so two values differing only in U's var id are
-	// alpha-equal. A parameter's identity is its position, not its var id.
-	value := func(id int) *soltype.ObjectType {
+	// value builds `{new <U: bound = def>(x: U) -> U, count: number}`, whose constructor
+	// parameter is the bound type parameter U, so two values differing only in U's var id
+	// are alpha-equal. A parameter's identity is its position, not its var id.
+	value := func(id int, bound, def soltype.Type) *soltype.ObjectType {
 		u := &soltype.TypeVarType{ID: id, Level: 1}
+		if bound != nil {
+			u.UpperBounds = []soltype.Type{bound}
+		}
 		ctor := &soltype.FuncType{
-			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u}},
+			TypeParams: []*soltype.TypeParam{{Name: "U", Var: u, Default: def}},
 			Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: u}},
 			Ret:        u,
 		}
@@ -713,8 +717,17 @@ func TestEqualTypeConstructorElem(t *testing.T) {
 			&soltype.PropertyElem{Name: "count", Type: num()},
 		)
 	}
-	// Same structure, distinct var ids on the bound parameter: alpha-equal.
-	require.True(t, equalType(value(10), value(20)))
+	// Same structure, distinct var ids on the bound parameter: alpha-equal, with or
+	// without a matching constraint and default.
+	require.True(t, equalType(value(10, nil, nil), value(20, nil, nil)))
+	require.True(t, equalType(value(10, num(), str()), value(20, num(), str())))
+	// A differing type-parameter constraint is not equal, and neither is a constraint
+	// present on one side only.
+	require.False(t, equalType(value(10, num(), nil), value(20, str(), nil)))
+	require.False(t, equalType(value(10, num(), nil), value(20, nil, nil)))
+	// A differing default is not equal, and neither is a default on one side only.
+	require.False(t, equalType(value(10, nil, num()), value(20, nil, str())))
+	require.False(t, equalType(value(10, nil, num()), value(20, nil, nil)))
 	// A constructor whose parameter type differs structurally is not equal.
 	strCtor := exactObj(&soltype.ConstructorElem{Fn: &soltype.FuncType{
 		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: str()}},

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -357,12 +357,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	case *soltype.ObjectType:
 		if sup, ok := super.(*soltype.FuncType); ok {
 			// An object with a constructor signature is a subtype of the matching function
-			// type. Its constructor call signature is checked against the function target,
-			// which is the synthesized call shape of `Point(1, 2)` or a `fn (…) -> Point`
-			// annotation. A ConstructorElem is the one callable member the lattice admits, so
-			// an object with no constructor is not a function and falls through to
-			// CannotConstrainError. Codegen bridges the runtime gap, emitting whatever a
-			// constructor needs to behave as a plain function where one is expected.
+			// type; codegen makes the constructor behave as a plain function where expected.
 			if ctor, ok := sub.Constructor(); ok {
 				return c.constrain(ctor.Fn, sup, seen, mutCtx)
 			}
@@ -400,11 +395,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					}
 					continue
 				}
-				// A method, getter, or setter requirement is carried only by a class value,
-				// since object annotations cannot express those members, so it appears here
-				// only when both sides are class values, as in a reassignment or join. Check
-				// it against the sub's same-named member by variance rather than routing it
-				// to AsProperty, which handles properties alone and would panic.
+				// A method, getter, or setter requirement, carried only by a class value,
+				// checks against the sub's member by variance instead of panicking in AsProperty.
 				if _, isProp := superElem.(*soltype.PropertyElem); !isProp {
 					errs = append(errs, c.constrainObjMember(superElem, sub, sup, seen, mutCtx)...)
 					continue
@@ -654,14 +646,10 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
-// constrainObjMember checks a method, getter, or setter requirement carried by an object
-// super against the sub's same-named member. Only a class value carries those members,
-// since object annotations cannot express them, so this fires only between two class
-// values, as in a reassignment or a join of class values. A method matches by its
-// callable signature with the receiver stripped, the shape a `p.m` read yields; a getter
-// matches covariantly on its read type; a setter matches contravariantly on its write
-// type. Overload-set dispatch across several method arms is E1, so a method compares its
-// first arm here. A missing or wrong-kind member fails.
+// constrainObjMember checks a method, getter, or setter requirement on an object super
+// against the sub's same-named member by variance: a method by its receiver-stripped
+// callable signature (first arm; overload dispatch is E1), a getter covariantly, a setter
+// contravariantly. A missing or wrong-kind member fails.
 func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *soltype.ObjectType, seen set.Set[constraintKey], mutCtx bool) []SolverError {
 	name := soltype.ObjElemName(superElem)
 	subElem, ok := sub.Member(name)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -356,11 +356,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.ObjectType:
 		if sup, ok := super.(*soltype.FuncType); ok {
-			// A class value flows into a function target through its constructor call
-			// signature. The target is the synthesized call shape of `Point(1, 2)` or a
-			// `fn (…) -> Point` annotation. The class value is the single callable object the
-			// lattice admits, so only a ConstructorElem satisfies a function target. A plain
-			// object with no constructor falls through to CannotConstrainError.
+			// An object with a constructor signature is a subtype of the matching function
+			// type. Its constructor call signature is checked against the function target,
+			// which is the synthesized call shape of `Point(1, 2)` or a `fn (…) -> Point`
+			// annotation. A ConstructorElem is the one callable member the lattice admits, so
+			// an object with no constructor is not a function and falls through to
+			// CannotConstrainError. Codegen bridges the runtime gap, emitting whatever a
+			// constructor needs to behave as a plain function where one is expected.
 			if ctor, ok := sub.Constructor(); ok {
 				return c.constrain(ctor.Fn, sup, seen, mutCtx)
 			}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -440,7 +440,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 				for _, subElem := range sub.Elems {
 					// A class value carries an unnamed ConstructorElem and may carry static
 					// method, getter, and setter members. None is a named property, so none
-					// counts as an extra property against an exact target.
+					// counts as an extra property against an exact target. Unifying properties
+					// with methods and accessors here is escalier-lang/escalier#864.
 					subProp, ok := subElem.(*soltype.PropertyElem)
 					if !ok {
 						continue

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -663,6 +663,8 @@ func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *so
 		if !ok || len(sm.Signatures) == 0 || len(se.Signatures) == 0 {
 			break
 		}
+		// Compares only the first arm of each overload set; full overload-set
+		// reconciliation is escalier-lang/escalier#865.
 		return c.constrain(callableView(sm.Signatures[0]), callableView(se.Signatures[0]), seen, mutCtx)
 	case *soltype.GetterElem:
 		if sg, ok := subElem.(*soltype.GetterElem); ok {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -398,7 +398,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					}
 					continue
 				}
-				superProp := soltype.AsProperty(superElem) // M4: every named elem is a property
+				// A method, getter, or setter requirement is carried only by a class value,
+				// since object annotations cannot express those members, so it appears here
+				// only when both sides are class values, as in a reassignment or join. Check
+				// it against the sub's same-named member by variance rather than routing it
+				// to AsProperty, which handles properties alone and would panic.
+				if _, isProp := superElem.(*soltype.PropertyElem); !isProp {
+					errs = append(errs, c.constrainObjMember(superElem, sub, sup, seen, mutCtx)...)
+					continue
+				}
+				superProp := soltype.AsProperty(superElem) // every remaining elem is a property
 				subProp, ok := sub.Prop(superProp.Name)
 				if !ok {
 					if !superProp.Optional {
@@ -641,6 +650,52 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	}
 
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// constrainObjMember checks a method, getter, or setter requirement carried by an object
+// super against the sub's same-named member. Only a class value carries those members,
+// since object annotations cannot express them, so this fires only between two class
+// values, as in a reassignment or a join of class values. A method matches by its
+// callable signature with the receiver stripped, the shape a `p.m` read yields; a getter
+// matches covariantly on its read type; a setter matches contravariantly on its write
+// type. Overload-set dispatch across several method arms is E1, so a method compares its
+// first arm here. A missing or wrong-kind member fails.
+func (c *Context) constrainObjMember(superElem soltype.ObjTypeElem, sub, sup *soltype.ObjectType, seen set.Set[constraintKey], mutCtx bool) []SolverError {
+	name := soltype.ObjElemName(superElem)
+	subElem, ok := sub.Member(name)
+	if !ok {
+		return []SolverError{&MissingPropertyError{Sub: sub, Super: sup, Name: name}}
+	}
+	switch se := superElem.(type) {
+	case *soltype.MethodElem:
+		sm, ok := subElem.(*soltype.MethodElem)
+		if !ok || len(sm.Signatures) == 0 || len(se.Signatures) == 0 {
+			break
+		}
+		return c.constrain(callableView(sm.Signatures[0]), callableView(se.Signatures[0]), seen, mutCtx)
+	case *soltype.GetterElem:
+		if sg, ok := subElem.(*soltype.GetterElem); ok {
+			return c.constrain(sg.Type, se.Type, seen, mutCtx) // covariant read
+		}
+	case *soltype.SetterElem:
+		if ss, ok := subElem.(*soltype.SetterElem); ok {
+			return c.constrain(se.Param, ss.Param, seen, mutCtx) // contravariant write
+		}
+	}
+	return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
+}
+
+// callableView returns a method signature as the callable value a member read yields:
+// the signature with its receiver dropped, since a method value binds no `self`. It is
+// the subtyping counterpart of memberValue's method projection.
+func callableView(ft *soltype.FuncType) *soltype.FuncType {
+	return &soltype.FuncType{
+		Params:         ft.Params,
+		Ret:            ft.Ret,
+		Inexact:        ft.Inexact,
+		TypeParams:     ft.TypeParams,
+		LifetimeParams: ft.LifetimeParams,
+	}
 }
 
 // ltPair keys constrainLt's coinductive seen-set by (sub, super) lifetime

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -355,6 +355,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return errs
 		}
 	case *soltype.ObjectType:
+		if sup, ok := super.(*soltype.FuncType); ok {
+			// A class value flows into a function target through its constructor call
+			// signature. The target is the synthesized call shape of `Point(1, 2)` or a
+			// `fn (…) -> Point` annotation. The class value is the single callable object the
+			// lattice admits, so only a ConstructorElem satisfies a function target. A plain
+			// object with no constructor falls through to CannotConstrainError.
+			if ctor, ok := sub.Constructor(); ok {
+				return c.constrain(ctor.Fn, sup, seen, mutCtx)
+			}
+		}
 		if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
 			// conflated: member-access field SELECTION (the super is an inexact
@@ -376,7 +386,19 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//     optional): covariant on the property type.
 			var errs []SolverError
 			for _, superElem := range sup.Elems {
-				superProp := soltype.AsProperty(superElem) // M4: every elem is a property
+				// A constructor requirement is satisfied by the source's own constructor,
+				// its call signature checked covariantly. This lets a class value flow into
+				// an object target that names a call signature. A source with no constructor
+				// cannot fill one.
+				if superCtor, ok := superElem.(*soltype.ConstructorElem); ok {
+					if subCtor, has := sub.Constructor(); has {
+						errs = append(errs, c.constrain(subCtor.Fn, superCtor.Fn, seen, mutCtx)...)
+					} else {
+						errs = append(errs, &CannotConstrainError{Sub: sub, Super: sup})
+					}
+					continue
+				}
+				superProp := soltype.AsProperty(superElem) // M4: every named elem is a property
 				subProp, ok := sub.Prop(superProp.Name)
 				if !ok {
 					if !superProp.Optional {
@@ -413,7 +435,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					errs = append(errs, &InexactIntoExactError{Sub: sub, Super: sup})
 				}
 				for _, subElem := range sub.Elems {
-					subProp := soltype.AsProperty(subElem)
+					// A class value carries an unnamed ConstructorElem and may carry static
+					// method, getter, and setter members. None is a named property, so none
+					// counts as an extra property against an exact target.
+					subProp, ok := subElem.(*soltype.PropertyElem)
+					if !ok {
+						continue
+					}
 					if _, ok := sup.Prop(subProp.Name); !ok {
 						errs = append(errs, &ExtraPropertyError{Sub: sub, Super: sup, Name: subProp.Name})
 					}

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -730,6 +730,68 @@ func TestConstrainObject(t *testing.T) {
 	}
 }
 
+// TestConstrainObjectMethodMembers exercises the object-object arm when the super
+// carries a method, getter, or setter member. Only a class value carries those members,
+// and a reassignment or join of class values reaches here, since object annotations
+// cannot express them, so the objects are built directly. constrainObjMember matches each
+// against the sub's same-named member by variance rather than routing it to AsProperty,
+// which handles properties alone and would panic.
+func TestConstrainObjectMethodMembers(t *testing.T) {
+	method := func(name string, param, ret soltype.Type) *soltype.MethodElem {
+		return &soltype.MethodElem{Name: name, Signatures: []*soltype.FuncType{{
+			Params: []*soltype.FuncParam{identParam("a", param)}, Ret: ret,
+		}}}
+	}
+	tests := []struct {
+		name       string
+		sub, super soltype.Type
+		want       []string
+	}{
+		{
+			name:  "identical method members",
+			sub:   exactObj(method("m", num(), num())),
+			super: exactObj(method("m", num(), num())),
+		},
+		{
+			// A method's return is covariant, read through its callable value.
+			name:  "method return covariant",
+			sub:   exactObj(method("m", num(), numLit(5))),
+			super: exactObj(method("m", num(), num())),
+		},
+		{
+			name:  "method return mismatch",
+			sub:   exactObj(method("m", num(), str())),
+			super: exactObj(method("m", num(), num())),
+			want:  []string{"cannot constrain string <: number"},
+		},
+		{
+			name:  "missing method member",
+			sub:   exactObj(),
+			super: exactObj(method("m", num(), num())),
+			want:  []string{"object is missing property: m"},
+		},
+		{
+			// A getter's read type is covariant.
+			name:  "getter covariant",
+			sub:   exactObj(&soltype.GetterElem{Name: "g", Type: numLit(5)}),
+			super: exactObj(&soltype.GetterElem{Name: "g", Type: num()}),
+		},
+		{
+			// A setter's write type is contravariant: the super's written value must be
+			// acceptable to the sub's setter.
+			name:  "setter contravariant",
+			sub:   exactObj(&soltype.SetterElem{Name: "s", Param: num()}),
+			super: exactObj(&soltype.SetterElem{Name: "s", Param: numLit(5)}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, Messages(c.Constrain(tt.sub, tt.super)))
+		})
+	}
+}
+
 // TestConstrainRef exercises the single RefType <: RefType rule — THE GATE (C2).
 // The headline property is mut-driven inner invariance: a mutable target takes both
 // a covariant read view and a contravariant write view, so the inner is invariant.

--- a/internal/solver/constrain_test.go
+++ b/internal/solver/constrain_test.go
@@ -792,6 +792,64 @@ func TestConstrainObjectMethodMembers(t *testing.T) {
 	}
 }
 
+// TestConstrainConstructorObjectAsFunction pins that an object carrying a constructor
+// signature is a subtype of the matching function type, so a class value is usable where
+// a plain function is expected. The constructor's call signature is checked against the
+// function target with the ordinary function variance, extra static members are ignored,
+// and an object with no constructor is not a function.
+func TestConstrainConstructorObjectAsFunction(t *testing.T) {
+	fn := func(param, ret soltype.Type) *soltype.FuncType {
+		return &soltype.FuncType{Params: []*soltype.FuncParam{identParam("a", param)}, Ret: ret}
+	}
+	ctorObj := func(param, ret soltype.Type, extra ...soltype.ObjTypeElem) *soltype.ObjectType {
+		return exactObj(append([]soltype.ObjTypeElem{&soltype.ConstructorElem{Fn: fn(param, ret)}}, extra...)...)
+	}
+	x := &soltype.ClassType{Name: "X"}
+	tests := []struct {
+		name       string
+		sub, super soltype.Type
+		want       []string
+	}{
+		{
+			name:  "constructor-only object fills a function",
+			sub:   ctorObj(num(), x),
+			super: fn(num(), x),
+		},
+		{
+			// A class value carries static members alongside its constructor; they are
+			// ignored against a function target.
+			name:  "constructor-plus-static object fills a function",
+			sub:   ctorObj(num(), x, propElem("dim", num())),
+			super: fn(num(), x),
+		},
+		{
+			// The constructor parameter is contravariant, as in any function.
+			name:  "constructor parameter is contravariant",
+			sub:   ctorObj(num(), x),
+			super: fn(numLit(5), x),
+		},
+		{
+			name:  "constructor return mismatch",
+			sub:   ctorObj(num(), num()),
+			super: fn(num(), str()),
+			want:  []string{"cannot constrain number <: string"},
+		},
+		{
+			// An object with no constructor is not callable.
+			name:  "plain object is not a function",
+			sub:   exactObj(propElem("dim", num())),
+			super: fn(num(), x),
+			want:  []string{"cannot constrain object <: function"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Context{}
+			require.Equal(t, tt.want, Messages(c.Constrain(tt.sub, tt.super)))
+		})
+	}
+}
+
 // TestConstrainRef exercises the single RefType <: RefType rule — THE GATE (C2).
 // The headline property is mut-driven inner invariance: a mutable target takes both
 // a covariant read view and a contravariant write view, so the inner is invariant.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -115,9 +115,11 @@ func (c *checker) classValue(ctorType soltype.Type, static *soltype.ObjectType) 
 	if len(static.Elems) == 0 {
 		return ctorType
 	}
+	// inferConstructor always returns a FuncType, so anything else is a wiring bug.
+	// Fail loudly rather than drop the statics by returning the bare ctorType.
 	ctorFn, ok := ctorType.(*soltype.FuncType)
 	if !ok {
-		return ctorType
+		panic(fmt.Sprintf("classValue: constructor is %T, not *soltype.FuncType", ctorType))
 	}
 	elems := make([]soltype.ObjTypeElem, 0, len(static.Elems)+1)
 	elems = append(elems, &soltype.ConstructorElem{Fn: ctorFn})

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -108,15 +108,9 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
 }
 
-// classValue produces the RAW value type a class name binds to for the SCC driver to
-// constrain into the value var. A class with no static members binds its bare
-// constructor FuncType, so a plain `class Point { … }` value renders `fn (…) -> Point`
-// and constructs through the function directly. A class with static members binds an
-// exact object holding a ConstructorElem for the callable side plus the class's static
-// fields, methods, getters, and setters, so `Point(…)` still constructs while
-// `Point.origin` reads a static off the same value. The object is minted only when a
-// static is present, keeping the single-callable-element lattice exception confined to
-// the class values that need it.
+// classValue produces the RAW value type a class name binds to. A class with no statics
+// binds its bare constructor FuncType; one with statics binds an exact object holding a
+// ConstructorElem plus the static members, so `Point(…)` constructs and `Point.origin` reads.
 func (c *checker) classValue(ctorType soltype.Type, static *soltype.ObjectType) soltype.Type {
 	if len(static.Elems) == 0 {
 		return ctorType

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -11,9 +11,11 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferClassDecl types a class declaration (M5 B1). It returns the class's constructor
-// as a raw FuncType for the SCC driver to constrain into the value binding var and
-// generalize, along with the decl's provenance. It has two side effects. It registers
+// inferClassDecl types a class declaration (M5 B1). It returns the class's value type
+// for the SCC driver to constrain into the value binding var and generalize, along with
+// the decl's provenance. The value is the bare constructor FuncType for a class with no
+// statics, or a ctor-plus-static object for one with static members (see classValue). It
+// has two side effects. It registers
 // the instance TypeBinding in scope, so the class name resolves as a type. It registers
 // the ClassDef in the nominal registry, so member lookup and the nominal constrain rule
 // can read the projected body.
@@ -103,7 +105,30 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 		c.freezeClassBody(static)
 	}
 
-	return ctorType, &ast.NodeProvenance{Node: decl}, true
+	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
+}
+
+// classValue produces the RAW value type a class name binds to for the SCC driver to
+// constrain into the value var. A class with no static members binds its bare
+// constructor FuncType, so a plain `class Point { … }` value renders `fn (…) -> Point`
+// and constructs through the function directly. A class with static members binds an
+// exact object holding a ConstructorElem for the callable side plus the class's static
+// fields, methods, getters, and setters, so `Point(…)` still constructs while
+// `Point.origin` reads a static off the same value. The object is minted only when a
+// static is present, keeping the single-callable-element lattice exception confined to
+// the class values that need it.
+func (c *checker) classValue(ctorType soltype.Type, static *soltype.ObjectType) soltype.Type {
+	if len(static.Elems) == 0 {
+		return ctorType
+	}
+	ctorFn, ok := ctorType.(*soltype.FuncType)
+	if !ok {
+		return ctorType
+	}
+	elems := make([]soltype.ObjTypeElem, 0, len(static.Elems)+1)
+	elems = append(elems, &soltype.ConstructorElem{Fn: ctorFn})
+	elems = append(elems, static.Elems...)
+	return &soltype.ObjectType{Elems: elems}
 }
 
 // getOrCreateClass returns the nominal ClassType token and ClassDef a class binds to,

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -125,8 +125,8 @@ func TestInferClassBasic(t *testing.T) {
 	}
 }
 
-// TestInferClassStatic covers the callable class value with static members (M5 B6):
-// the value binds a ctor-plus-static object rather than a bare constructor function, so
+// TestInferClassStatic covers the callable class value with static members. The value
+// binds a ctor-plus-static object rather than a bare constructor function, so
 // construction still resolves through the constructor call signature, a static field
 // reads its declared type, and a static method reads and calls through the same value.
 func TestInferClassStatic(t *testing.T) {
@@ -152,8 +152,8 @@ func TestInferClassStatic(t *testing.T) {
 }
 
 // A class with no static members keeps binding its bare constructor function, so the
-// single-callable-element object is minted only for the class values that need it (M5
-// B6). Construction and field access are unaffected.
+// single-callable-element object is minted only for the class values that need it.
+// Construction and field access are unaffected.
 func TestInferClassNoStaticStaysFunction(t *testing.T) {
 	src := `
 		class Point {
@@ -170,8 +170,7 @@ func TestInferClassNoStaticStaysFunction(t *testing.T) {
 
 // Binding a class value with statics to an un-annotated `var` widens the binding, which
 // walks the value object's members. A constructor and static methods carry no literal to
-// widen, so the walk passes them through rather than treating every element as a property
-// (M5 B6).
+// widen, so the walk passes them through rather than treating every element as a property.
 func TestInferClassValueVarWiden(t *testing.T) {
 	src := `
 		class Vec {
@@ -187,7 +186,7 @@ func TestInferClassValueVarWiden(t *testing.T) {
 
 // A read of a static member the class does not declare reports a MissingPropertyError,
 // blaming the property, so the class-value member path defers a genuine miss to the same
-// diagnostic an ordinary object read produces (M5 B6).
+// diagnostic an ordinary object read produces.
 func TestInferClassStaticMissing(t *testing.T) {
 	src := `
 		class Vec {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -125,6 +125,82 @@ func TestInferClassBasic(t *testing.T) {
 	}
 }
 
+// TestInferClassStatic covers the callable class value with static members (M5 B6):
+// the value binds a ctor-plus-static object rather than a bare constructor function, so
+// construction still resolves through the constructor call signature, a static field
+// reads its declared type, and a static method reads and calls through the same value.
+func TestInferClassStatic(t *testing.T) {
+	src := `
+		class Vec {
+			x: number,
+			y: number,
+			static dim: number = 2,
+			static unit(f: number) -> number { return f },
+		}
+		val v = Vec(1, 2)
+		val d = Vec.dim
+		val u = Vec.unit
+		val r = Vec.unit(3)
+	`
+	classValues(t, src, map[string]string{
+		"Vec": "{new (x: number, y: number) -> Vec, dim: number, unit(f: number) -> number}",
+		"v":   "Vec",
+		"d":   "number",
+		"u":   "fn (f: number) -> number",
+		"r":   "number",
+	}, map[string]string{"Vec": "Vec"})
+}
+
+// A class with no static members keeps binding its bare constructor function, so the
+// single-callable-element object is minted only for the class values that need it (M5
+// B6). Construction and field access are unaffected.
+func TestInferClassNoStaticStaysFunction(t *testing.T) {
+	src := `
+		class Point {
+			x: number,
+			y: number,
+		}
+		val p = Point(1, 2)
+	`
+	classValues(t, src, map[string]string{
+		"Point": "fn (x: number, y: number) -> Point",
+		"p":     "Point",
+	}, nil)
+}
+
+// Binding a class value with statics to an un-annotated `var` widens the binding, which
+// walks the value object's members. A constructor and static methods carry no literal to
+// widen, so the walk passes them through rather than treating every element as a property
+// (M5 B6).
+func TestInferClassValueVarWiden(t *testing.T) {
+	src := `
+		class Vec {
+			x: number,
+			static dim: number = 2,
+		}
+		var X = Vec
+	`
+	classValues(t, src, map[string]string{
+		"X": "{new (x: number) -> Vec, dim: number}",
+	}, nil)
+}
+
+// A read of a static member the class does not declare reports a MissingPropertyError,
+// blaming the property, so the class-value member path defers a genuine miss to the same
+// diagnostic an ordinary object read produces (M5 B6).
+func TestInferClassStaticMissing(t *testing.T) {
+	src := `
+		class Vec {
+			x: number,
+			static dim: number = 2,
+		}
+		val bad = Vec.nope
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: nope", errs[0].Message())
+}
+
 // TestInferClassGeneric covers a generic class: the constructor is generalized over
 // its type parameters, construction infers the type arguments, member access
 // projects the instance's argument into a field typed by a parameter, and a

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -61,12 +61,8 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl, ns string) (so
 		t, src := c.inferFuncDecl(scope, lvl, d)
 		return t, src, true
 	case *ast.ClassDecl:
-		// inferClassDecl returns the RAW class value — a bare constructor func type, or a
-		// ctor-plus-static object when the class declares statics — for the SCC driver to
-		// constrain into the value binding var and generalize, and registers the instance
-		// type binding plus the nominal ClassDef as side effects. ns is the class's
-		// dep_graph namespace, threaded through so the registry and the minted ClassType
-		// are keyed by the namespace-qualified name.
+		// inferClassDecl returns the RAW class value for the SCC driver and registers the
+		// instance type binding plus the nominal ClassDef; ns is the namespace for keying.
 		return c.inferClassDecl(scope, lvl, d, ns)
 	default:
 		c.reportUnsupported(d)

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -61,11 +61,12 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl, ns string) (so
 		t, src := c.inferFuncDecl(scope, lvl, d)
 		return t, src, true
 	case *ast.ClassDecl:
-		// inferClassDecl returns the RAW constructor func type for the SCC driver to
-		// constrain into the value binding var and generalize, and registers the
-		// instance type binding plus the nominal ClassDef as side effects. ns is the
-		// class's dep_graph namespace, threaded through so the registry and the minted
-		// ClassType are keyed by the namespace-qualified name.
+		// inferClassDecl returns the RAW class value — a bare constructor func type, or a
+		// ctor-plus-static object when the class declares statics — for the SCC driver to
+		// constrain into the value binding var and generalize, and registers the instance
+		// type binding plus the nominal ClassDef as side effects. ns is the class's
+		// dep_graph namespace, threaded through so the registry and the minted ClassType
+		// are keyed by the namespace-qualified name.
 		return c.inferClassDecl(scope, lvl, d, ns)
 	default:
 		c.reportUnsupported(d)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1257,14 +1257,29 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 // ok=false means no concrete func was found (e.g. a deferred callee with no lower
 // bound yet) — the caller skips return recovery. PR1 bindings have at most one
 // func lower bound; overload sets (PR6) resolve through resolveOverload, not here.
+//
+// A class value with static members is an object carrying its constructor as a
+// ConstructorElem rather than a bare FuncType, so a call `Point(1, 2)` recovers the
+// constructor signature through that element. An inline object callee yields it directly.
+// A binding var yields it through an object lower bound, the same look-through the
+// FuncType arm runs for a named function.
 func resolveFunc(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:
 		return t, true
+	case *soltype.ObjectType:
+		if ctor, ok := t.Constructor(); ok {
+			return ctor.Fn, true
+		}
 	case *soltype.TypeVarType:
 		for _, lb := range t.LowerBounds {
-			if fn, ok := lb.(*soltype.FuncType); ok {
-				return fn, true
+			switch lb := lb.(type) {
+			case *soltype.FuncType:
+				return lb, true
+			case *soltype.ObjectType:
+				if ctor, ok := lb.Constructor(); ok {
+					return ctor.Fn, true
+				}
 			}
 		}
 	}
@@ -1972,6 +1987,13 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// member resolves through member lookup here, since the structural field-requirement
 	// path below reads only properties and panics on a non-property member (M5 B3).
 	if res, ok := c.classBodyMember(lvl, blame, name, recvCarrier); ok {
+		return res
+	}
+	// A class value carries its static members on the same object as its constructor, so
+	// a static read `Point.origin` resolves through member lookup here. A static method,
+	// getter, or setter would otherwise be invisible to the structural path below, which
+	// reads only properties (M5 B6).
+	if res, ok := c.classValueMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
 	fieldVar := c.freshAt(lvl)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1992,7 +1992,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// A class value carries its static members on the same object as its constructor, so
 	// a static read `Point.origin` resolves through member lookup here. A static method,
 	// getter, or setter would otherwise be invisible to the structural path below, which
-	// reads only properties (M5 B6).
+	// reads only properties.
 	if res, ok := c.classValueMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1989,10 +1989,8 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	if res, ok := c.classBodyMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}
-	// A class value carries its static members on the same object as its constructor, so
-	// a static read `Point.origin` resolves through member lookup here. A static method,
-	// getter, or setter would otherwise be invisible to the structural path below, which
-	// reads only properties.
+	// A static read `Point.origin` resolves through member lookup here, since the
+	// structural path below reads only properties and misses a static method or accessor.
 	if res, ok := c.classValueMember(lvl, blame, name, recvCarrier); ok {
 		return res
 	}

--- a/internal/solver/widen.go
+++ b/internal/solver/widen.go
@@ -37,7 +37,14 @@ func widen(t soltype.Type) soltype.Type {
 	case *soltype.ObjectType:
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
 		for i, e := range t.Elems {
-			p := soltype.AsProperty(e)
+			// Only a property holds a literal to widen. A class value's constructor and
+			// its method, getter, and setter statics carry no literal field, so they pass
+			// through unchanged, the same way mutBubbler leaves a non-property member be.
+			p, ok := e.(*soltype.PropertyElem)
+			if !ok {
+				elems[i] = e
+				continue
+			}
 			elems[i] = &soltype.PropertyElem{Name: p.Name, Type: widen(p.Type), Optional: p.Optional, Readonly: p.Readonly}
 		}
 		return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact}


### PR DESCRIPTION
A class with static members now binds a ctor-plus-static object as its value type instead of a bare constructor function. This allows static field reads and method calls to resolve through the same value that constructs instances.

**Key changes:**

- Added `ConstructorElem` to represent the unnamed call signature a class value carries alongside its static members. A class with no statics continues to bind a bare `FuncType` for simplicity.

- `classValue()` in `infer_class.go` produces the appropriate value type: a bare constructor for classes without statics, or an exact object holding `ConstructorElem` plus static fields/methods/getters/setters for classes with statics.

- `classValueMember()` in `classes.go` resolves static member reads like `Point.origin` by looking up the member on the class-value object. Missing statics report through the standard `MissingPropertyError` path.

- Updated constraint rules to handle class values flowing into function targets (via the constructor element) and into object targets (matching constructor requirements covariantly).

- `resolveFunc()` in `infer_expr.go` now extracts the constructor signature from class-value objects when resolving callees, so `Point(1, 2)` works whether `Point` is a bare function or a ctor-plus-static object.

- `widen()` in `widen.go` passes through constructor and static method/getter/setter members unchanged, widening only property literals.

- Updated type equality, printing, visitor, and level-of checks to handle `ConstructorElem` consistently with other object members.

**Tests added:**

- `TestInferClassStatic`: class with static field and method
- `TestInferClassNoStaticStaysFunction`: class without statics keeps bare function binding
- `TestInferClassValueVarWiden`: widening a class-value binding
- `TestInferClassStaticMissing`: missing static member error
- `TestEqualTypeConstructorElem`: constructor equality under alpha-renaming
- `TestAcceptConstructorElem`: visitor traversal of constructor signatures
- `TestLevelOfConstructorElem`: level computation through constructors
- `TestPrintConstructorElem`: printing class values with constructors
- `TestFreeTypeVarsConstructorElem`: free variable collection in constructors

https://claude.ai/code/session_01JnehHYQ8SnV1FADAkBh5qY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Class values with static fields and methods can now be accessed directly, including static member reads and calls.
  * Classes with static members retain both callable constructor behavior and static member types.
  * Class constructors can participate in type checking, inference, comparisons, and displayed type information.

* **Bug Fixes**
  * Improved diagnostics for missing static members.
  * Preserved non-property class members during type widening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->