### PR TITLE
Support recursive and mutually recursive type aliases

### DIFF
--- a/internal/soltype/alias_test.go
+++ b/internal/soltype/alias_test.go
@@ -15,6 +15,24 @@ func TestPrintAliasType(t *testing.T) {
 	require.Equal(t, "Pair<number, string>", Print(&AliasType{Name: "Pair", TypeArgs: []Type{numP(), strP()}}))
 }
 
+// TestPrintQualifiedAliasType renders an alias and class under their full dep_graph
+// namespace prefix rather than the stripped display name, so a solver identity key formed
+// from PrintQualified keeps two same-local-name nominal types in different namespaces
+// distinct. A nested class argument is qualified too, so `Box<A.Point>` and `Box<B.Point>`
+// never collide on one key.
+func TestPrintQualifiedAliasType(t *testing.T) {
+	require.Equal(t, "Geometry.Point", PrintQualified(&AliasType{Name: "Geometry.Point"}))
+	require.NotEqual(t,
+		PrintQualified(&AliasType{Name: "Box", TypeArgs: []Type{&ClassType{Name: "A.Point"}}}),
+		PrintQualified(&AliasType{Name: "Box", TypeArgs: []Type{&ClassType{Name: "B.Point"}}}),
+		"a nested class argument keeps its namespace so cross-namespace types do not collide",
+	)
+	require.Equal(t,
+		"Box<A.Point>",
+		PrintQualified(&AliasType{Name: "Box", TypeArgs: []Type{&ClassType{Name: "A.Point"}}}),
+	)
+}
+
 // TestPrintAliasBorrow renders a borrow whose inner is an alias, since AliasType is a
 // RefInner that flows through the borrow machinery like a class instance.
 func TestPrintAliasBorrow(t *testing.T) {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -68,6 +68,15 @@ func Print(t Type) string {
 	return (&namedPrinter{}).printType(t)
 }
 
+// PrintQualified renders a type like Print but under the full dep_graph-qualified name of
+// every ClassType and AliasType, so two nominal types sharing a local name in different
+// namespaces render distinctly. Print strips the namespace for display, which suits
+// user-facing output but collapses `A.Point` and `B.Point` to one string. The solver forms
+// a collision-free canonical identity key from PrintQualified. It is not a surface form.
+func PrintQualified(t Type) string {
+	return (&namedPrinter{qualify: true}).printType(t)
+}
+
 // PrintAsScheme renders a coalesced GENERALIZED type (M3): it collects the type's
 // free variables into a <T0, T1, …> quantifier prefix and renders each as its
 // assigned name. A type with no free variables renders exactly as Print would (no
@@ -410,6 +419,11 @@ type namedPrinter struct {
 	// `'l{ID}` debug form; D4's display-time coalescing populates it so a
 	// param-originated lifetime renders under its quantified name.
 	ltNames map[*LifetimeVar]string
+	// qualify renders a ClassType or AliasType under its full dep_graph-qualified name
+	// instead of the namespace-stripped display name, so two nominal types sharing a local
+	// name across namespaces stay distinct. PrintQualified sets it for identity-key use;
+	// plain Print leaves it false so user-facing output stays unqualified.
+	qualify bool
 }
 
 // printLifetime renders a lifetime in Escalier surface syntax: 'static for the
@@ -534,6 +548,9 @@ func (p *namedPrinter) printType(t Type) string {
 			// two enums sharing a name stay distinct; a plain class strips to its bare name.
 			name = enumVariantDisplayName(t.Name)
 		}
+		if p.qualify {
+			name = t.Name // full qualified name for a collision-free identity key
+		}
 		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
 		}
@@ -552,6 +569,9 @@ func (p *namedPrinter) printType(t Type) string {
 		// the same way a class name is. Rendering the name rather than the expanded body is
 		// the point of the alias, so `val p: Point = {x: 1}` shows `Point`.
 		name := classDisplayName(t.Name)
+		if p.qualify {
+			name = t.Name // full qualified name for a collision-free identity key
+		}
 		if len(t.TypeArgs) == 0 {
 			return name
 		}

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -44,19 +44,37 @@ func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
 	return def.Body.Accept(subst, soltype.Positive)
 }
 
