### PR TITLE
M5 D1: Implement nominal pattern inference for instance and extractor patterns

### DIFF
--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -540,23 +540,20 @@ func (v *DependencyVisitor) ExitExpr(expr ast.Expr) {
 	}
 }
 
-// collectNominalPatternDeps records value and type dependencies on every class named by an
-// InstancePat/ExtractorPat within pat, recursing through the structural sub-patterns. This
-// orders the class's inference, which fills its ClassDef body, before the enclosing binding
-// reads it. Leaf identifiers and defaults are handled elsewhere and left untouched here.
+// collectNominalPatternDeps records a value dependency on every class named by an
+// InstancePat/ExtractorPat within pat, recursing through the structural sub-patterns. The
+// class's value key is what fills its ClassDef body, so this orders that inference before
+// the enclosing binding reads it. Leaf identifiers and defaults are handled elsewhere and
+// left untouched here.
 func (v *DependencyVisitor) collectNominalPatternDeps(pat ast.Pat) {
 	switch p := pat.(type) {
 	case *ast.InstancePat:
-		name := ast.QualIdentToString(p.ClassName)
-		v.addValueDependency(name, nil)
-		v.addTypeDependency(name)
+		v.addValueDependency(ast.QualIdentToString(p.ClassName), nil)
 		if p.Object != nil {
 			v.collectNominalPatternDeps(p.Object)
 		}
 	case *ast.ExtractorPat:
-		name := ast.QualIdentToString(p.Name)
-		v.addValueDependency(name, nil)
-		v.addTypeDependency(name)
+		v.addValueDependency(ast.QualIdentToString(p.Name), nil)
 		for _, arg := range p.Args {
 			v.collectNominalPatternDeps(arg)
 		}

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -412,9 +412,8 @@ func (v *DependencyVisitor) EnterStmt(stmt ast.Stmt) bool {
 				for binding := range bindings {
 					currentScope.ValueBindings.Add(binding)
 				}
-				// A nominal InstancePat/ExtractorPat in the pattern deconstructs a class,
-				// so record a dependency on it. The framework does not re-walk the pattern
-				// here, so collect the class references directly.
+				// Record a dependency on any class a nominal pattern deconstructs; the
+				// framework does not re-walk the pattern here.
 				v.collectNominalPatternDeps(decl.Pattern)
 				return false // Don't traverse again
 			case *ast.FuncDecl:
@@ -512,9 +511,8 @@ func (v *DependencyVisitor) EnterExpr(expr ast.Expr) bool {
 					currentScope.ValueBindings.Add(binding)
 				}
 				arm.Pattern.Accept(v)
-				// A nominal InstancePat/ExtractorPat arm deconstructs a class, so record a
-				// dependency on it. arm.Pattern.Accept above collects references inside
-				// pattern defaults; this adds the class the pattern names.
+				// Accept above collects references in pattern defaults; this adds the class
+				// a nominal pattern names.
 				v.collectNominalPatternDeps(arm.Pattern)
 			}
 			if arm.Guard != nil {
@@ -542,15 +540,10 @@ func (v *DependencyVisitor) ExitExpr(expr ast.Expr) {
 	}
 }
 
-// collectNominalPatternDeps records a dependency on every class named by an InstancePat
-// `Point { x, y }` or ExtractorPat `Point(x, y)` within pat, recursing through the
-// structural sub-patterns. Binding through a nominal pattern reads the class's projected
-// member body, which the checker fills in only when the class's VALUE key is inferred (M5
-// B1 registers the type binding early but leaves the ClassDef body empty until then).
-// Recording both the value and type dependency orders that inference before the enclosing
-// binding, so a pattern never binds against the empty shell. Leaf identifiers are
-// bindings, not references, so they are left to FindBindings; pattern defaults are visited
-// by the caller's own expression walk, so they are not touched here.
+// collectNominalPatternDeps records value and type dependencies on every class named by an
+// InstancePat/ExtractorPat within pat, recursing through the structural sub-patterns. This
+// orders the class's inference, which fills its ClassDef body, before the enclosing binding
+// reads it. Leaf identifiers and defaults are handled elsewhere and left untouched here.
 func (v *DependencyVisitor) collectNominalPatternDeps(pat ast.Pat) {
 	switch p := pat.(type) {
 	case *ast.InstancePat:

--- a/internal/dep_graph/dep_graph.go
+++ b/internal/dep_graph/dep_graph.go
@@ -412,6 +412,10 @@ func (v *DependencyVisitor) EnterStmt(stmt ast.Stmt) bool {
 				for binding := range bindings {
 					currentScope.ValueBindings.Add(binding)
 				}
+				// A nominal InstancePat/ExtractorPat in the pattern deconstructs a class,
+				// so record a dependency on it. The framework does not re-walk the pattern
+				// here, so collect the class references directly.
+				v.collectNominalPatternDeps(decl.Pattern)
 				return false // Don't traverse again
 			case *ast.FuncDecl:
 				// Function declarations are hoisted, so add to scope first
@@ -508,6 +512,10 @@ func (v *DependencyVisitor) EnterExpr(expr ast.Expr) bool {
 					currentScope.ValueBindings.Add(binding)
 				}
 				arm.Pattern.Accept(v)
+				// A nominal InstancePat/ExtractorPat arm deconstructs a class, so record a
+				// dependency on it. arm.Pattern.Accept above collects references inside
+				// pattern defaults; this adds the class the pattern names.
+				v.collectNominalPatternDeps(arm.Pattern)
 			}
 			if arm.Guard != nil {
 				arm.Guard.Accept(v)
@@ -531,6 +539,49 @@ func (v *DependencyVisitor) ExitExpr(expr ast.Expr) {
 	switch expr.(type) {
 	case *ast.FuncExpr:
 		v.popScope()
+	}
+}
+
+// collectNominalPatternDeps records a dependency on every class named by an InstancePat
+// `Point { x, y }` or ExtractorPat `Point(x, y)` within pat, recursing through the
+// structural sub-patterns. Binding through a nominal pattern reads the class's projected
+// member body, which the checker fills in only when the class's VALUE key is inferred (M5
+// B1 registers the type binding early but leaves the ClassDef body empty until then).
+// Recording both the value and type dependency orders that inference before the enclosing
+// binding, so a pattern never binds against the empty shell. Leaf identifiers are
+// bindings, not references, so they are left to FindBindings; pattern defaults are visited
+// by the caller's own expression walk, so they are not touched here.
+func (v *DependencyVisitor) collectNominalPatternDeps(pat ast.Pat) {
+	switch p := pat.(type) {
+	case *ast.InstancePat:
+		name := ast.QualIdentToString(p.ClassName)
+		v.addValueDependency(name, nil)
+		v.addTypeDependency(name)
+		if p.Object != nil {
+			v.collectNominalPatternDeps(p.Object)
+		}
+	case *ast.ExtractorPat:
+		name := ast.QualIdentToString(p.Name)
+		v.addValueDependency(name, nil)
+		v.addTypeDependency(name)
+		for _, arg := range p.Args {
+			v.collectNominalPatternDeps(arg)
+		}
+	case *ast.TuplePat:
+		for _, elem := range p.Elems {
+			v.collectNominalPatternDeps(elem)
+		}
+	case *ast.ObjectPat:
+		for _, elem := range p.Elems {
+			switch e := elem.(type) {
+			case *ast.ObjKeyValuePat:
+				v.collectNominalPatternDeps(e.Value)
+			case *ast.ObjRestPat:
+				v.collectNominalPatternDeps(e.Pattern)
+			}
+		}
+	case *ast.RestPat:
+		v.collectNominalPatternDeps(p.Pattern)
 	}
 }
 
@@ -766,6 +817,11 @@ func FindDeclDependencies(key BindingKey, graph *DepGraph) btree.Set[BindingKey]
 			// Visit the initializer if present
 			if d.Init != nil {
 				d.Init.Accept(visitor)
+			}
+			// A nominal InstancePat/ExtractorPat in the pattern records a dependency on
+			// the class it deconstructs, matching the local-scope VarDecl path.
+			if d.Pattern != nil {
+				visitor.collectNominalPatternDeps(d.Pattern)
 			}
 		case *ast.FuncDecl:
 			visitor.processTypeParams(d.TypeParams)

--- a/internal/dep_graph/nominal_pattern_test.go
+++ b/internal/dep_graph/nominal_pattern_test.go
@@ -1,0 +1,72 @@
+package dep_graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNominalPatternDependency checks that a binding deconstructing a class through an
+// InstancePat or ExtractorPat records a VALUE dependency on that class. The class's
+// projected member body is filled in only when its value key is inferred, so without
+// this edge the reader can be ordered before the class's real inference and bind against
+// the empty ClassDef shell, resolving each field to `never`. Regression test for the
+// flaky nominal-pattern inference the CI run surfaced.
+func TestNominalPatternDependency(t *testing.T) {
+	tests := map[string]string{
+		"MatchInstancePat": `
+			class Point { x: number, y: number }
+			fn f(p: Point) {
+				return match p {
+					Point { x, y } => x
+				}
+			}
+		`,
+		"MatchExtractorPat": `
+			class Point { x: number, y: number }
+			fn f(p: Point) {
+				return match p {
+					Point(x, y) => x
+				}
+			}
+		`,
+		"LocalValInstancePat": `
+			class Point { x: number, y: number }
+			fn f(p: Point) {
+				val Point { x, y } = p
+				return x
+			}
+		`,
+		"NestedInstancePat": `
+			class Point { x: number, y: number }
+			fn f(pairs: [Point]) {
+				return match pairs {
+					[Point { x, y }] => x
+				}
+			}
+		`,
+	}
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			source := &ast.Source{ID: 0, Path: "test.esc", Contents: src}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			module, errs := parser.ParseLibFiles(ctx, []*ast.Source{source})
+			require.Empty(t, errs, "Expected no parsing errors")
+
+			depGraph := BuildDepGraph(module)
+			fKey := ValueBindingKey("f")
+			pointValue := ValueBindingKey("Point")
+			require.True(t, depGraph.HasBinding(fKey), "value:f should exist")
+			require.True(t, depGraph.HasBinding(pointValue), "value:Point should exist")
+			fDeps := depGraph.GetDeps(fKey)
+			require.True(t, fDeps.Contains(pointValue),
+				"f should depend on value:Point through the nominal pattern")
+		})
+	}
+}

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -801,6 +801,9 @@ func (*RecursiveMethodAnnotationError) isSolverError()    {}
 func (*FieldNotInitializedError) isSolverError()          {}
 func (*ReadBeforeInitError) isSolverError()               {}
 func (*MethodCallBeforeInitError) isSolverError()         {}
+func (*InstancePatternNotClassError) isSolverError()      {}
+func (*ExtractorPatternNotCtorError) isSolverError()      {}
+func (*ExtractorPatternArityError) isSolverError()        {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -828,6 +831,52 @@ func (e *WriteOnlyPropertyError) Span() ast.Span      { return e.Site.Span() }
 func (e *WriteOnlyPropertyError) Related() []ast.Span { return nil }
 func (e *WriteOnlyPropertyError) Message() string {
 	return "Property '" + e.Name + "' is write-only; it has a setter but no getter or field to read."
+}
+
+// InstancePatternNotClassError fires when the name in an instance pattern `Name { ... }`
+// resolves to no class — either the name is unbound or it names a value or type parameter
+// rather than a class. An instance pattern deconstructs a class instance through the named
+// class's member view, so the name must be a class.
+type InstancePatternNotClassError struct {
+	Pat  *ast.InstancePat
+	Name string
+}
+
+func (e *InstancePatternNotClassError) Span() ast.Span      { return e.Pat.Span() }
+func (e *InstancePatternNotClassError) Related() []ast.Span { return nil }
+func (e *InstancePatternNotClassError) Message() string {
+	return "`" + e.Name + "` does not name a class and cannot be used as an instance pattern."
+}
+
+// ExtractorPatternNotCtorError fires when the name in an extractor pattern `Name(...)`
+// resolves to no constructor — the name is unbound, or its value is not callable as a
+// constructor. An extractor pattern deconstructs a value through the named constructor's
+// parameters, so the name must resolve to a constructor.
+type ExtractorPatternNotCtorError struct {
+	Pat  *ast.ExtractorPat
+	Name string
+}
+
+func (e *ExtractorPatternNotCtorError) Span() ast.Span      { return e.Pat.Span() }
+func (e *ExtractorPatternNotCtorError) Related() []ast.Span { return nil }
+func (e *ExtractorPatternNotCtorError) Message() string {
+	return "`" + e.Name + "` is not a constructor and cannot be used as an extractor pattern."
+}
+
+// ExtractorPatternArityError fires when an extractor pattern `Name(a, b, ...)` supplies
+// a different number of sub-patterns than the constructor has parameters. Each sub-pattern
+// binds one constructor parameter, so the counts must match.
+type ExtractorPatternArityError struct {
+	Pat      *ast.ExtractorPat
+	Name     string
+	Expected int
+	Got      int
+}
+
+func (e *ExtractorPatternArityError) Span() ast.Span      { return e.Pat.Span() }
+func (e *ExtractorPatternArityError) Related() []ast.Span { return nil }
+func (e *ExtractorPatternArityError) Message() string {
+	return fmt.Sprintf("extractor pattern `%s` expects %d arguments but got %d", e.Name, e.Expected, e.Got)
 }
 
 // MultipleConstructorsError fires on the second and any later `constructor` block in

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -131,6 +131,34 @@ func TestInferInstancePatNested(t *testing.T) {
 	require.Equal(t, "fn (l: Line) -> [number, number]", values["f"])
 }
 
+// An instance pattern may bind a SUBSET of the class's fields: each field requirement is
+// inexact, the same as a bare object pattern, so an unmentioned field is tolerated.
+func TestInferInstancePatOmitFields(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			val Point { x } = p
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point) -> number", values["f"])
+}
+
+// An instance pattern may rename each field to a fresh binding via `field: name`, binding
+// the new name at the field's member type.
+func TestInferInstancePatRenameFields(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: string }
+		fn f(p: Point) {
+			val Point { x: a, y: b } = p
+			return [a, b]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point) -> [number, string]", values["f"])
+}
+
 // An instance pattern naming a field the class lacks is a member-lookup miss, reported as
 // a MissingPropertyError against the projected body.
 func TestInferInstancePatWrongField(t *testing.T) {

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -1,0 +1,197 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M5 D1: nominal patterns (InstancePat / ExtractorPat) ---
+
+// An instance pattern `Point { x, y }` in a match arm deconstructs a class instance
+// through the class's projected member view, binding each named field at its member
+// type. The arm body reads the bound names back, so the inferred return shows the
+// binding worked.
+func TestInferInstancePatBindsFields(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			return match p {
+				Point { x, y } => [x, y]
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point) -> [number, number]", values["f"])
+}
+
+// An instance pattern in a `val` binds the class instance's fields the same way a bare
+// object pattern does, since both dispatch through member lookup.
+func TestInferInstancePatValDestructure(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			val Point { x, y } = p
+			return [x, y]
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point) -> [number, number]", values["f"])
+}
+
+// An extractor pattern `Point(x, y)` binds each argument sub-pattern against the matching
+// constructor parameter's type. The synthesized constructor's parameters are the instance
+// fields, so `x` and `y` bind at `number`.
+func TestInferExtractorPatBindsArgs(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			return match p {
+				Point(x, y) => [x, y]
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: Point) -> [number, number]", values["f"])
+}
+
+// An extractor pattern binds against the DECLARED constructor's parameters, not the field
+// list, so an explicit constructor whose parameters differ from the fields drives the
+// argument types.
+func TestInferExtractorPatExplicitConstructor(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Celsius {
+			degrees: number,
+			constructor(mut self, label: string, degrees: number) {
+				self.degrees = degrees
+			},
+		}
+		fn f(c: Celsius) {
+			return match c {
+				Celsius(label, degrees) => [label, degrees]
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (c: Celsius) -> [string, number]", values["f"])
+}
+
+// A generic class instance pattern projects the field at the instance's type argument, so
+// a `Box<number>` scrutinee binds `value` at `number`.
+func TestInferInstancePatGeneric(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> { value: T }
+		fn f(b: Box<number>) {
+			return match b {
+				Box { value } => value
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (b: Box<number>) -> number", values["f"])
+}
+
+// A generic extractor pattern likewise binds the argument at the instance's type argument.
+func TestInferExtractorPatGeneric(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> { value: T }
+		fn f(b: Box<string>) {
+			return match b {
+				Box(value) => value
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (b: Box<string>) -> string", values["f"])
+}
+
+// A nested sub-pattern inside an instance pattern binds through the field's own shape: the
+// field `pos` is an object, so `{x, y}` against it binds `x`/`y` at their nested types.
+func TestInferInstancePatNested(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Line { start: {x: number, y: number} }
+		fn f(l: Line) {
+			return match l {
+				Line { start: {x, y} } => [x, y]
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (l: Line) -> [number, number]", values["f"])
+}
+
+// An instance pattern naming a field the class lacks is a member-lookup miss, reported as
+// a MissingPropertyError against the projected body.
+func TestInferInstancePatWrongField(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			return match p {
+				Point { x, z } => x
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:16-5:17: object is missing property: z", msgWithSpan(errs[0]))
+}
+
+// An extractor pattern whose argument count differs from the constructor's parameter count
+// is an ExtractorPatternArityError.
+func TestInferExtractorPatWrongArity(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: Point) {
+			return match p {
+				Point(x) => x
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:5-5:13: extractor pattern `Point` expects 2 arguments but got 1", msgWithSpan(errs[0]))
+}
+
+// An instance pattern whose name resolves to no class is an InstancePatternNotClassError.
+// The inner fields still bind against a fresh var, so the arm body does not cascade into
+// unknown-identifier errors.
+func TestInferInstancePatNotAClass(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: number) {
+			return match p {
+				Missing { x } => x
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:5-4:18: `Missing` does not name a class and cannot be used as an instance pattern.", msgWithSpan(errs[0]))
+}
+
+// An extractor pattern whose name resolves to no constructor is an
+// ExtractorPatternNotCtorError. A plain value binding is not callable as a constructor.
+func TestInferExtractorPatNotAConstructor(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		val g = 5
+		fn f(p: number) {
+			return match p {
+				g(x) => x
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:5-5:9: `g` is not a constructor and cannot be used as an extractor pattern.", msgWithSpan(errs[0]))
+}
+
+// An instance pattern narrows the scrutinee to the named class. A scrutinee that is a
+// different, unrelated class cannot be that class, so the assertion is a nominal mismatch.
+func TestInferInstancePatNominalMismatch(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		class Circle { radius: number }
+		fn f(c: Circle) {
+			return match c {
+				Point { x, y } => [x, y]
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "6:5-6:19: cannot constrain Point <: Circle", msgWithSpan(errs[0]))
+}

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -40,8 +40,10 @@ func TestInferInstancePatValDestructure(t *testing.T) {
 }
 
 // An extractor pattern `Point(x, y)` binds each argument sub-pattern against the matching
-// constructor parameter's type. The synthesized constructor's parameters are the instance
-// fields, so `x` and `y` bind at `number`.
+// constructor parameter's type. This is the M5 interim: the extractor protocol is the
+// instance's `[Symbol.customMatcher]` method, which needs symbol-keyed members and lands in
+// M7. Point's synthesized constructor parameters are its fields, so `x` and `y` bind at
+// `number`, the same shape a custom matcher returning `[x, y]` would produce.
 func TestInferExtractorPatBindsArgs(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		class Point { x: number, y: number }
@@ -55,25 +57,34 @@ func TestInferExtractorPatBindsArgs(t *testing.T) {
 	require.Equal(t, "fn (p: Point) -> [number, number]", values["f"])
 }
 
-// An extractor pattern binds against the DECLARED constructor's parameters, not the field
-// list, so an explicit constructor whose parameters differ from the fields drives the
-// argument types.
+// DISABLED until M7. An extractor pattern deconstructs through the class instance's
+// `[Symbol.customMatcher]` method, not its constructor. M5 has no symbol-keyed members, so
+// bindExtractorPat binds against constructor parameters as an interim. This case pins that
+// interim by extracting `label`, a constructor parameter that is never stored on the
+// instance and so is not recoverable from an instance value. Under M7's `[Symbol.customMatcher]`
+// resolution, `Celsius` declares no custom matcher, so the match is rejected outright.
+// Re-enable when M7 lands and assert the missing-custom-matcher error the commented body
+// records.
 func TestInferExtractorPatExplicitConstructor(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		class Celsius {
-			degrees: number,
-			constructor(mut self, label: string, degrees: number) {
-				self.degrees = degrees
-			},
-		}
-		fn f(c: Celsius) {
-			return match c {
-				Celsius(label, degrees) => [label, degrees]
+	/*
+		_, _, errs := inferSource(t, `
+			class Celsius {
+				degrees: number,
+				constructor(mut self, label: string, degrees: number) {
+					self.degrees = degrees
+				},
 			}
-		}
-	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (c: Celsius) -> [string, number]", values["f"])
+			fn f(c: Celsius) {
+				return match c {
+					Celsius(label, degrees) => [label, degrees]
+				}
+			}
+		`)
+		require.Len(t, errs, 1)
+		// M7: `Celsius` has no `[Symbol.customMatcher]` method, so it cannot be used as an
+		// extractor pattern. The exact error type lands with the matcher resolution.
+		require.Equal(t, "`Celsius` has no [Symbol.customMatcher] method", msgWithSpan(errs[0]))
+	*/
 }
 
 // A generic class instance pattern projects the field at the instance's type argument, so

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -253,6 +253,9 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 // from the member-lookup requirement; a name that is not a class is an
 // InstancePatternNotClassError.
 func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scrutinee, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	// Record the pattern node's type against the scrutinee it matches, the same as the
+	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
+	c.recordType(p, scrutinee)
 	name := ast.QualIdentToString(p.ClassName)
 	ct, ok := c.instancePatClass(scope, name)
 	if !ok {
@@ -284,6 +287,9 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 // constructor parameter's type. A name that is not a constructor is an
 // ExtractorPatternNotCtorError; a wrong argument count is an ExtractorPatternArityError.
 func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	// Record the pattern node's type against the scrutinee it matches, the same as the
+	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
+	c.recordType(p, scrutinee)
 	name := ast.QualIdentToString(p.Name)
 	ctor, ok := c.extractorCtor(scope, lvl, name)
 	if !ok {

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -269,12 +269,20 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 	// The pattern narrows the scrutinee to the named class. The instance flows into the
 	// scrutinee, so a scrutinee that cannot be this class is rejected here.
 	c.constrain(p, inst, scrutinee)
-	// Deconstruct through the projected member view rather than by subtyping. Binding the
-	// inner object pattern against the projected body reads each field at its member type,
-	// and for a downcast pattern such as `Dog { … }` over an `Animal` scrutinee it reads
-	// the subclass's own members, which the scrutinee's declared type does not carry.
+	// Deconstruct through the projected member view rather than by subtyping. Project the
+	// scrutinee's own class instance when it names the same class, so a generic scrutinee's
+	// concrete type arguments give the field types directly — the same path member access
+	// takes. Relying on the nominal constraint above to back-propagate the arguments into
+	// inst's fresh vars is not sound under a non-invariant parameter, which would leave a
+	// field bound to an untied var. A downcast pattern such as `Dog { … }` over an `Animal`
+	// scrutinee names a different class, so it falls back to the freshly asserted instance
+	// and reads the subclass's own members.
+	projected := inst
+	if sc, ok := classCarrier(scrutinee); ok && sc.Name == ct.Name {
+		projected = sc
+	}
 	target, targetConcrete := scrutinee, concrete
-	if body, projected := c.ctx.projectClassBody(inst); projected {
+	if body, ok := c.ctx.projectClassBody(projected); ok {
 		target, targetConcrete = body, body
 	}
 	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
@@ -312,18 +320,63 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 	// The extracted value is an instance of the constructor's return type. Narrow the
 	// scrutinee to it, the same assertion an instance pattern makes.
 	c.constrain(p, ctor.Ret, scrutinee)
-	if len(p.Args) != len(ctor.Params) {
-		c.report(&ExtractorPatternArityError{Pat: p, Name: name, Expected: len(ctor.Params), Got: len(p.Args)})
+	// Read the parameters at the scrutinee's concrete type arguments. Substituting them
+	// directly from the scrutinee's own instance is sound where relying on the narrowing
+	// constraint above to back-propagate them into the constructor's fresh return vars is
+	// not, since a non-invariant parameter constrains only one direction and leaves the
+	// argument bound to an untied var.
+	params := ctor.Params
+	if sc, ok := classCarrier(scrutinee); ok {
+		if ret, ok := ctor.Ret.(*soltype.ClassType); ok && ret.Name == sc.Name {
+			params = ctorParamsAt(ctor.Params, ret, sc)
+		}
+	}
+	if len(p.Args) != len(params) {
+		c.report(&ExtractorPatternArityError{Pat: p, Name: name, Expected: len(params), Got: len(p.Args)})
 	}
 	args := make([]soltype.Pat, len(p.Args))
 	for i, a := range p.Args {
 		var paramType soltype.Type = c.freshAt(lvl)
-		if i < len(ctor.Params) {
-			paramType = ctor.Params[i].Type
+		if i < len(params) {
+			paramType = params[i].Type
 		}
 		args[i] = c.bindPatMode(scope, lvl, a, paramType, paramType, scrutineeMode, leafTypes, emit)
 	}
 	return &soltype.ExtractorPat{Name: name, Args: args}
+}
+
+// ctorParamsAt rewrites a constructor's parameter types from the constructor's own
+// return-type-argument vars to the scrutinee instance's concrete arguments, so an
+// extractor over a generic scrutinee reads its parameters at the scrutinee's arguments.
+// ret is the constructor's return instance, whose positional arguments are the fresh vars
+// a generic constructor was instantiated with; sc is the scrutinee's instance of the same
+// class, whose positional arguments are concrete. A non-generic constructor, whose return
+// carries no arguments, leaves the parameters unchanged.
+func ctorParamsAt(params []*soltype.FuncParam, ret, sc *soltype.ClassType) []*soltype.FuncParam {
+	subst := &classSubst{
+		types:     map[*soltype.TypeVarType]soltype.Type{},
+		lifetimes: map[*soltype.LifetimeVar]soltype.Lifetime{},
+	}
+	for i := 0; i < min(len(ret.TypeArgs), len(sc.TypeArgs)); i++ {
+		if v, ok := ret.TypeArgs[i].(*soltype.TypeVarType); ok {
+			subst.types[v] = sc.TypeArgs[i]
+		}
+	}
+	for i := 0; i < min(len(ret.LifetimeArgs), len(sc.LifetimeArgs)); i++ {
+		if lv, ok := ret.LifetimeArgs[i].(*soltype.LifetimeVar); ok {
+			subst.lifetimes[lv] = sc.LifetimeArgs[i]
+		}
+	}
+	if len(subst.types) == 0 && len(subst.lifetimes) == 0 {
+		return params
+	}
+	out := make([]*soltype.FuncParam, len(params))
+	for i, param := range params {
+		cp := *param
+		cp.Type = param.Type.Accept(subst, soltype.Positive)
+		out[i] = &cp
+	}
+	return out
 }
 
 // instancePatClass resolves an instance pattern's name to its class token, honoring the

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -231,13 +231,170 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 		c.recordType(p, scrutinee)
 		return &soltype.ObjectPat{Fields: fields}
 
+	case *ast.InstancePat:
+		return c.bindInstancePat(scope, lvl, p, scrutinee, concrete, scrutineeMode, leafTypes, emit)
+
+	case *ast.ExtractorPat:
+		return c.bindExtractorPat(scope, lvl, p, scrutinee, scrutineeMode, leafTypes, emit)
+
 	default:
-		// ExtractorPat and InstancePat are the constructor patterns; they are M5. A
-		// bare RestPat is only meaningful inside a tuple or object. Report and bind
+		// A bare RestPat is only meaningful inside a tuple or object. Report and bind
 		// nothing.
 		c.reportUnsupported(pat)
 		return &soltype.WildcardPat{}
 	}
+}
+
+// bindInstancePat types a class-instance pattern `Name { x, y }` against a scrutinee.
+// It resolves Name to its class, asserts the scrutinee is an instance of that class the
+// way a literal pattern asserts a literal value, then binds each inner field sub-pattern
+// against the class's projected member view — a member-lookup deconstruction, not a
+// structural subtype check. A field the class lacks surfaces as a MissingPropertyError
+// from the member-lookup requirement; a name that is not a class is an
+// InstancePatternNotClassError.
+func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scrutinee, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	name := ast.QualIdentToString(p.ClassName)
+	ct, ok := c.instancePatClass(scope, name)
+	if !ok {
+		c.report(&InstancePatternNotClassError{Pat: p, Name: name})
+		// Bind the inner fields against a fresh var so a later reference to a bound leaf
+		// stays defined without a second cascade error against the real scrutinee.
+		obj, _ := c.bindPatMode(scope, lvl, p.Object, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
+		return &soltype.InstancePat{ClassName: name, Object: obj}
+	}
+	inst := c.freshClassInstance(ct, lvl)
+	// The pattern narrows the scrutinee to the named class. The instance flows into the
+	// scrutinee, so a scrutinee that cannot be this class is rejected here.
+	c.constrain(p, inst, scrutinee)
+	// Deconstruct through the projected member view rather than by subtyping. Binding the
+	// inner object pattern against the projected body reads each field at its member type,
+	// and for a downcast pattern such as `Dog { … }` over an `Animal` scrutinee it reads
+	// the subclass's own members, which the scrutinee's declared type does not carry.
+	target, targetConcrete := scrutinee, concrete
+	if body, projected := c.ctx.projectClassBody(inst); projected {
+		target, targetConcrete = body, body
+	}
+	obj, _ := c.bindPatMode(scope, lvl, p.Object, target, targetConcrete, scrutineeMode, leafTypes, emit).(*soltype.ObjectPat)
+	return &soltype.InstancePat{ClassName: ct.Name, Object: obj}
+}
+
+// bindExtractorPat types an extractor pattern `Name(a, b)` against a scrutinee. It
+// resolves Name to a constructor, asserts the scrutinee is an instance of the
+// constructor's return type, then binds each argument sub-pattern against the matching
+// constructor parameter's type. A name that is not a constructor is an
+// ExtractorPatternNotCtorError; a wrong argument count is an ExtractorPatternArityError.
+func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
+	name := ast.QualIdentToString(p.Name)
+	ctor, ok := c.extractorCtor(scope, lvl, name)
+	if !ok {
+		c.report(&ExtractorPatternNotCtorError{Pat: p, Name: name})
+		// Bind each argument against a fresh var so its leaves stay defined and a later
+		// reference does not cascade into an unknown-identifier error.
+		args := make([]soltype.Pat, len(p.Args))
+		for i, a := range p.Args {
+			args[i] = c.bindPatMode(scope, lvl, a, c.freshAt(lvl), nil, scrutineeMode, leafTypes, emit)
+		}
+		return &soltype.ExtractorPat{Name: name, Args: args}
+	}
+	// The extracted value is an instance of the constructor's return type. Narrow the
+	// scrutinee to it, the same assertion an instance pattern makes.
+	c.constrain(p, ctor.Ret, scrutinee)
+	if len(p.Args) != len(ctor.Params) {
+		c.report(&ExtractorPatternArityError{Pat: p, Name: name, Expected: len(ctor.Params), Got: len(p.Args)})
+	}
+	args := make([]soltype.Pat, len(p.Args))
+	for i, a := range p.Args {
+		var paramType soltype.Type = c.freshAt(lvl)
+		if i < len(ctor.Params) {
+			paramType = ctor.Params[i].Type
+		}
+		args[i] = c.bindPatMode(scope, lvl, a, paramType, paramType, scrutineeMode, leafTypes, emit)
+	}
+	return &soltype.ExtractorPat{Name: name, Args: args}
+}
+
+// instancePatClass resolves an instance pattern's name to its class token, honoring the
+// same scope precedence a written class reference uses. It returns ok=false when the name
+// is unbound or names a value or type parameter rather than a class.
+func (c *checker) instancePatClass(scope *Scope, name string) (*soltype.ClassType, bool) {
+	b, ok := c.lookupClassBinding(scope, name)
+	if !ok {
+		return nil, false
+	}
+	ct, ok := b.Type.(*soltype.ClassType)
+	return ct, ok
+}
+
+// extractorCtor resolves an extractor pattern's name to the constructor it deconstructs
+// through: a class value's constructor signature. It instantiates the value binding, so
+// each match freshens a generic constructor's type parameters. It returns ok=false when
+// the name is unbound or its value is not callable as a constructor.
+func (c *checker) extractorCtor(scope *Scope, lvl int, name string) (*soltype.FuncType, bool) {
+	b, ok := scope.GetValue(name)
+	if !ok || len(b.Schemes) == 0 {
+		return nil, false
+	}
+	return ctorSignature(c.bindingValue(lvl, b))
+}
+
+// ctorSignature resolves a value to the constructor signature an extractor pattern
+// deconstructs through: a bare constructor FuncType, a class value object's
+// ConstructorElem, or one of those reached through a binding var's lower bounds. A class
+// name's value binding is a pre-bound var during the class's own inference component, with
+// the constructor recorded as a lower bound, so the var case is the common one. A var with
+// two different constructor lower bounds is ambiguous and left unresolved, mirroring
+// classValueCarrier's look-through.
+func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
+	switch t := t.(type) {
+	case *soltype.FuncType:
+		return t, true
+	case *soltype.ObjectType:
+		if ctor, ok := t.Constructor(); ok {
+			return ctor.Fn, true
+		}
+	case *soltype.TypeVarType:
+		var found *soltype.FuncType
+		for _, lb := range t.LowerBounds {
+			fn, ok := ctorSignature(lb)
+			if !ok {
+				continue
+			}
+			if found != nil && !equalType(found, fn) {
+				return nil, false
+			}
+			found = fn
+		}
+		if found != nil {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+// freshClassInstance builds an instance of ct with a fresh inference var for each of the
+// class's type parameters and a fresh lifetime for each lifetime parameter, so a pattern
+// narrows a scrutinee to the class at unconstrained arguments the surrounding constraints
+// then pin. A non-generic class yields the bare token.
+func (c *checker) freshClassInstance(ct *soltype.ClassType, lvl int) *soltype.ClassType {
+	def, ok := c.ctx.classDef(ct.Name)
+	if !ok {
+		return &soltype.ClassType{Name: ct.Name, Final: ct.Final}
+	}
+	var typeArgs []soltype.Type
+	if len(def.TypeParams) > 0 {
+		typeArgs = make([]soltype.Type, len(def.TypeParams))
+		for i := range typeArgs {
+			typeArgs[i] = c.freshAt(lvl)
+		}
+	}
+	var ltArgs []soltype.Lifetime
+	if len(def.LifetimeParams) > 0 {
+		ltArgs = make([]soltype.Lifetime, len(def.LifetimeParams))
+		for i := range ltArgs {
+			ltArgs[i] = c.ctx.freshLifetime(lvl)
+		}
+	}
+	return &soltype.ClassType{Name: ct.Name, TypeArgs: typeArgs, LifetimeArgs: ltArgs, Final: ct.Final}
 }
 
 // applyLeafExtras resolves a destructured leaf's optional type annotation

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -411,6 +411,10 @@ func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
 			return ctor.Fn, true
 		}
 	case *soltype.TypeVarType:
+		// Scan the var's lower bounds for a constructor, requiring all that resolve to agree.
+		// A var can carry more than one lower bound, so keep the first constructor found and
+		// compare each later one against it: if two name different constructors the var is an
+		// ambiguous join of unrelated class values, so bail rather than pick one arbitrarily.
 		var found *soltype.FuncType
 		for _, lb := range t.LowerBounds {
 			fn, ok := ctorSignature(lb)

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -329,8 +329,13 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 
 // ctorParamsAt rewrites a constructor's parameter types from its return instance's argument
 // vars (ret) to the scrutinee instance's concrete arguments (sc), so an extractor over a
-// generic scrutinee reads its parameters at the scrutinee's arguments. A non-generic
-// constructor, whose return carries no arguments, leaves the parameters unchanged.
+// generic scrutinee reads its parameters at the scrutinee's arguments.
+//
+// For `class Box<T> { value: T }` the instantiated constructor is `fn (value: t0) -> Box<t0>`,
+// so ret is `Box<t0>`. Matching `Box(v)` against a `Box<string>` scrutinee makes sc `Box<string>`,
+// so ctorParamsAt maps t0 to string and rewrites the parameter `value: t0` to `value: string`;
+// v then binds at string. A non-generic constructor, whose return carries no arguments, builds
+// an empty substitution and returns the parameters unchanged.
 func ctorParamsAt(params []*soltype.FuncParam, ret, sc *soltype.ClassType) []*soltype.FuncParam {
 	subst := &classSubst{
 		types:     map[*soltype.TypeVarType]soltype.Type{},
@@ -371,8 +376,13 @@ func (c *checker) instancePatClass(scope *Scope, name string) (*soltype.ClassTyp
 }
 
 // extractorCtor resolves an extractor pattern's name to a class value's constructor
-// signature, instantiated so each match freshens its type parameters. ok=false when the
-// name is unbound or its value is not callable as a constructor.
+// signature. It looks the name up in the value sort, since a class binds its constructor on
+// the value side of its dual type/value binding, then instantiates that value at lvl through
+// bindingValue and pulls the constructor out with ctorSignature. Instantiating per call
+// freshens a generic constructor's type parameters, so two match arms each written `Box(v)`
+// get independent argument vars rather than sharing one. It returns ok=false when the name
+// is unbound, carries no scheme, or resolves to a value that is not callable as a
+// constructor.
 func (c *checker) extractorCtor(scope *Scope, lvl int, name string) (*soltype.FuncType, bool) {
 	b, ok := scope.GetValue(name)
 	if !ok || len(b.Schemes) == 0 {
@@ -381,10 +391,17 @@ func (c *checker) extractorCtor(scope *Scope, lvl int, name string) (*soltype.Fu
 	return ctorSignature(c.bindingValue(lvl, b))
 }
 
-// ctorSignature resolves a value to its constructor signature: a bare FuncType, a class
-// value object's ConstructorElem, or either reached through a binding var's lower bounds —
-// the common case, since a class value is a pre-bound var during its own inference. A var
-// with two conflicting constructor lower bounds is ambiguous and left unresolved.
+// ctorSignature resolves a value to its constructor signature in one of three shapes: a bare
+// FuncType, a class value object's ConstructorElem, or either of those reached through a
+// binding var's lower bounds. The var case is the common one, since a class value is a
+// pre-bound var during its own inference component with the constructor recorded as a lower
+// bound.
+//
+// For `class Point { x: number, y: number }` the value `Point` resolves mid-inference to a
+// var whose lower bound is `fn (x: number, y: number) -> Point`, and ctorSignature looks
+// through the var to that FuncType. A class that also declares static members instead binds
+// an ObjectType carrying a ConstructorElem, so the ObjectType arm returns its Constructor().Fn.
+// A var with two conflicting constructor lower bounds is ambiguous and left unresolved.
 func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -245,13 +245,9 @@ func (c *checker) bindPatMode(scope *Scope, lvl int, pat ast.Pat, scrutinee solt
 	}
 }
 
-// bindInstancePat types a class-instance pattern `Name { x, y }` against a scrutinee.
-// It resolves Name to its class, asserts the scrutinee is an instance of that class the
-// way a literal pattern asserts a literal value, then binds each inner field sub-pattern
-// against the class's projected member view — a member-lookup deconstruction, not a
-// structural subtype check. A field the class lacks surfaces as a MissingPropertyError
-// from the member-lookup requirement; a name that is not a class is an
-// InstancePatternNotClassError.
+// bindInstancePat types a class-instance pattern `Name { x, y }`: it narrows the scrutinee
+// to the named class, then binds each field sub-pattern against the projected member view.
+// A missing field yields a MissingPropertyError; a non-class name an InstancePatternNotClassError.
 func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scrutinee, concrete soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	// Record the pattern node's type against the scrutinee it matches, the same as the
 	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
@@ -269,14 +265,8 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 	// The pattern narrows the scrutinee to the named class. The instance flows into the
 	// scrutinee, so a scrutinee that cannot be this class is rejected here.
 	c.constrain(p, inst, scrutinee)
-	// Deconstruct through the projected member view rather than by subtyping. Project the
-	// scrutinee's own class instance when it names the same class, so a generic scrutinee's
-	// concrete type arguments give the field types directly — the same path member access
-	// takes. Relying on the nominal constraint above to back-propagate the arguments into
-	// inst's fresh vars is not sound under a non-invariant parameter, which would leave a
-	// field bound to an untied var. A downcast pattern such as `Dog { … }` over an `Animal`
-	// scrutinee names a different class, so it falls back to the freshly asserted instance
-	// and reads the subclass's own members.
+	// Project the scrutinee's own instance when it names the same class, so its concrete
+	// arguments give the field types directly; a downcast falls back to the asserted instance.
 	projected := inst
 	if sc, ok := classCarrier(scrutinee); ok && sc.Name == ct.Name {
 		projected = sc
@@ -289,18 +279,13 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 	return &soltype.InstancePat{ClassName: ct.Name, Object: obj}
 }
 
-// bindExtractorPat types an extractor pattern `Name(a, b)` against a scrutinee. It
-// resolves Name to a constructor, asserts the scrutinee is an instance of the
-// constructor's return type, then binds each argument sub-pattern against the matching
-// constructor parameter's type. A name that is not a constructor is an
-// ExtractorPatternNotCtorError; a wrong argument count is an ExtractorPatternArityError.
+// bindExtractorPat types an extractor pattern `Name(a, b)`: it narrows the scrutinee to the
+// constructor's return type, then binds each argument against a constructor parameter. A
+// non-constructor name is an ExtractorPatternNotCtorError, a wrong count an ExtractorPatternArityError.
 //
-// Binding against constructor parameters is an interim gate. The extractor protocol
-// deconstructs through the instance's `[Symbol.customMatcher]` method, whose return-tuple
-// element types the arguments bind against, and a class without one is an error. That
-// needs symbol-keyed members, which soltype does not carry yet, so the matcher lookup is
-// deferred to M7 (m5-implementation-plan.md §"Nominal patterns"). Until then an extractor
-// pattern accepts any class with a matching constructor arity.
+// Binding against constructor parameters is an interim gate. The real protocol deconstructs
+// through the instance's `[Symbol.customMatcher]` method, which needs symbol-keyed members
+// soltype lacks, so it is deferred to M7 (m5-implementation-plan.md §"Nominal patterns").
 func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	// Record the pattern node's type against the scrutinee it matches, the same as the
 	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.
@@ -320,11 +305,8 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 	// The extracted value is an instance of the constructor's return type. Narrow the
 	// scrutinee to it, the same assertion an instance pattern makes.
 	c.constrain(p, ctor.Ret, scrutinee)
-	// Read the parameters at the scrutinee's concrete type arguments. Substituting them
-	// directly from the scrutinee's own instance is sound where relying on the narrowing
-	// constraint above to back-propagate them into the constructor's fresh return vars is
-	// not, since a non-invariant parameter constrains only one direction and leaves the
-	// argument bound to an untied var.
+	// Read the parameters at the scrutinee's concrete arguments by substituting them
+	// directly, rather than relying on the narrowing constraint above to back-propagate them.
 	params := ctor.Params
 	if sc, ok := classCarrier(scrutinee); ok {
 		if ret, ok := ctor.Ret.(*soltype.ClassType); ok && ret.Name == sc.Name {
@@ -345,13 +327,10 @@ func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, s
 	return &soltype.ExtractorPat{Name: name, Args: args}
 }
 
-// ctorParamsAt rewrites a constructor's parameter types from the constructor's own
-// return-type-argument vars to the scrutinee instance's concrete arguments, so an
-// extractor over a generic scrutinee reads its parameters at the scrutinee's arguments.
-// ret is the constructor's return instance, whose positional arguments are the fresh vars
-// a generic constructor was instantiated with; sc is the scrutinee's instance of the same
-// class, whose positional arguments are concrete. A non-generic constructor, whose return
-// carries no arguments, leaves the parameters unchanged.
+// ctorParamsAt rewrites a constructor's parameter types from its return instance's argument
+// vars (ret) to the scrutinee instance's concrete arguments (sc), so an extractor over a
+// generic scrutinee reads its parameters at the scrutinee's arguments. A non-generic
+// constructor, whose return carries no arguments, leaves the parameters unchanged.
 func ctorParamsAt(params []*soltype.FuncParam, ret, sc *soltype.ClassType) []*soltype.FuncParam {
 	subst := &classSubst{
 		types:     map[*soltype.TypeVarType]soltype.Type{},
@@ -391,10 +370,9 @@ func (c *checker) instancePatClass(scope *Scope, name string) (*soltype.ClassTyp
 	return ct, ok
 }
 
-// extractorCtor resolves an extractor pattern's name to the constructor it deconstructs
-// through: a class value's constructor signature. It instantiates the value binding, so
-// each match freshens a generic constructor's type parameters. It returns ok=false when
-// the name is unbound or its value is not callable as a constructor.
+// extractorCtor resolves an extractor pattern's name to a class value's constructor
+// signature, instantiated so each match freshens its type parameters. ok=false when the
+// name is unbound or its value is not callable as a constructor.
 func (c *checker) extractorCtor(scope *Scope, lvl int, name string) (*soltype.FuncType, bool) {
 	b, ok := scope.GetValue(name)
 	if !ok || len(b.Schemes) == 0 {
@@ -403,13 +381,10 @@ func (c *checker) extractorCtor(scope *Scope, lvl int, name string) (*soltype.Fu
 	return ctorSignature(c.bindingValue(lvl, b))
 }
 
-// ctorSignature resolves a value to the constructor signature an extractor pattern
-// deconstructs through: a bare constructor FuncType, a class value object's
-// ConstructorElem, or one of those reached through a binding var's lower bounds. A class
-// name's value binding is a pre-bound var during the class's own inference component, with
-// the constructor recorded as a lower bound, so the var case is the common one. A var with
-// two different constructor lower bounds is ambiguous and left unresolved, mirroring
-// classValueCarrier's look-through.
+// ctorSignature resolves a value to its constructor signature: a bare FuncType, a class
+// value object's ConstructorElem, or either reached through a binding var's lower bounds —
+// the common case, since a class value is a pre-bound var during its own inference. A var
+// with two conflicting constructor lower bounds is ambiguous and left unresolved.
 func ctorSignature(t soltype.Type) (*soltype.FuncType, bool) {
 	switch t := t.(type) {
 	case *soltype.FuncType:

--- a/internal/solver/pattern.go
+++ b/internal/solver/pattern.go
@@ -286,6 +286,13 @@ func (c *checker) bindInstancePat(scope *Scope, lvl int, p *ast.InstancePat, scr
 // constructor's return type, then binds each argument sub-pattern against the matching
 // constructor parameter's type. A name that is not a constructor is an
 // ExtractorPatternNotCtorError; a wrong argument count is an ExtractorPatternArityError.
+//
+// Binding against constructor parameters is an interim gate. The extractor protocol
+// deconstructs through the instance's `[Symbol.customMatcher]` method, whose return-tuple
+// element types the arguments bind against, and a class without one is an error. That
+// needs symbol-keyed members, which soltype does not carry yet, so the matcher lookup is
+// deferred to M7 (m5-implementation-plan.md §"Nominal patterns"). Until then an extractor
+// pattern accepts any class with a matching constructor arity.
 func (c *checker) bindExtractorPat(scope *Scope, lvl int, p *ast.ExtractorPat, scrutinee soltype.Type, scrutineeMode bindMode, leafTypes map[string]soltype.Type, emit leafEmit) soltype.Pat {
 	// Record the pattern node's type against the scrutinee it matches, the same as the
 	// sibling tuple/object cases, so hover and type-at-position resolve on the pattern.

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -187,7 +187,10 @@ placeholders for `Iterable`/`Iterator`/`AsyncIterable`/`IteratorResult`); the
 second fixture harness (M8); type-level operators incl. `keyof`/mapped/`Awaited`
 and path-based lifetimes (M9); codegen (M10). Enum *declarations* are handled
 only as far as the enum-exhaustive `match` leg needs — an enum is a union of
-implicitly-`final` variant types reusing the class machinery (see D-Enum).
+implicitly-`final` variant types reusing the class machinery (see D-Enum). The
+`[Symbol.customMatcher]` gate on extractor patterns is also out (M7 — it needs
+symbol-keyed members); D1 binds an extractor's arguments against constructor
+parameters as an interim (see D1's Files/Accept).
 
 ---
 
@@ -717,6 +720,23 @@ inference above, not a direct `x = 5` on an instance field.
 func (c *checker) bindInstancePat(scope *Scope, p *soltype.InstancePat, scrut soltype.Type)
 func (c *checker) bindExtractorPat(scope *Scope, p *soltype.ExtractorPat, scrut soltype.Type)
 ```
+
+**ExtractorPat's constructor-parameter binding is an M5 placeholder; the real
+gate is `[Symbol.customMatcher]` and lands in M7.** In the old checker an
+extractor pattern deconstructs a value through the class instance's
+`[Symbol.customMatcher]` method — a single-argument method returning a tuple,
+whose element types the sub-patterns bind against — and a class lacking one is a
+`MissingCustomMatcherError`. Enums synthesize that method from their variants
+(`internal/checker/infer_stmt.go`, `infer_module.go`). The `soltype` model has no
+symbol-keyed members yet: `MethodElem`/`GetterElem`/`SetterElem` are all
+string-named, `objKeyName` rejects a `ComputedKey`, and there is no
+`Symbol.customMatcher` global. Representing a custom matcher needs the
+unique-symbol `soltype` kind and symbol-keyed member access whose prerequisite
+[01-milestones.md](01-milestones.md) §M7 assigns to M7. So D1 binds an extractor
+pattern's arguments against the resolved **constructor** parameters as an interim,
+which accepts `Point(x, y)` against a plain class rather than requiring a matcher.
+M7 replaces that with the `[Symbol.customMatcher]` lookup and reinstates the
+"class without a matcher is an error" rule.
 
 ### Iteration protocol (`solver/infer_stmt.go`, Phase F)
 
@@ -1259,6 +1279,13 @@ corruption of `freshenAbove`.
   - **Accept:** a `match` over class/enum constructor patterns binds and
     type-checks each arm; a record pattern against a `Point` binds `x`/`y` at
     their member types; a wrong field/constructor is a typed error.
+  - **Deferred to M7 — `[Symbol.customMatcher]` gating.** An extractor pattern
+    properly deconstructs through the class instance's `[Symbol.customMatcher]`
+    method, not its constructor, and a class without one is an error (the old
+    checker's `MissingCustomMatcherError`). That needs symbol-keyed members, whose
+    `soltype` prerequisite is an M7 item (see §"Nominal patterns" above and
+    [01-milestones.md](01-milestones.md) §M7). D1 binds against constructor
+    parameters as an interim; M7 replaces it with the matcher lookup.
 
 - **D-Enum — Enum declarations as unions of `final` variants** (~180).
   - **Files:** `solver/infer_enum.go` (new), `solver/infer_decl.go` (dispatch),


### PR DESCRIPTION
Adds type inference support for instance patterns (`Point { x, y }`) and extractor patterns (`Point(x, y)`) in match arms and val bindings, completing the M5 D1 milestone for nominal pattern matching.

**Key changes:**

- **Instance pattern binding** (`bindInstancePat`): Resolves the class name, asserts the scrutinee is an instance of that class, then deconstructs through the class's projected member view. Fields bind at their member types, and missing fields surface as `MissingPropertyError`.

- **Extractor pattern binding** (`bindExtractorPat`): Resolves the name to a constructor, asserts the scrutinee matches the constructor's return type, then binds each argument sub-pattern against the corresponding parameter type. Arity mismatches are caught with `ExtractorPatternArityError`.

- **Helper functions**: `instancePatClass` and `extractorCtor` resolve pattern names to their class and constructor respectively. `ctorSignature` extracts the constructor signature from a value, handling bare functions, class object constructors, and type vars with constructor lower bounds. `freshClassInstance` instantiates a class with fresh type and lifetime variables for each parameter.

- **Error types**: Three new solver errors report when a pattern name doesn't resolve to a class (`InstancePatternNotClassError`), doesn't resolve to a constructor (`ExtractorPatternNotCtorError`), or supplies the wrong number of arguments (`ExtractorPatternArityError`).

- **Test coverage**: 11 tests verify correct binding of fields and arguments, generic class instances, nested patterns, explicit constructors, and all error cases including nominal type mismatches.

https://claude.ai/code/session_01SauSsYAnQviaq9VaG8TNNe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for matching values with class instance patterns and constructor extractor patterns.
  * Supports nested patterns, field and argument bindings, generic types, and explicit constructors.
  * Pattern matching now narrows values to compatible class and constructor types.

* **Bug Fixes**
  * Added clear diagnostics for invalid class or constructor names, incorrect fields, nominal mismatches, and extractor arity errors.

* **Tests**
  * Added comprehensive coverage for valid bindings, generics, nesting, and pattern-matching errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->