### PR TITLE
M5 B8: Keep class type parameters symbolic through generic body coalesce

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -278,12 +278,16 @@ func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visit
 // method resolves `T` to, since both members were walked in one class scope. Substituting,
 // the way external access does for a concrete receiver like `Box<5>`, would be wrong here.
 //
-// Per-method type parameters are a separate story that neither access path handles yet: a
-// method carrying its own `FuncType.TypeParams` must be wrapped in a scheme and instantiated
-// per call so each call freshens them, and that wrap belongs in memberValue, shared with
-// projectedMember, not here. Until it lands, a method whose return is a class or method type
-// parameter round-trips as `never` through a call — the same limitation external access has,
-// since an unannotated field read mints an intermediate var that projection cannot rewrite.
+// A method whose return flows from a class type parameter — such as `read(self) { self.v }`
+// on `class Box<T>` — resolves to that parameter because freezeClassBody coalesces the
+// generic body while keeping the class's own type-parameter vars symbolic (B8), so `read`'s
+// stored return reads as `T` rather than collapsing to `never`. A self call keeps `T` symbolic
+// and an external call substitutes the instance's argument.
+//
+// Per-method type parameters — a method carrying its own `FuncType.TypeParams`, freshened per
+// call by wrapping the resolved method in a scheme — remain future work: their inference
+// depends on the generic-function machinery outside this milestone, so no method carries them
+// yet and memberValue passes the field through unchanged.
 func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
 	obj, ok := carrier.(*soltype.ObjectType)
 	if !ok {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -36,6 +36,21 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
+// coalesceKeeping is coalesce with a set of variables held symbolic rather than inlined to
+// their bounds, plus a kept-flow map naming the kept vars that flow into each other var
+// through the upper-bound graph. It is the generic-class analogue of coalesce: a class
+// member whose type flows from a class type parameter reads as that parameter once the
+// intermediate vars are inlined, but only if the parameter var survives and its inbound flow
+// is recovered. B8's freezeClassBody passes the class's own TypeParam vars — and each
+// method's own TypeParams vars — as keep, so `class Box<T> { read(self) { self.v } }` stores
+// `read`'s return as `T` rather than collapsing the intermediate var to `never`.
+// projectClassMember then substitutes `T` for the instance's argument.
+func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) soltype.Type {
+	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType](), keep: keep, flow: flow}, pol)
+	c = bubbleOwnedMut(c)
+	return coalesceLifetimes(c, pol)
+}
+
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the
 // variance flip come from soltype.Accept (the shared rewriting visitor); the var
 // node — whose bounds are a side graph, not tree children — is the whole content
@@ -47,6 +62,15 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // the path is a genuine cycle.
 type coalescer struct {
 	seen set.Set[*soltype.TypeVarType]
+	// keep holds variables retained symbolically rather than inlined to their bounds —
+	// a generic class's own type-parameter vars, set only by coalesceKeeping. It is nil
+	// for a plain coalesce, and a nil Set reads as empty, so the check below is inert on
+	// that path.
+	keep set.Set[*soltype.TypeVarType]
+	// flow maps a var to the kept vars flowing into it through the upper-bound graph,
+	// recovered as positive-position lower-bound contributions (see keptFlowMap). nil on
+	// the plain coalesce path, where ranging over the nil map yields nothing.
+	flow map[*soltype.TypeVarType][]*soltype.TypeVarType
 }
 
 func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -55,6 +79,11 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 		// Atom or structural node — let Accept rebuild it from coalesced children
 		// (including an overload-arm Union/Intersection input — the scoped lattice exception; see overloadIntersection).
 		return soltype.EnterResult{}
+	}
+	// A retained type-parameter var stays symbolic: return it unchanged so a member typed
+	// through it survives coalescing for per-instance projection (B8).
+	if c.keep.Contains(v) {
+		return soltype.EnterResult{Type: v, SkipChildren: true}
 	}
 	// Re-entering a variable already on the current path is an ungrounded recursive
 	// position (no concrete type breaks the cycle). It collapses to the polarity
