### PR TITLE
Support lifetime arguments in alias type references

### DIFF
--- a/internal/ast/decl.go
+++ b/internal/ast/decl.go
@@ -192,14 +192,15 @@ func (d *FuncDecl) SetProvenance(p provenance.Provenance) {
 }
 
 type TypeDecl struct {
-	Name       *Ident
-	TypeParams []*TypeParam
-	TypeAnn    TypeAnn
-	export     bool
-	declare    bool
-	override   bool
-	span       Span
-	provenance provenance.Provenance
+	Name           *Ident
+	LifetimeParams []*LifetimeParam
+	TypeParams     []*TypeParam
+	TypeAnn        TypeAnn
+	export         bool
+	declare        bool
+	override       bool
+	span           Span
+	provenance     provenance.Provenance
 }
 
 func NewTypeDecl(name *Ident, typeParams []*TypeParam, typeAnn TypeAnn, export, declare bool, span Span) *TypeDecl {

--- a/internal/parser/__snapshots__/lifetime_test.snap
+++ b/internal/parser/__snapshots__/lifetime_test.snap
@@ -1587,3 +1587,108 @@
     span: 1:1-1:24,
 }
 ---
+
+[TestParseLifetimeAnnotations/TypeAliasWithLifetimeParamBound - 1]
+&ast.DeclStmt{
+    Decl: &ast.TypeDecl{
+        Name: &ast.Ident{
+            Name: "Pair",
+            span: 1:6-1:10,
+        },
+        LifetimeParams: []*ast.LifetimeParam{
+            &ast.LifetimeParam{
+                Name: "a",
+                span: 1:11-1:13,
+            },
+            &ast.LifetimeParam{
+                Name: "b",
+                Bounds: []*ast.LifetimeAnn{
+                    &ast.LifetimeAnn{
+                        Name: "a",
+                        span: 1:19-1:21,
+                    },
+                },
+                span: 1:15-1:21,
+            },
+        },
+        TypeParams: []*ast.TypeParam{
+            &ast.TypeParam{
+                Name: "T",
+            },
+        },
+        TypeAnn: &ast.TupleTypeAnn{
+            Elems: []ast.TypeAnn{
+                &ast.RefTypeAnn{
+                    Lifetime: &ast.LifetimeAnn{
+                        Name: "a",
+                        span: 1:30-1:32,
+                    },
+                    Inner: &ast.TypeRefTypeAnn{
+                        Name: &ast.Ident{
+                            Name: "T",
+                            span: 1:33-1:34,
+                        },
+                        span: 1:33-1:34,
+                    },
+                    span: 1:29-1:34,
+                },
+                &ast.RefTypeAnn{
+                    Lifetime: &ast.LifetimeAnn{
+                        Name: "b",
+                        span: 1:37-1:39,
+                    },
+                    Inner: &ast.TypeRefTypeAnn{
+                        Name: &ast.Ident{
+                            Name: "T",
+                            span: 1:40-1:41,
+                        },
+                        span: 1:40-1:41,
+                    },
+                    span: 1:36-1:41,
+                },
+            },
+            span: 1:28-1:42,
+        },
+        span: 1:1-1:42,
+    },
+    span: 1:1-1:42,
+}
+---
+
+[TestParseLifetimeAnnotations/TypeAliasWithLifetimeAndTypeParams - 1]
+&ast.DeclStmt{
+    Decl: &ast.TypeDecl{
+        Name: &ast.Ident{
+            Name: "Ref",
+            span: 1:6-1:9,
+        },
+        LifetimeParams: []*ast.LifetimeParam{
+            &ast.LifetimeParam{
+                Name: "a",
+                span: 1:10-1:12,
+            },
+        },
+        TypeParams: []*ast.TypeParam{
+            &ast.TypeParam{
+                Name: "T",
+            },
+        },
+        TypeAnn: &ast.RefTypeAnn{
+            Lifetime: &ast.LifetimeAnn{
+                Name: "a",
+                span: 1:20-1:22,
+            },
+            Inner: &ast.TypeRefTypeAnn{
+                Name: &ast.Ident{
+                    Name: "T",
+                    span: 1:23-1:24,
+                },
+                span: 1:23-1:24,
+            },
+            span: 1:19-1:24,
+        },
+        span: 1:1-1:24,
+    },
+    span: 1:1-1:24,
+}
+---

--- a/internal/parser/decl.go
+++ b/internal/parser/decl.go
@@ -1219,8 +1219,9 @@ func (p *Parser) typeDecl(start ast.Location, export bool, declare bool) ast.Dec
 		ident = ast.NewIdentifier(token.Value, token.Span)
 	}
 
-	// Parse optional type parameters
-	typeParams := p.maybeTypeParams()
+	// Parse optional lifetime and type parameters, so `type Ref<'a, T> = &'a T` binds both
+	// the lifetime parameter 'a and the type parameter T.
+	lifetimeParams, typeParams := p.maybeLifetimeAndTypeParams(false)
 
 	p.expect(Equal, AlwaysConsume)
 
@@ -1229,7 +1230,9 @@ func (p *Parser) typeDecl(start ast.Location, export bool, declare bool) ast.Dec
 	if typeAnn == nil {
 		end := p.lexer.currentLocation
 		span := ast.NewSpan(start, end, p.lexer.source.ID)
-		return ast.NewTypeDecl(ident, typeParams, nil, export, declare, span)
+		decl := ast.NewTypeDecl(ident, typeParams, nil, export, declare, span)
+		decl.LifetimeParams = lifetimeParams
+		return decl
 	}
 
 	// End position is the end of the type annotation
@@ -1237,6 +1240,7 @@ func (p *Parser) typeDecl(start ast.Location, export bool, declare bool) ast.Dec
 
 	span := ast.NewSpan(start, end, p.lexer.source.ID)
 	decl := ast.NewTypeDecl(ident, typeParams, typeAnn, export, declare, span)
+	decl.LifetimeParams = lifetimeParams
 	return decl
 }
 

