### PR TITLE
M5 C1: Implement nominal class subtyping and class-vs-object rules

### DIFF
--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -48,7 +48,7 @@ type MethodReceiver struct {
 func (r *MethodReceiver) Span() Span { return r.Span_ }
 
 // Exported constructor for use in parser
-func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*TypeParam, extends *TypeRefTypeAnn, implements []*TypeRefTypeAnn, body []ClassElem, export, declare bool, span Span) *ClassDecl {
+func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*TypeParam, extends *TypeRefTypeAnn, implements []*TypeRefTypeAnn, body []ClassElem, export, declare, final bool, span Span) *ClassDecl {
 	return &ClassDecl{
 		Name:           name,
 		LifetimeParams: lifetimeParams,
@@ -58,6 +58,7 @@ func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*Ty
 		Body:           body,
 		export:         export,
 		declare:        declare,
+		final:          final,
 		span:           span,
 		provenance:     nil,
 	}
@@ -73,9 +74,8 @@ func (d *ClassDecl) SetOverride(o bool) { d.override = o }
 // Final reports whether the class was declared `final`. A final class has no
 // subclasses, so its instance type is exact (exact-types §2.6): the checker projects
 // an exact body for it.
-func (d *ClassDecl) Final() bool     { return d.final }
-func (d *ClassDecl) SetFinal(f bool) { d.final = f }
-func (d *ClassDecl) Span() Span      { return d.span }
+func (d *ClassDecl) Final() bool { return d.final }
+func (d *ClassDecl) Span() Span  { return d.span }
 func (d *ClassDecl) Accept(v Visitor) {
 	// TODO(#634): traverse d.Decorators once Decorator has Accept.
 	if v.EnterDecl(d) {

--- a/internal/ast/class.go
+++ b/internal/ast/class.go
@@ -13,6 +13,7 @@ type ClassDecl struct {
 	export         bool
 	declare        bool
 	override       bool
+	final          bool
 	span           Span
 	provenance     provenance.Provenance
 }
@@ -62,13 +63,19 @@ func NewClassDecl(name *Ident, lifetimeParams []*LifetimeParam, typeParams []*Ty
 	}
 }
 
-func (*ClassDecl) isDecl()             {}
-func (d *ClassDecl) Export() bool      { return d.export }
-func (d *ClassDecl) SetExport(e bool)  { d.export = e }
-func (d *ClassDecl) Declare() bool     { return d.declare }
-func (d *ClassDecl) Override() bool    { return d.override }
+func (*ClassDecl) isDecl()              {}
+func (d *ClassDecl) Export() bool       { return d.export }
+func (d *ClassDecl) SetExport(e bool)   { d.export = e }
+func (d *ClassDecl) Declare() bool      { return d.declare }
+func (d *ClassDecl) Override() bool     { return d.override }
 func (d *ClassDecl) SetOverride(o bool) { d.override = o }
-func (d *ClassDecl) Span() Span        { return d.span }
+
+// Final reports whether the class was declared `final`. A final class has no
+// subclasses, so its instance type is exact (exact-types §2.6): the checker projects
+// an exact body for it.
+func (d *ClassDecl) Final() bool     { return d.final }
+func (d *ClassDecl) SetFinal(f bool) { d.final = f }
+func (d *ClassDecl) Span() Span      { return d.span }
 func (d *ClassDecl) Accept(v Visitor) {
 	// TODO(#634): traverse d.Decorators once Decorator has Accept.
 	if v.EnterDecl(d) {
@@ -120,9 +127,9 @@ func (f *FieldElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(f)
 }
-func (f *FieldElem) Span() Span { return f.Span_ }
-func (f *FieldElem) Doc() string         { return f.doc }
-func (f *FieldElem) SetDoc(doc string)   { f.doc = doc }
+func (f *FieldElem) Span() Span        { return f.Span_ }
+func (f *FieldElem) Doc() string       { return f.doc }
+func (f *FieldElem) SetDoc(doc string) { f.doc = doc }
 
 type MethodElem struct {
 	Name     ObjKey
@@ -144,9 +151,9 @@ func (m *MethodElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(m)
 }
-func (m *MethodElem) Span() Span { return m.Span_ }
-func (m *MethodElem) Doc() string         { return m.doc }
-func (m *MethodElem) SetDoc(doc string)   { m.doc = doc }
+func (m *MethodElem) Span() Span        { return m.Span_ }
+func (m *MethodElem) Doc() string       { return m.doc }
+func (m *MethodElem) SetDoc(doc string) { m.doc = doc }
 
 // GetterElem represents a getter in a class.
 type GetterElem struct {
@@ -169,9 +176,9 @@ func (g *GetterElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(g)
 }
-func (g *GetterElem) Span() Span { return g.Span_ }
-func (g *GetterElem) Doc() string         { return g.doc }
-func (g *GetterElem) SetDoc(doc string)   { g.doc = doc }
+func (g *GetterElem) Span() Span        { return g.Span_ }
+func (g *GetterElem) Doc() string       { return g.doc }
+func (g *GetterElem) SetDoc(doc string) { g.doc = doc }
 
 // ConstructorElem represents an explicit `constructor(...) { ... }` block
 // inside a class body. The constructor's receiver is represented by
@@ -199,9 +206,9 @@ func (c *ConstructorElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(c)
 }
-func (c *ConstructorElem) Span() Span { return c.Span_ }
-func (c *ConstructorElem) Doc() string         { return c.doc }
-func (c *ConstructorElem) SetDoc(doc string)   { c.doc = doc }
+func (c *ConstructorElem) Span() Span        { return c.Span_ }
+func (c *ConstructorElem) Doc() string       { return c.doc }
+func (c *ConstructorElem) SetDoc(doc string) { c.doc = doc }
 
 // SetterElem represents a setter in a class.
 type SetterElem struct {
@@ -224,6 +231,6 @@ func (s *SetterElem) Accept(v Visitor) {
 	}
 	v.ExitClassElem(s)
 }
-func (s *SetterElem) Span() Span { return s.Span_ }
-func (s *SetterElem) Doc() string         { return s.doc }
-func (s *SetterElem) SetDoc(doc string)   { s.doc = doc }
+func (s *SetterElem) Span() Span        { return s.Span_ }
+func (s *SetterElem) Doc() string       { return s.doc }
+func (s *SetterElem) SetDoc(doc string) { s.doc = doc }

--- a/internal/checker/tests/class_test.go
+++ b/internal/checker/tests/class_test.go
@@ -68,6 +68,60 @@ func TestClassImplements(t *testing.T) {
 	}
 }
 
+// TestClassInheritedMemberAccess verifies that a member declared on a superclass is
+// accessible through a subclass instance. `getObjectAccess` walks the instance object's
+// `Extends` chain when the member is not found directly, so an inherited field read and an
+// inherited method call both resolve to the member's declared type on the subclass value.
+func TestClassInheritedMemberAccess(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		bindingName  string
+		expectedType string
+	}{
+		"InheritedProperty": {
+			input: `
+				class Animal {
+					name: string,
+				}
+				class Dog extends Animal {
+					constructor(mut self) {}
+				}
+				val d = Dog()
+				val n = d.name
+			`,
+			bindingName:  "n",
+			expectedType: "string",
+		},
+		"InheritedMethod": {
+			input: `
+				class Animal {
+					name: string,
+					speak(self) -> string { return "..." },
+				}
+				class Dog extends Animal {
+					constructor(mut self) {}
+				}
+				val d = Dog()
+				val s = d.speak()
+			`,
+			bindingName:  "s",
+			expectedType: "string",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ns := mustInferAsModule(t, test.input)
+			actual := collectBindingTypes(ns)
+			got, ok := actual[test.bindingName]
+			require.Truef(t, ok, "binding %q not found", test.bindingName)
+			assert.Equalf(t, test.expectedType, got,
+				"unexpected type for %q", test.bindingName)
+		})
+	}
+}
+
 // TestClassImplementsConformance verifies that a class declaring
 // `implements I` is checked structurally against `I` (#558). Each
 // sub-case feeds source through InferModule and asserts on the resulting

--- a/internal/interop/decl.go
+++ b/internal/interop/decl.go
@@ -97,7 +97,7 @@ func convertFuncDecl(df *dts_parser.FuncDecl) (*ast.FuncDecl, error) {
 		typeParams,
 		params,
 		returnType,
-		nil, // nil throws is equivalent to throws never (PR #384)
+		nil,   // nil throws is equivalent to throws never (PR #384)
 		nil,   // body is nil for declarations
 		false, // export - will be set by export handling
 		true,  // declare is always true for .d.ts files
@@ -252,6 +252,7 @@ func convertClassDecl(cctx *convertCtx, dc *dts_parser.ClassDecl) (*ast.ClassDec
 		bodyElems,
 		false, // export - will be set by export handling
 		true,  // declare is always true for .d.ts files
+		false, // final
 		convertSpan(dc.Span()),
 	), nil
 }

--- a/internal/interop/dts_to_esc.go
+++ b/internal/interop/dts_to_esc.go
@@ -920,8 +920,9 @@ func fuseTrio(info *trioInfo) (*ast.ClassDecl, error) {
 		extends,
 		nil, // implements
 		body,
-		true, // export
-		true, // declare
+		true,  // export
+		true,  // declare
+		false, // final
 		convertSpan(info.instance.Span()),
 	), nil
 }

--- a/internal/interop/extract_test.go
+++ b/internal/interop/extract_test.go
@@ -261,7 +261,7 @@ func TestExtractClassRecordsStaticMembers(t *testing.T) {
 		ast.NewIdentifier("Widget", emptySpan()),
 		nil, nil, nil, nil,
 		[]ast.ClassElem{instMethod, staticMethod},
-		false, true, emptySpan(),
+		false, true, false, emptySpan(),
 	)
 	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{classDecl}, true, emptySpan())
 
@@ -308,7 +308,7 @@ func TestExtractClassResolvesStaticViaTypeRef(t *testing.T) {
 		ast.NewIdentifier("Foo", emptySpan()),
 		nil, nil, nil, nil,
 		[]ast.ClassElem{staticMethod},
-		false, true, emptySpan(),
+		false, true, false, emptySpan(),
 	)
 	declareGlobal := ast.NewDeclareGlobalDecl([]ast.Decl{classDecl}, true, emptySpan())
 

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -193,6 +193,7 @@ func (p *Parser) Decl() ast.Decl {
 	override := false
 	declare := false
 	async := false
+	final := false
 
 	decorators := p.parseDecorators()
 
@@ -253,6 +254,17 @@ func (p *Parser) Decl() ast.Decl {
 		p.reportError(token.Span, "async can only be used with functions")
 	}
 
+	var finalSpan ast.Span
+	if token.Type == Final {
+		final = true
+		finalSpan = token.Span
+		token = p.lexer.next()
+	}
+
+	if final && token.Type != Class {
+		p.reportError(finalSpan, "'final' can only be used with classes")
+	}
+
 	var decl ast.Decl
 	// nolint: exhaustive
 	switch token.Type {
@@ -267,7 +279,7 @@ func (p *Parser) Decl() ast.Decl {
 	case Enum:
 		decl = p.enumDecl(start, export, declare)
 	case Class:
-		decl = p.classDecl(start, export, declare)
+		decl = p.classDecl(start, export, declare, final)
 	case Identifier:
 		// `namespace` is contextual — only meaningful inside declare blocks,
 		// but we parse it wherever a decl is valid and let the checker enforce
@@ -469,7 +481,7 @@ func (p *Parser) declareBlockBody(override bool) []ast.Decl {
 //	('extends' typeAnn ('(' expr* ')')?)?
 //	('implements' typeAnn (',' typeAnn)*)?
 //	'{' classElem* '}'
-func (p *Parser) classDecl(start ast.Location, export, declare bool) ast.Decl {
+func (p *Parser) classDecl(start ast.Location, export, declare, final bool) ast.Decl {
 	token := p.lexer.peek()
 	var name *ast.Ident
 	if token.Type != Identifier {
@@ -553,6 +565,7 @@ func (p *Parser) classDecl(start ast.Location, export, declare bool) ast.Decl {
 		end := p.lexer.currentLocation
 		span := ast.Span{Start: start, End: end, SourceID: p.lexer.source.ID}
 		decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, nil, export, declare, span)
+		decl.SetFinal(final)
 		return decl
 	}
 	p.lexer.consume()
@@ -563,6 +576,7 @@ func (p *Parser) classDecl(start ast.Location, export, declare bool) ast.Decl {
 	end := p.lexer.currentLocation
 	span := ast.Span{Start: start, End: end, SourceID: p.lexer.source.ID}
 	decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, body, export, declare, span)
+	decl.SetFinal(final)
 	return decl
 }
 

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -564,8 +564,7 @@ func (p *Parser) classDecl(start ast.Location, export, declare, final bool) ast.
 		p.reportError(token.Span, "Expected '{' to start class body")
 		end := p.lexer.currentLocation
 		span := ast.Span{Start: start, End: end, SourceID: p.lexer.source.ID}
-		decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, nil, export, declare, span)
-		decl.SetFinal(final)
+		decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, nil, export, declare, final, span)
 		return decl
 	}
 	p.lexer.consume()
@@ -575,8 +574,7 @@ func (p *Parser) classDecl(start ast.Location, export, declare, final bool) ast.
 
 	end := p.lexer.currentLocation
 	span := ast.Span{Start: start, End: end, SourceID: p.lexer.source.ID}
-	decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, body, export, declare, span)
-	decl.SetFinal(final)
+	decl := ast.NewClassDecl(name, lifetimeParams, typeParams, extends, implements, body, export, declare, final, span)
 	return decl
 }
 

--- a/internal/parser/lexer.go
+++ b/internal/parser/lexer.go
@@ -39,6 +39,7 @@ var keywords = map[string]TokenType{
 	"export":     Export,
 	"declare":    Declare,
 	"override":   Override,
+	"final":      Final,
 	"infer":      Infer,
 	"if":         If,
 	"else":       Else,

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -885,6 +885,40 @@ func TestClassDeclarations(t *testing.T) {
 	}
 }
 
+func TestParseFinalClass(t *testing.T) {
+	parseClass := func(t *testing.T, src string) *ast.ClassDecl {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		decls, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc", Contents: src})
+		require.Empty(t, errors)
+		require.Len(t, decls, 1)
+		cls, ok := decls[0].(*ast.ClassDecl)
+		require.True(t, ok, "first decl is a class")
+		return cls
+	}
+
+	t.Run("final sets the flag", func(t *testing.T) {
+		require.True(t, parseClass(t, `final class Point { x: number }`).Final())
+	})
+	t.Run("a plain class is not final", func(t *testing.T) {
+		require.False(t, parseClass(t, `class Point { x: number }`).Final())
+	})
+	t.Run("export final composes", func(t *testing.T) {
+		cls := parseClass(t, `export final class Point { x: number }`)
+		require.True(t, cls.Final())
+		require.True(t, cls.Export())
+	})
+
+	t.Run("final on a non-class is rejected", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, errors := ParseDecls(ctx, &ast.Source{ID: 0, Path: "input.esc", Contents: `final fn foo() {}`})
+		require.Len(t, errors, 1)
+		require.Equal(t, "'final' can only be used with classes", errors[0].Message)
+	})
+}
+
 func TestClassElemDocs(t *testing.T) {
 	parseClass := func(t *testing.T, src string) *ast.ClassDecl {
 		t.Helper()

--- a/internal/parser/stmt.go
+++ b/internal/parser/stmt.go
@@ -13,7 +13,7 @@ func (p *Parser) isStatementInitiator(tt TokenType) bool {
 	// nolint: exhaustive
 	switch tt {
 	case Val, Var, Fn, Type, Interface, Enum, Class, Return, Throw,
-		For, If, Import, Export, Declare, Override, Async, AtSign,
+		For, If, Import, Export, Declare, Override, Async, Final, AtSign,
 		EndOfFile:
 		return true
 	default:
@@ -31,7 +31,7 @@ func (p *Parser) skipToNextStatement(stopOn TokenType) {
 		case EndOfFile, stopOn:
 			return
 		case Val, Var, Fn, Type, Interface, Enum, Class, Return, Throw,
-			For, If, Import, Export, Declare, Override, Async, AtSign:
+			For, If, Import, Export, Declare, Override, Async, Final, AtSign:
 			return
 		default:
 			p.lexer.consume()
@@ -146,7 +146,7 @@ func (p *Parser) stmt() ast.Stmt {
 		token.Type == Async, token.Type == Fn, token.Type == Var, token.Type == Val,
 		token.Type == Type, token.Type == Interface, token.Type == Enum,
 		token.Type == Declare, token.Type == Export, token.Type == Override, token.Type == Class,
-		token.Type == AtSign:
+		token.Type == Final, token.Type == AtSign:
 		decl := p.Decl()
 		if decl == nil {
 			return nil

--- a/internal/parser/token.go
+++ b/internal/parser/token.go
@@ -111,6 +111,7 @@ const (
 	Bigint
 	Void
 	Override
+	Final // 'final' class modifier
 )
 
 type Token struct {

--- a/internal/printer/print_decl_audit_test.go
+++ b/internal/printer/print_decl_audit_test.go
@@ -90,6 +90,8 @@ func TestPrintDeclAudit_RoundTrip(t *testing.T) {
 		{"declare class extends", `declare class C extends Base {}`},
 		{"declare class constrained generic", `declare class C<T: string> {}`},
 		{"export declare class", `export declare class C {}`},
+		{"final class", `final class C {}`},
+		{"export final class", `export final class C {}`},
 
 		// --- decorator syntax @js("...") (§3.3) ---
 		// @js attaches only to value-introducing decls (val/var, fn,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -227,6 +227,9 @@ func (p *Printer) printClassDecl(decl *ast.ClassDecl) {
 	if decl.Declare() {
 		p.writeString("declare ")
 	}
+	if decl.Final() {
+		p.writeString("final ")
+	}
 
 	p.writeString("class ")
 	p.writeString(decl.Name.Name)

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -109,8 +109,11 @@ func (c *Context) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, 
 		// AsProperty discipline.
 		panic(fmt.Sprintf("projectClassBody: %s projected to non-ObjectType %T", ct.Name, projected))
 	}
-	obj.Inexact = !ct.Final
-	return obj, true
+	// Accept returns def.Body's own ObjectType when the body holds none of the
+	// substituted vars, so setting Inexact on obj directly would mutate the shared
+	// registry Body. Wrap the projected elements in a fresh ObjectType and set exactness
+	// on the copy, matching the non-generic path above.
+	return &soltype.ObjectType{Elems: obj.Elems, Inexact: !ct.Final}, true
 }
 
 // classPair keys the nominal subtype walk's seen-set by the (sub, super) class NAMES,

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -144,7 +144,7 @@ func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen set.S
 		def, _ := c.classDef(sub.Name)
 		var errs []SolverError
 		n := min(len(sub.TypeArgs), len(super.TypeArgs))
-		for i := 0; i < n; i++ {
+		for i := range n {
 			variance := Invariant
 			if def != nil && i < len(def.Variance) {
 				variance = def.Variance[i]
@@ -167,11 +167,11 @@ func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen set.S
 	}
 
 	// Different names: sub <: super holds when any direct super of sub reaches super.
-	// Substitute sub's arguments into each super edge so a generic base is checked at the
-	// instance's arguments, e.g. B<5> declared `extends A<T>` walks the edge A<5>.
+	// Substitute sub's arguments into each superclass type so a generic base is checked
+	// at the instance's arguments, e.g. B<5> declared `extends A<T>` walks A<5>.
 	if def, ok := c.classDef(sub.Name); ok {
-		for _, edge := range def.Supers {
-			s := substituteSuperArgs(def, sub, edge)
+		for _, superType := range def.Supers {
+			s := substituteSuperArgs(def, sub, superType)
 			if len(c.constrainNominalWalk(s, super, seen, walked)) == 0 {
 				return nil
 			}
@@ -180,26 +180,27 @@ func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen set.S
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
-// substituteSuperArgs rewrites a super edge's references to sub's class type parameters
-// to sub's actual arguments, so `class B<T> extends A<T>` checked at B<5> yields the
-// edge A<5>. A non-generic sub, whose edge holds no parameter vars, returns the edge
-// unchanged.
-func substituteSuperArgs(def *ClassDef, sub, edge *soltype.ClassType) *soltype.ClassType {
+// substituteSuperArgs rewrites a superclass type's references to sub's class type
+// parameters to sub's actual arguments, so `class B<T> extends A<T>` checked at B<5>
+// yields A<5>. A non-generic sub, whose superclass type holds no parameter vars, returns
+// the superclass type unchanged.
+func substituteSuperArgs(def *ClassDef, sub, superType *soltype.ClassType) *soltype.ClassType {
 	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
-		return edge
+		return superType
 	}
-	if ct, ok := edge.Accept(newClassSubst(def, sub), soltype.Positive).(*soltype.ClassType); ok {
+	if ct, ok := superType.Accept(newClassSubst(def, sub), soltype.Positive).(*soltype.ClassType); ok {
 		return ct
 	}
-	return edge
+	return superType
 }
 
 // projectedMember resolves a member access against a class instance by looking the
-// member up on the registered class body and projecting just that member to the
-// instance's arguments, returning ok=false when the receiver is not a class instance —
-// a plain object property, or a type variable — so the caller falls back to the
-// structural field-requirement path. A class instance whose class has no such member
-// reports the miss here.
+// member up on the class body — walking the declared `extends` chain for a member the
+// class inherits rather than declares — and projecting just that member to the instance's
+// arguments. It returns ok=false when the receiver is not a class instance — a plain
+// object property, or a type variable — so the caller falls back to the structural
+// field-requirement path. A class instance whose class and none of its ancestors declare
+// the member reports the miss here.
 //
 // Only a class receiver is intercepted. A plain object keeps the structural
 // field-requirement path, which threads the read-through-borrow and read-after-write
@@ -214,10 +215,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	if !ok || def.Body == nil {
 		return pathResult{}, false
 	}
-	// Member names are invariant under substitution, so look the member up on the
-	// unprojected body and project only the one accessed, rather than rebuilding the
-	// whole body per access.
-	member, found := def.Body.Member(name)
+	member, found := c.projectedClassMember(ct, name, set.NewSet[string]())
 	if !found {
 		// The miss is rare, so project the whole body here to render the diagnostic at
 		// the instance's arguments rather than the declared type parameters.
@@ -227,7 +225,42 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 		c.errs = append(c.errs, err)
 		return pathResult{value: &soltype.ErrorType{}}, true
 	}
-	return c.memberValue(lvl, blame, c.projectClassMember(def, ct, member)), true
+	return c.memberValue(lvl, blame, member), true
+}
+
+// projectedClassMember looks name up on ct's class body, then walks the declared
+// `extends` chain when the class does not declare the member itself, so a member
+// inherited from a superclass reads through a subclass instance. It returns the member
+// projected to ct's arguments, or found=false when neither the class nor any ancestor
+// declares it.
+//
+// Each superclass edge is first re-expressed at ct's arguments through
+// substituteSuperArgs before the walk recurses into it, so `class Dog<T> extends
+// Animal<T>` accessed at Dog<string> walks Animal<string>, and an inherited member typed
+// `T` projects to `string`. visited holds the class names already on the current chain,
+// bounding the walk on a cyclic hierarchy the same way constrainNominalWalk does.
+func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visited set.Set[string]) (soltype.ObjTypeElem, bool) {
+	def, ok := c.ctx.classDef(ct.Name)
+	if !ok || def.Body == nil {
+		return nil, false
+	}
+	// Member names are invariant under substitution, so look the member up on the
+	// unprojected body and project only the one accessed, rather than rebuilding the
+	// whole body per access.
+	if member, found := def.Body.Member(name); found {
+		return c.projectClassMember(def, ct, member), true
+	}
+	if visited.Contains(ct.Name) {
+		return nil, false
+	}
+	visited.Add(ct.Name)
+	for _, superType := range def.Supers {
+		superInstance := substituteSuperArgs(def, ct, superType)
+		if member, found := c.projectedClassMember(superInstance, name, visited); found {
+			return member, true
+		}
+	}
+	return nil, false
 }
 
 // classBodyMember resolves a method, getter, or setter read off a class-body ObjectType —

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -81,17 +82,22 @@ const (
 // projectClassBody returns the instance member view of a class instance: the
 // registered Body with each class type parameter replaced by the instance's
 // corresponding type argument and each lifetime parameter by its lifetime argument.
-// A non-generic instance, or one whose class is unregistered, projects the stored
-// Body unchanged. The class-vs-object constrain rule reads the whole projected body;
-// a single member access projects just that member through projectClassMember, so it
-// pays only for the member it reads rather than rebuilding every member.
-func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, bool) {
-	def, ok := c.ctx.classDef(ct.Name)
+// It returns ok=false when the class is unregistered so the caller can recover. The
+// class-vs-object constrain rule reads the whole projected body; a single member access
+// projects just that member through projectClassMember, so it pays only for the member
+// it reads rather than rebuilding every member.
+//
+// The projected body's Inexact flag follows the instance's Final: a final class is
+// exact, its member set closed, while a non-final class is inexact, since a subclass may
+// widen it (exact-types §2.6). The returned ObjectType is always a fresh wrapper so the
+// shared registry Body keeps its own flag.
+func (c *Context) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, bool) {
+	def, ok := c.classDef(ct.Name)
 	if !ok || def.Body == nil {
 		return nil, false
 	}
 	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
-		return def.Body, true
+		return &soltype.ObjectType{Elems: def.Body.Elems, Inexact: !ct.Final}, true
 	}
 	subst := newClassSubst(def, ct)
 	projected := def.Body.Accept(subst, soltype.Positive)
@@ -103,7 +109,86 @@ func (c *checker) projectClassBody(ct *soltype.ClassType) (*soltype.ObjectType, 
 		// AsProperty discipline.
 		panic(fmt.Sprintf("projectClassBody: %s projected to non-ObjectType %T", ct.Name, projected))
 	}
+	obj.Inexact = !ct.Final
 	return obj, true
+}
+
+// classPair keys the nominal subtype walk's seen-set by the (sub, super) class NAMES,
+// so a cyclic extends hierarchy terminates: the same name pair is never re-walked.
+// This is coarser than constrain's type-keyed seen-set on purpose — the walk decides a
+// relationship between nominal identities, and two instances of one class at different
+// arguments share the identity the walk cares about.
+type classPair struct{ sub, super string }
+
+// constrainNominal decides sub <: super between two class instances. It succeeds when
+// they name the same class, checking each type argument by the class's per-position
+// variance, or when sub reaches super transitively through the declared extends graph.
+// A (subName, supName) seen-set bounds the walk on a cyclic hierarchy. Until C2 infers
+// real variance, every ClassDef.Variance entry is Invariant, so every argument is
+// constrained in both directions — the conservative choice a sound rule falls back to.
+func (c *Context) constrainNominal(sub, super *soltype.ClassType, seen set.Set[constraintKey]) []SolverError {
+	return c.constrainNominalWalk(sub, super, seen, set.NewSet[classPair]())
+}
+
+func (c *Context) constrainNominalWalk(sub, super *soltype.ClassType, seen set.Set[constraintKey], walked set.Set[classPair]) []SolverError {
+	key := classPair{sub.Name, super.Name}
+	if walked.Contains(key) {
+		return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+	}
+	walked.Add(key)
+
+	if sub.Name == super.Name {
+		def, _ := c.classDef(sub.Name)
+		var errs []SolverError
+		n := min(len(sub.TypeArgs), len(super.TypeArgs))
+		for i := 0; i < n; i++ {
+			variance := Invariant
+			if def != nil && i < len(def.Variance) {
+				variance = def.Variance[i]
+			}
+			argSub, argSup := sub.TypeArgs[i], super.TypeArgs[i]
+			switch variance {
+			case Covariant:
+				errs = append(errs, c.constrain(argSub, argSup, seen, false)...)
+			case Contravariant:
+				errs = append(errs, c.constrain(argSup, argSub, seen, false)...)
+			case Bivariant:
+				// A phantom parameter appears nowhere in the body, so its argument imposes
+				// no constraint.
+			default: // Invariant
+				errs = append(errs, c.constrain(argSub, argSup, seen, false)...)
+				errs = append(errs, c.constrain(argSup, argSub, seen, false)...)
+			}
+		}
+		return errs
+	}
+
+	// Different names: sub <: super holds when any direct super of sub reaches super.
+	// Substitute sub's arguments into each super edge so a generic base is checked at the
+	// instance's arguments, e.g. B<5> declared `extends A<T>` walks the edge A<5>.
+	if def, ok := c.classDef(sub.Name); ok {
+		for _, edge := range def.Supers {
+			s := substituteSuperArgs(def, sub, edge)
+			if len(c.constrainNominalWalk(s, super, seen, walked)) == 0 {
+				return nil
+			}
+		}
+	}
+	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// substituteSuperArgs rewrites a super edge's references to sub's class type parameters
+// to sub's actual arguments, so `class B<T> extends A<T>` checked at B<5> yields the
+// edge A<5>. A non-generic sub, whose edge holds no parameter vars, returns the edge
+// unchanged.
+func substituteSuperArgs(def *ClassDef, sub, edge *soltype.ClassType) *soltype.ClassType {
+	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
+		return edge
+	}
+	if ct, ok := edge.Accept(newClassSubst(def, sub), soltype.Positive).(*soltype.ClassType); ok {
+		return ct
+	}
+	return edge
 }
 
 // projectedMember resolves a member access against a class instance by looking the
@@ -133,7 +218,7 @@ func (c *checker) projectedMember(lvl int, blame ast.Node, name string, carrier 
 	if !found {
 		// The miss is rare, so project the whole body here to render the diagnostic at
 		// the instance's arguments rather than the declared type parameters.
-		obj, _ := c.projectClassBody(ct)
+		obj, _ := c.ctx.projectClassBody(ct)
 		err := &MissingPropertyError{Sub: obj, Super: propReq(name, &soltype.UnknownType{}, false), Name: name}
 		err.prov, err.site = c.prov, blame
 		c.errs = append(c.errs, err)

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -125,3 +125,24 @@ func TestConstrainNominalArgVariance(t *testing.T) {
 			Messages(c.Constrain(box(numLit(5)), box(num()))))
 	})
 }
+
+// TestProjectClassBodyDoesNotMutateRegistry pins that projecting a class instance never
+// writes back to the shared ClassDef.Body. A generic class whose body mentions none of
+// its type parameters projects through the substitution path, where ObjectType.Accept
+// returns the registry Body unchanged; setting the projected exactness must land on a
+// fresh copy, not on that shared object.
+func TestProjectClassBodyDoesNotMutateRegistry(t *testing.T) {
+	c := &Context{}
+	body := exactObj(propElem("n", num())) // the body does not mention the type parameter
+	c.registerClass("Phantom", &ClassDef{
+		TypeParams: []*soltype.TypeParam{{Name: "T", Var: &soltype.TypeVarType{ID: 200}}},
+		Variance:   []Variance{Invariant},
+		Body:       body,
+	})
+
+	proj, ok := c.projectClassBody(&soltype.ClassType{Name: "Phantom", TypeArgs: []soltype.Type{num()}})
+	require.True(t, ok)
+	require.NotSame(t, body, proj)  // a fresh wrapper, not the shared registry Body
+	require.True(t, proj.Inexact)   // the non-final instance projects an inexact view
+	require.False(t, body.Inexact)  // the registry Body stays exact — never mutated
+}

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -1,0 +1,127 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// cls builds a non-generic class instance token for the nominal constrain tests.
+func cls(name string, final bool) *soltype.ClassType {
+	return &soltype.ClassType{Name: name, Final: final}
+}
+
+// TestConstrainNominal exercises the C1 nominal constrain rule directly on the Context,
+// registering ClassDefs by hand so it can cover cases source cannot yet produce — most
+// importantly a `final` class, whose surface syntax the parser does not accept.
+func TestConstrainNominal(t *testing.T) {
+	// registerPoint seeds a two-field class `{x: number, y: number}` under name.
+	registerPoint := func(c *Context, name string) {
+		c.registerClass(name, &ClassDef{Body: exactObj(propElem("x", num()), propElem("y", num()))})
+	}
+
+	t.Run("same class succeeds", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Empty(t, Messages(c.Constrain(cls("Point", false), cls("Point", false))))
+	})
+
+	t.Run("different unrelated classes reject", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		c.registerClass("Vec", &ClassDef{Body: exactObj(propElem("x", num()))})
+		require.Equal(t,
+			[]string{"cannot constrain Point <: Vec"},
+			Messages(c.Constrain(cls("Point", false), cls("Vec", false))))
+	})
+
+	t.Run("subclass reaches superclass through the graph", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "A")
+		c.registerClass("B", &ClassDef{
+			Body:   exactObj(propElem("x", num()), propElem("y", num())),
+			Supers: []*soltype.ClassType{cls("A", false)},
+		})
+		require.Empty(t, Messages(c.Constrain(cls("B", false), cls("A", false))))
+		// The reverse never holds: a superclass instance is not one of its subclass.
+		require.Equal(t,
+			[]string{"cannot constrain A <: B"},
+			Messages(c.Constrain(cls("A", false), cls("B", false))))
+	})
+
+	t.Run("transitive superclass across two edges", func(t *testing.T) {
+		c := &Context{}
+		c.registerClass("A", &ClassDef{Body: exactObj(propElem("x", num()))})
+		c.registerClass("B", &ClassDef{Body: exactObj(propElem("x", num())), Supers: []*soltype.ClassType{cls("A", false)}})
+		c.registerClass("C", &ClassDef{Body: exactObj(propElem("x", num())), Supers: []*soltype.ClassType{cls("B", false)}})
+		require.Empty(t, Messages(c.Constrain(cls("C", false), cls("A", false))))
+	})
+
+	t.Run("class into inexact object projects the body", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Empty(t, Messages(c.Constrain(cls("Point", false), inexactObj(propElem("x", num())))))
+	})
+
+	t.Run("non-final class into exact object rejects", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Equal(t,
+			[]string{"cannot constrain class Point <: exact object"},
+			Messages(c.Constrain(cls("Point", false), exactObj(propElem("x", num()), propElem("y", num())))))
+	})
+
+	t.Run("final class into matching exact object succeeds", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Empty(t, Messages(c.Constrain(cls("Point", true), exactObj(propElem("x", num()), propElem("y", num())))))
+	})
+
+	t.Run("final class into exact object with an extra member rejects", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Equal(t,
+			[]string{"object has extra property: y"},
+			Messages(c.Constrain(cls("Point", true), exactObj(propElem("x", num())))))
+	})
+
+	t.Run("object into class rejects", func(t *testing.T) {
+		c := &Context{}
+		registerPoint(c, "Point")
+		require.Equal(t,
+			[]string{"cannot constrain object <: class Point"},
+			Messages(c.Constrain(exactObj(propElem("x", num()), propElem("y", num())), cls("Point", false))))
+	})
+}
+
+// TestConstrainNominalArgVariance covers the per-argument dispatch of the same-name
+// rule. C1 treats every argument position as Invariant, so an argument must match in
+// both directions; C2 replaces this with inferred variance.
+func TestConstrainNominalArgVariance(t *testing.T) {
+	newBox := func() *Context {
+		c := &Context{}
+		c.registerClass("Box", &ClassDef{
+			TypeParams: []*soltype.TypeParam{{Name: "T", Var: &soltype.TypeVarType{ID: 100}}},
+			Variance:   []Variance{Invariant},
+			Body:       exactObj(propElem("value", &soltype.TypeVarType{ID: 100})),
+		})
+		return c
+	}
+	box := func(arg soltype.Type) *soltype.ClassType {
+		return &soltype.ClassType{Name: "Box", TypeArgs: []soltype.Type{arg}}
+	}
+
+	t.Run("equal arguments succeed", func(t *testing.T) {
+		c := newBox()
+		require.Empty(t, Messages(c.Constrain(box(numLit(5)), box(numLit(5)))))
+	})
+
+	t.Run("invariant argument rejects a widening", func(t *testing.T) {
+		c := newBox()
+		// Box<5> <: Box<number> fails: the invariant position also demands number <: 5.
+		require.Equal(t,
+			[]string{"cannot constrain number <: 5"},
+			Messages(c.Constrain(box(numLit(5)), box(num()))))
+	})
+}

--- a/internal/solver/classes_test.go
+++ b/internal/solver/classes_test.go
@@ -64,28 +64,6 @@ func TestConstrainNominal(t *testing.T) {
 		require.Empty(t, Messages(c.Constrain(cls("Point", false), inexactObj(propElem("x", num())))))
 	})
 
