### PR TITLE
Support rank-2 callbacks in function parameters

### DIFF
--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -31,9 +31,12 @@ import (
 // See coalesceRec for the guard's behavior. M3 still owns the *precise* μ-bound
 // recursive rendering; this guard only keeps the monomorphic walk total.
 func coalesce(t soltype.Type, pol soltype.Polarity) soltype.Type {
-	// The uniform-inlining coalesce is coalesceKeeping with no retained vars and no
-	// kept-flow map, so both share one coalescer-invocation body.
-	return coalesceKeeping(t, pol, nil, nil)
+	// The uniform-inlining coalesce is coalesceKeeping with a kept-flow map of nil and, as
+	// the retained set, a generic function's own TypeParams binder vars. Holding those
+	// symbolic keeps a rank-2 callback type such as `<T>(x: T) -> T` intact instead of
+	// inlining its `T` binder to never. acceptTypeParamVar panics on a non-variable binder.
+	// funcTypeParamVars is empty for a monomorphic type, so this is inert on the common path.
+	return coalesceKeeping(t, pol, funcTypeParamVars(t), nil)
 }
 
 // coalesceKeeping is coalesce with a set of variables held symbolic rather than inlined to

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -337,14 +337,8 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.FuncType:
 		if sup, ok := super.(*soltype.FuncType); ok {
-			// Higher-rank subtyping for a rank-2 callback. A quantifier on the super, the
-			// side being checked against, is skolemized, so the sub must satisfy it for every
-			// instantiation. For example, `fn (x) { return 5 }` fails against `<T>(x: T) -> T`.
-			// A quantifier on the sub, the side supplying the value, is instantiated with fresh
-			// vars, so the sub picks the instantiation. Re-enter once one side's binder is
-			// removed. Contravariant recursion into the params swaps sub and super, so a
-			// negative-position quantifier instantiates and a positive one skolemizes without
-			// a polarity flag here.
+			// Higher-rank subtyping: skolemize a super quantifier, instantiate a sub one, then
+			// re-enter. Contravariant param recursion swaps the sides, so polarity needs no flag.
 			if len(sup.TypeParams) > 0 {
 				return c.constrain(sub, c.skolemizeFuncBinder(sup), seen, mutCtx)
 			}
@@ -943,11 +937,9 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 	}
 }
 
-// skolemizeFuncBinder returns a copy of ft with its own type parameters replaced by fresh
-// skolems, so a term checked against ft as a supertype must satisfy it for every
-// instantiation. Each parameter's declared bound becomes its skolem's Upper, seeded before
-// substitution so a bound naming a sibling resolves to that sibling's skolem. Only ft's own
-// TypeParams binders are substituted. A nested generic function keeps its quantifier.
+// skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked
+// against ft as a supertype must satisfy it for every instantiation. Each parameter's declared
+// bound becomes its skolem's Upper, seeded first so a bound naming a sibling reaches it.
 func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
 	sks := make([]*soltype.SkolemType, len(ft.TypeParams))
 	args := make([]soltype.Type, len(ft.TypeParams))
@@ -967,10 +959,8 @@ func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
 	return substFuncBinder(ft, sub)
 }
 
-// instantiateFuncBinder returns a copy of ft with its own type parameters replaced by fresh
-// inference vars at lvl, so the sub side of a subtype check picks the instantiation. Each
-// fresh var carries the original parameter's bounds, substituted so an F-bound referencing a
-// sibling reaches that sibling's fresh var. Only ft's own TypeParams binders are substituted.
+// instantiateFuncBinder replaces ft's own type parameters with fresh inference vars at lvl, so
+// the sub side of a subtype check picks the instantiation. Each fresh var carries its bounds.
 func (c *Context) instantiateFuncBinder(ft *soltype.FuncType, lvl int) *soltype.FuncType {
 	nvs := make([]*soltype.TypeVarType, len(ft.TypeParams))
 	args := make([]soltype.Type, len(ft.TypeParams))
@@ -987,9 +977,7 @@ func (c *Context) instantiateFuncBinder(ft *soltype.FuncType, lvl int) *soltype.
 }
 
 // substFuncBinder rebuilds ft with sub applied to its parameters and return and its own
