### PR TITLE
Allow reading optional properties as T | undefined

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -385,9 +385,19 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			//   - present on both, optional on the sub but required on the super: the
 			//     source may omit it, so it cannot fill a required property —
 			//     OptionalPropertyError, and skip the covariant type check (the
-			//     presence mismatch already rejects the constraint).
+			//     presence mismatch already rejects the constraint). The exception is
+			//     a field-read requirement, which reads the optional property as
+			//     `T | undefined` instead of erroring. See fieldRead below.
 			//   - otherwise (required<:required, required<:optional, optional<:
 			//     optional): covariant on the property type.
+			//
+			// A field-read or destructure requirement is not a subtyping demand but a read
+			// of `sub`'s property into a fresh result variable. Reading an optional property
+			// `x?: T` off a single object yields `T | undefined`, matching the union
+			// field-read path in constrainUnionFieldRead rather than rejecting the optional
+			// source. A read always constrains outside a mutable context, so the mutCtx
+			// guard keeps this off the write-back path a `mut` field selection takes.
+			fieldRead := !mutCtx && isFieldReadReq(sup)
 			var errs []SolverError
 			for _, superElem := range sup.Elems {
 				// A constructor requirement is satisfied by the source's own constructor,
@@ -417,6 +427,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 					continue
 				}
 				if subProp.Optional && !superProp.Optional {
+					if fieldRead {
+						// Read the optional property as `T | undefined`. The property's type
+						// flows into the result var, and undefined joins it because the source
+						// may omit the property at runtime.
+						errs = append(errs, c.constrain(subProp.Type, superProp.Type, seen, mutCtx)...)
+						errs = append(errs, c.constrain(&soltype.UndefinedType{}, superProp.Type, seen, mutCtx)...)
+						continue
+					}
 					errs = append(errs, &OptionalPropertyError{Sub: sub, Super: sup, Name: superProp.Name})
 					continue
 				}
@@ -658,6 +676,29 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 }
 
+// isFieldReadReq reports whether an object super is a field-read or destructure
+// requirement rather than a concrete subtyping target. valueProp and propReq mint
+// such a requirement as an inexact object whose every property type is a fresh
+// inference variable the read result flows into, for example `{x: β}` for `p.x`.
+// A concrete annotation target is either exact or carries a concrete property type,
+// so it fails this test and keeps the strict subtyping rules. Both the single-object
+// optional-read widening and the union field-read join key off this shape.
+func isFieldReadReq(o *soltype.ObjectType) bool {
+	if !o.Inexact {
+		return false
+	}
+	for _, elem := range o.Elems {
+		prop, isProp := elem.(*soltype.PropertyElem)
+		if !isProp {
+			return false
+		}
+		if _, isVar := prop.Type.(*soltype.TypeVarType); !isVar {
+			return false
+		}
+	}
+	return true
+}
+
 // constrainUnionFieldRead reads a property `f` off a union sub for a field-read/destructure
 // requirement `union <: {f: β}` (M5 D4), joining one contribution per member into β:
 //   - a member carrying `f` contributes its type;
@@ -676,17 +717,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 // https://github.com/escalier-lang/escalier/issues/886.
 func (c *Context) constrainUnionFieldRead(sub *soltype.UnionType, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (errs []SolverError, ok bool) {
 	req, isObj := super.(*soltype.ObjectType)
-	if !isObj || !req.Inexact {
+	if !isObj || !isFieldReadReq(req) {
 		return nil, false
-	}
-	for _, elem := range req.Elems {
-		prop, isProp := elem.(*soltype.PropertyElem)
-		if !isProp {
-			return nil, false
-		}
-		if _, isVar := prop.Type.(*soltype.TypeVarType); !isVar {
-			return nil, false
-		}
 	}
 	members := make([]*soltype.ObjectType, 0, len(sub.Types))
 	for _, m := range sub.Types {

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -541,3 +541,43 @@ func TestInferMemberUnionAbsentFieldErrors(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, "3:13-3:14: object is missing property: z", msgWithSpan(errs[0]))
 }
+
+// Reading an optional property off a single object is the single-object counterpart of the
+// union field-read rule (#887): `p.x` off `{x?: number}` yields `number | undefined` rather
+// than erroring, because the source may omit the property at runtime.
+func TestInferMemberOptionalFieldReadsAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x?: number}) {
+			return p.x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x?: number}) -> number | undefined", values["f"])
+}
+
+// Destructuring an optional property takes the same single-object read path (#887), so
+// `val {x} = p` over `{x?: number}` binds `x: number | undefined`.
+func TestValDestructureOptionalFieldReadsAsUndefined(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f(p: {x?: number}) {
+			val {x} = p
+			return x
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: {x?: number}) -> number | undefined", values["f"])
+}
+
+// The optional-read widening is specific to the field-read requirement. Filling a required
+// annotated property from an optional source is a genuine subtyping demand and still fails
+// with OptionalPropertyError (#887), since the source may omit the property.
+func TestOptionalSourceIntoRequiredTargetStillErrors(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		fn f(p: {x?: number}) {
+			val q: {x: number} = p
+			return q
+		}
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object property is optional but required: x", errs[0].Message())
+}


### PR DESCRIPTION
When reading a property off a single object or destructuring it, optional properties now yield `T | undefined` instead of erroring. This matches the union field-read behavior and reflects runtime semantics: the source may omit the property.

Key changes:

- Extract field-read requirement detection into `isFieldReadReq()`, which identifies inexact objects with all properties typed as fresh inference variables (the shape minted by property reads).
- In the object constraint path, detect field-read requirements and handle optional-to-required property mismatches by constraining both the property type and `undefined` into the result variable, rather than rejecting with `OptionalPropertyError`.
- Refactor `constrainUnionFieldRead()` to use the new `isFieldReadReq()` helper, eliminating duplicate detection logic.
- Add tests covering optional property reads on single objects (member access and destructuring) and confirming that annotated subtyping targets still enforce strict optionality rules.

The optional-read widening is gated by `!mutCtx` to keep it off the write-back path that mutable field selection takes, preserving strict checking for assignments to mutable fields.

https://claude.ai/code/session_01Aq6q6U2s4EW9v2Z9rdkuxs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Optional object properties now correctly read as their value type or `undefined`.
  - Destructuring optional properties now follows the same behavior without reporting an error.
  - Assigning an object with an optional property to a type requiring that property continues to produce an error.

- **Tests**
  - Added coverage for optional-property reads, destructuring, and invalid required-property assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->