### PR TITLE
Warn on ambiguous union-super commits and breadcrumb var conflicts

### DIFF
--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -271,13 +271,31 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	// var member is trialled.
 	if supU, ok := super.(*soltype.UnionType); ok {
 		if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar && len(supU.Types) > 0 {
-			committed, _ := c.trialAndCommit(specificityOrder(supU.Types), func(idx int) []SolverError {
+			order := specificityOrder(supU.Types)
+			committed, winIdx, winErrs, _ := c.trialAndCommit(order, func(idx int) []SolverError {
 				// A cloned seen keeps each member's coinductive cache independent, so a
 				// failed member's entries can't wrongly short-circuit a later member.
 				return c.constrain(sub, supU.Types[idx], seen.Clone(), mutCtx)
 			})
 			if committed {
-				return nil
+				// winErrs carries any warning the winning member's own nested trial emitted.
+				// Propagate it so a nested ambiguous union is not silently swallowed.
+				diags := winErrs
+				// A committed bare type-variable member pins that var to sub. Tag it so a
+				// later constraint that forces an incompatible bound onto the var can name
+				// the union choice that pinned it.
+				if v, ok := supU.Types[winIdx].(*soltype.TypeVarType); ok {
+					c.tagUnionCommit(v, supU)
+				}
+				// When another member would also match while binding an inference variable,
+				// the committed choice is ambiguous. Warn at the union so the user can
+				// annotate rather than depend on specificity order.
+				if alt := c.ambiguousAlternate(sub, supU, order, winIdx, seen, mutCtx); alt != nil {
+					diags = append(diags, &AmbiguousUnionCommitWarning{
+						Union: supU, Committed: supU.Types[winIdx], Alternate: alt,
+					})
+				}
+				return diags
 			}
 			if supU.Inexact {
 				// An inexact union super has an open, unknown-typed tail. A sub that
@@ -289,7 +307,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			// Every branch failed, the var members included. Promote a BorrowEscapeError
 			// when sub's peeled inner still satisfies the union; else emit the generic error.
 			if ref, ok := sub.(*soltype.RefType); ok && ref.Lt != nil {
-				if len(c.trialUnderProbe(ref.Inner, super)) == 0 {
+				if !hasHardError(c.trialUnderProbe(ref.Inner, super)) {
 					return []SolverError{&BorrowEscapeError{Sub: ref, Super: super}}
 				}
 			}
@@ -649,7 +667,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			if sub.Lt != nil {
 				// Emit BorrowEscapeError only when the peeled inner satisfies super, so
 				// the lifetime is the blocker; otherwise surface the inner's mismatch.
-				if innerErrs := c.trialUnderProbe(sub.Inner, super); len(innerErrs) > 0 {
+				if innerErrs := c.trialUnderProbe(sub.Inner, super); hasHardError(innerErrs) {
 					return innerErrs
 				}
 				return []SolverError{&BorrowEscapeError{Sub: sub, Super: super}}
@@ -685,13 +703,14 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		//     types, so a non-function intersection trials its more-specific
 		//     members first; incomparable members keep declaration order.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar && len(sub.Types) > 0 {
-			committed, trialErrs := c.trialAndCommit(specificityOrder(sub.Types), func(idx int) []SolverError {
+			committed, _, winErrs, trialErrs := c.trialAndCommit(specificityOrder(sub.Types), func(idx int) []SolverError {
 				// A cloned seen keeps each arm's coinductive cache independent, so a failed
 				// arm's entries can't wrongly short-circuit a later arm to success.
 				return c.constrain(sub.Types[idx], super, seen.Clone(), mutCtx)
 			})
 			if committed {
-				return nil
+				// winErrs carries any warning the winning arm's nested trial emitted.
+				return winErrs
 			}
 			if len(trialErrs) > 0 {
 				return trialErrs[len(trialErrs)-1] // no arm matched: surface the last arm's failure
@@ -725,7 +744,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			for _, lb := range subVar.LowerBounds {
 				errs = append(errs, c.constrain(lb, super, seen, false)...)
 			}
-			return errs
+			return c.breadcrumbUnionCommit(errs, subVar)
 		}
 		// super lives at an inner level: extrude it out so it isn't wrongly
 		// generalized at subVar's level.
@@ -739,12 +758,66 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			for _, ub := range superVar.UpperBounds {
 				errs = append(errs, c.constrain(sub, ub, seen, false)...)
 			}
-			return errs
+			return c.breadcrumbUnionCommit(errs, superVar)
 		}
 		return c.constrain(c.extrude(sub, soltype.Positive, superVar.Level, map[extrudeKey]*soltype.TypeVarType{}), super, seen, mutCtx)
 	}
 
 	return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+}
+
+// ambiguousAlternate returns a union member, other than the committed one, that would also
+// match sub while binding an inference variable, or nil when none does. The union-super
+// arm calls it after a member commits to detect a match that is ambiguous: `5 <: (T | number)`
+// commits number but T would also match by pinning T to 5, so T is returned. Each candidate
+// is trialled under a throwaway probe, so the peek records no bound. A member that would
+// match without binding a variable, such as a second concrete member, is not ambiguous and
+// is skipped, since the committed choice binds nothing either.
+//
+// A union with no bare type-variable member cannot produce an ambiguous binding, so the
+// scan is skipped entirely. This keeps the common all-concrete union super, such as an
+// enum value flowing into its variant union, from paying for an extra round of trials.
+// newUnion flattens nested unions, so a variable member always surfaces as a direct member
+// here rather than hiding inside a nested union.
+func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, order []int, winIdx int, seen set.Set[constraintKey], mutCtx bool) soltype.Type {
+	hasVar := false
+	for _, m := range u.Types {
+		if _, ok := m.(*soltype.TypeVarType); ok {
+			hasVar = true
+			break
+		}
+	}
+	if !hasVar {
+		return nil
+	}
+	for _, j := range order {
+		if j == winIdx {
+			continue
+		}
+		if ok, mutated := c.trialMutatesBounds(sub, u.Types[j], seen, mutCtx); ok && mutated {
+			return u.Types[j]
+		}
+	}
+	return nil
+}
+
+// breadcrumbUnionCommit stamps each CannotConstrainError in errs with v's union-trial
+// origin when v was pinned by a committed bare type-variable member, so the message names
+// the union choice that forced the conflict. A no-op when v carries no such tag or when an
+// error already has an origin, which keeps the innermost breadcrumb rather than overwriting
+// it as the failure unwinds through nested var arms.
+func (c *Context) breadcrumbUnionCommit(errs []SolverError, v *soltype.TypeVarType) []SolverError {
+	u, ok := c.unionCommits[v]
+	if !ok {
+		return errs
+	}
+	for _, e := range errs {
+		if cc, ok := e.(*CannotConstrainError); ok && cc.commitUnion == nil {
+			cc.commitUnion = u
+			cc.commitVar = v
+		}
+	}
+	return errs
 }
 
 // isFieldReadReq reports whether an object super is a field-read or destructure

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -767,18 +767,11 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 }
 
 // ambiguousAlternate returns a union member, other than the committed one, that would also
-// match sub while binding an inference variable, or nil when none does. The union-super
-// arm calls it after a member commits to detect a match that is ambiguous: `5 <: (T | number)`
-// commits number but T would also match by pinning T to 5, so T is returned. Each candidate
-// is trialled under a throwaway probe, so the peek records no bound. A member that would
-// match without binding a variable, such as a second concrete member, is not ambiguous and
-// is skipped, since the committed choice binds nothing either.
-//
-// A union with no bare type-variable member cannot produce an ambiguous binding, so the
-// scan is skipped entirely. This keeps the common all-concrete union super, such as an
-// enum value flowing into its variant union, from paying for an extra round of trials.
-// newUnion flattens nested unions, so a variable member always surfaces as a direct member
-// here rather than hiding inside a nested union.
+// match sub while binding an inference variable, or nil when none does. For `5 <: (T | number)`
+// number commits but T would also match by pinning to 5, so T is returned. Each candidate is
+// trialled under a throwaway probe, so the peek records no bound. A union with no bare
+// type-variable member cannot bind ambiguously, so the scan is skipped, sparing the common
+// all-concrete union super such as an enum value flowing into its variant union.
 func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, order []int, winIdx int, seen set.Set[constraintKey], mutCtx bool) soltype.Type {
 	hasVar := false
 	for _, m := range u.Types {
@@ -801,11 +794,10 @@ func (c *Context) ambiguousAlternate(sub soltype.Type, u *soltype.UnionType, ord
 	return nil
 }
 
-// breadcrumbUnionCommit stamps each CannotConstrainError in errs with v's union-trial
-// origin when v was pinned by a committed bare type-variable member, so the message names
-// the union choice that forced the conflict. A no-op when v carries no such tag or when an
-// error already has an origin, which keeps the innermost breadcrumb rather than overwriting
-// it as the failure unwinds through nested var arms.
+// breadcrumbUnionCommit stamps each CannotConstrainError in errs with v's union-trial origin
+// when v was pinned by a committed bare type-variable member, so the message names the union
+// choice that forced the conflict. It is a no-op when v carries no tag; an error that already
+// has an origin keeps it, so the innermost breadcrumb survives as the failure unwinds.
 func (c *Context) breadcrumbUnionCommit(errs []SolverError, v *soltype.TypeVarType) []SolverError {
 	u, ok := c.unionCommits[v]
 	if !ok {

--- a/internal/solver/constrain_lattice_test.go
+++ b/internal/solver/constrain_lattice_test.go
@@ -3,6 +3,7 @@ package solver
 import (
 	"testing"
 
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -161,14 +162,86 @@ func TestConstrainUnionSuperExists(t *testing.T) {
 		// 5 <: (T | number). The number member is trialled before the bare var T, since
 		// specificityOrder ranks a variable below every concrete, so `5 <: number` commits
 		// and the trial never reaches `5 <: T`. T is left with no bounds, proving the var
-		// member is a last-resort catch-all rather than a speculative first pin.
+		// member is a last-resort catch-all rather than a speculative first pin. The choice
+		// is ambiguous, since T would also match by pinning to 5, so an
+		// AmbiguousUnionCommitWarning surfaces while the constraint still succeeds.
 		c := &Context{}
 		tv := c.freshVar(0)
 		super := newUnion(nil, []soltype.Type{tv, num()}, false)
 
-		require.Empty(t, c.Constrain(numLit(5), super))
+		errs := c.Constrain(numLit(5), super)
+		require.Equal(t, []string{
+			"ambiguous match against t0 | number: committed number, but t0 would also match; annotate to disambiguate",
+		}, Messages(errs))
+		require.False(t, hasHardError(errs))
 		require.Empty(t, tv.LowerBounds)
 		require.Empty(t, tv.UpperBounds)
+	})
+}
+
+// TestConstrainUnionCommitDiagnostics covers the PR7 trial-and-commit diagnostics on the
+// union-super exists rule: the breadcrumb a committed bare-var member leaves for a later
+// conflicting use, and the ambiguity warning when another member would also match while
+// binding an inference variable.
+func TestConstrainUnionCommitDiagnostics(t *testing.T) {
+	t.Run("var-committed member breadcrumbs a later conflict back to the union", func(t *testing.T) {
+		// "hi" <: (T | number). The number member fails ("hi" is not number), so the trial
+		// falls through to the catch-all var member and commits `"hi" <: T`, pinning T to
+		// "hi". No other member matches, so the commit is unambiguous and reports nothing.
+		c := &Context{}
+		tv := c.freshVar(0)
+		super := newUnion(nil, []soltype.Type{tv, num()}, false)
+
+		require.Empty(t, c.Constrain(strLit("hi"), super))
+		require.Len(t, tv.LowerBounds, 1)
+
+		// A later use of T as number forces "hi" <: number, which fails. The breadcrumb
+		// names the union choice that pinned T rather than blaming only this use.
+		errs := c.Constrain(tv, num())
+		require.Equal(t, []string{
+			`cannot constrain "hi" <: number; t0 was committed to a branch of t0 | number by an earlier match, so it cannot also satisfy number`,
+		}, Messages(errs))
+	})
+
+	t.Run("concrete commit with a viable var member warns as ambiguous", func(t *testing.T) {
+		// 5 <: (T | number). The number member commits, but T would also match by pinning to
+		// 5, so the choice is ambiguous and a warning surfaces while the constraint succeeds.
+		c := &Context{}
+		tv := c.freshVar(0)
+		super := newUnion(nil, []soltype.Type{tv, num()}, false)
+
+		errs := c.Constrain(numLit(5), super)
+		require.Equal(t, []string{
+			"ambiguous match against t0 | number: committed number, but t0 would also match; annotate to disambiguate",
+		}, Messages(errs))
+		require.False(t, hasHardError(errs))
+	})
+
+	t.Run("concrete commit with only concrete members is unambiguous", func(t *testing.T) {
+		// 5 <: (number | string). The number member commits and no other member matches, so
+		// nothing is ambiguous and no warning surfaces.
+		c := &Context{}
+		super := newUnion(nil, parseTypes(t, "number", "string"), false)
+		require.Empty(t, c.Constrain(numLit(5), super))
+	})
+
+	t.Run("a discarded trial drops the union-commit tag and its bound", func(t *testing.T) {
+		// The tag rides the same probe as the bound it records, so a losing outer trial that
+		// discards the commit leaves neither behind.
+		c := &Context{}
+		tv := c.freshVar(0)
+		super := newUnion(nil, []soltype.Type{tv, num()}, false)
+
+		p := newProbe(c.probe)
+		c.probe = p
+		require.Empty(t, c.constrain(strLit("hi"), super, set.NewSet[constraintKey](), false))
+		c.probe = p.parent
+		require.Contains(t, c.unionCommits, tv)
+		require.Len(t, tv.LowerBounds, 1)
+
+		p.Discard()
+		require.NotContains(t, c.unionCommits, tv)
+		require.Empty(t, tv.LowerBounds)
 	})
 }
 

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -67,21 +67,15 @@ type Context struct {
 	// so a stale entry cannot make a constraint wrong.
 	aliasInterns map[string]*soltype.AliasType
 
-	// unionCommits records each inference var that a union-super exists trial pinned by
-	// committing a bare type-variable member. The key is the pinned var and the value is
-	// the super union it was chosen from, so `"hi" <: (T | number)` commits the T branch
-	// and records T → (T | number). A later constraint that forces an incompatible bound
-	// onto the var reads this to point the failure back to the union choice that pinned it,
-	// rather than blaming only the later use. The write is journaled under the active probe
-	// through tagUnionCommit, so a discarded trial drops the tag alongside the bound it
-	// recorded.
+	// unionCommits maps an inference var that a union-super trial pinned by committing a bare
+	// type-variable member to the super union it was chosen from, so `"hi" <: (T | number)`
+	// records T → (T | number). A later constraint that forces an incompatible bound onto the
+	// var reads this to breadcrumb the failure back to that union choice.
 	unionCommits map[*soltype.TypeVarType]*soltype.UnionType
 }
 
-// tagUnionCommit records that v was pinned by committing v as a bare type-variable member
-// of union u, so a later failing constraint on v can name the union that forced it. The
-// prior entry is captured and restored on rollback, so a discarded trial leaves the table
-// exactly as it was. The tag and the bound the trial recorded on v roll back together.
+// tagUnionCommit records that committing union u pinned v, so a later failure on v can name
+// u. The prior entry is restored on rollback, so a discarded trial drops the tag with its bound.
 func (c *Context) tagUnionCommit(v *soltype.TypeVarType, u *soltype.UnionType) {
 	if c.unionCommits == nil {
 		c.unionCommits = map[*soltype.TypeVarType]*soltype.UnionType{}

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -66,6 +66,37 @@ type Context struct {
 	// A representative is only ever compared by identity for the seen-set and never expanded,
 	// so a stale entry cannot make a constraint wrong.
 	aliasInterns map[string]*soltype.AliasType
+
+	// unionCommits records each inference var that a union-super exists trial pinned by
+	// committing a bare type-variable member. The key is the pinned var and the value is
+	// the super union it was chosen from, so `"hi" <: (T | number)` commits the T branch
+	// and records T → (T | number). A later constraint that forces an incompatible bound
+	// onto the var reads this to point the failure back to the union choice that pinned it,
+	// rather than blaming only the later use. The write is journaled under the active probe
+	// through tagUnionCommit, so a discarded trial drops the tag alongside the bound it
+	// recorded.
+	unionCommits map[*soltype.TypeVarType]*soltype.UnionType
+}
+
+// tagUnionCommit records that v was pinned by committing v as a bare type-variable member
+// of union u, so a later failing constraint on v can name the union that forced it. The
+// prior entry is captured and restored on rollback, so a discarded trial leaves the table
+// exactly as it was. The tag and the bound the trial recorded on v roll back together.
+func (c *Context) tagUnionCommit(v *soltype.TypeVarType, u *soltype.UnionType) {
+	if c.unionCommits == nil {
+		c.unionCommits = map[*soltype.TypeVarType]*soltype.UnionType{}
+	}
+	if c.probe != nil {
+		prev, had := c.unionCommits[v]
+		c.probe.onRollback(func() {
+			if had {
+				c.unionCommits[v] = prev
+			} else {
+				delete(c.unionCommits, v)
+			}
+		})
+	}
+	c.unionCommits[v] = u
 }
 
 // internAlias returns the shared representative for an alias reference's canonical

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -28,6 +28,26 @@ type SolverError interface {
 	Related() []ast.Span // node-derived; empty unless the kind carries related nodes
 }
 
+// isWarning reports whether e is a non-fatal diagnostic. The SolverError interface does
+// not require IsWarning, so a plain error that lacks the method is treated as fatal. Only
+// an error that implements IsWarning and returns true is a warning.
+func isWarning(e SolverError) bool {
+	w, ok := e.(interface{ IsWarning() bool })
+	return ok && w.IsWarning()
+}
+
+// hasHardError reports whether errs contains any fatal error, ignoring warnings. A
+// speculative trial consults it so a branch that succeeds while emitting a warning still
+// counts as a success rather than a failure.
+func hasHardError(errs []SolverError) bool {
+	for _, e := range errs {
+		if !isWarning(e) {
+			return true
+		}
+	}
+	return false
+}
+
 // CannotConstrainError fires when a non-variable sub/super pair fails to match:
 // prim/prim mismatch, lit/lit mismatch, lit/prim mismatch, and the generic
 // "no rule applies" fall-through at the end of constrain.
@@ -42,6 +62,15 @@ type CannotConstrainError struct {
 	Sub, Super soltype.Type
 	prov       NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
 	site       ast.Node     // M2.5: the constraint node n — the use, the fallback when Sub has no entry
+
+	// commitUnion and commitVar breadcrumb a failure back to a union-super exists trial that
+	// pinned an inference var. When a value flowed into `(T | number)` and committed the T
+	// branch, T is pinned. A later use of T as number reaches this error while propagating
+	// T's committed lower bound. The var arm sets these so Message names the union choice
+	// that forced the conflict rather than blaming only the later use. Both nil for a plain
+	// mismatch with no union-trial origin.
+	commitUnion *soltype.UnionType
+	commitVar   *soltype.TypeVarType
 }
 
 // FuncArityMismatchError fires on FuncType <: FuncType when the two arities
@@ -1235,6 +1264,32 @@ func (e *UnusedLifetimeParamError) Message() string {
 	return "lifetime parameter '" + e.Name + " is declared but never used"
 }
 
+// AmbiguousUnionCommitWarning fires when a value flowing into a union-super exists trial
+// matches more than one member. The trial commits the first match in specificity order,
+// but another member would also succeed while binding an inference variable, so which
+// member wins is not evident from the source. For `5 <: (T | number)` the number member
+// commits, yet the T member would also match by pinning T to 5, so the choice is
+// ambiguous. It is a warning rather than an error, since the program still type-checks
+// under the committed branch, and the user can annotate to fix which member wins.
+type AmbiguousUnionCommitWarning struct {
+	Union     *soltype.UnionType
+	Committed soltype.Type // the member the trial committed
+	Alternate soltype.Type // another member that would also have matched
+	prov      NodeResolver
+	site      ast.Node
+}
+
+func (*AmbiguousUnionCommitWarning) isSolverError()   {}
+func (e *AmbiguousUnionCommitWarning) IsWarning() bool { return true }
+func (e *AmbiguousUnionCommitWarning) Span() ast.Span {
+	return spanOf(e.prov, e.Union, e.site)
+}
+func (e *AmbiguousUnionCommitWarning) Related() []ast.Span { return nil }
+func (e *AmbiguousUnionCommitWarning) Message() string {
+	return fmt.Sprintf("ambiguous match against %s: committed %s, but %s would also match; annotate to disambiguate",
+		describe(e.Union), describe(e.Committed), describe(e.Alternate))
+}
+
 func (e *UnknownIdentifierError) Span() ast.Span      { return e.Ident.Span() }
 func (e *UnknownIdentifierError) Related() []ast.Span { return nil }
 func (e *UnknownIdentifierError) Message() string {
@@ -1424,7 +1479,15 @@ func (e *AsyncReturnNotPromiseError) Message() string {
 }
 
 func (e *CannotConstrainError) Message() string {
-	return fmt.Sprintf("cannot constrain %s <: %s", describe(e.Sub), describe(e.Super))
+	msg := fmt.Sprintf("cannot constrain %s <: %s", describe(e.Sub), describe(e.Super))
+	if e.commitUnion != nil {
+		// An earlier value committed the e.commitVar branch of e.commitUnion, pinning that
+		// var. This later use forces an incompatible bound onto the same var, so the
+		// breadcrumb names the union choice that caused the conflict.
+		msg += fmt.Sprintf("; %s was committed to a branch of %s by an earlier match, so it cannot also satisfy %s",
+			describe(e.commitVar), describe(e.commitUnion), describe(e.Super))
+	}
+	return msg
 }
 
 func (e *FuncArityMismatchError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -63,12 +63,10 @@ type CannotConstrainError struct {
 	prov       NodeResolver // M2.5: type→node index; assigned after Constrain returns (§3.5)
 	site       ast.Node     // M2.5: the constraint node n — the use, the fallback when Sub has no entry
 
-	// commitUnion and commitVar breadcrumb a failure back to a union-super exists trial that
-	// pinned an inference var. When a value flowed into `(T | number)` and committed the T
-	// branch, T is pinned. A later use of T as number reaches this error while propagating
-	// T's committed lower bound. The var arm sets these so Message names the union choice
-	// that forced the conflict rather than blaming only the later use. Both nil for a plain
-	// mismatch with no union-trial origin.
+	// commitUnion and commitVar breadcrumb a failure back to a union-super trial that pinned a
+	// var. After `"hi" <: (T | number)` commits T, a later use of T as number fails here while
+	// propagating T's lower bound. The var arm sets these so Message names the union choice,
+	// and both are nil for a plain mismatch with no union-trial origin.
 	commitUnion *soltype.UnionType
 	commitVar   *soltype.TypeVarType
 }
@@ -1264,13 +1262,10 @@ func (e *UnusedLifetimeParamError) Message() string {
 	return "lifetime parameter '" + e.Name + " is declared but never used"
 }
 
-// AmbiguousUnionCommitWarning fires when a value flowing into a union-super exists trial
-// matches more than one member. The trial commits the first match in specificity order,
-// but another member would also succeed while binding an inference variable, so which
-// member wins is not evident from the source. For `5 <: (T | number)` the number member
-// commits, yet the T member would also match by pinning T to 5, so the choice is
-// ambiguous. It is a warning rather than an error, since the program still type-checks
-// under the committed branch, and the user can annotate to fix which member wins.
+// AmbiguousUnionCommitWarning fires when a value matches more than one member of a union-super
+// trial, so the committed choice is not evident from the source. For `5 <: (T | number)` number
+// commits, yet T would also match by pinning to 5. It is a warning rather than an error, since
+// the program still type-checks under the committed branch and the user can annotate to fix it.
 type AmbiguousUnionCommitWarning struct {
 	Union     *soltype.UnionType
 	Committed soltype.Type // the member the trial committed

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -322,6 +322,8 @@ func (c *checker) blameConstraintErrors(n ast.Node, errs []SolverError) {
 		switch err := e.(type) {
 		case *CannotConstrainError:
 			err.prov, err.site = c.prov, n
+		case *AmbiguousUnionCommitWarning:
+			err.prov, err.site = c.prov, n
 		case *TupleLengthMismatchError:
 			err.prov, err.site = c.prov, n
 		case *MissingPropertyError:

--- a/internal/solver/infer_overload_test.go
+++ b/internal/solver/infer_overload_test.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -331,6 +332,35 @@ func TestResolveOverloadRollsBackLosingArm(t *testing.T) {
 	require.Equal(t, "number", soltype.Print(ret))
 	require.Len(t, argVar.UpperBounds, 1, "the losing string arm's speculative upper bound was rolled back")
 	require.Equal(t, num(), argVar.UpperBounds[0], "only the winning number arm's bound survives")
+}
+
+// TestResolveOverloadSurfacesWinningArmWarning checks that a warning the winning arm's
+// argument constraints emit reaches c.errs. The arm accepts the call, so hasHardError lets
+// it win, but the accepting constraint against a union param is ambiguous, and that warning
+// must not be swallowed by overload matching.
+func TestResolveOverloadSurfacesWinningArmWarning(t *testing.T) {
+	c := newChecker()
+
+	num := func() soltype.Type { return &soltype.PrimType{Prim: soltype.NumPrim} }
+	// The single arm takes `(T | number)`, a union with a bare type-variable member. Calling
+	// it with 5 commits the number member, but T would also match by pinning to 5, so the
+	// match is ambiguous.
+	tv := c.freshAt(0)
+	arm := &soltype.FuncType{
+		Params: []*soltype.FuncParam{{Pattern: &soltype.IdentPat{Name: "x"}, Type: newUnion(nil, []soltype.Type{tv, num()}, false)}},
+		Ret:    num(),
+	}
+	b := ValueBinding{Schemes: []TypeScheme{monoScheme(arm)}}
+
+	call := ast.NewCall(identExpr("f"), []ast.Expr{numExpr(5)}, false, testSpan())
+	ret := c.resolveOverload(0, b, []soltype.Type{numLit(5)}, call)
+
+	require.Equal(t, "number", soltype.Print(ret))
+	require.Equal(t, []string{
+		"ambiguous match against t" + strconv.Itoa(tv.ID) + " | number: committed number, but t" +
+			strconv.Itoa(tv.ID) + " would also match; annotate to disambiguate",
+	}, Messages(c.errs))
+	require.True(t, c.errs[0].(*AmbiguousUnionCommitWarning).IsWarning())
 }
 
 // An overload binding's Sources lines up one-to-one with its Schemes (each arm

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -296,7 +296,7 @@ func subsumeMembers(c *Context, parts []soltype.Type, drops func(c *Context, m, 
 // unionDrops returns true when union member m should be dropped because the
 // sibling subsumes it. The check is m <: sibling.
 func unionDrops(c *Context, m, sibling soltype.Type) bool {
-	return len(c.trialUnderProbe(m, sibling)) == 0
+	return !hasHardError(c.trialUnderProbe(m, sibling))
 }
 
 // intersectionDrops returns true when intersection member m should be
@@ -304,7 +304,7 @@ func unionDrops(c *Context, m, sibling soltype.Type) bool {
 // <: m. The sibling is narrower, so it already implies m, and m is the wider
 // one to discard.
 func intersectionDrops(c *Context, m, sibling soltype.Type) bool {
-	return len(c.trialUnderProbe(sibling, m)) == 0
+	return !hasHardError(c.trialUnderProbe(sibling, m))
 }
 
 // subsumeFinal re-mints every UnionType and IntersectionType node in a finalized

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -55,9 +55,15 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 			c.closeProbe(p, false)
 			continue
 		}
-		matched := c.tryOverloadArm(args, inst)
+		matched, diags := c.tryOverloadArm(args, inst)
 		c.closeProbe(p, matched)
 		if matched {
+			// The winning arm's argument constraints can accept while emitting a warning,
+			// such as an AmbiguousUnionCommitWarning from a union-typed param. tryOverloadArm
+			// runs the error-returning engine, so those diagnostics never reached c.errs.
+			// Blame them at the call so a losing arm's rolled-back diagnostics stay dropped
+			// while the winner's survive.
+			c.blameConstraintErrors(call, diags)
 			return inst.Ret
 		}
 	}
@@ -71,17 +77,23 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 // error-returning Context.Constrain rather than the accumulating checker.constrain, so a
 // rejected argument never reaches c.errs even before the probe's errs rollback.
 //
+// On a match it also returns the warnings the accepting constraints produced, so the
+// caller can surface them at the call. An arg that passes still counts as a match even when
+// it warns, since hasHardError draws the accept line, so the returned slice holds only
+// warnings. A non-match returns nil, keeping a rejected arm's diagnostics dropped.
+//
 // Arity follows the direct-call accept-set from #677, reusing acceptSet so the overload
 // arity gate and the FuncType<:FuncType constraint gate can never drift. A count below
 // acceptSet's lower bound is too few, and a count above its upper bound is too many.
 // Either is a non-match, unless the arm is inexact or has a rest. Extra arguments that
 // such an arm absorbs impose no per-element constraint here. That per-element check needs
 // Array types, which arrive in M4.
-func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bool {
+func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) (bool, []SolverError) {
 	n := len(args)
 	if lo, hi := acceptSet(inst); n < lo || n > hi {
-		return false
+		return false, nil
 	}
+	var diags []SolverError
 	for i, arg := range args {
 		if i >= len(inst.Params) || inst.Params[i].Rest {
 			// Past the fixed params, or AT a trailing rest param. The rest or inexact tail
@@ -90,11 +102,13 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 			// Per-element checking is M4.
 			break
 		}
-		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); hasHardError(errs) {
-			return false
+		errs := c.ctx.Constrain(arg, inst.Params[i].Type)
+		if hasHardError(errs) {
+			return false, nil
 		}
+		diags = append(diags, errs...)
 	}
-	return true
+	return true, diags
 }
 
 // overloadOrder returns the indices of schemes in the order arms should be tried. When

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -58,11 +58,8 @@ func (c *checker) resolveOverload(lvl int, b ValueBinding, args []soltype.Type, 
 		matched, diags := c.tryOverloadArm(args, inst)
 		c.closeProbe(p, matched)
 		if matched {
-			// The winning arm's argument constraints can accept while emitting a warning,
-			// such as an AmbiguousUnionCommitWarning from a union-typed param. tryOverloadArm
-			// runs the error-returning engine, so those diagnostics never reached c.errs.
-			// Blame them at the call so a losing arm's rolled-back diagnostics stay dropped
-			// while the winner's survive.
+			// tryOverloadArm runs the error-returning engine, so a warning the winning arm
+			// accepted with never reached c.errs. Blame it at the call so the winner's survive.
 			c.blameConstraintErrors(call, diags)
 			return inst.Ret
 		}

--- a/internal/solver/overload.go
+++ b/internal/solver/overload.go
@@ -90,7 +90,7 @@ func (c *checker) tryOverloadArm(args []soltype.Type, inst *soltype.FuncType) bo
 			// Per-element checking is M4.
 			break
 		}
-		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); len(errs) > 0 {
+		if errs := c.ctx.Constrain(arg, inst.Params[i].Type); hasHardError(errs) {
 			return false
 		}
 	}

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -176,11 +176,8 @@ func (p *Probe) rollback() {
 	}
 }
 
-// mutatedBounds reports whether any variable this probe journaled has grown a bound since
-// the probe first touched it. A throwaway trial consults it before discarding to tell a
-// match that binds an inference variable from one that succeeds without recording anything.
-// A first-touch snapshot equal to the current length means the trial touched the var for a
-// read but appended nothing, so it does not count as a mutation.
+// mutatedBounds reports whether any variable this probe journaled has grown a bound since first
+// touch, so a throwaway trial can tell a match that binds a var from one that records nothing.
 func (p *Probe) mutatedBounds() bool {
 	for _, e := range p.entries {
 		if len(e.v.LowerBounds) > e.prevLower || len(e.v.UpperBounds) > e.prevUpper {
@@ -305,11 +302,8 @@ func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError)
 	return false, -1, nil, trialErrs
 }
 
-// trialMutatesBounds trials sub <: super under a throwaway probe and reports both whether
-// it succeeded and whether it recorded any bound. The union-super ambiguity check uses it
-// to tell a member that would bind an inference variable from one that succeeds without
-// recording anything, so `5 <: T` reports (true, true) while `5 <: number` reports
-// (true, false). The probe is discarded either way, so the trial leaves no trace.
+// trialMutatesBounds trials sub <: super under a throwaway probe, reporting whether it succeeded
+// and whether it recorded a bound, so `5 <: T` gives (true, true) and `5 <: number` (true, false).
 func (c *Context) trialMutatesBounds(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (ok, mutated bool) {
 	p := newProbe(c.probe)
 	c.probe = p

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -176,6 +176,25 @@ func (p *Probe) rollback() {
 	}
 }
 
+// mutatedBounds reports whether any variable this probe journaled has grown a bound since
+// the probe first touched it. A throwaway trial consults it before discarding to tell a
+// match that binds an inference variable from one that succeeds without recording anything.
+// A first-touch snapshot equal to the current length means the trial touched the var for a
+// read but appended nothing, so it does not count as a mutation.
+func (p *Probe) mutatedBounds() bool {
+	for _, e := range p.entries {
+		if len(e.v.LowerBounds) > e.prevLower || len(e.v.UpperBounds) > e.prevUpper {
+			return true
+		}
+	}
+	for _, e := range p.ltEntries {
+		if len(e.v.LowerBounds) > e.prevLower || len(e.v.UpperBounds) > e.prevUpper {
+			return true
+		}
+	}
+	return false
+}
+
 // Discard rolls back every mutation journaled under this probe. Idempotent: a
 // second Discard (or a Discard after Commit) is a no-op.
 func (p *Probe) Discard() {
@@ -255,33 +274,50 @@ func (c *checker) openProbe() *Probe {
 }
 
 // trialAndCommit tries each index in order, running its trial under a fresh child probe.
-// The first trial whose body reports no errors wins. Its bound mutations commit, and the
-// method returns (true, nil). Every losing trial rolls back, so it leaves no bound behind.
+// The first trial whose body reports no fatal error wins. Its bound mutations commit, and
+// the method returns (true, winIdx, winErrs, nil), where winIdx is the winning member's
+// index and winErrs holds any warnings the winning trial produced. Every losing trial
+// rolls back, so it leaves no bound behind. A warning does not count as failure, so a
+// branch that succeeds while emitting one still wins. hasHardError draws that line.
 //
-// When no trial wins, the method returns false with each trial's errors in trial order.
-// The caller decides what to do with them. It can promote a shared failure or report the
-// last trial's diagnostics. The union-super rule, for example, promotes a uniform
-// BorrowEscapeError when every trial reports one.
+// When no trial wins, the method returns false with winIdx -1 and each trial's errors in
+// trial order. The caller decides what to do with them. It can promote a shared failure or
+// report the last trial's diagnostics. The union-super rule, for example, promotes a
+// uniform BorrowEscapeError when every trial reports one.
 //
 // This is the single path for the speculative member trials the lattice arms run. Both
 // constrain's IntersectionType-sub exists rule and its UnionType-super exists rule route
 // through it, so the probe push-and-pop discipline lives in one place. Each trial body
 // owns its own coinductive seen clone, since only the caller holds the constraint key.
-func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (bool, [][]SolverError) {
-	var trialErrs [][]SolverError
+func (c *Context) trialAndCommit(order []int, trial func(idx int) []SolverError) (committed bool, winIdx int, winErrs []SolverError, trialErrs [][]SolverError) {
 	for _, idx := range order {
 		p := newProbe(c.probe)
 		c.probe = p
 		errs := trial(idx)
 		c.probe = p.parent
-		if len(errs) == 0 {
+		if !hasHardError(errs) {
 			p.Commit()
-			return true, nil
+			return true, idx, errs, nil
 		}
 		p.Discard()
 		trialErrs = append(trialErrs, errs)
 	}
-	return false, trialErrs
+	return false, -1, nil, trialErrs
+}
+
+// trialMutatesBounds trials sub <: super under a throwaway probe and reports both whether
+// it succeeded and whether it recorded any bound. The union-super ambiguity check uses it
+// to tell a member that would bind an inference variable from one that succeeds without
+// recording anything, so `5 <: T` reports (true, true) while `5 <: number` reports
+// (true, false). The probe is discarded either way, so the trial leaves no trace.
+func (c *Context) trialMutatesBounds(sub, super soltype.Type, seen set.Set[constraintKey], mutCtx bool) (ok, mutated bool) {
+	p := newProbe(c.probe)
+	c.probe = p
+	errs := c.constrain(sub, super, seen.Clone(), mutCtx)
+	mutated = p.mutatedBounds()
+	c.probe = p.parent
+	p.Discard()
+	return !hasHardError(errs), mutated
 }
 
 // trialUnderProbe trials `sub <: super` under a discard-only probe and returns


### PR DESCRIPTION
Enhance union-super type constraint diagnostics to surface ambiguity when a value matches multiple union members and to trace var conflicts back to the union choice that pinned them.

When a value flows into a union super like `(T | number)`, the trial-and-commit logic picks the first matching member in specificity order. This change detects when another member would also match while binding an inference variable, making the choice ambiguous. For example, `5 <: (T | number)` commits the `number` member, but `T` would also match by pinning `T` to `5`. An `AmbiguousUnionCommitWarning` now surfaces in such cases, allowing users to annotate and disambiguate rather than relying on specificity order.

Additionally, when a bare type-variable member commits (like `"hi" <: T` in `"hi" <: (T | number)`), the var is pinned. A later constraint that forces an incompatible bound onto that var now breadcrumbs the failure back to the union choice that pinned it, so the error message names the union rather than blaming only the later use.

Key changes:
- Add `AmbiguousUnionCommitWarning` error type that reports when multiple union members would match
- Introduce `ambiguousAlternate` to detect viable alternative members that would bind a variable
- Add `tagUnionCommit` to record which union pinned each inference var, journaled under the active probe so discarded trials drop the tag
- Add `breadcrumbUnionCommit` to stamp `CannotConstrainError` with the union origin when a var conflict traces back to a committed choice
- Extend `trialAndCommit` to return the winning index and any warnings the winning trial produced
- Add `trialMutatesBounds` to distinguish matches that bind variables from those that succeed without recording bounds
- Add `mutatedBounds` to probe to detect whether a trial recorded any bounds
- Update `hasHardError` helper to treat warnings as non-fatal, so a branch succeeding with a warning still counts as a win
- Update union-super and intersection-sub rules to propagate warnings from winning trials

https://claude.ai/code/session_01FNvrsk6fxidYtsMqJXcMaN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference when multiple union members could match.
  * Warning-only matches no longer incorrectly fail overload resolution or type checks.
  * Corrected handling of union and intersection constraints during type analysis.
* **Diagnostics**
  * Added warnings for ambiguous union matches, with guidance to disambiguate.
  * Improved error messages by identifying conflicts caused by an earlier union choice.
  * Preserved relevant diagnostic details from successful constraint trials.
* **Tests**
  * Added coverage for ambiguous matches, diagnostic breadcrumbs, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->