### PR TITLE
Plan M7 (type aliases) and M9 (type-level operators); split library resolution into M7.5

### DIFF
--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -462,7 +462,9 @@ func (*ClassType) isRefInner()        {}
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
 // scope narrow: it is the one stdlib generic the milestone needs typed (Iterable/
 // Generator wait until M5+). The real, alias-driven `Promise<T>` lookup arrives
-// with TypeRef ingestion in M7; until then, an `async fn () -> T` mints a
+// with library type ingestion in M7.5 — the alias/`TypeRef` resolution machinery
+// it uses lands in M7, the real stdlib structure in M7.5; until then, an
+// `async fn () -> T` mints a
 // PromiseType{T} externally and `await e` constrains `e <: PromiseType{U}` for a
 // fresh U. Inner is covariant under subtyping (Promise<L> <: Promise<R> iff
 // L <: R) and the `await` rule does NOT recursively flatten (so awaiting

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1021,7 +1021,8 @@ records "soltype has no type aliases yet (M7)", and
 hardcoded `Promise<T>` reference — every other `TypeRefTypeAnn` falls through to
 `reportUnsupported`. This milestone closes that gap, so a written type name
 resolves through the scope to its declaration and a generic alias instantiates
-with its arguments.
+with its arguments. See [m7-implementation-plan.md](m7-implementation-plan.md) for
+the full PR breakdown and the M9 interlock.
 
 - **`AliasType` in `soltype`.** A `{Name, Params []*TypeParam, Body Type}` node,
   reusing the `TypeParam` sort M5 introduced for class parameters. An alias is

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -3,9 +3,9 @@
 Ordered milestones for the new checker. Each is independently testable and
 leaves the old checker fully working. "Structural core first"; lifetimes are
 introduced **with the first lifetime-carrying type** (records, M4). The MVP is
-M1–M9 (structural core + nominal classes + unions/intersections + library type
-resolution + fixture differential + type-level operators); codegen/LSP and the
-cutover come after.
+M1–M9 (structural core + nominal classes + unions/intersections + type aliases +
+library type resolution + fixture differential + type-level operators); codegen/LSP
+and the cutover come after.
 
 Spike provenance is cited where a milestone promotes proven spike work
 (`internal/simplesub/`).
