### PR TITLE
Implement method overload resolution and receiver mutability checks

### DIFF
--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -572,27 +572,12 @@ func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
 	}
 }
 
-// checkMethodReceiver constrains the `self` receiver of a member accessed inside a class
-// body against that member's declared `self` type, so a `mut self` sibling reached from a
-// plain-`self` method is rejected. This is the receiver-dependent half of method dispatch.
-// A method body holds a borrow of its receiver whose mutability its own declaration fixes.
-// A `mut self` receiver grants a mutable borrow and a plain `self` only a shared one, so a
-// `self.bump()` call to a `mut self` `bump` from inside `peek(self)` has no mutable access
-// to lend. This fires only for an inside-the-body access, where the receiver's mutability is
-// carried in `self`'s type. An external call reads its receiver off a binding, whose
-// mutability is a place property rather than a type property. Distinguishing `val c` from
-// `val mut c` there needs place-mutability tracking through member access that this check
-// does not perform.
-//
-// recv is the original `self` binding before its borrow was stripped for member lookup, so
-// its mutability is intact. The check is a no-op for a static member, a property, or a
-// member whose receiver is not a class instance.
-//
-// The receiver is rebuilt as the member's own `Self` type carried in the caller's
-// mutability rather than constraining recv directly, so the diagnostic names the class on
-// both sides. A `self.bump()` call from a plain-`self` method renders `immutable C <:
-// mutable C`, not `immutable object <: mutable C`, since `self` inside the body binds to
-// the class-body object view rather than the nominal instance.
+// checkMethodReceiver rejects a `mut self` member reached from a plain-`self` body, which
+// holds only a shared borrow to lend. It fires only for inside-the-body access, where recv
+// (the un-stripped `self` binding) carries the caller's mutability; an external call's
+// mutability is a place property this check does not see. The receiver is rebuilt as the
+// member's own `Self` carried in that mutability so the diagnostic names the class on both
+// sides. A no-op for a static member, a property, or a non-class receiver.
 func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member soltype.ObjTypeElem) {
 	self := memberSelfParam(member)
 	if self == nil {
@@ -609,13 +594,10 @@ func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member 
 	c.constrain(blame, recvT, self.Type)
 }
 
-// memberSelfParam returns the `self` receiver of a READABLE member — a method or getter —
-// or nil for a static member, a property, or a member with no receiver. An overloaded
-// method reads its first arm's receiver, which is representative because buildMemberSigs
-// rejects an overload set whose arms disagree on receiver mutability
-// (MethodOverloadReceiverMismatchError). A setter is excluded because reading one is already
-// a write-only error, and its write-side receiver mutability is checked on assignment rather
-// than on this read path.
+// memberSelfParam returns the `self` receiver of a readable member, a method or getter, or
+// nil otherwise. A method reads its first arm's receiver, representative because
+// buildMemberSigs rejects arms that disagree on receiver mutability. A setter is excluded,
+// since reading one is already a write-only error.
 func memberSelfParam(member soltype.ObjTypeElem) *soltype.FuncParam {
 	switch m := member.(type) {
 	case *soltype.MethodElem:

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -454,7 +454,7 @@ func (c *checker) projectedClassMember(ct *soltype.ClassType, name string, visit
 // call by wrapping the resolved method in a scheme — remain future work: their inference
 // depends on the generic-function machinery outside this milestone, so no method carries them
 // yet and memberValue passes the field through unchanged.
-func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, carrier soltype.Type) (pathResult, bool) {
+func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, recv, carrier soltype.Type) (pathResult, bool) {
 	obj, ok := carrier.(*soltype.ObjectType)
 	if !ok {
 		return pathResult{}, false
@@ -466,6 +466,7 @@ func (c *checker) classBodyMember(lvl int, blame ast.Node, name string, carrier 
 	if _, isProp := member.(*soltype.PropertyElem); isProp {
 		return pathResult{}, false
 	}
+	c.checkMethodReceiver(blame, recv, member)
 	return c.memberValue(lvl, blame, member), true
 }
 
@@ -521,8 +522,13 @@ func classCarrier(t soltype.Type) (*soltype.ClassType, bool) {
 // type directly, or a method's callable signature with the receiver applied — the
 // signature with its SelfParam stripped, since `p.m` binds the receiver and returns a
 // function of the remaining parameters. Reading a setter-only member is a write-only
-// access and is reported. An overloaded method resolves its arm at the call site (E1);
-// B1 hands back the first signature.
+// access and is reported.
+//
+// An overloaded method carries more than one signature in its MethodElem. Its member value
+// is the IntersectionType of those arms, each with its SelfParam stripped. A direct call
+// `p.m(args)` resolves one arm through resolveOverload at the call site in inferCall, and a
+// read of an overloaded method as a value carries the intersection the way a let-bound
+// overloaded function does.
 func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeElem) pathResult {
 	var out soltype.Type
 	switch m := member.(type) {
@@ -531,17 +537,17 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	case *soltype.GetterElem:
 		out = m.Type
 	case *soltype.MethodElem:
-		if len(m.Signatures) == 0 {
+		switch len(m.Signatures) {
+		case 0:
 			out = &soltype.ErrorType{}
-			break
-		}
-		sig := m.Signatures[0]
-		out = &soltype.FuncType{
-			Params:         sig.Params,
-			Ret:            sig.Ret,
-			Inexact:        sig.Inexact,
-			TypeParams:     sig.TypeParams,
-			LifetimeParams: sig.LifetimeParams,
+		case 1:
+			out = strippedMethodSig(m.Signatures[0])
+		default:
+			arms := make([]soltype.Type, len(m.Signatures))
+			for i, sig := range m.Signatures {
+				arms[i] = strippedMethodSig(sig)
+			}
+			out = &soltype.IntersectionType{Types: arms}
 		}
 	case *soltype.SetterElem:
 		out = c.report(&WriteOnlyPropertyError{Name: m.Name, Site: blame})
@@ -550,6 +556,89 @@ func (c *checker) memberValue(lvl int, blame ast.Node, member soltype.ObjTypeEle
 	}
 	c.recordType(blame, out)
 	return pathResult{value: out}
+}
+
+// strippedMethodSig returns a method signature as a plain callable, its SelfParam
+// dropped, since `p.m` binds the receiver and returns a function of the remaining
+// parameters. The receiver's own ownership is checked separately at member access as a
+// `receiver <: SelfParam` constraint.
+func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
+	return &soltype.FuncType{
+		Params:         sig.Params,
+		Ret:            sig.Ret,
+		Inexact:        sig.Inexact,
+		TypeParams:     sig.TypeParams,
+		LifetimeParams: sig.LifetimeParams,
+	}
+}
+
+// checkMethodReceiver constrains the `self` receiver of a member accessed inside a class
+// body against that member's declared `self` type, so a `mut self` sibling reached from a
+// plain-`self` method is rejected. This is the receiver-dependent half of method dispatch.
+// A method body holds a borrow of its receiver whose mutability its own declaration fixes.
+// A `mut self` receiver grants a mutable borrow and a plain `self` only a shared one, so a
+// `self.bump()` call to a `mut self` `bump` from inside `peek(self)` has no mutable access
+// to lend. This fires only for an inside-the-body access, where the receiver's mutability is
+// carried in `self`'s type. An external call reads its receiver off a binding, whose
+// mutability is a place property rather than a type property. Distinguishing `val c` from
+// `val mut c` there needs place-mutability tracking through member access that this check
+// does not perform.
+//
+// recv is the original `self` binding before its borrow was stripped for member lookup, so
+// its mutability is intact. The check is a no-op for a static member, a property, or a
+// member whose receiver is not a class instance.
+//
+// The receiver is rebuilt as the member's own `Self` type carried in the caller's
+// mutability rather than constraining recv directly, so the diagnostic names the class on
+// both sides. A `self.bump()` call from a plain-`self` method renders `immutable C <:
+// mutable C`, not `immutable object <: mutable C`, since `self` inside the body binds to
+// the class-body object view rather than the nominal instance.
+func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member soltype.ObjTypeElem) {
+	self := memberSelfParam(member)
+	if self == nil {
+		return
+	}
+	inner := receiverClass(self.Type)
+	if inner == nil {
+		return
+	}
+	recvT := soltype.Type(inner)
+	if r, ok := recv.(*soltype.RefType); ok && r.Mut {
+		recvT = soltype.NewRef(true, nil, inner)
+	}
+	c.constrain(blame, recvT, self.Type)
+}
+
+// memberSelfParam returns the `self` receiver of a READABLE member — a method or getter —
+// or nil for a static member, a property, or a member with no receiver. An overloaded
+// method reads its first arm's receiver, since a class's overload arms share one receiver
+// mutability. A setter is excluded because reading one is already a write-only error, and
+// its write-side receiver mutability is checked on assignment rather than on this read path.
+func memberSelfParam(member soltype.ObjTypeElem) *soltype.FuncParam {
+	switch m := member.(type) {
+	case *soltype.MethodElem:
+		if len(m.Signatures) > 0 {
+			return m.Signatures[0].SelfParam
+		}
+	case *soltype.GetterElem:
+		return m.SelfParam
+	}
+	return nil
+}
+
+// receiverClass returns the class instance a `self` receiver type names — the ClassType
+// directly for a plain `self`, or the ClassType inside the borrow for a `mut self` / `&self`
+// receiver. It returns nil when the receiver is not a class instance.
+func receiverClass(t soltype.Type) soltype.RefInner {
+	switch t := t.(type) {
+	case *soltype.ClassType:
+		return t
+	case *soltype.RefType:
+		if ct, ok := t.Inner.(*soltype.ClassType); ok {
+			return ct
+		}
+	}
+	return nil
 }
 
 // classValueMember resolves a static member read off a class value, such as

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -573,11 +573,17 @@ func strippedMethodSig(sig *soltype.FuncType) *soltype.FuncType {
 }
 
 // checkMethodReceiver rejects a `mut self` member reached from a plain-`self` body, which
-// holds only a shared borrow to lend. It fires only for inside-the-body access, where recv
-// (the un-stripped `self` binding) carries the caller's mutability; an external call's
-// mutability is a place property this check does not see. The receiver is rebuilt as the
-// member's own `Self` carried in that mutability so the diagnostic names the class on both
-// sides. A no-op for a static member, a property, or a non-class receiver.
+// holds only a shared borrow to lend. It constrains the enclosing `self` against the accessed
+// member's declared `self`. The four pairings:
+//
+//   - plain `self` body → `mut self` member: rejected, a shared borrow has no mut to lend
+//   - `mut self` body   → `mut self` member: ok
+//   - `mut self` body   → plain `self` member: ok, mutable downgrades to shared
+//   - plain `self` body → plain `self` member: ok
+//
+// It fires only inside a body, where the un-stripped `self` binding recv carries the caller's
+// mutability. The receiver is rebuilt as `Self` in that mutability, so the diagnostic reads
+// `immutable C <: mutable C`. A no-op for a static member, a property, or a non-class receiver.
 func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member soltype.ObjTypeElem) {
 	self := memberSelfParam(member)
 	if self == nil {

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -611,9 +611,11 @@ func (c *checker) checkMethodReceiver(blame ast.Node, recv soltype.Type, member 
 
 // memberSelfParam returns the `self` receiver of a READABLE member — a method or getter —
 // or nil for a static member, a property, or a member with no receiver. An overloaded
-// method reads its first arm's receiver, since a class's overload arms share one receiver
-// mutability. A setter is excluded because reading one is already a write-only error, and
-// its write-side receiver mutability is checked on assignment rather than on this read path.
+// method reads its first arm's receiver, which is representative because buildMemberSigs
+// rejects an overload set whose arms disagree on receiver mutability
+// (MethodOverloadReceiverMismatchError). A setter is excluded because reading one is already
+// a write-only error, and its write-side receiver mutability is checked on assignment rather
+// than on this read path.
 func memberSelfParam(member soltype.ObjTypeElem) *soltype.FuncParam {
 	switch m := member.(type) {
 	case *soltype.MethodElem:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -812,43 +812,44 @@ type MixedOwnershipError struct {
 	Node ast.Node
 }
 
-func (*UnknownIdentifierError) isSolverError()            {}
-func (*NamespaceUsedAsValueError) isSolverError()         {}
-func (*UnknownNamespaceMemberError) isSolverError()       {}
-func (*DynamicNamespaceIndexError) isSolverError()        {}
-func (*InvalidAssignmentTargetError) isSolverError()      {}
-func (*CannotAssignToImmutableError) isSolverError()      {}
-func (*TooManyArgsError) isSolverError()                  {}
-func (*NotEnoughArgsError) isSolverError()                {}
-func (*UnsupportedNodeError) isSolverError()              {}
-func (*UnsupportedFeatureError) isSolverError()           {}
-func (*BodyDeclNotAllowedError) isSolverError()           {}
-func (*MissingInitializerError) isSolverError()           {}
-func (*DuplicateDeclarationError) isSolverError()         {}
-func (*NoMatchingOverloadError) isSolverError()           {}
-func (*UnannotatedRecursiveOverloadError) isSolverError() {}
-func (*DuplicateOverloadError) isSolverError()            {}
-func (*AwaitOutsideAsyncError) isSolverError()            {}
-func (*ForAwaitOutsideAsyncError) isSolverError()         {}
-func (*NotIterableError) isSolverError()                  {}
-func (*ReturnOutsideFunctionError) isSolverError()        {}
-func (*AsyncReturnNotPromiseError) isSolverError()        {}
-func (*NonExhaustiveMatchError) isSolverError()           {}
-func (*MixedOwnershipError) isSolverError()               {}
-func (*MutLeafThroughSharedBorrowError) isSolverError()   {}
-func (*MissingSelfReceiverError) isSolverError()          {}
-func (*MultipleConstructorsError) isSolverError()         {}
-func (*FieldInitializerNotAllowedError) isSolverError()   {}
-func (*SubclassConstructorRequiredError) isSolverError()  {}
-func (*WriteOnlyPropertyError) isSolverError()            {}
-func (*SetterArityError) isSolverError()                  {}
-func (*RecursiveMethodAnnotationError) isSolverError()    {}
-func (*FieldNotInitializedError) isSolverError()          {}
-func (*ReadBeforeInitError) isSolverError()               {}
-func (*MethodCallBeforeInitError) isSolverError()         {}
-func (*InstancePatternNotClassError) isSolverError()      {}
-func (*ExtractorPatternNotCtorError) isSolverError()      {}
-func (*ExtractorPatternArityError) isSolverError()        {}
+func (*UnknownIdentifierError) isSolverError()              {}
+func (*NamespaceUsedAsValueError) isSolverError()           {}
+func (*UnknownNamespaceMemberError) isSolverError()         {}
+func (*DynamicNamespaceIndexError) isSolverError()          {}
+func (*InvalidAssignmentTargetError) isSolverError()        {}
+func (*CannotAssignToImmutableError) isSolverError()        {}
+func (*TooManyArgsError) isSolverError()                    {}
+func (*NotEnoughArgsError) isSolverError()                  {}
+func (*UnsupportedNodeError) isSolverError()                {}
+func (*UnsupportedFeatureError) isSolverError()             {}
+func (*BodyDeclNotAllowedError) isSolverError()             {}
+func (*MissingInitializerError) isSolverError()             {}
+func (*DuplicateDeclarationError) isSolverError()           {}
+func (*NoMatchingOverloadError) isSolverError()             {}
+func (*UnannotatedRecursiveOverloadError) isSolverError()   {}
+func (*DuplicateOverloadError) isSolverError()              {}
+func (*AwaitOutsideAsyncError) isSolverError()              {}
+func (*ForAwaitOutsideAsyncError) isSolverError()           {}
+func (*NotIterableError) isSolverError()                    {}
+func (*ReturnOutsideFunctionError) isSolverError()          {}
+func (*AsyncReturnNotPromiseError) isSolverError()          {}
+func (*NonExhaustiveMatchError) isSolverError()             {}
+func (*MixedOwnershipError) isSolverError()                 {}
+func (*MutLeafThroughSharedBorrowError) isSolverError()     {}
+func (*MissingSelfReceiverError) isSolverError()            {}
+func (*MethodOverloadReceiverMismatchError) isSolverError() {}
+func (*MultipleConstructorsError) isSolverError()           {}
+func (*FieldInitializerNotAllowedError) isSolverError()     {}
+func (*SubclassConstructorRequiredError) isSolverError()    {}
+func (*WriteOnlyPropertyError) isSolverError()              {}
+func (*SetterArityError) isSolverError()                    {}
+func (*RecursiveMethodAnnotationError) isSolverError()      {}
+func (*FieldNotInitializedError) isSolverError()            {}
+func (*ReadBeforeInitError) isSolverError()                 {}
+func (*MethodCallBeforeInitError) isSolverError()           {}
+func (*InstancePatternNotClassError) isSolverError()        {}
+func (*ExtractorPatternNotCtorError) isSolverError()        {}
+func (*ExtractorPatternArityError) isSolverError()          {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -862,6 +863,22 @@ func (e *MissingSelfReceiverError) Span() ast.Span      { return e.Elem.Span() }
 func (e *MissingSelfReceiverError) Related() []ast.Span { return nil }
 func (e *MissingSelfReceiverError) Message() string {
 	return "Instance member '" + e.Name + "' must declare a `self` receiver as its first parameter."
+}
+
+// MethodOverloadReceiverMismatchError fires when the arms of an overloaded method disagree
+// on their `self` receiver mutability, as when one arm declares `self` and another `mut
+// self`. Overload resolution dispatches on the value arguments rather than the receiver, and
+// the receiver-mutability check reads one representative arm, so every arm must agree on
+// whether it needs a mutable receiver. Elem is the offending arm.
+type MethodOverloadReceiverMismatchError struct {
+	Name string
+	Elem ast.ClassElem
+}
+
+func (e *MethodOverloadReceiverMismatchError) Span() ast.Span      { return e.Elem.Span() }
+func (e *MethodOverloadReceiverMismatchError) Related() []ast.Span { return nil }
+func (e *MethodOverloadReceiverMismatchError) Message() string {
+	return "Overloaded method '" + e.Name + "' must use the same `self` receiver mutability in every arm."
 }
 
 // WriteOnlyPropertyError fires when a setter-only member is read, as in `val v =

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -452,6 +452,13 @@ func (c *checker) buildMemberSigs(
 			stub := c.memberSigStub(lvl, elem.Fn)
 			stub.SelfParam = c.selfParam(elem.Receiver, elem.Static, self)
 			method, arm := appendMethodSig(targetBody(body, static, elem.Static), name, stub, elem.Static)
+			// An overloaded method dispatches on its value arguments, so its arms must agree
+			// on receiver mutability. The receiver-mutability check reads only the first arm,
+			// so a later `mut self` arm reached from a plain-`self` body would otherwise slip
+			// past it. Reject the mixture here, where the offending arm has a span to blame.
+			if arm > 0 && selfParamMut(stub.SelfParam) != selfParamMut(method.Signatures[0].SelfParam) {
+				c.report(&MethodOverloadReceiverMismatchError{Name: name, Elem: elem})
+			}
 			pending = append(pending, pendingMember{
 				fn: elem.Fn, recv: elem.Receiver, static: elem.Static, stub: stub,
 				apply: func(bodyFt *soltype.FuncType) {
@@ -619,6 +626,17 @@ func (c *checker) selfType(recv *ast.MethodReceiver, self soltype.Type) soltype.
 		return soltype.NewRef(true, nil, self.(soltype.RefInner))
 	}
 	return self
+}
+
+// selfParamMut reports whether a receiver grants mutable access to the instance. A `mut
+// self` receiver wraps the instance in an owned-mutable borrow, so its type is a mutable
+// RefType; a plain `self`, a shared `&self`, and a static member's absent receiver do not.
+func selfParamMut(sp *soltype.FuncParam) bool {
+	if sp == nil {
+		return false
+	}
+	r, ok := sp.Type.(*soltype.RefType)
+	return ok && r.Mut
 }
 
 // bindSelf binds the `self` identifier in a member or constructor body scope to the full

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -1759,3 +1759,41 @@ func TestInferMethodOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
 	require.Equal(t, "number", values["r"],
 		"an unconstrained argument defers to declaration-order first-match, pinning x to the first arm")
 }
+
+// TestInferMethodOverloadMixedReceiverRejected pins the receiver-mutability uniformity rule
+// for overloaded methods: arms that disagree on their `self` receiver are rejected at
+// declaration. Overload resolution dispatches on the value arguments, and the
+// receiver-mutability check reads only the first arm, so a `mut self` arm reached from a
+// plain-`self` body would otherwise dispatch to a mutable receiver unchecked.
+func TestInferMethodOverloadMixedReceiverRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			f(self, x: number) -> number { return self.n },
+			f(mut self, x: string) -> string { return x },
+			peek(self) -> string { return self.f("hi") },
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"Overloaded method 'f' must use the same `self` receiver mutability in every arm.",
+		errs[0].Message())
+}
+
+// TestInferMethodOverloadUniformMutReceiverAccepted is the passing companion: an overload
+// set whose arms all declare `mut self` is well-formed, resolves by argument, and calls
+// through a mutable receiver.
+func TestInferMethodOverloadUniformMutReceiverAccepted(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			f(mut self, x: number) -> number { return x },
+			f(mut self, x: string) -> string { return x },
+			run(mut self) -> string { return self.f("hi") },
+		}
+		val mut c = C(0)
+		val r = c.f(1)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"])
+}

--- a/internal/solver/infer_class_test.go
+++ b/internal/solver/infer_class_test.go
@@ -737,17 +737,9 @@ func TestInferClassMutualRecursionRequiresAnnotation(t *testing.T) {
 
 // TestInferClassMutMethodFromImmutMethod asserts that an immutable-`self` method calling a
 // `mut self` method of the same class is rejected: the mutable method needs a mutable
-// receiver, but `self` is immutable in the caller.
-//
-// DISABLED until E1. B3 resolves the call — `self.bump()` finds bump's signature — but does
-// not yet constrain the receiver against the method's SelfParam, so today the call
-// type-checks with no error. That `receiver <: SelfParam` check lands with E1's method-call
-// path through valueProp (receiver-dependent dispatch), and the same gap holds for an
-// external `mut` call on an immutable binding. The asserted message is the expected form
-// from the mutability machinery, which today reports `cannot constrain immutable object <:
-// mutable object` for the analogous immutable-value-into-`mut`-parameter case; E1 finalizes
-// the exact rendering for a class receiver.
-/*
+// receiver, but `self` is immutable in the caller. A plain-`self` body holds only a shared
+// borrow of its receiver, so it has no mutable access to lend `bump`, and the receiver
+// check renders the mismatch against the class name on both sides.
 func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		class C {
@@ -759,7 +751,40 @@ func TestInferClassMutMethodFromImmutMethod(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "cannot constrain immutable C <: mutable C", errs[0].Message())
 }
-*/
+
+// TestInferClassMutMethodFromMutMethod is the passing companion: a `mut self` method may
+// call another `mut self` method, since its own mutable borrow of the receiver satisfies
+// the callee's `mut self`. A plain-`self` method called from a `mut self` body also
+// type-checks, downgrading the mutable receiver to a shared read.
+func TestInferClassMutMethodFromMutMethod(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			bump(mut self) -> number { return self.n },
+			read(self) -> number { return self.n },
+			run(mut self) -> number { return self.bump() },
+			also(mut self) -> number { return self.read() },
+		}
+	`)
+	require.Empty(t, errs)
+}
+
+// TestInferClassMutGetterFromImmutMethod pins the receiver check for a getter member: a
+// `mut self` getter read from a plain-`self` method is rejected for the same reason a
+// `mut self` method call is — the caller holds only a shared borrow. The getter carries its
+// receiver on GetterElem.SelfParam rather than a FuncType, so this exercises a distinct
+// member kind from the method case.
+func TestInferClassMutGetterFromImmutMethod(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			v: number,
+			get doubled(mut self) -> number { return self.v },
+			peek(self) -> number { return self.doubled },
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "cannot constrain immutable C <: mutable C", errs[0].Message())
+}
 
 // TestInferClassGenericMethodReturnsTypeParam checks that a method whose return flows from a
 // class type parameter projects to the instance's argument — both through a `self.method()`
@@ -1654,4 +1679,83 @@ func TestInferClassNamespaceQualified(t *testing.T) {
 			require.Equal(t, test.wantTypes, types)
 		})
 	}
+}
+
+// TestInferMethodOverloadResolvesByArg pins method overload resolution (E1): a method
+// declared with two signatures resolves the arm whose parameter matches the argument, the
+// method analogue of a direct overloaded-function call. c.f(1) picks the number arm and
+// c.f("hi") the string arm, so the two reads take the two arms' distinct return types.
+func TestInferMethodOverloadResolvesByArg(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			f(self, x: number) -> number { return x },
+			f(self, x: string) -> string { return x },
+		}
+		val c = C(0)
+		val a = c.f(1)
+		val b = c.f("hi")
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["a"])
+	require.Equal(t, "string", values["b"])
+}
+
+// TestInferMethodOverloadObjectArgFieldSubsumption is the #723 case through a method: an
+// overloaded method with object parameters ranks a wider-field argument to the wider arm.
+// c.g({x, y}) picks the {x, y} arm over the earlier {x} arm, so method resolution ranks
+// most-specific-first rather than by declaration order.
+func TestInferMethodOverloadObjectArgFieldSubsumption(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			g(self, p: {x: number}) -> number { return p.x },
+			g(self, p: {x: number, y: number}) -> string { return "wide" },
+		}
+		val c = C(0)
+		val r = c.g({x: 1, y: 2})
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["r"],
+		"the wider-field arm outranks the earlier narrow arm for a superset argument")
+}
+
+// TestInferMethodOverloadNoMatch reports a NoMatchingOverloadError when no arm accepts the
+// argument, listing the arms tried. The candidate signatures render with their `self`
+// receiver stripped, since a call site supplies only the value arguments.
+func TestInferMethodOverloadNoMatch(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			f(self, x: number) -> number { return x },
+			f(self, x: string) -> string { return x },
+		}
+		val c = C(0)
+		val r = c.f(true)
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"No matching overload for this call\n  fn (x: number) -> number\n  fn (x: string) -> string",
+		errs[0].Message())
+}
+
+// TestInferMethodOverloadDeferredFallsBackToFirstMatch confirms the declaration-order
+// fallback for an unconstrained argument reaches method overloads too: inside a method
+// whose parameter x is unannotated, a self-call self.f(x) resolves to the first arm and
+// pins x, since an unconstrained argument cannot rank the arms. run's parameter x is
+// therefore number, the first arm's type.
+func TestInferMethodOverloadDeferredFallsBackToFirstMatch(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class C {
+			n: number,
+			f(self, x: number) -> number { return x },
+			f(self, x: string) -> string { return x },
+			run(self, x) -> number { return self.f(x) },
+		}
+		val c = C(0)
+		val r = c.run(1)
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"],
+		"an unconstrained argument defers to declaration-order first-match, pinning x to the first arm")
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1292,6 +1292,11 @@ func funcIntersectionArms(t soltype.Type) ([]*soltype.FuncType, bool) {
 	}
 	arms := make([]*soltype.FuncType, len(inter.Types))
 	for i, m := range inter.Types {
+		// A direct assertion, not resolveFunc: memberValue builds each arm with
+		// strippedMethodSig, so an arm is always a concrete FuncType with nothing to look
+		// through. resolveFunc's var and constructor-object look-through would only broaden
+		// this into a looser "is any intersection callable" test, pulling annotation- or
+		// class-value-derived intersections off the ordinary callee <: callShape path.
 		ft, ok := m.(*soltype.FuncType)
 		if !ok {
 			return nil, false

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1114,6 +1114,19 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 	// argument move against an inner branch instead of this call's statement.
 	consumeRef, hasConsumeRef := c.currentStmtRef()
 	callee := c.inferExpr(scope, lvl, e.Callee)
+	// A member callee whose type is an intersection of function arms is an overloaded
+	// method, since memberValue gathers a multi-signature method's arms into an
+	// IntersectionType. Resolving one arm here through resolveOverload, the method analogue
+	// of the direct overloaded-name call above, keeps the disjunction out of the callee <:
+	// callShape constraint and reuses the declaration-order deferral for an unconstrained
+	// argument (E1). A `g = f; g(x)` call through an intermediate binding has an ident
+	// callee, not a member one, so it stays on the value-position intersection path in
+	// constrain.
+	if _, isMember := e.Callee.(*ast.MemberExpr); isMember {
+		if arms, ok := funcIntersectionArms(callee); ok {
+			return c.inferMethodOverloadCall(scope, lvl, e, arms)
+		}
+	}
 	args := make([]*soltype.FuncParam, len(e.Args))
 	for i, a := range e.Args {
 		args[i] = &soltype.FuncParam{Type: c.inferExpr(scope, lvl, a)}
@@ -1245,6 +1258,47 @@ func (c *checker) inferOverloadedCall(scope *Scope, lvl int, e *ast.CallExpr, b 
 	ret := c.resolveOverload(lvl, b, args, e)
 	c.recordType(e, ret)
 	return ret
+}
+
+// inferMethodOverloadCall types a call to an overloaded method reached through a member
+// callee, such as `p.m(args)` where `m` carries several signatures. It infers the
+// arguments, then resolves one arm through resolveOverload — the same machinery a direct
+// overloaded-name call uses, driven by the method's arms wrapped as monomorphic schemes.
+// Like inferOverloadedCall it emits no callee <: callShape constraint. Overload resolution
+// owns arity and argument checking, and a no-match becomes a NoMatchingOverloadError.
+func (c *checker) inferMethodOverloadCall(scope *Scope, lvl int, e *ast.CallExpr, arms []*soltype.FuncType) soltype.Type {
+	args := make([]soltype.Type, len(e.Args))
+	for i, a := range e.Args {
+		args[i] = c.inferExpr(scope, lvl, a)
+	}
+	schemes := make([]TypeScheme, len(arms))
+	for i, arm := range arms {
+		schemes[i] = &MonoScheme{Ty: arm}
+	}
+	ret := c.resolveOverload(lvl, ValueBinding{Schemes: schemes}, args, e)
+	c.recordType(e, ret)
+	return ret
+}
+
+// funcIntersectionArms reports whether t is an IntersectionType whose members are all
+// FuncTypes, returning those arms. memberValue builds exactly this shape for an overloaded
+// method, so it identifies a method-overload callee. A non-intersection, an empty
+// intersection, or an intersection carrying a non-function member is not a method overload
+// set, so it stays on the ordinary callee <: callShape path.
+func funcIntersectionArms(t soltype.Type) ([]*soltype.FuncType, bool) {
+	inter, ok := t.(*soltype.IntersectionType)
+	if !ok || len(inter.Types) == 0 {
+		return nil, false
+	}
+	arms := make([]*soltype.FuncType, len(inter.Types))
+	for i, m := range inter.Types {
+		ft, ok := m.(*soltype.FuncType)
+		if !ok {
+			return nil, false
+		}
+		arms[i] = ft
+	}
+	return arms, true
 }
 
 // resolveFunc resolves a callee to its concrete FuncType, used to recover a
@@ -1986,7 +2040,7 @@ func (c *checker) valueProp(lvl int, blame ast.Node, provNode ast.Node, name str
 	// carries method, getter, and setter members alongside fields. A read of such a
 	// member resolves through member lookup here, since the structural field-requirement
 	// path below reads only properties and panics on a non-property member (M5 B3).
-	if res, ok := c.classBodyMember(lvl, blame, name, recvCarrier); ok {
+	if res, ok := c.classBodyMember(lvl, blame, name, recv, recvCarrier); ok {
 		return res
 	}
 	// A static read `Point.origin` resolves through member lookup here, since the

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -380,11 +380,12 @@ func TestInferOverloadMixedWithValCrossFileIsDuplicate(t *testing.T) {
 		"the cross-file val is rejected; the fn binding survives")
 }
 
-// #723 object-argument specificity: an overload set whose arms take objects ranks a
-// wider-field argument to the arm with the wider field set, even when the narrower arm is
-// declared first. f({x, y}) picks the {x, y} arm over the earlier {x} arm because a
-// superset-of-fields parameter is more specific — the object analogue of a concrete param
-// outranking a generic one.
+// #723 object-argument dispatch with EXACT parameters: a call selects the arm whose field
+// set matches the argument. Object parameters are exact by default, so the two arms accept
+// disjoint arguments — an exact `{x}` rejects `{x, y}` for the extra field, and an exact
+// `{x, y}` rejects `{x}` for the missing field. The constrain trial therefore selects the
+// only matching arm regardless of declaration order; the subsumption RANKING is inert here.
+// The inexact companion below exercises the ranking itself, where both arms can match.
 func TestInferOverloadObjectArgFieldSubsumption(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: {x: number}) -> number { return p.x }
@@ -393,12 +394,11 @@ func TestInferOverloadObjectArgFieldSubsumption(t *testing.T) {
 	`)
 	require.Empty(t, errs)
 	require.Equal(t, "string", values["r"],
-		"the wider-field arm outranks the earlier narrow arm for a superset argument")
+		"the {x, y} argument only matches the {x, y} arm; the exact {x} arm rejects the extra field")
 }
 
-// The narrow argument still selects the narrow arm: f({x}) cannot match the {x, y} arm
-// (missing y), so only the {x} arm accepts it. This confirms subsumption ranking does not
-// force every object call onto the widest arm.
+// The narrow argument selects the narrow arm: f({x}) cannot match the {x, y} arm (missing
+// y), so only the {x} arm accepts it.
 func TestInferOverloadObjectArgNarrowSelectsNarrow(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		fn f(p: {x: number}) -> number { return p.x }
@@ -408,4 +408,21 @@ func TestInferOverloadObjectArgNarrowSelectsNarrow(t *testing.T) {
 	require.Empty(t, errs)
 	require.Equal(t, "number", values["r"],
 		"a narrow argument only matches the narrow arm")
+}
+
+// The subsumption RANKING (objectSubsumes) changes a call only when both arms can accept the
+// same argument, which requires width-tolerant (inexact) parameters. With inexact arms
+// `{x, ...}` and `{x, y, ...}`, the argument `{x, y}` satisfies both, so declaration order no
+// longer decides — the ranking picks the wider `{x, y, ...}` arm as more specific. Stubbing
+// objectSubsumes to false flips this result to "number", so this is the case that isolates
+// the ranking from the constrain trial.
+func TestInferOverloadInexactObjectArgSubsumptionRanking(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number, ...}) -> number { return p.x }
+		fn f(p: {x: number, y: number, ...}) -> string { return "wide" }
+		val r = f({x: 1, y: 2})
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["r"],
+		"with overlapping inexact params, the wider-field arm outranks the earlier narrow arm")
 }

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -426,3 +426,20 @@ func TestInferOverloadInexactObjectArgSubsumptionRanking(t *testing.T) {
 	require.Equal(t, "string", values["r"],
 		"with overlapping inexact params, the wider-field arm outranks the earlier narrow arm")
 }
+
+// An optional field must not count toward specificity: `{x, y?}` accepts both `{x}` and
+// `{x, y}`, so it is wider than `{x}`, not more specific. For the argument `{x}`, both arms
+// match — the `{x, y?}` arm accepts it with y absent — so the ranking decides, and it must
+// pick the narrower `{x}` arm even though the `{x, y?}` arm carries more property entries and
+// is declared second. Counting the optional field would rank the wider arm first and return
+// "opt".
+func TestInferOverloadOptionalFieldNotMoreSpecific(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) -> number { return p.x }
+		fn f(p: {x: number, y?: number}) -> string { return "opt" }
+		val r = f({x: 1})
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"],
+		"an optional field widens rather than narrows, so {x} outranks {x, y?} for a {x} argument")
+}

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -379,3 +379,33 @@ func TestInferOverloadMixedWithValCrossFileIsDuplicate(t *testing.T) {
 	require.Equal(t, "fn (x: number) -> number", values["f"],
 		"the cross-file val is rejected; the fn binding survives")
 }
+
+// #723 object-argument specificity: an overload set whose arms take objects ranks a
+// wider-field argument to the arm with the wider field set, even when the narrower arm is
+// declared first. f({x, y}) picks the {x, y} arm over the earlier {x} arm because a
+// superset-of-fields parameter is more specific — the object analogue of a concrete param
+// outranking a generic one.
+func TestInferOverloadObjectArgFieldSubsumption(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) -> number { return p.x }
+		fn f(p: {x: number, y: number}) -> string { return "wide" }
+		val r = f({x: 1, y: 2})
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", values["r"],
+		"the wider-field arm outranks the earlier narrow arm for a superset argument")
+}
+
+// The narrow argument still selects the narrow arm: f({x}) cannot match the {x, y} arm
+// (missing y), so only the {x} arm accepts it. This confirms subsumption ranking does not
+// force every object call onto the widest arm.
+func TestInferOverloadObjectArgNarrowSelectsNarrow(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number}) -> number { return p.x }
+		fn f(p: {x: number, y: number}) -> string { return "wide" }
+		val r = f({x: 1})
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"],
+		"a narrow argument only matches the narrow arm")
+}

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -443,3 +443,22 @@ func TestInferOverloadOptionalFieldNotMoreSpecific(t *testing.T) {
 	require.Equal(t, "number", values["r"],
 		"an optional field widens rather than narrows, so {x} outranks {x, y?} for a {x} argument")
 }
