### PR TITLE
Add type alias support (M7 PR1)

### DIFF
--- a/internal/soltype/alias_test.go
+++ b/internal/soltype/alias_test.go
@@ -1,0 +1,85 @@
+package soltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrintAliasType renders an alias reference under its name, bare or with a type
+// argument list, stripping the dep_graph namespace prefix the way a class name is.
+func TestPrintAliasType(t *testing.T) {
+	require.Equal(t, "Point", Print(&AliasType{Name: "Point"}))
+	require.Equal(t, "Point", Print(&AliasType{Name: "Geometry.Point"}))
+	require.Equal(t, "Box<number>", Print(&AliasType{Name: "Box", TypeArgs: []Type{numP()}}))
+	require.Equal(t, "Pair<number, string>", Print(&AliasType{Name: "Pair", TypeArgs: []Type{numP(), strP()}}))
+}
+
+// TestPrintAliasBorrow renders a borrow whose inner is an alias, since AliasType is a
+// RefInner that flows through the borrow machinery like a class instance.
+func TestPrintAliasBorrow(t *testing.T) {
+	require.Equal(t, "&Point", Print(&RefType{Lt: Anon, Inner: &AliasType{Name: "Point"}}))
+	require.Equal(t, "mut Point", Print(&RefType{Mut: true, Inner: &AliasType{Name: "Point"}}))
+}
+
+// TestLevelOfAliasType takes the max level over the alias's type arguments, and is 0
+// for a bare reference whose name carries no variables.
+func TestLevelOfAliasType(t *testing.T) {
+	require.Equal(t, 0, LevelOf(&AliasType{Name: "Point"}), "no arguments ⇒ level 0")
+	alias := &AliasType{Name: "Box", TypeArgs: []Type{
+		&TypeVarType{ID: 1, Level: 3},
+		&TypeVarType{ID: 2, Level: 6},
+	}}
+	require.Equal(t, 6, LevelOf(alias), "the level is the max over the type arguments")
+}
+
+// skipAlias replaces an AliasType with repl and skips its children, exercising the
+// SkipChildren arm of AliasType.Accept.
+type skipAlias struct{ repl Type }
+
+func (v skipAlias) EnterType(t Type, _ Polarity) EnterResult {
+	if _, ok := t.(*AliasType); ok {
+		return EnterResult{Type: v.repl, SkipChildren: true}
+	}
+	return EnterResult{}
+}
+func (skipAlias) ExitType(t Type, _ Polarity) Type { return t }
+
+// TestAcceptAliasType rebuilds an AliasType only when a type argument changes, reuses
+// the pointer when nothing changes, and honors a SkipChildren replacement.
+func TestAcceptAliasType(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	str := &PrimType{Prim: StrPrim}
+	alias := &AliasType{Name: "Box", TypeArgs: []Type{a}}
+
+	got := alias.Accept(&replaceVar{target: a, repl: str}, Positive).(*AliasType)
+	require.NotSame(t, alias, got, "a changed argument forces a new token")
+	require.Equal(t, "Box", got.Name, "the name carries through")
+	require.Same(t, str, got.TypeArgs[0], "the changed argument took the replacement")
+
+	require.Same(t, alias, alias.Accept(identityVisitor{}, Positive), "an unchanged AliasType keeps its pointer")
+
+	num := numP()
+	require.Same(t, num, alias.Accept(skipAlias{repl: num}, Positive), "SkipChildren hands the replacement straight through")
+}
+
+// TestPrintAsSchemeAliasArg names a type variable that appears inside an alias
+// reference's arguments, so freeTypeVars descends into AliasType.TypeArgs.
+func TestPrintAsSchemeAliasArg(t *testing.T) {
+	a := &TypeVarType{ID: 1}
+	fn := &FuncType{
+		Params: []*FuncParam{identP("x", &AliasType{Name: "Box", TypeArgs: []Type{a}})},
+		Ret:    &AliasType{Name: "Box", TypeArgs: []Type{a}},
+	}
+	require.Equal(t, "fn <T0>(x: Box<T0>) -> Box<T0>", PrintAsScheme(fn))
+}
+
+// TestAliasTypeInterfaces asserts AliasType satisfies the sealed Type and RefInner
+// interfaces, so it is a first-class type and a borrowable inner.
+func TestAliasTypeInterfaces(t *testing.T) {
+	var _ Type = &AliasType{}
+	var _ RefInner = &AliasType{}
+	a := &AliasType{}
+	a.isType()
+	a.isRefInner()
+}

