### PR TITLE
Implement tuple spread type operator reduction

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -41,6 +41,11 @@ func typePrec(t Type) int {
 		return precAtom
 	case *TypeofType:
 		return precPrefix
+	case *RestSpreadType:
+		// A `...P` spread element only appears inside a tuple's bracket list, which prints each
+		// element unparenthesized, so its precedence is consulted only if it is rendered on its
+		// own. The `...` prefix binds like the other prefixes.
+		return precPrefix
 	default:
 		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, Void, NullType,
 		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited, and ClassType and
@@ -414,10 +419,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Index)
 		case *TypeofType:
 			walk(t.Ty)
-		case *TupleSpreadType:
-			for _, el := range t.Elems {
-				walk(el.Type)
-			}
+		case *RestSpreadType:
+			walk(t.Operand)
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -553,22 +556,12 @@ func (p *namedPrinter) printType(t Type) string {
 			elems = append(elems, "...")
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
-	case *TupleSpreadType:
-		// A residual tuple spread renders in surface syntax with a `...` prefix on each spread
-		// element, so `[...P, x]` round-trips. A spread operand prints at precPrefix so a looser
-		// operand such as a union gets parenthesized under the `...`.
-		elems := make([]string, 0, len(t.Elems)+1)
-		for _, el := range t.Elems {
-			if el.Spread {
-				elems = append(elems, "..."+p.printTypeMinPrec(el.Type, precPrefix))
-			} else {
-				elems = append(elems, p.printType(el.Type))
-			}
-		}
-		if t.Inexact {
-			elems = append(elems, "...")
-		}
-		return "[" + strings.Join(elems, ", ") + "]"
+	case *RestSpreadType:
+		// A `...P` spread element renders with a `...` prefix so `[...P, x]` round-trips. The
+		// operand prints at precPrefix so a looser operand such as a union gets parenthesized under
+		// the `...`. The enclosing TupleType arm renders each element through printType, so a spread
+		// element reaches here in place.
+		return "..." + p.printTypeMinPrec(t.Operand, precPrefix)
 	case *ObjectType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -414,6 +414,10 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Index)
 		case *TypeofType:
 			walk(t.Ty)
