### PR TITLE
Add template literal and string mapping type operators

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -62,7 +62,7 @@ func typePrec(t Type) int {
 		// A template literal is backtick-delimited, so like an object or a `Name<args>` reference
 		// it is an atom that never needs outer parens.
 		return precAtom
-	case *StringMappingType:
+	case *StringIntrinsicType:
 		// `Uppercase<T>` renders as a name with an argument list, the same atom shape a class or
 		// alias reference takes, so it never needs outer parens.
 		return precAtom
@@ -452,7 +452,7 @@ func freeTypeVars(t Type) []*TypeVarType {
 			for _, interp := range t.Interps {
 				walk(interp)
 			}
-		case *StringMappingType:
+		case *StringIntrinsicType:
 			walk(t.Operand)
 		case *PromiseType:
 			walk(t.Inner)
@@ -610,7 +610,7 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		b.WriteString("`")
 		return b.String()
-	case *StringMappingType:
+	case *StringIntrinsicType:
 		// `Uppercase<T>` and its three siblings render under the operator's name with the operand as
 		// the sole argument, so `Capitalize<K>` round-trips. The operand prints with no minimum since
 		// the `<…>` brackets stop anything from binding across it.

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -58,6 +58,14 @@ func typePrec(t Type) int {
 		// element unparenthesized, so its precedence is consulted only if it is rendered on its
 		// own. The `...` prefix binds like the other prefixes.
 		return precPrefix
+	case *TemplateLitType:
+		// A template literal is backtick-delimited, so like an object or a `Name<args>` reference
+		// it is an atom that never needs outer parens.
+		return precAtom
+	case *StringMappingType:
+		// `Uppercase<T>` renders as a name with an argument list, the same atom shape a class or
+		// alias reference takes, so it never needs outer parens.
+		return precAtom
 	default:
 		// PrimType, LitType, TupleType, ObjectType, ClassType, AliasType, Void, NullType,
 		// UndefinedType, NeverType, UnknownType — atoms. ObjectType is brace-delimited, and ClassType and
@@ -440,6 +448,12 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Else)
 		case *RestSpreadType:
 			walk(t.Operand)
+		case *TemplateLitType:
+			for _, interp := range t.Interps {
+				walk(interp)
+			}
+		case *StringMappingType:
+			walk(t.Operand)
 		case *PromiseType:
 			walk(t.Inner)
 		case *RefType:
@@ -581,6 +595,26 @@ func (p *namedPrinter) printType(t Type) string {
 		// the `...`. The enclosing TupleType arm renders each element through printType, so a spread
 		// element reaches here in place.
 		return "..." + p.printTypeMinPrec(t.Operand, precPrefix)
+	case *TemplateLitType:
+		// A template literal renders `q0${i0}q1${i1}…qn`, interleaving the fixed segments with
+		// each interpolation, so `on${T}` round-trips. Quasis holds one more entry than
+		// Interps. Each interpolation prints with no minimum since the `${…}` braces stop anything
+		// from binding across it.
+		var b strings.Builder
+		b.WriteString("`")
+		for i, quasi := range t.Quasis {
+			b.WriteString(quasi)
+			if i < len(t.Interps) {
+				b.WriteString("${" + p.printType(t.Interps[i]) + "}")
+			}
+		}
+		b.WriteString("`")
+		return b.String()
+	case *StringMappingType:
+		// `Uppercase<T>` and its three siblings render under the operator's name with the operand as
+		// the sole argument, so `Capitalize<K>` round-trips. The operand prints with no minimum since
+		// the `<…>` brackets stop anything from binding across it.
+		return t.Kind.String() + "<" + p.printType(t.Operand) + ">"
 	case *ObjectType:
 		elems := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -747,12 +747,12 @@ type TemplateLitType struct {
 	Interps []Type
 }
 
-// StringMappingKind names one of the four intrinsic string-manipulation operators TypeScript
-// exposes: Uppercase, Lowercase, Capitalize, and Uncapitalize.
-type StringMappingKind int
+// StringIntrinsicKind names one of the four string intrinsics TypeScript exposes: Uppercase,
+// Lowercase, Capitalize, and Uncapitalize. Each is written `intrinsic` in the shipped .d.ts.
+type StringIntrinsicKind int
 
 const (
-	Uppercase StringMappingKind = iota
+	Uppercase StringIntrinsicKind = iota
 	Lowercase
 	Capitalize
 	Uncapitalize
@@ -760,7 +760,7 @@ const (
 
 // String renders the operator's surface name, used by the printer to render `Uppercase<T>`
 // and by the resolver to register the four intrinsics under their reference names.
-func (k StringMappingKind) String() string {
+func (k StringIntrinsicKind) String() string {
 	switch k {
 	case Uppercase:
 		return "Uppercase"
@@ -771,47 +771,47 @@ func (k StringMappingKind) String() string {
 	case Uncapitalize:
 		return "Uncapitalize"
 	}
-	panic(fmt.Sprintf("StringMappingKind.String: unhandled kind %d", int(k)))
+	panic(fmt.Sprintf("StringIntrinsicKind.String: unhandled kind %d", int(k)))
 }
 
-// StringMappingType is the residual intrinsic string operator `Uppercase<T>` and its three
+// StringIntrinsicType is the residual intrinsic string operator `Uppercase<T>` and its three
 // siblings. Like KeyofType it is inert: it carries no bounds, constrain never records
 // one against it, and it flows through the solver's structural machinery untouched, rendering
 // `Uppercase<T>` the way the source wrote it. An evaluator reduces it over a string-literal
 // operand — `Uppercase<"abc">` ⇒ `"ABC"` — distributing over a union operand, and stays
 // symbolic over an abstract operand such as a type parameter.
-type StringMappingType struct {
-	Kind    StringMappingKind
+type StringIntrinsicType struct {
+	Kind    StringIntrinsicKind
 	Operand Type
 }
 
-func (*TypeVarType) isType()       {}
-func (*KeyofType) isType()         {}
-func (*IndexType) isType()         {}
-func (*TypeofType) isType()        {}
-func (*CondType) isType()          {}
-func (*InferType) isType()         {}
-func (*RestSpreadType) isType()    {}
-func (*TemplateLitType) isType()   {}
-func (*StringMappingType) isType() {}
-func (*PrimType) isType()          {}
-func (*LitType) isType()           {}
-func (*FuncType) isType()          {}
-func (*TupleType) isType()         {}
-func (*ObjectType) isType()        {}
-func (*RefType) isType()           {}
-func (*PromiseType) isType()       {}
-func (*Void) isType()              {}
-func (*NullType) isType()          {}
-func (*UndefinedType) isType()     {}
-func (*NeverType) isType()         {}
-func (*UnknownType) isType()       {}
-func (*UnionType) isType()         {}
-func (*IntersectionType) isType()  {}
-func (*ErrorType) isType()         {}
-func (*ClassType) isType()         {}
-func (*AliasType) isType()         {}
-func (*SkolemType) isType()        {}
+func (*TypeVarType) isType()         {}
+func (*KeyofType) isType()           {}
+func (*IndexType) isType()           {}
+func (*TypeofType) isType()          {}
+func (*CondType) isType()            {}
+func (*InferType) isType()           {}
+func (*RestSpreadType) isType()      {}
+func (*TemplateLitType) isType()     {}
+func (*StringIntrinsicType) isType() {}
+func (*PrimType) isType()            {}
+func (*LitType) isType()             {}
+func (*FuncType) isType()            {}
+func (*TupleType) isType()           {}
+func (*ObjectType) isType()          {}
+func (*RefType) isType()             {}
+func (*PromiseType) isType()         {}
+func (*Void) isType()                {}
+func (*NullType) isType()            {}
+func (*UndefinedType) isType()       {}
+func (*NeverType) isType()           {}
+func (*UnknownType) isType()         {}
+func (*UnionType) isType()           {}
+func (*IntersectionType) isType()    {}
+func (*ErrorType) isType()           {}
+func (*ClassType) isType()           {}
+func (*AliasType) isType()           {}
+func (*SkolemType) isType()          {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).
@@ -902,8 +902,8 @@ func LevelOf(t Type) int {
 			m = max(m, LevelOf(interp))
 		}
 		return m
-	case *StringMappingType:
-		// A string-mapping residual's level is its operand's, the same single-child rule the
+	case *StringIntrinsicType:
+		// A string-intrinsic residual's level is its operand's, the same single-child rule the
 		// KeyofType arm follows.
 		return LevelOf(t.Operand)
 	case *PromiseType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -733,31 +733,85 @@ type RestSpreadType struct {
 	Operand Type
 }
 
-func (*TypeVarType) isType()      {}
-func (*KeyofType) isType()        {}
-func (*IndexType) isType()        {}
-func (*TypeofType) isType()       {}
-func (*CondType) isType()         {}
-func (*InferType) isType()        {}
-func (*RestSpreadType) isType()   {}
-func (*PrimType) isType()         {}
-func (*LitType) isType()          {}
-func (*FuncType) isType()         {}
-func (*TupleType) isType()        {}
-func (*ObjectType) isType()       {}
-func (*RefType) isType()          {}
-func (*PromiseType) isType()      {}
-func (*Void) isType()             {}
-func (*NullType) isType()         {}
-func (*UndefinedType) isType()    {}
-func (*NeverType) isType()        {}
-func (*UnknownType) isType()      {}
-func (*UnionType) isType()        {}
-func (*IntersectionType) isType() {}
-func (*ErrorType) isType()        {}
-func (*ClassType) isType()        {}
-func (*AliasType) isType()        {}
-func (*SkolemType) isType()       {}
+// TemplateLitType is the residual template literal type operator (M9 PR7), such as
+// `on${T}`. Quasis holds the fixed string segments and Interps the interpolated
+// types between them, so Quasis has exactly one more entry than Interps. Like KeyofType
+// it is inert: it carries no bounds, constrain never records one against it, and it flows
+// through the solver's structural machinery untouched, rendering `on${T}` the way
+// the source wrote it. An evaluator reduces it once its interpolations are ground, taking
+// the cartesian product over interpolated unions — `on${"a" | "b"}` ⇒ `"ona" | "onb"`.
+// A template whose interpolation stays abstract, such as a type parameter, keeps that
+// interpolation and stays symbolic.
+type TemplateLitType struct {
+	Quasis  []string
+	Interps []Type
+}
+
+// StringMappingKind names one of the four intrinsic string-manipulation operators TypeScript
+// exposes: Uppercase, Lowercase, Capitalize, and Uncapitalize.
+type StringMappingKind int
+
+const (
+	Uppercase StringMappingKind = iota
+	Lowercase
+	Capitalize
+	Uncapitalize
+)
+
+// String renders the operator's surface name, used by the printer to render `Uppercase<T>`
+// and by the resolver to register the four intrinsics under their reference names.
+func (k StringMappingKind) String() string {
+	switch k {
+	case Uppercase:
+		return "Uppercase"
+	case Lowercase:
+		return "Lowercase"
+	case Capitalize:
+		return "Capitalize"
+	case Uncapitalize:
+		return "Uncapitalize"
+	}
+	panic(fmt.Sprintf("StringMappingKind.String: unhandled kind %d", int(k)))
+}
+
+// StringMappingType is the residual intrinsic string operator `Uppercase<T>` and its three
+// siblings (M9 PR7). Like KeyofType it is inert: it carries no bounds, constrain never records
+// one against it, and it flows through the solver's structural machinery untouched, rendering
+// `Uppercase<T>` the way the source wrote it. An evaluator reduces it over a string-literal
+// operand — `Uppercase<"abc">` ⇒ `"ABC"` — distributing over a union operand, and stays
+// symbolic over an abstract operand such as a type parameter.
+type StringMappingType struct {
+	Kind    StringMappingKind
+	Operand Type
+}
+
+func (*TypeVarType) isType()       {}
+func (*KeyofType) isType()         {}
+func (*IndexType) isType()         {}
+func (*TypeofType) isType()        {}
+func (*CondType) isType()          {}
+func (*InferType) isType()         {}
+func (*RestSpreadType) isType()    {}
+func (*TemplateLitType) isType()   {}
+func (*StringMappingType) isType() {}
+func (*PrimType) isType()          {}
+func (*LitType) isType()           {}
+func (*FuncType) isType()          {}
+func (*TupleType) isType()         {}
+func (*ObjectType) isType()        {}
+func (*RefType) isType()           {}
+func (*PromiseType) isType()       {}
+func (*Void) isType()              {}
+func (*NullType) isType()          {}
+func (*UndefinedType) isType()     {}
+func (*NeverType) isType()         {}
+func (*UnknownType) isType()       {}
+func (*UnionType) isType()         {}
+func (*IntersectionType) isType()  {}
+func (*ErrorType) isType()         {}
+func (*ClassType) isType()         {}
+func (*AliasType) isType()         {}
+func (*SkolemType) isType()        {}
 
 // LevelOf is the max level of any TypeVarType inside t; concrete leaves are 0.
 // Trimmed to the M1 type set (grows back as later milestones add formers).
@@ -838,6 +892,19 @@ func LevelOf(t Type) int {
 		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the
 		// same single-child rule the KeyofType arm follows. The TupleType arm already maxes over its
 		// elements, so this element contributes its operand's level there.
+		return LevelOf(t.Operand)
+	case *TemplateLitType:
+		// A template literal's level is the max over its interpolations, so an out-of-level
+		// interpolation lifts the level and the freshener/extruder prune descends into it, the
+		// multi-child analogue of the KeyofType arm. The fixed string segments carry no variables.
+		m := 0
+		for _, interp := range t.Interps {
+			m = max(m, LevelOf(interp))
+		}
+		return m
+	case *StringMappingType:
+		// A string-mapping residual's level is its operand's, the same single-child rule the
+		// KeyofType arm follows.
 		return LevelOf(t.Operand)
 	case *PromiseType:
 		return LevelOf(t.Inner)

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -733,7 +733,7 @@ type RestSpreadType struct {
 	Operand Type
 }
 
-// TemplateLitType is the residual template literal type operator (M9 PR7), such as
+// TemplateLitType is the residual template literal type operator, such as
 // `on${T}`. Quasis holds the fixed string segments and Interps the interpolated
 // types between them, so Quasis has exactly one more entry than Interps. Like KeyofType
 // it is inert: it carries no bounds, constrain never records one against it, and it flows
@@ -775,7 +775,7 @@ func (k StringMappingKind) String() string {
 }
 
 // StringMappingType is the residual intrinsic string operator `Uppercase<T>` and its three
-// siblings (M9 PR7). Like KeyofType it is inert: it carries no bounds, constrain never records
+// siblings. Like KeyofType it is inert: it carries no bounds, constrain never records
 // one against it, and it flows through the solver's structural machinery untouched, rendering
 // `Uppercase<T>` the way the source wrote it. An evaluator reduces it over a string-literal
 // operand — `Uppercase<"abc">` ⇒ `"ABC"` — distributing over a union operand, and stays

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -257,6 +257,41 @@ func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
+func (t *TemplateLitType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The interpolations walk in the current polarity, the multi-child analogue of KeyofType's
+	// single covariant visit. The residual is inert — the visit rebuilds it around rewritten
+	// interpolations without reducing the template, so extrude/coalesce/freshenAbove carry
+	// `on${T}` through untouched. The fixed string segments carry through unchanged.
+	interps, changed := acceptTypes(cur.Interps, v, pol)
+	out := cur
+	if changed {
+		out = &TemplateLitType{Quasis: cur.Quasis, Interps: interps}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *StringMappingType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The operand walks in the current polarity, the same single-child covariant visit KeyofType
+	// uses. The residual is inert — the visit rebuilds it around a rewritten operand without
+	// reducing the operator, so extrude/coalesce/freshenAbove carry `Uppercase<T>` through untouched.
+	operand := cur.Operand.Accept(v, pol)
+	out := cur
+	if operand != cur.Operand {
+		out = &StringMappingType{Kind: cur.Kind, Operand: operand}
+	}
+	return v.ExitType(out, pol)
+}
+
 func (t *RefType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -275,7 +275,7 @@ func (t *TemplateLitType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *StringMappingType) Accept(v TypeVisitor, pol Polarity) Type {
+func (t *StringIntrinsicType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
 	if e.SkipChildren {
 		return v.ExitType(skipReplace(t, e), pol)
@@ -287,7 +287,7 @@ func (t *StringMappingType) Accept(v TypeVisitor, pol Polarity) Type {
 	operand := cur.Operand.Accept(v, pol)
 	out := cur
 	if operand != cur.Operand {
-		out = &StringMappingType{Kind: cur.Kind, Operand: operand}
+		out = &StringIntrinsicType{Kind: cur.Kind, Operand: operand}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -75,6 +75,15 @@ type aliasShell struct {
 // body is still being walked. expandAlias only runs at subtyping time, after every body in
 // the component is filled, so the nil Body is never read during pre-binding.
 func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns string) *aliasShell {
+	// The four intrinsic string operators — Uppercase, Lowercase, Capitalize, Uncapitalize — are
+	// built-in type operators, not aliases a user may shadow. Reject a `type Uppercase<T> = …`
+	// declaration and skip binding it, so a `Uppercase<…>` reference resolves to the built-in
+	// operator rather than the user's definition.
+	if _, reserved := stringIntrinsics[decl.Name.Name]; reserved {
+		c.report(&ReservedTypeNameError{Decl: decl})
+		return nil
+	}
+
 	// An alias-body type reference resolves against the alias's own namespace first, the
 	// same qualified-first resolution a class or enum body uses, so a namespaced alias
 	// resolves a bare sibling reference. Save and restore around type-parameter resolution.

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1190,11 +1190,11 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// are equal position-for-position, compared structurally without reducing the template.
 		b, ok := b.(*soltype.TemplateLitType)
 		return ok && slices.Equal(a.Quasis, b.Quasis) && equalTypeSliceWith(a.Interps, b.Interps, ctx)
-	case *soltype.StringMappingType:
-		// Two string-mapping residuals are equal when they name the same operator over equal
+	case *soltype.StringIntrinsicType:
+		// Two string-intrinsic residuals are equal when they name the same operator over equal
 		// operands, compared structurally without reducing, the single-child analogue of the
 		// KeyofType arm.
-		b, ok := b.(*soltype.StringMappingType)
+		b, ok := b.(*soltype.StringIntrinsicType)
 		return ok && a.Kind == b.Kind && equalTypeWith(a.Operand, b.Operand, ctx)
 	}
 	return false

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/escalier-lang/escalier/internal/set"
@@ -1184,6 +1185,17 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// spread element reaches here in place, the spread twin of the plain element comparison.
 		b, ok := b.(*soltype.RestSpreadType)
 		return ok && equalTypeWith(a.Operand, b.Operand, ctx)
+	case *soltype.TemplateLitType:
+		// Two template literals are equal when their fixed segments match and their interpolations
+		// are equal position-for-position, compared structurally without reducing the template.
+		b, ok := b.(*soltype.TemplateLitType)
+		return ok && slices.Equal(a.Quasis, b.Quasis) && equalTypeSliceWith(a.Interps, b.Interps, ctx)
+	case *soltype.StringMappingType:
+		// Two string-mapping residuals are equal when they name the same operator over equal
+		// operands, compared structurally without reducing, the single-child analogue of the
+		// KeyofType arm.
+		b, ok := b.(*soltype.StringMappingType)
+		return ok && a.Kind == b.Kind && equalTypeWith(a.Operand, b.Operand, ctx)
 	}
 	return false
 }

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -152,7 +152,7 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) 
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.TemplateLitType, *soltype.StringMappingType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
 		if !tupleHasSpread(t) {
@@ -782,7 +782,7 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringMappingType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		// A residual type-level operator the pre-switch could not ground reaches here: a `keyof T`,
 		// `T[K]`, `on${T}`, or `Uppercase<T>` over a type parameter, or an expanding recursive
 		// alias. constrain treats every such operator inert, neither decomposing nor reducing it, so

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -136,7 +136,9 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
 // An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
 // to its key set, an indexed access `T[K]` reduces to the type at that key, a conditional selects
-// its Then or Else branch, and a tuple carrying a `...P` spread splices its operand tuples into a
+// its Then or Else branch, a template literal reduces to the union of string literals its
+// interpolations produce, an intrinsic string operator such as `Uppercase<T>` reduces over its
+// string-literal operand, and a tuple carrying a `...P` spread splices its operand tuples into a
 // plain tuple. A plain tuple is a structural type
 // constrain decomposes, not an operator, so it reports ok=false. The returned errs carry any
 // diagnostic the reduction produced — an unknown object key or an out-of-range tuple index — for
@@ -150,7 +152,7 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) 
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.TemplateLitType, *soltype.StringMappingType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
 		if !tupleHasSpread(t) {
@@ -780,29 +782,16 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		if _, ok := super.(*soltype.UndefinedType); ok {
 			return nil
 		}
-	case *soltype.KeyofType:
-		// A `keyof` residual the pre-switch could not ground reaches here: `keyof T` over a type
-		// parameter, or an expanding recursive alias. constrain treats it inert, neither
-		// decomposing nor reducing it, so two residuals are compatible only when structurally
-		// identical. `keyof T <: keyof T` succeeds reflexively without recording any bound, and a
-		// residual against any other concrete fails. When super is a variable the case falls
-		// through to the superVar arm below, which records the whole residual as one lower bound,
-		// keeping the operator symbolic on the coalesced binding.
-		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-			if equalType(sub, super) {
-				return nil
-			}
-			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
-		}
-	case *soltype.IndexType:
-		// A `T[K]` residual the pre-switch could not ground reaches here: an access over a type
-		// parameter, or an expanding recursive alias. constrain treats it inert, the same as the
-		// KeyofType arm above — two residuals are compatible only when structurally identical, so
-		// `T[K] <: T[K]` succeeds reflexively without recording a bound, and a residual against any
-		// other concrete fails. When super is a variable the case falls through to the superVar arm,
-		// which records the whole residual as one lower bound, keeping the operator symbolic on the
-		// coalesced binding. A tuple carrying a `...P` spread is handled inertly in the TupleType arm
-		// above, the spread twin of this arm.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.TemplateLitType, *soltype.StringMappingType:
+		// A residual type-level operator the pre-switch could not ground reaches here: a `keyof T`,
+		// `T[K]`, `on${T}`, or `Uppercase<T>` over a type parameter, or an expanding recursive
+		// alias. constrain treats every such operator inert, neither decomposing nor reducing it, so
+		// two residuals are compatible only when structurally identical. A reflexive `keyof T <: keyof
+		// T` succeeds without recording any bound, and a residual against any other concrete fails.
+		// When super is a variable the case falls through to the superVar arm below, which records the
+		// whole residual as one lower bound, keeping the operator symbolic on the coalesced binding. A
+		// tuple carrying a `...P` spread is handled inertly in the TupleType arm above, the spread
+		// twin of these operators.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1872,7 +1872,7 @@ func describe(t soltype.Type) string {
 		}
 		b.WriteString("`")
 		return b.String()
-	case *soltype.StringMappingType:
+	case *soltype.StringIntrinsicType:
 		// An intrinsic string-operator residual renders `Uppercase<operand>` structurally, recursing
 		// like the keyof arm. The operand renders in describe's raw mid-constrain form.
 		return t.Kind.String() + "<" + describe(t.Operand) + ">"

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1821,6 +1821,24 @@ func describe(t soltype.Type) string {
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders
 		// in describe's raw mid-constrain form.
 		return "..." + describe(t.Operand)
+	case *soltype.TemplateLitType:
+		// A template literal residual renders `q0${i0}…qn` structurally, recursing like the
+		// keyof arm, so a rejected constraint names it the way the source wrote it. Each
+		// interpolation renders in describe's raw mid-constrain form.
+		var b strings.Builder
+		b.WriteString("`")
+		for i, quasi := range t.Quasis {
+			b.WriteString(quasi)
+			if i < len(t.Interps) {
+				b.WriteString("${" + describe(t.Interps[i]) + "}")
+			}
+		}
+		b.WriteString("`")
+		return b.String()
+	case *soltype.StringMappingType:
+		// An intrinsic string-operator residual renders `Uppercase<operand>` structurally, recursing
+		// like the keyof arm. The operand renders in describe's raw mid-constrain form.
+		return t.Kind.String() + "<" + describe(t.Operand) + ">"
 	case *soltype.RefType:
 		// A borrow renders with its `mut` prefix over the nominal inner (`mut object`),
 		// recursing like the Promise arm. The lifetime is deliberately NOT rendered: D2

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -224,6 +224,17 @@ type TupleIndexOutOfRangeError struct {
 	site  ast.Node     // M2.5: constraint node fallback
 }
 
+// TemplateLitTooComplexError fires when reducing a template literal type would enumerate more than
+// maxTemplateLitCombinations string literals, as in `${A}${B}${C}` over three large unions whose
+// cartesian product explodes. Materializing that union would cost unbounded memory, so the type
+// expression is rejected. Like TupleIndexOutOfRangeError it is minted during the reduction constrain
+// performs, and carries the template it could not expand.
+type TemplateLitTooComplexError struct {
+	Template *soltype.TemplateLitType
+	prov     NodeResolver // M2.5: type→node index (§3.5)
+	site     ast.Node     // M2.5: constraint node fallback
+}
+
 // MutabilityMismatchError fires on RefType <: RefType when the sub is an immutable
 // borrow but the super is mutable: writing through the mutable target would mutate a
 // value the source only lent out as read-only, so an immutable reference cannot fill
@@ -412,6 +423,7 @@ func (*ExtraElementError) isSolverError()           {}
 func (*OptionalPropertyError) isSolverError()       {}
 func (*UnknownObjectKeyError) isSolverError()       {}
 func (*TupleIndexOutOfRangeError) isSolverError()   {}
+func (*TemplateLitTooComplexError) isSolverError()  {}
 func (*MutabilityMismatchError) isSolverError()     {}
 func (*BorrowEscapeError) isSolverError()           {}
 func (*ClassIntoExactObjectError) isSolverError()   {}
@@ -514,6 +526,12 @@ func (e *TupleIndexOutOfRangeError) Span() ast.Span {
 	return spanOf(e.prov, e.Tuple, e.site)
 }
 func (e *TupleIndexOutOfRangeError) Related() []ast.Span { return nil }
+
+func (e *TemplateLitTooComplexError) Span() ast.Span {
+	// The template is the offending type; blame it, else the constraint site.
+	return spanOf(e.prov, e.Template, e.site)
+}
+func (e *TemplateLitTooComplexError) Related() []ast.Span { return nil }
 
 func (e *MutabilityMismatchError) Span() ast.Span {
 	// The immutable source borrow is the actual value; blame it, degrade to the
@@ -1615,6 +1633,11 @@ func (e *UnknownObjectKeyError) Message() string {
 func (e *TupleIndexOutOfRangeError) Message() string {
 	return fmt.Sprintf("index %s is out of range for tuple %s",
 		strconv.FormatFloat(e.Index, 'f', -1, 64), soltype.Print(e.Tuple))
+}
+
+func (e *TemplateLitTooComplexError) Message() string {
+	return fmt.Sprintf("template literal type %s is too complex to reduce; it expands to more than %d members",
+		soltype.Print(e.Template), maxTemplateLitCombinations)
 }
 
 func (e *MutabilityMismatchError) Message() string {

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -965,6 +965,7 @@ func (*ExtractorPatternNotCtorError) isSolverError()        {}
 func (*ExtractorPatternArityError) isSolverError()          {}
 func (*AliasArityMismatchError) isSolverError()             {}
 func (*AliasLifetimeArityMismatchError) isSolverError()     {}
+func (*ReservedTypeNameError) isSolverError()               {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -1093,6 +1094,19 @@ func (e *AliasLifetimeArityMismatchError) Span() ast.Span      { return e.Ref.Sp
 func (e *AliasLifetimeArityMismatchError) Related() []ast.Span { return nil }
 func (e *AliasLifetimeArityMismatchError) Message() string {
 	return fmt.Sprintf("type alias `%s` expects %d lifetime arguments but got %d", e.Name, e.Expected, e.Got)
+}
+
+// ReservedTypeNameError fires when a `type` declaration uses the name of a built-in intrinsic
+// string operator — Uppercase, Lowercase, Capitalize, or Uncapitalize. These are compiler
+// operators, not aliases, so a user cannot redefine them.
+type ReservedTypeNameError struct {
+	Decl *ast.TypeDecl
+}
+
+func (e *ReservedTypeNameError) Span() ast.Span      { return e.Decl.Name.Span() }
+func (e *ReservedTypeNameError) Related() []ast.Span { return nil }
+func (e *ReservedTypeNameError) Message() string {
+	return fmt.Sprintf("%q is a built-in type operator and cannot be redefined", e.Decl.Name.Name)
 }
 
 // MultipleConstructorsError fires on the second and any later `constructor` block in

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -349,6 +349,8 @@ func (c *checker) blameConstraintErrors(n ast.Node, errs []SolverError) {
 			err.prov, err.site = c.prov, n
 		case *TupleIndexOutOfRangeError:
 			err.prov, err.site = c.prov, n
+		case *TemplateLitTooComplexError:
+			err.prov, err.site = c.prov, n
 		case *FuncArityMismatchError:
 			err.prov, err.site = c.prov, n
 		case *MutabilityMismatchError:

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -1,0 +1,236 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/escalier-lang/escalier/internal/soltype"
+	"github.com/stretchr/testify/require"
+)
+
+// A template literal type is stored as a residual and reduced by taking the cartesian product over
+// its interpolations, folding each string-literal interpolation into the surrounding segments. Each
+// case asserts the stored `Result` renders the way the source wrote it, then asserts that reducing
+// it with the alias environment — the expansion constrain performs to check a constraint — produces
+// the union of string literals. The cases cover a bare template, a literal interpolation, a union
+// interpolation, two interpolations whose product enumerates every pairing, and a named alias
+// interpolation that expands to its union body before the product.
+func TestInferTemplateLitReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// A template with no interpolation collapses to the lone string literal.
+			name:         "NoInterpolation",
+			src:          "type Result = `abc`",
+			wantSymbolic: "`abc`",
+			wantExpanded: `"abc"`,
+		},
+		{
+			// A single string-literal interpolation folds into the surrounding text.
+			name:         "LiteralInterpolation",
+			src:          "type Result = `on${\"click\"}`",
+			wantSymbolic: "`on${\"click\"}`",
+			wantExpanded: `"onclick"`,
+		},
+		{
+			// A union interpolation reduces to one string literal per member.
+			name:         "UnionInterpolation",
+			src:          "type Result = `on${\"a\" | \"b\"}`",
+			wantSymbolic: "`on${\"a\" | \"b\"}`",
+			wantExpanded: `"ona" | "onb"`,
+		},
+		{
+			// Two union interpolations enumerate every pairing as the cartesian product.
+			name:         "TwoInterpolations",
+			src:          "type Result = `${\"a\" | \"b\"}-${\"x\" | \"y\"}`",
+			wantSymbolic: "`${\"a\" | \"b\"}-${\"x\" | \"y\"}`",
+			wantExpanded: `"a-x" | "a-y" | "b-x" | "b-y"`,
+		},
+		{
+			// A named alias interpolation expands to its union body before the product.
+			name: "AliasInterpolation",
+			src: `
+				type Dir = "left" | "right"
+				type Result = ` + "`to-${Dir}`",
+			wantSymbolic: "`to-${Dir}`",
+			wantExpanded: `"to-left" | "to-right"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A template literal over a type parameter renders symbolically in a function signature and
+// round-trips from parameter to return. The function fn f<T>(k: `on${T}`) -> `on${T}` { return k }
+// keeps `on${T}` on both positions. The reflexive residual-to-residual constraint from `return k`
+// succeeds inertly by structural equality, since the abstract interpolation never grounds.
+func TestInferTemplateLitSignatureStaysSymbolic(t *testing.T) {
+	values, _, errs := inferSource(t, "fn f<T>(k: `on${T}`) -> `on${T}` { return k }")
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(k: `on${T}`) -> `on${T}`", values["f"])
+}
+
+// constrain reduces a ground template literal to the union of string literals to check
+// satisfaction, while the stored type stays the residual. A value in the reduced union is accepted;
+// one outside it is rejected against the union, so the diagnostic names the enumerated literals.
+func TestInferTemplateLitConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "MemberAccepted",
+			src:  "val r: `on${\"a\" | \"b\"}` = \"ona\"",
+		},
+		{
+			name:    "NonMemberRejected",
+			src:     "val r: `on${\"a\" | \"b\"}` = \"onc\"",
+			wantErr: `cannot constrain "onc" <: "ona" | "onb"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// An intrinsic string operator `Uppercase<T>` and its three siblings are stored as residuals and
+// reduced over a string-literal operand. Each case asserts the stored `Result` renders the way the
+// source wrote it, then asserts that reducing it maps the operand's characters, distributing over a
+// union operand. The cases cover each of the four operators and the union-distribution rule.
+func TestInferStringMappingReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			name:         "Uppercase",
+			src:          `type Result = Uppercase<"abc">`,
+			wantSymbolic: `Uppercase<"abc">`,
+			wantExpanded: `"ABC"`,
+		},
+		{
+			name:         "Lowercase",
+			src:          `type Result = Lowercase<"ABC">`,
+			wantSymbolic: `Lowercase<"ABC">`,
+			wantExpanded: `"abc"`,
+		},
+		{
+			name:         "Capitalize",
+			src:          `type Result = Capitalize<"abc">`,
+			wantSymbolic: `Capitalize<"abc">`,
+			wantExpanded: `"Abc"`,
+		},
+		{
+			name:         "Uncapitalize",
+			src:          `type Result = Uncapitalize<"ABC">`,
+			wantSymbolic: `Uncapitalize<"ABC">`,
+			wantExpanded: `"aBC"`,
+		},
+		{
+			// The operator distributes over a union operand, mapping each member.
+			name:         "UnionOperand",
+			src:          `type Result = Uppercase<"a" | "b">`,
+			wantSymbolic: `Uppercase<"a" | "b">`,
+			wantExpanded: `"A" | "B"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A string-mapping residual over a type parameter renders symbolically in a function signature and
+// round-trips from parameter to return: `fn f<T>(k: Uppercase<T>) -> Uppercase<T> { return k }`
+// keeps `Uppercase<T>` on both positions. The reflexive `Uppercase<T> <: Uppercase<T>` from
+// `return k` succeeds inertly by structural equality on the residual, since the abstract operand
+// never grounds.
+func TestInferStringMappingSignatureStaysSymbolic(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f<T>(k: Uppercase<T>) -> Uppercase<T> { return k }`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(k: Uppercase<T>) -> Uppercase<T>", values["f"])
+}
+
+// constrain reduces a ground string-mapping residual to the transformed literal to check
+// satisfaction, while the stored type stays the residual. The transformed literal is accepted; any
+// other literal is rejected against it, so the diagnostic names the mapped value.
+func TestInferStringMappingConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "MappedAccepted",
+			src:  `val r: Uppercase<"abc"> = "ABC"`,
+		},
+		{
+			name:    "UnmappedRejected",
+			src:     `val r: Uppercase<"abc"> = "abc"`,
+			wantErr: `cannot constrain "abc" <: "ABC"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A string intrinsic nested inside a template interpolation composes: `on${Capitalize<K>}`
+// over `type K = "click"` reduces the inner `Capitalize<K>` to `"Click"`, then folds it into the
+// template to yield `"onClick"`. This is the `EventName<K>` shape the utility-type suite builds on.
+func TestInferTemplateLitWithStringIntrinsic(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type K = "click"
+		type Result = `+"`on${Capitalize<K>}`")
+	require.Empty(t, errs)
+	result := nodes["Result"]
+	require.Equal(t, "`on${Capitalize<K>}`", soltype.Print(result))
+	require.Equal(t, `"onClick"`, soltype.Print(expandResidual(ctx, result)))
+}
+
+// A user-defined type named after an intrinsic takes precedence over the built-in operator, since
+// resolveScopedTypeRef runs before the intrinsic recognition. A `type Uppercase<T> = T` shadows the
+// string operator, so `Uppercase<"abc">` resolves to the alias body `"abc"`. A value `"abc"` then
+// satisfies the annotation; were the intrinsic still in force it would reduce to `"ABC"` and reject
+// `"abc"`, so acceptance witnesses that the user type won.
+func TestInferStringIntrinsicShadowedByUserType(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Uppercase<T> = T
+		val r: Uppercase<"abc"> = "abc"
+	`)
+	require.Empty(t, errs)
+}

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/soltype"
@@ -57,6 +59,17 @@ func TestInferTemplateLitReduction(t *testing.T) {
 				type Result = ` + "`to-${Dir}`",
 			wantSymbolic: "`to-${Dir}`",
 			wantExpanded: `"to-left" | "to-right"`,
+		},
+		{
+			// A union interpolation grounds each member, so an aliased member collapses to its
+			// literal rather than surviving as a residual interpolation.
+			name: "UnionMemberAlias",
+			src: `
+				type B = "b"
+				type U = "a" | B
+				type Result = ` + "`x${U}`",
+			wantSymbolic: "`x${U}`",
+			wantExpanded: `"xa" | "xb"`,
 		},
 	}
 	for _, tt := range tests {
@@ -233,4 +246,18 @@ func TestInferStringIntrinsicShadowedByUserType(t *testing.T) {
 		val r: Uppercase<"abc"> = "abc"
 	`)
 	require.Empty(t, errs)
+}
+
+// A template literal whose cartesian product would exceed the combination cap is rejected with one
+// diagnostic rather than materializing an unbounded union. A 25-member union across three
+// interpolations enumerates 25^3 = 15625 combinations, past the 10000 cap.
+func TestInferTemplateLitTooComplex(t *testing.T) {
+	members := make([]string, 25)
+	for i := range members {
+		members[i] = fmt.Sprintf("%q", fmt.Sprint(i))
+	}
+	src := "type D = " + strings.Join(members, " | ") + "\nval r: `${D}${D}${D}` = \"000\""
+	_, _, errs := inferSource(t, src)
+	require.Len(t, errs, 1)
+	require.Equal(t, "template literal type `${D}${D}${D}` is too complex to reduce; it expands to more than 10000 members", errs[0].Message())
 }

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -129,7 +129,7 @@ func TestInferTemplateLitConstraint(t *testing.T) {
 // reduced over a string-literal operand. Each case asserts the stored `Result` renders the way the
 // source wrote it, then asserts that reducing it maps the operand's characters, distributing over a
 // union operand. The cases cover each of the four operators and the union-distribution rule.
-func TestInferStringMappingReduction(t *testing.T) {
+func TestInferStringIntrinsicReduction(t *testing.T) {
 	tests := []struct {
 		name         string
 		src          string
@@ -179,21 +179,21 @@ func TestInferStringMappingReduction(t *testing.T) {
 	}
 }
 
-// A string-mapping residual over a type parameter renders symbolically in a function signature and
+// A string-intrinsic residual over a type parameter renders symbolically in a function signature and
 // round-trips from parameter to return: `fn f<T>(k: Uppercase<T>) -> Uppercase<T> { return k }`
 // keeps `Uppercase<T>` on both positions. The reflexive `Uppercase<T> <: Uppercase<T>` from
 // `return k` succeeds inertly by structural equality on the residual, since the abstract operand
 // never grounds.
-func TestInferStringMappingSignatureStaysSymbolic(t *testing.T) {
+func TestInferStringIntrinsicSignatureStaysSymbolic(t *testing.T) {
 	values, _, errs := inferSource(t, `fn f<T>(k: Uppercase<T>) -> Uppercase<T> { return k }`)
 	require.Empty(t, errs)
 	require.Equal(t, "fn <T>(k: Uppercase<T>) -> Uppercase<T>", values["f"])
 }
 
-// constrain reduces a ground string-mapping residual to the transformed literal to check
+// constrain reduces a ground string-intrinsic residual to the transformed literal to check
 // satisfaction, while the stored type stays the residual. The transformed literal is accepted; any
 // other literal is rejected against it, so the diagnostic names the mapped value.
-func TestInferStringMappingConstraint(t *testing.T) {
+func TestInferStringIntrinsicConstraint(t *testing.T) {
 	tests := []struct {
 		name    string
 		src     string

--- a/internal/solver/infer_template_lit_test.go
+++ b/internal/solver/infer_template_lit_test.go
@@ -235,17 +235,18 @@ func TestInferTemplateLitWithStringIntrinsic(t *testing.T) {
 	require.Equal(t, `"onClick"`, soltype.Print(expandResidual(ctx, result)))
 }
 
-// A user-defined type named after an intrinsic takes precedence over the built-in operator, since
-// resolveScopedTypeRef runs before the intrinsic recognition. A `type Uppercase<T> = T` shadows the
-// string operator, so `Uppercase<"abc">` resolves to the alias body `"abc"`. A value `"abc"` then
-// satisfies the annotation; were the intrinsic still in force it would reduce to `"ABC"` and reject
-// `"abc"`, so acceptance witnesses that the user type won.
-func TestInferStringIntrinsicShadowedByUserType(t *testing.T) {
+// The four intrinsic string operators are built-in, not aliases, so a `type Uppercase<T> = …`
+// declaration is rejected and the declaration never binds. A `Uppercase<…>` reference then still
+// resolves to the built-in operator: `Uppercase<"abc">` reduces to `"ABC"`, so `"abc"` is rejected
+// against it. Two errors surface — the reserved-name declaration and the failed constraint.
+func TestInferStringIntrinsicCannotBeRedefined(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type Uppercase<T> = T
 		val r: Uppercase<"abc"> = "abc"
 	`)
-	require.Empty(t, errs)
+	require.Len(t, errs, 2)
+	require.Equal(t, `"Uppercase" is a built-in type operator and cannot be redefined`, errs[0].Message())
+	require.Equal(t, `cannot constrain "abc" <: "ABC"`, errs[1].Message())
 }
 
 // A template literal whose cartesian product would exceed the combination cap is rejected with one

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -381,7 +381,11 @@ func (c *checker) inferComponent(
 				// the component is bound. Pre-binding the identity first lets a self or mutual
 				// reference — `type List<T> = {tail: List<T> | Null}`, or a mutual `type A =
 				// {b: B}` / `type B = {a: A}` pair — find its target already bound.
-				aliasShells = append(aliasShells, c.preBindAlias(scope, inner, decl, g.GetNamespace(key)))
+				// preBindAlias returns nil for a reserved built-in name it rejected, which is not
+				// bound and has no body to resolve, so skip appending it.
+				if sh := c.preBindAlias(scope, inner, decl, g.GetNamespace(key)); sh != nil {
+					aliasShells = append(aliasShells, sh)
+				}
 				handled.Add(d)
 			}
 		}

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -67,6 +67,9 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 			c.recordProv(t, ta, AnnotationType)
 			return t, true
 		}
+		if t, ok := c.resolveStringIntrinsic(scope, ta, lvl); ok {
+			return t, true
+		}
 		return c.reportUnsupported(ta), false
 	case *ast.ObjectTypeAnn:
 		return c.resolveObjectTypeAnn(scope, ta, lvl)
@@ -92,6 +95,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveCondTypeAnn(scope, ta, lvl)
 	case *ast.InferTypeAnn:
 		return c.resolveInferTypeAnn(scope, ta)
+	case *ast.TemplateLitTypeAnn:
+		return c.resolveTemplateLitTypeAnn(scope, ta, lvl)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -474,6 +479,59 @@ func (c *checker) resolveTypeOfTypeAnn(scope *Scope, ta *ast.TypeOfTypeAnn) (sol
 		return c.reportUnsupportedFeature(ta, "typeof of a name that is not a readable value"), false
 	}
 	t := &soltype.TypeofType{Ident: ast.QualIdentToString(ta.Value), Ty: ty}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveTemplateLitTypeAnn lowers a template literal type such as `on${T}` to a
+// TemplateLitType residual and stores it unreduced, so the annotation prints the way the source
+// wrote it rather than the reduced union of string literals. constrain reduces the residual when it
+// checks a constraint against it, mirroring resolveKeyOfTypeAnn. The parser records one more fixed
+// segment than interpolation, so Quasis carries len(Interps)+1 entries. An unsupported
+// interpolation recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
+func (c *checker) resolveTemplateLitTypeAnn(scope *Scope, ta *ast.TemplateLitTypeAnn, lvl int) (soltype.Type, bool) {
+	quasis := make([]string, len(ta.Quasis))
+	for i, q := range ta.Quasis {
+		quasis[i] = q.Value
+	}
+	interps := make([]soltype.Type, len(ta.TypeAnns))
+	for i, ann := range ta.TypeAnns {
+		t, ok := c.resolveTypeAnn(scope, ann, lvl)
+		if !ok {
+			t = c.freshAt(lvl)
+		}
+		interps[i] = t
+	}
+	t := &soltype.TemplateLitType{Quasis: quasis, Interps: interps}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// stringIntrinsics maps each intrinsic string operator's reference name to its kind, so a
+// `Uppercase<T>` reference resolves to a StringMappingType residual. A user-defined type of the
+// same name takes precedence, since resolveScopedTypeRef runs first.
+var stringIntrinsics = map[string]soltype.StringMappingKind{
+	"Uppercase":    soltype.Uppercase,
+	"Lowercase":    soltype.Lowercase,
+	"Capitalize":   soltype.Capitalize,
+	"Uncapitalize": soltype.Uncapitalize,
+}
+
+// resolveStringIntrinsic lowers an intrinsic string-operator reference `Uppercase<T>` and its three
+// siblings to a StringMappingType residual, stored unreduced so the annotation prints the way the
+// source wrote it. It matches only a single-argument reference with no lifetime arguments; any other
+// name or arity reports ok=false so the caller falls through to its unsupported-feature recovery. An
+// unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
+func (c *checker) resolveStringIntrinsic(scope *Scope, ta *ast.TypeRefTypeAnn, lvl int) (soltype.Type, bool) {
+	kind, ok := stringIntrinsics[ast.QualIdentToString(ta.Name)]
+	if !ok || len(ta.TypeArgs) != 1 || len(ta.LifetimeArgs) > 0 || ta.Lifetime != nil {
+		return nil, false
+	}
+	operand, ok := c.resolveTypeAnn(scope, ta.TypeArgs[0], lvl)
+	if !ok {
+		operand = c.freshAt(lvl)
+	}
+	t := &soltype.StringMappingType{Kind: kind, Operand: operand}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -508,9 +508,9 @@ func (c *checker) resolveTemplateLitTypeAnn(scope *Scope, ta *ast.TemplateLitTyp
 }
 
 // stringIntrinsics maps each intrinsic string operator's reference name to its kind, so a
-// `Uppercase<T>` reference resolves to a StringMappingType residual. A user-defined type of the
+// `Uppercase<T>` reference resolves to a StringIntrinsicType residual. A user-defined type of the
 // same name takes precedence, since resolveScopedTypeRef runs first.
-var stringIntrinsics = map[string]soltype.StringMappingKind{
+var stringIntrinsics = map[string]soltype.StringIntrinsicKind{
 	"Uppercase":    soltype.Uppercase,
 	"Lowercase":    soltype.Lowercase,
 	"Capitalize":   soltype.Capitalize,
@@ -518,7 +518,7 @@ var stringIntrinsics = map[string]soltype.StringMappingKind{
 }
 
 // resolveStringIntrinsic lowers an intrinsic string-operator reference `Uppercase<T>` and its three
-// siblings to a StringMappingType residual, stored unreduced so the annotation prints the way the
+// siblings to a StringIntrinsicType residual, stored unreduced so the annotation prints the way the
 // source wrote it. It matches only a single-argument reference with no lifetime arguments; any other
 // name or arity reports ok=false so the caller falls through to its unsupported-feature recovery. An
 // unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery.
@@ -531,7 +531,7 @@ func (c *checker) resolveStringIntrinsic(scope *Scope, ta *ast.TypeRefTypeAnn, l
 	if !ok {
 		operand = c.freshAt(lvl)
 	}
-	t := &soltype.StringMappingType{Kind: kind, Operand: operand}
+	t := &soltype.StringIntrinsicType{Kind: kind, Operand: operand}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -975,6 +975,11 @@ func buildTemplatePart(quasis []string, combo []soltype.Type) soltype.Type {
 	newInterps := []soltype.Type{}
 	current := ""
 	for i, quasi := range quasis {
+		// current accumulates the literal text since the last abstract interpolation. The folding
+		// branch below leaves current intact, so this appends quasi i onto the earlier quasi and
+		// any literals folded into it — `a${"1"}b` builds "a" then "a1" then "a1b". After the
+		// abstract branch resets current to "", or on the first iteration, this starts a fresh
+		// segment instead.
 		current += quasi
 		if i >= len(combo) {
 			continue

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -1,6 +1,11 @@
 package solver
 
 import (
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
 	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
@@ -14,10 +19,11 @@ import (
 const maxExpandDepth = 200
 
 // typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T`, indexed
-// access `T[K]`, and the conditional `if C : E { … } else { … }`; later operators join as they
-// land. Only constrain invokes it, to check a constraint against a residual. Annotation and display
-// keep the residual symbolic, so a stored type prints `keyof {x: number}` or `Point["x"]` the way
-// the source wrote it, never the reduced value.
+// access `T[K]`, the conditional `if C : E { … } else { … }`, template literals, and the intrinsic
+// string operators such as `Uppercase<T>`; later operators join as they land. Only constrain invokes
+// it, to check a constraint against a residual. Annotation and display keep the residual symbolic, so
+// a stored type prints `keyof {x: number}` or `Point["x"]` the way the source wrote it, never the
+// reduced value.
 //
 // reduce projects the operand's keys: a ground `keyof {x: number}` yields `"x"`, and an alias or
 // class operand expands to the referenced type's keys, the transparent-but-named treatment an
@@ -89,6 +95,10 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return e.reduceTuple(t)
 	case *soltype.ObjectType:
 		return e.reduceObject(t)
+	case *soltype.TemplateLitType:
+		return e.reduceTemplateLit(t)
+	case *soltype.StringMappingType:
+		return e.reduceStringMapping(t.Kind, t.Operand)
 	default:
 		return t
 	}
@@ -341,7 +351,7 @@ func (e *typeEvaluator) reduceTuple(t *soltype.TupleType) soltype.Type {
 			elems = append(elems, e.reduce(el))
 			continue
 		}
-		operand := e.groundSpreadOperand(rest.Operand)
+		operand := e.groundOperand(rest.Operand)
 		tup, ok := operand.(*soltype.TupleType)
 		last := i == len(t.Elems)-1
 		if !ok || hasRestSpread(tup.Elems) || (tup.Inexact && !last) {
@@ -373,19 +383,21 @@ func (e *typeEvaluator) groundTuple(t *soltype.TupleType) (*soltype.TupleType, b
 	return reduced, true
 }
 
-// groundSpreadOperand reduces a tuple-spread operand toward a concrete tuple. It reduces any
-// nested operator, then expands a named alias to its body under the shared termination guard, so
-// `[...Pair, x]` over `type Pair = [number, string]` grounds to the referenced tuple. A type
-// parameter, a recurring alias state, an exhausted budget, or an unresolved alias body each leaves
-// the operand unexpanded, which keeps the spread symbolic.
-func (e *typeEvaluator) groundSpreadOperand(operand soltype.Type) soltype.Type {
+// groundOperand reduces an operator's operand toward a concrete type. It reduces any nested
+// operator, then expands a named alias to its body under the shared termination guard, so a spread
+// operand `Pair` over `type Pair = [number, string]` grounds to the referenced tuple and a template
+// interpolation `Dir` over `type Dir = "a" | "b"` grounds to the referenced union. A type parameter,
+// a recurring alias state, an exhausted budget, or an unresolved alias body each leaves the operand
+// unexpanded, which keeps the enclosing operator symbolic. The tuple-spread, template-literal, and
+// string-mapping reductions share it.
+func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 	reduced := e.reduce(operand)
 	alias, ok := reduced.(*soltype.AliasType)
 	if !ok {
 		return reduced
 	}
 	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
-		return e.groundSpreadOperand(body)
+		return e.groundOperand(body)
 	})
 }
 
@@ -902,6 +914,153 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, e
 	return tup.Elems[i]
 }
 
+// reduceTemplateLit reduces a template literal to the union of string literals its interpolations
+// produce, taking the cartesian product over each interpolation's options. Each interpolation is
+// first grounded, so a named alias expands to its body. A grounded interpolation that is a union
+// contributes each member as an option, so `on${"a" | "b"}` yields `"ona" | "onb"`, while any
+// other grounded interpolation contributes itself. Each product combination folds its
+// string-literal interpolations into the surrounding segments; a combination whose interpolation
+// stays abstract — a type parameter, or a nested operator the evaluator could not ground — keeps
+// that interpolation and stays a `TemplateLitType`, so the whole template reduces later once the
+// interpolation grounds.
+func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
+	options := make([][]soltype.Type, len(t.Interps))
+	for i, interp := range t.Interps {
+		reduced := e.groundOperand(interp)
+		if u, ok := reduced.(*soltype.UnionType); ok {
+			options[i] = u.Types
+		} else {
+			options[i] = []soltype.Type{reduced}
+		}
+	}
+	combos := cartesianProduct(options)
+	parts := make([]soltype.Type, 0, len(combos))
+	for _, combo := range combos {
+		parts = append(parts, buildTemplatePart(t.Quasis, combo))
+	}
+	return newUnion(nil, parts, false)
+}
+
+// buildTemplatePart assembles one cartesian-product combination into a single template result.
+// It interleaves the fixed segments with the combination's interpolations: a string-representable
+// literal folds into the surrounding text, while any other interpolation closes the accumulated
+// segment and carries through as a residual interpolation. A combination whose interpolations all
+// fold collapses to a lone string-literal type; one carrying an abstract interpolation stays a
+// `TemplateLitType`. Quasis holds one more entry than the combination, so the loop reads
+// combo[i] between quasi i and quasi i+1.
+func buildTemplatePart(quasis []string, combo []soltype.Type) soltype.Type {
+	newQuasis := []string{}
+	newInterps := []soltype.Type{}
+	current := ""
+	for i, quasi := range quasis {
+		current += quasi
+		if i >= len(combo) {
+			continue
+		}
+		if s, ok := stringifyLit(combo[i]); ok {
+			current += s
+			continue
+		}
+		newQuasis = append(newQuasis, current)
+		current = ""
+		newInterps = append(newInterps, combo[i])
+	}
+	newQuasis = append(newQuasis, current)
+	if len(newInterps) == 0 {
+		return strLitType(newQuasis[0])
+	}
+	return &soltype.TemplateLitType{Quasis: newQuasis, Interps: newInterps}
+}
+
+// cartesianProduct returns every combination that picks one option from each position, so the
+// template reducer can enumerate `${A}${B}` over unions A and B. An empty options list — a
+// template with no interpolations — yields one empty combination, so a bare `abc` collapses
+// to the single literal `"abc"`.
+func cartesianProduct(options [][]soltype.Type) [][]soltype.Type {
+	result := [][]soltype.Type{{}}
+	for _, opts := range options {
+		next := make([][]soltype.Type, 0, len(result)*len(opts))
+		for _, combo := range result {
+			for _, opt := range opts {
+				extended := make([]soltype.Type, len(combo)+1)
+				copy(extended, combo)
+				extended[len(combo)] = opt
+				next = append(next, extended)
+			}
+		}
+		result = next
+	}
+	return result
+}
+
+// stringifyLit returns the surface string a literal type contributes inside a template, and false
+// for any non-literal type. A string literal contributes its value, a number its decimal form, and
+// a boolean `true`/`false`, matching how each renders in source.
+func stringifyLit(t soltype.Type) (string, bool) {
+	lit, ok := t.(*soltype.LitType)
+	if !ok {
+		return "", false
+	}
+	switch l := lit.Lit.(type) {
+	case *soltype.StrLit:
+		return l.Value, true
+	case *soltype.NumLit:
+		return strconv.FormatFloat(l.Value, 'f', -1, 64), true
+	case *soltype.BoolLit:
+		return strconv.FormatBool(l.Value), true
+	}
+	return "", false
+}
+
+// reduceStringMapping reduces an intrinsic string operator such as `Uppercase<T>` over its operand.
+// A string-literal operand maps to the transformed literal — `Uppercase<"abc">` ⇒ `"ABC"` — and a
+// union operand distributes member-wise, so `Uppercase<"a" | "b">` ⇒ `"A" | "B"`. The operand is
+// first grounded, so a named alias expands to its body. An operand that is not a string literal,
+// such as a type parameter, keeps the operator symbolic as a `StringMappingType` rebuilt around the
+// grounded operand.
+func (e *typeEvaluator) reduceStringMapping(kind soltype.StringMappingKind, operand soltype.Type) soltype.Type {
+	reduced := e.groundOperand(operand)
+	switch op := reduced.(type) {
+	case *soltype.UnionType:
+		parts := make([]soltype.Type, len(op.Types))
+		for i, m := range op.Types {
+			parts[i] = e.reduceStringMapping(kind, m)
+		}
+		return newUnion(nil, parts, false)
+	case *soltype.LitType:
+		if s, ok := op.Lit.(*soltype.StrLit); ok {
+			return strLitType(applyStringMapping(kind, s.Value))
+		}
+	}
+	return &soltype.StringMappingType{Kind: kind, Operand: reduced}
+}
+
+// applyStringMapping transforms one string by the named intrinsic operator. Uppercase and Lowercase
+// map every character; Capitalize and Uncapitalize map only the first, leaving the rest unchanged.
+func applyStringMapping(kind soltype.StringMappingKind, s string) string {
+	switch kind {
+	case soltype.Uppercase:
+		return strings.ToUpper(s)
+	case soltype.Lowercase:
+		return strings.ToLower(s)
+	case soltype.Capitalize:
+		return mapFirstRune(s, unicode.ToUpper)
+	case soltype.Uncapitalize:
+		return mapFirstRune(s, unicode.ToLower)
+	}
+	return s
+}
+
+// mapFirstRune applies f to the first rune of s and leaves the remainder unchanged, the transform
+// Capitalize and Uncapitalize share. An empty string maps to itself.
+func mapFirstRune(s string, f func(rune) rune) string {
+	if s == "" {
+		return s
+	}
+	r, size := utf8.DecodeRuneInString(s)
+	return string(f(r)) + s[size:]
+}
+
 // strLitName returns the property name a string-literal index selects, and false for any other
 // type. Object keys are strings, so only a StrLit names a member.
 func strLitName(t soltype.Type) (string, bool) {
@@ -913,12 +1072,14 @@ func strLitName(t soltype.Type) (string, bool) {
 	return "", false
 }
 
-// isResidualOp reports whether t is an unreduced type-level operator node — a `keyof`, an indexed
-// access, a conditional, or a `...P` tuple-spread element — at its top level. The evaluator consults
-// it to stop re-reducing an operand whose reduction stayed symbolic.
+// isResidualOp reports whether t is an unreduced type-level operator node at its top level — a
+// `keyof`, an indexed access, a conditional, a `...P` tuple-spread element, a template literal whose
+// interpolation stayed abstract, or an intrinsic string operator over an abstract operand. The
+// evaluator consults it to stop re-reducing an operand whose reduction stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType,
+		*soltype.TemplateLitType, *soltype.StringMappingType:
 		return true
 	}
 	return false

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -958,19 +958,18 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 	combos := cartesianProduct(interpChoices)
 	parts := make([]soltype.Type, 0, len(combos))
 	for _, combo := range combos {
-		parts = append(parts, buildTemplatePart(t.Quasis, combo))
+		parts = append(parts, foldTemplatePart(t.Quasis, combo))
 	}
 	return newUnion(nil, parts, false)
 }
 
-// buildTemplatePart assembles one cartesian-product combination into a single template result.
-// It interleaves the fixed segments with the combination's interpolations: a string-representable
-// literal folds into the surrounding text, while any other interpolation closes the accumulated
-// segment and carries through as a residual interpolation. A combination whose interpolations all
-// fold collapses to a lone string-literal type; one carrying an abstract interpolation stays a
-// `TemplateLitType`. Quasis holds one more entry than the combination, so the loop reads
-// combo[i] between quasi i and quasi i+1.
-func buildTemplatePart(quasis []string, combo []soltype.Type) soltype.Type {
+// foldTemplatePart folds one cartesian-product combination into a single template result. It
+// interleaves the fixed segments with that combination's interpolation values: a string-representable
+// literal folds into the surrounding text, while any other value closes the accumulated segment and
+// carries through as a residual interpolation. A combination whose values all fold collapses to a
+// lone string-literal type; one carrying an abstract value stays a `TemplateLitType`. Quasis holds
+// one more entry than interpValues, so the loop reads interpValues[i] between quasi i and quasi i+1.
+func foldTemplatePart(quasis []string, interpValues []soltype.Type) soltype.Type {
 	newQuasis := []string{}
 	newInterps := []soltype.Type{}
 	current := ""
@@ -981,16 +980,16 @@ func buildTemplatePart(quasis []string, combo []soltype.Type) soltype.Type {
 		// abstract branch resets current to "", or on the first iteration, this starts a fresh
 		// segment instead.
 		current += quasi
-		if i >= len(combo) {
+		if i >= len(interpValues) {
 			continue
 		}
-		if s, ok := stringifyLit(combo[i]); ok {
+		if s, ok := stringifyLit(interpValues[i]); ok {
 			current += s
 			continue
 		}
 		newQuasis = append(newQuasis, current)
 		current = ""
-		newInterps = append(newInterps, combo[i])
+		newInterps = append(newInterps, interpValues[i])
 	}
 	newQuasis = append(newQuasis, current)
 	if len(newInterps) == 0 {

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -103,8 +103,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return e.reduceObject(t)
 	case *soltype.TemplateLitType:
 		return e.reduceTemplateLit(t)
-	case *soltype.StringMappingType:
-		return e.reduceStringMapping(t.Kind, t.Operand)
+	case *soltype.StringIntrinsicType:
+		return e.reduceStringIntrinsic(t.Kind, t.Operand)
 	default:
 		return t
 	}
@@ -395,7 +395,7 @@ func (e *typeEvaluator) groundTuple(t *soltype.TupleType) (*soltype.TupleType, b
 // interpolation `Dir` over `type Dir = "a" | "b"` grounds to the referenced union. A type parameter,
 // a recurring alias state, an exhausted budget, or an unresolved alias body each leaves the operand
 // unexpanded, which keeps the enclosing operator symbolic. The tuple-spread, template-literal, and
-// string-mapping reductions share it.
+// string-intrinsic reductions share it.
 func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 	reduced := e.reduce(operand)
 	alias, ok := reduced.(*soltype.AliasType)
@@ -1038,32 +1038,32 @@ func stringifyLit(t soltype.Type) (string, bool) {
 	return "", false
 }
 
-// reduceStringMapping reduces an intrinsic string operator such as `Uppercase<T>` over its operand.
+// reduceStringIntrinsic reduces an intrinsic string operator such as `Uppercase<T>` over its operand.
 // A string-literal operand maps to the transformed literal — `Uppercase<"abc">` ⇒ `"ABC"` — and a
 // union operand distributes member-wise, so `Uppercase<"a" | "b">` ⇒ `"A" | "B"`. The operand is
 // first grounded, so a named alias expands to its body. An operand that is not a string literal,
-// such as a type parameter, keeps the operator symbolic as a `StringMappingType` rebuilt around the
+// such as a type parameter, keeps the operator symbolic as a `StringIntrinsicType` rebuilt around the
 // grounded operand.
-func (e *typeEvaluator) reduceStringMapping(kind soltype.StringMappingKind, operand soltype.Type) soltype.Type {
+func (e *typeEvaluator) reduceStringIntrinsic(kind soltype.StringIntrinsicKind, operand soltype.Type) soltype.Type {
 	reduced := e.groundOperand(operand)
 	switch op := reduced.(type) {
 	case *soltype.UnionType:
 		parts := make([]soltype.Type, len(op.Types))
 		for i, m := range op.Types {
-			parts[i] = e.reduceStringMapping(kind, m)
+			parts[i] = e.reduceStringIntrinsic(kind, m)
 		}
 		return newUnion(nil, parts, false)
 	case *soltype.LitType:
 		if s, ok := op.Lit.(*soltype.StrLit); ok {
-			return strLitType(applyStringMapping(kind, s.Value))
+			return strLitType(applyStringIntrinsic(kind, s.Value))
 		}
 	}
-	return &soltype.StringMappingType{Kind: kind, Operand: reduced}
+	return &soltype.StringIntrinsicType{Kind: kind, Operand: reduced}
 }
 
-// applyStringMapping transforms one string by the named intrinsic operator. Uppercase and Lowercase
+// applyStringIntrinsic transforms one string by the named intrinsic operator. Uppercase and Lowercase
 // map every character; Capitalize and Uncapitalize map only the first, leaving the rest unchanged.
-func applyStringMapping(kind soltype.StringMappingKind, s string) string {
+func applyStringIntrinsic(kind soltype.StringIntrinsicKind, s string) string {
 	switch kind {
 	case soltype.Uppercase:
 		return strings.ToUpper(s)
@@ -1105,7 +1105,7 @@ func strLitName(t soltype.Type) (string, bool) {
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType,
-		*soltype.TemplateLitType, *soltype.StringMappingType:
+		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return true
 	}
 	return false

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -921,9 +921,9 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, e
 }
 
 // reduceTemplateLit reduces a template literal to the union of string literals its interpolations
-// produce, taking the cartesian product over each interpolation's options. Each interpolation, and
+// produce, taking the cartesian product over each interpolation's choices. Each interpolation, and
 // each member of an interpolation that grounds to a union, is grounded so a named alias expands to
-// its body. A grounded interpolation that is a union contributes each member as an option, so
+// its body. A grounded interpolation that is a union contributes each member as a choice, so
 // `on${"a" | "b"}` yields `"ona" | "onb"`, while any other grounded interpolation contributes
 // itself. Each product combination folds its string-literal interpolations into the surrounding
 // segments; a combination whose interpolation stays abstract — a type parameter, or a nested
@@ -931,7 +931,7 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, e
 // so the whole template reduces later once the interpolation grounds. A product that would exceed
 // maxTemplateLitCombinations is rejected with a diagnostic rather than materialized.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
-	options := make([][]soltype.Type, len(t.Interps))
+	interpChoices := make([][]soltype.Type, len(t.Interps))
 	combinations := 1
 	for i, interp := range t.Interps {
 		reduced := e.groundOperand(interp)
@@ -943,11 +943,11 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 			for j, m := range u.Types {
 				members[j] = e.groundOperand(m)
 			}
-			options[i] = members
+			interpChoices[i] = members
 		} else {
-			options[i] = []soltype.Type{reduced}
+			interpChoices[i] = []soltype.Type{reduced}
 		}
-		combinations *= len(options[i])
+		combinations *= len(interpChoices[i])
 		if combinations > maxTemplateLitCombinations {
 			// The product would enumerate more string literals than the cap allows. Reject the
 			// template with one diagnostic rather than materializing an unbounded union.
@@ -955,7 +955,7 @@ func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Ty
 			return &soltype.ErrorType{}
 		}
 	}
-	combos := cartesianProduct(options)
+	combos := cartesianProduct(interpChoices)
 	parts := make([]soltype.Type, 0, len(combos))
 	for _, combo := range combos {
 		parts = append(parts, buildTemplatePart(t.Quasis, combo))
@@ -994,19 +994,19 @@ func buildTemplatePart(quasis []string, combo []soltype.Type) soltype.Type {
 	return &soltype.TemplateLitType{Quasis: newQuasis, Interps: newInterps}
 }
 
-// cartesianProduct returns every combination that picks one option from each position, so the
-// template reducer can enumerate `${A}${B}` over unions A and B. An empty options list — a
+// cartesianProduct returns every combination that picks one choice from each position, so the
+// template reducer can enumerate `${A}${B}` over unions A and B. An empty choice list — a
 // template with no interpolations — yields one empty combination, so a bare `abc` collapses
 // to the single literal `"abc"`.
-func cartesianProduct(options [][]soltype.Type) [][]soltype.Type {
+func cartesianProduct(interpChoices [][]soltype.Type) [][]soltype.Type {
 	result := [][]soltype.Type{{}}
-	for _, opts := range options {
-		next := make([][]soltype.Type, 0, len(result)*len(opts))
+	for _, choices := range interpChoices {
+		next := make([][]soltype.Type, 0, len(result)*len(choices))
 		for _, combo := range result {
-			for _, opt := range opts {
+			for _, choice := range choices {
 				extended := make([]soltype.Type, len(combo)+1)
 				copy(extended, combo)
-				extended[len(combo)] = opt
+				extended[len(combo)] = choice
 				next = append(next, extended)
 			}
 		}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -18,6 +18,12 @@ import (
 // operator over the unexpanded alias stays symbolic.
 const maxExpandDepth = 200
 
+// maxTemplateLitCombinations caps how many string literals a template literal may reduce to. Its
+// cartesian product over interpolated unions grows multiplicatively, so `${A}${B}${C}` over three
+// large unions could enumerate an unbounded union. The cap rejects such a template with a
+// diagnostic rather than materializing the product.
+const maxTemplateLitCombinations = 10_000
+
 // typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T`, indexed
 // access `T[K]`, the conditional `if C : E { … } else { … }`, template literals, and the intrinsic
 // string operators such as `Uppercase<T>`; later operators join as they land. Only constrain invokes
@@ -915,22 +921,38 @@ func (e *typeEvaluator) indexTuple(tup *soltype.TupleType, index soltype.Type, e
 }
 
 // reduceTemplateLit reduces a template literal to the union of string literals its interpolations
-// produce, taking the cartesian product over each interpolation's options. Each interpolation is
-// first grounded, so a named alias expands to its body. A grounded interpolation that is a union
-// contributes each member as an option, so `on${"a" | "b"}` yields `"ona" | "onb"`, while any
-// other grounded interpolation contributes itself. Each product combination folds its
-// string-literal interpolations into the surrounding segments; a combination whose interpolation
-// stays abstract — a type parameter, or a nested operator the evaluator could not ground — keeps
-// that interpolation and stays a `TemplateLitType`, so the whole template reduces later once the
-// interpolation grounds.
+// produce, taking the cartesian product over each interpolation's options. Each interpolation, and
+// each member of an interpolation that grounds to a union, is grounded so a named alias expands to
+// its body. A grounded interpolation that is a union contributes each member as an option, so
+// `on${"a" | "b"}` yields `"ona" | "onb"`, while any other grounded interpolation contributes
+// itself. Each product combination folds its string-literal interpolations into the surrounding
+// segments; a combination whose interpolation stays abstract — a type parameter, or a nested
+// operator the evaluator could not ground — keeps that interpolation and stays a `TemplateLitType`,
+// so the whole template reduces later once the interpolation grounds. A product that would exceed
+// maxTemplateLitCombinations is rejected with a diagnostic rather than materialized.
 func (e *typeEvaluator) reduceTemplateLit(t *soltype.TemplateLitType) soltype.Type {
 	options := make([][]soltype.Type, len(t.Interps))
+	combinations := 1
 	for i, interp := range t.Interps {
 		reduced := e.groundOperand(interp)
 		if u, ok := reduced.(*soltype.UnionType); ok {
-			options[i] = u.Types
+			// Ground each union member too, so a reducible member — an alias to a literal, or a
+			// nested operator such as `keyof O` — collapses to its string literal before the product
+			// rather than surviving as a residual interpolation.
+			members := make([]soltype.Type, len(u.Types))
+			for j, m := range u.Types {
+				members[j] = e.groundOperand(m)
+			}
+			options[i] = members
 		} else {
 			options[i] = []soltype.Type{reduced}
+		}
+		combinations *= len(options[i])
+		if combinations > maxTemplateLitCombinations {
+			// The product would enumerate more string literals than the cap allows. Reject the
+			// template with one diagnostic rather than materializing an unbounded union.
+			e.errs = append(e.errs, &TemplateLitTooComplexError{Template: t})
+			return &soltype.ErrorType{}
 		}
 	}
 	combos := cartesianProduct(options)


### PR DESCRIPTION
Implement residual type operators for template literals and intrinsic string transformations, enabling type-level string manipulation in the solver.

**Summary**

This PR adds two new residual type operators to the type system:
- Template literal types like `` `on${T}` `` that reduce to unions of string literals by taking the cartesian product over interpolations
- Intrinsic string operators (`Uppercase`, `Lowercase`, `Capitalize`, `Uncapitalize`) that transform string-literal operands

Both operators store their unreduced form for display and annotation, reducing only when constrain checks a constraint against them. This mirrors the existing behavior of `keyof` and indexed access operators.

**Key changes**

- Added `TemplateLitType` and `StringMappingType` to the type representation, with corresponding AST support for template literal type annotations
- Implemented reduction logic in `typeEvaluator` to handle template literals (cartesian product over interpolations) and string mappings (character transformation with union distribution)
- Extended the type visitor and printer to handle the new operators, keeping them symbolic in signatures and annotations
- Added constraint checking support so ground template literals and string mappings reduce to their concrete values for validation
- Refactored `groundSpreadOperand` to the more general `groundOperand` to support operand grounding across tuple spreads, template interpolations, and string-mapping operands
- Registered the four string intrinsics in the type resolver so `Uppercase<T>` references resolve to `StringMappingType` residuals (user-defined types of the same name take precedence)

**Implementation details**

Template literal reduction uses `cartesianProduct` to enumerate all combinations of interpolation options, then `buildTemplatePart` folds string-literal interpolations into surrounding segments. Non-literal interpolations (type parameters, nested operators) keep the template symbolic.

String mapping reduction distributes over union operands member-wise and applies character transformations (`strings.ToUpper`, `mapFirstRune` for capitalize/uncapitalize) to string literals.

Both operators are inert in the structural type machinery—they flow through unchanged during unification and only reduce when explicitly evaluated by constrain.

https://claude.ai/code/session_01MVDvhUXp71BV5nkqHoVLLm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for template literal types in type annotations, inference, reduction, and diagnostics.
  * Added intrinsic string utilities: `Uppercase`, `Lowercase`, `Capitalize`, and `Uncapitalize`.
  * Template literals and string utilities now reduce over literal and union values while remaining symbolic when unresolved.
  * Improved constraint checking and error messages for these type-level string operations.

* **Tests**
  * Added coverage for reductions, unions, nested operations, constraints, and user-defined types that share intrinsic names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->