### PR TITLE
Support field reads on class-instance unions (#886)

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -699,22 +699,29 @@ func isFieldReadReq(o *soltype.ObjectType) bool {
 	return true
 }
 
-// constrainUnionFieldRead reads a property `f` off a union sub for a field-read/destructure
+// constrainUnionFieldRead reads a member `f` off a union sub for a field-read/destructure
 // requirement `union <: {f: β}` (M5 D4), joining one contribution per member into β:
-//   - a member carrying `f` contributes its type;
-//   - a member lacking `f` contributes undefined, so `f` on some but not all members reads
-//     as `T | undefined`;
+//   - a member exposing `f` as a property or getter contributes its read type;
+//   - a member exposing `f` as a method contributes the method's callable type, the same
+//     receiver-stripped signature a direct `p.f` read yields, or their intersection for an
+//     overload set;
+//   - a member lacking `f`, or exposing it only as a setter, contributes undefined — a
+//     setter-only member reads as undefined at runtime — so `f` readable on some but not all
+//     members reads as `T | undefined`;
 //   - an inexact union's open `...` tail contributes unknown, since it may carry `f` at any type;
-//   - `f` on no member of an exact union is a MissingPropertyError, since the read is a
-//     constant undefined, like reading an absent field off a single object.
+//   - `f` readable on no member of an exact union is a MissingPropertyError, since the read is
+//     a constant undefined, like reading an absent field off a single object. This case also
+//     covers a member exposing `f` only as a setter with no readable member anywhere, so a
+//     write-only member is rejected rather than read as bare undefined.
+//
+// Each union member is normalized to the ObjectType its members read through: a structural
+// object directly, or a class instance's projected body (#886), so a union of class instances,
+// or a mix of objects and instances such as `{x: number} | Point`, joins through the same
+// per-member read.
 //
 // ok is false unless the shapes fit — an inexact object super of fresh-var properties over a
-// union of objects — so a genuine subtyping demand keeps the strict every-member rule.
-//
-// Limitation: only plain object members reading plain properties are handled. A class-instance
-// member, or a getter/method/setter requirement, does not fit and falls back to the
-// every-member rule. Extending the join to those through member lookup is
-// https://github.com/escalier-lang/escalier/issues/886.
+// union whose every member is an object or a class instance — so a genuine subtyping demand
+// keeps the strict every-member rule.
 func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (errs []SolverError, ok bool) {
 	req, isObj := super.(*soltype.ObjectType)
 	if !isObj || !isFieldReadReq(req) {
@@ -722,8 +729,8 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 	}
 	members := make([]*soltype.ObjectType, 0, len(sub.Types))
 	for _, m := range sub.Types {
-		obj, isObj := soltype.CarrierOf(m).(*soltype.ObjectType)
-		if !isObj {
+		obj, ok := c.readCarrierObject(soltype.CarrierOf(m))
+		if !ok {
 			return nil, false
 		}
 		members = append(members, obj)
@@ -731,27 +738,26 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 	for _, elem := range req.Elems {
 		prop := soltype.AsProperty(elem)
 		// The read joins what each member can yield for this property. anyValue records that
-		// some member yields a value; anyUndefined that the read can also yield undefined,
-		// because some member lacks the property or carries it optionally, so it may be absent
-		// at runtime. A member carrying an optional field sets both.
+		// some member yields a readable value; anyUndefined that the read can also yield
+		// undefined, because some member lacks the property, carries it optionally, or exposes
+		// it as a write-only setter, so it may be absent at runtime. A member carrying an
+		// optional field sets both.
 		anyValue := false
 		anyUndefined := false
 		for _, obj := range members {
-			mp, found := obj.Prop(prop.Name)
-			if !found {
-				anyUndefined = true
-				continue
+			read, hasValue, mayUndef := memberReadContribution(obj, prop.Name)
+			if hasValue {
+				anyValue = true
+				errs = append(errs, c.constrain(read, prop.Type, seen, mutCtx)...)
 			}
-			anyValue = true
-			errs = append(errs, c.constrain(mp.Type, prop.Type, seen, mutCtx)...)
-			if mp.Optional {
+			if mayUndef {
 				anyUndefined = true
 			}
 		}
 		if !anyValue && !sub.Inexact {
-			// No listed member yields a value and there is no open tail to carry the property,
-			// so the read is a constant undefined. Report it like an absent field on a single
-			// object. members is non-empty here, so members[0] is a valid receiver to blame.
+			// No listed member yields a readable value and there is no open tail to carry the
+			// property, so the read is a constant undefined. Report it like an absent field on a
+			// single object. members is non-empty here, so members[0] is a valid receiver to blame.
 			errs = append(errs, &MissingPropertyError{Sub: members[0], Super: req, Name: prop.Name})
 			continue
 		}
@@ -763,6 +769,57 @@ func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.
 		}
 	}
 	return errs, true
+}
+
+// readCarrierObject returns the ObjectType a union member's fields are read through: a
+// structural object directly, or a class instance's projected body. It returns ok=false for
+// any other carrier — a primitive, a bare type variable — so the field-read join falls back to
+// the strict every-member rule rather than reading a member off a value that carries none.
+func (c *Context) readCarrierObject(carrier soltype.Type) (*soltype.ObjectType, bool) {
+	switch t := carrier.(type) {
+	case *soltype.ObjectType:
+		return t, true
+	case *soltype.ClassType:
+		return c.projectClassBody(t)
+	}
+	return nil, false
+}
+
+// memberReadContribution reports what reading `name` off one union member yields for the
+// field-read join. hasValue is true when the member exposes a readable value — a property,
+// getter, or method — and read is that value's type: a property's or getter's declared type,
+// or a method's receiver-stripped callable signature, joined into an intersection for an
+// overload set, matching memberValue. mayUndef is true when the read can also yield undefined,
+// because the member is absent, is an optional property, or is a write-only setter, which reads
+// as undefined at runtime. An absent or setter-only member has hasValue false, so a property
+// readable on no member surfaces as a missing-property error rather than bare undefined.
+func memberReadContribution(obj *soltype.ObjectType, name string) (read soltype.Type, hasValue, mayUndef bool) {
+	member, found := obj.Member(name)
+	if !found {
+		return nil, false, true
+	}
+	switch m := member.(type) {
+	case *soltype.PropertyElem:
+		return m.Type, true, m.Optional
+	case *soltype.GetterElem:
+		return m.Type, true, false
+	case *soltype.MethodElem:
+		switch len(m.Signatures) {
+		case 0:
+			return &soltype.ErrorType{}, true, false
+		case 1:
+			return callableView(m.Signatures[0]), true, false
+		default:
+			arms := make([]soltype.Type, len(m.Signatures))
+			for i, sig := range m.Signatures {
+				arms[i] = callableView(sig)
+			}
+			return &soltype.IntersectionType{Types: arms}, true, false
+		}
+	case *soltype.SetterElem:
+		return nil, false, true
+	}
+	return nil, false, true
 }
 
 // constrainObjMember checks a method, getter, or setter requirement on an object super

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -581,3 +581,122 @@ func TestOptionalSourceIntoRequiredTargetStillErrors(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "object property is optional but required: x", errs[0].Message())
 }
+
+// The partial-union field read joins through a class instance's projected body, not only a
+// plain object (#886). A property every member of a class-instance union carries at a
+// different type reads as the join, so `p.x` over `A | B` where both declare `x` yields
+// `number | string`, with no undefined since no member lacks it.
+func TestInferMemberClassUnionReadsCommonFieldAsJoin(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { x: number, y: number }
+		class B { x: string, z: boolean }
+		fn f(p: A | B) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> number | string", values["f"])
+}
+
+// A property on some but not all members of a class-instance union reads as `T | undefined`
+// (#886), mirroring the plain-object rule: the member lacking the field contributes undefined.
+func TestInferMemberClassUnionReadsPartialFieldAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { x: number }
+		class B { y: string }
+		fn f(p: A | B) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> number | undefined", values["f"])
+}
+
+// A union mixing a plain object and a class instance joins through the same per-member read
+// (#886): `p.x` over `{x: string} | Point` reads the object's `x` and the instance's projected
+// `x`, yielding their join.
+func TestInferMemberMixedObjectClassUnionReadsField(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class Point { x: number, y: number }
+		fn f(p: {x: string} | Point) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x: string} | Point) -> number | string", values["f"])
+}
+
+// A getter resolves through member lookup in the partial-union read (#886), contributing its
+// declared return type like a property. So `p.v` over a union of classes each exposing `v` as
+// a getter reads as the join of the getter return types.
+func TestInferMemberClassUnionReadsGetter(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { _v: number, get v(self) -> number { return self._v } }
+		class B { _v: string, get v(self) -> string { return self._v } }
+		fn f(p: A | B) {
+			return p.v
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> number | string", values["f"])
+}
+
+// A method resolves through member lookup in the partial-union read (#886), contributing its
+// receiver-stripped callable signature — the same value a direct `p.area` read yields. Methods
+// with distinct signatures join into a union of function types.
+func TestInferMemberClassUnionReadsMethod(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { area(self) -> number { return 1 } }
+		class B { area(self, scale: number) -> string { return "x" } }
+		fn f(p: A | B) {
+			return p.area
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> (fn () -> number) | (fn (scale: number) -> string)", values["f"])
+}
+
+// A property readable on no member of an exact class-instance union is an error (#886), the
+// class analogue of TestInferMemberUnionAbsentFieldErrors.
+func TestInferMemberClassUnionAbsentFieldErrors(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class A { x: number }
+		class B { y: string }
+		fn f(p: A | B) {
+			return p.z
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:13-5:14: object is missing property: z", msgWithSpan(errs[0]))
+}
+
+// A setter-only member reads as undefined at runtime, so when another member exposes the name
+// readably the join includes undefined (#886). Here `A` exposes `v` only as a setter and `B`
+// carries it as a property, so `p.v` reads `string | undefined`.
+func TestInferMemberClassUnionSetterOnlyReadsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A { _v: number, set v(mut self, x: number) { self._v = x } }
+		class B { v: string }
+		fn f(p: A | B) {
+			return p.v
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> string | undefined", values["f"])
+}
+
+// A member exposed only as a setter across every union member is readable nowhere, so the read
+// is rejected rather than bound as bare undefined (#886). This reinstates the old checker's
+// write-only nuance: a setter-only member reported a property error rather than reading as
+// undefined.
+func TestInferMemberClassUnionSetterOnlyEverywhereErrors(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class A { _v: number, set v(mut self, x: number) { self._v = x } }
+		class B { _w: string, set v(mut self, x: string) { self._w = x } }
+		fn f(p: A | B) {
+			return p.v
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "5:13-5:14: object is missing property: v", msgWithSpan(errs[0]))
+}

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -656,6 +656,27 @@ func TestInferMemberClassUnionReadsMethod(t *testing.T) {
 	require.Equal(t, "fn (p: A | B) -> (fn () -> number) | (fn (scale: number) -> string)", values["f"])
 }
 
+// An overloaded method contributes the intersection of its receiver-stripped arms in the
+// partial-union read (#886), matching the value a direct read of an overloaded method yields.
+// Both members expose the same two-arm `area`, so the reads join to one intersection.
+func TestInferMemberClassUnionReadsOverloadedMethod(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		class A {
+			area(self, x: number) -> number { return x },
+			area(self, x: string) -> string { return x },
+		}
+		class B {
+			area(self, x: number) -> number { return x },
+			area(self, x: string) -> string { return x },
+		}
+		fn f(p: A | B) {
+			return p.area
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: A | B) -> (fn (x: number) -> number) & (fn (x: string) -> string)", values["f"])
+}
+
 // A property readable on no member of an exact class-instance union is an error (#886), the
 // class analogue of TestInferMemberUnionAbsentFieldErrors.
 func TestInferMemberClassUnionAbsentFieldErrors(t *testing.T) {
@@ -685,10 +706,9 @@ func TestInferMemberClassUnionSetterOnlyReadsUndefined(t *testing.T) {
 	require.Equal(t, "fn (p: A | B) -> string | undefined", values["f"])
 }
 
-// A member exposed only as a setter across every union member is readable nowhere, so the read
-// is rejected rather than bound as bare undefined (#886). This reinstates the old checker's
-// write-only nuance: a setter-only member reported a property error rather than reading as
-// undefined.
+// A setter-only member is not readable, so a member exposed only as a setter across every
+// union member yields no readable value. With no member to read, the access is a
+// missing-property error rather than binding as bare undefined (#886).
 func TestInferMemberClassUnionSetterOnlyEverywhereErrors(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		class A { _v: number, set v(mut self, x: number) { self._v = x } }


### PR DESCRIPTION
Extend the union field-read join to handle class instances and mixed object/class unions, matching the existing plain-object behavior.

When reading a property, getter, or method off a union, the type now joins contributions from each member through their readable carrier — a structural object directly, or a class instance's projected body. This allows unions like `A | B` (two classes) or `{x: string} | Point` (object and class) to read fields the same way plain-object unions do.

Key changes:

- `constrainUnionFieldRead` now normalizes each union member to its readable carrier object via `readCarrierObject`, which returns a class instance's projected body or the object itself.
- `memberReadContribution` determines what reading a name off one member yields: a property's or getter's type, a method's receiver-stripped callable signature (joined into an intersection for overload sets), or undefined for absent or write-only setter members.
- A property readable on no member of an exact union remains a `MissingPropertyError`, including the case where all members expose it only as a setter.
- Added nine test cases covering common fields, partial fields, mixed object/class unions, getters, methods, absent fields, and setter-only members.

https://claude.ai/code/session_01TedKCoVtFroGdGwfVRpNBQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved union member property reads across class instances and structural objects.
  - Supports fields, getters, methods, optional properties, and setter-only members with more accurate inferred types.
  - Correctly includes `undefined` when a property may be absent.

- **Bug Fixes**
  - Reports missing-property errors when no union member provides a readable property.
  - Preserves appropriate behavior for open or inexact unions.

- **Tests**
  - Added coverage for mixed unions, getters, methods, optional fields, absent properties, and setter-only members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->