--- a/internal/parser/lifetime_test.go
+++ b/internal/parser/lifetime_test.go
@@ -93,6 +93,12 @@ func TestParseLifetimeAnnotations(t *testing.T) {
 		"InterfaceWithLifetimeParam": {
 			input: `interface Holder<'a> { p: 'a Point }`,
 		},
+		"TypeAliasWithLifetimeAndTypeParams": {
+			input: `type Ref<'a, T> = &'a T`,
+		},
+		"TypeAliasWithLifetimeParamBound": {
+			input: `type Pair<'a, 'b: 'a, T> = [&'a T, &'b T]`,
+		},
 		"TypeRefBareLifetimeArg": {
 			input: `val v: View<'a> = ref`,
 		},
@@ -139,17 +145,16 @@ func TestParseLifetimeAnnotations(t *testing.T) {
 
 // TestParseLifetimeInUnsupportedContextErrors verifies that lifetime
 // parameters on declaration kinds that still don't support them
-// (type aliases, enums, object/class-field method shorthands) produce
-// a parse-time diagnostic rather than being silently dropped.
-// Functions, `fn`-type annotations, classes, and interfaces all
-// support `<'a, ...>` clauses — see TestParseLifetimeAnnotations.
+// (enums, object/class-field method shorthands) produce a parse-time
+// diagnostic rather than being silently dropped. Functions, `fn`-type
+// annotations, classes, interfaces, and type aliases all support
+// `<'a, ...>` clauses — see TestParseLifetimeAnnotations.
 func TestParseLifetimeInUnsupportedContextErrors(t *testing.T) {
 	const expected = "lifetime parameters are not supported in this context"
 
 	tests := map[string]struct {
 		input string
 	}{
-		"TypeAliasWithLifetimeParam":  {input: `type Box<'a> = 'a Point`},
 		"EnumWithLifetimeParam":       {input: `enum Maybe<'a> { Some, None }`},
 		"ClassFieldWithLifetimeParam":   {input: `class Box { p<'a>: Point }`},
 		"ObjectPropertyWithLifetimeParam": {input: `val x: { p<'a>: Point } = ref`},

--- a/internal/soltype/alias_test.go
+++ b/internal/soltype/alias_test.go
@@ -101,3 +101,66 @@ func TestAliasTypeInterfaces(t *testing.T) {
 	a.isType()
 	a.isRefInner()
 }
+
+// TestPrintAliasLifetimeArgs renders a lifetime-generic alias reference: the lifetime
+// argument 'a renders before any type argument, so `Foo<'a>` and `Foo<'a, number>` show
+// their lifetime first. PrintAsScheme names the free lifetime argument 'a.
+func TestPrintAliasLifetimeArgs(t *testing.T) {
+	lx := &LifetimeVar{ID: 0, Level: 1}
+	require.Equal(t, "Foo<'a>", PrintAsScheme(&AliasType{Name: "Foo", LifetimeArgs: []Lifetime{lx}}))
+	require.Equal(t, "Foo<'a, number>", PrintAsScheme(&AliasType{
+		Name:         "Foo",
+		LifetimeArgs: []Lifetime{lx},
+		TypeArgs:     []Type{numP()},
+	}))
+}
+
+// TestPrintQualifiedAliasLifetimeArgsDistinct is the distinctness property the LifetimeArgs
+// field exists for: two references to one alias at different lifetimes serialize to different
+// identity keys, so `Foo<'a>` and `Foo<'b>` never collide on the intern-cache key the
+// recursion guard uses. Keying without the lifetime arguments would let two borrows of one
+// alias at different lifetimes share a cache entry.
+func TestPrintQualifiedAliasLifetimeArgsDistinct(t *testing.T) {
+	la := &LifetimeVar{ID: 0, Level: 1}
+	lb := &LifetimeVar{ID: 1, Level: 1}
+	require.NotEqual(t,
+		PrintQualified(&AliasType{Name: "Foo", LifetimeArgs: []Lifetime{la}}),
+		PrintQualified(&AliasType{Name: "Foo", LifetimeArgs: []Lifetime{lb}}),
+		"two lifetimes render to distinct identity keys",
+	)
+}
+
+// TestLevelOfAliasLifetimeArgs folds an alias reference's lifetime argument into its level,
+// so a free lifetime argument lifts the level the same way a type argument does.
+func TestLevelOfAliasLifetimeArgs(t *testing.T) {
+	alias := &AliasType{
+		Name:         "Foo",
+		LifetimeArgs: []Lifetime{&LifetimeVar{ID: 0, Level: 7}},
+		TypeArgs:     []Type{&TypeVarType{ID: 1, Level: 3}},
+	}
+	require.Equal(t, 7, LevelOf(alias), "the level is the max over the lifetime and type arguments")
+}
+
+// TestAcceptAliasLifetimeArgsCopyOnWrite rewrites a type argument inside an alias reference,
+// rebuilds the AliasType, carries the lifetime argument through unchanged, and replaces the
+// type argument. Lifetimes are not Types, so Accept never walks the lifetime argument.
+func TestAcceptAliasLifetimeArgsCopyOnWrite(t *testing.T) {
+	str := &PrimType{Prim: StrPrim}
+	a := &TypeVarType{ID: 1}
+	lx := &LifetimeVar{ID: 0, Level: 1}
+	alias := &AliasType{Name: "Foo", LifetimeArgs: []Lifetime{lx}, TypeArgs: []Type{a}}
+
+	got := alias.Accept(&replaceVar{target: a, repl: str}, Positive).(*AliasType)
+
+	require.NotSame(t, alias, got, "a changed type argument forces a new AliasType")
+	require.Same(t, lx, got.LifetimeArgs[0], "the lifetime argument carries through unchanged")
+	require.Same(t, str, got.TypeArgs[0], "the type argument took the replacement")
+}
+
+// TestFreeLifetimeVarsAliasLifetimeArg collects a lifetime-generic alias reference's lifetime
+// argument, so `Foo<'a>` surfaces 'a as a free lifetime the scheme quantifies.
+func TestFreeLifetimeVarsAliasLifetimeArg(t *testing.T) {
+	lx := &LifetimeVar{ID: 0, Level: 1}
+	alias := &AliasType{Name: "Foo", LifetimeArgs: []Lifetime{lx}, TypeArgs: []Type{numP()}}
+	require.Equal(t, []*LifetimeVar{lx}, freeLifetimeVars(alias))
+}

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -157,12 +157,13 @@ func PrintAsSchemeWith(t Type, isParam func(*TypeVarType) bool, ltBounds map[*Li
 		return Print(t)
 	}
 	p := &namedPrinter{names: names, ltNames: ltNames}
-	if _, ok := t.(*ClassType); ok {
-		// A class instance already displays its type parameters inline in its `<...>`
-		// argument list, so it needs no separate quantifier prefix. A generalized
-		// Map<K, V> renders as Map<T0, T1>, not <T0, T1> Map<T0, T1>. A ClassType's only
-		// free-variable children are its arguments, so every quantified variable is
-		// shown inline and none is lost by dropping the prefix.
+	switch t.(type) {
+	case *ClassType, *AliasType:
+		// A class instance or alias reference already displays its parameters inline in its
+		// `<...>` argument list, so it needs no separate quantifier prefix. A generalized
+		// Map<K, V> renders as Map<T0, T1>, not <T0, T1> Map<T0, T1>, and Foo<'a> as Foo<'a>,
+		// not <'a> Foo<'a>. Their only free-variable children are their arguments, so every
+		// quantified variable is shown inline and none is lost by dropping the prefix.
 		return p.printType(t)
 	}
 	ltLabels := make([]string, len(ltVars))
@@ -285,6 +286,13 @@ func (c *ltVarCollector) EnterType(t Type, _ Polarity) EnterResult {
 			c.add(la)
 		}
 		c.add(t.Lt)
+	case *AliasType:
+		// An alias reference's lifetime arguments are free lifetimes reached here, so
+		// `Foo<'a>` collects 'a. They precede any lifetime nested inside the type arguments,
+		// matching print order. An alias has no own borrow lifetime. A borrow rides a RefType.
+		for _, la := range t.LifetimeArgs {
+			c.add(la)
+		}
 	case *FuncType:
 		// A function's own lifetime parameters are bound, not free, so mark their
 		// variables seen up front to exclude every use in the receiver, params, and
@@ -564,20 +572,24 @@ func (p *namedPrinter) printType(t Type) string {
 		return name + "<" + strings.Join(parts, ", ") + ">"
 	case *AliasType:
 		// An alias reference renders under its own name, with a `<...>` argument list when
-		// a generic reference supplies arguments: `Point`, `Box<number>`. The qualified
-		// Name carries a namespace prefix for registry keying, stripped here for display,
-		// the same way a class name is. Rendering the name rather than the expanded body is
-		// the point of the alias, so `val p: Point = {x: 1}` shows `Point`.
+		// a generic reference supplies arguments: `Point`, `Box<number>`, `Foo<'a>`. Lifetime
+		// arguments render first, then type arguments, matching the ClassType order. The
+		// qualified Name carries a namespace prefix for registry keying, stripped here for
+		// display, the same way a class name is. Rendering the name rather than the expanded
+		// body is the point of the alias, so `val p: Point = {x: 1}` shows `Point`.
 		name := classDisplayName(t.Name)
 		if p.qualify {
 			name = t.Name // full qualified name for a collision-free identity key
 		}
-		if len(t.TypeArgs) == 0 {
+		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
 		}
-		parts := make([]string, len(t.TypeArgs))
-		for i, a := range t.TypeArgs {
-			parts[i] = p.printType(a)
+		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.TypeArgs))
+		for _, la := range t.LifetimeArgs {
+			parts = append(parts, p.printLifetime(la))
+		}
+		for _, a := range t.TypeArgs {
+			parts = append(parts, p.printType(a))
 		}
 		return name + "<" + strings.Join(parts, ", ") + ">"
 	case *FuncType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -582,9 +582,15 @@ type AliasType struct {
 	// Name is the dep_graph-qualified name such as "Geometry.Point", so two aliases named
 	// Point in different namespaces stay distinct. It also keys the registry.
 	Name string
-	// TypeArgs are the arguments a generic reference supplies. Always empty today, since
-	// generic aliases are not yet supported.
+	// TypeArgs are the type arguments a generic reference supplies, one per alias type
+	// parameter, substituted into the body at expansion. A non-generic reference carries none.
 	TypeArgs []Type
+	// LifetimeArgs are the lifetime arguments a lifetime-generic reference supplies, one per
+	// alias lifetime parameter, so `Foo<'a>` and `Foo<'b>` are distinct nodes rather than
+	// colliding. They join Name and TypeArgs in the instance identity the recursion guard and
+	// M9's cycle cache key on, so two borrows of one alias at different lifetimes never share a
+	// cache entry. A borrow's own lifetime rides a RefType wrapper, not this field.
+	LifetimeArgs []Lifetime
 }
 
 func (*TypeVarType) isType()      {}
@@ -650,11 +656,16 @@ func LevelOf(t Type) int {
 		}
 		return max(m, LevelOfLifetime(t.Lt))
 	case *AliasType:
-		// An alias reference's level is the max level over its type arguments; the Name
-		// carries no variables. A bare reference with no arguments is level 0.
+		// An alias reference's level is the max level over its type and lifetime arguments;
+		// the Name carries no variables. A bare reference with no arguments is level 0. A free
+		// lifetime arg such as the 'a in Foo<'a> lifts the level so the freshener/extruder
+		// prune descends to freshen it, the same reason the ClassType arm folds in its args.
 		m := 0
 		for _, a := range t.TypeArgs {
 			m = max(m, LevelOf(a))
+		}
+		for _, la := range t.LifetimeArgs {
+			m = max(m, LevelOfLifetime(la))
 		}
 		return m
 	case *PromiseType:

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -265,7 +265,10 @@ func (t *AliasType) Accept(v TypeVisitor, pol Polarity) Type {
 		// Name is the handle's identity, carried through unchanged. An alias is
 		// transparent, so its arguments walk covariantly like a class's, and variance
 		// is resolved by expansion at subtyping time rather than stored on the handle.
-		out = &AliasType{Name: cur.Name, TypeArgs: args}
+		// LifetimeArgs are lifetimes, not Types, so Accept never walks them; a
+		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
+		// AliasType before this rebuild, so cur already holds the freshened lifetimes.
+		out = &AliasType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -125,12 +125,12 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 
 // resolveAliasLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through
 // namedLifetime, so a `&'a` in the body resolved under the same scope reaches that variable.
-func (c *checker) resolveAliasLifetimeParams(lvl int, params []*ast.LifetimeParam) []*soltype.LifetimeParam {
-	if len(params) == 0 {
+func (c *checker) resolveAliasLifetimeParams(lvl int, ltParams []*ast.LifetimeParam) []*soltype.LifetimeParam {
+	if len(ltParams) == 0 {
 		return nil
 	}
-	out := make([]*soltype.LifetimeParam, len(params))
-	for i, p := range params {
+	out := make([]*soltype.LifetimeParam, len(ltParams))
+	for i, p := range ltParams {
 		var bounds []soltype.Lifetime
 		for _, b := range p.Bounds {
 			bounds = append(bounds, c.boundLifetime(b.Name, lvl))

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -240,8 +240,8 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 // resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks
 // their count against the alias's lifetime parameters, which have no default. A mismatch
 // reports an AliasLifetimeArityMismatchError and recovers with fresh lifetimes.
-func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, params []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
-	total := len(params)
+func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, ltParams []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
+	total := len(ltParams)
 	got := len(ref.LifetimeArgs)
 	if got != total {
 		c.report(&AliasLifetimeArityMismatchError{

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -14,7 +14,9 @@ type AliasDef struct {
 	TypeParams []*soltype.TypeParam
 
 	// LifetimeParams are the alias's quantified lifetime parameters, the lifetime twin of
-	// TypeParams. Always nil today, since alias-typed borrows land with lifetime aliases.
+	// TypeParams, in declaration order so expansion substitutes lifetime arguments
+	// positionally. expandAlias maps each one to a reference's positional LifetimeArg. The
+	// slice stays empty until a `type` declaration parses a lifetime parameter binder.
 	LifetimeParams []*soltype.LifetimeParam
 
 	// Body is the type the alias expands to, the right-hand side of `type Name = Body`.
@@ -40,7 +42,7 @@ func (c *Context) expandAlias(ref *soltype.AliasType) soltype.Type {
 	if len(def.TypeParams) == 0 && len(def.LifetimeParams) == 0 {
 		return def.Body
 	}
-	subst := newTypeSubst(def.TypeParams, ref.TypeArgs, def.LifetimeParams, nil)
+	subst := newTypeSubst(def.TypeParams, ref.TypeArgs, def.LifetimeParams, ref.LifetimeArgs)
 	return def.Body.Accept(subst, soltype.Positive)
 }
 

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -123,11 +123,8 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 	return &aliasShell{decl: decl, ns: ns, lvl: lvl, declScope: declScope, namedLts: aliasNamedLts, def: def}
 }
 
-// resolveAliasLifetimeParams resolves an alias's `<'a, ...>` lifetime parameters into their
-// soltype form, minting one lifetime variable per parameter through namedLifetime so a `&'a`
-// in the body reaches the same variable. It runs inside the alias's fresh named-lifetime
-// scope, which preBindAlias installs and hands to inferAliasBody. An outlives bound resolves
-// through boundLifetime, sharing the variable a same-named parameter or borrow denotes.
+// resolveAliasLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through
+// namedLifetime, so a `&'a` in the body resolved under the same scope reaches that variable.
 func (c *checker) resolveAliasLifetimeParams(lvl int, params []*ast.LifetimeParam) []*soltype.LifetimeParam {
 	if len(params) == 0 {
 		return nil
@@ -240,12 +237,9 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
 }
 
-// resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments into their
-// soltype form and checks their count against the alias's declared lifetime parameters. A
-// lifetime parameter has no default, so the count must match exactly. A mismatch reports an
-// AliasLifetimeArityMismatchError and recovers with fresh lifetimes, so expansion still has
-// one argument per parameter. Each argument resolves through boundLifetime, so `'static` maps
-// to the static lifetime and a named `'a` shares the variable that name denotes at the site.
+// resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments and checks
+// their count against the alias's lifetime parameters, which have no default. A mismatch
+// reports an AliasLifetimeArityMismatchError and recovers with fresh lifetimes.
 func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, params []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
 	total := len(params)
 	got := len(ref.LifetimeArgs)

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -58,6 +58,11 @@ type aliasShell struct {
 	// declScope is scope, or a child holding a generic alias's type parameters. The body
 	// resolves here so it reads each `T` as the one shared var the def stores.
 	declScope *Scope
+	// namedLts is the alias's own named-lifetime scope, populated by preBindAlias when it
+	// resolves the `<'a>` parameters. inferAliasBody installs it so a `&'a` in the body reads
+	// the same lifetime variable the parameter binder minted. It is nil for an alias with no
+	// lifetime parameters, which gives the body a fresh scope.
+	namedLts map[string]*soltype.LifetimeVar
 	// def is the registered AliasDef preBindAlias inserted with a nil Body; inferAliasBody
 	// fills its Body once every sibling identity in the component is bound.
 	def *AliasDef
@@ -85,6 +90,13 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 		qname = ns + "." + decl.Name.Name
 	}
 
+	// Resolve the alias's parameters in a fresh named-lifetime scope so a lifetime parameter
+	// and every `&'a` in the body share one lifetime variable, and hand that scope to
+	// inferAliasBody. Saving and restoring keeps one alias's `'a` independent of a sibling's
+	// in the same component.
+	savedNamedLts := c.namedLifetimes
+	c.namedLifetimes = nil
+
 	// Resolve the alias's type parameters into a child scope so a bound, a default, and the
 	// body all read a sibling `T` as one shared var. A non-generic alias reuses the
 	// enclosing scope.
@@ -94,8 +106,11 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 		declScope = scope.Child()
 		typeParams = c.resolveTypeParams(declScope, lvl, decl.TypeParams)
 	}
+	lifetimeParams := c.resolveAliasLifetimeParams(lvl, decl.LifetimeParams)
+	aliasNamedLts := c.namedLifetimes
+	c.namedLifetimes = savedNamedLts
 
-	def := &AliasDef{TypeParams: typeParams, Level: lvl - 1}
+	def := &AliasDef{TypeParams: typeParams, LifetimeParams: lifetimeParams, Level: lvl - 1}
 	c.ctx.registerAlias(qname, def)
 
 	t := &soltype.AliasType{Name: qname}
@@ -105,7 +120,27 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 	})
 	c.recordType(decl.Name, t)
 
-	return &aliasShell{decl: decl, ns: ns, lvl: lvl, declScope: declScope, def: def}
+	return &aliasShell{decl: decl, ns: ns, lvl: lvl, declScope: declScope, namedLts: aliasNamedLts, def: def}
+}
+
+// resolveAliasLifetimeParams resolves an alias's `<'a, ...>` lifetime parameters into their
+// soltype form, minting one lifetime variable per parameter through namedLifetime so a `&'a`
+// in the body reaches the same variable. It runs inside the alias's fresh named-lifetime
+// scope, which preBindAlias installs and hands to inferAliasBody. An outlives bound resolves
+// through boundLifetime, sharing the variable a same-named parameter or borrow denotes.
+func (c *checker) resolveAliasLifetimeParams(lvl int, params []*ast.LifetimeParam) []*soltype.LifetimeParam {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]*soltype.LifetimeParam, len(params))
+	for i, p := range params {
+		var bounds []soltype.Lifetime
+		for _, b := range p.Bounds {
+			bounds = append(bounds, c.boundLifetime(b.Name, lvl))
+		}
+		out[i] = &soltype.LifetimeParam{Name: "'" + p.Name, Var: c.namedLifetime(p.Name, lvl), Bounds: bounds}
+	}
+	return out
 }
 
 // inferAliasBody resolves a pre-bound alias's body and stores it on the shell's AliasDef.
@@ -117,6 +152,13 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 	prevNS := c.classNamespace
 	c.classNamespace = sh.ns
 	defer func() { c.classNamespace = prevNS }()
+
+	// Install the alias's own named-lifetime scope, populated by preBindAlias, so a `&'a` in
+	// the body reads the lifetime variable its `<'a>` binder minted. A non-lifetime-generic
+	// alias carries a nil scope, which gives its body a fresh one independent of any sibling.
+	savedNamedLts := c.namedLifetimes
+	c.namedLifetimes = sh.namedLts
+	defer func() { c.namedLifetimes = savedNamedLts }()
 
 	// A nil TypeAnn is parser error recovery for `type Foo =`, already reported. Bind a
 	// fresh var and skip resolveTypeAnn, since a nil annotation has no span to report on.
@@ -133,17 +175,21 @@ func (c *checker) inferAliasBody(sh *aliasShell) {
 }
 
 // buildAliasInstance resolves a use-site reference to a registered alias into an AliasType
-// carrying one type argument per parameter. A trailing parameter with a default may be
-// omitted, so its argument is filled from the default with the earlier arguments already
-// substituted, letting `type Pair<T, U = T>` resolve `Pair<number>` to `Pair<number,
-// number>`. Fewer than the required count or more than the total parameter count reports an
-// AliasArityMismatchError and recovers, so a downstream reference still resolves.
+// carrying one type argument per type parameter and one lifetime argument per lifetime
+// parameter. A trailing type parameter with a default may be omitted, so its argument is
+// filled from the default with the earlier arguments already substituted, letting `type
+// Pair<T, U = T>` resolve `Pair<number>` to `Pair<number, number>`. A lifetime parameter has
+// no default, so its count must match exactly. A mismatch on either sort reports and recovers
+// with fresh arguments, so a downstream reference still resolves.
 func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *ast.TypeRefTypeAnn, lvl int) *soltype.AliasType {
 	def, _ := c.ctx.aliasDef(at.Name)
 	var params []*soltype.TypeParam
+	var ltParams []*soltype.LifetimeParam
 	if def != nil {
 		params = def.TypeParams
+		ltParams = def.LifetimeParams
 	}
+	ltArgs := c.resolveAliasLifetimeArgs(ref, ltParams, lvl)
 	total := len(params)
 	required := 0
 	for _, p := range params {
@@ -162,9 +208,13 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 		})
 	}
 	if total == 0 {
-		// A non-generic alias carries no arguments; any that were supplied are reported
-		// above. Return the bare handle so the alias still resolves under its name.
-		return at
+		// A non-generic alias carries no type arguments; any that were supplied are reported
+		// above. Return a handle carrying only the lifetime arguments, or the bare handle when
+		// there are none, so the alias still resolves under its name.
+		if len(ltArgs) == 0 {
+			return at
+		}
+		return &soltype.AliasType{Name: at.Name, LifetimeArgs: ltArgs}
 	}
 	args := make([]soltype.Type, total)
 	for i := range total {
@@ -187,5 +237,48 @@ func (c *checker) buildAliasInstance(scope *Scope, at *soltype.AliasType, ref *a
 			args[i] = c.freshAt(lvl)
 		}
 	}
-	return &soltype.AliasType{Name: at.Name, TypeArgs: args}
+	return &soltype.AliasType{Name: at.Name, TypeArgs: args, LifetimeArgs: ltArgs}
+}
+
+// resolveAliasLifetimeArgs resolves a reference's `<'a, ...>` lifetime arguments into their
+// soltype form and checks their count against the alias's declared lifetime parameters. A
+// lifetime parameter has no default, so the count must match exactly. A mismatch reports an
+// AliasLifetimeArityMismatchError and recovers with fresh lifetimes, so expansion still has
+// one argument per parameter. Each argument resolves through boundLifetime, so `'static` maps
+// to the static lifetime and a named `'a` shares the variable that name denotes at the site.
+func (c *checker) resolveAliasLifetimeArgs(ref *ast.TypeRefTypeAnn, params []*soltype.LifetimeParam, lvl int) []soltype.Lifetime {
+	total := len(params)
+	got := len(ref.LifetimeArgs)
+	if got != total {
+		c.report(&AliasLifetimeArityMismatchError{
+			Ref:      ref,
+			Name:     ast.QualIdentToString(ref.Name),
+			Expected: total,
+			Got:      got,
+		})
+	}
+	if total == 0 {
+		return nil
+	}
+	args := make([]soltype.Lifetime, total)
+	for i := range total {
+		if i < got {
+			args[i] = c.useLifetimeArg(ref.LifetimeArgs[i], lvl)
+		} else {
+			// A missing lifetime argument was reported above. Recover with a fresh lifetime so
+			// expansion substitutes one per parameter.
+			args[i] = c.ctx.freshLifetime(lvl)
+		}
+	}
+	return args
+}
+
+// useLifetimeArg resolves one written lifetime argument. A named `'a` shares the variable that
+// name denotes at the reference site, and `'static` maps to the static lifetime, matching the
+// bound-resolution rule. An unexpected node recovers to a fresh lifetime.
+func (c *checker) useLifetimeArg(node ast.LifetimeAnnNode, lvl int) soltype.Lifetime {
+	if n, ok := node.(*ast.LifetimeAnn); ok {
+		return c.boundLifetime(n.Name, lvl)
+	}
+	return c.ctx.freshLifetime(lvl)
 }

--- a/internal/solver/classes.go
+++ b/internal/solver/classes.go
@@ -718,14 +718,16 @@ func newClassSubst(def *ClassDef, ct *soltype.ClassType) *typeSubst {
 }
 
 func (s *typeSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
-	// A borrow's lifetime and a nested ClassType's lifetime arguments are a separate
-	// sort Accept does not walk, so rewrite them here on the way down through the
+	// A borrow's lifetime and a nested ClassType's or AliasType's lifetime arguments are a
+	// separate sort Accept does not walk, so rewrite them here on the way down through the
 	// shared lifetime-rewrite helpers and let Accept rebuild the type's children.
 	switch t := t.(type) {
 	case *soltype.RefType:
 		return rewriteRefLifetime(t, s.lifetime(t.Lt))
 	case *soltype.ClassType:
 		return rewriteClassLifetimes(t, s.lifetime)
+	case *soltype.AliasType:
+		return rewriteAliasLifetimes(t, s.lifetime)
 	case *soltype.TypeVarType:
 		if rep, ok := s.types[t]; ok {
 			return soltype.EnterResult{Type: rep, SkipChildren: true}

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1070,10 +1070,13 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)
 	case *soltype.AliasType:
 		b, ok := b.(*soltype.AliasType)
-		// Two alias references are equal when they name the same alias and their type
-		// arguments compare equal positionally. The Name is the handle's identity. An alias
-		// carries no exactness flag.
+		// Two alias references are equal when they name the same alias, their lifetime
+		// arguments compare equal positionally, and their type arguments do too. The Name is
+		// the handle's identity. An alias carries no exactness flag.
 		if !ok || a.Name != b.Name {
+			return false
+		}
+		if !sameLifetimeSlice(a.LifetimeArgs, b.LifetimeArgs, ctx) {
 			return false
 		}
 		return equalTypeSliceWith(a.TypeArgs, b.TypeArgs, ctx)

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -869,6 +869,7 @@ func (*InstancePatternNotClassError) isSolverError()        {}
 func (*ExtractorPatternNotCtorError) isSolverError()        {}
 func (*ExtractorPatternArityError) isSolverError()          {}
 func (*AliasArityMismatchError) isSolverError()             {}
+func (*AliasLifetimeArityMismatchError) isSolverError()     {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -981,6 +982,22 @@ func (e *AliasArityMismatchError) Message() string {
 		return fmt.Sprintf("type alias `%s` expects %d type arguments but got %d", e.Name, e.Total, e.Got)
 	}
 	return fmt.Sprintf("type alias `%s` expects between %d and %d type arguments but got %d", e.Name, e.Required, e.Total, e.Got)
+}
+
+// AliasLifetimeArityMismatchError fires when a generic-alias reference `Name<'a, …>` supplies
+// a number of lifetime arguments that does not match the alias's declared `<'a, …>` clause. A
+// lifetime parameter has no default, so the counts must match exactly.
+type AliasLifetimeArityMismatchError struct {
+	Ref      *ast.TypeRefTypeAnn
+	Name     string
+	Expected int
+	Got      int
+}
+
+func (e *AliasLifetimeArityMismatchError) Span() ast.Span      { return e.Ref.Span() }
+func (e *AliasLifetimeArityMismatchError) Related() []ast.Span { return nil }
+func (e *AliasLifetimeArityMismatchError) Message() string {
+	return fmt.Sprintf("type alias `%s` expects %d lifetime arguments but got %d", e.Name, e.Expected, e.Got)
 }
 
 // MultipleConstructorsError fires on the second and any later `constructor` block in

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -1,0 +1,71 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInferAliasBorrowRoundTripsLifetime borrows an alias-typed value at a declared
+// lifetime and returns it: the same lifetime appears on the parameter and the return, so
+// the borrow flows out at the lifetime it came in, and the pointee renders under the alias
+// name `Point` rather than its expanded body. AliasType is a RefInner, so a `&'a mut Point`
+// forms a RefType over the alias through the M4 borrow machinery unchanged.
+func TestInferAliasBorrowRoundTripsLifetime(t *testing.T) {
+	src := `
+		type Point = {x: number}
+		fn f<'a>(p: &'a mut Point) -> &'a mut Point { return p }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: &'a mut Point) -> &'a mut Point", values["f"])
+}
+
+// TestInferAliasFreshReturnCarriesNoLifetime returns a freshly-constructed value annotated
+// as an alias: the object literal is owned, so the result renders under the alias name with
+// no borrow lifetime, matching the record case a fresh object return produces.
+func TestInferAliasFreshReturnCarriesNoLifetime(t *testing.T) {
+	src := `
+		type Point = {x: number}
+		fn f() -> Point { return {x: 5} }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn () -> Point", values["f"])
+}
+
+// TestInferAliasInferredBorrowElidesLifetime borrows an alias-typed value at an inferred
+// lifetime that reaches nothing in the output: the borrow keeps its `&mut` but its lifetime
+// name is elided, exactly as an inferred borrow of a record does.
+func TestInferAliasInferredBorrowElidesLifetime(t *testing.T) {
+	src := `
+		type Point = {x: number}
+		fn f(p: &mut Point) -> number { return p.x }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn (p: &mut Point) -> number", values["f"])
+}
+
+// TestExpandAliasSubstitutesLifetimeArg checks that expandAlias substitutes a reference's
+// lifetime argument for the alias's lifetime-parameter var, the lifetime twin of the
+// type-argument substitution. A body borrowing at the parameter lifetime `'p` expands to a
+// borrow at the concrete argument the reference supplies. The parser does not yet bind a
+// lifetime parameter on a `type` declaration, so the def is built directly.
+func TestExpandAliasSubstitutesLifetimeArg(t *testing.T) {
+	c := newChecker()
+	param := &soltype.LifetimeVar{ID: 0, Level: 1}
+	body := &soltype.RefType{Mut: true, Lt: param, Inner: objT()}
+	c.ctx.registerAlias("Borrow", &AliasDef{
+		LifetimeParams: []*soltype.LifetimeParam{{Name: "'p", Var: param}},
+		Body:           body,
+	})
+
+	arg := c.ctx.freshLifetime(1)
+	got := c.ctx.expandAlias(&soltype.AliasType{Name: "Borrow", LifetimeArgs: []soltype.Lifetime{arg}})
+
+	ref, ok := got.(*soltype.RefType)
+	require.True(t, ok, "the expanded body is a borrow")
+	require.Same(t, arg, ref.Lt, "the parameter lifetime is substituted with the reference's argument")
+}

--- a/internal/solver/infer_alias_lifetime_test.go
+++ b/internal/solver/infer_alias_lifetime_test.go
@@ -69,3 +69,109 @@ func TestExpandAliasSubstitutesLifetimeArg(t *testing.T) {
 	require.True(t, ok, "the expanded body is a borrow")
 	require.Same(t, arg, ref.Lt, "the parameter lifetime is substituted with the reference's argument")
 }
+
+// TestInferLifetimeGenericAliasRoundTrip declares a lifetime-generic alias whose body is an
+// immutable borrow, then round-trips it through a function that supplies the lifetime and
+// type arguments. The reference renders under the alias name with its lifetime argument on
+// both the parameter and the return, so the borrow flows out at the lifetime it came in.
+func TestInferLifetimeGenericAliasRoundTrip(t *testing.T) {
+	src := `
+		type Ref<'a, T> = &'a T
+		fn f<'a>(p: Ref<'a, {x: number}>) -> Ref<'a, {x: number}> { return p }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: Ref<'a, {x: number}>) -> Ref<'a, {x: number}>", values["f"])
+}
+
+// TestInferLifetimeGenericMutAliasRoundTrip is the mutable-borrow twin: a `&'a mut T` alias
+// body carries the lifetime and mutability through instantiation, so a `mut` borrow of the
+// alias round-trips its lifetime the same way the immutable form does.
+func TestInferLifetimeGenericMutAliasRoundTrip(t *testing.T) {
+	src := `
+		type MutRef<'a, T> = &'a mut T
+		fn f<'a>(p: MutRef<'a, {x: number}>) -> MutRef<'a, {x: number}> { return p }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: MutRef<'a, {x: number}>) -> MutRef<'a, {x: number}>", values["f"])
+}
+
+// TestInferLifetimeGenericAliasKeepsLifetimesDistinct references one lifetime-generic alias
+// at two different lifetimes: the parameter carries 'a and the second carries 'b, so the two
+// instances render under distinct lifetimes rather than collapsing onto one.
+func TestInferLifetimeGenericAliasKeepsLifetimesDistinct(t *testing.T) {
+	src := `
+		type Ref<'a, T> = &'a T
+		fn f<'a, 'b>(p: Ref<'a, {x: number}>, q: Ref<'b, {x: number}>) -> Ref<'a, {x: number}> { return p }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <'a, 'b>(p: Ref<'a, {x: number}>, q: Ref<'b, {x: number}>) -> Ref<'a, {x: number}>",
+		values["f"],
+	)
+}
+
+// TestInferLifetimeGenericAliasIsTransparent checks that a lifetime-generic alias and its
+// expanded borrow are interchangeable under subtyping. A `Ref<'a, {x: number}>` value flows
+// into a plain `&'a {x: number}` target, and a plain borrow flows back into the alias, so the
+// alias expands to exactly the borrow its body writes.
+func TestInferLifetimeGenericAliasIsTransparent(t *testing.T) {
+	src := `
+		type Ref<'a, T> = &'a T
+		fn f<'a>(p: Ref<'a, {x: number}>) -> &'a {x: number} { return p }
+		fn g<'a>(p: &'a {x: number}) -> Ref<'a, {x: number}> { return p }
+	`
+	values, _, errs := inferSource(t, src)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <'a>(p: Ref<'a, {x: number}>) -> &{x: number}", values["f"])
+	require.Equal(t, "fn <'a>(p: &{x: number}) -> Ref<'a, {x: number}>", values["g"])
+}
+
+// TestInferLifetimeGenericAliasArityErrors covers the lifetime-argument arity checks. A
+// lifetime parameter has no default, so supplying too many or too few lifetime arguments each
+// report a single AliasLifetimeArityMismatchError, and supplying a lifetime argument to an
+// alias that declares none is rejected the same way.
+func TestInferLifetimeGenericAliasArityErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "TooManyLifetimeArgs",
+			src: `
+				type Ref<'a, T> = &'a T
+				fn f<'a, 'b>(p: Ref<'a, 'b, {x: number}>) -> number { return p.x }
+			`,
+			want: "type alias `Ref` expects 1 lifetime arguments but got 2",
+		},
+		{
+			name: "MissingLifetimeArg",
+			src: `
+				type Ref<'a, T> = &'a T
+				fn f<'a>(p: Ref<{x: number}>) -> number { return p.x }
+			`,
+			want: "type alias `Ref` expects 1 lifetime arguments but got 0",
+		},
+		{
+			name: "LifetimeArgOnNonGenericAlias",
+			src: `
+				type Point = {x: number}
+				fn f<'a>(p: Point<'a>) -> number { return p.x }
+			`,
+			want: "type alias `Point` expects 0 lifetime arguments but got 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			msgs := make([]string, len(errs))
+			for i, e := range errs {
+				msgs[i] = e.Message()
+			}
+			require.Contains(t, msgs, tt.want)
+		})
+	}
+}

--- a/internal/solver/lifetime_undeclared.go
+++ b/internal/solver/lifetime_undeclared.go
@@ -86,6 +86,14 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 			span:        u.Span(),
 		})
 	}
+	// A `'a` lifetime argument on a generic-alias reference marks a declared binder as used,
+	// so `<'a>` on a function that only mentions 'a inside `Ref<'a, T>` is not flagged unused.
+	// An undeclared one is not reported here. buildAliasInstance recovers it through
+	// namedLifetime, and a non-alias reference such as `Promise<'a, T>` rejects the lifetime on
+	// its own, so reporting it undeclared here would double up with misleading advice.
+	for _, u := range col.refArgs {
+		used.Add(u.Name)
+	}
 
 	// The symmetric companion: a binder no use references is dead weight. Iterating
 	// declaredOrder reports each unused name once and blames its first binder, even for a
@@ -103,20 +111,31 @@ func (c *checker) checkLifetimeDeclarations(lifetimeParams []*ast.LifetimeParam,
 // annotations, but stops at a nested function annotation, which owns its own lifetime
 // scope.
 //
-// The set of forms this records must match the forms resolveLifetimeAnn interns through
-// namedLifetime, since a use the scan misses is one namedLifetime still mints a fresh
-// recovery lifetime for. Today that is the `&'x` borrow alone; `'x` on a referenced type,
-// as `Foo<'x>` or `'x Point`, resolves as an unsupported feature and interns nothing. When
-// that form gains support, add it here and to addLifetime.
+// A borrow's `&'x` lifetime lands in uses, which drives both the undeclared and unused scans.
+// A `'a` lifetime argument on a referenced type, the `'a` in `Ref<'a, T>`, lands in refArgs
+// instead, which drives only the unused scan. The split keeps a genuine undeclared borrow an
+// error while letting an alias argument recover through namedLifetime without an extra,
+// misleading report, since a non-alias reference such as `Promise<'a, T>` rejects the lifetime
+// on its own. The `'x Point` prefix form does not resolve onto a referenced type, so it interns
+// nothing and is not collected.
 type lifetimeUseCollector struct {
 	ast.DefaultVisitor
-	uses []*ast.LifetimeAnn
+	uses    []*ast.LifetimeAnn
+	refArgs []*ast.LifetimeAnn
 }
 
 func (v *lifetimeUseCollector) EnterTypeAnn(t ast.TypeAnn) bool {
 	switch n := t.(type) {
 	case *ast.RefTypeAnn:
 		v.addLifetime(n.Lifetime)
+		return true
+	case *ast.TypeRefTypeAnn:
+		// A lifetime argument on a referenced type counts as a use of a declared binder, so
+		// `<'a>` used only inside `Ref<'a, T>` is not flagged unused. Record each into refArgs,
+		// then descend into the type arguments for any nested borrow.
+		for _, la := range n.LifetimeArgs {
+			v.addRefArg(la)
+		}
 		return true
 	case *ast.FuncTypeAnn:
 		// A nested function type is its own quantifier scope. Its inner borrows are not
@@ -135,6 +154,18 @@ func (v *lifetimeUseCollector) addLifetime(node ast.LifetimeAnnNode) {
 	case *ast.LifetimeAnn:
 		if n.Name != "static" {
 			v.uses = append(v.uses, n)
+		}
+	}
+}
+
+// addRefArg records a generic-alias reference's lifetime argument as a use that only marks a
+// declared binder used. A nil node carries no name and `'static` is never a binder, so both
+// are skipped, matching addLifetime.
+func (v *lifetimeUseCollector) addRefArg(node ast.LifetimeAnnNode) {
+	switch n := node.(type) {
+	case *ast.LifetimeAnn:
+		if n.Name != "static" {
+			v.refArgs = append(v.refArgs, n)
 		}
 	}
 }

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -344,6 +344,8 @@ func freshenLifetimeFormer(t soltype.Type, lf *ltFreshener) (soltype.EnterResult
 		return rewriteFuncLifetimes(t, lf.fresh), true
 	case *soltype.ClassType:
 		return rewriteClassLifetimes(t, lf.fresh), true
+	case *soltype.AliasType:
+		return rewriteAliasLifetimes(t, lf.fresh), true
 	}
 	return soltype.EnterResult{}, false
 }
@@ -385,6 +387,26 @@ func rewriteClassLifetimes(
 	repl := *t
 	repl.LifetimeArgs = nargs
 	repl.Lt = nlt
+	return soltype.EnterResult{Type: &repl}
+}
+
+// rewriteAliasLifetimes rewrites an AliasType's lifetime arguments through tf, the non-Type
+// lifetimes Accept never walks. The type arguments still descend, sharing tf's cache. An
+// alias has no own borrow lifetime, so only the arguments are rewritten. No change signals
+// an ordinary descent.
+func rewriteAliasLifetimes(
+	t *soltype.AliasType,
+	tf func(soltype.Lifetime) soltype.Lifetime,
+) soltype.EnterResult {
+	if len(t.LifetimeArgs) == 0 {
+		return soltype.EnterResult{}
+	}
+	nargs, changed := rewriteLtSlice(t.LifetimeArgs, tf)
+	if !changed {
+		return soltype.EnterResult{}
+	}
+	repl := *t
+	repl.LifetimeArgs = nargs
 	return soltype.EnterResult{Type: &repl}
 }
 


### PR DESCRIPTION
Add support for lifetime-generic aliases by threading lifetime arguments through the type system alongside existing type arguments.

**Summary**

Aliases can now carry lifetime arguments in their type references (e.g., `Foo<'a>` or `Foo<'a, number>`), enabling borrows of alias-typed values to preserve their lifetime information through expansion. This mirrors the existing support for type arguments and ensures that two references to the same alias at different lifetimes remain distinct in the type cache.

**Key changes**

- **AliasType**: Added `LifetimeArgs` field to hold lifetime arguments, distinct from type arguments. Lifetime arguments render first in printed form, matching ClassType order.
- **Printing and analysis**: Updated `PrintAsScheme`, `LevelOf`, `FreeLifetimeVars`, and `Accept` to handle lifetime arguments. Aliases now skip the quantifier prefix in schemes, like ClassTypes, since their parameters display inline.
- **Expansion**: Modified `expandAlias` to substitute lifetime arguments into the alias body alongside type arguments, enabling `Foo<'a>` to expand with the concrete lifetime in place of the parameter.
- **Freshening and substitution**: Added `rewriteAliasLifetimes` to freshen lifetime arguments during type variable instantiation, and updated `typeSubst.EnterType` to rewrite them during class/alias substitution.
- **Equality**: Updated `equalTypeWith` to compare lifetime arguments when checking alias reference equality, ensuring distinct lifetimes produce distinct types.
- **Tests**: Added comprehensive tests covering alias borrows with declared and inferred lifetimes, fresh alias returns, lifetime argument substitution, and printing of lifetime-generic aliases.

https://claude.ai/code/session_01DVQ6c9yw1CnaBXcDwERAtv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for lifetime parameters in type aliases (including parsing and solver handling).
  * Alias types now preserve, format (scheme/qualified/pretty printing), compare, and substitute lifetime arguments correctly.
  * Lifetime-generic alias expansion and lifetime rewriting for aliases now work consistently, with correct equality semantics.
  * Added a clear solver error when alias lifetime-argument arity doesn’t match.
* **Tests**
  * Added/expanded coverage for alias lifetime formatting, identity, inference, substitution, level calculation, copy-on-write behavior, and arity errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->