### PR TITLE
Implement for-in loop type inference (M5)

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -721,6 +721,31 @@ type ReturnOutsideFunctionError struct {
 	Return *ast.ReturnStmt
 }
 
+// ForAwaitOutsideAsyncError fires when a `for await (x in xs)` loop appears
+// outside the body of an `async fn`. Like AwaitOutsideAsyncError it is a WALK
+// rejection, not a type-rule failure: the iterable and body are still walked so
+// their own errors surface. EnclosingFn is the non-async function the loop sits
+// in, surfaced via Related() as the function to mark `async`; it is nil at module
+// top-level where there is no enclosing function.
+type ForAwaitOutsideAsyncError struct {
+	Loop        *ast.ForInStmt
+	EnclosingFn ast.Node
+}
+
+// NotIterableError fires when the operand of `for (x in xs)` is not iterable, or
+// the operand of `for await (x in xs)` is not async-iterable. M5 resolves the
+// iteration protocol structurally over the types the solver can represent: a
+// tuple yields the union of its elements, and a union of tuples yields the union
+// of their element types. Array<T> and the `[Symbol.iterator]` protocol land in
+// M7, so every other operand is reported here, as is every operand of a
+// `for await` since no async iterable is representable yet. Await selects the
+// message.
+type NotIterableError struct {
+	Iterable ast.Expr
+	Type     soltype.Type
+	Await    bool
+}
+
 // AsyncReturnNotPromiseError fires when an `async fn` declares a return annotation
 // that is not a `Promise<…>`. An async function's external type is always
 // `Promise<T>`, so the annotation NAMES that Promise; a bare type
@@ -804,6 +829,8 @@ func (*NoMatchingOverloadError) isSolverError()           {}
 func (*UnannotatedRecursiveOverloadError) isSolverError() {}
 func (*DuplicateOverloadError) isSolverError()            {}
 func (*AwaitOutsideAsyncError) isSolverError()            {}
+func (*ForAwaitOutsideAsyncError) isSolverError()         {}
+func (*NotIterableError) isSolverError()                  {}
 func (*ReturnOutsideFunctionError) isSolverError()        {}
 func (*AsyncReturnNotPromiseError) isSolverError()        {}
 func (*NonExhaustiveMatchError) isSolverError()           {}