-// typeDeclEntry pairs a `type` decl with its namespace, so the type-key loop can defer
-// alias-body resolution until every sibling class and enum in the component is bound.
-type typeDeclEntry struct {
+// aliasShell carries an alias's pre-bound state from preBindAlias to inferAliasBody: the
+// registered AliasDef whose Body the body pass fills, and the scope its body resolves in.
+// Pre-binding every alias identity in a dep_graph type-key component before any body
+// resolves is what lets a self or mutual reference find the sibling already bound, so
+// `type A = {b: B}` / `type B = {a: A}` resolve each other.
+type aliasShell struct {
 	decl *ast.TypeDecl
 	ns   string
+	lvl  int
+	// declScope is scope, or a child holding a generic alias's type parameters. The body
+	// resolves here so it reads each `T` as the one shared var the def stores.
+	declScope *Scope
+	// def is the registered AliasDef preBindAlias inserted with a nil Body; inferAliasBody
+	// fills its Body once every sibling identity in the component is bound.
+	def *AliasDef
 }
 
-// inferTypeDecl resolves a `type X = Body` or `type X<T, U = T> = Body`, registers its
-// AliasDef, and binds the name to an AliasType handle. A generic alias resolves its type
-// parameters into a child scope so the body reads each `T` as one shared var, matching the
-// class path. The vars stay symbolic in the stored body, and expandAlias substitutes an
-// instance's arguments for them at subtyping time.
-func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) {
+// preBindAlias resolves an alias's type parameters, registers a shell AliasDef whose Body
+// is still nil, and binds the alias name to an AliasType handle — without resolving the
+// body. It returns the shell inferAliasBody completes. Registering the name and def up
+// front is what lets a sibling alias, or the alias itself, resolve this name while its own
+// body is still being walked. expandAlias only runs at subtyping time, after every body in
+// the component is filled, so the nil Body is never read during pre-binding.
+func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) *aliasShell {
+	// An alias-body type reference resolves against the alias's own namespace first, the
+	// same qualified-first resolution a class or enum body uses, so a namespaced alias
+	// resolves a bare sibling reference. Save and restore around type-parameter resolution.
+	prevNS := c.classNamespace
+	c.classNamespace = ns
+	defer func() { c.classNamespace = prevNS }()
+
 	// The alias's dep_graph-qualified name is the namespace joined to the local name, or
 	// the bare local name at the root namespace, the same qualified key class and enum
 	// registration use, so the registry key and the AliasType handle match.
@@ -75,18 +93,8 @@ func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns st
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
 
-	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
-	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
-	var body soltype.Type = c.freshAt(lvl)
-	if decl.TypeAnn != nil {
-		if resolved, ok := c.resolveTypeAnn(declScope, decl.TypeAnn, lvl); ok {
-			body = resolved
-		}
-		// An unsupported body reported its own error. Keep the fresh var so a reference
-		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper
-		// recovery in resolveTypeAnn.
-	}
-	c.ctx.registerAlias(qname, &AliasDef{TypeParams: typeParams, Body: body, Level: lvl - 1})
+	def := &AliasDef{TypeParams: typeParams, Level: lvl - 1}
+	c.ctx.registerAlias(qname, def)
 
 	t := &soltype.AliasType{Name: qname}
 	scope.defineType(qname, TypeBinding{
@@ -94,6 +102,32 @@ func (c *checker) inferTypeDecl(scope *Scope, lvl int, decl *ast.TypeDecl, ns st
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},
 	})
 	c.recordType(decl.Name, t)
+
+	return &aliasShell{decl: decl, ns: ns, lvl: lvl, declScope: declScope, def: def}
+}
+
+// inferAliasBody resolves a pre-bound alias's body and stores it on the shell's AliasDef.
+// It runs after every alias, enum, and class identity in the recursive group is pre-bound,
+// so a body naming a sibling — or the alias itself — resolves. The type-parameter vars stay
+// symbolic in the stored body, and expandAlias substitutes an instance's arguments for them
+// at subtyping time.
+func (c *checker) inferAliasBody(sh *aliasShell) {
+	prevNS := c.classNamespace
+	c.classNamespace = sh.ns
+	defer func() { c.classNamespace = prevNS }()
+
+	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
+	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
+	var body soltype.Type = c.freshAt(sh.lvl)
+	if sh.decl.TypeAnn != nil {
+		if resolved, ok := c.resolveTypeAnn(sh.declScope, sh.decl.TypeAnn, sh.lvl); ok {
+			body = resolved
+		}
+		// An unsupported body reported its own error. Keep the fresh var so a reference
+		// resolves rather than cascading an unbound-name error, matching the Promise-wrapper
+		// recovery in resolveTypeAnn.
+	}
+	sh.def.Body = body
 }
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -263,6 +263,85 @@ func TestInferGenericTypeAliasDefaultConstrainsBody(t *testing.T) {
 	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
 }
 
