### PR TITLE
Implement infer clause capture in conditional types

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -24,7 +24,7 @@ const (
 
 // typePrec returns the printing precedence of a coalesced M1 type.
 func typePrec(t Type) int {
-	switch t.(type) {
+	switch t := t.(type) {
 	case *FuncType:
 		return precFunc
 	case *UnionType:
@@ -45,6 +45,13 @@ func typePrec(t Type) int {
 		// `if C : E { T } else { E }` is self-delimiting — the leading `if` and trailing `}` bound
 		// it — so it binds like an atom and never needs outer parens, matching type_system's
 		// CondType rendering.
+		return precAtom
+	case *InferType:
+		// The `infer U` binder leads with a keyword, so it binds like the other prefixes. A
+		// reference to that name renders as the bare `U`, an atom.
+		if t.Binder {
+			return precPrefix
+		}
 		return precAtom
 	case *RestSpreadType:
 		// A `...P` spread element only appears inside a tuple's bracket list, which prints each
@@ -654,6 +661,14 @@ func (p *namedPrinter) printType(t Type) string {
 		// neighbor and none needs parens.
 		return "if " + p.printType(t.Check) + " : " + p.printType(t.Extends) +
 			" { " + p.printType(t.Then) + " } else { " + p.printType(t.Else) + " }"
+	case *InferType:
+		// The binder renders `infer U`, the clause the source wrote in the Extends operand, and a
+		// reference to that name renders as the bare `U`, so a stored conditional round-trips to
+		// `if T : [infer U] { U } else { boolean }`.
+		if t.Binder {
+			return "infer " + t.Name
+		}
+		return t.Name
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -682,17 +682,24 @@ type CondType struct {
 	Distribute bool
 }
 
-// InferType is the `infer U` name a conditional's Extends operand introduces, and the reference to
-// that name from the conditional's Then branch. Binder tells the two apart: the `infer U` clause in
-// `if T : [infer U] { U } else { boolean }` resolves to an InferType with Binder set, while the `U` in
-// the Then branch resolves to one without it. The evaluator's structural matcher walks Check against
-// Extends, records the type at each binder's position, and substitutes those captures for both forms
-// before it reduces the selected branch, so a stored conditional prints `if T : [infer U] { U } else
-// { boolean }` the way the source wrote it.
+// InferType is the `infer U` clause a conditional's Extends operand declares, and the reference to
+// that name from the conditional's Then branch. The evaluator's structural matcher walks Check
+// against Extends, records the type at each clause's position, and substitutes those captures before
+// it reduces the selected branch.
 //
-// It is a leaf with no bounds, and nothing constrains against it. A conditional carrying an
-// unsubstituted binder has not decided its branch, so the whole conditional is still inert.
+// ID is the declaration the two forms share. The clause and every reference to it carry one id, so
+// substituting a captured type reaches exactly the positions that declaration stands at. A nested
+// conditional writing the same name draws a distinct id, which is what makes its clause and
+// references a separate declaration that shadows the enclosing one.
+//
+// Name is the source name, carried for display. Binder marks the declaring clause, which renders
+// `infer U` where a reference renders the bare `U`, so a stored conditional prints
+// `if T : [infer U] { U } else { boolean }` the way the source wrote it.
+//
+// It is a leaf with no bounds, and nothing constrains against it. A conditional whose captures no
+// match has filled has not decided its branch, so the whole conditional is still inert.
 type InferType struct {
+	ID     int
 	Name   string
 	Binder bool
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -700,9 +700,9 @@ type CondType struct {
 }
 
 // InferType is the `infer U` clause a conditional's Extends operand declares, and the reference to
-// that name from the conditional's Then branch. The evaluator's structural matcher walks Check
-// against Extends, records the type at each clause's position, and substitutes those captures before
-// it reduces the selected branch.
+// that name from the conditional's Then branch. The evaluator stands a fresh inference variable in
+// for each clause, lets the `Check <: Extends` constraint infer what that variable holds, and
+// substitutes the result before it reduces the selected branch.
 //
 // ID is the declaration the two forms share. The clause and every reference to it carry one id, so
 // substituting a captured type reaches exactly the positions that declaration stands at. A nested

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -662,16 +662,39 @@ type TypeofType struct {
 // CondType is the residual `if Check : Extends { Then } else { Else }` conditional type operator.
 // Like KeyofType it is inert: it carries no bounds, constrain never records one against it, and it
 // flows through the solver's structural machinery untouched, rendering the way the source wrote it.
-// An evaluator reduces it once Check and Extends are ground, reusing the M9 PR1b machinery. It
-// decides `Check <: Extends` with an assignability probe and reduces to Then on success or Else on
-// failure. Until then a conditional over a type parameter stays symbolic. The `infer` clause in
-// Extends and distribution over a naked type-parameter union are M9 PR3b, so a Check that is a bare
-// type parameter keeps the whole conditional symbolic here.
+// An evaluator reduces it once Check and Extends are ground. It decides `Check <: Extends` with an
+// assignability probe and reduces to Then on success or Else on failure. Until then a conditional
+// over a type parameter stays symbolic.
+//
+// An Extends carrying an `infer U` binder is matched structurally against Check first, so each
+// binder captures the type at its position and the Then branch reads those captures. See InferType.
 type CondType struct {
 	Check   Type
 	Extends Type
 	Then    Type
 	Else    Type
+	// Distribute marks a conditional whose Check was written as a bare type-parameter reference,
+	// such as the `T` of `type Wrap<T> = if T : string { [T] } else { boolean }`. Such a conditional
+	// distributes over a union Check, deciding each member separately and unioning the results, so
+	// `Wrap<"a" | 1>` reduces to `["a"] | boolean` rather than to the single branch the whole union
+	// selects. A Check written as anything else, `[T]` included, decides the union as a whole, which
+	// is how a user opts out of distribution. It mirrors TypeScript's naked-type-parameter rule.
+	Distribute bool
+}
+
+// InferType is the `infer U` name a conditional's Extends operand introduces, and the reference to
+// that name from the conditional's Then branch. Binder tells the two apart: the `infer U` clause in
+// `if T : [infer U] { U } else { boolean }` resolves to an InferType with Binder set, while the `U` in
+// the Then branch resolves to one without it. The evaluator's structural matcher walks Check against
+// Extends, records the type at each binder's position, and substitutes those captures for both forms
+// before it reduces the selected branch, so a stored conditional prints `if T : [infer U] { U } else
+// { boolean }` the way the source wrote it.
+//
+// It is a leaf with no bounds, and nothing constrains against it. A conditional carrying an
+// unsubstituted binder has not decided its branch, so the whole conditional is still inert.
+type InferType struct {
+	Name   string
+	Binder bool
 }
 
 // RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
@@ -691,6 +714,7 @@ func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
 func (*CondType) isType()         {}
+func (*InferType) isType()        {}
 func (*RestSpreadType) isType()   {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -820,7 +844,9 @@ func LevelOf(t Type) int {
 		return maxMemberLevel(t.Types)
 	default:
 		// PrimType, LitType, Void, NullType, UndefinedType, NeverType, UnknownType,
-		// ErrorType: childless leaves. ErrorType is a sentinel at level 0.
+		// ErrorType, InferType: childless leaves. ErrorType is a sentinel at level 0, and an
+		// InferType names a capture the evaluator substitutes rather than a variable the solver
+		// generalizes, so neither lifts the level.
 		return 0
 	}
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -674,11 +674,28 @@ type CondType struct {
 	Then    Type
 	Else    Type
 	// Distribute marks a conditional whose Check was written as a bare type-parameter reference,
-	// such as the `T` of `type Wrap<T> = if T : string { [T] } else { boolean }`. Such a conditional
-	// distributes over a union Check, deciding each member separately and unioning the results, so
-	// `Wrap<"a" | 1>` reduces to `["a"] | boolean` rather than to the single branch the whole union
-	// selects. A Check written as anything else, `[T]` included, decides the union as a whole, which
-	// is how a user opts out of distribution. It mirrors TypeScript's naked-type-parameter rule.
+	// such as the `T` of `type Wrap<T> = if T : string { [T] } else { boolean }`. It mirrors
+	// TypeScript's naked-type-parameter rule, stated here in full since two separate conditions
+	// decide whether a union Check is taken apart, and both must hold:
+	//
+	//  1. The Check was written as a bare parameter name, which is what this flag records. Every
+	//     other written form leaves it clear, `[T]`, `{value: T}`, and `Other<T>` alike.
+	//  2. The Check reduced to a union. A conditional over a single type has nothing to take apart,
+	//     so the flag on its own changes no reduction.
+	//
+	// When both hold, the conditional decides one member at a time and unions the results. Every
+	// position that named the parameter reads the member rather than the whole union, the Extends
+	// operand and both branches alike, so `Wrap<"a" | 1>` reduces to `["a"] | boolean`.
+	//
+	// When either fails, the conditional decides once over the whole union. That is how a user
+	// captures a union as a single type: `if [T] : [infer U] { [U] } else { "no" }` binds U to the
+	// whole union and yields `[1 | "a"]` for `"a" | 1`, where the same alias written `if T : [infer
+	// U]` over `["a"] | [1]` binds U per member and yields `[1] | ["a"]`.
+	//
+	// A body that needs both a Check it cannot write bare and distribution can wrap itself in
+	// `if T : T { … } else { … }`, whose own Check is bare. The wrapper distributes and each member
+	// runs the inner conditional on its own. Its Else branch is unreachable, since a member is
+	// always a subtype of itself.
 	Distribute bool
 }
 

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -84,6 +84,7 @@ func (t *NeverType) Accept(v TypeVisitor, pol Polarity) Type     { return accept
 func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return acceptLeaf(t, v, pol) }
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
+func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
@@ -233,7 +234,7 @@ func (t *CondType) Accept(v TypeVisitor, pol Polarity) Type {
 	els := cur.Else.Accept(v, pol)
 	out := cur
 	if check != cur.Check || extends != cur.Extends || then != cur.Then || els != cur.Else {
-		out = &CondType{Check: check, Extends: extends, Then: then, Else: els}
+		out = &CondType{Check: check, Extends: extends, Then: then, Else: els, Distribute: cur.Distribute}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1132,9 +1132,17 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	case *soltype.CondType:
 		// Two inert conditional residuals are equal when all four operands are equal, compared
 		// structurally without deciding either branch, the four-child analogue of the KeyofType arm.
+		// Distribute must match too: it changes what a union Check reduces to, so a distributive
+		// conditional is a different type from an otherwise identical non-distributive one.
 		b, ok := b.(*soltype.CondType)
-		return ok && equalTypeWith(a.Check, b.Check, ctx) && equalTypeWith(a.Extends, b.Extends, ctx) &&
+		return ok && a.Distribute == b.Distribute &&
+			equalTypeWith(a.Check, b.Check, ctx) && equalTypeWith(a.Extends, b.Extends, ctx) &&
 			equalTypeWith(a.Then, b.Then, ctx) && equalTypeWith(a.Else, b.Else, ctx)
+	case *soltype.InferType:
+		// Two `infer` nodes are equal when they name the same capture in the same role, so a binder
+		// never equals a reference to the name it introduces.
+		b, ok := b.(*soltype.InferType)
+		return ok && a.Name == b.Name && a.Binder == b.Binder
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -828,6 +828,12 @@ type alphaCtx struct {
 	// the common lifetime-param-free case allocates nothing.
 	ltpAToB map[int]int
 	ltpBToA map[int]int
+	// inferAToB and inferBToA pair the `infer` declarations of two conditionals, bound when a pair
+	// of declaring clauses meets rather than at a declaration list, since a clause sits at an
+	// arbitrary depth inside an Extends operand. They start nil and allocate on the first pairing,
+	// so a comparison over types carrying no conditional allocates nothing.
+	inferAToB map[int]int
+	inferBToA map[int]int
 }
 
 // bindTypeParams pairs two generic FuncTypes' type parameters positionally, so every
@@ -858,6 +864,33 @@ func (ctx *alphaCtx) sameTypeVar(a, b *soltype.TypeVarType) bool {
 		return false // b is a bound parameter, a is not — mismatch
 	}
 	return a == b
+}
+
+// sameInferDecl reports whether two `infer` nodes stand for corresponding declarations. Meeting a
+// pair of declaring clauses records the correspondence, the way bindTypeParams records a function's
+// parameters, and every later reference is checked against it. Two conditionals resolved separately
+// from the same source therefore compare equal even though each drew its own declaration id, which
+// is what lets `fn (k: if T : [infer U] { U } else { X }) -> if T : [infer U] { U } else { X }`
+// accept `return k`. A reference reached with no correspondence recorded — a branch compared on its
+// own, away from the conditional that declares its names — falls back to id equality, the rule
+// sameTypeVar applies to a variable bound on neither side.
+func (ctx *alphaCtx) sameInferDecl(a, b *soltype.InferType) bool {
+	if j, ok := ctx.inferAToB[a.ID]; ok {
+		return j == b.ID
+	}
+	if _, ok := ctx.inferBToA[b.ID]; ok {
+		return false // b's declaration corresponds to some other declaration on a's side
+	}
+	if !a.Binder {
+		return a.ID == b.ID
+	}
+	if ctx.inferAToB == nil {
+		ctx.inferAToB = map[int]int{}
+		ctx.inferBToA = map[int]int{}
+	}
+	ctx.inferAToB[a.ID] = b.ID
+	ctx.inferBToA[b.ID] = a.ID
+	return true
 }
 
 // bindLifetimeParams pairs two generic FuncTypes' lifetime parameters positionally, the
@@ -1139,10 +1172,12 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 			equalTypeWith(a.Check, b.Check, ctx) && equalTypeWith(a.Extends, b.Extends, ctx) &&
 			equalTypeWith(a.Then, b.Then, ctx) && equalTypeWith(a.Else, b.Else, ctx)
 	case *soltype.InferType:
-		// Two `infer` nodes are equal when they name the same capture in the same role, so a binder
-		// never equals a reference to the name it introduces.
+		// Two `infer` nodes are equal when they play the same role — a declaring clause never equals
+		// a reference to the name it declares — and their declarations correspond under the pairing
+		// sameInferDecl builds. The names themselves are not compared, the same way two functions'
+		// type parameters compare by position rather than by name.
 		b, ok := b.(*soltype.InferType)
-		return ok && a.Name == b.Name && a.Binder == b.Binder
+		return ok && a.Binder == b.Binder && ctx.sameInferDecl(a, b)
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -163,6 +163,17 @@ func (c *Context) freshSkolem(name string) *soltype.SkolemType {
 	return s
 }
 
+// freshInferDecl mints the declaration one `infer U` clause introduces, carrying the source name for
+// display. It draws from the same counter as freshVar so every declaration has a unique id, which is
+// what keeps a nested conditional's `infer U` distinct from the enclosing conditional's clause of the
+// same name. The node it returns is the reference form, which resolveCondTypeAnn binds in the scope
+// the branches read; the clause itself copies the id onto a binder.
+func (c *Context) freshInferDecl(name string) *soltype.InferType {
+	t := &soltype.InferType{ID: c.varCounter, Name: name}
+	c.varCounter++
+	return t
+}
+
 // freshLifetime allocates a new lifetime variable at the given level, assigning it
 // the next id in sequence. Lifetimes now ride the same let-generalization level
 // hierarchy as types (M4 D2.5): a lifetime minted inside its scheme's

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1808,6 +1808,14 @@ func describe(t soltype.Type) string {
 		// than the default `?`. Every operand renders in describe's raw mid-constrain form.
 		return "if " + describe(t.Check) + " : " + describe(t.Extends) +
 			" { " + describe(t.Then) + " } else { " + describe(t.Else) + " }"
+	case *soltype.InferType:
+		// An `infer U` binder renders with its keyword and a reference to the name renders bare, the
+		// same split the printer makes, so a rejected constraint over a conditional carrying a
+		// capture reads the way the source wrote it.
+		if t.Binder {
+			return "infer " + t.Name
+		}
+		return t.Name
 	case *soltype.RestSpreadType:
 		// A `...P` spread element renders `...` over its operand, reached in place when the
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -76,6 +76,13 @@ type checker struct {
 	// namespace-qualified name, so this reconstructs the qualified key a bare reference
 	// omits.
 	classNamespace string
+
+	// inCondExtends is set while resolveCondTypeAnn resolves a conditional's Extends operand, the
+	// one position an `infer U` clause may appear in. resolveTypeAnn's InferTypeAnn arm consults it
+	// to tell a binder from a stray `infer` elsewhere in an annotation, which it rejects. It is
+	// saved and restored around each operand, so an `infer` in a nested conditional's Then branch is
+	// rejected even though the outer Extends is still being walked.
+	inCondExtends bool
 }
 
 // fieldKey identifies a written field by the receiver variable's ID and the

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1663,6 +1663,19 @@ func TestInferCondRecursiveCaptureAlias(t *testing.T) {
 			`,
 			wantErr: `cannot constrain "hi" <: number`,
 		},
+		{
+			// A branch that re-wraps the capture reaches the same instantiation every lap, so it
+			// never shrinks toward the Else branch. It terminates on constrain's cycle-detection
+			// set instead: an alias operand is compared under an interned canonical representative,
+			// so the repeated `5 <: Same<[number]>` state closes the cycle and the constraint is
+			// accepted. The point of the case is termination, not the type the closed cycle admits.
+			// CheckRegular will reject the definition itself in a later milestone.
+			name: "SameSizeRecursionTerminates",
+			src: `
+				type Same<T> = if T : [infer U] { Same<[U]> } else { T }
+				val x: Same<[number]> = 5
+			`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1675,4 +1688,32 @@ func TestInferCondRecursiveCaptureAlias(t *testing.T) {
 			require.Equal(t, tt.wantErr, errs[0].Message())
 		})
 	}
+}
+
+// A nested conditional that binds a name its enclosing conditional already captured shadows it: the
+// inner Then branch reads the inner capture, and the inner binder is filled by the inner match
+// rather than by the outer one. Without shadowing the outer `U` would replace both the inner binder
+// and the inner reference, turning the inner pattern into `[number]`, which `[string]` fails to
+// match, so the case would take the inner Else branch and reduce to `boolean`.
+func TestInferCondNestedCaptureShadowsOuter(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Result = if [number] : [infer U] {
+			if [string] : [infer U] { U } else { boolean }
+		} else { boolean }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "string", soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+}
+
+// A conditional whose Check names a type that does not resolve recovers that operand to a fresh var,
+// and the recovery must not be read as a type parameter: the conditional is not distributive, so a
+// union reaching the Check position later would decide as a whole. The annotation reports the
+// unresolved name once and keeps the conditional shape.
+func TestInferCondUnresolvedCheckIsNotDistributive(t *testing.T) {
+	nodes, _, errs := inferTypeNodes(t, `type Result = if Bogus : string { number } else { boolean }`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+	cond, ok := nodes["Result"].(*soltype.CondType)
+	require.True(t, ok)
+	require.False(t, cond.Distribute)
 }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1729,3 +1729,19 @@ func TestInferCondUnresolvedCheckIsNotDistributive(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, cond.Distribute)
 }
+
+// Two conditionals resolved separately from the same source denote the same type, so a value of one
+// satisfies the other and `return k` is accepted. Each resolution declares its own identity for the
+// `infer` name, so equality pairs the two declarations where their clauses meet rather than
+// comparing the identities directly, the same way two functions' type parameters pair by position.
+func TestInferCondSeparateResolutionsAreEqual(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f<T>(k: if T : [infer U] { U } else { boolean }) -> if T : [infer U] { U } else { boolean } {
+			return k
+		}
+	`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <T>(k: if T : [infer U] { U } else { boolean }) -> if T : [infer U] { U } else { boolean }",
+		values["f"])
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1997,3 +1997,60 @@ func TestInferCondDistributionIntoBranchAlias(t *testing.T) {
 		})
 	}
 }
+
+// The capture for an `infer` declaration is whatever the `Check <: Extends` constraint inferred for
+// it, so the position it sits in decides how several matched types combine and what an unmatched one
+// yields. Each expectation matches TypeScript's reduction of the equivalent conditional.
+func TestInferCondCaptureFromConstraint(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// A covariant position collects the matched types as lower bounds, so two of them union.
+			name:         "CovariantCandidatesUnion",
+			src:          `type Result = if [number, string] : [infer U, infer U] { [U] } else { "no" }`,
+			wantExpanded: `[number | string]`,
+		},
+		{
+			// A function parameter is contravariant, so its candidates collect as upper bounds and
+			// meet instead.
+			name: "ContravariantCandidatesMeet",
+			src: `
+				type F = fn (x: {a: number}, y: {b: string}) -> boolean
+				type P2<T> = if T : fn (x: infer P, y: infer P) -> boolean { [P] } else { "no" }
+				type Result = P2<F>
+			`,
+			wantExpanded: `[{a: number} & {b: string}]`,
+		},
+		{
+			// An optional property the Check does not carry leaves its capture unconstrained, so the
+			// constraint holds and the capture is `unknown`.
+			name:         "UnconstrainedCaptureIsUnknown",
+			src:          `type Result = if {} : {a?: infer U, ...} { [U] } else { "no" }`,
+			wantExpanded: `[unknown]`,
+		},
+		{
+			// A union pattern is decided by constrain's union arm: `"a" <: number` fails, so the
+			// remaining arm takes the capture.
+			name:         "UnionPatternCaptures",
+			src:          `type Result = if "a" : number | infer U { [U] } else { "no" }`,
+			wantExpanded: `["a"]`,
+		},
+		{
+			// An intersection Check is decomposed by constrain too, so a pattern reads a member off
+			// whichever operand carries it.
+			name:         "IntersectionCheckCaptures",
+			src:          `type Result = if {a: number} & {b: string} : {a: infer A, ...} { [A] } else { "no" }`,
+			wantExpanded: `[number]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1855,6 +1855,12 @@ func TestInferCondAliasComposition(t *testing.T) {
 // and composed aliases included. A member selected at the outer conditional is the member the inner
 // one decides on, and an alias whose own Check is a naked parameter distributes inside its own
 // reduction. Each expectation matches TypeScript's reduction of the same chain.
+//
+// An alias that needs to distribute over a Check it cannot write nakedly can wrap its body in
+// `if T : T { … } else { … }`, the TypeScript idiom for forcing distribution. That outer Check is a
+// naked parameter, so it distributes, and each member then runs through the body on its own. Its
+// Else branch is unreachable, since a member is always a subtype of itself, so the type written
+// there never reaches the result.
 func TestInferCondDistributionThroughNesting(t *testing.T) {
 	const aliases = `
 		type IsStr<T> = if T : string { "y" } else { "n" }
@@ -1907,6 +1913,37 @@ func TestInferCondDistributionThroughNesting(t *testing.T) {
 			name:         "ThreeAliasesDeepWithUnion",
 			src:          aliases + `type Result = Outer<string | number>`,
 			wantExpanded: `"outer-other"`,
+		},
+		{
+			// Wrapping the previous case's body in `if T : T` gives it a naked Check, so each member
+			// runs the alias-check test on its own: `IsStr<string>` yields "y" and `IsStr<number>`
+			// yields "n", selecting a different branch per member instead of one branch for the union.
+			name: "ForcedDistributionOverAliasCheck",
+			src: aliases + `
+				type LabelF<T> = if T : T { if IsStr<T> : "y" { "text" } else { "other" } } else { "unreachable" }
+				type Result = LabelF<string | number>
+			`,
+			wantExpanded: `"other" | "text"`,
+		},
+		{
+			// The same idiom over a tuple-wrapped Check, which does not distribute on its own. Forcing
+			// it turns the single `["a" | "b"]` the union yields into one tuple per member.
+			name: "ForcedDistributionOverTupleWrappedCheck",
+			src: `
+				type WrapF<T> = if T : T { if [T] : [string] { [T] } else { boolean } } else { "unreachable" }
+				type Result = WrapF<"a" | "b">
+			`,
+			wantExpanded: `["a"] | ["b"]`,
+		},
+		{
+			// The unforced form of the case above, for contrast: the union decides as a whole and the
+			// branch keeps it, so one tuple of the union comes back rather than a union of tuples.
+			name: "UnforcedTupleWrappedCheckKeepsTheUnion",
+			src: `
+				type WrapN<T> = if [T] : [string] { [T] } else { boolean }
+				type Result = WrapN<"a" | "b">
+			`,
+			wantExpanded: `["a" | "b"]`,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1745,3 +1745,218 @@ func TestInferCondSeparateResolutionsAreEqual(t *testing.T) {
 		"fn <T>(k: if T : [infer U] { U } else { boolean }) -> if T : [infer U] { U } else { boolean }",
 		values["f"])
 }
+
+// A conditional may sit inside any operand of another conditional, and each one decides its own
+// branch once its own operands are ground. The cases place a nested conditional at each of the four
+// positions, stack three of them, and run a type parameter into an inner Check through alias
+// instantiation. Every expectation matches what TypeScript reduces the equivalent
+// `C extends E ? T : E` chain to.
+func TestInferCondNestedConditionals(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The outer Then holds a conditional, so selecting Then reduces it in turn.
+			name:         "NestedInThen",
+			src:          `type Result = if number : number { if string : string { "a" } else { "b" } } else { "c" }`,
+			wantExpanded: `"a"`,
+		},
+		{
+			// The outer Else holds a conditional, whose own Check fails, so its Else is selected.
+			name:         "NestedInElse",
+			src:          `type Result = if string : number { "a" } else { if number : string { "b" } else { "c" } }`,
+			wantExpanded: `"c"`,
+		},
+		{
+			// The Check is a conditional, which reduces to `string` before the outer test runs.
+			name:         "NestedInCheck",
+			src:          `type Result = if (if number : number { string } else { boolean }) : string { "yes" } else { "no" }`,
+			wantExpanded: `"yes"`,
+		},
+		{
+			// The Extends is a conditional, which reduces to `"a"` before the outer test runs.
+			name:         "NestedInExtends",
+			src:          `type Result = if "a" : (if number : number { "a" } else { "b" }) { "hit" } else { "miss" }`,
+			wantExpanded: `"hit"`,
+		},
+		{
+			name:         "ThreeLevels",
+			src:          `type Result = if number : number { if string : string { if boolean : boolean { "deep" } else { "x" } } else { "y" } } else { "z" }`,
+			wantExpanded: `"deep"`,
+		},
+		{
+			// Instantiating the alias substitutes the argument at both the outer and the inner Check,
+			// so the inner conditional decides on the same argument the outer one did.
+			name: "ArgumentReachesInnerCheck",
+			src: `
+				type Pick2<T> = if T : string { if T : "a" { "sa" } else { "s" } } else { "n" }
+				type Result = Pick2<"a">
+			`,
+			wantExpanded: `"sa"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A conditional alias may appear in another conditional's Check, so the outer test runs on what the
+// inner alias reduced to. The Check is not decided by the evaluator directly — an alias reference is
+// ground, so the `Check <: Extends` probe re-enters constrain, which expands the alias and reduces
+// the conditional in its body. Each expectation matches TypeScript's reduction of the same chain.
+func TestInferCondAliasComposition(t *testing.T) {
+	// isStr reduces to "y" for a string argument and "n" otherwise; label tests isStr's result and
+	// outer tests label's, so a reduction runs three aliases deep.
+	const aliases = `
+		type IsStr<T> = if T : string { "y" } else { "n" }
+		type Label<T> = if IsStr<T> : "y" { "text" } else { "other" }
+		type Outer<T> = if Label<T> : "text" { "outer-text" } else { "outer-other" }
+	`
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// IsStr<string> reduces to "y", which the outer conditional matches.
+			name:         "InnerAliasSelectsThen",
+			src:          aliases + `type Result = Label<string>`,
+			wantExpanded: `"text"`,
+		},
+		{
+			// IsStr<number> reduces to "n", so the outer conditional takes Else.
+			name:         "InnerAliasSelectsElse",
+			src:          aliases + `type Result = Label<number>`,
+			wantExpanded: `"other"`,
+		},
+		{
+			// Three aliases deep: Outer tests Label's result, which tested IsStr's.
+			name:         "ThreeAliasesDeep",
+			src:          aliases + `type Result = Outer<string>`,
+			wantExpanded: `"outer-text"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// Distribution reaches every position the distributed type parameter stands at, nested conditionals
+// and composed aliases included. A member selected at the outer conditional is the member the inner
+// one decides on, and an alias whose own Check is a naked parameter distributes inside its own
+// reduction. Each expectation matches TypeScript's reduction of the same chain.
+func TestInferCondDistributionThroughNesting(t *testing.T) {
+	const aliases = `
+		type IsStr<T> = if T : string { "y" } else { "n" }
+		type Label<T> = if IsStr<T> : "y" { "text" } else { "other" }
+		type Outer<T> = if Label<T> : "text" { "outer-text" } else { "outer-other" }
+	`
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The member reaches the nested conditional's Check, so `"a"` and `"b"` take the outer
+			// Then and then split on the inner test, while `1` takes the outer Else.
+			name: "MemberReachesNestedCheck",
+			src: `
+				type Wrap<T> = if T : string { if T : "a" { "exact" } else { "other" } } else { "num" }
+				type Result = Wrap<"a" | "b" | 1>
+			`,
+			wantExpanded: `"exact" | "num" | "other"`,
+		},
+		{
+			// Every member takes the outer Then, and the inner test still separates them.
+			name: "MembersSplitOnInnerCheckAlone",
+			src: `
+				type Wrap<T> = if T : string { if T : "a" { "exact" } else { "other" } } else { "num" }
+				type Result = Wrap<"a" | "b">
+			`,
+			wantExpanded: `"exact" | "other"`,
+		},
+		{
+			// The member also reaches a nested conditional's Extends operand: `"a" <: "a"` holds for
+			// the first member and `"a" <: "b"` fails for the second.
+			name: "MemberReachesNestedExtends",
+			src: `
+				type W<T> = if T : string { if "a" : T { "isA" } else { "notA" } } else { "num" }
+				type Result = W<"a" | "b">
+			`,
+			wantExpanded: `"isA" | "notA"`,
+		},
+		{
+			// Label's Check is `IsStr<T>`, an alias reference rather than a naked parameter, so Label
+			// does not distribute. IsStr does, reducing to `"y" | "n"`, which fails `<: "y"`.
+			name:         "OuterAliasDoesNotDistributeButInnerDoes",
+			src:          aliases + `type Result = Label<string | number>`,
+			wantExpanded: `"other"`,
+		},
+		{
+			// The same non-distributing composition one alias deeper.
+			name:         "ThreeAliasesDeepWithUnion",
+			src:          aliases + `type Result = Outer<string | number>`,
+			wantExpanded: `"outer-other"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A distributed member reaches an alias reference written in a branch, so each member instantiates
+// that alias with itself. `Branch<"a" | 1>` admits `"y"`, from `IsStr<"a">` on the string member, and
+// `"num"` from the other member, which is what TypeScript reduces the same alias to. reduce leaves an
+// alias in a result position under its own name, so the stored type is checked through constrain,
+// which expands it; a rejected value names the residual form the annotation holds.
+func TestInferCondDistributionIntoBranchAlias(t *testing.T) {
+	const aliases = `
+		type IsStr<T> = if T : string { "y" } else { "n" }
+		type Branch<T> = if T : string { IsStr<T> } else { "num" }
+	`
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "StringMemberBranchAccepted",
+			src:  aliases + `val x: Branch<"a" | 1> = "y"`,
+		},
+		{
+			name: "OtherMemberBranchAccepted",
+			src:  aliases + `val x: Branch<"a" | 1> = "num"`,
+		},
+		{
+			// "n" is what IsStr yields for a non-string argument, which no member produces here.
+			name:    "UnreachableBranchRejected",
+			src:     aliases + `val x: Branch<"a" | 1> = "n"`,
+			wantErr: `cannot constrain "n" <: "num" | IsStr<"a">`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1554,6 +1554,18 @@ func TestInferCondDistribution(t *testing.T) {
 			wantExpanded: `"n"`,
 		},
 		{
+			// The parameter also appears in the Extends operand, so each member is tested against a
+			// pattern built from that member: `[string]` against `[[string]]` and `string` against
+			// `[string]`, both of which fail. TypeScript reduces the same alias applied to the same
+			// union to `"no"`.
+			name: "MemberReachesTheExtendsOperand",
+			src: `
+				type X<T> = if T : [T] { "wrap" } else { "no" }
+				type Result = X<[string] | string>
+			`,
+			wantExpanded: `"no"`,
+		},
+		{
 			// Distribution and capture compose: each member matches the pattern on its own, so the
 			// captures union.
 			name: "DistributesOverCapture",

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -40,6 +40,17 @@ func expandResidual(ctx *Context, ty soltype.Type) soltype.Type {
 	return newTypeEvaluator(ctx, set.NewSet[constraintKey]()).reduce(ty)
 }
 
+// expandAliasResidual substitutes a generic alias instance's arguments into the alias body and then
+// reduces the result, the two steps constrain performs when it checks a constraint against a
+// reference such as `Elem<[number]>`. A test uses it to assert what one instantiation reduces to.
+// A type that is not an alias reference reduces directly, so a table may mix the two shapes.
+func expandAliasResidual(ctx *Context, ty soltype.Type) soltype.Type {
+	if alias, ok := ty.(*soltype.AliasType); ok {
+		ty = ctx.expandAlias(alias)
+	}
+	return expandResidual(ctx, ty)
+}
+
 // `keyof` over a named type reference — an alias or a class — is stored unexpanded, so the type
 // keeps the name the source wrote rather than the referenced type's keys. Each case names the
 // operand through an alias or class, asserts the stored `Result` renders `keyof Name`, and asserts
@@ -1290,14 +1301,27 @@ func TestInferCondResidualErrorMessage(t *testing.T) {
 	require.Equal(t, "1:12-1:51: cannot constrain if t1 : number { string } else { boolean } <: number", msgWithSpan(errs[0]))
 }
 
-// A conditional whose Extends holds an `infer` clause is unsupported until M9 PR3b: branch selection
-// has no matcher to bind the `infer` name. The annotation reports one UnsupportedFeatureError rather
-// than resolving the Extends and silently mis-deciding the branch.
-func TestInferCondInferUnsupported(t *testing.T) {
-	_, _, errs := inferSource(t, `fn f<T>(x: if T : Array<infer U> { U } else { never }) {}`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "Unsupported: infer clause in conditional type", errs[0].Message())
+// An `infer U` clause outside a conditional's Extends operand names no matched position, so it
+// reports one UnsupportedFeatureError rather than resolving to a capture nothing ever fills. The
+// cases cover the positions an `infer` can be written in but never captures from: a plain
+// annotation, a conditional's Check, and the Then branch of a conditional that captures nothing.
+func TestInferOutsideExtendsUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "PlainAnnotation", src: `val x: infer U = 5`},
+		{name: "CondCheck", src: `type Result = if infer U : number { "y" } else { "n" }`},
+		{name: "CondThen", src: `type Result = if number : number { infer U } else { "n" }`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+			require.Equal(t, "Unsupported: infer outside a conditional type's extends operand", errs[0].Message())
+		})
+	}
 }
 
 // Checking a value against a self-referential conditional alias terminates instead of looping. A
@@ -1343,6 +1367,312 @@ func TestInferCondComposesWithOperators(t *testing.T) {
 			nodes, ctx, errs := inferTypeNodes(t, tt.src)
 			require.Empty(t, errs)
 			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// An `infer U` clause in a conditional's Extends operand captures the type sitting at its matched
+// position, and the Then branch reads that capture. Each case reduces a conditional whose Check is
+// ground and asserts the type the selected branch yields. The cases cover the positions the matcher
+// walks — a tuple element, an object property, a function parameter and return, a promise payload,
+// and a type argument — plus the capture-combining and mismatch rules.
+func TestInferCondInferCapture(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The single tuple element is captured and returned by the Then branch.
+			name:         "TupleElement",
+			src:          `type Result = if [number] : [infer U] { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// Two captures bind independently, and the Then branch may reorder them.
+			name:         "TwoTupleElements",
+			src:          `type Result = if [number, string] : [infer A, infer B] { [B, A] } else { boolean }`,
+			wantExpanded: "[string, number]",
+		},
+		{
+			// One name written at two positions keeps both matched types, unioned.
+			name:         "RepeatedName",
+			src:          `type Result = if [number, string] : [infer U, infer U] { U } else { boolean }`,
+			wantExpanded: "number | string",
+		},
+		{
+			// A tuple whose arity differs from the pattern's does not align, so Else is selected.
+			name:         "TupleArityMismatch",
+			src:          `type Result = if [number] : [infer A, infer B] { A } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			// A pattern mixing a capture with a written type binds the capture, then the
+			// `Check <: Extends` probe rejects on the written position, so Else is selected.
+			name:         "WrittenPositionRejects",
+			src:          `type Result = if [number, string] : [infer A, number] { A } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			name:         "ObjectProperty",
+			src:          `type Result = if {a: number, b: string} : {a: infer A, b: infer B} { [A, B] } else { boolean }`,
+			wantExpanded: "[number, string]",
+		},
+		{
+			// An inexact pattern captures from a wider object, since the probe allows the extra key.
+			name:         "InexactObjectPattern",
+			src:          `type Result = if {a: number, b: string} : {a: infer A, ...} { A } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// An exact pattern narrower than the Check is rejected by the probe, so Else is selected.
+			name:         "ExactObjectPatternRejectsWiderCheck",
+			src:          `type Result = if {a: number, b: string} : {a: infer A} { A } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			// A property the Check does not carry cannot be matched, so Else is selected.
+			name:         "MissingObjectProperty",
+			src:          `type Result = if {a: number} : {z: infer Z, ...} { Z } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			name: "FunctionReturn",
+			src: `
+				type F = fn (x: number) -> string
+				type Result = if F : fn (x: number) -> infer R { R } else { boolean }
+			`,
+			wantExpanded: "string",
+		},
+		{
+			name: "FunctionParam",
+			src: `
+				type F = fn (x: number) -> string
+				type Result = if F : fn (x: infer P) -> string { P } else { boolean }
+			`,
+			wantExpanded: "number",
+		},
+		{
+			name:         "PromisePayload",
+			src:          `type Result = if Promise<number> : Promise<infer U> { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// The Check names an alias, which expands to the tuple the pattern matches against.
+			name: "AliasCheckExpands",
+			src: `
+				type Pair = [number, string]
+				type Result = if Pair : [infer A, infer B] { A } else { boolean }
+			`,
+			wantExpanded: "number",
+		},
+		{
+			// Both sides name the same alias, so the match runs argument by argument.
+			name: "SameAliasArguments",
+			src: `
+				type Box<T> = {v: T}
+				type Result = if Box<number> : Box<infer U> { U } else { boolean }
+			`,
+			wantExpanded: "number",
+		},
+		{
+			// The pattern's alias expands to its body, so a structural Check still captures.
+			name: "AliasPatternExpands",
+			src: `
+				type Box<T> = {v: T}
+				type Result = if {v: number} : Box<infer U> { U } else { boolean }
+			`,
+			wantExpanded: "number",
+		},
+		{
+			// A Check of an unrelated shape does not align with the pattern, so Else is selected.
+			name:         "ShapeMismatch",
+			src:          `type Result = if string : [infer U] { U } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+		{
+			// A capture may be read from a nested conditional in the Then branch, which decides
+			// after the capture is substituted in.
+			name:         "NestedConditionalReadsCapture",
+			src:          `type Result = if [number] : [infer U] { if U : number { "num" } else { "other" } } else { boolean }`,
+			wantExpanded: `"num"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A conditional written over a naked type parameter distributes over a union Check: each member
+// decides its own branch and the results union. A Check written as anything else decides the union
+// as a whole, which is how a user opts out. Each case instantiates a generic alias and asserts the
+// type the instantiation reduces to.
+func TestInferCondDistribution(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The members select different branches, so the result unions one of each.
+			name: "MembersSelectDifferentBranches",
+			src: `
+				type Wrap<T> = if T : string { [T] } else { boolean }
+				type Result = Wrap<"a" | 1>
+			`,
+			wantExpanded: `boolean | ["a"]`,
+		},
+		{
+			// A branch naming the distributed parameter reads it as the member, so the two members
+			// yield two distinct tuples rather than one tuple of the whole union.
+			name: "BranchReadsTheMember",
+			src: `
+				type Wrap<T> = if T : string { [T] } else { boolean }
+				type Result = Wrap<"a" | "b">
+			`,
+			wantExpanded: `["a"] | ["b"]`,
+		},
+		{
+			// A tuple-wrapped Check is not a naked type parameter, so the union decides as a whole and
+			// the branch keeps it: one tuple of the union rather than a union of tuples.
+			name: "TupleWrappedCheckOptsOut",
+			src: `
+				type NoDist<T> = if [T] : [string] { [T] } else { boolean }
+				type Result = NoDist<"a" | "b">
+			`,
+			wantExpanded: `["a" | "b"]`,
+		},
+		{
+			// A union written directly in the Check is not a type-parameter reference, so it decides
+			// as a whole and takes the Else branch.
+			name:         "WrittenUnionCheckDoesNotDistribute",
+			src:          `type Result = if number | string : number { "y" } else { "n" }`,
+			wantExpanded: `"n"`,
+		},
+		{
+			// Distribution and capture compose: each member matches the pattern on its own, so the
+			// captures union.
+			name: "DistributesOverCapture",
+			src: `
+				type Elem<T> = if T : [infer U] { U } else { boolean }
+				type Result = Elem<[number] | [string]>
+			`,
+			wantExpanded: "number | string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A conditional whose Check never grounds keeps its `infer` clause symbolic, so the stored type
+// renders the way the source wrote it: the Extends operand shows the `infer U` binder and the Then
+// branch shows the bare reference `U`.
+func TestInferCondInferStaysSymbolic(t *testing.T) {
+	values, _, errs := inferSource(t, `fn f<T>(x: if T : [infer U] { U } else { boolean }) {}`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: if T : [infer U] { U } else { boolean }) -> void", values["f"])
+}
+
+// constrain reduces a capturing conditional at the constraint site, so a value is checked against
+// the type the capture resolved to. The cases instantiate an element-extracting alias and check a
+// value against it, accepted when it matches the captured element type and rejected against that
+// type by name when it does not.
+func TestInferCondInferConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "CapturedTypeAccepted",
+			src: `
+				type Elem<T> = if T : [infer U] { U } else { boolean }
+				val x: Elem<[number]> = 5
+			`,
+		},
+		{
+			name: "CapturedTypeRejected",
+			src: `
+				type Elem<T> = if T : [infer U] { U } else { boolean }
+				val x: Elem<[number]> = "hi"
+			`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+		{
+			name: "NonMatchingArgumentTakesElse",
+			src: `
+				type Elem<T> = if T : [infer U] { U } else { boolean }
+				val x: Elem<string> = true
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A capture is in scope for the Then branch only, the position TypeScript scopes it to, so the same
+// name written in the Else branch is an unbound type reference.
+func TestInferCondCaptureNotInScopeInElse(t *testing.T) {
+	_, _, errs := inferSource(t, `type Result = if [number] : [infer U] { U } else { U }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedNodeError{}, errs[0])
+	require.Equal(t, "Unsupported: TypeRefTypeAnn", errs[0].Message())
+}
+
+// An alias whose Then branch re-instantiates itself with a capture terminates and resolves, one
+// expansion per lap: `Deep<[[number]]>` captures `[number]`, reduces to `Deep<[number]>`, and that
+// reduces to `number`, which the value is then checked against. This is the shape `Awaited<T>` takes,
+// so it is what a later flattening operator rests on. Each lap shrinks its argument, so the alias
+// guard is never what stops it — the Else branch is reached on its own.
+func TestInferCondRecursiveCaptureAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "InnermostTypeAccepted",
+			src: `
+				type Deep<T> = if T : [infer U] { Deep<U> } else { T }
+				val x: Deep<[[number]]> = 5
+			`,
+		},
+		{
+			name: "InnermostTypeRejected",
+			src: `
+				type Deep<T> = if T : [infer U] { Deep<U> } else { T }
+				val x: Deep<[[number]]> = "hi"
+			`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
 		})
 	}
 }

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -41,6 +41,10 @@ func newUnion(c *Context, parts []soltype.Type, inexact bool) soltype.Type {
 // newIntersection is the meet twin of newUnion. An IntersectionType carries
 // no exactness flag, since exactness is a property of the result rather than
 // the meet, so the API is one argument shorter.
+//
+// TODO(#927): collapse an uninhabited intersection to never. Two members that no value satisfies
+// together, such as `number & string`, survive the pipeline below, so a conditional capture that
+// meets contravariant candidates renders `number & string` where TypeScript renders `never`.
 func newIntersection(c *Context, parts []soltype.Type) soltype.Type {
 	flat := flattenIntersection(parts)
 	pruned, hadError := pruneIntersection(flat)

--- a/internal/solver/probe.go
+++ b/internal/solver/probe.go
@@ -314,6 +314,52 @@ func (c *Context) trialMutatesBounds(sub, super soltype.Type, seen set.Set[const
 	return !hasHardError(errs), mutated
 }
 
+// trialCaptures trials `sub <: super` under a throwaway probe and reports what each variable in vars
+// picked up, or ok=false when the trial failed. A conditional's `infer` reduction calls it with one
+// fresh variable per `infer` clause standing in the pattern, so the constraint that decides the
+// branch is also what infers the captures — the same read constrain performs for any other subtype
+// check, rather than a second structural walk that would have to know every type kind.
+//
+// The bounds are read after constrain returns and before the probe rolls them back, the window
+// trialMutatesBounds reads p.mutatedBounds() in. The trial is discarded either way, so no bound
+// survives on any type the caller handed in.
+func (c *Context) trialCaptures(sub, super soltype.Type, vars []*soltype.TypeVarType, seen set.Set[constraintKey]) ([]soltype.Type, bool) {
+	p := newProbe(c.probe)
+	c.probe = p
+	errs := c.constrain(sub, super, seen, false)
+	ok := !hasHardError(errs)
+	var captured []soltype.Type
+	if ok {
+		captured = make([]soltype.Type, len(vars))
+		for i, v := range vars {
+			captured[i] = capturedBound(v)
+		}
+	}
+	c.probe = p.parent
+	p.Discard()
+	return captured, ok
+}
+
+// capturedBound reads the type one `infer` variable was inferred to. A variable in a covariant
+// pattern position collects the matched types as lower bounds, so the capture is their union: a name
+// written at two tuple positions matched against `[number, string]` captures `number | string`. A
+// variable in a contravariant position, such as the parameter of a function pattern, collects upper
+// bounds instead, so the capture is their meet. A variable the constraint never bounded, which an
+// optional-property pattern matched against an object lacking that property produces, is
+// unconstrained, so the capture is `unknown`.
+//
+// It builds through newUnion and newIntersection with a nil Context, so their subsumption never
+// calls constrain while a trial is still open.
+func capturedBound(v *soltype.TypeVarType) soltype.Type {
+	if len(v.LowerBounds) > 0 {
+		return newUnion(nil, v.LowerBounds, false)
+	}
+	if len(v.UpperBounds) > 0 {
+		return newIntersection(nil, v.UpperBounds)
+	}
+	return &soltype.UnknownType{}
+}
+
 // trialUnderProbe trials `sub <: super` under a discard-only probe and returns
 // the trial's errors, leaving no bound behind; an empty result means it
 // succeeded. The seen-set starts fresh and the mut context at false, so the

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -91,7 +91,7 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 	case *ast.CondTypeAnn:
 		return c.resolveCondTypeAnn(scope, ta, lvl)
 	case *ast.InferTypeAnn:
-		return c.resolveInferTypeAnn(ta)
+		return c.resolveInferTypeAnn(scope, ta)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -343,16 +343,27 @@ func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl in
 // Else, while a conditional over a type parameter stays symbolic. An unsupported operand recovers to
 // a fresh var, cascade-safe like the Promise<bad> recovery.
 //
-// Each `infer U` clause in the Extends operand introduces the name U. The clause itself resolves to
-// an InferType binder, and the same name resolves in the Then branch to an InferType reference, so
-// `if T : [infer U] { U } else { boolean }` stores a conditional whose Then branch points at the
-// capture its Extends declares. The names are bound in a child scope covering the Then branch alone,
-// matching the position TypeScript scopes them to, so an `infer` name written in the Else branch is
-// an unbound reference. The evaluator binds each capture by structural match at reduction time.
+// Each `infer U` clause in the Extends operand introduces the name U. The name is declared once, in
+// a child scope, before either operand resolves, so the clause and the Then branch's references to
+// it share one declaration and a capture substituted for that declaration reaches both. The child
+// scope covers the Extends and Then operands, matching the position TypeScript scopes an `infer`
+// name to, so `if T : [infer U] { U } else { boolean }` resolves its Then branch to the capture its
+// Extends declares while the same name written in the Else branch is an unbound reference. The
+// evaluator fills each capture by structural match at reduction time.
 //
 // A conditional whose Check is written as a bare type-parameter reference is marked Distribute, the
 // naked-type-parameter rule the evaluator applies when the Check grounds to a union.
 func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int) (soltype.Type, bool) {
+	// Declare each name the Extends operand introduces, so the clause that declares it and the Then
+	// branch's references to it resolve to one shared declaration.
+	condScope := scope
+	if names := inferAnnNames(ta.Extends); len(names) > 0 {
+		condScope = scope.Child()
+		for _, name := range names {
+			condScope.defineType(name, TypeBinding{Type: c.ctx.freshInferDecl(name)})
+		}
+	}
+
 	// The Extends operand is the one position an `infer` clause is legal in. Save and restore the
 	// flag around each operand so a nested conditional's own operands decide it independently.
 	savedInCondExtends := c.inCondExtends
@@ -365,20 +376,13 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	}
 
 	c.inCondExtends = true
-	extends, ok := c.resolveTypeAnn(scope, ta.Extends, lvl)
+	extends, ok := c.resolveTypeAnn(condScope, ta.Extends, lvl)
 	if !ok {
 		extends = c.freshAt(lvl)
 	}
 
 	c.inCondExtends = false
-	thenScope := scope
-	if names := inferAnnNames(ta.Extends); len(names) > 0 {
-		thenScope = scope.Child()
-		for _, name := range names {
-			thenScope.defineType(name, TypeBinding{Type: &soltype.InferType{Name: name}})
-		}
-	}
-	then, ok := c.resolveTypeAnn(thenScope, ta.Then, lvl)
+	then, ok := c.resolveTypeAnn(condScope, ta.Then, lvl)
 	if !ok {
 		then = c.freshAt(lvl)
 	}
@@ -401,15 +405,21 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	return t, true
 }
 
-// resolveInferTypeAnn lowers an `infer U` clause to the InferType binder the evaluator's structural
-// matcher captures a type at. The clause is legal only inside a conditional's Extends operand, which
-// is where a matched position exists to capture; anywhere else it names no capture, so it reports an
-// unsupported feature and recovers.
-func (c *checker) resolveInferTypeAnn(ta *ast.InferTypeAnn) (soltype.Type, bool) {
-	if !c.inCondExtends {
+// resolveInferTypeAnn lowers an `infer U` clause to the binder the evaluator's structural matcher
+// captures a type at, reading U's declaration from the scope resolveCondTypeAnn declared it in so
+// the binder and the branch's references carry one id. The clause is legal only inside a
+// conditional's Extends operand, which is where a matched position exists to capture; anywhere else
+// it names no capture, so it reports an unsupported feature and recovers.
+func (c *checker) resolveInferTypeAnn(scope *Scope, ta *ast.InferTypeAnn) (soltype.Type, bool) {
+	b, found := scope.GetType(ta.Name)
+	decl, isDecl := b.Type.(*soltype.InferType)
+	// resolveCondTypeAnn declares every name it collects from an Extends operand, so a clause reached
+	// while resolving one always finds its declaration. A clause anywhere else finds none, or finds a
+	// binding of some other sort under the same name, and is rejected either way.
+	if !c.inCondExtends || !found || !isDecl {
 		return c.reportUnsupportedFeature(ta, "infer outside a conditional type's extends operand"), false
 	}
-	t := &soltype.InferType{Name: ta.Name, Binder: true}
+	t := &soltype.InferType{ID: decl.ID, Name: decl.Name, Binder: true}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -89,6 +90,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveTypeOfTypeAnn(scope, ta)
 	case *ast.CondTypeAnn:
 		return c.resolveCondTypeAnn(scope, ta, lvl)
+	case *ast.InferTypeAnn:
+		return c.resolveInferTypeAnn(ta)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -340,23 +343,42 @@ func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl in
 // Else, while a conditional over a type parameter stays symbolic. An unsupported operand recovers to
 // a fresh var, cascade-safe like the Promise<bad> recovery.
 //
-// The `infer` clause is M9 PR3b, so a conditional whose Extends holds an `infer` reports an
-// unsupported feature and recovers. Branch selection here has no matcher to bind the `infer` name.
-// Resolving the Extends anyway would recover each `infer U` to a fresh var and silently mis-decide
-// the branch, so rejecting it keeps the two milestones cleanly split.
+// Each `infer U` clause in the Extends operand introduces the name U. The clause itself resolves to
+// an InferType binder, and the same name resolves in the Then branch to an InferType reference, so
+// `if T : [infer U] { U } else { boolean }` stores a conditional whose Then branch points at the
+// capture its Extends declares. The names are bound in a child scope covering the Then branch alone,
+// matching the position TypeScript scopes them to, so an `infer` name written in the Else branch is
+// an unbound reference. The evaluator binds each capture by structural match at reduction time.
+//
+// A conditional whose Check is written as a bare type-parameter reference is marked Distribute, the
+// naked-type-parameter rule the evaluator applies when the Check grounds to a union.
 func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int) (soltype.Type, bool) {
-	if annContainsInfer(ta.Extends) {
-		return c.reportUnsupportedFeature(ta, "infer clause in conditional type"), false
-	}
+	// The Extends operand is the one position an `infer` clause is legal in. Save and restore the
+	// flag around each operand so a nested conditional's own operands decide it independently.
+	savedInCondExtends := c.inCondExtends
+	defer func() { c.inCondExtends = savedInCondExtends }()
+
+	c.inCondExtends = false
 	check, ok := c.resolveTypeAnn(scope, ta.Check, lvl)
 	if !ok {
 		check = c.freshAt(lvl)
 	}
+
+	c.inCondExtends = true
 	extends, ok := c.resolveTypeAnn(scope, ta.Extends, lvl)
 	if !ok {
 		extends = c.freshAt(lvl)
 	}
-	then, ok := c.resolveTypeAnn(scope, ta.Then, lvl)
+
+	c.inCondExtends = false
+	thenScope := scope
+	if names := inferAnnNames(ta.Extends); len(names) > 0 {
+		thenScope = scope.Child()
+		for _, name := range names {
+			thenScope.defineType(name, TypeBinding{Type: &soltype.InferType{Name: name}})
+		}
+	}
+	then, ok := c.resolveTypeAnn(thenScope, ta.Then, lvl)
 	if !ok {
 		then = c.freshAt(lvl)
 	}
@@ -364,29 +386,66 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	if !ok {
 		els = c.freshAt(lvl)
 	}
-	t := &soltype.CondType{Check: check, Extends: extends, Then: then, Else: els}
+
+	t := &soltype.CondType{
+		Check:      check,
+		Extends:    extends,
+		Then:       then,
+		Else:       els,
+		Distribute: nakedTypeParamCheck(ta.Check, check),
+	}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 
-// annContainsInfer reports whether a type annotation subtree holds an `infer U` clause. A
-// conditional consults it on its Extends operand to reject the `infer` form, which M9 PR3b handles.
-func annContainsInfer(ta ast.TypeAnn) bool {
-	f := &inferAnnFinder{}
-	ta.Accept(f)
-	return f.found
+// resolveInferTypeAnn lowers an `infer U` clause to the InferType binder the evaluator's structural
+// matcher captures a type at. The clause is legal only inside a conditional's Extends operand, which
+// is where a matched position exists to capture; anywhere else it names no capture, so it reports an
+// unsupported feature and recovers.
+func (c *checker) resolveInferTypeAnn(ta *ast.InferTypeAnn) (soltype.Type, bool) {
+	if !c.inCondExtends {
+		return c.reportUnsupportedFeature(ta, "infer outside a conditional type's extends operand"), false
+	}
+	t := &soltype.InferType{Name: ta.Name, Binder: true}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
 }
 
-// inferAnnFinder is the AST visitor behind annContainsInfer. It flags the first InferTypeAnn it
-// reaches and keeps walking; one occurrence is enough to answer.
+// nakedTypeParamCheck reports whether a conditional's Check was written as a bare reference to a
+// type parameter, the shape TypeScript distributes a union Check over. The written form must be a
+// name with no type arguments, and that name must resolve to a type variable, which is what
+// resolveTypeParams mints for each `<T>` binder. A literal type, an alias, or a `[T]` wrapper each
+// fails one of the two tests, so the conditional decides a union Check as a whole.
+func nakedTypeParamCheck(ann ast.TypeAnn, resolved soltype.Type) bool {
+	ref, ok := ann.(*ast.TypeRefTypeAnn)
+	if !ok || len(ref.TypeArgs) > 0 {
+		return false
+	}
+	_, isVar := resolved.(*soltype.TypeVarType)
+	return isVar
+}
+
+// inferAnnNames returns the names the `infer U` clauses of one annotation subtree introduce, in
+// source order with duplicates collapsed. resolveCondTypeAnn reads its Extends operand's names to
+// bind them for the Then branch.
+func inferAnnNames(ta ast.TypeAnn) []string {
+	f := &inferAnnFinder{seen: set.NewSet[string]()}
+	ta.Accept(f)
+	return f.names
+}
+
+// inferAnnFinder is the AST visitor behind inferAnnNames. It collects each InferTypeAnn name it
+// reaches, skipping one it has already recorded so a name written twice binds once.
 type inferAnnFinder struct {
 	ast.DefaultVisitor
-	found bool
+	seen  set.Set[string]
+	names []string
 }
 
 func (f *inferAnnFinder) EnterTypeAnn(ta ast.TypeAnn) bool {
-	if _, ok := ta.(*ast.InferTypeAnn); ok {
-		f.found = true
+	if it, ok := ta.(*ast.InferTypeAnn); ok && !f.seen.Contains(it.Name) {
+		f.seen.Add(it.Name)
+		f.names = append(f.names, it.Name)
 	}
 	return true
 }

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -428,7 +428,8 @@ func (c *checker) resolveInferTypeAnn(scope *Scope, ta *ast.InferTypeAnn) (solty
 // type parameter, the shape TypeScript distributes a union Check over. The written form must be a
 // name with no type arguments, and that name must resolve to a type variable, which is what
 // resolveTypeParams mints for each `<T>` binder. A literal type, an alias, or a `[T]` wrapper each
-// fails one of the two tests, so the conditional decides a union Check as a whole.
+// fails one of the two tests, so the conditional decides a union Check as a whole. This is the first
+// of the two conditions distribution needs; soltype.CondType's Distribute field states both.
 func nakedTypeParamCheck(ann ast.TypeAnn, resolved soltype.Type) bool {
 	ref, ok := ann.(*ast.TypeRefTypeAnn)
 	if !ok || len(ref.TypeArgs) > 0 {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -349,7 +349,7 @@ func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl in
 // scope covers the Extends and Then operands, matching the position TypeScript scopes an `infer`
 // name to, so `if T : [infer U] { U } else { boolean }` resolves its Then branch to the capture its
 // Extends declares while the same name written in the Else branch is an unbound reference. The
-// evaluator fills each capture by structural match at reduction time.
+// evaluator fills each capture from the subtype check that decides the branch, at reduction time.
 //
 // A conditional whose Check is written as a bare type-parameter reference is marked Distribute, the
 // naked-type-parameter rule the evaluator applies when the Check grounds to a union.
@@ -405,9 +405,9 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	return t, true
 }
 
-// resolveInferTypeAnn lowers an `infer U` clause to the binder the evaluator's structural matcher
-// captures a type at, reading U's declaration from the scope resolveCondTypeAnn declared it in so
-// the binder and the branch's references carry one id. The clause is legal only inside a
+// resolveInferTypeAnn lowers an `infer U` clause to the binder the evaluator captures a type at,
+// reading U's declaration from the scope resolveCondTypeAnn declared it in so the binder and the
+// branch's references carry one id. The clause is legal only inside a
 // conditional's Extends operand, which is where a matched position exists to capture; anywhere else
 // it names no capture, so it reports an unsupported feature and recovers.
 func (c *checker) resolveInferTypeAnn(scope *Scope, ta *ast.InferTypeAnn) (soltype.Type, bool) {

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -359,8 +359,8 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	defer func() { c.inCondExtends = savedInCondExtends }()
 
 	c.inCondExtends = false
-	check, ok := c.resolveTypeAnn(scope, ta.Check, lvl)
-	if !ok {
+	check, checkOK := c.resolveTypeAnn(scope, ta.Check, lvl)
+	if !checkOK {
 		check = c.freshAt(lvl)
 	}
 
@@ -392,7 +392,10 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 		Extends:    extends,
 		Then:       then,
 		Else:       els,
-		Distribute: nakedTypeParamCheck(ta.Check, check),
+		// A Check the resolver could not resolve recovered to a fresh var, which is the same kind
+		// nakedTypeParamCheck accepts, so the flag is decided only when the written Check actually
+		// resolved. Otherwise a bare unresolvable name would be read as a type parameter.
+		Distribute: checkOK && nakedTypeParamCheck(ta.Check, check),
 	}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -222,6 +222,13 @@ func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends solt
 // reference. A pattern position with no arm, such as a union or a borrow, reports a mismatch, which
 // selects the Else branch. Reporting success there instead would leave the binder uncaptured, and
 // the caller would reject the branch anyway.
+//
+// The type switch here is deliberate rather than a traversal that should be moved onto the soltype
+// visitor, which walks one tree. This is a relation over two, the shape equalTypeWith and constrain
+// also take. Four of its steps are outside what a single-tree rewrite expresses: it stops at the
+// first mismatch, it normalizes only the check side through alignCheck, it descends into an object
+// by member name rather than by child position, and it produces captures rather than a type. The
+// single-tree walks around it — containsInfer, substituteInfer, substituteOccurrences — are visitors.
 func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[int]soltype.Type) bool {
 	if binder, ok := pattern.(*soltype.InferType); ok {
 		capture(captures, binder.ID, check)

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -120,7 +120,7 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute}
 	}
 	if union, ok := check.(*soltype.UnionType); ok && t.Distribute {
-		return e.distributeCond(t, union, extends)
+		return e.distributeCond(t, union)
 	}
 	if containsInfer(extends) {
 		return e.reduceCondInfer(t, check, extends)
@@ -135,21 +135,27 @@ func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 // branches each member selects, so `type Wrap<T> = if T : string { [T] } else { boolean }` reduces
 // `Wrap<"a" | 1>` to `["a"] | boolean` rather than to the single branch the whole union selects.
 //
-// A branch that names the distributed type parameter reads it as the member, not the union, which is
-// why `Wrap<"a" | "b">` reduces to `["a"] | ["b"]`. Expanding the alias replaced every occurrence of
-// that parameter — the Check position and the two branches alike — with one shared type pointer, so
-// rewriting the branches' occurrences of the unreduced Check narrows exactly the positions the
-// parameter stood at. The Extends operand keeps the union, matching TypeScript, where each member is
-// tested against the whole right-hand side.
+// Every position that named the distributed type parameter reads it as the member, the Extends
+// operand included, so each lap is the conditional the alias would have produced had it been
+// instantiated with that member alone. `type X<T> = if T : [T] { "wrap" } else { "no" }` over
+// `[string] | string` therefore tests `[string]` against `[[string]]`, which fails, and reduces to
+// `"no"`, matching TypeScript. Expanding the alias installed one shared pointer at every occurrence
+// of the parameter, so replacing that pointer reaches exactly the positions it stood at, and a
+// branch naming it sees the member too — `Wrap<"a" | "b">` reduces to `["a"] | ["b"]`.
+//
+// The pointer replaced is the Check as stored, and each rebuilt operand is taken from the stored
+// conditional rather than from a reduced copy. Reduction may reallocate the nodes it walks, so
+// pointer identity holds only against the operands the alias expansion produced. reduceCond reduces
+// the rebuilt operands itself.
 //
 // Each member reduces through a copy of the conditional with Distribute cleared: the member is no
 // longer a union, and clearing it states that this pass already applied the rule.
-func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.UnionType, extends soltype.Type) soltype.Type {
+func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.UnionType) soltype.Type {
 	parts := make([]soltype.Type, len(check.Types))
 	for i, member := range check.Types {
 		parts[i] = e.reduceCond(&soltype.CondType{
 			Check:   member,
-			Extends: extends,
+			Extends: substituteOccurrences(t.Extends, t.Check, member),
 			Then:    substituteOccurrences(t.Then, t.Check, member),
 			Else:    substituteOccurrences(t.Else, t.Check, member),
 		})

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -108,7 +108,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 // A conditional written over a naked type parameter distributes: a Check that grounds to a union is
 // decided one member at a time and the branch results union, so `type Wrap<T> = if T : string { [T] }
 // else { boolean }` reduces `Wrap<"a" | 1>` to `["a"] | boolean`. An Extends carrying an `infer U`
-// binder routes through reduceCondInfer, which captures the type at each binder's position first.
+// binder routes through reduceCondInfer, which infers a capture for each binder from the same
+// subtype check that decides the branch.
 func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 	check := e.reduce(t.Check)
 	extends := e.reduce(t.Extends)
@@ -184,188 +185,68 @@ func (s *occurrenceSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.
 func (s *occurrenceSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // reduceCondInfer decides a conditional whose Extends operand declares `infer` captures, such as
-// `if T : [infer U] { U } else { boolean }`. It runs in three steps:
+// `if T : [infer U] { U } else { boolean }`. One subtype check does both jobs:
 //
-//  1. matchInfer walks Check against Extends and records the type at each binder's position.
-//  2. Those captures are substituted into Extends, turning the pattern into an ordinary type, and
-//     the resulting `Check <: Extends` probe decides the branch the same way a capture-free
-//     conditional does. Substituting first is what lets a pattern mix captures with written types:
-//     `[infer A, number]` over `[number, string]` binds A but the probe still rejects on element 1.
+//  1. Each declaration is replaced by a fresh inference variable, turning the pattern into an
+//     ordinary type. `[infer U]` becomes `[t7]`.
+//  2. `Check <: pattern` runs under a probe. Its result decides the branch, and the type each
+//     variable was inferred to along the way is the capture for that declaration.
 //  3. On success the captures are substituted into the Then branch, so a reference to a captured
-//     name reduces to the type that was matched.
+//     name reduces to the type the constraint inferred for it.
 //
-// A structural mismatch, or a pattern position the matcher has no arm for, leaves a binder without a
-// capture and selects Else. The post-substitution check for a surviving binder is what makes that
-// total: no branch is ever selected with an unsubstituted capture in it.
+// Letting constrain infer the captures is what keeps this total over the type set. A structural
+// matcher would need an arm per container kind and would silently take the Else branch for a kind it
+// had no arm for; constrain already decomposes every kind, so a pattern position it can align, it
+// can capture from. Union and intersection patterns work for the same reason.
+//
+// The probe is discarded, so the variables and every bound recorded against them are gone by the
+// time this returns and the evaluator's no-mutation invariant holds. A failed constraint selects
+// Else, which covers a shape mismatch and a pattern whose written positions reject the Check alike.
 func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends soltype.Type) soltype.Type {
-	captures := map[int]soltype.Type{}
-	if !e.matchInfer(check, extends, captures) {
+	decls := inferDeclIDs(extends)
+	vars := make([]*soltype.TypeVarType, len(decls))
+	holes := make(map[int]soltype.Type, len(decls))
+	for i, id := range decls {
+		// Level 0 matches the ground Check, so constrain records against these variables directly
+		// rather than extruding. They never outlive the probe, so no generalization sees them.
+		vars[i] = e.ctx.freshVar(0)
+		holes[id] = vars[i]
+	}
+	captured, ok := e.ctx.trialCaptures(check, substituteInfer(extends, holes), vars, e.seen.Clone())
+	if !ok {
 		return e.reduce(t.Else)
 	}
-	pattern := substituteInfer(extends, captures)
-	if containsInfer(pattern) {
-		return e.reduce(t.Else)
-	}
-	if !e.ctx.condExtends(check, pattern, e.seen) {
-		return e.reduce(t.Else)
+	captures := make(map[int]soltype.Type, len(decls))
+	for i, id := range decls {
+		captures[id] = captured[i]
 	}
 	return e.reduce(substituteInfer(t.Then, captures))
 }
 
-// matchInfer walks the ground type check alongside the Extends pattern and records into captures
-// the type sitting at each `infer` binder's position, reporting whether the two aligned. A pattern
-// subtree declaring no binder needs no alignment — the `Check <: Extends` probe decides it — so the
-// walk stops there and reports success.
-//
-// The arms cover the positions a capture is written in: a tuple element, an object property, a
-// function parameter or return, a promise payload, and a type argument of an alias or class
-// reference. A pattern position with no arm, such as a union or a borrow, reports a mismatch, which
-// selects the Else branch. Reporting success there instead would leave the binder uncaptured, and
-// the caller would reject the branch anyway.
-//
-// The type switch here is deliberate rather than a traversal that should be moved onto the soltype
-// visitor, which walks one tree. This is a relation over two, the shape equalTypeWith and constrain
-// also take. Four of its steps are outside what a single-tree rewrite expresses: it stops at the
-// first mismatch, it normalizes only the check side through alignCheck, it descends into an object
-// by member name rather than by child position, and it produces captures rather than a type. The
-// single-tree walks around it — containsInfer, substituteInfer, substituteOccurrences — are visitors.
-func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[int]soltype.Type) bool {
-	if binder, ok := pattern.(*soltype.InferType); ok {
-		capture(captures, binder.ID, check)
-		return true
-	}
-	if !containsInfer(pattern) {
-		return true
-	}
-	switch pat := pattern.(type) {
-	case *soltype.TupleType:
-		tup, ok := e.alignCheck(check).(*soltype.TupleType)
-		if !ok || len(tup.Elems) != len(pat.Elems) || hasRestSpread(tup.Elems) {
-			return false
-		}
-		for i, el := range pat.Elems {
-			if !e.matchInfer(tup.Elems[i], el, captures) {
-				return false
-			}
-		}
-		return true
-	case *soltype.ObjectType:
-		obj, ok := e.groundToObject(check)
-		if !ok {
-			return false
-		}
-		for _, el := range pat.Elems {
-			prop, ok := el.(*soltype.PropertyElem)
-			if !ok {
-				// Only a named property pattern has a member to read the capture off. Any other
-				// member is skipped, and a binder it carries stays uncaptured, which the caller
-				// rejects when it finds one surviving substitution.
-				continue
-			}
-			read, hasValue, _ := memberReadContribution(obj, prop.Name)
-			if !hasValue {
-				return false
-			}
-			if !e.matchInfer(read, prop.Type, captures) {
-				return false
-			}
-		}
-		return true
-	case *soltype.FuncType:
-		fn, ok := e.alignCheck(check).(*soltype.FuncType)
-		if !ok || len(fn.Params) != len(pat.Params) {
-			return false
-		}
-		for i, p := range pat.Params {
-			if !e.matchInfer(fn.Params[i].Type, p.Type, captures) {
-				return false
-			}
-		}
-		return e.matchInfer(fn.Ret, pat.Ret, captures)
-	case *soltype.PromiseType:
-		promise, ok := e.alignCheck(check).(*soltype.PromiseType)
-		if !ok {
-			return false
-		}
-		return e.matchInfer(promise.Inner, pat.Inner, captures)
-	case *soltype.ClassType:
-		cls, ok := e.alignCheck(check).(*soltype.ClassType)
-		if !ok || cls.Name != pat.Name {
-			return false
-		}
-		return e.matchInferArgs(cls.TypeArgs, pat.TypeArgs, captures)
-	case *soltype.AliasType:
-		return e.matchInferAlias(check, pat, captures)
-	default:
-		return false
-	}
+// inferDeclIDs returns the ids of the `infer` declarations t holds, in first-appearance order with
+// duplicates collapsed, so a name written at two positions in one pattern yields one id and takes
+// one variable. The order is the order trialCaptures reports its results in.
+func inferDeclIDs(t soltype.Type) []int {
+	f := &inferDeclFinder{seen: set.NewSet[int]()}
+	t.Accept(f, soltype.Positive)
+	return f.ids
 }
 
-// matchInferAlias matches a named-alias pattern such as `Box<infer U>`. A check naming the same
-// alias matches argument by argument, which is the exact case `Awaited`-shaped patterns rely on.
-// Otherwise the pattern's alias expands to its body and the match retries against that, so
-// `Box<infer U>` over `type Box<T> = {v: T}` still captures U from a plain `{v: number}`. Expansion
-// runs under the shared termination guard, so a recursive alias pattern stops rather than unfolding
-// forever, and a guard that blocks expansion reports a mismatch.
-//
-// Comparing names first is what makes a recursive alias such as `type List<T> = {head: T, tail:
-// List<T> | null}` match: expanding both sides would reach the `List<T> | null` field, a union the
-// matcher has no arm for. The match against the expanded body runs inside the guard's callback,
-// where the alias is still on the active path, so a body that re-references the alias stops.
-func (e *typeEvaluator) matchInferAlias(check soltype.Type, pat *soltype.AliasType, captures map[int]soltype.Type) bool {
-	if alias, ok := e.reduce(check).(*soltype.AliasType); ok && alias.Name == pat.Name {
-		return e.matchInferArgs(alias.TypeArgs, pat.TypeArgs, captures)
-	}
-	matched := false
-	e.expandAliasGuarded(pat, nil, func(body soltype.Type) soltype.Type {
-		matched = e.matchInfer(check, body, captures)
-		return nil
-	})
-	return matched
+// inferDeclFinder is the walking visitor behind inferDeclIDs.
+type inferDeclFinder struct {
+	seen set.Set[int]
+	ids  []int
 }
 
-// matchInferArgs matches two positional type-argument lists, the shared body of the class and alias
-// arms. Differing arity is a mismatch, since no position lines up.
-func (e *typeEvaluator) matchInferArgs(checkArgs, patArgs []soltype.Type, captures map[int]soltype.Type) bool {
-	if len(checkArgs) != len(patArgs) {
-		return false
+func (f *inferDeclFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if iv, ok := t.(*soltype.InferType); ok && !f.seen.Contains(iv.ID) {
+		f.seen.Add(iv.ID)
+		f.ids = append(f.ids, iv.ID)
 	}
-	for i, arg := range patArgs {
-		if !e.matchInfer(checkArgs[i], arg, captures) {
-			return false
-		}
-	}
-	return true
+	return soltype.EnterResult{}
 }
 
-// capture records the type matched at one binder's position. A name written at two positions, as in
-// `[infer U, infer U]`, keeps both matched types by unioning them, so `[number, string]` captures
-// `number | string`.
-func capture(captures map[int]soltype.Type, decl int, matched soltype.Type) {
-	if prev, ok := captures[decl]; ok {
-		captures[decl] = newUnion(nil, []soltype.Type{prev, matched}, false)
-		return
-	}
-	captures[decl] = matched
-}
-
-// alignCheck reduces a check operand toward the structural shape a pattern matches against. A
-// `typeof` query resolves to the value's type and a named alias expands to its body, both under the
-// termination guard, so `if Pair : [infer A, infer B]` over `type Pair = [number, string]` aligns
-// with the tuple pattern. A guard that blocks expansion leaves the alias in place, which the caller
-// reads as a mismatch. The object arm uses groundToObject instead, which also projects a class body.
-func (e *typeEvaluator) alignCheck(check soltype.Type) soltype.Type {
-	switch c := check.(type) {
-	case *soltype.TypeofType:
-		return e.alignCheck(c.Ty)
-	case *soltype.AliasType:
-		return e.expandAliasGuarded(c, c, func(body soltype.Type) soltype.Type {
-			return e.alignCheck(body)
-		})
-	default:
-		return e.reduce(check)
-	}
-}
+func (f *inferDeclFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
 // substituteInfer rewrites every `infer` node whose declaration captures holds a type for to that
 // type, covering the clause that declares the name and the branch references that read it alike,
@@ -396,7 +277,7 @@ func (s *inferSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.Enter
 func (s *inferSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
 
 // containsInfer reports whether t holds an `infer` node with no capture substituted into it yet. A
-// conditional consults it on its Extends operand to route to the matcher, and on a substituted
+// conditional consults it on its Extends operand to route to the capturing reduction, and on a
 // pattern to reject a match that left a binder uncaptured.
 func containsInfer(t soltype.Type) bool {
 	f := &inferFinder{}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -196,14 +196,14 @@ func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends solt
 	if !e.matchInfer(check, extends, captures) {
 		return e.reduce(t.Else)
 	}
-	pattern := substituteInfer(extends, captures)
+	pattern := substituteBinders(extends, captures)
 	if containsInfer(pattern) {
 		return e.reduce(t.Else)
 	}
 	if !e.ctx.condExtends(check, pattern, e.seen) {
 		return e.reduce(t.Else)
 	}
-	return e.reduce(substituteInfer(t.Then, captures))
+	return e.reduce(substituteCaptures(t.Then, captures))
 }
 
 // matchInfer walks the ground type check alongside the Extends pattern and records into captures
@@ -354,32 +354,112 @@ func (e *typeEvaluator) alignCheck(check soltype.Type) soltype.Type {
 	}
 }
 
-// substituteInfer rewrites every `infer` node in t whose name has a capture to the captured type,
-// covering both the binder in a pattern and a reference to that name in a Then branch. A name with
-// no capture is left in place, which is how the caller detects a match that bound only part of the
-// pattern. Names are matched as written, so a nested conditional inside the branch that reuses an
-// outer name is rewritten too rather than shadowing it.
-func substituteInfer(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
+// substituteBinders rewrites each `infer U` binder in a pattern to the type captured for U, turning
+// the Extends operand into an ordinary type the `Check <: Extends` probe can decide. A binder whose
+// name has no capture is left in place, which is how the caller detects a match that bound only part
+// of the pattern.
+func substituteBinders(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
+	return substituteInfer(t, captures, true)
+}
+
+// substituteCaptures rewrites each reference to a captured name in a selected branch to the type
+// captured for it, so the branch reduces to what the match found. A nested conditional that binds
+// the same name again keeps its own binder and its own Then branch, so the inner capture shadows the
+// outer one rather than being overwritten by it.
+func substituteCaptures(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
+	return substituteInfer(t, captures, false)
+}
+
+// substituteInfer is the shared body of substituteBinders and substituteCaptures. Its two callers
+// need opposite halves of the `infer` nodes, which binders selects: a pattern replaces the binders
+// that declare the names, and a branch replaces the references that read them.
+func substituteInfer(t soltype.Type, captures map[string]soltype.Type, binders bool) soltype.Type {
 	if len(captures) == 0 {
 		return t
 	}
-	return t.Accept(&inferSubst{captures: captures}, soltype.Positive)
+	return t.Accept(&inferSubst{captures: captures, binders: binders}, soltype.Positive)
 }
 
 // inferSubst is the rewriting visitor behind substituteInfer. It replaces a captured `infer` node
 // with the matched type and skips that node's children, since the replacement is already reduced.
-type inferSubst struct{ captures map[string]soltype.Type }
+type inferSubst struct {
+	captures map[string]soltype.Type
+	binders  bool
+}
 
-func (s *inferSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
-	if iv, ok := t.(*soltype.InferType); ok {
-		if matched, found := s.captures[iv.Name]; found {
+func (s *inferSubst) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t := t.(type) {
+	case *soltype.InferType:
+		if matched, found := s.captures[t.Name]; found && t.Binder == s.binders {
 			return soltype.EnterResult{Type: matched, SkipChildren: true}
+		}
+	case *soltype.CondType:
+		if shadowed := shadowedCaptures(t, s.captures); len(shadowed) > 0 {
+			return s.rewriteShadowingCond(t, pol, shadowed)
 		}
 	}
 	return soltype.EnterResult{}
 }
 
 func (s *inferSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// rewriteShadowingCond rewrites a nested conditional that declares a name the enclosing conditional
+// also captured. Its Then branch reads the inner capture, so that branch is rewritten with the
+// shadowed names dropped and the inner binder survives to be filled when the inner conditional
+// reduces. The other three operands sit outside the inner name's scope, so they still read the outer
+// captures and are rewritten with the full set.
+func (s *inferSubst) rewriteShadowingCond(t *soltype.CondType, pol soltype.Polarity, shadowed []string) soltype.EnterResult {
+	inner := &inferSubst{captures: withoutNames(s.captures, shadowed), binders: s.binders}
+	return soltype.EnterResult{
+		Type: &soltype.CondType{
+			Check:      t.Check.Accept(s, pol),
+			Extends:    t.Extends.Accept(s, pol),
+			Then:       t.Then.Accept(inner, pol),
+			Else:       t.Else.Accept(s, pol),
+			Distribute: t.Distribute,
+		},
+		SkipChildren: true,
+	}
+}
+
+// shadowedCaptures returns the names the nested conditional t declares that captures also holds a
+// type for. Those are the names whose meaning differs inside t's Then branch.
+func shadowedCaptures(t *soltype.CondType, captures map[string]soltype.Type) []string {
+	var shadowed []string
+	f := &inferBinderFinder{}
+	t.Extends.Accept(f, soltype.Positive)
+	for _, name := range f.names {
+		if _, found := captures[name]; found {
+			shadowed = append(shadowed, name)
+		}
+	}
+	return shadowed
+}
+
+// inferBinderFinder collects the names the `infer U` binders of one Extends operand declare.
+type inferBinderFinder struct{ names []string }
+
+func (f *inferBinderFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if iv, ok := t.(*soltype.InferType); ok && iv.Binder {
+		f.names = append(f.names, iv.Name)
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *inferBinderFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
+
+// withoutNames copies captures with the given names removed, the capture set that is in scope inside
+// a nested conditional's Then branch.
+func withoutNames(captures map[string]soltype.Type, names []string) map[string]soltype.Type {
+	out := make(map[string]soltype.Type, len(captures))
+	for name, matched := range captures {
+		out[name] = matched
+	}
+	for _, name := range names {
+		delete(out, name)
+	}
+	return out
+}
 
 // containsInfer reports whether t holds an `infer` node with no capture substituted into it yet. A
 // conditional consults it on its Extends operand to route to the matcher, and on a substituted

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -105,19 +105,304 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 //     conditional symbolic, rebuilt around the reduced Check and Extends, and reduces later once
 //     they ground. Then and Else stay unreduced in the symbolic form, since neither is selected yet.
 //
-// Distribution over a naked type-parameter union and the `infer` clause are M9 PR3b, so a bare
-// type-parameter Check stays symbolic here rather than distributing.
+// A conditional written over a naked type parameter distributes: a Check that grounds to a union is
+// decided one member at a time and the branch results union, so `type Wrap<T> = if T : string { [T] }
+// else { boolean }` reduces `Wrap<"a" | 1>` to `["a"] | boolean`. An Extends carrying an `infer U`
+// binder routes through reduceCondInfer, which captures the type at each binder's position first.
 func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 	check := e.reduce(t.Check)
 	extends := e.reduce(t.Extends)
-	if !condOperandGround(check) || !condOperandGround(extends) {
-		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else}
+	// An Extends operand holds its `infer` binders by design, so only the Check is tested for one. A
+	// binder reaches the Check position only when an enclosing conditional left its Then branch
+	// unsubstituted. That position stands for a type no match has chosen yet, so the Check is not
+	// ground and the conditional stays symbolic.
+	if !condOperandGround(check) || containsInfer(check) || !condOperandGround(extends) {
+		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute}
+	}
+	if union, ok := check.(*soltype.UnionType); ok && t.Distribute {
+		return e.distributeCond(t, union, extends)
+	}
+	if containsInfer(extends) {
+		return e.reduceCondInfer(t, check, extends)
 	}
 	if e.ctx.condExtends(check, extends, e.seen) {
 		return e.reduce(t.Then)
 	}
 	return e.reduce(t.Else)
 }
+
+// distributeCond decides a distributive conditional one union member at a time and unions the
+// branches each member selects, so `type Wrap<T> = if T : string { [T] } else { boolean }` reduces
+// `Wrap<"a" | 1>` to `["a"] | boolean` rather than to the single branch the whole union selects.
+//
+// A branch that names the distributed type parameter reads it as the member, not the union, which is
+// why `Wrap<"a" | "b">` reduces to `["a"] | ["b"]`. Expanding the alias replaced every occurrence of
+// that parameter — the Check position and the two branches alike — with one shared type pointer, so
+// rewriting the branches' occurrences of the unreduced Check narrows exactly the positions the
+// parameter stood at. The Extends operand keeps the union, matching TypeScript, where each member is
+// tested against the whole right-hand side.
+//
+// Each member reduces through a copy of the conditional with Distribute cleared: the member is no
+// longer a union, and clearing it states that this pass already applied the rule.
+func (e *typeEvaluator) distributeCond(t *soltype.CondType, check *soltype.UnionType, extends soltype.Type) soltype.Type {
+	parts := make([]soltype.Type, len(check.Types))
+	for i, member := range check.Types {
+		parts[i] = e.reduceCond(&soltype.CondType{
+			Check:   member,
+			Extends: extends,
+			Then:    substituteOccurrences(t.Then, t.Check, member),
+			Else:    substituteOccurrences(t.Else, t.Check, member),
+		})
+	}
+	return newUnion(nil, parts, false)
+}
+
+// substituteOccurrences rewrites every occurrence of the from type inside in to the to type,
+// matching on pointer identity. Expanding a generic alias substitutes one shared pointer for each
+// occurrence of a type parameter, so identity picks out the positions that parameter stood at
+// without touching an equal type the body wrote itself.
+func substituteOccurrences(in, from, to soltype.Type) soltype.Type {
+	return in.Accept(&occurrenceSubst{from: from, to: to}, soltype.Positive)
+}
+
+// occurrenceSubst is the rewriting visitor behind substituteOccurrences.
+type occurrenceSubst struct{ from, to soltype.Type }
+
+func (s *occurrenceSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if t == s.from {
+		return soltype.EnterResult{Type: s.to, SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *occurrenceSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// reduceCondInfer decides a conditional whose Extends operand declares `infer` captures, such as
+// `if T : [infer U] { U } else { boolean }`. It runs in three steps:
+//
+//  1. matchInfer walks Check against Extends and records the type at each binder's position.
+//  2. Those captures are substituted into Extends, turning the pattern into an ordinary type, and
+//     the resulting `Check <: Extends` probe decides the branch the same way a capture-free
+//     conditional does. Substituting first is what lets a pattern mix captures with written types:
+//     `[infer A, number]` over `[number, string]` binds A but the probe still rejects on element 1.
+//  3. On success the captures are substituted into the Then branch, so a reference to a captured
+//     name reduces to the type that was matched.
+//
+// A structural mismatch, or a pattern position the matcher has no arm for, leaves a binder without a
+// capture and selects Else. The post-substitution check for a surviving binder is what makes that
+// total: no branch is ever selected with an unsubstituted capture in it.
+func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends soltype.Type) soltype.Type {
+	captures := map[string]soltype.Type{}
+	if !e.matchInfer(check, extends, captures) {
+		return e.reduce(t.Else)
+	}
+	pattern := substituteInfer(extends, captures)
+	if containsInfer(pattern) {
+		return e.reduce(t.Else)
+	}
+	if !e.ctx.condExtends(check, pattern, e.seen) {
+		return e.reduce(t.Else)
+	}
+	return e.reduce(substituteInfer(t.Then, captures))
+}
+
+// matchInfer walks the ground type check alongside the Extends pattern and records into captures
+// the type sitting at each `infer` binder's position, reporting whether the two aligned. A pattern
+// subtree declaring no binder needs no alignment — the `Check <: Extends` probe decides it — so the
+// walk stops there and reports success.
+//
+// The arms cover the positions a capture is written in: a tuple element, an object property, a
+// function parameter or return, a promise payload, and a type argument of an alias or class
+// reference. A pattern position with no arm, such as a union or a borrow, reports a mismatch, which
+// selects the Else branch. Reporting success there instead would leave the binder uncaptured, and
+// the caller would reject the branch anyway.
+func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[string]soltype.Type) bool {
+	if binder, ok := pattern.(*soltype.InferType); ok {
+		capture(captures, binder.Name, check)
+		return true
+	}
+	if !containsInfer(pattern) {
+		return true
+	}
+	switch pat := pattern.(type) {
+	case *soltype.TupleType:
+		tup, ok := e.alignCheck(check).(*soltype.TupleType)
+		if !ok || len(tup.Elems) != len(pat.Elems) || hasRestSpread(tup.Elems) {
+			return false
+		}
+		for i, el := range pat.Elems {
+			if !e.matchInfer(tup.Elems[i], el, captures) {
+				return false
+			}
+		}
+		return true
+	case *soltype.ObjectType:
+		obj, ok := e.groundToObject(check)
+		if !ok {
+			return false
+		}
+		for _, el := range pat.Elems {
+			prop, ok := el.(*soltype.PropertyElem)
+			if !ok {
+				// Only a named property pattern has a member to read the capture off. Any other
+				// member is skipped, and a binder it carries stays uncaptured, which the caller
+				// rejects when it finds one surviving substitution.
+				continue
+			}
+			read, hasValue, _ := memberReadContribution(obj, prop.Name)
+			if !hasValue {
+				return false
+			}
+			if !e.matchInfer(read, prop.Type, captures) {
+				return false
+			}
+		}
+		return true
+	case *soltype.FuncType:
+		fn, ok := e.alignCheck(check).(*soltype.FuncType)
+		if !ok || len(fn.Params) != len(pat.Params) {
+			return false
+		}
+		for i, p := range pat.Params {
+			if !e.matchInfer(fn.Params[i].Type, p.Type, captures) {
+				return false
+			}
+		}
+		return e.matchInfer(fn.Ret, pat.Ret, captures)
+	case *soltype.PromiseType:
+		promise, ok := e.alignCheck(check).(*soltype.PromiseType)
+		if !ok {
+			return false
+		}
+		return e.matchInfer(promise.Inner, pat.Inner, captures)
+	case *soltype.ClassType:
+		cls, ok := e.alignCheck(check).(*soltype.ClassType)
+		if !ok || cls.Name != pat.Name {
+			return false
+		}
+		return e.matchInferArgs(cls.TypeArgs, pat.TypeArgs, captures)
+	case *soltype.AliasType:
+		return e.matchInferAlias(check, pat, captures)
+	default:
+		return false
+	}
+}
+
+// matchInferAlias matches a named-alias pattern such as `Box<infer U>`. A check naming the same
+// alias matches argument by argument, which is the exact case `Awaited`-shaped patterns rely on.
+// Otherwise the pattern's alias expands to its body and the match retries against that, so
+// `Box<infer U>` over `type Box<T> = {v: T}` still captures U from a plain `{v: number}`. Expansion
+// runs under the shared termination guard, so a recursive alias pattern stops rather than unfolding
+// forever, and a guard that blocks expansion reports a mismatch.
+//
+// Comparing names first is what makes a recursive alias such as `type List<T> = {head: T, tail:
+// List<T> | null}` match: expanding both sides would reach the `List<T> | null` field, a union the
+// matcher has no arm for. The match against the expanded body runs inside the guard's callback,
+// where the alias is still on the active path, so a body that re-references the alias stops.
+func (e *typeEvaluator) matchInferAlias(check soltype.Type, pat *soltype.AliasType, captures map[string]soltype.Type) bool {
+	if alias, ok := e.reduce(check).(*soltype.AliasType); ok && alias.Name == pat.Name {
+		return e.matchInferArgs(alias.TypeArgs, pat.TypeArgs, captures)
+	}
+	matched := false
+	e.expandAliasGuarded(pat, nil, func(body soltype.Type) soltype.Type {
+		matched = e.matchInfer(check, body, captures)
+		return nil
+	})
+	return matched
+}
+
+// matchInferArgs matches two positional type-argument lists, the shared body of the class and alias
+// arms. Differing arity is a mismatch, since no position lines up.
+func (e *typeEvaluator) matchInferArgs(checkArgs, patArgs []soltype.Type, captures map[string]soltype.Type) bool {
+	if len(checkArgs) != len(patArgs) {
+		return false
+	}
+	for i, arg := range patArgs {
+		if !e.matchInfer(checkArgs[i], arg, captures) {
+			return false
+		}
+	}
+	return true
+}
+
+// capture records the type matched at one binder's position. A name written at two positions, as in
+// `[infer U, infer U]`, keeps both matched types by unioning them, so `[number, string]` captures
+// `number | string`.
+func capture(captures map[string]soltype.Type, name string, matched soltype.Type) {
+	if prev, ok := captures[name]; ok {
+		captures[name] = newUnion(nil, []soltype.Type{prev, matched}, false)
+		return
+	}
+	captures[name] = matched
+}
+
+// alignCheck reduces a check operand toward the structural shape a pattern matches against. A
+// `typeof` query resolves to the value's type and a named alias expands to its body, both under the
+// termination guard, so `if Pair : [infer A, infer B]` over `type Pair = [number, string]` aligns
+// with the tuple pattern. A guard that blocks expansion leaves the alias in place, which the caller
+// reads as a mismatch. The object arm uses groundToObject instead, which also projects a class body.
+func (e *typeEvaluator) alignCheck(check soltype.Type) soltype.Type {
+	switch c := check.(type) {
+	case *soltype.TypeofType:
+		return e.alignCheck(c.Ty)
+	case *soltype.AliasType:
+		return e.expandAliasGuarded(c, c, func(body soltype.Type) soltype.Type {
+			return e.alignCheck(body)
+		})
+	default:
+		return e.reduce(check)
+	}
+}
+
+// substituteInfer rewrites every `infer` node in t whose name has a capture to the captured type,
+// covering both the binder in a pattern and a reference to that name in a Then branch. A name with
+// no capture is left in place, which is how the caller detects a match that bound only part of the
+// pattern. Names are matched as written, so a nested conditional inside the branch that reuses an
+// outer name is rewritten too rather than shadowing it.
+func substituteInfer(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
+	if len(captures) == 0 {
+		return t
+	}
+	return t.Accept(&inferSubst{captures: captures}, soltype.Positive)
+}
+
+// inferSubst is the rewriting visitor behind substituteInfer. It replaces a captured `infer` node
+// with the matched type and skips that node's children, since the replacement is already reduced.
+type inferSubst struct{ captures map[string]soltype.Type }
+
+func (s *inferSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if iv, ok := t.(*soltype.InferType); ok {
+		if matched, found := s.captures[iv.Name]; found {
+			return soltype.EnterResult{Type: matched, SkipChildren: true}
+		}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *inferSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// containsInfer reports whether t holds an `infer` node with no capture substituted into it yet. A
+// conditional consults it on its Extends operand to route to the matcher, and on a substituted
+// pattern to reject a match that left a binder uncaptured.
+func containsInfer(t soltype.Type) bool {
+	f := &inferFinder{}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+// inferFinder is the walking visitor behind containsInfer. It flags the first `infer` node it
+// reaches and skips that node's children, since one occurrence is enough.
+type inferFinder struct{ found bool }
+
+func (f *inferFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if _, ok := t.(*soltype.InferType); ok {
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *inferFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
 // condExtends decides a conditional's `Check <: Extends` test with an assignability probe. The
 // trial runs under a discard-only probe, so a speculative match records no bound and leaves no

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -198,18 +198,18 @@ func (s *occurrenceSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.T
 // capture and selects Else. The post-substitution check for a surviving binder is what makes that
 // total: no branch is ever selected with an unsubstituted capture in it.
 func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends soltype.Type) soltype.Type {
-	captures := map[string]soltype.Type{}
+	captures := map[int]soltype.Type{}
 	if !e.matchInfer(check, extends, captures) {
 		return e.reduce(t.Else)
 	}
-	pattern := substituteBinders(extends, captures)
+	pattern := substituteInfer(extends, captures)
 	if containsInfer(pattern) {
 		return e.reduce(t.Else)
 	}
 	if !e.ctx.condExtends(check, pattern, e.seen) {
 		return e.reduce(t.Else)
 	}
-	return e.reduce(substituteCaptures(t.Then, captures))
+	return e.reduce(substituteInfer(t.Then, captures))
 }
 
 // matchInfer walks the ground type check alongside the Extends pattern and records into captures
@@ -222,9 +222,9 @@ func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check, extends solt
 // reference. A pattern position with no arm, such as a union or a borrow, reports a mismatch, which
 // selects the Else branch. Reporting success there instead would leave the binder uncaptured, and
 // the caller would reject the branch anyway.
-func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[string]soltype.Type) bool {
+func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[int]soltype.Type) bool {
 	if binder, ok := pattern.(*soltype.InferType); ok {
-		capture(captures, binder.Name, check)
+		capture(captures, binder.ID, check)
 		return true
 	}
 	if !containsInfer(pattern) {
@@ -305,7 +305,7 @@ func (e *typeEvaluator) matchInfer(check, pattern soltype.Type, captures map[str
 // List<T> | null}` match: expanding both sides would reach the `List<T> | null` field, a union the
 // matcher has no arm for. The match against the expanded body runs inside the guard's callback,
 // where the alias is still on the active path, so a body that re-references the alias stops.
-func (e *typeEvaluator) matchInferAlias(check soltype.Type, pat *soltype.AliasType, captures map[string]soltype.Type) bool {
+func (e *typeEvaluator) matchInferAlias(check soltype.Type, pat *soltype.AliasType, captures map[int]soltype.Type) bool {
 	if alias, ok := e.reduce(check).(*soltype.AliasType); ok && alias.Name == pat.Name {
 		return e.matchInferArgs(alias.TypeArgs, pat.TypeArgs, captures)
 	}
@@ -319,7 +319,7 @@ func (e *typeEvaluator) matchInferAlias(check soltype.Type, pat *soltype.AliasTy
 
 // matchInferArgs matches two positional type-argument lists, the shared body of the class and alias
 // arms. Differing arity is a mismatch, since no position lines up.
-func (e *typeEvaluator) matchInferArgs(checkArgs, patArgs []soltype.Type, captures map[string]soltype.Type) bool {
+func (e *typeEvaluator) matchInferArgs(checkArgs, patArgs []soltype.Type, captures map[int]soltype.Type) bool {
 	if len(checkArgs) != len(patArgs) {
 		return false
 	}
@@ -334,12 +334,12 @@ func (e *typeEvaluator) matchInferArgs(checkArgs, patArgs []soltype.Type, captur
 // capture records the type matched at one binder's position. A name written at two positions, as in
 // `[infer U, infer U]`, keeps both matched types by unioning them, so `[number, string]` captures
 // `number | string`.
-func capture(captures map[string]soltype.Type, name string, matched soltype.Type) {
-	if prev, ok := captures[name]; ok {
-		captures[name] = newUnion(nil, []soltype.Type{prev, matched}, false)
+func capture(captures map[int]soltype.Type, decl int, matched soltype.Type) {
+	if prev, ok := captures[decl]; ok {
+		captures[decl] = newUnion(nil, []soltype.Type{prev, matched}, false)
 		return
 	}
-	captures[name] = matched
+	captures[decl] = matched
 }
 
 // alignCheck reduces a check operand toward the structural shape a pattern matches against. A
@@ -360,112 +360,33 @@ func (e *typeEvaluator) alignCheck(check soltype.Type) soltype.Type {
 	}
 }
 
-// substituteBinders rewrites each `infer U` binder in a pattern to the type captured for U, turning
-// the Extends operand into an ordinary type the `Check <: Extends` probe can decide. A binder whose
-// name has no capture is left in place, which is how the caller detects a match that bound only part
-// of the pattern.
-func substituteBinders(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
-	return substituteInfer(t, captures, true)
-}
-
-// substituteCaptures rewrites each reference to a captured name in a selected branch to the type
-// captured for it, so the branch reduces to what the match found. A nested conditional that binds
-// the same name again keeps its own binder and its own Then branch, so the inner capture shadows the
-// outer one rather than being overwritten by it.
-func substituteCaptures(t soltype.Type, captures map[string]soltype.Type) soltype.Type {
-	return substituteInfer(t, captures, false)
-}
-
-// substituteInfer is the shared body of substituteBinders and substituteCaptures. Its two callers
-// need opposite halves of the `infer` nodes, which binders selects: a pattern replaces the binders
-// that declare the names, and a branch replaces the references that read them.
-func substituteInfer(t soltype.Type, captures map[string]soltype.Type, binders bool) soltype.Type {
+// substituteInfer rewrites every `infer` node whose declaration captures holds a type for to that
+// type, covering the clause that declares the name and the branch references that read it alike,
+// since both carry the declaration's id. A nested conditional writing the same name declares its own
+// id, so its clause and references are left for that conditional's own match to fill — shadowing
+// needs no special handling here. A declaration with no capture is left in place, which is how the
+// caller detects a match that filled only part of the pattern.
+func substituteInfer(t soltype.Type, captures map[int]soltype.Type) soltype.Type {
 	if len(captures) == 0 {
 		return t
 	}
-	return t.Accept(&inferSubst{captures: captures, binders: binders}, soltype.Positive)
+	return t.Accept(&inferSubst{captures: captures}, soltype.Positive)
 }
 
 // inferSubst is the rewriting visitor behind substituteInfer. It replaces a captured `infer` node
 // with the matched type and skips that node's children, since the replacement is already reduced.
-type inferSubst struct {
-	captures map[string]soltype.Type
-	binders  bool
-}
+type inferSubst struct{ captures map[int]soltype.Type }
 
-func (s *inferSubst) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	switch t := t.(type) {
-	case *soltype.InferType:
-		if matched, found := s.captures[t.Name]; found && t.Binder == s.binders {
+func (s *inferSubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if iv, ok := t.(*soltype.InferType); ok {
+		if matched, found := s.captures[iv.ID]; found {
 			return soltype.EnterResult{Type: matched, SkipChildren: true}
-		}
-	case *soltype.CondType:
-		if shadowed := shadowedCaptures(t, s.captures); len(shadowed) > 0 {
-			return s.rewriteShadowingCond(t, pol, shadowed)
 		}
 	}
 	return soltype.EnterResult{}
 }
 
 func (s *inferSubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
-
-// rewriteShadowingCond rewrites a nested conditional that declares a name the enclosing conditional
-// also captured. Its Then branch reads the inner capture, so that branch is rewritten with the
-// shadowed names dropped and the inner binder survives to be filled when the inner conditional
-// reduces. The other three operands sit outside the inner name's scope, so they still read the outer
-// captures and are rewritten with the full set.
-func (s *inferSubst) rewriteShadowingCond(t *soltype.CondType, pol soltype.Polarity, shadowed []string) soltype.EnterResult {
-	inner := &inferSubst{captures: withoutNames(s.captures, shadowed), binders: s.binders}
-	return soltype.EnterResult{
-		Type: &soltype.CondType{
-			Check:      t.Check.Accept(s, pol),
-			Extends:    t.Extends.Accept(s, pol),
-			Then:       t.Then.Accept(inner, pol),
-			Else:       t.Else.Accept(s, pol),
-			Distribute: t.Distribute,
-		},
-		SkipChildren: true,
-	}
-}
-
-// shadowedCaptures returns the names the nested conditional t declares that captures also holds a
-// type for. Those are the names whose meaning differs inside t's Then branch.
-func shadowedCaptures(t *soltype.CondType, captures map[string]soltype.Type) []string {
-	var shadowed []string
-	f := &inferBinderFinder{}
-	t.Extends.Accept(f, soltype.Positive)
-	for _, name := range f.names {
-		if _, found := captures[name]; found {
-			shadowed = append(shadowed, name)
-		}
-	}
-	return shadowed
-}
-
-// inferBinderFinder collects the names the `infer U` binders of one Extends operand declare.
-type inferBinderFinder struct{ names []string }
-
-func (f *inferBinderFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
-	if iv, ok := t.(*soltype.InferType); ok && iv.Binder {
-		f.names = append(f.names, iv.Name)
-	}
-	return soltype.EnterResult{}
-}
-
-func (f *inferBinderFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
-
-// withoutNames copies captures with the given names removed, the capture set that is in scope inside
-// a nested conditional's Then branch.
-func withoutNames(captures map[string]soltype.Type, names []string) map[string]soltype.Type {
-	out := make(map[string]soltype.Type, len(captures))
-	for name, matched := range captures {
-		out[name] = matched
-	}
-	for _, name := range names {
-		delete(out, name)
-	}
-	return out
-}
 
 // containsInfer reports whether t holds an `infer` node with no capture substituted into it yet. A
 // conditional consults it on its Extends operand to route to the matcher, and on a substituted


### PR DESCRIPTION
Adds support for `infer U` clauses in conditional type Extends operands, allowing type parameters to be captured and used in the Then branch. This implements the structural matching and substitution logic needed to reduce conditionals like `if T : [infer U] { U } else { boolean }`.

Key changes:

- **Type representation**: Added `InferType` to represent both `infer U` binders and references to captured names, with a `Binder` flag to distinguish them.

- **Conditional distribution**: Implemented the naked-type-parameter rule where a conditional with a bare type-parameter Check distributes over union types, deciding each member separately. Added `Distribute` field to `CondType` to track this.

- **Structural matching**: Implemented `matchInfer` to walk a ground Check against an Extends pattern and record types at each binder's position. Covers tuple elements, object properties, function parameters and returns, promise payloads, and type arguments of aliases and classes.

- **Capture substitution**: Implemented `substituteInfer` to replace captured `infer` nodes with matched types in both the pattern and Then branch. A name written at multiple positions unions the matched types.

- **Scope binding**: Modified `resolveCondTypeAnn` to bind captured names in a child scope covering only the Then branch, matching TypeScript's scoping rules. An `infer` name in the Else branch is an unbound reference.

- **Error handling**: Updated error reporting to reject `infer` clauses outside the Extends operand with a clear message.

- **Tests**: Added comprehensive test coverage for capture positions, distribution behavior, recursive aliases, and constraint checking with captured types.

https://claude.ai/code/session_01862e55KPTUnCc25x8oEZjg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `infer` captures in conditional types, including tuples, objects, functions, promises, classes, and aliases.
  * Conditional types can now distribute across union members when checking a naked type parameter.
  * Captured types are substituted into resulting branches and remain symbolic when they cannot yet be resolved.

* **Bug Fixes**
  * Improved rendering and diagnostics for inferred types.
  * Preserved conditional-type behavior through transformations and comparisons.
  * Added clearer validation for `infer` usage outside supported conditional-type contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->