### PR TITLE
Implement enum type inference (M5 D-Enum)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -523,6 +523,11 @@ func (p *namedPrinter) printType(t Type) string {
 		// namespace prefix for registry keying, stripped here for display. Lt and the
 		// `mut` borrow forms come from a RefType wrapper, not this arm.
 		name := classDisplayName(t.Name)
+		if t.Variant {
+			// An enum variant renders qualified by its enum, `Color.RGB`, so variants of
+			// two enums sharing a name stay distinct; a plain class strips to its bare name.
+			name = enumVariantDisplayName(t.Name)
+		}
 		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
 		}
@@ -630,6 +635,21 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 func classDisplayName(qname string) string {
 	if i := strings.LastIndex(qname, "."); i >= 0 {
 		return qname[i+1:]
+	}
+	return qname
+}
+
+// enumVariantDisplayName renders an enum variant's qualified name as `Enum.Variant` —
+// the last two dot-components — stripping any dep_graph namespace prefix while keeping
+// the enum qualifier. A root-namespace `Color.RGB` and a namespaced `Geo.Color.RGB`
+// both render `Color.RGB`. A name with fewer than two components is returned unchanged.
+func enumVariantDisplayName(qname string) string {
+	last := strings.LastIndex(qname, ".")
+	if last < 0 {
+		return qname
+	}
+	if prev := strings.LastIndex(qname[:last], "."); prev >= 0 {
+		return qname[prev+1:]
 	}
 	return qname
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -545,6 +545,11 @@ type ClassType struct {
 	// closed the way an exact object is (exact-types §2.6). The zero value false is
 	// inexact, matching a non-final class whose subclasses may widen it.
 	Final bool
+	// Variant marks an enum variant such as `Color.RGB`, so it renders qualified by its
+	// enum — the last two components of Name — rather than stripped to the bare `RGB` a
+	// class renders under. This keeps two enums that share a variant name distinct at
+	// display time. The zero value false is an ordinary class or the enum type itself.
+	Variant bool
 }
 
 func (*TypeVarType) isType()      {}

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -246,7 +246,7 @@ func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
 		// LifetimeArgs and Lt are lifetimes, not Types, so Accept never walks them; a
 		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
 		// ClassType before this rebuild, so cur already holds the freshened lifetimes.
-		out = &ClassType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs, Lt: cur.Lt, Final: cur.Final}
+		out = &ClassType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs, Lt: cur.Lt, Final: cur.Final, Variant: cur.Variant}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -51,12 +51,6 @@ type ClassDef struct {
 	// constructor itself is the value binding's FuncType.
 	Static *soltype.ObjectType
 
-	// Variants holds an enum's variant types in declaration order, each a `final`
-	// ClassType whose Supers name this enum (M5 D-Enum). It is nil for an ordinary
-	// class; the enum-exhaustive `match` leg (D2) reads it to enumerate the cases a
-	// scrutinee of the enum type must cover.
-	Variants []*soltype.ClassType
-
 	// Level is the class binding's generalize level. A generic method's own type
 	// parameters live deeper than this, so member access wraps a resolved method in a
 	// scheme quantified at this level and instantiates it per access.

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -51,6 +51,12 @@ type ClassDef struct {
 	// constructor itself is the value binding's FuncType.
 	Static *soltype.ObjectType
 
+	// Variants holds an enum's variant types in declaration order, each a `final`
+	// ClassType whose Supers name this enum (M5 D-Enum). It is nil for an ordinary
+	// class; the enum-exhaustive `match` leg (D2) reads it to enumerate the cases a
+	// scrutinee of the enum type must cover.
+	Variants []*soltype.ClassType
+
 	// Level is the class binding's generalize level. A generic method's own type
 	// parameters live deeper than this, so member access wraps a resolved method in a
 	// scheme quantified at this level and instantiates it per access.

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -260,6 +260,15 @@ func (c *checker) pushFuncCtx(async bool, node ast.Node) *funcCtx {
 	return saved
 }
 
+// inScript reports whether the current statement runs at a script's top level (bin/).
+// InferScript pushes a funcCtx with a nil node; a real function body pushes its
+// FuncExpr/FuncDecl node, and module top-level has no funcCtx at all (c.fn == nil). It
+// gates the handful of top-level constructs a script admits but a function body does not,
+// such as a local enum declaration.
+func (c *checker) inScript() bool {
+	return c.fn != nil && c.fn.node == nil
+}
+
 // popFuncCtx restores the previous function context (the pointer pushFuncCtx
 // returned) and hands back the return-point types collected from the body just
 // walked, so the caller can join them into the function's return type.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -122,6 +122,24 @@ func (c *checker) inferClassDecl(scope *Scope, lvl int, decl *ast.ClassDecl, ns 
 	return c.classValue(ctorType, static), &ast.NodeProvenance{Node: decl}, true
 }
 
+// bindScriptClass infers a class declared at a script's top level (bin/) and binds its
+// constructor value in scope. inferClassDecl already registers the instance type binding
+// and the nominal ClassDef; this generalizes the returned constructor value and defines
+// it, the linear-body analogue of what the module SCC driver does after constraining the
+// class value into its binding var. A script is source-order, so a self-recursive class
+// resolves through the shell inferClassDecl pre-binds, while a forward reference to a
+// class declared later is an unknown identifier.
+func (c *checker) bindScriptClass(scope *Scope, lvl int, decl *ast.ClassDecl) {
+	t, src, ok := c.inferClassDecl(scope, lvl+1, decl, "")
+	if !ok {
+		return
+	}
+	scope.defineValue(decl.Name.Name, ValueBinding{
+		Schemes: []TypeScheme{c.generalize(t, lvl)},
+		Sources: []provenance.Provenance{src},
+	})
+}
+
 // classValue produces the RAW value type a class name binds to. A class with no statics
 // binds its bare constructor FuncType; one with statics binds an exact object holding a
 // ConstructorElem plus the static members, so `Point(…)` constructs and `Point.origin` reads.

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -272,7 +272,7 @@ func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *a
 			args[i] = c.freshAt(lvl)
 		}
 	}
-	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final}
+	return &soltype.ClassType{Name: ct.Name, TypeArgs: args, Final: ct.Final, Variant: ct.Variant}
 }
 
 // lookupClassBinding resolves a written type name to its scope TypeBinding, honoring

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -43,7 +43,13 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	c.classNamespace = ns
 	defer func() { c.classNamespace = prevNS }()
 
-	qname := qualifyEnumName(ns, decl)
+	// The enum's dep_graph-qualified name — the namespace joined to the local name, or the
+	// bare local name at the root namespace — mirroring the key dep_graph forms and the
+	// qualified names class registration uses.
+	qname := decl.Name.Name
+	if ns != "" {
+		qname = ns + "." + decl.Name.Name
+	}
 
 	// Resolve the enum's type parameters into a child scope so a variant parameter and a
 	// variant's own type arguments resolve the enum's T to one shared var, quantified at
@@ -137,15 +143,4 @@ func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVar
 		}
 	}
 	return &soltype.FuncType{Params: params, Ret: ret}
