### PR TITLE
M5 B7: Support namespace-qualified class registry keys

### DIFF
--- a/internal/solver/blame_test.go
+++ b/internal/solver/blame_test.go
@@ -347,7 +347,7 @@ func TestNilVarDeclPatternBlamesDeclWithoutPanic(t *testing.T) {
 	c := newChecker()
 	d := ast.NewVarDecl(ast.ValKind, nil, nil, numExpr(5), false, false, testSpan())
 	require.NotPanics(t, func() {
-		_, _, ok := c.inferDeclDef(NewScope(), 0, d)
+		_, _, ok := c.inferDeclDef(NewScope(), 0, d, "")
 		require.False(t, ok)
 	})
 	require.Len(t, c.errs, 1)

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -65,6 +65,17 @@ type checker struct {
 	// nested functions included. inferComponent clears it per top-level binding for the
 	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
+
+	// classNamespace is the dep_graph namespace of the class declaration currently
+	// being inferred, empty at the root namespace and outside any class body.
+	// inferClassDecl sets it on entry and restores it on exit. A class-body type
+	// reference resolves through it first, so a bare `Point` written inside a class in
+	// namespace `Geometry` finds the sibling `Geometry.Point` before falling back to a
+	// root-namespace `Point`, mirroring dep_graph's qualified-first dependency
+	// resolution. The class registry and every ClassType token are keyed by the
+	// namespace-qualified name, so this reconstructs the qualified key a bare reference
+	// omits.
+	classNamespace string
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -32,7 +32,15 @@ import (
 // Once every body has refined the field vars, a non-generic body is coalesced so member
 // lookup reads concrete member types. A generic body keeps its parameter vars symbolic
 // for per-instance projection.
-func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (soltype.Type, provenance.Provenance, bool) {
+func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns string) (soltype.Type, provenance.Provenance, bool) {
+	// A class-body type reference resolves against the class's own namespace first, so a
+	// bare sibling reference such as `start: Point` inside a class in namespace
+	// `Geometry` finds `Geometry.Point`. Save and restore around the walk, since a class
+	// is only ever inferred at top level.
+	prevNS := c.classNamespace
+	c.classNamespace = ns
+	defer func() { c.classNamespace = prevNS }()
+
 	// Resolve the class's type parameters into a child scope so the body resolves the
 	// class's T to one shared var, quantified at the class boundary and freshened per
 	// construction. A non-generic class reuses the enclosing scope.
@@ -47,10 +55,11 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 	// the pair the SCC pre-pass registered for this class — an empty shell it minted
 	// before any type params were resolved, so that a sibling in the same recursive group
 	// resolves a forward reference to this class through the shared token (B2). A class
-	// reached without a pre-registered shell mints and registers one here. B1 uses the
-	// bare local name as the qualified key, correct for the top-level default namespace;
-	// namespace-qualified keys ride the namespace work.
-	self, def := c.getOrCreateClass(scope, decl)
+	// reached without a pre-registered shell mints and registers one here. The registry,
+	// the minted token, and the scope type binding are all keyed by the namespace-
+	// qualified name, so two sibling `class Point` declarations in different namespaces
+	// stay distinct (B7).
+	self, def := c.getOrCreateClass(scope, decl, ns)
 	// Populate the type-param-derived fields the pre-pass left empty. This is the second
 	// phase: the pre-pass registers a bare identity so forward references resolve, and
 	// this call — running once every sibling is registered, so a bound like `<T: Sibling>`
@@ -110,25 +119,38 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl) (so
 // key infers a body (M5 B2). That pre-pass discards the return; only inferClassDecl reads
 // it. No placeholder-patch phase is needed: the token a sibling captured is the one that
 // carries the finished body.
-func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl) (*soltype.ClassType, *ClassDef) {
-	name := decl.Name.Name
-	if def, ok := c.ctx.classDef(name); ok {
-		if b, found := scope.GetType(name); found {
-			if self, ok := b.Type.(*soltype.ClassType); ok && self.Name == name {
+func (c *checker) getOrCreateClass(scope *Scope, decl *ast.ClassDecl, ns string) (*soltype.ClassType, *ClassDef) {
+	qname := qualifyClassName(ns, decl)
+	if def, ok := c.ctx.classDef(qname); ok {
+		if b, found := scope.GetType(qname); found {
+			if self, ok := b.Type.(*soltype.ClassType); ok && self.Name == qname {
 				return self, def
 			}
 		}
 	}
-	self := &soltype.ClassType{Name: name, Final: decl.Final()}
+	self := &soltype.ClassType{Name: qname, Final: decl.Final()}
 	def := &ClassDef{Body: &soltype.ObjectType{}, Static: &soltype.ObjectType{}}
-	c.ctx.registerClass(name, def)
-	// Register the type binding so a self-referential type in the body resolves to this
-	// class rather than falling through as unknown.
-	scope.defineType(name, TypeBinding{
+	c.ctx.registerClass(qname, def)
+	// Register the type binding under the qualified name so a cross-namespace reference
+	// resolves it and a self-referential type in the body resolves to this class rather
+	// than falling through as unknown. A bare sibling reference resolves through the
+	// checker's classNamespace, which reconstructs this qualified key.
+	scope.defineType(qname, TypeBinding{
 		Type:    self,
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
 	})
 	return self, def
+}
+
+// qualifyClassName returns a class's dep_graph-qualified name — the namespace joined
+// to the local name with a dot, or the bare local name at the root namespace. This is
+// the same `CurrentNamespace + "." + name` rule dep_graph forms binding keys with, so
+// the registry key and the ClassType token match the value binding's qualified key.
+func qualifyClassName(ns string, decl *ast.ClassDecl) string {
+	if ns == "" {
+		return decl.Name.Name
+	}
+	return ns + "." + decl.Name.Name
 }
 
 // typeParamVars returns each type parameter's var, the arguments a class's own
@@ -194,7 +216,7 @@ func (c *checker) resolveClassImplements(scope *Scope, decl *ast.ClassDecl) []*s
 // See planning/simple_sub/m5-implementation-plan.md.
 func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltype.ClassType {
 	name := ast.QualIdentToString(ref.Name)
-	b, ok := scope.GetType(name)
+	b, ok := c.lookupClassBinding(scope, name)
 	if !ok {
 		return nil
 	}
@@ -205,6 +227,35 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltyp
 	return nil
 }
 
+// lookupClassBinding resolves a written type name to its scope TypeBinding, honoring
+// three precedence levels in order:
+//
+//  1. A lexically-scoped type parameter shadows everything. A type parameter is bound
+//     under its bare name in the class's own child scope, so a bare lookup that lands on
+//     a non-class binding — a `T` in `class Box<T>` — wins outright, even against a
+//     sibling class of the same name.
+//  2. A same-namespace class comes next. Classes are keyed by their qualified name, so a
+//     bare `Point` written inside a class in namespace `Geometry` resolves the sibling
+//     `Geometry.Point` here, ahead of a root-namespace `Point`. This mirrors dep_graph's
+//     qualified-first dependency resolution.
+//  3. A bare class binding is the fallback — a root-namespace class referenced bare, or
+//     an already-qualified `Geometry.Point` reference written from another namespace,
+//     whose doubly-qualified probe in step 2 missed.
+func (c *checker) lookupClassBinding(scope *Scope, name string) (TypeBinding, bool) {
+	bare, bareOK := scope.GetType(name)
+	if bareOK {
+		if _, isClass := bare.Type.(*soltype.ClassType); !isClass {
+			return bare, true
+		}
+	}
+	if c.classNamespace != "" {
+		if b, ok := scope.GetType(c.classNamespace + "." + name); ok {
+			return b, true
+		}
+	}
+	return bare, bareOK
+}
+
 // resolveClassTypeAnn resolves a type annotation appearing in a class body or a
 // type-parameter bound. It first consults the type scope for a reference to a class or
 // type parameter — a bare `Point` or `T`, or a generic class instance `Box<number>` — the
@@ -213,7 +264,7 @@ func (c *checker) resolveClassRef(scope *Scope, ref *ast.TypeRefTypeAnn) *soltyp
 func (c *checker) resolveClassTypeAnn(scope *Scope, ann ast.TypeAnn, lvl int) (soltype.Type, bool) {
 	if ref, ok := ann.(*ast.TypeRefTypeAnn); ok {
 		name := ast.QualIdentToString(ref.Name)
-		if b, ok := scope.GetType(name); ok {
+		if b, ok := c.lookupClassBinding(scope, name); ok {
 			if len(ref.TypeArgs) == 0 {
 				return b.Type, true
 			}

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -58,7 +58,7 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	// reached without a pre-registered shell mints and registers one here. The registry,
 	// the minted token, and the scope type binding are all keyed by the namespace-
 	// qualified name, so two sibling `class Point` declarations in different namespaces
-	// stay distinct (B7).
+	// stay distinct.
 	self, def := c.getOrCreateClass(scope, decl, ns)
 	// Populate the type-param-derived fields the pre-pass left empty. This is the second
 	// phase: the pre-pass registers a bare identity so forward references resolve, and

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1159,6 +1159,35 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			wantValues: map[string]string{"Point": "fn (x: number) -> Point"},
 			wantTypes:  map[string]string{"Point": "Point"},
 		},
+		{
+			name: "MutuallyRecursiveAcrossNamespaces",
+			srcs: map[string]string{
+				"foo/a.esc": `
+					class A {
+						peer: bar.B,
+					}
+				`,
+				"bar/b.esc": `
+					class B {
+						peer: foo.A,
+					}
+				`,
+			},
+			// A cycle whose two classes live in different namespaces. The dep graph
+			// condenses it into one type-key component, and the SCC pre-pass registers
+			// both shells under their qualified names before either body is walked, so
+			// each cross-namespace forward reference — `foo.A` naming `bar.B` and back —
+			// resolves through the shared token with no placeholder leak. Each field
+			// renders the peer under its bare name.
+			wantValues: map[string]string{
+				"foo.A": "fn (peer: B) -> A",
+				"bar.B": "fn (peer: A) -> B",
+			},
+			wantTypes: map[string]string{
+				"foo.A": "A",
+				"bar.B": "B",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1054,10 +1054,9 @@ func TestConstructorInitErrors(t *testing.T) {
 // `class Point` declarations under different directory-derived namespaces stay distinct:
 // a bare "Point" key would collide and merge their bodies, while the qualified keys keep
 // each class's body its own. A class-body type reference resolves against its own
-// namespace first, so a bare sibling
-// reference still resolves and a qualified cross-namespace reference resolves too. Every
-// class still renders under its bare name, since the printer strips the namespace
-// prefix.
+// namespace first, so a bare sibling reference still resolves and a qualified
+// cross-namespace reference resolves too. Every class still renders under its bare name,
+// since the printer strips the namespace prefix.
 //
 // The instance-construction and member-access forms — `val p = Point(1, 2); p.x` — are
 // exercised at the root namespace by TestInferClassBasic. A namespaced instance is not
@@ -1076,8 +1075,16 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 		{
 			name: "SiblingSameNameDistinctNamespaces",
 			srcs: map[string]string{
-				"geometry/point.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
-				"shape/point.esc":    "class Point {\n\t\t\t\t\tlabel: string,\n\t\t\t\t}",
+				"geometry/point.esc": `
+					class Point {
+						x: number,
+					}
+				`,
+				"shape/point.esc": `
+					class Point {
+						label: string,
+					}
+				`,
 			},
 			// Each constructor is synthesized from its OWN class body, so the two bodies
 			// never merged on a shared "Point" registry entry. Both render bare.
@@ -1093,7 +1100,14 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 		{
 			name: "IntraNamespaceSiblingReference",
 			srcs: map[string]string{
-				"geometry/shapes.esc": "class Line {\n\t\t\t\t\tstart: Point,\n\t\t\t\t}\n\t\t\t\tclass Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+				"geometry/shapes.esc": `
+					class Line {
+						start: Point,
+					}
+					class Point {
+						x: number,
+					}
+				`,
 			},
 			// The bare `Point` in Line's field resolves to the sibling geometry.Point
 			// through the class's own namespace, not to any other namespace's Point.
@@ -1109,8 +1123,16 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 		{
 			name: "CrossNamespaceReference",
 			srcs: map[string]string{
-				"geometry/point.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
-				"shape/line.esc":     "class Line {\n\t\t\t\t\tstart: geometry.Point,\n\t\t\t\t}",
+				"geometry/point.esc": `
+					class Point {
+						x: number,
+					}
+				`,
+				"shape/line.esc": `
+					class Line {
+						start: geometry.Point,
+					}
+				`,
 			},
 			// The qualified `geometry.Point` reference from the shape namespace resolves
 			// to the geometry class's registered type binding.
@@ -1126,7 +1148,11 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 		{
 			name: "RootNamespaceUnchanged",
 			srcs: map[string]string{
-				"input.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+				"input.esc": `
+					class Point {
+						x: number,
+					}
+				`,
 			},
 			// A root-namespace class keeps its bare name as the qualified key, so nothing
 			// changes for the common single-namespace case.

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1048,7 +1048,7 @@ func TestConstructorInitErrors(t *testing.T) {
 	}
 }
 
-// TestInferClassNamespaceQualified covers the namespace-qualified class registry (B7).
+// TestInferClassNamespaceQualified covers the namespace-qualified class registry.
 // A class is keyed in the nominal registry, in its ClassType token, and in its scope
 // type binding by its dep_graph-qualified name, e.g. "geometry.Point". So two sibling
 // `class Point` declarations under different directory-derived namespaces stay distinct:
@@ -1165,12 +1165,11 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			values, types, errs := inferSources(t, test.srcs)
 			require.Empty(t, errs)
-			for name, want := range test.wantValues {
-				require.Equal(t, want, values[name], "value binding %q", name)
-			}
-			for name, want := range test.wantTypes {
-				require.Equal(t, want, types[name], "type binding %q", name)
-			}
+			// Compare the whole maps, not just the expected keys, so a stale bare `Point`
+			// binding left over from a namespace collision would surface as an unexpected
+			// extra entry rather than passing unnoticed.
+			require.Equal(t, test.wantValues, values)
+			require.Equal(t, test.wantTypes, types)
 		})
 	}
 }

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1047,3 +1047,104 @@ func TestConstructorInitErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestInferClassNamespaceQualified covers the namespace-qualified class registry (B7).
+// A class is keyed in the nominal registry, in its ClassType token, and in its scope
+// type binding by its dep_graph-qualified name, e.g. "geometry.Point". So two sibling
+// `class Point` declarations under different directory-derived namespaces stay distinct:
+// a bare "Point" key would collide and merge their bodies, while the qualified keys keep
+// each class's body its own. A class-body type reference resolves against its own
+// namespace first, so a bare sibling
+// reference still resolves and a qualified cross-namespace reference resolves too. Every
+// class still renders under its bare name, since the printer strips the namespace
+// prefix.
+//
+// The instance-construction and member-access forms — `val p = Point(1, 2); p.x` — are
+// exercised at the root namespace by TestInferClassBasic. A namespaced instance is not
+// constructed here because a bare value reference does not yet resolve across a
+// namespace boundary in the solver; that value-side resolution rides the broader
+// namespace-in-scope work. The per-class constructor signature, synthesized from the
+// class's own body, stands in as the observable proof that each class resolves its own
+// members with no cross-namespace collision.
+func TestInferClassNamespaceQualified(t *testing.T) {
+	tests := []struct {
+		name       string
+		srcs       map[string]string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			name: "SiblingSameNameDistinctNamespaces",
+			srcs: map[string]string{
+				"geometry/point.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+				"shape/point.esc":    "class Point {\n\t\t\t\t\tlabel: string,\n\t\t\t\t}",
+			},
+			// Each constructor is synthesized from its OWN class body, so the two bodies
+			// never merged on a shared "Point" registry entry. Both render bare.
+			wantValues: map[string]string{
+				"geometry.Point": "fn (x: number) -> Point",
+				"shape.Point":    "fn (label: string) -> Point",
+			},
+			wantTypes: map[string]string{
+				"geometry.Point": "Point",
+				"shape.Point":    "Point",
+			},
+		},
+		{
+			name: "IntraNamespaceSiblingReference",
+			srcs: map[string]string{
+				"geometry/shapes.esc": "class Line {\n\t\t\t\t\tstart: Point,\n\t\t\t\t}\n\t\t\t\tclass Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+			},
+			// The bare `Point` in Line's field resolves to the sibling geometry.Point
+			// through the class's own namespace, not to any other namespace's Point.
+			wantValues: map[string]string{
+				"geometry.Line":  "fn (start: Point) -> Line",
+				"geometry.Point": "fn (x: number) -> Point",
+			},
+			wantTypes: map[string]string{
+				"geometry.Line":  "Line",
+				"geometry.Point": "Point",
+			},
+		},
+		{
+			name: "CrossNamespaceReference",
+			srcs: map[string]string{
+				"geometry/point.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+				"shape/line.esc":     "class Line {\n\t\t\t\t\tstart: geometry.Point,\n\t\t\t\t}",
+			},
+			// The qualified `geometry.Point` reference from the shape namespace resolves
+			// to the geometry class's registered type binding.
+			wantValues: map[string]string{
+				"shape.Line":     "fn (start: Point) -> Line",
+				"geometry.Point": "fn (x: number) -> Point",
+			},
+			wantTypes: map[string]string{
+				"shape.Line":     "Line",
+				"geometry.Point": "Point",
+			},
+		},
+		{
+			name: "RootNamespaceUnchanged",
+			srcs: map[string]string{
+				"input.esc": "class Point {\n\t\t\t\t\tx: number,\n\t\t\t\t}",
+			},
+			// A root-namespace class keeps its bare name as the qualified key, so nothing
+			// changes for the common single-namespace case.
+			wantValues: map[string]string{"Point": "fn (x: number) -> Point"},
+			wantTypes:  map[string]string{"Point": "Point"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, types, errs := inferSources(t, test.srcs)
+			require.Empty(t, errs)
+			for name, want := range test.wantValues {
+				require.Equal(t, want, values[name], "value binding %q", name)
+			}
+			for name, want := range test.wantTypes {
+				require.Equal(t, want, types[name], "type binding %q", name)
+			}
+		})
+	}
+}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -10,7 +10,8 @@ import (
 // (inferComponent) and returns its RAW (un-coalesced, variable-carrying) type to
 // constrain against the binding's binding var, the decl's provenance, and ok=false
 // when it introduces no value. It does NOT bind the name — inferComponent owns
-// scope placement.
+// scope placement. ns is the decl's dep_graph namespace, used only by the ClassDecl
+// arm to reconstruct the class's qualified registry key; every other kind ignores it.
 //
 // The type MUST stay raw: inferComponent coalesces the binding var once, after every
 // group member has constrained it (phase 3). Coalescing a `val` initializer here
@@ -27,7 +28,7 @@ import (
 //   - VarDecl with a destructuring pattern → UnsupportedNodeError (initializer
 //     still walked first, so it surfaces its own errors)
 //   - any decl kind outside the M2 subset → UnsupportedNodeError
-func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type, provenance.Provenance, bool) {
+func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl, ns string) (soltype.Type, provenance.Provenance, bool) {
 	switch d := d.(type) {
 	case *ast.VarDecl:
 		if d.Else != nil {
@@ -62,8 +63,10 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl) (soltype.Type,
 	case *ast.ClassDecl:
 		// inferClassDecl returns the RAW constructor func type for the SCC driver to
 		// constrain into the value binding var and generalize, and registers the
-		// instance type binding plus the nominal ClassDef as side effects.
-		return c.inferClassDecl(scope, lvl, d)
+		// instance type binding plus the nominal ClassDef as side effects. ns is the
+		// class's dep_graph namespace, threaded through so the registry and the minted
+		// ClassType are keyed by the namespace-qualified name (B7).
+		return c.inferClassDecl(scope, lvl, d, ns)
 	default:
 		c.reportUnsupported(d)
 		return nil, nil, false

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -65,7 +65,7 @@ func (c *checker) inferDeclDef(scope *Scope, lvl int, d ast.Decl, ns string) (so
 		// constrain into the value binding var and generalize, and registers the
 		// instance type binding plus the nominal ClassDef as side effects. ns is the
 		// class's dep_graph namespace, threaded through so the registry and the minted
-		// ClassType are keyed by the namespace-qualified name (B7).
+		// ClassType are keyed by the namespace-qualified name.
 		return c.inferClassDecl(scope, lvl, d, ns)
 	default:
 		c.reportUnsupported(d)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -247,7 +247,10 @@ func (c *checker) inferComponent(
 				continue
 			}
 			handled.Add(d)
-			t, src, ok := c.inferDeclDef(scope, inner, d)
+			// A class decl is keyed by its dep_graph-qualified name, so pass the key's
+			// namespace down for inferClassDecl to reconstruct it (B7). Every other decl
+			// kind ignores it.
+			t, src, ok := c.inferDeclDef(scope, inner, d, g.GetNamespace(key))
 			if !ok {
 				continue
 			}
@@ -351,7 +354,9 @@ func (c *checker) inferComponent(
 				// The value key infers the body and marks the decl handled; leave it
 				// unhandled here so the reconciliation pass finds it through that key. The
 				// returned token and def are discarded here; inferClassDecl reuses them.
-				c.getOrCreateClass(scope, cd)
+				// The type key carries the same namespace as the value key, so the shell is
+				// keyed by the same qualified name inferClassDecl reconstructs (B7).
+				c.getOrCreateClass(scope, cd, g.GetNamespace(key))
 				continue
 			}
 			handled.Add(d)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -248,7 +248,7 @@ func (c *checker) inferComponent(
 			}
 			handled.Add(d)
 			// A class decl is keyed by its dep_graph-qualified name, so pass the key's
-			// namespace down for inferClassDecl to reconstruct it (B7). Every other decl
+			// namespace down for inferClassDecl to reconstruct it. Every other decl
 			// kind ignores it.
 			t, src, ok := c.inferDeclDef(scope, inner, d, g.GetNamespace(key))
 			if !ok {
@@ -355,7 +355,7 @@ func (c *checker) inferComponent(
 				// unhandled here so the reconciliation pass finds it through that key. The
 				// returned token and def are discarded here; inferClassDecl reuses them.
 				// The type key carries the same namespace as the value key, so the shell is
-				// keyed by the same qualified name inferClassDecl reconstructs (B7).
+				// keyed by the same qualified name inferClassDecl reconstructs.
 				c.getOrCreateClass(scope, cd, g.GetNamespace(key))
 				continue
 			}


### PR DESCRIPTION
Implement namespace-qualified class registry keys so sibling class declarations in different namespaces remain distinct. Previously, two `class Point` declarations under different directory-derived namespaces would collide on a shared "Point" registry entry and merge their bodies. Now each class is keyed by its dep_graph-qualified name (e.g., "geometry.Point"), keeping each class's body separate.

Key changes:

- Add `classNamespace` field to `checker` to track the current class's namespace during inference. Class-body type references resolve against this namespace first, so a bare `Point` reference inside a class in namespace `Geometry` finds the sibling `Geometry.Point` before falling back to root-namespace classes.

- Thread namespace down through `inferDeclDef` and `inferClassDecl` so the class registry, ClassType token, and scope type binding are all keyed by the qualified name.

- Introduce `qualifyClassName` helper to form the qualified key (namespace + "." + name, or bare name at root).

- Add `lookupClassBinding` to resolve type names with three-level precedence: type parameters shadow everything, same-namespace classes come next (reconstructing the qualified key from `classNamespace`), and bare class bindings are the fallback. This mirrors dep_graph's qualified-first dependency resolution.

- Update `resolveClassRef` and `resolveClassTypeAnn` to use `lookupClassBinding` instead of direct scope lookup.

- Add comprehensive test `TestInferClassNamespaceQualified` covering sibling classes with the same name in different namespaces, intra-namespace sibling references, cross-namespace qualified references, and root-namespace classes (unchanged behavior).

The printer still renders each class under its bare name since it strips the namespace prefix, so the observable output remains unchanged for single-namespace code.

https://claude.ai/code/session_018r3uudb1eMfutdZgAeodEL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for namespace-qualified classes.
  - Classes with the same name can now coexist across different namespaces without conflicts.
  - Unqualified class references resolve within their current namespace, while qualified references can target classes in other namespaces.
  - Root-level classes continue to support simple, unqualified names.

- **Bug Fixes**
  - Improved handling of class type references during inference, including generic type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->