-	t.Run("non-final class into exact object rejects", func(t *testing.T) {
-		c := &Context{}
-		registerPoint(c, "Point")
-		require.Equal(t,
-			[]string{"cannot constrain class Point <: exact object"},
-			Messages(c.Constrain(cls("Point", false), exactObj(propElem("x", num()), propElem("y", num())))))
-	})
-
-	t.Run("final class into matching exact object succeeds", func(t *testing.T) {
-		c := &Context{}
-		registerPoint(c, "Point")
-		require.Empty(t, Messages(c.Constrain(cls("Point", true), exactObj(propElem("x", num()), propElem("y", num())))))
-	})
-
-	t.Run("final class into exact object with an extra member rejects", func(t *testing.T) {
-		c := &Context{}
-		registerPoint(c, "Point")
-		require.Equal(t,
-			[]string{"object has extra property: y"},
-			Messages(c.Constrain(cls("Point", true), exactObj(propElem("x", num())))))
-	})
-
 	t.Run("object into class rejects", func(t *testing.T) {
 		c := &Context{}
 		registerPoint(c, "Point")

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -421,6 +421,36 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			}
 			return errs
 		}
+		// A structural object never satisfies a nominal class target: nominal identity is
+		// declared, not structural, so `{x: 0}` is not a Point even when it carries every
+		// field. A ClassType super is concrete, so intercept it here rather than letting it
+		// fall through to the var arms.
+		if sup, ok := super.(*soltype.ClassType); ok {
+			return []SolverError{&StructuralIntoClassError{Sub: sub, Super: sup}}
+		}
+	case *soltype.ClassType:
+		switch sup := super.(type) {
+		case *soltype.ClassType:
+			// Nominal: identical name with a per-position argument check, or sub reaches
+			// sup transitively through the declared extends graph.
+			return c.constrainNominal(sub, sup, seen)
+		case *soltype.ObjectType:
+			// Target-dispatched (m4 plan forward note): a class instance satisfies a
+			// structural object target when the target is inexact, or when the class is
+			// final so its member set is closed. A non-final instance into an exact target
+			// rejects, since a subclass could add members the exact target cannot tolerate.
+			// Otherwise project the class body — exact when final, inexact otherwise — and
+			// reuse the object arm's width and exactness rules.
+			if !sup.Inexact && !sub.Final {
+				return []SolverError{&ClassIntoExactObjectError{Sub: sub, Super: sup}}
+			}
+			body, ok := c.projectClassBody(sub)
+			if !ok {
+				return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
+			}
+			return c.constrain(body, sup, seen, mutCtx)
+		}
+		// A ClassType against any other concrete falls through to the var arms below.
 	case *soltype.PromiseType:
 		if sup, ok := super.(*soltype.PromiseType); ok {
 			// PromiseType is covariant in its Inner: Promise<L> <: Promise<R> iff

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -296,26 +296,35 @@ type NonClassSuperError struct {
 	Name string
 }
 
-func (*CannotConstrainError) isSolverError()       {}
-func (*MutFieldError) isSolverError()              {}
-func (*ReadonlyFieldError) isSolverError()         {}
-func (*ReadonlyFieldSubtypeError) isSolverError()  {}
-func (*FuncArityMismatchError) isSolverError()     {}
-func (*TupleLengthMismatchError) isSolverError()   {}
-func (*SpreadNotTupleError) isSolverError()        {}
-func (*InexactTupleSpreadError) isSolverError()    {}
-func (*MissingPropertyError) isSolverError()       {}
-func (*InexactIntoExactError) isSolverError()      {}
-func (*InexactTupleIntoExactError) isSolverError() {}
-func (*InexactUnionIntoExactError) isSolverError() {}
-func (*ExtraPropertyError) isSolverError()         {}
-func (*ExtraElementError) isSolverError()          {}
-func (*OptionalPropertyError) isSolverError()      {}
-func (*MutabilityMismatchError) isSolverError()    {}
-func (*BorrowEscapeError) isSolverError()          {}
-func (*ClassIntoExactObjectError) isSolverError()  {}
-func (*StructuralIntoClassError) isSolverError()   {}
-func (*NonClassSuperError) isSolverError()         {}
+// CannotExtendFinalClassError fires when an `extends` clause names a final class. A
+// final class has no subclasses (exact-types §2.6), so it cannot be a superclass. Ref
+// carries the blame span and Name the rendered reference.
+type CannotExtendFinalClassError struct {
+	Ref  *ast.TypeRefTypeAnn
+	Name string
+}
+
+func (*CannotConstrainError) isSolverError()        {}
+func (*MutFieldError) isSolverError()               {}
+func (*ReadonlyFieldError) isSolverError()          {}
+func (*ReadonlyFieldSubtypeError) isSolverError()   {}
+func (*FuncArityMismatchError) isSolverError()      {}
+func (*TupleLengthMismatchError) isSolverError()    {}
+func (*SpreadNotTupleError) isSolverError()         {}
+func (*InexactTupleSpreadError) isSolverError()     {}
+func (*MissingPropertyError) isSolverError()        {}
+func (*InexactIntoExactError) isSolverError()       {}
+func (*InexactTupleIntoExactError) isSolverError()  {}
+func (*InexactUnionIntoExactError) isSolverError()  {}
+func (*ExtraPropertyError) isSolverError()          {}
+func (*ExtraElementError) isSolverError()           {}
+func (*OptionalPropertyError) isSolverError()       {}
+func (*MutabilityMismatchError) isSolverError()     {}
+func (*BorrowEscapeError) isSolverError()           {}
+func (*ClassIntoExactObjectError) isSolverError()   {}
+func (*StructuralIntoClassError) isSolverError()    {}
+func (*NonClassSuperError) isSolverError()          {}
+func (*CannotExtendFinalClassError) isSolverError() {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -429,6 +438,9 @@ func (e *StructuralIntoClassError) Related() []ast.Span { return relatedOf(e.pro
 
 func (e *NonClassSuperError) Span() ast.Span      { return e.Ref.Span() }
 func (e *NonClassSuperError) Related() []ast.Span { return nil }
+
+func (e *CannotExtendFinalClassError) Span() ast.Span      { return e.Ref.Span() }
+func (e *CannotExtendFinalClassError) Related() []ast.Span { return nil }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -1305,6 +1317,10 @@ func (e *StructuralIntoClassError) Message() string {
 
 func (e *NonClassSuperError) Message() string {
 	return fmt.Sprintf("`%s` does not name a class and cannot be extended or implemented.", e.Name)
+}
+
+func (e *CannotExtendFinalClassError) Message() string {
+	return fmt.Sprintf("Cannot extend `%s`; it is a final class and has no subclasses.", e.Name)
 }
 
 // describeBorrowInner renders the pointee of a borrow for a diagnostic. An immutable

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -262,6 +262,40 @@ type ReadonlyFieldSubtypeError struct {
 	site  ast.Node
 }
 
+// ClassIntoExactObjectError fires when a class instance flows into an exact
+// structural object target — `val foo: {x: number, y: number} = Point(1, 2)`. A
+// non-final class may have subclasses that add members, so an instance carries an
+// open tail of unknown properties an exact target cannot tolerate. A final class is
+// exact instead, so it projects an exact body and is checked structurally rather than
+// rejected here (exact-types §2.6). Holds the class instance and the object target.
+type ClassIntoExactObjectError struct {
+	Sub   *soltype.ClassType
+	Super *soltype.ObjectType
+	prov  NodeResolver
+	site  ast.Node
+}
+
+// StructuralIntoClassError fires when a structural object flows into a class-typed
+// target — `self.item = {x: 0}` where `item` is typed by a class. Nominal identity is
+// declared, not structural, so an object literal that happens to carry a class's
+// fields is still not that class. Holds the object source and the class target.
+type StructuralIntoClassError struct {
+	Sub   *soltype.ObjectType
+	Super *soltype.ClassType
+	prov  NodeResolver
+	site  ast.Node
+}
+
+// NonClassSuperError fires when a name in an `extends` or `implements` clause resolves
+// to a binding that is not a class — a type parameter, say. Only a class can be
+// extended or implemented, so the edge is rejected rather than silently dropped. An
+// unbound super name stays silent until M7's general TypeRef resolution reports the
+// undefined name centrally. Ref carries the blame span and Name the rendered reference.
+type NonClassSuperError struct {
+	Ref  *ast.TypeRefTypeAnn
+	Name string
+}
+
 func (*CannotConstrainError) isSolverError()       {}
 func (*MutFieldError) isSolverError()              {}
 func (*ReadonlyFieldError) isSolverError()         {}
@@ -279,6 +313,9 @@ func (*ExtraElementError) isSolverError()          {}
 func (*OptionalPropertyError) isSolverError()      {}
 func (*MutabilityMismatchError) isSolverError()    {}
 func (*BorrowEscapeError) isSolverError()          {}
+func (*ClassIntoExactObjectError) isSolverError()  {}
+func (*StructuralIntoClassError) isSolverError()   {}
+func (*NonClassSuperError) isSolverError()         {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -375,6 +412,23 @@ func (e *BorrowEscapeError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
 }
 func (e *BorrowEscapeError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *ClassIntoExactObjectError) Span() ast.Span {
+	// The class instance is the source value; blame it, degrade to the object target,
+	// else the site.
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
+}
+func (e *ClassIntoExactObjectError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *StructuralIntoClassError) Span() ast.Span {
+	// The object literal is the source value; blame it, degrade to the class target,
+	// else the site.
+	return spanOfFirst(e.prov, e.site, e.Sub, e.Super)
+}
+func (e *StructuralIntoClassError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *NonClassSuperError) Span() ast.Span      { return e.Ref.Span() }
+func (e *NonClassSuperError) Related() []ast.Span { return nil }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -1241,6 +1295,18 @@ func (e *MutabilityMismatchError) Message() string {
 		describeBorrowInner(e.Sub.Inner), describeBorrowInner(e.Super.Inner))
 }
 
+func (e *ClassIntoExactObjectError) Message() string {
+	return fmt.Sprintf("cannot constrain class %s <: exact object", describe(e.Sub))
+}
+
+func (e *StructuralIntoClassError) Message() string {
+	return fmt.Sprintf("cannot constrain object <: class %s", describe(e.Super))
+}
+
+func (e *NonClassSuperError) Message() string {
+	return fmt.Sprintf("`%s` does not name a class and cannot be extended or implemented.", e.Name)
+}
+
 // describeBorrowInner renders the pointee of a borrow for a diagnostic. An immutable
 // field read routes its result through a fresh field-read variable (fieldReadBorrow),
 // so the borrow's inner can be an inference variable whose raw `t{N}` name means
@@ -1327,6 +1393,10 @@ func describe(t soltype.Type) string {
 		return "tuple"
 	case *soltype.ObjectType:
 		return "object"
+	case *soltype.ClassType:
+		// A class instance renders nominally under its display name, `Point` or
+		// `Box<number>`, so a diagnostic naming it matches the printer's surface form.
+		return soltype.Print(t)
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
 		// object above. That is deliberate and consistent with the Union/Intersection

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -313,6 +313,10 @@ func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
 			err.prov, err.site = c.prov, n
 		case *BorrowEscapeError:
 			err.prov, err.site = c.prov, n
+		case *ClassIntoExactObjectError:
+			err.prov, err.site = c.prov, n
+		case *StructuralIntoClassError:
+			err.prov, err.site = c.prov, n
 		case *ReadonlyFieldError:
 			err.site = n
 		case *ReadonlyFieldSubtypeError:

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -177,16 +177,20 @@ func (c *checker) resolveClassImplements(scope *Scope, decl *ast.ClassDecl) []*s
 // rather than routing through resolveTypeAnn, whose general TypeRef resolution lands
 // with the alias work.
 //
-// A nil result is currently dropped by the callers with no diagnostic. C1 reports the
-// non-class case as NonClassSuperError, and M7's general TypeRef resolution reports an
-// unbound name (planning/simple_sub/m5-implementation-plan.md).
+// A name bound to a non-class binding — a type parameter, say — is reported as a
+// NonClassSuperError. An unbound name stays silent, so the undefined name is not
+// reported twice: the general TypeRef resolution planned for M7 reports it centrally.
+// See planning/simple_sub/m5-implementation-plan.md.
 func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltype.ClassType {
 	name := ast.QualIdentToString(ref.Name)
-	if b, ok := scope.GetType(name); ok {
-		if ct, ok := b.Type.(*soltype.ClassType); ok {
-			return ct
-		}
+	b, ok := scope.GetType(name)
+	if !ok {
+		return nil
 	}
+	if ct, ok := b.Type.(*soltype.ClassType); ok {
+		return ct
+	}
+	c.errs = append(c.errs, &NonClassSuperError{Ref: ref, Name: name})
 	return nil
 }
 

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -152,10 +152,21 @@ func (c *checker) resolveClassSupers(scope *Scope, decl *ast.ClassDecl) []*solty
 	if decl.Extends == nil {
 		return nil
 	}
-	if ct := c.resolveClassRef(scope, decl.Extends); ct != nil {
-		return []*soltype.ClassType{ct}
+	ct := c.resolveClassRef(scope, decl.Extends)
+	if ct == nil {
+		return nil
 	}
-	return nil
+	if ct.Final {
+		// A final class has no subclasses, so it cannot be a superclass. Report the
+		// clause and drop the edge, so the erroneous subtype relationship is never
+		// recorded in the nominal graph.
+		c.errs = append(c.errs, &CannotExtendFinalClassError{
+			Ref:  decl.Extends,
+			Name: ast.QualIdentToString(decl.Extends.Name),
+		})
+		return nil
+	}
+	return []*soltype.ClassType{ct}
 }
 
 // resolveClassImplements resolves a class's `implements` interfaces to their

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -119,7 +119,7 @@ func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl) (*soltype.
 			}
 		}
 	}
-	self := &soltype.ClassType{Name: name}
+	self := &soltype.ClassType{Name: name, Final: decl.Final()}
 	def := &ClassDef{Body: &soltype.ObjectType{}, Static: &soltype.ObjectType{}}
 	c.ctx.registerClass(name, def)
 	// Register the type binding so a self-referential type in the body resolves to this

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -318,6 +318,30 @@ func TestInferClassIntoObject(t *testing.T) {
 	})
 }
 
+// TestInferClassFinal covers `final ⇒ exact instance` (exact-types §2.6): a final class
+// has no subclasses, so its instance projects an exact body and is checked structurally
+// against an exact object target rather than rejected outright the way a non-final
+// instance is. The `final` modifier is parsed by the class-declaration grammar.
+func TestInferClassFinal(t *testing.T) {
+	const finalPoint = `
+		final class Point { x: number, y: number }
+		val p = Point(1, 2)
+	`
+	t.Run("into a matching exact object succeeds", func(t *testing.T) {
+		_, _, errs := inferSource(t, finalPoint+`val foo: {x: number, y: number} = p`)
+		require.Empty(t, errs)
+	})
+	t.Run("into an exact object missing one of its members rejects", func(t *testing.T) {
+		_, _, errs := inferSource(t, finalPoint+`val foo: {x: number} = p`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "object has extra property: y", errs[0].Message())
+	})
+	t.Run("into an inexact object still succeeds", func(t *testing.T) {
+		_, _, errs := inferSource(t, finalPoint+`val foo: {x: number, y: number, ...} = p`)
+		require.Empty(t, errs)
+	})
+}
+
 // TestInferClassObjectDestructure covers destructuring a class instance with an object
 // pattern — `val {x, y} = p`. This is NOT the nominal InstancePat constructor pattern
 // `Point({x, y})`, which D1 adds; it is a plain object pattern, which lowers to the

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -710,6 +710,52 @@ func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
 }
 */
 
+// TestInferClassInheritedMemberAccess checks that a member declared on a superclass is
+// reachable through a subclass instance: reading an inherited field and calling an
+// inherited method both resolve to the member's declared type. projectedMember walks the
+// `extends` chain, so `class Dog extends Animal` lets `d.name` project to `string` and
+// `d.speak()` return `string`.
+func TestInferClassInheritedMemberAccess(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Animal {
+			name: string,
+			speak(self) -> string { return "..." },
+		}
+		class Dog extends Animal {
+			constructor(mut self) {}
+		}
+		val d = Dog()
+		val n = d.name
+		val s = d.speak()
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["n"])
+	require.Equal(t, "string", values["s"])
+}
+
+// TestInferClassInheritedMemberAccessMultiLevel checks that the extends walk reaches a
+// member declared two levels up. `class Leaf extends Mid extends Base` reads `base`,
+// declared on Base, through a Leaf instance. The binding names avoid the member names so a
+// separate dep-graph bug — a class field whose name matches a top-level `val` gets a
+// spurious dependency on it — does not scramble the inference order.
+func TestInferClassInheritedMemberAccessMultiLevel(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Base {
+			base: number,
+		}
+		class Mid extends Base {
+			constructor(mut self) {}
+		}
+		class Leaf extends Mid {
+			constructor(mut self) {}
+		}
+		val leaf = Leaf()
+		val got = leaf.base
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["got"])
+}
+
 // TestInferClassErrors asserts the full diagnostic for each rejected class shape.
 func TestInferClassErrors(t *testing.T) {
 	tests := []struct {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -397,6 +397,27 @@ func TestInferClassNonClassSuper(t *testing.T) {
 	})
 }
 
