### PR TITLE
Implement object spread operator for type and value level

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -402,6 +402,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 					walk(e.Param)
 				case *ConstructorElem:
 					walk(e.Fn)
+				case *SpreadElem:
+					walk(e.Type)
 				}
 			}
 		case *ClassType:
@@ -421,10 +423,6 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Ty)
 		case *RestSpreadType:
 			walk(t.Operand)
-		case *ObjectSpreadType:
-			for _, op := range t.Operands {
-				walk(op.Type)
-			}
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -639,27 +637,6 @@ func (p *namedPrinter) printType(t Type) string {
 		// `typeof x`, the value reference the source wrote. The resolved value type is not
 		// rendered — the query stays symbolic, so `keyof typeof x` prints as written.
 		return "typeof " + t.Ident
-	case *ObjectSpreadType:
-		// `{...A, x: T}`, the operator the source wrote, brace-delimited like an object. A spread
-		// operand renders `...` over its source at precPrefix, so a looser operand such as a union
-		// gets parenthesized. An inline field group renders its fields directly, without braces of
-		// its own. A trailing `...` inexact marker renders last, matching the ObjectType arm.
-		parts := make([]string, 0, len(t.Operands)+1)
-		for _, op := range t.Operands {
-			if op.Spread {
-				parts = append(parts, "..."+p.printTypeMinPrec(op.Type, precPrefix))
-				continue
-			}
-			if obj, ok := op.Type.(*ObjectType); ok {
-				for _, e := range obj.Elems {
-					parts = append(parts, p.printObjElem(e))
-				}
-			}
-		}
-		if t.Inexact {
-			parts = append(parts, "...")
-		}
-		return "{" + strings.Join(parts, ", ") + "}"
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
@@ -749,6 +726,11 @@ func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 		// A class value's constructor renders as the unnamed call signature
 		// `new (params) -> ret`.
 		return "new " + p.printFuncTail(e.Fn)
+	case *SpreadElem:
+		// A `...A` spread renders inline among the object's fields, so `{...A, x: T}` round-trips
+		// to the source. The operand prints at precPrefix, so a looser one such as a union gets
+		// parenthesized.
+		return "..." + p.printTypeMinPrec(e.Type, precPrefix)
 	}
 	panic(fmt.Sprintf("printObjElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -421,6 +421,10 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Ty)
 		case *RestSpreadType:
 			walk(t.Operand)
+		case *ObjectSpreadType:
+			for _, op := range t.Operands {
+				walk(op.Type)
+			}
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -635,6 +639,27 @@ func (p *namedPrinter) printType(t Type) string {
 		// `typeof x`, the value reference the source wrote. The resolved value type is not
 		// rendered — the query stays symbolic, so `keyof typeof x` prints as written.
 		return "typeof " + t.Ident
+	case *ObjectSpreadType:
+		// `{...A, x: T}`, the operator the source wrote, brace-delimited like an object. A spread
+		// operand renders `...` over its source at precPrefix, so a looser operand such as a union
+		// gets parenthesized. An inline field group renders its fields directly, without braces of
+		// its own. A trailing `...` inexact marker renders last, matching the ObjectType arm.
+		parts := make([]string, 0, len(t.Operands)+1)
+		for _, op := range t.Operands {
+			if op.Spread {
+				parts = append(parts, "..."+p.printTypeMinPrec(op.Type, precPrefix))
+				continue
+			}
+			if obj, ok := op.Type.(*ObjectType); ok {
+				for _, e := range obj.Elems {
+					parts = append(parts, p.printObjElem(e))
+				}
+			}
+		}
+		if t.Inexact {
+			parts = append(parts, "...")
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -331,10 +331,19 @@ type SetterElem struct {
 // general call-signature-in-any-object feature.
 type ConstructorElem struct{ Fn *FuncType }
 
+// SpreadElem is a `...A` object spread written as an element of an ObjectType, the object twin of
+// the tuple's RestSpreadType (M9 PR5). `{...A, x: T}` is an ObjectType whose first element is a
+// SpreadElem over A. An object carrying one is a residual: constrain passes it through untouched,
+// the inert contract KeyofType shares, until the evaluator grounds Type to an object and merges its
+// fields in at this position. A reduced object has no SpreadElem. A spread over a type parameter
+// never grounds, so it stays symbolic and renders `...A`. Type is the spread source.
+type SpreadElem struct{ Type Type }
+
 func (*MethodElem) isObjTypeElem()      {}
 func (*GetterElem) isObjTypeElem()      {}
 func (*SetterElem) isObjTypeElem()      {}
 func (*ConstructorElem) isObjTypeElem() {}
+func (*SpreadElem) isObjTypeElem()      {}
 
 // ObjElemName returns the member name of any ObjTypeElem kind. It is the shared
 // name accessor for member lookup and structural equality, so those sites need no
@@ -355,8 +364,25 @@ func ObjElemName(e ObjTypeElem) string {
 		return e.Name
 	case *ConstructorElem:
 		return ""
+	case *SpreadElem:
+		// A spread is anonymous. It only appears in an unreduced object, and the name-keyed
+		// equality and lookup paths compare such objects positionally instead, so this name is
+		// never a match key.
+		return ""
 	}
 	panic(fmt.Sprintf("ObjElemName: unhandled ObjTypeElem %T", e))
+}
+
+// HasObjectSpread reports whether an element list carries a `...A` spread, so the object is an
+// unreduced residual rather than a concrete object. It is the object twin of hasRestSpread on the
+// tuple side.
+func HasObjectSpread(elems []ObjTypeElem) bool {
+	for _, e := range elems {
+		if _, ok := e.(*SpreadElem); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Prop returns the named property and whether it is present. Property names are
@@ -645,39 +671,11 @@ type RestSpreadType struct {
 	Operand Type
 }
 
-// ObjectSpreadType is the residual object-spread operator `{...A, x: T}` (M9 PR5),
-// modeled on Flow's object spread. It is inert, sharing the KeyofType contract: it
-// carries no bounds, constrain never records one against it, and it flows through the
-// solver's structural machinery untouched. An evaluator merges its operands into a plain
-// ObjectType once every spread operand is a ground object. Until then a spread over a type
-// parameter stays symbolic and renders `{...A, x: T}` the way the source wrote it.
-//
-// Operands merge left to right, so a later operand's field wins over an earlier key. The
-// one exception is Flow's optional show-through rule: when a later operand's field is
-// optional and overlaps an earlier key, the two value types union rather than the later
-// overriding. Inexact records the annotation's trailing `...` marker. Reduction also folds
-// in each spread operand's own inexactness, so a spread of an inexact object is inexact.
-type ObjectSpreadType struct {
-	Operands []ObjectSpreadOperand
-	Inexact  bool
-}
-
-// ObjectSpreadOperand is one operand of an ObjectSpreadType. Spread is true for a `...A`
-// operand, whose Type is the spread source. Spread is false for an inline field group such
-// as `x: T, y: U` written between spreads, whose Type is an ObjectType holding those fields.
-// Keeping the two apart lets the printer render `...A` as a spread and the field group
-// inline, so the operator round-trips to the source form.
-type ObjectSpreadOperand struct {
-	Spread bool
-	Type   Type
-}
-
 func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
 func (*RestSpreadType) isType()   {}
-func (*ObjectSpreadType) isType() {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
@@ -772,15 +770,6 @@ func LevelOf(t Type) int {
 		// same single-child rule the KeyofType arm follows. The TupleType arm already maxes over its
 		// elements, so this element contributes its operand's level there.
 		return LevelOf(t.Operand)
-	case *ObjectSpreadType:
-		// A residual object spread's level is the max over its operands, so a spread of an
-		// out-of-level type parameter lifts the level and the freshener/extruder prune descends
-		// to freshen the operand, the same rule the single-child KeyofType arm applies.
-		m := 0
-		for _, op := range t.Operands {
-			m = max(m, LevelOf(op.Type))
-		}
-		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:
@@ -836,6 +825,10 @@ func levelOfElem(e ObjTypeElem) int {
 		return max(selfLevel(e.SelfParam), LevelOf(e.Param))
 	case *ConstructorElem:
 		return LevelOf(e.Fn)
+	case *SpreadElem:
+		// A `...A` spread element's level is its operand's, so an out-of-level spread operand lifts
+		// the enclosing object's level and the freshener/extruder prune descends to freshen it.
+		return LevelOf(e.Type)
 	}
 	panic(fmt.Sprintf("levelOfElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -645,11 +645,39 @@ type RestSpreadType struct {
 	Operand Type
 }
 
+// ObjectSpreadType is the residual object-spread operator `{...A, x: T}` (M9 PR5),
+// modeled on Flow's object spread. It is inert, sharing the KeyofType contract: it
+// carries no bounds, constrain never records one against it, and it flows through the
+// solver's structural machinery untouched. An evaluator merges its operands into a plain
+// ObjectType once every spread operand is a ground object. Until then a spread over a type
+// parameter stays symbolic and renders `{...A, x: T}` the way the source wrote it.
+//
+// Operands merge left to right, so a later operand's field wins over an earlier key. The
+// one exception is Flow's optional show-through rule: when a later operand's field is
+// optional and overlaps an earlier key, the two value types union rather than the later
+// overriding. Inexact records the annotation's trailing `...` marker. Reduction also folds
+// in each spread operand's own inexactness, so a spread of an inexact object is inexact.
+type ObjectSpreadType struct {
+	Operands []ObjectSpreadOperand
+	Inexact  bool
+}
+
+// ObjectSpreadOperand is one operand of an ObjectSpreadType. Spread is true for a `...A`
+// operand, whose Type is the spread source. Spread is false for an inline field group such
+// as `x: T, y: U` written between spreads, whose Type is an ObjectType holding those fields.
+// Keeping the two apart lets the printer render `...A` as a spread and the field group
+// inline, so the operator round-trips to the source form.
+type ObjectSpreadOperand struct {
+	Spread bool
+	Type   Type
+}
+
 func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
 func (*RestSpreadType) isType()   {}
+func (*ObjectSpreadType) isType() {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
 func (*FuncType) isType()         {}
@@ -744,6 +772,15 @@ func LevelOf(t Type) int {
 		// same single-child rule the KeyofType arm follows. The TupleType arm already maxes over its
 		// elements, so this element contributes its operand's level there.
 		return LevelOf(t.Operand)
+	case *ObjectSpreadType:
+		// A residual object spread's level is the max over its operands, so a spread of an
+		// out-of-level type parameter lifts the level and the freshener/extruder prune descends
+		// to freshen the operand, the same rule the single-child KeyofType arm applies.
+		m := 0
+		for _, op := range t.Operands {
+			m = max(m, LevelOf(op.Type))
+		}
+		return m
 	case *PromiseType:
 		return LevelOf(t.Inner)
 	case *RefType:

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -235,35 +235,6 @@ func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *ObjectSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
-	e := v.EnterType(t, pol)
-	if e.SkipChildren {
-		return v.ExitType(skipReplace(t, e), pol)
-	}
-	cur := descendReplacement(t, e)
-	// Each operand's type walks in the current polarity, the same covariant visit KeyofType
-	// applies to its single operand. The residual is inert: the visit rebuilds it around the
-	// rewritten operands without merging them, so extrude/coalesce/freshenAbove carry
-	// `{...A, x: T}` through untouched. The evaluator's merge lands at constrain time.
-	operands := cur.Operands
-	changed := false
-	for i, op := range cur.Operands {
-		ty := op.Type.Accept(v, pol)
-		if ty != op.Type {
-			if !changed {
-				operands = append([]ObjectSpreadOperand(nil), cur.Operands...)
-				changed = true
-			}
-			operands[i] = ObjectSpreadOperand{Spread: op.Spread, Type: ty}
-		}
-	}
-	out := cur
-	if changed {
-		out = &ObjectSpreadType{Operands: operands, Inexact: cur.Inexact}
-	}
-	return v.ExitType(out, pol)
-}
-
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {
@@ -520,6 +491,15 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 			return e
 		}
 		return &ConstructorElem{Fn: nf}
+	case *SpreadElem:
+		// The operand walks in the current polarity, the covariant visit KeyofType applies to its
+		// single operand. The spread is inert — the visit rebuilds it around a rewritten operand
+		// without merging, so extrude/coalesce/freshenAbove carry `...A` through untouched.
+		ty := e.Type.Accept(v, pol)
+		if ty == e.Type {
+			return e
+		}
+		return &SpreadElem{Type: ty}
 	}
 	panic(fmt.Sprintf("AcceptObjElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -235,6 +235,35 @@ func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *ObjectSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// Each operand's type walks in the current polarity, the same covariant visit KeyofType
+	// applies to its single operand. The residual is inert: the visit rebuilds it around the
+	// rewritten operands without merging them, so extrude/coalesce/freshenAbove carry
+	// `{...A, x: T}` through untouched. The evaluator's merge lands at constrain time.
+	operands := cur.Operands
+	changed := false
+	for i, op := range cur.Operands {
+		ty := op.Type.Accept(v, pol)
+		if ty != op.Type {
+			if !changed {
+				operands = append([]ObjectSpreadOperand(nil), cur.Operands...)
+				changed = true
+			}
+			operands[i] = ObjectSpreadOperand{Spread: op.Spread, Type: ty}
+		}
+	}
+	out := cur
+	if changed {
+		out = &ObjectSpreadType{Operands: operands, Inexact: cur.Inexact}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1037,6 +1037,17 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
+		// A spread-carrying object is an unreduced residual whose element order is significant,
+		// since a later `...B` overrides an earlier key. Two such objects are equal only when their
+		// elements match position for position, the order-sensitive rule a residual operator follows.
+		if soltype.HasObjectSpread(a.Elems) || soltype.HasObjectSpread(b.Elems) {
+			for i := range a.Elems {
+				if !equalObjElem(a.Elems[i], b.Elems[i], ctx) {
+					return false
+				}
+			}
+			return true
+		}
 		// Objects are equal up to member order, so each a-member must find a b-member
 		// that shares its name and equals it kind-for-kind. Equal lengths plus that
 		// match on every a-member is a full structural match. Comparing against every
@@ -1124,21 +1135,6 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// spread element reaches here in place, the spread twin of the plain element comparison.
 		b, ok := b.(*soltype.RestSpreadType)
 		return ok && equalTypeWith(a.Operand, b.Operand, ctx)
-	case *soltype.ObjectSpreadType:
-		// Two inert object spreads are equal when they carry the same inexactness and their
-		// operands match positionally in spread-flag and type, compared without merging — the
-		// operator flows through the solver untouched, matching the KeyofType arm.
-		b, ok := b.(*soltype.ObjectSpreadType)
-		if !ok || a.Inexact != b.Inexact || len(a.Operands) != len(b.Operands) {
-			return false
-		}
-		for i, ao := range a.Operands {
-			bo := b.Operands[i]
-			if ao.Spread != bo.Spread || !equalTypeWith(ao.Type, bo.Type, ctx) {
-				return false
-			}
-		}
-		return true
 	}
 	return false
 }
@@ -1180,6 +1176,9 @@ func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	case *soltype.ConstructorElem:
 		b, ok := b.(*soltype.ConstructorElem)
 		return ok && equalTypeWith(a.Fn, b.Fn, ctx)
+	case *soltype.SpreadElem:
+		b, ok := b.(*soltype.SpreadElem)
+		return ok && equalTypeWith(a.Type, b.Type, ctx)
 	}
 	panic(fmt.Sprintf("equalObjElem: unhandled ObjTypeElem %T", a))
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1124,6 +1124,21 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// spread element reaches here in place, the spread twin of the plain element comparison.
 		b, ok := b.(*soltype.RestSpreadType)
 		return ok && equalTypeWith(a.Operand, b.Operand, ctx)
+	case *soltype.ObjectSpreadType:
+		// Two inert object spreads are equal when they carry the same inexactness and their
+		// operands match positionally in spread-flag and type, compared without merging — the
+		// operator flows through the solver untouched, matching the KeyofType arm.
+		b, ok := b.(*soltype.ObjectSpreadType)
+		if !ok || a.Inexact != b.Inexact || len(a.Operands) != len(b.Operands) {
+			return false
+		}
+		for i, ao := range a.Operands {
+			bo := b.Operands[i]
+			if ao.Spread != bo.Spread || !equalTypeWith(ao.Type, bo.Type, ctx) {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -156,6 +156,17 @@ func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError,
 			return nil, nil, false
 		}
 		return c.reduceResidual(t)
+	case *soltype.ObjectSpreadType:
+		e := newTypeEvaluator(c)
+		reduced := e.reduce(t)
+		// A spread whose operands ground merges to an ObjectType. One with an abstract operand
+		// stays an ObjectSpreadType, which is inert, so leave it for the structural switch. The
+		// check is on the root rather than reduceResidual's containsResidualOp: a merged object
+		// grounds even when a field value is itself a residual, which reduces at its own site.
+		if _, stillSpread := reduced.(*soltype.ObjectSpreadType); stillSpread {
+			return nil, nil, false
+		}
+		return reduced, e.errs, true
 	default:
 		return nil, nil, false
 	}
@@ -772,6 +783,19 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// which records the whole residual as one lower bound, keeping the operator symbolic on the
 		// coalesced binding. A tuple carrying a `...P` spread is handled inertly in the TupleType arm
 		// above, the spread twin of this arm.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if equalType(sub, super) {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
+	case *soltype.ObjectSpreadType:
+		// An object spread the pre-switch could not ground reaches here: a `{...A}` over a type
+		// parameter, or a truncated expanding alias. constrain treats it inert like a `keyof`
+		// residual, neither merging nor decomposing it, so two residuals are compatible only when
+		// structurally identical. When super is a variable the case falls through to the superVar
+		// arm below, which records the whole residual as one lower bound so the operator stays
+		// symbolic on the coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -156,14 +156,19 @@ func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError,
 			return nil, nil, false
 		}
 		return c.reduceResidual(t)
-	case *soltype.ObjectSpreadType:
+	case *soltype.ObjectType:
+		// A plain object is handled structurally, not as a transparent operator. Only a
+		// spread-carrying object is a residual to reduce here, the object twin of the TupleType arm.
+		if !soltype.HasObjectSpread(t.Elems) {
+			return nil, nil, false
+		}
 		e := newTypeEvaluator(c)
 		reduced := e.reduce(t)
-		// A spread whose operands ground merges to an ObjectType. One with an abstract operand
-		// stays an ObjectSpreadType, which is inert, so leave it for the structural switch. The
+		// A spread whose operands ground merges to a spread-free object. One with an abstract operand
+		// stays a spread-carrying object, which is inert, so leave it for the structural switch. The
 		// check is on the root rather than reduceResidual's containsResidualOp: a merged object
 		// grounds even when a field value is itself a residual, which reduces at its own site.
-		if _, stillSpread := reduced.(*soltype.ObjectSpreadType); stillSpread {
+		if obj, ok := reduced.(*soltype.ObjectType); ok && soltype.HasObjectSpread(obj.Elems) {
 			return nil, nil, false
 		}
 		return reduced, e.errs, true
@@ -528,14 +533,26 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return errs
 		}
 	case *soltype.ObjectType:
-		if sup, ok := super.(*soltype.FuncType); ok {
+		if objectHasSpread(sub) || objectHasSpread(super) {
+			// One side carries an unreduced `...A` spread the pre-switch could not ground: a spread
+			// over a type parameter, or an expanding recursive alias. constrain treats such an object
+			// inert, the same as the spread-tuple and KeyofType/IndexType residuals — it is never
+			// decomposed, so two spread-objects are compatible only when structurally identical. When
+			// super is a variable the case falls through to the superVar arm below, which records the
+			// whole object as one lower bound, keeping the spread symbolic on the coalesced binding.
+			if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+				if equalType(sub, super) {
+					return nil
+				}
+				return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+			}
+		} else if sup, ok := super.(*soltype.FuncType); ok {
 			// An object with a constructor signature is a subtype of the matching function
 			// type; codegen makes the constructor behave as a plain function where expected.
 			if ctor, ok := sub.Constructor(); ok {
 				return c.constrain(ctor.Fn, sup, seen, mutCtx)
 			}
-		}
-		if sup, ok := super.(*soltype.ObjectType); ok {
+		} else if sup, ok := super.(*soltype.ObjectType); ok {
 			// One ObjectType <: ObjectType rule serves both uses the M2 arm
 			// conflated: member-access field SELECTION (the super is an inexact
 			// "has at least this field" requirement minted by inferMember) and
@@ -783,19 +800,6 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// which records the whole residual as one lower bound, keeping the operator symbolic on the
 		// coalesced binding. A tuple carrying a `...P` spread is handled inertly in the TupleType arm
 		// above, the spread twin of this arm.
-		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-			if equalType(sub, super) {
-				return nil
-			}
-			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
-		}
-	case *soltype.ObjectSpreadType:
-		// An object spread the pre-switch could not ground reaches here: a `{...A}` over a type
-		// parameter, or a truncated expanding alias. constrain treats it inert like a `keyof`
-		// residual, neither merging nor decomposing it, so two residuals are compatible only when
-		// structurally identical. When super is a variable the case falls through to the superVar
-		// arm below, which records the whole residual as one lower bound so the operator stays
-		// symbolic on the coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1806,6 +1806,11 @@ func describe(t soltype.Type) string {
 				}
 			}
 		}
+		if t.Inexact {
+			// A trailing `...` marks the residual inexact, matching soltype.Print and the
+			// UnionType arm so a diagnostic naming the spread reads `{...t1, ...}`.
+			parts = append(parts, "...")
+		}
 		return "{" + strings.Join(parts, ", ") + "}"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1746,7 +1746,28 @@ func describe(t soltype.Type) string {
 		}
 		return "tuple"
 	case *soltype.ObjectType:
-		return "object"
+		if !soltype.HasObjectSpread(t.Elems) {
+			return "object"
+		}
+		// A spread-carrying object is an unreduced residual, so it renders structurally like the
+		// KeyofType arm — a rejected constraint reads `{...t1, x: number}` rather than the nominal
+		// `object`. A spread element shows `...` over its raw mid-constrain operand; a property
+		// shows `name: <type>`. Other member kinds do not appear in a spread residual.
+		parts := make([]string, 0, len(t.Elems)+1)
+		for _, e := range t.Elems {
+			switch e := e.(type) {
+			case *soltype.SpreadElem:
+				parts = append(parts, "..."+describe(e.Type))
+			case *soltype.PropertyElem:
+				parts = append(parts, e.Name+": "+describe(e.Type))
+			}
+		}
+		if t.Inexact {
+			// A trailing `...` marks the residual inexact, matching soltype.Print and the UnionType
+			// arm so a diagnostic naming the spread reads `{...t1, ...}`.
+			parts = append(parts, "...")
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
 	case *soltype.ClassType:
 		// A class instance renders nominally under its display name, `Point` or
 		// `Box<number>`, so a diagnostic naming it matches the printer's surface form.
@@ -1786,32 +1807,6 @@ func describe(t soltype.Type) string {
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders
 		// in describe's raw mid-constrain form.
 		return "..." + describe(t.Operand)
-	case *soltype.ObjectSpreadType:
-		// An object spread renders structurally, recursing over its operands like the Promise
-		// arm, so a rejected constraint reads `{...t1, x: number}` rather than the default `?`.
-		// A spread operand shows `...` over its raw mid-constrain form; an inline field group
-		// shows its fields. describe carries the residual beside soltype.Print, so a later
-		// operator node must add an arm here as well as there.
-		parts := make([]string, 0, len(t.Operands))
-		for _, op := range t.Operands {
-			if op.Spread {
-				parts = append(parts, "..."+describe(op.Type))
-				continue
-			}
-			if obj, ok := op.Type.(*soltype.ObjectType); ok {
-				for _, e := range obj.Elems {
-					if p, ok := e.(*soltype.PropertyElem); ok {
-						parts = append(parts, p.Name+": "+describe(p.Type))
-					}
-				}
-			}
-		}
-		if t.Inexact {
-			// A trailing `...` marks the residual inexact, matching soltype.Print and the
-			// UnionType arm so a diagnostic naming the spread reads `{...t1, ...}`.
-			parts = append(parts, "...")
-		}
-		return "{" + strings.Join(parts, ", ") + "}"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -279,6 +279,17 @@ type InexactTupleSpreadError struct {
 	Operand *soltype.TupleType
 }
 
+// SpreadNotObjectError fires when an object-literal spread element ({...o}) has an
+// operand that has no ground object shape, so its fields cannot be merged into the
+// literal. The merge copies the operand object's fields in, so the operand must ground
+// to a concrete object — directly, or through an alias, class, or `typeof` query. A
+// spread of a type variable or a primitive cannot be merged statically. Spread is the
+// offending spread element and carries the blame span. Operand is the type it inferred to.
+type SpreadNotObjectError struct {
+	Spread  *ast.ObjSpreadExpr
+	Operand soltype.Type
+}
+
 // MutFieldError fires when a `mut T` annotation appears as an object property
 // value or a tuple element inside a non-mut container — `{a: mut {x}}` or
 // `[mut {x}]`. An owned-mutable cell nested inside an immutable container is
@@ -391,6 +402,7 @@ func (*FuncArityMismatchError) isSolverError()      {}
 func (*TupleLengthMismatchError) isSolverError()    {}
 func (*SpreadNotTupleError) isSolverError()         {}
 func (*InexactTupleSpreadError) isSolverError()     {}
+func (*SpreadNotObjectError) isSolverError()        {}
 func (*MissingPropertyError) isSolverError()        {}
 func (*InexactIntoExactError) isSolverError()       {}
 func (*InexactTupleIntoExactError) isSolverError()  {}
@@ -1562,6 +1574,12 @@ func (e *InexactTupleSpreadError) Message() string {
 	return "cannot spread an inexact tuple except as the last element"
 }
 
+func (e *SpreadNotObjectError) Span() ast.Span      { return e.Spread.Span() }
+func (e *SpreadNotObjectError) Related() []ast.Span { return nil }
+func (e *SpreadNotObjectError) Message() string {
+	return "cannot spread " + describe(e.Operand) + " into an object"
+}
+
 func (e *MissingPropertyError) Message() string {
 	return "object is missing property: " + e.Name
 }
@@ -1768,6 +1786,27 @@ func describe(t soltype.Type) string {
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders
 		// in describe's raw mid-constrain form.
 		return "..." + describe(t.Operand)
+	case *soltype.ObjectSpreadType:
+		// An object spread renders structurally, recursing over its operands like the Promise
+		// arm, so a rejected constraint reads `{...t1, x: number}` rather than the default `?`.
+		// A spread operand shows `...` over its raw mid-constrain form; an inline field group
+		// shows its fields. describe carries the residual beside soltype.Print, so a later
+		// operator node must add an arm here as well as there.
+		parts := make([]string, 0, len(t.Operands))
+		for _, op := range t.Operands {
+			if op.Spread {
+				parts = append(parts, "..."+describe(op.Type))
+				continue
+			}
+			if obj, ok := op.Type.(*soltype.ObjectType); ok {
+				for _, e := range obj.Elems {
+					if p, ok := e.(*soltype.PropertyElem); ok {
+						parts = append(parts, p.Name+": "+describe(p.Type))
+					}
+				}
+			}
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1856,9 +1856,10 @@ func (c *checker) inferTuple(scope *Scope, lvl int, e *ast.TupleExpr) soltype.Ty
 
 // inferObject types an object literal as an exact soltype.ObjectType. A property
 // with a static key folds into the object. A static key is an identifier label, a
-// string-literal key, or a numeric key like {0: v}. The forms it does not cover
-// each report an UnsupportedNodeError and are skipped rather than panicking:
-//   - spreads ({...o}), deferred to M9 with object rest/spread,
+// string-literal key, or a numeric key like {0: v}. A spread ({...o}) merges the
+// operand object's fields in, following the same left-to-right rule the type-level
+// operator applies. The forms it does not cover each report an UnsupportedNodeError
+// and are skipped rather than panicking:
 //   - method/constructor elements, which arrive with classes in M5,
 //   - computed keys ({[k]: v}), which need M9 index signatures,
 //   - shorthand ({x}, a property with no value).
@@ -1874,12 +1875,36 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 	// Resolve the enclosing statement's CFG point before inferring property values,
 	// which can overwrite c.fn.currentStmt with an inner branch statement.
 	stmtRef, hasStmtRef := c.currentStmtRef()
-	b := newObjElemBuilder(len(e.Elems))
+	// Each element contributes one field list, folded left to right by mergeSpreadOperands so a
+	// later element wins over an earlier key. A property contributes its single field; a spread
+	// contributes the operand object's fields, so `{...a, x: 1}` merges a's fields under x.
+	operandElems := make([][]soltype.ObjTypeElem, 0, len(e.Elems))
+	inexact := false
 	for _, elem := range e.Elems {
+		if spread, ok := elem.(*ast.ObjSpreadExpr); ok {
+			op := c.inferExpr(scope, lvl, spread.Value)
+			if _, errored := op.(*soltype.ErrorType); errored {
+				// The operand already reported its own failure; absorb it rather than layering a
+				// SpreadNotObjectError on the recovery sentinel, the object twin of the array arm.
+				continue
+			}
+			obj, ground := newTypeEvaluator(c.ctx).groundToObject(op)
+			if !ground {
+				// A spread whose operand has no ground object shape — a type variable, a
+				// primitive — cannot merge its fields. Report it and keep the rest of the object.
+				c.report(&SpreadNotObjectError{Spread: spread, Operand: op})
+				continue
+			}
+			operandElems = append(operandElems, obj.Elems)
+			inexact = inexact || obj.Inexact
+			// Spreading an owned object moves it into the new object, the object twin of the
+			// array-spread move.
+			c.consumeIntoLiteral(spread.Value, op, stmtRef, hasStmtRef)
+			continue
+		}
 		prop, ok := elem.(*ast.PropertyExpr)
 		if !ok {
-			// ObjSpreadExpr is object rest/spread, which is M9. The method and
-			// constructor elements CallableExpr and ConstructorExpr arrive with
+			// The method and constructor elements CallableExpr and ConstructorExpr arrive with
 			// classes in M5.
 			c.reportUnsupported(elem)
 			continue
@@ -1898,11 +1923,12 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 			continue
 		}
 		ft := c.inferExpr(scope, lvl, prop.Value)
-		b.add(name, ft, false, false) // a literal property is never optional or readonly
+		// A literal property is never optional or readonly.
+		operandElems = append(operandElems, []soltype.ObjTypeElem{&soltype.PropertyElem{Name: name, Type: ft}})
 		// Building an owned value into the object moves it.
 		c.consumeIntoLiteral(prop.Value, ft, stmtRef, hasStmtRef)
 	}
-	t := &soltype.ObjectType{Elems: b.elems}
+	t := &soltype.ObjectType{Elems: mergeSpreadOperands(operandElems), Inexact: inexact}
 	c.recordType(e, t)
 	c.recordProv(t, e, ObjectField)
 	return t

--- a/internal/solver/infer_obj_spread_test.go
+++ b/internal/solver/infer_obj_spread_test.go
@@ -266,3 +266,34 @@ func TestInferObjectSpreadResidualErrorMessage(t *testing.T) {
 	require.IsType(t, &CannotConstrainError{}, errs[0])
 	require.Equal(t, "1:12-1:23: cannot constrain {...t1, ...} <: number", msgWithSpan(errs[0]))
 }
+
+// keyof and indexed access compose with an object spread: over a ground spread they merge the
+// object first and then project or index it, and over an abstract spread operand they stay
+// symbolic. `keyof {...A, b}` projects A's keys plus b; `{...A, b}["a"]` selects A's field.
+func TestInferObjectSpreadUnderOperators(t *testing.T) {
+	t.Run("KeyofGroundSpread", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type A = {a: number}
+			type Result = keyof {...A, b: string}
+		`)
+		require.Empty(t, errs)
+		result := nodes["Result"]
+		require.Equal(t, "keyof {...A, b: string}", soltype.Print(result))
+		require.Equal(t, `"a" | "b"`, soltype.Print(expandResidual(ctx, result)))
+	})
+	t.Run("IndexGroundSpread", func(t *testing.T) {
+		nodes, ctx, errs := inferTypeNodes(t, `
+			type A = {a: number}
+			type Result = {...A, b: string}["a"]
+		`)
+		require.Empty(t, errs)
+		result := nodes["Result"]
+		require.Equal(t, `{...A, b: string}["a"]`, soltype.Print(result))
+		require.Equal(t, "number", soltype.Print(expandResidual(ctx, result)))
+	})
+	t.Run("KeyofAbstractSpreadStaysSymbolic", func(t *testing.T) {
+		values, _, errs := inferSource(t, `fn f<T>(k: keyof {...T, a: number}) {}`)
+		require.Empty(t, errs)
+		require.Equal(t, "fn <T>(k: keyof {...T, a: number}) -> void", values["f"])
+	})
+}

--- a/internal/solver/infer_obj_spread_test.go
+++ b/internal/solver/infer_obj_spread_test.go
@@ -88,6 +88,16 @@ func TestInferObjectSpreadStaysSymbolic(t *testing.T) {
 			wantExpanded: "{a: number, x: string}",
 		},
 		{
+			// Nested spreads reduce all the way down: each level grounds to the object one level
+			// in, so `{...{...{...{x}}}}` collapses to the innermost object.
+			name: "NestedSpreads",
+			src: `
+				type Result = {...{...{...{x: number}}}}
+			`,
+			wantSymbolic: "{...{...{...{x: number}}}}",
+			wantExpanded: "{x: number}",
+		},
+		{
 			// A spread of an inexact object makes the merged object inexact.
 			name: "InexactOperand",
 			src: `

--- a/internal/solver/infer_obj_spread_test.go
+++ b/internal/solver/infer_obj_spread_test.go
@@ -1,0 +1,235 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// An object-spread annotation over named or inline operands is stored unreduced, so the type keeps
+// the `{...A, x: T}` form the source wrote rather than the merged object. Each case asserts the
+// stored `Result` renders symbolically and that reducing it with the alias environment — the merge
+// constrain performs to check a constraint — yields the merged object. The cases cover the merge
+// rules the operator applies: field union, rightmost-wins override, the Flow optional show-through
+// union, explicit fields beside spreads, and inexactness threading from an operand.
+func TestInferObjectSpreadStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// Two disjoint operands union their fields.
+			name: "DisjointOperands",
+			src: `
+				type A = {a: number}
+				type B = {b: string}
+				type Result = {...A, ...B}
+			`,
+			wantSymbolic: "{...A, ...B}",
+			wantExpanded: "{a: number, b: string}",
+		},
+		{
+			// A later operand's required field overrides an earlier one on the same key.
+			name: "RightmostWins",
+			src: `
+				type A = {k: number}
+				type B = {k: string}
+				type Result = {...A, ...B}
+			`,
+			wantSymbolic: "{...A, ...B}",
+			wantExpanded: "{k: string}",
+		},
+		{
+			// The Flow optional show-through rule: a later optional field unions with the earlier
+			// value and stays required, since the earlier field was required.
+			name: "OptionalShowThrough",
+			src: `
+				type A = {k: number}
+				type B = {k?: string}
+				type Result = {...A, ...B}
+			`,
+			wantSymbolic: "{...A, ...B}",
+			wantExpanded: "{k: number | string}",
+		},
+		{
+			// Optional in both operands unions the values and keeps the field optional.
+			name: "OptionalBoth",
+			src: `
+				type A = {k?: number}
+				type B = {k?: string}
+				type Result = {...A, ...B}
+			`,
+			wantSymbolic: "{...A, ...B}",
+			wantExpanded: "{k?: number | string}",
+		},
+		{
+			// A show-through union of two equal types collapses to the one type, so the merged
+			// field is `k: number`, not `k: number | number`.
+			name: "OptionalSameTypeDedups",
+			src: `
+				type A = {k: number}
+				type B = {k?: number}
+				type Result = {...A, ...B}
+			`,
+			wantSymbolic: "{...A, ...B}",
+			wantExpanded: "{k: number}",
+		},
+		{
+			// An explicit field written after a spread merges in like a one-field operand.
+			name: "SpreadThenField",
+			src: `
+				type A = {a: number}
+				type Result = {...A, x: string}
+			`,
+			wantSymbolic: "{...A, x: string}",
+			wantExpanded: "{a: number, x: string}",
+		},
+		{
+			// A spread of an inexact object makes the merged object inexact.
+			name: "InexactOperand",
+			src: `
+				type A = {a: number, ...}
+				type Result = {...A}
+			`,
+			wantSymbolic: "{...A}",
+			wantExpanded: "{a: number, ...}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// An object spread over a type parameter has no ground operand shape, so it stays symbolic in a
+// function signature and round-trips from parameter to return. The reflexive `{...T} <: {...T}`
+// from `return x` succeeds inertly by structural equality on the residual, so the displayed
+// signature keeps the spread form rather than a merged object.
+func TestInferObjectSpreadSignatureStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "TypeParam",
+			src:  `fn f<T>(x: {...T, a: number}) -> {...T, a: number} { return x }`,
+			want: map[string]string{"f": "fn <T>(x: {...T, a: number}) -> {...T, a: number}"},
+		},
+		{
+			name: "InlineOperand",
+			src:  `fn g(x: {...{a: number}, b: string}) {}`,
+			want: map[string]string{"g": "fn (x: {...{a: number}, b: string}) -> void"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
+}
+
+// constrain merges an object-spread residual to check satisfaction, while the stored type stays
+// the `{...A, ...B}` form. A value matching the merged object is accepted; one whose field the
+// merge rejects fails against the merged shape, so the diagnostic names the merged field's type.
+func TestInferObjectSpreadConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "MergedObjectAccepted",
+			src: `
+				type A = {a: number}
+				type B = {b: string}
+				val v: {...A, ...B} = {a: 1, b: "x"}
+			`,
+		},
+		{
+			name: "MissingFieldRejected",
+			src: `
+				type A = {a: number}
+				type B = {b: string}
+				val v: {...A, ...B} = {a: 1}
+			`,
+			wantErr: "object is missing property: b",
+		},
+		{
+			// The rightmost operand wins, so the merged `k` is string and a number is rejected.
+			name: "OverrideRejected",
+			src: `
+				type A = {k: number}
+				type B = {k: string}
+				val v: {...A, ...B} = {k: 1}
+			`,
+			wantErr: `cannot constrain 1 <: string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A value-level object spread `{...o, x: v}` merges the operand's fields eagerly when the operand
+// is a concrete object. Like the array-spread literal, the merge needs a concrete operand: an
+// inline object splices in, while a bare variable reference stays a type variable during the value
+// solve and is rejected. The merge rules match the type level: fields splice in, a later property
+// overrides an earlier key, and an operand with no ground object shape is rejected.
+func TestInferObjectSpreadLiteral(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "MergeInlineObject",
+			src:  `val o = {...{p: 1}, x: 2}`,
+			want: "{p: 1, x: 2}",
+		},
+		{
+			// A later property overrides an earlier spread field on the same key.
+			name: "LaterPropertyWins",
+			src:  `val o = {...{p: 1}, p: 2}`,
+			want: "{p: 2}",
+		},
+		{
+			name:    "SpreadNonObjectRejected",
+			src:     `val o = {...5, x: 1}`,
+			wantErr: "cannot spread 5 into an object",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			if tt.wantErr != "" {
+				require.Len(t, errs, 1)
+				require.Equal(t, tt.wantErr, errs[0].Message())
+				return
+			}
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["o"])
+		})
+	}
+}

--- a/internal/solver/infer_obj_spread_test.go
+++ b/internal/solver/infer_obj_spread_test.go
@@ -219,6 +219,17 @@ func TestInferObjectSpreadLiteral(t *testing.T) {
 			src:     `val o = {...5, x: 1}`,
 			wantErr: "cannot spread 5 into an object",
 		},
+		{
+			// A bare variable operand stays a type variable during the value solve, like the
+			// array-spread literal, so it has no ground object shape to merge and is rejected.
+			// The message names the raw mid-solve variable the operand inferred to.
+			name: "SpreadVariableRejected",
+			src: `
+				val x = {a: 1}
+				val o = {...x}
+			`,
+			wantErr: "cannot spread t2 into an object",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -232,4 +243,16 @@ func TestInferObjectSpreadLiteral(t *testing.T) {
 			require.Equal(t, tt.want, values["o"])
 		})
 	}
+}
+
+// A rejected constraint whose subject is an object-spread residual names it structurally in the
+// diagnostic — `{...t1, ...}` rather than the bare `?` the default describe arm would render — so
+// the inert node stays legible in error messages. The trailing `...` marks the residual inexact,
+// matching soltype.Print. describe is the raw mid-constrain renderer, so the operand shows as the
+// raw var `t1` rather than the param name `T` the coalesced printer would use.
+func TestInferObjectSpreadResidualErrorMessage(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(x: {...T, ...}) -> number { return x }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:12-1:23: cannot constrain {...t1, ...} <: number", msgWithSpan(errs[0]))
 }

--- a/internal/solver/infer_obj_spread_test.go
+++ b/internal/solver/infer_obj_spread_test.go
@@ -119,6 +119,20 @@ func TestInferObjectSpreadStaysSymbolic(t *testing.T) {
 	}
 }
 
+// A property value that is itself an operator reduces when the enclosing spread object reduces, the
+// same per-element reduction reduceTuple runs on a tuple element. `{k: keyof {a}, ...A}` merges to
+// `{k: "a", b: ...}`, with the `k` field's `keyof` projected rather than left symbolic.
+func TestInferObjectSpreadReducesFieldValues(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type A = {b: number}
+		type Result = {k: keyof {a: number}, ...A}
+	`)
+	require.Empty(t, errs)
+	result := nodes["Result"]
+	require.Equal(t, "{k: keyof {a: number}, ...A}", soltype.Print(result))
+	require.Equal(t, `{k: "a", b: number}`, soltype.Print(expandResidual(ctx, result)))
+}
+
 // An object spread over a type parameter has no ground operand shape, so it stays symbolic in a
 // function signature and round-trips from parameter to return. The reflexive `{...T} <: {...T}`
 // from `return x` succeeds inertly by structural equality on the residual, so the displayed

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -217,15 +217,27 @@ func TestInferObjectShorthandUnsupported(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// A spread element ({...o}) is M4; it reports unsupported without walking its
-// value, so the unknown `o` inside it never surfaces a second error.
-func TestInferObjectSpreadUnsupported(t *testing.T) {
+// A spread element ({...o}) splices the operand object's fields into the literal (M9 PR5). A
+// concrete inline operand merges its fields; a later property on the same key overrides. An
+// operand with no ground object shape, such as the primitive below, reports a SpreadNotObjectError.
+func TestInferObjectSpreadMerges(t *testing.T) {
 	c := newChecker()
-	spread := ast.NewRestSpread(identExpr("o"), testSpan())
-	got := c.inferExpr(NewScope(), 0, objExpr(spread))
-	require.Equal(t, "{}", render(got))
+	// {...{a: 1}, b: 2}
+	spread := ast.NewRestSpread(objExpr(prop("a", numExpr(1))), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(spread, prop("b", numExpr(2))))
+	require.Empty(t, c.errs)
+	require.Equal(t, "{a: 1, b: 2}", render(got))
+}
+
+// Spreading a value with no ground object shape — a primitive here — cannot merge its fields, so
+// it reports a SpreadNotObjectError and keeps the rest of the object.
+func TestInferObjectSpreadNonObject(t *testing.T) {
+	c := newChecker()
+	spread := ast.NewRestSpread(numExpr(5), testSpan())
+	got := c.inferExpr(NewScope(), 0, objExpr(spread, prop("b", numExpr(2))))
+	require.Equal(t, "{b: 2}", render(got))
 	require.Len(t, c.errs, 1)
-	require.Equal(t, "Unsupported: ObjSpreadExpr", c.errs[0].Message())
+	require.Equal(t, "cannot spread 5 into an object", c.errs[0].Message())
 }
 
 // A computed key ({[k]: v}) carries no static field name — M4.

--- a/internal/solver/infer_obj_test.go
+++ b/internal/solver/infer_obj_test.go
@@ -217,27 +217,51 @@ func TestInferObjectShorthandUnsupported(t *testing.T) {
 	require.Equal(t, testSpan(), c.errs[0].Span())
 }
 
-// A spread element ({...o}) splices the operand object's fields into the literal (M9 PR5). A
-// concrete inline operand merges its fields; a later property on the same key overrides. An
-// operand with no ground object shape, such as the primitive below, reports a SpreadNotObjectError.
-func TestInferObjectSpreadMerges(t *testing.T) {
-	c := newChecker()
-	// {...{a: 1}, b: 2}
-	spread := ast.NewRestSpread(objExpr(prop("a", numExpr(1))), testSpan())
-	got := c.inferExpr(NewScope(), 0, objExpr(spread, prop("b", numExpr(2))))
-	require.Empty(t, c.errs)
-	require.Equal(t, "{a: 1, b: 2}", render(got))
-}
-
-// Spreading a value with no ground object shape — a primitive here — cannot merge its fields, so
-// it reports a SpreadNotObjectError and keeps the rest of the object.
-func TestInferObjectSpreadNonObject(t *testing.T) {
-	c := newChecker()
-	spread := ast.NewRestSpread(numExpr(5), testSpan())
-	got := c.inferExpr(NewScope(), 0, objExpr(spread, prop("b", numExpr(2))))
-	require.Equal(t, "{b: 2}", render(got))
-	require.Len(t, c.errs, 1)
-	require.Equal(t, "cannot spread 5 into an object", c.errs[0].Message())
+// A spread element ({...o}) splices the operand object's fields into the literal. A concrete inline
+// operand merges its fields; a later property on the same key overrides the spread field; an
+// operand with no ground object shape, such as a primitive, reports a SpreadNotObjectError and
+// keeps the rest of the object.
+func TestInferObjectSpread(t *testing.T) {
+	tests := []struct {
+		name       string
+		elems      []ast.ObjExprElem
+		wantRender string
+		wantErr    string // "" ⇒ expect no error
+	}{
+		{
+			// {...{a: 1}, b: 2} — the operand's field splices in beside the explicit property.
+			name:       "MergesInlineObject",
+			elems:      []ast.ObjExprElem{ast.NewRestSpread(objExpr(prop("a", numExpr(1))), testSpan()), prop("b", numExpr(2))},
+			wantRender: "{a: 1, b: 2}",
+		},
+		{
+			// {...{a: 1}, a: 2} — a later property on the same key overrides the spread field.
+			name:       "LaterPropertyOverrides",
+			elems:      []ast.ObjExprElem{ast.NewRestSpread(objExpr(prop("a", numExpr(1))), testSpan()), prop("a", numExpr(2))},
+			wantRender: "{a: 2}",
+		},
+		{
+			// {...5, b: 2} — a primitive has no ground object shape, so the spread reports an
+			// error and the rest of the object still builds.
+			name:       "NonObjectRejected",
+			elems:      []ast.ObjExprElem{ast.NewRestSpread(numExpr(5), testSpan()), prop("b", numExpr(2))},
+			wantRender: "{b: 2}",
+			wantErr:    "cannot spread 5 into an object",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newChecker()
+			got := c.inferExpr(NewScope(), 0, objExpr(tt.elems...))
+			require.Equal(t, tt.wantRender, render(got))
+			if tt.wantErr == "" {
+				require.Empty(t, c.errs)
+				return
+			}
+			require.Len(t, c.errs, 1)
+			require.Equal(t, tt.wantErr, c.errs[0].Message())
+		})
+	}
 }
 
 // A computed key ({[k]: v}) carries no static field name — M4.

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -33,16 +33,14 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 	require.Equal(t, "fn () -> number", values["f"])
 }
 
-// An unsupported expression recovers to the ErrorType sentinel and flows on without
-// cascading. Here the unsupported expression is an object spread, which is M9. The
-// only error is the unsupported-node one, and the surrounding object still builds.
+// An object spread over an unknown identifier walks its operand, which recovers to the ErrorType
+// sentinel. The spread absorbs that sentinel rather than layering a SpreadNotObjectError on it, so
+// the only error is the unknown-identifier one and the surrounding object still builds.
 func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val o = {...xs}
 	`)
-	// One error for the spread itself; `xs` is never walked (so no extra
-	// unknown-identifier), and the broken element does not cascade.
 	require.Len(t, errs, 1)
-	require.Equal(t, "2:12-2:17: Unsupported: ObjSpreadExpr", msgWithSpan(errs[0]))
+	require.Equal(t, "2:15-2:17: Unknown identifier: xs", msgWithSpan(errs[0]))
 	require.Equal(t, "{}", values["o"])
 }

--- a/internal/solver/infer_recovery_test.go
+++ b/internal/solver/infer_recovery_test.go
@@ -36,7 +36,7 @@ func TestInferErrorBindingFlowsIntoCallNoCascade(t *testing.T) {
 // An object spread over an unknown identifier walks its operand, which recovers to the ErrorType
 // sentinel. The spread absorbs that sentinel rather than layering a SpreadNotObjectError on it, so
 // the only error is the unknown-identifier one and the surrounding object still builds.
-func TestInferUnsupportedExprRecoversWithoutCascade(t *testing.T) {
+func TestInferObjectSpreadOverUnknownIdentifierRecovers(t *testing.T) {
 	values, _, errs := inferSource(t, `
 		val o = {...xs}
 	`)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -103,41 +103,69 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 }
 
 // resolveObjectTypeAnn lowers an object type annotation to a soltype.ObjectType,
-// honoring the trailing `...` inexact marker. M4 ships PropertyElem only: a
-// `name: T` / `name?: T` property resolves to a PropertyElem; method/getter/setter
-// members (M5), mapped/index signatures and the object rest/spread (M9) are not
-// part of M4's object and report an unsupported feature, with the object still
-// built from the properties that do resolve. Duplicate keys follow the
-// last-wins-first-position dedup inferObject uses, keeping property names unique.
+// honoring the trailing `...` inexact marker. A `name: T` / `name?: T` property resolves
+// to a PropertyElem; a `...A` spread resolves to a SpreadElem, so `{...A, x: T}` is an
+// ObjectType carrying a spread element — the object twin of a spread-carrying tuple. The
+// evaluator merges the spread once its operand grounds; until then the object stays a
+// residual that prints the way the source wrote it. Method/getter/setter members (M5) and
+// mapped/index signatures (M9) are not yet part of an object annotation and report an
+// unsupported feature, with the object still built from the members that do resolve.
 //
-// A property whose value annotation is itself unsupported recovers that value to a
-// fresh var and keeps the object shape — cascade-safe, mirroring the Promise<bad>
-// recovery — so the binding still checks structurally. The arm therefore always
-// returns ok=true: any unsupported sub-part has already reported its own error.
+// A spread-free object dedups duplicate keys last-wins-first-position, keeping property
+// names unique for Prop/equalType. A spread-carrying object keeps its elements in source
+// order without deduping, since order is significant to the merge and reduceObject dedups
+// when it grounds. A property whose value annotation is itself unsupported recovers that
+// value to a fresh var and keeps the object shape — cascade-safe, mirroring the
+// Promise<bad> recovery. The arm therefore always returns ok=true.
 func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
+	hasSpread := false
 	for _, elem := range ta.Elems {
 		if _, ok := elem.(*ast.RestSpreadTypeAnn); ok {
-			return c.resolveObjectSpreadTypeAnn(scope, ta, lvl)
+			hasSpread = true
+			break
 		}
 	}
-	b := newObjElemBuilder(len(ta.Elems))
 	unsupported := false
-	for _, elem := range ta.Elems {
-		prop, ok := elem.(*ast.PropertyTypeAnn)
-		if !ok {
-			unsupported = true
-			continue
+	var elems []soltype.ObjTypeElem
+	if !hasSpread {
+		b := newObjElemBuilder(len(ta.Elems))
+		for _, elem := range ta.Elems {
+			prop, ok := elem.(*ast.PropertyTypeAnn)
+			if !ok {
+				unsupported = true
+				continue
+			}
+			name, ft, ok := c.resolveObjectProperty(scope, prop, lvl)
+			if !ok {
+				continue
+			}
+			b.add(name, ft, prop.Optional, prop.Readonly)
 		}
-		name, ft, ok := c.resolveObjectProperty(scope, prop, lvl)
-		if !ok {
-			continue
+		elems = b.elems
+	} else {
+		for _, elem := range ta.Elems {
+			switch elem := elem.(type) {
+			case *ast.PropertyTypeAnn:
+				name, ft, ok := c.resolveObjectProperty(scope, elem, lvl)
+				if !ok {
+					continue
+				}
+				elems = append(elems, &soltype.PropertyElem{Name: name, Type: ft, Optional: elem.Optional, Readonly: elem.Readonly})
+			case *ast.RestSpreadTypeAnn:
+				src, ok := c.resolveTypeAnn(scope, elem.Value, lvl)
+				if !ok {
+					src = c.freshAt(lvl)
+				}
+				elems = append(elems, &soltype.SpreadElem{Type: src})
+			default:
+				unsupported = true
+			}
 		}
-		b.add(name, ft, prop.Optional, prop.Readonly)
 	}
 	if unsupported {
-		c.reportUnsupportedFeature(ta, "object type member other than a property")
+		c.reportUnsupportedFeature(ta, "object type member other than a property or spread")
 	}
-	t := &soltype.ObjectType{Elems: b.elems, Inexact: ta.Inexact}
+	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
@@ -145,7 +173,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 // resolveObjectProperty lowers one `name: T` / `name?: T` property annotation to its name and
 // resolved field type. It reports false only when the property key is not a static name. A missing
 // or unsupported value annotation recovers to a fresh var, keeping the object shape cascade-safe,
-// mirroring the Promise<bad> recovery. Shared by the plain-object and object-spread arms.
+// mirroring the Promise<bad> recovery. Shared by the spread-free and spread-carrying paths.
 func (c *checker) resolveObjectProperty(scope *Scope, prop *ast.PropertyTypeAnn, lvl int) (string, soltype.Type, bool) {
 	name, ok := objKeyName(prop.Name)
 	if !ok {
@@ -169,56 +197,6 @@ func (c *checker) resolveObjectProperty(scope *Scope, prop *ast.PropertyTypeAnn,
 		}
 	}
 	return name, ft, true
-}
-
-// resolveObjectSpreadTypeAnn lowers an object annotation carrying a `...A` spread to an
-// ObjectSpreadType residual and stores it unreduced, so the annotation prints the way the source
-// wrote it — `{...A, x: T}` renders `{...A, x: T}`, not the merged object. constrain merges the
-// residual when it checks a constraint against it. Consecutive explicit properties between spreads
-// group into one inline field-group operand; each `...A` becomes a spread operand. A non-property,
-// non-spread member reports an unsupported feature and is skipped, cascade-safe like the plain
-// object arm.
-func (c *checker) resolveObjectSpreadTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
-	operands := make([]soltype.ObjectSpreadOperand, 0, len(ta.Elems))
-	var pending *objElemBuilder
-	unsupported := false
-	flush := func() {
-		if pending == nil {
-			return
-		}
-		obj := &soltype.ObjectType{Elems: pending.elems}
-		operands = append(operands, soltype.ObjectSpreadOperand{Spread: false, Type: obj})
-		pending = nil
-	}
-	for _, elem := range ta.Elems {
-		switch elem := elem.(type) {
-		case *ast.PropertyTypeAnn:
-			name, ft, ok := c.resolveObjectProperty(scope, elem, lvl)
-			if !ok {
-				continue
-			}
-			if pending == nil {
-				pending = newObjElemBuilder(len(ta.Elems))
-			}
-			pending.add(name, ft, elem.Optional, elem.Readonly)
-		case *ast.RestSpreadTypeAnn:
-			flush()
-			src, ok := c.resolveTypeAnn(scope, elem.Value, lvl)
-			if !ok {
-				src = c.freshAt(lvl)
-			}
-			operands = append(operands, soltype.ObjectSpreadOperand{Spread: true, Type: src})
-		default:
-			unsupported = true
-		}
-	}
-	flush()
-	if unsupported {
-		c.reportUnsupportedFeature(ta, "object type member other than a property or spread")
-	}
-	t := &soltype.ObjectSpreadType{Operands: operands, Inexact: ta.Inexact}
-	c.recordProv(t, ta, AnnotationType)
-	return t, true
 }
 
 // resolveTupleTypeAnn lowers a tuple type annotation to a soltype.TupleType, honoring the trailing

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -115,6 +115,11 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 // recovery — so the binding still checks structurally. The arm therefore always
 // returns ok=true: any unsupported sub-part has already reported its own error.
 func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
+	for _, elem := range ta.Elems {
+		if _, ok := elem.(*ast.RestSpreadTypeAnn); ok {
+			return c.resolveObjectSpreadTypeAnn(scope, ta, lvl)
+		}
+	}
 	b := newObjElemBuilder(len(ta.Elems))
 	unsupported := false
 	for _, elem := range ta.Elems {
@@ -123,28 +128,9 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 			unsupported = true
 			continue
 		}
-		name, ok := objKeyName(prop.Name)
+		name, ft, ok := c.resolveObjectProperty(scope, prop, lvl)
 		if !ok {
-			c.reportUnsupported(prop.Name)
 			continue
-		}
-		// A missing or unsupported value annotation recovers to a fresh var, keeping
-		// the object shape cascade-safe — mirroring the Promise<bad> recovery.
-		var ft soltype.Type = c.freshAt(lvl)
-		if prop.Value != nil {
-			value := prop.Value
-			// An owned-mutable field `{a: mut {x}}` is rejected (#779): a `mut` cell
-			// nested inside a non-mut container is misleading, since the container's
-			// immutability already reaches into the field. Recover to the field's bare
-			// inner so the object keeps a sensible shape. A `&`/`&mut` borrow field is a
-			// reference to external storage, not an interior cell, so it stays legal.
-			if mta, ok := value.(*ast.MutableTypeAnn); ok {
-				c.report(&MutFieldError{Ann: mta})
-				value = mta.Target
-			}
-			if t, ok := c.resolveTypeAnn(scope, value, lvl); ok {
-				ft = t
-			}
 		}
 		b.add(name, ft, prop.Optional, prop.Readonly)
 	}
@@ -152,6 +138,85 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 		c.reportUnsupportedFeature(ta, "object type member other than a property")
 	}
 	t := &soltype.ObjectType{Elems: b.elems, Inexact: ta.Inexact}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveObjectProperty lowers one `name: T` / `name?: T` property annotation to its name and
+// resolved field type. It reports false only when the property key is not a static name. A missing
+// or unsupported value annotation recovers to a fresh var, keeping the object shape cascade-safe,
+// mirroring the Promise<bad> recovery. Shared by the plain-object and object-spread arms.
+func (c *checker) resolveObjectProperty(scope *Scope, prop *ast.PropertyTypeAnn, lvl int) (string, soltype.Type, bool) {
+	name, ok := objKeyName(prop.Name)
+	if !ok {
+		c.reportUnsupported(prop.Name)
+		return "", nil, false
+	}
+	var ft soltype.Type = c.freshAt(lvl)
+	if prop.Value != nil {
+		value := prop.Value
+		// An owned-mutable field `{a: mut {x}}` is rejected (#779): a `mut` cell
+		// nested inside a non-mut container is misleading, since the container's
+		// immutability already reaches into the field. Recover to the field's bare
+		// inner so the object keeps a sensible shape. A `&`/`&mut` borrow field is a
+		// reference to external storage, not an interior cell, so it stays legal.
+		if mta, ok := value.(*ast.MutableTypeAnn); ok {
+			c.report(&MutFieldError{Ann: mta})
+			value = mta.Target
+		}
+		if t, ok := c.resolveTypeAnn(scope, value, lvl); ok {
+			ft = t
+		}
+	}
+	return name, ft, true
+}
+
+// resolveObjectSpreadTypeAnn lowers an object annotation carrying a `...A` spread to an
+// ObjectSpreadType residual and stores it unreduced, so the annotation prints the way the source
+// wrote it — `{...A, x: T}` renders `{...A, x: T}`, not the merged object. constrain merges the
+// residual when it checks a constraint against it. Consecutive explicit properties between spreads
+// group into one inline field-group operand; each `...A` becomes a spread operand. A non-property,
+// non-spread member reports an unsupported feature and is skipped, cascade-safe like the plain
+// object arm.
+func (c *checker) resolveObjectSpreadTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
+	operands := make([]soltype.ObjectSpreadOperand, 0, len(ta.Elems))
+	var pending *objElemBuilder
+	unsupported := false
+	flush := func() {
+		if pending == nil {
+			return
+		}
+		obj := &soltype.ObjectType{Elems: pending.elems}
+		operands = append(operands, soltype.ObjectSpreadOperand{Spread: false, Type: obj})
+		pending = nil
+	}
+	for _, elem := range ta.Elems {
+		switch elem := elem.(type) {
+		case *ast.PropertyTypeAnn:
+			name, ft, ok := c.resolveObjectProperty(scope, elem, lvl)
+			if !ok {
+				continue
+			}
+			if pending == nil {
+				pending = newObjElemBuilder(len(ta.Elems))
+			}
+			pending.add(name, ft, elem.Optional, elem.Readonly)
+		case *ast.RestSpreadTypeAnn:
+			flush()
+			src, ok := c.resolveTypeAnn(scope, elem.Value, lvl)
+			if !ok {
+				src = c.freshAt(lvl)
+			}
+			operands = append(operands, soltype.ObjectSpreadOperand{Spread: true, Type: src})
+		default:
+			unsupported = true
+		}
+	}
+	flush()
+	if unsupported {
+		c.reportUnsupportedFeature(ta, "object type member other than a property or spread")
+	}
+	t := &soltype.ObjectSpreadType{Operands: operands, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -127,6 +127,10 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	}
 	unsupported := false
 	var elems []soltype.ObjTypeElem
+	// The two paths differ only in when duplicate keys collapse. A spread-free object is never
+	// reduced later, so its duplicates must collapse here to the unique-key shape Prop and equalType
+	// assume. A spread-carrying object keeps source order for the override merge and dedups in
+	// reduceObject once its spreads ground.
 	if !hasSpread {
 		b := newObjElemBuilder(len(ta.Elems))
 		for _, elem := range ta.Elems {

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -269,6 +269,9 @@ func mergeSpreadOperands(operandElems [][]soltype.ObjTypeElem) []soltype.ObjType
 // `A = {k: number}` and `B = {k?: string}` therefore yields `k: number | string`, required. A
 // non-property member on either side has no optional flag to key the union off, so the later one
 // overrides.
+//
+// The later operand supplies the merged Readonly flag in both branches, the same rightmost-wins
+// source the override branch uses when it returns the later member whole.
 func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 	ep, eok := earlier.(*soltype.PropertyElem)
 	lp, lok := later.(*soltype.PropertyElem)
@@ -279,7 +282,7 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 		Name:     ep.Name,
 		Type:     newUnion(nil, []soltype.Type{ep.Type, lp.Type}, false),
 		Optional: ep.Optional && lp.Optional,
-		Readonly: ep.Readonly,
+		Readonly: lp.Readonly,
 	}
 }
 

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -76,8 +76,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return t.Ty
 	case *soltype.TupleType:
 		return e.reduceTuple(t)
-	case *soltype.ObjectSpreadType:
-		return e.reduceObjectSpread(t)
+	case *soltype.ObjectType:
+		return e.reduceObject(t)
 	default:
 		return t
 	}
@@ -154,68 +154,77 @@ func (e *typeEvaluator) groundSpreadOperand(operand soltype.Type) soltype.Type {
 	})
 }
 
-// reduceObjectSpread merges an object spread's operands left to right into a plain ObjectType,
-// following Flow's spread semantics. Each operand contributes its fields; a later field wins over
-// an earlier key, except that a later optional field unions with the earlier value rather than
-// overriding it — see mergeSpreadElem.
+// reduceObject merges a spread-carrying object's elements left to right into a plain ObjectType,
+// following Flow's spread semantics. An object with no `...A` spread element returns unchanged, so a
+// plain object keeps its pointer. Each element contributes its fields: a property as its own
+// one-field group, a `...A` spread as the fields of the object its operand grounds to. A later
+// field wins over an earlier key, except that a later optional field unions with the earlier value
+// rather than overriding it, see mergeSpreadElem.
 //
-// The merge runs only when every spread operand grounds to a concrete object. groundToObject
-// expands an alias, projects a class body, and resolves a `typeof` query under the same
-// termination guard reduceKeyofAlias uses. A spread operand that stays abstract — a type
-// parameter, or a truncated expanding alias — leaves the whole operator symbolic, rebuilt around
-// its reduced operands so it merges later once the operand grounds. An inline field group is
-// always concrete, since resolveObjectTypeAnn builds it from explicit properties.
-func (e *typeEvaluator) reduceObjectSpread(t *soltype.ObjectSpreadType) soltype.Type {
-	operandElems := make([][]soltype.ObjTypeElem, 0, len(t.Operands))
+// The merge runs only when every spread element grounds to a concrete object. groundToObject
+// expands an alias, projects a class body, and resolves a `typeof` query under the same termination
+// guard reduceKeyofAlias uses. A spread whose operand stays abstract — a type parameter, or a
+// truncated expanding alias — leaves the object symbolic: it returns the original elements with each
+// spread's operand reduced, so the object merges later once the operand grounds.
+func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
+	if !soltype.HasObjectSpread(t.Elems) {
+		return t
+	}
+	operandElems := make([][]soltype.ObjTypeElem, 0, len(t.Elems))
 	inexact := t.Inexact
-	reduced := make([]soltype.ObjectSpreadOperand, len(t.Operands))
 	ground := true
-	for i, op := range t.Operands {
-		if !op.Spread {
-			// An inline field group is an ObjectType of explicit properties, already concrete.
-			reduced[i] = op
-			if obj, ok := op.Type.(*soltype.ObjectType); ok {
-				operandElems = append(operandElems, obj.Elems)
-				inexact = inexact || obj.Inexact
-			}
+	for _, el := range t.Elems {
+		spread, ok := el.(*soltype.SpreadElem)
+		if !ok {
+			// A non-spread member contributes itself as a one-field group.
+			operandElems = append(operandElems, []soltype.ObjTypeElem{el})
 			continue
 		}
-		obj, ok := e.groundToObject(op.Type)
+		obj, ok := e.groundToObject(spread.Type)
 		if !ok {
-			// The operand is not a concrete object yet. Keep the reduced operand so the residual
-			// carries any progress made, and mark the whole operator not ground.
-			reduced[i] = soltype.ObjectSpreadOperand{Spread: true, Type: e.reduce(op.Type)}
 			ground = false
 			continue
 		}
-		reduced[i] = op
 		operandElems = append(operandElems, obj.Elems)
 		inexact = inexact || obj.Inexact
 	}
 	if !ground {
-		return &soltype.ObjectSpreadType{Operands: reduced, Inexact: t.Inexact}
+		// Keep the residual: the original elements, with each spread's operand reduced but not
+		// expanded, so it renders the way the source wrote it and re-reduces once the operand
+		// grounds.
+		reduced := make([]soltype.ObjTypeElem, len(t.Elems))
+		for i, el := range t.Elems {
+			if spread, ok := el.(*soltype.SpreadElem); ok {
+				reduced[i] = &soltype.SpreadElem{Type: e.reduce(spread.Type)}
+			} else {
+				reduced[i] = el
+			}
+		}
+		return &soltype.ObjectType{Elems: reduced, Inexact: t.Inexact}
 	}
 	return &soltype.ObjectType{Elems: mergeSpreadOperands(operandElems), Inexact: inexact}
 }
 
 // groundToObject reduces a spread operand to the concrete ObjectType whose fields it contributes,
-// reporting false when the operand has no ground object shape. It resolves a `typeof` query to the
-// value's type, projects a class instance body, and expands an alias under the active-state and
-// depth guard reduceKeyofAlias uses, so a recursive alias reached through a spread terminates. A
-// type variable, a skolem, or any other kind has no object shape and reports false.
+// reporting false when the operand has no ground object shape. It reduces a nested-spread object,
+// resolves a `typeof` query to the value's type, projects a class instance body, and expands an
+// alias under the active-state and depth guard reduceKeyofAlias uses, so a recursive alias reached
+// through a spread terminates. A type variable, a skolem, or any other kind has no object shape and
+// reports false.
 func (e *typeEvaluator) groundToObject(operand soltype.Type) (*soltype.ObjectType, bool) {
 	switch op := operand.(type) {
 	case *soltype.ObjectType:
-		return op, true
+		// The object may itself carry spreads, as in `{...{...A}}`: reduce it first, and treat it
+		// as ground only when no spread element remains.
+		reduced, ok := e.reduceObject(op).(*soltype.ObjectType)
+		if !ok || soltype.HasObjectSpread(reduced.Elems) {
+			return nil, false
+		}
+		return reduced, true
 	case *soltype.TypeofType:
 		return e.groundToObject(op.Ty)
 	case *soltype.ClassType:
 		return e.ctx.projectClassBody(op)
-	case *soltype.ObjectSpreadType:
-		if obj, ok := e.reduceObjectSpread(op).(*soltype.ObjectType); ok {
-			return obj, true
-		}
-		return nil, false
 	case *soltype.AliasType:
 		key := soltype.PrintQualified(op)
 		if e.active.Contains(key) || e.depth <= 0 {
@@ -317,7 +326,12 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Ty
 		// `keyof typeof x` resolves the query to the value's type, then projects that type's keys.
 		return e.reduceKeyof(op.Ty, exact)
 	case *soltype.ObjectType:
-		return e.keyofObject(op)
+		// An object carrying an unreduced `...A` spread has no ground key set, so `keyof` over it
+		// stays symbolic until the spread grounds, mirroring the TupleType arm below.
+		if obj, ok := e.groundToObject(op); ok {
+			return e.keyofObject(obj)
+		}
+		return &soltype.KeyofType{Operand: operand, Exact: exact}
 	case *soltype.ClassType:
 		obj, ok := e.ctx.projectClassBody(op)
 		if !ok {
@@ -470,7 +484,12 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 		}
 		return e.reduceIndex(inner, idx, exact)
 	case *soltype.ObjectType:
-		return e.indexObject(tgt, idx, exact)
+		// An object carrying an unreduced `...A` spread has no ground fields, so indexing it stays
+		// symbolic until the spread grounds, mirroring the TupleType arm below.
+		if obj, ok := e.groundToObject(tgt); ok {
+			return e.indexObject(obj, idx, exact)
+		}
+		return &soltype.IndexType{Target: target, Index: idx, Exact: exact}
 	case *soltype.ClassType:
 		obj, ok := e.ctx.projectClassBody(tgt)
 		if !ok {
@@ -641,6 +660,13 @@ func isResidualOp(t soltype.Type) bool {
 func tupleHasSpread(t soltype.Type) bool {
 	tup, ok := t.(*soltype.TupleType)
 	return ok && hasRestSpread(tup.Elems)
+}
+
+// objectHasSpread reports whether t is an object carrying an unreduced `...A` spread element, the
+// object twin of tupleHasSpread.
+func objectHasSpread(t soltype.Type) bool {
+	obj, ok := t.(*soltype.ObjectType)
+	return ok && soltype.HasObjectSpread(obj.Elems)
 }
 
 // hasRestSpread reports whether any element of elems is a `...P` spread.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -76,6 +76,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return t.Ty
 	case *soltype.TupleType:
 		return e.reduceTuple(t)
+	case *soltype.ObjectSpreadType:
+		return e.reduceObjectSpread(t)
 	default:
 		return t
 	}
@@ -150,6 +152,135 @@ func (e *typeEvaluator) groundSpreadOperand(operand soltype.Type) soltype.Type {
 	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
 		return e.groundSpreadOperand(body)
 	})
+}
+
+// reduceObjectSpread merges an object spread's operands left to right into a plain ObjectType,
+// following Flow's spread semantics. Each operand contributes its fields; a later field wins over
+// an earlier key, except that a later optional field unions with the earlier value rather than
+// overriding it — see mergeSpreadElem.
+//
+// The merge runs only when every spread operand grounds to a concrete object. groundToObject
+// expands an alias, projects a class body, and resolves a `typeof` query under the same
+// termination guard reduceKeyofAlias uses. A spread operand that stays abstract — a type
+// parameter, or a truncated expanding alias — leaves the whole operator symbolic, rebuilt around
+// its reduced operands so it merges later once the operand grounds. An inline field group is
+// always concrete, since resolveObjectTypeAnn builds it from explicit properties.
+func (e *typeEvaluator) reduceObjectSpread(t *soltype.ObjectSpreadType) soltype.Type {
+	operandElems := make([][]soltype.ObjTypeElem, 0, len(t.Operands))
+	inexact := t.Inexact
+	reduced := make([]soltype.ObjectSpreadOperand, len(t.Operands))
+	ground := true
+	for i, op := range t.Operands {
+		if !op.Spread {
+			// An inline field group is an ObjectType of explicit properties, already concrete.
+			reduced[i] = op
+			if obj, ok := op.Type.(*soltype.ObjectType); ok {
+				operandElems = append(operandElems, obj.Elems)
+				inexact = inexact || obj.Inexact
+			}
+			continue
+		}
+		obj, ok := e.groundToObject(op.Type)
+		if !ok {
+			// The operand is not a concrete object yet. Keep the reduced operand so the residual
+			// carries any progress made, and mark the whole operator not ground.
+			reduced[i] = soltype.ObjectSpreadOperand{Spread: true, Type: e.reduce(op.Type)}
+			ground = false
+			continue
+		}
+		reduced[i] = op
+		operandElems = append(operandElems, obj.Elems)
+		inexact = inexact || obj.Inexact
+	}
+	if !ground {
+		return &soltype.ObjectSpreadType{Operands: reduced, Inexact: t.Inexact}
+	}
+	return &soltype.ObjectType{Elems: mergeSpreadOperands(operandElems), Inexact: inexact}
+}
+
+// groundToObject reduces a spread operand to the concrete ObjectType whose fields it contributes,
+// reporting false when the operand has no ground object shape. It resolves a `typeof` query to the
+// value's type, projects a class instance body, and expands an alias under the active-state and
+// depth guard reduceKeyofAlias uses, so a recursive alias reached through a spread terminates. A
+// type variable, a skolem, or any other kind has no object shape and reports false.
+func (e *typeEvaluator) groundToObject(operand soltype.Type) (*soltype.ObjectType, bool) {
+	switch op := operand.(type) {
+	case *soltype.ObjectType:
+		return op, true
+	case *soltype.TypeofType:
+		return e.groundToObject(op.Ty)
+	case *soltype.ClassType:
+		return e.ctx.projectClassBody(op)
+	case *soltype.ObjectSpreadType:
+		if obj, ok := e.reduceObjectSpread(op).(*soltype.ObjectType); ok {
+			return obj, true
+		}
+		return nil, false
+	case *soltype.AliasType:
+		key := soltype.PrintQualified(op)
+		if e.active.Contains(key) || e.depth <= 0 {
+			return nil, false
+		}
+		body := e.ctx.expandAlias(op)
+		if _, unresolved := body.(*soltype.ErrorType); unresolved {
+			return nil, false
+		}
+		e.active.Add(key)
+		e.depth--
+		obj, ok := e.groundToObject(body)
+		e.active.Remove(key)
+		e.depth++
+		return obj, ok
+	default:
+		return nil, false
+	}
+}
+
+// mergeSpreadOperands folds the field lists of an object spread's operands into one element list,
+// preserving first-appearance order. A field whose name is new is appended; one that overlaps an
+// earlier key is merged through mergeSpreadElem, so the operands compose left to right. It is
+// shared by the type-level reduction and the literal-level inferObject, so the spread merge rule
+// lives in one place.
+func mergeSpreadOperands(operandElems [][]soltype.ObjTypeElem) []soltype.ObjTypeElem {
+	total := 0
+	for _, elems := range operandElems {
+		total += len(elems)
+	}
+	out := make([]soltype.ObjTypeElem, 0, total)
+	pos := make(map[string]int, total)
+	for _, elems := range operandElems {
+		for _, elem := range elems {
+			name := soltype.ObjElemName(elem)
+			if i, seen := pos[name]; seen {
+				out[i] = mergeSpreadElem(out[i], elem)
+				continue
+			}
+			pos[name] = len(out)
+			out = append(out, elem)
+		}
+	}
+	return out
+}
+
+// mergeSpreadElem combines an earlier object member with a later one of the same name under Flow's
+// spread rule. A later required field overrides the earlier one, the rightmost-wins default. A
+// later optional field instead shows the earlier value through: the merged value unions
+// `earlier | later`, and the field stays required unless both are optional. `{...A, ...B}` with
+// `A = {k: number}` and `B = {k?: string}` therefore yields `k: number | string`, required. A
+// non-property member on either side has no optional flag to key the union off, so the later one
+// overrides.
+func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
+	ep, eok := earlier.(*soltype.PropertyElem)
+	lp, lok := later.(*soltype.PropertyElem)
+	if !eok || !lok || !lp.Optional {
+		return later
+	}
+	return &soltype.PropertyElem{
+		Name:     ep.Name,
+		Type:     newUnion(nil, []soltype.Type{ep.Type, lp.Type}, false),
+		Optional: ep.Optional && lp.Optional,
+		Readonly: ep.Readonly,
+	}
 }
 
 // reduceKeyof reduces `keyof operand` to the union of the operand's keys, mirroring the old

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -161,27 +161,39 @@ func (e *typeEvaluator) groundSpreadOperand(operand soltype.Type) soltype.Type {
 // field wins over an earlier key, except that a later optional field unions with the earlier value
 // rather than overriding it, see mergeSpreadElem.
 //
-// The merge runs only when every spread element grounds to a concrete object. groundToObject
-// expands an alias, projects a class body, and resolves a `typeof` query under the same termination
-// guard reduceKeyofAlias uses. A spread whose operand stays abstract — a type parameter, or a
-// truncated expanding alias — leaves the object symbolic: it returns the original elements with each
-// spread's operand reduced, so the object merges later once the operand grounds.
+// Per element it mirrors reduceTuple: a non-spread member has its value types reduced in place, and
+// a spread's operand is reduced and expanded toward a concrete object through groundObjectOperand,
+// under the termination guard reduceKeyofAlias uses.
+//
+// Unlike reduceTuple, the merge is all-or-nothing. If any spread operand stays abstract, such as a
+// type parameter or a truncated expanding alias, the whole object stays symbolic and carries every
+// element in its reduced form, so it merges once the operand grounds. reduceTuple can finalize each
+// ground spread independently, because tuple splice is positional concatenation and a later element
+// never disturbs an earlier position. An object spread instead overrides earlier keys, so a field is
+// safe to finalize only when no un-ground spread follows it. reduceObject keeps the whole object
+// symbolic rather than finalizing just that safe suffix: it is simpler and renders the way the
+// source wrote it, at the cost of re-reducing from scratch each pass.
 func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
 	if !soltype.HasObjectSpread(t.Elems) {
 		return t
 	}
+	reducedElems := make([]soltype.ObjTypeElem, len(t.Elems))
 	operandElems := make([][]soltype.ObjTypeElem, 0, len(t.Elems))
 	inexact := t.Inexact
 	ground := true
-	for _, el := range t.Elems {
+	for i, el := range t.Elems {
 		spread, ok := el.(*soltype.SpreadElem)
 		if !ok {
-			// A non-spread member contributes itself as a one-field group.
-			operandElems = append(operandElems, []soltype.ObjTypeElem{el})
+			// A non-spread member has its value types reduced, then contributes as a one-field group.
+			re := e.reduceElem(el)
+			reducedElems[i] = re
+			operandElems = append(operandElems, []soltype.ObjTypeElem{re})
 			continue
 		}
-		obj, ok := e.groundToObject(spread.Type)
-		if !ok {
+		operand := e.groundObjectOperand(spread.Type)
+		reducedElems[i] = &soltype.SpreadElem{Type: operand}
+		obj, ok := operand.(*soltype.ObjectType)
+		if !ok || soltype.HasObjectSpread(obj.Elems) {
 			ground = false
 			continue
 		}
@@ -189,60 +201,75 @@ func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
 		inexact = inexact || obj.Inexact
 	}
 	if !ground {
-		// Keep the residual: the original elements, with each spread's operand reduced but not
-		// expanded, so it renders the way the source wrote it and re-reduces once the operand
-		// grounds.
-		reduced := make([]soltype.ObjTypeElem, len(t.Elems))
-		for i, el := range t.Elems {
-			if spread, ok := el.(*soltype.SpreadElem); ok {
-				reduced[i] = &soltype.SpreadElem{Type: e.reduce(spread.Type)}
-			} else {
-				reduced[i] = el
-			}
-		}
-		return &soltype.ObjectType{Elems: reduced, Inexact: t.Inexact}
+		return &soltype.ObjectType{Elems: reducedElems, Inexact: inexact}
 	}
 	return &soltype.ObjectType{Elems: mergeSpreadOperands(operandElems), Inexact: inexact}
 }
 
-// groundToObject reduces a spread operand to the concrete ObjectType whose fields it contributes,
-// reporting false when the operand has no ground object shape. It reduces a nested-spread object,
-// resolves a `typeof` query to the value's type, projects a class instance body, and expands an
-// alias under the active-state and depth guard reduceKeyofAlias uses, so a recursive alias reached
-// through a spread terminates. A type variable, a skolem, or any other kind has no object shape and
-// reports false.
-func (e *typeEvaluator) groundToObject(operand soltype.Type) (*soltype.ObjectType, bool) {
+// reduceElem reduces the value types inside one non-spread object member, the object analogue of the
+// `e.reduce(el)` reduceTuple runs on each non-spread tuple element. A property, getter, or setter
+// carries a value type that may itself be an operator such as `keyof X`, so its type is reduced. A
+// method or constructor carries only function types, which reduce leaves untouched, so it passes
+// through unchanged.
+func (e *typeEvaluator) reduceElem(el soltype.ObjTypeElem) soltype.ObjTypeElem {
+	switch el := el.(type) {
+	case *soltype.PropertyElem:
+		return &soltype.PropertyElem{Name: el.Name, Type: e.reduce(el.Type), Optional: el.Optional, Readonly: el.Readonly}
+	case *soltype.GetterElem:
+		return &soltype.GetterElem{Name: el.Name, SelfParam: el.SelfParam, Type: e.reduce(el.Type)}
+	case *soltype.SetterElem:
+		return &soltype.SetterElem{Name: el.Name, SelfParam: el.SelfParam, Param: e.reduce(el.Param)}
+	default:
+		return el
+	}
+}
+
+// groundObjectOperand reduces a `...A` spread operand toward the concrete object whose fields it
+// contributes, the object analogue of the tuple's groundSpreadOperand. It resolves a `typeof` query
+// to the value's type, projects a class instance body, and expands an alias to its body under the
+// active-state and depth guard reduceKeyofAlias uses, so a recursive alias reached through a spread
+// terminates. Any other kind — an object, a type variable, a nested operator — is reduced. It
+// returns the reduced operand rather than an ok flag, so a caller keeps that reduced form when the
+// operand does not ground, matching how reduceTuple keeps the operand it could not splice.
+func (e *typeEvaluator) groundObjectOperand(operand soltype.Type) soltype.Type {
 	switch op := operand.(type) {
-	case *soltype.ObjectType:
-		// The object may itself carry spreads, as in `{...{...A}}`: reduce it first, and treat it
-		// as ground only when no spread element remains.
-		reduced, ok := e.reduceObject(op).(*soltype.ObjectType)
-		if !ok || soltype.HasObjectSpread(reduced.Elems) {
-			return nil, false
-		}
-		return reduced, true
 	case *soltype.TypeofType:
-		return e.groundToObject(op.Ty)
+		return e.groundObjectOperand(op.Ty)
 	case *soltype.ClassType:
-		return e.ctx.projectClassBody(op)
+		if obj, ok := e.ctx.projectClassBody(op); ok {
+			return obj
+		}
+		return op
 	case *soltype.AliasType:
 		key := soltype.PrintQualified(op)
 		if e.active.Contains(key) || e.depth <= 0 {
-			return nil, false
+			return op
 		}
 		body := e.ctx.expandAlias(op)
 		if _, unresolved := body.(*soltype.ErrorType); unresolved {
-			return nil, false
+			return op
 		}
 		e.active.Add(key)
 		e.depth--
-		obj, ok := e.groundToObject(body)
+		red := e.groundObjectOperand(body)
 		e.active.Remove(key)
 		e.depth++
-		return obj, ok
+		return red
 	default:
+		return e.reduce(operand)
+	}
+}
+
+// groundToObject reports the concrete ObjectType a spread operand contributes, or ok=false when the
+// operand has no ground object shape — a type variable, a truncated expanding alias, or an object
+// that still carries a spread. It is the ok-returning wrapper over groundObjectOperand that keyof
+// and indexed access use to decide whether a spread target has grounded.
+func (e *typeEvaluator) groundToObject(operand soltype.Type) (*soltype.ObjectType, bool) {
+	obj, ok := e.groundObjectOperand(operand).(*soltype.ObjectType)
+	if !ok || soltype.HasObjectSpread(obj.Elems) {
 		return nil, false
 	}
+	return obj, true
 }
 
 // mergeSpreadOperands folds the field lists of an object spread's operands into one element list,


### PR DESCRIPTION
Adds support for the object spread operator `{...A, x: T}` at both type and value level, following Flow's spread semantics (M9 PR5).

**Type level:**
- New `ObjectSpreadType` residual stores spreads unreduced so `{...A, x: T}` renders as written rather than merged
- `reduceObjectSpread` merges operands left-to-right once all spread operands ground to concrete objects
- Implements Flow's optional show-through rule: a later optional field unions with the earlier value and stays required if the earlier field was required
- `resolveObjectSpreadTypeAnn` lowers object type annotations containing spreads, grouping consecutive explicit properties between spreads into inline field-group operands

**Value level:**
- Object literals now support spread elements that merge operand object fields
- `inferObject` merges spread operands eagerly when they are concrete (inline objects or resolvable through aliases/classes/typeof)
- Spreads of non-objects (primitives, type variables) report `SpreadNotObjectError` and continue with the rest of the object
- Spreading an owned object moves it into the new object, matching array-spread semantics

**Shared merge logic:**
- `mergeSpreadOperands` folds field lists left-to-right with first-appearance order
- `mergeSpreadElem` applies the optional show-through rule: later required fields override, later optional fields union with earlier values
- `groundToObject` resolves spread operands through aliases, classes, and typeof queries under termination guards

**Visitor and equality:**
- `ObjectSpreadType.Accept` walks operands in current polarity without merging, so extrude/coalesce/freshen carry spreads through untouched
- `equalTypeWith` compares spreads structurally without merging, matching the inert contract
- `constrain` treats spreads as inert residuals compatible only when structurally identical
- `Print` renders spreads as `{...A, x: T}` with spread operands prefixed by `...`

**Tests:**
- `TestInferObjectSpreadStaysSymbolic` asserts spreads over named/inline operands stay symbolic and reduce correctly
- `TestInferObjectSpreadSignatureStaysSymbolic` asserts spreads over type parameters round-trip in signatures
- `TestInferObjectSpreadConstraint` asserts constraint checking merges spreads and rejects mismatched fields
- `TestInferObjectSpreadLiteral` asserts value-level spreads merge inline objects and reject non-objects

https://claude.ai/code/session_01MuzYLhsHSNN8ZAD2KZ5pMs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for spreading object values in object literals and type annotations.
  * Object spreads now merge fields with left-to-right override behavior.
  * Added support for nested spreads, aliases, classes, and `typeof` object sources.
  * Preserved symbolic spread types when they cannot yet be fully resolved.
* **Bug Fixes**
  * Added clear diagnostics when a non-object value is spread.
  * Improved error recovery for invalid or unresolved spread operands.
* **Tests**
  * Expanded coverage for merging, overrides, optional fields, inexact objects, constraints, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->