-// TypeParams list dropped, since the binder vars are being replaced by their substitutes. A
-// nested generic function's own TypeParams pass through Accept unchanged, so it keeps its
-// quantifier.
+// TypeParams dropped. A nested generic function's own TypeParams pass through unchanged.
 func substFuncBinder(ft *soltype.FuncType, sub *typeSubst) *soltype.FuncType {
 	cp := *ft
 	cp.TypeParams = nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -337,6 +337,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	case *soltype.FuncType:
 		if sup, ok := super.(*soltype.FuncType); ok {
+			// Higher-rank subtyping for a rank-2 callback. A quantifier on the super, the
+			// side being checked against, is skolemized, so the sub must satisfy it for every
+			// instantiation. For example, `fn (x) { return 5 }` fails against `<T>(x: T) -> T`.
+			// A quantifier on the sub, the side supplying the value, is instantiated with fresh
+			// vars, so the sub picks the instantiation. Re-enter once one side's binder is
+			// removed. Contravariant recursion into the params swaps sub and super, so a
+			// negative-position quantifier instantiates and a positive one skolemizes without
+			// a polarity flag here.
+			if len(sup.TypeParams) > 0 {
+				return c.constrain(sub, c.skolemizeFuncBinder(sup), seen, mutCtx)
+			}
+			if len(sub.TypeParams) > 0 {
+				return c.constrain(c.instantiateFuncBinder(sub, sub.TypeParams[0].Var.Level), sup, seen, mutCtx)
+			}
 			// Accept-set subtyping (#677 §4.2.1): read super as a callback parameter.
 			// sub <: super iff accept(sub) ⊇ accept(super) — sub must tolerate every
 			// argument count a holder of super may invoke it with. With
@@ -927,6 +941,84 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 		TypeParams:     ft.TypeParams,
 		LifetimeParams: ft.LifetimeParams,
 	}
+}
+
+// skolemizeFuncBinder returns a copy of ft with its own type parameters replaced by fresh
+// skolems, so a term checked against ft as a supertype must satisfy it for every
+// instantiation. Each parameter's declared bound becomes its skolem's Upper, seeded before
+// substitution so a bound naming a sibling resolves to that sibling's skolem. Only ft's own
+// TypeParams binders are substituted. A nested generic function keeps its quantifier.
+func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
+	sks := make([]*soltype.SkolemType, len(ft.TypeParams))
+	args := make([]soltype.Type, len(ft.TypeParams))
+	for i, tp := range ft.TypeParams {
+		sks[i] = c.freshSkolem(tp.Name)
+		args[i] = sks[i]
+	}
+	sub := newTypeSubst(ft.TypeParams, args, nil, nil)
+	for i, tp := range ft.TypeParams {
+		// resolveTypeParams records at most one upper bound per parameter, itself an
+		// IntersectionType for a `<T: A & B>` bound, so the first bound is the whole declared
+		// constraint.
+		if len(tp.Var.UpperBounds) > 0 {
+			sks[i].Upper = tp.Var.UpperBounds[0].Accept(sub, soltype.Positive)
+		}
+	}
+	return substFuncBinder(ft, sub)
+}
+
+// instantiateFuncBinder returns a copy of ft with its own type parameters replaced by fresh
+// inference vars at lvl, so the sub side of a subtype check picks the instantiation. Each
+// fresh var carries the original parameter's bounds, substituted so an F-bound referencing a
+// sibling reaches that sibling's fresh var. Only ft's own TypeParams binders are substituted.
+func (c *Context) instantiateFuncBinder(ft *soltype.FuncType, lvl int) *soltype.FuncType {
+	nvs := make([]*soltype.TypeVarType, len(ft.TypeParams))
+	args := make([]soltype.Type, len(ft.TypeParams))
+	for i := range ft.TypeParams {
+		nvs[i] = c.freshVar(lvl)
+		args[i] = nvs[i]
+	}
+	sub := newTypeSubst(ft.TypeParams, args, nil, nil)
+	for i, tp := range ft.TypeParams {
+		nvs[i].LowerBounds = acceptBounds(tp.Var.LowerBounds, sub)
+		nvs[i].UpperBounds = acceptBounds(tp.Var.UpperBounds, sub)
+	}
+	return substFuncBinder(ft, sub)
+}
+
+// substFuncBinder rebuilds ft with sub applied to its parameters and return and its own
+// TypeParams list dropped, since the binder vars are being replaced by their substitutes. A
+// nested generic function's own TypeParams pass through Accept unchanged, so it keeps its
+// quantifier.
+func substFuncBinder(ft *soltype.FuncType, sub *typeSubst) *soltype.FuncType {
+	cp := *ft
+	cp.TypeParams = nil
+	cp.Params = make([]*soltype.FuncParam, len(ft.Params))
+	for i, p := range ft.Params {
+		np := *p
+		np.Type = p.Type.Accept(sub, soltype.Negative)
+		cp.Params[i] = &np
+	}
+	cp.Ret = ft.Ret.Accept(sub, soltype.Positive)
+	if ft.SelfParam != nil {
+		ns := *ft.SelfParam
+		ns.Type = ft.SelfParam.Type.Accept(sub, soltype.Negative)
+		cp.SelfParam = &ns
+	}
+	return &cp
+}
+
+// acceptBounds applies sub to each bound in a var's bound list, preserving the nil-for-empty
+// shape.
+func acceptBounds(bounds []soltype.Type, sub *typeSubst) []soltype.Type {
+	if len(bounds) == 0 {
+		return nil
+	}
+	out := make([]soltype.Type, len(bounds))
+	for i, b := range bounds {
+		out[i] = b.Accept(sub, soltype.Positive)
+	}
+	return out
 }
 
 // ltPair keys constrainLt's coinductive seen-set by (sub, super) lifetime

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -939,7 +939,9 @@ func callableView(ft *soltype.FuncType) *soltype.FuncType {
 
 // skolemizeFuncBinder replaces ft's own type parameters with fresh skolems, so a term checked
 // against ft as a supertype must satisfy it for every instantiation. Each parameter's declared
-// bound becomes its skolem's Upper, seeded first so a bound naming a sibling reaches it.
+// bound becomes its skolem's Upper, seeded first so a bound naming a sibling reaches it. For
+// example `<T>(x: T) -> T` becomes `(x: sk) -> sk` for a fresh skolem sk, which `fn (x) {
+// return 5 }` fails but a polymorphic identity satisfies.
 func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
 	sks := make([]*soltype.SkolemType, len(ft.TypeParams))
 	args := make([]soltype.Type, len(ft.TypeParams))
@@ -961,6 +963,8 @@ func (c *Context) skolemizeFuncBinder(ft *soltype.FuncType) *soltype.FuncType {
 
 // instantiateFuncBinder replaces ft's own type parameters with fresh inference vars at lvl, so
 // the sub side of a subtype check picks the instantiation. Each fresh var carries its bounds.
+// For example a call `cb(5)` instantiates `cb: <T>(x: T) -> T` to `(x: T0) -> T0` for a fresh
+// var T0, which `5` then binds, so a later `cb("hi")` gets its own T1 rather than reusing T0.
 func (c *Context) instantiateFuncBinder(ft *soltype.FuncType, lvl int) *soltype.FuncType {
 	nvs := make([]*soltype.TypeVarType, len(ft.TypeParams))
 	args := make([]soltype.Type, len(ft.TypeParams))

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -277,15 +277,9 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 }
 
 // skolemizeGenericAnn copies a resolved annotation, replacing a positive-position generic
-// function's own type-parameter var by a fresh skolem of the same name. This pushes the
-// expected type into the term with its parameters held abstract, so constrain rejects a body
-// that forces a parameter to a concrete value, both directly (`return 5`) and through an
-// inference var (`return x` where the annotation promises a different type).
-//
-// A generic function in NEGATIVE position is a rank-2 callback parameter such as
-// `fn (cb: <T>(x: T) -> T) -> …`. It is left generic rather than skolemized. The initializer
-// supplies its own callback there, so constrain instantiates the annotation's `T` when
-// checking that supplied callback against it, exactly as a call site would.
+// function's own type-parameter var by a fresh skolem, so constrain rejects a body that forces
+// that parameter to a concrete value. A negative-position generic function is a rank-2 callback
+// parameter, left generic instead so constrain instantiates its `T` like a call site would.
 func (c *checker) skolemizeGenericAnn(annT soltype.Type) soltype.Type {
 	return annT.Accept(&skolemizer{c: c, subst: map[*soltype.TypeVarType]*soltype.SkolemType{}}, soltype.Positive)
 }

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -276,19 +276,25 @@ func (c *checker) constrainInitAgainstAnnotation(init ast.Expr, initT, annT solt
 	return annT
 }
 
-// skolemizeGenericAnn copies a resolved annotation, replacing every generic function's own
-// type-parameter var by a fresh skolem of the same name. This pushes the expected type into
-// the term with its parameters held abstract, so constrain rejects a body that forces a
-// parameter to a concrete value, both directly (`return 5`) and through an inference var
-// (`return x` where the annotation promises a different type).
+// skolemizeGenericAnn copies a resolved annotation, replacing a positive-position generic
+// function's own type-parameter var by a fresh skolem of the same name. This pushes the
+// expected type into the term with its parameters held abstract, so constrain rejects a body
+// that forces a parameter to a concrete value, both directly (`return 5`) and through an
+// inference var (`return x` where the annotation promises a different type).
+//
+// A generic function in NEGATIVE position is a rank-2 callback parameter such as
+// `fn (cb: <T>(x: T) -> T) -> …`. It is left generic rather than skolemized. The initializer
+// supplies its own callback there, so constrain instantiates the annotation's `T` when
+// checking that supplied callback against it, exactly as a call site would.
 func (c *checker) skolemizeGenericAnn(annT soltype.Type) soltype.Type {
 	return annT.Accept(&skolemizer{c: c, subst: map[*soltype.TypeVarType]*soltype.SkolemType{}}, soltype.Positive)
 }
 
-// skolemizer rewrites a resolved annotation, substituting each generic function's
-// type-parameter var with a distinct skolem. It seeds a skolem per TypeParam as it enters
-// each FuncType, then substitutes at every later occurrence of that var in the params and
-// return, so a nested generic function is skolemized under its own binder too.
+// skolemizer rewrites a resolved annotation, substituting each positive-position generic
+// function's type-parameter var with a distinct skolem. It seeds a skolem per TypeParam as it
+// enters each such FuncType, then substitutes at every later occurrence of that var in the
+// params and return, so a nested positive generic function is skolemized under its own binder
+// too.
 //
 // The rebuilt FuncType drops its TypeParams list: its binder vars become skolems in the
 // params and return, and constrain ignores the list. Nil-ing it also avoids acceptTypeParamVar,
@@ -298,11 +304,13 @@ type skolemizer struct {
 	subst map[*soltype.TypeVarType]*soltype.SkolemType
 }
 
-func (s *skolemizer) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+func (s *skolemizer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	switch t := t.(type) {
 	case *soltype.FuncType:
-		if len(t.TypeParams) == 0 {
-			return soltype.EnterResult{} // monomorphic: ordinary descent
+		if len(t.TypeParams) == 0 || pol == soltype.Negative {
+			// Monomorphic, or a rank-2 callback parameter left generic for constrain to
+			// instantiate. Descend ordinarily, keeping the binder intact.
+			return soltype.EnterResult{}
 		}
 		// Seed every skolem before carrying bounds, so a bound naming a sibling parameter
 		// resolves to that sibling's skolem.

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -224,13 +224,11 @@ func (c *checker) inferFunc(scope *Scope, lvl int, sig ast.FuncSig, body *ast.Bl
 	paramTypes := make(map[string]soltype.Type, len(sig.Params))
 	for i, p := range sig.Params {
 		pt := c.paramType(declScope, p, lvl)
-		// A generic function in parameter position is rank-2, beyond the rank-1
-		// boundary, so report it and recover to a fresh var. This mirrors the same
-		// check resolveFuncTypeAnn applies to a nested function-type annotation.
-		if ft, ok := pt.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
-			c.reportUnsupportedFeature(p.TypeAnn, "higher-rank function parameter")
-			pt = c.freshAt(lvl)
-		}
+		// A generic function in parameter position is a rank-2 callback such as
+		// `g: <V>(x: V) -> V`. Its `<V>` binder is kept on the parameter's FuncType so a
+		// caller's argument is checked against it by skolemizing `V`, and a call to the
+		// parameter inside this body instantiates `V` per use. constrain's FuncType arm
+		// performs both steps.
 		// Rule 2 of PR 3. A bare annotation is owned and only an `&` annotation
 		// borrows. An `&` annotation already mints its lifetime in
 		// resolveLifetimeAnn, so a parameter has nothing to attach here. A bare
@@ -1148,6 +1146,14 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 		if arms, ok := funcIntersectionArms(callee); ok {
 			return c.inferMethodOverloadCall(scope, lvl, e, arms)
 		}
+	}
+	// A generic callee is instantiated at the call site so each call binds its type
+	// parameters independently. inferIdent already freshens a generalized generic binding,
+	// but a rank-2 callback parameter such as `cb: <T>(x: T) -> T` reaches here as a
+	// MonoScheme that inferIdent returns unfreshened. Without this a second `cb(...)` would
+	// pile onto the first call's binding of `T`, corrupting the parameter's own quantifier.
+	if ft, ok := callee.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
+		callee = c.ctx.instantiateFuncBinder(ft, lvl)
 	}
 	args := make([]*soltype.FuncParam, len(e.Args))
 	for i, a := range e.Args {

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1147,11 +1147,8 @@ func (c *checker) inferCall(scope *Scope, lvl int, e *ast.CallExpr) soltype.Type
 			return c.inferMethodOverloadCall(scope, lvl, e, arms)
 		}
 	}
-	// A generic callee is instantiated at the call site so each call binds its type
-	// parameters independently. inferIdent already freshens a generalized generic binding,
-	// but a rank-2 callback parameter such as `cb: <T>(x: T) -> T` reaches here as a
-	// MonoScheme that inferIdent returns unfreshened. Without this a second `cb(...)` would
-	// pile onto the first call's binding of `T`, corrupting the parameter's own quantifier.
+	// Instantiate a generic callee so each call binds its type parameters independently. A
+	// rank-2 callback param is an unfreshened MonoScheme, so this keeps its `T` per-call.
 	if ft, ok := callee.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
 		callee = c.ctx.instantiateFuncBinder(ft, lvl)
 	}

--- a/internal/solver/infer_func_ann_test.go
+++ b/internal/solver/infer_func_ann_test.go
@@ -123,16 +123,59 @@ func TestInferGenericFuncAnnotation(t *testing.T) {
 	}
 }
 
-// A generic function in parameter position is rank-2: the annotation `fn(cb: fn<T>(x: T)
-// -> T) -> number` would demand a caller pass an argument that is itself polymorphic. That
-// is beyond the rank-1 boundary, so it reports an unsupported feature and recovers to a
-// fresh var for the parameter, keeping the outer function shape.
-func TestInferHigherRankFuncParamReportsUnsupported(t *testing.T) {
+// A generic function in parameter position is a rank-2 callback: the annotation
+// `fn(cb: fn<T>(x: T) -> T) -> number` demands a caller pass an argument that is itself
+// polymorphic. The `<T>` binder is kept on the parameter, so the binding resolves and
+// renders the parameter with its quantifier rather than approximating it.
+func TestInferHigherRankFuncParamResolves(t *testing.T) {
 	values, _, errs := inferSource(t, `val f: fn(cb: fn<T>(x: T) -> T) -> number = fn (cb) { return 1 }`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "1:15-1:31: Unsupported: higher-rank function parameter", msgWithSpan(errs[0]))
-	require.Equal(t, "fn (cb: unknown) -> number", values["f"])
+	require.Empty(t, errs)
+	require.Equal(t, "fn (cb: fn <T>(x: T) -> T) -> number", values["f"])
+}
+
+// The body of a function with a rank-2 callback parameter may call that callback at more
+// than one type. Each `cb(...)` instantiates the callback's `T` independently, so `cb(5)`
+// and `cb("hi")` both type-check within one body rather than unifying `T` across the two
+// calls.
+func TestInferRank2CallbackCalledAtSeveralTypes(t *testing.T) {
+	src := `val f: fn(cb: fn<T>(x: T) -> T) -> number = fn (cb) {
+  val a = cb(5)
+  val b = cb("hi")
+  return 1
+}`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (cb: fn <T>(x: T) -> T) -> number", values["f"])
+}
+
+// A polymorphic argument satisfies a rank-2 callback parameter. Passing the generic `id`
+// into `f`'s `cb: fn<T>(x: T) -> T` parameter checks `id`'s type against the parameter by
+// skolemizing `T`, which `id` satisfies, so the call type-checks and yields `f`'s return.
+func TestInferRank2CallbackAcceptsPolymorphicArg(t *testing.T) {
+	src := `
+fn id<T>(x: T) -> T { return x }
+val f: fn(cb: fn<T>(x: T) -> T) -> number = fn (cb) { return 1 }
+val r = f(id)`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "number", values["r"])
+}
+
+// A monomorphic argument does not satisfy a rank-2 callback parameter. Passing `inc:
+// fn(x: number) -> number` where `fn<T>(x: T) -> T` is expected checks `inc` against the
+// parameter with `T` held rigid as a skolem, which `inc`'s concrete `number` cannot fill in
+// either the argument or the result position, so the call is rejected.
+func TestInferRank2CallbackRejectsMonomorphicArg(t *testing.T) {
+	src := `
+fn inc(x: number) -> number { return x }
+val f: fn(cb: fn<T>(x: T) -> T) -> number = fn (cb) { return 1 }
+val r = f(inc)`
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 2)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.IsType(t, &CannotConstrainError{}, errs[1])
+	require.Equal(t, "4:9-4:15: cannot constrain T <: number", msgWithSpan(errs[0]))
+	require.Equal(t, "4:9-4:15: cannot constrain number <: T", msgWithSpan(errs[1]))
 }
 
 // A function-literal body whose return type is not the declared parameter does not

