### PR TITLE
Check generic function annotations in checking mode with skolems

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -615,6 +615,11 @@ func (p *namedPrinter) printType(t Type) string {
 			parts[i] = p.printTypeMinPrec(m, precIntersection)
 		}
 		return strings.Join(parts, " & ")
+	case *SkolemType:
+		// A skolem renders under its source parameter name. It is transient to a
+		// checking-mode pass and does not survive into a displayed type, so this arm is
+		// reached only defensively.
+		return t.Name
 	}
 	panic(fmt.Sprintf("printType: unhandled %T", t))
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -38,6 +38,31 @@ type TypeVarType struct {
 	Widenable bool
 }
 
+// SkolemType is a rigid type parameter, a placeholder held abstract while a term is
+// checked against a polymorphic expected type. It is a CONCRETE atomic type, not an
+// inference var, so it carries no bounds and constrain compares it nominally. A skolem is
+// a subtype only of itself, of an inference var it flows into, of its declared upper bound,
+// and of the top unknown. A concrete type is never a subtype of a skolem. Checking
+// `fn (x) { return 5 }` against `fn <T>(x: T) -> T` mints a skolem for `T`, and the return
+// `5 <: T` is rejected because `5` is not that skolem. Being concrete, a skolem also
+// propagates through an intermediate inference var as a lower bound. So
+// `fn (x) { return x }` against `fn <T>(x: T) -> number` is rejected too, since `x`'s skolem
+// floor cannot satisfy `number`.
+//
+// ID makes each parameter's skolem distinct, so two parameters `T` and `U` do not unify.
+// Name is the source parameter name, kept so a diagnostic and the printer render `T`.
+//
+// Upper is the declared constraint, so a `<U: T>` skolem is a subtype of `T` and of every
+// supertype of `T`. It is nil for an unconstrained parameter, which is a subtype of nothing
+// but itself. A parameter with several constraints carries their intersection here, matching
+// the intersection-sub subtyping rule. `fn <T, U: T>(x: U) -> T = fn (x) { return x }` is
+// accepted because the body's `U` reaches the return `T` through this bound.
+type SkolemType struct {
+	ID    int
+	Name  string
+	Upper Type
+}
+
 // BoundsAt returns the bounds relevant to a polarity: lowers in Positive
 // position (the var becomes their union), uppers in Negative (their meet).
 func (v *TypeVarType) BoundsAt(pol Polarity) []Type {
@@ -593,6 +618,7 @@ func (*IntersectionType) isType() {}
 func (*ErrorType) isType()        {}
 func (*ClassType) isType()        {}
 func (*AliasType) isType()        {}
+func (*SkolemType) isType()       {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -38,25 +38,12 @@ type TypeVarType struct {
 	Widenable bool
 }
 
-// SkolemType is a rigid type parameter, a placeholder held abstract while a term is
-// checked against a polymorphic expected type. It is a CONCRETE atomic type, not an
-// inference var, so it carries no bounds and constrain compares it nominally. A skolem is
-// a subtype only of itself, of an inference var it flows into, of its declared upper bound,
-// and of the top unknown. A concrete type is never a subtype of a skolem. Checking
-// `fn (x) { return 5 }` against `fn <T>(x: T) -> T` mints a skolem for `T`, and the return
-// `5 <: T` is rejected because `5` is not that skolem. Being concrete, a skolem also
-// propagates through an intermediate inference var as a lower bound. So
-// `fn (x) { return x }` against `fn <T>(x: T) -> number` is rejected too, since `x`'s skolem
-// floor cannot satisfy `number`.
-//
-// ID makes each parameter's skolem distinct, so two parameters `T` and `U` do not unify.
-// Name is the source parameter name, kept so a diagnostic and the printer render `T`.
-//
-// Upper is the declared constraint, so a `<U: T>` skolem is a subtype of `T` and of every
-// supertype of `T`. It is nil for an unconstrained parameter, which is a subtype of nothing
-// but itself. A parameter with several constraints carries their intersection here, matching
-// the intersection-sub subtyping rule. `fn <T, U: T>(x: U) -> T = fn (x) { return x }` is
-// accepted because the body's `U` reaches the return `T` through this bound.
+// SkolemType is a rigid type parameter held abstract while a term is checked against a
+// polymorphic expected type. It is a CONCRETE atomic type, so constrain compares it
+// nominally and no concrete type is a subtype of it. A skolem is a subtype only of itself,
+// of an inference var it flows into, and of its declared upper bound. ID keeps two
+// parameters `T` and `U` distinct; Name is the source name for diagnostics and the printer;
+// Upper is the declared constraint (`<U: T>`), nil when unconstrained.
 type SkolemType struct {
 	ID    int
 	Name  string

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -83,6 +83,7 @@ func (t *UndefinedType) Accept(v TypeVisitor, pol Polarity) Type { return accept
 func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
+func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -320,6 +320,23 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			}
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
+	case *soltype.SkolemType:
+		// A skolem is a subtype of the same skolem and of its declared upper bound. An
+		// unconstrained `T` fails against a concrete `number` and against a distinct skolem
+		// `U`, so `fn (x) { return x }` is rejected against both `fn <T>(x: T) -> number` and
+		// `fn <T>(x: T) -> U`. A `<U: T>` skolem satisfies `T` through its bound. When super
+		// is a var the case falls through to the superVar arm, which records the skolem as a
+		// lower bound so it propagates through the var. A union super was already handled by
+		// the exists rule above, so `T <: T | number` succeeds before reaching here.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if sup, ok := super.(*soltype.SkolemType); ok && sub.ID == sup.ID {
+				return nil
+			}
+			if sub.Upper != nil {
+				return c.constrain(sub.Upper, super, seen, mutCtx)
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
 	case *soltype.FuncType:
 		if sup, ok := super.(*soltype.FuncType); ok {
 			// Accept-set subtyping (#677 §4.2.1): read super as a callback parameter.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -321,13 +321,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: sup}}
 		}
 	case *soltype.SkolemType:
-		// A skolem is a subtype of the same skolem and of its declared upper bound. An
-		// unconstrained `T` fails against a concrete `number` and against a distinct skolem
-		// `U`, so `fn (x) { return x }` is rejected against both `fn <T>(x: T) -> number` and
-		// `fn <T>(x: T) -> U`. A `<U: T>` skolem satisfies `T` through its bound. When super
-		// is a var the case falls through to the superVar arm, which records the skolem as a
-		// lower bound so it propagates through the var. A union super was already handled by
-		// the exists rule above, so `T <: T | number` succeeds before reaching here.
+		// A skolem is a subtype of the same skolem and of its declared upper bound, so an
+		// unconstrained `T` fails against `number` or a distinct `U`, while a `<U: T>` skolem
+		// satisfies `T`. When super is a var the case falls through to the superVar arm, which
+		// records the skolem as a lower bound so it propagates through the var. A union super
+		// is handled by the exists rule above, so `T <: T | number` succeeds before here.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if sup, ok := super.(*soltype.SkolemType); ok && sub.ID == sup.ID {
 				return nil

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -129,6 +129,15 @@ func (c *Context) freshVar(level int) *soltype.TypeVarType {
 	return v
 }
 
+// freshSkolem mints a distinct rigid type parameter carrying the given source name. It
+// draws from the same counter as freshVar so every skolem has a unique ID, which is what
+// keeps two parameters `T` and `U` from unifying.
+func (c *Context) freshSkolem(name string) *soltype.SkolemType {
+	s := &soltype.SkolemType{ID: c.varCounter, Name: name}
+	c.varCounter++
+	return s
+}
+
 // freshLifetime allocates a new lifetime variable at the given level, assigning it
 // the next id in sequence. Lifetimes now ride the same let-generalization level
 // hierarchy as types (M4 D2.5): a lifetime minted inside its scheme's

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1645,6 +1645,10 @@ func describe(t soltype.Type) string {
 		return joinDescribe(t.Types, " & ")
 	case *soltype.TypeVarType:
 		return "t" + strconv.Itoa(t.ID)
+	case *soltype.SkolemType:
+		// A skolem renders under its source parameter name, so a rejected `return 5`
+		// against `fn <T>(x: T) -> T` reads `cannot constrain 5 <: T`.
+		return t.Name
 	}
 	return "?"
 }

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -309,7 +309,16 @@ func (c *checker) freshAt(lvl int) *soltype.TypeVarType {
 // so the hot loop stays off the table. That is the perf invariant, §3.9. Bridge
 // errors never flow through here; they self-blame from their own node.
 func (c *checker) constrain(n ast.Node, source, target soltype.Type) {
-	for _, e := range c.ctx.Constrain(source, target) {
+	c.blameConstraintErrors(n, c.ctx.Constrain(source, target))
+}
+
+// blameConstraintErrors stamps each error from a constraint run with the Prov table and
+// the constraint node n, then accumulates it. It is factored out of constrain so a
+// caller that runs the engine directly — the checking-mode probe in
+// constrainInitAgainstAnnotation — assigns blame the same way. See constrain's doc for how
+// Span()/Related() then resolve per-operand blame through Prov on demand.
+func (c *checker) blameConstraintErrors(n ast.Node, errs []SolverError) {
+	for _, e := range errs {
 		switch err := e.(type) {
 		case *CannotConstrainError:
 			err.prov, err.site = c.prov, n

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -331,22 +331,14 @@ func (s *skolemizer) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Enter
 func (s *skolemizer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // skolemizeBound resolves a type parameter's declared constraint into its skolem's Upper,
-// substituting a sibling parameter for that sibling's skolem. An unconstrained parameter
-// has no bound, so it returns nil. A parameter with several constraints returns their
-// intersection, so the skolem satisfies a super reachable through any one of them.
+// substituting a sibling parameter for that sibling's skolem. resolveTypeParams records at
+// most one constraint per parameter, itself an IntersectionType for a `<T: A & B>` bound, so
+// an unconstrained parameter returns nil and any constraint is the single skolemized bound.
 func (s *skolemizer) skolemizeBound(bounds []soltype.Type) soltype.Type {
-	switch len(bounds) {
-	case 0:
+	if len(bounds) == 0 {
 		return nil
-	case 1:
-		return bounds[0].Accept(s, soltype.Positive)
-	default:
-		members := make([]soltype.Type, len(bounds))
-		for i, b := range bounds {
-			members[i] = b.Accept(s, soltype.Positive)
-		}
-		return &soltype.IntersectionType{Types: members}
 	}
+	return bounds[0].Accept(s, soltype.Positive)
 }
 
 // tryUpgradeToOwnedMut grants the immutable→mutable upgrade when a value of type srcT,

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -205,7 +205,7 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 		// error and adopting `never` would poison the binding. Keep the inferred
 		// initializer type instead (error recovery).
 		if annT, ok := c.resolveTypeAnn(scope, d.TypeAnn, lvl); ok {
-			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT, lvl)
+			annT = c.constrainInitAgainstAnnotation(d.Init, initT, annT)
 			c.checkExcessLiteralMembers(d.Init, initT, annT)
 			initT = annT
 		}
@@ -259,21 +259,18 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // bare owned destination, as in `val q: {x} = p`, does not alias `p`. The constraint takes the
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
-func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type, lvl int) soltype.Type {
-	// Check a generic function annotation against a FRESH instance and adopt the untouched
-	// annotation, so it renders `fn <T>(x: T) -> T`. Constraining the initializer against the
-	// annotation itself would leak its vars as a second quantifier, `fn <T0, T: T0>(x: T) ->
-	// T`. Binder vars sit at lvl, so freshenAbove(lvl-1, …) copies them.
+func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
+	// Check a generic function annotation in checking mode and adopt the untouched
+	// annotation, so it renders `fn <T>(x: T) -> T`. Each declared type parameter is held
+	// rigid as a skolem while the initializer is checked against it, so a body that forces a
+	// parameter to a concrete value is rejected. `fn (x) { return x }` satisfies
+	// `fn <T>(x: T) -> T`, while `fn (x) { return 5 }` fails with `cannot constrain 5 <: T`.
+	// The check runs under a discard-only probe so the skolem bounds it records on the
+	// initializer's own vars leave no trace, and the pristine annT is adopted as the binding
+	// type. Constraining against the annotation directly would instead leak its vars as a
+	// second quantifier, `fn <T0, T: T0>(x: T) -> T`.
 	if funcTypeParamVars(annT).Len() > 0 {
-		inst := c.freshenAbove(lvl-1, annT, lvl, map[*soltype.TypeVarType]*soltype.TypeVarType{})
-		c.constrain(init, initT, inst)
-		// The initializer's body flows into inst, so inst's type-param vars carry any
-		// concrete floor the body forces. Check them, not the pristine annT the binding
-		// adopts, so `val f: fn<T>(x: number) -> T = fn (x) { return x }` is flagged the
-		// same as the standalone `fn make<T>(x: number) -> T`.
-		if instFn, ok := inst.(*soltype.FuncType); ok {
-			c.checkTypeParamsProducible(init, instFn)
-		}
+		c.blameConstraintErrors(init, c.ctx.trialUnderProbe(initT, c.skolemizeGenericAnn(annT)))
 		return annT
 	}
 	if c.tryUpgradeToOwnedMut(init, init, initT, annT) {
@@ -281,6 +278,82 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 	}
 	c.constrain(init, initT, annT)
 	return annT
+}
+
+// skolemizeGenericAnn copies a resolved annotation, replacing every generic function's own
+// type-parameter var by a fresh skolem of the same name. This is the checking-mode rule for
+// a function literal against a polymorphic annotation: the expected type is pushed into the
+// term with its parameters held abstract, so constrain rejects a body that forces a
+// parameter to a concrete value. For example `fn (x) { return 5 }` checked against
+// `fn <T>(x: T) -> T` fails with `5 <: T`. A skolem is concrete, so it also propagates
+// through an intermediate inference var, rejecting `fn (x) { return x }` against
+// `fn <T>(x: T) -> number` where `x`'s skolem floor cannot satisfy `number`.
+func (c *checker) skolemizeGenericAnn(annT soltype.Type) soltype.Type {
+	return annT.Accept(&skolemizer{c: c, subst: map[*soltype.TypeVarType]*soltype.SkolemType{}}, soltype.Positive)
+}
+
+// skolemizer rewrites a resolved annotation, substituting each generic function's
+// type-parameter var with a distinct skolem. It seeds a skolem per TypeParam as it enters
+// each FuncType, then substitutes at every later occurrence of that var in the params and
+// return, so a nested generic function is skolemized under its own binder too.
+//
+// The rebuilt FuncType drops its TypeParams list: its binder vars become skolems in the
+// params and return, and constrain ignores the list. Nil-ing it also avoids acceptTypeParamVar,
+// which requires a binder to stay a *TypeVarType and would panic on a skolem.
+type skolemizer struct {
+	c     *checker
+	subst map[*soltype.TypeVarType]*soltype.SkolemType
+}
+
+func (s *skolemizer) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.FuncType:
+		if len(t.TypeParams) == 0 {
+			return soltype.EnterResult{} // monomorphic: ordinary descent
+		}
+		// Seed every skolem before carrying bounds, so a bound naming a sibling parameter
+		// resolves to that sibling's skolem.
+		for _, tp := range t.TypeParams {
+			if _, done := s.subst[tp.Var]; !done {
+				s.subst[tp.Var] = s.c.ctx.freshSkolem(tp.Name)
+			}
+		}
+		for _, tp := range t.TypeParams {
+			sk := s.subst[tp.Var]
+			if sk.Upper == nil {
+				sk.Upper = s.skolemizeBound(tp.Var.UpperBounds)
+			}
+		}
+		cp := *t
+		cp.TypeParams = nil
+		return soltype.EnterResult{Type: &cp} // descend into the copy's params and return
+	case *soltype.TypeVarType:
+		if sk, ok := s.subst[t]; ok {
+			return soltype.EnterResult{Type: sk, SkipChildren: true}
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *skolemizer) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// skolemizeBound resolves a type parameter's declared constraint into its skolem's Upper,
+// substituting a sibling parameter for that sibling's skolem. An unconstrained parameter
+// has no bound, so it returns nil. A parameter with several constraints returns their
+// intersection, so the skolem satisfies a super reachable through any one of them.
+func (s *skolemizer) skolemizeBound(bounds []soltype.Type) soltype.Type {
+	switch len(bounds) {
+	case 0:
+		return nil
+	case 1:
+		return bounds[0].Accept(s, soltype.Positive)
+	default:
+		members := make([]soltype.Type, len(bounds))
+		for i, b := range bounds {
+			members[i] = b.Accept(s, soltype.Positive)
+		}
+		return &soltype.IntersectionType{Types: members}
+	}
 }
 
 // tryUpgradeToOwnedMut grants the immutable→mutable upgrade when a value of type srcT,

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -260,15 +260,11 @@ func (c *checker) inferVarDeclInit(scope *Scope, lvl int, d *ast.VarDecl) (solty
 // ordinary RefType<:bare arm, which trips BorrowEscapeError. The explicit `&` form
 // `val q: &{x} = p` is the opt-in for an alias.
 func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT soltype.Type) soltype.Type {
-	// Check a generic function annotation in checking mode and adopt the untouched
-	// annotation, so it renders `fn <T>(x: T) -> T`. Each declared type parameter is held
-	// rigid as a skolem while the initializer is checked against it, so a body that forces a
-	// parameter to a concrete value is rejected. `fn (x) { return x }` satisfies
-	// `fn <T>(x: T) -> T`, while `fn (x) { return 5 }` fails with `cannot constrain 5 <: T`.
-	// The check runs under a discard-only probe so the skolem bounds it records on the
-	// initializer's own vars leave no trace, and the pristine annT is adopted as the binding
-	// type. Constraining against the annotation directly would instead leak its vars as a
-	// second quantifier, `fn <T0, T: T0>(x: T) -> T`.
+	// Check a generic function annotation in checking mode, holding each declared type
+	// parameter rigid as a skolem, so `fn (x) { return 5 }` is rejected against
+	// `fn <T>(x: T) -> T` with `cannot constrain 5 <: T`. The check runs under a discard-only
+	// probe so the skolem bounds it records leave no trace, and the pristine annT is adopted
+	// as the binding type so it renders `fn <T>(x: T) -> T` rather than leaking its vars.
 	if funcTypeParamVars(annT).Len() > 0 {
 		c.blameConstraintErrors(init, c.ctx.trialUnderProbe(initT, c.skolemizeGenericAnn(annT)))
 		return annT
@@ -281,13 +277,10 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 }
 
 // skolemizeGenericAnn copies a resolved annotation, replacing every generic function's own
-// type-parameter var by a fresh skolem of the same name. This is the checking-mode rule for
-// a function literal against a polymorphic annotation: the expected type is pushed into the
-// term with its parameters held abstract, so constrain rejects a body that forces a
-// parameter to a concrete value. For example `fn (x) { return 5 }` checked against
-// `fn <T>(x: T) -> T` fails with `5 <: T`. A skolem is concrete, so it also propagates
-// through an intermediate inference var, rejecting `fn (x) { return x }` against
-// `fn <T>(x: T) -> number` where `x`'s skolem floor cannot satisfy `number`.
+// type-parameter var by a fresh skolem of the same name. This pushes the expected type into
+// the term with its parameters held abstract, so constrain rejects a body that forces a
+// parameter to a concrete value, both directly (`return 5`) and through an inference var
+// (`return x` where the annotation promises a different type).
 func (c *checker) skolemizeGenericAnn(annT soltype.Type) soltype.Type {
 	return annT.Accept(&skolemizer{c: c, subst: map[*soltype.TypeVarType]*soltype.SkolemType{}}, soltype.Positive)
 }

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -137,23 +137,104 @@ func TestInferHigherRankFuncParamReportsUnsupported(t *testing.T) {
 
 // A function-literal body whose return type is not the declared parameter does not
 // satisfy the polymorphic annotation `fn <T>(x: T) -> T`, since a caller expecting `T`
-// back would receive a `number`. Rejecting it needs the initializer checked against the
-// annotation with `T` held RIGID, so a concrete return cannot unify with `T`. The current
-// check runs against a fresh instance, whose `T` is an ordinary inference var, so `number`
-// unifies with it and the binding is wrongly accepted as `fn <T>(x: T) -> T`.
-//
-// DISABLED until rigid generic-annotation checking: re-enable by removing the /* */
-// wrapper once the initializer is checked against the annotation's type parameters as
-// rigid constants, so a non-polymorphic body is rejected. The generic-functions plan
-// (planning/simple_sub/generic-functions-implementation-plan.md) stays rank-1 and does
-// not schedule this, so it is follow-on work.
+// back would receive a `number`. The initializer is checked against the annotation with
+// `T` held RIGID, so the concrete return `5` cannot satisfy `T` and the definition is
+// rejected. The parameter-into-return flow in `fn (x) { return x }` still passes, since
+// the body relates `T` only to itself.
 func TestInferGenericFuncAnnotationRejectsNonPolymorphicBody(t *testing.T) {
-	/*
-		_, _, errs := inferSource(t, `val f: fn<T>(x: T) -> T = fn (x) { return 5 }`)
+	_, _, errs := inferSource(t, `val f: fn<T>(x: T) -> T = fn (x) { return 5 }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:43-1:44: cannot constrain 5 <: T", msgWithSpan(errs[0]))
+}
+
+// Checking-mode skolems are concrete, so a parameter's skolem propagates through the
+// initializer's own inference var and is checked where the body returns it. A body that
+// returns a parameter typed `T` where the annotation promises a different type is therefore
+// rejected even though the offending value flows through the lambda's param var rather than
+// appearing as a literal. Each case renders `f` with its declared quantifier alongside the
+// error.
+func TestInferGenericFuncAnnotationChecksIndirectReturn(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		msg  string
+		want string
+	}{
+		{
+			// `return x` yields the skolem `T`, which cannot satisfy the concrete return
+			// `number`, so the definition is rejected.
+			name: "ParamReturnedAsConcrete",
+			src:  `val f: fn<T>(x: T) -> number = fn (x) { return x }`,
+			msg:  "1:32-1:51: cannot constrain T <: number",
+			want: "fn <T>(x: T) -> number",
+		},
+		{
+			// `return x` yields the first parameter's skolem `T`, which cannot satisfy the
+			// second parameter's distinct skolem `U` in the return, so the two do not unify.
+			name: "ParamReturnedAsDistinctSkolem",
+			src:  `val f: fn<T, U>(x: T, y: U) -> U = fn (x, y) { return x }`,
+			msg:  "1:36-1:58: cannot constrain T <: U",
+			want: "fn <T, U>(x: T, y: U) -> U",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, &CannotConstrainError{}, errs[0])
+			require.Equal(t, tt.msg, msgWithSpan(errs[0]))
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A skolem is a subtype of a union that contains it, so a body returning a parameter `T`
+// into a `T | number` return is accepted: the caller's `T` is a valid `T | number`. A
+// swapped two-parameter body that returns the value of the matching return parameter is
+// likewise accepted. These guard the acceptance side against an over-eager skolem rejection.
+func TestInferGenericFuncAnnotationChecksAcceptsPolymorphicBody(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "ParamIntoUnionReturn",
+			src:  `val f: fn<T>(x: T) -> (T | number) = fn (x) { return x }`,
+			want: "fn <T>(x: T) -> T | number",
+		},
+		{
+			name: "SecondParamReturned",
+			src:  `val f: fn<T, U>(x: T, y: U) -> U = fn (x, y) { return y }`,
+			want: "fn <T, U>(x: T, y: U) -> U",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// A declared constraint `<U: T>` makes the skolem for `U` a subtype of the skolem for `T`,
+// so a body that returns a `U` where the annotation promises `T` is accepted. Reversing the
+// direction is still rejected, since the bound gives `U <: T`, not `T <: U`.
+func TestInferGenericFuncAnnotationChecksBoundedParam(t *testing.T) {
+	t.Run("BoundedParamReachesReturn", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val f: fn<T, U: T>(x: U) -> T = fn (x) { return x }`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <T, U: T>(x: U) -> T", values["f"])
+	})
+	t.Run("BoundDirectionIsOneWay", func(t *testing.T) {
+		values, _, errs := inferSource(t, `val f: fn<T, U: T>(x: T) -> U = fn (x) { return x }`)
 		require.Len(t, errs, 1)
 		require.IsType(t, &CannotConstrainError{}, errs[0])
-		require.Equal(t, "1:44-1:45: cannot constrain 5 <: T", msgWithSpan(errs[0]))
-	*/
+		require.Equal(t, "1:33-1:52: cannot constrain T <: U", msgWithSpan(errs[0]))
+		require.Equal(t, "fn <T, U: T>(x: T) -> U", values["f"])
+	})
 }
 
 // A throws clause reports the documented unsupported feature and recovers

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -129,11 +129,11 @@ func TestInferGenericFuncBodyOverPromises(t *testing.T) {
 	}
 }
 
-// The annotation form reuses the same bounded-inference-var core. The body's return value
-// flows into the annotation's fresh instance through an intermediate var, so the floor is
-// reached transitively and the annotation form is flagged the same as the standalone
-// declaration. The binding still adopts its pristine annotation, so `f` renders with the
-// declared quantifier alongside the error.
+// The annotation form is checked in checking mode: each declared type parameter is held
+// rigid while the initializer is checked against the annotation, so a body that forces a
+// parameter to a concrete value is rejected by constrain. The body returns `x: number` as
+// the rigid `T`, so the concrete `number` cannot satisfy `T`. The binding still adopts its
+// pristine annotation, so `f` renders with the declared quantifier alongside the error.
 func TestInferGenericFuncAnnotationBodyOverPromises(t *testing.T) {
 	tests := []struct {
 		name string
@@ -144,17 +144,18 @@ func TestInferGenericFuncAnnotationBodyOverPromises(t *testing.T) {
 		{
 			name: "ReturnParamForcedToConcrete",
 			src:  `val f: fn<T>(x: number) -> T = fn (x) { return x }`,
-			msg:  "1:32-1:51: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+			msg:  "1:32-1:51: cannot constrain number <: T",
 			want: "fn <T>(x: number) -> T",
 		},
 		{
-			// The union member `T` still binds through the annotation's child scope and
-			// reaches constrain's union-super two-pass rule, so the binding solves and
-			// renders. The `number` branch is the independently concrete floor that the
-			// producibility check rejects.
+			// A `T | number` parameter returned as `T` is unsound: a caller doing
+			// `f<string>(5)` passes a valid `string | number` and receives `5` typed as
+			// `string`. Checking `x: T | number` against the rigid return `T` splits the
+			// union, and the `number` branch cannot satisfy `T`, since it is not the
+			// caller's `T`.
 			name: "UnionParamWithConcreteBranch",
 			src:  `val f: fn<T>(x: T | number) -> T = fn (x) { return x }`,
-			msg:  "1:36-1:55: the body forces type parameter `T` to `number`, so it cannot stand for an arbitrary type",
+			msg:  "1:36-1:55: cannot constrain number <: T",
 			want: "fn <T>(x: T | number) -> T",
 		},
 	}
@@ -162,7 +163,7 @@ func TestInferGenericFuncAnnotationBodyOverPromises(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			values, _, errs := inferSource(t, tt.src)
 			require.Len(t, errs, 1)
-			require.IsType(t, &TypeParamNotProducibleError{}, errs[0])
+			require.IsType(t, &CannotConstrainError{}, errs[0])
 			require.Equal(t, tt.msg, msgWithSpan(errs[0]))
 			require.Equal(t, tt.want, values["f"])
 		})

--- a/internal/solver/type_param_producible.go
+++ b/internal/solver/type_param_producible.go
@@ -11,9 +11,10 @@ import (
 // `return x` with `x: number` records `number` as a LOWER bound of `T` rather than being
 // rejected, and `fn make<T>(x: number) -> T { return x }` renders `fn <T>(x: number) -> T`,
 // which over-promises. A parameter is flagged only when it occurs in an OUTPUT position
-// and forcedConcreteFloor finds a concrete floor the body forced onto it; `fn id<T>(x: T)
-// -> T` records none and stays valid. inferFunc calls this for a standalone declaration
-// and constrainInitAgainstAnnotation for the annotation form; node supplies the blame span.
+// and forcedConcreteFloor finds a concrete floor the body forced onto it. `fn id<T>(x: T)
+// -> T` records none and stays valid. inferFunc calls this for a standalone declaration,
+// which has no expected type to check against. The annotation form instead checks the body
+// against a skolemized annotation in constrainInitAgainstAnnotation. node supplies the blame span.
 func (c *checker) checkTypeParamsProducible(node ast.Node, ft *soltype.FuncType) {
 	if len(ft.TypeParams) == 0 {
 		return


### PR DESCRIPTION
Replace the fresh-instance approach for checking generic function annotations with a checking-mode strategy that holds type parameters rigid as skolems. This rejects function bodies that force a parameter to a concrete value while accepting polymorphic bodies that respect parameter relationships.

**Key changes:**

- Introduce `SkolemType` in `soltype` to represent rigid type parameters during checking. A skolem is concrete and carries an optional upper bound from declared constraints.
- Add `skolemizeGenericAnn` and `skolemizer` to convert a generic function annotation into checking mode by replacing each type parameter with a fresh skolem.
- Update `constrainInitAgainstAnnotation` to run the initializer against the skolemized annotation under a discard-only probe, so constraint errors are reported but skolem bounds don't leak into the final type.
- Extend `constrain` in `context.go` to handle skolem subtyping: a skolem is a subtype of itself, its declared upper bound, and inference vars it flows into, but not of concrete types.
- Add `blameConstraintErrors` to factor out error attribution so both the main `constrain` path and the checking-mode probe assign blame consistently.
- Update tests to reflect the new error messages and add comprehensive test cases for polymorphic bodies, indirect returns through parameters, and bounded type parameters.

**Implementation details:**

The skolemizer walks the annotation's type tree, seeding a distinct skolem for each generic function's type parameters before descending into the params and return. This ensures bounds naming sibling parameters resolve to those siblings' skolems. The rebuilt `FuncType` drops its `TypeParams` list so constrain ignores it and treats the skolems as the actual parameter types. Constraint errors from the probe are blamed to the initializer node and accumulated normally, so diagnostics render the binding with its declared quantifier alongside the error.

https://claude.ai/code/session_01Qu2x69f4FPnkRuDQpNmACM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for generic function type annotations and rigid type parameters.
  * Generic annotations now correctly validate polymorphic bodies, bounds, indirect returns, and union returns.

* **Bug Fixes**
  * Improved constraint handling and diagnostics for incompatible generic function bodies.
  * Error messages now display meaningful type-parameter names.

* **Tests**
  * Added and updated coverage for generic annotation acceptance, rejection, bounds, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->