@@ -1299,6 +1326,28 @@ func (e *ReturnOutsideFunctionError) Span() ast.Span      { return e.Return.Span
 func (e *ReturnOutsideFunctionError) Related() []ast.Span { return nil }
 func (e *ReturnOutsideFunctionError) Message() string {
 	return "return can only be used inside a function"
+}
+
+func (e *ForAwaitOutsideAsyncError) Span() ast.Span { return e.Loop.Span() }
+func (e *ForAwaitOutsideAsyncError) Related() []ast.Span {
+	// Point at the enclosing function (the one to make `async`) when there is one;
+	// empty at module top-level, mirroring AwaitOutsideAsyncError.
+	if e.EnclosingFn != nil {
+		return []ast.Span{e.EnclosingFn.Span()}
+	}
+	return nil
+}
+func (e *ForAwaitOutsideAsyncError) Message() string {
+	return "for await can only be used inside an async function"
+}
+
+func (e *NotIterableError) Span() ast.Span      { return e.Iterable.Span() }
+func (e *NotIterableError) Related() []ast.Span { return nil }
+func (e *NotIterableError) Message() string {
+	if e.Await {
+		return describe(e.Type) + " is not an async iterable"
+	}
+	return describe(e.Type) + " is not iterable"
 }
 
 func (e *AsyncReturnNotPromiseError) Span() ast.Span { return e.Return.Span() }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1330,8 +1330,8 @@ func (e *ReturnOutsideFunctionError) Message() string {
 
 func (e *ForAwaitOutsideAsyncError) Span() ast.Span { return e.Loop.Span() }
 func (e *ForAwaitOutsideAsyncError) Related() []ast.Span {
-	// Point at the enclosing function (the one to make `async`) when there is one;
-	// empty at module top-level, mirroring AwaitOutsideAsyncError.
+	// Point at the enclosing function to mark `async` when there is one; empty at
+	// module top-level, mirroring AwaitOutsideAsyncError.
 	if e.EnclosingFn != nil {
 		return []ast.Span{e.EnclosingFn.Span()}
 	}

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -59,6 +59,17 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 		elem = &soltype.ErrorType{}
 	}
 
+	// A `never` element type means no value can ever be bound to the loop variable,
+	// so the body is statically unreachable — iterating an empty tuple runs it zero
+	// times. Skip it: the loop contributes nothing and control falls through, so
+	// `for x in []` leaves the enclosing function returning void rather than folding
+	// an unreachable `return x` into its return type. Collecting that return would
+	// type the function as `never`, which is unsound: `fn f(xs: []) { for x in xs {
+	// return x } }` returns void at runtime.
+	if _, unreachable := elem.(*soltype.NeverType); unreachable {
+		return &soltype.Void{}
+	}
+
 	// The loop body runs in its own scope so the loop variable is invisible after
 	// the loop. bindPattern binds each leaf as a monomorphic, non-reassignable
 	// binding — a loop variable is rebound by iteration, never by assignment — since

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -1,0 +1,125 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// inferForIn types a `for (x in xs)` / `for await (x in xs)` loop. The milestone
+// desugars both forms to a protocol subtype check: a sync loop needs
+// `xs <: Iterable<T>` and a `for await` needs `xs <: AsyncIterable<T>`, binding
+// the loop variable at the element type T. The full protocol resolves T through
+// the iterable's `[Symbol.iterator]()` method, which needs symbol-keyed members
+// and the real Iterable/Iterator stdlib types that both land in M7. Until then M5
+// resolves the element type STRUCTURALLY over the types the solver can
+// represent — a tuple, the solver's stand-in for an array, and a union of
+// tuples — and rejects everything else as non-iterable. See iterableElemType.
+//
+// A `for await` outside an `async fn` is a WALK rejection symmetric to
+// AwaitOutsideAsyncError: the iterable and body are still walked so their own
+// errors surface. A `for await` over any structural operand is rejected by the
+// type rule, since no async iterable is representable yet. A sync iterable is not
+// an AsyncIterable.
+//
+// The loop contributes Void to its enclosing block — a loop is a statement, not a
+// value. The CFG builder already decomposes a ForInStmt into a header, a body
+// block carrying the loop-variable defs, and a back edge (liveness.processForIn),
+// so the move and borrow-edge dataflow over the loop body — including across the
+// back edge — is handled by the existing per-statement recording as inferBlock
+// walks the body. This function adds no move/borrow wiring of its own.
+func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Type {
+	awaitRejected := false
+	if s.IsAwait && (c.fn == nil || !c.fn.async) {
+		// The enclosing function is the one the user would mark `async`; nil at
+		// module top-level, where Related() stays empty.
+		var enclosing ast.Node
+		if c.fn != nil {
+			enclosing = c.fn.node
+		}
+		c.report(&ForAwaitOutsideAsyncError{Loop: s, EnclosingFn: enclosing})
+		awaitRejected = true
+	}
+
+	iterable := c.inferExpr(scope, lvl, s.Iterable)
+	elem, ok := c.iterableElemType(s.IsAwait, iterable)
+	if !ok {
+		// An iterable that already failed to infer is the ErrorType recovery
+		// placeholder; it absorbs rather than cascading a second diagnostic, so a
+		// `for x in <broken>` reports only the underlying error. A `for await`
+		// already rejected by the walk likewise reports only that walk error — one
+		// diagnostic per loop, mirroring how an await outside async surfaces only the
+		// walk rejection.
+		_, brokenIterable := soltype.CarrierOf(iterable).(*soltype.ErrorType)
+		if !awaitRejected && !brokenIterable {
+			c.report(&NotIterableError{Iterable: s.Iterable, Type: iterable, Await: s.IsAwait})
+		}
+		// Recover with the ErrorType placeholder so the loop variable does not leak
+		// an unsolved inference variable, and so a pattern binding against it absorbs
+		// rather than cascading a second diagnostic.
+		elem = &soltype.ErrorType{}
+	}
+
+	// The loop body runs in its own scope so the loop variable is invisible after
+	// the loop. bindPattern binds each leaf as a monomorphic, non-reassignable
+	// binding — a loop variable is rebound by iteration, never by assignment — since
+	// a leaf's ValueBinding is left at ValKind, the immutable default. A `for mut x`
+	// still binds a mutable owned value, because bindPattern reads the `mut` marker
+	// off the pattern and the tuple-element scrutinee is owned.
+	bodyScope := scope.Child()
+	c.bindPattern(bodyScope, lvl, s.Pattern, elem, nil)
+	c.inferBlock(bodyScope, lvl, &s.Body)
+	return &soltype.Void{}
+}
+
+// iterableElemType resolves the element type T yielded by iterating a value of
+// type t, returning ok=false when t is not iterable in the current sense.
+//
+// For a `for await`, T must come from an AsyncIterable. No async iterable is
+// representable in the solver yet — the real AsyncIterable stdlib type and the
+// symbol-keyed protocol land in M7 — so a `for await` over any structural operand
+// returns false, which is how a sync iterable is rejected by the type rule.
+//
+// For a sync `for`, the resolution is structural (see syncElemType): a tuple
+// yields the union of its element types, a union yields the union of its
+// branches' element types, and every other type is not iterable.
+func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bool) {
+	if await {
+		return nil, false
+	}
+	return c.syncElemType(t)
+}
+
+// syncElemType resolves the element type of a synchronously-iterable value
+// structurally. A borrow is peeled first — iterating `&xs` yields the same
+// elements as `xs` — and an inference variable is coalesced to its structural
+// lower-bound shape, the way inferMatch snapshots a variable scrutinee before
+// inspecting it. A tuple yields the union of its elements, so `[1, 2, 3]` yields
+// `1 | 2 | 3` and the empty tuple yields `never`. A union yields the union of its
+// branches' element types, failing if any branch is not iterable. Every other
+// type — a primitive, an object, a class instance without the M7 iterator
+// protocol — is not iterable.
+//
+// An inexact tuple's trailing `...` tail is not resolved: the element union
+// covers only the listed elements. The precise element type of the open tail
+// needs the Array<T> the tuple approximates, which lands in M7.
+func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
+	t = soltype.CarrierOf(t)
+	if _, isVar := t.(*soltype.TypeVarType); isVar {
+		t = soltype.CarrierOf(coalesce(t, soltype.Positive))
+	}
+	switch t := t.(type) {
+	case *soltype.TupleType:
+		return newUnion(c.ctx, t.Elems, false), true
+	case *soltype.UnionType:
+		elems := make([]soltype.Type, 0, len(t.Types))
+		for _, branch := range t.Types {
+			e, ok := c.syncElemType(branch)
+			if !ok {
+				return nil, false
+			}
+			elems = append(elems, e)
+		}
+		return newUnion(c.ctx, elems, false), true
+	}
+	return nil, false
+}