@@ -41,7 +41,8 @@ are recorded in
 - [M5 — Nominal types (classes)](#m5--nominal-types-classes)
 - [M6 — Unions / intersections](#m6--unions--intersections)
 - [M6.5 — Lifetime bounds](#m65--lifetime-bounds)
-- [M7 — Library type resolution (`std:*` / `web:*` / `node:*`)](#m7--library-type-resolution-std--web--node)
+- [M7 — Type aliases](#m7--type-aliases)
+- [M7.5 — Library type resolution (`std:*` / `web:*` / `node:*`)](#m75--library-type-resolution-std--web--node)
 - [M8 — Second fixture harness + differential triage](#m8--second-fixture-harness--differential-triage)
 - [M9 — Type-level operators](#m9--type-level-operators)
 - [Later (post-MVP)](#later-post-mvp)
@@ -144,21 +145,21 @@ Replace the spike's hand-built IR with a real constraint-generating walk over
   built-ins need a `{value, done}` `IteratorResult<T>`. None of these
   type-checking *rules* land in M2 (they sit in the milestones that own the
   language features below), and the **real** stdlib type definitions are ingested
-  in **M7** (library type resolution), once the representational machinery they
+  in **M7.5** (library type resolution), once the representational machinery they
   need (generics, objects, classes, unions) exists. M2's narrower job is just to
   **seed placeholder bindings** for these names — hand-built opaque `soltype`
   stubs in the new checker's prelude — so a *reference* resolves without an
   unbound-name error and downstream rules can be authored against a stand-in. M2
   does **not** read the real stdlib decls (that path is old-checker- and
   `type_system`-coupled, and `soltype` has no generic-type node until M3/M4);
-  M7 swaps the placeholders for real structures. See the M2 implementation
+  M7.5 swaps the placeholders for real structures. See the M2 implementation
   plan §3.8.
 
 **Accept:** top-level `val`/`fn` declarations from real source infer correct
 rendered types end-to-end; multi-file module via the dep graph resolves;
 references to the stdlib type names listed above resolve to placeholder
 `soltype.Type` stubs without an unbound-name error (real structures and the
-rules that *use* them land in M7 and the feature milestones).
+rules that *use* them land in M7.5 and the feature milestones).
 
 **Gate:** if driving from the real AST/dep-graph requires reaching back into the
 old checker's internals, the parallel-package boundary is wrong — stop and
@@ -270,7 +271,7 @@ scheme instantiation introduces the first interior origin (`FromInstantiation`).
   flattening) is a type-level operator that lands in M9; user code that
   cares about flattening writes `Awaited<T>` explicitly until then.
   Depends on `Promise<T>` being available from the stdlib (M2 placeholder;
-  real resolution lands in M7).
+  real resolution lands in M7.5).
 - **Function exactness flag.** `Function` carries an `exact` flag; a bare
   `fn(...)` is exact, `fn(..., ...)` is inexact. **Direct calls reject extra
   args regardless of exactness** (an inexact function ignores them, but passing
@@ -548,8 +549,8 @@ further.
   callback need the `_ <: unknown` (⊤) rule, which lands in **M6**. M4 excludes
   function annotations and fails the branch loud, keeping the path closed.
 - **Rest-param element checking (#677)** — `...xs: T[]` element checking needs
-  `Array<T>`, so it lands in **M7**. M4 stays arity-only and marks the
-  `FuncParam.Rest` note "M7."
+  `Array<T>`, so it lands in **M7.5**. M4 stays arity-only and marks the
+  `FuncParam.Rest` note "M7.5."
 
 **Open design question — per-property lifetimes on alias-typed params (needs type
 annotations first).** Per-property and tuple-per-slot lifetimes have a syntactic
@@ -736,7 +737,7 @@ M4 substrate without retrofitting.
   No new constraint machinery needed; this is purely "wire the loop syntax to
   the existing dispatch path." Depends on `Iterable<T>` / `Iterator<T>` /
   `AsyncIterable<T>` / `IteratorResult<T>` being available from the stdlib
-  (M2 placeholder; real resolution lands in M7).
+  (M2 placeholder; real resolution lands in M7.5).
   - **Back-edge validation for the borrow-edge dataflow.** A `for` loop is the
     first inferable source that gives the CFG a back edge, so it is where the
     affine flow-sensitive analyses first meet one from real code. The move
@@ -996,8 +997,8 @@ declaring, and checking relations the solver already computes, not new inference
 
 **Why it lands here.** It sits after M6 because M6 changes the join machinery
 directly — the permissive mut-borrow join and the canonical union member order — and
-the bound set is built on that settled representation. It sits with or just before M7
-because M7 library imports are the first site where declared bounds become
+the bound set is built on that settled representation. It sits with or just before M7.5
+because M7.5 library imports are the first site where declared bounds become
 mandatory, which is the first configuration where the unified model beats a
 display-only one. Earlier would be premature: nothing in M4 or M5 is blocked, since
 the D4 union rendering is sound and only less precise.
@@ -1010,161 +1011,74 @@ implied by transitivity is dropped from the rendered set.
 
 ---
 
-## M7 — Library type resolution (`std:*` / `web:*` / `node:*`)
+## M7 — Type aliases
 
-Port the standard-library type ingestion onto `soltype`. Today this is a
-self-contained subsystem living entirely in `internal/checker/`
-(`infer_import.go`, `infer_stdlib_import.go`, `infer_stdlib_scc.go`) plus
-`internal/interop/`, and it produces `type_system.Type`. This milestone
-retargets it to produce `soltype.Type` in the new checker's `Scope`/`Namespace`,
-covering both ingestion channels:
+Add the `soltype` type-alias representation and user-written alias declarations —
+the foundation both library ingestion (M7.5) and type-level operators (M9) build
+on. Today `soltype` has no alias node: [infer_enum.go:12-17](../../internal/solver/infer_enum.go)
+records "soltype has no type aliases yet (M7)", and
+[type_ann.go:21](../../internal/solver/type_ann.go) resolves only the single
+hardcoded `Promise<T>` reference — every other `TypeRefTypeAnn` falls through to
+`reportUnsupported`. This milestone closes that gap, so a written type name
+resolves through the scope to its declaration and a generic alias instantiates
+with its arguments.
 
-- **Ambient global lib** — `Array`, `Promise`, `Map`, `Set`, `console`, `Math`,
-  `JSON`, the iteration protocols, etc., loaded from `lib.*.d.ts` without an
-  import (the `globalThis` surface).
-- **Scheme imports** — `std:*` / `web:*` / `node:*` (the DOM lives under
-  `web:dom`), routed through the `interop` partition table to the stdlib `.esc`
-  modules.
+- **`AliasType` in `soltype`.** A `{Name, Params []*TypeParam, Body Type}` node,
+  reusing the `TypeParam` sort M5 introduced for class parameters. An alias is
+  **structurally its body** for subtyping (transparent), so `Box<A> <: Box<B>`
+  reduces to the structural subtyping of the two expansions — which is why a
+  non-recursive alias carries no separate variance, per M5's "Generic type aliases
+  do not carry variance separately." Lifetimes ride on an alias-typed borrow
+  exactly as on a record: `mut 'a Point` where `Point` is an alias wraps the alias
+  in `Ref{mut, lt, inner}`, no new machinery.
+- **Scope-driven `TypeRef` resolution.** Replace the hardcoded `Promise` check in
+  `resolveTypeAnn` — the "FOOTGUN (removed in M7)" note at
+  [type_ann.go:21](../../internal/solver/type_ann.go) — with real resolution: look
+  a written name up in the **type scope**, and when it binds an alias, instantiate
+  the alias body with the type arguments. Route the alias's `<…>` parameter list
+  through the existing two-pass `resolveTypeParams`
+  ([type_params.go](../../internal/solver/type_params.go), M5) so a bound, a
+  default, and a forward or mutual reference between sibling parameters all resolve
+  the way they do for a class. A real `type Promise<T> = …` alias now wins over the
+  stub instead of being silently shadowed by it.
+- **Instantiation / expansion.** Instantiating a generic alias substitutes the
+  arguments into the body; structural subtyping expands on demand. A non-recursive
+  alias expands eagerly. A **recursive** alias — `type List<T> = {head: T, tail:
+  List<T> | Null}` — is structurally its body, with `constrain`'s existing
+  coinductive seen-cache closing the cycle, the same Amadio–Cardelli discipline the
+  spike's [lazy.go](../../internal/simplesub/lazy.go) uses. **Operator reduction
+  *over* a recursive alias** — the cycle cache, depth budget, and `CheckRegular` —
+  is **M9**, not here; M7 supports a recursive alias only as a subtyping subject,
+  not as an operand the evaluator unfolds.
+- **Mutually-recursive alias groups** resolve via the same "fresh var per binding +
+  constrain + generalize" pattern already proven for recursive functions (M3) and
+  classes (M5) — no placeholder / `typeRefsToUpdate` patching.
+- **Enum name binds to a real alias.** M5 bound an enum name to a namespace plus a
+  union type built directly, leaving [infer_enum.go:12-17](../../internal/solver/infer_enum.go)
+  a TODO to bind it to a proper alias once aliases exist. Do that here: the enum
+  name's *type* binding becomes an alias whose body is the union of the variant
+  types, so `keyof` / indexed access (M9) and structural subtyping reach the enum
+  through the same alias path as any other named type.
 
-This **replaces M2's placeholder "prerequisite tracking"**: the names M2 stubbed
-(`Promise`/`Iterable`/`Generator`/`IteratorResult`) and the broader lib surface
-now resolve to real `soltype` structures rather than opaque placeholders.
+**Accept:** `type Point = {x: number, y: number}` and a reference `Point` in a
+value annotation type-check; a generic `type Box<T> = {value: T}` instantiates so
+`Box<number> <: Box<number | string>` holds by structural expansion; a recursive
+`type List<T> = {head: T, tail: List<T> | Null}` type-checks as a subtyping subject
+with the cycle closed by the seen-cache and no budget needed; a mutually-recursive
+alias group resolves; an enum name resolves as an alias whose body is the variant
+union. Plus the generic-union call `fn f<T>(x: T | number)` behaves per the design
+chosen in the open question below.
 
-- **Interop reuse, gate intact.** The front half of the existing pipeline
-  (`dts_parser` parse → `interop.ConvertModule` → `*ast.Module`) is reusable as
-  AST. The back half (the old checker's `InferModule` → `type_system`) is what
-  this milestone replaces with the new checker's `soltype` walk over that AST.
-  `interop` itself imports `type_system`, so this milestone must consume only its
-  AST-producing surface and keep the `soltype` output path free of `type_system`
-  — confirm the M2 parallel-package gate still holds.
-- **Scope = the operator-free lib subset.** Everything expressible with the
-  M3–M6 representational features (generics, object/record types, nominal
-  classes + `final`, unions): `Array`, `Promise`, `Map`/`Set`, the
-  `Iterable`/`Iterator`/`IteratorResult` protocols, `console`, `Math`, `JSON`,
-  the `string`/`number`/`boolean`/`symbol`/`regexp` method surfaces, and the
-  common `web:dom` types.
-- **Deferred to a phase-2 backfill (after M9).** Lib types whose definitions
-  need conditional/mapped/utility **type operators** (`Awaited<T>`, `Partial`,
-  `Pick`, `Record`, and the operator-heavy parts of `web:dom`) cannot be
-  represented until M9 (type-level operators) lands. Until then they resolve as
-  placeholders/inexact stubs — the same posture M2 takes — and are backfilled
-  once the operator machinery exists. Record which lib names are stubbed so the
-  gap stays visible rather than reading as full coverage.
-- **Exactness.** TS-imported lib types are **inexact by default**
-  ([exact-types/requirements.md](../exact-types/requirements.md) §8); this
-  milestone stamps the inexact flag on ingested lib formers as they land.
-- **Not in scope: operators.** The built-in operator schemes (`+`, `==`, `&&`,
-  `++`, …) are **not** library types and are **not** owned here. They are
-  hand-coded, monomorphic-over-primitive value bindings the expression walk needs
-  from day one, so they live in the M2 prelude (a port of the old checker's
-  `addOperatorBindings`). M7 ports *type* ingestion (`.d.ts`/interop → `soltype`),
-  not the value-level operator env.
-- **Rest-param element checking (#677; deferred from M4).** Typed rest params
-  `...xs: T[]` check each trailing argument against `T`, which needs `Array<T>` to
-  resolve — so the element type only exists once this milestone lands. M4 kept
-  rest params arity-only (trailing args unchecked, a documented hole) and marked
-  `FuncParam.Rest`'s note "M7." Wire the element check here against the real
-  `Array<T>`, dropping the arity-only restriction.
-- **Variadic tuple types `[number, ...Array<number>]`.** A tuple with a fixed
-  prefix and a *typed*, unbounded, homogeneous tail — distinct from M4's `Inexact`
-  tuple flag `[A, B, ...]`, which means "at least these, then *unknown*." The typed
-  tail needs `Array<T>`, so it lands here with the rest of library type resolution.
-  Add a typed rest/variadic element to `TupleType` — a tail carrying its element
-  type, not just a boolean flag — plus the variadic-tuple subtyping rules, e.g.
-  `[number, number] <: [number, ...Array<number>]` and
-  `[number, ...Array<number>] <: Array<number>`. The `infer`-matching form
-  `T extends [any, ...infer R] ? R : never` is M9 (conditional + `infer`), not here.
-- **Index-read usage inference + tuple/array closing (the M4 object-close analogue,
-  deferred from M4).** M4 shipped `.prop` usage inference plus the close-to-exact
-  seal for objects: `inferMember` lowers `recv.prop` to an inexact one-property
-  requirement, and `sealUsageObjects` (M4 B2, `solver/poly.go`) folds those
-  requirements into one exact object at generalization unless the var escapes to an
-  output position or is marked `open`. F1 (#730) extended that to a constant STRING
-  index: `recv["bar"]` routes through `valueProp` to the same inexact object
-  requirement, so it already gets the object seal. **What index reads still lack is
-  the TUPLE path** — `resolveIndexPath` (`solver/infer_expr.go`) sends a constant
-  NUMERIC index `recv[0]` and any dynamic key to `reportUnsupported`, because the
-  read shape there depends on whether the receiver is a tuple or an `Array`, and
-  `Array` only exists at this milestone. Wire it here:
-    - **`inferIndex` tuple arm (NEW), constant numeric key.** `recv[0]` lowers to an
-      inexact *tuple* requirement "has at least a slot at this index" — the
-      positional twin of the `{prop: β, ...}` object requirement `valueProp` already
-      builds. So `recv[0]; recv[1]` lands two inexact tuple upper bounds on the
-      receiver var, mirroring the object path. The result type is the element var β.
-      This is the new-checker port of the reference checker's "single literal index
-      infers a tuple" behavior (`checker/tests/row_types_test.go` `NumericIndex` /
-      `ArrayElementReadAccess`). It slots into `resolveIndexPath`'s value-index
-      branch beside the existing constant-string-key `valueProp` call.
-    - **Tuple merge-by-position.** Where the object fold (`mergeObjectGroup`) unions
-      properties by NAME, the tuple fold unions slots by INDEX: `recv[0]; recv[2]`
-      requires length ≥ 3, with index 1 a hole filled by a fresh var, and a slot
-      required at several indices intersects its element types (`recv[0] <: β` and
-      `recv[0] <: γ` ⇒ slot 0 is `β & γ`), exactly as the object fold intersects a
-      shared property. Add this as a `mergeTupleGroup` beside `mergeObjectGroup`.
-    - **Seal arm.** `sealUsageObjects` grows a `TupleType` arm beside its
-      `ObjectType` arm, reusing the SAME gating verbatim: a var that is not `open`,
-      occurs only negatively, and has no lower bounds gets its inexact tuple upper
-      bounds folded into one exact tuple, so `fn f(t) { t[0]; t[1] }` seals to
-      `[T0, T1]` and a caller passing a longer tuple is rejected. An escaping
-      receiver (`fn f(t) { t[0]; return t }`) is NOT sealed and keeps its open row
-      so the returned tuple retains the caller's extra elements, and `open` leaves
-      the A2 inexact `[T0, ...]` form — both fall straight out of the existing
-      escape/`open` checks, no new gating. The exact rendered form of an escaping
-      tuple row follows whatever the object case renders (today `{x} & T0`); the
-      tuple row's display is settled when this lands, not specified here.
-    - **Dynamic key → `Array`, not tuple.** A non-constant key (`recv[i]`) cannot
-      address a positional slot, so it infers an `Array`/index-signature read
-      against the now-resolvable `Array<T>` rather than a tuple requirement. **The
-      index-signature inference itself is M9** (index types); until then a dynamic
-      key against a non-array receiver is a typed error, consistent with M4's
-      object computed-key handling and the M9 index-signature deferral. So M7 owns
-      constant-index tuple inference and array reads; M9 owns index signatures.
-    - **Index WRITES** (`recv[0] = v`) extend C3's `inferMemberAssign` the same way
-      — M4 kept the `*ast.IndexExpr` write sub-case as `reportUnsupported` with a
-      "needs Array types — M7" note (m4-implementation-plan §C3). The write path
-      reuses the tuple/array read classification above plus C3's `mut` receiver
-      requirement and `widen`.
-- **Field-level move tracking of computed keys (PR 7 follow-up).** The move engine
-  tracks moves and uses at field granularity over a `movePlace` — a root binding plus
-  a path of `placeSeg` segments (`solver/moves.go`). Today the segment representation is
-  already a tagged struct, `placeSeg{kind, name}`, but only the `namedSeg` kind exists,
-  built from a static member (`pair.a`) or a *string-literal* index key (`obj["a"]`) via
-  `constStringKey`. A computed key — `obj[k]`, `obj[Symbol.iterator]` — currently isn't a
-  supported access form, so `exprPlace`/`resolveIndexPath` reach `reportUnsupported` and
-  the move engine never sees it. When this milestone makes computed-key and symbol-keyed
-  member access infer a type, extend the move engine to derive a segment from the index
-  expression's *resolved type*, not its syntax, so a key behind a variable tracks the
-  same place as the literal. Concretely:
-    - **Generalize `constStringKey` to a type-aware `constKey`** for the move engine,
-      keeping the existing syntactic `constStringKey` for the name-resolution call sites
-      that need the literal. Priority: an index whose inferred type is a *singleton*
-      string or number `LitType` → a `namedSeg` carrying that literal, so `obj[k]` with
-      `k: "foo"` keys the same as `obj.foo`; a key whose type is `unique symbol` → a new
-      `symbolSeg` kind keyed on the symbol's stable id. A non-singleton or otherwise
-      non-constant key falls back to the container place, exactly as a dynamic index does
-      now — sound, at worst over-conservative, never a missed use-after-move.
-      - **Number keys — decide `namedSeg` vs a distinct `indexSeg`.** Mapping a
-        singleton-number key to a `namedSeg` carrying the literal conflates `a[0]` with the
-        string key `a["0"]`, since a `namedSeg` is keyed by string text. The
-        "Tuple-index place segments" item in
-        [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)
-        instead calls for a distinct index-segment kind keyed by the integer, so `a[0]` and
-        `a["0"]` stay separate. Both are sound; the distinct kind is more precise and is what
-        tuple-element tracking needs. Pick one here and apply it uniformly to `constKey`,
-        `renderPlace`, and the tuple-literal walk.
-    - **`soltype` prerequisite for the symbol case.** `soltype` has only the `symbol`
-      primitive (`SymbolPrim`), no unique-symbol type carrying a stable id; the
-      `UniqueSymbolType{Value int}` with that id lives in `internal/type_system`, the old
-      checker. So a unique-symbol `soltype` kind must land first, plumbed through the
-      visitor/printer/constrain/coalesce, before a `symbolSeg` can key on it. Keying on
-      that type id rather than the binding makes `val it = Symbol.iterator` and the
-      original `Symbol.iterator` resolve to one place.
-    - **Wiring.** Add the `symbolSeg` kind to `placeSeg` and render it as
-      `[Symbol.iterator]` in `renderPlace`; thread the index expression's type into
-      `exprPlace` (today a free, purely syntactic function), `recordMemberUse`, and
-      `consumeOwned`; and give `objKeyName` a `ComputedKey` arm so a symbol-keyed object
-      field is tracked. `placeKey` already encodes each segment's kind and length-prefixed
-      name, so it admits a new kind without change.
+**Depends on:** M3 (generics / let-generalization), M4 (objects/records), M5
+(classes, enums, and the `resolveTypeParams` resolver this reuses), M6 (unions —
+the enum body and the generic-union surface). **Feeds:** M7.5 (library ingestion
+produces aliases and generic types), M9 (type-level operators are written as
+generic aliases and reduce over them).
+
+The two design notes below concern the **generic-union annotation surface** this
+milestone first makes reachable from source: a user-written `T | number` in an
+annotation cannot resolve until a written type parameter resolves, which lands
+here.
 
 **Open design question — free type-var members in a union-super exists trial.**
 M6 PR2's union-super exists rule trials each member of `sub <: (A | B | …)`
@@ -1268,6 +1182,178 @@ user. Land them once that happens:
   Roughly doubles the work for ambiguous unions, which matches the cost
   of the original failure mode. Worth landing once user reports of
   confusion start coming in.
+
+---
+
+## M7.5 — Library type resolution (`std:*` / `web:*` / `node:*`)
+
+Port the standard-library type ingestion onto `soltype`, on top of the M7 alias
+representation. Today this is a self-contained subsystem living entirely in
+`internal/checker/` (`infer_import.go`, `infer_stdlib_import.go`,
+`infer_stdlib_scc.go`) plus `internal/interop/`, and it produces
+`type_system.Type`. This milestone retargets it to produce `soltype.Type` in the
+new checker's `Scope`/`Namespace`.
+
+- **No ambient global lib — imports only.** There is **no `globalThis` surface and
+  no `lib.*.d.ts` auto-loading.** Every standard-library type is reached through a
+  scheme import: to use `Array`, `Promise`, `Map`, `Set`, `console`, `Math`,
+  `JSON`, the iteration protocols, and so on in a file, import it from a `std:*` /
+  `web:*` / `node:*` pseudo-module — the DOM lives under `web:dom` — routed through
+  the `interop` partition table to the stdlib `.esc` modules. This is the single
+  ingestion channel; the old checker's dual ambient-plus-import model collapses to
+  imports alone. A file that names `Array` without importing it is an unbound-name
+  error, not an ambient reference.
+- **Well-known protocol types are resolved by the checker, not by lexical import.**
+  The desugaring rules reference stdlib types the user need not have imported:
+  `await e` needs `Promise`, `for (x in xs)` needs `Iterable`, `yield e` needs
+  `Generator`. The rule holds a handle to each well-known type obtained from its
+  stdlib module directly, independent of lexical scope, so `await` / `for-in` /
+  `yield` type-check in a file that never writes the name. Importing the name is
+  required only to **write it** in an annotation, not for the rule to fire. This is
+  the one seam where a stdlib type is reachable without an import, and it is
+  confined to the fixed, checker-known protocol set — not a general ambient surface.
+
+This **replaces M2's placeholder "prerequisite tracking"**: the names M2 stubbed
+(`Promise`/`Iterable`/`Generator`/`IteratorResult`) resolve to real `soltype`
+structures — via import for a written reference, via the well-known-type handle for
+a desugaring rule — rather than opaque placeholders.
+
+- **Interop reuse, gate intact.** The front half of the existing pipeline
+  (`dts_parser` parse → `interop.ConvertModule` → `*ast.Module`) is reusable as
+  AST. The back half (the old checker's `InferModule` → `type_system`) is what
+  this milestone replaces with the new checker's `soltype` walk over that AST.
+  `interop` itself imports `type_system`, so this milestone must consume only its
+  AST-producing surface and keep the `soltype` output path free of `type_system`
+  — confirm the M2 parallel-package gate still holds.
+- **Scope = the operator-free lib subset.** Everything expressible with the
+  M3–M6 representational features (generics, object/record types, nominal
+  classes + `final`, unions): `Array`, `Promise`, `Map`/`Set`, the
+  `Iterable`/`Iterator`/`IteratorResult` protocols, `console`, `Math`, `JSON`,
+  the `string`/`number`/`boolean`/`symbol`/`regexp` method surfaces, and the
+  common `web:dom` types.
+- **Deferred to a phase-2 backfill (after M9).** Lib types whose definitions
+  need conditional/mapped/utility **type operators** (`Awaited<T>`, `Partial`,
+  `Pick`, `Record`, and the operator-heavy parts of `web:dom`) cannot be
+  represented until M9 (type-level operators) lands. Until then they resolve as
+  placeholders/inexact stubs — the same posture M2 takes — and are backfilled
+  once the operator machinery exists. Record which lib names are stubbed so the
+  gap stays visible rather than reading as full coverage.
+- **Exactness.** TS-imported lib types are **inexact by default**
+  ([exact-types/requirements.md](../exact-types/requirements.md) §8); this
+  milestone stamps the inexact flag on ingested lib formers as they land.
+- **Not in scope: operators.** The built-in operator schemes (`+`, `==`, `&&`,
+  `++`, …) are **not** library types and are **not** owned here. They are
+  hand-coded, monomorphic-over-primitive value bindings the expression walk needs
+  from day one, so they live in the M2 prelude (a port of the old checker's
+  `addOperatorBindings`). M7.5 ports *type* ingestion (`.d.ts`/interop → `soltype`),
+  not the value-level operator env.
+- **Rest-param element checking (#677; deferred from M4).** Typed rest params
+  `...xs: T[]` check each trailing argument against `T`, which needs `Array<T>` to
+  resolve — so the element type only exists once this milestone lands. M4 kept
+  rest params arity-only (trailing args unchecked, a documented hole) and marked
+  `FuncParam.Rest`'s note "M7.5." Wire the element check here against the real
+  `Array<T>`, dropping the arity-only restriction.
+- **Variadic tuple types `[number, ...Array<number>]`.** A tuple with a fixed
+  prefix and a *typed*, unbounded, homogeneous tail — distinct from M4's `Inexact`
+  tuple flag `[A, B, ...]`, which means "at least these, then *unknown*." The typed
+  tail needs `Array<T>`, so it lands here with the rest of library type resolution.
+  Add a typed rest/variadic element to `TupleType` — a tail carrying its element
+  type, not just a boolean flag — plus the variadic-tuple subtyping rules, e.g.
+  `[number, number] <: [number, ...Array<number>]` and
+  `[number, ...Array<number>] <: Array<number>`. The `infer`-matching form
+  `T extends [any, ...infer R] ? R : never` is M9 (conditional + `infer`), not here.
+- **Index-read usage inference + tuple/array closing (the M4 object-close analogue,
+  deferred from M4).** M4 shipped `.prop` usage inference plus the close-to-exact
+  seal for objects: `inferMember` lowers `recv.prop` to an inexact one-property
+  requirement, and `sealUsageObjects` (M4 B2, `solver/poly.go`) folds those
+  requirements into one exact object at generalization unless the var escapes to an
+  output position or is marked `open`. F1 (#730) extended that to a constant STRING
+  index: `recv["bar"]` routes through `valueProp` to the same inexact object
+  requirement, so it already gets the object seal. **What index reads still lack is
+  the TUPLE path** — `resolveIndexPath` (`solver/infer_expr.go`) sends a constant
+  NUMERIC index `recv[0]` and any dynamic key to `reportUnsupported`, because the
+  read shape there depends on whether the receiver is a tuple or an `Array`, and
+  `Array` only exists at this milestone. Wire it here:
+    - **`inferIndex` tuple arm (NEW), constant numeric key.** `recv[0]` lowers to an
+      inexact *tuple* requirement "has at least a slot at this index" — the
+      positional twin of the `{prop: β, ...}` object requirement `valueProp` already
+      builds. So `recv[0]; recv[1]` lands two inexact tuple upper bounds on the
+      receiver var, mirroring the object path. The result type is the element var β.
+      This is the new-checker port of the reference checker's "single literal index
+      infers a tuple" behavior (`checker/tests/row_types_test.go` `NumericIndex` /
+      `ArrayElementReadAccess`). It slots into `resolveIndexPath`'s value-index
+      branch beside the existing constant-string-key `valueProp` call.
+    - **Tuple merge-by-position.** Where the object fold (`mergeObjectGroup`) unions
+      properties by NAME, the tuple fold unions slots by INDEX: `recv[0]; recv[2]`
+      requires length ≥ 3, with index 1 a hole filled by a fresh var, and a slot
+      required at several indices intersects its element types (`recv[0] <: β` and
+      `recv[0] <: γ` ⇒ slot 0 is `β & γ`), exactly as the object fold intersects a
+      shared property. Add this as a `mergeTupleGroup` beside `mergeObjectGroup`.
+    - **Seal arm.** `sealUsageObjects` grows a `TupleType` arm beside its
+      `ObjectType` arm, reusing the SAME gating verbatim: a var that is not `open`,
+      occurs only negatively, and has no lower bounds gets its inexact tuple upper
+      bounds folded into one exact tuple, so `fn f(t) { t[0]; t[1] }` seals to
+      `[T0, T1]` and a caller passing a longer tuple is rejected. An escaping
+      receiver (`fn f(t) { t[0]; return t }`) is NOT sealed and keeps its open row
+      so the returned tuple retains the caller's extra elements, and `open` leaves
+      the A2 inexact `[T0, ...]` form — both fall straight out of the existing
+      escape/`open` checks, no new gating. The exact rendered form of an escaping
+      tuple row follows whatever the object case renders (today `{x} & T0`); the
+      tuple row's display is settled when this lands, not specified here.
+    - **Dynamic key → `Array`, not tuple.** A non-constant key (`recv[i]`) cannot
+      address a positional slot, so it infers an `Array`/index-signature read
+      against the now-resolvable `Array<T>` rather than a tuple requirement. **The
+      index-signature inference itself is M9** (index types); until then a dynamic
+      key against a non-array receiver is a typed error, consistent with M4's
+      object computed-key handling and the M9 index-signature deferral. So M7.5 owns
+      constant-index tuple inference and array reads; M9 owns index signatures.
+    - **Index WRITES** (`recv[0] = v`) extend C3's `inferMemberAssign` the same way
+      — M4 kept the `*ast.IndexExpr` write sub-case as `reportUnsupported` with a
+      "needs Array types — M7.5" note (m4-implementation-plan §C3). The write path
+      reuses the tuple/array read classification above plus C3's `mut` receiver
+      requirement and `widen`.
+- **Field-level move tracking of computed keys (PR 7 follow-up).** The move engine
+  tracks moves and uses at field granularity over a `movePlace` — a root binding plus
+  a path of `placeSeg` segments (`solver/moves.go`). Today the segment representation is
+  already a tagged struct, `placeSeg{kind, name}`, but only the `namedSeg` kind exists,
+  built from a static member (`pair.a`) or a *string-literal* index key (`obj["a"]`) via
+  `constStringKey`. A computed key — `obj[k]`, `obj[Symbol.iterator]` — currently isn't a
+  supported access form, so `exprPlace`/`resolveIndexPath` reach `reportUnsupported` and
+  the move engine never sees it. When this milestone makes computed-key and symbol-keyed
+  member access infer a type, extend the move engine to derive a segment from the index
+  expression's *resolved type*, not its syntax, so a key behind a variable tracks the
+  same place as the literal. Concretely:
+    - **Generalize `constStringKey` to a type-aware `constKey`** for the move engine,
+      keeping the existing syntactic `constStringKey` for the name-resolution call sites
+      that need the literal. Priority: an index whose inferred type is a *singleton*
+      string or number `LitType` → a `namedSeg` carrying that literal, so `obj[k]` with
+      `k: "foo"` keys the same as `obj.foo`; a key whose type is `unique symbol` → a new
+      `symbolSeg` kind keyed on the symbol's stable id. A non-singleton or otherwise
+      non-constant key falls back to the container place, exactly as a dynamic index does
+      now — sound, at worst over-conservative, never a missed use-after-move.
+      - **Number keys — decide `namedSeg` vs a distinct `indexSeg`.** Mapping a
+        singleton-number key to a `namedSeg` carrying the literal conflates `a[0]` with the
+        string key `a["0"]`, since a `namedSeg` is keyed by string text. The
+        "Tuple-index place segments" item in
+        [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md)
+        instead calls for a distinct index-segment kind keyed by the integer, so `a[0]` and
+        `a["0"]` stay separate. Both are sound; the distinct kind is more precise and is what
+        tuple-element tracking needs. Pick one here and apply it uniformly to `constKey`,
+        `renderPlace`, and the tuple-literal walk.
+    - **`soltype` prerequisite for the symbol case.** `soltype` has only the `symbol`
+      primitive (`SymbolPrim`), no unique-symbol type carrying a stable id; the
+      `UniqueSymbolType{Value int}` with that id lives in `internal/type_system`, the old
+      checker. So a unique-symbol `soltype` kind must land first, plumbed through the
+      visitor/printer/constrain/coalesce, before a `symbolSeg` can key on it. Keying on
+      that type id rather than the binding makes `val it = Symbol.iterator` and the
+      original `Symbol.iterator` resolve to one place.
+    - **Wiring.** Add the `symbolSeg` kind to `placeSeg` and render it as
+      `[Symbol.iterator]` in `renderPlace`; thread the index expression's type into
+      `exprPlace` (today a free, purely syntactic function), `recordMemberUse`, and
+      `consumeOwned`; and give `objKeyName` a `ComputedKey` arm so a symbol-keyed object
+      field is tracked. `placeKey` already encodes each segment's kind and length-prefixed
+      name, so it admits a new kind without change.
+
 - **Unblocks (not owned here): affine borrow tracking through container methods.** The affine
   connected-component move records a borrow alias only at a binding initializer, a `var`
   reassignment, and a destructuring leaf, so a borrow stored into a container by a method
@@ -1283,12 +1369,15 @@ user. Land them once that happens:
   [affine_semantics/implementation_plan.md](../affine_semantics/implementation_plan.md).
   Recorded here so the dependency is visible from the milestone that unblocks it.
 
-**Accept:** real source referencing core lib types (`Array<T>`, `Promise<T>`,
-`Map<K, V>`, `Iterable<T>`/`Iterator<T>`/`IteratorResult<T>`, `console`) resolves
-to real `soltype` structures and type-checks (not placeholders); `import { … }
-from "std:array"` / `"web:dom"` resolves member types; the M3 `await` and M5
-`for (x in xs)` rules now exercise against the **real** `Promise`/`Iterable`
-(replacing the M2 placeholders); operator-dependent utility types remain stubbed
+**Accept:** real source that **imports** core lib types (`import { Array } from
+"std:array"`, `Promise`, `Map<K, V>`, `Iterable<T>`/`Iterator<T>`/
+`IteratorResult<T>`, `console`) resolves them to real `soltype` structures and
+type-checks, not placeholders, and `import { … } from "std:array"` / `"web:dom"`
+resolves member types. A file that names `Array` **without importing it** is an
+unbound-name error, proving there is no ambient surface. The M3 `await` and M5
+`for (x in xs)` rules exercise against the **real** `Promise`/`Iterable` (replacing
+the M2 placeholders) even in a file that never imports those names, through the
+checker's well-known-type handle. Operator-dependent utility types remain stubbed
 pending M9, and which names are stubbed is reported, not silently dropped.
 `fn f(t) { t[0]; t[1] }` infers and SEALS the param to exact `[T0, T1]`, rejecting a
 longer-tuple argument, while `fn f(open t) { … }` stays inexact `[T0, ...]` and
@@ -1296,11 +1385,12 @@ longer-tuple argument, while `fn f(open t) { … }` stays inexact `[T0, ...]` an
 analogue of M4's object close; a dynamic-key read resolves against the real
 `Array<T>`.
 
-**Depends on:** M3 (generics), M4 (objects/records — `sealUsageObjects`, the close
-machinery this extends), M5 (classes / methods / `final`), M6 (unions). **Feeds:**
-M8 — the real-package differential cannot run
-the existing `fixtures/` tree (which uses `console`/`Array`/`Promise`/…) without
-real lib types.
+**Depends on:** M7 (the alias representation and scope-driven `TypeRef` resolution
+that ingested generic types produce), M3 (generics), M4 (objects/records —
+`sealUsageObjects`, the close machinery this extends), M5 (classes / methods /
+`final`), M6 (unions). **Feeds:** M8 — the real-package differential cannot run the
+existing `fixtures/` tree (which uses `console`/`Array`/`Promise`/…) without real
+lib types.
 
 ---
 
@@ -1416,7 +1506,7 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
   is an abstract type parameter, reduced post-coalescing. M4 already handles the
   concrete case for tuple *literals* — `[...pair, 3]` where `pair` is a known
   tuple — but not the abstract-operand type. This is distinct from a typed variadic
-  tail like `[number, ...Array<number>]`, which is M7: that needs `Array` and is an
+  tail like `[number, ...Array<number>]`, which is M7.5: that needs `Array` and is an
   unbounded homogeneous tail, not a splice.
 - **Template literal types** — string-literal types built from interpolated
   type unions (e.g. `` `on${Capitalize<K>}` ``), including the intrinsic
@@ -1445,7 +1535,7 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
   The constraint engine extends just like `throws` did: parallel arms in
   `constrain`/`extrude`/`LevelOf`/printer, no new lattice machinery.
   Depends on `Generator<Y, R, TNext>` / `AsyncGenerator<…>` being
-  available from the stdlib (M2 placeholder; real resolution in M7 — M9 follows,
+  available from the stdlib (M2 placeholder; real resolution in M7.5 — M9 follows,
   so generators can rely on the real types).
 - **`throws T` clause on functions.** `FuncType` gains a `Throws Type` field
   (parallel to `Ret`), covariant in subtyping, defaulting to `never` (⊥) when
@@ -1641,7 +1731,7 @@ reduce through the M9 operator machinery.
 - M6.5 (lifetime bounds) is numbered `.5` for the same reason M2.5 is — to slot
   between M6 and M7 without renumbering. It rides *after* M6 because M6 settles the
   join machinery its canonical bound set is built on (the permissive mut-borrow join
-  and canonical union order), and *before/with* M7 because library imports are the
+  and canonical union order), and *before/with* M7.5 because library imports are the
   first no-body site where declared bounds become mandatory. It is deferred past M4,
   even though M4 D4 already renders the union approximation, because that rendering is
   sound and nothing in M4–M5 needs the precise bounded form.

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1016,12 +1016,14 @@ implied by transitivity is dropped from the rendered set.
 Add the `soltype` type-alias representation and user-written alias declarations —
 the foundation both library ingestion (M7.5) and type-level operators (M9) build
 on. Today `soltype` has no alias node: [infer_enum.go:12-17](../../internal/solver/infer_enum.go)
-records "soltype has no type aliases yet (M7)", and
-[type_ann.go:21](../../internal/solver/type_ann.go) resolves only the single
-hardcoded `Promise<T>` reference — every other `TypeRefTypeAnn` falls through to
-`reportUnsupported`. This milestone closes that gap, so a written type name
-resolves through the scope to its declaration and a generic alias instantiates
-with its arguments. See [m7-implementation-plan.md](m7-implementation-plan.md) for
+records "soltype has no type aliases yet (M7)". A `TypeRefTypeAnn` already resolves
+a class or an in-scope type parameter through `resolveScopedTypeRef`
+([infer_class.go:342](../../internal/solver/infer_class.go)), and
+[type_ann.go:21](../../internal/solver/type_ann.go) also matches the single
+hardcoded `Promise<T>` reference — but an **alias** reference has no path and falls
+through to `reportUnsupported`. This milestone adds that path, so a written alias
+name resolves through the scope to its declaration and a generic alias
+instantiates with its arguments. See [m7-implementation-plan.md](m7-implementation-plan.md) for
 the full PR breakdown and the M9 interlock.
 
 - **`AliasType` in `soltype`.** A `{Name, Params []*TypeParam, Body Type}` node,
@@ -1306,8 +1308,10 @@ a desugaring rule — rather than opaque placeholders.
       against the now-resolvable `Array<T>` rather than a tuple requirement. **The
       index-signature inference itself is M9** (index types); until then a dynamic
       key against a non-array receiver is a typed error, consistent with M4's
-      object computed-key handling and the M9 index-signature deferral. So M7.5 owns
-      constant-index tuple inference and array reads; M9 owns index signatures.
+      object computed-key handling and the M9 index-signature deferral. So M7.5
+      introduces the `IndexSignatureElem` representation and owns constant-index
+      tuple inference and array reads, while M9 owns the index-signature *inference*
+      (mapped-type production and the dynamic-key read).
     - **Index WRITES** (`recv[0] = v`) extend C3's `inferMemberAssign` the same way
       — M4 kept the `*ast.IndexExpr` write sub-case as `reportUnsupported` with a
       "needs Array types — M7.5" note (m4-implementation-plan §C3). The write path
@@ -1389,9 +1393,10 @@ analogue of M4's object close; a dynamic-key read resolves against the real
 **Depends on:** M7 (the alias representation and scope-driven `TypeRef` resolution
 that ingested generic types produce), M3 (generics), M4 (objects/records —
 `sealUsageObjects`, the close machinery this extends), M5 (classes / methods /
-`final`), M6 (unions). **Feeds:** M8 — the real-package differential cannot run the
-existing `fixtures/` tree (which uses `console`/`Array`/`Promise`/…) without real
-lib types.
+`final`), M6 (unions), M6.5 (declared lifetime bounds — a library signature is the
+first no-body site where declared bounds become mandatory, per M6.5's rationale).
+**Feeds:** M8 — the real-package differential cannot run the existing `fixtures/`
+tree (which uses `console`/`Array`/`Promise`/…) without real lib types.
 
 ---
 
@@ -1495,12 +1500,13 @@ and the M7 interlock.
   union.
 - **Index signatures** — the `IndexSignatureElem` representation the old checker
   carries on object types
-  ([internal/type_system/types.go](../../internal/type_system/types.go)). Escalier
-  has **no** hand-written `{[k: string]: T}` syntax; an index signature arises from
-  a **mapped type over a primitive key** (`{[k in string]: T}`, which reduces to
-  one) and from **library ingestion** — `web:dom`/`std:*` `.d.ts` types carry them,
-  so M7.5 needs the representation to exist. `keyof` and indexed access read it, and
-  it backs the dynamic-key read (`recv[i]`) M7.5 deferred here.
+  ([internal/type_system/types.go](../../internal/type_system/types.go)). The
+  representation is **introduced in M7.5**, whose ingested `web:dom`/`std:*` `.d.ts`
+  types carry index signatures; M9 produces and reads them, so the dependency runs
+  one way. Escalier has **no** hand-written `{[k: string]: T}` syntax; in user code
+  an index signature arises only from a **mapped type over a primitive key**
+  (`{[k in string]: T}`, which reduces to one). `keyof` and indexed access read it,
+  and M9 adds the dynamic-key read (`recv[i]`) M7.5 deferred here.
 - **Conditional types `T extends U ? X : Y`**, including:
   - **`infer T` clauses** in the `extends` operand, binding fresh variables to
     matched positions (function arg/return, tuple element, constructor return,

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1477,9 +1477,30 @@ the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.) See
 [m9-implementation-plan.md](m9-implementation-plan.md) for the full PR breakdown
 and the M7 interlock.
 
-- **`keyof T`** — keys of an object/class type as a union.
+- **`keyof T`** — keys of an object/class type as a union, matching the old
+  checker's coverage
+  ([internal/checker/expand_type.go](../../internal/checker/expand_type.go)
+  `KeyOfType` case): an object projects its property/getter/setter keys and folds
+  in an index signature's key type; a tuple yields its numeric indices plus
+  `"length"`; `keyof` distributes over a union/intersection target; and `keyof`
+  of a primitive or `never`/`unknown` is `never`.
+- **`typeof v` type queries** (`*ast.TypeOfTypeAnn`) — the type-level query that
+  reads a *value* binding's inferred type into type position, including a member
+  chain (`typeof p.x`), the old checker's `TypeOfType`
+  ([internal/checker/expand_type.go](../../internal/checker/expand_type.go)
+  `resolveTypeOfQualIdent`). It is the value→type bridge `keyof typeof x` relies
+  on. Resolved at annotation time by looking the name up in the *value* scope and
+  taking its type, not a residual reduction.
 - **Indexed access `T[K]`** — including distributive behavior when `K` is a
   union.
+- **Index signatures** — the `IndexSignatureElem` representation the old checker
+  carries on object types
+  ([internal/type_system/types.go](../../internal/type_system/types.go)). Escalier
+  has **no** hand-written `{[k: string]: T}` syntax; an index signature arises from
+  a **mapped type over a primitive key** (`{[k in string]: T}`, which reduces to
+  one) and from **library ingestion** — `web:dom`/`std:*` `.d.ts` types carry them,
+  so M7.5 needs the representation to exist. `keyof` and indexed access read it, and
+  it backs the dynamic-key read (`recv[i]`) M7.5 deferred here.
 - **Conditional types `T extends U ? X : Y`**, including:
   - **`infer T` clauses** in the `extends` operand, binding fresh variables to
     matched positions (function arg/return, tuple element, constructor return,
@@ -1566,6 +1587,10 @@ types incl. `infer` and distribution; recursive aliases terminate (finite knot
 or budget). Errors (e.g. arity, non-regular recursion) assert full messages.
 Plus: `keyof` of an exact object is an exact union and of an inexact object an
 inexact union; `Exact<{x, ...}>` ⇒ `{x}` and `Inexact<{x}>` ⇒ `{x, ...}`.
+Plus, matching the old checker's coverage: `keyof [a, b]` ⇒ `0 | 1 | "length"`
+and `keyof` distributes over a union target; `typeof v` for `val v = {a: 1}`
+resolves to `{a: number}` and `keyof typeof v` ⇒ `"a"`; a `{[k in string]: T}`
+mapped type reduces to an index signature that `obj[k]` reads through.
 Plus, the TS utility-type suite as end-to-end verification — defining them in
 Escalier and asserting their reductions match TS:
 

--- a/planning/simple_sub/01-milestones.md
+++ b/planning/simple_sub/01-milestones.md
@@ -1473,7 +1473,9 @@ gaps; burn down before proceeding.
 The last MVP milestone. The full type-level operator surface, reduced via
 Baseline-D (reduce when operands ground) + Design-A residual nodes reduced
 post-coalescing, + recursive-type handling (cycle cache + depth budget, and
-the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.)
+the level-2 regularity check). (Spike M5/M7/M9 + recursion + CheckRegular.) See
+[m9-implementation-plan.md](m9-implementation-plan.md) for the full PR breakdown
+and the M7 interlock.
 
 - **`keyof T`** — keys of an object/class type as a union.
 - **Indexed access `T[K]`** — including distributive behavior when `K` is a

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -334,10 +334,9 @@ PR1 (AliasType node + AliasDef registry + non-generic decl + resolution + expand
  ├─► PR2 (generic aliases: params, instantiation, arity)
  │    ├─► PR3 (recursive + mutually-recursive aliases, SCC two-pass)
  │    │    └─► PR5 (enum name binds to a real alias)     ── also needs PR1
- │    ├─► PR4 (lifetimes on alias-typed borrows)         ── also needs M4
  │    └─► PR6 (generic-union surface + exists-trial)     ── also needs M6
  │         └─► PR7 (trial-and-commit diagnostic follow-ups)
- └─► (PR4, PR5 also depend directly on PR1)
+ └─► PR4 (lifetimes on alias-typed borrows)              ── also needs M4
 
 feeds ─► M7.5 (library ingestion produces aliases + generic types)
 feeds ─► M9  (operators are generic aliases; expandAlias, AliasType identity, recursion split)

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -1,0 +1,394 @@
+# M7 implementation plan — Type aliases
+
+This plan covers **M7 — Type aliases** as listed in
+[01-milestones.md](01-milestones.md). It is a PR-by-PR breakdown, modeled on the
+[M4](m4-implementation-plan.md), [M5](m5-implementation-plan.md), and
+[M6](m6-implementation-plan.md) plans: it records what prior milestones shipped,
+the genuine delta M7 adds, the sequencing, the per-PR design with file
+references, and a dependency graph.
+
+M7 gives `soltype` its first named-type-definition sort: a user-written
+`type Name<Params…> = Body` declaration, the reference to it, and the
+instantiate/expand machinery that makes `Box<number>` type-check. It is the
+foundation two later milestones stand on — **M7.5 — Library type resolution**
+ingests `.d.ts` declarations *as* aliases and generic types, and **M9 —
+Type-level operators** are written as generic aliases and reduce over them. A
+dedicated [§Interlocks with M9](#interlocks-with-m9) section pins down the seams
+so nothing slips between the two plans.
+
+## What M1–M6.5 shipped (ground truth this plan builds on)
+
+The registry pattern, the resolution seam, and the recursion machinery all
+already exist for classes and enums; M7 adds the alias sort alongside them.
+
+- **`soltype` has no alias node — but reserves its slot.** There is no
+  `AliasType` and no use-site type-reference node today.
+  [soltype/type.go:447](../../internal/soltype/type.go) already reserves the arm:
+  "ClassType is a RefInner too … **AliasType adds its `isRefInner` arm when that
+  type is introduced**." [PromiseType's comment](../../internal/soltype/type.go)
+  calls the M7 work "the real, alias-driven `Promise<T>` lookup … TypeRef
+  ingestion." So the intended node name is `AliasType`, playing the role the old
+  checker's `type_system.TypeRefType` plays.
+- **A `type X = …` decl is `reportUnsupported` today.** In the module SCC
+  type-key loop ([module.go:385-400](../../internal/solver/module.go)), any
+  non-value decl that is not a class or enum falls through to
+  `c.reportUnsupported(d)`. A plain `*ast.TypeDecl`
+  ([ast/decl.go:194](../../internal/ast/decl.go), carrying `Name`, `TypeParams`,
+  `TypeAnn`, `declare`) lands there. M7 slots an alias case in beside the class
+  and enum cases.
+- **The `ClassDef` registry is the template.** `Context.classes
+  map[string]*ClassDef` with `registerClass` / `classDef`
+  ([context.go:46-63](../../internal/solver/context.go)) stores a class's
+  definition off to the side, keyed by qualified name, while the `soltype`
+  `ClassType` node at use sites carries only `{Name, TypeArgs}`. `ClassDef`
+  ([classes.go](../../internal/solver/classes.go)) holds `TypeParams`,
+  `LifetimeParams`, `Variance`, `Body`, `Level`. M7's `AliasDef` is the direct
+  analogue: `{TypeParams, LifetimeParams, Body, Level}`.
+- **The resolution seam already exists.** `resolveScopedTypeRef`
+  ([infer_class.go:342](../../internal/solver/infer_class.go)) resolves a written
+  `*ast.TypeRefTypeAnn` against the scope — a bare `Point` or `T`, or a generic
+  `Box<number>` via `buildClassInstance`. `resolveTypeAnn`'s `TypeRefTypeAnn` arm
+  ([type_ann.go:72](../../internal/solver/type_ann.go)) already delegates to it
+  before the hardcoded `Promise` stub. M7 extends `resolveScopedTypeRef` so a name
+  bound to an alias instantiates the alias, and deletes the "FOOTGUN (removed in
+  M7)" `Promise` special-case.
+- **The two-pass SCC recursion machinery exists.** `preBindEnum` /
+  `inferEnumBody` ([infer_enum.go](../../internal/solver/infer_enum.go)) pre-bind
+  every nominal identity in a dep-graph type-key component before resolving any
+  body, so a group of mutually-recursive enums and classes resolves each other.
+  M7's `preBindAlias` / `inferAliasBody` is the same shape, simpler because an
+  alias has no variant-constructor namespace.
+- **`constrain` already carries a coinductive seen-set for recursive types.**
+  `constrain` keys a seen-set by pointer identity
+  ([constrain.go:58-134](../../internal/solver/constrain.go)); the comment names
+  "M4's recursive types (**aliases**, …)" as the reason. So the cycle-closing
+  discipline a recursive alias needs at subtyping time is already in place — M7
+  wires alias expansion through it, it does not build a new cache.
+- **The enum name binds to a bare union, with an explicit M7 TODO.**
+  `preBindEnum` binds `Color`'s type directly to `UnionType{RGB, Hex}`
+  ([infer_enum.go:122-127](../../internal/solver/infer_enum.go)), and
+  [infer_enum.go:11-20](../../internal/solver/infer_enum.go) records: "once type
+  aliases land, bind the enum name to a proper alias whose body is this union, so
+  a reference renders under its own name — `Color` rather than the expanded
+  `Color.RGB | Color.Hex`." M7 discharges that TODO.
+- **The generic-union surface is unreachable from source today.** M6 deferred
+  generic function-type annotations, so a user-written `T | number` in an
+  annotation cannot resolve. [01-milestones.md](01-milestones.md) M7 hosts the two
+  design notes — the union-super exists-trial open question and the trial-and-commit
+  diagnostic follow-ups — because M7 is where that surface first becomes reachable.
+
+## What M7 adds (the delta)
+
+1. **`soltype.AliasType{Name, TypeArgs}`** — the use-site reference node, with the
+   reserved `isRefInner` arm, a visitor arm, a printer arm rendering `Name` /
+   `Name<args>`, and `LevelOf` over its args.
+2. **An `AliasDef` registry** in `Context` (`aliases map[string]*AliasDef`,
+   `registerAlias` / `aliasDef`), holding `{TypeParams, LifetimeParams, Body,
+   Level}` — the class-registry pattern.
+3. **`type` declaration inference** — `inferTypeDecl`, slotted into the module SCC
+   type-key path, with a `preBindAlias` / `inferAliasBody` two-pass for recursion.
+4. **Scope-driven resolution + on-demand expansion** — `resolveScopedTypeRef`
+   resolves an alias reference; a reusable `expandAlias` substitutes `TypeArgs`
+   into the body; `constrain` expands an `AliasType` against its structural body
+   through the existing seen-set, transparently.
+5. **Lifetimes on alias-typed borrows** — `AliasType`'s `RefInner` arm, so
+   `mut 'a Point` over an alias works through the M4 `Ref` machinery unchanged.
+6. **The enum-as-alias binding** — the enum name binds to an `AliasType` whose
+   `AliasDef.Body` is the variant union, discharging the `infer_enum.go` TODO.
+7. **The generic-union annotation surface** — generic function-type and alias
+   annotations with type-var union members resolve, the union-super exists-trial
+   open question is settled and implemented, and the two trial-and-commit
+   diagnostic follow-ups land.
+
+---
+
+## PR-by-PR breakdown
+
+Seven PRs. PR1–PR3 are the alias core in strict dependency order. PR4 (lifetimes)
+and PR5 (enum-as-alias) hang off the core and are mutually independent. PR6–PR7
+are the generic-union surface, which depends only on generic aliases (PR2) and M6,
+so it runs in parallel with PR3–PR5.
+
+### PR1 — `AliasType` node + `AliasDef` registry + non-generic `type` decl
+
+The foundational PR: the representation, the registry, and the simplest decl.
+
+**Data structures.**
+- `soltype.AliasType{Name string, TypeArgs []Type}` — `isType()`, the reserved
+  `isRefInner()` arm ([type.go:447](../../internal/soltype/type.go)), a visitor arm
+  ([soltype/visitor.go](../../internal/soltype/visitor.go)), a printer arm
+  ([soltype/print.go](../../internal/soltype/print.go)) rendering `Name` when
+  `TypeArgs` is empty, and `LevelOf` as the max over `TypeArgs` (0 when empty).
+- `AliasDef{TypeParams []*soltype.TypeParam, LifetimeParams []*soltype.LifetimeParam,
+  Body soltype.Type, Level int}` plus `Context.aliases map[string]*AliasDef` with
+  `registerAlias` / `aliasDef`, mirroring
+  [context.go:46-63](../../internal/solver/context.go).
+
+**Algorithms.**
+- `inferTypeDecl` for a non-generic `type X = Body`: resolve `Body` via
+  `resolveTypeAnn`, `registerAlias("X", &AliasDef{Body, Level: lvl-1})`, and bind
+  the name with `scope.defineType("X", TypeBinding{Type: &AliasType{Name: "X"},
+  Sources: …})`. Slot the `*ast.TypeDecl` case into the module type-key loop
+  ([module.go:391-400](../../internal/solver/module.go)) so it stops reporting
+  unsupported. PR1 handles only the single-decl, non-recursive case; the
+  recursion two-pass is PR3.
+- Extend `resolveScopedTypeRef`
+  ([infer_class.go:342](../../internal/solver/infer_class.go)): when the looked-up
+  binding's `Type` is an `AliasType`, return it (the bare, no-args case). Delete
+  the hardcoded `Promise` branch in `resolveTypeAnn`
+  ([type_ann.go:21-72](../../internal/solver/type_ann.go)) — the "FOOTGUN (removed
+  in M7)" — so a real `type Promise<T> = …` wins over the stub.
+- **On-demand expansion in `constrain`.** A reusable `expandAlias(ref *AliasType)
+  soltype.Type` looks up the `AliasDef` and returns its `Body` (no args to
+  substitute in PR1). `constrain` gets an `AliasType` arm on both sides: expand and
+  recurse through the **existing seen-set**
+  ([constrain.go:129](../../internal/solver/constrain.go)), so an alias is
+  transparently its body. Exposing `expandAlias` as a standalone helper — not
+  inlined into `constrain` — is what M9's evaluator reuses (see
+  [§Interlocks with M9](#interlocks-with-m9)).
+
+**Accept.** `type Point = {x: number, y: number}` binds; `val p: Point = {x: 1, y:
+2}` type-checks; `val p: Point = {x: 1}` rejects the missing field with the full
+message; `p` renders as `Point`, not `{x: number, y: number}`.
+
+### PR2 — Generic aliases: type parameters, instantiation, arity
+
+**Algorithms.**
+- Resolve the alias's `<…>` list through the existing two-pass `resolveTypeParams`
+  ([type_params.go](../../internal/solver/type_params.go), M5) into
+  `AliasDef.TypeParams`, so a bound, a default, and a forward or mutual reference
+  between sibling parameters resolve exactly as they do for a class.
+- **Instantiation.** At a use site `Box<number>`, `resolveScopedTypeRef` returns
+  `AliasType{Name: "Box", TypeArgs: [number]}` — the generic-instance path beside
+  `buildClassInstance` ([infer_class.go:352](../../internal/solver/infer_class.go)).
+- **Expansion by substitution.** `expandAlias` substitutes `TypeArgs` for the
+  `AliasDef.TypeParams` vars in the body — a fresh substitution per expansion.
+  `Box<A> <: Box<B>` expands both to their structural bodies and constrains
+  structurally; since an alias is transparent, **M7 stores no alias variance** (the
+  M5 note "Generic type aliases do not carry variance separately"). Variance for the
+  non-expanding cycle-cache-hit dispatch is M9's concern, computed internally there
+  — flagged in [§Interlocks with M9](#interlocks-with-m9).
+- **Arity checking.** A reference whose arg count differs from the alias's parameter
+  count reports a full-message `AliasArityMismatchError` carrying the typed
+  references, modeled on [errors.go](../../internal/solver/errors.go).
+
+**Accept.** `type Box<T> = {value: T}`; `Box<number> <: Box<number | string>` holds
+by structural expansion; `Box<number, string>` rejects on arity;
+`Box<number>` renders as `Box<number>`.
+
+**Depends on** PR1.
+
+### PR3 — Recursive + mutually-recursive aliases (SCC two-pass)
+
+**Algorithms.**
+- `preBindAlias` / `inferAliasBody`, mirroring `preBindEnum` / `inferEnumBody`
+  ([infer_enum.go:65-170](../../internal/solver/infer_enum.go)): pre-bind every
+  alias identity in the dep-graph type-key component — register a shell `AliasDef`
+  and the `AliasType` `TypeBinding` — **before** any body resolves, so a self or
+  mutual reference finds the sibling already bound. Run this from the module
+  type-key SCC path ([module.go:356-383](../../internal/solver/module.go)) beside
+  the enum shells, so a component mixing aliases, enums, and classes resolves each
+  other.
+- **Recursion closes at subtyping time, not expansion time.** A recursive
+  `type List<T> = {head: T, tail: List<T> | Null}` body holds an `AliasType{List,
+  [T]}` reference. `expandAlias` unfolds one level; the `constrain` seen-set
+  ([constrain.go:129](../../internal/solver/constrain.go)) closes the cycle on the
+  second encounter. **No depth budget and no cycle cache here** — those are M9's,
+  for operator *reduction over* a recursive alias. M7 supports a recursive alias
+  **only as a subtyping subject**. This boundary is the single most important
+  M7/M9 seam; see [§Interlocks with M9](#interlocks-with-m9).
+
+**Accept.** `type List<T> = {head: T, tail: List<T> | Null}` type-checks as a
+subtyping subject with the cycle closed by the seen-set; a mutual group
+`type A = {b: B}` / `type B = {a: A}` resolves; a recursive alias renders under its
+own name at the knot rather than expanding forever.
+
+**Depends on** PR2 (recursion tests use generic `List<T>`), and the module SCC
+type-key path.
+
+### PR4 — Lifetimes on alias-typed borrows
+
+**Algorithms.**
+- `AliasType` already carries its `isRefInner` arm from PR1, so `mut 'a Point` over
+  an alias forms `Ref{mut, lt, inner: AliasType}` through the M4 machinery
+  unchanged. Ensure `borrowInner` / `resolveRefTypeAnn`
+  ([type_ann.go:386-451](../../internal/solver/type_ann.go)) accept an `AliasType`
+  inner.
+- A lifetime-generic alias carries `AliasDef.LifetimeParams`; expansion substitutes
+  lifetime arguments the same way it substitutes type arguments.
+
+**Accept.** With `type Point = {x: number}`, `fn f(p: mut 'a Point) -> mut 'a
+Point` round-trips the lifetime through the alias; a fresh-object return over an
+alias carries no lifetime, matching the record case.
+
+**Depends on** PR1 (the node), M4 (the `Ref` machinery). Independent of PR3.
+
+### PR5 — Enum name binds to a real alias
+
+**Algorithms.**
+- Replace the direct-union `TypeBinding` in `preBindEnum`
+  ([infer_enum.go:122-127](../../internal/solver/infer_enum.go)) with an
+  `AliasDef` whose `Body` is the variant union, binding the enum name to
+  `AliasType{Name: qname}`. Remove the `TODO(M7)` and update the package doc.
+- **Confirm the union-reading consumers expand the alias.** Exhaustiveness (D2,
+  `unionMatchExhaustive` in
+  [infer_expr.go](../../internal/solver/infer_expr.go)) and member lookup read the
+  enum's union members; they must expand the `AliasType` to its `AliasDef.Body`
+  first. This is the same `expandAlias` call `constrain` uses.
+
+**Accept.** `Color` renders as `Color`, not `Color.RGB | Color.Hex`;
+`Color.Hex("#fff")` still infers `Color`; a `match` over every variant is still
+exhaustive without a default arm (the alias expands to the union it checks against).
+
+**Depends on** PR1–PR3 (an enum can be recursive or mutually recursive with a
+field-holding class). This PR is what lets M9's `keyof Color` and indexed access
+reach the enum through the alias path — see
+[§Interlocks with M9](#interlocks-with-m9).
+
+### PR6 — Generic-union annotation surface + union-super exists-trial resolution
+
+The milestone hosts the union-super exists-trial open question here because this is
+where a user-written `T | number` first resolves.
+
+**Algorithms.**
+- **Generic annotation surface.** Resolve a generic function-type annotation
+  `fn <T>(x: T | number) -> …` and a union member that is a bare type parameter, by
+  routing the `<…>` list through `resolveTypeParams` and the union members through
+  the alias-aware `resolveTypeAnn`. This is the M6-deferred generic function-type
+  annotation, now reachable.
+- **Settle the union-super exists trial.** [01-milestones.md](01-milestones.md) M7
+  poses two designs for `sub <: (A | B | …)` when a member is a bare `TypeVarType`:
+  keep M6's conservative skip, or a two-pass trial (concrete members first, var
+  members second). Decide, document the choice against the mirror
+  `IntersectionType`-sub overload arm
+  ([constrain.go:366](../../internal/solver/constrain.go)), and implement it under
+  the existing probe journal ([probe.go](../../internal/solver/probe.go)).
+
+**Accept.** `fn f<T>(x: T | number)` resolves; `f("hi")` and `f(5)` behave per the
+chosen design; a boolean is rejected; the union and intersection exists arms are
+either aligned or their divergence is documented.
+
+**Depends on** PR2 (generic surface), M6 (unions). Independent of PR3–PR5.
+
+### PR7 — Trial-and-commit diagnostic follow-ups
+
+The two deferred mitigations that bite once generic-union annotations are reachable
+([01-milestones.md](01-milestones.md) M7).
+
+**Algorithms.**
+- **Trial-origin tagging.** When a union-super trial commits, tag the added bounds
+  with a side-table entry pointing at the union annotation node; a later failing
+  constraint on a tagged var chases the tag and emits "committed to branch A of
+  (A | B) at <span>; later use needs B." Probe-safe via the existing rollback hook.
+- **Ambient-time ambiguity detection.** After the first trial commits, peek at
+  later branches under throwaway probes; when another branch would also succeed with
+  different bounds, warn at the union annotation site.
+
+**Accept.** A downstream conflict on a union-committed var carries a breadcrumb back
+to the union; an ambiguous generic union warns at declaration time.
+
+**Depends on** PR6.
+
+---
+
+## Interlocks with M9
+
+The reason M7 and M9 are planned together. Each item is a seam where a decision in
+one plan constrains the other; getting them consistent here is the point.
+
+1. **`AliasType` + `AliasDef` are M9's input.** M9's `TypeEvaluator`
+   ([m9-implementation-plan.md](m9-implementation-plan.md) PR1) reduces `Pick<T,
+   K>` by instantiating and expanding the alias. It calls M7's `expandAlias` and
+   reads M7's `AliasDef`. **Action:** PR1 exposes `expandAlias` as a standalone
+   helper, not inlined into `constrain`, so the evaluator reuses it verbatim.
+2. **The recursion boundary is split, and the split must be exact.** M7 handles a
+   recursive alias **as a subtyping subject** via `constrain`'s seen-set (PR3), with
+   **no cycle cache and no depth budget**. M9 handles **operator reduction over** a
+   recursive alias with the cycle cache keyed on the `(alias, evaluated-args)` state
+   plus a depth budget (M9 PR1) and `CheckRegular` (M9 PR9). **Action:** the
+   instantiation-state identity M9's cycle cache keys on is exactly the
+   `AliasType{Name, TypeArgs}` M7 PR2 defines — M7 fixes that node's identity so M9
+   keys on it without a second representation.
+3. **Alias variance is M9's, not M7's.** M7 stores no alias variance (PR2), because
+   a transparent alias expands. M9's non-expanding cycle-cache-hit dispatch does
+   need it (the M5 note: "variance is inferred internally for use there, but is
+   never user-annotated"). **Action:** M7 leaves the `AliasDef` with no variance
+   field; M9 computes it internally when it lands the cycle-cache-hit rule. Named
+   here so neither plan assumes the other did it.
+4. **Enum-as-alias (PR5) is what M9's `keyof` / indexed access reach.** M9's `keyof
+   Color` and `Color["RGB"]` resolve the enum through its alias body. **Action:**
+   PR5 lands the enum-as-alias binding and confirms the union-reading consumers call
+   `expandAlias`; M9 relies on that path existing.
+5. **`Awaited<T>` (M9 PR12) is a recursive conditional alias.** It leans on M7's
+   recursive-alias representation (PR3) for its self-reference and on M7.5 for the
+   real `Promise<T>`. **Action:** none beyond PR3 — noted so the dependency is
+   visible from both plans.
+6. **The generic-union surface (PR6–PR7) is not an M9 dependency.** It is bundled
+   into M7 because M7 first makes it reachable, but M9's operators do not need it.
+   Named here so a reader does not infer a false edge between PR6/PR7 and M9.
+
+## Dependency graph
+
+```
+PR1 (AliasType node + AliasDef registry + non-generic decl + resolution + expand)
+ ├─► PR2 (generic aliases: params, instantiation, arity)
+ │    ├─► PR3 (recursive + mutually-recursive aliases, SCC two-pass)
+ │    │    └─► PR5 (enum name binds to a real alias)     ── also needs PR1
+ │    ├─► PR4 (lifetimes on alias-typed borrows)         ── also needs M4
+ │    └─► PR6 (generic-union surface + exists-trial)     ── also needs M6
+ │         └─► PR7 (trial-and-commit diagnostic follow-ups)
+ └─► (PR4, PR5 also depend directly on PR1)
+
+feeds ─► M7.5 (library ingestion produces aliases + generic types)
+feeds ─► M9  (operators are generic aliases; expandAlias, AliasType identity, recursion split)
+```
+
+The same graph in mermaid, with the alias-core critical path (PR1 → PR2 → PR3)
+highlighted and the downstream milestones dashed:
+
+```mermaid
+graph TD
+    PR1["PR1 (AliasType + AliasDef + non-generic decl + resolution + expand)"]
+    PR2["PR2 (generic aliases: params, instantiation, arity)"]
+    PR3["PR3 (recursive + mutually-recursive aliases)"]
+    PR4["PR4 (lifetimes on alias-typed borrows)"]
+    PR5["PR5 (enum name binds to a real alias)"]
+    PR6["PR6 (generic-union surface + exists-trial)"]
+    PR7["PR7 (trial-and-commit diagnostic follow-ups)"]
+    M4["M4 (Ref machinery, landed)"]
+    M6["M6 (unions, landed)"]
+    M75["M7.5 (library type resolution)"]
+    M9["M9 (type-level operators)"]
+
+    PR1 --> PR2
+    PR1 --> PR4
+    PR1 --> PR5
+    PR2 --> PR3
+    PR2 --> PR6
+    PR3 --> PR5
+    PR6 --> PR7
+    M4 -.-> PR4
+    M6 -.-> PR6
+
+    PR3 -.-> M75
+    PR3 -.-> M9
+    PR2 -.-> M9
+    PR5 -.-> M9
+
+    linkStyle default stroke:#888
+    style PR1 fill:#e06666,stroke:#333,color:#fff
+    style PR2 fill:#e06666,stroke:#333,color:#fff
+    style PR3 fill:#e06666,stroke:#333,color:#fff
+```
+
+### Parallelism
+
+- **Core** — PR1 → PR2 → PR3 is the critical path; every other PR hangs off it.
+- **PR4** (lifetimes) and **PR5** (enum-as-alias) are mutually independent once
+  their prerequisites land; PR4 needs only PR1 + M4, PR5 needs PR1–PR3.
+- **PR6 → PR7** (generic-union surface) needs only PR2 + M6, so it runs alongside
+  PR3–PR5 and never blocks the alias core.
+
+The critical path is `PR1 → PR2 → PR3`, and everything M9 consumes — `expandAlias`,
+the `AliasType` identity, the recursion split, and the enum-as-alias path — is in
+place once PR5 lands.

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -297,15 +297,15 @@ The reason M7 and M9 are planned together. Each item is a seam where a decision 
 one plan constrains the other; getting them consistent here is the point.
 
 1. **`AliasType` + `AliasDef` are M9's input.** M9's `TypeEvaluator`
-   ([m9-implementation-plan.md](m9-implementation-plan.md) PR1) reduces `Pick<T,
+   ([m9-implementation-plan.md](m9-implementation-plan.md) PR1b) reduces `Pick<T,
    K>` by instantiating and expanding the alias. It calls M7's `expandAlias` and
-   reads M7's `AliasDef`. **Action:** PR1 exposes `expandAlias` as a standalone
+   reads M7's `AliasDef`. **Action:** M7 PR1 exposes `expandAlias` as a standalone
    helper, not inlined into `constrain`, so the evaluator reuses it verbatim.
 2. **The recursion boundary is split, and the split must be exact.** M7 handles a
    recursive alias **as a subtyping subject** via `constrain`'s seen-set (PR3), with
    **no cycle cache and no depth budget**. M9 handles **operator reduction over** a
    recursive alias with the cycle cache keyed on the `(alias, evaluated-args)` state
-   plus a depth budget (M9 PR1) and `CheckRegular` (M9 PR9). **Action:** the
+   plus a depth budget (M9 PR1b) and `CheckRegular` (M9 PR9). **Action:** the
    instantiation-state identity M9's cycle cache keys on is exactly the
    `AliasType{Name, TypeArgs}` M7 PR2 defines — M7 fixes that node's identity so M9
    keys on it without a second representation.

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -58,12 +58,17 @@ already exist for classes and enums; M7 adds the alias sort alongside them.
   body, so a group of mutually-recursive enums and classes resolves each other.
   M7's `preBindAlias` / `inferAliasBody` is the same shape, simpler because an
   alias has no variant-constructor namespace.
-- **`constrain` already carries a coinductive seen-set for recursive types.**
-  `constrain` keys a seen-set by pointer identity
-  ([constrain.go:58-134](../../internal/solver/constrain.go)); the comment names
-  "M4's recursive types (**aliases**, …)" as the reason. So the cycle-closing
-  discipline a recursive alias needs at subtyping time is already in place — M7
-  wires alias expansion through it, it does not build a new cache.
+- **`constrain` carries a coinductive seen-set, but it keys by *pointer* identity.**
+  `constrain`'s `constraintKey` is `{sub, super, mutCtx}` compared by pointer
+  ([constrain.go:58-77](../../internal/solver/constrain.go)); its own comment warns
+  "M4's recursive types (**aliases**, letrec) must preserve this property." A
+  **non-generic** recursive alias whose reference node is reused preserves it, so
+  the existing seen-set closes the cycle directly. A **generic** recursive alias
+  does **not**: `expandAlias` substitutes the type arguments and mints a *fresh*
+  node each lap, so pointer identity never matches and it would expand forever.
+  PR3 therefore keys the alias recursion guard on the canonical
+  `(AliasDef, args)` identity for the generic case — it does not rely on pointer
+  identity alone.
 - **The enum name binds to a bare union, with an explicit M7 TODO.**
   `preBindEnum` binds `Color`'s type directly to `UnionType{RGB, Hex}`
   ([infer_enum.go:122-127](../../internal/solver/infer_enum.go)), and
@@ -118,7 +123,9 @@ The foundational PR: the representation, the registry, and the simplest decl.
   `isRefInner()` arm ([type.go:447](../../internal/soltype/type.go)), a visitor arm
   ([soltype/visitor.go](../../internal/soltype/visitor.go)), a printer arm
   ([soltype/print.go](../../internal/soltype/print.go)) rendering `Name` when
-  `TypeArgs` is empty, and `LevelOf` as the max over `TypeArgs` (0 when empty).
+  `TypeArgs` is empty, and `LevelOf` as the max over `TypeArgs` (0 when empty). PR4
+  extends the node with a `LifetimeArgs` field for lifetime-generic aliases; until
+  then it carries type arguments only.
 - `AliasDef{TypeParams []*soltype.TypeParam, LifetimeParams []*soltype.LifetimeParam,
   Body soltype.Type, Level int}` plus `Context.aliases map[string]*AliasDef` with
   `registerAlias` / `aliasDef`, mirroring
@@ -168,13 +175,21 @@ message; `p` renders as `Point`, not `{x: number, y: number}`.
   M5 note "Generic type aliases do not carry variance separately"). Variance for the
   non-expanding cycle-cache-hit dispatch is M9's concern, computed internally there
   — flagged in [§Interlocks with M9](#interlocks-with-m9).
-- **Arity checking.** A reference whose arg count differs from the alias's parameter
-  count reports a full-message `AliasArityMismatchError` carrying the typed
-  references, modeled on [errors.go](../../internal/solver/errors.go).
+- **Arity checking honors defaults.** `soltype.TypeParam.Default` (`nil ⇒
+  required`, already resolved by `resolveTypeParams`) makes a trailing parameter
+  optional, so arity is a range, not an equality. A reference may omit trailing
+  arguments that have defaults — those slots are filled from the `AliasDef`
+  defaults during instantiation — and only **fewer than the required count** or
+  **more than the total parameter count** reports a full-message
+  `AliasArityMismatchError` carrying the typed references, modeled on
+  [errors.go](../../internal/solver/errors.go). This applies the defaults the old
+  checker's `TODO(#475)` left unapplied.
 
 **Accept.** `type Box<T> = {value: T}`; `Box<number> <: Box<number | string>` holds
-by structural expansion; `Box<number, string>` rejects on arity;
-`Box<number>` renders as `Box<number>`.
+by structural expansion; `Box<number>` renders as `Box<number>`. With
+`type Pair<T, U = T> = [T, U]`, `Pair<number>` fills `U` from its default (`[number,
+number]`) while `Pair<number, string, bool>` rejects on arity and a zero-arg `Pair`
+rejects for too few required.
 
 **Depends on** PR1.
 
@@ -189,19 +204,30 @@ by structural expansion; `Box<number, string>` rejects on arity;
   type-key SCC path ([module.go:356-383](../../internal/solver/module.go)) beside
   the enum shells, so a component mixing aliases, enums, and classes resolves each
   other.
-- **Recursion closes at subtyping time, not expansion time.** A recursive
-  `type List<T> = {head: T, tail: List<T> | Null}` body holds an `AliasType{List,
-  [T]}` reference. `expandAlias` unfolds one level; the `constrain` seen-set
-  ([constrain.go:129](../../internal/solver/constrain.go)) closes the cycle on the
-  second encounter. **No depth budget and no cycle cache here** — those are M9's,
-  for operator *reduction over* a recursive alias. M7 supports a recursive alias
-  **only as a subtyping subject**. This boundary is the single most important
-  M7/M9 seam; see [§Interlocks with M9](#interlocks-with-m9).
+- **Recursion closes at subtyping time — via canonical identity, not pointer
+  identity.** A recursive `type List<T> = {head: T, tail: List<T> | Null}` body
+  holds an `AliasType{List, [T]}` reference; `expandAlias` unfolds one level. The
+  `constrain` seen-set keys by pointer identity
+  ([constrain.go:58-77](../../internal/solver/constrain.go)), but `expandAlias`
+  **substitutes** the arguments, minting a fresh `AliasType{List, [number]}` each
+  lap, so `List<number>` would never hit that cache and would diverge. The guard
+  must key on the **canonical instance identity** — the `(AliasDef, evaluated type
+  args, lifetime args)` triple, the same key M9's cycle cache and the old checker's
+  `expandSeen` (`{aliasPtr, typeArgKey}`) both use. Two implementations satisfy it:
+  **intern** expanded `AliasType` instances so the same `List<number>` is
+  pointer-stable and the existing seen-set closes it, or add a **dedicated
+  alias-expansion seen-set** keyed on that triple. Pick one in this PR. **No depth
+  budget and no cycle cache here** — those are M9's, for operator *reduction over* a
+  recursive alias. M7 supports a recursive alias **only as a subtyping subject**.
+  This boundary is the single most important M7/M9 seam; see
+  [§Interlocks with M9](#interlocks-with-m9).
 
 **Accept.** `type List<T> = {head: T, tail: List<T> | Null}` type-checks as a
-subtyping subject with the cycle closed by the seen-set; a mutual group
-`type A = {b: B}` / `type B = {a: A}` resolves; a recursive alias renders under its
-own name at the knot rather than expanding forever.
+subtyping subject with the cycle closed by canonical `(alias, args)` identity —
+**including a generic instance** `List<number>` used as a subtyping subject, which
+a pointer-identity guard would diverge on; a mutual group `type A = {b: B}` /
+`type B = {a: A}` resolves; a recursive alias renders under its own name at the
+knot rather than expanding forever.
 
 **Depends on** PR2 (recursion tests use generic `List<T>`), and the module SCC
 type-key path.
@@ -216,10 +242,18 @@ type-key path.
   inner.
 - A lifetime-generic alias carries `AliasDef.LifetimeParams`; expansion substitutes
   lifetime arguments the same way it substitutes type arguments.
+- **`AliasType` grows a `LifetimeArgs` field.** So `Foo<'a>` and `Foo<'b>` are
+  distinct nodes rather than colliding, the lifetime arguments join `Name` and
+  `TypeArgs` in the node, the visitor/printer/`LevelOf` traverse them, and — the
+  load-bearing part — they are part of the **instance identity** the PR3 recursion
+  guard and M9's cycle cache key on (see [§Interlocks with M9](#interlocks-with-m9)
+  item 2). Keying without them would let two borrows of the same alias at different
+  lifetimes share a cache entry.
 
 **Accept.** With `type Point = {x: number}`, `fn f(p: mut 'a Point) -> mut 'a
 Point` round-trips the lifetime through the alias; a fresh-object return over an
-alias carries no lifetime, matching the record case.
+alias carries no lifetime, matching the record case; `mut 'a Foo` and `mut 'b Foo`
+over a lifetime-generic `Foo` stay distinct rather than collapsing.
 
 **Depends on** PR1 (the node), M4 (the `Ref` machinery). Independent of PR3.
 
@@ -301,14 +335,18 @@ one plan constrains the other; getting them consistent here is the point.
    K>` by instantiating and expanding the alias. It calls M7's `expandAlias` and
    reads M7's `AliasDef`. **Action:** M7 PR1 exposes `expandAlias` as a standalone
    helper, not inlined into `constrain`, so the evaluator reuses it verbatim.
-2. **The recursion boundary is split, and the split must be exact.** M7 handles a
-   recursive alias **as a subtyping subject** via `constrain`'s seen-set (PR3), with
+2. **The recursion boundary is split, and both halves key on the same canonical
+   identity.** M7 handles a recursive alias **as a subtyping subject** (PR3), with
    **no cycle cache and no depth budget**. M9 handles **operator reduction over** a
-   recursive alias with the cycle cache keyed on the `(alias, evaluated-args)` state
-   plus a depth budget (M9 PR1b) and `CheckRegular` (M9 PR9). **Action:** the
-   instantiation-state identity M9's cycle cache keys on is exactly the
-   `AliasType{Name, TypeArgs}` M7 PR2 defines — M7 fixes that node's identity so M9
-   keys on it without a second representation.
+   recursive alias with the cycle cache plus a depth budget (M9 PR1b) and
+   `CheckRegular` (M9 PR9). **Action:** both key on the **canonical** instance
+   identity — the `(AliasDef, evaluated type args, lifetime args)` triple, **not**
+   `constrain`'s pointer identity, since `expandAlias` mints a fresh substituted
+   node each expansion. M7 PR3 fixes that canonical key (interning instances or a
+   dedicated expansion seen-set) and M7 PR4 folds lifetime args into it, so M9's
+   cycle cache reuses one representation instead of inventing a second. Getting this
+   wrong makes a generic recursive alias diverge in one plan and terminate in the
+   other.
 3. **Alias variance is M9's, not M7's.** M7 stores no alias variance (PR2), because
    a transparent alias expands. M9's non-expanding cycle-cache-hit dispatch does
    need it (the M5 note: "variance is inferred internally for use there, but is

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -46,13 +46,16 @@ prerequisites:
 2. **Alias instantiation and expansion (M7).** The evaluator reduces `Pick<Person,
    "name">` by instantiating `Pick`'s body with the arguments and reducing the
    result. That instantiate/expand step is M7 infrastructure.
-3. **Real stdlib types (M7.5).** `Awaited<T>` needs the real `Promise<T>`;
-   generators need `Generator<Y, R, TNext>` / `AsyncGenerator<…>`; the
-   utility-type suite is checked against the real `.d.ts` shapes. Since M7.5 is
-   import-only — there is no ambient global lib — the utility definitions and
-   tests import these names from `std:*` / `web:*` / `node:*`. M2 seeded opaque
-   placeholders; M7.5 swaps in the real structures, and M9 follows so it can rely
-   on them.
+3. **Real stdlib types and the index-signature representation (M7.5).** `Awaited<T>`
+   needs the real `Promise<T>`; generators need `Generator<Y, R, TNext>` /
+   `AsyncGenerator<…>`; the utility-type suite is checked against the real `.d.ts`
+   shapes. Since M7.5 is import-only — there is no ambient global lib — the utility
+   definitions and tests import these names from `std:*` / `web:*` / `node:*`. M7.5
+   also **introduces the `IndexSignatureElem` representation**, because its ingested
+   library types carry index signatures; M9 PR4 only *produces* and *reads* them, so
+   the dependency runs one way (M7.5 → M9) — M9 introduces no artifact M7.5 needs.
+   M2 seeded opaque placeholders; M7.5 swaps in the real structures, and M9 follows
+   so it can rely on them.
 
 The AST nodes M9 consumes already exist:
 [`KeyOfTypeAnn`](../../internal/ast/type_ann.go),
@@ -304,14 +307,15 @@ ReadonlyMod, OptionalMod Modifier, As Type}` where `Modifier` is
 - **Index signatures.** A mapped type over a **primitive** key constraint
   (`{[k in string]: T}`) reduces to an `IndexSignatureElem`, the old checker's
   representation ([type_system/types.go](../../internal/type_system/types.go)) that
-  a literal-key map cannot express. This PR adds that element to
-  `soltype.ObjectType`. Escalier has no hand-written `{[k: string]: T}` syntax, so
-  mapped-type reduction is the *only* source of one in user code; `keyof` and
-  indexed access (PR1b, PR2) already read it. It also lands the dynamic-key read
-  inference (`recv[i]` against a non-tuple receiver) that M7.5 deferred here: a
-  primitive key resolves through the index signature rather than a positional slot.
-  Library types under `web:dom` / `std:*` carry index signatures, so M7.5 ingestion
-  relies on this representation existing.
+  a literal-key map cannot express. The `IndexSignatureElem` on `soltype.ObjectType`
+  is **introduced in M7.5, not here** — its ingested `web:dom` / `std:*` library
+  types carry index signatures and M7.5 lands first, so the dependency runs one way
+  (M7.5 → M9) with no cycle. This PR is the first *producer* in user code:
+  mapped-type reduction emits one, and Escalier has no hand-written
+  `{[k: string]: T}` syntax so that is the only source. `keyof` and indexed access
+  (PR1b, PR2) read it, and this PR adds the dynamic-key read inference (`recv[i]`
+  against a non-tuple receiver) M7.5 deferred here — a primitive key resolves
+  through the index signature rather than a positional slot.
 - This is the machinery underlying `Pick` / `Omit` / `Partial` / `Required` /
   `Readonly` / `Record`, verified end-to-end in PR13.
 

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -1,0 +1,534 @@
+# M9 implementation plan — Type-level operators
+
+This plan covers **M9 — Type-level operators** as listed in
+[01-milestones.md](01-milestones.md). It is a PR-by-PR breakdown, modeled on the
+[M4](m4-implementation-plan.md), [M5](m5-implementation-plan.md), and
+[M6](m6-implementation-plan.md) plans: it records what prior milestones shipped,
+the genuine delta M9 adds, the sequencing, the per-PR design with file
+references, and a dependency graph.
+
+M9 is the last MVP milestone and the largest by surface. It adds the full
+type-level operator suite — `keyof`, indexed access, conditional types with
+`infer`, mapped types, object and tuple spread types, and template literal types
+— plus two orthogonal function-signature effects (`throws` and generators), all
+resting on a shared **type-level evaluator** with a recursion-safe termination
+strategy. The reduction architecture is settled: **Baseline-D** reduces an
+operator as soon as its operands are ground, and **Design-A** keeps a
+not-yet-ground operator as an inert residual node that reduces after coalescing.
+Both are already prototyped in the spike ([internal/simplesub/typeops.go](../../internal/simplesub/typeops.go),
+[residual.go](../../internal/simplesub/residual.go)); M9 promotes them onto the
+production `soltype`/`solver` packages.
+
+## What "operator" means here
+
+A **type-level operator** is a type expression that *computes* a type from other
+types rather than naming one directly. `keyof {x: number, y: string}` computes
+the union `"x" | "y"`; `Pick<T, K>` computes a smaller object type. These are
+distinct from the value-expression constraint solver: they are pure reductions
+over already-formed types, with no inference variables in their results. The
+milestone's job is to represent them, reduce them, and thread exactness through
+the reduction.
+
+## Prerequisite: M7 must land first
+
+M9 builds directly on **M7 — Library type resolution**. Three M7 deliverables are
+hard prerequisites:
+
+1. **A generic type-alias representation in `soltype`.** Today `soltype` has no
+   alias node at all — [infer_enum.go:13](../../internal/solver/infer_enum.go)
+   records "soltype has no type aliases yet (M7)", and
+   [type_ann.go:21](../../internal/solver/type_ann.go) resolves only the single
+   hardcoded `Promise<T>` reference, reporting every other `TypeRefTypeAnn` as
+   unsupported. M9's operators are almost always written *as* generic aliases
+   (`type Pick<T, K> = ...`), so the alias node, its type parameters, and
+   scope-driven `TypeRef` resolution must exist first.
+2. **Alias instantiation and expansion.** The evaluator reduces `Pick<Person,
+   "name">` by instantiating `Pick`'s body with the arguments and reducing the
+   result. That instantiate/expand step is M7 infrastructure.
+3. **Real stdlib types.** `Awaited<T>` needs the real `Promise<T>`; generators
+   need `Generator<Y, R, TNext>` / `AsyncGenerator<…>`; the utility-type suite is
+   checked against the real `.d.ts` shapes. M2 seeded opaque placeholders; M7
+   swaps in the real structures, and M9 follows so it can rely on them.
+
+The AST nodes M9 consumes already exist:
+[`KeyOfTypeAnn`](../../internal/ast/type_ann.go),
+[`IndexTypeAnn`](../../internal/ast/type_ann.go),
+[`CondTypeAnn`](../../internal/ast/type_ann.go),
+[`InferTypeAnn`](../../internal/ast/type_ann.go),
+[`MappedTypeAnn`](../../internal/ast/type_ann.go), and
+[`TemplateLitTypeAnn`](../../internal/ast/type_ann.go) are all defined and
+visitable. What is missing is the `soltype` representation, the reduction, and
+the `resolveTypeAnn` arms that today fall through to `reportUnsupported`.
+
+## Spike provenance
+
+The spike has already de-risked every hard part of M9. This plan promotes proven
+spike work rather than inventing it:
+
+- **Baseline-D operators** — [typeops.go](../../internal/simplesub/typeops.go):
+  the `TypeEvaluator` over `TyExpr`, reducing `keyof` / indexed access /
+  conditional-with-`infer` / union distribution when operands are ground, with
+  the cycle cache plus depth budget for recursive aliases.
+- **Design-A residual nodes** — [residual.go](../../internal/simplesub/residual.go):
+  an operator whose operand is usage-inferred stays an inert `ResidualOp` that
+  carries no bounds and is never touched by `constrain`, then reduces at
+  coalescing once its operand has a concrete shape. Its defining property is that
+  it adds **no new mutable solver state**.
+- **CheckRegular** — [regularity.go](../../internal/simplesub/regularity.go): the
+  optional level-2 static check that rejects *expanding* recursion at definition
+  time, accepting `List` / `Json` / `DeepPartial` and rejecting `Grow`.
+- **The lazy/coinductive alternative** — [lazy.go](../../internal/simplesub/lazy.go):
+  an Amadio–Cardelli seen-set that decides regular recursive subtyping with no
+  budget. M9 keeps the eager evaluator as the backbone and borrows the
+  coinductive seen-set only where recursive-vs-recursive comparison needs it.
+
+## What M9 adds (the delta)
+
+1. **A residual type-operator representation in `soltype`.** New inert nodes —
+   `KeyofType`, `IndexType`, `CondType` (with an `InferVar` binding form),
+   `MappedType`, `ObjectSpreadType`, `TupleSpreadType`, `TemplateLitType` — that
+   flow through `constrain` / `coalesce` / `extrude` / `LevelOf` / the visitor /
+   the printer without being touched, exactly as `ResidualOp` does in the spike.
+2. **A `TypeEvaluator`** with the two-part termination strategy (cycle cache keyed
+   on the `(alias, evaluated-args)` instantiation state, plus a depth budget) and
+   two invocation sites: **eager** at `resolveTypeAnn` when operands are ground,
+   and **post-coalesce** for operands that only ground after the value solve.
+3. **Per-operator reduction rules** for each node above, including distribution
+   over unions, `infer`-variable binding by structural match, mapped-type modifier
+   and `as`-remapping semantics, and the Flow-faithful object-spread union rule.
+4. **Exactness propagation through reduction** — the first milestone where
+   exactness is *computed by* an operator, not merely checked — plus the
+   `Exact<T>` / `Inexact<T>` intrinsics.
+5. **`CheckRegular`** as a definition-time diagnostic for expanding recursion.
+6. **`FuncType.Throws` and `FuncType.Yields` fields** with parallel arms in
+   `constrain` / `extrude` / `LevelOf` / the printer, plus per-body inference
+   variables that accumulate lowers from `throw e` / `yield e`.
+7. **The TS utility-type suite** (`Pick`, `Omit`, `Partial`, …, `Awaited`,
+   `Record`, `Capitalize`) as end-to-end verification, defined in Escalier and
+   asserted to match TS reductions.
+
+---
+
+## PR-by-PR breakdown
+
+Thirteen PRs across five tracks. Track A builds the evaluator and the core
+operators in dependency order. Track B adds spread and template-literal
+operators, which hang off the backbone but are independent of each other. Track C
+adds exactness propagation and the recursion static-check. Track D is the two
+function-signature effects, which touch `FuncType` and not the evaluator at all,
+so it runs fully in parallel with A–C. Track E is the capstone verification.
+
+### PR1 — Evaluator backbone + residual nodes + `keyof T`
+
+The load-bearing PR. Everything else hangs off it.
+
+**Data structures.**
+- `soltype`: add a residual operator node kind. The minimal set for this PR is
+  `KeyofType{Operand Type, exact bool}`, plus the shared inert-node contract:
+  `isType()`, a visitor arm ([soltype/visitor.go](../../internal/soltype/visitor.go)),
+  a printer arm rendering `keyof T` ([soltype/print.go](../../internal/soltype/print.go)),
+  and `LevelOf` returning the operand's level. Model the node on the spike's
+  `ResidualOp` ([residual.go](../../internal/simplesub/residual.go)) — it holds no
+  bounds and is never a `constrain` participant.
+- `solver`: a `TypeEvaluator` (new `internal/solver/typeops.go`) holding the alias
+  environment, the cycle cache (`map[instantiationKey]soltype.Type`), and the
+  depth budget. Promote the structure from
+  [typeops.go](../../internal/simplesub/typeops.go).
+
+**Algorithms.**
+- `reduce(t soltype.Type) soltype.Type` — the evaluator's core. Walks the operator
+  tree; an operator reduces only when every operand is **ground** (no unresolved
+  `TypeVarType`, no unreduced residual sub-operand). `keyof` reduction: project an
+  `ObjectType` / `ClassType` to the union of its key literal types; `keyof` of a
+  type variable or a not-yet-ground operand stays the residual `KeyofType`.
+- The **two-part termination strategy** (promoted verbatim from the spike): the
+  cycle cache emits a symbolic back-reference when an `(alias, args)` state
+  recurs, giving the finite knot for a regular recursive type; the depth budget is
+  the catch-all for unbounded growth.
+- **Two reduction sites.** Eager: `resolveTypeAnn` calls `reduce` on the operator
+  it builds, so a ground `keyof {…}` reduces immediately (Baseline-D). Post-solve:
+  a coalescing-time sweep reduces any residual whose operand has become concrete
+  (Design-A). Wire the sweep into [coalesce.go](../../internal/solver/coalesce.go)
+  at the point the spike marks — [coalesce.go:213](../../internal/simplesub/coalesce.go)
+  ("a type operator left inert during the value solve reduces here").
+- `constrain` / `extrude` inert arms: a residual node is passed through untouched,
+  never decomposed. This is the "adds no new mutable solver state" invariant.
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.KeyOfTypeAnn`
+([type_ann.go](../../internal/solver/type_ann.go)); prov recording; printer.
+
+**Accept.** `keyof {x: number, y: string}` ⇒ `"x" | "y"`; `keyof` over a
+usage-inferred operand (`fn f(x) { x.a; x.b; keyof typeof x }`) reduces to `"a" |
+"b"` post-solve; `keyof` of an operand that never gains structure stays symbolic.
+
+### PR2 — Indexed access `T[K]` + distribution over union keys
+
+**Data structures.** `soltype.IndexType{Target, Index Type, exact bool}` with the
+same inert-node contract as PR1.
+
+**Algorithms.**
+- Indexed-access reduction: `{…}[k]` looks up field `k`; a tuple `[…][n]` selects
+  element `n`; `T[keyof T]` yields the union of all value types.
+- **Distribution:** when `Index` reduces to a union, the access distributes —
+  `T["a" | "b"]` ⇒ `T["a"] | T["b"]`. This is the same distribute-over-union
+  mechanism conditionals reuse in PR3.
+- Errors carry typed `soltype.Type` references and assert full messages: an
+  out-of-range tuple index and an unknown object key each get their own
+  `SolverError` struct, modeled on [errors.go](../../internal/solver/errors.go).
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.IndexTypeAnn`.
+
+**Depends on** PR1 (evaluator + `keyof`, since `T[keyof T]` is the canonical
+combination).
+
+### PR3 — Conditional types `T extends U ? X : Y` + `infer` + distribution
+
+The other large operator. Kept as one PR because branch selection, `infer`
+binding, and distribution share the evaluator's structural matcher.
+
+**Data structures.**
+- `soltype.CondType{Check, Extends, Then, Else Type}`.
+- An `infer`-binding form: the evaluator's structural matcher records
+  `infer`-named positions into an environment, so `Then`/`Else` resolve against
+  the captured types. Promote `TyInfer` and the match machinery from
+  [typeops.go](../../internal/simplesub/typeops.go).
+
+**Algorithms.**
+- **Branch selection.** Decide `Check <: Extends` via an assignability probe —
+  reuse the M6 `probe` journal ([probe.go](../../internal/solver/probe.go)) so a
+  speculative match rolls back cleanly. Ground operands decide eagerly; a
+  non-ground `Check` stays a residual `CondType` reduced post-coalescing.
+- **`infer` binding by structural match.** Match `Check` against `Extends`
+  structurally, binding each `infer U` to the matched position — function
+  arg/return, tuple element, constructor return, promise payload. This is the
+  Baseline-D structural matcher from
+  [typeops.go:274](../../internal/simplesub/typeops.go).
+- **Distribution over naked-type-parameter unions.** When `Check` is a bare type
+  parameter bound to a union, the conditional distributes member-wise, matching TS
+  semantics. Share the distribute helper introduced in PR2.
+
+**Wiring.** `resolveTypeAnn` arms for `*ast.CondTypeAnn` and `*ast.InferTypeAnn`
+(the latter valid only inside a conditional's `extends` operand — reject
+elsewhere with a full-message error).
+
+**Depends on** PR1. Reuses PR2's distribute helper.
+
+### PR4 — Mapped types `{[K in Keys]: F<K>}`
+
+**Data structures.** `soltype.MappedType{Key string, Keys Type, Value Type,
+ReadonlyMod, OptionalMod Modifier, As Type}` where `Modifier` is
+`add | remove | none` mirroring [`ast.MappedModifier`](../../internal/ast/type_ann.go).
+
+**Algorithms.**
+- Reduction iterates the `Keys` union; for each key it binds `K`, reduces the
+  `Value` expression, and emits a field. The value position routinely uses indexed
+  access (`T[K]`), which is why this depends on PR2.
+- **Modifier application:** `readonly`/`?` add or remove with `+`/`-`, adjusting
+  each emitted field's mutability and optionality.
+- **Key remapping via `as`:** the `as` clause reduces per key; a key remapping to
+  `never` drops the field. `as`-filtering commonly uses a conditional (`as K
+  extends … ? K : never`), which is why this depends on PR3.
+- This is the machinery underlying `Pick` / `Omit` / `Partial` / `Required` /
+  `Readonly`, verified end-to-end in PR13.
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.MappedTypeAnn`
+([type_ann.go](../../internal/solver/type_ann.go)); the printer renders the mapped
+form.
+
+**Depends on** PR1 (`keyof` for `Keys`), PR2 (indexed access in the value
+position), PR3 (`as`-clause conditional key filtering).
+
+### PR5 — Object spread types `{...A, x: T}`
+
+First-class object spread types, modeled on Flow — TypeScript has no equivalent.
+
+**Data structures.** `soltype.ObjectSpreadType{Operands []Type}` where an operand
+is either a spread (`...A`) or an explicit field.
+
+**Algorithms.**
+- Reduction merges operands left to right, **rightmost field winning** on overlap;
+  stays residual when an operand is an abstract type parameter, reduced
+  post-coalescing.
+- **Flow-faithful optional-field show-through union.** When a later operand's
+  *optional* field overlaps an earlier key, the values **union** rather than
+  override. Required-in-earlier with optional-in-later yields `T | U` **required**;
+  optional with optional yields `(T | U)?`. Concretely, `{...A, ...B}` with `A =
+  {k: number}`, `B = {k?: string}` reduces to `k: number | string`, required.
+- **Exactness threads from the operand:** a spread of an inexact object is inexact
+  (the seed for PR9's propagation work).
+- Object rest/spread in **both literals and type annotations** lands here, not M4.
+  This PR adds the parser/AST support for object rest/spread if not already
+  present.
+
+**Wiring.** `resolveTypeAnn` arm for the object-spread annotation; literal-level
+object spread in `inferObj`.
+
+**Depends on** PR1. Independent of PR2–PR4.
+
+### PR6 — Tuple spread types `[...P, x]`
+
+The positional analogue of PR5.
+
+**Data structures.** `soltype.TupleSpreadType{Elems []TupleElem}` where an element
+is a spread or a positional type.
+
+**Algorithms.**
+- Reduction splices the operand tuple in when it grounds to a concrete tuple;
+  stays residual when the operand is an abstract type parameter, reduced
+  post-coalescing.
+- Distinct from a typed variadic tail like `[number, ...Array<number>]` — that
+  needs `Array` and is an M7 concern. M4 already handles the concrete *literal*
+  case (`[...pair, 3]` where `pair` is a known tuple); this PR adds only the
+  abstract-operand **type**.
+
+**Wiring.** `resolveTypeAnn` arm for the tuple-spread annotation.
+
+**Depends on** PR1. Independent of PR2–PR5.
+
+### PR7 — Template literal types + string intrinsics
+
+**Data structures.** `soltype.TemplateLitType{Quasis []string, Interps []Type}`.
+
+**Algorithms.**
+- Reduction takes the **cartesian product** over interpolated unions, producing a
+  union of string-literal types. `` `on${"a" | "b"}` `` ⇒ `"ona" | "onb"`.
+- The intrinsic string-manipulation operators `Uppercase` / `Lowercase` /
+  `Capitalize` / `Uncapitalize` reduce over string-literal operands and stay
+  residual over abstract ones.
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.TemplateLitTypeAnn`; the four
+intrinsics registered as built-in operators.
+
+**Depends on** PR1. Independent of PR2–PR6.
+
+### PR8 — Exactness propagation through operators + `Exact<T>` / `Inexact<T>`
+
+The first milestone where exactness must **propagate through reduction**, not just
+be checked. Builds on the exactness flag laid down in M3–M6
+([exact-types/requirements.md](../exact-types/requirements.md) §7).
+
+**Algorithms.** Thread exactness through every operator's reduction:
+- `keyof T` is exact iff `T`'s key set is exact.
+- `T[K]`, conditional results, mapped types, object spread, and template literals
+  each derive exactness from their inputs.
+- Add the `Exact<T>` / `Inexact<T>` intrinsics: `Exact<{x, ...}>` ⇒ `{x}`,
+  `Inexact<{x}>` ⇒ `{x, ...}`. They are themselves type operators, so they slot
+  into the evaluator.
+
+**Wiring.** Touches each operator's reduce arm from PR1–PR7 and the residual
+nodes' `exact` fields.
+
+**Depends on** PR1–PR7 (it threads exactness through every operator, so it lands
+once the operators exist).
+
+### PR9 — `CheckRegular` static regularity check
+
+**Algorithms.** Promote [regularity.go](../../internal/simplesub/regularity.go):
+an optional level-2 static check that rejects *expanding* recursion up front. An
+alias is flagged when a recursive reference into its strongly-connected component
+passes a formal parameter nested under a type constructor, so the parameter grows
+each lap and the reachable-instantiation set is infinite. It **accepts** regular
+recursion (`List`, `Json`, `DeepPartial` on `T[P]`, conditionals recursing on an
+`infer` binding) and **rejects** expanding recursion (`Grow<T> = Grow<Array<T>>`)
+with a precise definition-time diagnostic.
+
+The check is sound but incomplete — an expanding alias gated on a base-case
+conditional terminates yet is still rejected, since deciding otherwise is the
+halting problem — so the PR1 depth budget remains the runtime backstop. The two
+are complementary: a precise early error where decidable, safe termination always.
+
+**Data structures.** Operates over the alias dependency graph / SCCs
+([internal/dep_graph/](../../internal/dep_graph/)); no new `soltype` node.
+
+**Depends on** PR1 (evaluator + cycle cache) and PR3 (conditionals recursing on an
+`infer` binding are an accept case). Independent of PR4–PR8.
+
+### PR10 — `throws T` clause on functions
+
+Orthogonal to the evaluator. Touches only `FuncType` and the function-inference
+walk.
+
+**Data structures.** `soltype.FuncType` gains a `Throws Type` field
+([soltype/type.go:201](../../internal/soltype/type.go)), parallel to `Ret`,
+defaulting to `never` (⊥) when the source has no `throws` clause.
+
+**Algorithms.**
+- **Constraint engine, parallel arms** — the function arm in `constrain` recurses
+  `l.Throws <: r.Throws` (covariant); `extrude` recurses into `Throws` with the
+  same polarity as `Ret`; `LevelOf` takes the max of params, ret, and throws; the
+  printer renders `throws T` after the return type when `T` isn't `never`.
+- **Per-body throws inference variable** that accumulates lowers as `throw e`
+  statements and calls to throwing functions emit `constrain(thrown, throws_var)`.
+- **Throws polymorphism** falls out of M3's let-generalization with no special
+  handling — `E` in `<E>(f: () -> T throws E) -> T throws E` is just another
+  quantified variable.
+- **Open design question to resolve in this PR:** how `try`/`catch` narrows the
+  inferred throws of the body. The conservative starting point is the two-variable
+  encoding `body_throws <: surrounding_throws ∪ caught_throws`, which fits the
+  existing lattice. Integration with the checker's narrowing semantics is the
+  actual question to settle before implementation.
+
+**Depends on** M3 only (the function machinery, landed). Independent of the whole
+operator track — can start immediately.
+
+### PR11 — Generators (`gen fn` / `yield e` / `yield from g`)
+
+Same shape as `throws`; PR10's arms are the template.
+
+**Data structures.** `soltype.FuncType` gains a `Yields Type` field, covariant in
+subtyping, defaulting to `never`.
+
+**Algorithms.**
+- A `gen fn () -> R` is internally typed with body return `R` and a
+  yields-inference variable accumulating each `yield e`'s type as a lower;
+  externally the function's type is `Generator<Y, R, TNext>` — or
+  `AsyncGenerator<…>` for `async gen fn` — where `Y` is the coalesced yields
+  variable.
+- `yield e` requires no special constraint beyond `typeof(e) <: yields_var`; the
+  expression itself has type `TNext`.
+- `yield from g` requires `g <: Iterable<Y>` and forwards yields.
+- The constraint engine extends exactly as `throws` did: parallel arms in
+  `constrain` / `extrude` / `LevelOf` / the printer, no new lattice machinery.
+- `yield` outside a `gen` context is rejected by the AST walk, not the type rule.
+
+**Depends on** PR10 (the parallel-arm template), M7 (the real `Generator<…>` /
+`AsyncGenerator<…>` stdlib types). The async-gen + `Awaited<ReturnType<F>>` accept
+case additionally rides on PR3 and PR13.
+
+### PR12 — `Awaited<T>`
+
+`Awaited<T>` is a recursive conditional with `infer` that flattens nested
+promises. The milestone explicitly lands it here — M3 deliberately left
+`Promise<Promise<T>>` un-flattened, deferring the recursive flattening to this
+operator.
+
+**Algorithms.** Define `Awaited<T>` as the recursive conditional `T extends
+Promise<infer U> ? Awaited<U> : T`, reduced through the PR3 machinery with the PR1
+cycle-cache/budget termination protecting the recursion.
+
+**Depends on** PR3 (conditional + `infer`), PR1 (recursion termination), M7 (real
+`Promise<T>`). Separated from PR13 because it is a real feature the async story in
+PR11 depends on, not just a test.
+
+### PR13 — TS utility-type suite (end-to-end verification)
+
+The capstone. Mostly tests, defining each utility in Escalier and asserting its
+reduction matches TS:
+
+- `Pick<T, K>`, `Omit<T, K>` — mapped + indexed access + key filtering via
+  conditional `K extends …`.
+- `Partial<T>`, `Required<T>`, `Readonly<T>` — mapped-type modifiers.
+- `Exclude<U, V>`, `Extract<U, V>`, `NonNullable<T>` — distributive conditional.
+- `ReturnType<F>`, `Parameters<F>`, `ConstructorParameters<F>`, `InstanceType<C>`
+  — conditional + `infer`.
+- `Record<K, V>` — mapped over a key union.
+- `Capitalize` / `Uncapitalize` / `Uppercase` / `Lowercase` and a small
+  template-literal case (`EventName<K>` ⇒ `` `on${Capitalize<K>}` ``).
+
+**Depends on** PR2, PR3, PR4, PR7, PR12. Verifies the whole operator suite
+composes.
+
+---
+
+## Sizing note
+
+Each PR is scoped to a single reviewable concern. PR1 and PR3 are the two largest
+— the evaluator backbone and the conditional/`infer` matcher — and are the natural
+places to split further if review demands it (PR1 into "residual nodes +
+constrain/coalesce inert arms" then "evaluator + `keyof`"; PR3 into "branch
+selection" then "`infer` binding + distribution"). The remaining PRs are each a
+single operator or a single function-signature effect, sized comparably to a
+typical M4/M6 PR. PR10 and PR11 touch only `FuncType` and never the evaluator, so
+they carry no operator-track review burden.
+
+## Dependency graph
+
+```
+M7 (aliases + generics + real stdlib, prerequisite)
+ │
+ ├─► PR1 (evaluator backbone + residual nodes + keyof)
+ │    ├─► PR2 (indexed access T[K] + union-key distribution)
+ │    │    └─► PR4 (mapped types)              ── also needs PR1, PR3
+ │    ├─► PR3 (conditional types + infer + distribution)
+ │    │    ├─► PR4 (mapped types)
+ │    │    ├─► PR9 (CheckRegular)              ── also needs PR1
+ │    │    └─► PR12 (Awaited<T>)               ── also needs PR1, M7
+ │    ├─► PR5 (object spread types)
+ │    ├─► PR6 (tuple spread types)
+ │    ├─► PR7 (template literal types + intrinsics)
+ │    └─► PR8 (exactness propagation + Exact/Inexact)  ── needs PR1–PR7
+ │
+ ├─► PR10 (throws clause)                      ── needs M3 only; parallel to A–C
+ │    └─► PR11 (generators)                    ── also needs M7 (+PR3/PR12 for the async-gen accept case)
+ │
+ └─► PR13 (TS utility-type suite)              ── needs PR2, PR3, PR4, PR7, PR12
+```
+
+The same graph in mermaid, with the operator-track critical path
+(PR1 → PR3 → PR4 → PR8) highlighted and the landed `M7` prerequisite dashed:
+
+```mermaid
+graph TD
+    M7["M7 (aliases + generics + real stdlib)"]
+    PR1["PR1 (evaluator backbone + residual nodes + keyof)"]
+    PR2["PR2 (indexed access T[K] + distribution)"]
+    PR3["PR3 (conditional types + infer + distribution)"]
+    PR4["PR4 (mapped types)"]
+    PR5["PR5 (object spread types)"]
+    PR6["PR6 (tuple spread types)"]
+    PR7["PR7 (template literal types + intrinsics)"]
+    PR8["PR8 (exactness propagation + Exact/Inexact)"]
+    PR9["PR9 (CheckRegular static check)"]
+    PR10["PR10 (throws clause)"]
+    PR11["PR11 (generators)"]
+    PR12["PR12 (Awaited<T>)"]
+    PR13["PR13 (TS utility-type suite)"]
+
+    M7 -.-> PR1
+    M7 -.-> PR11
+    M7 -.-> PR12
+
+    PR1 --> PR2
+    PR1 --> PR3
+    PR1 --> PR5
+    PR1 --> PR6
+    PR1 --> PR7
+    PR1 --> PR8
+    PR1 --> PR9
+    PR1 --> PR12
+    PR2 --> PR4
+    PR2 --> PR13
+    PR3 --> PR4
+    PR3 --> PR9
+    PR3 --> PR12
+    PR3 --> PR13
+    PR4 --> PR8
+    PR4 --> PR13
+    PR5 --> PR8
+    PR6 --> PR8
+    PR7 --> PR8
+    PR7 --> PR13
+    PR10 --> PR11
+    PR11 --> PR13
+    PR12 --> PR13
+
+    linkStyle default stroke:#888
+    style PR1 fill:#e06666,stroke:#333,color:#fff
+    style PR3 fill:#e06666,stroke:#333,color:#fff
+    style PR4 fill:#e06666,stroke:#333,color:#fff
+    style PR8 fill:#e06666,stroke:#333,color:#fff
+```
+
+### Parallelism
+
+- **Track A** (PR1 → PR2/PR3 → PR4, plus PR5/PR6/PR7 hanging directly off PR1) is
+  the operator core. PR5, PR6, and PR7 are mutually independent and can be built
+  concurrently once PR1 lands.
+- **Track C** — PR8 (exactness) is a barrier that waits for all operators; PR9
+  (CheckRegular) needs only PR1 + PR3 and runs alongside PR4–PR8.
+- **Track D** — PR10 (throws) has no operator dependency and can start on day one
+  alongside PR1; PR11 (generators) follows PR10.
+- **Track E** — PR13 is the final join, waiting on PR2, PR3, PR4, PR7, PR12.
+
+The critical path is `M7 → PR1 → PR3 → PR4 → PR8`, and — for the async-generator
+accept case — `M7 → PR1 → PR3 → PR12 → PR13`.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -562,6 +562,7 @@ graph TD
     PR3b --> PR9
     PR1b --> PR9
     PR3b --> PR12
+    PR1b --> PR12
     PR3b --> PR13
     PR4 --> PR8
     PR4 --> PR13

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -29,26 +29,30 @@ over already-formed types, with no inference variables in their results. The
 milestone's job is to represent them, reduce them, and thread exactness through
 the reduction.
 
-## Prerequisite: M7 must land first
+## Prerequisites: M7 and M7.5 must land first
 
-M9 builds directly on **M7 — Library type resolution**. Three M7 deliverables are
-hard prerequisites:
+M9 builds directly on **M7 — Type aliases** and **M7.5 — Library type
+resolution**. Three deliverables across those two milestones are hard
+prerequisites:
 
-1. **A generic type-alias representation in `soltype`.** Today `soltype` has no
-   alias node at all — [infer_enum.go:13](../../internal/solver/infer_enum.go)
+1. **A generic type-alias representation in `soltype` (M7).** Today `soltype` has
+   no alias node at all — [infer_enum.go:12-17](../../internal/solver/infer_enum.go)
    records "soltype has no type aliases yet (M7)", and
    [type_ann.go:21](../../internal/solver/type_ann.go) resolves only the single
    hardcoded `Promise<T>` reference, reporting every other `TypeRefTypeAnn` as
    unsupported. M9's operators are almost always written *as* generic aliases
    (`type Pick<T, K> = ...`), so the alias node, its type parameters, and
-   scope-driven `TypeRef` resolution must exist first.
-2. **Alias instantiation and expansion.** The evaluator reduces `Pick<Person,
+   scope-driven `TypeRef` resolution must exist first. M7 adds them.
+2. **Alias instantiation and expansion (M7).** The evaluator reduces `Pick<Person,
    "name">` by instantiating `Pick`'s body with the arguments and reducing the
    result. That instantiate/expand step is M7 infrastructure.
-3. **Real stdlib types.** `Awaited<T>` needs the real `Promise<T>`; generators
-   need `Generator<Y, R, TNext>` / `AsyncGenerator<…>`; the utility-type suite is
-   checked against the real `.d.ts` shapes. M2 seeded opaque placeholders; M7
-   swaps in the real structures, and M9 follows so it can rely on them.
+3. **Real stdlib types (M7.5).** `Awaited<T>` needs the real `Promise<T>`;
+   generators need `Generator<Y, R, TNext>` / `AsyncGenerator<…>`; the
+   utility-type suite is checked against the real `.d.ts` shapes. Since M7.5 is
+   import-only — there is no ambient global lib — the utility definitions and
+   tests import these names from `std:*` / `web:*` / `node:*`. M2 seeded opaque
+   placeholders; M7.5 swaps in the real structures, and M9 follows so it can rely
+   on them.
 
 The AST nodes M9 consumes already exist:
 [`KeyOfTypeAnn`](../../internal/ast/type_ann.go),
@@ -277,7 +281,7 @@ is a spread or a positional type.
   stays residual when the operand is an abstract type parameter, reduced
   post-coalescing.
 - Distinct from a typed variadic tail like `[number, ...Array<number>]` — that
-  needs `Array` and is an M7 concern. M4 already handles the concrete *literal*
+  needs `Array` and is an M7.5 concern. M4 already handles the concrete *literal*
   case (`[...pair, 3]` where `pair` is a known tuple); this PR adds only the
   abstract-operand **type**.
 
@@ -391,7 +395,7 @@ subtyping, defaulting to `never`.
   `constrain` / `extrude` / `LevelOf` / the printer, no new lattice machinery.
 - `yield` outside a `gen` context is rejected by the AST walk, not the type rule.
 
-**Depends on** PR10 (the parallel-arm template), M7 (the real `Generator<…>` /
+**Depends on** PR10 (the parallel-arm template), M7.5 (the real `Generator<…>` /
 `AsyncGenerator<…>` stdlib types). The async-gen + `Awaited<ReturnType<F>>` accept
 case additionally rides on PR3 and PR13.
 
@@ -406,9 +410,9 @@ operator.
 Promise<infer U> ? Awaited<U> : T`, reduced through the PR3 machinery with the PR1
 cycle-cache/budget termination protecting the recursion.
 
-**Depends on** PR3 (conditional + `infer`), PR1 (recursion termination), M7 (real
-`Promise<T>`). Separated from PR13 because it is a real feature the async story in
-PR11 depends on, not just a test.
+**Depends on** PR3 (conditional + `infer`), PR1 (recursion termination), M7.5
+(real `Promise<T>`). Separated from PR13 because it is a real feature the async
+story in PR11 depends on, not just a test.
 
 ### PR13 — TS utility-type suite (end-to-end verification)
 
@@ -444,32 +448,35 @@ they carry no operator-track review burden.
 ## Dependency graph
 
 ```
-M7 (aliases + generics + real stdlib, prerequisite)
- │
- ├─► PR1 (evaluator backbone + residual nodes + keyof)
- │    ├─► PR2 (indexed access T[K] + union-key distribution)
- │    │    └─► PR4 (mapped types)              ── also needs PR1, PR3
- │    ├─► PR3 (conditional types + infer + distribution)
- │    │    ├─► PR4 (mapped types)
- │    │    ├─► PR9 (CheckRegular)              ── also needs PR1
- │    │    └─► PR12 (Awaited<T>)               ── also needs PR1, M7
- │    ├─► PR5 (object spread types)
- │    ├─► PR6 (tuple spread types)
- │    ├─► PR7 (template literal types + intrinsics)
- │    └─► PR8 (exactness propagation + Exact/Inexact)  ── needs PR1–PR7
- │
- ├─► PR10 (throws clause)                      ── needs M3 only; parallel to A–C
- │    └─► PR11 (generators)                    ── also needs M7 (+PR3/PR12 for the async-gen accept case)
- │
- └─► PR13 (TS utility-type suite)              ── needs PR2, PR3, PR4, PR7, PR12
+M7   (type aliases: alias node + generics + scope-driven TypeRef)  ──► PR1
+M7.5 (library type resolution: real stdlib types, import-only)     ──► PR11, PR12
+
+PR1 (evaluator backbone + residual nodes + keyof)
+ ├─► PR2 (indexed access T[K] + union-key distribution)
+ │    └─► PR4 (mapped types)              ── also needs PR1, PR3
+ ├─► PR3 (conditional types + infer + distribution)
+ │    ├─► PR4 (mapped types)
+ │    ├─► PR9 (CheckRegular)              ── also needs PR1
+ │    └─► PR12 (Awaited<T>)               ── also needs PR1, M7.5
+ ├─► PR5 (object spread types)
+ ├─► PR6 (tuple spread types)
+ ├─► PR7 (template literal types + intrinsics)
+ └─► PR8 (exactness propagation + Exact/Inexact)  ── needs PR1–PR7
+
+PR10 (throws clause)                      ── needs M3 only; parallel to everything
+ └─► PR11 (generators)                    ── also needs M7.5 (+PR3/PR12 for the async-gen accept case)
+
+PR13 (TS utility-type suite)              ── needs PR2, PR3, PR4, PR7, PR12
 ```
 
 The same graph in mermaid, with the operator-track critical path
-(PR1 → PR3 → PR4 → PR8) highlighted and the landed `M7` prerequisite dashed:
+(PR1 → PR3 → PR4 → PR8) highlighted and the landed `M7` / `M7.5` prerequisites
+dashed:
 
 ```mermaid
 graph TD
-    M7["M7 (aliases + generics + real stdlib)"]
+    M7["M7 (type aliases)"]
+    M75["M7.5 (library type resolution: real stdlib, import-only)"]
     PR1["PR1 (evaluator backbone + residual nodes + keyof)"]
     PR2["PR2 (indexed access T[K] + distribution)"]
     PR3["PR3 (conditional types + infer + distribution)"]
@@ -485,8 +492,8 @@ graph TD
     PR13["PR13 (TS utility-type suite)"]
 
     M7 -.-> PR1
-    M7 -.-> PR11
-    M7 -.-> PR12
+    M75 -.-> PR11
+    M75 -.-> PR12
 
     PR1 --> PR2
     PR1 --> PR3

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -56,13 +56,19 @@ prerequisites:
 
 The AST nodes M9 consumes already exist:
 [`KeyOfTypeAnn`](../../internal/ast/type_ann.go),
+[`TypeOfTypeAnn`](../../internal/ast/type_ann.go),
 [`IndexTypeAnn`](../../internal/ast/type_ann.go),
 [`CondTypeAnn`](../../internal/ast/type_ann.go),
 [`InferTypeAnn`](../../internal/ast/type_ann.go),
-[`MappedTypeAnn`](../../internal/ast/type_ann.go), and
-[`TemplateLitTypeAnn`](../../internal/ast/type_ann.go) are all defined and
+[`MappedTypeAnn`](../../internal/ast/type_ann.go),
+[`TemplateLitTypeAnn`](../../internal/ast/type_ann.go), and
+[`IntrinsicTypeAnn`](../../internal/ast/type_ann.go) are all defined and
 visitable. What is missing is the `soltype` representation, the reduction, and
-the `resolveTypeAnn` arms that today fall through to `reportUnsupported`.
+the `resolveTypeAnn` arms that today fall through to `reportUnsupported`. Two
+sibling annotation nodes are **out of scope** and stay unsupported: `MatchTypeAnn`
+(the `match`-type surface the old checker never lowered — an alternative to
+`CondTypeAnn`, not a parity gap) and `ImportTypeAnn` (`import("mod").T`, also
+unsupported in the old checker; real imports cover the need).
 
 ## Spike provenance
 
@@ -99,15 +105,19 @@ spike work rather than inventing it:
    and **post-coalesce** for operands that only ground after the value solve.
 3. **Per-operator reduction rules** for each node above, including distribution
    over unions, `infer`-variable binding by structural match, mapped-type modifier
-   and `as`-remapping semantics, and the Flow-faithful object-spread union rule.
-4. **Exactness propagation through reduction** — the first milestone where
+   and `as`-remapping semantics, the Flow-faithful object-spread union rule, and
+   the `IndexSignatureElem` a primitive-key mapped type reduces to.
+4. **`typeof v` type queries**, resolved at annotation time against the value scope
+   (not a residual), porting the old checker's `resolveTypeOfQualIdent` — the
+   value→type bridge `keyof typeof x` needs.
+5. **Exactness propagation through reduction** — the first milestone where
    exactness is *computed by* an operator, not merely checked — plus the
    `Exact<T>` / `Inexact<T>` intrinsics.
-5. **`CheckRegular`** as a definition-time diagnostic for expanding recursion.
-6. **`FuncType.Throws` and `FuncType.Yields` fields** with parallel arms in
+6. **`CheckRegular`** as a definition-time diagnostic for expanding recursion.
+7. **`FuncType.Throws` and `FuncType.Yields` fields** with parallel arms in
    `constrain` / `extrude` / `LevelOf` / the printer, plus per-body inference
    variables that accumulate lowers from `throw e` / `yield e`.
-7. **The TS utility-type suite** (`Pick`, `Omit`, `Partial`, …, `Awaited`,
+8. **The TS utility-type suite** (`Pick`, `Omit`, `Partial`, …, `Awaited`,
    `Record`, `Capitalize`) as end-to-end verification, defined in Escalier and
    asserted to match TS reductions.
 
@@ -150,9 +160,18 @@ through the solver untouched, before any evaluator exists to reduce it.
 ([type_ann.go](../../internal/solver/type_ann.go)) that builds the **unreduced**
 residual node; prov recording; printer.
 
+**`typeof v` type queries land here too.** `typeof v` is the value→type bridge the
+canonical `keyof typeof x` relies on, so it lands alongside the `keyof` wiring. It
+is **not** a residual — a `resolveTypeAnn` arm for the `typeof` annotation looks the
+name up in the **value** scope, walks any member chain (`typeof p.x`), and returns
+that value's type directly, porting the old checker's `resolveTypeOfQualIdent`
+([expand_type.go](../../internal/checker/expand_type.go)). No reduction, no residual
+node — a resolution-time lookup.
+
 **Accept.** `keyof T` for a type parameter `T` round-trips as a residual — renders
 `keyof T` and flows through `constrain` / `coalesce` without being decomposed or
-crashing. No reduction yet; that is PR1b.
+crashing (no reduction yet; that is PR1b). `typeof v` for a `val v = {a: 1}`
+resolves to `{a: number}` at annotation time.
 
 **Depends on** M7 (the alias representation the residual's operand may name).
 
@@ -169,9 +188,14 @@ The algorithm half: the evaluator that reduces the PR1a node.
 **Algorithms.**
 - `reduce(t soltype.Type) soltype.Type` — the evaluator's core. Walks the operator
   tree; an operator reduces only when every operand is **ground** (no unresolved
-  `TypeVarType`, no unreduced residual sub-operand). `keyof` reduction: project an
-  `ObjectType` / `ClassType` to the union of its key literal types; `keyof` of a
-  type variable or a not-yet-ground operand stays the residual `KeyofType`.
+  `TypeVarType`, no unreduced residual sub-operand). `keyof` reduction matches the
+  old checker's `KeyOfType` case
+  ([expand_type.go](../../internal/checker/expand_type.go)): an `ObjectType` /
+  `ClassType` projects its property/getter/setter keys and folds in an index
+  signature's key type; a `TupleType` yields its numeric indices plus `"length"`;
+  `keyof` distributes over a union or intersection target; `keyof` of a primitive
+  or `never` / `unknown` is `never`; and `keyof` of a type variable or a
+  not-yet-ground operand stays the residual `KeyofType`.
 - The **two-part termination strategy** (promoted verbatim from the spike): the
   cycle cache emits a symbolic back-reference when an `(alias, args)` state
   recurs, giving the finite knot for a regular recursive type; the depth budget is
@@ -197,7 +221,9 @@ same inert-node contract as PR1a.
 
 **Algorithms.**
 - Indexed-access reduction: `{…}[k]` looks up field `k`; a tuple `[…][n]` selects
-  element `n`; `T[keyof T]` yields the union of all value types.
+  element `n`; `T[keyof T]` yields the union of all value types; an object carrying
+  an index signature (PR4) resolves a primitive-typed `K` to the signature's value
+  type.
 - **Distribution:** when `Index` reduces to a union, the access distributes —
   `T["a" | "b"]` ⇒ `T["a"] | T["b"]`. This is the same distribute-over-union
   mechanism conditionals reuse in PR3b.
@@ -275,12 +301,23 @@ ReadonlyMod, OptionalMod Modifier, As Type}` where `Modifier` is
   `never` drops the field. `as`-filtering commonly uses a conditional (`as K
   extends … ? K : never`) — branch selection, not `infer` — which is why this
   depends on PR3a.
+- **Index signatures.** A mapped type over a **primitive** key constraint
+  (`{[k in string]: T}`) reduces to an `IndexSignatureElem`, the old checker's
+  representation ([type_system/types.go](../../internal/type_system/types.go)) that
+  a literal-key map cannot express. This PR adds that element to
+  `soltype.ObjectType`. Escalier has no hand-written `{[k: string]: T}` syntax, so
+  mapped-type reduction is the *only* source of one in user code; `keyof` and
+  indexed access (PR1b, PR2) already read it. It also lands the dynamic-key read
+  inference (`recv[i]` against a non-tuple receiver) that M7.5 deferred here: a
+  primitive key resolves through the index signature rather than a positional slot.
+  Library types under `web:dom` / `std:*` carry index signatures, so M7.5 ingestion
+  relies on this representation existing.
 - This is the machinery underlying `Pick` / `Omit` / `Partial` / `Required` /
-  `Readonly`, verified end-to-end in PR13.
+  `Readonly` / `Record`, verified end-to-end in PR13.
 
 **Wiring.** `resolveTypeAnn` arm for `*ast.MappedTypeAnn`
 ([type_ann.go](../../internal/solver/type_ann.go)); the printer renders the mapped
-form.
+and index-signature forms.
 
 **Depends on** PR1b (`keyof` for `Keys`), PR2 (indexed access in the value
 position), PR3a (`as`-clause conditional key filtering).
@@ -471,6 +508,15 @@ reduction matches TS:
 - `Record<K, V>` — mapped over a key union.
 - `Capitalize` / `Uncapitalize` / `Uppercase` / `Lowercase` and a small
   template-literal case (`EventName<K>` ⇒ `` `on${Capitalize<K>}` ``).
+
+**Provisioning under the no-ambient model.** The old checker inherits these
+utilities from the bundled TypeScript `lib.es*.d.ts`, resolved as ambient globals.
+M7.5 has no ambient lib, so the same definitions — ordinary generic aliases built
+from the M9 operators — ship as **importable** stdlib declarations a user pulls
+from a `std:*` module. This PR's Escalier definitions are both the verification
+corpus *and* the source of those shipped declarations; the operators PR1b–PR12
+land are what make them reduce. So M9 does not just verify the utilities, it makes
+them expressible at all under import-only resolution.
 
 **Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -115,25 +115,52 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Thirteen PRs across five tracks. Track A builds the evaluator and the core
+Fifteen PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the two
 function-signature effects, which touch `FuncType` and not the evaluator at all,
 so it runs fully in parallel with A–C. Track E is the capstone verification.
 
-### PR1 — Evaluator backbone + residual nodes + `keyof T`
+The two heaviest concerns — the evaluator backbone and the conditional/`infer`
+matcher — are each split in two so no single PR carries both a new representation
+and a new algorithm: PR1a/PR1b and PR3a/PR3b below.
 
-The load-bearing PR. Everything else hangs off it.
+### PR1a — Residual-node representation + inert plumbing
+
+The representation half of the backbone: a residual operator node that flows
+through the solver untouched, before any evaluator exists to reduce it.
 
 **Data structures.**
-- `soltype`: add a residual operator node kind. The minimal set for this PR is
+- `soltype`: add a residual operator node kind, starting with
   `KeyofType{Operand Type, exact bool}`, plus the shared inert-node contract:
   `isType()`, a visitor arm ([soltype/visitor.go](../../internal/soltype/visitor.go)),
   a printer arm rendering `keyof T` ([soltype/print.go](../../internal/soltype/print.go)),
   and `LevelOf` returning the operand's level. Model the node on the spike's
   `ResidualOp` ([residual.go](../../internal/simplesub/residual.go)) — it holds no
   bounds and is never a `constrain` participant.
+
+**Algorithms.**
+- **Inert arms in `constrain` / `extrude` / `coalesce`.** A residual node is passed
+  through untouched, never decomposed — the "adds no new mutable solver state"
+  invariant. This is the plumbing every later operator relies on; landing it alone,
+  with one node kind, keeps the diff to the hot paths small and reviewable.
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.KeyOfTypeAnn`
+([type_ann.go](../../internal/solver/type_ann.go)) that builds the **unreduced**
+residual node; prov recording; printer.
+
+**Accept.** `keyof T` for a type parameter `T` round-trips as a residual — renders
+`keyof T` and flows through `constrain` / `coalesce` without being decomposed or
+crashing. No reduction yet; that is PR1b.
+
+**Depends on** M7 (the alias representation the residual's operand may name).
+
+### PR1b — Evaluator backbone + `keyof` reduction
+
+The algorithm half: the evaluator that reduces the PR1a node.
+
+**Data structures.**
 - `solver`: a `TypeEvaluator` (new `internal/solver/typeops.go`) holding the alias
   environment, the cycle cache (`map[instantiationKey]soltype.Type`), and the
   depth budget. Promote the structure from
@@ -148,60 +175,73 @@ The load-bearing PR. Everything else hangs off it.
 - The **two-part termination strategy** (promoted verbatim from the spike): the
   cycle cache emits a symbolic back-reference when an `(alias, args)` state
   recurs, giving the finite knot for a regular recursive type; the depth budget is
-  the catch-all for unbounded growth.
+  the catch-all for unbounded growth. This is where `reduce` becomes safe over a
+  recursive alias; `CheckRegular` (PR9) later rejects the expanding cases up front.
 - **Two reduction sites.** Eager: `resolveTypeAnn` calls `reduce` on the operator
   it builds, so a ground `keyof {…}` reduces immediately (Baseline-D). Post-solve:
   a coalescing-time sweep reduces any residual whose operand has become concrete
   (Design-A). Wire the sweep into [coalesce.go](../../internal/solver/coalesce.go)
   at the point the spike marks — [coalesce.go:213](../../internal/simplesub/coalesce.go)
   ("a type operator left inert during the value solve reduces here").
-- `constrain` / `extrude` inert arms: a residual node is passed through untouched,
-  never decomposed. This is the "adds no new mutable solver state" invariant.
-
-**Wiring.** `resolveTypeAnn` arm for `*ast.KeyOfTypeAnn`
-([type_ann.go](../../internal/solver/type_ann.go)); prov recording; printer.
 
 **Accept.** `keyof {x: number, y: string}` ⇒ `"x" | "y"`; `keyof` over a
 usage-inferred operand (`fn f(x) { x.a; x.b; keyof typeof x }`) reduces to `"a" |
 "b"` post-solve; `keyof` of an operand that never gains structure stays symbolic.
 
+**Depends on** PR1a (the node and its inert plumbing).
+
 ### PR2 — Indexed access `T[K]` + distribution over union keys
 
 **Data structures.** `soltype.IndexType{Target, Index Type, exact bool}` with the
-same inert-node contract as PR1.
+same inert-node contract as PR1a.
 
 **Algorithms.**
 - Indexed-access reduction: `{…}[k]` looks up field `k`; a tuple `[…][n]` selects
   element `n`; `T[keyof T]` yields the union of all value types.
 - **Distribution:** when `Index` reduces to a union, the access distributes —
   `T["a" | "b"]` ⇒ `T["a"] | T["b"]`. This is the same distribute-over-union
-  mechanism conditionals reuse in PR3.
+  mechanism conditionals reuse in PR3b.
 - Errors carry typed `soltype.Type` references and assert full messages: an
   out-of-range tuple index and an unknown object key each get their own
   `SolverError` struct, modeled on [errors.go](../../internal/solver/errors.go).
 
 **Wiring.** `resolveTypeAnn` arm for `*ast.IndexTypeAnn`.
 
-**Depends on** PR1 (evaluator + `keyof`, since `T[keyof T]` is the canonical
+**Depends on** PR1b (evaluator + `keyof`, since `T[keyof T]` is the canonical
 combination).
 
-### PR3 — Conditional types `T extends U ? X : Y` + `infer` + distribution
+### PR3a — Conditional types: branch selection
 
-The other large operator. Kept as one PR because branch selection, `infer`
-binding, and distribution share the evaluator's structural matcher.
+The subtyping-decision half of conditionals, without `infer` or distribution.
 
-**Data structures.**
-- `soltype.CondType{Check, Extends, Then, Else Type}`.
-- An `infer`-binding form: the evaluator's structural matcher records
-  `infer`-named positions into an environment, so `Then`/`Else` resolve against
-  the captured types. Promote `TyInfer` and the match machinery from
-  [typeops.go](../../internal/simplesub/typeops.go).
+**Data structures.** `soltype.CondType{Check, Extends, Then, Else Type}`, an inert
+residual node with the PR1a contract.
 
 **Algorithms.**
 - **Branch selection.** Decide `Check <: Extends` via an assignability probe —
   reuse the M6 `probe` journal ([probe.go](../../internal/solver/probe.go)) so a
-  speculative match rolls back cleanly. Ground operands decide eagerly; a
-  non-ground `Check` stays a residual `CondType` reduced post-coalescing.
+  speculative match rolls back cleanly. Ground operands decide eagerly and reduce
+  to `Then` or `Else`; a non-ground `Check` stays a residual `CondType` reduced
+  post-coalescing.
+
+**Wiring.** `resolveTypeAnn` arm for `*ast.CondTypeAnn` whose `extends` operand
+holds no `infer`; an `*ast.InferTypeAnn` reports unsupported until PR3b.
+
+**Accept.** `T extends string ? A : B` with a ground `T` reduces to the matching
+branch; a non-ground `T` stays a residual `CondType` that reduces post-coalescing.
+
+**Depends on** PR1b.
+
+### PR3b — `infer` clauses + distribution
+
+The structural-matcher half: the part that makes conditionals extract types.
+
+**Data structures.** An `infer`-binding form: the evaluator's structural matcher
+records `infer`-named positions into an environment, so `Then`/`Else` resolve
+against the captured types. Promote `TyInfer` and the match machinery from
+[typeops.go](../../internal/simplesub/typeops.go).
+
+**Algorithms.**
 - **`infer` binding by structural match.** Match `Check` against `Extends`
   structurally, binding each `infer U` to the matched position — function
   arg/return, tuple element, constructor return, promise payload. This is the
@@ -211,11 +251,13 @@ binding, and distribution share the evaluator's structural matcher.
   parameter bound to a union, the conditional distributes member-wise, matching TS
   semantics. Share the distribute helper introduced in PR2.
 
-**Wiring.** `resolveTypeAnn` arms for `*ast.CondTypeAnn` and `*ast.InferTypeAnn`
-(the latter valid only inside a conditional's `extends` operand — reject
-elsewhere with a full-message error).
+**Wiring.** `resolveTypeAnn` arm for `*ast.InferTypeAnn` (valid only inside a
+conditional's `extends` operand — reject elsewhere with a full-message error).
 
-**Depends on** PR1. Reuses PR2's distribute helper.
+**Accept.** `T extends (infer U)[] ? U : never` binds `U` to the element type; a
+naked type-parameter union distributes member-wise.
+
+**Depends on** PR3a. Reuses PR2's distribute helper.
 
 ### PR4 — Mapped types `{[K in Keys]: F<K>}`
 
@@ -231,7 +273,8 @@ ReadonlyMod, OptionalMod Modifier, As Type}` where `Modifier` is
   each emitted field's mutability and optionality.
 - **Key remapping via `as`:** the `as` clause reduces per key; a key remapping to
   `never` drops the field. `as`-filtering commonly uses a conditional (`as K
-  extends … ? K : never`), which is why this depends on PR3.
+  extends … ? K : never`) — branch selection, not `infer` — which is why this
+  depends on PR3a.
 - This is the machinery underlying `Pick` / `Omit` / `Partial` / `Required` /
   `Readonly`, verified end-to-end in PR13.
 
@@ -239,8 +282,8 @@ ReadonlyMod, OptionalMod Modifier, As Type}` where `Modifier` is
 ([type_ann.go](../../internal/solver/type_ann.go)); the printer renders the mapped
 form.
 
-**Depends on** PR1 (`keyof` for `Keys`), PR2 (indexed access in the value
-position), PR3 (`as`-clause conditional key filtering).
+**Depends on** PR1b (`keyof` for `Keys`), PR2 (indexed access in the value
+position), PR3a (`as`-clause conditional key filtering).
 
 ### PR5 — Object spread types `{...A, x: T}`
 
@@ -267,7 +310,7 @@ is either a spread (`...A`) or an explicit field.
 **Wiring.** `resolveTypeAnn` arm for the object-spread annotation; literal-level
 object spread in `inferObj`.
 
-**Depends on** PR1. Independent of PR2–PR4.
+**Depends on** PR1b. Independent of PR2–PR4.
 
 ### PR6 — Tuple spread types `[...P, x]`
 
@@ -287,7 +330,7 @@ is a spread or a positional type.
 
 **Wiring.** `resolveTypeAnn` arm for the tuple-spread annotation.
 
-**Depends on** PR1. Independent of PR2–PR5.
+**Depends on** PR1b. Independent of PR2–PR5.
 
 ### PR7 — Template literal types + string intrinsics
 
@@ -303,7 +346,7 @@ is a spread or a positional type.
 **Wiring.** `resolveTypeAnn` arm for `*ast.TemplateLitTypeAnn`; the four
 intrinsics registered as built-in operators.
 
-**Depends on** PR1. Independent of PR2–PR6.
+**Depends on** PR1b. Independent of PR2–PR6.
 
 ### PR8 — Exactness propagation through operators + `Exact<T>` / `Inexact<T>`
 
@@ -319,10 +362,10 @@ be checked. Builds on the exactness flag laid down in M3–M6
   `Inexact<{x}>` ⇒ `{x, ...}`. They are themselves type operators, so they slot
   into the evaluator.
 
-**Wiring.** Touches each operator's reduce arm from PR1–PR7 and the residual
+**Wiring.** Touches each operator's reduce arm from PR1b–PR7 and the residual
 nodes' `exact` fields.
 
-**Depends on** PR1–PR7 (it threads exactness through every operator, so it lands
+**Depends on** PR1b–PR7 (it threads exactness through every operator, so it lands
 once the operators exist).
 
 ### PR9 — `CheckRegular` static regularity check
@@ -338,14 +381,14 @@ with a precise definition-time diagnostic.
 
 The check is sound but incomplete — an expanding alias gated on a base-case
 conditional terminates yet is still rejected, since deciding otherwise is the
-halting problem — so the PR1 depth budget remains the runtime backstop. The two
+halting problem — so the PR1b depth budget remains the runtime backstop. The two
 are complementary: a precise early error where decidable, safe termination always.
 
 **Data structures.** Operates over the alias dependency graph / SCCs
 ([internal/dep_graph/](../../internal/dep_graph/)); no new `soltype` node.
 
-**Depends on** PR1 (evaluator + cycle cache) and PR3 (conditionals recursing on an
-`infer` binding are an accept case). Independent of PR4–PR8.
+**Depends on** PR1b (evaluator + cycle cache) and PR3b (conditionals recursing on
+an `infer` binding are an accept case). Independent of PR4–PR8.
 
 ### PR10 — `throws T` clause on functions
 
@@ -397,7 +440,7 @@ subtyping, defaulting to `never`.
 
 **Depends on** PR10 (the parallel-arm template), M7.5 (the real `Generator<…>` /
 `AsyncGenerator<…>` stdlib types). The async-gen + `Awaited<ReturnType<F>>` accept
-case additionally rides on PR3 and PR13.
+case additionally rides on PR3b and PR13.
 
 ### PR12 — `Awaited<T>`
 
@@ -407,10 +450,10 @@ promises. The milestone explicitly lands it here — M3 deliberately left
 operator.
 
 **Algorithms.** Define `Awaited<T>` as the recursive conditional `T extends
-Promise<infer U> ? Awaited<U> : T`, reduced through the PR3 machinery with the PR1
-cycle-cache/budget termination protecting the recursion.
+Promise<infer U> ? Awaited<U> : T`, reduced through the PR3b machinery with the
+PR1b cycle-cache/budget termination protecting the recursion.
 
-**Depends on** PR3 (conditional + `infer`), PR1 (recursion termination), M7.5
+**Depends on** PR3b (conditional + `infer`), PR1b (recursion termination), M7.5
 (real `Promise<T>`). Separated from PR13 because it is a real feature the async
 story in PR11 depends on, not just a test.
 
@@ -429,57 +472,66 @@ reduction matches TS:
 - `Capitalize` / `Uncapitalize` / `Uppercase` / `Lowercase` and a small
   template-literal case (`EventName<K>` ⇒ `` `on${Capitalize<K>}` ``).
 
-**Depends on** PR2, PR3, PR4, PR7, PR12. Verifies the whole operator suite
+**Depends on** PR2, PR3b, PR4, PR7, PR12. Verifies the whole operator suite
 composes.
 
 ---
 
 ## Sizing note
 
-Each PR is scoped to a single reviewable concern. PR1 and PR3 are the two largest
-— the evaluator backbone and the conditional/`infer` matcher — and are the natural
-places to split further if review demands it (PR1 into "residual nodes +
-constrain/coalesce inert arms" then "evaluator + `keyof`"; PR3 into "branch
-selection" then "`infer` binding + distribution"). The remaining PRs are each a
-single operator or a single function-signature effect, sized comparably to a
-typical M4/M6 PR. PR10 and PR11 touch only `FuncType` and never the evaluator, so
-they carry no operator-track review burden.
+Each PR is scoped to a single reviewable concern. The two heaviest — the evaluator
+backbone and the conditional/`infer` matcher — are split so neither PR pairs a new
+representation with a new algorithm: **PR1a** is the residual node plus its inert
+`constrain`/`coalesce`/`extrude` plumbing, **PR1b** is the evaluator and `keyof`
+reduction; **PR3a** is conditional branch selection, **PR3b** is the `infer`
+structural matcher and distribution. The remaining PRs are each a single operator
+or a single function-signature effect, sized comparably to a typical M4/M6 PR.
+Mapped types (PR4) and object spread (PR5) are the next-largest — the fiddly
+modifier/`as`-remapping semantics and the Flow optional-field union rule
+respectively — but each is one self-contained operator and stays within the M4/M6
+band. PR10 and PR11 touch only `FuncType` and never the evaluator, so they carry
+no operator-track review burden. PR13 is verification-heavy but low-risk; if the
+utility corpus balloons it splits cleanly by category (mapped-based,
+conditional-based, template-based).
 
 ## Dependency graph
 
 ```
-M7   (type aliases: alias node + generics + scope-driven TypeRef)  ──► PR1
+M7   (type aliases: alias node + generics + scope-driven TypeRef)  ──► PR1a
 M7.5 (library type resolution: real stdlib types, import-only)     ──► PR11, PR12
 
-PR1 (evaluator backbone + residual nodes + keyof)
- ├─► PR2 (indexed access T[K] + union-key distribution)
- │    └─► PR4 (mapped types)              ── also needs PR1, PR3
- ├─► PR3 (conditional types + infer + distribution)
- │    ├─► PR4 (mapped types)
- │    ├─► PR9 (CheckRegular)              ── also needs PR1
- │    └─► PR12 (Awaited<T>)               ── also needs PR1, M7.5
- ├─► PR5 (object spread types)
- ├─► PR6 (tuple spread types)
- ├─► PR7 (template literal types + intrinsics)
- └─► PR8 (exactness propagation + Exact/Inexact)  ── needs PR1–PR7
+PR1a (residual-node representation + inert plumbing)
+ └─► PR1b (evaluator backbone + keyof reduction)
+      ├─► PR2 (indexed access T[K] + union-key distribution)
+      │    └─► PR4 (mapped types)              ── also needs PR1b, PR3a
+      ├─► PR3a (conditional types: branch selection)
+      │    └─► PR3b (infer clauses + distribution)   ── also needs PR2
+      │         ├─► PR9 (CheckRegular)          ── also needs PR1b
+      │         └─► PR12 (Awaited<T>)           ── also needs PR1b, M7.5
+      ├─► PR5 (object spread types)
+      ├─► PR6 (tuple spread types)
+      ├─► PR7 (template literal types + intrinsics)
+      └─► PR8 (exactness propagation + Exact/Inexact)  ── needs PR1b–PR7
 
 PR10 (throws clause)                      ── needs M3 only; parallel to everything
- └─► PR11 (generators)                    ── also needs M7.5 (+PR3/PR12 for the async-gen accept case)
+ └─► PR11 (generators)                    ── also needs M7.5 (+PR3b/PR12 for the async-gen accept case)
 
-PR13 (TS utility-type suite)              ── needs PR2, PR3, PR4, PR7, PR12
+PR13 (TS utility-type suite)              ── needs PR2, PR3b, PR4, PR7, PR12
 ```
 
 The same graph in mermaid, with the operator-track critical path
-(PR1 → PR3 → PR4 → PR8) highlighted and the landed `M7` / `M7.5` prerequisites
-dashed:
+(PR1a → PR1b → PR3a → PR3b → PR4 → PR8) highlighted and the landed `M7` / `M7.5`
+prerequisites dashed:
 
 ```mermaid
 graph TD
     M7["M7 (type aliases)"]
     M75["M7.5 (library type resolution: real stdlib, import-only)"]
-    PR1["PR1 (evaluator backbone + residual nodes + keyof)"]
+    PR1a["PR1a (residual node + inert plumbing)"]
+    PR1b["PR1b (evaluator backbone + keyof)"]
     PR2["PR2 (indexed access T[K] + distribution)"]
-    PR3["PR3 (conditional types + infer + distribution)"]
+    PR3a["PR3a (conditional types: branch selection)"]
+    PR3b["PR3b (infer clauses + distribution)"]
     PR4["PR4 (mapped types)"]
     PR5["PR5 (object spread types)"]
     PR6["PR6 (tuple spread types)"]
@@ -491,24 +543,26 @@ graph TD
     PR12["PR12 (Awaited<T>)"]
     PR13["PR13 (TS utility-type suite)"]
 
-    M7 -.-> PR1
+    M7 -.-> PR1a
     M75 -.-> PR11
     M75 -.-> PR12
 
-    PR1 --> PR2
-    PR1 --> PR3
-    PR1 --> PR5
-    PR1 --> PR6
-    PR1 --> PR7
-    PR1 --> PR8
-    PR1 --> PR9
-    PR1 --> PR12
+    PR1a --> PR1b
+    PR1b --> PR2
+    PR1b --> PR3a
+    PR1b --> PR5
+    PR1b --> PR6
+    PR1b --> PR7
+    PR1b --> PR8
+    PR3a --> PR3b
+    PR2 --> PR3b
     PR2 --> PR4
     PR2 --> PR13
-    PR3 --> PR4
-    PR3 --> PR9
-    PR3 --> PR12
-    PR3 --> PR13
+    PR3a --> PR4
+    PR3b --> PR9
+    PR1b --> PR9
+    PR3b --> PR12
+    PR3b --> PR13
     PR4 --> PR8
     PR4 --> PR13
     PR5 --> PR8
@@ -520,22 +574,24 @@ graph TD
     PR12 --> PR13
 
     linkStyle default stroke:#888
-    style PR1 fill:#e06666,stroke:#333,color:#fff
-    style PR3 fill:#e06666,stroke:#333,color:#fff
+    style PR1a fill:#e06666,stroke:#333,color:#fff
+    style PR1b fill:#e06666,stroke:#333,color:#fff
+    style PR3a fill:#e06666,stroke:#333,color:#fff
+    style PR3b fill:#e06666,stroke:#333,color:#fff
     style PR4 fill:#e06666,stroke:#333,color:#fff
     style PR8 fill:#e06666,stroke:#333,color:#fff
 ```
 
 ### Parallelism
 
-- **Track A** (PR1 → PR2/PR3 → PR4, plus PR5/PR6/PR7 hanging directly off PR1) is
-  the operator core. PR5, PR6, and PR7 are mutually independent and can be built
-  concurrently once PR1 lands.
+- **Track A** (PR1a → PR1b → PR2/PR3a → PR3b/PR4, plus PR5/PR6/PR7 hanging directly
+  off PR1b) is the operator core. PR5, PR6, and PR7 are mutually independent and can
+  be built concurrently once PR1b lands.
 - **Track C** — PR8 (exactness) is a barrier that waits for all operators; PR9
-  (CheckRegular) needs only PR1 + PR3 and runs alongside PR4–PR8.
+  (CheckRegular) needs only PR1b + PR3b and runs alongside PR4–PR8.
 - **Track D** — PR10 (throws) has no operator dependency and can start on day one
-  alongside PR1; PR11 (generators) follows PR10.
-- **Track E** — PR13 is the final join, waiting on PR2, PR3, PR4, PR7, PR12.
+  alongside PR1a; PR11 (generators) follows PR10.
+- **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12.
 
-The critical path is `M7 → PR1 → PR3 → PR4 → PR8`, and — for the async-generator
-accept case — `M7 → PR1 → PR3 → PR12 → PR13`.
+The critical path is `M7 → PR1a → PR1b → PR3a → PR3b → PR4 → PR8`, and — for the
+async-generator accept case — `M7 → PR1a → PR1b → PR3b → PR12 → PR13`.


### PR DESCRIPTION
Planning-only PR (docs under `planning/simple_sub/`, no code changes) that lays out the last two MVP checker milestones so their designs interlock and nothing slips between them.

## What changed

**1. Split the old M7 into two milestones (`01-milestones.md`)**
- **M7 — Type aliases:** the `soltype` alias representation, generic aliases, instantiation/expansion, scope-driven `TypeRef` resolution, mutually-recursive alias groups, and the enum-as-alias binding — the foundation M9 needs.
- **M7.5 — Library type resolution:** the stdlib ingestion (`std:*` / `web:*` / `node:*`), retargeted onto `soltype`.
- **No ambient global lib.** M7.5 is import-only — no `globalThis`, no `lib.*.d.ts` auto-loading. `Array`/`Promise`/`Map`/`Set`/etc. must be imported; naming one unimported is an unbound-name error. The well-known protocol types the desugaring rules need (`await`→`Promise`, `for-in`→`Iterable`, `yield`→`Generator`) are resolved by the checker directly, so those rules still fire without an import; writing the name in an annotation requires one.
- Cross-references across the M2–M6.5 and M9 bodies redirected to M7 (aliases) vs M7.5 (library) as appropriate.

**2. New M7 implementation plan (`m7-implementation-plan.md`)**
- Seven dependency-ordered PRs, each grounded in the class/enum registry and SCC machinery it mirrors and the exact code sites it touches (e.g. `type X = …` currently hits `reportUnsupported`; the `preBindEnum`/`inferEnumBody` two-pass is the template).
- An **"Interlocks with M9"** section pinning the six seams between the plans: `expandAlias` as the evaluator's expansion primitive, the `AliasType` identity M9's cycle cache keys on, the recursion split (M7 = subtyping-subject via the seen-set; M9 = operator reduction via cycle-cache + budget + `CheckRegular`), alias variance deferred to M9, the enum-as-alias path `keyof`/indexed access reach, and `Awaited`'s reliance on recursive aliases.

**3. New M9 implementation plan (`m9-implementation-plan.md`)**
- **15 PRs across 5 tracks.** The two heaviest concerns are split so no PR pairs a new representation with a new algorithm: **PR1a** (residual node + inert `constrain`/`coalesce`/`extrude` plumbing) / **PR1b** (evaluator + `keyof`), and **PR3a** (conditional branch selection) / **PR3b** (`infer` matcher + distribution). Remaining PRs are one operator or one function-signature effect each.
- Covers `keyof`, `typeof`, indexed access, index signatures, conditional + `infer` + distribution, mapped types, object/tuple spread, template literals + intrinsics, exactness propagation + `Exact`/`Inexact`, `CheckRegular`, `throws`, generators, `Awaited`, and the TS utility-type suite. Promotes the spike's proven machinery (`typeops.go`, `residual.go`, `regularity.go`, `lazy.go`).
- ASCII + mermaid dependency graphs with the critical path highlighted, plus a parallelism breakdown.

**4. Old-checker parity audit (`internal/checker`)**
Cross-checked both plans against the old checker's full type-level surface and closed four gaps:
- **`typeof v` type queries** (`TypeOfTypeAnn` / `resolveTypeOfQualIdent`) — the value→type bridge `keyof typeof x` relies on; was scoped nowhere.
- **Index signatures** (`IndexSignatureElem`) — M7.5 deferred these to M9, which was silent. Escalier has no hand-written `{[k: string]: T}` syntax, so they arise only from primitive-key mapped types and library ingestion.
- **`keyof` breadth** — matched the old checker (tuple numeric indices + `"length"`, union/intersection distribution, `keyof` of a primitive/`never`/`unknown` is `never`).
- **Utility-type provisioning** — recorded that Pick/Omit/etc. ship as importable stdlib definitions built from the M9 operators, not as ambient `lib.es*.d.ts` globals.

Confirmed unique symbols, `Symbol.iterator`, and interfaces are already scoped in M7.5/M5; that Escalier intentionally has no `any`; and that `MatchTypeAnn`/`ImportTypeAnn` were never lowered by the old checker, so they are explicitly out of scope rather than parity gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3G5oTzMru299M6R1Xnctj