### PR TITLE
Support rank-1 generic function type annotations

### DIFF
--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -261,8 +261,9 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	// Check a generic function annotation against a FRESH instance and adopt the untouched
-	// annotation, so its declared `<T>` stays the binding's only quantifier instead of also
-	// rendering the initializer's vars, `fn <T0, T: T0>(x: T) -> T`. Binder vars sit at lvl.
+	// annotation, so it renders `fn <T>(x: T) -> T`. Constraining the initializer against the
+	// annotation itself would leak its vars as a second quantifier, `fn <T0, T: T0>(x: T) ->
+	// T`. Binder vars sit at lvl, so freshenAbove(lvl-1, …) copies them.
 	if funcTypeParamVars(annT).Len() > 0 {
 		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
 		c.constrain(init, initT, inst)

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -261,10 +261,8 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
 	// Check a generic function annotation against a FRESH instance and adopt the untouched
-	// annotation, so its declared `<T>` stays the binding's only quantifier rather than
-	// rendering the initializer's own vars as a second one, `fn <T0, T: T0>(x: T) -> T`
-	// instead of `fn <T>(x: T) -> T`. funcTypeParamVars also catches a rank-1 generic in
-	// return position, and the binder vars sit at lvl, so freshenAbove(lvl-1, …) copies them.
+	// annotation, so its declared `<T>` stays the binding's only quantifier instead of also
+	// rendering the initializer's vars, `fn <T0, T: T0>(x: T) -> T`. Binder vars sit at lvl.
 	if funcTypeParamVars(annT).Len() > 0 {
 		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
 		c.constrain(init, initT, inst)

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -205,7 +205,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// error and adopting `never` would poison the binding. Keep the inferred
 		// initializer type instead (error recovery).
 		if annT, ok := c.resolveTypeAnn(scope, d.TypeAnn, lvl); ok {
-			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT)
+			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT, lvl)
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
@@ -227,7 +227,10 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 
 // constrainInitAgainstAnnotation constrains a `val`/`var` initializer against its
 // resolved annotation and returns the type the binding adopts, which may differ from
-// the written annotation in two refinements over a plain constrain.
+// the written annotation in three refinements over a plain constrain.
+//
+// 0. A generic function annotation is checked against a fresh instance, so the adopted
+// annotation keeps its declared `<T>` as its only quantifier. See the inline note.
 //
 // 1. A uniquely-owned initializer flowing into an OWNED-mutable annotation is allowed to
 // take that mutable type. The C2 gate rejects immutable <: mutable structurally, because
@@ -256,7 +259,24 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // bare owned destination, as in `val q: {x} = p`, does not alias `p`. The constraint takes the
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
-func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
+func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
+	// A generic function annotation is a quantified type, so the initializer must satisfy
+	// it at every instantiation. Check the initializer against a FRESH instance whose
+	// type-param vars are throwaway copies. Constraining against the annotation itself
+	// would record the initializer's own inference vars as bounds on its declared
+	// type-param vars, so the adopted binding would render those copies as a second
+	// quantifier — `fn <T0, T: T0>(x: T) -> T` instead of `fn <T>(x: T) -> T`. Adopting the
+	// untouched annotation keeps its declared `<T>` as the binding's only quantifier. The
+	// binder vars are minted at lvl, so freshenAbove(lvl-1, …) copies exactly them.
+	//
+	// funcTypeParamVars finds a generic function anywhere in the annotation, so a rank-1
+	// generic in return position — `fn(x: number) -> (fn<T>(y: T) -> T)` — gets a fresh
+	// instance and renders clean too, not only a top-level `fn<T>(…)`.
+	if funcTypeParamVars(annT).Len() > 0 {
+		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
+		c.constrain(init, initT, inst)
+		return annT
+	}
 	if c.tryUpgradeToOwnedMut(init, init, initT, annT) {
 		return annT
 	}

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -260,18 +260,11 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
-	// A generic function annotation is a quantified type, so the initializer must satisfy
-	// it at every instantiation. Check the initializer against a FRESH instance whose
-	// type-param vars are throwaway copies. Constraining against the annotation itself
-	// would record the initializer's own inference vars as bounds on its declared
-	// type-param vars, so the adopted binding would render those copies as a second
-	// quantifier — `fn <T0, T: T0>(x: T) -> T` instead of `fn <T>(x: T) -> T`. Adopting the
-	// untouched annotation keeps its declared `<T>` as the binding's only quantifier. The
-	// binder vars are minted at lvl, so freshenAbove(lvl-1, …) copies exactly them.
-	//
-	// funcTypeParamVars finds a generic function anywhere in the annotation, so a rank-1
-	// generic in return position — `fn(x: number) -> (fn<T>(y: T) -> T)` — gets a fresh
-	// instance and renders clean too, not only a top-level `fn<T>(…)`.
+	// Check a generic function annotation against a FRESH instance and adopt the untouched
+	// annotation, so its declared `<T>` stays the binding's only quantifier rather than
+	// rendering the initializer's own vars as a second one, `fn <T0, T: T0>(x: T) -> T`
+	// instead of `fn <T>(x: T) -> T`. funcTypeParamVars also catches a rank-1 generic in
+	// return position, and the binder vars sit at lvl, so freshenAbove(lvl-1, …) copies them.
 	if funcTypeParamVars(annT).Len() > 0 {
 		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
 		c.constrain(init, initT, inst)

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -73,15 +73,95 @@ func TestInferFuncAnnotationAcceptSetTooManyParamsRejected(t *testing.T) {
 	require.IsType(t, &FuncArityMismatchError{}, errs[0])
 }
 
-// A generic function annotation reports the documented unsupported feature and
-// recovers function-shaped, so the binding still resolves as a function rather
-// than collapsing to an unconstrained var.
-func TestInferGenericFuncAnnotationReportsUnsupported(t *testing.T) {
-	values, _, errs := inferSource(t, `val f: fn<T>(x: number) -> number = fn (x) { return x }`)
+// A generic function annotation resolves its `<T>` list through resolveTypeParams and
+// an annotated binding adopts the quantified type, so the rendered binding keeps its
+// declared `<T>` as its only quantifier. Each case renders the binding named `f` and
+// reports no error.
+func TestInferGenericFuncAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		// The type parameter reaches both a parameter and the return, so it is retained in
+		// both positions. The initializer's own inference var links to a fresh instance
+		// rather than the declared `T`, so it renders `fn <T>(x: T) -> T`, not the
+		// double-quantified `fn <T0, T: T0>(x: T) -> T`.
+		{
+			name: "parameter and return",
+			src:  `val f: fn<T>(x: T) -> T = fn (x) { return x }`,
+			want: "fn <T>(x: T) -> T",
+		},
+		// A type parameter named in neither the parameters nor the return stays quantified
+		// but unused, so it renders in the prefix over a monomorphic body.
+		{
+			name: "unused parameter",
+			src:  `val f: fn<T>(x: number) -> number = fn (x) { return x }`,
+			want: "fn <T>(x: number) -> number",
+		},
+		// Two distinct type parameters each stay their own quantifier.
+		{
+			name: "two parameters",
+			src:  `val f: fn<T, U>(x: T, y: U) -> T = fn (x, y) { return x }`,
+			want: "fn <T, U>(x: T, y: U) -> T",
+		},
+		// A union member that is a bare type parameter resolves against the annotation's
+		// child scope, so `T` in `T | number` binds to the declared parameter and reaches
+		// constrain's union-super two-pass rule from source.
+		{
+			name: "union member type parameter",
+			src:  `val f: fn<T>(x: T | number) -> T = fn (x) { return x }`,
+			want: "fn <T>(x: T | number) -> T",
+		},
+		// A generic function in RETURN position is rank-1: the quantifier floats out of the
+		// positive position, so it is supported. The nested `T` renders on the inner function
+		// without leaking the initializer's body var as an outer quantifier.
+		{
+			name: "generic return is rank-1",
+			src:  `val f: fn(x: number) -> (fn<T>(y: T) -> T) = fn (x) { return fn (y) { return y } }`,
+			want: "fn (x: number) -> fn <T>(y: T) -> T",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A generic function in parameter position is rank-2: the annotation `fn(cb: fn<T>(x: T)
+// -> T) -> number` would demand a caller pass an argument that is itself polymorphic. That
+// is beyond the rank-1 boundary, so it reports an unsupported feature and recovers to a
+// fresh var for the parameter, keeping the outer function shape.
+func TestInferHigherRankFuncParamReportsUnsupported(t *testing.T) {
+	values, _, errs := inferSource(t, `val f: fn(cb: fn<T>(x: T) -> T) -> number = fn (cb) { return 1 }`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "1:8-1:34: Unsupported: generic function type annotation", msgWithSpan(errs[0]))
-	require.Equal(t, "fn (x: number) -> number", values["f"])
+	require.Equal(t, "1:15-1:31: Unsupported: higher-rank function parameter", msgWithSpan(errs[0]))
+	require.Equal(t, "fn (cb: unknown) -> number", values["f"])
+}
+
+// A function-literal body whose return type is not the declared parameter does not
+// satisfy the polymorphic annotation `fn <T>(x: T) -> T`, since a caller expecting `T`
+// back would receive a `number`. Rejecting it needs the initializer checked against the
+// annotation with `T` held RIGID, so a concrete return cannot unify with `T`. The current
+// check runs against a fresh instance, whose `T` is an ordinary inference var, so `number`
+// unifies with it and the binding is wrongly accepted as `fn <T>(x: T) -> T`.
+//
+// DISABLED until rigid generic-annotation checking: re-enable by removing the /* */
+// wrapper once the initializer is checked against the annotation's type parameters as
+// rigid constants, so a non-polymorphic body is rejected. The generic-functions plan
+// (planning/simple_sub/generic-functions-implementation-plan.md) stays rank-1 and does
+// not schedule this, so it is follow-on work.
+func TestInferGenericFuncAnnotationRejectsNonPolymorphicBody(t *testing.T) {
+	/*
+		_, _, errs := inferSource(t, `val f: fn<T>(x: T) -> T = fn (x) { return 5 }`)
+		require.Len(t, errs, 1)
+		require.IsType(t, &CannotConstrainError{}, errs[0])
+		require.Equal(t, "1:44-1:45: cannot constrain 5 <: T", msgWithSpan(errs[0]))
+	*/
 }
 
 // A throws clause reports the documented unsupported feature and recovers

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -228,26 +228,19 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 	return t, true
 }
 
-// resolveFuncTypeAnn lowers a monomorphic function type annotation
-// `fn(p: A, ...) -> R` into a soltype.FuncType, mapping ta.Inexact to
-// FuncType.Inexact. An unsupported part recovers to a fresh var so the function
-// shape survives, cascade-safe like the Promise/object/tuple arms. Generic, throws,
-// and rest-param annotations report an unsupported feature and recover as a
-// monomorphic function. A lifetime parameter is supported. Its declared outlives
-// bounds lower into constrainLt so the annotation's borrows solve against them.
+// resolveFuncTypeAnn lowers a function type annotation `fn<T>(p: A, ...) -> R` into a
+// soltype.FuncType, mapping ta.Inexact to FuncType.Inexact. An unsupported part recovers
+// to a fresh var so the function shape survives, cascade-safe like the Promise/object/tuple
+// arms. Throws and rest-param annotations report an unsupported feature and recover as a
+// monomorphic function. A lifetime parameter is supported. Its declared outlives bounds
+// lower into constrainLt so the annotation's borrows solve against them.
 //
-// A generic annotation reports an unsupported feature rather than resolving its `<…>`
-// list. Routing it through resolveTypeParams resolves the parameters, but the resulting
-// FuncType.TypeParams vars break the value-binding generalization path. That path inlines
-// them to `never` and panics in acceptTypeParams, since a bound parameter must stay a
-// variable. Holding them symbolic needs the keep-set retention coalesceKeeping already
-// gives a generic class's own parameters. That retention lands with the generic-function
-// generalization work, so until then the conservative report keeps a `val f: fn<T>(…)`
-// binding sound.
+// A `<T>` type-parameter list resolves through resolveTypeParams into a child scope, so a
+// parameter, the return, or a union member that names `T` reads it as the annotation's own
+// quantified var. The resulting FuncType.TypeParams vars stay symbolic through the
+// value-binding generalization path, retained by the keep-set analogue coalesceScheme runs
+// for a generic function's own binder vars.
 func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
-	if len(ta.TypeParams) > 0 {
-		c.reportUnsupportedFeature(ta, "generic function type annotation")
-	}
 	if ta.Throws != nil {
 		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")
 	}
@@ -259,6 +252,17 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 	savedNamedLts := c.namedLifetimes
 	c.namedLifetimes = nil
 	defer func() { c.namedLifetimes = savedNamedLts }()
+
+	// Resolve the annotation's type parameters into a child scope so a parameter, the
+	// return, and any union member all read a sibling `T` as one shared var. A
+	// non-generic annotation reuses the enclosing scope.
+	annScope := scope
+	var typeParams []*soltype.TypeParam
+	if len(ta.TypeParams) > 0 {
+		annScope = scope.Child()
+		typeParams = c.resolveTypeParams(annScope, lvl, ta.TypeParams)
+	}
+
 	// Report any named lifetime this annotation uses without binding it in its own `<…>`
 	// list, and the symmetric unused binder, before lowering its bounds interns the names.
 	c.checkLifetimeDeclarations(ta.LifetimeParams, ta.Params, ta.Return, ta.Throws)
@@ -277,9 +281,19 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 		// the function keeps its arity and shape, cascade-safe like Promise<bad>.
 		var pt soltype.Type = c.freshAt(lvl)
 		if p.TypeAnn != nil {
-			if t, ok := c.resolveTypeAnn(scope, p.TypeAnn, lvl); ok {
+			if t, ok := c.resolveTypeAnn(annScope, p.TypeAnn, lvl); ok {
 				pt = t
 			}
+		}
+		// A generic function in parameter position is rank-2: its `<…>` quantifier sits to
+		// the left of an arrow, so a caller would have to supply an argument polymorphic in
+		// its own right. That is beyond the rank-1 boundary this work keeps, so report it and
+		// recover to a fresh var. A generic function in RETURN position is rank-1, since the
+		// quantifier floats out of a positive position, so only the parameter case is
+		// rejected here.
+		if ft, ok := pt.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
+			c.reportUnsupportedFeature(p.TypeAnn, "higher-rank function parameter")
+			pt = c.freshAt(lvl)
 		}
 		// The pattern is carried for rendering and round-tripping only, with no scope
 		// binding. mirrorParamPat preserves its full shape.
@@ -291,12 +305,12 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 	// keeping the function shape.
 	var ret soltype.Type = c.freshAt(lvl)
 	if ta.Return != nil {
-		if t, ok := c.resolveTypeAnn(scope, ta.Return, lvl); ok {
+		if t, ok := c.resolveTypeAnn(annScope, ta.Return, lvl); ok {
 			ret = t
 		}
 	}
 
-	t := &soltype.FuncType{Params: params, Ret: ret, Inexact: ta.Inexact}
+	t := &soltype.FuncType{Params: params, Ret: ret, Inexact: ta.Inexact, TypeParams: typeParams}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -229,17 +229,9 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 }
 
 // resolveFuncTypeAnn lowers a function type annotation `fn<T>(p: A, ...) -> R` into a
-// soltype.FuncType, mapping ta.Inexact to FuncType.Inexact. An unsupported part recovers
-// to a fresh var so the function shape survives, cascade-safe like the Promise/object/tuple
-// arms. Throws and rest-param annotations report an unsupported feature and recover as a
-// monomorphic function. A lifetime parameter is supported. Its declared outlives bounds
-// lower into constrainLt so the annotation's borrows solve against them.
-//
-// A `<T>` type-parameter list resolves through resolveTypeParams into a child scope, so a
-// parameter, the return, or a union member that names `T` reads it as the annotation's own
-// quantified var. The resulting FuncType.TypeParams vars stay symbolic through the
-// value-binding generalization path, retained by the keep-set analogue coalesceScheme runs
-// for a generic function's own binder vars.
+// soltype.FuncType, recovering an unsupported part to a fresh var so the shape survives. A
+// `<T>` list resolves through resolveTypeParams into a child scope, so a parameter, return,
+// or union member that names `T` reads the annotation's own quantified var.
 func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int) (soltype.Type, bool) {
 	if ta.Throws != nil {
 		c.reportUnsupportedFeature(ta, "throws clause in function type annotation")

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -285,12 +285,8 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 				pt = t
 			}
 		}
-		// A generic function in parameter position is rank-2: its `<…>` quantifier sits to
-		// the left of an arrow, so a caller would have to supply an argument polymorphic in
-		// its own right. That is beyond the rank-1 boundary this work keeps, so report it and
-		// recover to a fresh var. A generic function in RETURN position is rank-1, since the
-		// quantifier floats out of a positive position, so only the parameter case is
-		// rejected here.
+		// A generic function in parameter position is rank-2, beyond the rank-1 boundary, so
+		// report it and recover to a fresh var. In return position it is rank-1 and kept.
 		if ft, ok := pt.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
 			c.reportUnsupportedFeature(p.TypeAnn, "higher-rank function parameter")
 			pt = c.freshAt(lvl)


### PR DESCRIPTION
Enable generic function type annotations like `fn<T>(x: T) -> T` by resolving type parameters into a child scope and checking initializers against fresh instances. Reject rank-2 cases where a generic function appears in parameter position, as those require higher-rank polymorphism beyond the current scope.

**Key changes:**

- `resolveFuncTypeAnn` now resolves `<T>` type-parameter lists through `resolveTypeParams` into a child scope, allowing parameters, returns, and union members to reference the annotation's own quantified variables.
- `constrainInitAgainstAnnotation` checks generic function annotations against fresh instances (via `freshenAbove`) so the adopted binding keeps its declared `<T>` as the only quantifier, rather than accumulating the initializer's inference vars as a second quantifier.
- Higher-rank function parameters (generic functions in parameter position) are detected and rejected with an unsupported-feature error, recovering to a fresh var to preserve function shape.
- Rank-1 generic functions in return position are supported, since the quantifier floats out of a positive position.
- Test coverage expanded from a single unsupported case to a table-driven suite covering parameter/return type parameters, unused parameters, multiple parameters, union members, and rank-1 returns. A disabled test documents the follow-on work needed for rigid generic-annotation checking.

https://claude.ai/code/session_01CEPDe18q7jrWeC84hGC8Zh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generic function type annotations are now supported, including multiple type parameters and generic return types.
  * Type parameters declared in annotations are preserved and resolved correctly.

* **Bug Fixes**
  * Generic function annotations now infer initializer types more accurately.
  * Higher-rank generic function parameters are rejected with a safe fallback type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->