+// TestInferClassExtendFinal covers the rule that a final class cannot be a superclass:
+// a final class has no subclasses (exact-types §2.6), so an `extends` clause naming one
+// reports CannotExtendFinalClassError. A non-final superclass is unaffected.
+func TestInferClassExtendFinal(t *testing.T) {
+	t.Run("extending a final class is rejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			final class A { x: number, constructor(mut self) { self.x = 0 } }
+			class B extends A { constructor(mut self) {} }
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "Cannot extend `A`; it is a final class and has no subclasses.", errs[0].Message())
+	})
+	t.Run("extending a non-final class is allowed", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class A { x: number, constructor(mut self) { self.x = 0 } }
+			class B extends A { constructor(mut self) {} }
+		`)
+		require.Empty(t, errs)
+	})
+}
+
 // TestInferClassMutualRecursion covers classes that reference each other, or
 // themselves, through the SCC path (M5 B2). The dep graph condenses a mutually
 // recursive group into one type-key component ordered before every class's value key,

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -318,6 +318,44 @@ func TestInferClassIntoObject(t *testing.T) {
 	})
 }
 
+// TestInferClassObjectDestructure covers destructuring a class instance with an object
+// pattern — `val {x, y} = p`. This is NOT the nominal InstancePat constructor pattern
+// `Point({x, y})`, which D1 adds; it is a plain object pattern, which lowers to the
+// constraint `p <: {x: _, y: _, ...}` — an inexact object requirement — and so rides
+// C1's class-vs-object projection rule. Each named field binds at the projected member
+// type, and a field the class lacks reports the object-requirement miss. Before C1 the
+// requirement had no class-vs-object rule and failed with `cannot constrain ? <: object`.
+func TestInferClassObjectDestructure(t *testing.T) {
+	t.Run("binds fields at their member types", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Point { x: number, y: number }
+			val p = Point(1, 2)
+			val {x, y} = p
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "number", values["x"])
+		require.Equal(t, "number", values["y"])
+	})
+	t.Run("projects a generic instance's argument into the bound field", func(t *testing.T) {
+		values, _, errs := inferSource(t, `
+			class Box<T> { value: T }
+			val b = Box(5)
+			val {value} = b
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "5", values["value"])
+	})
+	t.Run("a field the class lacks is rejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Point { x: number, y: number }
+			val p = Point(1, 2)
+			val {z} = p
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "object is missing property: z", errs[0].Message())
+	})
+}
+
 // TestInferClassNonClassSuper covers the C1 diagnostic for an `extends` or `implements`
 // clause naming something that is not a class. A class type parameter resolves to a
 // binding that is not a ClassType, so using it as a super reports NonClassSuperError

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -248,14 +248,10 @@ func TestInferClassJoinDistinctArgs(t *testing.T) {
 }
 
 // Reading a member off that union — `b.value` for b : Box<5> | Box<"hello"> — distributes
