### PR TITLE
Bind enum names to transparent type aliases

### DIFF
--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -8,29 +8,26 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Enum inference (M5 D-Enum) ports the old checker's enum model to soltype. The old
-// checker binds the enum name to BOTH a namespace and a type alias whose body is a union
-// of the variant types. soltype has no type aliases yet (M7), so the enum name binds as a
-// namespace and its type binds directly to that union: `Color` resolves to
-// `Color.RGB | Color.Hex`.
-//
-// TODO(M7): once type aliases land, bind the enum name to a proper alias whose body is
-// this union, so a reference to the enum renders under its own name — `Color` rather than
-// the expanded `Color.RGB | Color.Hex` — the way the old checker's TypeRefType does. The
-// union built here becomes that alias's body.
+// Enum inference (M5 D-Enum) ports the old checker's enum model to soltype. The enum name
+// binds to BOTH a namespace and a transparent type alias whose body is the union of the
+// variant types. A reference to the enum renders under its own name, `Color` rather than
+// the expanded `Color.RGB | Color.Hex`, the way the old checker's TypeRefType does. A
+// consumer that reads the variant members, such as match exhaustiveness, first expands the
+// alias to its union body through the shared expandAlias helper, the same unfold constrain
+// performs on an alias sub or super.
 //
 // Each variant is a `final` ClassType named `Color.RGB` — a nominal handle qualified by
 // its enum, so two enums that share a variant name stay distinct. Each variant's
-// constructor binds as a value under the enum namespace and returns the enum type, so
-// `Color.Hex("#fff")` infers `Color.RGB | Color.Hex`, the union the enum names.
+// constructor binds as a value under the enum namespace and returns the enum's alias type,
+// so `Color.Hex("#fff")` infers `Color`, the enum the alias names.
 //
 // Inference is two-phase, so a group of mutually-recursive enums resolves each other:
 //
-//   - preBindEnum mints every variant handle and binds the enum's union TYPE, but does
+//   - preBindEnum mints every variant handle and binds the enum's alias TYPE, but does
 //     NOT resolve variant parameters. Running it over every enum in a dep_graph type-key
 //     component before any body means `enum A { X(b: B) }` / `enum B { Y(a: A) }` each
-//     find the sibling's union already bound. A self-recursive enum resolves through its
-//     own union the same way.
+//     find the sibling's alias already bound. A self-recursive enum resolves through its
+//     own alias the same way.
 //   - inferEnumBody then resolves each variant's parameters, builds its constructor, and
 //     binds the constructor namespace.
 //
@@ -63,10 +60,10 @@ type enumShell struct {
 }
 
 // preBindEnum mints an enum's variant handles, registers their ClassDefs, and binds the