-}
-
-// qualifyEnumName returns an enum's dep_graph-qualified name — the namespace joined to
-// the local name with a dot, or the bare local name at the root namespace. It mirrors
-// qualifyClassName so an enum's registry keys and type binding match the qualified key
-// dep_graph forms.
-func qualifyEnumName(ns string, decl *ast.EnumDecl) string {
-	if ns == "" {
-		return decl.Name.Name
-	}
-	return ns + "." + decl.Name.Name
 }

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"fmt"
+
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/provenance"
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -121,9 +123,12 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVariant, ret soltype.Type) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(variant.Params))
 	for i, p := range variant.Params {
+		// A destructuring or wildcard parameter has no single name, so fall back to a
+		// positional placeholder — distinct per position, mirroring memberSigStub — so
+		// two unnamed params do not collide on one name.
 		name, ok := identPatName(p.Pattern)
 		if !ok {
-			name = "arg"
+			name = fmt.Sprintf("arg%d", i)
 		}
 		params[i] = &soltype.FuncParam{
 			Pattern:  &soltype.IdentPat{Name: name},

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -6,28 +6,28 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferEnumDecl types an enum declaration (M5 D-Enum). An enum is modeled as a union
-// of implicitly-`final` variant class types, reusing B1's nominal machinery: each
-// variant is a ClassType token backed by a minimal ClassDef in the registry, the enum
-// name binds as a TYPE to the union of those variants, and each variant's constructor
-// binds as a VALUE under a namespace named for the enum, so `Maybe.Some` resolves the
-// constructor and `Maybe.Some(5)` produces a value of the variant type — a subtype of
-// the enum union.
+// inferEnumDecl types an enum declaration (M5 D-Enum), porting the old checker's
+// nominal enum model to soltype. An enum name binds as a TYPE to a nominal ClassType,
+// so a value annotated `: Color` renders `Color`. Each variant is a `final` ClassType
+// named `Color.RGB` whose Supers name the enum, so a variant value is a subtype of the
+// enum, and each variant's constructor binds as a VALUE under a namespace named for the
+// enum: `Color.RGB(255, 0, 0)` constructs a `Color.RGB`, which flows into `Color`.
+//
+// Qualifying every variant with its enum keeps two enums that share a variant name
+// distinct — `Color.RGB` and `Pixel.RGB` are separate nominal tokens.
 //
 // It is driven from the SCC type-key path (module.go), which is ordered before the
-// enum's value-key component, so the type binding and namespace exist for every later
-// declaration that references the enum. The value key is a no-op skipped as handled.
+// enum's value-key component, so the enum type binding and the constructor namespace
+// exist for every later declaration that references the enum. The value key is a no-op
+// skipped as handled.
 //
-// The type binding is defined BEFORE variant constructor parameters are resolved, so a
-// self-recursive enum such as `enum Tree { Leaf, Node(left: Tree, right: Tree) }`
-// resolves each variant's `Tree` parameter to the union under construction.
+// The enum type binding is defined BEFORE variant constructor parameters are resolved,
+// so a self-recursive enum such as `enum Tree { Leaf, Node(left: Tree, right: Tree) }`
+// resolves each variant's `Tree` parameter to the enum under construction.
 //
-// Scope: this is the exhaustiveness substrate D2 needs — a union of nominal variant
-// tokens — not full enum semantics. A generic enum's variant constructors generalize
-// and construct correctly, but the enum type name itself carries no type arguments: the
-// union binding holds the enum's raw parameter vars, so instantiating `MyOption<number>`
-// as a type annotation waits on M7's generic-alias resolution. Non-generic enums are
-// complete.
+// Scope: the enum is the nominal identity plus its variant subtypes, enough for the
+// exhaustiveness substrate D2 needs. Per-variant variance on a generic enum's arguments
+// falls out of the shared class variance inference and is not specialized here.
 func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) {
 	// An enum-body type reference resolves against the enum's own namespace first, the
 	// same qualified-first resolution a class body uses. Save and restore around the walk.
@@ -38,8 +38,8 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	qname := qualifyEnumName(ns, decl)
 
 	// Resolve the enum's type parameters into a child scope so a variant parameter and a
-	// variant type argument resolve the enum's T to one shared var, quantified at the enum
-	// boundary and freshened per construction. A non-generic enum reuses the enclosing scope.
+	// variant's own type arguments resolve the enum's T to one shared var, quantified at
+	// the enum boundary and freshened per construction. A non-generic enum reuses scope.
 	declScope := scope
 	var typeParams []*soltype.TypeParam
 	if len(decl.TypeParams) > 0 {
@@ -48,10 +48,27 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	}
 	typeArgs := typeParamVars(typeParams)
 
-	// Phase 1: mint each variant's nominal token and register its ClassDef, so a variant
-	// parameter referencing a sibling variant resolves before any constructor is built.
+	// The enum's own nominal token. It is non-final, since its variants are subtypes that
+	// extend it, and it carries the enum's type arguments so `MyOption<number>` resolves.
+	enumType := &soltype.ClassType{Name: qname, TypeArgs: typeArgs}
+	c.ctx.registerClass(qname, &ClassDef{
+		TypeParams: typeParams,
+		Variance:   make([]Variance, len(typeParams)),
+		Body:       &soltype.ObjectType{},
+		Static:     &soltype.ObjectType{},
+		Level:      lvl - 1,
+	})
+	scope.defineType(qname, TypeBinding{
+		Type:    enumType,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	c.recordType(decl.Name, enumType)
+
+	// Phase 1: mint each variant's nominal token and register its ClassDef, extending the
+	// enum, so a variant parameter referencing a sibling variant resolves before any
+	// constructor is built.
 	variants := make([]*ast.EnumVariant, 0, len(decl.Elems))
-	variantTypes := make([]soltype.Type, 0, len(decl.Elems))
+	variantTypes := make([]*soltype.ClassType, 0, len(decl.Elems))
 	for _, elem := range decl.Elems {
 		variant, ok := elem.(*ast.EnumVariant)
 		if !ok {
@@ -61,10 +78,11 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 			continue
 		}
 		vname := qname + "." + variant.Name.Name
-		vt := &soltype.ClassType{Name: vname, TypeArgs: typeArgs, Final: true}
+		vt := &soltype.ClassType{Name: vname, TypeArgs: typeArgs, Final: true, Variant: true}
 		c.ctx.registerClass(vname, &ClassDef{
 			TypeParams: typeParams,
 			Variance:   make([]Variance, len(typeParams)),
+			Supers:     []*soltype.ClassType{enumType},
 			Body:       &soltype.ObjectType{},
 			Static:     &soltype.ObjectType{},
 			Level:      lvl - 1,
@@ -73,15 +91,9 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 		variants = append(variants, variant)
 		variantTypes = append(variantTypes, vt)
 	}
-
-	// The enum type is the union of its variants. Define it before resolving variant
-	// parameters so a recursive variant resolves the enum name to this union.
-	enumType := soltype.Type(&soltype.UnionType{Types: variantTypes})
-	scope.defineType(qname, TypeBinding{
-		Type:    enumType,
-		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
-	})
-	c.recordType(decl.Name, enumType)
+	if def, ok := c.ctx.classDef(qname); ok {
+		def.Variants = variantTypes
+	}
 
 	// Phase 2: build each variant's constructor and bind it in the enum's namespace.
 	nsValues := map[string]ValueBinding{}

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -6,16 +6,21 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferEnumDecl types an enum declaration (M5 D-Enum), porting the old checker's
-// nominal enum model to soltype. An enum name binds as a TYPE to a nominal ClassType,
-// so a value of the enum renders `Color`. Each variant is a `final` ClassType named
-// `Color.RGB` whose Supers name the enum, and each variant's constructor binds as a
-// VALUE under a namespace named for the enum. A constructor returns the enum type, so
-// `Color.Hex("#fff")` infers `Color`; the variant type surfaces when a match narrows
-// the enum back to one case (D2).
+// inferEnumDecl types an enum declaration (M5 D-Enum), porting the old checker's enum
+// model to soltype. The old checker binds the enum name to BOTH a namespace and a type
+// alias whose body is a union of the variant types. soltype has no type aliases yet
+// (M7), so this binds the enum name as a namespace and binds the type directly to that
+// union: `Color` resolves to `Color.RGB | Color.Hex`.
 //
-// Qualifying every variant with its enum keeps two enums that share a variant name
-// distinct — `Color.RGB` and `Pixel.RGB` are separate nominal tokens.
+// TODO(M7): once type aliases land, bind the enum name to a proper alias whose body is
+// this union, so a reference to the enum renders under its own name — `Color` rather
+// than the expanded `Color.RGB | Color.Hex` — the way the old checker's TypeRefType
+// does. The union built here becomes that alias's body.
+//
+// Each variant is a `final` ClassType named `Color.RGB` — a nominal token qualified by
+// its enum, so two enums that share a variant name stay distinct. Each variant's
+// constructor binds as a value under the enum namespace and returns the enum type, so
+// `Color.Hex("#fff")` infers `Color.RGB | Color.Hex`, the union the enum names.
 //
 // It is driven from the SCC type-key path (module.go), which is ordered before the
 // enum's value-key component, so the enum type binding and the constructor namespace
@@ -24,11 +29,11 @@ import (
 //
 // The enum type binding is defined BEFORE variant constructor parameters are resolved,
 // so a self-recursive enum such as `enum Tree { Leaf, Node(left: Tree, right: Tree) }`
-// resolves each variant's `Tree` parameter to the enum under construction.
+// resolves each variant's `Tree` parameter to the enum union under construction.
 //
-// Scope: the enum is the nominal identity plus its variant subtypes, enough for the
-// exhaustiveness substrate D2 needs. Per-variant variance on a generic enum's arguments
-// falls out of the shared class variance inference and is not specialized here.
+// Scope: the enum is the union of its variant tokens — the exhaustiveness substrate D2
+// needs, which reads the union's members. A generic enum's variant arguments follow the
+// shared class variance and are not specialized here.
 func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) {
 	// An enum-body type reference resolves against the enum's own namespace first, the
 	// same qualified-first resolution a class body uses. Save and restore around the walk.
@@ -49,27 +54,10 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	}
 	typeArgs := typeParamVars(typeParams)
 
-	// The enum's own nominal token. It is non-final, since its variants are subtypes that
-	// extend it, and it carries the enum's type arguments so `MyOption<number>` resolves.
-	enumType := &soltype.ClassType{Name: qname, TypeArgs: typeArgs}
-	c.ctx.registerClass(qname, &ClassDef{
-		TypeParams: typeParams,
-		Variance:   make([]Variance, len(typeParams)),
-		Body:       &soltype.ObjectType{},
-		Static:     &soltype.ObjectType{},
-		Level:      lvl - 1,
-	})
-	scope.defineType(qname, TypeBinding{
-		Type:    enumType,
-		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
-	})
-	c.recordType(decl.Name, enumType)
-
-	// Phase 1: mint each variant's nominal token and register its ClassDef, extending the
-	// enum, so a variant parameter referencing a sibling variant resolves before any
-	// constructor is built.
+	// Phase 1: mint each variant's nominal token and register its ClassDef, so a variant
+	// parameter referencing a sibling variant resolves before any constructor is built.
 	variants := make([]*ast.EnumVariant, 0, len(decl.Elems))
-	variantTypes := make([]*soltype.ClassType, 0, len(decl.Elems))
+	variantTypes := make([]soltype.Type, 0, len(decl.Elems))
 	for _, elem := range decl.Elems {
 		variant, ok := elem.(*ast.EnumVariant)
 		if !ok {
@@ -83,7 +71,6 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 		c.ctx.registerClass(vname, &ClassDef{
 			TypeParams: typeParams,
 			Variance:   make([]Variance, len(typeParams)),
-			Supers:     []*soltype.ClassType{enumType},
 			Body:       &soltype.ObjectType{},
 			Static:     &soltype.ObjectType{},
 			Level:      lvl - 1,
@@ -92,22 +79,27 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 		variants = append(variants, variant)
 		variantTypes = append(variantTypes, vt)
 	}
-	if def, ok := c.ctx.classDef(qname); ok {
-		def.Variants = variantTypes
-	}
+
+	// The enum type is the union of its variants. Define it before resolving variant
+	// parameters so a recursive variant resolves the enum name to this union.
+	enumType := soltype.Type(&soltype.UnionType{Types: variantTypes})
+	scope.defineType(qname, TypeBinding{
+		Type:    enumType,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	c.recordType(decl.Name, enumType)
 
 	// Phase 2: build each variant's constructor and bind it in the enum's namespace.
 	nsValues := map[string]ValueBinding{}
 	nsTypes := map[string]TypeBinding{}
 	for i, variant := range variants {
-		vt := variantTypes[i]
 		ctor := c.variantConstructor(declScope, lvl, variant, enumType)
 		nsValues[variant.Name.Name] = ValueBinding{
 			Schemes: []TypeScheme{c.generalize(ctor, lvl-1)},
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
 		}
 		nsTypes[variant.Name.Name] = TypeBinding{
-			Type:    vt,
+			Type:    variantTypes[i],
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
 		}
 	}
@@ -121,11 +113,11 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 
 // variantConstructor builds one enum variant's constructor: a function taking the
 // variant's declared parameters and returning the ENUM type, so `Color.Hex("#fff")`
-// infers `Color`, not the narrower `Color.Hex` — matching the old checker, where a
-// constructor call yields the enum and a match narrows it back to a variant. For a
-// generic enum the return `MyOption<T>` and the parameters share the enum's
-// type-parameter vars; the caller generalizes the result so each construction freshens
-// them, the same let-polymorphism a plain generic value uses.
+// infers the enum union `Color.RGB | Color.Hex`, not one variant — matching the old
+// checker, where a constructor yields the enum and a match narrows it back to a variant.
+// For a generic enum the return and the parameters share the enum's type-parameter vars;
+// the caller generalizes the result so each construction freshens them, the same
+// let-polymorphism a plain generic value uses.
 func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVariant, ret soltype.Type) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(variant.Params))
 	for i, p := range variant.Params {

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -8,10 +8,11 @@ import (
 
 // inferEnumDecl types an enum declaration (M5 D-Enum), porting the old checker's
 // nominal enum model to soltype. An enum name binds as a TYPE to a nominal ClassType,
-// so a value annotated `: Color` renders `Color`. Each variant is a `final` ClassType
-// named `Color.RGB` whose Supers name the enum, so a variant value is a subtype of the
-// enum, and each variant's constructor binds as a VALUE under a namespace named for the
-// enum: `Color.RGB(255, 0, 0)` constructs a `Color.RGB`, which flows into `Color`.
+// so a value of the enum renders `Color`. Each variant is a `final` ClassType named
+// `Color.RGB` whose Supers name the enum, and each variant's constructor binds as a
+// VALUE under a namespace named for the enum. A constructor returns the enum type, so
+// `Color.Hex("#fff")` infers `Color`; the variant type surfaces when a match narrows
+// the enum back to one case (D2).
 //
 // Qualifying every variant with its enum keeps two enums that share a variant name
 // distinct — `Color.RGB` and `Pixel.RGB` are separate nominal tokens.
@@ -100,7 +101,7 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	nsTypes := map[string]TypeBinding{}
 	for i, variant := range variants {
 		vt := variantTypes[i]
-		ctor := c.variantConstructor(declScope, lvl, variant, vt)
+		ctor := c.variantConstructor(declScope, lvl, variant, enumType)
 		nsValues[variant.Name.Name] = ValueBinding{
 			Schemes: []TypeScheme{c.generalize(ctor, lvl-1)},
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
@@ -119,11 +120,13 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 }
 
 // variantConstructor builds one enum variant's constructor: a function taking the
-// variant's declared parameters and returning the variant's nominal type, such as
-// `Some(value: T) -> Some<T>`. For a generic enum the return and the parameters share
-// the enum's type-parameter vars; the caller generalizes the result so each
-// construction freshens them, the same let-polymorphism a plain generic value uses.
-func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVariant, vt soltype.Type) *soltype.FuncType {
+// variant's declared parameters and returning the ENUM type, so `Color.Hex("#fff")`
+// infers `Color`, not the narrower `Color.Hex` — matching the old checker, where a
+// constructor call yields the enum and a match narrows it back to a variant. For a
+// generic enum the return `MyOption<T>` and the parameters share the enum's
+// type-parameter vars; the caller generalizes the result so each construction freshens
+// them, the same let-polymorphism a plain generic value uses.
+func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVariant, ret soltype.Type) *soltype.FuncType {
 	params := make([]*soltype.FuncParam, len(variant.Params))
 	for i, p := range variant.Params {
 		name, ok := identPatName(p.Pattern)
@@ -136,7 +139,7 @@ func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVar
 			Optional: p.Optional,
 		}
 	}
-	return &soltype.FuncType{Params: params, Ret: vt}
+	return &soltype.FuncType{Params: params, Ret: ret}
 }
 
 // qualifyEnumName returns an enum's dep_graph-qualified name — the namespace joined to

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -8,35 +8,66 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// inferEnumDecl types an enum declaration (M5 D-Enum), porting the old checker's enum
-// model to soltype. The old checker binds the enum name to BOTH a namespace and a type
-// alias whose body is a union of the variant types. soltype has no type aliases yet
-// (M7), so this binds the enum name as a namespace and binds the type directly to that
-// union: `Color` resolves to `Color.RGB | Color.Hex`.
+// Enum inference (M5 D-Enum) ports the old checker's enum model to soltype. The old
+// checker binds the enum name to BOTH a namespace and a type alias whose body is a union
+// of the variant types. soltype has no type aliases yet (M7), so the enum name binds as a
+// namespace and its type binds directly to that union: `Color` resolves to
+// `Color.RGB | Color.Hex`.
 //
 // TODO(M7): once type aliases land, bind the enum name to a proper alias whose body is
-// this union, so a reference to the enum renders under its own name — `Color` rather
-// than the expanded `Color.RGB | Color.Hex` — the way the old checker's TypeRefType
-// does. The union built here becomes that alias's body.
+// this union, so a reference to the enum renders under its own name — `Color` rather than
+// the expanded `Color.RGB | Color.Hex` — the way the old checker's TypeRefType does. The
+// union built here becomes that alias's body.
 //
 // Each variant is a `final` ClassType named `Color.RGB` — a nominal token qualified by
 // its enum, so two enums that share a variant name stay distinct. Each variant's
 // constructor binds as a value under the enum namespace and returns the enum type, so
 // `Color.Hex("#fff")` infers `Color.RGB | Color.Hex`, the union the enum names.
 //
-// It is driven from the SCC type-key path (module.go), which is ordered before the
-// enum's value-key component, so the enum type binding and the constructor namespace
-// exist for every later declaration that references the enum. The value key is a no-op
-// skipped as handled.
+// Inference is two-phase, so a group of mutually-recursive enums resolves each other:
 //
-// The enum type binding is defined BEFORE variant constructor parameters are resolved,
-// so a self-recursive enum such as `enum Tree { Leaf, Node(left: Tree, right: Tree) }`
-// resolves each variant's `Tree` parameter to the enum union under construction.
+//   - preBindEnum mints every variant token and binds the enum's union TYPE, but does
+//     NOT resolve variant parameters. Running it over every enum in a dep_graph type-key
+//     component before any body means `enum A { X(b: B) }` / `enum B { Y(a: A) }` each
+//     find the sibling's union already bound. A self-recursive enum resolves through its
+//     own union the same way.
+//   - inferEnumBody then resolves each variant's parameters, builds its constructor, and
+//     binds the constructor namespace.
+//
+// Both run from the SCC type-key path (module.go), which is ordered before the enum's
+// value-key component, so the enum type binding and the constructor namespace exist for
+// every later declaration that references the enum. The value key is a no-op skipped as
+// handled.
 //
 // Scope: the enum is the union of its variant tokens — the exhaustiveness substrate D2
 // needs, which reads the union's members. A generic enum's variant arguments follow the
 // shared class variance and are not specialized here.
-func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) {
+
+// enumShell carries an enum's pre-bound state from preBindEnum to inferEnumBody: the
+// resolved type parameters, the minted variant tokens, and the union those form. The
+// body pass reuses this state so a variant constructor shares the exact type-parameter
+// vars the union holds rather than minting a second, unrelated set.
+type enumShell struct {
+	decl  *ast.EnumDecl
+	ns    string
+	qname string
+	lvl   int
+	// scope is the scope the enum is declared in — where its type binding and namespace
+	// live. declScope is scope, or a child holding a generic enum's type parameters, and
+	// is where variant parameters resolve.
+	scope        *Scope
+	declScope    *Scope
+	variants     []*ast.EnumVariant
+	variantTypes []soltype.Type
+	enumType     soltype.Type
+}
+
+// preBindEnum mints an enum's variant tokens, registers their ClassDefs, and binds the
+// enum name's TYPE to the union of those tokens — without resolving any variant
+// parameter. It returns the shell inferEnumBody completes. Binding the union up front is
+// what lets a sibling enum, or the enum itself, resolve this name while its own body is
+// still being walked.
+func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) *enumShell {
 	// An enum-body type reference resolves against the enum's own namespace first, the
 	// same qualified-first resolution a class body uses. Save and restore around the walk.
 	prevNS := c.classNamespace
@@ -62,8 +93,8 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	}
 	typeArgs := typeParamVars(typeParams)
 
-	// Phase 1: mint each variant's nominal token and register its ClassDef, so a variant
-	// parameter referencing a sibling variant resolves before any constructor is built.
+	// Mint each variant's nominal token and register its ClassDef, so a variant parameter
+	// referencing a sibling variant resolves before any constructor is built.
 	variants := make([]*ast.EnumVariant, 0, len(decl.Elems))
 	variantTypes := make([]soltype.Type, 0, len(decl.Elems))
 	for _, elem := range decl.Elems {
@@ -88,8 +119,6 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 		variantTypes = append(variantTypes, vt)
 	}
 
-	// The enum type is the union of its variants. Define it before resolving variant
-	// parameters so a recursive variant resolves the enum name to this union.
 	enumType := soltype.Type(&soltype.UnionType{Types: variantTypes})
 	scope.defineType(qname, TypeBinding{
 		Type:    enumType,
@@ -97,22 +126,43 @@ func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns st
 	})
 	c.recordType(decl.Name, enumType)
 
-	// Phase 2: build each variant's constructor and bind it in the enum's namespace.
+	return &enumShell{
+		decl:         decl,
+		ns:           ns,
+		qname:        qname,
+		lvl:          lvl,
+		scope:        scope,
+		declScope:    declScope,
+		variants:     variants,
+		variantTypes: variantTypes,
+		enumType:     enumType,
+	}
+}
+
+// inferEnumBody completes a pre-bound enum: it resolves each variant's parameters — which
+// may name a sibling enum bound by preBindEnum — builds each variant's constructor, and
+// binds the constructor namespace. It runs after every enum in the recursive group is
+// pre-bound, so a cross-enum parameter reference resolves.
+func (c *checker) inferEnumBody(sh *enumShell) {
+	prevNS := c.classNamespace
+	c.classNamespace = sh.ns
+	defer func() { c.classNamespace = prevNS }()
+
 	nsValues := map[string]ValueBinding{}
 	nsTypes := map[string]TypeBinding{}
-	for i, variant := range variants {
-		ctor := c.variantConstructor(declScope, lvl, variant, enumType)
+	for i, variant := range sh.variants {
+		ctor := c.variantConstructor(sh.declScope, sh.lvl, variant, sh.enumType)
 		nsValues[variant.Name.Name] = ValueBinding{
-			Schemes: []TypeScheme{c.generalize(ctor, lvl-1)},
+			Schemes: []TypeScheme{c.generalize(ctor, sh.lvl-1)},
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
 		}
 		nsTypes[variant.Name.Name] = TypeBinding{
-			Type:    variantTypes[i],
+			Type:    sh.variantTypes[i],
 			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
 		}
 	}
-	scope.defineNamespace(decl.Name.Name, &Namespace{
-		Name:   qname,
+	sh.scope.defineNamespace(sh.decl.Name.Name, &Namespace{
+		Name:   sh.qname,
 		Values: nsValues,
 		Types:  nsTypes,
 		Nested: map[string]*Namespace{},

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -1,0 +1,139 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferEnumDecl types an enum declaration (M5 D-Enum). An enum is modeled as a union
+// of implicitly-`final` variant class types, reusing B1's nominal machinery: each
+// variant is a ClassType token backed by a minimal ClassDef in the registry, the enum
+// name binds as a TYPE to the union of those variants, and each variant's constructor
+// binds as a VALUE under a namespace named for the enum, so `Maybe.Some` resolves the
+// constructor and `Maybe.Some(5)` produces a value of the variant type — a subtype of
+// the enum union.
+//
+// It is driven from the SCC type-key path (module.go), which is ordered before the
+// enum's value-key component, so the type binding and namespace exist for every later
+// declaration that references the enum. The value key is a no-op skipped as handled.
+//
+// The type binding is defined BEFORE variant constructor parameters are resolved, so a
+// self-recursive enum such as `enum Tree { Leaf, Node(left: Tree, right: Tree) }`
+// resolves each variant's `Tree` parameter to the union under construction.
+//
+// Scope: this is the exhaustiveness substrate D2 needs — a union of nominal variant
+// tokens — not full enum semantics. A generic enum's variant constructors generalize
+// and construct correctly, but the enum type name itself carries no type arguments: the
+// union binding holds the enum's raw parameter vars, so instantiating `MyOption<number>`
+// as a type annotation waits on M7's generic-alias resolution. Non-generic enums are
+// complete.
+func (c *checker) inferEnumDecl(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) {
+	// An enum-body type reference resolves against the enum's own namespace first, the
+	// same qualified-first resolution a class body uses. Save and restore around the walk.
+	prevNS := c.classNamespace
+	c.classNamespace = ns
+	defer func() { c.classNamespace = prevNS }()
+
+	qname := qualifyEnumName(ns, decl)
+
+	// Resolve the enum's type parameters into a child scope so a variant parameter and a
+	// variant type argument resolve the enum's T to one shared var, quantified at the enum
+	// boundary and freshened per construction. A non-generic enum reuses the enclosing scope.
+	declScope := scope
+	var typeParams []*soltype.TypeParam
+	if len(decl.TypeParams) > 0 {
+		declScope = scope.Child()
+		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
+	}
+	typeArgs := typeParamVars(typeParams)
+
+	// Phase 1: mint each variant's nominal token and register its ClassDef, so a variant
+	// parameter referencing a sibling variant resolves before any constructor is built.
+	variants := make([]*ast.EnumVariant, 0, len(decl.Elems))
+	variantTypes := make([]soltype.Type, 0, len(decl.Elems))
+	for _, elem := range decl.Elems {
+		variant, ok := elem.(*ast.EnumVariant)
+		if !ok {
+			// Enum spreads (`...OtherEnum`) merge another enum's variants and are deferred;
+			// the EnumDecl kind is supported, so report the spread as an unsupported feature.
+			c.reportUnsupportedFeature(elem, "EnumSpread")
+			continue
+		}
+		vname := qname + "." + variant.Name.Name
+		vt := &soltype.ClassType{Name: vname, TypeArgs: typeArgs, Final: true}
+		c.ctx.registerClass(vname, &ClassDef{
+			TypeParams: typeParams,
+			Variance:   make([]Variance, len(typeParams)),
+			Body:       &soltype.ObjectType{},
+			Static:     &soltype.ObjectType{},
+			Level:      lvl - 1,
+		})
+		c.recordType(variant.Name, vt)
+		variants = append(variants, variant)
+		variantTypes = append(variantTypes, vt)
+	}
+
+	// The enum type is the union of its variants. Define it before resolving variant
+	// parameters so a recursive variant resolves the enum name to this union.
+	enumType := soltype.Type(&soltype.UnionType{Types: variantTypes})
+	scope.defineType(qname, TypeBinding{
+		Type:    enumType,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	c.recordType(decl.Name, enumType)
+
+	// Phase 2: build each variant's constructor and bind it in the enum's namespace.
+	nsValues := map[string]ValueBinding{}
+	nsTypes := map[string]TypeBinding{}
+	for i, variant := range variants {
+		vt := variantTypes[i]
+		ctor := c.variantConstructor(declScope, lvl, variant, vt)
+		nsValues[variant.Name.Name] = ValueBinding{
+			Schemes: []TypeScheme{c.generalize(ctor, lvl-1)},
+			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
+		}
+		nsTypes[variant.Name.Name] = TypeBinding{
+			Type:    vt,
+			Sources: []provenance.Provenance{&ast.NodeProvenance{Node: variant}},
+		}
+	}
+	scope.defineNamespace(decl.Name.Name, &Namespace{
+		Name:   qname,
+		Values: nsValues,
+		Types:  nsTypes,
+		Nested: map[string]*Namespace{},
+	})
+}
+
+// variantConstructor builds one enum variant's constructor: a function taking the
+// variant's declared parameters and returning the variant's nominal type, such as
+// `Some(value: T) -> Some<T>`. For a generic enum the return and the parameters share
+// the enum's type-parameter vars; the caller generalizes the result so each
+// construction freshens them, the same let-polymorphism a plain generic value uses.
+func (c *checker) variantConstructor(scope *Scope, lvl int, variant *ast.EnumVariant, vt soltype.Type) *soltype.FuncType {
+	params := make([]*soltype.FuncParam, len(variant.Params))
+	for i, p := range variant.Params {
+		name, ok := identPatName(p.Pattern)
+		if !ok {
+			name = "arg"
+		}
+		params[i] = &soltype.FuncParam{
+			Pattern:  &soltype.IdentPat{Name: name},
+			Type:     c.paramType(scope, p, lvl),
+			Optional: p.Optional,
+		}
+	}
+	return &soltype.FuncType{Params: params, Ret: vt}
+}
+
+// qualifyEnumName returns an enum's dep_graph-qualified name — the namespace joined to
+// the local name with a dot, or the bare local name at the root namespace. It mirrors
+// qualifyClassName so an enum's registry keys and type binding match the qualified key
+// dep_graph forms.
+func qualifyEnumName(ns string, decl *ast.EnumDecl) string {
+	if ns == "" {
+		return decl.Name.Name
+	}
+	return ns + "." + decl.Name.Name
+}

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -3,13 +3,13 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
 // TestInferEnumBasic covers a non-generic enum end to end (M5 D-Enum): the enum name
-// binds as a nominal type, each variant constructor resolves under the enum namespace
-// and constructs a value of the enum-qualified variant type, and a variant value flows
-// into the enum type through the nominal subtype edge.
+// binds as a nominal type, each variant constructor resolves under the enum namespace,
+// and a constructor call yields the enum type — `Color.Hex(...)` is `Color`.
 func TestInferEnumBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -29,9 +29,9 @@ func TestInferEnumBasic(t *testing.T) {
 				val blue = Color.Hex("#0000FF")
 			`,
 			wantValues: map[string]string{
-				"rgb":  "fn (r: number, g: number, b: number) -> Color.RGB",
+				"rgb":  "fn (r: number, g: number, b: number) -> Color",
 				"red":  "Color",
-				"blue": "Color.Hex",
+				"blue": "Color",
 			},
 			wantTypes: map[string]string{"Color": "Color"},
 		},
@@ -45,7 +45,7 @@ func TestInferEnumBasic(t *testing.T) {
 				val stop = Signal.Stop()
 				val s: Signal = Signal.Go()
 			`,
-			wantValues: map[string]string{"stop": "Signal.Stop", "s": "Signal"},
+			wantValues: map[string]string{"stop": "Signal", "s": "Signal"},
 			wantTypes:  map[string]string{"Signal": "Signal"},
 		},
 		{
@@ -70,7 +70,7 @@ func TestInferEnumBasic(t *testing.T) {
 				val leaf: Tree = Tree.Leaf()
 				val node = Tree.Node(Tree.Leaf(), Tree.Leaf())
 			`,
-			wantValues: map[string]string{"leaf": "Tree", "node": "Tree.Node"},
+			wantValues: map[string]string{"leaf": "Tree", "node": "Tree"},
 			wantTypes:  map[string]string{"Tree": "Tree"},
 		},
 	}
@@ -81,38 +81,34 @@ func TestInferEnumBasic(t *testing.T) {
 	}
 }
 
-// TestInferEnumSubtyping checks the nominal subtype edge each variant carries: a value
-// of a variant type is a subtype of its enum, and a variant of a different enum — even
-// one sharing a variant name — is not.
-func TestInferEnumSubtyping(t *testing.T) {
-	t.Run("VariantIsSubtypeOfEnum", func(t *testing.T) {
-		// The annotated binding constrains the variant value against the enum, so a clean
-		// inference proves Color.Hex <: Color.
-		classValues(t, `
-			enum Color {
-				RGB(r: number, g: number, b: number),
-				Hex(code: string),
-			}
-			val c: Color = Color.Hex("#fff")
-		`, map[string]string{"c": "Color"}, nil)
-	})
+// TestInferEnumNominalDistinctness checks that two enums are distinct nominal types
+// even when they declare a variant of the same name: a value of one enum never
+// satisfies the other's annotation.
+func TestInferEnumNominalDistinctness(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		enum Color { RGB(r: number) }
+		enum Palette { RGB(r: number) }
+		val bad: Color = Palette.RGB(1)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain Palette <: Color", errs[0].Message())
+}
 
-	t.Run("VariantOfOtherEnumRejected", func(t *testing.T) {
-		// Both enums declare an `RGB` variant; qualifying by enum keeps them distinct, so
-		// a Palette.RGB never satisfies a Color annotation.
-		_, _, errs := inferSource(t, `
-			enum Color { RGB(r: number) }
-			enum Palette { RGB(r: number) }
-			val bad: Color = Palette.RGB(1)
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain Palette.RGB <: Color", errs[0].Message())
-	})
+// TestEnumVariantDisplay locks in the qualified rendering of an enum variant token: a
+// variant prints as `Enum.Variant` — its enum plus its own name — so two enums sharing
+// a variant name stay distinct wherever a variant surfaces, such as a narrowed `match`
+// arm (D2). A plain class token still prints under its bare name.
+func TestEnumVariantDisplay(t *testing.T) {
+	variant := &soltype.ClassType{Name: "Geometry.Color.RGB", Final: true, Variant: true}
+	require.Equal(t, "Color.RGB", soltype.Print(variant))
+
+	class := &soltype.ClassType{Name: "Geometry.Point"}
+	require.Equal(t, "Point", soltype.Print(class))
 }
 
 // TestInferEnumGeneric checks that a generic enum's constructor is generalized like a
 // plain generic value, so each construction freshens the enum's type parameter and the
-// argument's type flows into the variant instance.
+// argument's type flows into the enum instance.
 func TestInferEnumGeneric(t *testing.T) {
 	classValues(t, `
 		enum MyOption<T> {
@@ -122,7 +118,7 @@ func TestInferEnumGeneric(t *testing.T) {
 		val some = MyOption.Some(5)
 		val str = MyOption.Some("hi")
 	`, map[string]string{
-		"some": "MyOption.Some<5>",
-		"str":  `MyOption.Some<"hi">`,
+		"some": "MyOption<5>",
+		"str":  `MyOption<"hi">`,
 	}, nil)
 }

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -204,6 +204,20 @@ func TestInferEnumUnnamedParams(t *testing.T) {
 	}, nil)
 }
 
+// TestInferEnumInFunctionBodyRejected checks that a local enum inside a function body is
+// rejected, the same as a local class: enum declarations are supported at module top
+// level and script top level, not inside a function body.
+func TestInferEnumInFunctionBodyRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f() {
+			enum Local { A, B }
+			return 0
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Declaration not allowed in function body: EnumDecl", errs[0].Message())
+}
+
 // TestEnumVariantDisplay locks in the qualified rendering of an enum variant token: a
 // variant prints as `Enum.Variant` — its enum plus its own name — so two enums sharing
 // a variant name stay distinct wherever a variant surfaces, such as a union member or a

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 // TestInferEnumBasic covers a non-generic enum end to end (M5 D-Enum): the enum name
-// binds as a type to the union of its variants, each variant constructor resolves and
-// constructs a value of the variant type, and a variant value flows into the enum type.
+// binds as a nominal type, each variant constructor resolves under the enum namespace
+// and constructs a value of the enum-qualified variant type, and a variant value flows
+// into the enum type through the nominal subtype edge.
 func TestInferEnumBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -17,7 +18,7 @@ func TestInferEnumBasic(t *testing.T) {
 		wantTypes  map[string]string
 	}{
 		{
-			name: "VariantConstructorAndUnionType",
+			name: "VariantConstructorAndEnumType",
 			src: `
 				enum Color {
 					RGB(r: number, g: number, b: number),
@@ -28,11 +29,11 @@ func TestInferEnumBasic(t *testing.T) {
 				val blue = Color.Hex("#0000FF")
 			`,
 			wantValues: map[string]string{
-				"rgb":  "fn (r: number, g: number, b: number) -> RGB",
-				"red":  "RGB | Hex",
-				"blue": "Hex",
+				"rgb":  "fn (r: number, g: number, b: number) -> Color.RGB",
+				"red":  "Color",
+				"blue": "Color.Hex",
 			},
-			wantTypes: map[string]string{"Color": "RGB | Hex"},
+			wantTypes: map[string]string{"Color": "Color"},
 		},
 		{
 			name: "NullaryVariant",
@@ -42,9 +43,10 @@ func TestInferEnumBasic(t *testing.T) {
 					Go,
 				}
 				val stop = Signal.Stop()
+				val s: Signal = Signal.Go()
 			`,
-			wantValues: map[string]string{"stop": "Stop"},
-			wantTypes:  map[string]string{"Signal": "Stop | Go"},
+			wantValues: map[string]string{"stop": "Signal.Stop", "s": "Signal"},
+			wantTypes:  map[string]string{"Signal": "Signal"},
 		},
 		{
 			name: "OutOfOrderReference",
@@ -55,8 +57,8 @@ func TestInferEnumBasic(t *testing.T) {
 					Hex(code: string),
 				}
 			`,
-			wantValues: map[string]string{"red": "RGB | Hex"},
-			wantTypes:  map[string]string{"Color": "RGB | Hex"},
+			wantValues: map[string]string{"red": "Color"},
+			wantTypes:  map[string]string{"Color": "Color"},
 		},
 		{
 			name: "RecursiveEnum",
@@ -66,9 +68,10 @@ func TestInferEnumBasic(t *testing.T) {
 					Node(left: Tree, right: Tree),
 				}
 				val leaf: Tree = Tree.Leaf()
+				val node = Tree.Node(Tree.Leaf(), Tree.Leaf())
 			`,
-			wantValues: map[string]string{"leaf": "Leaf | Node"},
-			wantTypes:  map[string]string{"Tree": "Leaf | Node"},
+			wantValues: map[string]string{"leaf": "Tree", "node": "Tree.Node"},
+			wantTypes:  map[string]string{"Tree": "Tree"},
 		},
 	}
 	for _, tt := range tests {
@@ -78,30 +81,32 @@ func TestInferEnumBasic(t *testing.T) {
 	}
 }
 
-// TestInferEnumSubtyping checks the nominal relationship the enum union rides on: a
-// value of a variant type is a subtype of its own enum, and a variant of a different
-// enum is not.
+// TestInferEnumSubtyping checks the nominal subtype edge each variant carries: a value
+// of a variant type is a subtype of its enum, and a variant of a different enum — even
+// one sharing a variant name — is not.
 func TestInferEnumSubtyping(t *testing.T) {
 	t.Run("VariantIsSubtypeOfEnum", func(t *testing.T) {
-		// The annotated binding constrains the variant value against the enum union, so a
-		// clean inference proves RGB <: (RGB | Hex).
+		// The annotated binding constrains the variant value against the enum, so a clean
+		// inference proves Color.Hex <: Color.
 		classValues(t, `
 			enum Color {
 				RGB(r: number, g: number, b: number),
 				Hex(code: string),
 			}
 			val c: Color = Color.Hex("#fff")
-		`, map[string]string{"c": "RGB | Hex"}, nil)
+		`, map[string]string{"c": "Color"}, nil)
 	})
 
 	t.Run("VariantOfOtherEnumRejected", func(t *testing.T) {
+		// Both enums declare an `RGB` variant; qualifying by enum keeps them distinct, so
+		// a Palette.RGB never satisfies a Color annotation.
 		_, _, errs := inferSource(t, `
-			enum A { X, Y }
-			enum B { Z }
-			val bad: B = A.X()
+			enum Color { RGB(r: number) }
+			enum Palette { RGB(r: number) }
+			val bad: Color = Palette.RGB(1)
 		`)
 		require.Len(t, errs, 1)
-		require.Equal(t, "cannot constrain X <: Z", errs[0].Message())
+		require.Equal(t, "cannot constrain Palette.RGB <: Color", errs[0].Message())
 	})
 }
 
@@ -117,7 +122,7 @@ func TestInferEnumGeneric(t *testing.T) {
 		val some = MyOption.Some(5)
 		val str = MyOption.Some("hi")
 	`, map[string]string{
-		"some": "Some<5>",
-		"str":  `Some<"hi">`,
+		"some": "MyOption.Some<5>",
+		"str":  `MyOption.Some<"hi">`,
 	}, nil)
 }

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -131,6 +131,20 @@ func TestInferEnumNominalDistinctness(t *testing.T) {
 	require.Equal(t, "cannot constrain Palette.RGB <: Color.RGB | Color.Hex", errs[0].Message())
 }
 
+// TestInferEnumUnnamedParams checks that a variant with several parameters that carry no
+// single name — here two wildcards — gives each constructor parameter a distinct
+// positional name rather than colliding on one shared name.
+func TestInferEnumUnnamedParams(t *testing.T) {
+	classValues(t, `
+		enum E {
+			Pair(_: number, _: string),
+		}
+		val ctor = E.Pair
+	`, map[string]string{
+		"ctor": "fn (arg0: number, arg1: string) -> E.Pair",
+	}, nil)
+}
+
 // TestEnumVariantDisplay locks in the qualified rendering of an enum variant token: a
 // variant prints as `Enum.Variant` — its enum plus its own name — so two enums sharing
 // a variant name stay distinct wherever a variant surfaces, such as a union member or a

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -1,0 +1,123 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferEnumBasic covers a non-generic enum end to end (M5 D-Enum): the enum name
+// binds as a type to the union of its variants, each variant constructor resolves and
+// constructs a value of the variant type, and a variant value flows into the enum type.
+func TestInferEnumBasic(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			name: "VariantConstructorAndUnionType",
+			src: `
+				enum Color {
+					RGB(r: number, g: number, b: number),
+					Hex(code: string),
+				}
+				val rgb = Color.RGB
+				val red: Color = Color.RGB(255, 0, 0)
+				val blue = Color.Hex("#0000FF")
+			`,
+			wantValues: map[string]string{
+				"rgb":  "fn (r: number, g: number, b: number) -> RGB",
+				"red":  "RGB | Hex",
+				"blue": "Hex",
+			},
+			wantTypes: map[string]string{"Color": "RGB | Hex"},
+		},
+		{
+			name: "NullaryVariant",
+			src: `
+				enum Signal {
+					Stop,
+					Go,
+				}
+				val stop = Signal.Stop()
+			`,
+			wantValues: map[string]string{"stop": "Stop"},
+			wantTypes:  map[string]string{"Signal": "Stop | Go"},
+		},
+		{
+			name: "OutOfOrderReference",
+			src: `
+				val red: Color = Color.RGB(255, 0, 0)
+				enum Color {
+					RGB(r: number, g: number, b: number),
+					Hex(code: string),
+				}
+			`,
+			wantValues: map[string]string{"red": "RGB | Hex"},
+			wantTypes:  map[string]string{"Color": "RGB | Hex"},
+		},
+		{
+			name: "RecursiveEnum",
+			src: `
+				enum Tree {
+					Leaf,
+					Node(left: Tree, right: Tree),
+				}
+				val leaf: Tree = Tree.Leaf()
+			`,
+			wantValues: map[string]string{"leaf": "Leaf | Node"},
+			wantTypes:  map[string]string{"Tree": "Leaf | Node"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			classValues(t, tt.src, tt.wantValues, tt.wantTypes)
+		})
+	}
+}
+
+// TestInferEnumSubtyping checks the nominal relationship the enum union rides on: a
+// value of a variant type is a subtype of its own enum, and a variant of a different
+// enum is not.
+func TestInferEnumSubtyping(t *testing.T) {
+	t.Run("VariantIsSubtypeOfEnum", func(t *testing.T) {
+		// The annotated binding constrains the variant value against the enum union, so a
+		// clean inference proves RGB <: (RGB | Hex).
+		classValues(t, `
+			enum Color {
+				RGB(r: number, g: number, b: number),
+				Hex(code: string),
+			}
+			val c: Color = Color.Hex("#fff")
+		`, map[string]string{"c": "RGB | Hex"}, nil)
+	})
+
+	t.Run("VariantOfOtherEnumRejected", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			enum A { X, Y }
+			enum B { Z }
+			val bad: B = A.X()
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "cannot constrain X <: Z", errs[0].Message())
+	})
+}
+
+// TestInferEnumGeneric checks that a generic enum's constructor is generalized like a
+// plain generic value, so each construction freshens the enum's type parameter and the
+// argument's type flows into the variant instance.
+func TestInferEnumGeneric(t *testing.T) {
+	classValues(t, `
+		enum MyOption<T> {
+			Some(value: T),
+			None,
+		}
+		val some = MyOption.Some(5)
+		val str = MyOption.Some("hi")
+	`, map[string]string{
+		"some": "Some<5>",
+		"str":  `Some<"hi">`,
+	}, nil)
+}

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -116,6 +116,37 @@ func TestInferEnumMutuallyRecursive(t *testing.T) {
 	})
 }
 
+// TestInferEnumClassMutuallyRecursive checks that an enum and a class that reference each
+// other are inferred correctly: the enum variant `Branch(node: Node)` names the class and
+// the class field `left: Tree` names the enum, forming one recursive group. Every nominal
+// identity — the enum union and the class token — is pre-bound before any body resolves a
+// reference, so both directions type-check.
+func TestInferEnumClassMutuallyRecursive(t *testing.T) {
+	classValues(t, `
+		enum Tree {
+			Leaf(value: number),
+			Branch(node: Node),
+		}
+		class Node {
+			left: Tree,
+			right: Tree,
+		}
+		val node = Node(Tree.Leaf(1), Tree.Leaf(2))
+		val branch: Tree = Tree.Branch(node)
+		val treeCtor = Tree.Branch
+		val kids = node.left
+	`, map[string]string{
+		"Node":     "fn (left: Tree.Leaf | Tree.Branch, right: Tree.Leaf | Tree.Branch) -> Node",
+		"node":     "Node",
+		"branch":   "Tree.Leaf | Tree.Branch",
+		"treeCtor": "fn (node: Node) -> Tree.Leaf | Tree.Branch",
+		"kids":     "Tree.Leaf | Tree.Branch",
+	}, map[string]string{
+		"Tree": "Tree.Leaf | Tree.Branch",
+		"Node": "Node",
+	})
+}
+
 // TestInferEnumSharedVariantName checks that two enums declaring a variant of the same
 // name do not collide: each `RGB` constructor resolves under its own enum namespace with
 // its own signature and produces its own enum union. The two constructors differ in

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -94,6 +94,35 @@ func TestInferEnumNominalDistinctness(t *testing.T) {
 	require.Equal(t, "cannot constrain Palette <: Color", errs[0].Message())
 }
 
+// TestInferEnumSharedVariantName checks that two enums declaring a variant of the same
+// name do not collide: each `RGB` constructor resolves under its own enum namespace with
+// its own signature and produces its own enum type. The two constructors differ in arity
+// (three params vs two), which they could not if they shared one registry entry.
+func TestInferEnumSharedVariantName(t *testing.T) {
+	classValues(t, `
+		enum Color {
+			RGB(r: number, g: number, b: number),
+			Hex(code: string),
+		}
+		enum Pixel {
+			RGB(x: number, y: number),
+			Empty,
+		}
+		val colorRGB = Color.RGB
+		val pixelRGB = Pixel.RGB
+		val c = Color.RGB(1, 2, 3)
+		val p = Pixel.RGB(4, 5)
+	`, map[string]string{
+		"colorRGB": "fn (r: number, g: number, b: number) -> Color",
+		"pixelRGB": "fn (x: number, y: number) -> Pixel",
+		"c":        "Color",
+		"p":        "Pixel",
+	}, map[string]string{
+		"Color": "Color",
+		"Pixel": "Pixel",
+	})
+}
+
 // TestEnumVariantDisplay locks in the qualified rendering of an enum variant token: a
 // variant prints as `Enum.Variant` — its enum plus its own name — so two enums sharing
 // a variant name stay distinct wherever a variant surfaces, such as a narrowed `match`

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -88,6 +88,34 @@ func TestInferEnumBasic(t *testing.T) {
 	}
 }
 
+// TestInferEnumMutuallyRecursive checks that two enums whose variants reference each
+// other are inferred correctly: each enum's union type is bound before either enum's
+// variant parameters are resolved, so `A`'s `ANode(next: B)` and `B`'s `BNode(next: A)`
+// both resolve the sibling enum. A single-pass walk would report the later enum's name
+// as an unknown type.
+func TestInferEnumMutuallyRecursive(t *testing.T) {
+	classValues(t, `
+		enum A {
+			AEnd,
+			ANode(next: B),
+		}
+		enum B {
+			BEnd,
+			BNode(next: A),
+		}
+		val a: A = A.AEnd()
+		val b = B.BNode(A.AEnd())
+		val ctorA = A.ANode
+	`, map[string]string{
+		"a":     "A.AEnd | A.ANode",
+		"b":     "B.BEnd | B.BNode",
+		"ctorA": "fn (next: B.BEnd | B.BNode) -> A.AEnd | A.ANode",
+	}, map[string]string{
+		"A": "A.AEnd | A.ANode",
+		"B": "B.BEnd | B.BNode",
+	})
+}
+
 // TestInferEnumSharedVariantName checks that two enums declaring a variant of the same
 // name do not collide: each `RGB` constructor resolves under its own enum namespace with
 // its own signature and produces its own enum union. The two constructors differ in

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 // TestInferEnumBasic covers a non-generic enum end to end (M5 D-Enum): the enum name
-// binds as a nominal type, each variant constructor resolves under the enum namespace,
-// and a constructor call yields the enum type — `Color.Hex(...)` is `Color`.
+// binds as a namespace and its type binds to the union of its variants, each variant
+// constructor resolves under the namespace, and a constructor call yields the enum
+// union — `Color.Hex(...)` is `Color.RGB | Color.Hex`.
 func TestInferEnumBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -29,11 +30,11 @@ func TestInferEnumBasic(t *testing.T) {
 				val blue = Color.Hex("#0000FF")
 			`,
 			wantValues: map[string]string{
-				"rgb":  "fn (r: number, g: number, b: number) -> Color",
-				"red":  "Color",
-				"blue": "Color",
+				"rgb":  "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex",
+				"red":  "Color.RGB | Color.Hex",
+				"blue": "Color.RGB | Color.Hex",
 			},
-			wantTypes: map[string]string{"Color": "Color"},
+			wantTypes: map[string]string{"Color": "Color.RGB | Color.Hex"},
 		},
 		{
 			name: "NullaryVariant",
@@ -45,8 +46,11 @@ func TestInferEnumBasic(t *testing.T) {
 				val stop = Signal.Stop()
 				val s: Signal = Signal.Go()
 			`,
-			wantValues: map[string]string{"stop": "Signal", "s": "Signal"},
-			wantTypes:  map[string]string{"Signal": "Signal"},
+			wantValues: map[string]string{
+				"stop": "Signal.Stop | Signal.Go",
+				"s":    "Signal.Stop | Signal.Go",
+			},
+			wantTypes: map[string]string{"Signal": "Signal.Stop | Signal.Go"},
 		},
 		{
 			name: "OutOfOrderReference",
@@ -57,8 +61,8 @@ func TestInferEnumBasic(t *testing.T) {
 					Hex(code: string),
 				}
 			`,
-			wantValues: map[string]string{"red": "Color"},
-			wantTypes:  map[string]string{"Color": "Color"},
+			wantValues: map[string]string{"red": "Color.RGB | Color.Hex"},
+			wantTypes:  map[string]string{"Color": "Color.RGB | Color.Hex"},
 		},
 		{
 			name: "RecursiveEnum",
@@ -70,8 +74,11 @@ func TestInferEnumBasic(t *testing.T) {
 				val leaf: Tree = Tree.Leaf()
 				val node = Tree.Node(Tree.Leaf(), Tree.Leaf())
 			`,
-			wantValues: map[string]string{"leaf": "Tree", "node": "Tree"},
-			wantTypes:  map[string]string{"Tree": "Tree"},
+			wantValues: map[string]string{
+				"leaf": "Tree.Leaf | Tree.Node",
+				"node": "Tree.Leaf | Tree.Node",
+			},
+			wantTypes: map[string]string{"Tree": "Tree.Leaf | Tree.Node"},
 		},
 	}
 	for _, tt := range tests {
@@ -81,23 +88,10 @@ func TestInferEnumBasic(t *testing.T) {
 	}
 }
 
-// TestInferEnumNominalDistinctness checks that two enums are distinct nominal types
-// even when they declare a variant of the same name: a value of one enum never
-// satisfies the other's annotation.
-func TestInferEnumNominalDistinctness(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		enum Color { RGB(r: number) }
-		enum Palette { RGB(r: number) }
-		val bad: Color = Palette.RGB(1)
-	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "cannot constrain Palette <: Color", errs[0].Message())
-}
-
 // TestInferEnumSharedVariantName checks that two enums declaring a variant of the same
 // name do not collide: each `RGB` constructor resolves under its own enum namespace with
-// its own signature and produces its own enum type. The two constructors differ in arity
-// (three params vs two), which they could not if they shared one registry entry.
+// its own signature and produces its own enum union. The two constructors differ in
+// arity (three params vs two), which they could not if they shared one registry entry.
 func TestInferEnumSharedVariantName(t *testing.T) {
 	classValues(t, `
 		enum Color {
@@ -113,20 +107,34 @@ func TestInferEnumSharedVariantName(t *testing.T) {
 		val c = Color.RGB(1, 2, 3)
 		val p = Pixel.RGB(4, 5)
 	`, map[string]string{
-		"colorRGB": "fn (r: number, g: number, b: number) -> Color",
-		"pixelRGB": "fn (x: number, y: number) -> Pixel",
-		"c":        "Color",
-		"p":        "Pixel",
+		"colorRGB": "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex",
+		"pixelRGB": "fn (x: number, y: number) -> Pixel.RGB | Pixel.Empty",
+		"c":        "Color.RGB | Color.Hex",
+		"p":        "Pixel.RGB | Pixel.Empty",
 	}, map[string]string{
-		"Color": "Color",
-		"Pixel": "Pixel",
+		"Color": "Color.RGB | Color.Hex",
+		"Pixel": "Pixel.RGB | Pixel.Empty",
 	})
+}
+
+// TestInferEnumNominalDistinctness checks that two enums are distinct types even when
+// they declare a variant of the same name: a value of one enum never satisfies the
+// other's annotation, and the qualified variant name in the error keeps the two `RGB`s
+// apart.
+func TestInferEnumNominalDistinctness(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		enum Color { RGB(r: number), Hex(code: string) }
+		enum Palette { RGB(r: number) }
+		val bad: Color = Palette.RGB(1)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain Palette.RGB <: Color.RGB | Color.Hex", errs[0].Message())
 }
 
 // TestEnumVariantDisplay locks in the qualified rendering of an enum variant token: a
 // variant prints as `Enum.Variant` — its enum plus its own name — so two enums sharing
-// a variant name stay distinct wherever a variant surfaces, such as a narrowed `match`
-// arm (D2). A plain class token still prints under its bare name.
+// a variant name stay distinct wherever a variant surfaces, such as a union member or a
+// narrowed `match` arm. A plain class token still prints under its bare name.
 func TestEnumVariantDisplay(t *testing.T) {
 	variant := &soltype.ClassType{Name: "Geometry.Color.RGB", Final: true, Variant: true}
 	require.Equal(t, "Color.RGB", soltype.Print(variant))
@@ -137,7 +145,9 @@ func TestEnumVariantDisplay(t *testing.T) {
 
 // TestInferEnumGeneric checks that a generic enum's constructor is generalized like a
 // plain generic value, so each construction freshens the enum's type parameter and the
-// argument's type flows into the enum instance.
+// argument's type flows into the enum union. Without type aliases the enum name expands
+// to its union at each use, so the parameter also reaches the sibling variant — `None`
+// prints parameterized here; naming the union to hide that waits on M7's aliases.
 func TestInferEnumGeneric(t *testing.T) {
 	classValues(t, `
 		enum MyOption<T> {
@@ -147,7 +157,7 @@ func TestInferEnumGeneric(t *testing.T) {
 		val some = MyOption.Some(5)
 		val str = MyOption.Some("hi")
 	`, map[string]string{
-		"some": "MyOption<5>",
-		"str":  `MyOption<"hi">`,
+		"some": "MyOption.Some<5> | MyOption.None<5>",
+		"str":  `MyOption.Some<"hi"> | MyOption.None<"hi">`,
 	}, nil)
 }

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -88,6 +88,21 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		return t
 	case *ast.DeclStmt:
+		if ed, ok := s.Decl.(*ast.EnumDecl); ok {
+			// A script (bin/) walks its top-level statements in source order, so an enum
+			// binds where it appears — used before its declaration it is an unknown
+			// identifier, unlike the module dep-graph path's out-of-order resolution.
+			// preBindEnum binds the enum's union type first so a self-recursive variant
+			// resolves, then inferEnumBody builds the constructors. A real function body
+			// still rejects a local enum, as it rejects a local class, so this is gated on
+			// the script context (a funcCtx with a nil node; see InferScript).
+			if c.inScript() {
+				c.inferEnumBody(c.preBindEnum(scope, lvl+1, ed, ""))
+				return &soltype.Void{}
+			}
+			c.report(&BodyDeclNotAllowedError{Decl: s.Decl})
+			return &soltype.Void{}
+		}
 		vd, ok := s.Decl.(*ast.VarDecl)
 		if !ok {
 			c.report(&BodyDeclNotAllowedError{Decl: s.Decl})

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -88,16 +88,26 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 		}
 		return t
 	case *ast.DeclStmt:
-		if ed, ok := s.Decl.(*ast.EnumDecl); ok {
-			// A script (bin/) walks its top-level statements in source order, so an enum
-			// binds where it appears — used before its declaration it is an unknown
-			// identifier, unlike the module dep-graph path's out-of-order resolution.
-			// preBindEnum binds the enum's union type first so a self-recursive variant
-			// resolves, then inferEnumBody builds the constructors. A real function body
-			// still rejects a local enum, as it rejects a local class, so this is gated on
-			// the script context (a funcCtx with a nil node; see InferScript).
+		// A script (bin/) walks its top-level statements in source order, so a class or
+		// enum binds where it appears — used before its declaration it is an unknown
+		// identifier, unlike the module dep-graph path's out-of-order resolution. A real
+		// function body still rejects a local class or enum, so both are gated on the
+		// script context (a funcCtx with a nil node; see InferScript). A script's top-level
+		// declarations live for the whole run, so the class registry's insert/overwrite
+		// invariant holds exactly as it does for a module's top-level decls.
+		switch decl := s.Decl.(type) {
+		case *ast.EnumDecl:
 			if c.inScript() {
-				c.inferEnumBody(c.preBindEnum(scope, lvl+1, ed, ""))
+				// preBindEnum binds the enum's union type first so a self-recursive variant
+				// resolves, then inferEnumBody builds the constructors.
+				c.inferEnumBody(c.preBindEnum(scope, lvl+1, decl, ""))
+				return &soltype.Void{}
+			}
+			c.report(&BodyDeclNotAllowedError{Decl: s.Decl})
+			return &soltype.Void{}
+		case *ast.ClassDecl:
+			if c.inScript() {
+				c.bindScriptClass(scope, lvl, decl)
 				return &soltype.Void{}
 			}
 			c.report(&BodyDeclNotAllowedError{Decl: s.Decl})

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -340,30 +340,20 @@ func (c *checker) inferComponent(
 	// union type binding and the variant-constructor namespace — and marks the decl
 	// handled, so its value key becomes a no-op. The enum two-pass below runs first for
 	// exactly that reason.
-	// Enums are inferred at their type key (M5 D-Enum) in two passes over the whole
-	// component, so a group of mutually-recursive enums resolves each other:
-	// preBindEnum binds every enum's union type first, then inferEnumBody resolves each
-	// enum's variant parameters — which may name a sibling enum now bound. The type-key
-	// component is ordered before the enum's value-key component, so the union type
-	// binding and the variant-constructor namespace exist for every later reference. Each
-	// enum decl is marked handled, so its value key becomes a no-op (its pre-bound value
-	// var is retracted in phase 3) and the reconciliation pass does not re-report it.
+	// Pre-bind every nominal identity in this component — each class token and each enum
+	// union type — before any enum body resolves a variant parameter, so a group of
+	// mutually-recursive classes AND enums resolves each other. A class's variant-holding
+	// enum and an enum's field-holding class land in one type-key SCC component; binding
+	// all their identities first lets `enum Json { Arr(items: JsonArray) }` /
+	// `class JsonArray { head: Json }` each resolve the sibling.
+	//
+	//   - A class is pre-bound to its nominal identity (M5 B2) and left for its value key,
+	//     which infers the body and marks the decl handled. Leaving it unhandled here lets
+	//     the reconciliation pass find it through that key.
+	//   - An enum is pre-bound to its union type (preBindEnum) and marked handled, then
+	//     completed by inferEnumBody once every sibling is bound; its value key is then a
+	//     no-op whose pre-bound value var is retracted in phase 3.
 	var enumShells []*enumShell
-	for _, key := range component {
-		if _, isValue := bindings[key]; isValue {
-			continue
-		}
-		for _, d := range g.GetDecls(key) {
-			if ed, ok := d.(*ast.EnumDecl); ok && !handled.Contains(d) {
-				enumShells = append(enumShells, c.preBindEnum(scope, inner, ed, g.GetNamespace(key)))
-				handled.Add(d)
-			}
-		}
-	}
-	for _, sh := range enumShells {
-		c.inferEnumBody(sh)
-	}
-
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -372,18 +362,37 @@ func (c *checker) inferComponent(
 			if handled.Contains(d) {
 				continue
 			}
-			if cd, ok := d.(*ast.ClassDecl); ok {
-				// Pre-bind the class's nominal identity before any body in its recursive
-				// group is walked (M5 B2). A type-key component is the SCC condensation of
-				// a group of mutually-recursive classes, so registering every class's type
-				// binding and empty ClassDef here lets a sibling defined later in the group
-				// resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
-				// The value key infers the body and marks the decl handled; leave it
-				// unhandled here so the reconciliation pass finds it through that key. The
-				// returned token and def are discarded here; inferClassDecl reuses them.
-				// The type key carries the same namespace as the value key, so the shell is
-				// keyed by the same qualified name inferClassDecl reconstructs.
-				c.getOrCreateClass(scope, cd, g.GetNamespace(key))
+			switch decl := d.(type) {
+			case *ast.EnumDecl:
+				enumShells = append(enumShells, c.preBindEnum(scope, inner, decl, g.GetNamespace(key)))
+				handled.Add(d)
+			case *ast.ClassDecl:
+				// A type-key component is the SCC condensation of mutually-recursive classes,
+				// so registering every class's type binding and empty ClassDef here lets a
+				// sibling resolve a forward reference — `class A { b: B }` / `class B { a: A }`.
+				// The returned token and def are discarded here; inferClassDecl reuses them,
+				// keyed by the same qualified name the shared namespace reconstructs.
+				c.getOrCreateClass(scope, decl, g.GetNamespace(key))
+			}
+		}
+	}
+	// Every enum body resolves its variant parameters against the fully pre-bound
+	// identities above, so a parameter naming a sibling enum or class resolves.
+	for _, sh := range enumShells {
+		c.inferEnumBody(sh)
+	}
+
+	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
+	// is completed at its value key, so skip it rather than mis-reporting it.
+	for _, key := range component {
+		if _, isValue := bindings[key]; isValue {
+			continue
+		}
+		for _, d := range g.GetDecls(key) {
+			if handled.Contains(d) {
+				continue
+			}
+			if _, ok := d.(*ast.ClassDecl); ok {
 				continue
 			}
 			handled.Add(d)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -336,10 +336,34 @@ func (c *checker) inferComponent(
 	// mis-report the class and mark the decl handled, blocking the value key. So a class
 	// type key skips without marking handled and the value key does the work.
 	//
-	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum —
-	// the union type binding and the variant-constructor namespace — and marks the decl
-	// handled, so its value key becomes a no-op. The type key's component is ordered
-	// before the value key's, so the enum's bindings exist for every later reference.
+	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum — the
+	// union type binding and the variant-constructor namespace — and marks the decl
+	// handled, so its value key becomes a no-op. The enum two-pass below runs first for
+	// exactly that reason.
+	// Enums are inferred at their type key (M5 D-Enum) in two passes over the whole
+	// component, so a group of mutually-recursive enums resolves each other:
+	// preBindEnum binds every enum's union type first, then inferEnumBody resolves each
+	// enum's variant parameters — which may name a sibling enum now bound. The type-key
+	// component is ordered before the enum's value-key component, so the union type
+	// binding and the variant-constructor namespace exist for every later reference. Each
+	// enum decl is marked handled, so its value key becomes a no-op (its pre-bound value
+	// var is retracted in phase 3) and the reconciliation pass does not re-report it.
+	var enumShells []*enumShell
+	for _, key := range component {
+		if _, isValue := bindings[key]; isValue {
+			continue
+		}
+		for _, d := range g.GetDecls(key) {
+			if ed, ok := d.(*ast.EnumDecl); ok && !handled.Contains(d) {
+				enumShells = append(enumShells, c.preBindEnum(scope, inner, ed, g.GetNamespace(key)))
+				handled.Add(d)
+			}
+		}
+	}
+	for _, sh := range enumShells {
+		c.inferEnumBody(sh)
+	}
+
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -360,17 +384,6 @@ func (c *checker) inferComponent(
 				// The type key carries the same namespace as the value key, so the shell is
 				// keyed by the same qualified name inferClassDecl reconstructs.
 				c.getOrCreateClass(scope, cd, g.GetNamespace(key))
-				continue
-			}
-			if ed, ok := d.(*ast.EnumDecl); ok {
-				// Infer the whole enum at its type key (M5 D-Enum). The type-key component
-				// is ordered before the enum's value-key component, so the union type
-				// binding and the variant-constructor namespace both exist for every later
-				// declaration that references the enum. Mark the decl handled so the value
-				// key skips it (its pre-bound value var is retracted in phase 3) and the
-				// reconciliation pass does not report it as unmodeled.
-				c.inferEnumDecl(scope, inner, ed, g.GetNamespace(key))
-				handled.Add(d)
 				continue
 			}
 			handled.Add(d)

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -327,16 +327,19 @@ func (c *checker) inferComponent(
 
 	// Non-value keys such as type aliases are outside the M2 subset. Report each
 	// contributing decl once, skipping any already handled by a value key. A class or
-	// enum contributes both a value and a type key for the same decl, so its type key
-	// is skipped here.
+	// enum contributes both a value and a type key for the same decl, so one of the two
+	// keys is handled here and the other elsewhere.
 	//
-	// A class's type key is left to its value key, which infers the class and
-	// registers both the instance type and the constructor together (M5 B1). The two
-	// keys land in separate components, and the type key's component is ordered first,
-	// so reporting it here would both mis-report the class as unsupported and mark the
-	// decl handled — blocking the value key. Skip such a decl without marking it
-	// handled; its value key infers it and the reconciliation pass then finds it
-	// handled.
+	// A class's type key is left to its value key, which infers the class and registers
+	// both the instance type and the constructor together (M5 B1). Its type key here only
+	// pre-binds the nominal identity for recursion; reporting it as unsupported would
+	// mis-report the class and mark the decl handled, blocking the value key. So a class
+	// type key skips without marking handled and the value key does the work.
+	//
+	// An enum inverts the split (M5 D-Enum): its type key here infers the whole enum —
+	// the union type binding and the variant-constructor namespace — and marks the decl
+	// handled, so its value key becomes a no-op. The type key's component is ordered
+	// before the value key's, so the enum's bindings exist for every later reference.
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -357,6 +360,17 @@ func (c *checker) inferComponent(
 				// The type key carries the same namespace as the value key, so the shell is
 				// keyed by the same qualified name inferClassDecl reconstructs.
 				c.getOrCreateClass(scope, cd, g.GetNamespace(key))
+				continue
+			}
+			if ed, ok := d.(*ast.EnumDecl); ok {
+				// Infer the whole enum at its type key (M5 D-Enum). The type-key component
+				// is ordered before the enum's value-key component, so the union type
+				// binding and the variant-constructor namespace both exist for every later
+				// declaration that references the enum. Mark the decl handled so the value
+				// key skips it (its pre-bound value var is retracted in phase 3) and the
+				// reconciliation pass does not report it as unmodeled.
+				c.inferEnumDecl(scope, inner, ed, g.GetNamespace(key))
+				handled.Add(d)
 				continue
 			}
 			handled.Add(d)

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -54,6 +54,40 @@ func TestInferScriptSourceOrder(t *testing.T) {
 	require.Equal(t, "5", values["y"])
 }
 
+// TestInferScriptEnum checks that an enum can be declared and used in a script (bin/).
+// A script's top-level statements run in source order, so an enum declared before its
+// use binds its type and variant constructors just as in a module: a constructor call
+// yields the enum union.
+func TestInferScriptEnum(t *testing.T) {
+	values, types, errs := inferScriptSource(t, `
+		enum Color {
+			RGB(r: number, g: number, b: number),
+			Hex(code: string),
+		}
+		val c = Color.Hex("#fff")
+		val mk = Color.RGB
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "Color.RGB | Color.Hex", types["Color"])
+	require.Equal(t, "Color.RGB | Color.Hex", values["c"])
+	require.Equal(t, "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex", values["mk"])
+}
+
+// TestInferScriptEnumOutOfOrder checks that a script does NOT resolve an enum used before
+// its declaration. Unlike a module, whose top-level declarations are dependency-ordered,
+// a script's statements are linear, so a forward reference is an unknown identifier.
+func TestInferScriptEnumOutOfOrder(t *testing.T) {
+	_, _, errs := inferScriptSource(t, `
+		val c = Color.Hex("#fff")
+		enum Color {
+			RGB(r: number),
+			Hex(code: string),
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: Color", errs[0].Message())
+}
+
 // TestScriptTransitionParity is the milestone's central claim: a `mut`→immutable
 // transition at script top level is checked identically to the same statements
 // wrapped in a function body. Each case runs through InferScript directly, then again

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -88,6 +88,40 @@ func TestInferScriptEnumOutOfOrder(t *testing.T) {
 	require.Equal(t, "Unknown identifier: Color", errs[0].Message())
 }
 
+// TestInferScriptClass checks that a class can be declared and used in a script (bin/):
+// the constructor value and instance type bind, and field and method access resolve
+// through the projected class body, just as in a module.
+func TestInferScriptClass(t *testing.T) {
+	values, types, errs := inferScriptSource(t, `
+		class Point {
+			x: number,
+			y: number,
+			getX(self) -> number { return self.x },
+		}
+		val p = Point(1, 2)
+		val px = p.x
+		val d = p.getX()
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "Point", types["Point"])
+	require.Equal(t, "fn (x: number, y: number) -> Point", values["Point"])
+	require.Equal(t, "Point", values["p"])
+	require.Equal(t, "number", values["px"])
+	require.Equal(t, "number", values["d"])
+}
+
+// TestInferScriptClassOutOfOrder checks that a script does NOT resolve a class used
+// before its declaration — its statements are linear, so a forward reference is an
+// unknown identifier, unlike a module's dependency-ordered declarations.
+func TestInferScriptClassOutOfOrder(t *testing.T) {
+	_, _, errs := inferScriptSource(t, `
+		val p = Point(1, 2)
+		class Point { x: number, y: number }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unknown identifier: Point", errs[0].Message())
+}
+
 // TestScriptTransitionParity is the milestone's central claim: a `mut`→immutable
 // transition at script top level is checked identically to the same statements
 // wrapped in a function body. Each case runs through InferScript directly, then again


### PR DESCRIPTION
Adds type inference for enum declarations, modeling each enum as a union of nominal variant class types. The implementation follows the M5 D-Enum specification and integrates with the existing class machinery for nominal typing.

## Changes

- **New `inferEnumDecl` function** in `internal/solver/infer_enum.go`: Infers enum declarations in two phases. Phase 1 mints a nominal `ClassType` token for each variant and registers a minimal `ClassDef` in the registry, allowing variants to reference each other. Phase 2 builds each variant's constructor function and binds it in the enum's namespace. The enum type itself is defined as a union of its variant types before variant parameters are resolved, enabling self-recursive enums like `Tree { Node(left: Tree, right: Tree) }`.

- **New `variantConstructor` function**: Builds a variant's constructor as a function type taking the variant's declared parameters and returning the variant's nominal type. For generic enums, the constructor is generalized so each construction freshens the enum's type parameters.

- **New `qualifyEnumName` helper**: Mirrors `qualifyClassName` to produce dep_graph-qualified enum names for registry keys and type bindings.

- **Updated `inferComponent` in `internal/solver/module.go`**: Routes enum type keys to `inferEnumDecl` instead of reporting them as unsupported. The type-key component is ordered before the value-key component, so the enum's union type binding and variant-constructor namespace exist for all later references. The enum declaration is marked handled at the type key, making the value key a no-op.

- **Comprehensive test suite** in `internal/solver/infer_enum_test.go`: Covers non-generic enums (variant constructors, union types, nullary variants, recursive enums), subtyping (variants as subtypes of their enum, rejection of variants from other enums), and generic enums (constructor generalization and type parameter freshening).

## Implementation notes

Generic enums carry their raw type parameter vars in the union binding, so instantiating `MyOption<number>` as a type annotation awaits M7's generic-alias resolution. Non-generic enums are complete. Enum spreads (`...OtherEnum`) are reported as unsupported and deferred to a future milestone.

https://claude.ai/code/session_01V7fr2nnoyjSEEh1NMKaDtb