### PR TITLE
Implement union-super two-pass exists trial for type variables

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -231,38 +231,41 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each concrete member under a
-	// probe most-specific-first; the first success commits, the losers roll back.
-	// Free TypeVar members are skipped to avoid speculatively pinning them to sub.
+	// sub <: (A | B) ⟹ sub <: A OR sub <: B. Trial each member under a probe in
+	// specificityOrder, which ranks a variable below every concrete, so a concrete member
+	// is tried before a bare TypeVar member. A var member is therefore a last-resort
+	// catch-all, not a speculative first pin. `5 <: (T | number)` commits `number` and
+	// never touches T. `"hi" <: (T | number)` finds no concrete match and falls through to
+	// `"hi" <: T`, recording "hi" as T's lower bound. This two-pass exists rule settles the
+	// M7 union-super open question. It mirrors the IntersectionType-sub arm below, which
+	// trials its members through the same specificityOrder, so the union-super and
+	// intersection-sub exists rules share one ordering rather than diverging on whether a
+	// var member is trialled.
 	if supU, ok := super.(*soltype.UnionType); ok {
-		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
-			order := concreteSpecificityOrder(supU.Types)
-			if len(order) > 0 {
-				committed, _ := c.trialAndCommit(order, func(idx int) []SolverError {
-					// A cloned seen keeps each member's coinductive cache independent, so a
-					// failed member's entries can't wrongly short-circuit a later member.
-					return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
-				})
-				if committed {
-					return nil
-				}
-				if supU.Inexact {
-					// An inexact union super has an open, unknown-typed tail. A sub that
-					// matches no named member is subsumed by that tail, so accept it. This
-					// is the dual of the union-sub arm above, which rejects an inexact sub
-					// into a closed super because that open tail can't be absorbed.
-					return nil
-				}
-				// Every concrete branch failed. Promote a BorrowEscapeError when sub's
-				// peeled inner still satisfies the union; else emit the generic error.
-				if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
-					if len(c.trialUnderProbe(ref.Inner, super)) == 0 {
-						return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
-					}
-				}
-				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
+			committed, _ := c.trialAndCommit(specificityOrder(supU.Types), func(idx int) []SolverError {
+				// A cloned seen keeps each member's coinductive cache independent, so a
+				// failed member's entries can't wrongly short-circuit a later member.
+				return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
+			})
+			if committed {
+				return nil
 			}
-			// Every member was a free var; fall through to the var arms.
+			if supU.Inexact {
+				// An inexact union super has an open, unknown-typed tail. A sub that
+				// matches no named member is subsumed by that tail, so accept it. This
+				// is the dual of the union-sub arm above, which rejects an inexact sub
+				// into a closed super because that open tail can't be absorbed.
+				return nil
+			}
+			// Every branch failed, the var members included. Promote a BorrowEscapeError
+			// when sub's peeled inner still satisfies the union; else emit the generic error.
+			if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
+				if len(c.trialUnderProbe(ref.Inner, super)) == 0 {
+					return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
+				}
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 		}
 	}
 

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -150,8 +150,10 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 		extra := c.freshVar(0)
 		super := newUnion(nil, []soltype.Type{extra, num()}, false)
 
-		require.Empty(t, c.Constrain(strLit("hi"), super))
+		hi := strLit("hi")
+		require.Empty(t, c.Constrain(hi, super))
 		require.Len(t, extra.LowerBounds, 1)
+		require.Same(t, hi, extra.LowerBounds[0])
 		require.Empty(t, extra.UpperBounds)
 	})
 

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -138,25 +138,35 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 		require.True(t, isUnion, "variable sub should record the union whole, got %T", a.UpperBounds[0])
 	})
 
