### PR TITLE
Implement match-arm narrowing for structural union members

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2675,14 +2675,15 @@ func patternMatchesMemberShape(pat ast.Pat, member soltype.Type) bool {
 }
 
 // objectPatFieldNames returns the field names an object pattern binds. A shorthand or
-// key-value element names one field. An `...rest` element names none. The parser flattens an
-// identifier, string-literal, or number-literal key into Key.Name, so `{x}`, `{"foo": a}`,
-// and `{42: a}` all surface their field name here directly.
+// key-value element names one field. An `...rest` element names none. Every object-pattern key
+// is an identifier, so it arrives as Key.Name; the parser also accepts the reserved type-name
+// words `number`, `string`, `boolean`, and `bigint` as plain field names.
 //
-// TODO: once object patterns gain computed keys (`{ [expr]: pat }`), resolve a key whose type
-// is a string- or number-literal type to its field name here. A symbol key such as
-// `[Symbol.iterator]` needs symbol-keyed member access, which M7 adds, and has no string field
-// name.
+// The parser rejects a string-literal key `{ "foo": pat }`, a number-literal key `{ 42: pat }`,
+// and a computed key `{ [expr]: pat }` alike, each with "Expected identifier or '...'".
+// TODO: when those land, resolve a string- or number-literal key, and a computed key whose type
+// is a string- or number-literal type, to its field name here. A symbol key such as
+// `[Symbol.iterator]` needs the symbol-keyed member access M7 adds and has no string field name.
 func objectPatFieldNames(p *ast.ObjectPat) []string {
 	names := make([]string, 0, len(p.Elems))
 	for _, elem := range p.Elems {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2675,7 +2675,14 @@ func patternMatchesMemberShape(pat ast.Pat, member soltype.Type) bool {
 }
 
 // objectPatFieldNames returns the field names an object pattern binds. A shorthand or
-// key-value element names one field. An `...rest` element names none.
+// key-value element names one field. An `...rest` element names none. The parser flattens an
+// identifier, string-literal, or number-literal key into Key.Name, so `{x}`, `{"foo": a}`,
+// and `{42: a}` all surface their field name here directly.
+//
+// TODO: once object patterns gain computed keys (`{ [expr]: pat }`), resolve a key whose type
+// is a string- or number-literal type to its field name here. A symbol key such as
+// `[Symbol.iterator]` needs symbol-keyed member access, which M7 adds, and has no string field
+// name.
 func objectPatFieldNames(p *ast.ObjectPat) []string {
 	names := make([]string, 0, len(p.Elems))
 	for _, elem := range p.Elems {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2492,7 +2492,12 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 		// leaf, so a leaf of a `&mut` scrutinee binds as a `&mut` borrow, just as `val`
 		// destructuring does. A missing field or wrong tuple arity surfaces here too.
 		armScope := scope.Child()
-		c.bindPattern(armScope, lvl, arm.Pattern, scrutinee, nil)
+		// A structural pattern over a union scrutinee binds against only the members
+		// whose shape it matches, so a match arm may destructure one variant while
+		// leaving the rest for later arms. narrowMatchArm drops the members `arm.Pattern`
+		// cannot destructure. Every other pattern binds against the whole scrutinee.
+		armScrut := narrowMatchArm(matchShape, scrutinee, arm.Pattern)
+		c.bindPattern(armScope, lvl, arm.Pattern, armScrut, nil)
 		if arm.Guard != nil {
 			// A guard is an ordinary boolean condition over the arm's bindings. As in
 			// inferIfElse, the synthesized boolean requirement is left out of Prov. It
@@ -2541,10 +2546,8 @@ func (c *checker) checkMatchExhaustive(scope *Scope, e *ast.MatchExpr, scrutinee
 // inexact union needs a catch-all. An exact one is exhaustive when every member is
 // covered. A literal member is covered by an equal literal pattern. A nominal member, an
 // enum variant or class token, is covered by an instance or extractor pattern naming that
-// class. A structural-object member needs match-arm union narrowing, which M5 does not
-// build. A structural arm over such a member is reported unsupported and the match
-// deferred, but when no arm covers the member the match is non-exhaustive rather than
-// silently accepted.
+// class. A structural object or tuple member is covered by an irrefutable object or tuple
+// pattern of the member's shape. A member no arm covers leaves the match non-exhaustive.
 func (c *checker) unionMatchExhaustive(scope *Scope, e *ast.MatchExpr, u *soltype.UnionType) bool {
 	for _, arm := range e.Cases {
 		if arm.Guard == nil && isCatchAll(arm.Pattern) {
@@ -2554,38 +2557,30 @@ func (c *checker) unionMatchExhaustive(scope *Scope, e *ast.MatchExpr, u *soltyp
 	if u.Inexact {
 		return false
 	}
-	covered := true
-	hasUnevaluable := false
 	for _, member := range u.Types {
-		switch m := member.(type) {
-		case *soltype.LitType:
-			if !c.litMemberCovered(m, e.Cases) {
-				covered = false
-			}
-		case *soltype.ClassType:
-			if !c.nominalMemberCovered(scope, m, e.Cases) {
-				covered = false
-			}
-		default:
-			// A structural-object or other non-nominal member needs match-arm union
-			// narrowing to bind and cover, which M5 does not build.
-			hasUnevaluable = true
+		if !c.unionMemberCovered(scope, member, e.Cases) {
+			return false
 		}
 	}
-	// An uncovered literal or nominal member is a real gap, so report it before
-	// deferring on a member the coverage rules cannot evaluate.
-	if !covered {
+	return true
+}
+
+// unionMemberCovered reports whether some unguarded arm covers a single union member,
+// dispatching on the member's kind. A literal member needs an equal literal pattern, a
+// nominal member an instance or extractor pattern naming its class, and a structural
+// object or tuple member an irrefutable pattern of its shape. Any other member kind has
+// no covering pattern short of a catch-all, which the caller has already checked.
+func (c *checker) unionMemberCovered(scope *Scope, member soltype.Type, arms []*ast.MatchCase) bool {
+	switch m := member.(type) {
+	case *soltype.LitType:
+		return c.litMemberCovered(m, arms)
+	case *soltype.ClassType:
+		return c.nominalMemberCovered(scope, m, arms)
+	case *soltype.ObjectType, *soltype.TupleType:
+		return structuralMemberCovered(member, arms)
+	default:
 		return false
 	}
-	if hasUnevaluable {
-		// A member the coverage rules cannot evaluate is deferred only when a structural
-		// arm exists to explain it: reportStructuralUnionArms flags each such arm as
-		// unsupported and reports whether it found any. When it finds none — every arm is
-		// literal or nominal — the unevaluable member has no arm covering it, so the match
-		// is non-exhaustive rather than silently accepted.
-		return c.reportStructuralUnionArms(scope, e)
-	}
-	return true
 }
 
 // nominalMemberCovered reports whether some unguarded arm covers a nominal union member.
@@ -2628,44 +2623,133 @@ func (c *checker) nominalArmCovers(scope *Scope, p ast.Pat, member *soltype.Clas
 	}
 }
 
-// reportStructuralUnionArms flags each unguarded arm that the union coverage rules cannot
-// evaluate — a structural pattern over a union carrying a non-nominal member — as
-// unsupported, and reports whether it flagged any. A literal or nominal arm is covered by
-// its own rule, and the catch-all case has already returned, so neither is reported here.
-// A false result means no arm explains an unevaluable member, so the caller treats the
-// match as non-exhaustive.
-func (c *checker) reportStructuralUnionArms(scope *Scope, e *ast.MatchExpr) bool {
-	reported := false
-	for _, arm := range e.Cases {
+// structuralMemberCovered reports whether some unguarded arm's object or tuple pattern
+// irrefutably matches every value of a structural union member. An object pattern covers
+// an object member when the member carries every field the pattern names. A tuple pattern
+// covers a tuple member when their arities match. In both cases every sub-pattern must be
+// irrefutable, so a nested literal such as `{x: 1}` or `[a, 2]` does not cover.
+func structuralMemberCovered(member soltype.Type, arms []*ast.MatchCase) bool {
+	for _, arm := range arms {
 		if arm.Guard != nil {
 			continue
 		}
-		if _, isLit := arm.Pattern.(*ast.LitPat); isLit {
-			continue
+		if patternMatchesMemberShape(arm.Pattern, member) && irrefutablePat(arm.Pattern) {
+			return true
 		}
-		if c.isNominalArm(scope, arm.Pattern) {
-			continue
-		}
-		c.reportUnsupportedFeature(arm.Pattern, "non-literal match arm pattern over a union scrutinee")
-		reported = true
 	}
-	return reported
+	return false
 }
 
-// isNominalArm reports whether a pattern names a class in the type sort, so it is an
-// instance or extractor pattern the nominal coverage rule evaluates rather than a
-// structural pattern.
-func (c *checker) isNominalArm(scope *Scope, p ast.Pat) bool {
-	switch pat := p.(type) {
-	case *ast.InstancePat:
-		_, ok := c.instancePatClass(scope, ast.QualIdentToString(pat.ClassName))
-		return ok
-	case *ast.ExtractorPat:
-		_, ok := c.resolveQualClassType(scope, pat.Name)
-		return ok
+// patternMatchesMemberShape reports whether a structural pattern's shape fits a union
+// member, so the pattern can destructure that member. An object pattern fits an object
+// member carrying every field the pattern names. A tuple pattern fits a tuple member of
+// its fixed arity, or of at least that arity when the pattern ends in `...rest`. This is a
+// shape test only. Refutability of the sub-patterns is checked separately by the caller
+// that needs it. Every non-structural pattern returns false.
+func patternMatchesMemberShape(pat ast.Pat, member soltype.Type) bool {
+	switch p := pat.(type) {
+	case *ast.ObjectPat:
+		obj, ok := soltype.CarrierOf(member).(*soltype.ObjectType)
+		if !ok {
+			return false
+		}
+		for _, name := range objectPatFieldNames(p) {
+			if _, found := obj.Prop(name); !found {
+				return false
+			}
+		}
+		return true
+	case *ast.TuplePat:
+		tup, ok := soltype.CarrierOf(member).(*soltype.TupleType)
+		if !ok {
+			return false
+		}
+		arity, hasRest := tuplePatArity(p)
+		if hasRest {
+			return len(tup.Elems) >= arity
+		}
+		return len(tup.Elems) == arity
 	default:
 		return false
 	}
+}
+
+// objectPatFieldNames returns the field names an object pattern binds. A shorthand or
+// key-value element names one field. An `...rest` element names none.
+func objectPatFieldNames(p *ast.ObjectPat) []string {
+	names := make([]string, 0, len(p.Elems))
+	for _, elem := range p.Elems {
+		switch e := elem.(type) {
+		case *ast.ObjShorthandPat:
+			names = append(names, e.Key.Name)
+		case *ast.ObjKeyValuePat:
+			names = append(names, e.Key.Name)
+		}
+	}
+	return names
+}
+
+// tuplePatArity returns a tuple pattern's fixed-element count and whether it ends in a
+// `...rest`. A rest element makes the pattern match any tuple at least as long as the
+// fixed prefix.
+func tuplePatArity(p *ast.TuplePat) (fixed int, hasRest bool) {
+	for _, e := range p.Elems {
+		if _, ok := e.(*ast.RestPat); ok {
+			hasRest = true
+			continue
+		}
+		fixed++
+	}
+	return fixed, hasRest
+}
+
+// narrowMatchArm returns the type a match arm's pattern binds against. For a structural
+// object or tuple pattern over a union scrutinee, it keeps only the members whose shape the
+// pattern matches, so the pattern destructures those members and leaves the rest for other
+// arms. Narrowing is sound only in a refutable context such as a match arm. An irrefutable
+// binding must still require the pattern's fields on every member. Every other pattern, and
+// every non-union scrutinee, binds against the scrutinee unchanged. shape is the coalesced
+// scrutinee the union structure is read from. scrutinee is what a non-narrowing arm binds
+// against, so its var identity and borrow survive when no narrowing applies.
+func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
+	switch pat.(type) {
+	case *ast.ObjectPat, *ast.TuplePat:
+	default:
+		return scrutinee
+	}
+	inner, mut, lt := soltype.UnwrapRef(shape)
+	u, ok := inner.(*soltype.UnionType)
+	if !ok {
+		return scrutinee
+	}
+	kept := make([]soltype.Type, 0, len(u.Types))
+	for _, m := range u.Types {
+		if patternMatchesMemberShape(pat, m) {
+			kept = append(kept, m)
+		}
+	}
+	// When the pattern matches no member, or every member, there is nothing to narrow.
+	// Binding against the original scrutinee then keeps the existing whole-union behavior.
+	if len(kept) == 0 || len(kept) == len(u.Types) {
+		return scrutinee
+	}
+	var narrowed soltype.Type
+	if len(kept) == 1 {
+		narrowed = kept[0]
+	} else {
+		// The narrowed union is the exact set of members the pattern matches. A member the
+		// pattern cannot destructure is excluded, and the original union's open tail holds
+		// only such unknown members, so the narrowed target carries no `...` — binding
+		// against it must not require an unknown tail member to also fit the pattern.
+		narrowed = &soltype.UnionType{Types: kept}
+	}
+	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed
+	// scrutinee re-wraps its narrowed carrier under the same borrow. NewRef drops the
+	// wrapper when the scrutinee was owned.
+	if ri, ok := narrowed.(soltype.RefInner); ok {
+		return soltype.NewRef(mut, lt, ri)
+	}
+	return narrowed
 }
 
 // litMemberCovered reports whether some unguarded arm is a literal pattern equal to

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2722,6 +2722,14 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	if !ok {
 		return scrutinee
 	}
+	// An inexact union carries an open `...` tail of unknown members. A structural pattern
+	// may match a tail member whose field or element types the listed members do not cover,
+	// so narrowing to the listed members would under-type the arm's leaves. Leave an inexact
+	// union unnarrowed. Binding against the whole union then soundly rejects a pattern the
+	// tail may not satisfy, and an inexact union already requires a catch-all arm.
+	if u.Inexact {
+		return scrutinee
+	}
 	kept := make([]soltype.Type, 0, len(u.Types))
 	for _, m := range u.Types {
 		if patternMatchesMemberShape(pat, m) {
@@ -2737,10 +2745,8 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	if len(kept) == 1 {
 		narrowed = kept[0]
 	} else {
-		// The narrowed union is the exact set of members the pattern matches. A member the
-		// pattern cannot destructure is excluded, and the original union's open tail holds
-		// only such unknown members, so the narrowed target carries no `...` — binding
-		// against it must not require an unknown tail member to also fit the pattern.
+		// The narrowed union is the exact set of members the pattern matches, drawn from an
+		// exact source union, so it is exact too.
 		narrowed = &soltype.UnionType{Types: kept}
 	}
 	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -323,48 +323,105 @@ func TestInferMatchNominalMemberUncoveredStructural(t *testing.T) {
 	require.Equal(t, "5:11-7:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
-// DISABLED until M5 D3. A union mixing a structural-object member with a non-object member,
-// `"a" | {x: number}`, matched only by the object pattern `{x}`. The `"a"` member is
-// uncovered, so the match is non-exhaustive. Binding `{x}` against the whole union today
-// also constrains every member to carry `x`, reporting a spurious `cannot constrain "a" <:
-// object` on the `"a"` member. D3's match-arm narrowing binds `{x}` against only the
-// `{x: number}` member, dropping that binding error while the non-exhaustive report stays.
-// Re-enable when D3 lands and assert the single non-exhaustive error the commented body
-// records.
+// A union mixing a structural-object member with a non-object member, `"a" | {x: number}`,
+// matched only by the object pattern `{x}`. Match-arm narrowing binds `{x}` against only
+// the `{x: number}` member, so no spurious `cannot constrain "a" <: object` is reported.
+// The `"a"` member is uncovered, so the match stays non-exhaustive.
 func TestInferMatchUnionUncoveredWithStructuralMember(t *testing.T) {
-	/*
-		_, _, errs := inferSource(t, `
-			fn f(b: boolean) {
-				val p = if b { "a" } else { {x: 1} }
-				return match p {
-					{x} => x
-				}
+	_, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val p = if b { "a" } else { {x: 1} }
+			return match p {
+				{x} => x
 			}
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "4:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
-	*/
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "4:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
 }
 
-// DISABLED until M5 D3. A match over a structural-object union such as
-// `{x: number} | {y: string}` with an object pattern per member should be exhaustive and
-// bind each arm against its matching member. Binding an object pattern against a union
-// scrutinee currently constrains every member to carry the named field, so `{x}` against
-// the `{y: string}` member reports a missing property, and the union exhaustiveness path
-// reports each structural arm unsupported. Both resolve when D3's match-arm narrowing
-// lands, which binds an object pattern against only the members carrying its fields.
-// Re-enable then and assert the empty-error, exhaustive result the commented body records.
+// A match over a structural-object union such as `{x: number} | {y: string}` with an object
+// pattern per member is exhaustive and binds each arm against its matching member. Match-arm
+// narrowing binds `{x}` against only the `{x: number}` member and `{y}` against only the
+// `{y: string}` member, so neither reports a missing property and both members are covered.
 func TestInferMatchStructuralObjectUnion(t *testing.T) {
-	/*
-		values, _, errs := inferSource(t, `
-			fn f(p: {x: number} | {y: string}) {
-				return match p {
-					{x} => 1,
-					{y} => 2
-				}
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}) {
+			return match p {
+				{x} => 1,
+				{y} => 2
 			}
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (p: {x: number} | {y: string}) -> 1 | 2", values["f"])
-	*/
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> 1 | 2", values["f"])
+}
+
+// A structural-object union with a member no arm's shape covers stays non-exhaustive. The
+// `{x}` and `{y}` arms cover the first two members of `{x: number} | {y: string} |
+// {z: boolean}`, but no arm names the `z` field, so the third member is uncovered.
+func TestInferMatchStructuralObjectUnionUncovered(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string} | {z: boolean}) {
+			return match p {
+				{x} => 1,
+				{y} => 2
+			}
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:11-6:5: match is not exhaustive; add a catch-all branch", msgWithSpan(errs[0]))
+}
+
+// Match-arm narrowing routes each tuple pattern to the union members of its fixed arity, so
+// a union of differently-sized tuples covers with one arm per arity. `[a, c]` binds against
+// the arity-2 member `[1, 2]` and `[s]` against the arity-1 member `["a"]`, so the match is
+// exhaustive and each arm reads its own member's element types.
+func TestInferMatchTupleUnionDifferentArity(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { [1, 2] } else { ["a"] }
+			return match x {
+				[a, c] => a,
+				[s] => s
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, `fn (b: boolean) -> 1 | "a"`, values["f"])
+}
+
+// Narrowing an inexact union to a multi-member subset drops the open `...` tail, so the
+// narrowed target does not require the tail's unknown members to fit the pattern. Matching
+// `{x}` against `{x: number} | {x: string} | {y: boolean} | ...` narrows to the exact
+// `{x: number} | {x: string}`, so `x` binds at `number | string` with no spurious
+// `object | object | ... <: object` constraint error. The inexact scrutinee still needs a
+// catch-all, which the `_` arm supplies.
+func TestInferMatchInexactUnionMultiMemberNarrow(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {x: string} | {y: boolean} | ...) {
+			return match p {
+				{x} => x,
+				{y} => 2,
+				_ => 0
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {x: string} | {y: boolean} | ...) -> number | string", values["f"])
+}
+
+// Match-arm narrowing is refutable-only. An irrefutable `val {x} = p` over a union must
+// still require `x` on every member, so binding it against `{x: number} | {y: string}`
+// reports the missing property on the `{y: string}` member rather than narrowing to the
+// `{x: number}` member the way a match arm does.
+func TestValDestructureUnionRequiresFieldOnAllMembers(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}) {
+			val {x} = p
+			return x
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "2:25-2:36: object is missing property: x", msgWithSpan(errs[0]))
 }

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -391,6 +391,27 @@ func TestInferMatchTupleUnionDifferentArity(t *testing.T) {
 	require.Equal(t, `fn (b: boolean) -> 1 | "a"`, values["f"])
 }
 
+// DISABLED until M9. A tuple rest pattern `[head, ...tail]` binds the first element and
+// captures the remaining elements as a tuple. It matches any tuple at least as long as its
+// fixed prefix, so a single such arm covers a union of tuples of differing arity and the
+// match is exhaustive. M5 defers the typed rest-tuple binding. bindPatMode reports the
+// `...tail` element unsupported, and irrefutablePat treats a RestPat as refutable, so the
+// arm neither binds nor covers today. Re-enable when M9's typed rest tuples land and assert
+// the exhaustive, empty-error result the commented body records.
+func TestInferMatchTupleRestPattern(t *testing.T) {
+	/*
+		values, _, errs := inferSource(t, `
+			fn f(p: [number, number] | [string]) {
+				return match p {
+					[head, ...tail] => head
+				}
+			}
+		`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn (p: [number, number] | [string]) -> number | string", values["f"])
+	*/
+}
+
 // Narrowing does not apply to an inexact union's open `...` tail. A tail member could carry
 // `x` at a type the listed members do not cover, so narrowing `{x}` to the listed
 // `{x: number}` member would under-type `x`. narrowMatchArm leaves an inexact union

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -417,6 +417,12 @@ func TestInferMatchTupleRestPattern(t *testing.T) {
 // `{x: number}` member would under-type `x`. narrowMatchArm leaves an inexact union
 // unnarrowed, so `{x}` binds against the whole union and is soundly rejected because the
 // `{y}` member lacks `x`, and the `...` tail may too.
+//
+// M5 D4 changes this. Once field access through an inexact union's open tail yields
+// `unknown`, narrowMatchArm narrows the union to `{x: number} | ...` and `{x}` binds `x` at
+// `number | unknown`, which collapses to `unknown`, so the match type-checks. When D4 lands,
+// the assertions below flip from these two rejection errors to an empty-error result binding
+// `x: unknown`.
 func TestInferMatchInexactUnionNotNarrowed(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(p: {x: number} | {y: string} | ...) {

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -391,24 +391,38 @@ func TestInferMatchTupleUnionDifferentArity(t *testing.T) {
 	require.Equal(t, `fn (b: boolean) -> 1 | "a"`, values["f"])
 }
 
-// Narrowing an inexact union to a multi-member subset drops the open `...` tail, so the
-// narrowed target does not require the tail's unknown members to fit the pattern. Matching
-// `{x}` against `{x: number} | {x: string} | {y: boolean} | ...` narrows to the exact
-// `{x: number} | {x: string}`, so `x` binds at `number | string` with no spurious
-// `object | object | ... <: object` constraint error. The inexact scrutinee still needs a
-// catch-all, which the `_` arm supplies.
-func TestInferMatchInexactUnionMultiMemberNarrow(t *testing.T) {
-	values, _, errs := inferSource(t, `
-		fn f(p: {x: number} | {x: string} | {y: boolean} | ...) {
+// Narrowing does not apply to an inexact union's open `...` tail. A tail member could carry
+// `x` at a type the listed members do not cover, so narrowing `{x}` to the listed
+// `{x: number}` member would under-type `x`. narrowMatchArm leaves an inexact union
+// unnarrowed, so `{x}` binds against the whole union and is soundly rejected because the
+// `{y}` member lacks `x`, and the `...` tail may too.
+func TestInferMatchInexactUnionNotNarrowed(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string} | ...) {
 			return match p {
 				{x} => x,
-				{y} => 2,
+				_ => 0
+			}
+		}
+	`)
+	require.Len(t, errs, 2)
+	require.Equal(t, "2:11-2:36: cannot constrain object | object | ... <: object", msgWithSpan(errs[0]))
+	require.Equal(t, "2:25-2:36: object is missing property: x", msgWithSpan(errs[1]))
+}
+
+// The exact counterpart of the inexact case above still narrows soundly. With no open tail,
+// `{x}` binds against only the `{x: number}` member and reads `x` at `number` without error.
+func TestInferMatchExactUnionNarrowsCleanly(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn g(p: {x: number} | {y: string}) {
+			return match p {
+				{x} => x,
 				_ => 0
 			}
 		}
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "fn (p: {x: number} | {x: string} | {y: boolean} | ...) -> number | string", values["f"])
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number", values["g"])
 }
 
 // Match-arm narrowing is refutable-only. An irrefutable `val {x} = p` over a union must

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -452,10 +452,16 @@ func TestInferMatchExactUnionNarrowsCleanly(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number", values["g"])
 }
 
-// Match-arm narrowing is refutable-only. An irrefutable `val {x} = p` over a union must
-// still require `x` on every member, so binding it against `{x: number} | {y: string}`
-// reports the missing property on the `{y: string}` member rather than narrowing to the
-// `{x: number}` member the way a match arm does.
+// An irrefutable `val {x} = p` cannot narrow the way a refutable match arm does, so it reads
+// `x` off the whole `{x: number} | {y: string}` union. The solver currently rejects because
+// the `{y: string}` member lacks `x`.
+//
+// M5 D4 changes this. Porting the old checker's partial-union member access in
+// internal/checker/unify.go, a property on some but not all members reads as
+// `T | undefined`, so `val {x} = p` will bind `x: number | undefined` with no error. The
+// refutable/irrefutable split survives: a refutable `{x}` arm narrows to `x: number`, while
+// this irrefutable read keeps the `undefined`. When D4 lands, the assertion below flips from
+// the missing-property error to the `number | undefined` result.
 func TestValDestructureUnionRequiresFieldOnAllMembers(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		fn f(p: {x: number} | {y: string}) {

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -324,6 +324,22 @@ func TestInferMatchExactNeedsNoCatchAll(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number, y: number}) -> number", values["f"])
 }
 
+// An object pattern may name a subset of the scrutinee's fields. `{x}` over the exact
+// two-field `{x: number, y: string}` binds `x` and ignores `y`. The pattern is irrefutable,
+// so it covers the scrutinee and the match needs no catch-all. Coverage requires only that
+// the scrutinee carry every field the pattern names, not that the pattern name every field.
+func TestInferMatchPartialObjectPatternCovers(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number, y: string}) {
+			return match p {
+				{x} => x
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number, y: string}) -> number", values["f"])
+}
+
 // An inexact-object scrutinee carries an open tail of unknown values, so a
 // structural arm does not cover it. A missing catch-all is a NonExhaustiveMatchError.
 func TestInferMatchInexactNeedsCatchAll(t *testing.T) {

--- a/internal/solver/infer_pattern_test.go
+++ b/internal/solver/infer_pattern_test.go
@@ -439,27 +439,21 @@ func TestInferMatchInexactUnionWithCatchAll(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// DISABLED until M5 D3. A tuple pattern `[a, c]` over the union `[1, 2] | [3, 4]`. Both
-// members are arity-2 tuples, so the arm covers every member and the match is exhaustive.
-// Binding the pattern against the whole union today constrains every member to the tuple
-// shape, which the union leg cannot yet evaluate and reports as the unsupported structural
-// arm. D3's match-arm narrowing binds `[a, c]` against the tuple members and computes
-// coverage, so the arm binds `a`/`c` at the joined element types and the match type-checks.
-// Re-enable when D3 lands and assert the empty-error, exhaustive result the commented body
-// records.
+// A tuple pattern `[a, c]` over the union `[1, 2] | [3, 4]`. Both members are arity-2
+// tuples, so the arm covers every member and the match is exhaustive. Binding `[a, c]`
+// against the whole union constrains each member to the tuple shape, so `a`/`c` bind at the
+// joined element types `1 | 3` / `2 | 4` and the match type-checks.
 func TestInferMatchTupleUnionExhaustive(t *testing.T) {
-	/*
-		values, _, errs := inferSource(t, `
-			fn f(b: boolean) {
-				val x = if b { [1, 2] } else { [3, 4] }
-				return match x {
-					[a, c] => a
-				}
+	values, _, errs := inferSource(t, `
+		fn f(b: boolean) {
+			val x = if b { [1, 2] } else { [3, 4] }
+			return match x {
+				[a, c] => a
 			}
-		`)
-		require.Empty(t, errs)
-		require.Equal(t, "fn (b: boolean) -> 1 | 3", values["f"])
-	*/
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (b: boolean) -> 1 | 3", values["f"])
 }
 
 // A guarded arm can always fail its guard, so it never makes a match exhaustive. An

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -757,7 +757,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-17 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+18 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -1391,6 +1391,50 @@ corruption of `freshenAbove`.
     arm covers is non-exhaustive; an irrefutable `val {x} = u` over that union
     still reports the missing property on the `{y: string}` member.
 
+- **D4 — Inexact-union member access + refutable narrowing over an open tail**
+  (~170).
+  - **Files:** `solver/constrain.go` (the object-requirement arm against an inexact
+    union, the `UnionType`-sub site that today rejects an open `...` tail),
+    `solver/infer_expr.go` (`narrowMatchArm` — narrow an inexact union to its
+    matching members and keep the tail), tests.
+  - **The gap D3 leaves.** D3 does not narrow an inexact union such as
+    `{x: number} | {y: string} | ...`, because narrowing `{x}` to the listed
+    `{x: number}` member would under-type the leaf: the open `...` tail may hold an
+    `{x: boolean}` value that also matches `{x}`, and that value is assignable to the
+    union through the tail. So `match p { {x} => x, _ => 0 }` binds `{x}` against the
+    whole union and is rejected with `cannot constrain object | ... <: object` plus a
+    missing-`x` report on the `{y: string}` member — the same errors a direct `p.x`
+    read produces, since binding `{x}` is a field read. The rejection is sound but
+    unhelpful; a refutable match with a catch-all should type-check.
+  - **The fix is one mechanism, not a match special-case.** The root capability is
+    field access through an inexact union's open tail. Reading a field off
+    `A | B | ...` projects that field from each listed member and treats the tail as
+    contributing `unknown`, so the read yields `A.f | B.f | unknown` rather than being
+    rejected. This is the constrain arm both the direct `p.x` read and the pattern
+    read reach, so fixing it there fixes both uniformly rather than layering a match
+    special-case on top.
+  - **Match narrowing re-enables for inexact unions.** `narrowMatchArm` narrows an
+    inexact union to the members whose shape the pattern matches and keeps the open
+    tail, so `{x}` over `{x: number} | {y: string} | ...` binds against
+    `{x: number} | ...`. Each leaf reads through the inexact-union field access above,
+    so `x` binds at `number | unknown`, which collapses to the top `unknown`. That is
+    sound: a tail `{x: boolean}` value contributes its `x` through the `unknown` tail
+    rather than being dropped, so the leaf is never under-typed.
+  - **Exhaustiveness and irrefutability are unchanged.** An inexact union still needs
+    a catch-all — `unionMatchExhaustive` returns false on an `Inexact` union unless a
+    catch-all arm is present — so D4 changes only what a covered arm binds, never
+    whether the match is exhaustive. The narrowing stays refutable-only, so an
+    irrefutable `val {x} = p` over the inexact union still requires `x` on every value
+    and reports the missing property.
+  - **Depends on:** D3 (the `narrowMatchArm` path and the exact-union narrowing it
+    reuses).
+  - **Accept:** `match p { {x} => x, _ => 0 }` over `{x: number} | {y: string} | ...`
+    type-checks and binds `x: unknown` — flipping
+    `TestInferMatchInexactUnionNotNarrowed` from its two rejection errors to the
+    empty-error, `x: unknown` result; a direct `p.x` read over an inexact union yields
+    `unknown` instead of the constraint error; an irrefutable `val {x} = p` over the
+    inexact union still reports the missing property.
+
 ### Phase E — Method overloading
 
 - **E1 — Method overload resolution + #723 object-argument specificity** (~200).
@@ -1460,6 +1504,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► D1 (ExtractorPat / InstancePat binding)
       │    └─► D2 (enum-exhaustive / nominal union exhaustiveness)   ── also needs D-Enum + M6
       │         └─► D3 (structural union narrowing + exhaustiveness)
+      │              └─► D4 (inexact-union member access + refutable narrowing)
       ├─► D-Enum (enum decls as unions of final variants)     ── needs M6 (landed)
       └─► E1 (method overload resolution + #723 specificity)
 ```
@@ -1487,6 +1532,7 @@ graph TD
     DEnum["D-Enum (enum decls as unions of final variants)"]
     D2["D2 (enum-exhaustive / nominal union exhaustiveness)"]
     D3["D3 (structural union narrowing + exhaustiveness)"]
+    D4["D4 (inexact-union member access + refutable narrowing)"]
     E1["E1 (method overload resolution + #723 specificity)"]
     M6["M6 (unions / intersections, landed)"]
 
@@ -1507,6 +1553,7 @@ graph TD
     D1 --> D2
     DEnum --> D2
     D2 --> D3
+    D3 --> D4
     M6 -.-> DEnum
     M6 -.-> D2
     B1 --> B6
@@ -1566,6 +1613,8 @@ in parallel** (five tracks). The second-tier dependents each wait on one first-t
 PR: **C2** on C1, **F1** on C1, **D2** on both D1 and D-Enum. The only PR that joins
 two tracks is D2 (patterns × enums × M6's union exhaustiveness). **D3** is third-tier,
 waiting on D2 for the union-member loop it extends with structural-object coverage.
+**D4** is fourth-tier, waiting on D3 for the `narrowMatchArm` path it extends to inexact
+unions once field access through an open `...` tail yields `unknown`.
 
 ## Algorithms and data structures added or modified — summary
 

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -1391,49 +1391,55 @@ corruption of `freshenAbove`.
     arm covers is non-exhaustive; an irrefutable `val {x} = u` over that union
     still reports the missing property on the `{y: string}` member.
 
-- **D4 — Inexact-union member access + refutable narrowing over an open tail**
-  (~170).
-  - **Files:** `solver/constrain.go` (the object-requirement arm against an inexact
-    union, the `UnionType`-sub site that today rejects an open `...` tail),
+- **D4 — Partial-union member access yields `T | undefined`** (~190).
+  - **Files:** `solver/constrain.go` (the object-requirement arm against a
+    `UnionType` sub, the site that today rejects a member lacking the property),
     `solver/infer_expr.go` (`narrowMatchArm` — narrow an inexact union to its
     matching members and keep the tail), tests.
-  - **The gap D3 leaves.** D3 does not narrow an inexact union such as
-    `{x: number} | {y: string} | ...`, because narrowing `{x}` to the listed
-    `{x: number}` member would under-type the leaf: the open `...` tail may hold an
-    `{x: boolean}` value that also matches `{x}`, and that value is assignable to the
-    union through the tail. So `match p { {x} => x, _ => 0 }` binds `{x}` against the
-    whole union and is rejected with `cannot constrain object | ... <: object` plus a
-    missing-`x` report on the `{y: string}` member — the same errors a direct `p.x`
-    read produces, since binding `{x}` is a field read. The rejection is sound but
-    unhelpful; a refutable match with a catch-all should type-check.
-  - **The fix is one mechanism, not a match special-case.** The root capability is
-    field access through an inexact union's open tail. Reading a field off
-    `A | B | ...` projects that field from each listed member and treats the tail as
-    contributing `unknown`, so the read yields `A.f | B.f | unknown` rather than being
-    rejected. This is the constrain arm both the direct `p.x` read and the pattern
-    read reach, so fixing it there fixes both uniformly rather than layering a match
-    special-case on top.
-  - **Match narrowing re-enables for inexact unions.** `narrowMatchArm` narrows an
-    inexact union to the members whose shape the pattern matches and keeps the open
-    tail, so `{x}` over `{x: number} | {y: string} | ...` binds against
-    `{x: number} | ...`. Each leaf reads through the inexact-union field access above,
-    so `x` binds at `number | unknown`, which collapses to the top `unknown`. That is
-    sound: a tail `{x: boolean}` value contributes its `x` through the `unknown` tail
-    rather than being dropped, so the leaf is never under-typed.
-  - **Exhaustiveness and irrefutability are unchanged.** An inexact union still needs
-    a catch-all — `unionMatchExhaustive` returns false on an `Inexact` union unless a
-    catch-all arm is present — so D4 changes only what a covered arm binds, never
-    whether the match is exhaustive. The narrowing stays refutable-only, so an
-    irrefutable `val {x} = p` over the inexact union still requires `x` on every value
-    and reports the missing property.
+  - **The regression this closes.** The old checker resolves a property read against
+    a union member by member: a member carrying the property contributes its type, a
+    member lacking it contributes `undefined`, and a property on no member is
+    `undefined`, erroring only for a write-only setter
+    ([internal/checker/unify.go:1458-1469](../../internal/checker/unify.go), the
+    destructure-against-union arm). So `p.x` and `val {x} = p` over
+    `{x: number} | {y: string}` bind `x: number | undefined`. The solver instead
+    rejects with `object is missing property: x`, since a field read emits
+    `p <: {x: β}` and the `UnionType`-sub rule requires *every* member to satisfy it.
+    D4 ports the old checker's semantics, so partial-union access resolves to
+    `T | undefined` rather than failing.
+  - **The rule.** Reading a property `f` off a union joins one contribution per
+    member: a member with `f` contributes `member.f`, a member without `f`
+    contributes `undefined`, and an inexact union's open `...` tail contributes
+    `unknown` — a tail member may carry `f` at any type, so the sound contribution is
+    the top. So `{x: number} | {y: string}` reads `x` as `number | undefined`, a
+    property on no listed member reads as `undefined`, and
+    `{x: number} | {y: string} | ...` reads `x` as `number | undefined | unknown`,
+    which collapses to `unknown`. This lands at the `UnionType`-sub object-requirement
+    arm both a direct `p.x` read and a `val`/parameter destructure reach, so field
+    read and destructure fix uniformly rather than as a pattern special-case.
+  - **Interaction with D3's refutable narrowing.** A refutable `match`/`if let` arm
+    still narrows to the matching members first (D3), so `{x}` over the exact
+    `{x: number} | {y: string}` binds the precise `x: number`, not `number | undefined`
+    — the arm fires only when `x` is present, so the `undefined` contribution of the
+    `{y: string}` member is not reachable. D4 changes the IRREFUTABLE path — `p.x`,
+    `val {x} = p` — and the inexact match case: `narrowMatchArm` narrows an inexact
+    union to its matching members plus the kept `...` tail, so `{x}` over
+    `{x: number} | {y: string} | ...` binds against `{x: number} | ...` and reads `x`
+    through the rule above as `number | unknown`, i.e. `unknown`.
+  - **Exhaustiveness is unchanged.** An inexact union still needs a catch-all —
+    `unionMatchExhaustive` returns false on an `Inexact` union unless a catch-all arm
+    is present — so D4 changes only the TYPE a covered arm binds, never whether the
+    match is exhaustive.
   - **Depends on:** D3 (the `narrowMatchArm` path and the exact-union narrowing it
     reuses).
-  - **Accept:** `match p { {x} => x, _ => 0 }` over `{x: number} | {y: string} | ...`
-    type-checks and binds `x: unknown` — flipping
+  - **Accept:** `p.x` and `val {x} = p` over `{x: number} | {y: string}` bind
+    `x: number | undefined` — flipping `TestValDestructureUnionRequiresFieldOnAllMembers`
+    from its missing-property error to the `number | undefined` result; a property on
+    no listed member reads as `undefined`; `match p { {x} => x, _ => 0 }` over
+    `{x: number} | {y: string} | ...` binds `x: unknown` — flipping
     `TestInferMatchInexactUnionNotNarrowed` from its two rejection errors to the
-    empty-error, `x: unknown` result; a direct `p.x` read over an inexact union yields
-    `unknown` instead of the constraint error; an irrefutable `val {x} = p` over the
-    inexact union still reports the missing property.
+    empty-error, `x: unknown` result; a refutable `{x}` arm over the exact
+    `{x: number} | {y: string}` still binds the precise `x: number`, preserving D3.
 
 ### Phase E — Method overloading
 
@@ -1504,7 +1510,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► D1 (ExtractorPat / InstancePat binding)
       │    └─► D2 (enum-exhaustive / nominal union exhaustiveness)   ── also needs D-Enum + M6
       │         └─► D3 (structural union narrowing + exhaustiveness)
-      │              └─► D4 (inexact-union member access + refutable narrowing)
+      │              └─► D4 (partial-union member access → T | undefined)
       ├─► D-Enum (enum decls as unions of final variants)     ── needs M6 (landed)
       └─► E1 (method overload resolution + #723 specificity)
 ```
@@ -1532,7 +1538,7 @@ graph TD
     DEnum["D-Enum (enum decls as unions of final variants)"]
     D2["D2 (enum-exhaustive / nominal union exhaustiveness)"]
     D3["D3 (structural union narrowing + exhaustiveness)"]
-    D4["D4 (inexact-union member access + refutable narrowing)"]
+    D4["D4 (partial-union member access → T | undefined)"]
     E1["E1 (method overload resolution + #723 specificity)"]
     M6["M6 (unions / intersections, landed)"]
 
@@ -1613,8 +1619,9 @@ in parallel** (five tracks). The second-tier dependents each wait on one first-t
 PR: **C2** on C1, **F1** on C1, **D2** on both D1 and D-Enum. The only PR that joins
 two tracks is D2 (patterns × enums × M6's union exhaustiveness). **D3** is third-tier,
 waiting on D2 for the union-member loop it extends with structural-object coverage.
-**D4** is fourth-tier, waiting on D3 for the `narrowMatchArm` path it extends to inexact
-unions once field access through an open `...` tail yields `unknown`.
+**D4** is fourth-tier, waiting on D3 for the `narrowMatchArm` path it extends, porting the
+old checker's partial-union member access so a property on some but not all members reads as
+`T | undefined` rather than erroring.
 
 ## Algorithms and data structures added or modified — summary
 

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -757,7 +757,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-18 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+19 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -1441,6 +1441,77 @@ corruption of `freshenAbove`.
     empty-error, `x: unknown` result; a refutable `{x}` arm over the exact
     `{x: number} | {y: string}` still binds the precise `x: number`, preserving D3.
 
+- **D5 — Comprehensive (nested) match exhaustiveness via a usefulness algorithm**
+  (~500).
+  - **Files:** `solver/exhaustiveness.go` (new — the usefulness engine),
+    `solver/infer_expr.go` (retire the top-level checks `checkMatchExhaustive`
+    dispatches to — `unionMatchExhaustive`, `structuralMemberCovered`,
+    `nominalMemberCovered`, `armCoversShape`, `litMemberCovered` — and call the engine
+    instead), tests.
+  - **What D2/D3 shipped, and the gap.** D2/D3's exhaustiveness reads only the
+    OUTERMOST shape: a union member is covered when some irrefutable arm names its
+    top-level field-set or tuple arity (`structuralMemberCovered` +
+    `patternMatchesMemberShape`). It cannot tell union members apart by nested
+    structure, and it cannot verify that a nested finite domain — a boolean field, an
+    enum variant inside a record or tuple — is fully covered. `match p { {pt: {x:
+    true}} => .., {pt: {x: false}} => .. }` over `{pt: {x: boolean}}` is exhaustive,
+    but D3 cannot prove it. D5 makes the verdict comprehensive: a match is exhaustive
+    iff the arms' matched value-space leaves the scrutinee's value-space empty,
+    decided structurally at every depth.
+  - **Why a usefulness algorithm, not the `internal/checker` port.** The old checker
+    ENUMERATES the value space by cartesian product — `expandObjectCoverageSet`,
+    `cartesianProductObjects`, `cartesianProductTuples`
+    ([internal/checker/exhaustiveness.go](../../internal/checker/exhaustiveness.go)) —
+    which blows up combinatorially, since a record of k booleans is 2^k cases and
+    nesting multiplies, and it special-cases infinite domains. D5 ports the SEMANTICS,
+    not the mechanism: it implements Maranget's usefulness algorithm, the standard
+    Rust/OCaml approach. A lazy matrix `specialize`/`default` recursion explores only
+    the constructors the patterns mention, folds an open domain into one
+    "missing constructor" case, and yields a witness — a concrete uncovered pattern —
+    for the diagnostic. Same verdicts the old checker computes, without the
+    enumeration blowup and with better witnesses.
+  - **Why now, and not gated on MLstruct.** Exhaustiveness is a GROUND decision
+    procedure. It runs after inference on the coalesced scrutinee and answers whether
+    `scrutinee − ⋁ patterns` is empty, with a witness if not. It needs no negation
+    type to be inferable or first-class. MLstruct's Boolean algebra (`¬T`) is what
+    NARROWING wants — an arm binds `scrutinee ∧ pattern` and the next sees
+    `scrutinee ∧ ¬earlier`, inferred types that flow — and narrowing owns no M-series
+    milestone ([03-references.md](03-references.md) §"Beyond a plain lattice"). Gating
+    exhaustiveness on that unscheduled work would defer a safety feature indefinitely
+    for a benefit that accrues mostly to narrowing. So the two stay decoupled: D5 lands
+    the ground exhaustiveness engine now, and nested-narrowing PRECISION stays
+    MLstruct-future, with D3's top-level `narrowMatchArm` as the interim.
+  - **Forward-compatible with MLstruct, not throwaway.** MLstruct changes how the
+    residual is REPRESENTED — a real `∧`/`¬` type rather than a matrix witness — not
+    the need to decide emptiness and render a witness on ground types. A well-factored
+    usefulness engine survives as that decision procedure; at most its emptiness leaf
+    is reframed to consult the algebra. The piece MLstruct eventually subsumes is D3's
+    `narrowMatchArm`, not D5's engine.
+  - **Algorithm.** `useful(matrix, row)` over a constructor set derived from the
+    coalesced scrutinee type. Constructors are tuple arity, object field-set, literal
+    value, `boolean` = {true, false}, class or enum variant, and `undefined` from D4's
+    `T | undefined`. An inexact object/tuple/union, or a primitive with an infinite
+    domain such as `number`/`string`, is an OPEN constructor set — the
+    missing-constructor case is always live, so it requires a catch-all, exactly D3's
+    inexact rule generalized. `specialize` peels one constructor and recurses into its
+    sub-patterns, so nesting and union members decompose uniformly. Redundancy falls
+    out — an arm is unreachable iff it is not useful against the arms above it — and is
+    reported as a warning. A guarded arm contributes nothing to coverage, as today.
+  - **M5 boundary.** Extractor patterns through `[Symbol.customMatcher]` and
+    type-alias / `TypeRef` resolution are M7, so D5 decomposes an extractor by D1's
+    interim constructor parameters and treats an unresolved alias conservatively. A
+    scrutinee position that is still an inference variable is an open domain, never
+    silently exhaustive.
+  - **Depends on:** D3 (the exhaustiveness surface it replaces) + D-Enum (enum
+    variants as the nominal constructor set). Independent of D4.
+  - **Accept:** a `match` over `{pt: {x: boolean}}` with a `{pt: {x: true}}` and a
+    `{pt: {x: false}}` arm is exhaustive with no catch-all, and dropping either is
+    non-exhaustive with a witness naming the missing nested case; a `match` over
+    `[boolean, boolean]` needs all four corners or a wildcard; a nested enum inside a
+    tuple is exhaustive iff every variant is covered at that position; a `number` field
+    always needs a catch-all; an arm shadowed by an earlier one is reported redundant;
+    D2/D3's existing top-level accept cases stay green against the engine.
+
 ### Phase E — Method overloading
 
 - **E1 — Method overload resolution + #723 object-argument specificity** (~200).
@@ -1510,7 +1581,8 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► D1 (ExtractorPat / InstancePat binding)
       │    └─► D2 (enum-exhaustive / nominal union exhaustiveness)   ── also needs D-Enum + M6
       │         └─► D3 (structural union narrowing + exhaustiveness)
-      │              └─► D4 (partial-union member access → T | undefined)
+      │              ├─► D4 (partial-union member access → T | undefined)
+      │              └─► D5 (comprehensive nested exhaustiveness — usefulness algorithm)
       ├─► D-Enum (enum decls as unions of final variants)     ── needs M6 (landed)
       └─► E1 (method overload resolution + #723 specificity)
 ```
@@ -1539,6 +1611,7 @@ graph TD
     D2["D2 (enum-exhaustive / nominal union exhaustiveness)"]
     D3["D3 (structural union narrowing + exhaustiveness)"]
     D4["D4 (partial-union member access → T | undefined)"]
+    D5["D5 (comprehensive nested exhaustiveness — usefulness algorithm)"]
     E1["E1 (method overload resolution + #723 specificity)"]
     M6["M6 (unions / intersections, landed)"]
 
@@ -1560,6 +1633,8 @@ graph TD
     DEnum --> D2
     D2 --> D3
     D3 --> D4
+    D3 --> D5
+    DEnum --> D5
     M6 -.-> DEnum
     M6 -.-> D2
     B1 --> B6
@@ -1621,7 +1696,10 @@ two tracks is D2 (patterns × enums × M6's union exhaustiveness). **D3** is thi
 waiting on D2 for the union-member loop it extends with structural-object coverage.
 **D4** is fourth-tier, waiting on D3 for the `narrowMatchArm` path it extends, porting the
 old checker's partial-union member access so a property on some but not all members reads as
-`T | undefined` rather than erroring.
+`T | undefined` rather than erroring. **D5** is also fourth-tier on D3 and independent of D4:
+it replaces D2/D3's top-level exhaustiveness with a full usefulness algorithm on ground types,
+deciding nested coverage structurally while leaving nested-narrowing precision to the
+unscheduled MLstruct work.
 
 ## Algorithms and data structures added or modified — summary
 

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -757,7 +757,7 @@ func (c *checker) inferForIn(scope *Scope, lvl int, s *ast.ForInStmt) soltype.Ty
 
 ## PR breakdown
 
-19 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
+18 PRs across 6 phases (A–F) plus one enum PR, each independently mergeable and
 green, each with table-driven tests asserting rendered types (Escalier
 type-annotation syntax) and **full** error messages. Every PR names the files
 touched, the structures added/modified, the algorithm changes, and its
@@ -1441,77 +1441,6 @@ corruption of `freshenAbove`.
     empty-error, `x: unknown` result; a refutable `{x}` arm over the exact
     `{x: number} | {y: string}` still binds the precise `x: number`, preserving D3.
 
-- **D5 — Comprehensive (nested) match exhaustiveness via a usefulness algorithm**
-  (~500).
-  - **Files:** `solver/exhaustiveness.go` (new — the usefulness engine),
-    `solver/infer_expr.go` (retire the top-level checks `checkMatchExhaustive`
-    dispatches to — `unionMatchExhaustive`, `structuralMemberCovered`,
-    `nominalMemberCovered`, `armCoversShape`, `litMemberCovered` — and call the engine
-    instead), tests.
-  - **What D2/D3 shipped, and the gap.** D2/D3's exhaustiveness reads only the
-    OUTERMOST shape: a union member is covered when some irrefutable arm names its
-    top-level field-set or tuple arity (`structuralMemberCovered` +
-    `patternMatchesMemberShape`). It cannot tell union members apart by nested
-    structure, and it cannot verify that a nested finite domain — a boolean field, an
-    enum variant inside a record or tuple — is fully covered. `match p { {pt: {x:
-    true}} => .., {pt: {x: false}} => .. }` over `{pt: {x: boolean}}` is exhaustive,
-    but D3 cannot prove it. D5 makes the verdict comprehensive: a match is exhaustive
-    iff the arms' matched value-space leaves the scrutinee's value-space empty,
-    decided structurally at every depth.
-  - **Why a usefulness algorithm, not the `internal/checker` port.** The old checker
-    ENUMERATES the value space by cartesian product — `expandObjectCoverageSet`,
-    `cartesianProductObjects`, `cartesianProductTuples`
-    ([internal/checker/exhaustiveness.go](../../internal/checker/exhaustiveness.go)) —
-    which blows up combinatorially, since a record of k booleans is 2^k cases and
-    nesting multiplies, and it special-cases infinite domains. D5 ports the SEMANTICS,
-    not the mechanism: it implements Maranget's usefulness algorithm, the standard
-    Rust/OCaml approach. A lazy matrix `specialize`/`default` recursion explores only
-    the constructors the patterns mention, folds an open domain into one
-    "missing constructor" case, and yields a witness — a concrete uncovered pattern —
-    for the diagnostic. Same verdicts the old checker computes, without the
-    enumeration blowup and with better witnesses.
-  - **Why now, and not gated on MLstruct.** Exhaustiveness is a GROUND decision
-    procedure. It runs after inference on the coalesced scrutinee and answers whether
-    `scrutinee − ⋁ patterns` is empty, with a witness if not. It needs no negation
-    type to be inferable or first-class. MLstruct's Boolean algebra (`¬T`) is what
-    NARROWING wants — an arm binds `scrutinee ∧ pattern` and the next sees
-    `scrutinee ∧ ¬earlier`, inferred types that flow — and narrowing owns no M-series
-    milestone ([03-references.md](03-references.md) §"Beyond a plain lattice"). Gating
-    exhaustiveness on that unscheduled work would defer a safety feature indefinitely
-    for a benefit that accrues mostly to narrowing. So the two stay decoupled: D5 lands
-    the ground exhaustiveness engine now, and nested-narrowing PRECISION stays
-    MLstruct-future, with D3's top-level `narrowMatchArm` as the interim.
-  - **Forward-compatible with MLstruct, not throwaway.** MLstruct changes how the
-    residual is REPRESENTED — a real `∧`/`¬` type rather than a matrix witness — not
-    the need to decide emptiness and render a witness on ground types. A well-factored
-    usefulness engine survives as that decision procedure; at most its emptiness leaf
-    is reframed to consult the algebra. The piece MLstruct eventually subsumes is D3's
-    `narrowMatchArm`, not D5's engine.
-  - **Algorithm.** `useful(matrix, row)` over a constructor set derived from the
-    coalesced scrutinee type. Constructors are tuple arity, object field-set, literal
-    value, `boolean` = {true, false}, class or enum variant, and `undefined` from D4's
-    `T | undefined`. An inexact object/tuple/union, or a primitive with an infinite
-    domain such as `number`/`string`, is an OPEN constructor set — the
-    missing-constructor case is always live, so it requires a catch-all, exactly D3's
-    inexact rule generalized. `specialize` peels one constructor and recurses into its
-    sub-patterns, so nesting and union members decompose uniformly. Redundancy falls
-    out — an arm is unreachable iff it is not useful against the arms above it — and is
-    reported as a warning. A guarded arm contributes nothing to coverage, as today.
-  - **M5 boundary.** Extractor patterns through `[Symbol.customMatcher]` and
-    type-alias / `TypeRef` resolution are M7, so D5 decomposes an extractor by D1's
-    interim constructor parameters and treats an unresolved alias conservatively. A
-    scrutinee position that is still an inference variable is an open domain, never
-    silently exhaustive.
-  - **Depends on:** D3 (the exhaustiveness surface it replaces) + D-Enum (enum
-    variants as the nominal constructor set). Independent of D4.
-  - **Accept:** a `match` over `{pt: {x: boolean}}` with a `{pt: {x: true}}` and a
-    `{pt: {x: false}}` arm is exhaustive with no catch-all, and dropping either is
-    non-exhaustive with a witness naming the missing nested case; a `match` over
-    `[boolean, boolean]` needs all four corners or a wildcard; a nested enum inside a
-    tuple is exhaustive iff every variant is covered at that position; a `number` field
-    always needs a catch-all; an arm shadowed by an earlier one is reported redundant;
-    D2/D3's existing top-level accept cases stay green against the engine.
-
 ### Phase E — Method overloading
 
 - **E1 — Method overload resolution + #723 object-argument specificity** (~200).
@@ -1581,8 +1510,7 @@ A3 (LifetimeParam + FuncType.LifetimeParams)  ──┤   ── A3 needs A1's C
       ├─► D1 (ExtractorPat / InstancePat binding)
       │    └─► D2 (enum-exhaustive / nominal union exhaustiveness)   ── also needs D-Enum + M6
       │         └─► D3 (structural union narrowing + exhaustiveness)
-      │              ├─► D4 (partial-union member access → T | undefined)
-      │              └─► D5 (comprehensive nested exhaustiveness — usefulness algorithm)
+      │              └─► D4 (partial-union member access → T | undefined)
       ├─► D-Enum (enum decls as unions of final variants)     ── needs M6 (landed)
       └─► E1 (method overload resolution + #723 specificity)
 ```
@@ -1611,7 +1539,6 @@ graph TD
     D2["D2 (enum-exhaustive / nominal union exhaustiveness)"]
     D3["D3 (structural union narrowing + exhaustiveness)"]
     D4["D4 (partial-union member access → T | undefined)"]
-    D5["D5 (comprehensive nested exhaustiveness — usefulness algorithm)"]
     E1["E1 (method overload resolution + #723 specificity)"]
     M6["M6 (unions / intersections, landed)"]
 
@@ -1633,8 +1560,6 @@ graph TD
     DEnum --> D2
     D2 --> D3
     D3 --> D4
-    D3 --> D5
-    DEnum --> D5
     M6 -.-> DEnum
     M6 -.-> D2
     B1 --> B6
@@ -1696,10 +1621,7 @@ two tracks is D2 (patterns × enums × M6's union exhaustiveness). **D3** is thi
 waiting on D2 for the union-member loop it extends with structural-object coverage.
 **D4** is fourth-tier, waiting on D3 for the `narrowMatchArm` path it extends, porting the
 old checker's partial-union member access so a property on some but not all members reads as
-`T | undefined` rather than erroring. **D5** is also fourth-tier on D3 and independent of D4:
-it replaces D2/D3's top-level exhaustiveness with a full usefulness algorithm on ground types,
-deciding nested coverage structurally while leaving nested-narrowing precision to the
-unscheduled MLstruct work.
+`T | undefined` rather than erroring.
 
 ## Algorithms and data structures added or modified — summary
 


### PR DESCRIPTION
Implement match-arm union narrowing to bind structural patterns against only the union members whose shape they match, rather than the entire union. This eliminates spurious type errors when a pattern cannot destructure all members and enables exhaustiveness checking for structural-object and tuple unions.

Key changes:

- Add `narrowMatchArm` to filter a union scrutinee to only members matching a structural pattern's shape. For non-structural patterns and non-union scrutinees, the scrutinee passes through unchanged.
- Add `structuralMemberCovered` to check whether an object or tuple pattern irrefutably covers a structural union member by shape.
- Add `patternMatchesMemberShape` to test whether a pattern's shape fits a member: object patterns require all named fields to exist on the member, tuple patterns require matching arity (or at least that arity with `...rest`).
- Add helper functions `objectPatFieldNames` and `tuplePatArity` to extract pattern metadata.
- Refactor `unionMatchExhaustive` to dispatch coverage checking through a new `unionMemberCovered` method that handles literal, nominal, and structural members uniformly.
- Remove `reportStructuralUnionArms` and `isNominalArm`, which flagged structural patterns as unsupported. Structural patterns now work correctly.
- Update test cases: re-enable `TestInferMatchUnionUncoveredWithStructuralMember`, `TestInferMatchStructuralObjectUnion`, and `TestInferMatchTupleUnionExhaustive` which were disabled pending this feature. Add new tests for uncovered structural members, tuple unions with different arities, and inexact union narrowing.

Narrowing is refutable-only: irrefutable bindings like `val {x} = p` still require the field on all members, preserving type safety for non-match contexts.

https://claude.ai/code/session_01R5qm9oq28EGKMAJgXnwUEn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved match exhaustiveness and type narrowing for union values with structural object and tuple patterns.
  * Exhaustiveness now accounts for structural patterns that cover the relevant union member shapes.
  * Destructuring and match narrowing now correctly report missing fields when required properties aren’t present on all union members, with correct handling for inexact unions.
* **Tests**
  * Expanded and re-enabled match/destructuring test coverage for structural unions, tuple arities, narrowing behavior, and uncovered cases.
* **Documentation**
  * Updated guidance for how structural union members are treated in exhaustiveness checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->