### PR TITLE
Preserve generic function type parameters through value-binding generalization

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -269,15 +269,65 @@ type occKey struct {
 // its own polarities, so the check is exactly PR1's per-variable both-polarities
 // test.
 func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
+	keep := funcTypeParamVars(t)
 	c := t.Accept(&schemeCoalescer{
-		simp:     simplifyScheme(t, genLevel),
+		simp:     simplifyScheme(t, genLevel, keep),
 		genLevel: genLevel,
+		keep:     keep,
 		seen:     set.NewSet[*soltype.TypeVarType](),
 	}, soltype.Positive)
 	c = bubbleOwnedMut(c) // #779: lift an owned-mut cell out of an immutable container
 	// A scheme display is always coalesced from the Positive root.
 	return coalesceLifetimes(c, soltype.Positive) // D4: resolve borrow lifetimes to their display form
 }
+
+// funcTypeParamVars collects every generic function's own TypeParams binder var
+// reachable from t. It is the value-path analogue of classKeepVars. coalesceScheme
+// holds these symbolic rather than inlining them to their bounds, so a function type's
+// declared quantifier survives value-binding generalization instead of collapsing to
+// never and tripping acceptTypeParamVar. The walk descends structural children through
+// Accept and each var's bound side-graph, so it reaches the value FuncType a binding
+// var carries as its own lower bound and any generic function nested in a constraint.
+func funcTypeParamVars(t soltype.Type) set.Set[*soltype.TypeVarType] {
+	keep := set.NewSet[*soltype.TypeVarType]()
+	t.Accept(&typeParamCollector{keep: keep, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
+	return keep
+}
+
+// typeParamCollector gathers FuncType.TypeParams binder vars for funcTypeParamVars. A
+// FuncType records its own type parameters, then Accept descends into the params,
+// return, and each parameter's constraint bounds. A var's bounds are a side graph, not
+// tree children, so the var arm walks them explicitly to reach a generic function a
+// binding var carries as a bound, guarding re-entry with seen.
+type typeParamCollector struct {
+	keep set.Set[*soltype.TypeVarType]
+	seen set.Set[*soltype.TypeVarType]
+}
+
+func (tc *typeParamCollector) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.FuncType:
+		for _, tp := range t.TypeParams {
+			tc.keep.Add(tp.Var)
+		}
+		return soltype.EnterResult{} // descend into params, return, and type-param bounds
+	case *soltype.TypeVarType:
+		if tc.seen.Contains(t) {
+			return soltype.EnterResult{SkipChildren: true}
+		}
+		tc.seen.Add(t)
+		for _, b := range t.LowerBounds {
+			b.Accept(tc, pol)
+		}
+		for _, b := range t.UpperBounds {
+			b.Accept(tc, pol)
+		}
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (tc *typeParamCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // schemeCoalescer is the soltype-visitor form of coalesceScheme. It has the same
 // shape as coalescer. The structural arms and the pol.Flip() variance come from
@@ -296,7 +346,11 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 type schemeCoalescer struct {
 	simp     *schemeSimplification
 	genLevel int
-	seen     set.Set[*soltype.TypeVarType]
+	// keep holds a generic function's own TypeParams binder vars, held symbolic rather
+	// than inlined to their bounds so the function's declared quantifier survives
+	// coalescing. It is the value-path analogue of coalescer.keep for a class body.
+	keep set.Set[*soltype.TypeVarType]
+	seen set.Set[*soltype.TypeVarType]
 }
 
 func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
@@ -305,6 +359,14 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		// Atom or structural node — let Accept rebuild it from coalesced children
 		// (including an overload-arm Union/Intersection input — the scoped lattice exception; see overloadIntersection).
 		return soltype.EnterResult{}
+	}
+	// A generic function's own type-parameter var stays symbolic: return it unchanged so
+	// the function's declared quantifier survives, instead of inlining a return-only
+	// parameter to never and tripping acceptTypeParamVar's binder-must-stay-a-var guard.
+	// simplifyScheme excludes these vars from its merge candidates, so a kept var is
+	// always its own representative and never masks another var's name.
+	if c.keep.Contains(v) {
+		return soltype.EnterResult{Type: v, SkipChildren: true}
 	}
 	rep := c.simp.rep(v)
 	retain := rep.Level > c.genLevel && c.simp.mergedOcc[rep.ID].both() && !hasEqualBounds(rep)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -282,23 +282,15 @@ func coalesceScheme(t soltype.Type, genLevel int) soltype.Type {
 }
 
 // funcTypeParamVars collects every generic function's own TypeParams binder var
-// reachable from t. It is the value-path analogue of classKeepVars. coalesceScheme
-// holds these symbolic rather than inlining them to their bounds, so a function type's
-// declared quantifier survives value-binding generalization instead of collapsing to
-// never and tripping acceptTypeParamVar. The walk descends structural children through
-// Accept and each var's bound side-graph, so it reaches the value FuncType a binding
-// var carries as its own lower bound and any generic function nested in a constraint.
+// reachable from t, descending structural children and each var's bound side-graph.
 func funcTypeParamVars(t soltype.Type) set.Set[*soltype.TypeVarType] {
 	keep := set.NewSet[*soltype.TypeVarType]()
 	t.Accept(&typeParamCollector{keep: keep, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
 	return keep
 }
 
-// typeParamCollector gathers FuncType.TypeParams binder vars for funcTypeParamVars. A
-// FuncType records its own type parameters, then Accept descends into the params,
-// return, and each parameter's constraint bounds. A var's bounds are a side graph, not
-// tree children, so the var arm walks them explicitly to reach a generic function a
-// binding var carries as a bound, guarding re-entry with seen.
+// typeParamCollector gathers FuncType.TypeParams binder vars for funcTypeParamVars,
+// walking each var's bounds explicitly since they are a side graph, not tree children.
 type typeParamCollector struct {
 	keep set.Set[*soltype.TypeVarType]
 	seen set.Set[*soltype.TypeVarType]
@@ -361,10 +353,7 @@ func (c *schemeCoalescer) EnterType(t soltype.Type, pol soltype.Polarity) soltyp
 		return soltype.EnterResult{}
 	}
 	// A generic function's own type-parameter var stays symbolic: return it unchanged so
-	// the function's declared quantifier survives, instead of inlining a return-only
-	// parameter to never and tripping acceptTypeParamVar's binder-must-stay-a-var guard.
-	// simplifyScheme excludes these vars from its merge candidates, so a kept var is
-	// always its own representative and never masks another var's name.
+	// the declared quantifier survives rather than inlining a return-only param to never.
 	if c.keep.Contains(v) {
 		return soltype.EnterResult{Type: v, SkipChildren: true}
 	}

--- a/internal/solver/generalize_generic_func_test.go
+++ b/internal/solver/generalize_generic_func_test.go
@@ -7,14 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A generic FuncType round-trips through value-binding generalization: generalize
-// coalesces the binding var whose lower bound is the function value, and the
-// function's own TypeParams binder vars are held symbolic rather than inlined to
-// their bounds. So the declared quantifier is the function's ONLY quantifier and the
-// signature renders `fn <T>(x: T) -> T`, not the double-quantified
-// `fn <T0, T: T0>(x: T) -> T`. The return-only shape is the regression that used to
-// inline its parameter var to never and trip acceptTypeParamVar's binder-must-stay-a-
-// var guard (PR1).
+// A generic FuncType round-trips through value-binding generalization: its own
+// TypeParams binder vars stay symbolic, so it renders `fn <T>(x: T) -> T` rather than
+// `fn <T0, T: T0>(x: T) -> T`, and a return-only param no longer inlines to never (PR1).
 func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
 	tests := []struct {
 		name string
@@ -107,9 +102,7 @@ func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
 }
 
 // funcTypeParamVars descends a binding var's bound side-graph to reach the value
-// FuncType, so a function's own type parameter is collected even though it is not a
-// structural child of the binding var. It also reaches a generic function nested in a
-// parameter's constraint.
+// FuncType, collecting a type parameter that is not a structural child of the var.
 func TestFuncTypeParamVarsDescendsBoundGraph(t *testing.T) {
 	c := newChecker()
 	vT := c.freshAt(1)

--- a/internal/solver/generalize_generic_func_test.go
+++ b/internal/solver/generalize_generic_func_test.go
@@ -1,0 +1,127 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A generic FuncType round-trips through value-binding generalization: generalize
+// coalesces the binding var whose lower bound is the function value, and the
+// function's own TypeParams binder vars are held symbolic rather than inlined to
+// their bounds. So the declared quantifier is the function's ONLY quantifier and the
+// signature renders `fn <T>(x: T) -> T`, not the double-quantified
+// `fn <T0, T: T0>(x: T) -> T`. The return-only shape is the regression that used to
+// inline its parameter var to never and trip acceptTypeParamVar's binder-must-stay-a-
+// var guard (PR1).
+func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns a generic FuncType, taking a fresh-var factory so each
+		// parameter var is minted above the generalize level.
+		build func(fresh func() *soltype.TypeVarType) *soltype.FuncType
+		want  string
+	}{
+		{
+			name: "both polarities",
+			build: func(fresh func() *soltype.TypeVarType) *soltype.FuncType {
+				vT := fresh()
+				return &soltype.FuncType{
+					TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},
+					Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: vT}},
+					Ret:        vT,
+				}
+			},
+			want: "fn <T>(x: T) -> T",
+		},
+		{
+			name: "return only",
+			build: func(fresh func() *soltype.TypeVarType) *soltype.FuncType {
+				vT := fresh()
+				return &soltype.FuncType{
+					TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},
+					Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: num()}},
+					Ret:        vT,
+				}
+			},
+			want: "fn <T>(x: number) -> T",
+		},
+		{
+			name: "param only",
+			build: func(fresh func() *soltype.TypeVarType) *soltype.FuncType {
+				vT := fresh()
+				return &soltype.FuncType{
+					TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},
+					Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: vT}},
+					Ret:        num(),
+				}
+			},
+			want: "fn <T>(x: T) -> number",
+		},
+		{
+			name: "constrained param keeps its bound off the use site",
+			build: func(fresh func() *soltype.TypeVarType) *soltype.FuncType {
+				vT := fresh()
+				vT.UpperBounds = []soltype.Type{num()}
+				return &soltype.FuncType{
+					TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},
+					Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: vT}},
+					Ret:        vT,
+				}
+			},
+			want: "fn <T: number>(x: T) -> T",
+		},
+		{
+			name: "two distinct params",
+			build: func(fresh func() *soltype.TypeVarType) *soltype.FuncType {
+				vT := fresh()
+				vU := fresh()
+				return &soltype.FuncType{
+					TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}, {Name: "U", Var: vU}},
+					Params: []*soltype.FuncParam{
+						{Pattern: &soltype.IdentPat{Name: "x"}, Type: vT},
+						{Pattern: &soltype.IdentPat{Name: "y"}, Type: vU},
+					},
+					Ret: &soltype.TupleType{Elems: []soltype.Type{vT, vU}},
+				}
+			},
+			want: "fn <T, U>(x: T, y: U) -> [T, U]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			fn := tt.build(func() *soltype.TypeVarType { return c.freshAt(1) })
+			// Model the value-binding path: the SCC driver constrains the function value
+			// into a binding var, then generalizes that var at the component's level.
+			vb := c.freshAt(1)
+			vb.LowerBounds = []soltype.Type{fn}
+
+			var scheme TypeScheme
+			require.NotPanics(t, func() { scheme = c.generalize(vb, 0) })
+			require.Equal(t, tt.want, renderScheme(scheme))
+		})
+	}
+}
+
+// funcTypeParamVars descends a binding var's bound side-graph to reach the value
+// FuncType, so a function's own type parameter is collected even though it is not a
+// structural child of the binding var. It also reaches a generic function nested in a
+// parameter's constraint.
+func TestFuncTypeParamVarsDescendsBoundGraph(t *testing.T) {
+	c := newChecker()
+	vT := c.freshAt(1)
+	fn := &soltype.FuncType{
+		TypeParams: []*soltype.TypeParam{{Name: "T", Var: vT}},
+		Params:     []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: vT}},
+		Ret:        vT,
+	}
+	vb := c.freshAt(1)
+	vb.LowerBounds = []soltype.Type{fn}
+
+	keep := funcTypeParamVars(vb)
+	require.True(t, keep.Contains(vT), "the type parameter reached through the binding var's bound is kept")
+	require.Equal(t, 1, keep.Len())
+}

