### PR TITLE
Support generic function declarations with type parameters

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -161,6 +161,18 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		return nil
 	}
 
+	// A variable constrained against itself is reflexively true, so it records
+	// nothing. Without this guard the self-edge `T <: T` lands in the variable's own
+	// upper bounds and renders as `fn <T: T>(x: T) -> T`. A generic function whose
+	// body flows a parameter straight into a same-typed return annotation, such as
+	// `fn id<T>(x: T) -> T { return x }`, constrains the inferred return `T` against
+	// the annotated return `T` and hits exactly this.
+	if subVar, ok := sub.(*soltype.TypeVarType); ok {
+		if superVar, ok := super.(*soltype.TypeVarType); ok && subVar == superVar {
+			return nil
+		}
+	}
+
 	// A type alias is transparent: expand an AliasType on either side to its body and
 	// recurse through the existing seen-set, which also closes a recursive alias. This
 	// sits above the structural switch, which dispatches on sub and would otherwise

--- a/internal/solver/infer_class.go
+++ b/internal/solver/infer_class.go
@@ -585,7 +585,10 @@ func (c *checker) inferMemberFunc(
 	if !static {
 		c.bindSelf(memberScope, recv, body)
 	}
-	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn)
+	// A method's own type parameters stay gated because their per-instance projection
+	// is not yet applied by the class-body freeze, so inferFunc reports them as
+	// unsupported.
+	return c.inferFunc(memberScope, lvl, fn.FuncSig, fn.Body, fn, false)
 }
 
 // appendMethodSig installs a method signature under name, merging it into an existing

--- a/internal/solver/infer_class_ctor.go
+++ b/internal/solver/infer_class_ctor.go
@@ -68,7 +68,9 @@ func (c *checker) walkConstructorBody(scope *Scope, lvl int, self *soltype.Class
 	// regardless of the class's default mutability.
 	c.bindSelf(ctorScope, &ast.MethodReceiver{Mut: true}, body)
 
-	ft := c.inferFunc(ctorScope, lvl, bodySig, ctor.Fn.Body, ctor)
+	// A constructor carries no type parameters of its own, since the class owns them,
+	// so generic resolution stays off here, matching the method path.
+	ft := c.inferFunc(ctorScope, lvl, bodySig, ctor.Fn.Body, ctor, false)
 	c.checkConstructorInit(body, ctor)
 	// A constructor returns a fresh instance, not the void its statement body falls off
 	// to, so override the inferred return with the instance type.

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -755,6 +755,6 @@ func (c *checker) inferFuncDecl(scope *Scope, lvl int, d *ast.FuncDecl) (soltype
 	// A `declare fn` carries a nil body, so inferFunc types it as the no-body site it is:
 	// it adopts the declared return without constraining a synthetic `void`, and lowers
 	// its declared lifetime bounds instead of checking them against a body.
-	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d)
+	t := c.inferFunc(scope, lvl, d.FuncSig, d.Body, d, true)
 	return t, &ast.NodeProvenance{Node: d}
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -162,15 +162,14 @@ func astKind(n any) string {
 }
 
 // inferFuncExpr types a function expression as a soltype.FuncType and records it
-// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl
-// (the plan's "reuse inferFuncExpr on the decl's sig+body", factored so neither
-// side owns the other). M2 is monomorphic: any TypeParams on the signature are a
-// generic function (M3) and are diagnosed as unsupported by inferFunc, not
-// silently erased; an un-annotated param simply gets a fresh var, which
-// coalesces to unknown/never at render time rather than a <T0> quantifier
-// (generalization is M3).
+// in Info. It delegates to inferFunc, the shared core also used by inferFuncDecl,
+// factored so neither side owns the other. A `<T>` type-param list resolves into
+// the function's own FuncType.TypeParams, quantified by value-binding
+// generalization and freshened per call. An un-annotated param gets a fresh var,
+// which generalization turns into a quantifier or coalesces to unknown/never at
+// render time.
 func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.Type {
-	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e)
+	t := c.inferFunc(scope, lvl, e.FuncSig, e.Body, e, true)
 	c.recordType(e, t)
 	return t
 }
@@ -185,7 +184,7 @@ func (c *checker) inferFuncExpr(scope *Scope, lvl int, e *ast.FuncExpr) soltype.
 // type. A bodyless (declare/ambient) function adopts its return annotation
 // without constraining anything. node supplies the span stamped onto a
 // return-annotation constraint failure.