-// over the union and joins each arm's `value` field into 5 | "hello".
-//
-// DISABLED until C1 lands. classCarrier resolves only an unambiguous class, so a variable
-// whose lower bounds carry two different instantiations falls to the structural
-// field-requirement path. That path has no class-vs-object rule yet, so each Box<…> arm
-// fails `cannot constrain ? <: object` and v coalesces to never. C1 adds the
-// nominal-vs-structural rule; re-enable then and assert v : 5 | "hello" with no errors.
-/*
+// over the union and joins each arm's `value` field into 5 | "hello". Each Box<…> arm
+// rides C1's class-vs-object rule: the field read constrains the arm against an inexact
+// `{value: _, ...}` requirement, which projects the class body and binds the requirement's
+// var to that arm's field type.
 func TestInferClassJoinMemberAccess(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		class Box<T> { value: T }
@@ -266,7 +262,78 @@ func TestInferClassJoinMemberAccess(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, `5 | "hello"`, values["v"])
 }
-*/
+
+// TestInferClassNominalSubtype covers C1's nominal constrain rule reached from source
+// through a type-parameter bound, the one class-typed constraint target source can
+// produce before M7's general TypeRef resolution. `class Box<T: A>` makes a construction
+// `Box(arg)` constrain `arg <: A`, so the argument exercises each leg of the rule.
+func TestInferClassNominalSubtype(t *testing.T) {
+	// base declares A, a subclass B, an unrelated Other, and a bounded Box<T: A>.
+	const base = `
+		class A { x: number, constructor(mut self) { self.x = 0 } }
+		class B extends A { constructor(mut self) {} }
+		class Other { y: number, constructor(mut self) { self.y = 0 } }
+		class Box<T: A> { value: T }
+	`
+	t.Run("same class satisfies the bound", func(t *testing.T) {
+		values, _, errs := inferSource(t, base+`val b = Box(A())`)
+		require.Empty(t, errs)
+		require.Equal(t, "Box<A>", values["b"])
+	})
+	t.Run("subclass satisfies the bound through the graph", func(t *testing.T) {
+		values, _, errs := inferSource(t, base+`val b = Box(B())`)
+		require.Empty(t, errs)
+		require.Equal(t, "Box<B>", values["b"])
+	})
+	t.Run("unrelated class rejects", func(t *testing.T) {
+		_, _, errs := inferSource(t, base+`val b = Box(Other())`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain Other <: A", errs[0].Message())
+	})
+	t.Run("structural object rejects against a class bound", func(t *testing.T) {
+		_, _, errs := inferSource(t, base+`val b = Box({x: 0})`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain object <: class A", errs[0].Message())
+	})
+}
+
+// TestInferClassIntoObject covers C1's target-dispatched class-vs-object rule reached
+// from source through an object type annotation, which resolves today even though a
+// bare class name in annotation position does not. A class instance flows into an inexact
+// object target by projecting its body, and into an exact object target it is rejected,
+// since a non-final class may have subclasses that add members.
+func TestInferClassIntoObject(t *testing.T) {
+	const point = `
+		class Point { x: number, y: number }
+		val p = Point(1, 2)
+	`
+	t.Run("into inexact object succeeds", func(t *testing.T) {
+		_, _, errs := inferSource(t, point+`val foo: {x: number, y: number, ...} = p`)
+		require.Empty(t, errs)
+	})
+	t.Run("into exact object rejects", func(t *testing.T) {
+		_, _, errs := inferSource(t, point+`val foo: {x: number, y: number} = p`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain class Point <: exact object", errs[0].Message())
+	})
+}
+
+// TestInferClassNonClassSuper covers the C1 diagnostic for an `extends` or `implements`
+// clause naming something that is not a class. A class type parameter resolves to a
+// binding that is not a ClassType, so using it as a super reports NonClassSuperError
+// rather than silently dropping the edge.
+func TestInferClassNonClassSuper(t *testing.T) {
+	t.Run("extends a type parameter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `class B<T> extends T { constructor(mut self) {} }`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "`T` does not name a class and cannot be extended or implemented.", errs[0].Message())
+	})
+	t.Run("implements a type parameter", func(t *testing.T) {
+		_, _, errs := inferSource(t, `class C<T> implements T {}`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "`T` does not name a class and cannot be extended or implemented.", errs[0].Message())
+	})
+}
 
 // TestInferClassMutualRecursion covers classes that reference each other, or
 // themselves, through the SCC path (M5 B2). The dep graph condenses a mutually


### PR DESCRIPTION
Adds the C1 constraint rule for nominal class subtyping and class-to-object projection, enabling classes to flow into structural object targets and participate in inheritance hierarchies.

**Key changes:**

- **Nominal subtyping (`constrainNominal`)**: Classes satisfy a class target when they have the same name (checking type arguments by variance) or reach the target transitively through the declared `extends` graph. A cyclic hierarchy is bounded by a seen-set on class name pairs.

- **Class-vs-object projection**: A class instance flows into an inexact object target by projecting its body. Into an exact object target, a non-final class is rejected (since a subclass could add members), while a final class projects an exact body and is checked structurally. The projected body's exactness follows the instance's `Final` flag.

- **Structural-into-class rejection**: A structural object never satisfies a nominal class target, since nominal identity is declared, not structural.

- **Super edge validation**: An `extends` or `implements` clause naming a non-class binding (e.g., a type parameter) now reports `NonClassSuperError` rather than silently dropping the edge.

- **Error types**: Added `ClassIntoExactObjectError`, `StructuralIntoClassError`, and `NonClassSuperError` with appropriate diagnostics and span attribution.

- **Test coverage**: Comprehensive tests for nominal subtyping (same class, subclass through graph, transitive supers, type argument variance), class-into-object projection (inexact vs. exact targets), object destructuring of class instances, and non-class super detection. Re-enabled `TestInferClassJoinMemberAccess` now that the class-vs-object rule exists.

https://claude.ai/code/session_01UkwMtTvwJJZMc5NG1ZVnnN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nominal class subtyping, including inheritance and generic variance rules.
  * Improved class compatibility with object types, including member projection and destructuring.
  * Added clearer diagnostics for invalid class, object, and superclass relationships.

* **Bug Fixes**
  * Corrected class exactness handling and union-based class member access.
  * Type inference now reports errors when a superclass reference is not a class.

* **Tests**
  * Expanded coverage for class inheritance, generics, object compatibility, destructuring, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->