--- a/internal/solver/generalize_generic_func_test.go
+++ b/internal/solver/generalize_generic_func_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// A generic FuncType round-trips through value-binding generalization: its own
-// TypeParams binder vars stay symbolic, so it renders `fn <T>(x: T) -> T` rather than
-// `fn <T0, T: T0>(x: T) -> T`, and a return-only param no longer inlines to never (PR1).
+// Value-binding generalization keeps a generic FuncType's own TypeParams binder vars
+// symbolic, so it renders `fn <T>(x: T) -> T` rather than `fn <T0, T: T0>(x: T) -> T`,
+// and a type parameter used only in the return stays valid instead of inlining to never.
 func TestGeneralizeRetainsFuncTypeParams(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/solver/simplify.go
+++ b/internal/solver/simplify.go
@@ -390,7 +390,13 @@ func (s *schemeSimplification) rep(v *soltype.TypeVarType) *soltype.TypeVarType 
 // body. Only quantifiable variables (Level > genLevel) are merge candidates:
 // captured outer variables are not type parameters and never merge into one, which
 // also keeps every representative quantifiable so the retain decision stays uniform.
-func simplifyScheme(body soltype.Type, genLevel int) *schemeSimplification {
+//
+// A generic function's own TypeParams binder vars in keep are excluded from the
+// candidates too. They are distinct declared parameters that coalesceScheme holds
+// symbolic, so merging one into another var's class would rename it or let it mask
+// another var's name. Excluding them keeps each a singleton class that is its own
+// representative.
+func simplifyScheme(body soltype.Type, genLevel int, keep set.Set[*soltype.TypeVarType]) *schemeSimplification {
 	vars := map[int]*soltype.TypeVarType{}
 	body.Accept(&varCollector{out: vars, seen: set.NewSet[*soltype.TypeVarType]()}, soltype.Positive)
 
@@ -406,7 +412,7 @@ func simplifyScheme(body soltype.Type, genLevel int) *schemeSimplification {
 
 	candidates := make([]int, 0, len(vars))
 	for id, v := range vars {
-		if v.Level > genLevel {
+		if v.Level > genLevel && !keep.Contains(v) {
 			candidates = append(candidates, id)
 		}
 	}

--- a/internal/solver/simplify_test.go
+++ b/internal/solver/simplify_test.go
@@ -31,7 +31,7 @@ func TestCoalesceSchemeMergesCoOccurring(t *testing.T) {
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, T0]", renderScheme(scheme))
 
 	// All three variables resolve to one representative.
-	simp := simplifyScheme(body, 0)
+	simp := simplifyScheme(body, 0, nil)
 	require.Equal(t, simp.uf.find(1), simp.uf.find(2))
 	require.Equal(t, simp.uf.find(2), simp.uf.find(3))
 }
@@ -50,7 +50,7 @@ func TestCoalesceSchemeKeepsDistinctParams(t *testing.T) {
 
 	require.Equal(t, "fn <T0, T1>(a: T0, b: T1) -> [T0, T1]", renderScheme(scheme))
 
-	simp := simplifyScheme(body, 0)
+	simp := simplifyScheme(body, 0, nil)
 	require.NotEqual(t, simp.uf.find(1), simp.uf.find(2))
 }
 
@@ -110,7 +110,7 @@ func TestCoOccUnionMergesTransitively(t *testing.T) {
 	require.False(t, mutualCoOcc(2, 3, occ, coOcc), "b and c never directly co-occur")
 
 	// The union-find still collapses all three into one class via a.
-	simp := simplifyScheme(body, 0)
+	simp := simplifyScheme(body, 0, nil)
 	require.Equal(t, simp.uf.find(1), simp.uf.find(2))
 	require.Equal(t, simp.uf.find(1), simp.uf.find(3))
 }
@@ -123,7 +123,7 @@ func TestSimplifySchemeExcludesCapturedVars(t *testing.T) {
 	quantified := &soltype.TypeVarType{ID: 2, Level: 1}
 	body := &soltype.TupleType{Elems: []soltype.Type{captured, quantified}}
 
-	simp := simplifyScheme(body, 0)
+	simp := simplifyScheme(body, 0, nil)
 	require.Equal(t, 1, simp.uf.find(1), "a captured var is its own (singleton) class")
 	require.Equal(t, 2, simp.uf.find(2), "a quantified var is its own class when nothing co-occurs")
 }


### PR DESCRIPTION
When a generic function is constrained into a binding variable and then generalized, the function's own type parameters were being inlined to their bounds during coalescing. This caused return-only type parameters to collapse to `never`, triggering a guard in `acceptTypeParamVar` that requires type parameter vars to remain symbolic.

This change preserves a function's declared type parameters as symbolic during scheme coalescing, so the function's quantifier survives value-binding generalization intact. For example, `fn <T>(x: number) -> T` now renders correctly instead of collapsing the return-only `T` to `never`.

**Key changes:**

- Added `funcTypeParamVars()` to collect all generic function type parameter vars reachable from a type, including those in a binding var's lower bounds and in parameter constraints
- Added `typeParamCollector` visitor to walk the bound side-graph and reach generic functions carried as values
- Modified `schemeCoalescer` to skip inlining type parameter vars held in the `keep` set, returning them unchanged
- Updated `simplifyScheme()` to exclude kept type parameter vars from merge candidates, ensuring each remains a singleton class with its own representative
- Added comprehensive tests covering both-polarity, return-only, param-only, constrained, and multi-parameter generic functions

https://claude.ai/code/session_01877BAewRuJtuWeG1xvshzs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved generic function type parameters during type analysis and generalization.
  * Prevented generic parameters from incorrectly collapsing into bounds or resolving to `never`.
  * Improved handling of type parameters referenced through bound relationships and constrained generics.

* **Tests**
  * Added coverage for generic functions, constrained parameters, multiple type parameters, polarity cases, and bound-graph traversal.
  * Updated simplification tests for the revised analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->