### PR TITLE
Implement indexed-access type operator T[K]

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -35,6 +35,10 @@ func typePrec(t Type) int {
 		return precPrefix
 	case *KeyofType:
 		return precPrefix
+	case *IndexType:
+		// `T[K]` is a postfix primary that binds tighter than any prefix, so it never needs
+		// outer parens. `keyof T[K]` reads as `keyof (T[K])`, matching TypeScript.
+		return precAtom
 	case *TypeofType:
 		return precPrefix
 	default:
@@ -405,6 +409,9 @@ func freeTypeVars(t Type) []*TypeVarType {
 			}
 		case *KeyofType:
 			walk(t.Operand)
+		case *IndexType:
+			walk(t.Target)
+			walk(t.Index)
 		case *TypeofType:
 			walk(t.Ty)
 		case *PromiseType:
@@ -606,6 +613,11 @@ func (p *namedPrinter) printType(t Type) string {
 		// `keyof T`, mirroring type_system's KeyOfType rendering. The operand prints at
 		// precPrefix so a looser operand such as a union gets parenthesized: `keyof (A | B)`.
 		return "keyof " + p.printTypeMinPrec(t.Operand, precPrefix)
+	case *IndexType:
+		// `T[K]`. The target prints at precAtom so a looser target such as a union or a
+		// `keyof` gets parenthesized: `(A | B)["x"]`, `(keyof T)[K]`. The index sits inside
+		// the brackets, where nothing can bind across it, so it prints with no minimum.
+		return p.printTypeMinPrec(t.Target, precAtom) + "[" + p.printType(t.Index) + "]"
 	case *TypeofType:
 		// `typeof x`, the value reference the source wrote. The resolved value type is not
 		// rendered — the query stays symbolic, so `keyof typeof x` prints as written.

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -607,6 +607,21 @@ type KeyofType struct {
 	Exact   bool
 }
 
+// IndexType is the residual `Target[Index]` indexed-access type operator (M9 PR2), the
+// sibling of KeyofType. Like KeyofType it is inert: it carries no bounds, constrain never
+// records one against it, and it flows through the solver's structural machinery untouched.
+// An evaluator reduces it once its operands are ground — `{x: number}["x"]` ⇒ `number`, a
+// tuple `[a, b][0]` ⇒ `a`, and a union index distributes so `T["a" | "b"]` ⇒ `T["a"] |
+// T["b"]`. Until then a `T[K]` over a type parameter stays symbolic and renders `T[K]`.
+// Exact records whether the target's member set is complete, the seed for exactness
+// propagation through reduction (M9 PR8). It is carried through the visitor and left unread
+// until that work lands.
+type IndexType struct {
+	Target Type
+	Index  Type
+	Exact  bool
+}
+
 // TypeofType is the residual `typeof x` type query. Like KeyofType it is inert: it carries no
 // bounds, constrain never records one against it, and it flows through the solver's structural
 // machinery untouched, rendering `typeof <Ident>` the way the source wrote it. Ty is the queried
@@ -620,6 +635,7 @@ type TypeofType struct {
 
 func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
+func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -700,6 +716,11 @@ func LevelOf(t Type) int {
 		// type parameter lifts the level and the freshener/extruder prune descends to
 		// freshen the operand, exactly as the single-child PromiseType arm does.
 		return LevelOf(t.Operand)
+	case *IndexType:
+		// An indexed-access residual's level is the max over its two operands, so a `T[K]`
+		// with an out-of-level target or index lifts the level and the freshener/extruder
+		// prune descends into both, the two-child analogue of the KeyofType arm.
+		return max(LevelOf(t.Target), LevelOf(t.Index))
 	case *TypeofType:
 		// A `typeof x` query's level is its resolved value type's, the same single-child rule
 		// KeyofType and PromiseType follow.

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -180,6 +180,25 @@ func (t *KeyofType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *IndexType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// Both operands walk in the current polarity, the two-child analogue of KeyofType's
+	// single covariant visit. The residual is inert — the visit rebuilds it around
+	// rewritten operands without reducing the access, so extrude/coalesce/freshenAbove
+	// carry `T[K]` through untouched.
+	target := cur.Target.Accept(v, pol)
+	index := cur.Index.Accept(v, pol)
+	out := cur
+	if target != cur.Target || index != cur.Index {
+		out = &IndexType{Target: target, Index: index, Exact: cur.Exact}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *TypeofType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1107,6 +1107,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// matching how the operator flows through the solver untouched in M9 PR1a.
 		b, ok := b.(*soltype.KeyofType)
 		return ok && a.Exact == b.Exact && equalTypeWith(a.Operand, b.Operand, ctx)
+	case *soltype.IndexType:
+		// Two inert `T[K]` residuals are equal when they carry the same exactness over equal
+		// targets and equal indices, compared structurally without reducing the access, the
+		// two-child analogue of the KeyofType arm.
+		b, ok := b.(*soltype.IndexType)
+		return ok && a.Exact == b.Exact && equalTypeWith(a.Target, b.Target, ctx) && equalTypeWith(a.Index, b.Index, ctx)
 	case *soltype.TypeofType:
 		// Two `typeof` queries are equal when they name the same value and resolve to equal
 		// types, compared without unwrapping — the query flows through the solver untouched.

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -134,24 +134,28 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
-// An alias expands to its body, a `typeof` query resolves to the value's type, and a `keyof`
-// reduces to its key set. It reports ok=false for any other type, and for a `keyof` that does not
-// fully ground — a `keyof T` over a type parameter, or an expanding alias whose reduction is
-// truncated to a `keyof` residual that would re-expand without bound — which stays inert.
-func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, bool) {
+// An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
+// to its key set, and an indexed access `T[K]` reduces to the type at that key. The returned
+// errs carry any diagnostic the reduction produced — an unknown object key or an out-of-range
+// tuple index — for constrain to surface at the constraint site. It reports ok=false for any
+// other type, and for a reduced operator that does not fully ground — a `keyof T` or `T[K]` over
+// a type parameter, or an expanding alias whose reduction is truncated to a residual that would
+// re-expand without bound — which stays inert.
+func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
-		return c.expandAlias(t), true
+		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
-		return t.Ty, true
-	case *soltype.KeyofType:
-		reduced := newTypeEvaluator(c).reduce(t)
-		if containsKeyof(reduced) {
-			return nil, false
+		return t.Ty, nil, true
+	case *soltype.KeyofType, *soltype.IndexType:
+		e := newTypeEvaluator(c)
+		reduced := e.reduce(t)
+		if containsResidualOp(reduced) {
+			return nil, nil, false
 		}
-		return reduced, true
+		return reduced, e.errs, true
 	default:
-		return nil, false
+		return nil, nil, false
 	}
 }
 
@@ -212,21 +216,31 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// An alias, a `typeof` query, and a `keyof` are transparent for checking: evaluate the
-	// outermost operator to the type it stands for and recurse, so the constraint runs on that
-	// while the stored residual keeps its name. This sits above the structural switch, which
-	// dispatches on sub and would otherwise reject a concrete sub against an operator super before
-	// it could unwrap. When the other side is a variable, fall through to the var arms so the whole
-	// operator is recorded as one bound and its name survives on the coalesced binding. A recursive
-	// alias closes through the existing seen-set, and a `keyof` that does not fully ground stays
-	// inert — see evalTypeOperator — and falls through to the KeyofType arm in the switch.
+	// An alias, a `typeof` query, a `keyof`, and an indexed access `T[K]` are transparent for
+	// checking: evaluate the outermost operator to the type it stands for and recurse, so the
+	// constraint runs on that while the stored residual keeps its name. This sits above the
+	// structural switch, which dispatches on sub and would otherwise reject a concrete sub against
+	// an operator super before it could unwrap. When the other side is a variable, fall through to
+	// the var arms so the whole operator is recorded as one bound and its name survives on the
+	// coalesced binding. A recursive alias closes through the existing seen-set, and a `keyof` or
+	// `T[K]` that does not fully ground stays inert — see evalTypeOperator — and falls through to
+	// its residual arm in the switch.
 	if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-		if evaluated, ok := c.evalTypeOperator(sub); ok {
+		if evaluated, reduceErrs, ok := c.evalTypeOperator(sub); ok {
+			// A reduction diagnostic — an unknown key or an out-of-range index — makes the
+			// operator malformed, so surface it and stop rather than checking the constraint
+			// against the error sentinel the reduction returned.
+			if len(reduceErrs) > 0 {
+				return reduceErrs
+			}
 			return c.constrain(evaluated, super, seen, mutCtx)
 		}
 	}
 	if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
-		if evaluated, ok := c.evalTypeOperator(super); ok {
+		if evaluated, reduceErrs, ok := c.evalTypeOperator(super); ok {
+			if len(reduceErrs) > 0 {
+				return reduceErrs
+			}
 			return c.constrain(sub, evaluated, seen, mutCtx)
 		}
 	}
@@ -716,6 +730,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// residual against any other concrete fails. When super is a variable the case falls
 		// through to the superVar arm below, which records the whole residual as one lower bound,
 		// keeping the operator symbolic on the coalesced binding.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if equalType(sub, super) {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
+	case *soltype.IndexType:
+		// A `T[K]` residual the pre-switch could not ground reaches here: an access over a type
+		// parameter, or an expanding recursive alias. constrain treats it inert, the same as the
+		// KeyofType arm above — two residuals are compatible only when structurally identical, so
+		// `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
+		// other concrete fails. When super is a variable the case falls through to the superVar arm,
+		// which records the whole residual as one lower bound, keeping the access symbolic on the
+		// coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -200,6 +200,30 @@ type OptionalPropertyError struct {
 	site       ast.Node     // M2.5: constraint node fallback
 }
 
+// UnknownObjectKeyError fires when an indexed-access type `T[K]` (M9 PR2) indexes an object
+// with a string-literal key the object carries no member for, as in `{x: number}["z"]`. The
+// access resolves to no value, so the type expression is rejected. It is minted during the
+// reduction constrain performs to check a constraint against an indexed-access residual, and
+// carries the object and the offending key so a consumer can inspect what was indexed.
+type UnknownObjectKeyError struct {
+	Object *soltype.ObjectType
+	Key    string
+	prov   NodeResolver // M2.5: type→node index (§3.5)
+	site   ast.Node     // M2.5: constraint node fallback
+}
+
+// TupleIndexOutOfRangeError fires when an indexed-access type `T[N]` (M9 PR2) indexes a tuple
+// with a numeric literal outside its element range, as in `[number, string][5]`. The tuple has
+// no element at that position, so the type expression is rejected. Like UnknownObjectKeyError
+// it is minted during the reduction constrain performs, and carries the tuple and the offending
+// index. A non-integer or negative literal index reports through this same kind.
+type TupleIndexOutOfRangeError struct {
+	Tuple *soltype.TupleType
+	Index float64
+	prov  NodeResolver // M2.5: type→node index (§3.5)
+	site  ast.Node     // M2.5: constraint node fallback
+}
+
 // MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
 // borrow but the super is mutable: writing through the mutable target would mutate a
 // value the source only lent out as read-only, so an immutable reference cannot fill
@@ -374,6 +398,8 @@ func (*InexactUnionIntoExactError) isSolverError()  {}
 func (*ExtraPropertyError) isSolverError()          {}
 func (*ExtraElementError) isSolverError()           {}
 func (*OptionalPropertyError) isSolverError()       {}
+func (*UnknownObjectKeyError) isSolverError()       {}
+func (*TupleIndexOutOfRangeError) isSolverError()   {}
 func (*MutabilityMismatchError) isSolverError()     {}
 func (*BorrowEscapeError) isSolverError()           {}
 func (*ClassIntoExactObjectError) isSolverError()   {}
@@ -464,6 +490,18 @@ func (e *OptionalPropertyError) Span() ast.Span {
 	return spanOfFirst(e.prov, e.site, ops...)
 }
 func (e *OptionalPropertyError) Related() []ast.Span { return relatedOf(e.prov, e.Super) }
+
+func (e *UnknownObjectKeyError) Span() ast.Span {
+	// The indexed object is the offending value; blame it, else the constraint site.
+	return spanOf(e.prov, e.Object, e.site)
+}
+func (e *UnknownObjectKeyError) Related() []ast.Span { return nil }
+
+func (e *TupleIndexOutOfRangeError) Span() ast.Span {
+	// The indexed tuple is the offending value; blame it, else the constraint site.
+	return spanOf(e.prov, e.Tuple, e.site)
+}
+func (e *TupleIndexOutOfRangeError) Related() []ast.Span { return nil }
 
 func (e *MutabilityMismatchError) Span() ast.Span {
 	// The immutable source borrow is the actual value; blame it, degrade to the
@@ -1552,6 +1590,15 @@ func (e *OptionalPropertyError) Message() string {
 	return "object property is optional but required: " + e.Name
 }
 
+func (e *UnknownObjectKeyError) Message() string {
+	return fmt.Sprintf("object %s has no property %q", soltype.Print(e.Object), e.Key)
+}
+
+func (e *TupleIndexOutOfRangeError) Message() string {
+	return fmt.Sprintf("index %s is out of range for tuple %s",
+		strconv.FormatFloat(e.Index, 'f', -1, 64), soltype.Print(e.Tuple))
+}
+
 func (e *MutabilityMismatchError) Message() string {
 	return fmt.Sprintf("cannot constrain immutable %s <: mutable %s",
 		describeBorrowInner(e.Sub.Inner), describeBorrowInner(e.Super.Inner))
@@ -1693,6 +1740,11 @@ func describe(t soltype.Type) string {
 		// per-node type renderer beside soltype.Print; both carry the residual, so a later
 		// operator node must add an arm here as well as there.
 		return "keyof " + describe(t.Operand)
+	case *soltype.IndexType:
+		// A `T[K]` residual renders structurally, recursing like the keyof arm, so a rejected
+		// constraint names it `<target>[<index>]` rather than the default `?`. Both operands
+		// render in describe's raw mid-constrain form.
+		return describe(t.Target) + "[" + describe(t.Index) + "]"
 	case *soltype.TypeofType:
 		// A `typeof` query names the value it references, matching the printer. constrain
 		// unwraps it to the resolved type before comparing, so a diagnostic rarely names the

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -338,6 +338,10 @@ func (c *checker) blameConstraintErrors(n ast.Node, errs []SolverError) {
 			err.prov, err.site = c.prov, n
 		case *OptionalPropertyError:
 			err.prov, err.site = c.prov, n
+		case *UnknownObjectKeyError:
+			err.prov, err.site = c.prov, n
+		case *TupleIndexOutOfRangeError:
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
 		case *MutabilityMismatchError:

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -515,3 +515,254 @@ func TestInferKeyofTypeofValue(t *testing.T) {
 	require.Equal(t, "keyof typeof x", soltype.Print(result))
 	require.Equal(t, `"a"`, soltype.Print(expandResidual(ctx, result)))
 }
+
+// Indexed access `T[K]` over a named type reference is stored unexpanded, like `keyof`, so the
+// type keeps the name the source wrote rather than the type at the key. Each case names the target
+// through an alias or class, asserts the stored `Result` renders `Name[K]`, and asserts that
+// reducing it — the expansion constrain performs to check a constraint — yields the type at the
+// key. The cases cover the target shapes indexed access resolves through: an object property, a
+// tuple element, the `T[keyof T]` value union, a union-key distribution, a generic alias
+// instantiation, and a class body.
+func TestInferIndexNamedTypeStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// A string-literal key selects the named property's value type.
+			name: "ObjectProperty",
+			src: `
+				type Obj = {x: number, y: string}
+				type Result = Obj["x"]
+			`,
+			wantSymbolic: `Obj["x"]`,
+			wantExpanded: "number",
+		},
+		{
+			// A numeric-literal key selects the tuple element at that position.
+			name: "TupleElement",
+			src: `
+				type Tup = [number, string]
+				type Result = Tup[1]
+			`,
+			wantSymbolic: "Tup[1]",
+			wantExpanded: "string",
+		},
+		{
+			// `T[keyof T]` reduces `keyof T` to the key union, then distributes the access over it,
+			// yielding the union of every value type.
+			name: "ValueUnion",
+			src: `
+				type Obj = {x: number, y: string}
+				type Result = Obj[keyof Obj]
+			`,
+			wantSymbolic: "Obj[keyof Obj]",
+			wantExpanded: "number | string",
+		},
+		{
+			// An explicit union index distributes member-wise: `Obj["x" | "y"]` ⇒ `Obj["x"] |
+			// Obj["y"]`, the same distribute mechanism `T[keyof T]` rides.
+			name: "UnionKeyDistribution",
+			src: `
+				type Obj = {x: number, y: string}
+				type Result = Obj["x" | "y"]
+			`,
+			wantSymbolic: `Obj["x" | "y"]`,
+			wantExpanded: "number | string",
+		},
+		{
+			// A generic alias instantiation substitutes its argument, then selects the property.
+			name: "GenericAlias",
+			src: `
+				type Box<T> = {value: T}
+				type Result = Box<number>["value"]
+			`,
+			wantSymbolic: `Box<number>["value"]`,
+			wantExpanded: "number",
+		},
+		{
+			// A class projects its instance body, the same key set an object yields.
+			name: "Class",
+			src: `
+				class Point {
+					x: number,
+					y: number,
+				}
+				type Result = Point["x"]
+			`,
+			wantSymbolic: `Point["x"]`,
+			wantExpanded: "number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// An indexed-access residual renders symbolically in a function signature and round-trips from
+// parameter to return: `fn f<T>(k: T["a"]) -> T["a"] { return k }` keeps `T["a"]` on both
+// positions. The reflexive `T["a"] <: T["a"]` from `return k` succeeds inertly by structural
+// equality on the residual, so the displayed signature keeps the access rather than the value.
+// An inline structural target keeps its braces under the access, and a `keyof` index prints
+// verbatim inside the brackets.
+func TestInferIndexStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "TypeParamRoundTrip",
+			src:  `fn f<T>(k: T["a"]) -> T["a"] { return k }`,
+			want: map[string]string{"f": `fn <T>(k: T["a"]) -> T["a"]`},
+		},
+		{
+			name: "InlineObjectTarget",
+			src:  `fn h(k: {x: number, y: string}["x"]) {}`,
+			want: map[string]string{"h": `fn (k: {x: number, y: string}["x"]) -> void`},
+		},
+		{
+			name: "KeyofIndex",
+			src:  `fn g<T>(k: T[keyof T]) {}`,
+			want: map[string]string{"g": "fn <T>(k: T[keyof T]) -> void"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
+}
+
+// constrain expands an indexed-access residual over an alias, tuple, or class to check
+// satisfaction, while the stored type stays named. A value matching the type at the key is
+// accepted; a mismatch is rejected against the resolved type, so the diagnostic names it. The
+// expansion runs at every constraint site: a `val` annotation and a function argument.
+func TestInferIndexConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "ObjectPropertyAccepted",
+			src: `
+				type Obj = {x: number, y: string}
+				val v: Obj["x"] = 5
+			`,
+		},
+		{
+			name: "ObjectPropertyRejected",
+			src: `
+				type Obj = {x: number, y: string}
+				val v: Obj["x"] = "hi"
+			`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+		{
+			name: "TupleElementAccepted",
+			src: `
+				type Tup = [number, string]
+				val v: Tup[1] = "hi"
+			`,
+		},
+		{
+			name: "TupleElementRejected",
+			src: `
+				type Tup = [number, string]
+				val v: Tup[1] = 5
+			`,
+			wantErr: `cannot constrain 5 <: string`,
+		},
+		{
+			name: "ValueUnionAccepted",
+			src: `
+				type Obj = {x: number, y: string}
+				val v: Obj[keyof Obj] = "hi"
+			`,
+		},
+		{
+			name: "CallArgumentRejected",
+			src: `
+				type Obj = {x: number, y: string}
+				fn take(v: Obj["x"]) -> number { return 1 }
+				val r = take("hi")
+			`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// Reducing a ground indexed access to a key the target lacks reports a dedicated diagnostic at
+// the constraint site: an object key with no member is an UnknownObjectKeyError, and a tuple index
+// outside the element range is a TupleIndexOutOfRangeError. Each names the target's shape and the
+// offending key.
+func TestInferIndexReductionError(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string
+		wantTyp SolverError
+	}{
+		{
+			name: "UnknownObjectKey",
+			src: `
+				type Obj = {x: number}
+				val v: Obj["z"] = 5
+			`,
+			wantErr: `object {x: number} has no property "z"`,
+			wantTyp: &UnknownObjectKeyError{},
+		},
+		{
+			name: "TupleIndexOutOfRange",
+			src: `
+				type Tup = [number, string]
+				val v: Tup[5] = 1
+			`,
+			wantErr: "index 5 is out of range for tuple [number, string]",
+			wantTyp: &TupleIndexOutOfRangeError{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, tt.wantTyp, errs[0])
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A rejected constraint whose subject is an indexed-access residual names it structurally in the
+// diagnostic — `cannot constrain t1["a"] <: number` rather than the bare `?` the default describe
+// arm would render — so the inert node stays legible. describe is the raw mid-constrain renderer,
+// so the target shows as the raw var `t1` rather than the coalesced printer's param name `T`.
+func TestInferIndexResidualErrorMessage(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(k: T["a"]) -> number { return k }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, `1:12-1:18: cannot constrain t1["a"] <: number`, msgWithSpan(errs[0]))
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -586,6 +586,33 @@ func TestInferIndexNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: "number | string",
 		},
 		{
+			// An intersection target carries a key when any member has it, so `(A & B)["x"]`
+			// selects `x` from the member that declares it.
+			name: "IntersectionTarget",
+			src: `
+				type A = {x: number}
+				type B = {y: string}
+				type C = A & B
+				type Result = C["y"]
+			`,
+			wantSymbolic: `C["y"]`,
+			wantExpanded: "string",
+		},
+		{
+			// When more than one member carries the key, the access is the meet of their value
+			// types, so `(A & B)["x"]` with `A.x: number` and `B.x: string` reduces to their
+			// intersection.
+			name: "IntersectionTargetOverlap",
+			src: `
+				type A = {x: number}
+				type B = {x: string}
+				type C = A & B
+				type Result = C["x"]
+			`,
+			wantSymbolic: `C["x"]`,
+			wantExpanded: "number & string",
+		},
+		{
 			// A generic alias instantiation substitutes its argument, then selects the property.
 			name: "GenericAlias",
 			src: `
@@ -757,6 +784,18 @@ func TestInferIndexReductionError(t *testing.T) {
 			`,
 			wantErr: "index 5 is out of range for tuple [number, string]",
 			wantTyp: &TupleIndexOutOfRangeError{},
+		},
+		{
+			// A key absent from every intersection member is genuinely missing, so one member's
+			// absence diagnostic surfaces rather than one per member.
+			name: "IntersectionKeyAbsentFromAll",
+			src: `
+				type A = {x: number}
+				type B = {y: string}
+				val v: (A & B)["z"] = 5
+			`,
+			wantErr: `object {x: number} has no property "z"`,
+			wantTyp: &UnknownObjectKeyError{},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -573,6 +573,19 @@ func TestInferIndexNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: "number | string",
 		},
 		{
+			// A union target distributes the access member-wise: `(A | B)["x"]` reads `x` off each
+			// member and unions the results.
+			name: "UnionTarget",
+			src: `
+				type A = {x: number}
+				type B = {x: string}
+				type U = A | B
+				type Result = U["x"]
+			`,
+			wantSymbolic: `U["x"]`,
+			wantExpanded: "number | string",
+		},
+		{
 			// A generic alias instantiation substitutes its argument, then selects the property.
 			name: "GenericAlias",
 			src: `

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -18,6 +18,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.annPrim(ta, soltype.StrPrim), true
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
+	case *ast.LitTypeAnn:
+		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:
 		// Resolve through the type scope first so a user-defined alias, class, or type
 		// parameter takes precedence over the built-in Promise stub below. A bare alias or
@@ -81,6 +83,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveFuncTypeAnn(scope, ta, lvl)
 	case *ast.KeyOfTypeAnn:
 		return c.resolveKeyOfTypeAnn(scope, ta, lvl)
+	case *ast.IndexTypeAnn:
+		return c.resolveIndexTypeAnn(scope, ta, lvl)
 	case *ast.TypeOfTypeAnn:
 		return c.resolveTypeOfTypeAnn(scope, ta)
 	case *ast.WildcardTypeAnn:
@@ -242,6 +246,38 @@ func (c *checker) resolveKeyOfTypeAnn(scope *Scope, ta *ast.KeyOfTypeAnn, lvl in
 		operand = c.freshAt(lvl)
 	}
 	t := &soltype.KeyofType{Operand: operand}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveLitTypeAnn lowers a string, number, or boolean literal type annotation to its LitType,
+// reusing litTypeOf. It is the annotation home for a literal type, which an indexed access needs
+// for its key, so `Point["x"]` carries `"x"` as a LitTypeAnn index. A literal with no soltype
+// form, such as a regex, a bigint, null, or undefined, reports unsupported and recovers.
+func (c *checker) resolveLitTypeAnn(ta *ast.LitTypeAnn) (soltype.Type, bool) {
+	lit, ok := c.litTypeOf(ta.Lit)
+	if !ok {
+		return c.reportUnsupported(ta), false
+	}
+	c.recordProv(lit, ta, AnnotationType)
+	return lit, true
+}
+
+// resolveIndexTypeAnn lowers `T[K]` to an IndexType residual and stores it unreduced, so the
+// annotation prints the way the source wrote it — `Point["x"]` renders `Point["x"]`, not
+// `number`. constrain reduces the residual when it checks a constraint against it, mirroring
+// resolveKeyOfTypeAnn. An unsupported target or index recovers to a fresh var, cascade-safe like
+// the Promise<bad> recovery.
+func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl int) (soltype.Type, bool) {
+	target, ok := c.resolveTypeAnn(scope, ta.Target, lvl)
+	if !ok {
+		target = c.freshAt(lvl)
+	}
+	index, ok := c.resolveTypeAnn(scope, ta.Index, lvl)
+	if !ok {
+		index = c.freshAt(lvl)
+	}
+	t := &soltype.IndexType{Target: target, Index: index}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -13,10 +13,11 @@ import (
 // operator over the unexpanded alias stays symbolic.
 const maxExpandDepth = 200
 
-// typeEvaluator reduces a residual type-level operator to its value. It currently handles
-// `keyof T`; later operators join as they land. Only constrain invokes it, to check a constraint
-// against a `keyof` residual. Annotation and display keep the residual symbolic, so a stored type
-// prints `keyof {x: number}` or `keyof Point` the way the source wrote it, never the reduced keys.
+// typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T` and
+// indexed access `T[K]`; later operators join as they land. Only constrain invokes it, to check
+// a constraint against a residual. Annotation and display keep the residual symbolic, so a
+// stored type prints `keyof {x: number}` or `Point["x"]` the way the source wrote it, never the
+// reduced value.
 //
 // reduce projects the operand's keys: a ground `keyof {x: number}` yields `"x"`, and an alias or
 // class operand expands to the referenced type's keys, the transparent-but-named treatment an
@@ -34,10 +35,11 @@ const maxExpandDepth = 200
 //   - depth caps expansions along one path. It backstops an expanding recursion whose argument
 //     grows every lap, so its key never repeats and the active guard never fires.
 //
-// The evaluator adds no mutable solver state. reduce is a pure function of its input. It builds
-// its result unions through newUnion with a nil Context so newUnion's subsumption never calls
-// constrain — which reduces `keyof` residuals through this evaluator and would otherwise re-enter
-// it and loop.
+// The evaluator mutates no solver state — no bound or variable is touched. It accumulates
+// reduction diagnostics on errs, but a fresh evaluator is minted per reduction, so nothing
+// leaks across calls. It builds its result unions through newUnion with a nil Context so
+// newUnion's subsumption never calls constrain — which reduces residuals through this evaluator
+// and would otherwise re-enter it and loop.
 type typeEvaluator struct {
 	// ctx is the alias environment, used to expand an alias operand and project a class body so a
 	// reduction reaches the referenced type's keys. constrain and the test expander both supply a
@@ -45,6 +47,13 @@ type typeEvaluator struct {
 	ctx    *Context
 	active set.Set[string]
 	depth  int
+	// errs collects the diagnostics a reduction produces. `keyof` reduction is total and adds
+	// none; indexed-access reduction records an UnknownObjectKeyError or a
+	// TupleIndexOutOfRangeError when a ground access resolves to no member. constrain reads
+	// these after reducing an operator it is checking a constraint against, so a malformed
+	// `{x: number}["z"]` surfaces at the constraint site. It records diagnostics, not solver
+	// state, so no bound or variable is mutated.
+	errs []SolverError
 }
 
 func newTypeEvaluator(ctx *Context) *typeEvaluator {
@@ -59,6 +68,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 	switch t := t.(type) {
 	case *soltype.KeyofType:
 		return e.reduceKeyof(t.Operand, t.Exact)
+	case *soltype.IndexType:
+		return e.reduceIndex(t.Target, t.Index, t.Exact)
 	case *soltype.TypeofType:
 		// A `typeof x` query reduces to the value's resolved type. constrain unwraps it directly
 		// in its pre-switch, so this arm serves a `typeof` reached through another operator.
@@ -192,34 +203,181 @@ func (e *typeEvaluator) keyofDistribute(members []soltype.Type, exact bool) solt
 	return newUnion(nil, parts, false)
 }
 
+// reduceIndex reduces `target[index]` to the type stored at that key, mirroring the old
+// checker's IndexType case (internal/checker/expand_type.go):
+//
+//   - an object indexed by a string-literal key yields that member's read type, and an unknown
+//     key records an UnknownObjectKeyError;
+//   - a tuple indexed by a numeric-literal key yields that element, and an out-of-range or
+//     non-integer index records a TupleIndexOutOfRangeError;
+//   - a union index distributes, so `T["a" | "b"]` reduces to `T["a"] | T["b"]`; `T[keyof T]`
+//     rides this once `keyof T` reduces to its key union;
+//   - an alias expands to its body and a class projects its instance body, and the access
+//     reduces over that under the termination guard;
+//   - a `typeof` query resolves to the value's type, and the access reduces over that.
+//
+// A type-variable target or index, or any operand the evaluator does not ground, keeps the
+// access symbolic, rebuilt around the reduced operands.
+func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) soltype.Type {
+	idx := e.reduce(index)
+	// A union index distributes member-wise. `T[keyof T]` rides this once `keyof T` reduces to
+	// its `"a" | "b"` key union, so the access yields the union of the members' value types.
+	if u, ok := idx.(*soltype.UnionType); ok {
+		parts := make([]soltype.Type, len(u.Types))
+		for i, m := range u.Types {
+			parts[i] = e.reduceIndex(target, m, exact)
+		}
+		return newUnion(nil, parts, false)
+	}
+	switch tgt := target.(type) {
+	case *soltype.AliasType:
+		return e.reduceIndexAlias(tgt, idx, exact)
+	case *soltype.TypeofType:
+		// `(typeof x)[K]` resolves the query to the value's type, then indexes that type.
+		return e.reduceIndex(tgt.Ty, idx, exact)
+	case *soltype.KeyofType, *soltype.IndexType:
+		// The target is itself an operator. Reduce it first, then index its value. When it
+		// stays symbolic because its own operands are not ground, keep the access wrapped
+		// around the reduced target rather than re-reducing the same shape forever.
+		inner := e.reduce(target)
+		if isResidualOp(inner) {
+			return &soltype.IndexType{Target: inner, Index: idx, Exact: exact}
+		}
+		return e.reduceIndex(inner, idx, exact)
+	case *soltype.ObjectType:
+		return e.indexObject(tgt, idx, exact)
+	case *soltype.ClassType:
+		obj, ok := e.ctx.projectClassBody(tgt)
+		if !ok {
+			return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
+		}
+		return e.indexObject(obj, idx, exact)
+	case *soltype.TupleType:
+		return e.indexTuple(tgt, idx, exact)
+	default:
+		return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
+	}
+}
+
+// reduceIndexAlias reduces `Alias[K]` by expanding the alias and indexing its body under the
+// termination guard, the indexed-access twin of reduceKeyofAlias. The alias stays on the active
+// path for the whole reduction of its body, so a member that re-references it stops. A recurring
+// instantiation state, an exhausted budget, or an unresolved body each leaves the access
+// unexpanded and symbolic.
+func (e *typeEvaluator) reduceIndexAlias(op *soltype.AliasType, index soltype.Type, exact bool) soltype.Type {
+	symbolic := &soltype.IndexType{Target: op, Index: index, Exact: exact}
+	key := soltype.PrintQualified(op)
+	if e.active.Contains(key) || e.depth <= 0 {
+		return symbolic
+	}
+	body := e.ctx.expandAlias(op)
+	if _, unresolved := body.(*soltype.ErrorType); unresolved {
+		return symbolic
+	}
+	e.active.Add(key)
+	e.depth--
+	result := e.reduceIndex(body, index, exact)
+	e.active.Remove(key)
+	e.depth++
+	return result
+}
+
+// indexObject reduces `obj[key]` for a ground object. A string-literal key selects the named
+// member's read type — a property's or getter's declared type, a method's callable value — and a
+// key the object carries no member for records an UnknownObjectKeyError and reduces to the error
+// sentinel. A non-string-literal index, such as a bare `string` primitive, selects no single
+// member yet. An index signature reads it once mapped types land (M9 PR4), so the access stays
+// symbolic until then.
+func (e *typeEvaluator) indexObject(obj *soltype.ObjectType, index soltype.Type, exact bool) soltype.Type {
+	name, ok := strLitName(index)
+	if !ok {
+		return &soltype.IndexType{Target: obj, Index: index, Exact: exact}
+	}
+	if _, found := obj.Member(name); !found {
+		e.errs = append(e.errs, &UnknownObjectKeyError{Object: obj, Key: name})
+		return &soltype.ErrorType{}
+	}
+	read, hasValue, _ := memberReadContribution(obj, name)
+	if !hasValue {
+		// The member is a write-only setter, which exposes no readable value. Leave the access
+		// symbolic rather than resolving a write slot to a read type.
+		return &soltype.IndexType{Target: obj, Index: index, Exact: exact}
+	}
+	return read
+}
+
+// indexTuple reduces `tup[n]` for a ground tuple. A numeric-literal key selects the element at
+// that position. An index outside `[0, len)`, or a non-integer or negative literal, records a
+// TupleIndexOutOfRangeError and reduces to the error sentinel. A non-numeric-literal index has no
+// positional slot to select, so the access stays symbolic.
+func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, exact bool) soltype.Type {
+	lit, ok := index.(*soltype.LitType)
+	if !ok {
+		return &soltype.IndexType{Target: tup, Index: index, Exact: exact}
+	}
+	num, ok := lit.Lit.(*soltype.NumLit)
+	if !ok {
+		return &soltype.IndexType{Target: tup, Index: index, Exact: exact}
+	}
+	i := int(num.Value)
+	if float64(i) != num.Value || i < 0 || i >= len(tup.Elems) {
+		e.errs = append(e.errs, &TupleIndexOutOfRangeError{Tuple: tup, Index: num.Value})
+		return &soltype.ErrorType{}
+	}
+	return tup.Elems[i]
+}
+
+// strLitName returns the property name a string-literal index selects, and false for any other
+// type. Object keys are strings, so only a StrLit names a member.
+func strLitName(t soltype.Type) (string, bool) {
+	if lit, ok := t.(*soltype.LitType); ok {
+		if s, ok := lit.Lit.(*soltype.StrLit); ok {
+			return s.Value, true
+		}
+	}
+	return "", false
+}
+
+// isResidualOp reports whether t is an unreduced type-level operator node — a `keyof` or an
+// indexed access — at its top level. The evaluator consults it to stop re-reducing an operand
+// whose reduction stayed symbolic.
+func isResidualOp(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.KeyofType, *soltype.IndexType:
+		return true
+	}
+	return false
+}
+
 // strLitType builds the string-literal type for one key name, the form a projected object or
 // tuple key takes in a `keyof` union.
 func strLitType(name string) soltype.Type {
 	return &soltype.LitType{Lit: &soltype.StrLit{Value: name}}
 }
 
-// containsKeyof reports whether t holds any KeyofType node. constrain consults it to decide
-// whether a reduced `keyof` fully grounded: a result with no residual is safe to recurse on,
-// while one that still carries a `keyof` — an unexpanded type parameter or a budget-truncated
-// expanding alias — must not, since re-reducing it would loop.
-func containsKeyof(t soltype.Type) bool {
-	f := &keyofFinder{}
+// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`
+// or an indexed access. constrain consults it to decide whether a reduced operator fully
+// grounded: a result with no residual is safe to recurse on, while one that still carries a
+// `keyof` or a `T[K]` — an unexpanded type parameter or a budget-truncated expanding alias —
+// must not, since re-reducing it would loop.
+func containsResidualOp(t soltype.Type) bool {
+	f := &residualOpFinder{}
 	t.Accept(f, soltype.Positive)
 	return f.found
 }
 
-// keyofFinder is the walking visitor behind containsKeyof. It flags the first KeyofType it
-// reaches and skips that node's children, since one occurrence is enough.
-type keyofFinder struct{ found bool }
+// residualOpFinder is the walking visitor behind containsResidualOp. It flags the first residual
+// operator it reaches and skips that node's children, since one occurrence is enough.
+type residualOpFinder struct{ found bool }
 
-func (f *keyofFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	if _, ok := t.(*soltype.KeyofType); ok {
+func (f *residualOpFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if isResidualOp(t) {
 		f.found = true
 		return soltype.EnterResult{SkipChildren: true}
 	}
 	return soltype.EnterResult{}
 }
 
-func (f *keyofFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+func (f *residualOpFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	return t
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -212,7 +212,10 @@ func (e *typeEvaluator) keyofDistribute(members []soltype.Type, exact bool) solt
 //     non-integer index records a TupleIndexOutOfRangeError;
 //   - a union index distributes, so `T["a" | "b"]` reduces to `T["a"] | T["b"]`; `T[keyof T]`
 //     rides this once `keyof T` reduces to its key union;
-//   - a union target distributes the other way, so `(A | B)[K]` reduces to `A[K] | B[K]`;
+//   - a union target distributes the other way, so `(A | B)[K]` reduces to `A[K] | B[K]`, where
+//     every member must carry K;
+//   - an intersection target reduces to the meet of the value types the members that carry K
+//     contribute, so `(A & B)[K]` picks K from whichever members have it;
 //   - an alias expands to its body and a class projects its instance body, and the access
 //     reduces over that under the termination guard;
 //   - a `typeof` query resolves to the value's type, and the access reduces over that.
@@ -258,15 +261,61 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 	case *soltype.UnionType:
 		// A union target distributes member-wise: `(A | B)[K]` ⇒ `A[K] | B[K]`, the other-axis
 		// twin of the union-index distribution above, matching how keyof distributes over a union
-		// operand. Each member indexes with the same reduced key.
+		// operand. A union value is one of its members, so every member must carry K — a member
+		// lacking it records its own absence diagnostic through reduceIndex. Each member indexes
+		// with the same reduced key.
 		parts := make([]soltype.Type, len(tgt.Types))
 		for i, m := range tgt.Types {
 			parts[i] = e.reduceIndex(m, idx, exact)
 		}
 		return newUnion(nil, parts, false)
+	case *soltype.IntersectionType:
+		return e.reduceIndexIntersection(tgt, idx, exact)
 	default:
 		return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
 	}
+}
+
+// reduceIndexIntersection reduces `(A & B & …)[K]`. An intersection value satisfies every member,
+// so it carries key K when ANY member does, and the access yields the meet of the value types the
+// members that carry K contribute. This is the opposite of the union-target rule, where every
+// member must carry K. A member lacking K contributes nothing rather than erroring, so its own
+// absence diagnostic is rolled back and kept aside. The access stays symbolic when a member is not
+// ground enough to decide whether it carries K, and reports absence only when no member carries it.
+func (e *typeEvaluator) reduceIndexIntersection(tgt *soltype.IntersectionType, idx soltype.Type, exact bool) soltype.Type {
+	var resolved []soltype.Type
+	var absentErrs []SolverError
+	anySymbolic := false
+	for _, m := range tgt.Types {
+		before := len(e.errs)
+		r := e.reduceIndex(m, idx, exact)
+		if produced := e.errs[before:]; len(produced) > 0 {
+			// A ground member lacking K recorded its own absence diagnostic. A sibling may still
+			// carry K, so roll the diagnostic back and keep it aside in case none does.
+			absentErrs = append(absentErrs, produced...)
+			e.errs = e.errs[:before]
+			continue
+		}
+		if isResidualOp(r) {
+			anySymbolic = true
+			continue
+		}
+		resolved = append(resolved, r)
+	}
+	// A member the evaluator could not ground might carry K with an unknown type, so the meet is
+	// undecided. Stay symbolic rather than committing to the members that did resolve.
+	if anySymbolic {
+		return &soltype.IndexType{Target: tgt, Index: idx, Exact: exact}
+	}
+	if len(resolved) > 0 {
+		return newIntersection(nil, resolved)
+	}
+	// Every member is ground and none carries K, so K is genuinely absent. Surface one member's
+	// absence diagnostic and reduce to the error sentinel.
+	if len(absentErrs) > 0 {
+		e.errs = append(e.errs, absentErrs[0])
+	}
+	return &soltype.ErrorType{}
 }
 
 // reduceIndexAlias reduces `Alias[K]` by expanding the alias and indexing its body under the

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -212,6 +212,7 @@ func (e *typeEvaluator) keyofDistribute(members []soltype.Type, exact bool) solt
 //     non-integer index records a TupleIndexOutOfRangeError;
 //   - a union index distributes, so `T["a" | "b"]` reduces to `T["a"] | T["b"]`; `T[keyof T]`
 //     rides this once `keyof T` reduces to its key union;
+//   - a union target distributes the other way, so `(A | B)[K]` reduces to `A[K] | B[K]`;
 //   - an alias expands to its body and a class projects its instance body, and the access
 //     reduces over that under the termination guard;
 //   - a `typeof` query resolves to the value's type, and the access reduces over that.
@@ -254,6 +255,15 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 		return e.indexObject(obj, idx, exact)
 	case *soltype.TupleType:
 		return e.indexTuple(tgt, idx, exact)
+	case *soltype.UnionType:
+		// A union target distributes member-wise: `(A | B)[K]` ⇒ `A[K] | B[K]`, the other-axis
+		// twin of the union-index distribution above, matching how keyof distributes over a union
+		// operand. Each member indexes with the same reduced key.
+		parts := make([]soltype.Type, len(tgt.Types))
+		for i, m := range tgt.Types {
+			parts[i] = e.reduceIndex(m, idx, exact)
+		}
+		return newUnion(nil, parts, false)
 	default:
 		return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
 	}


### PR DESCRIPTION
Add support for indexed-access types `T[K]` (M9 PR2), the sibling operator to `keyof T`. Like `keyof`, indexed access is stored as an inert residual type that stays symbolic in annotations and displays, but reduces when constrain checks a constraint against it.

**Key changes:**

- Add `IndexType` to the type representation (`soltype.IndexType`) with `Target`, `Index`, and `Exact` fields, mirroring `KeyofType`.
- Extend the type evaluator (`typeEvaluator`) to reduce indexed access over objects, tuples, aliases, classes, and unions. Object access with a string-literal key selects the member's read type; tuple access with a numeric-literal key selects the element. Union indices distribute member-wise, so `T["a" | "b"]` reduces to `T["a"] | T["b"]`. Alias and class targets expand under the termination guard, the same as `keyof` reduction.
- Add two new error types for reduction failures: `UnknownObjectKeyError` when indexing an object with a key it has no member for, and `TupleIndexOutOfRangeError` when indexing a tuple outside its element range. Both surface at the constraint site where the reduction occurs.
- Update `constrain` to evaluate indexed-access residuals alongside `keyof` and `typeof`, unwrapping them to check constraints against the resolved type while keeping the stored residual symbolic.
- Add annotation support: `LitTypeAnn` for literal types (needed as index expressions) and `IndexTypeAnn` for the indexed-access syntax `T[K]`.
- Extend the visitor and printer to handle `IndexType` traversal and rendering.
- Update `containsKeyof` to `containsResidualOp` to detect both `keyof` and indexed-access residuals, preventing re-reduction loops.

The implementation mirrors the existing `keyof` design: the residual is inert in the solver's structural machinery, flows through untouched, and reduces only when constrain needs to check a constraint against it. Diagnostics from reduction (unknown keys, out-of-range indices) are collected and surfaced at the constraint site rather than mutating solver state.

https://claude.ai/code/session_01PighTC8NiQevwLU3ENKZn1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for indexed access types (`T[K]`) in type annotations and evaluation.
  * Indexed access now resolves object properties and tuple elements, including union indexes.
  * Improved diagnostics for unknown object keys and out-of-range tuple indexes.
  * Enhanced type error messages to display indexed access expressions clearly.

* **Tests**
  * Added coverage for indexed access inference, constraints, reductions, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->