--- a/internal/solver/infer_for_in.go
+++ b/internal/solver/infer_for_in.go
@@ -110,9 +110,12 @@ func (c *checker) iterableElemType(await bool, t soltype.Type) (soltype.Type, bo
 // type — a primitive, an object, a class instance without the M7 iterator
 // protocol — is not iterable.
 //
-// An inexact tuple's trailing `...` tail is not resolved: the element union
-// covers only the listed elements. The precise element type of the open tail
-// needs the Array<T> the tuple approximates, which lands in M7.
+// Inexactness carries through. An inexact tuple `[number, ...]` has an open tail
+// of unknown additional elements, and an inexact union `[number] | ...` an open
+// tail of unknown additional branches, so either yields an inexact element union:
+// the loop variable may also be some unlisted element, so `[number, ...]` yields
+// `number | ...` rather than a bare `number`. The precise type of the tail needs
+// the Array<T> the tuple approximates, which lands in M7.
 func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 	t = soltype.CarrierOf(t)
 	if _, isVar := t.(*soltype.TypeVarType); isVar {
@@ -120,7 +123,7 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 	}
 	switch t := t.(type) {
 	case *soltype.TupleType:
-		return newUnion(c.ctx, t.Elems, false), true
+		return newUnion(c.ctx, t.Elems, t.Inexact), true
 	case *soltype.UnionType:
 		elems := make([]soltype.Type, 0, len(t.Types))
 		for _, branch := range t.Types {
@@ -130,7 +133,7 @@ func (c *checker) syncElemType(t soltype.Type) (soltype.Type, bool) {
 			}
 			elems = append(elems, e)
 		}
-		return newUnion(c.ctx, elems, false), true
+		return newUnion(c.ctx, elems, t.Inexact), true
 	}
 	return nil, false
 }

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -55,6 +55,19 @@ func TestInferForInElementType(t *testing.T) {
 			`,
 			want: map[string]string{"f": "fn (xs: [number, string]) -> number | string"},
 		},
+		// An inexact tuple `[number, ...]` has an open tail of unknown extra elements, so
+		// its element union stays inexact — `number | ...`, not a bare `number` — since
+		// the loop variable may also be some unlisted tail element.
+		"InexactTupleElementUnionInexact": {
+			src: `
+				fn f(xs: [number, ...]) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number, ...]) -> number | ..."},
+		},
 		// The empty tuple has no elements, so nothing can be bound to the loop variable
 		// and the body is statically unreachable. The `return x` never runs, so the
 		// function falls through to void — not `never`, which would unsoundly claim the

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -224,6 +224,81 @@ func TestForInBackEdgeMoves(t *testing.T) {
 	require.Equal(t, []string{`5:13-5:14: use of moved value 'p'`}, messagesWithSpan(errs))
 }
 
