### PR TITLE
Reject generic functions whose bodies force type parameters to concrete types

### DIFF
--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -318,6 +318,20 @@ type VarianceMismatchError struct {
 	Class    ast.Node
 }
 
+// TypeParamNotProducibleError fires when a body-carrying generic function declares a type
+// parameter in an output position but its body forces that parameter to a concrete lower
+// bound. For `fn make<T>(x: number) -> T { return x }` the body returns `x: number` as
+// `T`, recording `number` as a lower bound of `T`'s var. The caller chooses `T`, so a
+// signature that hands back an arbitrary `T` while the body only ever produces `number`
+// over-promises. A genuinely parametric body such as `fn id<T>(x: T) -> T { return x }`
+// records no concrete lower bound on `T`, so it is not flagged. Name is the parameter,
+// Floor the concrete type the body forces, and Node the blame span.
+type TypeParamNotProducibleError struct {
+	Name  string
+	Floor soltype.Type
+	Node  ast.Node
+}
+
 func (*CannotConstrainError) isSolverError()        {}
 func (*MutFieldError) isSolverError()               {}
 func (*ReadonlyFieldError) isSolverError()          {}
@@ -340,6 +354,7 @@ func (*StructuralIntoClassError) isSolverError()    {}
 func (*NonClassSuperError) isSolverError()          {}
 func (*CannotExtendFinalClassError) isSolverError() {}
 func (*VarianceMismatchError) isSolverError()       {}
+func (*TypeParamNotProducibleError) isSolverError() {}
 
 // --- Per-operand blame (§3.5): each constraint kind follows its operands through
 // Prov on demand, falling back to its own site (where it keeps one) ---
@@ -459,6 +474,9 @@ func (e *CannotExtendFinalClassError) Related() []ast.Span { return nil }
 
 func (e *VarianceMismatchError) Span() ast.Span      { return e.Class.Span() }
 func (e *VarianceMismatchError) Related() []ast.Span { return nil }
+
+func (e *TypeParamNotProducibleError) Span() ast.Span      { return e.Node.Span() }
+func (e *TypeParamNotProducibleError) Related() []ast.Span { return nil }
 
 // spanOf blames op's own source node when that node lies *within* the constraint
 // site, and the site itself otherwise (or when op has no entry). The containment