+// TestInferRecursiveTypeAliasBinds covers a non-generic self-recursive alias. The type
+// binding renders the self-reference under its own name at the knot rather than expanding
+// forever, and a value inhabiting the type through the optional recursive field type-checks.
+func TestInferRecursiveTypeAliasBinds(t *testing.T) {
+	src := `
+		type IntList = {head: number, tail?: IntList}
+		val one: IntList = {head: 1}
+		val two: IntList = {head: 1, tail: {head: 2}}
+	`
+	values, types, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "{head: number, tail?: IntList}", types["IntList"])
+	require.Equal(t, "IntList", values["one"])
+	require.Equal(t, "IntList", values["two"])
+}
+
+// TestInferRecursiveTypeAliasSubtypingSubject exercises a recursive alias as a subtyping
+// subject: an alias-typed binding assigned to another binding of the same alias expands
+// both sides and walks the recursive field, closing the cycle through the alias's own name.
+func TestInferRecursiveTypeAliasSubtypingSubject(t *testing.T) {
+	src := `
+		type IntList = {head: number, tail?: IntList}
+		val a: IntList = {head: 1}
+		val b: IntList = a
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "IntList", values["a"])
+	require.Equal(t, "IntList", values["b"])
+}
+
+// TestInferGenericRecursiveTypeAliasSubtypingSubject is the divergence case the canonical
+// recursion guard exists for: a generic instance List<number> used as a subtyping subject.
+// expandAlias substitutes the argument into a fresh node each unfold, so a pointer-identity
+// guard would mint a new List<number> every lap and loop; keying on the canonical
+// (alias, args) identity closes the cycle.
+func TestInferGenericRecursiveTypeAliasSubtypingSubject(t *testing.T) {
+	src := `
+		type List<T> = {head: T, tail?: List<T>}
+		val a: List<number> = {head: 1, tail: {head: 2}}
+		val b: List<number> = a
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "List<number>", values["a"])
+	require.Equal(t, "List<number>", values["b"])
+}
+
+// TestInferGenericRecursiveTypeAliasRejectsMismatch checks that a generic recursive alias
+// stays transparent under subtyping: a nested value whose recursive field carries the wrong
+// element type is rejected against the expanded body, with the full message.
+func TestInferGenericRecursiveTypeAliasRejectsMismatch(t *testing.T) {
+	src := `
+		type List<T> = {head: T, tail?: List<T>}
+		val a: List<number> = {head: 1, tail: {head: "hi"}}
+	`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, `cannot constrain "hi" <: number`, errs[0].Message())
+}
+
+// TestInferMutuallyRecursiveTypeAliases covers a mutual alias group: each body names the
+// other, so both must be pre-bound before either body resolves. Both render under their own
+// names, and an alias-typed binding assigned across the pair closes the cross-alias cycle.
+func TestInferMutuallyRecursiveTypeAliases(t *testing.T) {
+	src := `
+		type Ping = {next?: Pong}
+		type Pong = {next?: Ping}
+		val a: Ping = {}
+		val b: Ping = a
+	`
+	values, types, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "{next?: Pong}", types["Ping"])
+	require.Equal(t, "{next?: Ping}", types["Pong"])
+	require.Equal(t, "Ping", values["a"])
+	require.Equal(t, "Ping", values["b"])
+}
+
 // TestInferGenericTypeAliasArityErrors covers the two out-of-range counts. Supplying more
 // than the total parameter count and fewer than the required count each report a single
 // AliasArityMismatchError, whose message states a range when a default makes a parameter

