### PR TITLE
Add keyof and typeof type operators (M9 PR1a)

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -11,14 +11,14 @@ import (
 )
 
 // Precedence levels for type operators, matching the Escalier parser (and
-// type_system/print_type.go). Higher values bind more tightly. M4 adds precPrefix
-// for the `mut`/lifetime borrow prefix (RefType); type_system's other prefix forms
-// (keyof, ...T) land with their later milestones.
+// type_system/print_type.go). Higher values bind more tightly. precPrefix covers the
+// prefix forms — the `mut`/lifetime borrow prefix (RefType) and the `keyof` operator
+// (KeyofType); the `...T` spread prefix lands with tuple/object spread types.
 const (
 	precFunc         = 2 // fn (...) -> T — return type is greedy, needs parens in union/intersection
 	precUnion        = 3 // A | B
 	precIntersection = 4 // A & B
-	precPrefix       = 5 // mut T, 'a T — a borrow prefix binds looser than an atom
+	precPrefix       = 5 // mut T, 'a T, keyof T — a prefix binds looser than an atom
 	precAtom         = 6 // primary types, never need parens
 )
 
@@ -32,6 +32,8 @@ func typePrec(t Type) int {
 	case *IntersectionType:
 		return precIntersection
 	case *RefType:
+		return precPrefix
+	case *KeyofType:
 		return precPrefix
 	default:
 		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, Void, NullType,
@@ -399,6 +401,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, a := range t.TypeArgs {
 				walk(a)
 			}
+		case *KeyofType:
+			walk(t.Operand)
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -594,6 +598,10 @@ func (p *namedPrinter) printType(t Type) string {
 		return name + "<" + strings.Join(parts, ", ") + ">"
 	case *FuncType:
 		return "fn " + p.printFuncTail(t)
+	case *KeyofType:
+		// `keyof T`, mirroring type_system's KeyOfType rendering. The operand prints at
+		// precPrefix so a looser operand such as a union gets parenthesized: `keyof (A | B)`.
+		return "keyof " + p.printTypeMinPrec(t.Operand, precPrefix)
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -593,7 +593,22 @@ type AliasType struct {
 	LifetimeArgs []Lifetime
 }
 
+// KeyofType is the residual `keyof Operand` type operator (M9 PR1a), the first of
+// the type-level operators. It is inert: it carries no bounds, constrain never
+// records one against it, and it flows through the solver's structural machinery
+// untouched — the "adds no new mutable solver state" invariant it shares with the
+// spike's ResidualOp. An evaluator reduces it once its operand is ground (M9 PR1b);
+// until then a `keyof T` over a type parameter stays symbolic and renders `keyof T`.
+// Exact records whether the operand's key set is complete, the seed for exactness
+// propagation through reduction (M9 PR8). It is carried through the visitor and left
+// unread until that work lands.
+type KeyofType struct {
+	Operand Type
+	Exact   bool
+}
+
 func (*TypeVarType) isType()      {}
+func (*KeyofType) isType()        {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
@@ -668,6 +683,11 @@ func LevelOf(t Type) int {
 			m = max(m, LevelOfLifetime(la))
 		}
 		return m
+	case *KeyofType:
+		// A residual operator's level is its operand's, so a `keyof T` over an out-of-level
+		// type parameter lifts the level and the freshener/extruder prune descends to
+		// freshen the operand, exactly as the single-child PromiseType arm does.
+		return LevelOf(t.Operand)
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -162,6 +162,24 @@ func (t *PromiseType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *KeyofType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The operand walks in the current polarity, the same single-child covariant visit
+	// PromiseType uses. The residual is inert in M9 PR1a — the visit rebuilds it around a
+	// rewritten operand without reducing the operator, so extrude/coalesce/freshenAbove
+	// carry `keyof T` through untouched. The evaluator's reduction lands in PR1b.
+	operand := cur.Operand.Accept(v, pol)
+	out := cur
+	if operand != cur.Operand {
+		out = &KeyofType{Operand: operand, Exact: cur.Exact}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1101,6 +1101,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.IntersectionType:
 		b, ok := b.(*soltype.IntersectionType)
 		return ok && equalTypeSliceWith(a.Types, b.Types, ctx)
+	case *soltype.KeyofType:
+		// Two inert `keyof` residuals are equal when they carry the same exactness over
+		// equal operands. This compares the residual structurally without reducing it,
+		// matching how the operator flows through the solver untouched in M9 PR1a.
+		b, ok := b.(*soltype.KeyofType)
+		return ok && a.Exact == b.Exact && equalTypeWith(a.Operand, b.Operand, ctx)
 	}
 	return false
 }

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -683,6 +683,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
+	case *soltype.KeyofType:
+		// A `keyof` residual is inert (M9 PR1a): constrain neither decomposes nor reduces
+		// it. Two residuals are compatible only when structurally identical, so `keyof T
+		// <: keyof T` succeeds reflexively without recording any bound — the "adds no new
+		// mutable solver state" invariant. An unreduced residual against any other concrete
+		// cannot be compared until the evaluator reduces it (PR1b), so it fails here. When
+		// super is a variable the case falls through to the superVar arm below, which
+		// records the whole residual as one lower bound, keeping the operator symbolic on
+		// the coalesced binding.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if equalType(sub, super) {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
 	case *soltype.IntersectionType:
 		// (A & B) <: super ⟹ A <: super OR B <: super. Trial each member in
 		// specificity order under a probe; the first success commits. Stays in

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1685,6 +1685,14 @@ func describe(t soltype.Type) string {
 		// and informative (`Promise<number>`), whereas a function/tuple/record would
 		// be verbose spelled out, so those stay nominal.
 		return "Promise<" + describe(t.Inner) + ">"
+	case *soltype.KeyofType:
+		// A `keyof` residual renders structurally, recursing like the Promise arm, so a
+		// rejected constraint names it `keyof <operand>` rather than the default `?`. The
+		// operand renders in describe's raw mid-constrain form, so a type-variable operand
+		// shows as `t1`, not the coalesced printer's param name. describe is the second
+		// per-node type renderer beside soltype.Print; both carry the residual, so a later
+		// operator node must add an arm here as well as there.
+		return "keyof " + describe(t.Operand)
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1,0 +1,117 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- M9 PR1a: keyof residual node + inert plumbing ---
+
+// A `keyof T` over a type parameter builds the inert KeyofType residual (M9 PR1a): it
+// renders `keyof T` and flows through constrain and coalesce without being decomposed or
+// reduced, since the evaluator that reduces it lands in PR1b. A ground operand also stays
+// symbolic here, and a union operand parenthesizes under the prefix precedence.
+func TestInferKeyofResidual(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			// The residual round-trips through the whole solve: resolveTypeAnn builds it, the
+			// body's `return k` flows `keyof T <: keyof T` through constrain reflexively, and
+			// coalescing renders it back as `keyof T`.
+			name: "TypeParamRoundTrips",
+			src:  `fn f<T>(k: keyof T) -> keyof T { return k }`,
+			want: map[string]string{"f": "fn <T>(k: keyof T) -> keyof T"},
+		},
+		{
+			// A ground object operand stays symbolic in PR1a — reduction to `"a" | "b"` is
+			// PR1b — so the residual renders with the object still inside it.
+			name: "GroundOperandStaysSymbolic",
+			src:  `fn g(x: keyof {a: number, b: string}) {}`,
+			want: map[string]string{"g": "fn (x: keyof {a: number, b: string}) -> void"},
+		},
+		{
+			// A union operand binds looser than the `keyof` prefix, so it parenthesizes.
+			name: "UnionOperandParenthesizes",
+			src:  `fn g(x: keyof ({a: number} | {b: number})) {}`,
+			want: map[string]string{"g": "fn (x: keyof ({a: number} | {b: number})) -> void"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
+}
+
+// A rejected constraint whose subject is a `keyof` residual names it structurally in the
+// diagnostic — `cannot constrain keyof t1 <: number` rather than the bare `?` the default
+// describe arm would render — so the inert node stays legible in error messages. describe is
+// the raw mid-constrain renderer, so the operand shows as the raw var `t1` rather than the
+// param name `T` the coalesced printer would use.
+func TestInferKeyofResidualErrorMessage(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(k: keyof T) -> number { return k }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:12-1:19: cannot constrain keyof t1 <: number", msgWithSpan(errs[0]))
+}
+
+// A `typeof v` query resolves against the value scope at annotation time, returning the
+// value's concrete type directly rather than a residual (M9 PR1a). It resolves a bare name,
+// a member chain, and the operand of `keyof typeof x` — the value→type bridge keyof relies
+// on. The value's coalesced type keeps its literal (`{a: 1}`), so that is what the query
+// yields.
+func TestInferTypeof(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			// A bare `typeof v` resolves to the value's object type, which the annotated
+			// binding then adopts.
+			name: "BareValue",
+			src: `
+				val v = {a: 1}
+				val w: typeof v = v
+			`,
+			want: map[string]string{"w": "{a: 1}"},
+		},
+		{
+			// A member chain `typeof p.inner` resolves the base value and projects the named
+			// property off it.
+			name: "MemberChain",
+			src: `
+				val p = {inner: {a: 1}}
+				val w: typeof p.inner = {a: 1}
+			`,
+			want: map[string]string{"w": "{a: 1}"},
+		},
+		{
+			// The canonical `keyof typeof x`: typeof resolves the value, and keyof wraps the
+			// result as an unreduced residual (PR1a), so it renders `keyof {a: 1}`.
+			name: "KeyofTypeofOperand",
+			src: `
+				val x = {a: 1}
+				fn h(k: keyof typeof x) {}
+			`,
+			want: map[string]string{"h": "fn (k: keyof {a: 1}) -> void"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -232,11 +232,9 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 	return t, true
 }
 
-// resolveKeyOfTypeAnn lowers a `keyof T` annotation to the inert KeyofType residual
-// (M9 PR1a). The operand resolves through resolveTypeAnn; an unsupported operand recovers
-// to a fresh var so the residual survives, cascade-safe like the Promise<bad> recovery.
-// The residual is built UNREDUCED — the evaluator reduces a ground operand in PR1b, so a
-// `keyof T` over a type parameter renders and flows through constrain/coalesce as-is.
+// resolveKeyOfTypeAnn lowers `keyof T` to the inert, unreduced KeyofType residual (M9 PR1a;
+// PR1b reduces a ground operand). An unsupported operand recovers to a fresh var, cascade-safe
+// like the Promise<bad> recovery.
 func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl int) (soltype.Type, bool) {
 	operand, ok := c.resolveTypeAnn(scope, ta.Type, lvl)
 	if !ok {
@@ -247,13 +245,9 @@ func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl in
 	return t, true
 }
 
-// resolveTypeOfTypeAnn resolves a `typeof v` query against the VALUE scope, returning that
-// value's type directly (M9 PR1a). It is not a residual: `typeof` is the value→type bridge
-// `keyof typeof x` relies on, resolved at annotation time. resolveTypeOfQualIdent handles a
-// bare name and a member chain. A name that names no value, or a member read that does not
-// resolve to a readable property, reports an unsupported feature and recovers so the caller
-// keeps the type it already inferred. No level is threaded: a query reads existing bindings
-// and mints nothing fresh.
+// resolveTypeOfTypeAnn resolves a `typeof v` query to the value's type at annotation time (M9
+// PR1a) — not a residual, the value→type bridge `keyof typeof x` relies on. A name or member
+// that resolves to no readable value reports an unsupported feature and recovers.
 func (c *checker) resolveTypeOfTypeAnn(scope *Scope, ta *ast.TypeOfTypeAnn) (soltype.Type, bool) {
 	if t, ok := c.resolveTypeOfQualIdent(scope, ta.Value); ok {
 		return t, true
@@ -263,26 +257,19 @@ func (c *checker) resolveTypeOfTypeAnn(scope *Scope, ta *ast.TypeOfTypeAnn) (sol
 
 // resolveTypeOfQualIdent resolves a `typeof` operand — a bare value name or a member chain
 // `p.x` — to the value's type, porting the old checker's resolveTypeOfQualIdent
-// (internal/checker/expand_type.go). A bare name looks the value up in scope and takes its
-// scheme's coalesced concrete type; a member chain resolves the base value and then projects
-// each named property off the resolved type. It returns ok=false when the base name is not a
-// value or a step does not resolve, leaving the diagnostic to the caller.
+// (internal/checker/expand_type.go). A name reads the value's coalesced scheme type; a member
+// chain projects each property off the resolved base. ok=false when a step does not resolve.
 //
-// The result is deliberately not stamped with provenance: bindingType returns the binding's
-// coalesced scheme type and a projected member returns the property's shared type, neither of
-// which is the freshly-minted unique pointer recordProv requires, so recording provenance
-// would trip its unique-pointer guard. A downstream mismatch blames its constraint site
-// instead, the same fallback a provenance-less type takes elsewhere.
+// The result is not stamped with provenance: it is a shared binding/property type, not the
+// freshly-minted unique pointer recordProv requires, so a mismatch blames its constraint site.
 func (c *checker) resolveTypeOfQualIdent(scope *Scope, ident ast.QualIdent) (soltype.Type, bool) {
 	switch id := ident.(type) {
 	case *ast.Ident:
 		if b, ok := scope.GetValue(id.Name); ok {
-			// bindingType takes the scheme's coalesced concrete type — the object `{a: 1}`
-			// for a `val v = {a: 1}` — rather than a freshly instantiated inference var. A raw
-			// var would coalesce to unknown wherever the query lands in a negative position,
-			// such as the operand of `keyof typeof v`. The dep graph orders v ahead of any
-			// annotation naming it, so its scheme is final when this runs. It returns nil for a
-			// definition-less binding, which becomes the ok=false path.
+			// bindingType takes the scheme's coalesced concrete type, not a fresh inference
+			// var that would coalesce to unknown in a negative position such as the operand of
+			// `keyof typeof v`. The dep graph orders v first, so its scheme is final here; a
+			// definition-less binding yields nil, i.e. the ok=false path.
 			if t := bindingType(b); t != nil {
 				return t, true
 			}
@@ -298,10 +285,9 @@ func (c *checker) resolveTypeOfQualIdent(scope *Scope, ident ast.QualIdent) (sol
 	return nil, false
 }
 
-// typeofMember projects the named property off a `typeof p.x` receiver type. It strips any
-// borrow wrapper, then reads the member off the carrier object, so the query returns the
-// field's declared type directly with no fresh var or constraint. A receiver that is not an
-// object, or a member it does not carry as a readable value, does not resolve.
+// typeofMember projects the named property off a `typeof p.x` receiver: it strips any borrow
+// wrapper, then reads the member off the carrier object, returning nothing when the receiver
+// is not an object or carries no such readable member.
 func (c *checker) typeofMember(recv soltype.Type, name string) (soltype.Type, bool) {
 	obj, ok := c.ctx.readCarrierObject(readCarrier(recv))
 	if !ok {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -79,6 +79,10 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveIntersectionTypeAnn(scope, ta, lvl)
 	case *ast.FuncTypeAnn:
 		return c.resolveFuncTypeAnn(scope, ta, lvl)
+	case *ast.KeyOfTypeAnn:
+		return c.resolveKeyOfTypeAnn(scope, ta, lvl)
+	case *ast.TypeOfTypeAnn:
+		return c.resolveTypeOfTypeAnn(scope, ta)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -226,6 +230,88 @@ func (c *checker) resolveIntersectionTypeAnn(scope *Scope, ta *ast.IntersectionT
 		c.recordProv(t, ta, AnnotationType)
 	}
 	return t, true
+}
+
+// resolveKeyOfTypeAnn lowers a `keyof T` annotation to the inert KeyofType residual
+// (M9 PR1a). The operand resolves through resolveTypeAnn; an unsupported operand recovers
+// to a fresh var so the residual survives, cascade-safe like the Promise<bad> recovery.
+// The residual is built UNREDUCED — the evaluator reduces a ground operand in PR1b, so a
+// `keyof T` over a type parameter renders and flows through constrain/coalesce as-is.
+func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl int) (soltype.Type, bool) {
+	operand, ok := c.resolveTypeAnn(scope, ta.Type, lvl)
+	if !ok {
+		operand = c.freshAt(lvl)
+	}
+	t := &soltype.KeyofType{Operand: operand}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveTypeOfTypeAnn resolves a `typeof v` query against the VALUE scope, returning that
+// value's type directly (M9 PR1a). It is not a residual: `typeof` is the value→type bridge
+// `keyof typeof x` relies on, resolved at annotation time. resolveTypeOfQualIdent handles a
+// bare name and a member chain. A name that names no value, or a member read that does not
+// resolve to a readable property, reports an unsupported feature and recovers so the caller
+// keeps the type it already inferred. No level is threaded: a query reads existing bindings
+// and mints nothing fresh.
+func (c *checker) resolveTypeOfTypeAnn(scope *Scope, ta *ast.TypeOfTypeAnn) (soltype.Type, bool) {
+	if t, ok := c.resolveTypeOfQualIdent(scope, ta.Value); ok {
+		return t, true
+	}
+	return c.reportUnsupportedFeature(ta, "typeof of a name that is not a readable value"), false
+}
+
+// resolveTypeOfQualIdent resolves a `typeof` operand — a bare value name or a member chain
+// `p.x` — to the value's type, porting the old checker's resolveTypeOfQualIdent
+// (internal/checker/expand_type.go). A bare name looks the value up in scope and takes its
+// scheme's coalesced concrete type; a member chain resolves the base value and then projects
+// each named property off the resolved type. It returns ok=false when the base name is not a
+// value or a step does not resolve, leaving the diagnostic to the caller.
+//
+// The result is deliberately not stamped with provenance: bindingType returns the binding's
+// coalesced scheme type and a projected member returns the property's shared type, neither of
+// which is the freshly-minted unique pointer recordProv requires, so recording provenance
+// would trip its unique-pointer guard. A downstream mismatch blames its constraint site
+// instead, the same fallback a provenance-less type takes elsewhere.
+func (c *checker) resolveTypeOfQualIdent(scope *Scope, ident ast.QualIdent) (soltype.Type, bool) {
+	switch id := ident.(type) {
+	case *ast.Ident:
+		if b, ok := scope.GetValue(id.Name); ok {
+			// bindingType takes the scheme's coalesced concrete type — the object `{a: 1}`
+			// for a `val v = {a: 1}` — rather than a freshly instantiated inference var. A raw
+			// var would coalesce to unknown wherever the query lands in a negative position,
+			// such as the operand of `keyof typeof v`. The dep graph orders v ahead of any
+			// annotation naming it, so its scheme is final when this runs. It returns nil for a
+			// definition-less binding, which becomes the ok=false path.
+			if t := bindingType(b); t != nil {
+				return t, true
+			}
+		}
+		return nil, false
+	case *ast.Member:
+		recv, ok := c.resolveTypeOfQualIdent(scope, id.Left)
+		if !ok {
+			return nil, false
+		}
+		return c.typeofMember(recv, id.Right.Name)
+	}
+	return nil, false
+}
+
+// typeofMember projects the named property off a `typeof p.x` receiver type. It strips any
+// borrow wrapper, then reads the member off the carrier object, so the query returns the
+// field's declared type directly with no fresh var or constraint. A receiver that is not an
+// object, or a member it does not carry as a readable value, does not resolve.
+func (c *checker) typeofMember(recv soltype.Type, name string) (soltype.Type, bool) {
+	obj, ok := c.ctx.readCarrierObject(readCarrier(recv))
+	if !ok {
+		return nil, false
+	}
+	read, hasValue, _ := memberReadContribution(obj, name)
+	if !hasValue {
+		return nil, false
+	}
+	return read, true
 }
 
 // resolveFuncTypeAnn lowers a function type annotation `fn<T>(p: A, ...) -> R` into a


### PR DESCRIPTION
Implements the `keyof` and `typeof` type operators as the first phase of M9 type-level operators work.

**Summary**

Adds support for `keyof T` as an inert residual type operator and `typeof v` as a value-to-type query. The `keyof` operator builds a symbolic residual that flows through the solver untouched until reduction lands in a later phase. The `typeof` operator resolves against the value scope at annotation time, returning the value's concrete type directly.

**Changes**

- **Type representation**: Added `KeyofType` to `soltype` with `Operand` and `Exact` fields. The residual carries no bounds and flows through constrain/coalesce without decomposition.

- **Type annotation resolution**: Implemented `resolveKeyOfTypeAnn` to lower `keyof T` annotations to the inert residual, and `resolveTypeOfTypeAnn` with `resolveTypeOfQualIdent` to resolve `typeof` queries against the value scope. Supports bare names and member chains in `typeof` operands.

- **Visitor support**: Added `Accept` method for `KeyofType` that walks the operand in the current polarity without reducing the operator, matching the single-child covariant pattern of `PromiseType`.

- **Printing and diagnostics**: Added `KeyofType` rendering in `print.go` at prefix precedence (parenthesizing looser operands like unions), and in `errors.go` for structural error messages that name the residual in constraints.

- **Constraint handling**: `KeyofType` in constrain is inert—two residuals unify only when structurally identical, and an unreduced residual against concrete types fails. When the supertype is a variable, the whole residual is recorded as a lower bound.

- **Coalescing**: Added equality check for `KeyofType` that compares exactness and operand equality without reducing the operator.

- **Tests**: Added comprehensive test coverage for `keyof` residual round-tripping, ground and union operands, error messages, and `typeof` queries including the `keyof typeof x` pattern.

https://claude.ai/code/session_019q159Y4G4vnuymwJRzBVeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `keyof` type annotations, including nested and unresolved type expressions.
  * Added support for `typeof` annotations referencing values and member chains.
  * Improved handling of type-operator constraints during type inference.
* **Bug Fixes**
  * Error messages now display rejected `keyof` constraints accurately instead of generic placeholders.
  * Type rendering correctly adds parentheses where needed.
* **Tests**
  * Added coverage for `keyof` residuals, diagnostics, and `typeof` resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->