### PR TITLE
Implement infer clause and distributive conditionals

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -431,6 +431,8 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Extends)
 			walk(t.Then)
 			walk(t.Else)
+		case *InferType:
+			walk(t.Var)
 		case *RestSpreadType:
 			walk(t.Operand)
 		case *PromiseType:
@@ -654,6 +656,10 @@ func (p *namedPrinter) printType(t Type) string {
 		// neighbor and none needs parens.
 		return "if " + p.printType(t.Check) + " : " + p.printType(t.Extends) +
 			" { " + p.printType(t.Then) + " } else { " + p.printType(t.Else) + " }"
+	case *InferType:
+		// `infer U`, the binding position inside a conditional's Extends. The branches render
+		// their references to the same variable under the variable's own name, not this prefix.
+		return "infer " + t.Name
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -662,16 +662,34 @@ type TypeofType struct {
 // CondType is the residual `if Check : Extends { Then } else { Else }` conditional type operator.
 // Like KeyofType it is inert: it carries no bounds, constrain never records one against it, and it
 // flows through the solver's structural machinery untouched, rendering the way the source wrote it.
-// An evaluator reduces it once Check and Extends are ground, reusing the M9 PR1b machinery. It
-// decides `Check <: Extends` with an assignability probe and reduces to Then on success or Else on
-// failure. Until then a conditional over a type parameter stays symbolic. The `infer` clause in
-// Extends and distribution over a naked type-parameter union are M9 PR3b, so a Check that is a bare
-// type parameter keeps the whole conditional symbolic here.
+// An evaluator reduces it once Check and Extends are ground. It decides the branch two ways. When
+// Extends holds no `infer`, it probes `Check <: Extends` and reduces to Then on success or Else on
+// failure. When Extends holds an `infer U`, a structural matcher binds each `infer` position and
+// reduces Then with those bindings substituted in. Until Check grounds a conditional over a type
+// parameter stays symbolic.
+//
+// Distribute marks a conditional whose Check is written as a naked type parameter, the syntactic
+// condition TypeScript uses for a distributive conditional. When the parameter is instantiated with
+// a union, the conditional evaluates per member and unions the results, so `Exclude<"a" | "b", "a">`
+// reduces to `"b"`. It is set at annotation time from the source shape and carried through the
+// solver untouched.
 type CondType struct {
-	Check   Type
-	Extends Type
-	Then    Type
-	Else    Type
+	Check      Type
+	Extends    Type
+	Then       Type
+	Else       Type
+	Distribute bool
+}
+
+// InferType is an `infer U` binding position inside a conditional's Extends operand. Var is the
+// type variable the same conditional's Then and Else branches resolve their `U` references to, so
+// binding Var to the type matched at this position and substituting it into Then is what extracts
+// the captured type. It is inert: it carries no bounds and flows through the solver's structural
+// machinery untouched, rendering `infer U`. It is only meaningful nested inside a CondType.Extends;
+// the resolver rejects it anywhere else.
+type InferType struct {
+	Name string
+	Var  *TypeVarType
 }
 
 // RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
@@ -691,6 +709,7 @@ func (*KeyofType) isType()        {}
 func (*IndexType) isType()        {}
 func (*TypeofType) isType()       {}
 func (*CondType) isType()         {}
+func (*InferType) isType()        {}
 func (*RestSpreadType) isType()   {}
 func (*PrimType) isType()         {}
 func (*LitType) isType()          {}
@@ -785,6 +804,11 @@ func LevelOf(t Type) int {
 		// operand lifts the level and the freshener/extruder prune descends into all four, the
 		// four-child analogue of the two-child IndexType arm.
 		return max(max(LevelOf(t.Check), LevelOf(t.Extends)), max(LevelOf(t.Then), LevelOf(t.Else)))
+	case *InferType:
+		// An `infer U` binding's level is its variable's, so an out-of-level infer var lifts the
+		// enclosing conditional's level and the freshener/extruder prune descends to freshen it,
+		// the same single-child rule the KeyofType arm follows.
+		return LevelOf(t.Var)
 	case *RestSpreadType:
 		// A `...P` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -233,7 +233,33 @@ func (t *CondType) Accept(v TypeVisitor, pol Polarity) Type {
 	els := cur.Else.Accept(v, pol)
 	out := cur
 	if check != cur.Check || extends != cur.Extends || then != cur.Then || els != cur.Else {
-		out = &CondType{Check: check, Extends: extends, Then: then, Else: els}
+		out = &CondType{Check: check, Extends: extends, Then: then, Else: els, Distribute: cur.Distribute}
+	}
+	return v.ExitType(out, pol)
+}
+
+func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// The binding variable walks in the current polarity so a freshening or instantiation rewrites
+	// it in lockstep with the Then and Else branches that reference the same variable.
+	//
+	// A FuncType type-parameter binder demands to stay a variable and panics through
+	// acceptTypeParamVar when a visitor inlines it to a non-variable, on the contract that an
+	// inlining visitor skips the binder first. An `infer` binder deliberately relaxes that: the
+	// display coalescer inlines the branch references but has no retention entry to skip this binder,
+	// so a non-variable rewrite is tolerated by keeping the original Var. Var must stay a variable to
+	// remain a binding position, so the inlined form is dropped here and the branch references inline
+	// independently at display time. This affects only the display of a fully symbolic conditional,
+	// never a reduction, and giving `infer` binders the same retention treatment type parameters get
+	// is deferred.
+	rewritten := cur.Var.Accept(v, pol)
+	out := cur
+	if nv, ok := rewritten.(*TypeVarType); ok && nv != cur.Var {
+		out = &InferType{Name: cur.Name, Var: nv}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1130,11 +1130,18 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		b, ok := b.(*soltype.TypeofType)
 		return ok && a.Ident == b.Ident && equalTypeWith(a.Ty, b.Ty, ctx)
 	case *soltype.CondType:
-		// Two inert conditional residuals are equal when all four operands are equal, compared
-		// structurally without deciding either branch, the four-child analogue of the KeyofType arm.
+		// Two inert conditional residuals are equal when they share the distributive flag and all
+		// four operands are equal, compared structurally without deciding either branch, the
+		// four-child analogue of the KeyofType arm.
 		b, ok := b.(*soltype.CondType)
-		return ok && equalTypeWith(a.Check, b.Check, ctx) && equalTypeWith(a.Extends, b.Extends, ctx) &&
-			equalTypeWith(a.Then, b.Then, ctx) && equalTypeWith(a.Else, b.Else, ctx)
+		return ok && a.Distribute == b.Distribute && equalTypeWith(a.Check, b.Check, ctx) &&
+			equalTypeWith(a.Extends, b.Extends, ctx) && equalTypeWith(a.Then, b.Then, ctx) &&
+			equalTypeWith(a.Else, b.Else, ctx)
+	case *soltype.InferType:
+		// Two `infer U` bindings are equal when they name the same capture and bind the same
+		// variable, so a reflexive symbolic conditional compares equal against itself.
+		b, ok := b.(*soltype.InferType)
+		return ok && a.Name == b.Name && a.Var == b.Var
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1808,6 +1808,10 @@ func describe(t soltype.Type) string {
 		// than the default `?`. Every operand renders in describe's raw mid-constrain form.
 		return "if " + describe(t.Check) + " : " + describe(t.Extends) +
 			" { " + describe(t.Then) + " } else { " + describe(t.Else) + " }"
+	case *soltype.InferType:
+		// An `infer U` binding renders under its `infer` prefix, reached in place when the
+		// enclosing conditional's Extends arm describes its operand.
+		return "infer " + t.Name
 	case *soltype.RestSpreadType:
 		// A `...P` spread element renders `...` over its operand, reached in place when the
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders

--- a/internal/solver/infer.go
+++ b/internal/solver/infer.go
@@ -66,6 +66,13 @@ type checker struct {
 	// same reason. The map is allocated lazily by namedLifetime on first use.
 	namedLifetimes map[string]*soltype.LifetimeVar
 
+	// inCondExtends is true only while resolving a conditional type's Extends operand, the one
+	// position where an `infer U` clause is legal. resolveInferTypeAnn reads it to accept the
+	// clause there and report an unsupported feature anywhere else. resolveCondTypeAnn sets it
+	// around the Extends resolution and clears it around Check, Then, and Else, so a nested
+	// conditional's non-Extends operands reject `infer` even when they sit inside an outer Extends.
+	inCondExtends bool
+
 	// classNamespace is the dep_graph namespace of the class declaration currently
 	// being inferred, empty at the root namespace and outside any class body.
 	// inferClassDecl sets it on entry and restores it on exit. A class-body type

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1290,14 +1290,215 @@ func TestInferCondResidualErrorMessage(t *testing.T) {
 	require.Equal(t, "1:12-1:51: cannot constrain if t1 : number { string } else { boolean } <: number", msgWithSpan(errs[0]))
 }
 
-// A conditional whose Extends holds an `infer` clause is unsupported until M9 PR3b: branch selection
-// has no matcher to bind the `infer` name. The annotation reports one UnsupportedFeatureError rather
-// than resolving the Extends and silently mis-deciding the branch.
-func TestInferCondInferUnsupported(t *testing.T) {
-	_, _, errs := inferSource(t, `fn f<T>(x: if T : Array<infer U> { U } else { never }) {}`)
+// A conditional whose Extends holds an `infer U` reduces by matching the ground Check against the
+// Extends pattern structurally, binding `U` to the matched position and substituting it into the
+// selected branch. Each case names a ground Check and an Extends carrying an `infer`, and asserts
+// the reduced branch. The cases cover the pattern shapes the matcher decomposes: a tuple element, a
+// function parameter, a function return, a promise payload, an object property, two positions
+// sharing one `infer`, and a Check whose shape does not match the pattern so the Else branch is
+// taken.
+func TestInferCondInferReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// A tuple pattern binds `U` to the element at the `infer` position.
+			name:         "TupleElement",
+			src:          `type Result = if [number, string] : [infer U, string] { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// A function pattern binds `U` to the parameter at the `infer` position.
+			name:         "FunctionParameter",
+			src:          `type Result = if fn (x: number) -> string : fn (x: infer U) -> string { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// A function pattern binds `R` to the return at the `infer` position.
+			name:         "FunctionReturn",
+			src:          `type Result = if fn (x: number) -> string : fn (x: number) -> infer R { R } else { boolean }`,
+			wantExpanded: "string",
+		},
+		{
+			// A promise pattern binds `U` to the payload, the extraction Awaited<T> builds on.
+			name:         "PromisePayload",
+			src:          `type Result = if Promise<number> : Promise<infer U> { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// An object pattern binds `U` to the named property's type.
+			name:         "ObjectProperty",
+			src:          `type Result = if {value: number} : {value: infer U} { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// Two positions sharing one `infer U` capture the leftmost, so the branch reads the
+			// first element's type.
+			name:         "RepeatedInferName",
+			src:          `type Result = if [number, string] : [infer U, infer U] { U } else { boolean }`,
+			wantExpanded: "number",
+		},
+		{
+			// A Check whose shape does not match the pattern takes the Else branch: a primitive is
+			// not a tuple, so no `infer` binds.
+			name:         "MismatchTakesElse",
+			src:          `type Result = if number : [infer U, string] { U } else { boolean }`,
+			wantExpanded: "boolean",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// constrain reduces an `infer` conditional to the selected branch to check satisfaction, expanding a
+// generic alias's argument into the Check before matching. A value matching the captured type is
+// accepted; a mismatch is rejected against that type, so the diagnostic names the branch the
+// conditional resolved to. Each case defines a generic alias whose body extracts a type through
+// `infer` and checks a value against an instantiation of it.
+func TestInferCondInferConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "TupleFirstAccepted",
+			src: `
+				type First<T> = if T : [infer U, string] { U } else { boolean }
+				val v: First<[number, string]> = 5
+			`,
+		},
+		{
+			name: "TupleFirstRejected",
+			src: `
+				type First<T> = if T : [infer U, string] { U } else { boolean }
+				val v: First<[number, string]> = "hi"
+			`,
+			wantErr: `cannot constrain "hi" <: number`,
+		},
+		{
+			name: "PromisePayloadAccepted",
+			src: `
+				type Payload<T> = if T : Promise<infer U> { U } else { boolean }
+				val v: Payload<Promise<string>> = "hi"
+			`,
+		},
+		{
+			name: "ReturnTypeRejected",
+			src: `
+				type Ret<T> = if T : fn (x: number) -> infer R { R } else { boolean }
+				val v: Ret<fn (x: number) -> string> = 5
+			`,
+			wantErr: `cannot constrain 5 <: string`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A conditional whose Check is a naked type parameter distributes over a union argument member-wise,
+// matching TypeScript. Each member evaluates the conditional independently, so `Widen` maps every
+// member of `"a" | "b"` through its own branch decision and unions the results. Without
+// distribution the whole union `"a" | "b"` would fail the `<: "a"` probe and take the Else branch
+// alone; distribution instead selects Then for `"a"` and Else for `"b"`, so the result is the union
+// `number | boolean`. constrain accepts a value the distributed union covers and rejects one it does
+// not.
+func TestInferCondDistribution(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			// number rides the "a" member's Then branch, present only because distribution evaluates
+			// that member on its own.
+			name: "MemberThenBranchAccepted",
+			src: `
+				type Widen<T> = if T : "a" { number } else { boolean }
+				val v: Widen<"a" | "b"> = 5
+			`,
+		},
+		{
+			// boolean rides the "b" member's Else branch.
+			name: "MemberElseBranchAccepted",
+			src: `
+				type Widen<T> = if T : "a" { number } else { boolean }
+				val v: Widen<"a" | "b"> = true
+			`,
+		},
+		{
+			// A string is in neither branch of the distributed union number | boolean.
+			name: "OutsideDistributedUnionRejected",
+			src: `
+				type Widen<T> = if T : "a" { number } else { boolean }
+				val v: Widen<"a" | "b"> = "hi"
+			`,
+			wantErr: `cannot constrain "hi" <: number | boolean`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A distributive conditional reduces to the distributed union directly. `Widen<"a" | "b">` maps `"a"`
+// to its Then branch `number` and `"b"` to its Else branch `boolean`, so the reduction is the union
+// `number | boolean`. The alias reference expands its union argument into the naked Check before
+// distributing.
+func TestInferCondDistributionReduction(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Widen<T> = if T : "a" { number } else { boolean }
+		type Result = Widen<"a" | "b">
+	`)
+	require.Empty(t, errs)
+	ref, ok := nodes["Result"].(*soltype.AliasType)
+	require.True(t, ok)
+	reduced := expandResidual(ctx, ctx.expandAlias(ref))
+	require.Equal(t, "number | boolean", soltype.Print(reduced))
+}
+
+// An `infer` clause is legal only inside a conditional type's Extends operand. Outside it — here in a
+// bare type alias — there is no conditional to bind the name, so the annotation reports one
+// UnsupportedFeatureError and recovers.
+func TestInferInferOutsideCondRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `type Result = infer U`)
 	require.Len(t, errs, 1)
 	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
-	require.Equal(t, "Unsupported: infer clause in conditional type", errs[0].Message())
+	require.Equal(t, "Unsupported: infer clause outside a conditional type's extends operand", errs[0].Message())
+}
+
+// An `infer` in a conditional's Then branch — not its Extends — is rejected: `infer` binds a capture
+// only in the pattern position. The Then is resolved with the `infer`-legal context cleared, so it
+// reports the same unsupported feature as an `infer` in a bare alias.
+func TestInferInferInThenRejected(t *testing.T) {
+	_, _, errs := inferSource(t, `type Result = if number : number { infer U } else { boolean }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &UnsupportedFeatureError{}, errs[0])
+	require.Equal(t, "Unsupported: infer clause outside a conditional type's extends operand", errs[0].Message())
 }
 
 // Checking a value against a self-referential conditional alias terminates instead of looping. A

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1290,6 +1290,19 @@ func TestInferCondResidualErrorMessage(t *testing.T) {
 	require.Equal(t, "1:12-1:51: cannot constrain if t1 : number { string } else { boolean } <: number", msgWithSpan(errs[0]))
 }
 
+// A symbolic conditional whose Extends holds an `infer U` renders the binding under its `infer`
+// prefix in a diagnostic. A type-parameter Check keeps the conditional symbolic — the `infer` matcher
+// never runs and the branch is never expanded — so the rejected `return k` names the whole residual,
+// and describe's InferType arm shows the Extends position as `Promise<infer U>`. describe is the raw
+// mid-constrain renderer, so the Check shows as the raw var `t1` and the Then's `U` reference as the
+// raw var `t2`, not the coalesced printer's names.
+func TestInferCondInferResidualErrorMessage(t *testing.T) {
+	_, _, errs := inferSource(t, `fn f<T>(k: if T : Promise<infer U> { U } else { boolean }) -> number { return k }`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, "1:12-1:56: cannot constrain if t1 : Promise<infer U> { t2 } else { boolean } <: number", msgWithSpan(errs[0]))
+}
+
 // A conditional whose Extends holds an `infer U` reduces by matching the ground Check against the
 // Extends pattern structurally, binding `U` to the matched position and substituting it into the
 // selected branch. Each case names a ground Check and an Extends carrying an `infer`, and asserts
@@ -1479,6 +1492,36 @@ func TestInferCondDistributionReduction(t *testing.T) {
 	require.True(t, ok)
 	reduced := expandResidual(ctx, ctx.expandAlias(ref))
 	require.Equal(t, "number | boolean", soltype.Print(reduced))
+}
+
+// A conditional is marked distributive only when its Check is written as a naked type parameter, so
+// distribution fires for exactly the TypeScript-distributive conditionals. A bare `T` reference is
+// distributive; a wildcard `_` Check and a Check whose reference does not resolve each reduce to a
+// fresh variable but are not naked parameters, so neither is marked distributive.
+func TestInferCondDistributeFlag(t *testing.T) {
+	t.Run("NakedParameter", func(t *testing.T) {
+		nodes, _, errs := inferTypeNodes(t, `type Choose<T> = if T : number { string } else { boolean }`)
+		require.Empty(t, errs)
+		cond, ok := nodes["Choose"].(*soltype.CondType)
+		require.True(t, ok)
+		require.True(t, cond.Distribute)
+	})
+	t.Run("WildcardCheckNotDistributive", func(t *testing.T) {
+		nodes, _, errs := inferTypeNodes(t, `type Result = if _ : number { string } else { boolean }`)
+		require.Empty(t, errs)
+		cond, ok := nodes["Result"].(*soltype.CondType)
+		require.True(t, ok)
+		require.False(t, cond.Distribute)
+	})
+	t.Run("UnresolvedCheckNotDistributive", func(t *testing.T) {
+		nodes, _, errs := inferTypeNodes(t, `type Result = if Bogus : number { string } else { boolean }`)
+		// Bogus does not resolve, so the Check recovers to a fresh variable and the annotation
+		// reports the unresolved reference.
+		require.Len(t, errs, 1)
+		cond, ok := nodes["Result"].(*soltype.CondType)
+		require.True(t, ok)
+		require.False(t, cond.Distribute)
+	})
 }
 
 // An `infer` clause is legal only inside a conditional type's Extends operand. Outside it — here in a

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -367,8 +367,8 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 
 	savedInExtends := c.inCondExtends
 	c.inCondExtends = false
-	check, ok := c.resolveTypeAnn(scope, ta.Check, lvl)
-	if !ok {
+	check, checkOK := c.resolveTypeAnn(scope, ta.Check, lvl)
+	if !checkOK {
 		check = c.freshAt(lvl)
 	}
 	c.inCondExtends = true
@@ -387,7 +387,14 @@ func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int)
 	}
 	c.inCondExtends = savedInExtends
 
-	_, distribute := check.(*soltype.TypeVarType)
+	// A conditional is distributive only when Check is written as a naked type parameter: a bare
+	// TypeRefTypeAnn that resolved to a type variable. Guarding on the source node and the
+	// successful resolution keeps a wildcard `_` and a recovery variable from a failed Check
+	// resolution — both fresh TypeVarTypes — from being mistaken for a naked parameter.
+	distribute := false
+	if ref, isRef := ta.Check.(*ast.TypeRefTypeAnn); isRef && checkOK && len(ref.TypeArgs) == 0 {
+		_, distribute = check.(*soltype.TypeVarType)
+	}
 	t := &soltype.CondType{Check: check, Extends: extends, Then: then, Else: els, Distribute: distribute}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"github.com/escalier-lang/escalier/internal/ast"
+	"github.com/escalier-lang/escalier/internal/set"
 	"github.com/escalier-lang/escalier/internal/soltype"
 )
 
@@ -89,6 +90,8 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.resolveTypeOfTypeAnn(scope, ta)
 	case *ast.CondTypeAnn:
 		return c.resolveCondTypeAnn(scope, ta, lvl)
+	case *ast.InferTypeAnn:
+		return c.resolveInferTypeAnn(scope, ta)
 	case *ast.WildcardTypeAnn:
 		// `_` in type-annotation position is an inference placeholder: mint a fresh
 		// var at the current level for the surrounding annotation to fill in. Today
@@ -336,57 +339,109 @@ func (c *checker) resolveIndexTypeAnn(scope *Scope, ta *ast.IndexTypeAnn, lvl in
 
 // resolveCondTypeAnn lowers `if Check : Extends { Then } else { Else }` to a CondType residual and
 // stores it unreduced, so the annotation prints the way the source wrote it. constrain decides the
-// branch when it checks a constraint against it: a ground `Check <: Extends` probe selects Then or
-// Else, while a conditional over a type parameter stays symbolic. An unsupported operand recovers to
-// a fresh var, cascade-safe like the Promise<bad> recovery.
+// branch when it checks a constraint against it: a ground conditional selects Then or Else, while a
+// conditional over a type parameter stays symbolic. An unsupported operand recovers to a fresh var,
+// cascade-safe like the Promise<bad> recovery.
 //
-// The `infer` clause is M9 PR3b, so a conditional whose Extends holds an `infer` reports an
-// unsupported feature and recovers. Branch selection here has no matcher to bind the `infer` name.
-// Resolving the Extends anyway would recover each `infer U` to a fresh var and silently mis-decide
-// the branch, so rejecting it keeps the two milestones cleanly split.
+// An `infer U` in Extends binds `U` for the branches. Each infer name is declared in a child scope
+// before Extends resolves, so its InferType node reads the same variable the Then and Else
+// references resolve to, and the evaluator's matcher binds that variable to the type matched at the
+// `infer` position. Check, Then, and Else resolve with `inCondExtends` cleared so an `infer` outside
+// the Extends operand is rejected.
+//
+// Distribute records whether Check is written as a naked type parameter, the syntactic condition for
+// a distributive conditional: a bare TypeRefTypeAnn resolving to a type variable. When that
+// parameter is later instantiated with a union, the evaluator distributes the conditional over the
+// union members.
 func (c *checker) resolveCondTypeAnn(scope *Scope, ta *ast.CondTypeAnn, lvl int) (soltype.Type, bool) {
-	if annContainsInfer(ta.Extends) {
-		return c.reportUnsupportedFeature(ta, "infer clause in conditional type"), false
+	// Declare each `infer U` name in a child scope before Extends resolves, so the InferType node
+	// built in Extends and the `U` references in the branches all resolve to one shared variable.
+	condScope := scope
+	inferNames := collectInferNames(ta.Extends)
+	if len(inferNames) > 0 {
+		condScope = scope.Child()
+		for _, name := range inferNames {
+			condScope.defineType(name, TypeBinding{Type: c.freshAt(lvl)})
+		}
 	}
+
+	savedInExtends := c.inCondExtends
+	c.inCondExtends = false
 	check, ok := c.resolveTypeAnn(scope, ta.Check, lvl)
 	if !ok {
 		check = c.freshAt(lvl)
 	}
-	extends, ok := c.resolveTypeAnn(scope, ta.Extends, lvl)
+	c.inCondExtends = true
+	extends, ok := c.resolveTypeAnn(condScope, ta.Extends, lvl)
 	if !ok {
 		extends = c.freshAt(lvl)
 	}
-	then, ok := c.resolveTypeAnn(scope, ta.Then, lvl)
+	c.inCondExtends = false
+	then, ok := c.resolveTypeAnn(condScope, ta.Then, lvl)
 	if !ok {
 		then = c.freshAt(lvl)
 	}
-	els, ok := c.resolveTypeAnn(scope, ta.Else, lvl)
+	els, ok := c.resolveTypeAnn(condScope, ta.Else, lvl)
 	if !ok {
 		els = c.freshAt(lvl)
 	}
-	t := &soltype.CondType{Check: check, Extends: extends, Then: then, Else: els}
+	c.inCondExtends = savedInExtends
+
+	_, distribute := check.(*soltype.TypeVarType)
+	t := &soltype.CondType{Check: check, Extends: extends, Then: then, Else: els, Distribute: distribute}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }
 
-// annContainsInfer reports whether a type annotation subtree holds an `infer U` clause. A
-// conditional consults it on its Extends operand to reject the `infer` form, which M9 PR3b handles.
-func annContainsInfer(ta ast.TypeAnn) bool {
-	f := &inferAnnFinder{}
+// resolveInferTypeAnn lowers an `infer U` clause to a soltype.InferType binding, reading `U`'s
+// variable from the scope resolveCondTypeAnn declared it in, so the binding shares one variable with
+// the branches' `U` references. An `infer` outside a conditional's Extends operand — the only legal
+// position — reports an unsupported feature and recovers, since there is no conditional to bind it.
+func (c *checker) resolveInferTypeAnn(scope *Scope, ta *ast.InferTypeAnn) (soltype.Type, bool) {
+	if !c.inCondExtends {
+		return c.reportUnsupportedFeature(ta, "infer clause outside a conditional type's extends operand"), false
+	}
+	b, ok := scope.GetType(ta.Name)
+	v, isVar := b.Type.(*soltype.TypeVarType)
+	if !ok || !isVar {
+		// resolveCondTypeAnn declares every infer name it collects, so a resolved name is always a
+		// variable. A missing binding means the name was not collected, which cannot happen for an
+		// `infer` reached inside a collected Extends; recover defensively rather than crash.
+		return c.reportUnsupportedFeature(ta, "infer clause outside a conditional type's extends operand"), false
+	}
+	t := &soltype.InferType{Name: ta.Name, Var: v}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// collectInferNames returns the `infer U` names declared in a conditional's Extends operand, in
+// first-appearance order with duplicates removed, so resolveCondTypeAnn declares one variable per
+// name. Two `infer U` positions sharing a name bind the same variable, matching TypeScript.
+func collectInferNames(ta ast.TypeAnn) []string {
+	f := &inferNameCollector{seen: set.NewSet[string]()}
 	ta.Accept(f)
-	return f.found
+	return f.names
 }
 
-// inferAnnFinder is the AST visitor behind annContainsInfer. It flags the first InferTypeAnn it
-// reaches and keeps walking; one occurrence is enough to answer.
-type inferAnnFinder struct {
+// inferNameCollector is the AST visitor behind collectInferNames. It records each InferTypeAnn name
+// once, keeping first-appearance order.
+type inferNameCollector struct {
 	ast.DefaultVisitor
-	found bool
+	seen  set.Set[string]
+	names []string
 }
 
-func (f *inferAnnFinder) EnterTypeAnn(ta ast.TypeAnn) bool {
-	if _, ok := ta.(*ast.InferTypeAnn); ok {
-		f.found = true
+func (f *inferNameCollector) EnterTypeAnn(ta ast.TypeAnn) bool {
+	switch ta := ta.(type) {
+	case *ast.InferTypeAnn:
+		if !f.seen.Contains(ta.Name) {
+			f.seen.Add(ta.Name)
+			f.names = append(f.names, ta.Name)
+		}
+	case *ast.CondTypeAnn:
+		// A nested conditional scopes its own `infer` names, declared by its own resolveCondTypeAnn
+		// call. Stop descending so the enclosing conditional claims only the names in its own Extends.
+		return false
 	}
 	return true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -94,30 +94,254 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 	}
 }
 
-// reduceCond reduces `if Check : Extends { Then } else { Else }` by deciding `Check <: Extends`
-// and selecting a branch, mirroring the old checker's CondType case
-// (internal/checker/expand_type.go), which unifies Check with Extends and returns Then on success
-// or Else on failure. The decision runs only when both operands are ground:
+// reduceCond reduces `if Check : Extends { Then } else { Else }` to the selected branch. It first
+// reduces Check, then handles distribution before deciding the branch:
 //
-//   - a ground Check and Extends decide the branch with an assignability probe, and the reduction
-//     continues into the selected branch alone, so an error in the unselected branch never surfaces;
-//   - a Check or Extends still carrying a type parameter or an unreduced residual keeps the whole
-//     conditional symbolic, rebuilt around the reduced Check and Extends, and reduces later once
-//     they ground. Then and Else stay unreduced in the symbolic form, since neither is selected yet.
-//
-// Distribution over a naked type-parameter union and the `infer` clause are M9 PR3b, so a bare
-// type-parameter Check stays symbolic here rather than distributing.
+//   - a distributive conditional whose naked type parameter has been instantiated with a union
+//     evaluates once per member and unions the results, matching TypeScript. The naked parameter was
+//     substituted to the whole union at every position, so each member evaluation replaces that union
+//     with the one member throughout Check, Extends, and the branches, reconstructing the per-member
+//     conditional. `Exclude<"a" | "b", "a">` reduces to `"b"`;
+//   - otherwise the branch is decided directly on the reduced Check by reduceCondBranch.
 func (e *typeEvaluator) reduceCond(t *soltype.CondType) soltype.Type {
 	check := e.reduce(t.Check)
+	if t.Distribute {
+		if u, ok := check.(*soltype.UnionType); ok {
+			parts := make([]soltype.Type, len(u.Types))
+			for i, m := range u.Types {
+				parts[i] = e.reduceCondBranch(distributeMember(t, m), m)
+			}
+			return newUnion(nil, parts, false)
+		}
+	}
+	return e.reduceCondBranch(t, check)
+}
+
+// reduceCondBranch decides one conditional's branch given its already-reduced Check. It takes two
+// paths, mirroring the old checker's CondType case (internal/checker/expand_type.go):
+//
+//   - an Extends carrying an `infer U` reduces through the structural matcher in reduceCondInfer,
+//     which binds each `infer` position and substitutes the captures into Then;
+//   - an Extends with no `infer` decides `Check <: Extends` with an assignability probe once both
+//     operands are ground, reducing to Then on success or Else on failure. A Check or Extends still
+//     carrying a type parameter or an unreduced residual keeps the whole conditional symbolic,
+//     rebuilt around the reduced operands, and reduces later once they ground.
+func (e *typeEvaluator) reduceCondBranch(t *soltype.CondType, check soltype.Type) soltype.Type {
+	if containsInferType(t.Extends) {
+		return e.reduceCondInfer(t, check)
+	}
 	extends := e.reduce(t.Extends)
 	if !condOperandGround(check) || !condOperandGround(extends) {
-		return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else}
+		return symbolicCond(t, check, extends)
 	}
 	if e.ctx.condExtends(check, extends, e.seen) {
 		return e.reduce(t.Then)
 	}
 	return e.reduce(t.Else)
 }
+
+// symbolicCond rebuilds a conditional around a reduced Check and Extends while keeping its branches
+// and distributive flag, the form the evaluator returns when it cannot yet decide the branch. The
+// conditional reduces later once the operands ground.
+func symbolicCond(t *soltype.CondType, check, extends soltype.Type) *soltype.CondType {
+	return &soltype.CondType{Check: check, Extends: extends, Then: t.Then, Else: t.Else, Distribute: t.Distribute}
+}
+
+// reduceCondInfer decides a conditional whose Extends holds one or more `infer U` positions. It
+// matches the ground Check against the Extends pattern structurally, recording each `infer`
+// position's type; on a match it substitutes those captures into Then and reduces it, and on a
+// mismatch it reduces Else. The conditional stays symbolic when Check is not ground or the non-infer
+// part of Extends is not ground, since the matcher needs a concrete Check and a ground leaf position
+// to decide against.
+func (e *typeEvaluator) reduceCondInfer(t *soltype.CondType, check soltype.Type) soltype.Type {
+	if !condOperandGround(check) || !inferExtendsGround(t.Extends) {
+		return symbolicCond(t, check, t.Extends)
+	}
+	bindings := map[*soltype.TypeVarType]soltype.Type{}
+	if e.matchInfer(check, t.Extends, bindings) {
+		return e.reduce(substituteInferBindings(t.Then, bindings))
+	}
+	return e.reduce(t.Else)
+}
+
+// matchInfer reports whether the ground type check satisfies the Extends pattern pat, recording each
+// `infer U` position's matched type into bindings keyed by the InferType's variable. It matches
+// structurally over the constructors an `infer` can be extracted from — a promise payload, a tuple
+// element, a function parameter or return, and an object property — and binds an `infer` position to
+// whatever check carries there. A leaf pattern with no `infer` is a plain constraint, decided by the
+// `Check <: pat` probe branch selection uses.
+func (e *typeEvaluator) matchInfer(check, pat soltype.Type, bindings map[*soltype.TypeVarType]soltype.Type) bool {
+	check = e.reduce(check)
+	switch p := pat.(type) {
+	case *soltype.InferType:
+		// Bind the first match for a name and keep it, so two positions sharing an `infer U` capture
+		// the leftmost, matching TypeScript's behavior for a repeated infer name in covariant
+		// positions.
+		if _, seen := bindings[p.Var]; !seen {
+			bindings[p.Var] = check
+		}
+		return true
+	case *soltype.PromiseType:
+		c, ok := check.(*soltype.PromiseType)
+		return ok && e.matchInfer(c.Inner, p.Inner, bindings)
+	case *soltype.TupleType:
+		c, ok := check.(*soltype.TupleType)
+		if !ok || len(c.Elems) != len(p.Elems) || hasRestSpread(c.Elems) || hasRestSpread(p.Elems) {
+			return false
+		}
+		for i := range p.Elems {
+			if !e.matchInfer(c.Elems[i], p.Elems[i], bindings) {
+				return false
+			}
+		}
+		return true
+	case *soltype.FuncType:
+		c, ok := check.(*soltype.FuncType)
+		if !ok || len(c.Params) != len(p.Params) {
+			return false
+		}
+		for i := range p.Params {
+			if !e.matchInfer(c.Params[i].Type, p.Params[i].Type, bindings) {
+				return false
+			}
+		}
+		return e.matchInfer(c.Ret, p.Ret, bindings)
+	case *soltype.ObjectType:
+		return e.matchInferObject(check, p, bindings)
+	default:
+		if containsInferType(pat) {
+			// An `infer` nested in a pattern shape the matcher does not decompose cannot be bound.
+			// Fail the whole match rather than probe against the free infer variable, which would
+			// record a bound and break the evaluator's no-mutation invariant.
+			return false
+		}
+		return e.ctx.condExtends(check, pat, e.seen)
+	}
+}
+
+// matchInferObject matches an object pattern property by property: check must be an object carrying
+// each pattern property under a readable value, and that value must match the pattern property's
+// type. Extra members on check are ignored, the structural width TypeScript allows.
+func (e *typeEvaluator) matchInferObject(check soltype.Type, pat *soltype.ObjectType, bindings map[*soltype.TypeVarType]soltype.Type) bool {
+	obj, ok := check.(*soltype.ObjectType)
+	if !ok {
+		return false
+	}
+	for _, elem := range pat.Elems {
+		prop, ok := elem.(*soltype.PropertyElem)
+		if !ok {
+			// Only a plain-property pattern is matched; a method, getter, or spread pattern is not.
+			return false
+		}
+		read, hasValue, _ := memberReadContribution(obj, prop.Name)
+		if !hasValue || !e.matchInfer(read, prop.Type, bindings) {
+			return false
+		}
+	}
+	return true
+}
+
+// substituteInferBindings replaces each `infer` variable in a conditional's Then branch with the
+// type matched at its `infer` position, so the branch reads the captured types. It reuses the
+// generic-body substitution typeSubst, mapping each infer variable to its bound type.
+func substituteInferBindings(t soltype.Type, bindings map[*soltype.TypeVarType]soltype.Type) soltype.Type {
+	if len(bindings) == 0 {
+		return t
+	}
+	subst := &typeSubst{types: bindings, lifetimes: map[*soltype.LifetimeVar]soltype.Lifetime{}}
+	return t.Accept(subst, soltype.Positive)
+}
+
+// distributeMember builds the per-member conditional for one union member of a distributive
+// conditional. Instantiating the alias substituted the naked type parameter to the whole union at
+// every position, installing one shared pointer — t.Check — at each occurrence. Replacing that
+// pointer with the member m throughout reconstructs the conditional as if the parameter had been
+// instantiated with m alone. The result is non-distributive: a single member is not a union, so
+// nothing distributes.
+//
+// The replaced pointer is t.Check as stored, not the reduced Check: typeSubst installs the identical
+// argument pointer at every naked-parameter position, and no visitor runs between that substitution
+// and this reduction, so t.Check is the exact pointer sitting in Extends, Then, and Else. Keying on
+// the stored pointer rather than the reduced one keeps the match correct even if reduce later grows
+// a union arm that reallocates.
+func distributeMember(t *soltype.CondType, m soltype.Type) *soltype.CondType {
+	return &soltype.CondType{
+		Check:   m,
+		Extends: replaceType(t.Extends, t.Check, m),
+		Then:    replaceType(t.Then, t.Check, m),
+		Else:    replaceType(t.Else, t.Check, m),
+	}
+}
+
+// inferExtendsGround reports whether the non-`infer` part of a conditional's Extends pattern is
+// ground, so the matcher can decide each leaf position. An `infer` position is a hole to fill rather
+// than an operand, so its subtree is skipped; a type variable, a skolem, or an unreduced residual
+// anywhere else makes the pattern non-ground and keeps the conditional symbolic.
+func inferExtendsGround(extends soltype.Type) bool {
+	f := &inferGroundFinder{}
+	extends.Accept(f, soltype.Positive)
+	return !f.nonGround
+}
+
+type inferGroundFinder struct{ nonGround bool }
+
+func (f *inferGroundFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	switch t.(type) {
+	case *soltype.InferType:
+		return soltype.EnterResult{SkipChildren: true}
+	case *soltype.TypeVarType, *soltype.SkolemType:
+		f.nonGround = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	if isResidualOp(t) {
+		f.nonGround = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *inferGroundFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
+
+// containsInferType reports whether t holds an `infer U` binding position. reduceCondBranch consults
+// it on Extends to route into the structural matcher, and matchInfer consults it to refuse a pattern
+// shape it cannot decompose.
+func containsInferType(t soltype.Type) bool {
+	f := &inferTypeFinder{}
+	t.Accept(f, soltype.Positive)
+	return f.found
+}
+
+type inferTypeFinder struct{ found bool }
+
+func (f *inferTypeFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if _, ok := t.(*soltype.InferType); ok {
+		f.found = true
+		return soltype.EnterResult{SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (f *inferTypeFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
+
+// replaceType rewrites every occurrence of the type from — matched by pointer identity — to the type
+// to, leaving the rest of root unchanged. distributeMember uses it to swap a distributive
+// conditional's union for one member; the union appears by the same pointer at every naked-parameter
+// position, so pointer identity finds exactly those positions.
+func replaceType(root, from, to soltype.Type) soltype.Type {
+	r := &typeReplacer{from: from, to: to}
+	return root.Accept(r, soltype.Positive)
+}
+
+type typeReplacer struct{ from, to soltype.Type }
+
+func (r *typeReplacer) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
+	if t == r.from {
+		return soltype.EnterResult{Type: r.to, SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (r *typeReplacer) ExitType(t soltype.Type, pol soltype.Polarity) soltype.Type { return t }
 
 // condExtends decides a conditional's `Check <: Extends` test with an assignability probe. The
 // trial runs under a discard-only probe, so a speculative match records no bound and leaves no
@@ -736,6 +960,11 @@ func strLitName(t soltype.Type) (string, bool) {
 // isResidualOp reports whether t is an unreduced type-level operator node — a `keyof`, an indexed
 // access, a conditional, or a `...P` tuple-spread element — at its top level. The evaluator consults
 // it to stop re-reducing an operand whose reduction stayed symbolic.
+//
+// An `infer` binding is deliberately not listed: it only ever sits inside a conditional's Extends,
+// never as a top-level reduce target, and every site that inspects an Extends pattern —
+// inferExtendsGround, matchInfer, containsInferType — handles it explicitly before consulting this
+// predicate. A symbolic conditional carrying an `infer` is already caught here by its CondType head.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
 	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType:


### PR DESCRIPTION
Adds support for `infer U` type capture in conditional types and distributive conditionals over union types, matching TypeScript semantics.

## Summary

This PR implements two related features for conditional types:

1. **`infer` clause support**: Conditionals can now use `infer U` in the Extends operand to capture types at specific positions. The evaluator structurally matches the Check against the Extends pattern, binds each `infer` position to the matched type, and substitutes those bindings into the Then branch.

2. **Distributive conditionals**: When a conditional's Check is a naked type parameter instantiated with a union, the conditional now evaluates per member and unions the results, matching TypeScript's behavior. For example, `Exclude<"a" | "b", "a">` reduces to `"b"`.

## Key changes

- **Type system**: Added `InferType` to represent `infer U` binding positions and `Distribute` flag to `CondType` to mark distributive conditionals.

- **Resolver** (`type_ann.go`): 
  - `resolveCondTypeAnn` now declares `infer` names in a child scope before resolving Extends, so the InferType node and branch references share one variable.
  - Added `resolveInferTypeAnn` to lower `infer U` clauses, rejecting them outside the Extends operand.
  - Detects distributive conditionals by checking if Check is a naked type parameter.

- **Evaluator** (`typeops.go`):
  - `reduceCond` now handles distribution: if Check reduces to a union and the conditional is marked distributive, it evaluates once per member and unions the results.
  - `reduceCondBranch` routes to `reduceCondInfer` when Extends contains `infer`, otherwise uses the existing assignability probe.
  - `reduceCondInfer` implements the structural matcher via `matchInfer`, which decomposes tuple elements, function parameters/returns, promise payloads, and object properties to bind `infer` positions.
  - `matchInfer` binds the leftmost occurrence of each `infer` name, matching TypeScript's behavior for repeated names in covariant positions.
  - Helper functions: `distributeMember` reconstructs per-member conditionals by replacing the union pointer with one member; `inferExtendsGround` checks if the non-`infer` part of Extends is ground; `containsInferType` detects `infer` in a type; `replaceType` swaps one type pointer for another by identity.

- **Visitor** (`visitor.go`): Updated `CondType.Accept` to preserve the Distribute flag and added `InferType.Accept` to walk the binding variable.

- **Tests** (`infer_typeops_test.go`): Replaced the unsupported-feature test with comprehensive coverage of `infer` reduction, constraint checking, and distributive conditionals.

## Implementation notes

- `infer` names are scoped to the conditional's Extends operand; nested conditionals declare their own `infer` names independently.
- The matcher requires Check and the non-`infer` part of Extends to be ground before deciding the branch; a symbolic conditional carries unreduced operands and reduces later.
- Distribution replaces the union pointer — the exact object stored in Check at annotation time — at every naked-parameter position, so pointer identity finds exactly those positions even if reduce later reallocates.

https://claude.ai/code/session_013FsrBWc2rXvkPXcPwgjnUY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for conditional type `infer` bindings.
  * `infer` types can now be matched and substituted across tuples, functions, promises, and object properties.
  * Added distributive conditional type behavior for union types.
  * Improved type diagnostics to display inferred bindings clearly.

* **Bug Fixes**
  * Unsupported `infer` placements now produce clear validation errors.
  * Conditional type reductions and constraints now resolve more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->