--- a/internal/solver/aliases_test.go
+++ b/internal/solver/aliases_test.go
@@ -297,8 +297,8 @@ func TestInferRecursiveTypeAliasSubtypingSubject(t *testing.T) {
 // TestInferGenericRecursiveTypeAliasSubtypingSubject is the divergence case the canonical
 // recursion guard exists for: a generic instance List<number> used as a subtyping subject.
 // expandAlias substitutes the argument into a fresh node each unfold, so a pointer-identity
-// guard would mint a new List<number> every lap and loop; keying on the canonical
-// (alias, args) identity closes the cycle.
+// guard would mint a new List<number> every lap and loop. Keying on the canonical identity
+// formed from the alias and its arguments closes the cycle.
 func TestInferGenericRecursiveTypeAliasSubtypingSubject(t *testing.T) {
 	src := `
 		type List<T> = {head: T, tail?: List<T>}

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -138,11 +138,11 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // borrow's mutability, the object/tuple arms propagate it, and the function and
 // promise arms reset it since each carries its own annotation context.
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) []SolverError {
-	// An AliasType operand keys on its canonical (alias, args) identity rather than its raw
-	// pointer, so two structurally-equal instances of a generic recursive alias close the
-	// cycle. expandAlias substitutes arguments into a fresh node each unfold, so a raw
-	// pointer key would see a new List<number> every lap and diverge. Every other operand is
-	// its own key.
+	// An AliasType operand keys on the canonical identity formed from the alias and its
+	// arguments rather than on its raw pointer, so two structurally-equal instances of a
+	// generic recursive alias close the cycle. expandAlias substitutes arguments into a fresh
+	// node each unfold, so a raw pointer key would see a new List<number> every lap and
+	// diverge. Every other operand is its own key.
 	key := constraintKey{c.aliasKey(sub), c.aliasKey(super), mutCtx}
 	if seen.Contains(key) {
 		return nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -76,6 +76,17 @@ type constraintKey struct {
 	mutCtx     bool
 }
 
+// aliasKey returns the seen-set key operand for one side of a constraint: an AliasType's
+// interned canonical representative, or the type itself for every other kind. Canonicalizing
+// only the alias operands keeps the common path a cheap type assertion and confines the
+// interning cost to a reference that carries type arguments.
+func (c *Context) aliasKey(t soltype.Type) soltype.Type {
+	if at, ok := t.(*soltype.AliasType); ok {
+		return c.internAlias(at)
+	}
+	return t
+}
+
 // extrudeKey keys extrude's per-extrusion cache by both the origin variable's
 // ID and the polarity it was reached in, so the same variable copied in
 // covariant and contravariant position produces two distinct fresh vars.
@@ -127,7 +138,12 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // borrow's mutability, the object/tuple arms propagate it, and the function and
 // promise arms reset it since each carries its own annotation context.
 func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) []SolverError {
-	key := constraintKey{sub, super, mutCtx}
+	// An AliasType operand keys on its canonical (alias, args) identity rather than its raw
+	// pointer, so two structurally-equal instances of a generic recursive alias close the
+	// cycle. expandAlias substitutes arguments into a fresh node each unfold, so a raw
+	// pointer key would see a new List<number> every lap and diverge. Every other operand is
+	// its own key.
+	key := constraintKey{c.aliasKey(sub), c.aliasKey(super), mutCtx}
 	if seen.Contains(key) {
 		return nil
 	}

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -74,9 +74,9 @@ type Context struct {
 
 // internAlias returns the shared representative for an alias reference's canonical
 // identity, minting one on first sight. Two AliasType nodes naming the same alias with
-// type arguments that render identically map to one pointer — the canonical
-// (alias, args) identity constrain's cycle guard keys on. A non-generic reference keys on
-// its name alone.
+// type arguments that render identically map to one pointer. That pointer is the canonical
+// identity formed from the alias and its arguments, the identity constrain's cycle guard
+// keys on. A non-generic reference keys on its name alone.
 func (c *Context) internAlias(at *soltype.AliasType) *soltype.AliasType {
 	k := at.Name
 	if len(at.TypeArgs) > 0 {

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -1,6 +1,10 @@
 package solver
 
-import "github.com/escalier-lang/escalier/internal/soltype"
+import (
+	"strings"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
 
 // Context owns the engine's mutable counters. M1 carries ONLY varCounter; M4 D1
 // adds lifetimeCounter for the lifetime sort. M4 C3's read-after-write cache,
@@ -50,11 +54,55 @@ type Context struct {
 
 	// aliases is the type-alias registry, the transparent-alias twin of classes. It holds
 	// each alias's Body and level, keyed by the alias's dep_graph-qualified name, the same
-	// string stored in soltype.AliasType.Name. inferTypeDecl writes an entry per `type`
-	// decl, and expandAlias reads the Body to unfold an alias reference to its structural
-	// type at subtyping time. Every AliasDef comes from a top-level decl and lives for the
-	// whole inference run.
+	// string stored in soltype.AliasType.Name. preBindAlias writes an entry per `type` decl,
+	// and expandAlias reads the Body to unfold an alias reference to its structural type at
+	// subtyping time. Every AliasDef comes from a top-level decl and lives for the whole
+	// inference run.
 	aliases map[string]*AliasDef
+
+	// aliasInterns maps an alias reference's canonical identity — its name and the rendered
+	// form of its type arguments, e.g. "List<number>" — to one representative AliasType, so
+	// two structurally-equal reference nodes share a pointer. constrain's seen-set keys by
+	// pointer identity, and expandAlias mints a fresh substituted node each unfold, so a
+	// generic recursive alias such as List<number> would produce a new node every lap and
+	// never hit the cache. Interning gives the cache a stable canonical key so the cycle
+	// closes. The map lives for the whole run and is never rolled back on a discarded probe.
+	// A representative is only ever compared by identity for the seen-set and never expanded,
+	// so a stale entry cannot make a constraint wrong.
+	aliasInterns map[string]*soltype.AliasType
+}
+
+// internAlias returns the shared representative for an alias reference's canonical
+// identity, minting one on first sight. Two AliasType nodes naming the same alias with
+// type arguments that render identically map to one pointer — the canonical
+// (alias, args) identity constrain's cycle guard keys on. A non-generic reference keys on
+// its name alone.
+func (c *Context) internAlias(at *soltype.AliasType) *soltype.AliasType {
+	k := at.Name
+	if len(at.TypeArgs) > 0 {
+		var b strings.Builder
+		b.WriteString(at.Name)
+		b.WriteByte('<')
+		for i, arg := range at.TypeArgs {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			// Print renders an alias argument under its own name without expanding it, so a
+			// nested recursive alias such as List<List<number>> serializes finitely. A live
+			// type variable renders as its unique `t{ID}` form.
+			b.WriteString(soltype.Print(arg))
+		}
+		b.WriteByte('>')
+		k = b.String()
+	}
+	if c.aliasInterns == nil {
+		c.aliasInterns = map[string]*soltype.AliasType{}
+	}
+	if rep, ok := c.aliasInterns[k]; ok {
+		return rep
+	}
+	c.aliasInterns[k] = at
+	return at
 }
 
 // aliasDef returns the registered AliasDef for a qualified alias name, or ok=false

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -1,10 +1,6 @@
 package solver
 
-import (
-	"strings"
-
-	"github.com/escalier-lang/escalier/internal/soltype"
-)
+import "github.com/escalier-lang/escalier/internal/soltype"
 
 // Context owns the engine's mutable counters. M1 carries ONLY varCounter; M4 D1
 // adds lifetimeCounter for the lifetime sort. M4 C3's read-after-write cache,
@@ -78,23 +74,11 @@ type Context struct {
 // identity formed from the alias and its arguments, the identity constrain's cycle guard
 // keys on. A non-generic reference keys on its name alone.
 func (c *Context) internAlias(at *soltype.AliasType) *soltype.AliasType {
-	k := at.Name
-	if len(at.TypeArgs) > 0 {
-		var b strings.Builder
-		b.WriteString(at.Name)
-		b.WriteByte('<')
-		for i, arg := range at.TypeArgs {
-			if i > 0 {
-				b.WriteByte(',')
-			}
-			// Print renders an alias argument under its own name without expanding it, so a
-			// nested recursive alias such as List<List<number>> serializes finitely. A live
-			// type variable renders as its unique `t{ID}` form.
-			b.WriteString(soltype.Print(arg))
-		}
-		b.WriteByte('>')
-		k = b.String()
-	}
+	// PrintQualified renders the reference under qualified names for every nested alias and
+	// class, so two aliases sharing a local name across namespaces never collide on one key,
+	// and a nested recursive alias such as List<List<number>> serializes finitely because an
+	// argument renders under its own name without expanding.
+	k := soltype.PrintQualified(at)
 	if c.aliasInterns == nil {
 		c.aliasInterns = map[string]*soltype.AliasType{}
 	}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -354,7 +354,7 @@ func (c *checker) inferComponent(
 	//     completed by inferEnumBody once every sibling is bound; its value key is then a
 	//     no-op whose pre-bound value var is retracted in phase 3.
 	var enumShells []*enumShell
-	var typeDecls []typeDeclEntry
+	var aliasShells []*aliasShell
 	for _, key := range component {
 		if _, isValue := bindings[key]; isValue {
 			continue
@@ -375,12 +375,13 @@ func (c *checker) inferComponent(
 				// keyed by the same qualified name the shared namespace reconstructs.
 				c.getOrCreateClass(scope, decl, g.GetNamespace(key))
 			case *ast.TypeDecl:
-				// A `type X = Body` alias infers fully at its type key and is marked handled,
-				// so its value key is a no-op. Collect it and resolve its body after every
-				// class handle and enum union in this component is bound, so a body naming a
-				// sibling class or enum resolves. A body naming a sibling that is only bound
-				// later in a mutually recursive group is not resolved here.
-				typeDecls = append(typeDecls, typeDeclEntry{decl: decl, ns: g.GetNamespace(key)})
+				// A `type X = Body` alias infers at its type key and is marked handled, so its
+				// value key is a no-op. preBindAlias registers the alias identity and binds its
+				// name; inferAliasBody resolves the body below, once every sibling identity in
+				// the component is bound. Pre-binding the identity first lets a self or mutual
+				// reference — `type List<T> = {tail: List<T> | Null}`, or a mutual `type A =
+				// {b: B}` / `type B = {a: A}` pair — find its target already bound.
+				aliasShells = append(aliasShells, c.preBindAlias(scope, inner, decl, g.GetNamespace(key)))
 				handled.Add(d)
 			}
 		}