-// enum name's TYPE to the union of those handles — without resolving any variant
-// parameter. It returns the shell inferEnumBody completes. Binding the union up front is
-// what lets a sibling enum, or the enum itself, resolve this name while its own body is
-// still being walked.
+// enum name's TYPE to an alias whose body is the union of those handles — without resolving
+// any variant parameter. It returns the shell inferEnumBody completes. Binding the alias up
+// front is what lets a sibling enum, or the enum itself, resolve this name while its own
+// body is still being walked.
 func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns string) *enumShell {
 	// An enum-body type reference resolves against the enum's own namespace first, the
 	// same qualified-first resolution a class body uses. Save and restore around the walk.
@@ -119,7 +116,17 @@ func (c *checker) preBindEnum(scope *Scope, lvl int, decl *ast.EnumDecl, ns stri
 		variantTypes = append(variantTypes, vt)
 	}
 
-	enumType := soltype.Type(&soltype.UnionType{Types: variantTypes})
+	// Register the enum as a transparent alias whose body is the variant union, then bind
+	// the enum name to an AliasType handle carrying the enum's own type-parameter vars. A
+	// reference renders under the enum name, and a consumer reading the variants expands the
+	// alias to this union body through expandAlias. The variant constructor returns the same
+	// handle, so `Color.Hex("#fff")` infers `Color`.
+	c.ctx.registerAlias(qname, &AliasDef{
+		TypeParams: typeParams,
+		Body:       &soltype.UnionType{Types: variantTypes},
+		Level:      lvl - 1,
+	})
+	enumType := soltype.Type(&soltype.AliasType{Name: qname, TypeArgs: typeArgs})
 	scope.defineType(qname, TypeBinding{
 		Type:    enumType,
 		Sources: []provenance.Provenance{&ast.NodeProvenance{Node: decl}},

--- a/internal/solver/infer_enum.go
+++ b/internal/solver/infer_enum.go
@@ -8,13 +8,12 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
-// Enum inference (M5 D-Enum) ports the old checker's enum model to soltype. The enum name
-// binds to BOTH a namespace and a transparent type alias whose body is the union of the
-// variant types. A reference to the enum renders under its own name, `Color` rather than
-// the expanded `Color.RGB | Color.Hex`, the way the old checker's TypeRefType does. A
-// consumer that reads the variant members, such as match exhaustiveness, first expands the
-// alias to its union body through the shared expandAlias helper, the same unfold constrain
-// performs on an alias sub or super.
+// An enum's name binds to BOTH a namespace and a transparent type alias whose body is the
+// union of the variant types. A reference to the enum renders under its own name, `Color`
+// rather than the expanded `Color.RGB | Color.Hex`. A consumer that reads the variant
+// members, such as match exhaustiveness, first expands the alias to its union body through
+// the shared expandAlias helper, the same unfold constrain performs on an alias sub or
+// super.
 //
 // Each variant is a `final` ClassType named `Color.RGB` — a nominal handle qualified by
 // its enum, so two enums that share a variant name stay distinct. Each variant's

--- a/internal/solver/infer_enum_test.go
+++ b/internal/solver/infer_enum_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 // TestInferEnumBasic covers a non-generic enum end to end (M5 D-Enum): the enum name
-// binds as a namespace and its type binds to the union of its variants, each variant
-// constructor resolves under the namespace, and a constructor call yields the enum
-// union — `Color.Hex(...)` is `Color.RGB | Color.Hex`.
+// binds as a namespace and its type binds to an alias whose body is the union of its
+// variants, each variant constructor resolves under the namespace, and a constructor call
+// yields the enum's alias type — `Color.Hex(...)` is `Color`.
 func TestInferEnumBasic(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -30,10 +30,12 @@ func TestInferEnumBasic(t *testing.T) {
 				val blue = Color.Hex("#0000FF")
 			`,
 			wantValues: map[string]string{
-				"rgb":  "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex",
-				"red":  "Color.RGB | Color.Hex",
-				"blue": "Color.RGB | Color.Hex",
+				"rgb":  "fn (r: number, g: number, b: number) -> Color",
+				"red":  "Color",
+				"blue": "Color",
 			},
+			// The test harness renders a type-alias binding as its body, so the enum's alias
+			// shows the variant union it stands for. A value of the enum renders as `Color`.
 			wantTypes: map[string]string{"Color": "Color.RGB | Color.Hex"},
 		},
 		{
@@ -47,8 +49,8 @@ func TestInferEnumBasic(t *testing.T) {
 				val s: Signal = Signal.Go()
 			`,
 			wantValues: map[string]string{
-				"stop": "Signal.Stop | Signal.Go",
-				"s":    "Signal.Stop | Signal.Go",
+				"stop": "Signal",
+				"s":    "Signal",
 			},
 			wantTypes: map[string]string{"Signal": "Signal.Stop | Signal.Go"},
 		},
@@ -61,7 +63,7 @@ func TestInferEnumBasic(t *testing.T) {
 					Hex(code: string),
 				}
 			`,
-			wantValues: map[string]string{"red": "Color.RGB | Color.Hex"},
+			wantValues: map[string]string{"red": "Color"},
 			wantTypes:  map[string]string{"Color": "Color.RGB | Color.Hex"},
 		},
 		{
@@ -75,8 +77,8 @@ func TestInferEnumBasic(t *testing.T) {
 				val node = Tree.Node(Tree.Leaf(), Tree.Leaf())
 			`,
 			wantValues: map[string]string{
-				"leaf": "Tree.Leaf | Tree.Node",
-				"node": "Tree.Leaf | Tree.Node",
+				"leaf": "Tree",
+				"node": "Tree",
 			},
 			wantTypes: map[string]string{"Tree": "Tree.Leaf | Tree.Node"},
 		},
@@ -107,9 +109,9 @@ func TestInferEnumMutuallyRecursive(t *testing.T) {
 		val b = B.BNode(A.AEnd())
 		val ctorA = A.ANode
 	`, map[string]string{
-		"a":     "A.AEnd | A.ANode",
-		"b":     "B.BEnd | B.BNode",
-		"ctorA": "fn (next: B.BEnd | B.BNode) -> A.AEnd | A.ANode",
+		"a":     "A",
+		"b":     "B",
+		"ctorA": "fn (next: B) -> A",
 	}, map[string]string{
 		"A": "A.AEnd | A.ANode",
 		"B": "B.BEnd | B.BNode",
@@ -136,11 +138,11 @@ func TestInferEnumClassMutuallyRecursive(t *testing.T) {
 		val treeCtor = Tree.Branch
 		val kids = node.left
 	`, map[string]string{
-		"Node":     "fn (left: Tree.Leaf | Tree.Branch, right: Tree.Leaf | Tree.Branch) -> Node",
+		"Node":     "fn (left: Tree, right: Tree) -> Node",
 		"node":     "Node",
-		"branch":   "Tree.Leaf | Tree.Branch",
-		"treeCtor": "fn (node: Node) -> Tree.Leaf | Tree.Branch",
-		"kids":     "Tree.Leaf | Tree.Branch",
+		"branch":   "Tree",
+		"treeCtor": "fn (node: Node) -> Tree",
+		"kids":     "Tree",
 	}, map[string]string{
 		"Tree": "Tree.Leaf | Tree.Branch",
 		"Node": "Node",
@@ -166,10 +168,10 @@ func TestInferEnumSharedVariantName(t *testing.T) {
 		val c = Color.RGB(1, 2, 3)
 		val p = Pixel.RGB(4, 5)
 	`, map[string]string{
-		"colorRGB": "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex",
-		"pixelRGB": "fn (x: number, y: number) -> Pixel.RGB | Pixel.Empty",
-		"c":        "Color.RGB | Color.Hex",
-		"p":        "Pixel.RGB | Pixel.Empty",
+		"colorRGB": "fn (r: number, g: number, b: number) -> Color",
+		"pixelRGB": "fn (x: number, y: number) -> Pixel",
+		"c":        "Color",
+		"p":        "Pixel",
 	}, map[string]string{
 		"Color": "Color.RGB | Color.Hex",
 		"Pixel": "Pixel.RGB | Pixel.Empty",
@@ -200,7 +202,7 @@ func TestInferEnumUnnamedParams(t *testing.T) {
 		}
 		val ctor = E.Pair
 	`, map[string]string{
-		"ctor": "fn (arg0: number, arg1: string) -> E.Pair",
+		"ctor": "fn (arg0: number, arg1: string) -> E",
 	}, nil)
 }
 
@@ -232,9 +234,10 @@ func TestEnumVariantDisplay(t *testing.T) {
 
 // TestInferEnumGeneric checks that a generic enum's constructor is generalized like a
 // plain generic value, so each construction freshens the enum's type parameter and the
-// argument's type flows into the enum union. Without type aliases the enum name expands
-// to its union at each use, so the parameter also reaches the sibling variant — `None`
-// prints parameterized here; naming the union to hide that waits on M7's aliases.
+// argument's type flows into the enum's alias instance. The enum name binds to an alias
+// carrying the enum's type-parameter var, so a construction renders under the enum name
+// with the argument's type — `MyOption.Some(5)` is `MyOption<5>`, the union hidden behind
+// the alias.
 func TestInferEnumGeneric(t *testing.T) {
 	classValues(t, `
 		enum MyOption<T> {
@@ -244,7 +247,7 @@ func TestInferEnumGeneric(t *testing.T) {
 		val some = MyOption.Some(5)
 		val str = MyOption.Some("hi")
 	`, map[string]string{
-		"some": "MyOption.Some<5> | MyOption.None<5>",
-		"str":  `MyOption.Some<"hi"> | MyOption.None<"hi">`,
+		"some": "MyOption<5>",
+		"str":  `MyOption<"hi">`,
 	}, nil)
 }

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -8,6 +8,7 @@ import (
 	"github.com/escalier-lang/escalier/internal/ast"
 	"github.com/escalier-lang/escalier/internal/liveness"
 	"github.com/escalier-lang/escalier/internal/provenance"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -2547,6 +2548,21 @@ func (c *checker) inferMatch(scope *Scope, lvl int, e *ast.MatchExpr) soltype.Ty
 // value the coalesced scrutinee can take, dispatching on its union or object/tuple shape.
 func (c *checker) checkMatchExhaustive(scope *Scope, e *ast.MatchExpr, scrutinee soltype.Type) {
 	carrier := soltype.CarrierOf(scrutinee)
+	// A transparent alias scrutinee, an enum handle or a user `type` reference, carries the
+	// alias rather than the type it stands for. Expand it to that type before dispatching, the
+	// same unfold constrain performs, so `match c { Color.RGB(..) => .., Color.Hex(..) => .. }`
+	// over `val c: Color` covers the variant union without a default arm. The loop follows a
+	// chain of aliases to the underlying union or shape, and a seen-set of names breaks a
+	// degenerate alias cycle.
+	seenAliases := set.NewSet[string]()
+	for {
+		at, ok := carrier.(*soltype.AliasType)
+		if !ok || seenAliases.Contains(at.Name) {
+			break
+		}
+		seenAliases.Add(at.Name)
+		carrier = c.ctx.expandAlias(at)
+	}
 	if u, ok := carrier.(*soltype.UnionType); ok {
 		if !c.unionMatchExhaustive(scope, e, u) {
 			c.report(&NonExhaustiveMatchError{Match: e})

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -325,38 +325,46 @@ func TestInferMatchGenericEnumExhaustiveness(t *testing.T) {
 }
 
 // TestInferMatchUnionAliasExhaustiveness checks that exhaustiveness looks through a
-// transparent user alias, the same expansion the enum path relies on. A scrutinee typed by
-// `type Pet = Dog | Cat` expands to its class union, so an arm per class is exhaustive
-// without a catch-all, and dropping one leaves the match non-exhaustive.
+// transparent user alias, the same expansion the enum path relies on. Each row shares the
+// same `type Pet = Dog | Cat` alias and varies only the arms. The alias expands to its class
+// union, so an arm per class is exhaustive without a catch-all, and dropping one row's arm
+// leaves the match non-exhaustive with a diagnostic spanning the match expression.
 func TestInferMatchUnionAliasExhaustiveness(t *testing.T) {
-	t.Run("ArmPerMemberIsExhaustive", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			class Dog { name: string }
-			class Cat { name: string }
-			type Pet = Dog | Cat
-			fn f(p: Pet) {
-				return match p {
-					Dog(name) => name,
-					Cat(name) => name,
-				}
+	tests := []struct {
+		name    string
+		arms    string
+		wantErr string // full diagnostic with span; empty when the match is exhaustive
+	}{
+		{
+			name: "ArmPerMemberIsExhaustive",
+			arms: "Dog(name) => name,\n\t\t\t\tCat(name) => name",
+		},
+		{
+			name:    "MissingMemberIsNonExhaustive",
+			arms:    "Dog(name) => name",
+			wantErr: "6:11-8:5: match is not exhaustive; add a catch-all branch",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, `
+		class Dog { name: string }
+		class Cat { name: string }
+		type Pet = Dog | Cat
+		fn f(p: Pet) {
+			return match p {
+				`+tt.arms+`
 			}
-		`)
-		require.Empty(t, errs)
-	})
-	t.Run("MissingMemberIsNonExhaustive", func(t *testing.T) {
-		_, _, errs := inferSource(t, `
-			class Dog { name: string }
-			class Cat { name: string }
-			type Pet = Dog | Cat
-			fn f(p: Pet) {
-				return match p {
-					Dog(name) => name,
-				}
+		}
+	`)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+			} else {
+				require.Len(t, errs, 1)
+				require.Equal(t, tt.wantErr, msgWithSpan(errs[0]))
 			}
-		`)
-		require.Len(t, errs, 1)
-		require.Equal(t, "match is not exhaustive; add a catch-all branch", errs[0].Message())
-	})
+		})
+	}
 }
 
 // A union member the coverage rules cannot evaluate — an object member here — is

--- a/internal/solver/infer_pattern_nominal_test.go
+++ b/internal/solver/infer_pattern_nominal_test.go
@@ -260,7 +260,7 @@ func TestInferMatchEnumExhaustiveness(t *testing.T) {
 		{
 			name:    "ArmPerVariantNeedsNoCatchAll",
 			arms:    "Color.RGB(r, g, b) => r,\n\t\t\t\tColor.Hex(code) => 0",
-			wantVal: "fn (c: Color.RGB | Color.Hex) -> number",
+			wantVal: "fn (c: Color) -> number",
 		},
 		{
 			name:    "MissingVariant",
@@ -270,7 +270,7 @@ func TestInferMatchEnumExhaustiveness(t *testing.T) {
 		{
 			name:    "CatchAllCoversRemainingVariants",
 			arms:    "Color.RGB(r, g, b) => r,\n\t\t\t\t_ => 0",
-			wantVal: "fn (c: Color.RGB | Color.Hex) -> number",
+			wantVal: "fn (c: Color) -> number",
 		},
 		{
 			name:    "RefutableArgDoesNotCover",
@@ -300,6 +300,63 @@ func TestInferMatchEnumExhaustiveness(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInferMatchGenericEnumExhaustiveness checks that a match over a generic enum value is
+// exhaustive through the alias. The scrutinee `o: MyOption<number>` carries the enum's alias
+// handle with a `number` argument, and checkMatchExhaustive expands it to the substituted
+// variant union `MyOption.Some<number> | MyOption.None<number>`. An arm per variant covers
+// that union without a catch-all.
+func TestInferMatchGenericEnumExhaustiveness(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		enum MyOption<T> {
+			Some(value: T),
+			None,
+		}
+		fn f(o: MyOption<number>) {
+			return match o {
+				MyOption.Some(value) => value,
+				MyOption.None() => 0,
+			}
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (o: MyOption<number>) -> number", values["f"])
+}
+
+// TestInferMatchUnionAliasExhaustiveness checks that exhaustiveness looks through a
+// transparent user alias, the same expansion the enum path relies on. A scrutinee typed by
+// `type Pet = Dog | Cat` expands to its class union, so an arm per class is exhaustive
+// without a catch-all, and dropping one leaves the match non-exhaustive.
+func TestInferMatchUnionAliasExhaustiveness(t *testing.T) {
+	t.Run("ArmPerMemberIsExhaustive", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Dog { name: string }
+			class Cat { name: string }
+			type Pet = Dog | Cat
+			fn f(p: Pet) {
+				return match p {
+					Dog(name) => name,
+					Cat(name) => name,
+				}
+			}
+		`)
+		require.Empty(t, errs)
+	})
+	t.Run("MissingMemberIsNonExhaustive", func(t *testing.T) {
+		_, _, errs := inferSource(t, `
+			class Dog { name: string }
+			class Cat { name: string }
+			type Pet = Dog | Cat
+			fn f(p: Pet) {
+				return match p {
+					Dog(name) => name,
+				}
+			}
+		`)
+		require.Len(t, errs, 1)
+		require.Equal(t, "match is not exhaustive; add a catch-all branch", errs[0].Message())
+	})
 }
 
 // A union member the coverage rules cannot evaluate — an object member here — is

--- a/internal/solver/script_test.go
+++ b/internal/solver/script_test.go
@@ -57,7 +57,7 @@ func TestInferScriptSourceOrder(t *testing.T) {
 // TestInferScriptEnum checks that an enum can be declared and used in a script (bin/).
 // A script's top-level statements run in source order, so an enum declared before its
 // use binds its type and variant constructors just as in a module: a constructor call
-// yields the enum union.
+// yields the enum's alias type, rendered under its own name.
 func TestInferScriptEnum(t *testing.T) {
 	values, types, errs := inferScriptSource(t, `
 		enum Color {
@@ -68,9 +68,9 @@ func TestInferScriptEnum(t *testing.T) {
 		val mk = Color.RGB
 	`)
 	require.Empty(t, errs)
-	require.Equal(t, "Color.RGB | Color.Hex", types["Color"])
-	require.Equal(t, "Color.RGB | Color.Hex", values["c"])
-	require.Equal(t, "fn (r: number, g: number, b: number) -> Color.RGB | Color.Hex", values["mk"])
+	require.Equal(t, "Color", types["Color"])
+	require.Equal(t, "Color", values["c"])
+	require.Equal(t, "fn (r: number, g: number, b: number) -> Color", values["mk"])
 }
 
 // TestInferScriptEnumOutOfOrder checks that a script does NOT resolve an enum used before


### PR DESCRIPTION
Enums now bind their names to transparent type aliases whose bodies are the variant unions, rather than directly to the unions themselves. This allows enum values and constructor returns to render under the enum name (e.g., `Color` instead of `Color.RGB | Color.Hex`) while still supporting exhaustiveness checking through alias expansion.

**Key changes:**

- `preBindEnum` now registers each enum as a transparent `AliasDef` and binds the enum name to an `AliasType` handle carrying the enum's type-parameter vars, instead of binding directly to the union type.
- `checkMatchExhaustive` expands alias scrutinees to their union bodies before dispatching exhaustiveness checks, using the same `expandAlias` helper that constraint unfold uses. This allows match expressions over enum values to check exhaustiveness against the variant union without requiring a catch-all arm.
- Updated test expectations across `infer_enum_test.go`, `infer_pattern_nominal_test.go`, and `script_test.go` to reflect enum values and constructor returns now rendering as the enum name rather than the expanded union.
- Added `TestInferMatchGenericEnumExhaustiveness` to verify exhaustiveness checking works correctly for generic enums with substituted type arguments.
- Added `TestInferMatchUnionAliasExhaustiveness` to verify exhaustiveness checking expands user-defined union type aliases the same way.

The change aligns enum handling with the old checker's `TypeRefType` model, where the enum name is both a namespace and a type alias, improving readability while maintaining the same exhaustiveness semantics.

https://claude.ai/code/session_01SR974PGcK3U7XcgtLw2rCR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enum types now display using their declared names, including generic enums, instead of expanded variant unions.
  * Pattern matching continues to correctly verify exhaustive coverage through enum and transparent union aliases.
  * Updated inferred types and constructor signatures provide clearer, more concise output across recursive and mutually recursive enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->