### PR TITLE
Add conditional type operator (if C : E { T } else { E })

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -41,6 +41,11 @@ func typePrec(t Type) int {
 		return precAtom
 	case *TypeofType:
 		return precPrefix
+	case *CondType:
+		// `if C : E { T } else { E }` is self-delimiting — the leading `if` and trailing `}` bound
+		// it — so it binds like an atom and never needs outer parens, matching type_system's
+		// CondType rendering.
+		return precAtom
 	case *RestSpreadType:
 		// A `...P` spread element only appears inside a tuple's bracket list, which prints each
 		// element unparenthesized, so its precedence is consulted only if it is rendered on its
@@ -421,6 +426,11 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Index)
 		case *TypeofType:
 			walk(t.Ty)
+		case *CondType:
+			walk(t.Check)
+			walk(t.Extends)
+			walk(t.Then)
+			walk(t.Else)
 		case *RestSpreadType:
 			walk(t.Operand)
 		case *PromiseType:
@@ -637,6 +647,13 @@ func (p *namedPrinter) printType(t Type) string {
 		// `typeof x`, the value reference the source wrote. The resolved value type is not
 		// rendered — the query stays symbolic, so `keyof typeof x` prints as written.
 		return "typeof " + t.Ident
+	case *CondType:
+		// `if Check : Extends { Then } else { Else }`, the surface conditional-type syntax the
+		// parser reads and the AST printer writes. Each operand prints with no minimum precedence:
+		// the `:`, `{`, `}`, and `else` delimiters bound every position, so none can bind across a
+		// neighbor and none needs parens.
+		return "if " + p.printType(t.Check) + " : " + p.printType(t.Extends) +
+			" { " + p.printType(t.Then) + " } else { " + p.printType(t.Else) + " }"
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -659,13 +659,12 @@ type TypeofType struct {
 	Ty    Type
 }
 
-// CondType is the residual `if Check : Extends { Then } else { Else }` conditional type operator
-// (M9 PR3a). Like KeyofType it is inert: it carries no bounds, constrain never records one against
-// it, and it flows through the solver's structural machinery untouched, rendering the way the
-// source wrote it. An evaluator reduces it once Check and Extends are ground, reusing the M9 PR1b
-// machinery. It decides `Check <: Extends` with an assignability probe and reduces to Then on
-// success or Else on failure. Until then a conditional over a type parameter stays symbolic. The
-// `infer` clause in
+// CondType is the residual `if Check : Extends { Then } else { Else }` conditional type operator.
+// Like KeyofType it is inert: it carries no bounds, constrain never records one against it, and it
+// flows through the solver's structural machinery untouched, rendering the way the source wrote it.
+// An evaluator reduces it once Check and Extends are ground, reusing the M9 PR1b machinery. It
+// decides `Check <: Extends` with an assignability probe and reduces to Then on success or Else on
+// failure. Until then a conditional over a type parameter stays symbolic. The `infer` clause in
 // Extends and distribution over a naked type-parameter union are M9 PR3b, so a Check that is a bare
 // type parameter keeps the whole conditional symbolic here.
 type CondType struct {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -659,6 +659,22 @@ type TypeofType struct {
 	Ty    Type
 }
 
+// CondType is the residual `if Check : Extends { Then } else { Else }` conditional type operator
+// (M9 PR3a). Like KeyofType it is inert: it carries no bounds, constrain never records one against
+// it, and it flows through the solver's structural machinery untouched, rendering the way the
+// source wrote it. An evaluator reduces it once Check and Extends are ground, reusing the M9 PR1b
+// machinery. It decides `Check <: Extends` with an assignability probe and reduces to Then on
+// success or Else on failure. Until then a conditional over a type parameter stays symbolic. The
+// `infer` clause in
+// Extends and distribution over a naked type-parameter union are M9 PR3b, so a Check that is a bare
+// type parameter keeps the whole conditional symbolic here.
+type CondType struct {
+	Check   Type
+	Extends Type
+	Then    Type
+	Else    Type
+}
+
 // RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
 // checker's RestSpreadType (internal/type_system/types.go). It is only meaningful as an element of
 // a TupleType.Elems list: `[...P, x]` is a TupleType whose first element is a RestSpreadType. A
@@ -675,6 +691,7 @@ func (*TypeVarType) isType()      {}
 func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
+func (*CondType) isType()         {}
 func (*RestSpreadType) isType()   {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -764,6 +781,11 @@ func LevelOf(t Type) int {
 		// A `typeof x` query's level is its resolved value type's, the same single-child rule
 		// KeyofType and PromiseType follow.
 		return LevelOf(t.Ty)
+	case *CondType:
+		// A conditional residual's level is the max over its four operands, so an out-of-level
+		// operand lifts the level and the freshener/extruder prune descends into all four, the
+		// four-child analogue of the two-child IndexType arm.
+		return max(max(LevelOf(t.Check), LevelOf(t.Extends)), max(LevelOf(t.Then), LevelOf(t.Else)))
 	case *RestSpreadType:
 		// A `...P` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -217,6 +217,27 @@ func (t *TypeofType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *CondType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// All four operands walk in the current polarity, the four-child analogue of KeyofType's
+	// single covariant visit. The residual is inert — the visit rebuilds it around rewritten
+	// operands without deciding the branch, so extrude/coalesce/freshenAbove carry the whole
+	// conditional through untouched.
+	check := cur.Check.Accept(v, pol)
+	extends := cur.Extends.Accept(v, pol)
+	then := cur.Then.Accept(v, pol)
+	els := cur.Else.Accept(v, pol)
+	out := cur
+	if check != cur.Check || extends != cur.Extends || then != cur.Then || els != cur.Else {
+		out = &CondType{Check: check, Extends: extends, Then: then, Else: els}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1129,6 +1129,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// types, compared without unwrapping — the query flows through the solver untouched.
 		b, ok := b.(*soltype.TypeofType)
 		return ok && a.Ident == b.Ident && equalTypeWith(a.Ty, b.Ty, ctx)
+	case *soltype.CondType:
+		// Two inert conditional residuals are equal when all four operands are equal, compared
+		// structurally without deciding either branch, the four-child analogue of the KeyofType arm.
+		b, ok := b.(*soltype.CondType)
+		return ok && equalTypeWith(a.Check, b.Check, ctx) && equalTypeWith(a.Extends, b.Extends, ctx) &&
+			equalTypeWith(a.Then, b.Then, ctx) && equalTypeWith(a.Else, b.Else, ctx)
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -135,34 +135,35 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // evalTypeOperator evaluates the outermost transparent type operator of t to the type it stands
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
 // An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
-// to its key set, an indexed access `T[K]` reduces to the type at that key, and a tuple carrying a
-// `...P` spread splices its operand tuples into a plain tuple. A plain tuple is a structural type
+// to its key set, an indexed access `T[K]` reduces to the type at that key, a conditional selects
+// its Then or Else branch, and a tuple carrying a `...P` spread splices its operand tuples into a
+// plain tuple. A plain tuple is a structural type
 // constrain decomposes, not an operator, so it reports ok=false. The returned errs carry any
 // diagnostic the reduction produced — an unknown object key or an out-of-range tuple index — for
 // constrain to surface at the constraint site. It reports ok=false for any other type, and for a
 // reduced operator that does not fully ground — a `keyof T`, `T[K]`, or `[...T, x]` over a type
 // parameter, or an expanding alias whose reduction is truncated to a residual that would re-expand
 // without bound — which stays inert.
-func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError, bool) {
+func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType:
-		return c.reduceResidual(t)
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
 		if !tupleHasSpread(t) {
 			return nil, nil, false
 		}
-		return c.reduceResidual(t)
+		return c.reduceResidual(t, seen)
 	case *soltype.ObjectType:
 		// A plain object is handled structurally, not as a transparent operator. Only a
 		// spread-carrying object is a residual to reduce here, the object twin of the TupleType arm.
 		if !soltype.HasObjectSpread(t.Elems) {
 			return nil, nil, false
 		}
-		e := newTypeEvaluator(c)
+		e := newTypeEvaluator(c, seen)
 		reduced := e.reduce(t)
 		// A spread whose operands ground merges to a spread-free object. One with an abstract operand
 		// stays a spread-carrying object, which is inert, so leave it for the structural switch. The
@@ -179,9 +180,11 @@ func (c *Context) evalTypeOperator(t soltype.Type) (soltype.Type, []SolverError,
 
 // reduceResidual reduces a residual operator and reports its value, or ok=false when the reduction
 // stays symbolic — an operand that never ground, or an expanding alias truncated to a residual
-// that would re-expand without bound. The errs carry any diagnostic the reduction produced.
-func (c *Context) reduceResidual(t soltype.Type) (soltype.Type, []SolverError, bool) {
-	e := newTypeEvaluator(c)
+// that would re-expand without bound. The errs carry any diagnostic the reduction produced. seen is
+// the enclosing constraint's cycle-detection set, handed to the evaluator so a conditional's branch
+// probe closes a recursive alias through the same guard.
+func (c *Context) reduceResidual(t soltype.Type, seen set.Set[constraintKey]) (soltype.Type, []SolverError, bool) {
+	e := newTypeEvaluator(c, seen)
 	reduced := e.reduce(t)
 	if containsResidualOp(reduced) {
 		return nil, nil, false
@@ -246,17 +249,17 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 
-	// An alias, a `typeof` query, a `keyof`, and an indexed access `T[K]` are transparent for
-	// checking: evaluate the outermost operator to the type it stands for and recurse, so the
-	// constraint runs on that while the stored residual keeps its name. This sits above the
-	// structural switch, which dispatches on sub and would otherwise reject a concrete sub against
-	// an operator super before it could unwrap. When the other side is a variable, fall through to
-	// the var arms so the whole operator is recorded as one bound and its name survives on the
-	// coalesced binding. A recursive alias closes through the existing seen-set, and a `keyof` or
-	// `T[K]` that does not fully ground stays inert — see evalTypeOperator — and falls through to
-	// its residual arm in the switch.
+	// An alias, a `typeof` query, a `keyof`, an indexed access `T[K]`, and a conditional are
+	// transparent for checking: evaluate the outermost operator to the type it stands for and
+	// recurse, so the constraint runs on that while the stored residual keeps its name. This sits
+	// above the structural switch, which dispatches on sub and would otherwise reject a concrete sub
+	// against an operator super before it could unwrap. When the other side is a variable, fall
+	// through to the var arms so the whole operator is recorded as one bound and its name survives on
+	// the coalesced binding. A recursive alias closes through the existing seen-set, and an operator
+	// that does not fully ground stays inert — see evalTypeOperator — and falls through to its
+	// residual arm in the switch.
 	if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-		if evaluated, reduceErrs, ok := c.evalTypeOperator(sub); ok {
+		if evaluated, reduceErrs, ok := c.evalTypeOperator(sub, seen); ok {
 			// A reduction diagnostic — an unknown key or an out-of-range index — makes the
 			// operator malformed, so surface it and stop rather than checking the constraint
 			// against the error sentinel the reduction returned.
@@ -267,7 +270,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		}
 	}
 	if _, subIsVar := sub.(*soltype.TypeVarType); !subIsVar {
-		if evaluated, reduceErrs, ok := c.evalTypeOperator(super); ok {
+		if evaluated, reduceErrs, ok := c.evalTypeOperator(super, seen); ok {
 			if len(reduceErrs) > 0 {
 				return reduceErrs
 			}
@@ -800,6 +803,20 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// which records the whole residual as one lower bound, keeping the operator symbolic on the
 		// coalesced binding. A tuple carrying a `...P` spread is handled inertly in the TupleType arm
 		// above, the spread twin of this arm.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if equalType(sub, super) {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
+	case *soltype.CondType:
+		// A conditional residual the pre-switch could not ground reaches here: a conditional over a
+		// type parameter, whose branch cannot be decided. constrain treats it inert, the same as the
+		// KeyofType and IndexType arms above — two residuals are compatible only when structurally
+		// identical, so a conditional against an equal conditional succeeds reflexively without
+		// recording a bound, and a residual against any other concrete fails. When super is a
+		// variable the case falls through to the superVar arm, which records the whole conditional as
+		// one lower bound, keeping the operator symbolic on the coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1802,6 +1802,12 @@ func describe(t soltype.Type) string {
 		// unwraps it to the resolved type before comparing, so a diagnostic rarely names the
 		// query itself, but a rejected bound that still carries it reads `typeof x`.
 		return "typeof " + t.Ident
+	case *soltype.CondType:
+		// A conditional residual renders structurally as the surface syntax, recursing like the
+		// keyof arm, so a rejected constraint over a symbolic conditional names it in full rather
+		// than the default `?`. Every operand renders in describe's raw mid-constrain form.
+		return "if " + describe(t.Check) + " : " + describe(t.Extends) +
+			" { " + describe(t.Then) + " } else { " + describe(t.Else) + " }"
 	case *soltype.RestSpreadType:
 		// A `...P` spread element renders `...` over its operand, reached in place when the
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -1888,7 +1888,7 @@ func (c *checker) inferObject(scope *Scope, lvl int, e *ast.ObjectExpr) soltype.
 				// SpreadNotObjectError on the recovery sentinel, the object twin of the array arm.
 				continue
 			}
-			obj, ground := newTypeEvaluator(c.ctx).groundToObject(op)
+			obj, ground := newTypeEvaluator(c.ctx, set.NewSet[constraintKey]()).groundToObject(op)
 			if !ground {
 				// A spread whose operand has no ground object shape — a type variable, a
 				// primitive — cannot merge its fields. Report it and keep the rest of the object.

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/dep_graph"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +37,7 @@ func inferTypeNodes(t *testing.T, src string) (map[string]soltype.Type, *Context
 // keeps a named residual symbolic at annotation and display time, so this test-only helper lets a
 // test assert what a residual expands to without routing through a constraint.
 func expandResidual(ctx *Context, ty soltype.Type) soltype.Type {
-	return newTypeEvaluator(ctx).reduce(ty)
+	return newTypeEvaluator(ctx, set.NewSet[constraintKey]()).reduce(ty)
 }
 
 // `keyof` over a named type reference — an alias or a class — is stored unexpanded, so the type
@@ -1107,6 +1108,241 @@ func TestInferKeyofIndexOverSpreadTuple(t *testing.T) {
 			result := nodes["Result"]
 			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
 			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A conditional `if Check : Extends { Then } else { Else }` over ground operands is stored
+// unreduced, so the type prints the way the source wrote it, and reducing it — the branch selection
+// constrain performs to check a constraint — decides `Check <: Extends` and yields the selected
+// branch. Each case names a ground Check and Extends, asserts the stored `Result` renders the
+// conditional verbatim, and asserts the reduced branch. The cases cover the decision shapes branch
+// selection handles: a reflexive primitive match, a literal against its primitive, a rejected
+// primitive that takes Else, a selected branch that is itself a union, and a Check resolved through
+// an alias.
+func TestInferCondBranchSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// A primitive is a subtype of itself, so the Then branch is selected.
+			name:         "ReflexivePrimitive",
+			src:          `type Result = if number : number { "yes" } else { "no" }`,
+			wantSymbolic: `if number : number { "yes" } else { "no" }`,
+			wantExpanded: `"yes"`,
+		},
+		{
+			// A string literal is a subtype of the `string` primitive, so Then is selected.
+			name:         "LiteralUnderPrimitive",
+			src:          `type Result = if "hi" : string { number } else { boolean }`,
+			wantSymbolic: `if "hi" : string { number } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// `string` is not a subtype of `number`, so the Else branch is selected.
+			name:         "RejectedTakesElse",
+			src:          `type Result = if string : number { number } else { boolean }`,
+			wantSymbolic: `if string : number { number } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			// The selected branch is reduced too, so a union branch yields the union.
+			name:         "UnionBranch",
+			src:          `type Result = if number : number { number | string } else { boolean }`,
+			wantSymbolic: `if number : number { number | string } else { boolean }`,
+			wantExpanded: "number | string",
+		},
+		{
+			// A Check named through an alias decides by expanding the alias for the probe, while the
+			// stored conditional keeps the alias name.
+			name: "AliasCheck",
+			src: `
+				type N = number
+				type Result = if N : number { "yes" } else { "no" }
+			`,
+			wantSymbolic: `if N : number { "yes" } else { "no" }`,
+			wantExpanded: `"yes"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A conditional over a type parameter renders symbolically in a function signature and stays
+// symbolic there: `fn f<T>(x: if T : number { string } else { boolean })` keeps the whole
+// conditional, since `T` never grounds so the `T <: number` probe cannot decide a branch. A
+// non-ground Extends keeps it symbolic the same way.
+func TestInferCondSignatureStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want map[string]string
+	}{
+		{
+			name: "TypeParamCheck",
+			src:  `fn f<T>(x: if T : number { string } else { boolean }) {}`,
+			want: map[string]string{"f": "fn <T>(x: if T : number { string } else { boolean }) -> void"},
+		},
+		{
+			name: "TypeParamExtends",
+			src:  `fn g<T>(x: if number : T { string } else { boolean }) {}`,
+			want: map[string]string{"g": "fn <T>(x: if number : T { string } else { boolean }) -> void"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			for name, want := range tt.want {
+				require.Equal(t, want, values[name])
+			}
+		})
+	}
+}
+
+// constrain reduces a conditional to the selected branch to check satisfaction, while the stored
+// type stays the residual. A value matching the selected branch is accepted; a mismatch is rejected
+// against that branch, so the diagnostic names the branch the conditional resolved to. The reduction
+// runs at every constraint site: a `val` annotation whose conditional takes Then, one that takes
+// Else, a generic alias instantiation that substitutes its argument before deciding, and a function
+// argument.
+func TestInferCondConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "ThenBranchAccepted",
+			src:  `val x: if number : number { string } else { boolean } = "hi"`,
+		},
+		{
+			name:    "ThenBranchRejected",
+			src:     `val x: if number : number { string } else { boolean } = 5`,
+			wantErr: `cannot constrain 5 <: string`,
+		},
+		{
+			name: "ElseBranchAccepted",
+			src:  `val x: if string : number { string } else { boolean } = true`,
+		},
+		{
+			name:    "ElseBranchRejected",
+			src:     `val x: if string : number { string } else { boolean } = "hi"`,
+			wantErr: `cannot constrain "hi" <: boolean`,
+		},
+		{
+			// A generic alias substitutes its argument into the conditional, then decides the branch:
+			// `Choose<number>` reduces to the Then branch `string`.
+			name: "GenericAliasThen",
+			src: `
+				type Choose<T> = if T : number { string } else { boolean }
+				val x: Choose<number> = "hi"
+			`,
+		},
+		{
+			name: "GenericAliasElse",
+			src: `
+				type Choose<T> = if T : number { string } else { boolean }
+				val x: Choose<string> = 5
+			`,
+			wantErr: "cannot constrain 5 <: boolean",
+		},
+		{
+			name: "CallArgumentRejected",
+			src: `
+				fn take(v: if number : number { string } else { boolean }) -> number { return 1 }
+				val r = take(5)
+			`,
+			wantErr: `cannot constrain 5 <: string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A rejected constraint whose subject is a symbolic conditional names it structurally in the
+// diagnostic — the full `if … : … { … } else { … }` form rather than the bare `?` the default
+// describe arm would render — so the inert node stays legible. describe is the raw mid-constrain
+// renderer, so the Check shows as the raw var `t1` rather than the coalesced printer's param name.
+func TestInferCondResidualErrorMessage(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(k: if T : number { string } else { boolean }) -> number { return k }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:12-1:51: cannot constrain if t1 : number { string } else { boolean } <: number", msgWithSpan(errs[0]))
+}
+
+// A conditional whose Extends holds an `infer` clause is unsupported until M9 PR3b: branch selection
+// has no matcher to bind the `infer` name. The annotation reports one UnsupportedFeatureError rather
+// than resolving the Extends and silently mis-deciding the branch.
+func TestInferCondInferUnsupported(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(x: if T : Array<infer U> { U } else { never }) {}`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "Unsupported: infer clause in conditional type", errs[0].Message())
+}
+
+// Checking a value against a self-referential conditional alias terminates instead of looping. A
+// conditional decides its branch by re-entering constrain to probe `Check <: Extends`, and constrain
+// expands an alias Check back into the same conditional, so `type Bad = if Bad : number { … }` would
+// recurse without bound if the probe started a fresh cycle-detection set. The probe reuses the
+// caller's set, so the repeated `Bad <: number` state closes the cycle. The point of the test is
+// termination; the branch the truncated cycle selects is a consequence, which CheckRegular will
+// reject at definition time in a later milestone.
+func TestInferCondRecursiveAliasTerminates(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Bad = if Bad : number { number } else { string }
+		val x: Bad = 5
+	`)
+	require.Empty(t, errs)
+}
+
+// `keyof` and indexed access compose over a ground conditional: the conditional selects its branch
+// first, then the outer operator reduces over that branch. `keyof (if number : number { {x, y} }
+// else { {z} })` projects the Then branch's keys, and indexing the Else branch of a rejected
+// conditional selects that branch's member.
+func TestInferCondComposesWithOperators(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// number <: number holds, so keyof projects the Then branch's keys.
+			name:         "KeyofOverCond",
+			src:          `type Result = keyof if number : number { {x: number, y: string} } else { {z: boolean} }`,
+			wantExpanded: `"x" | "y"`,
+		},
+		{
+			// string is not a subtype of number, so the access reads `x` off the Else branch.
+			name:         "IndexOverCond",
+			src:          `type Result = (if string : number { {x: number} } else { {x: boolean} })["x"]`,
+			wantExpanded: "boolean",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, nodes["Result"])))
 		})
 	}
 }

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -319,9 +319,17 @@ func (c *Context) trialMutatesBounds(sub, super soltype.Type, seen set.Set[const
 // succeeded. The seen-set starts fresh and the mut context at false, so the
 // trial is a self-contained covariant read check.
 func (c *Context) trialUnderProbe(sub, super soltype.Type) []SolverError {
+	return c.trialUnderProbeSeen(sub, super, set.NewSet[constraintKey]())
+}
+
+// trialUnderProbeSeen is trialUnderProbe over a caller-supplied cycle-detection set rather than a
+// fresh one, so a conditional's `Check <: Extends` branch probe closes a recursive alias through the
+// same seen-set the enclosing constraint built up. The caller clones the set when it must keep the
+// trial's keys out of its own.
+func (c *Context) trialUnderProbeSeen(sub, super soltype.Type, seen set.Set[constraintKey]) []SolverError {
 	p := newProbe(c.probe)
 	c.probe = p
-	errs := c.constrain(sub, super, set.NewSet[constraintKey](), false)
+	errs := c.constrain(sub, super, seen, false)
 	c.probe = p.parent
 	p.Discard()
 	return errs

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -87,6 +87,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveIndexTypeAnn(scope, ta, lvl)
 	case *ast.TypeOfTypeAnn:
 		return c.resolveTypeOfTypeAnn(scope, ta)
+	case *ast.CondTypeAnn:
+		return c.resolveCondTypeAnn(scope, ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -330,6 +332,63 @@ func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl in
 	t := &soltype.IndexType{Target: target, Index: index}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// resolveCondTypeAnn lowers `if Check : Extends { Then } else { Else }` to a CondType residual and
+// stores it unreduced, so the annotation prints the way the source wrote it. constrain decides the
+// branch when it checks a constraint against it: a ground `Check <: Extends` probe selects Then or
+// Else, while a conditional over a type parameter stays symbolic. An unsupported operand recovers to
+// a fresh var, cascade-safe like the Promise<bad> recovery.
+//
+// The `infer` clause is M9 PR3b, so a conditional whose Extends holds an `infer` reports an
+// unsupported feature and recovers. Branch selection here has no matcher to bind the `infer` name.
+// Resolving the Extends anyway would recover each `infer U` to a fresh var and silently mis-decide
+// the branch, so rejecting it keeps the two milestones cleanly split.
+func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int) (soltype.Type, bool) {
+	if annContainsInfer(ta.Extends) {
+		return c.reportUnsupportedFeature(ta, "infer clause in conditional type"), false
+	}
+	check, ok := c.resolveTypeAnn(scope, ta.Check, lvl)
+	if !ok {
+		check = c.freshAt(lvl)
+	}
+	extends, ok := c.resolveTypeAnn(scope, ta.Extends, lvl)
+	if !ok {
+		extends = c.freshAt(lvl)
+	}
+	then, ok := c.resolveTypeAnn(scope, ta.Then, lvl)
+	if !ok {
+		then = c.freshAt(lvl)
+	}
+	els, ok := c.resolveTypeAnn(scope, ta.Else, lvl)
+	if !ok {
+		els = c.freshAt(lvl)
+	}
+	t := &soltype.CondType{Check: check, Extends: extends, Then: then, Else: els}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// annContainsInfer reports whether a type annotation subtree holds an `infer U` clause. A
+// conditional consults it on its Extends operand to reject the `infer` form, which M9 PR3b handles.
+func annContainsInfer(ta ast.TypeAnn) bool {
+	f := &inferAnnFinder{}
+	ta.Accept(f)
+	return f.found
+}
+
+// inferAnnFinder is the AST visitor behind annContainsInfer. It flags the first InferTypeAnn it
+// reaches and keeps walking; one occurrence is enough to answer.
+type inferAnnFinder struct {
+	ast.DefaultVisitor
+	found bool
+}
+
+func (f *inferAnnFinder) EnterTypeAnn(ta ast.TypeAnn) bool {
+	if _, ok := ta.(*ast.InferTypeAnn); ok {
+		f.found = true
+	}
+	return true
 }
 
 // resolveTypeOfTypeAnn lowers a `typeof v` query to a TypeofType residual: it resolves the value's

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -13,11 +13,11 @@ import (
 // operator over the unexpanded alias stays symbolic.
 const maxExpandDepth = 200
 
-// typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T` and
-// indexed access `T[K]`; later operators join as they land. Only constrain invokes it, to check
-// a constraint against a residual. Annotation and display keep the residual symbolic, so a
-// stored type prints `keyof {x: number}` or `Point["x"]` the way the source wrote it, never the
-// reduced value.
+// typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T`, indexed
+// access `T[K]`, and the conditional `if C : E { … } else { … }`; later operators join as they
+// land. Only constrain invokes it, to check a constraint against a residual. Annotation and display
+// keep the residual symbolic, so a stored type prints `keyof {x: number}` or `Point["x"]` the way
+// the source wrote it, never the reduced value.
 //
 // reduce projects the operand's keys: a ground `keyof {x: number}` yields `"x"`, and an alias or
 // class operand expands to the referenced type's keys, the transparent-but-named treatment an
@@ -47,6 +47,15 @@ type typeEvaluator struct {
 	ctx    *Context
 	active set.Set[string]
 	depth  int
+	// seen is the enclosing constraint's cycle-detection set, carried in so a conditional's
+	// `Check <: Extends` probe shares the caller's alias-cycle guard. A conditional reduces by
+	// re-entering constrain to decide its branch, and constrain expands an alias operand and
+	// re-reduces the conditional in its body, so a self-referential alias such as
+	// `type Bad = if Bad : number { number } else { string }` would recurse without bound if the
+	// probe started a fresh set. Reusing the caller's set closes that cycle the same way two
+	// structurally-equal instances of a recursive alias close through constrain's seen-set. The
+	// value solve seeds it fresh at each constraint site, and the test expander passes an empty set.
+	seen set.Set[constraintKey]
 	// errs collects the diagnostics a reduction produces. `keyof` reduction is total and adds
 	// none; indexed-access reduction records an UnknownObjectKeyError or a
 	// TupleIndexOutOfRangeError when a ground access resolves to no member. constrain reads
@@ -56,8 +65,8 @@ type typeEvaluator struct {
 	errs []SolverError
 }
 
-func newTypeEvaluator(ctx *Context) *typeEvaluator {
-	return &typeEvaluator{ctx: ctx, active: set.NewSet[string](), depth: maxExpandDepth}
+func newTypeEvaluator(ctx *Context, seen set.Set[constraintKey]) *typeEvaluator {
+	return &typeEvaluator{ctx: ctx, active: set.NewSet[string](), depth: maxExpandDepth, seen: seen}
 }
 
 // reduce reduces one type-level operator node to its value, returning any other type
@@ -74,6 +83,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		// A `typeof x` query reduces to the value's resolved type. constrain unwraps it directly
 		// in its pre-switch, so this arm serves a `typeof` reached through another operator.
 		return t.Ty
+	case *soltype.CondType:
+		return e.reduceCond(t)
 	case *soltype.TupleType:
 		return e.reduceTuple(t)
 	case *soltype.ObjectType:
@@ -81,6 +92,50 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 	default:
 		return t
 	}
+}
+
+// reduceCond reduces `if Check : Extends { Then } else { Else }` by deciding `Check <: Extends`
+// and selecting a branch, mirroring the old checker's CondType case
+// (internal/checker/expand_type.go), which unifies Check with Extends and returns Then on success
+// or Else on failure. The decision runs only when both operands are ground:
+//
+//   - a ground Check and Extends decide the branch with an assignability probe, and the reduction
+//     continues into the selected branch alone, so an error in the unselected branch never surfaces;
+//   - a Check or Extends still carrying a type parameter or an unreduced residual keeps the whole
+//     conditional symbolic, rebuilt around the reduced Check and Extends, and reduces later once
+//     they ground. Then and Else stay unreduced in the symbolic form, since neither is selected yet.
+//
+// Distribution over a naked type-parameter union and the `infer` clause are M9 PR3b, so a bare
+// type-parameter Check stays symbolic here rather than distributing.
+func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
+	check := e.reduce(t.Check)
+	extends := e.reduce(t.Extends)
+	if !condOperandGround(check) || !condOperandGround(extends) {
+		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else}
+	}
+	if e.ctx.condExtends(check, extends, e.seen) {
+		return e.reduce(t.Then)
+	}
+	return e.reduce(t.Else)
+}
+
+// condExtends decides a conditional's `Check <: Extends` test with an assignability probe. The
+// trial runs under a discard-only probe, so a speculative match records no bound and leaves no
+// solver state behind, preserving the evaluator's no-mutation invariant. It runs constrain over a
+// clone of the caller's cycle-detection set, so a recursive alias reached through the probe closes
+// through the same seen-set the caller built up, while the clone keeps the probe's own keys out of
+// the caller's set. An empty result means the subtype check held, selecting the Then branch.
+func (c *Context) condExtends(check, extends soltype.Type, seen set.Set[constraintKey]) bool {
+	return !hasHardError(c.trialUnderProbeSeen(check, extends, seen.Clone()))
+}
+
+// condOperandGround reports whether a conditional's Check or Extends operand is ground enough to
+// decide the branch. An operand carrying a type variable, a skolem, or an unreduced residual
+// operator is abstract, so the `Check <: Extends` probe cannot decide a branch over it and the
+// conditional stays symbolic. containsFreeVar catches the variable and skolem cases;
+// containsResidualOp catches a residual such as a `keyof T` the reduction left symbolic.
+func condOperandGround(t soltype.Type) bool {
+	return !containsFreeVar(t) && !containsResidualOp(t)
 }
 
 // reduceTuple splices each `...P` spread element whose operand grounds to a concrete tuple into
@@ -338,12 +393,14 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // operator symbolic, rebuilt around the operand.
 func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Type {
 	switch op := operand.(type) {
-	case *soltype.KeyofType:
-		// The operand is itself a keyof operator. Reduce it first, then take keyof its value. If
-		// the inner operator stays symbolic because its own operand is not ground, wrap it as
-		// `keyof (keyof …)` rather than re-reducing the same shape forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+		// The operand is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
+		// it first, then take keyof its value, so a ground conditional operand selects its branch and
+		// `keyof` projects that branch's keys. If the inner operator stays symbolic because its own
+		// operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the same shape
+		// forever.
 		inner := e.reduce(op)
-		if _, stillKeyof := inner.(*soltype.KeyofType); stillKeyof {
+		if isResidualOp(inner) {
 			return &soltype.KeyofType{Operand: inner, Exact: exact}
 		}
 		return e.reduceKeyof(inner, exact)
@@ -506,10 +563,12 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 	case *soltype.TypeofType:
 		// `(typeof x)[K]` resolves the query to the value's type, then indexes that type.
 		return e.reduceIndex(tgt.Ty, idx, exact)
-	case *soltype.KeyofType, *soltype.IndexType:
-		// The target is itself an operator. Reduce it first, then index its value. When it
-		// stays symbolic because its own operands are not ground, keep the access wrapped
-		// around the reduced target rather than re-reducing the same shape forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+		// The target is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
+		// it first, then index its value, so a ground conditional target selects its branch and the
+		// access reduces over that. When the target stays symbolic because its own operands are not
+		// ground, keep the access wrapped around the reduced target rather than re-reducing the same
+		// shape forever.
 		inner := e.reduce(target)
 		if isResidualOp(inner) {
 			return &soltype.IndexType{Target: inner, Index: idx, Exact: exact}
@@ -675,11 +734,11 @@ func strLitName(t soltype.Type) (string, bool) {
 }
 
 // isResidualOp reports whether t is an unreduced type-level operator node — a `keyof`, an indexed
-// access, or a `...P` tuple-spread element — at its top level. The evaluator consults it to stop
-// re-reducing an operand whose reduction stayed symbolic.
+// access, a conditional, or a `...P` tuple-spread element — at its top level. The evaluator consults
+// it to stop re-reducing an operand whose reduction stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.RestSpreadType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType:
 		return true
 	}
 	return false
@@ -741,5 +800,32 @@ func (f *residualOpFinder) EnterType(t soltype.Type, pol soltype.Polarity) solty
 }
 
 func (f *residualOpFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
+	return t
+}
+
+// containsFreeVar reports whether t holds any type variable or skolem — an abstract leaf that makes
+// t non-ground. A conditional consults it to decide whether its Check and Extends are concrete
+// enough to probe `Check <: Extends`. A conditional whose Check is a bare type parameter stays
+// symbolic, since that parameter is a free variable.
+func containsFreeVar(t soltype.Type) bool {
+	f := &freeVarFinder{}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+// freeVarFinder is the walking visitor behind containsFreeVar. It flags the first type variable or
+// skolem it reaches and skips that node's children, since one occurrence is enough.
+type freeVarFinder struct{ found bool }
+
+func (f *freeVarFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t.(type) {
+	case *soltype.TypeVarType, *soltype.SkolemType:
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *freeVarFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type {
 	return t
 }


### PR DESCRIPTION
Implement the conditional type operator from M9 PR3a, which reduces `if Check : Extends { Then } else { Else }` by deciding the `Check <: Extends` subtype test and selecting a branch. The conditional is stored as an inert residual and renders symbolically until both operands ground, mirroring the behavior of `keyof` and indexed access.

**Key changes:**

- Add `CondType` to the type representation in `soltype/type.go` with four operands (Check, Extends, Then, Else) and integrate it into the visitor and printer.
- Implement `reduceCond` in `typeops.go` to reduce conditionals by probing `Check <: Extends` with an assignability trial and selecting the appropriate branch. The reduction only proceeds when both operands are ground (no free type variables or unreduced residual operators).
- Add `condExtends` to `Context` to run the subtype probe under a discard-only trial, reusing the caller's cycle-detection set so recursive aliases close through the same guard.
- Update `evalTypeOperator` and `reduceResidual` in `constrain.go` to handle conditionals and thread the cycle-detection set through to the evaluator.
- Add `resolveCondTypeAnn` in `type_ann.go` to lower conditional type annotations, with early rejection of `infer` clauses (unsupported until M9 PR3b).
- Extend `reduceKeyof` and `reduceIndex` to compose over conditionals, so `keyof (if … { … } else { … })` and indexed access reduce the conditional first, then operate on the selected branch.
- Add helper functions `containsFreeVar` and `condOperandGround` to detect abstract operands that keep conditionals symbolic.
- Update `isResidualOp` to include `CondType` so the evaluator recognizes it as an operator that may stay symbolic.
- Integrate conditional equality checking in `coalesce.go` and error description in `errors.go`.

**Implementation notes:**

The conditional probe reuses the caller's `seen` set (cloned when necessary) to detect cycles through recursive aliases, preventing infinite recursion when a self-referential alias like `type Bad = if Bad : number { … }` is checked. The reduction is total for ground operands but stays symbolic when either operand carries a type parameter or unreduced operator, deferring the branch decision until they ground.

https://claude.ai/code/session_01YNQokeycCsb9wTgf49iiib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for conditional types using `if Check : Extends { Then } else { Else }` syntax.
  - Conditional types can now be inferred, reduced, composed with type operators, and preserved symbolically when unresolved.
  - Improved diagnostics now display conditional types clearly.

- **Bug Fixes**
  - Added safeguards for recursive conditional types to prevent non-terminating evaluation.
  - Unsupported `infer` clauses in conditional types now produce clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->