+// TestForInBorrowAvoidsMove pairs each move that a loop makes into a use-after-move
+// with its `&`-borrow counterpart, which reads the source without consuming it and
+// so type-checks cleanly. Borrowing is how a loop reads a value it must keep usable
+// across iterations or after the loop.
+func TestForInBorrowAvoidsMove(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// Moving p into q inside the body consumes p; the back edge re-enters the body
+		// with p already moved, so the next iteration's `val q = p` reads a moved value.
+		"MoveReusedAcrossBackEdge": {
+			src: `
+				fn f(xs: [number]) {
+					val mut p = {x: 0}
+					for x in xs {
+						val q = p
+					}
+				}
+			`,
+			want: []string{`5:15-5:16: use of moved value 'p'`},
+		},
+		// Borrowing p leaves it live, so re-entering the body across the back edge finds
+		// p usable — no use-after-move.
+		"BorrowReusedAcrossBackEdge": {
+			src: `
+				fn f(xs: [number]) {
+					val mut p = {x: 0}
+					for x in xs {
+						val q = &p
+					}
+				}
+			`,
+			want: nil,
+		},
+		// Moving p inside the loop leaves it moved after the loop, so reading `p.x` once
+		// the loop exits is a use-after-move — and the next-iteration re-read is one too.
+		"MoveThenUsedAfterLoop": {
+			src: `
+				fn f(xs: [number]) {
+					val mut p = {x: 0}
+					for x in xs {
+						val q = p
+					}
+					p.x
+				}
+			`,
+			want: []string{
+				`5:15-5:16: use of moved value 'p'`,
+				`7:6-7:9: use of moved value 'p'`,
+			},
+		},
+		// Borrowing p inside the loop keeps it owned, so reading `p.x` after the loop is
+		// valid.
+		"BorrowThenUsedAfterLoop": {
+			src: `
+				fn f(xs: [number]) {
+					val mut p = {x: 0}
+					for x in xs {
+						val q = &p
+					}
+					p.x
+				}
+			`,
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}
+
 // TestForInBackEdgeBorrows confirms the flow-sensitive borrow-edge dataflow
 // (analyzeBorrows) joins across the loop back edge and clears referents correctly.
 // These are the loop analogues of the branch-merge borrow tests, exercising the

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -1,0 +1,303 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// F1 — the `for (x in xs)` / `for await (x in xs)` iteration protocol. The loop
+// variable binds at the iterable's element type. M5 resolves that element type
+// structurally over the types the solver can represent — a tuple, the stand-in
+// for an array, and a union of tuples — since Array<T> and the `[Symbol.iterator]`
+// protocol land in M7. The element type is surfaced through a function's return
+// type: a `return x` inside the loop makes the loop variable's type the function's
+// return type, so `values["f"]` renders it.
+
+func TestInferForInElementType(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want map[string]string
+	}{
+		// A tuple yields the union of its element types, so iterating `[1, 2, 3]` binds
+		// the loop variable at `1 | 2 | 3`.
+		"TupleLiteralElementUnion": {
+			src: `
+				fn f() {
+					for x in [1, 2, 3] {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn () -> 1 | 2 | 3"},
+		},
+		// A single-element tuple binds the loop variable at that element's type — the
+		// milestone's `for (x in numbers)` where `numbers: Array<number>` binds
+		// `x: number`, expressed with the tuple that stands in for the array.
+		"SingleElementTupleBindsElement": {
+			src: `
+				fn f(xs: [number]) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number]) -> number"},
+		},
+		// A heterogeneous tuple yields the union of its element types.
+		"HeterogeneousTupleElementUnion": {
+			src: `
+				fn f(xs: [number, string]) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number, string]) -> number | string"},
+		},
+		// The empty tuple has no elements, so its element union is `never`.
+		"EmptyTupleElementNever": {
+			src: `
+				fn f(xs: []) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: []) -> never"},
+		},
+		// A union of tuples yields the union of the branches' element types, since a
+		// union is iterable when every branch is.
+		"UnionOfTuplesElementUnion": {
+			src: `
+				fn f(xs: [number] | [string]) {
+					for x in xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number] | [string]) -> number | string"},
+		},
+		// A borrowed iterable is peeled first, so `for x in &xs` binds the same element
+		// type as `for x in xs`.
+		"BorrowedIterablePeeled": {
+			src: `
+				fn f(xs: [number]) {
+					for x in &xs {
+						return x
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number]) -> number"},
+		},
+		// Nested loops each resolve their own iterable; the inner loop variable is the
+		// one returned here.
+		"NestedLoops": {
+			src: `
+				fn f(xs: [number], ys: [string]) {
+					for x in xs {
+						for y in ys {
+							return y
+						}
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number], ys: [string]) -> string"},
+		},
+		// A `for mut x` loop variable binds cleanly — bindPattern reads the `mut` marker
+		// off the pattern against the owned tuple-element scrutinee.
+		"ForMutLoopVariable": {
+			src: `
+				fn f(xs: [number]) {
+					for mut x in xs {
+					}
+				}
+			`,
+			want: map[string]string{"f": "fn (xs: [number]) -> void"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Empty(t, errs)
+			require.Equal(t, tc.want, values)
+		})
+	}
+}
+
+// TestInferForInErrors covers the loop forms F1 rejects: a non-iterable operand, a
+// `for await` outside an async function, and a `for await` over a synchronously
+// iterable operand.
+func TestInferForInErrors(t *testing.T) {
+	tests := map[string]struct {
+		src  string
+		want []string
+	}{
+		// A number is not iterable, so `for (x in 5)` is rejected. The operand renders
+		// as its literal type in the message.
+		"NumberNotIterable": {
+			src: `
+				fn f() {
+					for x in 5 {
+					}
+				}
+			`,
+			want: []string{`3:15-3:16: 5 is not iterable`},
+		},
+		// A plain object is not iterable — the M7 `[Symbol.iterator]` protocol is what a
+		// class instance would satisfy, and it is out of scope until then.
+		"ObjectNotIterable": {
+			src: `
+				fn f(o: {x: number}) {
+					for x in o {
+					}
+				}
+			`,
+			want: []string{`3:15-3:16: object is not iterable`},
+		},
+		// `for await` is a walk rejection outside an async function, symmetric to
+		// awaiting outside async. Only the walk error is reported, not a second protocol
+		// failure.
+		"ForAwaitOutsideAsync": {
+			src: `
+				fn f(xs: [number]) {
+					for await x in xs {
+					}
+				}
+			`,
+			want: []string{`3:6-4:7: for await can only be used inside an async function`},
+		},
+		// Inside an async function, `for await` over a synchronously iterable tuple is
+		// rejected by the type rule: a tuple is a sync iterable, not an async iterable.
+		"ForAwaitOverSyncIterable": {
+			src: `
+				async fn f(xs: [number]) {
+					for await x in xs {
+					}
+				}
+			`,
+			want: []string{`3:21-3:23: tuple is not an async iterable`},
+		},
+		// An iterable that itself failed to infer is the ErrorType recovery
+		// placeholder, which absorbs rather than cascading a second "not iterable"
+		// diagnostic on top of the underlying error.
+		"BrokenIterableNoCascade": {
+			src: `
+				fn f() {
+					for x in nope {
+					}
+				}
+			`,
+			want: []string{`3:15-3:19: Unknown identifier: nope`},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// TestForInBackEdgeMoves confirms the affine move engine sees the loop back edge: a
+// value moved in the loop body is a use-after-move on the next iteration, which the
+// engine catches because it replays every use against the branch-merged consumed
+// lattice, loop back edges included. A `for` loop is the first inferable source that
+// gives the CFG a back edge, so this is where AnalyzeMoves first meets one from real
+// code.
+func TestForInBackEdgeMoves(t *testing.T) {
+	// `val q = p` moves p out on the first iteration; the back edge re-enters the body
+	// with p already moved, so the same statement on the next iteration reads a moved
+	// value.
+	src := `
+		fn f(xs: [number]) {
+			val mut p = {x: 0}
+			for x in xs {
+				val q = p
+			}
+		}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Equal(t, []string{`5:13-5:14: use of moved value 'p'`}, messagesWithSpan(errs))
+}
+
+// TestForInBackEdgeBorrows confirms the flow-sensitive borrow-edge dataflow
+// (analyzeBorrows) joins across the loop back edge and clears referents correctly.
+// These are the loop analogues of the branch-merge borrow tests, exercising the
+// back-edge join, the whole-binding kill, and the field-store subtree kill.
+func TestForInBackEdgeBorrows(t *testing.T) {
+	tests := map[string]struct {
+		src   string
+		want  []string
+		types map[string]string
+	}{
+		// A borrow repointed inside the loop reaches the loop merge alongside the
+		// pre-loop referent: with zero iterations a still borrows c, and after the body a
+		// borrows d, so the union at the exit escapes both locals.
+		"ReassignInLoopUnionsAtMerge": {
+			src: `
+				fn f(xs: [number]) {
+					val mut c = {value: 1}
+					val mut d = {value: 0}
+					var a = &mut c
+					for x in xs {
+						a = &mut d
+					}
+					return a
+				}
+			`,
+			want: []string{
+				`9:13-9:14: borrowed value 'c' does not live long enough to escape the function`,
+				`9:13-9:14: borrowed value 'd' does not live long enough to escape the function`,
+			},
+			types: map[string]string{"f": "fn (xs: [number]) -> &mut {value: number}"},
+		},
+		// A whole-binding reassignment after the loop clears every referent the loop
+		// carried into it: `a = &mut d` replaces a's whole edge set, so returning a
+		// escapes only d, not the c the loop body kept repointing to. This is
+		// clearEagerSubtree's unconditional kill clearing a referent that reaches the
+		// reassignment through the back edge.
+		"PostLoopReassignClearsLoopEdges": {
+			src: `
+				fn f(xs: [number]) {
+					val mut c = {value: 1}
+					val mut d = {value: 0}
+					var a = &mut c
+					for x in xs {
+						a = &mut c
+					}
+					a = &mut d
+					return a
+				}
+			`,
+			want:  []string{`10:13-10:14: borrowed value 'd' does not live long enough to escape the function`},
+			types: map[string]string{"f": "fn (xs: [number]) -> &mut {value: number}"},
+		},
+		// A field store inside the loop repoints only the stored field's subtree, so
+		// returning the carrier component-moves the stored local and re-anchors it in the
+		// returned tree rather than escaping. The prune-gated subtree kill holds across
+		// the back edge: it does not over-report a false escape.
+		"FieldStoreInLoopComoves": {
+			src: `
+				fn f(xs: [number]) {
+					val mut c = {x: 1}
+					val mut d = {x: 0}
+					val mut b = {peer: &mut c}
+					for x in xs {
+						b.peer = &mut d
+					}
+					return b
+				}
+			`,
+			want:  nil,
+			types: map[string]string{"f": "fn (xs: [number]) -> mut {peer: {x: number}}"},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tc.src)
+			require.Equal(t, tc.want, messagesWithSpan(errs))
+			require.Equal(t, tc.types, values)
+		})
+	}
+}