--- a/internal/solver/infer_generic_func_test.go
+++ b/internal/solver/infer_generic_func_test.go
@@ -203,20 +203,13 @@ func TestInferGenericMethodStillGated(t *testing.T) {
 	}, msgs)
 }
 
-// A parameter whose own type is polymorphic — a callback annotated `fn <V>(x: V) -> V` —
-// stays rejected at the rank-1 boundary. The generic function-type annotation itself
-// resolves, so its `<V>` binds and the two `V` references read that quantified var, but
-// a generic function in parameter position is rank-2, so the declaration reports the
-// parameter as unsupported and recovers to a fresh var rather than approximating it.
-func TestInferGenericFuncHigherRankParamRejected(t *testing.T) {
-	_, _, errs := inferSource(t, `fn apply<T>(g: fn <V>(x: V) -> V, y: T) -> T { return g(y) }`)
-	msgs := make([]string, len(errs))
-	for i, e := range errs {
-		msgs[i] = e.Message()
-	}
-	// The `<V>` annotation resolves, so there is no `TypeRefTypeAnn` cascade; only the
-	// rank-1 boundary rejects the generic function in parameter position.
-	require.Equal(t, []string{
-		"Unsupported: higher-rank function parameter",
-	}, msgs)
+// A parameter whose own type is polymorphic — a rank-2 callback annotated `fn <V>(x: V) ->
+// V` — is accepted. The `<V>` binder is kept on the parameter, so the body's `g(y)` call
+// instantiates `V` per use and the declaration type-checks. The extra `T0` quantifier is the
+// generalization artifact a decl that instantiates a generic function in its body always
+// leaves. The monomorphic `fn wrap<U>(g: fn(x: U) -> U, …)` renders it the same way.
+func TestInferGenericFuncHigherRankParamResolves(t *testing.T) {
+	values, _, errs := inferSource(t, `fn apply<T>(g: fn <V>(x: V) -> V, y: T) -> T { return g(y) }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T0, T: T0>(g: fn <V>(x: V) -> V, y: T) -> T", values["apply"])
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -277,12 +277,10 @@ func (c *checker) resolveFuncTypeAnn(scope *Scope, ta *ast.FuncTypeAnn, lvl int)
 				pt = t
 			}
 		}
-		// A generic function in parameter position is rank-2, beyond the rank-1 boundary, so
-		// report it and recover to a fresh var. In return position it is rank-1 and kept.
-		if ft, ok := pt.(*soltype.FuncType); ok && len(ft.TypeParams) > 0 {
-			c.reportUnsupportedFeature(p.TypeAnn, "higher-rank function parameter")
-			pt = c.freshAt(lvl)
-		}
+		// A generic function in parameter position is a rank-2 callback such as
+		// `cb: <T>(x: T) -> T`. Its `<T>` binder is kept on the parameter's FuncType, so a
+		// call site checks each argument against it by skolemizing `T`, and a use inside the
+		// body instantiates `T` per call. constrain's FuncType arm performs both steps.
 		// The pattern is carried for rendering and round-tripping only, with no scope
 		// binding. mirrorParamPat preserves its full shape.
 		params[i] = &soltype.FuncParam{Pattern: c.mirrorParamPat(pat), Type: pt, Optional: p.Optional}


### PR DESCRIPTION
Enable generic functions in parameter position (rank-2 callbacks) by implementing proper higher-rank subtyping. Previously, generic function parameters were rejected as unsupported. Now they are accepted and checked correctly.

**Key changes:**

- Add `skolemizeFuncBinder` and `instantiateFuncBinder` to handle rank-2 subtyping in `constrain`. When checking a function against a generic function type, skolemize the supertype's binder so the argument must satisfy it for all instantiations, and instantiate the subtype's binder so the argument picks the instantiation.

- Update `constrain`'s `FuncType` arm to detect and handle generic function types on either side before proceeding to accept-set subtyping.

- Modify `skolemizer` to preserve generic function types in negative position (callback parameters) rather than skolemizing them, allowing `constrain` to instantiate them at call sites.

- Remove the "higher-rank function parameter" unsupported-feature error from `inferFunc` and `resolveFuncTypeAnn`. Generic callbacks are now valid.

- Update `inferCall` to freshen generic callback parameters on each call, so multiple calls to the same callback parameter bind its type parameters independently.

- Adjust `coalesce` to retain generic function binders as symbolic variables rather than inlining them, preserving rank-2 callback types in rendered output.

**Tests:**

- `TestInferHigherRankFuncParamResolves`: Generic callback parameters now resolve with their quantifier intact.
- `TestInferRank2CallbackCalledAtSeveralTypes`: A callback can be called at different types within one body.
- `TestInferRank2CallbackAcceptsPolymorphicArg`: Polymorphic arguments satisfy generic callback parameters.
- `TestInferRank2CallbackRejectsMonomorphicArg`: Monomorphic arguments are correctly rejected.
- `TestInferGenericFuncHigherRankParamResolves`: Generic functions with generic callback parameters type-check.

https://claude.ai/code/session_01UKdYuvW6C1YJ5FQ1EQxekA