--- a/internal/soltype/alias_test.go
+++ b/internal/soltype/alias_test.go
@@ -53,7 +53,7 @@ func TestAcceptAliasType(t *testing.T) {
 	alias := &AliasType{Name: "Box", TypeArgs: []Type{a}}
 
 	got := alias.Accept(&replaceVar{target: a, repl: str}, Positive).(*AliasType)
-	require.NotSame(t, alias, got, "a changed argument forces a new token")
+	require.NotSame(t, alias, got, "a changed argument forces a new type")
 	require.Equal(t, "Box", got.Name, "the name carries through")
 	require.Same(t, str, got.TypeArgs[0], "the changed argument took the replacement")
 

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -34,9 +34,9 @@ func typePrec(t Type) int {
 	case *RefType:
 		return precPrefix
 	default:
-		// PrimType, LitType, TupleType, ObjectType, ClassType, Void, NullType,
-		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited and ClassType renders as
-		// a bare name or `Name<args>`, so neither needs parens. A raw TypeVarType
+		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, Void, NullType,
+		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited, and ClassType and
+		// AliasType each render as a bare name or `Name<args>`, so none needs parens. A raw TypeVarType
 		// appears only when printing an un-coalesced type, see printType; it is also an
 		// atom rendered as `t{ID}`, so it lands here. A `mut 'a Point` borrow wraps the
 		// ClassType in a RefType, which carries the looser precPrefix precedence.
@@ -378,6 +378,10 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, a := range t.TypeArgs {
 				walk(a)
 			}
+		case *AliasType:
+			for _, a := range t.TypeArgs {
+				walk(a)
+			}
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -539,6 +543,21 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		for _, a := range t.TypeArgs {
 			parts = append(parts, p.printType(a))
+		}
+		return name + "<" + strings.Join(parts, ", ") + ">"
+	case *AliasType:
+		// An alias reference renders under its own name, with a `<...>` argument list when
+		// a generic reference supplies arguments: `Point`, `Box<number>`. The qualified
+		// Name carries a namespace prefix for registry keying, stripped here for display,
+		// the same way a class name is. Rendering the name rather than the expanded body is
+		// the point of the alias, so `val p: Point = {x: 1}` shows `Point`.
+		name := classDisplayName(t.Name)
+		if len(t.TypeArgs) == 0 {
+			return name
+		}
+		parts := make([]string, len(t.TypeArgs))
+		for i, a := range t.TypeArgs {
+			parts[i] = p.printType(a)
 		}
 		return name + "<" + strings.Join(parts, ", ") + ">"
 	case *FuncType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -563,21 +563,15 @@ type ClassType struct {
 	Variant bool
 }
 
-// AliasType is the use-site reference to a user-written `type Name<Params…> = Body`
-// declaration. Like ClassType it is a small token. Name keys a side registry holding
-// the heavy Body, so the token stays cheap to compare and rewrite. An alias is
-// transparent, meaning it subtypes exactly as its expanded Body does, so the subtyping
-// engine expands it through the alias registry rather than comparing the token
-// nominally. A reference renders under Name, so `type Point = {x: number}` followed by
-// `val p: Point = …` shows `Point`, not the expanded record.
+// AliasType is the use-site reference to a `type Name = Body` declaration, a small token
+// whose Name keys the Body in a side registry, like ClassType. An alias is transparent:
+// the subtyping engine expands it to its Body, while it renders under Name.
 type AliasType struct {
-	// Name is the dep_graph-qualified name such as "Geometry.Point", not the bare local
-	// identifier, so two aliases named Point in different namespaces stay distinct. It
-	// also keys the registry holding the alias's Body.
+	// Name is the dep_graph-qualified name such as "Geometry.Point", so two aliases named
+	// Point in different namespaces stay distinct. It also keys the registry.
 	Name string
-	// TypeArgs are the type arguments a generic reference supplies, one per alias type
-	// parameter. Empty for a bare reference such as `Point`, which is the only form minted
-	// today, since generic aliases are not yet supported.
+	// TypeArgs are the arguments a generic reference supplies. Always empty today, since
+	// generic aliases are not yet supported.
 	TypeArgs []Type
 }
 

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -444,8 +444,9 @@ type RefType struct {
 // `&A | &B` with independent lifetimes. A union or intersection must have uniform
 // ownership. A borrowed member beside an owned one has no single owned-or-borrowed
 // verdict and is rejected at the inference join where it forms. ClassType is a
-// RefInner too, so a `mut 'a Point` borrows a class instance. AliasType adds its
-// isRefInner arm when that type is introduced.
+// RefInner too, so a `mut 'a Point` borrows a class instance. AliasType is a
+// RefInner as well, so a `mut 'a Point` over a type alias borrows through the same
+// machinery; the lifetime-generic alias form lands in M7 PR4.
 type RefInner interface {
 	Type
 	isRefInner()
@@ -457,6 +458,7 @@ func (*TypeVarType) isRefInner()      {}
 func (*UnionType) isRefInner()        {}
 func (*IntersectionType) isRefInner() {}
 func (*ClassType) isRefInner()        {}
+func (*AliasType) isRefInner()        {}
 
 // PromiseType is the result of an `async fn` and the requirement of an `await`.
 // M3 carries it as a dedicated concrete (not a generic TypeRefType), keeping the
@@ -561,6 +563,27 @@ type ClassType struct {
 	Variant bool
 }
 
+// AliasType is the use-site reference to a user-written `type Name<Params…> = Body`
+// declaration. Like ClassType it is a small token. Name keys a side registry holding
+// the heavy Body, so the token stays cheap to compare and rewrite. An alias is
+// transparent, meaning it subtypes exactly as its expanded Body does, so the subtyping
+// engine expands it through the alias registry rather than comparing the token
+// nominally. A reference renders under Name, so `type Point = {x: number}` followed by
+// `val p: Point = …` shows `Point`, not the expanded record.
+//
+// M7 PR4 adds a LifetimeArgs field for a lifetime-generic alias; until then a
+// reference carries type arguments only.
+type AliasType struct {
+	// Name is the dep_graph-qualified name such as "Geometry.Point", not the bare local
+	// identifier, so two aliases named Point in different namespaces stay distinct. It
+	// also keys the registry holding the alias's Body.
+	Name string
+	// TypeArgs are the type arguments a generic reference supplies, one per alias type
+	// parameter. Empty for a bare reference such as `Point`. The generic-instance and
+	// substitution machinery lands in M7 PR2; PR1 mints only the empty-args form.
+	TypeArgs []Type
+}
+
 func (*TypeVarType) isType()      {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -578,6 +601,7 @@ func (*UnionType) isType()        {}
 func (*IntersectionType) isType() {}
 func (*ErrorType) isType()        {}
 func (*ClassType) isType()        {}
+func (*AliasType) isType()        {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).
@@ -621,6 +645,14 @@ func LevelOf(t Type) int {
 			m = max(m, LevelOfLifetime(la))
 		}
 		return max(m, LevelOfLifetime(t.Lt))
+	case *AliasType:
+		// An alias reference's level is the max level over its type arguments; the Name
+		// carries no variables. A bare reference with no arguments is level 0.
+		m := 0
+		for _, a := range t.TypeArgs {
+			m = max(m, LevelOf(a))
+		}
+		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -446,7 +446,7 @@ type RefType struct {
 // verdict and is rejected at the inference join where it forms. ClassType is a
 // RefInner too, so a `mut 'a Point` borrows a class instance. AliasType is a
 // RefInner as well, so a `mut 'a Point` over a type alias borrows through the same
-// machinery; the lifetime-generic alias form lands in M7 PR4.
+// machinery.
 type RefInner interface {
 	Type
 	isRefInner()
@@ -570,17 +570,14 @@ type ClassType struct {
 // engine expands it through the alias registry rather than comparing the token
 // nominally. A reference renders under Name, so `type Point = {x: number}` followed by
 // `val p: Point = …` shows `Point`, not the expanded record.
-//
-// M7 PR4 adds a LifetimeArgs field for a lifetime-generic alias; until then a
-// reference carries type arguments only.
 type AliasType struct {
 	// Name is the dep_graph-qualified name such as "Geometry.Point", not the bare local
 	// identifier, so two aliases named Point in different namespaces stay distinct. It
 	// also keys the registry holding the alias's Body.
 	Name string
 	// TypeArgs are the type arguments a generic reference supplies, one per alias type
-	// parameter. Empty for a bare reference such as `Point`. The generic-instance and
-	// substitution machinery lands in M7 PR2; PR1 mints only the empty-args form.
+	// parameter. Empty for a bare reference such as `Point`, which is the only form minted
+	// today, since generic aliases are not yet supported.
 	TypeArgs []Type
 }
 

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -252,6 +252,23 @@ func (t *ClassType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *AliasType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	args, changed := acceptTypes(cur.TypeArgs, v, pol) // type arguments covariant
+	out := cur
+	if changed {
+		// Name is the token's identity, carried through unchanged. An alias is
+		// transparent, so its arguments walk covariantly like a class's, and variance
+		// is resolved by expansion at subtyping time rather than stored on the token.
+		out = &AliasType{Name: cur.Name, TypeArgs: args}
+	}
+	return v.ExitType(out, pol)
+}
+
 // acceptTypes walks each element covariantly, returning (originalSlice, false)
 // when nothing changed and (copy-on-write slice, true) otherwise.
 func acceptTypes(ts []Type, v TypeVisitor, pol Polarity) ([]Type, bool) {

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -7,41 +7,38 @@ import (
 )
 
 // AliasDef is the heavy per-alias data the token soltype.AliasType points at.
-// inferTypeDecl builds one per `type` declaration and registers it on the Context
-// under the alias's dep_graph-qualified name; expandAlias reads Body to unfold a
-// reference. Keeping Body out of soltype.AliasType lets the token stay a small,
-// cheap-to-compare identity, mirroring the split between ClassType and ClassDef.
+// inferTypeDecl builds one per `type` declaration and registers it on the Context under
+// the alias's dep_graph-qualified name. expandAlias reads Body to unfold a reference.
+// Keeping Body out of soltype.AliasType lets the token stay a small, cheap-to-compare
+// identity, mirroring the split between ClassType and ClassDef.
 type AliasDef struct {
-	// TypeParams are the alias's own quantified type parameters in declaration order,
-	// resolved from the `<…>` list. nil for a non-generic alias. Instantiation and
-	// arity checking over these land in M7 PR2. PR1 registers only non-generic aliases,
-	// so this is always nil today.
+	// TypeParams are the alias's own quantified type parameters in declaration order.
+	// Always nil today: generic aliases are not yet supported, so only non-generic
+	// aliases are registered.
 	TypeParams []*soltype.TypeParam
 
-	// LifetimeParams are the alias's quantified lifetime parameters, the lifetime twin
-	// of TypeParams. nil until the lifetime-generic alias form lands in M7 PR4.
+	// LifetimeParams are the alias's quantified lifetime parameters, the lifetime twin of
+	// TypeParams. Always nil today, for the same reason.
 	LifetimeParams []*soltype.LifetimeParam
 
 	// Body is the type the alias expands to, the resolved right-hand side of
 	// `type Name = Body`. expandAlias returns it so an alias reference subtypes exactly
-	// as its body does. M7 stores no variance beside it. A transparent alias expands, so
+	// as its body does. No variance is stored beside it. A transparent alias expands, so
 	// variance is resolved structurally on the body rather than per parameter.
 	Body soltype.Type
 
-	// Level is the alias binding's generalize level, kept for the generic-instantiation
-	// machinery in later PRs. A non-generic alias has no parameters to freshen, so PR1
-	// only records it.
+	// Level is the alias binding's generalize level. A non-generic alias has no parameters
+	// to freshen, so it is recorded but not otherwise consulted.
 	Level int
 }
 
-// expandAlias unfolds an alias reference to the structural type it names, by reading
-// the registered AliasDef's Body. It is the standalone helper the subtyping engine
-// calls to treat an alias transparently, and the same helper M9's type-level operator
-// evaluator reuses to reduce over an alias. PR1 has no type arguments to substitute, so
-// it returns Body directly. PR2 substitutes ref.TypeArgs for the AliasDef's type
-// parameters here. An unregistered reference yields an ErrorType so a stray reference
-// absorbs rather than looping. A well-formed program never produces one, since
-// inferTypeDecl registers the alias before binding its name.
+// expandAlias unfolds an alias reference to the structural type it names, by reading the
+// registered AliasDef's Body. It is a standalone helper the subtyping engine calls to
+// treat an alias transparently, kept separate from constrain so other callers can reuse
+// the same unfolding. There are no type arguments to substitute, so it returns Body
+// directly. An unregistered reference yields an ErrorType so a stray reference absorbs
+// rather than looping. A well-formed program never produces one, since inferTypeDecl
+// registers the alias before binding its name.
 func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
 	def, ok := c.aliasDef(ref.Name)
 	if !ok || def.Body == nil {
@@ -59,31 +56,40 @@ type typeDeclEntry struct {
 	ns   string
 }
 
-// inferTypeDecl resolves a non-generic `type X = Body` declaration: it resolves the
-// body annotation, registers an AliasDef holding that body, and binds the type name to
-// an AliasType token so a later reference resolves and renders under its own name. PR1
-// handles only the single, non-recursive decl. The SCC two-pass for recursive and
-// mutually recursive aliases is PR3, and type parameters are PR2, so a `<…>` list is
-// ignored here and its aliases behave as their bare-name body.
+// inferTypeDecl infers a `type X = Body` declaration. It resolves the body annotation,
+// registers an AliasDef holding that body, and binds the type name to an AliasType token
+// so a reference resolves and renders under its own name. Only a non-generic alias is
+// supported. A declaration carrying type parameters reports an unsupported-feature
+// diagnostic and binds nothing, because argument substitution and arity checking are not
+// implemented.
 func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) {
-	// The alias's dep_graph-qualified name — the namespace joined to the local name, or
-	// the bare local name at the root namespace — the same qualified key class and enum
+	if len(decl.TypeParams) > 0 {
+		// A generic alias needs argument substitution and arity checking that are not
+		// implemented. Report the declaration and bind nothing, so a reference fails as an
+		// unknown type rather than resolving to a half-built alias whose body references
+		// unbound parameters.
+		c.reportUnsupportedFeature(decl, "generic type alias")
+		return
+	}
+
+	// The alias's dep_graph-qualified name is the namespace joined to the local name, or
+	// the bare local name at the root namespace, the same qualified key class and enum
 	// registration use, so the registry key and the AliasType token match.
 	qname := decl.Name.Name
 	if ns != "" {
 		qname = ns + "." + decl.Name.Name
 	}
 
-	// A missing body is a parser error-recovery case: `type Foo =` with no annotation
+	// A missing body is a parser error-recovery case. `type Foo =` with no annotation
 	// yields a nil TypeAnn, which the parser already reported. Bind the alias to a fresh
-	// var so a later reference still resolves, and skip resolveTypeAnn — passing nil there
+	// var so a later reference still resolves, and skip resolveTypeAnn. Passing nil there
 	// routes to reportUnsupported(nil), whose error node has no span to render.
 	var body soltype.Type = c.freshAt(lvl)
 	if decl.TypeAnn != nil {
 		if resolved, ok := c.resolveTypeAnn(scope, decl.TypeAnn, lvl); ok {
 			body = resolved
 		}
-		// An unsupported body reported its own error; keep the fresh var so a reference
+		// An unsupported body reported its own error. Keep the fresh var so a reference
 		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper
 		// recovery in resolveTypeAnn.
 	}

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -74,10 +74,10 @@ func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns st
 	}
 	c.ctx.registerAlias(qname, &AliasDef{Body: body, Level: lvl - 1})
 
-	token := &soltype.AliasType{Name: qname}
+	t := &soltype.AliasType{Name: qname}
 	scope.defineType(qname, TypeBinding{
-		Type:    token,
+		Type:    t,
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
 	})
-	c.recordType(decl.Name, token)
+	c.recordType(decl.Name, t)
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -6,25 +6,19 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// AliasDef is the heavy per-alias data the token soltype.AliasType points at.
-// inferTypeDecl builds one per `type` declaration and registers it on the Context under
-// the alias's dep_graph-qualified name. expandAlias reads Body to unfold a reference.
-// Keeping Body out of soltype.AliasType lets the token stay a small, cheap-to-compare
-// identity, mirroring the split between ClassType and ClassDef.
+// AliasDef is the heavy per-alias data the AliasType token points at, keyed in the
+// Context registry by qualified name, mirroring the ClassType/ClassDef split.
 type AliasDef struct {
-	// TypeParams are the alias's own quantified type parameters in declaration order.
-	// Always nil today: generic aliases are not yet supported, so only non-generic
-	// aliases are registered.
+	// TypeParams are the alias's own type parameters. Always nil today, since generic
+	// aliases are not yet supported.
 	TypeParams []*soltype.TypeParam
 
 	// LifetimeParams are the alias's quantified lifetime parameters, the lifetime twin of
 	// TypeParams. Always nil today, for the same reason.
 	LifetimeParams []*soltype.LifetimeParam
 
-	// Body is the type the alias expands to, the resolved right-hand side of
-	// `type Name = Body`. expandAlias returns it so an alias reference subtypes exactly
-	// as its body does. No variance is stored beside it. A transparent alias expands, so
-	// variance is resolved structurally on the body rather than per parameter.
+	// Body is the type the alias expands to, the right-hand side of `type Name = Body`.
+	// No variance is stored: a transparent alias expands, so variance follows the body.
 	Body soltype.Type
 
 	// Level is the alias binding's generalize level. A non-generic alias has no parameters
@@ -32,13 +26,8 @@ type AliasDef struct {
 	Level int
 }
 
-// expandAlias unfolds an alias reference to the structural type it names, by reading the
-// registered AliasDef's Body. It is a standalone helper the subtyping engine calls to
-// treat an alias transparently, kept separate from constrain so other callers can reuse
-// the same unfolding. There are no type arguments to substitute, so it returns Body
-// directly. An unregistered reference yields an ErrorType so a stray reference absorbs
-// rather than looping. A well-formed program never produces one, since inferTypeDecl
-// registers the alias before binding its name.
+// expandAlias unfolds an alias reference to its registered AliasDef Body, the shared
+// transparent-alias helper. An unregistered reference yields an ErrorType so it absorbs.
 func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
 	def, ok := c.aliasDef(ref.Name)
 	if !ok || def.Body == nil {
@@ -47,27 +36,19 @@ func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
 	return def.Body
 }
 
-// typeDeclEntry pairs a `type` decl with its dep_graph namespace, so the module
-// type-key loop can defer alias-body resolution until every class token and enum union
-// in the component is bound. It is the alias counterpart of the enumShell the enum
-// two-pass carries between its passes.
+// typeDeclEntry pairs a `type` decl with its namespace, so the type-key loop can defer
+// alias-body resolution until every sibling class and enum in the component is bound.
 type typeDeclEntry struct {
 	decl *ast.TypeDecl
 	ns   string
 }
 
-// inferTypeDecl infers a `type X = Body` declaration. It resolves the body annotation,
-// registers an AliasDef holding that body, and binds the type name to an AliasType token
-// so a reference resolves and renders under its own name. Only a non-generic alias is
-// supported. A declaration carrying type parameters reports an unsupported-feature
-// diagnostic and binds nothing, because argument substitution and arity checking are not
-// implemented.
+// inferTypeDecl resolves a non-generic `type X = Body`, registers its AliasDef, and binds
+// the name to an AliasType token. A generic alias is reported as unsupported.
 func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) {
 	if len(decl.TypeParams) > 0 {
-		// A generic alias needs argument substitution and arity checking that are not
-		// implemented. Report the declaration and bind nothing, so a reference fails as an
-		// unknown type rather than resolving to a half-built alias whose body references
-		// unbound parameters.
+		// A generic alias needs substitution and arity checking that are not implemented.
+		// Report it and bind nothing, so a reference fails as an unknown type.
 		c.reportUnsupportedFeature(decl, "generic type alias")
 		return
 	}
@@ -80,10 +61,8 @@ func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns st
 		qname = ns + "." + decl.Name.Name
 	}
 
-	// A missing body is a parser error-recovery case. `type Foo =` with no annotation
-	// yields a nil TypeAnn, which the parser already reported. Bind the alias to a fresh
-	// var so a later reference still resolves, and skip resolveTypeAnn. Passing nil there
-	// routes to reportUnsupported(nil), whose error node has no span to render.
+	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
+	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
 	var body soltype.Type = c.freshAt(lvl)
 	if decl.TypeAnn != nil {
 		if resolved, ok := c.resolveTypeAnn(scope, decl.TypeAnn, lvl); ok {

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -1,0 +1,98 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// AliasDef is the heavy per-alias data the token soltype.AliasType points at.
+// inferTypeDecl builds one per `type` declaration and registers it on the Context
+// under the alias's dep_graph-qualified name; expandAlias reads Body to unfold a
+// reference. Keeping Body out of soltype.AliasType lets the token stay a small,
+// cheap-to-compare identity, mirroring the split between ClassType and ClassDef.
+type AliasDef struct {
+	// TypeParams are the alias's own quantified type parameters in declaration order,
+	// resolved from the `<…>` list. nil for a non-generic alias. Instantiation and
+	// arity checking over these land in M7 PR2. PR1 registers only non-generic aliases,
+	// so this is always nil today.
+	TypeParams []*soltype.TypeParam
+
+	// LifetimeParams are the alias's quantified lifetime parameters, the lifetime twin
+	// of TypeParams. nil until the lifetime-generic alias form lands in M7 PR4.
+	LifetimeParams []*soltype.LifetimeParam
+
+	// Body is the type the alias expands to, the resolved right-hand side of
+	// `type Name = Body`. expandAlias returns it so an alias reference subtypes exactly
+	// as its body does. M7 stores no variance beside it. A transparent alias expands, so
+	// variance is resolved structurally on the body rather than per parameter.
+	Body soltype.Type
+
+	// Level is the alias binding's generalize level, kept for the generic-instantiation
+	// machinery in later PRs. A non-generic alias has no parameters to freshen, so PR1
+	// only records it.
+	Level int
+}
+
+// expandAlias unfolds an alias reference to the structural type it names, by reading
+// the registered AliasDef's Body. It is the standalone helper the subtyping engine
+// calls to treat an alias transparently, and the same helper M9's type-level operator
+// evaluator reuses to reduce over an alias. PR1 has no type arguments to substitute, so
+// it returns Body directly. PR2 substitutes ref.TypeArgs for the AliasDef's type
+// parameters here. An unregistered reference yields an ErrorType so a stray reference
+// absorbs rather than looping. A well-formed program never produces one, since
+// inferTypeDecl registers the alias before binding its name.
+func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
+	def, ok := c.aliasDef(ref.Name)
+	if !ok || def.Body == nil {
+		return &soltype.ErrorType{}
+	}
+	return def.Body
+}
+
+// typeDeclEntry pairs a `type` decl with its dep_graph namespace, so the module
+// type-key loop can defer alias-body resolution until every class token and enum union
+// in the component is bound. It is the alias counterpart of the enumShell the enum
+// two-pass carries between its passes.
+type typeDeclEntry struct {
+	decl *ast.TypeDecl
+	ns   string
+}
+
+// inferTypeDecl resolves a non-generic `type X = Body` declaration: it resolves the
+// body annotation, registers an AliasDef holding that body, and binds the type name to
+// an AliasType token so a later reference resolves and renders under its own name. PR1
+// handles only the single, non-recursive decl. The SCC two-pass for recursive and
+// mutually recursive aliases is PR3, and type parameters are PR2, so a `<…>` list is
+// ignored here and its aliases behave as their bare-name body.
+func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) {
+	// The alias's dep_graph-qualified name — the namespace joined to the local name, or
+	// the bare local name at the root namespace — the same qualified key class and enum
+	// registration use, so the registry key and the AliasType token match.
+	qname := decl.Name.Name
+	if ns != "" {
+		qname = ns + "." + decl.Name.Name
+	}
+
+	// A missing body is a parser error-recovery case: `type Foo =` with no annotation
+	// yields a nil TypeAnn, which the parser already reported. Bind the alias to a fresh
+	// var so a later reference still resolves, and skip resolveTypeAnn — passing nil there
+	// routes to reportUnsupported(nil), whose error node has no span to render.
+	var body soltype.Type = c.freshAt(lvl)
+	if decl.TypeAnn != nil {
+		if resolved, ok := c.resolveTypeAnn(scope, decl.TypeAnn, lvl); ok {
+			body = resolved
+		}
+		// An unsupported body reported its own error; keep the fresh var so a reference
+		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper
+		// recovery in resolveTypeAnn.
+	}
+	c.ctx.registerAlias(qname, &AliasDef{Body: body, Level: lvl - 1})
+
+	token := &soltype.AliasType{Name: qname}
+	scope.defineType(qname, TypeBinding{
+		Type:    token,
+		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
+	})
+	c.recordType(decl.Name, token)
+}

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,4 +147,62 @@ func TestInferTypeAliasShadowingPromiseRejectsArgs(t *testing.T) {
 	_, _, errs := inferSource(t, src)
 	require.Len(t, errs, 1)
 	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+}
+
+// TestExpandAliasUnregisteredReturnsError covers the defensive path in expandAlias: a
+// reference whose name is not in the registry yields an ErrorType, which absorbs under
+// subtyping rather than looping. inferTypeDecl registers before binding, so this never
+// arises from source, but the guard keeps a stray reference from diverging.
+func TestExpandAliasUnregisteredReturnsError(t *testing.T) {
+	c := newChecker()
+	got := c.ctx.expandAlias(&soltype.AliasType{Name: "Missing"})
+	require.IsType(t, &soltype.ErrorType{}, got)
+}
+
+// TestDescribeAliasType renders an alias reference under its own name in a diagnostic,
+// bare or with arguments, matching the printer's surface form.
+func TestDescribeAliasType(t *testing.T) {
+	require.Equal(t, "Point", describe(&soltype.AliasType{Name: "Point"}))
+	require.Equal(t, "Box<number>", describe(&soltype.AliasType{Name: "Box", TypeArgs: []soltype.Type{numT()}}))
+}
+
+// TestEqualTypeAliasType compares two alias references: equal when they name the same
+// alias with equal arguments, unequal on a different name, argument, or kind.
+func TestEqualTypeAliasType(t *testing.T) {
+	require.True(t, equalType(&soltype.AliasType{Name: "A"}, &soltype.AliasType{Name: "A"}))
+	require.False(t, equalType(&soltype.AliasType{Name: "A"}, &soltype.AliasType{Name: "B"}))
+	require.True(t, equalType(
+		&soltype.AliasType{Name: "Box", TypeArgs: []soltype.Type{numT()}},
+		&soltype.AliasType{Name: "Box", TypeArgs: []soltype.Type{numT()}},
+	))
+	require.False(t, equalType(
+		&soltype.AliasType{Name: "Box", TypeArgs: []soltype.Type{numT()}},
+		&soltype.AliasType{Name: "Box"},
+	))
+	require.False(t, equalType(&soltype.AliasType{Name: "Box"}, numT()))
+}
+
+// TestInferTypeAliasFlowsIntoStructuralTarget exercises the alias-on-the-sub-side path in
+// constrain: an alias-typed value assigned to a structural target expands to its body and
+// checks structurally.
+func TestInferTypeAliasFlowsIntoStructuralTarget(t *testing.T) {
+	src := `
+		type Point = {x: number, y: number}
+		val p: Point = {x: 1, y: 2}
+		val o: {x: number, y: number} = p
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "Point", values["p"])
+	require.Equal(t, "{x: number, y: number}", values["o"])
+}
+
+// TestInferTypeAliasNamespaced binds an alias declared in a namespace under its
+// dep_graph-qualified name, so the registry key carries the namespace prefix.
+func TestInferTypeAliasNamespaced(t *testing.T) {
+	_, types, errs := inferSources(t, map[string]string{
+		"geometry/types.esc": `type Coord = number`,
+	})
+	require.Empty(t, errs)
+	require.Equal(t, "number", types["geometry.Coord"])
 }

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 // TestInferTypeAliasBasic covers a non-generic `type` alias end to end. The type binding
-// renders under the alias name, an object literal that fits the aliased record
-// type-checks and the binding renders under the alias name rather than the expanded body,
-// and a primitive alias flows structurally.
+// renders as its definition body, an annotated value that fits the aliased record
+// type-checks and keeps the alias name on the value binding, and a primitive alias flows
+// structurally.
 func TestInferTypeAliasBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -24,7 +24,7 @@ func TestInferTypeAliasBasic(t *testing.T) {
 		{
 			name:      "RecordAliasBinds",
 			src:       `type Point = {x: number, y: number}`,
-			wantTypes: map[string]string{"Point": "Point"},
+			wantTypes: map[string]string{"Point": "{x: number, y: number}"},
 		},
 		{
 			name: "AnnotatedValueRendersUnderAliasName",
@@ -32,8 +32,9 @@ func TestInferTypeAliasBasic(t *testing.T) {
 				type Point = {x: number, y: number}
 				val p: Point = {x: 1, y: 2}
 			`,
+			// The value binding keeps the alias name, while the type binding shows the body.
 			wantValues: map[string]string{"p": "Point"},
-			wantTypes:  map[string]string{"Point": "Point"},
+			wantTypes:  map[string]string{"Point": "{x: number, y: number}"},
 		},
 		{
 			name: "PrimitiveAliasAcceptsMatchingValue",
@@ -42,7 +43,7 @@ func TestInferTypeAliasBasic(t *testing.T) {
 				val x: Foo = 5
 			`,
 			wantValues: map[string]string{"x": "Foo"},
-			wantTypes:  map[string]string{"Foo": "Foo"},
+			wantTypes:  map[string]string{"Foo": "number"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -1,0 +1,110 @@
+package solver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferTypeAliasBasic covers a non-generic `type` alias end to end (M7 PR1): the
+// type binding renders under the alias name, an object literal that fits the aliased
+// record type-checks and the binding renders under the alias name rather than the
+// expanded body, and a primitive alias flows structurally.
+func TestInferTypeAliasBasic(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantValues map[string]string
+		wantTypes  map[string]string
+	}{
+		{
+			name:      "RecordAliasBinds",
+			src:       `type Point = {x: number, y: number}`,
+			wantTypes: map[string]string{"Point": "Point"},
+		},
+		{
+			name: "AnnotatedValueRendersUnderAliasName",
+			src: `
+				type Point = {x: number, y: number}
+				val p: Point = {x: 1, y: 2}
+			`,
+			wantValues: map[string]string{"p": "Point"},
+			wantTypes:  map[string]string{"Point": "Point"},
+		},
+		{
+			name: "PrimitiveAliasAcceptsMatchingValue",
+			src: `
+				type Foo = number
+				val x: Foo = 5
+			`,
+			wantValues: map[string]string{"x": "Foo"},
+			wantTypes:  map[string]string{"Foo": "Foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, types, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.wantValues {
+				require.Equal(t, want, values[name], "value binding %q", name)
+			}
+			for name, want := range tt.wantTypes {
+				require.Equal(t, want, types[name], "type binding %q", name)
+			}
+		})
+	}
+}
+
+// TestInferTypeAliasRejectsMissingField checks that an alias is transparent under
+// subtyping: an object literal missing a field the aliased record requires is rejected
+// against the expanded body, with the full missing-property message (M7 PR1).
+func TestInferTypeAliasRejectsMissingField(t *testing.T) {
+	src := `
+		type Point = {x: number, y: number}
+		val p: Point = {x: 1}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: y", errs[0].Message())
+}
+
+// TestInferTypeAliasRejectsMismatchedPrimitive checks that a primitive alias rejects a
+// value of the wrong primitive, since the alias expands to its body at subtyping time.
+func TestInferTypeAliasRejectsMismatchedPrimitive(t *testing.T) {
+	src := `
+		type Foo = number
+		val x: Foo = "hi"
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+}
+
+// TestInferTypeAliasMissingBodyDoesNotPanic guards the parser error-recovery case where
+// `type Foo =` yields a TypeDecl with a nil TypeAnn. Inference runs despite parse errors
+// in the real pipeline, so inferTypeDecl must bind the alias to a recovery type rather
+// than route the nil annotation to reportUnsupported(nil), whose error has no span.
+func TestInferTypeAliasMissingBodyDoesNotPanic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	// Parse directly so the malformed source reaches inference; the standard harness
+	// rejects parse errors, but the real compiler and LSP keep going on a partial AST.
+	// `type Foo =` yields a TypeDecl with a nil TypeAnn that reaches inferTypeDecl.
+	module, _ := parser.ParseLibFiles(ctx, []*ast.Source{
+		{ID: 0, Path: "input.esc", Contents: `type Foo =`},
+	})
+	// InferModule only collects diagnostics; the nil-Node crash surfaces when a caller
+	// renders one, so exercise Span() and Message() on every returned error the way the
+	// CLI and LSP formatters do.
+	require.NotPanics(t, func() {
+		_, _, errs := InferModule(module)
+		for _, e := range errs {
+			_ = e.Span()
+			_ = e.Message()
+		}
+	})
+}

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestInferTypeAliasBasic covers a non-generic `type` alias end to end (M7 PR1): the
-// type binding renders under the alias name, an object literal that fits the aliased
-// record type-checks and the binding renders under the alias name rather than the
-// expanded body, and a primitive alias flows structurally.
+// TestInferTypeAliasBasic covers a non-generic `type` alias end to end. The type binding
+// renders under the alias name, an object literal that fits the aliased record
+// type-checks and the binding renders under the alias name rather than the expanded body,
+// and a primitive alias flows structurally.
 func TestInferTypeAliasBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -60,8 +60,8 @@ func TestInferTypeAliasBasic(t *testing.T) {
 }
 
 // TestInferTypeAliasRejectsMissingField checks that an alias is transparent under
-// subtyping: an object literal missing a field the aliased record requires is rejected
-// against the expanded body, with the full missing-property message (M7 PR1).
+// subtyping. An object literal missing a field the aliased record requires is rejected
+// against the expanded body, with the full missing-property message.
 func TestInferTypeAliasRejectsMissingField(t *testing.T) {
 	src := `
 		type Point = {x: number, y: number}
@@ -93,10 +93,24 @@ func TestInferTypeAliasMissingBodyDoesNotPanic(t *testing.T) {
 	defer cancel()
 	// Parse directly so the malformed source reaches inference; the standard harness
 	// rejects parse errors, but the real compiler and LSP keep going on a partial AST.
-	// `type Foo =` yields a TypeDecl with a nil TypeAnn that reaches inferTypeDecl.
 	module, _ := parser.ParseLibFiles(ctx, []*ast.Source{
 		{ID: 0, Path: "input.esc", Contents: `type Foo =`},
 	})
+
+	// Prove the malformed decl reaches inference: the parsed module must carry a Foo
+	// TypeDecl with a nil TypeAnn, the exact shape inferTypeDecl must survive.
+	var foo *ast.TypeDecl
+	module.Namespaces.Scan(func(_ string, ns *ast.Namespace) bool {
+		for _, d := range ns.Decls {
+			if td, ok := d.(*ast.TypeDecl); ok && td.Name.Name == "Foo" {
+				foo = td
+			}
+		}
+		return true
+	})
+	require.NotNil(t, foo, "expected a Foo TypeDecl in the parsed module")
+	require.Nil(t, foo.TypeAnn, "expected Foo's body to be nil after error recovery")
+
 	// InferModule only collects diagnostics; the nil-Node crash surfaces when a caller
 	// renders one, so exercise Span() and Message() on every returned error the way the
 	// CLI and LSP formatters do.
@@ -107,4 +121,28 @@ func TestInferTypeAliasMissingBodyDoesNotPanic(t *testing.T) {
 			_ = e.Message()
 		}
 	})
+}
+
+// TestInferTypeAliasGenericReportsUnsupported checks that a generic alias, which needs
+// argument substitution and arity checking that are not implemented, reports a single
+// unsupported-feature diagnostic and binds no type, rather than registering a half-built
+// alias whose body references unbound parameters.
+func TestInferTypeAliasGenericReportsUnsupported(t *testing.T) {
+	_, types, errs := inferSource(t, `type Box<T> = {value: T}`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported: generic type alias", errs[0].Message())
+	require.NotContains(t, types, "Box")
+}
+
+// TestInferTypeAliasShadowingPromiseRejectsArgs checks that a user `type Promise = …`
+// alias is not silently reinterpreted as the built-in Promise: applying type arguments to
+// the non-generic alias is an invalid application and reports unsupported.
+func TestInferTypeAliasShadowingPromiseRejectsArgs(t *testing.T) {
+	src := `
+		type Promise = number
+		val p: Promise<string> = 5
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -952,6 +952,15 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 			return false
 		}
 		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)
+	case *soltype.AliasType:
+		b, ok := b.(*soltype.AliasType)
+		// Two alias references are equal when they name the same alias and their type
+		// arguments compare equal positionally. The Name is the token's identity. An alias
+		// carries no exactness flag.
+		if !ok || a.Name != b.Name {
+			return false
+		}
+		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)
 	case *soltype.PromiseType:
 		b, ok := b.(*soltype.PromiseType)
 		return ok && equalTypeWith(a.Inner, b.Inner, ctx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -161,6 +161,31 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		return nil
 	}
 
+	// A type alias is transparent, meaning it subtypes exactly as its expanded body
+	// does, in either direction. Expand an AliasType on either side to its body and
+	// recurse through the EXISTING seen-set, so an alias is checked as its structure.
+	// This sits above the structural switch because that switch dispatches on sub and
+	// would otherwise reject a concrete sub against an AliasType super before the alias
+	// could expand. The seen-set closes a recursive alias. A non-generic recursive body
+	// reuses one Body node, so the pointer-keyed cache terminates the cycle. M7 PR3 keys
+	// the generic case on canonical identity. expandAlias is a standalone helper so M9's
+	// type-level evaluator reuses the same unfolding.
+	//
+	// When the OTHER side is a variable, fall through to the var arms instead so the
+	// whole AliasType node is recorded as one bound, exactly as the union/intersection
+	// blocks below do. Recording the token rather than the expanded body keeps the alias
+	// name on the coalesced binding, so `val p: Point = {…}` renders `p` as `Point`.
+	if alias, ok := sub.(*soltype.AliasType); ok {
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			return c.constrain(c.expandAlias(alias), super, seen, mutCtx)
+		}
+	}
+	if alias, ok := super.(*soltype.AliasType); ok {
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
+			return c.constrain(sub, c.expandAlias(alias), seen, mutCtx)
+		}
+	}
+
 	// M6 PR2 pre-switch lattice block. The structural switch below dispatches
 	// on sub and several arms return early on a non-variable super (the
 	// RefType arm most importantly), so a union/intersection super has to be

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -161,19 +161,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		return nil
 	}
 
-	// A type alias is transparent, meaning it subtypes exactly as its expanded body
-	// does, in either direction. Expand an AliasType on either side to its body and
-	// recurse through the EXISTING seen-set, so an alias is checked as its structure.
-	// This sits above the structural switch because that switch dispatches on sub and
-	// would otherwise reject a concrete sub against an AliasType super before the alias
-	// could expand. The seen-set closes a recursive alias. A non-generic recursive body
-	// reuses one Body node, so the pointer-keyed cache terminates the cycle. expandAlias
-	// is a standalone helper so callers other than constrain can reuse the same unfolding.
-	//
-	// When the OTHER side is a variable, fall through to the var arms instead so the
-	// whole AliasType node is recorded as one bound, exactly as the union/intersection
-	// blocks below do. Recording the token rather than the expanded body keeps the alias
-	// name on the coalesced binding, so `val p: Point = {…}` renders `p` as `Point`.
+	// A type alias is transparent: expand an AliasType on either side to its body and
+	// recurse through the existing seen-set, which also closes a recursive alias. This
+	// sits above the structural switch, which dispatches on sub and would otherwise
+	// reject a concrete sub against an AliasType super before it could expand. When the
+	// other side is a variable, fall through to the var arms so the whole AliasType is
+	// recorded as one bound, keeping the alias name on the coalesced binding.
 	if alias, ok := sub.(*soltype.AliasType); ok {
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			return c.constrain(c.expandAlias(alias), super, seen, mutCtx)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -167,9 +167,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// This sits above the structural switch because that switch dispatches on sub and
 	// would otherwise reject a concrete sub against an AliasType super before the alias
 	// could expand. The seen-set closes a recursive alias. A non-generic recursive body
-	// reuses one Body node, so the pointer-keyed cache terminates the cycle. M7 PR3 keys
-	// the generic case on canonical identity. expandAlias is a standalone helper so M9's
-	// type-level evaluator reuses the same unfolding.
+	// reuses one Body node, so the pointer-keyed cache terminates the cycle. expandAlias
+	// is a standalone helper so callers other than constrain can reuse the same unfolding.
 	//
 	// When the OTHER side is a variable, fall through to the var arms instead so the
 	// whole AliasType node is recorded as one bound, exactly as the union/intersection

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -48,12 +48,12 @@ type Context struct {
 	// overwritten but never removed for scope exit.
 	classes map[string]*ClassDef
 
-	// aliases is the type-alias registry (M7), the transparent-alias twin of classes:
-	// each alias's Body, type parameters, and level, keyed by the alias's
-	// dep_graph-qualified name — the same string stored in soltype.AliasType.Name.
-	// inferTypeDecl writes an entry per `type` decl; expandAlias reads the Body to
-	// unfold an alias reference to its structural type at subtyping time. Every
-	// AliasDef comes from a top-level decl and lives for the whole inference run.
+	// aliases is the type-alias registry, the transparent-alias twin of classes. It holds
+	// each alias's Body and level, keyed by the alias's dep_graph-qualified name, the same
+	// string stored in soltype.AliasType.Name. inferTypeDecl writes an entry per `type`
+	// decl, and expandAlias reads the Body to unfold an alias reference to its structural
+	// type at subtyping time. Every AliasDef comes from a top-level decl and lives for the
+	// whole inference run.
 	aliases map[string]*AliasDef
 }
 

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -47,6 +47,30 @@ type Context struct {
 	// top-level decl and lives for the whole inference run, so an entry is inserted or
 	// overwritten but never removed for scope exit.
 	classes map[string]*ClassDef
+
+	// aliases is the type-alias registry (M7), the transparent-alias twin of classes:
+	// each alias's Body, type parameters, and level, keyed by the alias's
+	// dep_graph-qualified name — the same string stored in soltype.AliasType.Name.
+	// inferTypeDecl writes an entry per `type` decl; expandAlias reads the Body to
+	// unfold an alias reference to its structural type at subtyping time. Every
+	// AliasDef comes from a top-level decl and lives for the whole inference run.
+	aliases map[string]*AliasDef
+}
+
+// aliasDef returns the registered AliasDef for a qualified alias name, or ok=false
+// when no alias of that name has been registered on this Context.
+func (c *Context) aliasDef(name string) (*AliasDef, bool) {
+	def, ok := c.aliases[name]
+	return def, ok
+}
+
+// registerAlias inserts def under a qualified alias name, allocating the registry
+// map on first use.
+func (c *Context) registerAlias(name string, def *AliasDef) {
+	if c.aliases == nil {
+		c.aliases = map[string]*AliasDef{}
+	}
+	c.aliases[name] = def
 }
 
 // classDef returns the registered ClassDef for a qualified class name, or ok=false

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1551,6 +1551,11 @@ func describe(t soltype.Type) string {
 		// A class instance renders nominally under its display name, `Point` or
 		// `Box<number>`, so a diagnostic naming it matches the printer's surface form.
 		return soltype.Print(t)
+	case *soltype.AliasType:
+		// An alias reference renders under its own name, `Point` or `Box<number>`, so a
+		// diagnostic naming it matches the printer's surface form rather than the expanded
+		// body the constraint actually compares.
+		return soltype.Print(t)
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
 		// object above. That is deliberate and consistent with the Union/Intersection

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -284,7 +284,7 @@ func (c *checker) buildClassInstance(scope *Scope, ct *soltype.ClassType, ref *a
 	}
 	args := make([]soltype.Type, len(ref.TypeArgs))
 	for i, arg := range ref.TypeArgs {
-		if at, ok := c.resolveClassTypeAnn(scope, arg, lvl); ok {
+		if at, ok := c.resolveTypeAnn(scope, arg, lvl); ok {
 			args[i] = at
 		} else {
 			args[i] = c.freshAt(lvl)
@@ -320,15 +320,6 @@ func (c *checker) lookupClassBinding(scope *Scope, name string) (TypeBinding, bo
 		}
 	}
 	return bare, bareOK
-}
-
-// resolveClassTypeAnn resolves a type annotation in a class body or type-parameter bound.
-// It is a thin named marker over resolveTypeAnn, which already consults the scope first for
-// a type reference so a class, alias, or type parameter in scope resolves ahead of the
-// Promise stub. The wrapper stays so class-context call sites read distinctly from ordinary
-// annotation resolution.
-func (c *checker) resolveClassTypeAnn(scope *Scope, ann ast.TypeAnn, lvl int) (soltype.Type, bool) {
-	return c.resolveTypeAnn(scope, ann, lvl)
 }
 
 // resolveScopedTypeRef resolves a type reference through lookupClassBinding, covering a
@@ -383,7 +374,7 @@ func (c *checker) buildFieldSigs(scope *Scope, lvl int, decl *ast.ClassDecl, bod
 		}
 		var fieldType soltype.Type
 		if field.Type != nil {
-			if t, ok := c.resolveClassTypeAnn(scope, field.Type, lvl); ok {
+			if t, ok := c.resolveTypeAnn(scope, field.Type, lvl); ok {
 				fieldType = t
 			} else {
 				fieldType = c.freshAt(lvl)

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -323,15 +323,11 @@ func (c *checker) lookupClassBinding(scope *Scope, name string) (TypeBinding, bo
 }
 
 // resolveClassTypeAnn resolves a type annotation in a class body or type-parameter bound.
-// It tries the scope through resolveScopedTypeRef first, so a class or type parameter takes
-// precedence over resolveTypeAnn's hardcoded `Promise` stub, then delegates to resolveTypeAnn
-// for primitives and structural types.
+// It is a thin named marker over resolveTypeAnn, which already consults the scope first for
+// a type reference so a class, alias, or type parameter in scope resolves ahead of the
+// Promise stub. The wrapper stays so class-context call sites read distinctly from ordinary
+// annotation resolution.
 func (c *checker) resolveClassTypeAnn(scope *Scope, ann ast.TypeAnn, lvl int) (soltype.Type, bool) {
-	if ref, ok := ann.(*ast.TypeRefTypeAnn); ok {
-		if t, ok := c.resolveScopedTypeRef(scope, ref, lvl); ok {
-			return t, true
-		}
-	}
 	return c.resolveTypeAnn(scope, ann, lvl)
 }
 

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -221,20 +221,14 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 	require.Equal(t, map[string]string{"x": "5", "y": "5"}, values)
 }
 
-// A top-level declaration outside the M2 subset reports a clean
-// UnsupportedNodeError rather than panicking. A type alias is such a decl — type
-// bindings are M3+ — so it registers a type-sort dep_graph key the SCC driver
-// reports as unsupported. (FuncDecl, unsupported at the module level through
-// PR-2, is now wired in by PR-5; see the func/recursion tests.)
-func TestInferModuleUnsupportedDecl(t *testing.T) {
+// A top-level `type X = Body` alias binds a type-sort name (M7 PR1): it registers
+// an AliasDef holding the resolved body and binds the name to an AliasType token, so
+// the name resolves and renders under itself rather than reporting unsupported.
+func TestInferModuleTypeAliasBinds(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)
-	require.Len(t, errs, 1)
-	require.Equal(t, "1:1-1:18: Unsupported: TypeDecl", msgWithSpan(errs[0]))
-	// M2.5: the error self-blames from the decl node.
-	require.Equal(t, src, spanText(src, errs[0].Span()))
-	// The unsupported decl must not leak a type binding.
-	require.NotContains(t, types, "Foo")
+	require.Empty(t, errs)
+	require.Equal(t, "Foo", types["Foo"])
 }
 
 // A `val` with no initializer can't be inferred in M2 (annotation-driven binding

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -221,9 +221,9 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 	require.Equal(t, map[string]string{"x": "5", "y": "5"}, values)
 }
 
-// A top-level `type X = Body` alias binds a type-sort name (M7 PR1): it registers
-// an AliasDef holding the resolved body and binds the name to an AliasType token, so
-// the name resolves and renders under itself rather than reporting unsupported.
+// A top-level `type X = Body` alias binds a type-sort name. It registers an AliasDef
+// holding the resolved body and binds the name to an AliasType token, so the name
+// resolves and renders under itself rather than reporting unsupported.
 func TestInferModuleTypeAliasBinds(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)

--- a/internal/solver/infer_test.go
+++ b/internal/solver/infer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/dep_graph"
 	"github.com/escalier-lang/escalier/internal/parser"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
@@ -46,12 +47,18 @@ func parseModule(t *testing.T, src string) *ast.Module {
 	return parseModuleFiles(t, map[string]string{"input.esc": src})
 }
 
-// inferModule runs InferModule on an already-parsed module and renders the
-// top-level value/type bindings straight off the module scope's own maps (not the
-// prelude parent), so operators and the stdlib-type placeholders are excluded.
-// Only inference errors flow back; parse errors fail the test in parseModuleFiles.
+// inferModule infers an already-parsed module and renders the top-level value/type
+// bindings straight off the module scope's own maps (not the prelude parent), so
+// operators and the stdlib-type placeholders are excluded. Only inference errors flow
+// back; parse errors fail the test in parseModuleFiles.
+//
+// It builds the checker directly rather than through InferModule so the alias registry
+// stays reachable: a type-alias binding renders as its definition body, which lives on
+// the checker's Context, not on the AliasType token in scope.
 func inferModule(module *ast.Module) (values, types map[string]string, errs []SolverError) {
-	scope, _, errs := InferModule(module)
+	c := newChecker()
+	scope := sharedPrelude().Child()
+	c.inferDepGraph(scope, 0, module, dep_graph.BuildDepGraph(module))
 	values = make(map[string]string, len(scope.values))
 	for name, b := range scope.values {
 		if b.IsOverloaded() {
@@ -68,8 +75,21 @@ func inferModule(module *ast.Module) (values, types map[string]string, errs []So
 		// <T0, …> quantifier prefix when generalization left type parameters behind.
 		values[name] = renderScheme(b.Schemes[0])
 	}
-	types = renderBindings(scope.types, func(b TypeBinding) soltype.Type { return b.Type })
-	return values, types, errs
+	// A type-alias binding renders as its definition body, not its opaque name, so a test
+	// asserts the structure the alias stands for. `type Point = {x: number}` shows
+	// `{x: number}`, not `Point`. Every other type binding, including a nominal class,
+	// renders as itself.
+	types = make(map[string]string, len(scope.types))
+	for name, b := range scope.types {
+		ty := b.Type
+		if alias, ok := ty.(*soltype.AliasType); ok {
+			if def, ok := c.ctx.aliasDef(alias.Name); ok {
+				ty = def.Body
+			}
+		}
+		types[name] = soltype.Print(ty)
+	}
+	return values, types, c.errs
 }
 
 // inferSource is the single-file table harness (§3.6) — fast, no on-disk
@@ -223,12 +243,14 @@ func TestInferModuleForwardReferenceResolves(t *testing.T) {
 
 // A top-level `type X = Body` alias binds a type-sort name. It registers an AliasDef
 // holding the resolved body and binds the name to an AliasType token, so the name
-// resolves and renders under itself rather than reporting unsupported.
+// resolves rather than reporting unsupported. The test harness renders the binding as the
+// alias's definition body, so `type Foo = number` shows `number`.
 func TestInferModuleTypeAliasBinds(t *testing.T) {
 	src := `type Foo = number`
 	_, types, errs := inferSource(t, src)
 	require.Empty(t, errs)
-	require.Equal(t, "Foo", types["Foo"])
+	require.Contains(t, types, "Foo")
+	require.Equal(t, "number", types["Foo"])
 }
 
 // A `val` with no initializer can't be inferred in M2 (annotation-driven binding

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -354,6 +354,7 @@ func (c *checker) inferComponent(
 	//     completed by inferEnumBody once every sibling is bound; its value key is then a
 	//     no-op whose pre-bound value var is retracted in phase 3.
 	var enumShells []*enumShell
+	var typeDecls []typeDeclEntry
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -373,6 +374,14 @@ func (c *checker) inferComponent(
 				// The returned token and def are discarded here; inferClassDecl reuses them,
 				// keyed by the same qualified name the shared namespace reconstructs.
 				c.getOrCreateClass(scope, decl, g.GetNamespace(key))
+			case *ast.TypeDecl:
+				// A `type X = Body` alias infers fully at its type key and is marked handled,
+				// so its value key is a no-op. Collect it and resolve its body after every
+				// class token and enum union in this component is bound, so a body naming a
+				// sibling class or enum resolves. PR1 handles only the non-recursive case; the
+				// recursive alias two-pass is M7 PR3.
+				typeDecls = append(typeDecls, typeDeclEntry{decl: decl, ns: g.GetNamespace(key)})
+				handled.Add(d)
 			}
 		}
 	}
@@ -380,6 +389,11 @@ func (c *checker) inferComponent(
 	// identities above, so a parameter naming a sibling enum or class resolves.
 	for _, sh := range enumShells {
 		c.inferEnumBody(sh)
+	}
+	// Each alias body resolves after the class tokens and enum unions are bound, so a
+	// non-recursive alias naming a sibling type resolves.
+	for _, td := range typeDecls {
+		c.inferTypeDecl(scope, inner, td.decl, td.ns)
 	}
 
 	// Report any remaining non-value decl as unsupported. A class was pre-bound above and

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -378,8 +378,8 @@ func (c *checker) inferComponent(
 				// A `type X = Body` alias infers fully at its type key and is marked handled,
 				// so its value key is a no-op. Collect it and resolve its body after every
 				// class token and enum union in this component is bound, so a body naming a
-				// sibling class or enum resolves. PR1 handles only the non-recursive case; the
-				// recursive alias two-pass is M7 PR3.
+				// sibling class or enum resolves. A body naming a sibling that is only bound
+				// later in a mutually recursive group is not resolved here.
 				typeDecls = append(typeDecls, typeDeclEntry{decl: decl, ns: g.GetNamespace(key)})
 				handled.Add(d)
 			}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -19,18 +19,20 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
 	case *ast.TypeRefTypeAnn:
-		// M3 (PR3) recognises a single generic stdlib reference: Promise<T>. The
-		// real, alias-driven TypeRef resolution arrives in M7 — until then, any
-		// other name (or arity) reports unsupported with a `never` placeholder so
-		// the caller can recover by keeping the inferred type.
-		//
-		// FOOTGUN (removed in M7): this matches the bare NAME "Promise" WITHOUT
-		// consulting the type scope, so it would preempt any user-defined
-		// `type Promise<T> = …` alias. That is harmless today (user type aliases
-		// don't resolve yet, and the prelude only seeds Promise as an opaque
-		// placeholder), but M7's scope-driven TypeRef resolution MUST replace this
-		// hardcoded check — resolve the name through the scope first — so a real
-		// alias wins instead of being silently shadowed by this stub.
+		// Consult the type scope first so a user-defined alias, class, or type parameter
+		// wins over the hardcoded Promise stub below. A real `type Promise<T> = …` alias
+		// then resolves through its AliasDef rather than being shadowed by the stub. The
+		// prelude seeds Promise as an opaque `unknown` placeholder, not a class, so a
+		// `Promise<T>` reference with no real alias falls through here and lands on the
+		// stub. Only a bare `Promise` resolves to that placeholder.
+		if t, ok := c.resolveScopedTypeRef(scope, ta, lvl); ok {
+			return t, true
+		}
+		// M3 recognises a single generic stdlib reference: Promise<T>. The real,
+		// alias-driven Promise arrives with library type ingestion in M7.5 — until then
+		// an `async fn () -> Promise<T>` annotation resolves here, and any other name or
+		// arity reports unsupported with a `never` placeholder so the caller can recover
+		// by keeping the inferred type.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
 			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
 			// supported: M3's PromiseType carries no lifetime, so silently accepting it
@@ -62,14 +64,6 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 			}
 			t := &soltype.PromiseType{Inner: inner}
 			c.recordProv(t, ta, AnnotationType)
-			return t, true
-		}
-		// Consult the type scope so a reference to a class or type parameter in scope —
-		// the `D` in a `class Dog<D>` constructor's `food: D`, or a bare class name —
-		// resolves rather than reporting unsupported. Outside a class body the scope holds
-		// no such binding and this falls through; the general scope-driven TypeRef
-		// resolution for aliases and stdlib names arrives in M7.
-		if t, ok := c.resolveScopedTypeRef(scope, ta, lvl); ok {
 			return t, true
 		}
 		return c.reportUnsupported(ta), false

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -19,20 +19,28 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
 	case *ast.TypeRefTypeAnn:
-		// Consult the type scope first so a user-defined alias, class, or type parameter
-		// wins over the hardcoded Promise stub below. A real `type Promise<T> = …` alias
-		// then resolves through its AliasDef rather than being shadowed by the stub. The
-		// prelude seeds Promise as an opaque `unknown` placeholder, not a class, so a
-		// `Promise<T>` reference with no real alias falls through here and lands on the
-		// stub. Only a bare `Promise` resolves to that placeholder.
+		// Resolve through the type scope first so a user-defined alias, class, or type
+		// parameter takes precedence over the built-in Promise stub below. A bare alias or
+		// class reference resolves here; the prelude Promise placeholder is not a class, so
+		// a `Promise<T>` reference with no user binding does not resolve here and reaches
+		// the stub.
 		if t, ok := c.resolveScopedTypeRef(scope, ta, lvl); ok {
 			return t, true
 		}
-		// M3 recognises a single generic stdlib reference: Promise<T>. The real,
-		// alias-driven Promise arrives with library type ingestion in M7.5 — until then
-		// an `async fn () -> Promise<T>` annotation resolves here, and any other name or
-		// arity reports unsupported with a `never` placeholder so the caller can recover
-		// by keeping the inferred type.
+		// A reference that applies type arguments to a user-defined non-generic alias is an
+		// invalid application, not an unknown name. Report it before the Promise stub, so a
+		// user `type Promise = …` alias is not silently reinterpreted as the built-in
+		// Promise. A bare alias reference already resolved above, so reaching here with an
+		// alias binding means arguments were supplied.
+		if b, ok := c.lookupClassBinding(scope, ast.QualIdentToString(ta.Name)); ok {
+			if _, isAlias := b.Type.(*soltype.AliasType); isAlias {
+				return c.reportUnsupported(ta), false
+			}
+		}
+		// The built-in Promise<T>. The prelude seeds Promise as an opaque placeholder, so
+		// an `async fn () -> Promise<T>` annotation resolves here. Any other name or arity
+		// reports unsupported with a `never` placeholder so the caller can recover by
+		// keeping the inferred type.
 		if ast.QualIdentToString(ta.Name) == "Promise" && len(ta.TypeArgs) == 1 {
 			// A lifetime-annotated Promise (`'a Promise<T>` or `Promise<'a, T>`) is not
 			// supported: M3's PromiseType carries no lifetime, so silently accepting it

--- a/internal/solver/type_params.go
+++ b/internal/solver/type_params.go
@@ -35,12 +35,12 @@ func (c *checker) resolveTypeParams(scope *Scope, lvl int, params []*ast.TypePar
 	// every sibling name is in scope.
 	for i, p := range params {
 		if p.Constraint != nil {
-			if ct, ok := c.resolveClassTypeAnn(scope, p.Constraint, lvl); ok {
+			if ct, ok := c.resolveTypeAnn(scope, p.Constraint, lvl); ok {
 				c.ctx.addUpperBound(out[i].Var, ct)
 			}
 		}
 		if p.Default != nil {
-			if dt, ok := c.resolveClassTypeAnn(scope, p.Default, lvl); ok {
+			if dt, ok := c.resolveTypeAnn(scope, p.Default, lvl); ok {
 				out[i].Default = dt
 			}
 		}


### PR DESCRIPTION
Implement transparent type aliases for the Escalier type system. A `type Name = Body` declaration now resolves its body, registers an `AliasDef` holding that body, and binds the name to an `AliasType` token so references resolve and render under the alias name rather than the expanded type.

**Key changes:**

- Add `AliasType` to the type representation (`soltype/type.go`): a small token carrying the qualified alias name and type arguments, mirroring the `ClassType` / `ClassDef` split. An alias is transparent, so it subtypes exactly as its expanded body does.
- Add `AliasDef` registry to `Context` (`solver/context.go`): stores the resolved body, type parameters (nil for non-generic aliases in PR1), and level for each alias, keyed by qualified name.
- Implement `inferTypeDecl` (`solver/aliases.go`): resolves a non-generic `type X = Body` declaration, registers the `AliasDef`, and binds the name to an `AliasType` token. Handles parser error recovery when the body is missing by binding to a fresh variable.
- Expand aliases transparently in subtyping (`solver/constrain.go`): when either side of a constraint is an `AliasType`, expand it to its body and recurse through the existing seen-set. When the other side is a variable, fall through to the variable arms so the alias token itself is recorded as a bound, preserving the alias name on coalesced bindings.
- Wire alias inference into the module SCC loop (`solver/module.go`): collect `type` declarations and resolve their bodies after every class token and enum union in the component is bound, so a non-recursive alias naming a sibling type resolves.
- Update type annotation resolution (`solver/type_ann.go`): consult the type scope first so a user-defined alias wins over the hardcoded `Promise` stub.
- Add visitor support (`soltype/visitor.go`): walk type arguments covariantly; variance is resolved by expansion at subtyping time.
- Add printing support (`soltype/print.go`): render an alias reference under its name with optional `<args>` list, stripping the qualified namespace prefix for display.
- Add equality checking (`solver/coalesce.go`): two alias references are equal when they name the same alias and their type arguments match.
- Add error description (`solver/errors.go`): describe an alias reference by its printed form so diagnostics match the surface syntax.
- Simplify class type annotation resolution (`solver/infer_class.go`): remove the redundant scope lookup since `resolveTypeAnn` now consults the scope first.
- Add comprehensive tests (`solver/aliases_test.go`): cover basic alias binding, rendering under the alias name, primitive aliases, rejection of missing fields, rejection of type mismatches, and parser error recovery.
- Update existing test (`solver/infer_test.go`): change `TestInferModuleUnsupportedDecl` to `TestInferModuleTypeAliasBinds` to reflect that type aliases are now supported.

This PR handles only non-generic, non-recursive aliases. Generic instantiation and type parameter substitution land in M7 PR2, and recursive alias handling in M7 PR3.

https://claude.ai/code/session_014KTz9s7uabV4jA98R3ZLdF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining and using non-generic type aliases.
  * Type aliases now preserve readable names, including aliases with type arguments.
  * Aliases participate correctly in type checking, subtyping, and diagnostic messages.

* **Bug Fixes**
  * Improved error recovery for incomplete type alias declarations without causing diagnostic crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->