--- a/internal/solver/infer_for_in_test.go
+++ b/internal/solver/infer_for_in_test.go
@@ -55,8 +55,11 @@ func TestInferForInElementType(t *testing.T) {
 			`,
 			want: map[string]string{"f": "fn (xs: [number, string]) -> number | string"},
 		},
-		// The empty tuple has no elements, so its element union is `never`.
-		"EmptyTupleElementNever": {
+		// The empty tuple has no elements, so nothing can be bound to the loop variable
+		// and the body is statically unreachable. The `return x` never runs, so the
+		// function falls through to void — not `never`, which would unsoundly claim the
+		// function never returns.
+		"EmptyTupleBodyUnreachable": {
 			src: `
 				fn f(xs: []) {
 					for x in xs {
@@ -64,7 +67,7 @@ func TestInferForInElementType(t *testing.T) {
 					}
 				}
 			`,
-			want: map[string]string{"f": "fn (xs: []) -> never"},
+			want: map[string]string{"f": "fn (xs: []) -> void"},
 		},
 		// A union of tuples yields the union of the branches' element types, since a
 		// union is iterable when every branch is.

--- a/internal/solver/infer_stmt.go
+++ b/internal/solver/infer_stmt.go
@@ -54,6 +54,8 @@ func (c *checker) inferStmt(scope *Scope, lvl int, s ast.Stmt) soltype.Type {
 	switch s := s.(type) {
 	case *ast.ExprStmt:
 		return c.inferExpr(scope, lvl, s.Expr)
+	case *ast.ForInStmt:
+		return c.inferForIn(scope, lvl, s)
 	case *ast.ReturnStmt:
 		// A return contributes both as the block's tail value (consumed only by
 		// value-position blocks; inferFunc discards the tail) AND as one of the


### PR DESCRIPTION
Adds type inference for `for (x in xs)` and `for await (x in xs)` loops, resolving the iteration protocol structurally over representable types until the full `[Symbol.iterator]` protocol lands in M7.

**Changes:**

- Add `inferForIn` to type for-in loops, binding the loop variable at the iterable's element type and contributing `Void` to the enclosing block
- Implement `iterableElemType` and `syncElemType` to resolve element types structurally: tuples yield the union of their elements, unions yield the union of their branches' element types, and all other types are rejected as non-iterable
- Reject `for await` outside async functions with `ForAwaitOutsideAsyncError`, a walk rejection symmetric to `AwaitOutsideAsyncError`
- Reject `for await` over any operand with `NotIterableError` since no async iterable is representable yet
- Add comprehensive tests covering element type inference, error cases, and back-edge behavior for move and borrow-edge dataflow across loop iterations

The loop body runs in its own scope so the loop variable is invisible after the loop. Borrowed iterables are peeled before resolution, so `for x in &xs` yields the same element type as `for x in xs`. The CFG builder already decomposes for-in loops into header, body, and back edge, so move and borrow-edge dataflow over the loop body (including the back edge) is handled by existing per-statement recording.

https://claude.ai/code/session_0142yqTvE9ASXu8hH8R17APo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type checking for `for ... in` loops, including tuple, union, borrowed, nested, and mutable iteration patterns.
  * Added diagnostics for non-iterable values and invalid `for await` usage outside async functions.
  * Added loop-variable type inference and improved recovery from invalid iterable expressions.

* **Bug Fixes**
  * Improved move and borrow analysis across loop iterations to prevent false diagnostics and detect use-after-move errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->