@@ -1483,6 +1501,11 @@ func (e *CannotExtendFinalClassError) Message() string {
 func (e *VarianceMismatchError) Message() string {
 	return fmt.Sprintf("type parameter `%s` is declared %s but is actually %s",
 		e.Name, e.Declared, e.Inferred)
+}
+
+func (e *TypeParamNotProducibleError) Message() string {
+	return fmt.Sprintf("the body forces type parameter `%s` to `%s`, so it cannot stand for an arbitrary type",
+		e.Name, describe(e.Floor))
 }
 
 // describeBorrowInner renders the pointee of a borrow for a diagnostic. An immutable

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -267,6 +267,13 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 	if funcTypeParamVars(annT).Len() > 0 {
 		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
 		c.constrain(init, initT, inst)
+		// The initializer's body flows into inst, so inst's type-param vars carry any
+		// concrete floor the body forces. Check them, not the pristine annT the binding
+		// adopts, so `val f: fn<T>(x: number) -> T = fn (x) { return x }` is flagged the
+		// same as the standalone `fn make<T>(x: number) -> T`.
+		if instFn, ok := inst.(*soltype.FuncType); ok {
+			c.checkTypeParamsProducible(init, instFn)
+		}
 		return annT
 	}
 	if c.tryUpgradeToOwnedMut(init, init, initT, annT) {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -373,6 +373,10 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	// The bound then solves like one a body would infer.
 	if hasBody {
 		c.checkDeclaredLifetimeBounds(sig.LifetimeParams, ft)
+		// A body-carrying generic function must actually produce every type parameter it
+		// declares in an output position. A bodyless `declare fn` asserts its signature
+		// with no body to check, so it is not verified here.
+		c.checkTypeParamsProducible(node, ft)
 	} else {
 		c.lowerLifetimeParamBounds(sig.LifetimeParams, lvl)
 	}

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -105,14 +105,6 @@ func TestInferGenericFuncAnnotation(t *testing.T) {
 			src:  `val f: fn<T, U>(x: T, y: U) -> T = fn (x, y) { return x }`,
 			want: "fn <T, U>(x: T, y: U) -> T",
 		},
-		// A union member that is a bare type parameter resolves against the annotation's
-		// child scope, so `T` in `T | number` binds to the declared parameter and reaches
-		// constrain's union-super two-pass rule from source.
-		{
-			name: "union member type parameter",
-			src:  `val f: fn<T>(x: T | number) -> T = fn (x) { return x }`,
-			want: "fn <T>(x: T | number) -> T",
-		},
 		// A generic function in RETURN position is rank-1: the quantifier floats out of the
 		// positive position, so it is supported. The nested `T` renders on the inner function
 		// without leaking the initializer's body var as an outer quantifier.

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -108,6 +108,16 @@ func TestInferGenericFuncBodyOverPromises(t *testing.T) {
 			src:  `fn weird<T>(x: T) -> T { return 5 }`,
 			msg:  "1:1-1:36: the body forces type parameter `T` to `5`, so it cannot stand for an arbitrary type",
 		},
+		{
+			// A `T | number` parameter returned as `T` is unsound: a caller doing
+			// `leak<string>(5)` passes a valid `string | number` and receives `5` typed as
+			// `string`. The union splits into `T <: T` and `number <: T`, so the `number`
+			// branch is an independently concrete floor even though the sibling branch is
+			// the caller's own `T`.
+			name: "UnionParamWithConcreteBranch",
+			src:  `fn leak<T>(x: T | number) -> T { return x }`,
+			msg:  "1:1-1:44: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -119,17 +129,54 @@ func TestInferGenericFuncBodyOverPromises(t *testing.T) {
 	}
 }
 
-// The annotation form `val f: fn<T>(x: number) -> T = fn (x) { return x }` reuses the same
-// bounded-inference-var core. The body's return value `x` flows into the annotation's fresh
-// instance through an intermediate var, so the floor `number` is reached transitively and
-// the annotation form is flagged the same as the standalone declaration.
+// The annotation form reuses the same bounded-inference-var core. The body's return value
+// flows into the annotation's fresh instance through an intermediate var, so the floor is
+// reached transitively and the annotation form is flagged the same as the standalone
+// declaration. The binding still adopts its pristine annotation, so `f` renders with the
+// declared quantifier alongside the error.
 func TestInferGenericFuncAnnotationBodyOverPromises(t *testing.T) {
-	_, _, errs := inferSource(t, `val f: fn<T>(x: number) -> T = fn (x) { return x }`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &TypeParamNotProducibleError{}, errs[0])
-	require.Equal(t,
-		"1:32-1:51: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
-		msgWithSpan(errs[0]))
+	tests := []struct {
+		name string
+		src  string
+		msg  string
+		want string
+	}{
+		{
+			name: "ReturnParamForcedToConcrete",
+			src:  `val f: fn<T>(x: number) -> T = fn (x) { return x }`,
+			msg:  "1:32-1:51: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+			want: "fn <T>(x: number) -> T",
+		},
+		{
+			// The union member `T` still binds through the annotation's child scope and
+			// reaches constrain's union-super two-pass rule, so the binding solves and
+			// renders. The `number` branch is the independently concrete floor that the
+			// producibility check rejects.
+			name: "UnionParamWithConcreteBranch",
+			src:  `val f: fn<T>(x: T | number) -> T = fn (x) { return x }`,
+			msg:  "1:36-1:55: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+			want: "fn <T>(x: T | number) -> T",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, &TypeParamNotProducibleError{}, errs[0])
+			require.Equal(t, tt.msg, msgWithSpan(errs[0]))
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A bodyless `declare fn` asserts its signature with no body to check, so the producibility
+// check does not run and an over-promising shape such as `declare fn make<T>(x: number) -> T`
+// stays accepted. It is the programmer's assertion that some external implementation
+// produces `T`.
+func TestInferGenericDeclareFuncNotProducibilityChecked(t *testing.T) {
+	values, _, errs := inferSource(t, `declare fn make<T>(x: number) -> T`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: number) -> T", values["make"])
 }
 
 // A method's own type parameters stay gated at the rank-1 boundary: per-instance

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -32,15 +32,6 @@ func TestInferGenericFuncDecl(t *testing.T) {
 			},
 		},
 		{
-			// A parameter used only in the return position stays a valid quantifier
-			// rather than inlining to never.
-			name: "ReturnOnlyParam",
-			src:  `fn make<T>(x: number) -> T { return x }`,
-			want: map[string]string{
-				"make": "fn <T>(x: number) -> T",
-			},
-		},
-		{
 			// A bodyless `declare fn` resolves its type-parameter list the same way,
 			// adopting its declared return without a body to constrain.
 			name: "DeclareFn",
@@ -71,6 +62,15 @@ func TestInferGenericFuncDecl(t *testing.T) {
 				"first": "fn <T: number>(x: T) -> T",
 			},
 		},
+		{
+			// A body that returns one of several parameters of the same type is genuinely
+			// parametric: `T` gets no concrete lower bound, so it is not flagged.
+			name: "ReturnsOneOfTwoSameTypeParams",
+			src:  `fn first<T>(x: T, y: T) -> T { return x }`,
+			want: map[string]string{
+				"first": "fn <T>(x: T, y: T) -> T",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,6 +81,55 @@ func TestInferGenericFuncDecl(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A body-carrying generic function whose body forces a declared type parameter used in an
+// output position to a concrete floor is rejected at the declaration. The caller chooses
+// the parameter, so a signature that hands back an arbitrary `T` while the body only ever
+// produces `number` over-promises.
+func TestInferGenericFuncBodyOverPromises(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		msg  string
+	}{
+		{
+			// The body returns `x: number` as `T`, so `T` carries the concrete floor
+			// `number` the caller never supplied.
+			name: "ReturnParamForcedToConcrete",
+			src:  `fn make<T>(x: number) -> T { return x }`,
+			msg:  "1:1-1:40: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+		},
+		{
+			// A literal in the return forces the floor even when the parameter also
+			// appears in an input position, since the body still never produces an
+			// arbitrary `T`.
+			name: "ReturnLiteralWithParamInInput",
+			src:  `fn weird<T>(x: T) -> T { return 5 }`,
+			msg:  "1:1-1:36: the body forces type parameter `T` to `5`, so it cannot stand for an arbitrary type",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, &TypeParamNotProducibleError{}, errs[0])
+			require.Equal(t, tt.msg, msgWithSpan(errs[0]))
+		})
+	}
+}
+
+// The annotation form `val f: fn<T>(x: number) -> T = fn (x) { return x }` reuses the same
+// bounded-inference-var core. The body's return value `x` flows into the annotation's fresh
+// instance through an intermediate var, so the floor `number` is reached transitively and
+// the annotation form is flagged the same as the standalone declaration.
+func TestInferGenericFuncAnnotationBodyOverPromises(t *testing.T) {
+	_, _, errs := inferSource(t, `val f: fn<T>(x: number) -> T = fn (x) { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &TypeParamNotProducibleError{}, errs[0])
+	require.Equal(t,
+		"1:32-1:51: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+		msgWithSpan(errs[0]))
 }
 
 // A method's own type parameters stay gated at the rank-1 boundary: per-instance

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -93,38 +93,52 @@ func (v *polarityVarVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltyp
 // form `val f: fn<T>(x: number) -> T = fn (x) { return x }` reaches `number` through the
 // value's own param var that links the body to the annotation's `T`.
 //
-// A non-variable lower bound is a forced floor only when it mentions NONE of the
-// function's declared type-param vars in paramVars. `number` mentions none, so the body
-// produced a value with no dependence on the caller's choice. A `T | number` lower bound,
-// from `fn<T>(x: T | number) -> T`, mentions `T`, so the returned value carries the
-// caller's own `T` and is not a value the body forced. The seen set keeps a cyclic bound
-// graph terminating.
+// A union lower bound splits into independent obligations, since `A | B <: T` holds only
+// when both `A <: T` and `B <: T`. So each branch is examined on its own, and an
+// independently concrete branch such as the `number` in `T | number` from
+// `fn<T>(x: T | number) -> T` is a forced floor even though a sibling branch is the
+// caller's own `T`. A branch that mentions a declared type-param var carries the caller's
+// choice and is not forced. The seen set keeps a cyclic bound graph terminating.
 func forcedConcreteFloor(root *soltype.TypeVarType, paramVars set.Set[*soltype.TypeVarType]) (soltype.Type, bool) {
 	seen := set.NewSet[*soltype.TypeVarType]()
-	var walk func(v *soltype.TypeVarType) (soltype.Type, bool)
-	walk = func(v *soltype.TypeVarType) (soltype.Type, bool) {
+	var walkVar func(v *soltype.TypeVarType) (soltype.Type, bool)
+	var walkBound func(b soltype.Type) (soltype.Type, bool)
+	walkBound = func(b soltype.Type) (soltype.Type, bool) {
+		switch b := b.(type) {
+		case *soltype.TypeVarType:
+			if paramVars.Contains(b) {
+				return nil, false // a declared parameter is a rigid boundary, not a forced floor
+			}
+			return walkVar(b)
+		case *soltype.UnionType:
+			// `A | B <: T` splits into `A <: T` and `B <: T`, so any branch that forces a
+			// floor forces one on T.
+			for _, m := range b.Types {
+				if floor, found := walkBound(m); found {
+					return floor, true
+				}
+			}
+			return nil, false
+		default:
+			if mentionsAnyVar(b, paramVars) {
+				return nil, false // the value depends on the caller's own type parameter
+			}
+			return b, true // a fully concrete lower bound: the body forced this value
+		}
+	}
+	walkVar = func(v *soltype.TypeVarType) (soltype.Type, bool) {
 		if seen.Contains(v) {
 			return nil, false
 		}
 		seen.Add(v)
 		for _, b := range v.LowerBounds {
-			if bv, ok := b.(*soltype.TypeVarType); ok {
-				if paramVars.Contains(bv) {
-					continue // another declared parameter is a rigid boundary, not a forced floor
-				}
-				if floor, found := walk(bv); found {
-					return floor, true
-				}
-				continue
+			if floor, found := walkBound(b); found {
+				return floor, true
 			}
-			if mentionsAnyVar(b, paramVars) {
-				continue // the value depends on the caller's own type parameter, not forced
-			}
-			return b, true // a fully concrete lower bound: the body forced this value
 		}
 		return nil, false
 	}
-	return walk(root)
+	return walkVar(root)
 }
 
 // mentionsAnyVar reports whether t structurally contains any of the given vars. It reads

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -1,0 +1,154 @@
+package solver
+
+import (
+	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// checkTypeParamsProducible reports each declared type parameter of a body-carrying
+// generic function that its body cannot produce for an arbitrary caller choice. A
+// declared parameter's var is a bounded inference var, so checking the body's `return x`
+// runs `constrain(number, T)`, which records `number` as a LOWER bound of `T` rather than
+// rejecting it. Nothing else verifies that the body actually produces every `T` the caller
+// could pick, so `fn make<T>(x: number) -> T { return x }` is accepted and its rendered
+// `fn <T>(x: number) -> T` over-promises.
+//
+// A parameter is flagged only when BOTH hold, so a genuinely parametric body stays valid:
+//   - it occurs in an OUTPUT position of the signature, since only an output parameter is
+//     handed back to the caller. A concrete lower bound on an input-only parameter, such
+//     as a reassignment `fn h<T>(mut x: T) { x = 5 }`, is never observed by the caller.
+//   - the body forces a concrete floor onto it, a non-variable lower bound the caller did
+//     not supply. `fn id<T>(x: T) -> T { return x }` records no concrete lower bound, so
+//     it is not flagged.
+//
+// The two callers cover both surfaces that mint a generic function. inferFunc checks a
+// standalone `fn make<T>(…)` declaration, and constrainInitAgainstAnnotation checks the
+// annotation form `val f: fn<T>(…) = fn (…) {…}` against the fresh instance its body flows
+// into. node supplies the blame span.
+func (c *checker) checkTypeParamsProducible(node ast.Node, ft *soltype.FuncType) {
+	if len(ft.TypeParams) == 0 {
+		return
+	}
+	paramVars := set.NewSet[*soltype.TypeVarType]()
+	for _, tp := range ft.TypeParams {
+		paramVars.Add(tp.Var)
+	}
+	output := outputTypeVars(ft)
+	for _, tp := range ft.TypeParams {
+		if !output.Contains(tp.Var) {
+			continue
+		}
+		if floor, ok := forcedConcreteFloor(tp.Var, paramVars); ok {
+			c.report(&TypeParamNotProducibleError{Name: tp.Name, Floor: floor, Node: node})
+		}
+	}
+}
+
+// outputTypeVars collects the inference vars that occur in an OUTPUT position of a
+// function signature, walking the return covariantly and each parameter contravariantly.
+// A var inside a callback parameter's return `fn(cb: fn() -> T)` therefore reads as an
+// input and is excluded. It walks only the signature's value positions, never the
+// TypeParams binder list. FuncType.Accept visits each binder var at the call polarity,
+// which would mark every parameter as output regardless of where it appears.
+func outputTypeVars(ft *soltype.FuncType) set.Set[*soltype.TypeVarType] {
+	pv := &polarityVarVisitor{out: set.NewSet[*soltype.TypeVarType]()}
+	ft.Ret.Accept(pv, soltype.Positive)
+	if ft.SelfParam != nil {
+		ft.SelfParam.Type.Accept(pv, soltype.Negative)
+	}
+	for _, p := range ft.Params {
+		p.Type.Accept(pv, soltype.Negative)
+	}
+	return pv.out
+}
+
+// polarityVarVisitor records every inference var it meets in POSITIVE position. It reads
+// only the structural polarity a var occurs at, so it does not descend into a var's bound
+// side-graph. A var is a leaf whose Accept visits it and stops. recordMutWriteView adds
+// the write view of a `mut` borrow's inner, so a var written through a mut field is seen
+// in both polarities like the occurrence visitors in simplify.go.
+type polarityVarVisitor struct {
+	out set.Set[*soltype.TypeVarType]
+}
+
+func (v *polarityVarVisitor) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if recordMutWriteView(v, t, pol) {
+		return soltype.EnterResult{}
+	}
+	if tv, ok := t.(*soltype.TypeVarType); ok {
+		if pol == soltype.Positive {
+			v.out.Add(tv)
+		}
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *polarityVarVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// forcedConcreteFloor returns the concrete type the body forces as a lower bound of a
+// type parameter, or ok=false when the parameter carries no concrete floor. It follows a
+// lower bound that is an inference var into that var's own lower bounds, so the annotation
+// form `val f: fn<T>(x: number) -> T = fn (x) { return x }` reaches `number` through the
+// value's own param var that links the body to the annotation's `T`.
+//
+// A non-variable lower bound is a forced floor only when it mentions NONE of the
+// function's declared type-param vars in paramVars. `number` mentions none, so the body
+// produced a value with no dependence on the caller's choice. A `T | number` lower bound,
+// from `fn<T>(x: T | number) -> T`, mentions `T`, so the returned value carries the
+// caller's own `T` and is not a value the body forced. The seen set keeps a cyclic bound
+// graph terminating.
+func forcedConcreteFloor(root *soltype.TypeVarType, paramVars set.Set[*soltype.TypeVarType]) (soltype.Type, bool) {
+	seen := set.NewSet[*soltype.TypeVarType]()
+	var walk func(v *soltype.TypeVarType) (soltype.Type, bool)
+	walk = func(v *soltype.TypeVarType) (soltype.Type, bool) {
+		if seen.Contains(v) {
+			return nil, false
+		}
+		seen.Add(v)
+		for _, b := range v.LowerBounds {
+			if bv, ok := b.(*soltype.TypeVarType); ok {
+				if paramVars.Contains(bv) {
+					continue // another declared parameter is a rigid boundary, not a forced floor
+				}
+				if floor, found := walk(bv); found {
+					return floor, true
+				}
+				continue
+			}
+			if mentionsAnyVar(b, paramVars) {
+				continue // the value depends on the caller's own type parameter, not forced
+			}
+			return b, true // a fully concrete lower bound: the body forced this value
+		}
+		return nil, false
+	}
+	return walk(root)
+}
+
+// mentionsAnyVar reports whether t structurally contains any of the given vars. It reads
+// only the written shape, so it does not descend into a var's bound side-graph. A var is
+// a leaf whose Accept visits it and stops.
+func mentionsAnyVar(t soltype.Type, vars set.Set[*soltype.TypeVarType]) bool {
+	v := &varMentionVisitor{vars: vars}
+	t.Accept(v, soltype.Positive)
+	return v.found
+}
+
+type varMentionVisitor struct {
+	vars  set.Set[*soltype.TypeVarType]
+	found bool
+}
+
+func (v *varMentionVisitor) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if tv, ok := t.(*soltype.TypeVarType); ok {
+		if v.vars.Contains(tv) {
+			v.found = true
+		}
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *varMentionVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -6,26 +6,14 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// checkTypeParamsProducible reports each declared type parameter of a body-carrying
-// generic function that its body cannot produce for an arbitrary caller choice. A
-// declared parameter's var is a bounded inference var, so checking the body's `return x`
-// runs `constrain(number, T)`, which records `number` as a LOWER bound of `T` rather than
-// rejecting it. Nothing else verifies that the body actually produces every `T` the caller
-// could pick, so `fn make<T>(x: number) -> T { return x }` is accepted and its rendered
-// `fn <T>(x: number) -> T` over-promises.
-//
-// A parameter is flagged only when BOTH hold, so a genuinely parametric body stays valid:
-//   - it occurs in an OUTPUT position of the signature, since only an output parameter is
-//     handed back to the caller. A concrete lower bound on an input-only parameter, such
-//     as a reassignment `fn h<T>(mut x: T) { x = 5 }`, is never observed by the caller.
-//   - the body forces a concrete floor onto it, a non-variable lower bound the caller did
-//     not supply. `fn id<T>(x: T) -> T { return x }` records no concrete lower bound, so
-//     it is not flagged.
-//
-// The two callers cover both surfaces that mint a generic function. inferFunc checks a
-// standalone `fn make<T>(…)` declaration, and constrainInitAgainstAnnotation checks the
-// annotation form `val f: fn<T>(…) = fn (…) {…}` against the fresh instance its body flows
-// into. node supplies the blame span.
+// checkTypeParamsProducible flags a declared type parameter whose body cannot produce it
+// for an arbitrary caller choice. A parameter's var is a bounded inference var, so a body
+// `return x` with `x: number` records `number` as a LOWER bound of `T` rather than being
+// rejected, and `fn make<T>(x: number) -> T { return x }` renders `fn <T>(x: number) -> T`,
+// which over-promises. A parameter is flagged only when it occurs in an OUTPUT position
+// and forcedConcreteFloor finds a concrete floor the body forced onto it; `fn id<T>(x: T)
+// -> T` records none and stays valid. inferFunc calls this for a standalone declaration
+// and constrainInitAgainstAnnotation for the annotation form; node supplies the blame span.
 func (c *checker) checkTypeParamsProducible(node ast.Node, ft *soltype.FuncType) {
 	if len(ft.TypeParams) == 0 {
 		return
@@ -45,12 +33,9 @@ func (c *checker) checkTypeParamsProducible(node ast.Node, ft *soltype.FuncType)
 	}
 }
 
-// outputTypeVars collects the inference vars that occur in an OUTPUT position of a
-// function signature, walking the return covariantly and each parameter contravariantly.
-// A var inside a callback parameter's return `fn(cb: fn() -> T)` therefore reads as an
-// input and is excluded. It walks only the signature's value positions, never the
-// TypeParams binder list. FuncType.Accept visits each binder var at the call polarity,
-// which would mark every parameter as output regardless of where it appears.
+// outputTypeVars collects the inference vars in an OUTPUT position of a signature, walking
+// the return covariantly and each parameter contravariantly. It skips the TypeParams
+// binder list, which FuncType.Accept would otherwise visit at the call polarity.
 func outputTypeVars(ft *soltype.FuncType) set.Set[*soltype.TypeVarType] {
 	pv := &polarityVarVisitor{out: set.NewSet[*soltype.TypeVarType]()}
 	ft.Ret.Accept(pv, soltype.Positive)

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -48,11 +48,10 @@ func outputTypeVars(ft *soltype.FuncType) set.Set[*soltype.TypeVarType] {
 	return pv.out
 }
 
-// polarityVarVisitor records every inference var it meets in POSITIVE position. It reads
-// only the structural polarity a var occurs at, so it does not descend into a var's bound
-// side-graph. A var is a leaf whose Accept visits it and stops. recordMutWriteView adds
-// the write view of a `mut` borrow's inner, so a var written through a mut field is seen
-// in both polarities like the occurrence visitors in simplify.go.
+// polarityVarVisitor records every inference var it meets in POSITIVE position, reading
+// only structural polarity without descending into a var's bound side-graph.
+// recordMutWriteView adds the write view of a `mut` borrow's inner, so a var written
+// through a mut field is seen in both polarities like the occurrence visitors in simplify.go.
 type polarityVarVisitor struct {
 	out set.Set[*soltype.TypeVarType]
 }
@@ -72,18 +71,13 @@ func (v *polarityVarVisitor) EnterType(t soltype.Type, pol soltype.Polarity) sol
 
 func (v *polarityVarVisitor) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
-// forcedConcreteFloor returns the concrete type the body forces as a lower bound of a
-// type parameter, or ok=false when the parameter carries no concrete floor. It follows a
-// lower bound that is an inference var into that var's own lower bounds, so the annotation
-// form `val f: fn<T>(x: number) -> T = fn (x) { return x }` reaches `number` through the
-// value's own param var that links the body to the annotation's `T`.
-//
-// A union lower bound splits into independent obligations, since `A | B <: T` holds only
-// when both `A <: T` and `B <: T`. So each branch is examined on its own, and an
-// independently concrete branch such as the `number` in `T | number` from
-// `fn<T>(x: T | number) -> T` is a forced floor even though a sibling branch is the
-// caller's own `T`. A branch that mentions a declared type-param var carries the caller's
-// choice and is not forced. The seen set keeps a cyclic bound graph terminating.
+// forcedConcreteFloor returns the concrete type the body forces as a lower bound of a type
+// parameter, following inference-var lower bounds transitively into their own bounds. A
+// union lower bound splits into independent obligations, since `A | B <: T` needs both
+// `A <: T` and `B <: T`, so an independently concrete branch such as the `number` in
+// `T | number` is a forced floor even when a sibling branch is the caller's own `T`. A
+// branch that mentions a declared type-param var carries the caller's choice and is not
+// forced. The seen set keeps a cyclic bound graph terminating.
 func forcedConcreteFloor(root *soltype.TypeVarType, paramVars set.Set[*soltype.TypeVarType]) (soltype.Type, bool) {
 	seen := set.NewSet[*soltype.TypeVarType]()
 	var walkVar func(v *soltype.TypeVarType) (soltype.Type, bool)


### PR DESCRIPTION
A body-carrying generic function can declare a type parameter in an output position but have its body force that parameter to a concrete lower bound. For example, `fn make<T>(x: number) -> T { return x }` returns `x: number` as `T`, recording `number` as a lower bound of `T`'s inference variable. Since the caller chooses `T`, a signature that promises to return an arbitrary `T` while the body only ever produces `number` over-promises.

This change adds validation to reject such functions at declaration time. A genuinely parametric body like `fn id<T>(x: T) -> T { return x }` records no concrete lower bound on `T` and remains valid.

Key changes:

- Add `checkTypeParamsProducible` to detect when a type parameter appears in an output position but the body forces it to a concrete floor. The check walks the function signature's polarity to identify output-position parameters, then traces each parameter's inference variable's lower bounds to find concrete types the body forced.
- Add `TypeParamNotProducibleError` error type with the parameter name, forced concrete type, and blame span.
- Call `checkTypeParamsProducible` from `inferFunc` for body-carrying generic functions (but not bodyless `declare fn` declarations).
- Call `checkTypeParamsProducible` from `constrainInitAgainstAnnotation` for the annotation form `val f: fn<T>(…) = fn (…) {…}`, checking the freshened instance so transitive bounds through intermediate variables are caught.
- Update test expectations: remove the `ReturnOnlyParam` test case that expected `fn make<T>(x: number) -> T` to be accepted, and add test cases verifying the new error is reported for both standalone declarations and annotation forms.

https://claude.ai/code/session_01SBhbYUkJJyaek1JoBTuZvD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generic function checking now detects when a promised type parameter is forced to a concrete type.
  - Added clearer diagnostics identifying the affected type parameter and inferred concrete type.
  - Validation applies to generic function bodies and functions initialized from annotated bodies.

- **Bug Fixes**
  - Prevents generic functions from over-promising arbitrary type parameters.
  - Preserves valid behavior when returning among multiple parameters sharing the same type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->