-func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node) *soltype.FuncType {
+func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Block, node ast.Node, allowTypeParams bool) *soltype.FuncType {
 	// Give this function its own named-lifetime scope so a `&'a` in its signature
 	// resolves consistently across its params and return, without sharing the name
 	// with an enclosing or sibling function. Restored on exit so a nested function
@@ -198,21 +197,33 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// list, and the symmetric unused binder. Run before resolving the params so the scan
 	// reads the written names, not what namedLifetime has since interned.
 	c.checkLifetimeDeclarations(sig.LifetimeParams, sig.Params, sig.Return, sig.Throws)
+	// Resolve a standalone function's type parameters into a child scope so a param or
+	// return annotation reads each `T` as one shared var. The var is minted above the
+	// generalization level, so value-binding generalization quantifies it into
+	// FuncType.TypeParams and instantiate freshens it per call. A non-generic function
+	// reuses the enclosing scope and carries no type parameters.
+	//
+	// A method or constructor passes allowTypeParams=false. A member's own type
+	// parameters need the per-instance projection the class-body freeze does not yet
+	// apply, so resolving them would collapse two calls to one shared var. Report the
+	// feature as unsupported and infer monomorphically until that work lands.
+	declScope := scope
+	var typeParams []*soltype.TypeParam
 	if len(sig.TypeParams) > 0 {
-		// Generic functions (fn <T>(...)) need type schemes / generalization,
-		// which are M3. The FuncExpr/FuncDecl kind itself is supported — it is the
-		// type-param feature that is not — so diagnose it as an unsupported feature
-		// (blaming the function node) rather than silently erasing the params, then
-		// continue inferring monomorphically.
-		c.reportUnsupportedFeature(node, "TypeParam")
+		if allowTypeParams {
+			declScope = scope.Child()
+			typeParams = c.resolveTypeParams(declScope, lvl, sig.TypeParams)
+		} else {
+			c.reportUnsupportedFeature(node, "TypeParam")
+		}
 	}
-	fnScope := scope.Child()
+	fnScope := declScope.Child()
 	params := make([]*soltype.FuncParam, len(sig.Params))
 	// paramTypes maps each bound parameter name to its soltype, consumed by the M4
 	// G1 liveness pre-pass to seed parameter alias mutability.
 	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
-		pt := c.paramType(scope, p, lvl)
+		pt := c.paramType(declScope, p, lvl)
 		// Rule 2 of PR 3. A bare annotation is owned and only an `&` annotation
 		// borrows. An `&` annotation already mints its lifetime in
 		// resolveLifetimeAnn, so a parameter has nothing to attach here. A bare
@@ -323,9 +334,9 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// there is no body, since a synthetic Void would falsely signal "returns
 	// nothing").
 	if sig.Async {
-		ret = c.asyncReturn(scope, node, sig.Return, ret, hasBody, lvl)
+		ret = c.asyncReturn(declScope, node, sig.Return, ret, hasBody, lvl)
 	} else if sig.Return != nil {
-		if annT, ok := c.resolveTypeAnn(scope, sig.Return, lvl); ok {
+		if annT, ok := c.resolveTypeAnn(declScope, sig.Return, lvl); ok {
 			// Only constrain the body when there IS one; a bodyless (declare/ambient)
 			// function simply adopts the annotation (constraining the synthetic Void
 			// would raise a spurious `void <: T`).
@@ -342,7 +353,7 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// inexact — it tolerates extra args when used as a callback (#677 §4.1), accept
 	// [required, ∞). Note exactness governs callback subtyping, not direct calls: an
 	// inexact value still rejects extras at a visible call site (the inferCall lint).
-	ft := &soltype.FuncType{Params: params, Ret: ret, Inexact: sig.Inexact}
+	ft := &soltype.FuncType{Params: params, Ret: ret, Inexact: sig.Inexact, TypeParams: typeParams}
 	// Record the function's own type against its node so a function flowing into a
 	// non-function requirement blames the function, and FuncArityMismatchError can
 	// carry a "defined here" related span. (For a named callee this raw FuncType is

--- a/internal/solver/infer_func_test.go
+++ b/internal/solver/infer_func_test.go
@@ -169,19 +169,26 @@ func TestInferFuncExprDestructuringParam(t *testing.T) {
 	require.Equal(t, "fn ([a, b]: [unknown, unknown]) -> void", render(got))
 }
 
-// A generic function (fn <T>() { ... }) is diagnosed rather than silently erased
-// to a monomorphic type — type schemes / generalization are M3.
-func TestInferFuncExprGenericUnsupported(t *testing.T) {
+// A generic function `fn <T>(x: T) -> T` resolves its type-parameter list into the
+// function's own FuncType.TypeParams, so the parameter and return read the one shared
+// `T` var rather than reporting the parameter feature as unsupported.
+func TestInferFuncExprGenericResolves(t *testing.T) {
 	c := newChecker()
-	// fn <T>() { 1 }
+	// fn <T>(x: T) -> T { return x }
 	tp := ast.NewTypeParam("T", nil, nil)
-	e := ast.NewFuncExpr(nil, []*ast.TypeParam{&tp}, nil, nil, nil, false,
-		block(exprStmt(numExpr(1))), testSpan())
+	tRef := func() ast.TypeAnn { return ast.NewRefTypeAnn(ast.NewIdentifier("T", testSpan()), nil, testSpan()) }
+	e := ast.NewFuncExpr(nil, []*ast.TypeParam{&tp}, []*ast.Param{param("x", tRef())}, tRef(),
+		nil, false, block(returnStmt(identExpr("x"))), testSpan())
 
-	c.inferExpr(NewScope(), 0, e)
-	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported: TypeParam", c.errs[0].Message())
-	require.Equal(t, testSpan(), c.errs[0].Span())
+	got := c.inferExpr(NewScope(), 0, e)
+	require.Empty(t, c.errs)
+	ft, ok := got.(*soltype.FuncType)
+	require.True(t, ok)
+	require.Len(t, ft.TypeParams, 1)
+	// The parameter and return read the same var the type-param list minted, so the
+	// param type, the return type, and the TypeParams binder are one identity.
+	require.Same(t, ft.TypeParams[0].Var, ft.Params[0].Type)
+	require.Same(t, ft.TypeParams[0].Var, ft.Ret)
 }
 
 // --- CallExpr ---

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -97,7 +97,13 @@ func TestInferGenericMethodStillGated(t *testing.T) {
 	for i, e := range errs {
 		msgs[i] = e.Message()
 	}
-	require.Contains(t, msgs, "Unsupported: TypeParam")
+	// The gate reports the type-param feature, then the two `T` references cascade to
+	// unsupported because the parameter was never declared in scope.
+	require.Equal(t, []string{
+		"Unsupported: TypeParam",
+		"Unsupported: TypeRefTypeAnn",
+		"Unsupported: TypeRefTypeAnn",
+	}, msgs)
 }
 
 // A parameter whose own type is polymorphic — a callback annotated `fn <V>(x: V) -> V` —
@@ -110,5 +116,11 @@ func TestInferGenericFuncHigherRankParamRejected(t *testing.T) {
 	for i, e := range errs {
 		msgs[i] = e.Message()
 	}
-	require.Contains(t, msgs, "Unsupported: generic function type annotation")
+	// The annotation gate reports the higher-rank feature, then the two `V` references
+	// inside it cascade to unsupported because the annotation's `<V>` was not resolved.
+	require.Equal(t, []string{
+		"Unsupported: generic function type annotation",
+		"Unsupported: TypeRefTypeAnn",
+		"Unsupported: TypeRefTypeAnn",
+	}, msgs)
 }

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -1,0 +1,114 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A standalone `fn f<T>(…)` declaration resolves its explicit type-parameter list into
+// the function's own FuncType.TypeParams, so the declared quantifier renders with the
+// written name and each call instantiates it independently, each argument keeping its
+// own literal type rather than widening or unifying across calls.
+func TestInferGenericFuncDecl(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			// The declared `<T>` renders with its written name, and the two calls
+			// instantiate it independently, so `a` and `b` keep their own literal types.
+			name: "IdentityRendersAndInstantiates",
+			src: `
+				fn id<T>(x: T) -> T { return x }
+				val a = id(5)
+				val b = id("hi")
+			`,
+			want: map[string]string{
+				"id": "fn <T>(x: T) -> T",
+				"a":  "5",
+				"b":  `"hi"`,
+			},
+		},
+		{
+			// A parameter used only in the return position stays a valid quantifier
+			// rather than inlining to never.
+			name: "ReturnOnlyParam",
+			src:  `fn make<T>(x: number) -> T { return x }`,
+			want: map[string]string{
+				"make": "fn <T>(x: number) -> T",
+			},
+		},
+		{
+			// A bodyless `declare fn` resolves its type-parameter list the same way,
+			// adopting its declared return without a body to constrain.
+			name: "DeclareFn",
+			src:  `declare fn id<T>(x: T) -> T`,
+			want: map[string]string{
+				"id": "fn <T>(x: T) -> T",
+			},
+		},
+		{
+			// Two distinct type parameters bind independently, so a call passing a
+			// number and a string returns a tuple of each argument's literal type.
+			name: "TwoParams",
+			src: `
+				fn pair<T, U>(x: T, y: U) -> [T, U] { return [x, y] }
+				val p = pair(1, "two")
+			`,
+			want: map[string]string{
+				"pair": "fn <T, U>(x: T, y: U) -> [T, U]",
+				"p":    `[1, "two"]`,
+			},
+		},
+		{
+			// A bounded parameter keeps its bound on the quantifier but not on the use
+			// site, so `x` reads as `T` while `<T: number>` carries the constraint.
+			name: "BoundedParam",
+			src:  `fn first<T: number>(x: T) -> T { return x }`,
+			want: map[string]string{
+				"first": "fn <T: number>(x: T) -> T",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name], "type mismatch for %q", name)
+			}
+		})
+	}
+}
+
+// A method's own type parameters stay gated at the rank-1 boundary: per-instance
+// projection is not yet applied by the class-body freeze, so resolving them would
+// collapse two calls to one shared var. The method reports the type-param feature as
+// unsupported and infers monomorphically rather than panicking in the body freeze.
+func TestInferGenericMethodStillGated(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		class Box {
+			wrap<T>(self, x: T) -> T { return x }
+		}
+	`)
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Message()
+	}
+	require.Contains(t, msgs, "Unsupported: TypeParam")
+}
+
+// A parameter whose own type is polymorphic — a callback annotated `fn <V>(x: V) -> V` —
+// stays rejected at the rank-1 boundary. The type-parameter list on the declaration
+// resolves, but the generic function-type annotation on the parameter is the higher-rank
+// surface a later PR handles, so it reports as unsupported rather than being approximated.
+func TestInferGenericFuncHigherRankParamRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `fn apply<T>(g: fn <V>(x: V) -> V, y: T) -> T { return g(y) }`)
+	msgs := make([]string, len(errs))
+	for i, e := range errs {
+		msgs[i] = e.Message()
+	}
+	require.Contains(t, msgs, "Unsupported: generic function type annotation")
+}

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -187,7 +187,7 @@ func (c *checker) inferComponent(
 					// discarding keeps phase 2's inferFunc — which re-derives the signature
 					// while checking the body — the single reporter of any signature error.
 					p := c.openProbe()
-					sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd)
+					sig := c.inferFunc(scope, inner, fd.FuncSig, nil, fd, true)
 					c.closeProbe(p, false)
 					arms[i] = overloadArm{decl: fd, t: sig, annotated: true}
 					schemes[i] = monoScheme(sig)
@@ -225,7 +225,7 @@ func (c *checker) inferComponent(
 			for _, arm := range b.arms {
 				handled.Add(arm.decl)
 				b.sources = append(b.sources, &ast.NodeProvenance{Node: arm.decl})
-				c.inferFunc(scope, inner, arm.decl.FuncSig, arm.decl.Body, arm.decl)
+				c.inferFunc(scope, inner, arm.decl.FuncSig, arm.decl.Body, arm.decl, true)
 			}
 			continue
 		}


### PR DESCRIPTION
This PR adds support for generic function declarations with explicit type parameters (e.g., `fn id<T>(x: T) -> T`). Type parameters now resolve into the function's own `FuncType.TypeParams` field, enabling proper quantification and per-call instantiation.

**Key changes:**

- Modified `inferFunc` to accept an `allowTypeParams` parameter that gates type-parameter resolution. Standalone functions and function declarations pass `true` to resolve type parameters into a child scope; methods and constructors pass `false` to keep the feature unsupported until per-instance projection is implemented in the class-body freeze.

- Added `resolveTypeParams` call in `inferFunc` to mint type-parameter variables above the generalization level, so value-binding generalization quantifies them into `FuncType.TypeParams` and instantiation freshens them per call.

- Updated `FuncType` construction to populate the `TypeParams` field with resolved parameters.

- Added a reflexivity guard in `constrain` to prevent self-edges like `T <: T` from polluting a variable's bounds. This handles cases where a generic function's body flows a parameter directly into a same-typed return annotation.

- Updated call sites in `module.go`, `infer_class.go`, and `infer_class_ctor.go` to pass the appropriate `allowTypeParams` value.

- Updated test in `infer_func_test.go` to verify that generic function expressions resolve their type parameters correctly, with the parameter and return reading the same shared variable.

- Added comprehensive test suite in `infer_generic_func_test.go` covering generic function declarations, multiple type parameters, bounded parameters, declared functions, and error cases for methods and higher-rank function types.

https://claude.ai/code/session_0119YxRNDgaD5pN6ZBvwZ9wj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generic standalone functions now support type-parameter inference and preserve type parameters in their inferred signatures.
  * Generic function declarations support independent instantiation, parameter bounds, and tuple return types.
  * Fully annotated generic overloads retain their type-parameter information.

* **Bug Fixes**
  * Prevented self-referential type constraints from appearing during inference.
  * Improved handling of generic constructors and methods, with unsupported cases reported consistently.

* **Tests**
  * Added coverage for generic functions, bounds, overloads, and unsupported higher-rank annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->