+
+// Overloading on object field TYPES rather than field counts: two arms share their field
+// names but give the fields disjoint types, so they accept disjoint arguments. objectSubsumes
+// ties them — it ranks by required-field count and exactness, not by field type — but the tie
+// is moot, since no argument satisfies both arms and the constrain trial selects the matching
+// one regardless of declaration order.
+func TestInferOverloadObjectArgDisjointFieldTypes(t *testing.T) {
+	base := `
+		fn f(p: {x: string, y: string}) -> number { return 1 }
+		fn f(p: {x: number, y: number}) -> boolean { return true }
+	`
+	sv, _, se := inferSource(t, base+`val r = f({x: "a", y: "b"})`)
+	require.Empty(t, se)
+	require.Equal(t, "number", sv["r"], "a string-valued argument matches only the string arm")
+
+	nv, _, ne := inferSource(t, base+`val r = f({x: 1, y: 2})`)
+	require.Empty(t, ne)
+	require.Equal(t, "boolean", nv["r"], "a number-valued argument matches only the number arm")
+}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -360,10 +360,14 @@ func structuralSubtype(a, b soltype.Type) bool {
 // property b declares with an alpha-equal type, and a is narrower in the width sense: it
 // has a strictly larger field set, or the same field set while a is exact and b is not.
 //
-// A wider field set is more specific because a parameter typed `{x, y}` accepts fewer
-// arguments than one typed `{x}`, the object analogue of a concrete param outranking a
-// generic one. An exact object is likewise more specific than an inexact one over the same
-// fields, since it accepts no extra properties. Two objects with the same fields and same
+// A larger field set is the stricter requirement, since an argument must carry more
+// properties to match, so it ranks more specific. This is the object analogue of a concrete
+// param outranking a generic one. The wider parameter literally accepts fewer arguments only
+// when the narrower parameter is width-tolerant, and that is also the only case where the
+// order changes the result. Two exact objects with different field sets instead accept
+// disjoint arguments, so at most one arm matches and the constrain trial in tryOverloadArm
+// settles the call. An exact object is likewise more specific than an inexact one over the
+// same fields, since it accepts no extra properties. Two objects with the same fields and same
 // exactness are alpha-equal and never reach here — structuralSubtype's alphaEqualTypes arm
 // resolves them to a tie first. Any non-property member makes the pair incomparable and
 // ranks as false, deferring to declaration order.

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -347,7 +347,53 @@ func structuralSubtype(a, b soltype.Type) bool {
 			return primOf(l.Lit) == p.Prim
 		}
 	}