-	t.Run("free-var super member is skipped, not pinned by the trial", func(t *testing.T) {
-		// A super-union member that is itself an unbounded TypeVar must not
-		// be trialled. Trialling it would speculatively pin it to sub. The
-		// super union here has a fresh var on one branch and an
-		// incompatible prim on the other. Trialling the var would trivially
-		// succeed by recording "hi" as its lower bound. The rule skips the
-		// var member instead. The number trial then fails on its own merits
-		// (StrLit "hi" against PrimType number), the rule reports a clean
-		// union-level CannotConstrainError, and the variable carries no
-		// bounds.
+	t.Run("free-var super member is trialled last as a catch-all", func(t *testing.T) {
+		// A super-union member that is itself an unbounded TypeVar is trialled after every
+		// concrete member, since specificityOrder ranks a variable below every concrete. The
+		// super union here has a fresh var on one branch and an incompatible prim on the
+		// other. The number trial fails on its own merits (StrLit "hi" against PrimType
+		// number), so the rule falls through to the var branch: `"hi" <: extra` records "hi"
+		// as extra's lower bound and commits. The var member is a last-resort catch-all, not
+		// a speculative first pin, because it is reached only when no concrete member matches.
 		c := &Context{}
 		extra := c.freshVar(0)
 		super := newUnion(nil, []soltype.Type{extra, num()}, false)
 
-		errs := c.Constrain(strLit("hi"), super)
-		require.Len(t, errs, 1)
-		require.IsType(t, &CannotConstrainError{}, errs[0])
-		require.Empty(t, extra.LowerBounds)
+		require.Empty(t, c.Constrain(strLit("hi"), super))
+		require.Len(t, extra.LowerBounds, 1)
 		require.Empty(t, extra.UpperBounds)
+	})
+
+	t.Run("concrete match commits before the var member and leaves it unpinned", func(t *testing.T) {
+		// 5 <: (T | number). The number member is trialled before the bare var T, since
+		// specificityOrder ranks a variable below every concrete, so `5 <: number` commits
+		// and the trial never reaches `5 <: T`. T is left with no bounds, proving the var
+		// member is a last-resort catch-all rather than a speculative first pin.
+		c := &Context{}
+		tv := c.freshVar(0)
+		super := newUnion(nil, []soltype.Type{tv, num()}, false)
+
+		require.Empty(t, c.Constrain(numLit(5), super))
+		require.Empty(t, tv.LowerBounds)
+		require.Empty(t, tv.UpperBounds)
 	})
 }
 

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -200,28 +200,6 @@ func typeSpecificity(a, b soltype.Type) int {
 	}
 }
 
-// concreteSpecificityOrder returns the indices of types' concrete members in
-// most-specific-first order, skipping any member that is a free type variable. The
-// union-super exists rule trials these. The skip keeps the trial from speculatively
-// pinning a variable member to sub, and the specificity order keeps a less-specific
-// member from changing which branch commits.
-func concreteSpecificityOrder(types []soltype.Type) []int {
-	var concrete []soltype.Type
-	var origIdx []int
-	for i, m := range types {
-		if _, isVar := m.(*soltype.TypeVarType); isVar {
-			continue
-		}
-		concrete = append(concrete, m)
-		origIdx = append(origIdx, i)
-	}
-	order := make([]int, len(concrete))
-	for k, pos := range specificityOrder(concrete) {
-		order[k] = origIdx[pos]
-	}
-	return order
-}
-
 // hasUnconstrainedArg reports whether any top-level call argument is a fully-unconstrained
 // inference variable — a bare var with no bounds either way, which carries no type
 // information to rank overloads by. overloadOrder treats a true result as "can't rank the

--- a/internal/solver/specificity_test.go
+++ b/internal/solver/specificity_test.go
@@ -60,20 +60,11 @@ func TestSpecificityOrderStability(t *testing.T) {
 
 	// A nil candidate, a non-function overload arm, sorts last without disturbing the rest.
 	require.Equal(t, []int{1, 0, 2}, specificityOrder([]soltype.Type{num(), numLit(1), nil}))
-}
 