@@ -390,10 +391,10 @@ func (c *checker) inferComponent(
 	for _, sh := range enumShells {
 		c.inferEnumBody(sh)
 	}
-	// Each alias body resolves after the class handles and enum unions are bound, so a
-	// non-recursive alias naming a sibling type resolves.
-	for _, td := range typeDecls {
-		c.inferTypeDecl(scope, inner, td.decl, td.ns)
+	// Each alias body resolves after every alias, enum, and class identity in the component
+	// is bound, so a body naming a sibling type — or the alias itself — resolves.
+	for _, sh := range aliasShells {
+		c.inferAliasBody(sh)
 	}
 
 	// Report any remaining non-value decl as unsupported. A class was pre-bound above and


### PR DESCRIPTION
This change enables type aliases to reference themselves and each other, closing cycles that previously would diverge during type checking.

The implementation splits alias inference into two phases:

- **Pre-binding** registers each alias's identity and binds its name before resolving any bodies. This lets a self-referential or mutually recursive alias find its target already bound when the body is walked.
- **Body resolution** happens after every alias, class, and enum identity in a recursive component is pre-bound, so forward references resolve correctly.

Key changes:

- Renamed `inferTypeDecl` to `preBindAlias` and split it into two functions. `preBindAlias` registers an `AliasDef` with a nil `Body` and binds the alias name; `inferAliasBody` fills the body once all siblings are bound.
- Introduced `aliasShell` to carry an alias's pre-bound state from pre-binding to body resolution.
- Added `internAlias` to the `Context` to canonicalize generic alias references by their (name, rendered args) identity. This prevents divergence when a generic recursive alias like `List<number>` is used as a subtyping subject, since `expandAlias` substitutes arguments into a fresh node each unfold. The interning gives the cycle guard a stable key so the constraint cache closes the loop.
- Updated `constrain` to key `AliasType` operands on their canonical identity via `aliasKey` rather than raw pointer identity.
- Updated `inferComponent` to call `preBindAlias` during the identity-binding phase and `inferAliasBody` during the body-resolution phase.

The change is transparent to users: recursive aliases now type-check correctly, and non-recursive aliases continue to work as before.

https://claude.ai/code/session_015mD3nXZ5V7NBBH9wM2u1SC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recursive and mutually recursive type aliases.
  * Generic recursive aliases can now be resolved and used in type relationships.

* **Bug Fixes**
  * Improved handling of recursive aliases to prevent infinite expansion.
  * Ensured structurally equivalent alias references are consistently recognized.
  * Added validation for invalid recursive structures with clear type errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->