### PR TITLE
Implement partial-union field reads (M5 D4)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -34,8 +34,8 @@ func typePrec(t Type) int {
 	case *RefType:
 		return precPrefix
 	default:
-		// PrimType, LitType, TupleType, ObjectType, ClassType, Void, NeverType,
-		// UnknownType — atoms. ObjectType is brace-delimited and ClassType renders as
+		// PrimType, LitType, TupleType, ObjectType, ClassType, Void, NullType,
+		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited and ClassType renders as
 		// a bare name or `Name<args>`, so neither needs parens. A raw TypeVarType
 		// appears only when printing an un-coalesced type, see printType; it is also an
 		// atom rendered as `t{ID}`, so it lands here. A `mut 'a Point` borrow wraps the
@@ -497,6 +497,8 @@ func (p *namedPrinter) printType(t Type) string {
 		return "void"
 	case *NullType:
 		return "null"
+	case *UndefinedType:
+		return "undefined"
 	case *TupleType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -480,6 +480,13 @@ type Void struct{}
 // first.
 type NullType struct{}
 
+// UndefinedType is the type whose only inhabitant is `undefined`, the atomic
+// twin of NullType. Reading a property off a union where only some members
+// carry it joins `undefined` for the members that lack it, so the read
+// resolves to `T | undefined` (M5 D4). No source syntax produces it yet; it is
+// minted internally by that join and renders as `undefined`.
+type UndefinedType struct{}
+
 // NeverType (⊥) and UnknownType (⊤) are the bottom/top of the subtype lattice —
 // the coalesced output of an empty-bounds single-polarity variable (positive ⇒
 // never, negative ⇒ unknown). The spike emits these via type_system; M1 carries
@@ -562,6 +569,7 @@ func (*RefType) isType()          {}
 func (*PromiseType) isType()      {}
 func (*Void) isType()             {}
 func (*NullType) isType()         {}
+func (*UndefinedType) isType()    {}
 func (*NeverType) isType()        {}
 func (*UnknownType) isType()      {}
 func (*UnionType) isType()        {}
@@ -639,8 +647,8 @@ func LevelOf(t Type) int {
 	case *IntersectionType:
 		return maxMemberLevel(t.Types)
 	default:
-		// PrimType, LitType, Void, NullType, NeverType, UnknownType, ErrorType:
-		// childless leaves. ErrorType is a sentinel at level 0.
+		// PrimType, LitType, Void, NullType, UndefinedType, NeverType, UnknownType,
+		// ErrorType: childless leaves. ErrorType is a sentinel at level 0.
 		return 0
 	}
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -74,14 +74,15 @@ func descendReplacement[T Type](original T, e EnterResult) T {
 	return repl
 }
 
-func (t *TypeVarType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
-func (t *PrimType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
-func (t *LitType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
-func (t *Void) Accept(v TypeVisitor, pol Polarity) Type        { return acceptLeaf(t, v, pol) }
-func (t *NullType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
-func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
-func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
-func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
+func (t *TypeVarType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
+func (t *PrimType) Accept(v TypeVisitor, pol Polarity) Type      { return acceptLeaf(t, v, pol) }
+func (t *LitType) Accept(v TypeVisitor, pol Polarity) Type       { return acceptLeaf(t, v, pol) }
+func (t *Void) Accept(v TypeVisitor, pol Polarity) Type          { return acceptLeaf(t, v, pol) }
+func (t *NullType) Accept(v TypeVisitor, pol Polarity) Type      { return acceptLeaf(t, v, pol) }
+func (t *UndefinedType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
+func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
+func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
+func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -841,6 +841,9 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.NullType:
 		_, ok := b.(*soltype.NullType)
 		return ok
+	case *soltype.UndefinedType:
+		_, ok := b.(*soltype.UndefinedType)
+		return ok
 	case *soltype.NeverType:
 		_, ok := b.(*soltype.NeverType)
 		return ok

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -658,28 +658,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
-// constrainUnionFieldRead implements the partial-union member read (M5 D4). A field read
-// `p.x` or a destructure `val {x} = p` lowers to a requirement `p <: {x: β}`, an inexact
-// object whose property types are the fresh vars the read binds. Against a union sub, the
-// default every-member rule rejects a member that lacks the property, so `p.x` over
-// `{x: number} | {y: string}` fails on the `{y: string}` member. This joins one contribution
-// per member into each requirement var instead: a member carrying the property contributes
-// its type, a member lacking it contributes undefined, and the union's own open `...` tail
-// contributes unknown, since a tail member may carry the property at any type. So the read
-// resolves to `number | undefined`, and reading through an inexact union's tail resolves to
-// `unknown`.
+// constrainUnionFieldRead reads a property `f` off a union sub for a field-read/destructure
+// requirement `union <: {f: β}` (M5 D4), joining one contribution per member into β:
+//   - a member carrying `f` contributes its type;
+//   - a member lacking `f` contributes undefined, so `f` on some but not all members reads
+//     as `T | undefined`;
+//   - an inexact union's open `...` tail contributes unknown, since it may carry `f` at any type;
+//   - `f` on no member of an exact union is a MissingPropertyError, since the read is a
+//     constant undefined, like reading an absent field off a single object.
 //
-// A property no listed member carries is rejected with a MissingPropertyError, since the read
-// would always evaluate to undefined and so is never useful, the same reason reading an absent
-// field off a single object is an error. An inexact union's open tail may still carry it, so a
-// property absent from every listed member of an inexact union is not an error; it reads as
-// unknown through the tail.
-//
-// It applies only to a field-read / destructure requirement: an inexact object super carrying
-// only property elements whose types are all fresh vars, read off a union every member of
-// which is an object. A genuine object subtyping demand — an exact object annotation, or an
-// inexact one with concrete property types — keeps the strict every-member rule. ok is false
-// when the shapes do not fit, telling the caller to fall back to that rule.
+// ok is false unless the shapes fit — an inexact object super of fresh-var properties over a
+// union of objects — so a genuine subtyping demand keeps the strict every-member rule.
 func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (errs []SolverError, ok bool) {
 	req, isObj := super.(*soltype.ObjectType)
 	if !isObj || !req.Inexact {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -669,6 +669,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 //
 // ok is false unless the shapes fit — an inexact object super of fresh-var properties over a
 // union of objects — so a genuine subtyping demand keeps the strict every-member rule.
+//
+// Limitation: only plain object members reading plain properties are handled. A class-instance
+// member, or a getter/method/setter requirement, does not fit and falls back to the
+// every-member rule. Extending the join to those through member lookup is
+// https://github.com/escalier-lang/escalier/issues/886.
 func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (errs []SolverError, ok bool) {
 	req, isObj := super.(*soltype.ObjectType)
 	if !isObj || !req.Inexact {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -698,31 +698,32 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 	}
 	for _, elem := range req.Elems {
 		prop := soltype.AsProperty(elem)
-		// present tracks whether some listed member carries the property, missing whether some
-		// lacks it as a required field, in which case the joined read includes undefined. An
-		// optional member field counts as missing too, since it may be absent at runtime.
-		present := false
-		missing := false
+		// The read joins what each member can yield for this property. anyValue records that
+		// some member yields a value; anyUndefined that the read can also yield undefined,
+		// because some member lacks the property or carries it optionally, so it may be absent
+		// at runtime. A member carrying an optional field sets both.
+		anyValue := false
+		anyUndefined := false
 		for _, obj := range members {
 			mp, found := obj.Prop(prop.Name)
 			if !found {
-				missing = true
+				anyUndefined = true
 				continue
 			}
-			present = true
+			anyValue = true
 			errs = append(errs, c.constrain(mp.Type, prop.Type, seen, mutCtx)...)
 			if mp.Optional {
-				missing = true
+				anyUndefined = true
 			}
 		}
-		if !present && !sub.Inexact {
-			// No listed member carries the property and there is no open tail to carry it, so
-			// the read is a constant undefined. Report it like an absent field on a single
+		if !anyValue && !sub.Inexact {
+			// No listed member yields a value and there is no open tail to carry the property,
+			// so the read is a constant undefined. Report it like an absent field on a single
 			// object. members is non-empty here, so members[0] is a valid receiver to blame.
 			errs = append(errs, &MissingPropertyError{Sub: members[0], Super: req, Name: prop.Name})
 			continue
 		}
-		if missing {
+		if anyUndefined {
 			errs = append(errs, c.constrain(&soltype.UndefinedType{}, prop.Type, seen, mutCtx)...)
 		}
 		if sub.Inexact {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -177,6 +177,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// lower bound on the var.
 	if subU, ok := sub.(*soltype.UnionType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			// M5 D4: a field-read or destructure requirement against a union reads the
+			// property per member rather than demanding it on every member. When it
+			// applies, this yields `T | undefined` instead of failing on the first
+			// member that lacks the field.
+			if errs, ok := c.constrainUnionFieldRead(subU, super, seen, mutCtx); ok {
+				return errs
+			}
 			var errs []SolverError
 			if subU.Inexact {
 				closed := true
@@ -565,6 +572,10 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, ok := super.(*soltype.Void); ok {
 			return nil
 		}
+	case *soltype.UndefinedType:
+		if _, ok := super.(*soltype.UndefinedType); ok {
+			return nil
+		}
 	case *soltype.IntersectionType:
 		// (A & B) <: super ⟹ A <: super OR B <: super. Trial each member in
 		// specificity order under a probe; the first success commits. Stays in
@@ -645,6 +656,71 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	}
 
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// constrainUnionFieldRead implements the partial-union member read (M5 D4). A field read
+// `p.x` or a destructure `val {x} = p` lowers to a requirement `p <: {x: β}`, an inexact
+// object whose property types are the fresh vars the read binds. Against a union sub, the
+// default every-member rule rejects a member that lacks the property, so `p.x` over
+// `{x: number} | {y: string}` fails on the `{y: string}` member. This joins one contribution
+// per member into each requirement var instead: a member carrying the property contributes
+// its type, a member lacking it contributes undefined, and the union's own open `...` tail
+// contributes unknown, since a tail member may carry the property at any type. So the read
+// resolves to `number | undefined`, and reading through an inexact union's tail resolves to
+// `unknown`.
+//
+// It applies only to a field-read / destructure requirement: an inexact object super carrying
+// only property elements whose types are all fresh vars, read off a union every member of
+// which is an object. A genuine object subtyping demand — an exact object annotation, or an
+// inexact one with concrete property types — keeps the strict every-member rule. ok is false
+// when the shapes do not fit, telling the caller to fall back to that rule.
+func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (errs []SolverError, ok bool) {
+	req, isObj := super.(*soltype.ObjectType)
+	if !isObj || !req.Inexact {
+		return nil, false
+	}
+	for _, elem := range req.Elems {
+		prop, isProp := elem.(*soltype.PropertyElem)
+		if !isProp {
+			return nil, false
+		}
+		if _, isVar := prop.Type.(*soltype.TypeVarType); !isVar {
+			return nil, false
+		}
+	}
+	members := make([]*soltype.ObjectType, 0, len(sub.Types))
+	for _, m := range sub.Types {
+		obj, isObj := soltype.CarrierOf(m).(*soltype.ObjectType)
+		if !isObj {
+			return nil, false
+		}
+		members = append(members, obj)
+	}
+	for _, elem := range req.Elems {
+		prop := soltype.AsProperty(elem)
+		// missing tracks whether some listed member lacks the property as a required field, in
+		// which case the joined read includes undefined. An optional member field counts too,
+		// since it may be absent at runtime.
+		missing := false
+		for _, obj := range members {
+			mp, found := obj.Prop(prop.Name)
+			if !found {
+				missing = true
+				continue
+			}
+			errs = append(errs, c.constrain(mp.Type, prop.Type, seen, mutCtx)...)
+			if mp.Optional {
+				missing = true
+			}
+		}
+		if missing {
+			errs = append(errs, c.constrain(&soltype.UndefinedType{}, prop.Type, seen, mutCtx)...)
+		}
+		if sub.Inexact {
+			errs = append(errs, c.constrain(&soltype.UnknownType{}, prop.Type, seen, mutCtx)...)
+		}
+	}
+	return errs, true
 }
 
 // constrainObjMember checks a method, getter, or setter requirement on an object super

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -669,6 +669,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 // resolves to `number | undefined`, and reading through an inexact union's tail resolves to
 // `unknown`.
 //
+// A property no listed member carries is rejected with a MissingPropertyError, since the read
+// would always evaluate to undefined and so is never useful, the same reason reading an absent
+// field off a single object is an error. An inexact union's open tail may still carry it, so a
+// property absent from every listed member of an inexact union is not an error; it reads as
+// unknown through the tail.
+//
 // It applies only to a field-read / destructure requirement: an inexact object super carrying
 // only property elements whose types are all fresh vars, read off a union every member of
 // which is an object. A genuine object subtyping demand — an exact object annotation, or an
@@ -698,9 +704,10 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 	}
 	for _, elem := range req.Elems {
 		prop := soltype.AsProperty(elem)
-		// missing tracks whether some listed member lacks the property as a required field, in
-		// which case the joined read includes undefined. An optional member field counts too,
-		// since it may be absent at runtime.
+		// present tracks whether some listed member carries the property, missing whether some
+		// lacks it as a required field, in which case the joined read includes undefined. An
+		// optional member field counts as missing too, since it may be absent at runtime.
+		present := false
 		missing := false
 		for _, obj := range members {
 			mp, found := obj.Prop(prop.Name)
@@ -708,10 +715,18 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 				missing = true
 				continue
 			}
+			present = true
 			errs = append(errs, c.constrain(mp.Type, prop.Type, seen, mutCtx)...)
 			if mp.Optional {
 				missing = true
 			}
+		}
+		if !present && !sub.Inexact {
+			// No listed member carries the property and there is no open tail to carry it, so
+			// the read is a constant undefined. Report it like an absent field on a single
+			// object. members is non-empty here, so members[0] is a valid receiver to blame.
+			errs = append(errs, &MissingPropertyError{Sub: members[0], Super: req, Name: prop.Name})
+			continue
 		}
 		if missing {
 			errs = append(errs, c.constrain(&soltype.UndefinedType{}, prop.Type, seen, mutCtx)...)

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1573,6 +1573,8 @@ func describe(t soltype.Type) string {
 		return "void"
 	case *soltype.NullType:
 		return "null"
+	case *soltype.UndefinedType:
+		return "undefined"
 	case *soltype.NeverType:
 		return "never"
 	case *soltype.UnknownType:

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2751,6 +2751,11 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	if len(kept) == 1 && !u.Inexact {
 		narrowed = kept[0]
 	} else {
+		// The Inexact flag is the open `...` tail, not an `unknown` member, so this does not
+		// collapse the way `T | unknown` does. Keep the structured inexact union rather than
+		// returning unknown: it is the bind target for the arm's pattern, and constrainUnionFieldRead
+		// needs the listed members to read each field before the tail widens it to unknown.
+		// Binding the pattern against bare unknown would leave nothing to destructure.
 		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
 	}
 	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2730,32 +2730,28 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	if !ok {
 		return scrutinee
 	}
-	// An inexact union carries an open `...` tail of unknown members. A structural pattern
-	// may match a tail member whose field or element types the listed members do not cover,
-	// so narrowing to the listed members would under-type the arm's leaves. Leave an inexact
-	// union unnarrowed. Binding against the whole union then soundly rejects a pattern the
-	// tail may not satisfy, and an inexact union already requires a catch-all arm.
-	if u.Inexact {
-		return scrutinee
-	}
 	kept := make([]soltype.Type, 0, len(u.Types))
 	for _, m := range u.Types {
 		if patternMatchesMemberShape(pat, m) {
 			kept = append(kept, m)
 		}
 	}
-	// When the pattern matches no member, or every member, there is nothing to narrow.
-	// Binding against the original scrutinee then keeps the existing whole-union behavior.
+	// When the pattern matches no listed member, there is nothing to narrow to. When it
+	// matches every listed member, narrowing would reproduce the whole union, including an
+	// inexact union's open tail. Either way, bind against the original scrutinee and keep the
+	// whole-union behavior.
 	if len(kept) == 0 || len(kept) == len(u.Types) {
 		return scrutinee
 	}
+	// An inexact union keeps its open `...` tail through narrowing. A tail member may carry
+	// the pattern's fields at any type, so the tail is retained and the field-read rule (D4)
+	// reads a narrowed inexact member's fields as `... | unknown`, i.e. unknown. An exact
+	// union narrows to precisely the members the pattern matches.
 	var narrowed soltype.Type
-	if len(kept) == 1 {
+	if len(kept) == 1 && !u.Inexact {
 		narrowed = kept[0]
 	} else {
-		// The narrowed union is the exact set of members the pattern matches, drawn from an
-		// exact source union, so it is exact too.
-		narrowed = &soltype.UnionType{Types: kept}
+		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
 	}
 	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed
 	// scrutinee re-wraps its narrowed carrier under the same borrow. NewRef drops the

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -2751,11 +2751,10 @@ func narrowMatchArm(shape, scrutinee soltype.Type, pat ast.Pat) soltype.Type {
 	if len(kept) == 1 && !u.Inexact {
 		narrowed = kept[0]
 	} else {
-		// The Inexact flag is the open `...` tail, not an `unknown` member, so this does not
-		// collapse the way `T | unknown` does. Keep the structured inexact union rather than
-		// returning unknown: it is the bind target for the arm's pattern, and constrainUnionFieldRead
-		// needs the listed members to read each field before the tail widens it to unknown.
-		// Binding the pattern against bare unknown would leave nothing to destructure.
+		// Keep the structured inexact union rather than returning unknown: it is the bind target
+		// for the arm's pattern, and constrainUnionFieldRead needs the listed members to read
+		// each field before the tail widens it to unknown. Binding the pattern against bare
+		// unknown would leave nothing to destructure.
 		narrowed = &soltype.UnionType{Types: kept, Inexact: u.Inexact}
 	}
 	// A kept object or tuple member is a RefInner, as is a rebuilt union, so a borrowed

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -474,15 +474,15 @@ func TestInferMemberUnionReadsPartialFieldAsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
 }
 
-// A property no listed union member carries reads as `undefined` alone (M5 D4): every member
-// contributes the missing-field `undefined` and none contributes a value, so `p.z` over
-// `{x: number} | {y: string}` binds `undefined`.
-func TestInferMemberUnionReadsAbsentFieldAsUndefined(t *testing.T) {
-	values, _, errs := inferSource(t, `
+// A property no member of an exact union carries is an error (M5 D4). Reading `p.z` off
+// `{x: number} | {y: string}` would always evaluate to undefined, which is never useful, so
+// it is rejected like an absent field on a single object rather than binding `undefined`.
+func TestInferMemberUnionAbsentFieldErrors(t *testing.T) {
+	_, _, errs := inferSource(t, `
 		fn f(p: {x: number} | {y: string}) {
 			return p.z
 		}
 	`)
-	require.Empty(t, errs)
-	require.Equal(t, "fn (p: {x: number} | {y: string}) -> undefined", values["f"])
+	require.Len(t, errs, 1)
+	require.Equal(t, "3:13-3:14: object is missing property: z", msgWithSpan(errs[0]))
 }

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -474,6 +474,19 @@ func TestInferMemberUnionReadsPartialFieldAsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
 }
 
+// A property every member carries at a different type reads as the join of those types (M5
+// D4), with no undefined since no member lacks it. So `p.x` over `{x: number} | {x: string}`
+// yields `number | string`.
+func TestInferMemberUnionReadsCommonFieldAsJoin(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {x: string}) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {x: string}) -> number | string", values["f"])
+}
+
 // A property no member of an exact union carries is an error (M5 D4). Reading `p.z` off
 // `{x: number} | {y: string}` would always evaluate to undefined, which is never useful, so
 // it is rejected like an absent field on a single object rather than binding `undefined`.

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -412,19 +412,13 @@ func TestInferMatchTupleRestPattern(t *testing.T) {
 	*/
 }
 
-// Narrowing does not apply to an inexact union's open `...` tail. A tail member could carry
-// `x` at a type the listed members do not cover, so narrowing `{x}` to the listed
-// `{x: number}` member would under-type `x`. narrowMatchArm leaves an inexact union
-// unnarrowed, so `{x}` binds against the whole union and is soundly rejected because the
-// `{y}` member lacks `x`, and the `...` tail may too.
-//
-// M5 D4 changes this. Once field access through an inexact union's open tail yields
-// `unknown`, narrowMatchArm narrows the union to `{x: number} | ...` and `{x}` binds `x` at
-// `number | unknown`, which collapses to `unknown`, so the match type-checks. When D4 lands,
-// the assertions below flip from these two rejection errors to an empty-error result binding
-// `x: unknown`.
-func TestInferMatchInexactUnionNotNarrowed(t *testing.T) {
-	_, _, errs := inferSource(t, `
+// An inexact union's open `...` tail survives match-arm narrowing. narrowMatchArm keeps the
+// tail, so `{x}` over `{x: number} | {y: string} | ...` narrows to `{x: number} | ...`. The
+// field-read rule (M5 D4) then reads `x` off that narrowed inexact union as `number | unknown`,
+// which collapses to `unknown`, so the arm type-checks and `x` binds `unknown`. The `_` arm
+// keeps the match exhaustive, which an inexact union still requires.
+func TestInferMatchInexactUnionNarrowsKeepingTail(t *testing.T) {
+	values, _, errs := inferSource(t, `
 		fn f(p: {x: number} | {y: string} | ...) {
 			return match p {
 				{x} => x,
@@ -432,9 +426,8 @@ func TestInferMatchInexactUnionNotNarrowed(t *testing.T) {
 			}
 		}
 	`)
-	require.Len(t, errs, 2)
-	require.Equal(t, "2:11-2:36: cannot constrain object | object | ... <: object", msgWithSpan(errs[0]))
-	require.Equal(t, "2:25-2:36: object is missing property: x", msgWithSpan(errs[1]))
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string} | ...) -> unknown", values["f"])
 }
 
 // The exact counterpart of the inexact case above still narrows soundly. With no open tail,
@@ -453,22 +446,43 @@ func TestInferMatchExactUnionNarrowsCleanly(t *testing.T) {
 }
 
 // An irrefutable `val {x} = p` cannot narrow the way a refutable match arm does, so it reads
-// `x` off the whole `{x: number} | {y: string}` union. The solver currently rejects because
-// the `{y: string}` member lacks `x`.
-//
-// M5 D4 changes this. Porting the old checker's partial-union member access in
-// internal/checker/unify.go, a property on some but not all members reads as
-// `T | undefined`, so `val {x} = p` will bind `x: number | undefined` with no error. The
-// refutable/irrefutable split survives: a refutable `{x}` arm narrows to `x: number`, while
-// this irrefutable read keeps the `undefined`. When D4 lands, the assertion below flips from
-// the missing-property error to the `number | undefined` result.
-func TestValDestructureUnionRequiresFieldOnAllMembers(t *testing.T) {
-	_, _, errs := inferSource(t, `
+// `x` off the whole `{x: number} | {y: string}` union. The field-read rule (M5 D4) reads a
+// property present on some but not all members as `T | undefined`, so `val {x} = p` binds
+// `x: number | undefined` with no error. The refutable/irrefutable split survives: a refutable
+// `{x}` arm narrows to `x: number`, while this irrefutable read keeps the `undefined`.
+func TestValDestructureUnionReadsPartialFieldAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
 		fn f(p: {x: number} | {y: string}) {
 			val {x} = p
 			return x
 		}
 	`)
-	require.Len(t, errs, 1)
-	require.Equal(t, "2:25-2:36: object is missing property: x", msgWithSpan(errs[0]))
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
+}
+
+// A direct field read `p.x` takes the same partial-union path as a destructure (M5 D4), so
+// reading `x` off `{x: number} | {y: string}` yields `number | undefined` rather than
+// rejecting on the `{y: string}` member that lacks `x`.
+func TestInferMemberUnionReadsPartialFieldAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
+}
+
+// A property no listed union member carries reads as `undefined` alone (M5 D4): every member
+// contributes the missing-field `undefined` and none contributes a value, so `p.z` over
+// `{x: number} | {y: string}` binds `undefined`.
+func TestInferMemberUnionReadsAbsentFieldAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string}) {
+			return p.z
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string}) -> undefined", values["f"])
 }

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -502,6 +502,20 @@ func TestInferMemberUnionReadsPartialFieldAsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
 }
 
+// A direct field read `p.x` over an inexact union reads through the open tail (M5 D4), the
+// member-access counterpart of the destructure case. The `{x: number}` member contributes
+// `number`, `{y: string}` contributes undefined, and the tail contributes unknown, so the
+// read collapses to `unknown`.
+func TestInferMemberInexactUnionReadsThroughTail(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string} | ...) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string} | ...) -> unknown", values["f"])
+}
+
 // A property every member carries at a different type reads as the join of those types (M5
 // D4), with no undefined since no member lacks it. So `p.x` over `{x: number} | {x: string}`
 // yields `number | string`.

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -461,6 +461,34 @@ func TestValDestructureUnionReadsPartialFieldAsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: {x: number} | {y: string}) -> number | undefined", values["f"])
 }
 
+// An irrefutable `val {x} = p` over an inexact union reads `x` off the whole union, tail
+// included (M5 D4). The `{x: number}` member contributes `number`, `{y: string}` contributes
+// undefined, and the open tail contributes unknown, so the join collapses to `unknown`.
+func TestValDestructureInexactUnionPartialFieldIsUnknown(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string} | ...) {
+			val {x} = p
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string} | ...) -> unknown", values["f"])
+}
+
+// A field absent from every listed member of an inexact union is not an error, unlike the
+// exact case (M5 D4). The open tail may carry the field at any type, so `val {z} = p` reads
+// `z` as unknown through the tail rather than reporting a missing property.
+func TestValDestructureInexactUnionAbsentFieldIsUnknown(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x: number} | {y: string} | ...) {
+			val {z} = p
+			return z
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: number} | {y: string} | ...) -> unknown", values["f"])
+}
+
 // A direct field read `p.x` takes the same partial-union path as a destructure (M5 D4), so
 // reading `x` off `{x: number} | {y: string}` yields `number | undefined` rather than
 // rejecting on the `{y: string}` member that lacks `x`.

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -602,9 +602,10 @@ func lifetimeKindOrder(lt soltype.Lifetime) int {
 // bounds and the error sentinel come first, then TypeVarType so quantified
 // parameters lead in a rendered union, then primitives and literals, then
 // the remaining structural kinds, then the lattice forms, and finally
-// NullType and Void. A union renders its parameters and data members
-// before its absence markers. NullType precedes Void by convention, so
-// `T0 | number | null | void` is the canonical render.
+// NullType, Void, and UndefinedType. A union renders its parameters and data
+// members before its absence markers. NullType precedes Void, which precedes
+// UndefinedType, so `T0 | number | null | void | undefined` is the canonical
+// render.
 func typeKindOrder(t soltype.Type) int {
 	switch t.(type) {
 	case *soltype.NeverType:
@@ -637,6 +638,8 @@ func typeKindOrder(t soltype.Type) int {
 		return 13
 	case *soltype.Void:
 		return 14
+	case *soltype.UndefinedType:
+		return 15
 	}
-	return 15
+	return 16
 }


### PR DESCRIPTION
Implements the M5 D4 feature for reading properties off unions where only some members carry them. Previously, accessing a field present on some but not all union members would fail. Now it succeeds and yields the union of the present type and `undefined`.

**Key changes:**

- Add `UndefinedType` to the type system as the atomic counterpart to `NullType`, representing the sole inhabitant `undefined`. It renders as `undefined` and participates in the subtype lattice as a leaf type.

- Implement `constrainUnionFieldRead` in the constraint solver to handle field reads and destructures against unions. When the requirement is an inexact object with only fresh-var properties (the shape of a field read), and the union contains only objects, the solver joins contributions per member: present fields contribute their type, absent or optional fields contribute `undefined`, and an inexact union's open tail contributes `unknown`.

- Update `narrowMatchArm` to preserve an inexact union's open `...` tail through pattern narrowing. This allows the field-read rule to apply to narrowed inexact unions, reading fields as `... | unknown` (which collapses to `unknown`).

- Update test cases to reflect the new behavior: `val {x} = p` over `{x: number} | {y: string}` now binds `x: number | undefined` instead of failing, and direct field reads like `p.x` behave the same way.

**Implementation details:**

The field-read rule applies only when the super type is an inexact object carrying only property elements with fresh-var types—the signature of a lowered field access or destructure. Against other object supertypes (exact annotations or inexact ones with concrete property types), the strict every-member rule still applies. This preserves soundness for genuine object subtyping demands while enabling the partial-member reads that field access requires.

https://claude.ai/code/session_01YX5kqnvxh7Xnw87wnvZTqz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `undefined` type across type checking, formatting, comparisons, and diagnostics.
  * Improved union pattern inference by narrowing to matching members while preserving open-ended union tail behavior.
  * Union destructuring and property reads now yield `undefined` for missing/optional fields, with appropriate errors for truly absent required fields.

* **Bug Fixes**
  * Corrected structural equality and deterministic type ordering/rendering for `undefined`.

* **Tests**
  * Updated and expanded coverage for inexact-union narrowing and partial field reads from unions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->