@@ -72,6 +101,15 @@ func (c *coalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.Ente
 	bounds := make([]soltype.Type, 0, len(bs))
 	for _, b := range bs {
 		bounds = append(bounds, b.Accept(c, pol))
+	}
+	// A kept type-parameter var flowing into v is a lower-bound contribution the var-var
+	// edge stored on the parameter's side rather than on v (see keptFlowMap). It is a
+	// positive-position value, so add it only in Positive position and recurse so a kept
+	// var stays symbolic through the keep check above.
+	if pol == soltype.Positive {
+		for _, kv := range c.flow[v] {
+			bounds = append(bounds, kv.Accept(c, pol))
+		}
 	}
 	if len(bounds) == 0 {
 		return soltype.EnterResult{Type: emptyOf(pol), SkipChildren: true}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -31,9 +31,9 @@ import (
 // See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType]()}, pol)
-	c = bubbleOwnedMut(c)            // #779: lift an owned-mut cell out of an immutable container
-	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
+	// The uniform-inlining coalesce is coalesceKeeping with no retained vars and no
+	// kept-flow map, so both share one coalescer-invocation body.
+	return coalesceKeeping(t, pol, nil, nil)
 }
 
 // coalesceKeeping is coalesce with a set of variables held symbolic rather than inlined to
@@ -44,11 +44,12 @@ func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
 // is recovered. B8's freezeClassBody passes the class's own TypeParam vars — and each
 // method's own TypeParams vars — as keep, so `class Box<T> { read(self) { self.v } }` stores
 // `read`'s return as `T` rather than collapsing the intermediate var to `never`.
-// projectClassMember then substitutes `T` for the instance's argument.
+// projectClassMember then substitutes `T` for the instance's argument. A nil keep and nil
+// flow reduce it to the plain uniform-inlining coalesce.
 func coalesceKeeping(t soltype.Type, pol soltype.Polarity, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) soltype.Type {
 	c := t.Accept(&coalescer{seen: set.NewSet[*soltype.TypeVarType](), keep: keep, flow: flow}, pol)
-	c = bubbleOwnedMut(c)
-	return coalesceLifetimes(c, pol)
+	c = bubbleOwnedMut(c)            // #779: lift an owned-mut cell out of an immutable container
+	return coalesceLifetimes(c, pol) // D4: resolve borrow lifetimes to their display form
 }
 
 // coalescer is the soltype-visitor form of coalesce. The structural arms and the

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -777,6 +777,25 @@ func classKeepVars(typeParams []*soltype.TypeParam, bodies ...*soltype.ObjectTyp
 // map lets freezeClassBody recover T as the value flowing into such a var, adding it
 // back as a positive-position lower-bound contribution. Each var's kept sources are sorted by
 // id so the coalesced union orders deterministically.
+//
+// Worked example. For
+//
+//	class Box<T> {
+//	    v: T,
+//	    read(self) { return self.v },
+//	    alias(self) { return self.read() },
+//	}
+//
+// T is the kept var t1. Reading `self.v` inside `read` constrains t1 <: t4, where t4 is
+// `read`'s return var, and `alias` returning `self.read()` constrains t4 <: t5, where t5 is
+// `alias`'s return var. constrain records each edge on the smaller var's upper bounds, so the
+// stored graph is t1.upper=[t4], t4.upper=[t5]; t4 and t5 have no lower bounds. Given
+// keep={t1}, the forward walk over upper-bound edges reaches t4 then t5, so the result is
+//
+//	{ t4: [t1], t5: [t1] }
+//
+// The kept var t1 is not itself a key — only the vars it flows into are. freezeClassBody then
+// coalesces `read`'s return t4 to t1 and `alias`'s return t5 to t1 rather than to `never`.
 func keptFlowMap(keep set.Set[*soltype.TypeVarType]) map[*soltype.TypeVarType][]*soltype.TypeVarType {
 	reached := map[*soltype.TypeVarType]set.Set[*soltype.TypeVarType]{}
 	for kv := range keep {

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -96,13 +96,21 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	c.inferMemberBodies(declScope, lvl, body, pending)
 	ctorType := c.inferConstructor(declScope, lvl, decl, self, body, ctors)
 
-	// A generic class keeps its member types symbolic — a field typed `T` stays the
-	// class type-parameter var so member lookup can substitute an instance's argument
-	// for it. Freezing would coalesce that unconstrained var to `never`. A non-generic
-	// class has no such vars, so its body is coalesced to concrete member types.
+	// Coalesce each member so lookup reads concrete member types rather than the fresh
+	// vars a field held before a constructor assignment refined it. A non-generic class
+	// has no type-parameter vars, so its body coalesces fully. A generic class keeps its
+	// own type-parameter vars — and each method's own type parameters — symbolic so member
+	// lookup can substitute an instance's argument for them (B8): a plain freeze would
+	// collapse a member typed through `T`, such as `read(self) { self.v }`, to `never`
+	// because the intermediate inference var's only bound is the still-unconstrained `T`.
 	if len(typeParams) == 0 {
-		c.freezeClassBody(body)
-		c.freezeClassBody(static)
+		c.freezeClassBody(body, nil, nil)
+		c.freezeClassBody(static, nil, nil)
+	} else {
+		keep := classKeepVars(typeParams, body, static)
+		flow := keptFlowMap(keep)
+		c.freezeClassBody(body, keep, flow)
+		c.freezeClassBody(static, keep, flow)
 	}
 
 	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
@@ -736,24 +744,96 @@ func (v *selfMethodVisitor) EnterExpr(e ast.Expr) bool {
 	return true
 }
 
+// classKeepVars collects the type-parameter vars a generic class body coalesces around:
+// the class's own TypeParam vars plus every method signature's own TypeParam vars. These
+// stay symbolic through the coalesce so member lookup can substitute an instance's
+// argument for a class parameter and instantiate a method's own parameters per call (B8).
+func classKeepVars(typeParams []*soltype.TypeParam, bodies ...*soltype.ObjectType) set.Set[*soltype.TypeVarType] {
+	keep := set.NewSet[*soltype.TypeVarType]()
+	for _, tp := range typeParams {
+		keep.Add(tp.Var)
+	}
+	for _, obj := range bodies {
+		for _, elem := range obj.Elems {
+			m, ok := elem.(*soltype.MethodElem)
+			if !ok {
+				continue
+			}
+			for _, sig := range m.Signatures {
+				for _, tp := range sig.TypeParams {
+					keep.Add(tp.Var)
+				}
+			}
+		}
+	}
+	return keep
+}
+
+// keptFlowMap maps each inference var to the kept type-parameter vars that flow into it —
+// the kept vars T for which T <: v is recorded transitively through the upper-bound graph.
+// It exists because constrain stores a var-var edge on ONE side: an unannotated field read
+// `self.v` on `class Box<T>` records the read's result var on T's upper bounds rather than T
+// on the result's lower bounds, so the result coalesces to `never` when read positively. The
+// map lets freezeClassBody recover T as the value flowing into such a var, adding it
+// back as a positive-position lower-bound contribution. Each var's kept sources are sorted by
+// id so the coalesced union orders deterministically.
+func keptFlowMap(keep set.Set[*soltype.TypeVarType]) map[*soltype.TypeVarType][]*soltype.TypeVarType {
+	reached := map[*soltype.TypeVarType]set.Set[*soltype.TypeVarType]{}
+	for kv := range keep {
+		// Forward DFS over upper-bound var edges from kv: every var reached has kv <: it,
+		// so kv is one of the values flowing into it. seen bounds the walk on a cycle.
+		seen := set.NewSet[*soltype.TypeVarType]()
+		stack := []*soltype.TypeVarType{kv}
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, ub := range v.UpperBounds {
+				uv, ok := ub.(*soltype.TypeVarType)
+				if !ok || seen.Contains(uv) {
+					continue
+				}
+				seen.Add(uv)
+				if reached[uv] == nil {
+					reached[uv] = set.NewSet[*soltype.TypeVarType]()
+				}
+				reached[uv].Add(kv)
+				stack = append(stack, uv)
+			}
+		}
+	}
+	flow := make(map[*soltype.TypeVarType][]*soltype.TypeVarType, len(reached))
+	for v, sources := range reached {
+		vars := sources.ToSlice()
+		sort.Slice(vars, func(i, j int) bool { return vars[i].ID < vars[j].ID })
+		flow[v] = vars
+	}
+	return flow
+}
+
 // freezeClassBody coalesces each member's type in place so member lookup and the
-// class-vs-object rule read concrete member types rather than the fresh vars a field
-// held before a constructor assignment refined it. Each member is coalesced
-// individually rather than the whole object at once, since coalesce's object-merge pass
-// reads every element as a property and panics on a method, getter, or setter member.
-func (c *checker) freezeClassBody(obj *soltype.ObjectType) {
+// class-vs-object rule read concrete member types rather than the fresh vars a field held
+// before a constructor assignment refined it. Each member is coalesced individually rather
+// than the whole object at once, since coalesce's object-merge pass reads every element as a
+// property and panics on a method, getter, or setter member.
+//
+// keep and flow are nil for a non-generic class, where coalesceKeeping reduces to a plain
+// coalesce. A generic class passes its type-parameter vars as keep — held symbolic instead of
+// inlined to their bounds — and the kept-flow map so a member typed through a class parameter,
+// such as `read(self) { self.v }` on `class Box<T>`, reads `T` rather than collapsing to
+// `never`, leaving `T` in place for projectClassMember to substitute at an instance's argument.
+func (c *checker) freezeClassBody(obj *soltype.ObjectType, keep set.Set[*soltype.TypeVarType], flow map[*soltype.TypeVarType][]*soltype.TypeVarType) {
 	for i, e := range obj.Elems {
 		switch e := e.(type) {
 		case *soltype.PropertyElem:
-			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesce(e.Type, soltype.Positive), Optional: e.Optional, Readonly: e.Readonly}
+			obj.Elems[i] = &soltype.PropertyElem{Name: e.Name, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow), Optional: e.Optional, Readonly: e.Readonly}
 		case *soltype.GetterElem:
-			obj.Elems[i] = &soltype.GetterElem{Name: e.Name, SelfParam: e.SelfParam, Type: coalesce(e.Type, soltype.Positive)}
+			obj.Elems[i] = &soltype.GetterElem{Name: e.Name, SelfParam: e.SelfParam, Type: coalesceKeeping(e.Type, soltype.Positive, keep, flow)}
 		case *soltype.SetterElem:
-			obj.Elems[i] = &soltype.SetterElem{Name: e.Name, SelfParam: e.SelfParam, Param: coalesce(e.Param, soltype.Negative)}
+			obj.Elems[i] = &soltype.SetterElem{Name: e.Name, SelfParam: e.SelfParam, Param: coalesceKeeping(e.Param, soltype.Negative, keep, flow)}
 		case *soltype.MethodElem:
 			sigs := make([]*soltype.FuncType, len(e.Signatures))
 			for j, sig := range e.Signatures {
-				if cs, ok := coalesce(sig, soltype.Positive).(*soltype.FuncType); ok {
+				if cs, ok := coalesceKeeping(sig, soltype.Positive, keep, flow).(*soltype.FuncType); ok {
 					sigs[j] = cs
 				} else {
 					sigs[j] = sig

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -761,21 +761,17 @@ func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 }
 */
 
-// TestInferClassGenericMethodReturnsTypeParam pins the gap where a method whose return is a
-// class type parameter round-trips as `never` through a call — both a `self.method()` call
-// and external access. `read` returns the field typed `T`, so `b.read()` for `b : Box<5>`
-// should project `T` to `5`, and `alias` calling `self.read()` should reach the same value.
+// TestInferClassGenericMethodReturnsTypeParam checks that a method whose return flows from a
+// class type parameter projects to the instance's argument — both through a `self.method()`
+// call and external access. `read` returns the field typed `T`, so `b.read()` for `b : Box<5>`
+// projects `T` to `5`, and `alias` calling `self.read()` reaches the same value.
 //
-// DISABLED until B8 (planning/simple_sub/m5-implementation-plan.md §"Phase B"). B1's
-// §"Member access" owned this — wire a resolved method through the projected ClassDef.Body,
-// wrapping the method's own TypeParams in a PolyScheme and substituting the class arguments —
-// but the shipped B1 slice descoped the generic case. Today member access returns the
-// method's raw FuncType, and an unannotated field read mints an intermediate var that
-// class-argument projection cannot rewrite, so the return collapses to `never`. Neither
-// classBodyMember (self access) nor projectedMember (external access) needs its own fix — the
-// selective generic-body coalesce and the wrap belong in the shared member-access path. B8
-// lands it; re-enable then.
-/*
+// B8 (planning/simple_sub/m5-implementation-plan.md §"Phase B") lands this. A generic class
+// body is coalesced at decl time in a mode that keeps the class's own type-parameter vars
+// symbolic, so a method whose return is an unannotated field read reads as `T` — recovered
+// through the kept-flow map, since the read's var-var edge is stored on `T`'s upper bounds —
+// and class-argument projection then rewrites `T`. The fix lives in the shared member-access
+// path, so both classBodyMember (self access) and projectedMember (external access) benefit.
 func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		class Box<T> {
@@ -791,7 +787,46 @@ func TestInferClassGenericMethodReturnsTypeParam(t *testing.T) {
 	require.Equal(t, "5", values["x"])
 	require.Equal(t, "5", values["y"])
 }
-*/
+
+// TestInferClassGenericGetterReturnsTypeParam checks the getter analogue of the method case:
+// a getter whose return flows from a class type parameter projects to the instance's argument.
+// `get first(self) { return self.v }` on `class Box<T>` reads `T`, so `b.first` for `b : Box<5>`
+// projects to `5`. The kept-flow coalesce keeps `T` symbolic through the getter's return var
+// the same way it does for a method return.
+func TestInferClassGenericGetterReturnsTypeParam(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> {
+			v: T,
+			get first(self) { return self.v },
+		}
+		val b = Box("hi")
+		val x = b.first
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `"hi"`, values["x"])
+}
+
+// TestInferClassGenericMixedMembers checks that keeping the class's type-parameter var symbolic
+// does not disturb a concrete member. `label` returns a plain `string` regardless of the type
+// argument, while `read` returns the parameter `T`, so `b.label()` is `string` and `b.read()`
+// is the argument. This confirms the generic-body coalesce still collapses a member with a
+// concrete value the way a non-generic class's freeze does, coalescing only the type-parameter
+// flow symbolically.
+func TestInferClassGenericMixedMembers(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Box<T> {
+			v: T,
+			read(self) { return self.v },
+			label(self) -> string { return "box" },
+		}
+		val b = Box(5)
+		val r = b.read()
+		val l = b.label()
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "5", values["r"])
+	require.Equal(t, "string", values["l"])
+}
 
 // TestInferClassInheritedMemberAccess checks that a member declared on a superclass is
 // reachable through a subclass instance: reading an inherited field and calling an


### PR DESCRIPTION
Implements the generic-class coalescing strategy for B8. When a generic class body is frozen, type-parameter vars are now held symbolic rather than inlined to their bounds, allowing methods and getters whose returns flow from class parameters to preserve those parameters through coalescing instead of collapsing to `never`.

**Key changes:**

- Added `classKeepVars` to collect the class's own type-parameter vars plus each method's own type-parameter vars for symbolic retention during coalescing.
- Added `keptFlowMap` to recover type-parameter vars that flow into intermediate inference vars through the upper-bound graph. This addresses the asymmetry where an unannotated field read stores its result var on the parameter's upper bounds rather than the parameter on the result's lower bounds.
- Introduced `coalesceKeeping` as a variant of `coalesce` that accepts a set of vars to keep symbolic and a flow map to restore their contributions as positive-position lower bounds.
- Updated `freezeClassBody` to call `coalesceKeeping` for generic classes (passing the kept vars and flow map) and plain `coalesce` for non-generic classes (nil arguments, preserving existing behavior).
- Updated `coalescer` to skip inlining kept type-parameter vars and to add kept-var contributions as lower bounds in positive positions.
- Re-enabled `TestInferClassGenericMethodReturnsTypeParam` and added `TestInferClassGenericGetterReturnsTypeParam` and `TestInferClassGenericMixedMembers` to verify the fix works for methods, getters, and mixed concrete/generic members.
- Updated comments in `classBodyMember` to reflect that the limitation for class type parameters is now resolved; per-method type parameters remain future work.

The fix ensures that `class Box<T> { read(self) { self.v } }` stores `read`'s return as `T` rather than `never`, so both self calls and external calls can project `T` to the instance's argument.

https://claude.ai/code/session_01YQ3C2DEBTrUkhvWZ1Z8Jcd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for generic classes so methods and getters correctly preserve and return class type parameters.
  * Fixed inference for classes containing a mix of generic and concrete members, preventing valid type information from being lost.

* **Tests**
  * Added coverage for generic method returns, getter returns, and mixed-member inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->