+		case *TupleSpreadType:
+			for _, el := range t.Elems {
+				walk(el.Type)
+			}
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -544,6 +548,22 @@ func (p *namedPrinter) printType(t Type) string {
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
 			elems = append(elems, p.printType(e))
+		}
+		if t.Inexact {
+			elems = append(elems, "...")
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case *TupleSpreadType:
+		// A residual tuple spread renders in surface syntax with a `...` prefix on each spread
+		// element, so `[...P, x]` round-trips. A spread operand prints at precPrefix so a looser
+		// operand such as a union gets parenthesized under the `...`.
+		elems := make([]string, 0, len(t.Elems)+1)
+		for _, el := range t.Elems {
+			if el.Spread {
+				elems = append(elems, "..."+p.printTypeMinPrec(el.Type, precPrefix))
+			} else {
+				elems = append(elems, p.printType(el.Type))
+			}
 		}
 		if t.Inexact {
 			elems = append(elems, "...")

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -633,10 +633,33 @@ type TypeofType struct {
 	Ty    Type
 }
 
+// TupleSpreadType is the residual `[...P, x]` tuple-spread type operator (M9 PR6), the positional
+// analogue of the object spread. It is inert: it carries no bounds, constrain never records one
+// against it, and it flows through the solver's structural machinery untouched, the "adds no new
+// mutable solver state" invariant it shares with KeyofType. An evaluator reduces it once every
+// spread operand grounds to a concrete tuple, splicing each spread operand's elements in at the
+// operand's position to yield a plain TupleType. Until then a spread over a type parameter stays
+// symbolic and renders `[...T, x]`. The M4 literal case `[...pair, 3]` over a known tuple value
+// reduces in inferTuple. This residual covers the annotation over an abstract operand. Inexact
+// carries a trailing `...` marker, so `[...T, ...]` round-trips and reduces to an inexact tuple.
+type TupleSpreadType struct {
+	Elems   []TupleSpreadElem
+	Inexact bool
+}
+
+// TupleSpreadElem is one position of a TupleSpreadType. When Spread is true it is a spread `...P`
+// and Type is the operand spliced in on reduction; when Spread is false it is a plain positional
+// element and Type is that element's type.
+type TupleSpreadElem struct {
+	Type   Type
+	Spread bool
+}
+
 func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
+func (*TupleSpreadType) isType()  {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
@@ -725,6 +748,15 @@ func LevelOf(t Type) int {
 		// A `typeof x` query's level is its resolved value type's, the same single-child rule
 		// KeyofType and PromiseType follow.
 		return LevelOf(t.Ty)
+	case *TupleSpreadType:
+		// A residual tuple spread's level is the max over its element operands, so an out-of-level
+		// spread operand lifts the level and the freshener/extruder prune descends to freshen it,
+		// the same rule the TupleType arm applies to its elements.
+		m := 0
+		for _, el := range t.Elems {
+			m = max(m, LevelOf(el.Type))
+		}
+		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -633,33 +633,23 @@ type TypeofType struct {
 	Ty    Type
 }
 
-// TupleSpreadType is the residual `[...P, x]` tuple-spread type operator, the positional
-// analogue of the object spread. It is inert: it carries no bounds, constrain never records one
-// against it, and it flows through the solver's structural machinery untouched, the "adds no new
-// mutable solver state" invariant it shares with KeyofType. An evaluator reduces it once every
-// spread operand grounds to a concrete tuple, splicing each spread operand's elements in at the
-// operand's position to yield a plain TupleType. Until then a spread over a type parameter stays
-// symbolic and renders `[...T, x]`. The M4 literal case `[...pair, 3]` over a known tuple value
-// reduces in inferTuple. This residual covers the annotation over an abstract operand. Inexact
-// carries a trailing `...` marker, so `[...T, ...]` round-trips and reduces to an inexact tuple.
-type TupleSpreadType struct {
-	Elems   []TupleSpreadElem
-	Inexact bool
-}
-
-// TupleSpreadElem is one position of a TupleSpreadType. When Spread is true it is a spread `...P`
-// and Type is the operand spliced in on reduction; when Spread is false it is a plain positional
-// element and Type is that element's type.
-type TupleSpreadElem struct {
-	Type   Type
-	Spread bool
+// RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
+// checker's RestSpreadType (internal/type_system/types.go). It is only meaningful as an element of
+// a TupleType.Elems list: `[...P, x]` is a TupleType whose first element is a RestSpreadType. A
+// tuple carrying one is inert — constrain passes it through untouched, the "adds no new mutable
+// solver state" invariant it shares with KeyofType — until the evaluator splices Operand's tuple
+// elements in at its position. A spread over a type parameter never grounds, so it stays symbolic
+// and renders `...T`. The M4 literal case `[...pair, 3]` over a known tuple value reduces in
+// inferTuple; this element covers the annotation over an abstract operand.
+type RestSpreadType struct {
+	Operand Type
 }
 
 func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
-func (*TupleSpreadType) isType()  {}
+func (*RestSpreadType) isType()   {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
@@ -748,15 +738,12 @@ func LevelOf(t Type) int {
 		// A `typeof x` query's level is its resolved value type's, the same single-child rule
 		// KeyofType and PromiseType follow.
 		return LevelOf(t.Ty)
-	case *TupleSpreadType:
-		// A residual tuple spread's level is the max over its element operands, so an out-of-level
-		// spread operand lifts the level and the freshener/extruder prune descends to freshen it,
-		// the same rule the TupleType arm applies to its elements.
-		m := 0
-		for _, el := range t.Elems {
-			m = max(m, LevelOf(el.Type))
-		}
-		return m
+	case *RestSpreadType:
+		// A `...P` spread element's level is its operand's, so an out-of-level spread operand lifts
+		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the
+		// same single-child rule the KeyofType arm follows. The TupleType arm already maxes over its
+		// elements, so this element contributes its operand's level there.
+		return LevelOf(t.Operand)
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -633,7 +633,7 @@ type TypeofType struct {
 	Ty    Type
 }
 
-// TupleSpreadType is the residual `[...P, x]` tuple-spread type operator (M9 PR6), the positional
+// TupleSpreadType is the residual `[...P, x]` tuple-spread type operator, the positional
 // analogue of the object spread. It is inert: it carries no bounds, constrain never records one
 // against it, and it flows through the solver's structural machinery untouched, the "adds no new
 // mutable solver state" invariant it shares with KeyofType. An evaluator reduces it once every

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -217,33 +217,20 @@ func (t *TypeofType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *TupleSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
+func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
 	}
 	cur := descendReplacement(t, e)
-	// Each element operand walks in the current polarity, the covariant visit TupleType uses for
-	// its elements, copy-on-write like acceptTypes: a changed operand gets a fresh TupleSpreadElem
-	// carrying its Spread marker, unchanged operands keep their slot. The residual is inert — the
-	// visit rebuilds it around rewritten operands without reducing the spread, so
-	// extrude/coalesce/freshenAbove carry `[...T, x]` through untouched. The evaluator's reduction
-	// lands separately.
-	elems := cur.Elems
-	changed := false
-	for i, el := range cur.Elems {
-		ty := el.Type.Accept(v, pol)
-		if ty != el.Type {
-			if !changed {
-				elems = append([]TupleSpreadElem(nil), cur.Elems...)
-				changed = true
-			}
-			elems[i] = TupleSpreadElem{Type: ty, Spread: el.Spread}
-		}
-	}
+	// The operand walks in the current polarity, the covariant visit a tuple element gets. The
+	// spread is inert — the visit rebuilds it around a rewritten operand without splicing, so
+	// extrude/coalesce/freshenAbove carry `...T` through untouched. The enclosing TupleType.Accept
+	// walks this element like any other, so no separate spread-list traversal is needed.
+	operand := cur.Operand.Accept(v, pol)
 	out := cur
-	if changed {
-		out = &TupleSpreadType{Elems: elems, Inexact: cur.Inexact}
+	if operand != cur.Operand {
+		out = &RestSpreadType{Operand: operand}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -217,6 +217,43 @@ func (t *TypeofType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *TupleSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// Each element operand walks in the current polarity, the covariant visit TupleType uses for
+	// its elements. The residual is inert — the visit rebuilds it around rewritten operands
+	// without reducing the spread, so extrude/coalesce/freshenAbove carry `[...T, x]` through
+	// untouched. The evaluator's reduction lands separately.
+	elems, changed := acceptTupleSpreadElems(cur.Elems, v, pol)
+	out := cur
+	if changed {
+		out = &TupleSpreadType{Elems: elems, Inexact: cur.Inexact}
+	}
+	return v.ExitType(out, pol)
+}
+
+// acceptTupleSpreadElems walks each element operand covariantly, copy-on-write like acceptTypes: a
+// changed operand gets a fresh TupleSpreadElem carrying its Spread marker, unchanged operands keep
+// their slot.
+func acceptTupleSpreadElems(es []TupleSpreadElem, v TypeVisitor, pol Polarity) ([]TupleSpreadElem, bool) {
+	out := es
+	changed := false
+	for i, el := range es {
+		ty := el.Type.Accept(v, pol)
+		if ty != el.Type {
+			if !changed {
+				out = append([]TupleSpreadElem(nil), es...)
+				changed = true
+			}
+			out[i] = TupleSpreadElem{Type: ty, Spread: el.Spread}
+		}
+	}
+	return out, changed
+}
+
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -224,34 +224,28 @@ func (t *TupleSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	}
 	cur := descendReplacement(t, e)
 	// Each element operand walks in the current polarity, the covariant visit TupleType uses for
-	// its elements. The residual is inert — the visit rebuilds it around rewritten operands
-	// without reducing the spread, so extrude/coalesce/freshenAbove carry `[...T, x]` through
-	// untouched. The evaluator's reduction lands separately.
-	elems, changed := acceptTupleSpreadElems(cur.Elems, v, pol)
+	// its elements, copy-on-write like acceptTypes: a changed operand gets a fresh TupleSpreadElem
+	// carrying its Spread marker, unchanged operands keep their slot. The residual is inert — the
+	// visit rebuilds it around rewritten operands without reducing the spread, so
+	// extrude/coalesce/freshenAbove carry `[...T, x]` through untouched. The evaluator's reduction
+	// lands separately.
+	elems := cur.Elems
+	changed := false
+	for i, el := range cur.Elems {
+		ty := el.Type.Accept(v, pol)
+		if ty != el.Type {
+			if !changed {
+				elems = append([]TupleSpreadElem(nil), cur.Elems...)
+				changed = true
+			}
+			elems[i] = TupleSpreadElem{Type: ty, Spread: el.Spread}
+		}
+	}
 	out := cur
 	if changed {
 		out = &TupleSpreadType{Elems: elems, Inexact: cur.Inexact}
 	}
 	return v.ExitType(out, pol)
-}
-
-// acceptTupleSpreadElems walks each element operand covariantly, copy-on-write like acceptTypes: a
-// changed operand gets a fresh TupleSpreadElem carrying its Spread marker, unchanged operands keep
-// their slot.
-func acceptTupleSpreadElems(es []TupleSpreadElem, v TypeVisitor, pol Polarity) ([]TupleSpreadElem, bool) {
-	out := es
-	changed := false
-	for i, el := range es {
-		ty := el.Type.Accept(v, pol)
-		if ty != el.Type {
-			if !changed {
-				out = append([]TupleSpreadElem(nil), es...)
-				changed = true
-			}
-			out[i] = TupleSpreadElem{Type: ty, Spread: el.Spread}
-		}
-	}
-	return out, changed
 }
 
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1118,22 +1118,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// types, compared without unwrapping — the query flows through the solver untouched.
 		b, ok := b.(*soltype.TypeofType)
 		return ok && a.Ident == b.Ident && equalTypeWith(a.Ty, b.Ty, ctx)
-	case *soltype.TupleSpreadType:
-		// Two inert tuple-spread residuals are equal when they carry the same elements in order,
-		// each with a matching spread marker over an equal operand. This compares the residual
-		// structurally without reducing it, matching how the operator flows through the solver
-		// untouched.
-		b, ok := b.(*soltype.TupleSpreadType)
-		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
-			return false
-		}
-		for i, ae := range a.Elems {
-			be := b.Elems[i]
-			if ae.Spread != be.Spread || !equalTypeWith(ae.Type, be.Type, ctx) {
-				return false
-			}
-		}
-		return true
+	case *soltype.RestSpreadType:
+		// Two `...P` spread elements are equal when their operands are, compared structurally
+		// without reducing. The enclosing TupleType arm compares element lists positionally, so a
+		// spread element reaches here in place, the spread twin of the plain element comparison.
+		b, ok := b.(*soltype.RestSpreadType)
+		return ok && equalTypeWith(a.Operand, b.Operand, ctx)
 	}
 	return false
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1118,6 +1118,22 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// types, compared without unwrapping — the query flows through the solver untouched.
 		b, ok := b.(*soltype.TypeofType)
 		return ok && a.Ident == b.Ident && equalTypeWith(a.Ty, b.Ty, ctx)
+	case *soltype.TupleSpreadType:
+		// Two inert tuple-spread residuals are equal when they carry the same elements in order,
+		// each with a matching spread marker over an equal operand. This compares the residual
+		// structurally without reducing it, matching how the operator flows through the solver
+		// untouched.
+		b, ok := b.(*soltype.TupleSpreadType)
+		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
+			return false
+		}
+		for i, ae := range a.Elems {
+			be := b.Elems[i]
+			if ae.Spread != be.Spread || !equalTypeWith(ae.Type, be.Type, ctx) {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -135,29 +135,42 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
 // An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
-// to its key set, an indexed access `T[K]` reduces to the type at that key, and a tuple spread
-// splices its operand tuples into a plain tuple. The returned errs carry any diagnostic the
-// reduction produced — an unknown object key or an out-of-range tuple index — for constrain to
-// surface at the constraint site. It reports ok=false for any other type, and for a reduced
-// operator that does not fully ground — a `keyof T`, `T[K]`, or `[...T, x]` over a type parameter,
-// or an expanding alias whose reduction is truncated to a residual that would re-expand without
-// bound — which stays inert.
+// to its key set, an indexed access `T[K]` reduces to the type at that key, and a tuple carrying a
+// `...P` spread splices its operand tuples into a plain tuple. A plain tuple is a structural type
+// constrain decomposes, not an operator, so it reports ok=false. The returned errs carry any
+// diagnostic the reduction produced — an unknown object key or an out-of-range tuple index — for
+// constrain to surface at the constraint site. It reports ok=false for any other type, and for a
+// reduced operator that does not fully ground — a `keyof T`, `T[K]`, or `[...T, x]` over a type
+// parameter, or an expanding alias whose reduction is truncated to a residual that would re-expand
+// without bound — which stays inert.
 func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.TupleSpreadType:
-		e := newTypeEvaluator(c)
-		reduced := e.reduce(t)
-		if containsResidualOp(reduced) {
+	case *soltype.KeyofType, *soltype.IndexType:
+		return c.reduceResidual(t)
+	case *soltype.TupleType:
+		if !tupleHasSpread(t) {
 			return nil, nil, false
 		}
-		return reduced, e.errs, true
+		return c.reduceResidual(t)
 	default:
 		return nil, nil, false
 	}
+}
+
+// reduceResidual reduces a residual operator and reports its value, or ok=false when the reduction
+// stays symbolic — an operand that never ground, or an expanding alias truncated to a residual
+// that would re-expand without bound. The errs carry any diagnostic the reduction produced.
+func (c *Context) reduceResidual(t soltype.Type) (soltype.Type, []SolverError, bool) {
+	e := newTypeEvaluator(c)
+	reduced := e.reduce(t)
+	if containsResidualOp(reduced) {
+		return nil, nil, false
+	}
+	return reduced, e.errs, true
 }
 
 // constrain asserts sub <: super. mutCtx (PR 14) is the deep-mut context flag: true
@@ -453,7 +466,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return append(errs, c.constrain(sub.Ret, sup.Ret, seen, false)...) // covariant
 		}
 	case *soltype.TupleType:
-		if sup, ok := super.(*soltype.TupleType); ok {
+		if tupleHasSpread(sub) || tupleHasSpread(super) {
+			// One side carries an unreduced `...P` spread the pre-switch could not ground: a spread
+			// over a type parameter, or an expanding recursive alias. constrain treats such a tuple
+			// inert, the same as the KeyofType/IndexType residuals — it is never decomposed, so two
+			// spread-tuples are compatible only when structurally identical. When super is a variable
+			// the case falls through to the superVar arm below, which records the whole tuple as one
+			// lower bound, keeping the spread symbolic on the coalesced binding.
+			if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+				if equalType(sub, super) {
+					return nil
+				}
+				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+			}
+		} else if sup, ok := super.(*soltype.TupleType); ok {
 			// Element-wise covariant over the shared prefix. Length tolerance
 			// follows the super's exactness. An exact super such as `[A, B]`
 			// fixes its length. An inexact super such as `[A, ...]` only
@@ -737,14 +763,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			}
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 		}
-	case *soltype.IndexType, *soltype.TupleSpreadType:
-		// A `T[K]` or `[...T, x]` residual the pre-switch could not ground reaches here: an operator
-		// over a type parameter, or an expanding recursive alias. constrain treats it inert, the same
-		// as the KeyofType arm above — two residuals are compatible only when structurally identical,
-		// so `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
+	case *soltype.IndexType:
+		// A `T[K]` residual the pre-switch could not ground reaches here: an access over a type
+		// parameter, or an expanding recursive alias. constrain treats it inert, the same as the
+		// KeyofType arm above — two residuals are compatible only when structurally identical, so
+		// `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
 		// other concrete fails. When super is a variable the case falls through to the superVar arm,
 		// which records the whole residual as one lower bound, keeping the operator symbolic on the
-		// coalesced binding.
+		// coalesced binding. A tuple carrying a `...P` spread is handled inertly in the TupleType arm
+		// above, the spread twin of this arm.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -135,19 +135,20 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
 // An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
-// to its key set, and an indexed access `T[K]` reduces to the type at that key. The returned
-// errs carry any diagnostic the reduction produced — an unknown object key or an out-of-range
-// tuple index — for constrain to surface at the constraint site. It reports ok=false for any
-// other type, and for a reduced operator that does not fully ground — a `keyof T` or `T[K]` over
-// a type parameter, or an expanding alias whose reduction is truncated to a residual that would
-// re-expand without bound — which stays inert.
+// to its key set, an indexed access `T[K]` reduces to the type at that key, and a tuple spread
+// splices its operand tuples into a plain tuple. The returned errs carry any diagnostic the
+// reduction produced — an unknown object key or an out-of-range tuple index — for constrain to
+// surface at the constraint site. It reports ok=false for any other type, and for a reduced
+// operator that does not fully ground — a `keyof T`, `T[K]`, or `[...T, x]` over a type parameter,
+// or an expanding alias whose reduction is truncated to a residual that would re-expand without
+// bound — which stays inert.
 func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.TupleSpreadType:
 		e := newTypeEvaluator(c)
 		reduced := e.reduce(t)
 		if containsResidualOp(reduced) {
@@ -736,13 +737,13 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			}
 			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
 		}
-	case *soltype.IndexType:
-		// A `T[K]` residual the pre-switch could not ground reaches here: an access over a type
-		// parameter, or an expanding recursive alias. constrain treats it inert, the same as the
-		// KeyofType arm above — two residuals are compatible only when structurally identical, so
-		// `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
+	case *soltype.IndexType, *soltype.TupleSpreadType:
+		// A `T[K]` or `[...T, x]` residual the pre-switch could not ground reaches here: an operator
+		// over a type parameter, or an expanding recursive alias. constrain treats it inert, the same
+		// as the KeyofType arm above — two residuals are compatible only when structurally identical,
+		// so `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
 		// other concrete fails. When super is a variable the case falls through to the superVar arm,
-		// which records the whole residual as one lower bound, keeping the access symbolic on the
+		// which records the whole residual as one lower bound, keeping the operator symbolic on the
 		// coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1750,6 +1750,22 @@ func describe(t soltype.Type) string {
 		// unwraps it to the resolved type before comparing, so a diagnostic rarely names the
 		// query itself, but a rejected bound that still carries it reads `typeof x`.
 		return "typeof " + t.Ident
+	case *soltype.TupleSpreadType:
+		// A tuple-spread residual renders structurally, recursing like the Promise arm, so a
+		// rejected constraint names it `[...t1, number]` rather than the default `?`. Each spread
+		// element leads with `...`; operands render in describe's raw mid-constrain form.
+		parts := make([]string, 0, len(t.Elems)+1)
+		for _, el := range t.Elems {
+			if el.Spread {
+				parts = append(parts, "..."+describe(el.Type))
+			} else {
+				parts = append(parts, describe(el.Type))
+			}
+		}
+		if t.Inexact {
+			parts = append(parts, "...")
+		}
+		return "[" + strings.Join(parts, ", ") + "]"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1713,6 +1713,19 @@ func describe(t soltype.Type) string {
 	case *soltype.FuncType:
 		return "function"
 	case *soltype.TupleType:
+		if tupleHasSpread(t) {
+			// A tuple carrying an unreduced `...P` spread renders structurally so a rejected
+			// constraint names it `[...t1, number]` rather than the bare nominal "tuple". A plain
+			// tuple stays nominal, since spelling out every element would be verbose.
+			parts := make([]string, 0, len(t.Elems)+1)
+			for _, el := range t.Elems {
+				parts = append(parts, describe(el))
+			}
+			if t.Inexact {
+				parts = append(parts, "...")
+			}
+			return "[" + strings.Join(parts, ", ") + "]"
+		}
 		return "tuple"
 	case *soltype.ObjectType:
 		return "object"
@@ -1750,22 +1763,11 @@ func describe(t soltype.Type) string {
 		// unwraps it to the resolved type before comparing, so a diagnostic rarely names the
 		// query itself, but a rejected bound that still carries it reads `typeof x`.
 		return "typeof " + t.Ident
-	case *soltype.TupleSpreadType:
-		// A tuple-spread residual renders structurally, recursing like the Promise arm, so a
-		// rejected constraint names it `[...t1, number]` rather than the default `?`. Each spread
-		// element leads with `...`; operands render in describe's raw mid-constrain form.
-		parts := make([]string, 0, len(t.Elems)+1)
-		for _, el := range t.Elems {
-			if el.Spread {
-				parts = append(parts, "..."+describe(el.Type))
-			} else {
-				parts = append(parts, describe(el.Type))
-			}
-		}
-		if t.Inexact {
-			parts = append(parts, "...")
-		}
-		return "[" + strings.Join(parts, ", ") + "]"
+	case *soltype.RestSpreadType:
+		// A `...P` spread element renders `...` over its operand, reached in place when the
+		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders
+		// in describe's raw mid-constrain form.
+		return "..." + describe(t.Operand)
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1013,3 +1013,55 @@ func TestInferTupleSpreadExpandingAliasTerminates(t *testing.T) {
 	require.IsType(t, &CannotConstrainError{}, errs[0])
 	require.Equal(t, "3:36-3:42: cannot constrain tuple <: [...A<number>, boolean]", msgWithSpan(errs[0]))
 }
+
+// `keyof` and indexed access over a tuple carrying an unreduced `...P` spread stay symbolic: the
+// tuple has no ground index set until the spread grounds. Over a concrete inline spread the tuple
+// reduces first, so `keyof` projects the spliced indices and indexed access selects the spliced
+// element. Over an abstract operand both keep the operator symbolic rather than projecting the
+// `...P` element as a single position.
+func TestInferKeyofIndexOverSpreadTuple(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// keyof over a ground spread reduces the tuple to [number, string, boolean], then
+			// projects its indices.
+			name:         "KeyofGroundSpread",
+			src:          `type Result = keyof [...[number, string], boolean]`,
+			wantSymbolic: "keyof [...[number, string], boolean]",
+			wantExpanded: "0 | 1 | 2",
+		},
+		{
+			// keyof over an abstract spread operand stays symbolic.
+			name:         "KeyofAbstractSpread",
+			src:          `fn f<T>(k: keyof [...T, boolean]) {}`,
+			wantSymbolic: "keyof [...T, boolean]",
+		},
+		{
+			// Indexed access over a ground spread reduces the tuple, then selects the element.
+			name:         "IndexGroundSpread",
+			src:          `type Result = [...[number, string], boolean][2]`,
+			wantSymbolic: "[...[number, string], boolean][2]",
+			wantExpanded: "boolean",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantExpanded == "" {
+				// A signature-level case: assert the residual renders symbolically and does not crash.
+				values, _, errs := inferSource(t, tt.src)
+				require.Empty(t, errs)
+				require.Equal(t, "fn <T>(k: "+tt.wantSymbolic+") -> void", values["f"])
+				return
+			}
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1009,5 +1009,7 @@ func TestInferTupleSpreadExpandingAliasTerminates(t *testing.T) {
 		type A<T> = [T, ...A<[T]>]
 		val r: [...A<number>, boolean] = [1, 2]
 	`)
-	require.NotEmpty(t, errs)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "3:36-3:42: cannot constrain tuple <: [...A<number>, boolean]", msgWithSpan(errs[0]))
 }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -853,6 +853,14 @@ func TestInferTupleSpreadReduction(t *testing.T) {
 			wantExpanded: "[number, string, boolean]",
 		},
 		{
+			// Nested spreads collapse inside-out: each spread operand reduces before the outer
+			// splice, so a chain of single-element spreads flattens to the innermost tuple.
+			name:         "NestedSpreads",
+			src:          `type Result = [...[...[...[number]]]]`,
+			wantSymbolic: "[...[...[...[number]]]]",
+			wantExpanded: "[number]",
+		},
+		{
 			// Two spread operands splice left to right around a positional element.
 			name: "TwoSpreads",
 			src: `

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -983,6 +983,21 @@ func TestInferTupleSpreadConstraint(t *testing.T) {
 	}
 }
 
+// A `mut` spread operand `[...mut P]` is rejected at the annotation site the same way a positional
+// `[mut X]` element is: the enclosing tuple decides mutability, so an owned-mutable operand nested
+// in it is misleading. The annotation reports MutFieldError and recovers to the bare operand, which
+// still splices in position, so `[...mut P, boolean]` over `type P = [number]` checks against
+// `[1, true]` with only the one diagnostic.
+func TestInferTupleSpreadMutOperandRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type P = [number]
+		val r: [...mut P, boolean] = [1, true]
+	`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &MutFieldError{}, errs[0])
+	require.Equal(t, "owned-mutable field annotation is not allowed; the enclosing context decides mutability — wrap the whole annotation in `mut` to make this field writable, or use interior mutability", errs[0].Message())
+}
+
 // Checking a value against a tuple spread of an expanding recursive alias terminates instead of
 // looping. The reduction is budget-truncated and leaves a `[...A<…>, …]` residual, so constrain
 // does not recurse on it — re-expanding would grow the operand without bound — and the residual

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -818,3 +818,181 @@ func TestInferIndexResidualErrorMessage(t *testing.T) {
 	require.IsType(t, &CannotConstrainError{}, errs[0])
 	require.Equal(t, `1:12-1:18: cannot constrain t1["a"] <: number`, msgWithSpan(errs[0]))
 }
+
+// A tuple-spread annotation `[...P, x]` is stored as a residual and reduced by splicing each
+// spread operand's tuple in position once the operand grounds to a concrete tuple. Each case
+// asserts the stored `Result` renders the way the source wrote it, then asserts that reducing it
+// with the alias environment — the expansion constrain performs to check a constraint — splices
+// the operands. The cases cover the operand shapes reduction handles: an inline tuple, a named
+// alias expanded to a tuple, an inexact operand spliced only as the last element, an inexact
+// operand in an earlier position that keeps the spread symbolic, and a trailing `...` marker.
+func TestInferTupleSpreadReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// An inline tuple operand splices its elements in position.
+			name: "InlineTuple",
+			src: `
+				type Result = [...[number, string], boolean]
+			`,
+			wantSymbolic: "[...[number, string], boolean]",
+			wantExpanded: "[number, string, boolean]",
+		},
+		{
+			// A named alias operand expands to its tuple body, then splices.
+			name: "AliasOperand",
+			src: `
+				type Pair = [number, string]
+				type Result = [...Pair, boolean]
+			`,
+			wantSymbolic: "[...Pair, boolean]",
+			wantExpanded: "[number, string, boolean]",
+		},
+		{
+			// Two spread operands splice left to right around a positional element.
+			name: "TwoSpreads",
+			src: `
+				type Result = [...[number], string, ...[boolean]]
+			`,
+			wantSymbolic: "[...[number], string, ...[boolean]]",
+			wantExpanded: "[number, string, boolean]",
+		},
+		{
+			// An inexact operand spliced as the last element extends the prefix and carries its
+			// open tail, so the result is inexact too.
+			name: "InexactOperandLast",
+			src: `
+				type Rest = [number, ...]
+				type Result = [boolean, ...Rest]
+			`,
+			wantSymbolic: "[boolean, ...Rest]",
+			wantExpanded: "[boolean, number, ...]",
+		},
+		{
+			// An inexact operand in an earlier position would put a later element at an unknown
+			// position, so the spread stays symbolic around the expanded operand.
+			name: "InexactOperandNotLast",
+			src: `
+				type Rest = [number, ...]
+				type Result = [...Rest, boolean]
+			`,
+			wantSymbolic: "[...Rest, boolean]",
+			wantExpanded: "[...[number, ...], boolean]",
+		},
+		{
+			// A trailing `...` marker round-trips and reduces to an inexact tuple.
+			name: "TrailingInexactMarker",
+			src: `
+				type Result = [...[number], ...]
+			`,
+			wantSymbolic: "[...[number], ...]",
+			wantExpanded: "[number, ...]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A tuple-spread residual over a type parameter renders symbolically in a function signature and
+// round-trips from parameter to return: `fn f<T>(x: [...T, number]) -> [...T, number] { return x }`
+// keeps `[...T, number]` on both positions. The reflexive `[...T, number] <: [...T, number]` from
+// `return x` succeeds inertly by structural equality on the residual, since the abstract operand
+// never grounds.
+func TestInferTupleSpreadSignatureStaysSymbolic(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f<T>(x: [...T, number]) -> [...T, number] { return x }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: [...T, number]) -> [...T, number]", values["f"])
+}
+
+// constrain reduces a ground tuple-spread annotation to the spliced tuple to check satisfaction,
+// while the stored type stays the residual. A value whose elements match the spliced positions is
+// accepted; a mismatch is rejected against the spliced element, so the diagnostic names the
+// reduced position. The reduction runs at every constraint site: a `val` annotation over an inline
+// operand, over an aliased operand, and an argument checked against a parameter's type.
+func TestInferTupleSpreadConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "InlineOperandAccepted",
+			src: `
+				val r: [...[number, string], boolean] = [1, "a", true]
+			`,
+		},
+		{
+			name: "InlineOperandRejected",
+			src: `
+				val r: [...[number, string], boolean] = [1, "a", "b"]
+			`,
+			wantErr: `cannot constrain "b" <: boolean`,
+		},
+		{
+			name: "AliasOperandAccepted",
+			src: `
+				type Pair = [number, string]
+				val r: [...Pair, boolean] = [1, "a", true]
+			`,
+		},
+		{
+			name: "AliasOperandRejected",
+			src: `
+				type Pair = [number, string]
+				val r: [...Pair, boolean] = [1, "a", 2]
+			`,
+			wantErr: `cannot constrain 2 <: boolean`,
+		},
+		{
+			name: "CallArgumentAccepted",
+			src: `
+				fn f(p: [...[number], string]) -> number { return 1 }
+				val r = f([1, "a"])
+			`,
+		},
+		{
+			name: "CallArgumentRejected",
+			src: `
+				fn f(p: [...[number], string]) -> number { return 1 }
+				val r = f([1, 2])
+			`,
+			wantErr: `cannot constrain 2 <: string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// Checking a value against a tuple spread of an expanding recursive alias terminates instead of
+// looping. The reduction is budget-truncated and leaves a `[...A<…>, …]` residual, so constrain
+// does not recurse on it — re-expanding would grow the operand without bound — and the residual
+// stays inert, conservatively rejecting the value. The point is termination; the precise rejection
+// is a consequence of the truncation, which CheckRegular will reject at definition time in a later
+// milestone.
+func TestInferTupleSpreadExpandingAliasTerminates(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type A<T> = [T, ...A<[T]>]
+		val r: [...A<number>, boolean] = [1, 2]
+	`)
+	require.NotEmpty(t, errs)
+}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -206,9 +206,12 @@ func (c *checker) resolveTupleSpreadTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, 
 		if rest, ok := el.(*ast.RestSpreadTypeAnn); ok {
 			spread = true
 			operand = rest.Value
-		} else if mta, ok := el.(*ast.MutableTypeAnn); ok {
-			// An owned-mutable positional element is rejected here for the same reason the
-			// plain tuple path rejects it; recover to its bare inner.
+		}
+		// An owned-mutable element `[mut {x}]` or a mutable spread operand `[...mut P]` is
+		// rejected for the same reason the plain tuple path rejects a positional mut: a `mut`
+		// cell nested inside a non-mut container is misleading. Recover to its bare inner,
+		// keeping the spread flag so the recovered operand still splices in position.
+		if mta, ok := operand.(*ast.MutableTypeAnn); ok {
 			c.report(&MutFieldError{Ann: mta})
 			operand = mta.Target
 		}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -156,50 +156,16 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	return t, true
 }
 
-// resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType,
-// honoring the trailing `...` inexact marker. A rest-spread element (`[...P, x]`)
-// routes to resolveTupleSpreadTypeAnn, which builds a residual TupleSpreadType the
-// evaluator reduces once the operand grounds. The bare trailing `...` inexact marker
-// is carried on ta.Inexact, not as an element. An element whose annotation is
-// unsupported recovers to a fresh var so the tuple keeps its arity.
+// resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType, honoring the trailing
+// `...` inexact marker. A rest-spread element (`[...P, x]`) becomes a soltype.RestSpreadType
+// element; a tuple carrying one is a residual the evaluator reduces once the spread operand grounds
+// to a concrete tuple, splicing it in position. Until then a spread over a type parameter stays
+// symbolic. The bare trailing `...` inexact marker is carried on ta.Inexact, not as an element. An
+// element whose annotation is unsupported recovers to a fresh var so the tuple keeps its arity. A
+// `[number, ...Array<number>]` variadic tail is distinct and stays out of scope until Array lands;
+// its spread operand fails to resolve today and recovers.
 func (c *checker) resolveTupleTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
-	for _, el := range ta.Elems {
-		if _, isRest := el.(*ast.RestSpreadTypeAnn); isRest {
-			return c.resolveTupleSpreadTypeAnn(scope, ta, lvl)
-		}
-	}
 	elems := make([]soltype.Type, 0, len(ta.Elems))
-	for _, el := range ta.Elems {
-		// An owned-mutable element `[mut {x}]` is rejected (#779), the tuple twin of
-		// the object-property rejection above: a `mut` cell nested inside a non-mut
-		// container is misleading. Recover to the element's bare inner. A `&`/`&mut`
-		// borrow element stays legal — it references external storage.
-		if mta, ok := el.(*ast.MutableTypeAnn); ok {
-			c.report(&MutFieldError{Ann: mta})
-			el = mta.Target
-		}
-		if t, ok := c.resolveTypeAnn(scope, el, lvl); ok {
-			elems = append(elems, t)
-		} else {
-			elems = append(elems, c.freshAt(lvl))
-		}
-	}
-	t := &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
-	c.recordProv(t, ta, AnnotationType)
-	return t, true
-}
-
-// resolveTupleSpreadTypeAnn lowers a tuple annotation carrying a rest-spread element
-// (`[...P, x]`) to a residual soltype.TupleSpreadType and stores it unreduced, so the
-// annotation prints the way the source wrote it. The evaluator reduces it once every
-// spread operand grounds to a concrete tuple, splicing the operands in position; until
-// then a spread over a type parameter stays symbolic. Each element resolves to its type:
-// a spread carries its operand under a spread marker, a positional element carries its
-// own type. An unsupported operand recovers to a fresh var, cascade-safe like the plain
-// tuple path. A `[number, ...Array<number>]` variadic tail is distinct and stays out of
-// scope until Array lands; its spread operand fails to resolve today and recovers.
-func (c *checker) resolveTupleSpreadTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
-	elems := make([]soltype.TupleSpreadElem, 0, len(ta.Elems))
 	for _, el := range ta.Elems {
 		spread := false
 		operand := el
@@ -207,10 +173,10 @@ func (c *checker) resolveTupleSpreadTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, 
 			spread = true
 			operand = rest.Value
 		}
-		// An owned-mutable element `[mut {x}]` or a mutable spread operand `[...mut P]` is
-		// rejected for the same reason the plain tuple path rejects a positional mut: a `mut`
-		// cell nested inside a non-mut container is misleading. Recover to its bare inner,
-		// keeping the spread flag so the recovered operand still splices in position.
+		// An owned-mutable element `[mut {x}]` or a mutable spread operand `[...mut P]` is rejected
+		// (#779), the tuple twin of the object-property rejection: a `mut` cell nested inside a
+		// non-mut container is misleading. Recover to its bare inner. A `&`/`&mut` borrow element
+		// stays legal — it references external storage.
 		if mta, ok := operand.(*ast.MutableTypeAnn); ok {
 			c.report(&MutFieldError{Ann: mta})
 			operand = mta.Target
@@ -219,9 +185,12 @@ func (c *checker) resolveTupleSpreadTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, 
 		if !ok {
 			t = c.freshAt(lvl)
 		}
-		elems = append(elems, soltype.TupleSpreadElem{Type: t, Spread: spread})
+		if spread {
+			t = &soltype.RestSpreadType{Operand: t}
+		}
+		elems = append(elems, t)
 	}
-	t := &soltype.TupleSpreadType{Elems: elems, Inexact: ta.Inexact}
+	t := &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -157,19 +157,19 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 }
 
 // resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType,
-// honoring the trailing `...` inexact marker. A rest-spread / variadic element
-// (`[...P]`, `[number, ...Array<number>]`) defers with its type-level feature
-// (M9 / M7) and reports unsupported; the bare trailing `...` inexact marker is
-// carried on ta.Inexact, not as an element. An element whose annotation is
+// honoring the trailing `...` inexact marker. A rest-spread element (`[...P, x]`)
+// routes to resolveTupleSpreadTypeAnn, which builds a residual TupleSpreadType the
+// evaluator reduces once the operand grounds. The bare trailing `...` inexact marker
+// is carried on ta.Inexact, not as an element. An element whose annotation is
 // unsupported recovers to a fresh var so the tuple keeps its arity.
 func (c *checker) resolveTupleTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
-	elems := make([]soltype.Type, 0, len(ta.Elems))
-	unsupported := false
 	for _, el := range ta.Elems {
 		if _, isRest := el.(*ast.RestSpreadTypeAnn); isRest {
-			unsupported = true
-			continue
+			return c.resolveTupleSpreadTypeAnn(scope, ta, lvl)
 		}
+	}
+	elems := make([]soltype.Type, 0, len(ta.Elems))
+	for _, el := range ta.Elems {
 		// An owned-mutable element `[mut {x}]` is rejected (#779), the tuple twin of
 		// the object-property rejection above: a `mut` cell nested inside a non-mut
 		// container is misleading. Recover to the element's bare inner. A `&`/`&mut`
@@ -184,10 +184,41 @@ func (c *checker) resolveTupleTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl in
 			elems = append(elems, c.freshAt(lvl))
 		}
 	}
-	if unsupported {
-		c.reportUnsupportedFeature(ta, "tuple spread or variadic element")
-	}
 	t := &soltype.TupleType{Elems: elems, Inexact: ta.Inexact}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveTupleSpreadTypeAnn lowers a tuple annotation carrying a rest-spread element
+// (`[...P, x]`) to a residual soltype.TupleSpreadType and stores it unreduced, so the
+// annotation prints the way the source wrote it. The evaluator reduces it once every
+// spread operand grounds to a concrete tuple, splicing the operands in position; until
+// then a spread over a type parameter stays symbolic. Each element resolves to its type:
+// a spread carries its operand under a spread marker, a positional element carries its
+// own type. An unsupported operand recovers to a fresh var, cascade-safe like the plain
+// tuple path. A `[number, ...Array<number>]` variadic tail is distinct and stays out of
+// scope until Array lands; its spread operand fails to resolve today and recovers.
+func (c *checker) resolveTupleSpreadTypeAnn(scope *Scope, ta *ast.TupleTypeAnn, lvl int) (soltype.Type, bool) {
+	elems := make([]soltype.TupleSpreadElem, 0, len(ta.Elems))
+	for _, el := range ta.Elems {
+		spread := false
+		operand := el
+		if rest, ok := el.(*ast.RestSpreadTypeAnn); ok {
+			spread = true
+			operand = rest.Value
+		} else if mta, ok := el.(*ast.MutableTypeAnn); ok {
+			// An owned-mutable positional element is rejected here for the same reason the
+			// plain tuple path rejects it; recover to its bare inner.
+			c.report(&MutFieldError{Ann: mta})
+			operand = mta.Target
+		}
+		t, ok := c.resolveTypeAnn(scope, operand, lvl)
+		if !ok {
+			t = c.freshAt(lvl)
+		}
+		elems = append(elems, soltype.TupleSpreadElem{Type: t, Spread: spread})
+	}
+	t := &soltype.TupleSpreadType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -74,48 +74,43 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		// A `typeof x` query reduces to the value's resolved type. constrain unwraps it directly
 		// in its pre-switch, so this arm serves a `typeof` reached through another operator.
 		return t.Ty
-	case *soltype.TupleSpreadType:
-		return e.reduceTupleSpread(t)
+	case *soltype.TupleType:
+		return e.reduceTuple(t)
 	default:
 		return t
 	}
 }
 
-// reduceTupleSpread splices each spread operand's tuple into position, reducing `[...P, x]` to a
-// plain tuple once every spread operand grounds to a concrete tuple. It mirrors the M4 literal
-// splice in inferTuple:
+// reduceTuple splices each `...P` spread element whose operand grounds to a concrete tuple into
+// position, reducing `[...P, x]` to a plain tuple. A tuple with no spread element returns unchanged
+// so a plain tuple keeps its pointer. The splice mirrors the M4 literal case in inferTuple:
 //
-//   - a positional element carries through unchanged, reduced in case it holds a nested operator;
+//   - a non-spread element carries through, reduced in case it holds a nested operator;
 //   - a spread whose operand grounds to an exact tuple contributes that tuple's elements;
 //   - an inexact operand splices only as the last element, where its known prefix extends the
 //     result and its open tail makes the result inexact too;
-//   - an inexact operand in any earlier position keeps the whole spread symbolic, since a later
-//     element would then sit at an unknown position.
-//
-// When any spread operand stays abstract — a type parameter, or an alias the guard leaves
-// unexpanded — the spread reduces to the same operator rebuilt around the reduced operands, so it
-// stays symbolic and reduces later once the operand grounds.
-func (e *typeEvaluator) reduceTupleSpread(t *soltype.TupleSpreadType) soltype.Type {
+//   - a spread whose operand stays abstract — a type parameter, an alias the guard leaves
+//     unexpanded, or an inexact operand in a non-last position — is kept as a `...P` element around
+//     the reduced operand, so the tuple stays inert and reduces later once the operand grounds.
+func (e *typeEvaluator) reduceTuple(t *soltype.TupleType) soltype.Type {
+	if !hasRestSpread(t.Elems) {
+		return t
+	}
 	elems := make([]soltype.Type, 0, len(t.Elems))
-	rebuilt := make([]soltype.TupleSpreadElem, 0, len(t.Elems))
 	inexact := t.Inexact
-	ground := true
 	for i, el := range t.Elems {
-		if !el.Spread {
-			reduced := e.reduce(el.Type)
-			elems = append(elems, reduced)
-			rebuilt = append(rebuilt, soltype.TupleSpreadElem{Type: reduced})
-			continue
-		}
-		operand := e.groundSpreadOperand(el.Type)
-		rebuilt = append(rebuilt, soltype.TupleSpreadElem{Type: operand, Spread: true})
-		tup, ok := operand.(*soltype.TupleType)
+		rest, ok := el.(*soltype.RestSpreadType)
 		if !ok {
-			ground = false
+			elems = append(elems, e.reduce(el))
 			continue
 		}
-		if tup.Inexact && i != len(t.Elems)-1 {
-			ground = false
+		operand := e.groundSpreadOperand(rest.Operand)
+		tup, ok := operand.(*soltype.TupleType)
+		last := i == len(t.Elems)-1
+		if !ok || hasRestSpread(tup.Elems) || (tup.Inexact && !last) {
+			// The operand is not a fully-ground tuple, or is inexact in a non-last position: keep
+			// the spread residual around the reduced operand rather than splicing.
+			elems = append(elems, &soltype.RestSpreadType{Operand: operand})
 			continue
 		}
 		elems = append(elems, tup.Elems...)
@@ -123,10 +118,22 @@ func (e *typeEvaluator) reduceTupleSpread(t *soltype.TupleSpreadType) soltype.Ty
 			inexact = true
 		}
 	}
-	if !ground {
-		return &soltype.TupleSpreadType{Elems: rebuilt, Inexact: t.Inexact}
-	}
 	return &soltype.TupleType{Elems: elems, Inexact: inexact}
+}
+
+// groundTuple reduces a tuple's `...P` spreads and reports the concrete tuple when none remain. A
+// tuple with no spread returns unchanged with ok=true. A tuple whose spread never grounds returns
+// ok=false, so `keyof`/indexed access over it stays symbolic rather than projecting the spread
+// element as if it were a single position.
+func (e *typeEvaluator) groundTuple(t *soltype.TupleType) (*soltype.TupleType, bool) {
+	if !hasRestSpread(t.Elems) {
+		return t, true
+	}
+	reduced, ok := e.reduceTuple(t).(*soltype.TupleType)
+	if !ok || hasRestSpread(reduced.Elems) {
+		return nil, false
+	}
+	return reduced, true
 }
 
 // groundSpreadOperand reduces a tuple-spread operand toward a concrete tuple. It reduces any
@@ -184,7 +191,12 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Ty
 		}
 		return e.keyofObject(obj)
 	case *soltype.TupleType:
-		return e.keyofTuple(op)
+		// A tuple carrying an unreduced `...P` spread has no ground index set, so `keyof` over it
+		// stays symbolic until the spread grounds to a concrete tuple.
+		if tup, ok := e.groundTuple(op); ok {
+			return e.keyofTuple(tup)
+		}
+		return &soltype.KeyofType{Operand: operand, Exact: exact}
 	case *soltype.UnionType:
 		return e.keyofDistribute(op.Types, exact)
 	case *soltype.IntersectionType:
@@ -332,7 +344,12 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 		}
 		return e.indexObject(obj, idx, exact)
 	case *soltype.TupleType:
-		return e.indexTuple(tgt, idx, exact)
+		// A tuple carrying an unreduced `...P` spread has no ground positions, so indexing it stays
+		// symbolic until the spread grounds to a concrete tuple.
+		if tup, ok := e.groundTuple(tgt); ok {
+			return e.indexTuple(tup, idx, exact)
+		}
+		return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
 	case *soltype.UnionType:
 		// A union target distributes member-wise: `(A | B)[K]` ⇒ `A[K] | B[K]`, the other-axis
 		// twin of the union-index distribution above, matching how keyof distributes over a union
@@ -473,12 +490,31 @@ func strLitName(t soltype.Type) (string, bool) {
 }
 
 // isResidualOp reports whether t is an unreduced type-level operator node — a `keyof`, an indexed
-// access, or a tuple spread — at its top level. The evaluator consults it to stop re-reducing an
-// operand whose reduction stayed symbolic.
+// access, or a `...P` tuple-spread element — at its top level. The evaluator consults it to stop
+// re-reducing an operand whose reduction stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.TupleSpreadType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.RestSpreadType:
 		return true
+	}
+	return false
+}
+
+// tupleHasSpread reports whether t is a tuple carrying at least one unreduced `...P` spread
+// element. Such a tuple is inert — constrain passes it through untouched until the evaluator
+// splices the spread — whereas a plain tuple is a structural type constrain decomposes. A non-tuple
+// is never a spread tuple.
+func tupleHasSpread(t soltype.Type) bool {
+	tup, ok := t.(*soltype.TupleType)
+	return ok && hasRestSpread(tup.Elems)
+}
+
+// hasRestSpread reports whether any element of elems is a `...P` spread.
+func hasRestSpread(elems []soltype.Type) bool {
+	for _, el := range elems {
+		if _, ok := el.(*soltype.RestSpreadType); ok {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -74,9 +74,75 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		// A `typeof x` query reduces to the value's resolved type. constrain unwraps it directly
 		// in its pre-switch, so this arm serves a `typeof` reached through another operator.
 		return t.Ty
+	case *soltype.TupleSpreadType:
+		return e.reduceTupleSpread(t)
 	default:
 		return t
 	}
+}
+
+// reduceTupleSpread splices each spread operand's tuple into position, reducing `[...P, x]` to a
+// plain tuple once every spread operand grounds to a concrete tuple. It mirrors the M4 literal
+// splice in inferTuple:
+//
+//   - a positional element carries through unchanged, reduced in case it holds a nested operator;
+//   - a spread whose operand grounds to an exact tuple contributes that tuple's elements;
+//   - an inexact operand splices only as the last element, where its known prefix extends the
+//     result and its open tail makes the result inexact too;
+//   - an inexact operand in any earlier position keeps the whole spread symbolic, since a later
+//     element would then sit at an unknown position.
+//
+// When any spread operand stays abstract — a type parameter, or an alias the guard leaves
+// unexpanded — the spread reduces to the same operator rebuilt around the reduced operands, so it
+// stays symbolic and reduces later once the operand grounds.
+func (e *typeEvaluator) reduceTupleSpread(t *soltype.TupleSpreadType) soltype.Type {
+	elems := make([]soltype.Type, 0, len(t.Elems))
+	rebuilt := make([]soltype.TupleSpreadElem, 0, len(t.Elems))
+	inexact := t.Inexact
+	ground := true
+	for i, el := range t.Elems {
+		if !el.Spread {
+			reduced := e.reduce(el.Type)
+			elems = append(elems, reduced)
+			rebuilt = append(rebuilt, soltype.TupleSpreadElem{Type: reduced})
+			continue
+		}
+		operand := e.groundSpreadOperand(el.Type)
+		rebuilt = append(rebuilt, soltype.TupleSpreadElem{Type: operand, Spread: true})
+		tup, ok := operand.(*soltype.TupleType)
+		if !ok {
+			ground = false
+			continue
+		}
+		if tup.Inexact && i != len(t.Elems)-1 {
+			ground = false
+			continue
+		}
+		elems = append(elems, tup.Elems...)
+		if tup.Inexact {
+			inexact = true
+		}
+	}
+	if !ground {
+		return &soltype.TupleSpreadType{Elems: rebuilt, Inexact: t.Inexact}
+	}
+	return &soltype.TupleType{Elems: elems, Inexact: inexact}
+}
+
+// groundSpreadOperand reduces a tuple-spread operand toward a concrete tuple. It reduces any
+// nested operator, then expands a named alias to its body under the shared termination guard, so
+// `[...Pair, x]` over `type Pair = [number, string]` grounds to the referenced tuple. A type
+// parameter, a recurring alias state, an exhausted budget, or an unresolved alias body each leaves
+// the operand unexpanded, which keeps the spread symbolic.
+func (e *typeEvaluator) groundSpreadOperand(operand soltype.Type) soltype.Type {
+	reduced := e.reduce(operand)
+	alias, ok := reduced.(*soltype.AliasType)
+	if !ok {
+		return reduced
+	}
+	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
+		return e.groundSpreadOperand(body)
+	})
 }
 
 // reduceKeyof reduces `keyof operand` to the union of the operand's keys, mirroring the old
@@ -131,25 +197,34 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Ty
 }
 
 // reduceKeyofAlias reduces `keyof Alias` by expanding the alias and reducing `keyof` over its
-// body under the termination guard. The alias stays on the active path for the whole reduction
-// of its body, so a union or intersection member that re-references it, directly or through a
-// chain, sees it active and stops. A recurring instantiation state, an exhausted budget, or an
-// unresolved body each leaves the alias unexpanded and symbolic.
+// body under the termination guard, leaving the alias symbolic when the guard blocks expansion.
 func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, exact bool) soltype.Type {
 	symbolic := &soltype.KeyofType{Operand: op, Exact: exact}
+	return e.expandAliasGuarded(op, symbolic, func(body soltype.Type) soltype.Type {
+		return e.reduceKeyof(body, exact)
+	})
+}
+
+// expandAliasGuarded expands a named alias to its body and applies cont to the result, under the
+// two-part termination guard that makes reduction safe over a recursive alias. The alias stays on
+// the active path for the whole reduction of its body, so a member that re-references it, directly
+// or through a chain, sees it active and stops. A recurring instantiation state, an exhausted
+// budget, or an unresolved body each returns fallback with the alias left unexpanded, so the
+// operator over it stays symbolic.
+func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback soltype.Type, cont func(body soltype.Type) soltype.Type) soltype.Type {
 	key := soltype.PrintQualified(op)
 	if e.active.Contains(key) || e.depth <= 0 {
-		return symbolic
+		return fallback
 	}
 	body := e.ctx.expandAlias(op)
 	if _, unresolved := body.(*soltype.ErrorType); unresolved {
 		// expandAlias yields ErrorType for an unregistered alias, or one whose body a dep-graph
-		// sibling has not filled yet. Keep the operator symbolic rather than reducing `keyof error`.
-		return symbolic
+		// sibling has not filled yet. Keep the operator symbolic rather than reducing over `error`.
+		return fallback
 	}
 	e.active.Add(key)
 	e.depth--
-	result := e.reduceKeyof(body, exact)
+	result := cont(body)
 	e.active.Remove(key)
 	e.depth++
 	return result
@@ -397,12 +472,12 @@ func strLitName(t soltype.Type) (string, bool) {
 	return "", false
 }
 
-// isResidualOp reports whether t is an unreduced type-level operator node — a `keyof` or an
-// indexed access — at its top level. The evaluator consults it to stop re-reducing an operand
-// whose reduction stayed symbolic.
+// isResidualOp reports whether t is an unreduced type-level operator node — a `keyof`, an indexed
+// access, or a tuple spread — at its top level. The evaluator consults it to stop re-reducing an
+// operand whose reduction stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.TupleSpreadType:
 		return true
 	}
 	return false
@@ -414,11 +489,11 @@ func strLitType(name string) soltype.Type {
 	return &soltype.LitType{Lit: &soltype.StrLit{Value: name}}
 }
 
-// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`
-// or an indexed access. constrain consults it to decide whether a reduced operator fully
-// grounded: a result with no residual is safe to recurse on, while one that still carries a
-// `keyof` or a `T[K]` — an unexpanded type parameter or a budget-truncated expanding alias —
-// must not, since re-reducing it would loop.
+// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`,
+// an indexed access, or a tuple spread. constrain consults it to decide whether a reduced operator
+// fully grounded: a result with no residual is safe to recurse on, while one that still carries a
+// `keyof`, a `T[K]`, or a `[...T, x]` — an unexpanded type parameter or a budget-truncated
+// expanding alias — must not, since re-reducing it would loop.
 func containsResidualOp(t soltype.Type) bool {
 	f := &residualOpFinder{}
 	t.Accept(f, soltype.Positive)


### PR DESCRIPTION
Adds support for the tuple spread type operator `[...P, x]` (M9 PR6), which splices spread operand tuples into position once they ground to concrete tuples. The operator is stored as an inert residual that flows through the solver untouched, then reduces during constraint checking.

**Key changes:**

- **Type representation**: Added `TupleSpreadType` and `TupleSpreadElem` to represent residual tuple spreads with spread markers on operands.

- **Annotation resolution**: `resolveTupleTypeAnn` now routes annotations with rest-spread elements to `resolveTupleSpreadTypeAnn`, which builds the residual without reducing it so the annotation prints as written.

- **Reduction logic**: `reduceTupleSpread` splices each spread operand's tuple elements in position once the operand grounds. Handles exact tuples (splice elements), inexact operands as the last element (extend prefix and carry tail), and inexact operands in earlier positions (keep spread symbolic to avoid unknown positions). Operands that stay abstract rebuild the spread symbolically.

- **Operand grounding**: `groundSpreadOperand` reduces nested operators and expands named aliases under the termination guard, so `[...Pair, x]` over `type Pair = [number, string]` grounds to the referenced tuple. Type parameters and recurring aliases stay unexpanded.

- **Constraint evaluation**: `evalTypeOperator` reduces tuple spreads and checks they fully ground (no residual spread remains) before using the result, preventing loops on expanding recursive aliases. Residuals that don't ground stay inert.

- **Inert handling**: Tuple spreads are treated like `keyof` residuals—they flow through structural machinery untouched, constrain treats them inert (only compatible when structurally identical), and visitors rebuild them around rewritten operands without reducing.

- **Printing and equality**: Added printing support to render spreads in surface syntax with `...` prefixes, and equality checking that compares residuals structurally without reducing.

- **Termination guard refactor**: Extracted `expandAliasGuarded` to share the two-part termination guard (active path tracking and budget depth) between `keyof` and tuple spread reduction, ensuring both safely handle recursive aliases.

Tests cover reduction of inline tuples, named aliases, multiple spreads, inexact operands in various positions, trailing inexact markers, signature round-tripping, constraint checking with inline and aliased operands, and termination on expanding recursive aliases.

https://claude.ai/code/session_0137kZgtn3e4z5m3s372vjFz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tuple spread and variadic elements in tuple type annotations.
  * Tuple spreads now reduce correctly when their contents are known, while remaining symbolic when unresolved.
  * Improved type checking, inference, signatures, and diagnostics for tuple spreads.
  * Added safeguards to prevent recursive type expansion from looping.

* **Bug Fixes**
  * Preserved trailing inexact tuple markers and spread syntax during type processing and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->