### PR TITLE
Reject generic functions in parameter position at rank-1

### DIFF
--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -224,6 +224,13 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(declScope, p, lvl)
+		// A generic function in parameter position is rank-2, beyond the rank-1
+		// boundary, so report it and recover to a fresh var. This mirrors the same
+		// check resolveFuncTypeAnn applies to a nested function-type annotation.
+		if ft, ok := pt.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
+			c.reportUnsupportedFeature(p.TypeAnn, "higher-rank function parameter")
+			pt = c.freshAt(lvl)
+		}
 		// Rule 2 of PR 3. A bare annotation is owned and only an `&` annotation
 		// borrows. An `&` annotation already mints its lifetime in
 		// resolveLifetimeAnn, so a parameter has nothing to attach here. A bare

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -107,20 +107,19 @@ func TestInferGenericMethodStillGated(t *testing.T) {
 }
 
 // A parameter whose own type is polymorphic — a callback annotated `fn <V>(x: V) -> V` —
-// stays rejected at the rank-1 boundary. The type-parameter list on the declaration
-// resolves, but the generic function-type annotation on the parameter is the higher-rank
-// surface a later PR handles, so it reports as unsupported rather than being approximated.
+// stays rejected at the rank-1 boundary. The generic function-type annotation itself
+// resolves, so its `<V>` binds and the two `V` references read that quantified var, but
+// a generic function in parameter position is rank-2, so the declaration reports the
+// parameter as unsupported and recovers to a fresh var rather than approximating it.
 func TestInferGenericFuncHigherRankParamRejected(t *testing.T) {
 	_, _, errs := inferSource(t, `fn apply<T>(g: fn <V>(x: V) -> V, y: T) -> T { return g(y) }`)
 	msgs := make([]string, len(errs))
 	for i, e := range errs {
 		msgs[i] = e.Message()
 	}
-	// The annotation gate reports the higher-rank feature, then the two `V` references
-	// inside it cascade to unsupported because the annotation's `<V>` was not resolved.
+	// The `<V>` annotation resolves, so there is no `TypeRefTypeAnn` cascade; only the
+	// rank-1 boundary rejects the generic function in parameter position.
 	require.Equal(t, []string{
-		"Unsupported: generic function type annotation",
-		"Unsupported: TypeRefTypeAnn",
-		"Unsupported: TypeRefTypeAnn",
+		"Unsupported: higher-rank function parameter",
 	}, msgs)
 }


### PR DESCRIPTION
Move the check for generic functions in parameter position from the function-type annotation gate to the parameter type inference path. This allows the `<V>` quantifier in a generic function parameter annotation to resolve correctly, so only the rank-2 boundary violation is reported rather than cascading unsupported errors.

**Changes:**
- Add a rank-2 check in `inferFunc` that detects generic function types in parameter position and reports "higher-rank function parameter" before recovering to a fresh variable
- Remove the now-redundant annotation gate that was blocking the entire generic function-type annotation
- Update test expectations in `TestInferGenericFuncHigherRankParamRejected` to reflect the single, more precise error message

This mirrors the same check already applied in `resolveFuncTypeAnn` for nested function-type annotations, ensuring consistent handling of rank-2 violations across both contexts.

https://claude.ai/code/session_01VrcLGqZscKZTaFdqvAq9Lg