-// concreteSpecificityOrder skips free type-variable members and orders the rest
-// most-specific-first, returning original indices. The union-super exists rule consults
-// it, so a variable member is never trialled and the concrete members trial
-// most-specific-first.
-func TestConcreteSpecificityOrder(t *testing.T) {
-	v := &soltype.TypeVarType{}
-
-	// Members number(0), α(1), 1(2). The variable is skipped; the literal outranks the
-	// primitive, so the trial order over original indices is [2, 0].
-	require.Equal(t, []int{2, 0}, concreteSpecificityOrder([]soltype.Type{num(), v, numLit(1)}))
-
-	// All-variable members yield an empty order, the signal the union-super rule reads to
-	// fall through to the var arms.
-	require.Empty(t, concreteSpecificityOrder([]soltype.Type{v, &soltype.TypeVarType{}}))
+	// A union of a concrete and a bare variable orders the concrete first and the variable
+	// last. The union-super exists rule reads this order directly, so a concrete member is
+	// trialled before the variable and the variable is only reached as a last-resort
+	// catch-all.
+	v2 := &soltype.TypeVarType{}
+	require.Equal(t, []int{1, 0}, specificityOrder([]soltype.Type{v2, num()}))
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -235,6 +235,15 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 // and rest-param annotations report an unsupported feature and recover as a
 // monomorphic function. A lifetime parameter is supported. Its declared outlives
 // bounds lower into constrainLt so the annotation's borrows solve against them.
+//
+// A generic annotation reports an unsupported feature rather than resolving its `<…>`
+// list. Routing it through resolveTypeParams resolves the parameters, but the resulting
+// FuncType.TypeParams vars break the value-binding generalization path. That path inlines
+// them to `never` and panics in acceptTypeParams, since a bound parameter must stay a
+// variable. Holding them symbolic needs the keep-set retention coalesceKeeping already
+// gives a generic class's own parameters. That retention lands with the generic-function
+// generalization work, so until then the conservative report keeps a `val f: fn<T>(…)`
+// binding sound.
 func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
 	if len(ta.TypeParams) > 0 {
 		c.reportUnsupportedFeature(ta, "generic function type annotation")

--- a/planning/simple_sub/generic-functions-implementation-plan.md
+++ b/planning/simple_sub/generic-functions-implementation-plan.md
@@ -116,9 +116,10 @@ without panicking and renders `fn <T>(x: T) -> T`, not `fn <T0, T: T0>(x: T) -> 
 - Generalize the inferred body into `FuncType.TypeParams` (PR1's retention), and
   instantiate the scheme per call so `f(5)` and `f("hi")` bind `T` independently.
 
-**Accept.** `fn id<T>(x: T) -> T` type-checks; `id(5)` yields `number` and
-`id("hi")` yields `string` from independent instantiations; a higher-rank parameter
-is still rejected at the rank-1 boundary.
+**Accept.** `fn id<T>(x: T) -> T` type-checks; `id(5)` yields `5` and `id("hi")`
+yields `"hi"` from independent instantiations, each preserving its literal type
+rather than widening to `number` / `string`; a higher-rank parameter is still
+rejected at the rank-1 boundary.
 
 **Depends on** PR1.
 

--- a/planning/simple_sub/generic-functions-implementation-plan.md
+++ b/planning/simple_sub/generic-functions-implementation-plan.md
@@ -136,8 +136,9 @@ rejected at the rank-1 boundary.
   exercises M7's union-super two-pass exists trial from source.
 
 **Accept.** `val f: fn<T>(x: T) -> T = fn (x) { return x }` resolves and renders
-`fn <T>(x: T) -> T`; `fn f<T>(x: T | number)` resolves and its union member `T`
-binds per the union-super two-pass rule already in `constrain`.
+`fn <T>(x: T) -> T`; the annotation `val g: fn<T>(x: T | number) -> …` resolves and
+its union member `T` binds per the union-super two-pass rule already in `constrain`.
+The standalone-declaration form `fn f<T>(x: T | number)` is PR2's, not this PR's.
 
 **Depends on** PR1. Independent of PR2.
 

--- a/planning/simple_sub/generic-functions-implementation-plan.md
+++ b/planning/simple_sub/generic-functions-implementation-plan.md
@@ -1,0 +1,170 @@
+# Generic-function generalization — implementation plan
+
+This plan covers **the generic-function work** that [M5](m5-implementation-plan.md)
+and [M7](m7-implementation-plan.md) both name and defer: inferring and generalizing
+a standalone generic function `fn f<T>(…)` and a generic function-type annotation
+`fn <T>(…) -> …`. It is not a numbered milestone. It is a cross-cutting
+prerequisite whose *representation* M5 already shipped and whose remaining
+consumers span several milestones, so it is written as its own plan rather than
+folded into any one of them.
+
+M5's own note draws the line this plan starts from
+([m5-implementation-plan.md](m5-implementation-plan.md) §"Scope expansion this
+implies"):
+
+> `FuncType.TypeParams` is not class-specific … M5 populates and consumes it for
+> methods and leaves general `fn f<U>` *inference* to the generic-function work;
+> the *representation* is shared.
+
+## What M5 shipped (ground truth this plan builds on)
+
+The representation and the *class/method* consumer are done. Only the
+value-binding path and the standalone-function surfaces are missing.
+
+- **`FuncType.TypeParams` is the shared representation.** Every function type has a
+  home for its own generics. `TypeParam.Var` is an ordinary bounded inference var
+  freshened by the existing level-based `instantiate`/`freshenAbove`, not a named
+  parameter resolved by substitution, so no second polymorphism mechanism runs
+  ([soltype/type.go:206-229](../../internal/soltype/type.go),
+  [m5-implementation-plan.md](m5-implementation-plan.md) §"Why `TypeParam.Var` is a
+  bounded inference var").
+- **`resolveTypeParams` resolves a `<…>` list.** The two-pass resolver mints one
+  var per parameter, declares it in a child scope, then resolves bounds and
+  defaults, so a forward, mutual, or F-bound reference between siblings resolves
+  ([type_params.go](../../internal/solver/type_params.go)). The class, enum, and
+  alias paths already route through it; this plan routes the function and
+  function-type-annotation paths through it too, the "once generic-function
+  inference lands" case its own doc comment anticipates.
+- **The keep-set retention exists — but only inside the class-body freeze.**
+  `coalesceKeeping` holds a set of vars symbolic rather than inlining them to their
+  bounds, and `freezeClassBody` passes a generic class's own type-param vars *and
+  each method's own `FuncType.TypeParams` vars* as `keep`, so a member typed
+  through `T` stores as `T` rather than collapsing to `never`
+  ([coalesce.go:39-52](../../internal/solver/coalesce.go),
+  [infer_class.go:99-115](../../internal/solver/infer_class.go),
+  `classKeepVars`/`keptFlowMap`). The **value-binding** generalization path has no
+  equivalent — see the gap below.
+- **The rank-1 boundary is fixed.** A parameter whose own type is polymorphic (a
+  higher-rank callback `<V>(V) -> V`) is rejected rather than approximated, matching
+  SimpleSub's and MLstruct's rank-1 boundary
+  ([m5-implementation-plan.md](m5-implementation-plan.md) §"Known limitation"). This
+  plan stays rank-1; relaxing it is out of scope.
+
+## The gap (the delta this plan adds)
+
+Three seams, one shared core.
+
+1. **The value-binding generalization path drops `FuncType.TypeParams`.** `generalize`
+   quantifies every var with `Level > lvl` into a `PolyScheme` and coalesces the rest
+   ([poly.go:451-472](../../internal/solver/poly.go)). A function's own type-param
+   vars are neither in a `keep` set nor excluded from that quantification, so a
+   binding whose type is a generic `FuncType` breaks two ways:
+   - inlined to `never` and a panic in `acceptTypeParams`, which requires a bound
+     parameter to stay a variable
+     ([soltype/visitor.go:338-349](../../internal/soltype/visitor.go)); or
+   - double-quantified — the same var appears once as a retained scheme variable and
+     once in `FuncType.TypeParams`, rendering `fn <T0, T: T0>(x: T) -> T`.
+
+   The fix is the freezeClassBody analogue for the value path: hold a function
+   type's own `TypeParams` vars symbolic through coalescing, and exclude them from
+   the outer scheme's free-var quantification, so the function's declared quantifier
+   is its *only* quantifier.
+2. **`fn f<T>(…)` decls are gated unsupported.** `inferFunc` reports
+   `reportUnsupportedFeature(node, "TypeParam")` and infers monomorphically, leaving
+   `T` unbound ([infer_expr.go:201-208](../../internal/solver/infer_expr.go)). Once
+   the core lands, route `sig.TypeParams` through `resolveTypeParams` into the
+   function's child scope, generalize the body into `FuncType.TypeParams`, and
+   instantiate per call.
+3. **`fn <T>(…) -> …` annotations are gated unsupported.** `resolveFuncTypeAnn`
+   reports `"generic function type annotation"` rather than resolving the `<…>` list
+   ([type_ann.go](../../internal/solver/type_ann.go),
+   `resolveFuncTypeAnn`). This is the **M7 PR6 deferred half**: routing the list
+   through `resolveTypeParams` resolves the parameters, but the resulting vars hit
+   the value-path gap above. It also unblocks a union member that is a bare type
+   parameter, the source path that makes M7's already-landed union-super two-pass
+   exists trial reachable.
+
+## PR-by-PR breakdown
+
+Three PRs. PR1 is the shared core; PR2 and PR3 are the two surfaces and are
+mutually independent once PR1 lands.
+
+### PR1 — Retain `FuncType.TypeParams` through value-binding generalization
+
+The core. Lift the `keep`/`flow` retention `freezeClassBody` gives a class body
+into the value-binding generalization path, so a function type's own type-param
+vars survive coalescing as its quantifier instead of inlining to `never`.
+
+- Collect a binding's function-type `TypeParams` vars the way `classKeepVars`
+  collects a class's, and thread them as `keep` into the coalescing that
+  `generalize` / `coalesceScheme` run
+  ([poly.go:451-472](../../internal/solver/poly.go),
+  [coalesce.go:252-291](../../internal/solver/coalesce.go)).
+- Exclude those vars from the outer scheme's free-var quantification so the same var
+  is not both a retained scheme variable and a `FuncType.TypeParams` entry — the
+  `fn <T0, T: T0>` double-render.
+
+**Accept.** A `FuncType` carrying `TypeParams` round-trips through a value binding
+without panicking and renders `fn <T>(x: T) -> T`, not `fn <T0, T: T0>(x: T) -> T`.
+
+### PR2 — Generic function declarations `fn f<T>(…)`
+
+- Lift the `reportUnsupportedFeature(node, "TypeParam")` gate in `inferFunc`
+  ([infer_expr.go:201-208](../../internal/solver/infer_expr.go)); route
+  `sig.TypeParams` through `resolveTypeParams` into the function's child scope so a
+  parameter or return annotation reads each `T` as one shared var.
+- Generalize the inferred body into `FuncType.TypeParams` (PR1's retention), and
+  instantiate the scheme per call so `f(5)` and `f("hi")` bind `T` independently.
+
+**Accept.** `fn id<T>(x: T) -> T` type-checks; `id(5)` yields `number` and
+`id("hi")` yields `string` from independent instantiations; a higher-rank parameter
+is still rejected at the rank-1 boundary.
+
+**Depends on** PR1.
+
+### PR3 — Generic function-type annotations (M7 PR6 deferred half)
+
+- Route `ta.TypeParams` through `resolveTypeParams` in `resolveFuncTypeAnn` into a
+  child scope, and resolve the parameters, return, and any union member that is a
+  bare type parameter against it
+  ([type_ann.go](../../internal/solver/type_ann.go)). Delete the
+  `"generic function type annotation"` unsupported report.
+- Re-enable `TestInferGenericFuncAnnotationReportsUnsupported`
+  ([infer_func_ann_test.go](../../internal/solver/infer_func_ann_test.go)) as a
+  resolves-and-renders test, and add the `fn <T>(x: T | number) -> …` case that
+  exercises M7's union-super two-pass exists trial from source.
+
+**Accept.** `val f: fn<T>(x: T) -> T = fn (x) { return x }` resolves and renders
+`fn <T>(x: T) -> T`; `fn f<T>(x: T | number)` resolves and its union member `T`
+binds per the union-super two-pass rule already in `constrain`.
+
+**Depends on** PR1. Independent of PR2.
+
+## Who this unblocks
+
+- **M7 PR6** — the generic-union annotation surface. Its union-super two-pass exists
+  trial already landed in `constrain`
+  ([constrain.go](../../internal/solver/constrain.go)); PR3 here makes the surface
+  that reaches it with a real type-var union member from source.
+- **Standalone `fn f<T>(…)` decls** — the general generic-function inference M5 and
+  M3 both point at.
+
+## Not blocked on MLstruct
+
+Generalization over bounded variables already works in Simple-sub; it is M3
+let-polymorphism. MLstruct is a *possible future* extension for negation types and
+narrowing, "relevant if we later add negation-based narrowing"
+([03-references.md:27-29](03-references.md)). The `TypeParam.Var`-as-bounded-var
+design is forward-compatible with it
+([m5-implementation-plan.md](m5-implementation-plan.md) §"Why `TypeParam.Var` is a
+bounded inference var"), but MLstruct neither delivers nor blocks this work.
+
+## Dependency graph
+
+```
+PR1 (retain FuncType.TypeParams through value-binding generalization)
+ ├─► PR2 (generic function declarations fn f<T>)
+ └─► PR3 (generic function-type annotations)  ── unblocks M7 PR6 annotation surface
+
+feeds ─► M7 PR6 (generic-union annotation surface + union-super trial, already landed in constrain)
+```

--- a/planning/simple_sub/m5-implementation-plan.md
+++ b/planning/simple_sub/m5-implementation-plan.md
@@ -387,7 +387,8 @@ gives every function type a home for its own generics, so it partially lifts the
 current "generic functions are unsupported" gate
 ([infer_expr.go:197-203](../../internal/solver/infer_expr.go)). M5 populates and
 consumes it for methods and leaves general `fn f<U>` *inference* to the
-generic-function work; the *representation* is shared.
+[generic-function work](generic-functions-implementation-plan.md); the
+*representation* is shared.
 
 **Known limitation.** These parameters are rank-1: a parameter whose own type is
 polymorphic (higher-rank, e.g. a callback typed `<V>(V) -> V`) is not expressible

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -284,23 +284,42 @@ reach the enum through the alias path — see
 The milestone hosts the union-super exists-trial open question here because this is
 where a user-written `T | number` first resolves.
 
-**Algorithms.**
-- **Generic annotation surface.** Resolve a generic function-type annotation
-  `fn <T>(x: T | number) -> …` and a union member that is a bare type parameter, by
-  routing the `<…>` list through `resolveTypeParams` and the union members through
-  the alias-aware `resolveTypeAnn`. This is the M6-deferred generic function-type
-  annotation, now reachable.
-- **Settle the union-super exists trial.** [01-milestones.md](01-milestones.md) M7
-  poses two designs for `sub <: (A | B | …)` when a member is a bare `TypeVarType`:
-  keep M6's conservative skip, or a two-pass trial (concrete members first, var
-  members second). Decide, document the choice against the mirror
-  `IntersectionType`-sub overload arm
-  ([constrain.go:366](../../internal/solver/constrain.go)), and implement it under
-  the existing probe journal ([probe.go](../../internal/solver/probe.go)).
+**Status.** The union-super exists trial is **done**; the generic function-type
+annotation surface is **deferred** to
+[generic-functions-implementation-plan.md](generic-functions-implementation-plan.md)
+PR3. The two halves separate cleanly: the trial is a `constrain`-local rule, while
+the annotation surface needs a value-binding generalization path that retains a
+function type's own `TypeParams` — the freezeClassBody analogue M5 built for methods
+but never wired into the value path. Routing the `<…>` list through
+`resolveTypeParams` resolves the parameters, but the resulting `FuncType.TypeParams`
+vars then inline to `never` and panic in `acceptTypeParams`, so the surface waits on
+that core.
 
-**Accept.** `fn f<T>(x: T | number)` resolves; `f("hi")` and `f(5)` behave per the
-chosen design; a boolean is rejected; the union and intersection exists arms are
-either aligned or their divergence is documented.
+**Algorithms.**
+- **Generic annotation surface (deferred).** Resolve a generic function-type
+  annotation `fn <T>(x: T | number) -> …` and a union member that is a bare type
+  parameter, by routing the `<…>` list through `resolveTypeParams` and the union
+  members through the alias-aware `resolveTypeAnn`. Deferred to the generic-function
+  work; see the Status note above.
+- **Settle the union-super exists trial (done — two-pass).** [01-milestones.md](01-milestones.md)
+  M7 posed two designs for `sub <: (A | B | …)` when a member is a bare
+  `TypeVarType`: keep M6's conservative skip, or a two-pass trial (concrete members
+  first, var members second). Chosen: the **two-pass trial**, implemented by trialing
+  every member through `specificityOrder`, which ranks a variable below every
+  concrete, so a concrete member commits before a var member and a var member is a
+  last-resort catch-all. This aligns the union-super arm with the mirror
+  `IntersectionType`-sub arm, which already trials through the same
+  `specificityOrder` ([constrain.go](../../internal/solver/constrain.go), the
+  `UnionType`-super and `IntersectionType`-sub arms), under the existing probe
+  journal ([probe.go](../../internal/solver/probe.go)). PR7's diagnostic follow-ups
+  build on the committed-var trial this rule performs.
+
+**Accept.** The union-super two-pass rule is exercised in
+[constrain_lattice_test.go](../../internal/solver/constrain_lattice_test.go)
+(`TestConstrainUnionSuperExists`): `5 <: (T | number)` commits `number` and leaves
+`T` unpinned, `"hi" <: (T | number)` falls through to `"hi" <: T`, and a concrete
+`string | number` still rejects a boolean. The source-reachable `fn f<T>(x: T |
+number)` form lands with the deferred annotation surface.
 
 **Depends on** PR2 (generic surface), M6 (unions). Independent of PR3–PR5.
 

--- a/planning/simple_sub/m7-implementation-plan.md
+++ b/planning/simple_sub/m7-implementation-plan.md
@@ -318,8 +318,11 @@ that core.
 [constrain_lattice_test.go](../../internal/solver/constrain_lattice_test.go)
 (`TestConstrainUnionSuperExists`): `5 <: (T | number)` commits `number` and leaves
 `T` unpinned, `"hi" <: (T | number)` falls through to `"hi" <: T`, and a concrete
-`string | number` still rejects a boolean. The source-reachable `fn f<T>(x: T |
-number)` form lands with the deferred annotation surface.
+`string | number` still rejects a boolean. The source-reachable annotation form
+`val f: fn<T>(x: T | number) -> …` lands with the deferred annotation surface; the
+standalone-declaration form `fn f<T>(x: T | number)` lands with the generic-function
+declaration work, both in
+[generic-functions-implementation-plan.md](generic-functions-implementation-plan.md).
 
 **Depends on** PR2 (generic surface), M6 (unions). Independent of PR3–PR5.
 


### PR DESCRIPTION
Settles the M7 union-super exists-trial open question by implementing a two-pass rule for `sub <: (A | B | …)` when a member is a bare `TypeVarType`. Concrete members are now trialled before variable members, making a variable member a last-resort catch-all rather than a speculative first pin.

**Changes:**

- **constrain.go**: Refactored the `UnionType`-super arm to trial all members through `specificityOrder` instead of skipping variable members. This ranks variables below every concrete type, so `5 <: (T | number)` commits `number` and leaves `T` unpinned, while `"hi" <: (T | number)` falls through to `"hi" <: T`. Aligns the union-super rule with the mirror `IntersectionType`-sub arm, which already uses `specificityOrder`.

- **overload.go**: Removed `concreteSpecificityOrder`, which filtered out variable members. The union-super rule now uses `specificityOrder` directly on all members, eliminating the need for a separate filtering function.

- **specificity_test.go**: Removed `TestConcreteSpecificityOrder` and added a test case to `TestSpecificityOrderStability` demonstrating that `specificityOrder` ranks a bare variable below a concrete type.

- **constrain_lattice_test.go**: Updated `TestConstrainUnionSuperExists` to reflect the new two-pass behavior. The test case "free-var super member is skipped, not pinned by the trial" is now "free-var super member is trialled last as a catch-all", and a new test case "concrete match commits before the var member and leaves it unpinned" verifies that concrete matches prevent variable pinning.

- **type_ann.go**: Added documentation explaining why generic function-type annotations remain unsupported. The `FuncType.TypeParams` vars break the value-binding generalization path until a keep-set retention mechanism lands.

- **m7-implementation-plan.md**: Updated to reflect that the union-super exists trial is complete and the generic function-type annotation surface is deferred to the generic-functions-implementation-plan.

- **generic-functions-implementation-plan.md** (new): Added comprehensive implementation plan for generic function generalization, covering the value-binding retention core (PR1) and the two surfaces (PR2 for `fn f<T>(…)` declarations, PR3 for generic function-type annotations).

The two-pass rule is exercised in the test suite and unblocks the deferred generic function-type annotation surface.

https://claude.ai/code/session_017PZMs2Q6DX58RganQatxTT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type resolution for union types containing generic variables.
  * Concrete union members are now prioritized, while generic variables serve as a fallback when no concrete match applies.
  * Prevented unnecessary variable binding when a concrete union match succeeds.

* **Documentation**
  * Added implementation plans and clarified the current status and limitations of generic function annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->