+	if ao, ok := a.(*soltype.ObjectType); ok {
+		if bo, ok := b.(*soltype.ObjectType); ok {
+			return objectSubsumes(ao, bo)
+		}
+	}
 	return false
+}
+
+// objectSubsumes reports whether object a ranks strictly more specific than object b for
+// overload specificity — the #723 object-argument case. a subsumes b when a carries every
+// property b declares with an alpha-equal type, and a is narrower in the width sense: it
+// has a strictly larger field set, or the same field set while a is exact and b is not.
+//
+// A wider field set is more specific because a parameter typed `{x, y}` accepts fewer
+// arguments than one typed `{x}`, the object analogue of a concrete param outranking a
+// generic one. An exact object is likewise more specific than an inexact one over the same
+// fields, since it accepts no extra properties. Two objects with the same fields and same
+// exactness are alpha-equal and never reach here — structuralSubtype's alphaEqualTypes arm
+// resolves them to a tie first. Any non-property member makes the pair incomparable and
+// ranks as false, deferring to declaration order.
+func objectSubsumes(a, b *soltype.ObjectType) bool {
+	bCount := 0
+	for _, be := range b.Elems {
+		bp, ok := be.(*soltype.PropertyElem)
+		if !ok {
+			return false
+		}
+		bCount++
+		ap, ok := a.Prop(bp.Name)
+		if !ok {
+			return false
+		}
+		if !alphaEqualTypes(ap.Type, bp.Type) {
+			return false
+		}
+	}
+	aCount := 0
+	for _, ae := range a.Elems {
+		if _, ok := ae.(*soltype.PropertyElem); !ok {
+			return false
+		}
+		aCount++
+	}
+	if aCount > bCount {
+		return true
+	}
+	return !a.Inexact && b.Inexact
 }
 
 // overloadIntersection synthesizes the value-position type of an overloaded name, the

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -357,44 +357,57 @@ func structuralSubtype(a, b soltype.Type) bool {
 
 // objectSubsumes reports whether object a ranks strictly more specific than object b for
 // overload specificity — the #723 object-argument case. a subsumes b when a carries every
-// property b declares with an alpha-equal type, and a is narrower in the width sense: it
-// has a strictly larger field set, or the same field set while a is exact and b is not.
+// required property b requires with an alpha-equal type, and a is narrower in the width
+// sense: it has strictly more required properties, or the same required properties while a
+// is exact and b is not.
 //
-// A larger field set is the stricter requirement, since an argument must carry more
+// Only required properties count toward specificity. An optional property widens an object
+// rather than narrowing it — `{x, y?}` accepts both `{x}` and `{x, y}`, so it is not more
+// specific than `{x}`. Counting it would rank the wider arm as narrower and pick it over the
+// genuinely more specific one. A required property that a carries but b lacks does narrow a,
+// so a must also carry each of b's required properties as required, not optional.
+//
+// A larger required-field set is the stricter requirement, since an argument must carry more
 // properties to match, so it ranks more specific. This is the object analogue of a concrete
 // param outranking a generic one. The wider parameter literally accepts fewer arguments only
 // when the narrower parameter is width-tolerant, and that is also the only case where the
-// order changes the result. Two exact objects with different field sets instead accept
-// disjoint arguments, so at most one arm matches and the constrain trial in tryOverloadArm
-// settles the call. An exact object is likewise more specific than an inexact one over the
-// same fields, since it accepts no extra properties. Two objects with the same fields and same
-// exactness are alpha-equal and never reach here — structuralSubtype's alphaEqualTypes arm
-// resolves them to a tie first. Any non-property member makes the pair incomparable and
-// ranks as false, deferring to declaration order.
+// order changes the result. Two exact objects with different required-field sets instead
+// accept disjoint arguments, so at most one arm matches and the constrain trial in
+// tryOverloadArm settles the call. An exact object is likewise more specific than an inexact
+// one over the same fields, since it accepts no extra properties. Two objects with the same
+// fields and same exactness are alpha-equal and never reach here — structuralSubtype's
+// alphaEqualTypes arm resolves them to a tie first. Any non-property member makes the pair
+// incomparable and ranks as false, deferring to declaration order.
 func objectSubsumes(a, b *soltype.ObjectType) bool {
-	bCount := 0
+	bReq := 0
 	for _, be := range b.Elems {
 		bp, ok := be.(*soltype.PropertyElem)
 		if !ok {
 			return false
 		}
-		bCount++
+		if bp.Optional {
+			continue
+		}
+		bReq++
 		ap, ok := a.Prop(bp.Name)
-		if !ok {
+		if !ok || ap.Optional {
 			return false
 		}
 		if !alphaEqualTypes(ap.Type, bp.Type) {
 			return false
 		}
 	}
-	aCount := 0
+	aReq := 0
 	for _, ae := range a.Elems {
-		if _, ok := ae.(*soltype.PropertyElem); !ok {
+		ap, ok := ae.(*soltype.PropertyElem)
+		if !ok {
 			return false
 		}
-		aCount++
+		if !ap.Optional {
+			aReq++
+		}
 	}
-	if aCount > bCount {
+	if aReq > bReq {
 		return true
 	}
 	return !a.Inexact && b.Inexact

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -356,28 +356,30 @@ func structuralSubtype(a, b soltype.Type) bool {
 }
 
 // objectSubsumes reports whether object a ranks strictly more specific than object b for
-// overload specificity — the #723 object-argument case. a subsumes b when a carries every
-// required property b requires with an alpha-equal type, and a is narrower in the width
-// sense: it has strictly more required properties, or the same required properties while a
-// is exact and b is not.
+// overload specificity (the #723 object-argument case). "More specific" means a narrower
+// parameter, one accepting fewer arguments, so it wins dispatch when both arms match an
+// argument. It ranks two axes and deliberately ignores a third:
 //
-// Only required properties count toward specificity. An optional property widens an object
-// rather than narrowing it — `{x, y?}` accepts both `{x}` and `{x, y}`, so it is not more
-// specific than `{x}`. Counting it would rank the wider arm as narrower and pick it over the
-// genuinely more specific one. A required property that a carries but b lacks does narrow a,
-// so a must also carry each of b's required properties as required, not optional.
+//   - Required-field count. When a's required properties are a strict superset of b's, a is
+//     stricter and ranks more specific, the object analogue of a concrete param outranking a
+//     generic one. a must carry every required property of b, as required and with an
+//     alpha-equal type. A missing, optional, or differently-typed match makes the pair
+//     incomparable, so this returns false.
+//   - Exactness, only when the required-field sets are equal. An exact a is more specific
+//     than an inexact b over the same fields, since it accepts no extra properties.
+//   - Field types, which are NOT ranked. Arms whose shared fields differ in type tie here.
+//     Disjoint types make the arms accept disjoint arguments, so the trial picks the match.
+//     Overlapping types fall back to declaration order.
 //
-// A larger required-field set is the stricter requirement, since an argument must carry more
-// properties to match, so it ranks more specific. This is the object analogue of a concrete
-// param outranking a generic one. The wider parameter literally accepts fewer arguments only
-// when the narrower parameter is width-tolerant, and that is also the only case where the
-// order changes the result. Two exact objects with different required-field sets instead
-// accept disjoint arguments, so at most one arm matches and the constrain trial in
-// tryOverloadArm settles the call. An exact object is likewise more specific than an inexact
-// one over the same fields, since it accepts no extra properties. Two objects with the same
-// fields and same exactness are alpha-equal and never reach here — structuralSubtype's
-// alphaEqualTypes arm resolves them to a tie first. Any non-property member makes the pair
-// incomparable and ranks as false, deferring to declaration order.
+// Only required properties count. An optional property widens an object rather than
+// narrowing it. `{x, y?}` accepts both `{x}` and `{x, y}`, so it is not more specific than
+// `{x}`. Counting it would rank the wider arm as narrower.
+//
+// This is a heuristic, not the full subtype relation. Resolution correctness comes from the
+// constrain trial in tryOverloadArm. objectSubsumes only orders the arms that could match.
+// Two objects with identical fields and exactness are alpha-equal and never reach here, since
+// structuralSubtype resolves them to a tie first. A non-property member on either side makes
+// the pair incomparable and ranks as false.
 func objectSubsumes(a, b *soltype.ObjectType) bool {
 	bReq := 0
 	for _, be := range b.Elems {


### PR DESCRIPTION
Adds method overload resolution (E1) and receiver mutability checking for class methods and getters.

**Summary**

This change implements two related features for class members:

1. **Method overload resolution**: Overloaded methods now resolve their arm at the call site based on argument types, matching the behavior of overloaded functions. An `IntersectionType` of function signatures is built for multi-signature methods, and `inferMethodOverloadCall` resolves one arm through the existing `resolveOverload` machinery.

2. **Receiver mutability checking**: A `mut self` method or getter accessed from a plain-`self` method is now rejected, since the caller holds only a shared borrow and cannot lend mutable access. The check constrains the receiver against the member's `SelfParam`, rendering diagnostics like "cannot constrain immutable C <: mutable C".

**Key changes**

- `memberValue` now builds an `IntersectionType` for overloaded methods (multiple signatures) instead of returning only the first arm.
- `checkMethodReceiver` enforces that the receiver's mutability satisfies the member's declared `SelfParam`, firing for method and getter access inside class bodies.
- `inferMethodOverloadCall` handles method calls with intersection-type callees, extracting function arms and resolving one through `resolveOverload`.
- `funcIntersectionArms` identifies method-overload callees (intersection of functions) to route them through method-specific resolution.
- `objectSubsumes` implements #723 object-argument specificity: a parameter with more fields ranks as more specific than one with fewer fields, so `f({x, y})` picks the `{x, y}` arm over an earlier `{x}` arm.
- Helper functions `strippedMethodSig`, `memberSelfParam`, and `receiverClass` extract and validate method receiver information.

**Tests**

- Re-enabled `TestInferClassMutMethodFromImmutMethod` with updated assertion for the receiver check.
- Added `TestInferClassMutMethodFromMutMethod` (passing case for `mut self` calling `mut self`).
- Added `TestInferClassMutGetterFromImmutMethod` (receiver check for getter members).
- Added four method-overload tests: basic resolution, object-field subsumption, no-match error, and deferred fallback for unconstrained arguments.
- Added two function-overload tests for object-argument specificity.

https://claude.ai/code/session_01M5dfmC1oFAyAky4io1yJZb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved overload resolution for methods, including argument-type and object-field matching.
  * Added support for overloaded method calls with clearer no-match errors.
  * Added receiver mutability checks for class methods and getters.

* **Bug Fixes**
  * Corrected selection of the most specific object-parameter overload.
  * Improved handling of receiver constraints and method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->