### PR TITLE
Make keyof respect object and class exactness

### DIFF
--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -74,6 +74,28 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: `"only"`,
 		},
 		{
+			// An inexact object carries an open key tail, so its key union is inexact: the known
+			// keys plus a trailing `...` standing for the unlisted ones.
+			name: "InexactObject",
+			src: `
+				type Obj = {x: number, y: string, ...}
+				type Result = keyof Obj
+			`,
+			wantSymbolic: "keyof Obj",
+			wantExpanded: `"x" | "y" | ...`,
+		},
+		{
+			// A single-key inexact object keeps the union wrapper rather than collapsing to the lone
+			// literal, since the open tail makes `"only" | ...` strictly weaker than bare `"only"`.
+			name: "InexactSingleKeyObject",
+			src: `
+				type Obj = {only: number, ...}
+				type Result = keyof Obj
+			`,
+			wantSymbolic: "keyof Obj",
+			wantExpanded: `"only" | ...`,
+		},
+		{
 			// keyof distributes over a union operand, so each member's keys union together.
 			name: "Union",
 			src: `
@@ -126,10 +148,25 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: `"value"`,
 		},
 		{
-			// A class projects its instance body, the same key set an object yields.
+			// A non-final class projects to an inexact instance body, since a subclass may add
+			// members, so its key union is open: `"x" | "y" | ...`.
 			name: "Class",
 			src: `
 				class Point {
+					x: number,
+					y: number,
+				}
+				type Result = keyof Point
+			`,
+			wantSymbolic: "keyof Point",
+			wantExpanded: `"x" | "y" | ...`,
+		},
+		{
+			// A final class has no subclasses to widen it, so its instance body is exact and its
+			// key union closed.
+			name: "FinalClass",
+			src: `
+				final class Point {
 					x: number,
 					y: number,
 				}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -148,6 +148,11 @@ func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, exact bool) solt
 // and unions them. An empty projection collapses to `never`, the union identity newUnion returns
 // for no members.
 //
+// An inexact object carries an unknown-keyed tail, so its key set is open: `keyof {a: number, ...}`
+// is `"a" | ...`, an inexact union whose members are the known keys and whose tail stands for the
+// unlisted ones. keyofObject seeds the union's exactness from the object's, so an exact object
+// yields an exact key union and an inexact object an inexact one.
+//
 // It omits methods, which is correct for a class instance whose methods live on the prototype
 // and so are absent from Object.keys, but wrong for a bare object whose methods are own
 // enumerable keys. keyofObject cannot tell the two apart from the ObjectType alone, so it
@@ -165,7 +170,7 @@ func (e *typeEvaluator) keyofObject(obj *soltype.ObjectType) soltype.Type {
 			keys = append(keys, strLitType(elem.Name))
 		}
 	}
-	return newUnion(nil, keys, false)
+	return newUnion(nil, keys, obj.Inexact)
 }
 
 // keyofTuple yields a tuple's own keys: one number-literal type per positional element, the


### PR DESCRIPTION
The `keyof` type operator now correctly reflects whether an object or class type is exact or inexact. An inexact object or non-final class carries an open key tail, so its key union includes a trailing `...` to represent unlisted keys.

**Changes:**

- Updated `keyofObject` to seed the result union's exactness from the object's `Inexact` field, so exact objects yield exact key unions and inexact objects yield inexact ones.
- Added test cases for inexact objects (both multi-key and single-key) to verify the `...` tail appears in the expanded form.
- Clarified that non-final classes project to inexact instance bodies since subclasses may add members. Added a separate test case for final classes, which have exact key unions.
- Updated comments to explain the relationship between object/class exactness and the openness of their key unions.

The fix ensures that `keyof {x: number, ...}` expands to `"x" | ...` rather than just `"x"`, and `keyof Point` (for a non-final class) expands to `"x" | "y" | ...` rather than `"x" | "y"`.

https://claude.ai/code/session_01TVurytCpFVn4bdd5nDg7Fa