### PR TITLE
Implement mapped type reduction in type evaluator

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -53,6 +53,13 @@ func typePrec(t Type) int {
 			return precPrefix
 		}
 		return precAtom
+	case *MappedType:
+		// `{[K]: V for K in Keys}` is brace-delimited like an object type, so it binds like an atom
+		// and never needs outer parens.
+		return precAtom
+	case *MappedKeyType:
+		// A mapped type's key variable renders as its bare name, an atom.
+		return precAtom
 	case *RestSpreadType:
 		// A `...P` spread element only appears inside a tuple's bracket list, which prints each
 		// element unparenthesized, so its precedence is consulted only if it is rendered on its
@@ -446,6 +453,14 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Extends)
 			walk(t.Then)
 			walk(t.Else)
+		case *MappedType:
+			walk(t.Keys)
+			walk(t.Value)
+			for _, operand := range []Type{t.Name, t.Check, t.Extends} {
+				if operand != nil {
+					walk(operand)
+				}
+			}
 		case *RestSpreadType:
 			walk(t.Operand)
 		case *TemplateLitType:
@@ -703,6 +718,12 @@ func (p *namedPrinter) printType(t Type) string {
 			return "infer " + t.Name
 		}
 		return t.Name
+	case *MappedType:
+		return p.printMapped(t)
+	case *MappedKeyType:
+		// A mapped type's key variable renders as the bare name the source bound it under, so a
+		// stored mapped type round-trips to `{[K]: T[K] for K in keyof T}`.
+		return t.Name
 	case *PromiseType:
 		return "Promise<" + p.printType(t.Inner) + ">"
 	case *RefType:
@@ -743,6 +764,47 @@ func (p *namedPrinter) printType(t Type) string {
 		return t.Name
 	}
 	panic(fmt.Sprintf("printType: unhandled %T", t))
+}
+
+// printMapped renders a mapped type in the surface syntax the parser reads and the AST printer
+// writes, `{readonly [Name]+?: Value for Key in Keys if Check : Extends}`, so a stored mapped type
+// round-trips to what the source wrote. It mirrors type_system's MappedElem rendering so the two
+// checkers' rendered types stay string-comparable.
+//
+// The brackets hold the key-remapping expression when the source wrote one and the bare key name
+// otherwise. Every operand prints with no minimum precedence: the brackets, the `:`, and the `for`,
+// `in`, and `if` keywords bound each position, so none can bind across a neighbor. A trailing `...`
+// renders after the member, the same inexact marker an object type carries.
+func (p *namedPrinter) printMapped(t *MappedType) string {
+	out := "{"
+	switch t.Readonly {
+	case ModAdd:
+		out += "readonly "
+	case ModRemove:
+		out += "-readonly "
+	case ModNone:
+	}
+	if t.Name != nil {
+		out += "[" + p.printType(t.Name) + "]"
+	} else {
+		out += "[" + t.Key.Name + "]"
+	}
+	switch t.Optional {
+	case ModAdd:
+		out += "+?"
+	case ModRemove:
+		out += "-?"
+	case ModNone:
+	}
+	out += ": " + p.printType(t.Value)
+	out += " for " + t.Key.Name + " in " + p.printType(t.Keys)
+	if t.Check != nil && t.Extends != nil {
+		out += " if " + p.printType(t.Check) + " : " + p.printType(t.Extends)
+	}
+	if t.Inexact {
+		out += ", ..."
+	}
+	return out + "}"
 }
 
 // printObjElem renders one object member in Escalier surface syntax. Each kind has

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -53,10 +53,6 @@ func typePrec(t Type) int {
 			return precPrefix
 		}
 		return precAtom
-	case *MappedType:
-		// `{[K]: V for K in Keys}` is brace-delimited like an object type, so it binds like an atom
-		// and never needs outer parens.
-		return precAtom
 	case *MappedKeyType:
 		// A mapped type's key variable renders as its bare name, an atom.
 		return precAtom
@@ -431,6 +427,12 @@ func freeTypeVars(t Type) []*TypeVarType {
 					walk(e.Fn)
 				case *SpreadElem:
 					walk(e.Type)
+				case *MappedElem:
+					walk(e.Keys)
+					walk(e.Value)
+					for _, operand := range MappedOptionalOperands(e) {
+						walk(operand)
+					}
 				}
 			}
 		case *ClassType:
@@ -453,14 +455,6 @@ func freeTypeVars(t Type) []*TypeVarType {
 			walk(t.Extends)
 			walk(t.Then)
 			walk(t.Else)
-		case *MappedType:
-			walk(t.Keys)
-			walk(t.Value)
-			for _, operand := range []Type{t.Name, t.Check, t.Extends} {
-				if operand != nil {
-					walk(operand)
-				}
-			}
 		case *RestSpreadType:
 			walk(t.Operand)
 		case *TemplateLitType:
@@ -718,8 +712,6 @@ func (p *namedPrinter) printType(t Type) string {
 			return "infer " + t.Name
 		}
 		return t.Name
-	case *MappedType:
-		return p.printMapped(t)
 	case *MappedKeyType:
 		// A mapped type's key variable renders as the bare name the source bound it under, so a
 		// stored mapped type round-trips to `{[K]: T[K] for K in keyof T}`.
@@ -766,17 +758,17 @@ func (p *namedPrinter) printType(t Type) string {
 	panic(fmt.Sprintf("printType: unhandled %T", t))
 }
 
-// printMapped renders a mapped type in the surface syntax the parser reads and the AST printer
-// writes, `{readonly [Name]+?: Value for Key in Keys if Check : Extends}`, so a stored mapped type
+// printMapped renders a mapped member in the surface syntax the parser reads and the AST printer
+// writes, `readonly [Name]+?: Value for Key in Keys if Check : Extends`, so a stored mapped type
 // round-trips to what the source wrote. It mirrors type_system's MappedElem rendering so the two
-// checkers' rendered types stay string-comparable.
+// checkers' rendered types stay string-comparable. The enclosing object supplies the braces and any
+// trailing `...`, the same way it does for an ordinary member.
 //
 // The brackets hold the key-remapping expression when the source wrote one and the bare key name
 // otherwise. Every operand prints with no minimum precedence: the brackets, the `:`, and the `for`,
-// `in`, and `if` keywords bound each position, so none can bind across a neighbor. A trailing `...`
-// renders after the member, the same inexact marker an object type carries.
-func (p *namedPrinter) printMapped(t *MappedType) string {
-	out := "{"
+// `in`, and `if` keywords bound each position, so none can bind across a neighbor.
+func (p *namedPrinter) printMapped(t *MappedElem) string {
+	out := ""
 	switch t.Readonly {
 	case ModAdd:
 		out += "readonly "
@@ -801,10 +793,7 @@ func (p *namedPrinter) printMapped(t *MappedType) string {
 	if t.Check != nil && t.Extends != nil {
 		out += " if " + p.printType(t.Check) + " : " + p.printType(t.Extends)
 	}
-	if t.Inexact {
-		out += ", ..."
-	}
-	return out + "}"
+	return out
 }
 
 // printObjElem renders one object member in Escalier surface syntax. Each kind has
@@ -822,6 +811,8 @@ func (p *namedPrinter) printMapped(t *MappedType) string {
 // method's. It panics on an unknown element kind, matching AsProperty.
 func (p *namedPrinter) printObjElem(e ObjTypeElem) string {
 	switch e := e.(type) {
+	case *MappedElem:
+		return p.printMapped(e)
 	case *PropertyElem:
 		opt := ""
 		if e.Optional {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -721,9 +721,11 @@ type InferType struct {
 	Binder bool
 }
 
-// MappedModifier states how a mapped type adjusts one member marker — `readonly` or `?` — on each
-// field it emits. ModNone leaves the marker off, ModAdd sets it, and ModRemove clears it. The
-// source writes `readonly`/`+readonly` and `?`/`+?` for ModAdd and `-readonly`/`-?` for ModRemove.
+// MappedModifier states how a mapped type adjusts one member marker, `readonly` or `?`, on each
+// field it emits. ModAdd sets the marker and ModRemove clears it. ModNone means the source wrote no
+// modifier, which leaves the marker to be inherited from the field's source member when the mapped
+// type is homomorphic and off otherwise. The source writes `readonly`/`+readonly` and `?`/`+?` for
+// ModAdd and `-readonly`/`-?` for ModRemove.
 type MappedModifier int
 
 const (
@@ -760,11 +762,14 @@ type MappedKeyType struct {
 //   - Value is the type each emitted field takes, normally an indexed access such as `T[K]`.
 //   - Name is the key-remapping expression written in the brackets. It is nil when the brackets
 //     hold the bare key variable, so no remapping applies. A key it reduces to `never` drops that
-//     field, the way TypeScript's `as` clause filters.
+//     field, the way TypeScript's `as` clause filters, and one it reduces to a union of names
+//     contributes a field per name.
 //   - Check and Extends are the optional `if C : E` filter. A key whose substituted `Check <: Extends`
 //     fails is dropped. Both are nil when the source wrote no filter.
 //   - Optional and Readonly are the `?` and `readonly` markers, each adding or removing the marker
-//     on every emitted field.
+//     on every emitted field. With neither written, a mapped type whose Keys is written `keyof T`
+//     inherits each marker from the member the key names on T, so the identity mapped type really
+//     is the identity.
 //   - Inexact carries the enclosing object annotation's trailing `...`, so `{[K]: V for K in Keys, ...}`
 //     reduces to an inexact object.
 type MappedType struct {

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -721,6 +721,64 @@ type InferType struct {
 	Binder bool
 }
 
+// MappedModifier states how a mapped type adjusts one member marker — `readonly` or `?` — on each
+// field it emits. ModNone leaves the marker off, ModAdd sets it, and ModRemove clears it. The
+// source writes `readonly`/`+readonly` and `?`/`+?` for ModAdd and `-readonly`/`-?` for ModRemove.
+type MappedModifier int
+
+const (
+	ModNone MappedModifier = iota
+	ModAdd
+	ModRemove
+)
+
+// MappedKeyType is the key variable a mapped type binds, the `K` of
+// `{[K]: T[K] for K in keyof T}`. It is an inert leaf: nothing constrains against it, and the
+// evaluator substitutes one key of the mapped type's Keys union for it before reducing the
+// positions that name it. A mapped type still carrying it in a reduced position has not chosen a
+// key yet, so the whole mapped type is inert.
+//
+// ID is the binding this node stands for. The `for K in …` clause and every reference to K in the
+// value, key-remapping, and filter positions carry one id, so substituting a key reaches exactly
+// the positions that binding stands at. A nested mapped type writing the same name draws a distinct
+// id, which is what makes its own binding shadow the enclosing one. Name is the source name,
+// carried for display.
+type MappedKeyType struct {
+	ID   int
+	Name string
+}
+
+// MappedType is the residual `{[K]: V for K in Keys}` mapped type operator. Like KeyofType it is
+// inert: it carries no bounds, constrain never records one against it, and it flows through the
+// solver's structural machinery untouched, rendering the way the source wrote it. The evaluator
+// reduces it to a plain ObjectType once Keys grounds to a union of string-literal keys, emitting
+// one field per key with Key bound to that key.
+//
+// The fields mirror the surface syntax `{readonly [Name]?: Value for Key in Keys if Check : Extends}`:
+//
+//   - Keys is the constraint after `in`, the key set to iterate. `keyof T` is the usual source.
+//   - Value is the type each emitted field takes, normally an indexed access such as `T[K]`.
+//   - Name is the key-remapping expression written in the brackets. It is nil when the brackets
+//     hold the bare key variable, so no remapping applies. A key it reduces to `never` drops that
+//     field, the way TypeScript's `as` clause filters.
+//   - Check and Extends are the optional `if C : E` filter. A key whose substituted `Check <: Extends`
+//     fails is dropped. Both are nil when the source wrote no filter.
+//   - Optional and Readonly are the `?` and `readonly` markers, each adding or removing the marker
+//     on every emitted field.
+//   - Inexact carries the enclosing object annotation's trailing `...`, so `{[K]: V for K in Keys, ...}`
+//     reduces to an inexact object.
+type MappedType struct {
+	Key      *MappedKeyType
+	Keys     Type
+	Value    Type
+	Name     Type // nil ⇒ the brackets hold the bare key variable, no remapping
+	Check    Type // nil with Extends ⇒ no `if C : E` filter
+	Extends  Type
+	Optional MappedModifier
+	Readonly MappedModifier
+	Inexact  bool
+}
+
 // RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
 // checker's RestSpreadType (internal/type_system/types.go). It is only meaningful as an element of
 // a TupleType.Elems list: `[...P, x]` is a TupleType whose first element is a RestSpreadType. A
@@ -791,6 +849,8 @@ func (*IndexType) isType()           {}
 func (*TypeofType) isType()          {}
 func (*CondType) isType()            {}
 func (*InferType) isType()           {}
+func (*MappedKeyType) isType()       {}
+func (*MappedType) isType()          {}
 func (*RestSpreadType) isType()      {}
 func (*TemplateLitType) isType()     {}
 func (*StringIntrinsicType) isType() {}
@@ -887,6 +947,19 @@ func LevelOf(t Type) int {
 		// operand lifts the level and the freshener/extruder prune descends into all four, the
 		// four-child analogue of the two-child IndexType arm.
 		return max(max(LevelOf(t.Check), LevelOf(t.Extends)), max(LevelOf(t.Then), LevelOf(t.Else)))
+	case *MappedType:
+		// A mapped residual's level is the max over the operands that can hold a variable, so an
+		// out-of-level operand lifts the level and the freshener/extruder prune descends into each,
+		// the many-child analogue of the four-child CondType arm. Key is a binding this node owns
+		// rather than a variable the solver generalizes, so it contributes nothing. Name, Check, and
+		// Extends are absent unless the source wrote them.
+		m := max(LevelOf(t.Keys), LevelOf(t.Value))
+		for _, operand := range []Type{t.Name, t.Check, t.Extends} {
+			if operand != nil {
+				m = max(m, LevelOf(operand))
+			}
+		}
+		return m
 	case *RestSpreadType:
 		// A `...P` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the
@@ -935,9 +1008,9 @@ func LevelOf(t Type) int {
 		return maxMemberLevel(t.Types)
 	default:
 		// PrimType, LitType, Void, NullType, UndefinedType, NeverType, UnknownType,
-		// ErrorType, InferType: childless leaves. ErrorType is a sentinel at level 0, and an
-		// InferType names a capture the evaluator substitutes rather than a variable the solver
-		// generalizes, so neither lifts the level.
+		// ErrorType, InferType, MappedKeyType: childless leaves. ErrorType is a sentinel at level 0.
+		// An InferType names a capture and a MappedKeyType names a mapped type's key, both of which
+		// the evaluator substitutes rather than the solver generalizing, so none lifts the level.
 		return 0
 	}
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -343,6 +343,7 @@ func (*MethodElem) isObjTypeElem()      {}
 func (*GetterElem) isObjTypeElem()      {}
 func (*SetterElem) isObjTypeElem()      {}
 func (*ConstructorElem) isObjTypeElem() {}
+func (*MappedElem) isObjTypeElem()      {}
 func (*SpreadElem) isObjTypeElem()      {}
 
 // ObjElemName returns the member name of any ObjTypeElem kind. It is the shared
@@ -369,6 +370,11 @@ func ObjElemName(e ObjTypeElem) string {
 		// equality and lookup paths compare such objects positionally instead, so this name is
 		// never a match key.
 		return ""
+	case *MappedElem:
+		// A mapped member names no single field; it stands for the whole computed member list. Like
+		// a spread it only appears in an unreduced object, compared positionally rather than by
+		// name, so this name is never a match key either.
+		return ""
 	}
 	panic(fmt.Sprintf("ObjElemName: unhandled ObjTypeElem %T", e))
 }
@@ -383,6 +389,50 @@ func HasObjectSpread(elems []ObjTypeElem) bool {
 		}
 	}
 	return false
+}
+
+// HasMappedElem reports whether an element list carries a `[K]: V for K in Keys` member, so the
+// object is an unreduced residual rather than a concrete object. Such a member is always the only
+// one in its list, since resolveObjectTypeAnn rejects an object mixing it with ordinary members.
+func HasMappedElem(elems []ObjTypeElem) bool {
+	for _, e := range elems {
+		if _, ok := e.(*MappedElem); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// HasResidualElem reports whether an element list makes its object an unreduced residual, carrying
+// either a `...A` spread whose operand may still merge or a `[K]: V for K in Keys` member whose key
+// set may still ground. Such an object is never decomposed structurally, since its final member list
+// is not yet known; the evaluator reduces it first and constrain compares it inertly until then.
+func HasResidualElem(elems []ObjTypeElem) bool {
+	return HasObjectSpread(elems) || HasMappedElem(elems)
+}
+
+// AsMapped returns the mapped member of an element list and whether one is present. A caller that
+// has already checked HasMappedElem uses it to reach the member without repeating the type switch.
+func AsMapped(elems []ObjTypeElem) (*MappedElem, bool) {
+	for _, e := range elems {
+		if m, ok := e.(*MappedElem); ok {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+// MappedOptionalOperands returns the operands a mapped member carries only when the source wrote
+// them, skipping the absent ones. The key-remapping expression and the two filter operands each
+// have a nil form, so every walk over them shares this one nil-filtering step.
+func MappedOptionalOperands(m *MappedElem) []Type {
+	operands := make([]Type, 0, 3)
+	for _, operand := range []Type{m.Name, m.Check, m.Extends} {
+		if operand != nil {
+			operands = append(operands, operand)
+		}
+	}
+	return operands
 }
 
 // Prop returns the named property and whether it is present. Property names are
@@ -750,11 +800,13 @@ type MappedKeyType struct {
 	Name string
 }
 
-// MappedType is the residual `{[K]: V for K in Keys}` mapped type operator. Like KeyofType it is
-// inert: it carries no bounds, constrain never records one against it, and it flows through the
-// solver's structural machinery untouched, rendering the way the source wrote it. The evaluator
-// reduces it to a plain ObjectType once Keys grounds to a union of string-literal keys, emitting
-// one field per key with Key bound to that key.
+// MappedElem is the `[K]: V for K in Keys` member that computes an object's whole member list. It
+// is the only member its object carries, because it describes every field rather than one of them;
+// resolveObjectTypeAnn rejects an object mixing it with ordinary members. An object holding one is
+// an unreduced residual: constrain records no bound against it and it flows through the solver's
+// structural machinery untouched, rendering the way the source wrote it. The evaluator replaces it
+// with the members it computes once Keys grounds to a union of string-literal keys, emitting one
+// field per key with Key bound to that key.
 //
 // The fields mirror the surface syntax `{readonly [Name]?: Value for Key in Keys if Check : Extends}`:
 //
@@ -767,12 +819,13 @@ type MappedKeyType struct {
 //   - Check and Extends are the optional `if C : E` filter. A key whose substituted `Check <: Extends`
 //     fails is dropped. Both are nil when the source wrote no filter.
 //   - Optional and Readonly are the `?` and `readonly` markers, each adding or removing the marker
-//     on every emitted field. With neither written, a mapped type whose Keys is written `keyof T`
+//     on every emitted field. With neither written, a mapped member whose Keys is written `keyof T`
 //     inherits each marker from the member the key names on T, so the identity mapped type really
 //     is the identity.
-//   - Inexact carries the enclosing object annotation's trailing `...`, so `{[K]: V for K in Keys, ...}`
-//     reduces to an inexact object.
-type MappedType struct {
+//
+// The enclosing ObjectType carries the trailing `...` inexact marker, so `{[K]: V for K in Keys, ...}`
+// reduces to an inexact object without this member holding a flag of its own.
+type MappedElem struct {
 	Key      *MappedKeyType
 	Keys     Type
 	Value    Type
@@ -781,7 +834,6 @@ type MappedType struct {
 	Extends  Type
 	Optional MappedModifier
 	Readonly MappedModifier
-	Inexact  bool
 }
 
 // RestSpreadType is the residual `...P` spread element inside a tuple type, mirroring the old
@@ -855,7 +907,6 @@ func (*TypeofType) isType()          {}
 func (*CondType) isType()            {}
 func (*InferType) isType()           {}
 func (*MappedKeyType) isType()       {}
-func (*MappedType) isType()          {}
 func (*RestSpreadType) isType()      {}
 func (*TemplateLitType) isType()     {}
 func (*StringIntrinsicType) isType() {}
@@ -952,19 +1003,6 @@ func LevelOf(t Type) int {
 		// operand lifts the level and the freshener/extruder prune descends into all four, the
 		// four-child analogue of the two-child IndexType arm.
 		return max(max(LevelOf(t.Check), LevelOf(t.Extends)), max(LevelOf(t.Then), LevelOf(t.Else)))
-	case *MappedType:
-		// A mapped residual's level is the max over the operands that can hold a variable, so an
-		// out-of-level operand lifts the level and the freshener/extruder prune descends into each,
-		// the many-child analogue of the four-child CondType arm. Key is a binding this node owns
-		// rather than a variable the solver generalizes, so it contributes nothing. Name, Check, and
-		// Extends are absent unless the source wrote them.
-		m := max(LevelOf(t.Keys), LevelOf(t.Value))
-		for _, operand := range []Type{t.Name, t.Check, t.Extends} {
-			if operand != nil {
-				m = max(m, LevelOf(operand))
-			}
-		}
-		return m
 	case *RestSpreadType:
 		// A `...P` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing tuple's level and the freshener/extruder prune descends to freshen it, the
@@ -1045,6 +1083,17 @@ func levelOfElem(e ObjTypeElem) int {
 		// A `...A` spread element's level is its operand's, so an out-of-level spread operand lifts
 		// the enclosing object's level and the freshener/extruder prune descends to freshen it.
 		return LevelOf(e.Type)
+	case *MappedElem:
+		// A mapped member's level is the max over the operands that can hold a variable, so an
+		// out-of-level operand lifts the enclosing object's level and the freshener/extruder prune
+		// descends into each. Key is a binding this member owns rather than a variable the solver
+		// generalizes, so it contributes nothing. Name, Check, and Extends are absent unless the
+		// source wrote them.
+		m := max(LevelOf(e.Keys), LevelOf(e.Value))
+		for _, operand := range MappedOptionalOperands(e) {
+			m = max(m, LevelOf(operand))
+		}
+		return m
 	}
 	panic(fmt.Sprintf("levelOfElem: unhandled ObjTypeElem %T", e))
 }

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -240,38 +240,6 @@ func (t *CondType) Accept(v TypeVisitor, pol Polarity) Type {
 	return v.ExitType(out, pol)
 }
 
-func (t *MappedType) Accept(v TypeVisitor, pol Polarity) Type {
-	e := v.EnterType(t, pol)
-	if e.SkipChildren {
-		return v.ExitType(skipReplace(t, e), pol)
-	}
-	cur := descendReplacement(t, e)
-	// Every operand walks in the current polarity, the many-child analogue of CondType's four-child
-	// visit. The residual is inert — the visit rebuilds it around rewritten operands without
-	// emitting any field, so extrude/coalesce/freshenAbove carry the whole mapped type through
-	// untouched. Key is the binding this node owns, not a type to rewrite, so it carries through.
-	keys := cur.Keys.Accept(v, pol)
-	value := cur.Value.Accept(v, pol)
-	name, nameChanged := acceptOptional(cur.Name, v, pol)
-	check, checkChanged := acceptOptional(cur.Check, v, pol)
-	extends, extendsChanged := acceptOptional(cur.Extends, v, pol)
-	out := cur
-	if keys != cur.Keys || value != cur.Value || nameChanged || checkChanged || extendsChanged {
-		out = &MappedType{
-			Key:      cur.Key,
-			Keys:     keys,
-			Value:    value,
-			Name:     name,
-			Check:    check,
-			Extends:  extends,
-			Optional: cur.Optional,
-			Readonly: cur.Readonly,
-			Inexact:  cur.Inexact,
-		}
-	}
-	return v.ExitType(out, pol)
-}
-
 // acceptOptional walks an operand a node carries only when the source wrote it, returning the
 // walked type and whether the visit replaced it. A nil operand stays nil and reports no change, so
 // a caller rebuilds only when a present operand was rewritten.
@@ -563,6 +531,30 @@ func AcceptObjElem(e ObjTypeElem, v TypeVisitor, pol Polarity) ObjTypeElem {
 			return e
 		}
 		return &PropertyElem{Name: e.Name, Type: pt, Optional: e.Optional, Readonly: e.Readonly}
+	case *MappedElem:
+		// Every operand walks in the current polarity, the many-child analogue of CondType's
+		// four-child visit. The member is inert — the visit rebuilds it around rewritten operands
+		// without emitting any field, so extrude/coalesce/freshenAbove carry the whole mapped member
+		// through untouched. Key is the binding this member owns, not a type to rewrite, so it
+		// carries through.
+		keys := e.Keys.Accept(v, pol)
+		value := e.Value.Accept(v, pol)
+		name, nameChanged := acceptOptional(e.Name, v, pol)
+		check, checkChanged := acceptOptional(e.Check, v, pol)
+		extends, extendsChanged := acceptOptional(e.Extends, v, pol)
+		if keys == e.Keys && value == e.Value && !nameChanged && !checkChanged && !extendsChanged {
+			return e
+		}
+		return &MappedElem{
+			Key:      e.Key,
+			Keys:     keys,
+			Value:    value,
+			Name:     name,
+			Check:    check,
+			Extends:  extends,
+			Optional: e.Optional,
+			Readonly: e.Readonly,
+		}
 	case *GetterElem:
 		self, selfChanged := acceptSelfParam(e.SelfParam, v, pol) // receiver contravariant
 		rt := e.Type.Accept(v, pol)                               // covariant read

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -85,6 +85,7 @@ func (t *UnknownType) Accept(v TypeVisitor, pol Polarity) Type   { return accept
 func (t *ErrorType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
 func (t *SkolemType) Accept(v TypeVisitor, pol Polarity) Type    { return acceptLeaf(t, v, pol) }
 func (t *InferType) Accept(v TypeVisitor, pol Polarity) Type     { return acceptLeaf(t, v, pol) }
+func (t *MappedKeyType) Accept(v TypeVisitor, pol Polarity) Type { return acceptLeaf(t, v, pol) }
 
 func (t *FuncType) Accept(v TypeVisitor, pol Polarity) Type {
 	e := v.EnterType(t, pol)
@@ -237,6 +238,49 @@ func (t *CondType) Accept(v TypeVisitor, pol Polarity) Type {
 		out = &CondType{Check: check, Extends: extends, Then: then, Else: els, Distribute: cur.Distribute}
 	}
 	return v.ExitType(out, pol)
+}
+
+func (t *MappedType) Accept(v TypeVisitor, pol Polarity) Type {
+	e := v.EnterType(t, pol)
+	if e.SkipChildren {
+		return v.ExitType(skipReplace(t, e), pol)
+	}
+	cur := descendReplacement(t, e)
+	// Every operand walks in the current polarity, the many-child analogue of CondType's four-child
+	// visit. The residual is inert — the visit rebuilds it around rewritten operands without
+	// emitting any field, so extrude/coalesce/freshenAbove carry the whole mapped type through
+	// untouched. Key is the binding this node owns, not a type to rewrite, so it carries through.
+	keys := cur.Keys.Accept(v, pol)
+	value := cur.Value.Accept(v, pol)
+	name, nameChanged := acceptOptional(cur.Name, v, pol)
+	check, checkChanged := acceptOptional(cur.Check, v, pol)
+	extends, extendsChanged := acceptOptional(cur.Extends, v, pol)
+	out := cur
+	if keys != cur.Keys || value != cur.Value || nameChanged || checkChanged || extendsChanged {
+		out = &MappedType{
+			Key:      cur.Key,
+			Keys:     keys,
+			Value:    value,
+			Name:     name,
+			Check:    check,
+			Extends:  extends,
+			Optional: cur.Optional,
+			Readonly: cur.Readonly,
+			Inexact:  cur.Inexact,
+		}
+	}
+	return v.ExitType(out, pol)
+}
+
+// acceptOptional walks an operand a node carries only when the source wrote it, returning the
+// walked type and whether the visit replaced it. A nil operand stays nil and reports no change, so
+// a caller rebuilds only when a present operand was rewritten.
+func acceptOptional(t Type, v TypeVisitor, pol Polarity) (Type, bool) {
+	if t == nil {
+		return nil, false
+	}
+	out := t.Accept(v, pol)
+	return out, out != t
 }
 
 func (t *RestSpreadType) Accept(v TypeVisitor, pol Polarity) Type {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -1105,10 +1105,11 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		if !ok || a.Inexact != b.Inexact || len(a.Elems) != len(b.Elems) {
 			return false
 		}
-		// A spread-carrying object is an unreduced residual whose element order is significant,
-		// since a later `...B` overrides an earlier key. Two such objects are equal only when their
-		// elements match position for position, the order-sensitive rule a residual operator follows.
-		if soltype.HasObjectSpread(a.Elems) || soltype.HasObjectSpread(b.Elems) {
+		// An unreduced residual object compares position for position rather than by member name.
+		// A spread-carrying object needs that because element order is significant, since a later
+		// `...B` overrides an earlier key. A mapped-carrying object needs it because its member names
+		// no field, so the name-keyed path below has no key to match on.
+		if soltype.HasResidualElem(a.Elems) || soltype.HasResidualElem(b.Elems) {
 			for i := range a.Elems {
 				if !equalObjElem(a.Elems[i], b.Elems[i], ctx) {
 					return false
@@ -1218,18 +1219,6 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// the enclosing pair of mapped types recorded.
 		b, ok := b.(*soltype.MappedKeyType)
 		return ok && ctx.sameMappedKey(a, b)
-	case *soltype.MappedType:
-		// Two inert mapped residuals are equal when every operand is equal and the modifiers and the
-		// inexact marker match, compared structurally without emitting a field. Pairing the key
-		// bindings first lets each side's references to its own key match the other's.
-		b, ok := b.(*soltype.MappedType)
-		if !ok || a.Optional != b.Optional || a.Readonly != b.Readonly || a.Inexact != b.Inexact {
-			return false
-		}
-		ctx.bindMappedKeys(a.Key, b.Key)
-		return equalTypeWith(a.Keys, b.Keys, ctx) && equalTypeWith(a.Value, b.Value, ctx) &&
-			equalOptionalType(a.Name, b.Name, ctx) && equalOptionalType(a.Check, b.Check, ctx) &&
-			equalOptionalType(a.Extends, b.Extends, ctx)
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a
@@ -1275,6 +1264,19 @@ func equalOptionalType(a, b soltype.Type, ctx *alphaCtx) bool {
 // It panics on an unknown element kind, matching AsProperty.
 func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	switch a := a.(type) {
+	case *soltype.MappedElem:
+		// Two inert mapped members are equal when every operand is equal and the modifiers match,
+		// compared structurally without emitting a field. Pairing the key bindings first lets each
+		// side's references to its own key match the other's. The enclosing objects compare their
+		// inexact markers, so this member carries none.
+		b, ok := b.(*soltype.MappedElem)
+		if !ok || a.Optional != b.Optional || a.Readonly != b.Readonly {
+			return false
+		}
+		ctx.bindMappedKeys(a.Key, b.Key)
+		return equalTypeWith(a.Keys, b.Keys, ctx) && equalTypeWith(a.Value, b.Value, ctx) &&
+			equalOptionalType(a.Name, b.Name, ctx) && equalOptionalType(a.Check, b.Check, ctx) &&
+			equalOptionalType(a.Extends, b.Extends, ctx)
 	case *soltype.PropertyElem:
 		b, ok := b.(*soltype.PropertyElem)
 		return ok && a.Optional == b.Optional && a.Readonly == b.Readonly && equalTypeWith(a.Type, b.Type, ctx)

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -835,6 +835,12 @@ type alphaCtx struct {
 	// so a comparison over types carrying no conditional allocates nothing.
 	inferAToB map[int]int
 	inferBToA map[int]int
+	// keyAToB and keyBToA pair the key bindings of two mapped types, bound when a pair of mapped
+	// types meets, the way bindTypeParams binds a function's parameters. They start nil and
+	// allocate on the first pairing, so a comparison over types carrying no mapped type allocates
+	// nothing.
+	keyAToB map[int]int
+	keyBToA map[int]int
 }
 
 // bindTypeParams pairs two generic FuncTypes' type parameters positionally, so every
@@ -892,6 +898,33 @@ func (ctx *alphaCtx) sameInferDecl(a, b *soltype.InferType) bool {
 	ctx.inferAToB[a.ID] = b.ID
 	ctx.inferBToA[b.ID] = a.ID
 	return true
+}
+
+// bindMappedKeys pairs the key bindings of two mapped types, so every later reference to one side's
+// key must match the other's partner. Two mapped types resolved separately from the same source
+// therefore compare equal even though each drew its own binding id, the same reason
+// sameInferDecl pairs two conditionals' capture declarations.
+func (ctx *alphaCtx) bindMappedKeys(a, b *soltype.MappedKeyType) {
+	if ctx.keyAToB == nil {
+		ctx.keyAToB = map[int]int{}
+		ctx.keyBToA = map[int]int{}
+	}
+	ctx.keyAToB[a.ID] = b.ID
+	ctx.keyBToA[b.ID] = a.ID
+}
+
+// sameMappedKey reports whether two mapped-type key references stand for corresponding bindings
+// under the pairing bindMappedKeys recorded. A reference reached with no pairing recorded — a value
+// position compared on its own, away from the mapped type that binds its key — falls back to id
+// equality, the rule sameTypeVar applies to a variable bound on neither side.
+func (ctx *alphaCtx) sameMappedKey(a, b *soltype.MappedKeyType) bool {
+	if j, ok := ctx.keyAToB[a.ID]; ok {
+		return j == b.ID
+	}
+	if _, ok := ctx.keyBToA[b.ID]; ok {
+		return false // b's binding corresponds to some other binding on a's side
+	}
+	return a.ID == b.ID
 }
 
 // bindLifetimeParams pairs two generic FuncTypes' lifetime parameters positionally, the
@@ -1179,6 +1212,23 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 		// type parameters compare by position rather than by name.
 		b, ok := b.(*soltype.InferType)
 		return ok && a.Binder == b.Binder && ctx.sameInferDecl(a, b)
+	case *soltype.MappedKeyType:
+		// Two mapped-type key references are equal when their bindings correspond under the pairing
+		// the enclosing pair of mapped types recorded.
+		b, ok := b.(*soltype.MappedKeyType)
+		return ok && ctx.sameMappedKey(a, b)
+	case *soltype.MappedType:
+		// Two inert mapped residuals are equal when every operand is equal and the modifiers and the
+		// inexact marker match, compared structurally without emitting a field. Pairing the key
+		// bindings first lets each side's references to its own key match the other's.
+		b, ok := b.(*soltype.MappedType)
+		if !ok || a.Optional != b.Optional || a.Readonly != b.Readonly || a.Inexact != b.Inexact {
+			return false
+		}
+		ctx.bindMappedKeys(a.Key, b.Key)
+		return equalTypeWith(a.Keys, b.Keys, ctx) && equalTypeWith(a.Value, b.Value, ctx) &&
+			equalOptionalType(a.Name, b.Name, ctx) && equalOptionalType(a.Check, b.Check, ctx) &&
+			equalOptionalType(a.Extends, b.Extends, ctx)
 	case *soltype.RestSpreadType:
 		// Two `...P` spread elements are equal when their operands are, compared structurally
 		// without reducing. The enclosing TupleType arm compares element lists positionally, so a
@@ -1211,6 +1261,16 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 //   - a setter compares its parameter type;
 //   - a constructor compares its call signature.
 //
+// equalOptionalType compares two operands a node carries only when the source wrote them. Two
+// absent operands are equal, one absent and one present are not, and two present operands compare
+// structurally.
+func equalOptionalType(a, b soltype.Type, ctx *alphaCtx) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return equalTypeWith(a, b, ctx)
+}
+
 // It panics on an unknown element kind, matching AsProperty.
 func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	switch a := a.(type) {

--- a/internal/solver/coalesce.go
+++ b/internal/solver/coalesce.go
@@ -914,9 +914,10 @@ func (ctx *alphaCtx) bindMappedKeys(a, b *soltype.MappedKeyType) {
 }
 
 // sameMappedKey reports whether two mapped-type key references stand for corresponding bindings
-// under the pairing bindMappedKeys recorded. A reference reached with no pairing recorded — a value
-// position compared on its own, away from the mapped type that binds its key — falls back to id
-// equality, the rule sameTypeVar applies to a variable bound on neither side.
+// under the pairing bindMappedKeys recorded. A reference may be reached with no pairing recorded,
+// which happens when a value position is compared on its own, away from the mapped type that binds
+// its key. That case falls back to id equality, the rule sameTypeVar applies to a variable bound on
+// neither side.
 func (ctx *alphaCtx) sameMappedKey(a, b *soltype.MappedKeyType) bool {
 	if j, ok := ctx.keyAToB[a.ID]; ok {
 		return j == b.ID
@@ -1250,6 +1251,16 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 	return false
 }
 
+// equalOptionalType compares two operands a node carries only when the source wrote them. Two
+// absent operands are equal, one absent and one present are not, and two present operands compare
+// structurally.
+func equalOptionalType(a, b soltype.Type, ctx *alphaCtx) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return equalTypeWith(a, b, ctx)
+}
+
 // equalObjElem reports structural equality of two object members. It returns false
 // on a kind mismatch, so the caller matches a-members to b-members by name and kind
 // together. Each kind compares its own payload:
@@ -1261,16 +1272,6 @@ func equalTypeWith(a, b soltype.Type, ctx *alphaCtx) bool {
 //   - a setter compares its parameter type;
 //   - a constructor compares its call signature.
 //
-// equalOptionalType compares two operands a node carries only when the source wrote them. Two
-// absent operands are equal, one absent and one present are not, and two present operands compare
-// structurally.
-func equalOptionalType(a, b soltype.Type, ctx *alphaCtx) bool {
-	if a == nil || b == nil {
-		return a == nil && b == nil
-	}
-	return equalTypeWith(a, b, ctx)
-}
-
 // It panics on an unknown element kind, matching AsProperty.
 func equalObjElem(a, b soltype.ObjTypeElem, ctx *alphaCtx) bool {
 	switch a := a.(type) {

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -136,23 +136,24 @@ func needsResidualWriteBack(sub, sup soltype.Type) bool {
 // for, so constrain can check a constraint against that while the stored residual keeps its name.
 // An alias expands to its body, a `typeof` query resolves to the value's type, a `keyof` reduces
 // to its key set, an indexed access `T[K]` reduces to the type at that key, a conditional selects
-// its Then or Else branch, a template literal reduces to the union of string literals its
-// interpolations produce, an intrinsic string operator such as `Uppercase<T>` reduces over its
-// string-literal operand, and a tuple carrying a `...P` spread splices its operand tuples into a
-// plain tuple. A plain tuple is a structural type
+// its Then or Else branch, a mapped type emits one field per key, a template literal reduces to the
+// union of string literals its interpolations produce, an intrinsic string operator such as
+// `Uppercase<T>` reduces over its string-literal operand, and a tuple carrying a `...P` spread
+// splices its operand tuples into a plain tuple. A plain tuple is a structural type
 // constrain decomposes, not an operator, so it reports ok=false. The returned errs carry any
 // diagnostic the reduction produced — an unknown object key or an out-of-range tuple index — for
 // constrain to surface at the constraint site. It reports ok=false for any other type, and for a
-// reduced operator that does not fully ground — a `keyof T`, `T[K]`, or `[...T, x]` over a type
-// parameter, or an expanding alias whose reduction is truncated to a residual that would re-expand
-// without bound — which stays inert.
+// reduced operator that does not fully ground — a `keyof T`, `T[K]`, `{[K]: V for K in Keys}`, or
+// `[...T, x]` over a type parameter, or an expanding alias whose reduction is truncated to a
+// residual that would re-expand without bound — which stays inert.
 func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) (soltype.Type, []SolverError, bool) {
 	switch t := t.(type) {
 	case *soltype.AliasType:
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType,
+		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
 		if !tupleHasSpread(t) {
@@ -806,6 +807,21 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// recording a bound, and a residual against any other concrete fails. When super is a
 		// variable the case falls through to the superVar arm, which records the whole conditional as
 		// one lower bound, keeping the operator symbolic on the coalesced binding.
+		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
+			if equalType(sub, super) {
+				return nil
+			}
+			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
+		}
+	case *soltype.MappedType:
+		// A mapped residual the pre-switch could not ground reaches here: a mapped type whose Keys
+		// operand is a type parameter, so no key set exists to emit fields from. constrain treats it
+		// inert, the same as the KeyofType, IndexType, and CondType arms above — two residuals are
+		// compatible only when structurally identical, so a mapped type against an equal mapped type
+		// succeeds reflexively without recording a bound, and a residual against any other concrete
+		// fails. When super is a variable the case falls through to the superVar arm, which records
+		// the whole mapped type as one lower bound, keeping the operator symbolic on the coalesced
+		// binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -816,12 +816,12 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 	case *soltype.MappedType:
 		// A mapped residual the pre-switch could not ground reaches here: a mapped type whose Keys
 		// operand is a type parameter, so no key set exists to emit fields from. constrain treats it
-		// inert, the same as the KeyofType, IndexType, and CondType arms above — two residuals are
-		// compatible only when structurally identical, so a mapped type against an equal mapped type
-		// succeeds reflexively without recording a bound, and a residual against any other concrete
-		// fails. When super is a variable the case falls through to the superVar arm, which records
-		// the whole mapped type as one lower bound, keeping the operator symbolic on the coalesced
-		// binding.
+		// inert, the same as the KeyofType, IndexType, and CondType arms above. Two residuals are
+		// compatible only when structurally identical. A mapped type against an equal mapped type
+		// therefore succeeds reflexively without recording a bound, and a residual against any other
+		// concrete type fails. When super is a variable the case falls through to the superVar arm,
+		// which records the whole mapped type as one lower bound, keeping the operator symbolic on
+		// the coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/constrain.go
+++ b/internal/solver/constrain.go
@@ -152,7 +152,7 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) 
 		return c.expandAlias(t), nil, true
 	case *soltype.TypeofType:
 		return t.Ty, nil, true
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType,
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType,
 		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return c.reduceResidual(t, seen)
 	case *soltype.TupleType:
@@ -161,18 +161,21 @@ func (c *Context) evalTypeOperator(t soltype.Type, seen set.Set[constraintKey]) 
 		}
 		return c.reduceResidual(t, seen)
 	case *soltype.ObjectType:
-		// A plain object is handled structurally, not as a transparent operator. Only a
-		// spread-carrying object is a residual to reduce here, the object twin of the TupleType arm.
-		if !soltype.HasObjectSpread(t.Elems) {
+		// A plain object is handled structurally, not as a transparent operator. Only a residual
+		// object is reduced here, the object twin of the TupleType arm. An object is residual when it
+		// carries a `...A` spread whose operand may still merge, or a `[K]: V for K in Keys` member
+		// whose key set may still ground.
+		if !soltype.HasResidualElem(t.Elems) {
 			return nil, nil, false
 		}
 		e := newTypeEvaluator(c, seen)
 		reduced := e.reduce(t)
-		// A spread whose operands ground merges to a spread-free object. One with an abstract operand
-		// stays a spread-carrying object, which is inert, so leave it for the structural switch. The
-		// check is on the root rather than reduceResidual's containsResidualOp: a merged object
-		// grounds even when a field value is itself a residual, which reduces at its own site.
-		if obj, ok := reduced.(*soltype.ObjectType); ok && soltype.HasObjectSpread(obj.Elems) {
+		// A spread whose operands ground merges to a spread-free object, and a mapped member whose
+		// key set grounds becomes the fields it emits. One that stays residual is inert, so leave it
+		// for the structural switch. The check is on the root rather than reduceResidual's
+		// containsResidualOp: a reduced object grounds even when a field value is itself a residual,
+		// which reduces at its own site.
+		if obj, ok := reduced.(*soltype.ObjectType); ok && soltype.HasResidualElem(obj.Elems) {
 			return nil, nil, false
 		}
 		return reduced, e.errs, true
@@ -539,13 +542,15 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 			return errs
 		}
 	case *soltype.ObjectType:
-		if objectHasSpread(sub) || objectHasSpread(super) {
-			// One side carries an unreduced `...A` spread the pre-switch could not ground: a spread
-			// over a type parameter, or an expanding recursive alias. constrain treats such an object
-			// inert, the same as the spread-tuple and KeyofType/IndexType residuals — it is never
-			// decomposed, so two spread-objects are compatible only when structurally identical. When
-			// super is a variable the case falls through to the superVar arm below, which records the
-			// whole object as one lower bound, keeping the spread symbolic on the coalesced binding.
+		if objectIsResidual(sub) || objectIsResidual(super) {
+			// One side is an unreduced residual the pre-switch could not ground. That is an object
+			// carrying a `...A` spread over a type parameter or an expanding recursive alias, or one
+			// carrying a `[K]: V for K in Keys` member whose key set never ground. constrain treats
+			// such an object inert, the same as the spread-tuple and KeyofType/IndexType residuals —
+			// it is never decomposed, so two residual objects are compatible only when structurally
+			// identical. When super is a variable the case falls through to the superVar arm below,
+			// which records the whole object as one lower bound, keeping the residual symbolic on the
+			// coalesced binding.
 			if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 				if equalType(sub, super) {
 					return nil
@@ -807,21 +812,6 @@ func (c *Context) constrain(sub, super soltype.Type, seen set.Set[constraintKey]
 		// recording a bound, and a residual against any other concrete fails. When super is a
 		// variable the case falls through to the superVar arm, which records the whole conditional as
 		// one lower bound, keeping the operator symbolic on the coalesced binding.
-		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
-			if equalType(sub, super) {
-				return nil
-			}
-			return []SolverError{&CannotConstrainError{Sub: sub, Super: super}}
-		}
-	case *soltype.MappedType:
-		// A mapped residual the pre-switch could not ground reaches here: a mapped type whose Keys
-		// operand is a type parameter, so no key set exists to emit fields from. constrain treats it
-		// inert, the same as the KeyofType, IndexType, and CondType arms above. Two residuals are
-		// compatible only when structurally identical. A mapped type against an equal mapped type
-		// therefore succeeds reflexively without recording a bound, and a residual against any other
-		// concrete type fails. When super is a variable the case falls through to the superVar arm,
-		// which records the whole mapped type as one lower bound, keeping the operator symbolic on
-		// the coalesced binding.
 		if _, superIsVar := super.(*soltype.TypeVarType); !superIsVar {
 			if equalType(sub, super) {
 				return nil

--- a/internal/solver/context.go
+++ b/internal/solver/context.go
@@ -174,6 +174,17 @@ func (c *Context) freshInferDecl(name string) *soltype.InferType {
 	return t
 }
 
+// freshMappedKey mints the binding one mapped type's `for K in …` clause introduces, carrying the
+// source name for display. It draws from the same counter as freshVar so every binding has a unique
+// id, which is what keeps a nested mapped type's key distinct from the enclosing one's when both are
+// written K. resolveMappedTypeAnn binds the node it returns in the scope the value, key-remapping,
+// and filter positions resolve in, so each reference to K is that one binding.
+func (c *Context) freshMappedKey(name string) *soltype.MappedKeyType {
+	t := &soltype.MappedKeyType{ID: c.varCounter, Name: name}
+	c.varCounter++
+	return t
+}
+
 // freshLifetime allocates a new lifetime variable at the given level, assigning it
 // the next id in sequence. Lifetimes now ride the same let-generalization level
 // hierarchy as types (M4 D2.5): a lifetime minted inside its scheme's

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1860,16 +1860,38 @@ func describe(t soltype.Type) string {
 	case *soltype.MappedType:
 		// A mapped residual renders structurally as the surface syntax, recursing like the keyof arm,
 		// so a rejected constraint over a symbolic mapped type names it in full rather than the
-		// default `?`. Every operand renders in describe's raw mid-constrain form. The modifiers and
-		// the inexact marker are omitted, since a diagnostic names the shape rather than round-trips
-		// it.
-		key := t.Key.Name
-		if t.Name != nil {
-			key = describe(t.Name)
+		// default `?`. Every operand renders in describe's raw mid-constrain form.
+		//
+		// The modifiers and the inexact marker render too, because equalTypeWith reads them when it
+		// decides whether two inert mapped residuals are equal. Omitting one lets a rejection print
+		// both sides identically, so `{[K]: T[K] for K in keyof T}` against its `?`-adding twin would
+		// read as a type failing to satisfy itself.
+		out := "{"
+		switch t.Readonly {
+		case soltype.ModAdd:
+			out += "readonly "
+		case soltype.ModRemove:
+			out += "-readonly "
+		case soltype.ModNone:
 		}
-		out := "{[" + key + "]: " + describe(t.Value) + " for " + t.Key.Name + " in " + describe(t.Keys)
+		if t.Name != nil {
+			out += "[" + describe(t.Name) + "]"
+		} else {
+			out += "[" + t.Key.Name + "]"
+		}
+		switch t.Optional {
+		case soltype.ModAdd:
+			out += "+?"
+		case soltype.ModRemove:
+			out += "-?"
+		case soltype.ModNone:
+		}
+		out += ": " + describe(t.Value) + " for " + t.Key.Name + " in " + describe(t.Keys)
 		if t.Check != nil && t.Extends != nil {
 			out += " if " + describe(t.Check) + " : " + describe(t.Extends)
+		}
+		if t.Inexact {
+			out += ", ..."
 		}
 		return out + "}"
 	case *soltype.RestSpreadType:

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1853,6 +1853,25 @@ func describe(t soltype.Type) string {
 			return "infer " + t.Name
 		}
 		return t.Name
+	case *soltype.MappedKeyType:
+		// A mapped type's key variable renders as its bare name, matching the printer, so a rejected
+		// constraint over a symbolic mapped type reads the way the source wrote it.
+		return t.Name
+	case *soltype.MappedType:
+		// A mapped residual renders structurally as the surface syntax, recursing like the keyof arm,
+		// so a rejected constraint over a symbolic mapped type names it in full rather than the
+		// default `?`. Every operand renders in describe's raw mid-constrain form. The modifiers and
+		// the inexact marker are omitted, since a diagnostic names the shape rather than round-trips
+		// it.
+		key := t.Key.Name
+		if t.Name != nil {
+			key = describe(t.Name)
+		}
+		out := "{[" + key + "]: " + describe(t.Value) + " for " + t.Key.Name + " in " + describe(t.Keys)
+		if t.Check != nil && t.Extends != nil {
+			out += " if " + describe(t.Check) + " : " + describe(t.Extends)
+		}
+		return out + "}"
 	case *soltype.RestSpreadType:
 		// A `...P` spread element renders `...` over its operand, reached in place when the
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1373,7 +1373,7 @@ type AmbiguousUnionCommitWarning struct {
 	site      ast.Node
 }
 
-func (*AmbiguousUnionCommitWarning) isSolverError()   {}
+func (*AmbiguousUnionCommitWarning) isSolverError()    {}
 func (e *AmbiguousUnionCommitWarning) IsWarning() bool { return true }
 func (e *AmbiguousUnionCommitWarning) Span() ast.Span {
 	return spanOf(e.prov, e.Union, e.site)
@@ -1746,6 +1746,42 @@ func (e *ReadonlyFieldSubtypeError) Message() string {
 // output as user-facing Escalier syntax (see m1-implementation-plan §2.2). It
 // lives in solver because it walks bound-carrying variables, and its wording
 // matches the spike's verbatim so test assertions stay stable.
+// describeMapped renders a `[K]: V for K in Keys` member in describe's raw mid-constrain form, so a
+// rejected constraint over a symbolic mapped type names it in full rather than the default `?`. The
+// enclosing object supplies the braces and any trailing `...`.
+//
+// The modifiers render too, because equalObjElem reads them when it decides whether two inert mapped
+// members are equal. Omitting one lets a rejection print both sides identically, so
+// `{[K]: T[K] for K in keyof T}` against its `?`-adding twin would read as a type failing to satisfy
+// itself.
+func describeMapped(t *soltype.MappedElem) string {
+	out := ""
+	switch t.Readonly {
+	case soltype.ModAdd:
+		out += "readonly "
+	case soltype.ModRemove:
+		out += "-readonly "
+	case soltype.ModNone:
+	}
+	if t.Name != nil {
+		out += "[" + describe(t.Name) + "]"
+	} else {
+		out += "[" + t.Key.Name + "]"
+	}
+	switch t.Optional {
+	case soltype.ModAdd:
+		out += "+?"
+	case soltype.ModRemove:
+		out += "-?"
+	case soltype.ModNone:
+	}
+	out += ": " + describe(t.Value) + " for " + t.Key.Name + " in " + describe(t.Keys)
+	if t.Check != nil && t.Extends != nil {
+		out += " if " + describe(t.Check) + " : " + describe(t.Extends)
+	}
+	return out
+}
+
 func describe(t soltype.Type) string {
 	switch t := t.(type) {
 	case *soltype.PrimType:
@@ -1783,13 +1819,13 @@ func describe(t soltype.Type) string {
 		}
 		return "tuple"
 	case *soltype.ObjectType:
-		if !soltype.HasObjectSpread(t.Elems) {
+		if !soltype.HasResidualElem(t.Elems) {
 			return "object"
 		}
-		// A spread-carrying object is an unreduced residual, so it renders structurally like the
-		// KeyofType arm — a rejected constraint reads `{...t1, x: number}` rather than the nominal
-		// `object`. A spread element shows `...` over its raw mid-constrain operand; a property
-		// shows `name: <type>`. Other member kinds do not appear in a spread residual.
+		// A residual object renders structurally like the KeyofType arm, so a rejected constraint
+		// reads `{...t1, x: number}` rather than the nominal `object`. A spread element shows `...`
+		// over its raw mid-constrain operand, a property shows `name: <type>`, and a mapped member
+		// shows the surface form describeMapped builds. No other member kind appears in a residual.
 		parts := make([]string, 0, len(t.Elems)+1)
 		for _, e := range t.Elems {
 			switch e := e.(type) {
@@ -1797,6 +1833,8 @@ func describe(t soltype.Type) string {
 				parts = append(parts, "..."+describe(e.Type))
 			case *soltype.PropertyElem:
 				parts = append(parts, e.Name+": "+describe(e.Type))
+			case *soltype.MappedElem:
+				parts = append(parts, describeMapped(e))
 			}
 		}
 		if t.Inexact {
@@ -1857,43 +1895,6 @@ func describe(t soltype.Type) string {
 		// A mapped type's key variable renders as its bare name, matching the printer, so a rejected
 		// constraint over a symbolic mapped type reads the way the source wrote it.
 		return t.Name
-	case *soltype.MappedType:
-		// A mapped residual renders structurally as the surface syntax, recursing like the keyof arm,
-		// so a rejected constraint over a symbolic mapped type names it in full rather than the
-		// default `?`. Every operand renders in describe's raw mid-constrain form.
-		//
-		// The modifiers and the inexact marker render too, because equalTypeWith reads them when it
-		// decides whether two inert mapped residuals are equal. Omitting one lets a rejection print
-		// both sides identically, so `{[K]: T[K] for K in keyof T}` against its `?`-adding twin would
-		// read as a type failing to satisfy itself.
-		out := "{"
-		switch t.Readonly {
-		case soltype.ModAdd:
-			out += "readonly "
-		case soltype.ModRemove:
-			out += "-readonly "
-		case soltype.ModNone:
-		}
-		if t.Name != nil {
-			out += "[" + describe(t.Name) + "]"
-		} else {
-			out += "[" + t.Key.Name + "]"
-		}
-		switch t.Optional {
-		case soltype.ModAdd:
-			out += "+?"
-		case soltype.ModRemove:
-			out += "-?"
-		case soltype.ModNone:
-		}
-		out += ": " + describe(t.Value) + " for " + t.Key.Name + " in " + describe(t.Keys)
-		if t.Check != nil && t.Extends != nil {
-			out += " if " + describe(t.Check) + " : " + describe(t.Extends)
-		}
-		if t.Inexact {
-			out += ", ..."
-		}
-		return out + "}"
 	case *soltype.RestSpreadType:
 		// A `...P` spread element renders `...` over its operand, reached in place when the
 		// enclosing spread-carrying TupleType arm above describes its elements. The operand renders

--- a/internal/solver/infer_decl.go
+++ b/internal/solver/infer_decl.go
@@ -481,6 +481,12 @@ func stripOwnedMut(t soltype.Type) soltype.Type {
 		}
 		return t
 	case *soltype.ObjectType:
+		// A residual object carries a `...A` spread or a `[K]: V for K in Keys` member instead of a
+		// settled property list, so there is no field to peel. Return it unchanged; the evaluator
+		// reduces it at the constraint site and the peel applies to whatever it becomes.
+		if soltype.HasResidualElem(t.Elems) {
+			return t
+		}
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
 		for i, e := range t.Elems {
 			p := soltype.AsProperty(e)

--- a/internal/solver/infer_expr.go
+++ b/internal/solver/infer_expr.go
@@ -788,6 +788,11 @@ func sameObjectKeys(a, b *soltype.ObjectType) bool {
 	if len(a.Elems) != len(b.Elems) {
 		return false
 	}
+	// A residual object has no settled key set to compare, so it never satisfies the join's
+	// invariant-field precondition.
+	if soltype.HasResidualElem(a.Elems) || soltype.HasResidualElem(b.Elems) {
+		return false
+	}
 	for _, e := range a.Elems {
 		if _, ok := b.Prop(soltype.AsProperty(e).Name); !ok {
 			return false

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2119,17 +2119,6 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			wantExpanded: "{x?: number, y?: string}",
 		},
 		{
-			// `-?` leaves every field required, the shape `Required<T>` takes. A field this reduction
-			// emits carries no marker of its own, so removing one is already the default.
-			name: "RemoveOptional",
-			src: `
-				type Point = {x?: number, y: string}
-				type Result = {[K]-?: Point[K] for K in keyof Point}
-			`,
-			wantSymbolic: "{[K]-?: Point[K] for K in keyof Point}",
-			wantExpanded: "{x: number, y: string}",
-		},
-		{
 			// `readonly` marks every emitted field readonly, the shape `Readonly<T>` takes.
 			name: "AddReadonly",
 			src: `
@@ -2138,16 +2127,6 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			`,
 			wantSymbolic: "{readonly [K]: Point[K] for K in keyof Point}",
 			wantExpanded: "{readonly x: number, readonly y: string}",
-		},
-		{
-			// `-readonly` leaves every field writable, the twin of the `-?` case above.
-			name: "RemoveReadonly",
-			src: `
-				type Point = {readonly x: number, y: string}
-				type Result = {-readonly [K]: Point[K] for K in keyof Point}
-			`,
-			wantSymbolic: "{-readonly [K]: Point[K] for K in keyof Point}",
-			wantExpanded: "{x: number, y: string}",
 		},
 		{
 			// The `if C : E` filter drops a key that fails the test, narrowing the key set the way
@@ -2204,15 +2183,70 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			wantExpanded: "{renamed: number}",
 		},
 		{
-			// Two keys remapped to one name collapse to a single field, last value winning, the
-			// duplicate-key rule an object literal follows.
-			name: "RemapCollidingKeysCollapse",
+			// Two keys remapped to one name merge into a single field whose type unions both keys'
+			// values, so neither key's contribution is lost.
+			name: "RemapCollidingKeysUnion",
 			src: `
 				type Point = {x: number, y: string}
 				type Result = {["one"]: Point[K] for K in keyof Point}
 			`,
 			wantSymbolic: `{["one"]: Point[K] for K in keyof Point}`,
-			wantExpanded: "{one: string}",
+			wantExpanded: "{one: number | string}",
+		},
+		{
+			// A remapping that reduces to a union of names emits one field per name, each carrying
+			// the value the key it came from contributes.
+			name: "RemapToUnionOfNames",
+			src: `
+				type Names = "a" | "b"
+				type Src = {x: number}
+				type Result = {[Names]: Src[K] for K in keyof Src}
+			`,
+			wantSymbolic: "{[Names]: Src[K] for K in keyof Src}",
+			wantExpanded: "{a: number, b: number}",
+		},
+		{
+			// The identity mapped type is the identity: with no modifier written, each emitted field
+			// inherits the source member's `?` and `readonly` markers.
+			name: "HomomorphicPreservesMarkers",
+			src: `
+				type Src = {a?: number, readonly b: string, c: boolean}
+				type Result = {[K]: Src[K] for K in keyof Src}
+			`,
+			wantSymbolic: "{[K]: Src[K] for K in keyof Src}",
+			wantExpanded: "{a?: number, readonly b: string, c: boolean}",
+		},
+		{
+			// `-?` clears an inherited optional marker, which is what distinguishes it from writing
+			// no modifier at all.
+			name: "RemoveOptionalClearsInherited",
+			src: `
+				type Src = {a?: number, b: string}
+				type Result = {[K]-?: Src[K] for K in keyof Src}
+			`,
+			wantSymbolic: "{[K]-?: Src[K] for K in keyof Src}",
+			wantExpanded: "{a: number, b: string}",
+		},
+		{
+			// `-readonly` clears an inherited readonly marker, the twin of the case above.
+			name: "RemoveReadonlyClearsInherited",
+			src: `
+				type Src = {readonly a: number, b: string}
+				type Result = {-readonly [K]: Src[K] for K in keyof Src}
+			`,
+			wantSymbolic: "{-readonly [K]: Src[K] for K in keyof Src}",
+			wantExpanded: "{a: number, b: string}",
+		},
+		{
+			// A mapped type over a bare key union has no source object to read a marker off, so its
+			// fields are unmarked even though the value type is shared. This is the `Record` shape.
+			name: "NonHomomorphicEmitsUnmarkedFields",
+			src: `
+				type Names = "a" | "b"
+				type Result = {[K]: boolean for K in Names}
+			`,
+			wantSymbolic: "{[K]: boolean for K in Names}",
+			wantExpanded: "{a: boolean, b: boolean}",
 		},
 		{
 			// A mapped type nests: the outer key is in scope inside the inner one, so the inner value
@@ -2287,6 +2321,69 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			result := nodes["Result"]
 			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
 			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A homomorphic mapped type — one whose key set is written `keyof T` — carries the source member's
+// `?` and `readonly` markers onto each field it emits, so the identity mapped type really is the
+// identity and a marker survives composition. Dropping a marker here would be unsound rather than
+// imprecise: it launders a readonly field into a writable one, and it makes a `Pick` parameter
+// reject a value TypeScript accepts.
+func TestInferMappedTypeMarkersSurviveComposition(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// The identity applied to `Partial<T>` must give `Partial<T>` back. Reducing to
+			// `{a: number}` would silently make an optional field required.
+			name: "IdentityOverPartial",
+			src: `
+				type Partial<T> = {[K]?: T[K] for K in keyof T}
+				type Id<T> = {[K]: T[K] for K in keyof T}
+				type Result = Id<Partial<{a: number}>>
+			`,
+			wantExpanded: "{a?: number}",
+		},
+		{
+			// A readonly field stays readonly through the identity. Reducing to `{x: number}` would
+			// hand out a writable view of a readonly field.
+			name: "IdentityPreservesReadonly",
+			src: `
+				type Src = {readonly x: number, y?: string}
+				type Id<T> = {[K]: T[K] for K in keyof T}
+				type Result = Id<Src>
+			`,
+			wantExpanded: "{readonly x: number, y?: string}",
+		},
+		{
+			// `Pick` keeps an optional member optional, so a `Pick<Src, "a">` parameter accepts a
+			// value that omits `a`.
+			name: "PickKeepsOptional",
+			src: `
+				type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
+				type Src = {a?: number, b: string}
+				type Result = Pick<Src, "a">
+			`,
+			wantExpanded: "{a?: number}",
+		},
+		{
+			// `Required<T>` is what clears the marker, and it must still do so.
+			name: "RequiredClearsOptional",
+			src: `
+				type Required<T> = {[K]-?: T[K] for K in keyof T}
+				type Result = Required<{a?: number, b: string}>
+			`,
+			wantExpanded: "{a: number, b: string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 		})
 	}
 }

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2339,6 +2339,30 @@ func TestInferMappedTypeReduction(t *testing.T) {
 	}
 }
 
+// A residual object — one carrying a `...A` spread or a `[K]: V for K in Keys` member — reaches the
+// property-level walks that peel owned-mut cells, strip borrows, and compare key sets. None of those
+// has a settled property list to walk, so each treats the object as opaque. Asserting every member
+// is a property instead panics, which is what these shapes pin.
+func TestInferResidualObjectSurvivesPropertyWalks(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"MappedIntoOwnedMutCell", "type P = {x: number}\nvar v: mut {[K]: P[K] for K in keyof P} = {x: 1}"},
+		{"SpreadIntoOwnedMutCell", "fn f<T>(p: T) -> number { return 1 }\nvar v: mut {...T} = {x: 1}"},
+		{"MappedBehindBorrow", "type P = {x: number}\nfn f(a: &{[K]: P[K] for K in keyof P}) -> number { return 1 }"},
+		{"MappedInUnion", "type P = {x: number}\nfn f(a: {[K]: P[K] for K in keyof P} | number) -> number { return 1 }"},
+		{"MappedReturnPosition", "type P = {x: number}\nfn f() -> {[K]: P[K] for K in keyof P} { return {x: 1} }"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The assertion is that inference completes at all. Each shape panicked before the walks
+			// learned to skip a residual object, so reaching any conclusion here is the result.
+			require.NotPanics(t, func() { inferSource(t, tt.src) })
+		})
+	}
+}
+
 // A rejected constraint between two inert mapped residuals names each side's modifiers and inexact
 // marker. equalTypeWith reads those fields when deciding whether two residuals are equal, so a
 // diagnostic that omitted one would print both sides identically and read as a type failing to

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -86,7 +86,7 @@ func TestInferKeyofNamedTypeStaysSymbolic(t *testing.T) {
 			wantExpanded: `"only"`,
 		},
 		{
-			// An inexact object carries an open key tail, so its key union is inexact: the known
+			// An inexact object's key union is inexact too: the known
 			// keys plus a trailing `...` standing for the unlisted ones.
 			name: "InexactObject",
 			src: `
@@ -2274,7 +2274,7 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			wantExpanded: "{x: {x: number}}",
 		},
 		{
-			// An inexact operand has an open key set, so `keyof` yields an inexact key union and the
+			// An inexact operand has an inexact key set, so `keyof` yields an inexact key union and the
 			// object built from it stays open too.
 			name: "InexactOperandYieldsInexactObject",
 			src: `

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2398,6 +2398,28 @@ func TestInferMappedMemberMixesWithOrdinaryMembers(t *testing.T) {
 			wantExpanded: "{a: string, b: string, c: number}",
 		},
 		{
+			// Two mapped members whose key sets overlap merge under the same rightmost-wins rule an
+			// explicit collision follows, so the later member's value type wins on the shared key.
+			name: "TwoMappedMembersCollide",
+			src: `
+				type K1 = "a" | "b"
+				type K2 = "b" | "c"
+				type Result = {[K]: string for K in K1, [K]: number for K in K2}
+			`,
+			wantExpanded: "{a: string, b: number, c: number}",
+		},
+		{
+			// Each mapped member carries its own modifiers, so one may add `?` while its sibling adds
+			// `readonly` without either leaking onto the other's fields.
+			name: "TwoMappedMembersKeepOwnModifiers",
+			src: `
+				type K1 = "a"
+				type K2 = "b"
+				type Result = {[K]?: string for K in K1, readonly [K]: number for K in K2}
+			`,
+			wantExpanded: "{a?: string, readonly b: number}",
+		},
+		{
 			// The homomorphic marker inheritance still applies to the computed fields, and leaves the
 			// explicit sibling alone.
 			name: "MarkersSurviveAlongsideExplicitMember",
@@ -2415,6 +2437,33 @@ func TestInferMappedMemberMixesWithOrdinaryMembers(t *testing.T) {
 			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
 		})
 	}
+}
+
+// Two mapped members in one object each bind their own K. The two bindings draw distinct ids even
+// when the source writes the same name, so equality pairs each member's binder with its counterpart
+// at the same position rather than conflating the two. That makes the reflexive constraint succeed
+// and a swapped pair fail, since member order is significant in an unreduced object.
+func TestInferTwoMappedMembersBindIndependently(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f<T, U>(x: {[K]: T[K] for K in keyof T, [K]: U[K] for K in keyof U}) -> number { return 1 }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t,
+		"fn <T, U>(x: {[K]: T[K] for K in keyof T, [K]: U[K] for K in keyof U}) -> number",
+		values["f"])
+
+	_, _, errs = inferSource(t, `
+		fn g<T, U>(x: {[K]: T[K] for K in keyof T, [K]: U[K] for K in keyof U}) -> {[K]: T[K] for K in keyof T, [K]: U[K] for K in keyof U} { return x }
+	`)
+	require.Empty(t, errs)
+
+	_, _, errs = inferSource(t, `
+		fn h<T, U>(x: {[K]: T[K] for K in keyof T, [K]: U[K] for K in keyof U}) -> {[K]: U[K] for K in keyof U, [K]: T[K] for K in keyof T} { return x }
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t,
+		"cannot constrain {[K]: t1[K] for K in keyof t1, [K]: t2[K] for K in keyof t2} <: {[K]: t2[K] for K in keyof t2, [K]: t1[K] for K in keyof t1}",
+		errs[0].Message())
 }
 
 // A mixed object with an abstract key set stays symbolic and renders the way the source wrote it,

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2054,3 +2054,440 @@ func TestInferCondCaptureFromConstraint(t *testing.T) {
 		})
 	}
 }
+
+// A mapped type is stored unreduced, so an annotation prints the way the source wrote it, and
+// reducing it — what constrain does to check a constraint against it — emits one field per key of
+// the Keys union. Each case asserts both forms. The expectations match what TypeScript reduces the
+// equivalent `{[K in Keys]: …}` to, except where noted.
+func TestInferMappedTypeReduction(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantSymbolic string
+		wantExpanded string
+	}{
+		{
+			// The identity map: every key of the operand keeps its own value type.
+			name: "IdentityOverKeyof",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[K]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{[K]: Point[K] for K in keyof Point}",
+			wantExpanded: "{x: number, y: string}",
+		},
+		{
+			// A value expression that never names the key gives every field the same type, the shape
+			// `Record<K, V>` takes.
+			name: "ValueIgnoresKey",
+			src: `
+				type Names = "a" | "b"
+				type Result = {[K]: boolean for K in Names}
+			`,
+			wantSymbolic: "{[K]: boolean for K in Names}",
+			wantExpanded: "{a: boolean, b: boolean}",
+		},
+		{
+			// A single-key operand emits a single-field object; `keyof` collapsed its union to the
+			// lone literal, which mappedKeyMembers reads as one key.
+			name: "SingleKey",
+			src: `
+				type One = {only: number}
+				type Result = {[K]: One[K] for K in keyof One}
+			`,
+			wantSymbolic: "{[K]: One[K] for K in keyof One}",
+			wantExpanded: "{only: number}",
+		},
+		{
+			// An empty key set emits no fields. `keyof {}` is `never`, the union identity.
+			name: "EmptyKeySet",
+			src: `
+				type Empty = {}
+				type Result = {[K]: Empty[K] for K in keyof Empty}
+			`,
+			wantSymbolic: "{[K]: Empty[K] for K in keyof Empty}",
+			wantExpanded: "{}",
+		},
+		{
+			// `?` marks every emitted field optional, the shape `Partial<T>` takes.
+			name: "AddOptional",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[K]?: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{[K]+?: Point[K] for K in keyof Point}",
+			wantExpanded: "{x?: number, y?: string}",
+		},
+		{
+			// `-?` leaves every field required, the shape `Required<T>` takes. A field this reduction
+			// emits carries no marker of its own, so removing one is already the default.
+			name: "RemoveOptional",
+			src: `
+				type Point = {x?: number, y: string}
+				type Result = {[K]-?: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{[K]-?: Point[K] for K in keyof Point}",
+			wantExpanded: "{x: number, y: string}",
+		},
+		{
+			// `readonly` marks every emitted field readonly, the shape `Readonly<T>` takes.
+			name: "AddReadonly",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {readonly [K]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{readonly [K]: Point[K] for K in keyof Point}",
+			wantExpanded: "{readonly x: number, readonly y: string}",
+		},
+		{
+			// `-readonly` leaves every field writable, the twin of the `-?` case above.
+			name: "RemoveReadonly",
+			src: `
+				type Point = {readonly x: number, y: string}
+				type Result = {-readonly [K]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{-readonly [K]: Point[K] for K in keyof Point}",
+			wantExpanded: "{x: number, y: string}",
+		},
+		{
+			// The `if C : E` filter drops a key that fails the test, narrowing the key set the way
+			// `Pick<T, K>` does. Only "x" is a subtype of `"x"`.
+			name: "FilterKeepsMatchingKeys",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[K]: Point[K] for K in keyof Point if K : "x"}
+			`,
+			wantSymbolic: `{[K]: Point[K] for K in keyof Point if K : "x"}`,
+			wantExpanded: "{x: number}",
+		},
+		{
+			// The filter reads the value at the key as well as the key itself, so a key whose value
+			// type fails the test is dropped.
+			name: "FilterOnValueType",
+			src: `
+				type Mixed = {n: number, s: string}
+				type Result = {[K]: Mixed[K] for K in keyof Mixed if Mixed[K] : number}
+			`,
+			wantSymbolic: "{[K]: Mixed[K] for K in keyof Mixed if Mixed[K] : number}",
+			wantExpanded: "{n: number}",
+		},
+		{
+			// A filter no key satisfies drops every field.
+			name: "FilterDropsEveryKey",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[K]: Point[K] for K in keyof Point if K : "z"}
+			`,
+			wantSymbolic: `{[K]: Point[K] for K in keyof Point if K : "z"}`,
+			wantExpanded: "{}",
+		},
+		{
+			// A key the bracketed expression remaps to `never` is dropped, the way `Omit<T, K>`
+			// removes a key. The conditional in the brackets is branch selection, not a capture.
+			name: "RemapToNeverDropsKey",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[if K : "x" { never } else { K }]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: `{[if K : "x" { never } else { K }]: Point[K] for K in keyof Point}`,
+			wantExpanded: "{y: string}",
+		},
+		{
+			// A key remapped to another literal renames the field while the value still reads the
+			// original key.
+			name: "RemapRenamesField",
+			src: `
+				type Point = {x: number}
+				type Result = {["renamed"]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: `{["renamed"]: Point[K] for K in keyof Point}`,
+			wantExpanded: "{renamed: number}",
+		},
+		{
+			// Two keys remapped to one name collapse to a single field, last value winning, the
+			// duplicate-key rule an object literal follows.
+			name: "RemapCollidingKeysCollapse",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {["one"]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: `{["one"]: Point[K] for K in keyof Point}`,
+			wantExpanded: "{one: string}",
+		},
+		{
+			// A mapped type nests: the outer key is in scope inside the inner one, so the inner value
+			// reads it.
+			name: "Nested",
+			src: `
+				type Point = {x: number}
+				type Result = {[K]: {[J]: Point[K] for J in keyof Point} for K in keyof Point}
+			`,
+			wantSymbolic: "{[K]: {[J]: Point[K] for J in keyof Point} for K in keyof Point}",
+			wantExpanded: "{x: {x: number}}",
+		},
+		{
+			// An inexact operand has an open key set, so `keyof` yields an inexact key union and the
+			// object built from it stays open too.
+			name: "InexactOperandYieldsInexactObject",
+			src: `
+				type Point = {x: number, ...}
+				type Result = {[K]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "{[K]: Point[K] for K in keyof Point}",
+			wantExpanded: "{x: number, ...}",
+		},
+		{
+			// The mapped type's own trailing `...` makes the result inexact even over an exact
+			// operand.
+			name: "InexactMarkerOnMappedType",
+			src: `
+				type Point = {x: number}
+				type Result = {[K]: Point[K] for K in keyof Point, ...}
+			`,
+			wantSymbolic: "{[K]: Point[K] for K in keyof Point, ...}",
+			wantExpanded: "{x: number, ...}",
+		},
+		{
+			// `keyof` over a mapped type reduces the mapped type first, then projects the names of
+			// the fields it emitted.
+			name: "KeyofOverMappedType",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = keyof {[K]: Point[K] for K in keyof Point}
+			`,
+			wantSymbolic: "keyof {[K]: Point[K] for K in keyof Point}",
+			wantExpanded: `"x" | "y"`,
+		},
+		{
+			// An indexed access into a mapped type reduces the mapped type first, then reads one of
+			// the fields it emitted.
+			name: "IndexIntoMappedType",
+			src: `
+				type Point = {x: number, y: string}
+				type Result = {[K]: Point[K] for K in keyof Point}["y"]
+			`,
+			wantSymbolic: `{[K]: Point[K] for K in keyof Point}["y"]`,
+			wantExpanded: "string",
+		},
+		{
+			// A spread of a mapped type merges the fields it emits into the enclosing object.
+			name: "SpreadOfMappedType",
+			src: `
+				type Point = {x: number}
+				type Result = {...{[K]: Point[K] for K in keyof Point}, y: string}
+			`,
+			wantSymbolic: "{...{[K]: Point[K] for K in keyof Point}, y: string}",
+			wantExpanded: "{x: number, y: string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			result := nodes["Result"]
+			require.Equal(t, tt.wantSymbolic, soltype.Print(result))
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandResidual(ctx, result)))
+		})
+	}
+}
+
+// A generic alias whose body is a mapped type reduces per instantiation: the argument substituted
+// for the type parameter grounds the Keys operand, so the alias reference reduces to the object for
+// that argument. These are the shapes the TS utility types take, verified end to end in a later PR.
+func TestInferMappedTypeGenericAlias(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// `Partial<T>`: every key optional.
+			name: "Partial",
+			src: `
+				type Partial<T> = {[K]?: T[K] for K in keyof T}
+				type Result = Partial<{a: number, b: string}>
+			`,
+			wantExpanded: "{a?: number, b?: string}",
+		},
+		{
+			// `Readonly<T>`: every key readonly.
+			name: "Readonly",
+			src: `
+				type Readonly<T> = {readonly [K]: T[K] for K in keyof T}
+				type Result = Readonly<{a: number}>
+			`,
+			wantExpanded: "{readonly a: number}",
+		},
+		{
+			// `Pick<T, K>`: the filter keeps the keys the second argument names.
+			name: "Pick",
+			src: `
+				type Pick<T, Ks> = {[K]: T[K] for K in keyof T if K : Ks}
+				type Result = Pick<{a: number, b: string, c: boolean}, "a" | "c">
+			`,
+			wantExpanded: "{a: number, c: boolean}",
+		},
+		{
+			// `Omit<T, K>`: the bracketed expression remaps the named keys to `never`, dropping them.
+			name: "Omit",
+			src: `
+				type Omit<T, Ks> = {[if K : Ks { never } else { K }]: T[K] for K in keyof T}
+				type Result = Omit<{a: number, b: string, c: boolean}, "b">
+			`,
+			wantExpanded: "{a: number, c: boolean}",
+		},
+		{
+			// `Record<Ks, V>` over a literal key union. The primitive-key form `Record<string, V>`
+			// needs an index signature, which stays symbolic — see TestInferMappedTypeStaysSymbolic.
+			name: "Record",
+			src: `
+				type Record<Ks, V> = {[K]: V for K in Ks}
+				type Result = Record<"a" | "b", number>
+			`,
+			wantExpanded: "{a: number, b: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A mapped type whose key set the evaluator cannot enumerate stays symbolic: reducing it returns
+// the same operator rebuilt around its reduced operands, so it renders the way the source wrote it
+// and reduces later once the operand grounds. Each case asserts the reduction is a no-op on the
+// printed form.
+func TestInferMappedTypeStaysSymbolic(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// A type parameter has no ground key set, so the whole mapped type is inert. This is the
+			// form every generic utility alias is written in.
+			name: "TypeParameterOperand",
+			src:  `fn f<T>(x: {[K]: T[K] for K in keyof T}) -> number { return 1 }`,
+			want: "fn <T>(x: {[K]: T[K] for K in keyof T}) -> number",
+		},
+		{
+			// A primitive key constraint names infinitely many keys, which an object with named
+			// fields cannot express. TypeScript writes it as the index signature `{[k: string]: T}`;
+			// soltype has no index-signature element yet, so the mapped type stays inert.
+			name: "PrimitiveKeyConstraint",
+			src:  `fn f(x: {[K]: number for K in string}) -> number { return 1 }`,
+			want: "fn (x: {[K]: number for K in string}) -> number",
+		},
+		{
+			// A tuple's keys are number literals, which name no object field, so the mapped type
+			// stays inert rather than emitting fields under stringified indices.
+			name: "TupleKeys",
+			src: `
+				type Pair = [number, string]
+				fn f(x: {[K]: Pair[K] for K in keyof Pair}) -> number { return 1 }
+			`,
+			want: "fn (x: {[K]: Pair[K] for K in keyof Pair}) -> number",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, _, errs := inferSource(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.want, values["f"])
+		})
+	}
+}
+
+// constrain reduces a mapped type to check satisfaction, while the stored type keeps the form the
+// source wrote. A value matching the emitted fields is accepted; one that does not is rejected
+// against the reduced object, so the diagnostic names the field that failed.
+func TestInferMappedTypeConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string // "" ⇒ expect no error
+	}{
+		{
+			name: "MatchingValueAccepted",
+			src: `
+				type Point = {x: number, y: string}
+				val p: {[K]: Point[K] for K in keyof Point} = {x: 1, y: "hi"}
+			`,
+		},
+		{
+			name: "WrongFieldTypeRejected",
+			src: `
+				type Point = {x: number, y: string}
+				val p: {[K]: Point[K] for K in keyof Point} = {x: 1, y: 2}
+			`,
+			wantErr: `cannot constrain 2 <: string`,
+		},
+		{
+			// An optional-marking mapped type accepts a value that omits a field.
+			name: "OptionalFieldMayBeOmitted",
+			src: `
+				type Point = {x: number, y: string}
+				val p: {[K]?: Point[K] for K in keyof Point} = {x: 1}
+			`,
+		},
+		{
+			// A field a filter dropped is not part of the reduced object, so supplying it is an
+			// excess property.
+			name: "FilteredFieldRejected",
+			src: `
+				type Point = {x: number, y: string}
+				val p: {[K]: Point[K] for K in keyof Point if K : "x"} = {x: 1, y: "hi"}
+			`,
+			wantErr: `object has extra property: y`,
+		},
+		{
+			// A member read goes through the reduced object, so a field the mapped type emits reads
+			// at the value type its Value expression gave it.
+			name: "FieldReadThroughMappedParam",
+			src: `
+				type Point = {x: number, y: string}
+				fn f(p: {[K]: Point[K] for K in keyof Point}) -> number { return p.x }
+				val n = f({x: 1, y: "hi"})
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			if tt.wantErr == "" {
+				require.Empty(t, errs)
+				return
+			}
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.wantErr, errs[0].Message())
+		})
+	}
+}
+
+// A mapped type over a recursive alias terminates on the evaluator's active-state guard: the alias
+// stays on the active path while its body reduces, so a field that re-references it is left as the
+// unexpanded alias rather than unfolding forever. The reduction finishes and the recursive position
+// keeps the alias name.
+func TestInferMappedTypeRecursiveAliasTerminates(t *testing.T) {
+	nodes, ctx, errs := inferTypeNodes(t, `
+		type Rec<T> = {[K]: Rec<T> for K in keyof T}
+		type Result = Rec<{a: number}>
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "{a: Rec<{a: number}>}", soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+}
+
+// Two mapped types resolved separately from the same source compare equal even though each drew its
+// own key binding id, so a signature that writes one in both a parameter and the return accepts
+// `return x`. The reflexive `M <: M` succeeds inertly on the symbolic form, by structural equality
+// under the key pairing rather than by reducing.
+func TestInferMappedTypeSignatureRoundTrips(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f<T>(x: {[K]: T[K] for K in keyof T}) -> {[K]: T[K] for K in keyof T} { return x }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: {[K]: T[K] for K in keyof T}) -> {[K]: T[K] for K in keyof T}", values["f"])
+}

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2200,8 +2200,10 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			// own: substituteMappedKey rewrites K to the key, the template literal and `Capitalize`
 			// reduce it to a string literal, and remappedNames reads that literal as the field name.
 			name: "RemapComputesNameFromKey",
-			src: "\n\t\t\t\ttype Src = {name: string, age: number}\n" +
-				"\t\t\t\ttype Result = {[`get${Capitalize<K>}`]: Src[K] for K in keyof Src}\n",
+			src: `
+				type Src = {name: string, age: number}
+				type Result = {[` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src}
+			`,
 			wantSymbolic: "{[`get${Capitalize<K>}`]: Src[K] for K in keyof Src}",
 			wantExpanded: "{getAge: number, getName: string}",
 		},

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2339,6 +2339,110 @@ func TestInferMappedTypeReduction(t *testing.T) {
 	}
 }
 
+// A mapped member sits in its object's element list alongside whatever else the source wrote, so
+// `{id: number, [K]: V for K in Keys}` is one object annotation. TypeScript has no such form and
+// writes the intersection `{id: number} & {[K in Keys]: V}` instead. reduceObject merges the
+// computed fields with their siblings in source order, the same merge a `...A` spread feeds, so a
+// collision follows the rightmost-wins rule spreads already use.
+func TestInferMappedMemberMixesWithOrdinaryMembers(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			name: "ExplicitBeforeMapped",
+			src: `
+				type Keys = "a" | "b"
+				type Result = {id: number, [K]: string for K in Keys}
+			`,
+			wantExpanded: "{id: number, a: string, b: string}",
+		},
+		{
+			// Source order decides the member order, so a mapped member written first contributes
+			// its fields first.
+			name: "MappedBeforeExplicit",
+			src: `
+				type Keys = "a" | "b"
+				type Result = {[K]: string for K in Keys, id: number}
+			`,
+			wantExpanded: "{a: string, b: string, id: number}",
+		},
+		{
+			// A computed field colliding with an explicit one written earlier overrides it, the
+			// rightmost-wins rule mergeSpreadOperands applies to every group it merges.
+			name: "CollisionTakesRightmost",
+			src: `
+				type Keys = "a" | "id"
+				type Result = {id: number, [K]: string for K in Keys}
+			`,
+			wantExpanded: "{id: string, a: string}",
+		},
+		{
+			name: "ComposesWithSpread",
+			src: `
+				type Keys = "a" | "b"
+				type Base = {z: boolean}
+				type Result = {...Base, id: number, [K]: string for K in Keys}
+			`,
+			wantExpanded: "{z: boolean, id: number, a: string, b: string}",
+		},
+		{
+			// Two mapped members in one object each contribute their own group.
+			name: "TwoMappedMembers",
+			src: `
+				type K1 = "a" | "b"
+				type K2 = "c"
+				type Result = {[K]: string for K in K1, [K]: number for K in K2}
+			`,
+			wantExpanded: "{a: string, b: string, c: number}",
+		},
+		{
+			// The homomorphic marker inheritance still applies to the computed fields, and leaves the
+			// explicit sibling alone.
+			name: "MarkersSurviveAlongsideExplicitMember",
+			src: `
+				type Src = {x?: number, readonly y: string}
+				type Result = {id: boolean, [K]: Src[K] for K in keyof Src}
+			`,
+			wantExpanded: "{id: boolean, x?: number, readonly y: string}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
+// A mixed object with an abstract key set stays symbolic and renders the way the source wrote it,
+// and a value checked against a ground one must satisfy the explicit member and the computed ones
+// alike.
+func TestInferMappedMemberMixedConstraint(t *testing.T) {
+	values, _, errs := inferSource(t, `
+		fn f<T>(x: {id: number, [K]: T[K] for K in keyof T}) -> number { return 1 }
+	`)
+	require.Empty(t, errs)
+	require.Equal(t, "fn <T>(x: {id: number, [K]: T[K] for K in keyof T}) -> number", values["f"])
+
+	_, _, errs = inferSource(t, `
+		type Keys = "a" | "b"
+		fn g(p: {id: number, [K]: string for K in Keys}) -> number { return 1 }
+		val ok = g({id: 1, a: "x", b: "y"})
+	`)
+	require.Empty(t, errs)
+
+	_, _, errs = inferSource(t, `
+		type Keys = "a" | "b"
+		fn g(p: {id: number, [K]: string for K in Keys}) -> number { return 1 }
+		val bad = g({id: 1, a: "x"})
+	`)
+	require.Len(t, errs, 1)
+	require.Equal(t, "object is missing property: b", errs[0].Message())
+}
+
 // A residual object — one carrying a `...A` spread or a `[K]: V for K in Keys` member — reaches the
 // property-level walks that peel owned-mut cells, strip borrows, and compare key sets. None of those
 // has a settled property list to walk, so each treats the object as opaque. Asserting every member

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2339,6 +2339,83 @@ func TestInferMappedTypeReduction(t *testing.T) {
 	}
 }
 
+// The `if Check : Extends` filter tests two arbitrary type expressions, not just the key. Both
+// operands resolve in the scope where K is bound and are reduced with the key substituted, so either
+// side may name the key, the value at that key, a computed type over the key, or nothing at all.
+// That makes value-based filtering — TypeScript's `PickByType` idiom — expressible without any
+// filter machinery specific to it.
+func TestInferMappedTypeFilterTestsArbitraryTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// Keep the keys whose value is a number, testing the value rather than the key.
+			name: "ByValueType",
+			src: `
+				type Src = {a: number, b: string, c: number}
+				type Result = {[K]: Src[K] for K in keyof Src if Src[K] : number}
+			`,
+			wantExpanded: "{a: number, c: number}",
+		},
+		{
+			// The same shape with the test inverted keeps the complementary keys.
+			name: "ByValueTypeComplement",
+			src: `
+				type Src = {a: number, b: string, c: number}
+				type Result = {[K]: Src[K] for K in keyof Src if Src[K] : string}
+			`,
+			wantExpanded: "{b: string}",
+		},
+		{
+			// The check may reach into the value rather than comparing it whole.
+			name: "ByNestedFieldOfValue",
+			src: `
+				type Src = {a: {kind: "x"}, b: {kind: "y"}}
+				type Result = {[K]: Src[K] for K in keyof Src if Src[K]["kind"] : "x"}
+			`,
+			wantExpanded: `{a: {kind: "x"}}`,
+		},
+		{
+			// The check may be a computed type over the key rather than the key itself.
+			name: "ByComputedTypeOverKey",
+			src: `
+				type Src = {ax: number, bx: string}
+				type Result = {[K]: Src[K] for K in keyof Src if ` + "`${K}`" + ` : "ax"}
+			`,
+			wantExpanded: "{ax: number}",
+		},
+		{
+			// Neither operand need mention the key. A condition that fails drops every key, leaving
+			// the empty object.
+			name: "ConditionIndependentOfKey",
+			src: `
+				type Src = {a: number, b: string}
+				type Result = {[K]: Src[K] for K in keyof Src if number : string}
+			`,
+			wantExpanded: "{}",
+		},
+		{
+			// Value-based filtering works through a generic parameter, which is how a reusable
+			// `PickByType<T, V>` alias would be written.
+			name: "ByValueTypeThroughGeneric",
+			src: `
+				type NumbersOf<T> = {[K]: T[K] for K in keyof T if T[K] : number}
+				type Result = NumbersOf<{a: number, b: string}>
+			`,
+			wantExpanded: "{a: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
 // A mapped member sits in its object's element list alongside whatever else the source wrote, so
 // `{id: number, [K]: V for K in Keys}` is one object annotation. TypeScript has no such form and
 // writes the intersection `{id: number} & {[K in Keys]: V}` instead. reduceObject merges the

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2339,6 +2339,76 @@ func TestInferMappedTypeReduction(t *testing.T) {
 	}
 }
 
+// A key remapping may compute the name with a template literal and a string intrinsic, and that
+// composes with everything else an object's member list can hold. The mapped member is one member
+// among others, so a renamed field merges with explicit siblings, spreads, and a second mapped
+// member under the same source-order rule.
+func TestInferMappedTypeTemplateRenameInObject(t *testing.T) {
+	tests := []struct {
+		name         string
+		src          string
+		wantExpanded string
+	}{
+		{
+			// A computed rename composes with an ordinary sibling, the `Getters<T>` shape written as one
+			// object rather than an intersection.
+			name: "RenameAlongsideExplicitMember",
+			src: `
+				type Src = {name: string, age: number}
+				type Result = {id: number, [` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src}
+			`,
+			wantExpanded: "{id: number, getAge: number, getName: string}",
+		},
+		{
+			// A computed name colliding with an explicit sibling overrides it, the rightmost-wins rule
+			// every merged group follows.
+			name: "RenameCollidesWithExplicitMember",
+			src: `
+				type Src = {x: number}
+				type Result = {getX: string, [` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src}
+			`,
+			wantExpanded: "{getX: number}",
+		},
+		{
+			// Two mapped members may each rename over the same key set, which is how a getter/setter pair
+			// is expressed.
+			name: "TwoRenamingMembers",
+			src: `
+				type Src = {a: number}
+				type Result = {[` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src, [` + "`set${Capitalize<K>}`" + `]: Src[K] for K in keyof Src}
+			`,
+			wantExpanded: "{getA: number, setA: number}",
+		},
+		{
+			// A renaming member merges after a spread's fields, in source order.
+			name: "RenameComposesWithSpread",
+			src: `
+				type Base = {z: boolean}
+				type Src = {a: number}
+				type Result = {...Base, [` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src}
+			`,
+			wantExpanded: "{z: boolean, getA: number}",
+		},
+		{
+			// Renaming and filtering apply together: the filter reads the pre-rename key, so only the keys
+			// that survive it are renamed.
+			name: "RenameWithFilter",
+			src: `
+				type Src = {a: number, b: string}
+				type Result = {id: boolean, [` + "`get${Capitalize<K>}`" + `]: Src[K] for K in keyof Src if Src[K] : number}
+			`,
+			wantExpanded: "{id: boolean, getA: number}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, ctx, errs := inferTypeNodes(t, tt.src)
+			require.Empty(t, errs)
+			require.Equal(t, tt.wantExpanded, soltype.Print(expandAliasResidual(ctx, nodes["Result"])))
+		})
+	}
+}
+
 // The `if Check : Extends` filter tests two arbitrary type expressions, not just the key. Both
 // operands resolve in the scope where K is bound and are reduced with the key substituted, so either
 // side may name the key, the value at that key, a computed type over the key, or nothing at all.

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2194,6 +2194,18 @@ func TestInferMappedTypeReduction(t *testing.T) {
 			wantExpanded: "{one: number | string}",
 		},
 		{
+			// A key remapping may compute a name rather than naming one written in source, by
+			// interpolating the key into a template literal and running it through a string
+			// intrinsic. This is the `Getters<T>` shape, and it needs no mapped-type machinery of its
+			// own: substituteMappedKey rewrites K to the key, the template literal and `Capitalize`
+			// reduce it to a string literal, and remappedNames reads that literal as the field name.
+			name: "RemapComputesNameFromKey",
+			src: "\n\t\t\t\ttype Src = {name: string, age: number}\n" +
+				"\t\t\t\ttype Result = {[`get${Capitalize<K>}`]: Src[K] for K in keyof Src}\n",
+			wantSymbolic: "{[`get${Capitalize<K>}`]: Src[K] for K in keyof Src}",
+			wantExpanded: "{getAge: number, getName: string}",
+		},
+		{
 			// A remapping that reduces to a union of names emits one field per name, each carrying
 			// the value the key it came from contributes.
 			name: "RemapToUnionOfNames",

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2337,6 +2337,41 @@ func TestInferMappedTypeReduction(t *testing.T) {
 	}
 }
 
+// A rejected constraint between two inert mapped residuals names each side's modifiers and inexact
+// marker. equalTypeWith reads those fields when deciding whether two residuals are equal, so a
+// diagnostic that omitted one would print both sides identically and read as a type failing to
+// satisfy itself.
+func TestInferMappedTypeErrorNamesModifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "AddOptional",
+			src:  `fn f<T>(x: {[K]: T[K] for K in keyof T}) -> {[K]?: T[K] for K in keyof T} { return x }`,
+			want: "cannot constrain {[K]: t1[K] for K in keyof t1} <: {[K]+?: t1[K] for K in keyof t1}",
+		},
+		{
+			name: "RemoveOptional",
+			src:  `fn f<T>(x: {[K]: T[K] for K in keyof T}) -> {[K]-?: T[K] for K in keyof T} { return x }`,
+			want: "cannot constrain {[K]: t1[K] for K in keyof t1} <: {[K]-?: t1[K] for K in keyof t1}",
+		},
+		{
+			name: "AddReadonly",
+			src:  `fn f<T>(x: {[K]: T[K] for K in keyof T}) -> {readonly [K]: T[K] for K in keyof T} { return x }`,
+			want: "cannot constrain {[K]: t1[K] for K in keyof t1} <: {readonly [K]: t1[K] for K in keyof t1}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, tt.src)
+			require.Len(t, errs, 1)
+			require.Equal(t, tt.want, errs[0].Message())
+		})
+	}
+}
+
 // A homomorphic mapped type — one whose key set is written `keyof T` — carries the source member's
 // `?` and `readonly` markers onto each field it emits, so the identity mapped type really is the
 // identity and a marker survives composition. Dropping a marker here would be unsound rather than

--- a/internal/solver/lattice.go
+++ b/internal/solver/lattice.go
@@ -506,9 +506,12 @@ func compareObjectFields(a, b *soltype.ObjectType) int {
 }
 
 func sortedPropertyNames(o *soltype.ObjectType) []string {
+	// A residual object's members are a spread or a mapped member, neither of which names a field.
+	// soltype.ObjElemName returns "" for both, so they sort together and compare equal, which leaves
+	// the caller's ordering decided by the members that do name something.
 	names := make([]string, len(o.Elems))
 	for i, e := range o.Elems {
-		names[i] = soltype.AsProperty(e).Name
+		names[i] = soltype.ObjElemName(e)
 	}
 	sort.Strings(names)
 	return names

--- a/internal/solver/poly.go
+++ b/internal/solver/poly.go
@@ -593,7 +593,13 @@ func propagateOpen(vars map[int]*soltype.TypeVarType) {
 				continue
 			}
 			for _, elem := range ob.Elems {
-				pv, ok := soltype.AsProperty(elem).Type.(*soltype.TypeVarType)
+				// Only a property carries a value var to open. A residual object's spread or mapped
+				// member holds operands the evaluator substitutes rather than the solver generalizes.
+				prop, isProp := elem.(*soltype.PropertyElem)
+				if !isProp {
+					continue
+				}
+				pv, ok := prop.Type.(*soltype.TypeVarType)
 				if ok && !pv.Open {
 					pv.Open = true
 					work = append(work, pv)

--- a/internal/solver/return_strip.go
+++ b/internal/solver/return_strip.go
@@ -156,6 +156,11 @@ func stripBorrowTree(
 		}
 		return soltype.NewRef(t.Mut, nil, inner)
 	case *soltype.ObjectType:
+		// A residual object has no settled property list to walk, the same guard stripOwnedMut
+		// applies. Its borrows are reached once the evaluator reduces it.
+		if soltype.HasResidualElem(t.Elems) {
+			return t
+		}
 		elems := make([]soltype.ObjTypeElem, len(t.Elems))
 		for i, e := range t.Elems {
 			p := soltype.AsProperty(e)

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -19,6 +19,13 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		return c.annPrim(ta, soltype.StrPrim), true
 	case *ast.BooleanTypeAnn:
 		return c.annPrim(ta, soltype.BoolPrim), true
+	case *ast.NeverTypeAnn:
+		// `never` is the bottom of the lattice, the empty type. A mapped type's key-remapping
+		// expression names it to drop a field, `{[if K : "id" { never } else { K }]: … }`, which is
+		// how a mapped type filters its key set.
+		t := &soltype.NeverType{}
+		c.recordProv(t, ta, AnnotationType)
+		return t, true
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:
@@ -128,6 +135,15 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 // value to a fresh var and keeps the object shape — cascade-safe, mirroring the
 // Promise<bad> recovery. The arm therefore always returns ok=true.
 func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
+	// A mapped type is written as an object annotation whose single member is the `[K]: V for K in
+	// Keys` form, and it describes the whole object rather than one of its members, so it lowers to
+	// its own type node instead of an element. An object mixing the mapped member with ordinary ones
+	// has no such reading and falls through to the member loop below, which reports it unsupported.
+	if len(ta.Elems) == 1 {
+		if mapped, ok := ta.Elems[0].(*ast.MappedTypeAnn); ok {
+			return c.resolveMappedTypeAnn(scope, ta, mapped, lvl)
+		}
+	}
 	hasSpread := false
 	for _, elem := range ta.Elems {
 		if _, ok := elem.(*ast.RestSpreadTypeAnn); ok {
@@ -182,6 +198,86 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	t := &soltype.ObjectType{Elems: elems, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
+}
+
+// resolveMappedTypeAnn lowers `{[K]: V for K in Keys}` to a MappedType residual and stores it
+// unreduced, so the annotation prints the way the source wrote it rather than as the object it
+// reduces to. constrain reduces the residual when it checks a constraint against it, mirroring
+// resolveKeyOfTypeAnn.
+//
+// The `for K in Keys` clause binds K, so the constraint resolves in the enclosing scope while the
+// value, the bracketed key-remapping expression, and the `if C : E` filter resolve in a child scope
+// where K names the binding the evaluator substitutes a key for. That is the scope TypeScript gives
+// a mapped type's key parameter, so `{[K]: T[K] for K in keyof T}` reads the same K in its value
+// position that its clause introduced.
+//
+// An unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery. A
+// recovered operand leaves the mapped type unable to ground, so it stays symbolic rather than
+// reducing to a wrong object.
+func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapped *ast.MappedTypeAnn, lvl int) (soltype.Type, bool) {
+	keys, ok := c.resolveTypeAnn(scope, mapped.TypeParam.Constraint, lvl)
+	if !ok {
+		keys = c.freshAt(lvl)
+	}
+
+	key := c.ctx.freshMappedKey(mapped.TypeParam.Name)
+	mappedScope := scope.Child()
+	mappedScope.defineType(mapped.TypeParam.Name, TypeBinding{Type: key})
+
+	value, ok := c.resolveTypeAnn(mappedScope, mapped.Value, lvl)
+	if !ok {
+		value = c.freshAt(lvl)
+	}
+	name := c.resolveMappedOperand(mappedScope, mapped.Name, lvl)
+	// The parser fills Check and Extends together or leaves both nil, so one present without the
+	// other is a malformed filter the reduction would have to guess at. Resolve the pair only when
+	// both are written, which drops such a filter rather than applying half of it.
+	var check, extends soltype.Type
+	if mapped.Check != nil && mapped.Extends != nil {
+		check = c.resolveMappedOperand(mappedScope, mapped.Check, lvl)
+		extends = c.resolveMappedOperand(mappedScope, mapped.Extends, lvl)
+	}
+
+	t := &soltype.MappedType{
+		Key:      key,
+		Keys:     keys,
+		Value:    value,
+		Name:     name,
+		Check:    check,
+		Extends:  extends,
+		Optional: mappedModifier(mapped.Optional),
+		Readonly: mappedModifier(mapped.ReadOnly),
+		Inexact:  ta.Inexact,
+	}
+	c.recordProv(t, ta, AnnotationType)
+	return t, true
+}
+
+// resolveMappedOperand lowers one of a mapped type's optional operands — the bracketed key-remapping
+// expression, or either half of the `if C : E` filter. An absent annotation stays absent, and an
+// unsupported one recovers to a fresh var so the mapped type keeps its shape.
+func (c *checker) resolveMappedOperand(scope *Scope, ta ast.TypeAnn, lvl int) soltype.Type {
+	if ta == nil {
+		return nil
+	}
+	if t, ok := c.resolveTypeAnn(scope, ta, lvl); ok {
+		return t
+	}
+	return c.freshAt(lvl)
+}
+
+// mappedModifier converts one written `readonly` or `?` marker to the modifier the reduction
+// applies. An absent marker leaves the emitted field unmarked; `+` and the bare form add the marker
+// and `-` removes it.
+func mappedModifier(m *ast.MappedModifier) soltype.MappedModifier {
+	switch {
+	case m == nil:
+		return soltype.ModNone
+	case *m == ast.MMRemove:
+		return soltype.ModRemove
+	default:
+		return soltype.ModAdd
+	}
 }
 
 // resolveObjectProperty lowers one `name: T` / `name?: T` property annotation to its name and

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -23,9 +23,14 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 		// `never` is the bottom of the lattice, the empty type. A mapped type's key-remapping
 		// expression names it to drop a field, `{[if K : "id" { never } else { K }]: … }`, which is
 		// how a mapped type filters its key set.
-		t := &soltype.NeverType{}
-		c.recordProv(t, ta, AnnotationType)
-		return t, true
+		//
+		// No provenance is recorded. soltype.NeverType has no fields, so Go gives every
+		// `&soltype.NeverType{}` the same address, and the Prov side table is keyed by pointer
+		// identity. Recording against it would file every `never` annotation in the module under one
+		// entry, so each would report the last one's span as its blame, and the debugProv guard would
+		// panic on the second. A caller that needs a span for a rejected `never` falls back to the
+		// constraint site.
+		return &soltype.NeverType{}, true
 	case *ast.LitTypeAnn:
 		return c.resolveLitTypeAnn(ta)
 	case *ast.TypeRefTypeAnn:
@@ -136,9 +141,9 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 // Promise<bad> recovery. The arm therefore always returns ok=true.
 func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
 	// A mapped type is written as an object annotation whose single member is the `[K]: V for K in
-	// Keys` form, and it describes the whole object rather than one of its members, so it lowers to
-	// its own type node instead of an element. An object mixing the mapped member with ordinary ones
-	// has no such reading and falls through to the member loop below, which reports it unsupported.
+	// Keys` form. It describes the whole object rather than one of its members, so it lowers to its
+	// own type node instead of an element. An object mixing the mapped member with ordinary ones has
+	// no such reading and falls through to the member loop below, which reports it unsupported.
 	if len(ta.Elems) == 1 {
 		if mapped, ok := ta.Elems[0].(*ast.MappedTypeAnn); ok {
 			return c.resolveMappedTypeAnn(scope, ta, mapped, lvl)
@@ -205,11 +210,12 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 // reduces to. constrain reduces the residual when it checks a constraint against it, mirroring
 // resolveKeyOfTypeAnn.
 //
-// The `for K in Keys` clause binds K, so the constraint resolves in the enclosing scope while the
-// value, the bracketed key-remapping expression, and the `if C : E` filter resolve in a child scope
-// where K names the binding the evaluator substitutes a key for. That is the scope TypeScript gives
-// a mapped type's key parameter, so `{[K]: T[K] for K in keyof T}` reads the same K in its value
-// position that its clause introduced.
+// The `for K in Keys` clause binds K. The constraint itself resolves in the enclosing scope, since
+// K is not in scope for the key set that binds it. The value, the bracketed key-remapping
+// expression, and the `if C : E` filter each resolve in a child scope where K names the binding the
+// evaluator substitutes a key for. That is the scope TypeScript gives a mapped type's key parameter,
+// so `{[K]: T[K] for K in keyof T}` reads the same K in its value position that its clause
+// introduced.
 //
 // An unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery. A
 // recovered operand leaves the mapped type unable to ground, so it stays symbolic rather than

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -140,29 +140,27 @@ func (c *checker) resolveTypeAnn(scope *Scope, ta ast.TypeAnn, lvl int) (soltype
 // value to a fresh var and keeps the object shape — cascade-safe, mirroring the
 // Promise<bad> recovery. The arm therefore always returns ok=true.
 func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl int) (soltype.Type, bool) {
-	// A mapped type is written as an object annotation whose single member is the `[K]: V for K in
-	// Keys` form. It describes the whole object rather than one of its members, so it lowers to its
-	// own type node instead of an element. An object mixing the mapped member with ordinary ones has
-	// no such reading and falls through to the member loop below, which reports it unsupported.
-	if len(ta.Elems) == 1 {
-		if mapped, ok := ta.Elems[0].(*ast.MappedTypeAnn); ok {
-			return c.resolveMappedTypeAnn(scope, ta, mapped, lvl)
-		}
-	}
-	hasSpread := false
+	// A `...A` spread and a `[K]: V for K in Keys` mapped member each make the object an unreduced
+	// residual whose final member list the evaluator computes. Either one puts the whole object on
+	// the ordered path below, which keeps source order for the override merge.
+	//
+	// The two mix freely with ordinary members, so `{a: number, [K]: V for K in Keys}` is one object
+	// annotation. TypeScript has no such form and writes the intersection
+	// `{a: number} & {[K in Keys]: V}` instead.
+	hasResidual := false
 	for _, elem := range ta.Elems {
-		if _, ok := elem.(*ast.RestSpreadTypeAnn); ok {
-			hasSpread = true
-			break
+		switch elem.(type) {
+		case *ast.RestSpreadTypeAnn, *ast.MappedTypeAnn:
+			hasResidual = true
 		}
 	}
 	unsupported := false
 	var elems []soltype.ObjTypeElem
-	// The two paths differ only in when duplicate keys collapse. A spread-free object is never
+	// The two paths differ only in when duplicate keys collapse. A residual-free object is never
 	// reduced later, so its duplicates must collapse here to the unique-key shape Prop and equalType
-	// assume. A spread-carrying object keeps source order for the override merge and dedups in
-	// reduceObject once its spreads ground.
-	if !hasSpread {
+	// assume. A residual object keeps source order for the override merge and dedups in reduceObject
+	// once its spreads and mapped members ground.
+	if !hasResidual {
 		b := newObjElemBuilder(len(ta.Elems))
 		for _, elem := range ta.Elems {
 			prop, ok := elem.(*ast.PropertyTypeAnn)
@@ -192,6 +190,8 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 					src = c.freshAt(lvl)
 				}
 				elems = append(elems, &soltype.SpreadElem{Type: src})
+			case *ast.MappedTypeAnn:
+				elems = append(elems, c.resolveMappedElem(scope, elem, lvl))
 			default:
 				unsupported = true
 			}
@@ -205,15 +205,13 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	return t, true
 }
 
-// resolveMappedTypeAnn lowers `{[K]: V for K in Keys}` to an ObjectType whose sole member is a
-// MappedElem, stored unreduced so the annotation prints the way the source wrote it rather than as
-// the members it reduces to. constrain reduces the object when it checks a constraint against it,
-// mirroring resolveKeyOfTypeAnn.
+// resolveMappedElem lowers a `[K]: V for K in Keys` member to a MappedElem, stored unreduced so the
+// annotation prints the way the source wrote it rather than as the members it computes. constrain
+// reduces the enclosing object when it checks a constraint against it, mirroring resolveKeyOfTypeAnn.
 //
-// The member is alone in the list because it computes every field rather than naming one, so an
-// object mixing it with ordinary members has no reading. resolveObjectTypeAnn rejects that mix
-// before reaching here, which is what lets every walk over an element list treat a mapped member as
-// standing for the whole object.
+// The member sits in its object's element list alongside whatever else the source wrote, so
+// `{a: number, [K]: V for K in Keys}` is one object rather than an intersection. reduceObject merges
+// the computed fields with the sibling members in source order, the same merge a `...A` spread feeds.
 //
 // The `for K in Keys` clause binds K. The constraint itself resolves in the enclosing scope, since
 // K is not in scope for the key set that binds it. The value, the bracketed key-remapping
@@ -225,7 +223,7 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 // An unsupported operand recovers to a fresh var, cascade-safe like the Promise<bad> recovery. A
 // recovered operand leaves the mapped type unable to ground, so it stays symbolic rather than
 // reducing to a wrong object.
-func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapped *ast.MappedTypeAnn, lvl int) (soltype.Type, bool) {
+func (c *checker) resolveMappedElem(scope *Scope, mapped *ast.MappedTypeAnn, lvl int) *soltype.MappedElem {
 	keys, ok := c.resolveTypeAnn(scope, mapped.TypeParam.Constraint, lvl)
 	if !ok {
 		keys = c.freshAt(lvl)
@@ -249,7 +247,7 @@ func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapp
 		extends = c.resolveMappedOperand(mappedScope, mapped.Extends, lvl)
 	}
 
-	elem := &soltype.MappedElem{
+	return &soltype.MappedElem{
 		Key:      key,
 		Keys:     keys,
 		Value:    value,
@@ -259,9 +257,6 @@ func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapp
 		Optional: mappedModifier(mapped.Optional),
 		Readonly: mappedModifier(mapped.ReadOnly),
 	}
-	t := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{elem}, Inexact: ta.Inexact}
-	c.recordProv(t, ta, AnnotationType)
-	return t, true
 }
 
 // resolveMappedOperand lowers one of a mapped type's optional operands — the bracketed key-remapping

--- a/internal/solver/type_ann.go
+++ b/internal/solver/type_ann.go
@@ -205,10 +205,15 @@ func (c *checker) resolveObjectTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, lvl 
 	return t, true
 }
 
-// resolveMappedTypeAnn lowers `{[K]: V for K in Keys}` to a MappedType residual and stores it
-// unreduced, so the annotation prints the way the source wrote it rather than as the object it
-// reduces to. constrain reduces the residual when it checks a constraint against it, mirroring
-// resolveKeyOfTypeAnn.
+// resolveMappedTypeAnn lowers `{[K]: V for K in Keys}` to an ObjectType whose sole member is a
+// MappedElem, stored unreduced so the annotation prints the way the source wrote it rather than as
+// the members it reduces to. constrain reduces the object when it checks a constraint against it,
+// mirroring resolveKeyOfTypeAnn.
+//
+// The member is alone in the list because it computes every field rather than naming one, so an
+// object mixing it with ordinary members has no reading. resolveObjectTypeAnn rejects that mix
+// before reaching here, which is what lets every walk over an element list treat a mapped member as
+// standing for the whole object.
 //
 // The `for K in Keys` clause binds K. The constraint itself resolves in the enclosing scope, since
 // K is not in scope for the key set that binds it. The value, the bracketed key-remapping
@@ -244,7 +249,7 @@ func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapp
 		extends = c.resolveMappedOperand(mappedScope, mapped.Extends, lvl)
 	}
 
-	t := &soltype.MappedType{
+	elem := &soltype.MappedElem{
 		Key:      key,
 		Keys:     keys,
 		Value:    value,
@@ -253,8 +258,8 @@ func (c *checker) resolveMappedTypeAnn(scope *Scope, ta *ast.ObjectTypeAnn, mapp
 		Extends:  extends,
 		Optional: mappedModifier(mapped.Optional),
 		Readonly: mappedModifier(mapped.ReadOnly),
-		Inexact:  ta.Inexact,
 	}
+	t := &soltype.ObjectType{Elems: []soltype.ObjTypeElem{elem}, Inexact: ta.Inexact}
 	c.recordProv(t, ta, AnnotationType)
 	return t, true
 }

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -16,6 +16,11 @@ import (
 // whose argument grows every lap so its state never repeats and the active guard never matches.
 // No finite analytical bound exists for that fragment, so the budget stops the walk and the
 // operator over the unexpanded alias stays symbolic.
+//
+// TODO(#929): expandAliasGuarded restores the budget after each sibling, so a caller that expands
+// one operand per member gives every member the full remaining budget. A mapped type reduces its
+// value expression once per key, which makes an expanding alias reached from there an exponential
+// walk rather than a capped one.
 const maxExpandDepth = 200
 
 // maxTemplateLitCombinations caps how many string literals a template literal may reduce to. Its
@@ -598,6 +603,9 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // soltype has no index-signature element, so such a mapped type stays inert rather than reducing to
 // a wrong shape. The same holds for a key that is a number literal, which names no object field.
 //
+// TODO(#930): reduce a primitive key constraint to an index-signature element once soltype carries
+// one, and give a number-literal key a field to name.
+//
 // Two keys that remap to one name merge into a single field whose type is their union, so no key's
 // contribution is lost. See mergeMappedField.
 //
@@ -858,8 +866,12 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Ty
 		}
 		return &soltype.KeyofType{Operand: operand, Exact: exact}
 	case *soltype.UnionType:
+		// TODO(#928): a key is readable from a union only when every member carries it, so this
+		// should intersect the operands' key sets. Unioning them lets `keyof (A | B)` name a key
+		// that only A has, and `(A | B)[K]` then reads it off a value that is a B.
 		return e.keyofDistribute(op.Types, exact)
 	case *soltype.IntersectionType:
+		// An intersection carries every operand's members, so its key sets union.
 		return e.keyofDistribute(op.Types, exact)
 	case *soltype.PrimType, *soltype.LitType, *soltype.NeverType, *soltype.UnknownType:
 		return &soltype.NeverType{}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -433,12 +433,7 @@ func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 // symbolic rather than finalizing just that safe suffix: it is simpler and renders the way the
 // source wrote it, at the cost of re-reducing from scratch each pass.
 func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
-	// A mapped member computes the whole member list, so it is reduced instead of merged. It is
-	// always alone in the list, which is why the two paths never meet.
-	if mapped, ok := soltype.AsMapped(t.Elems); ok {
-		return e.reduceMapped(t, mapped)
-	}
-	if !soltype.HasObjectSpread(t.Elems) {
+	if !soltype.HasResidualElem(t.Elems) {
 		return t
 	}
 	reducedElems := make([]soltype.ObjTypeElem, len(t.Elems))
@@ -446,23 +441,34 @@ func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
 	inexact := t.Inexact
 	ground := true
 	for i, el := range t.Elems {
-		spread, ok := el.(*soltype.SpreadElem)
-		if !ok {
-			// A non-spread member has its value types reduced, then contributes as a one-field group.
+		switch el := el.(type) {
+		case *soltype.SpreadElem:
+			operand := e.groundObjectOperand(el.Type)
+			reducedElems[i] = &soltype.SpreadElem{Type: operand}
+			obj, ok := operand.(*soltype.ObjectType)
+			if !ok || soltype.HasResidualElem(obj.Elems) {
+				ground = false
+				continue
+			}
+			operandElems = append(operandElems, obj.Elems)
+			inexact = inexact || obj.Inexact
+		case *soltype.MappedElem:
+			// A mapped member contributes the fields it computes as one group, the same shape a
+			// spread's operand object contributes, so both merge under one rule in source order.
+			reduced, fields, openKeys, ok := e.expandMapped(el)
+			reducedElems[i] = reduced
+			if !ok {
+				ground = false
+				continue
+			}
+			operandElems = append(operandElems, fields)
+			inexact = inexact || openKeys
+		default:
+			// An ordinary member has its value types reduced, then contributes as a one-field group.
 			re := e.reduceElem(el)
 			reducedElems[i] = re
 			operandElems = append(operandElems, []soltype.ObjTypeElem{re})
-			continue
 		}
-		operand := e.groundObjectOperand(spread.Type)
-		reducedElems[i] = &soltype.SpreadElem{Type: operand}
-		obj, ok := operand.(*soltype.ObjectType)
-		if !ok || soltype.HasObjectSpread(obj.Elems) {
-			ground = false
-			continue
-		}
-		operandElems = append(operandElems, obj.Elems)
-		inexact = inexact || obj.Inexact
 	}
 	if !ground {
 		return &soltype.ObjectType{Elems: reducedElems, Inexact: inexact}
@@ -586,69 +592,73 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 	}
 }
 
-// reduceMapped reduces `{[K]: V for K in Keys}` to the object its keys and value expression
-// describe, mirroring the old checker's expandMappedElems (internal/checker/expand_type.go). It
-// emits one field per key of the Keys union, each built by mappedFields with that key substituted
-// for K:
+// expandMapped computes the fields a `[K]: V for K in Keys` member contributes to its object,
+// mirroring the old checker's expandMappedElems (internal/checker/expand_type.go). It emits one
+// field per key of the Keys union, each built by mappedFields with that key substituted for K:
 //
 //	{[K]: T[K] for K in keyof T}   with T = {x: number, y: string}
 //	⇒ {x: number, y: string}
 //
-// The whole mapped type stays symbolic unless every key resolves. Keys must ground to a union of
-// string-literal types, which is what a `keyof` over an object reduces to, and each key must reach
-// a field mappedFields can build. A Keys operand that is a type parameter or an unreduced operator
-// keeps the mapped type inert, so `{[K]: T[K] for K in keyof T}` over an abstract T renders the way
-// the source wrote it and reduces later once T grounds.
+// reduceObject merges the returned fields with the member's siblings in source order, so a mapped
+// member composes with ordinary members and with `...A` spreads in one object:
 //
-// A key set the evaluator cannot enumerate leaves the mapped type symbolic too. A primitive key
+//	{id: number, [K]: string for K in Keys}   with Keys = "a" | "b"
+//	⇒ {id: number, a: string, b: string}
+//
+// TypeScript has no such form and writes that as the intersection `{id: number} & {[K in Keys]: string}`.
+//
+// ok=false leaves the member unexpanded and its object symbolic, carrying the reduced key set so a
+// later pass resumes from it. That happens when Keys does not ground to a union of string-literal
+// keys, which is what a `keyof` over an object reduces to, or when a key reaches no field
+// mappedFields can build. A Keys operand that is a type parameter or an unreduced operator keeps the
+// member inert, so `{[K]: T[K] for K in keyof T}` over an abstract T renders the way the source
+// wrote it and expands later once T grounds.
+//
+// A key set the evaluator cannot enumerate leaves the member unexpanded too. A primitive key
 // constraint such as `{[K]: T for K in string}` names infinitely many keys, which an object with
 // named fields cannot express. TypeScript writes that as the index signature `{[k: string]: T}`.
-// soltype has no index-signature element, so such a mapped type stays inert rather than reducing to
-// a wrong shape. The same holds for a key that is a number literal, which names no object field.
+// soltype has no index-signature element, so such a member stays inert rather than expanding to a
+// wrong shape. The same holds for a key that is a number literal, which names no object field.
 //
-// TODO(#930): reduce a primitive key constraint to an index-signature element once soltype carries
+// TODO(#930): expand a primitive key constraint to an index-signature element once soltype carries
 // one, and give a number-literal key a field to name.
 //
 // Two keys that remap to one name merge into a single field whose type is their union, so no key's
 // contribution is lost. See mergeMappedField.
 //
-// The result is inexact when the source object's trailing `...` said so, and also when the key union
-// is inexact. `keyof {a: number, ...}` reduces to `"a" | ...`, an open key set, so the object built
-// from it lists the fields for the known keys and stays open for the rest. A filter narrows which of
-// the known keys survive but cannot rule out the unlisted ones, so the result stays open there too.
-func (e *typeEvaluator) reduceMapped(obj *soltype.ObjectType, t *soltype.MappedElem) soltype.Type {
+// openKeys reports that the key union was itself open, as `keyof {a: number, ...}` is. The caller
+// folds it into the object's inexact marker, so the fields for the known keys are listed and the
+// object stays open for the rest. A filter narrows which of the known keys survive but cannot rule
+// out the unlisted ones, so the result stays open there too.
+func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.MappedElem, fields []soltype.ObjTypeElem, openKeys bool, ok bool) {
 	keys := e.groundOperand(t.Keys)
-	// The symbolic form keeps the reduced key set, so a later pass resumes from the ground it gained
-	// rather than re-expanding the operand from scratch.
-	symbolic := &soltype.ObjectType{
-		Elems: []soltype.ObjTypeElem{&soltype.MappedElem{
-			Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
-			Optional: t.Optional, Readonly: t.Readonly,
-		}},
-		Inexact: obj.Inexact,
+	// The unexpanded form keeps the reduced key set, so a later pass resumes from the ground it
+	// gained rather than re-expanding the operand from scratch.
+	reduced = &soltype.MappedElem{
+		Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
+		Optional: t.Optional, Readonly: t.Readonly,
 	}
 	if !condOperandGround(keys) {
-		return symbolic
+		return reduced, nil, false, false
 	}
 	source, homomorphic := e.homomorphicSource(t.Keys)
-	members, inexact := mappedKeyMembers(keys)
-	var elems []soltype.ObjTypeElem
+	members, openKeys := mappedKeyMembers(keys)
 	pos := make(map[string]int, len(members))
 	for _, member := range members {
-		fields, ok := e.mappedFields(t, member, source, homomorphic)
+		built, ok := e.mappedFields(t, member, source, homomorphic)
 		if !ok {
-			return symbolic
+			return reduced, nil, false, false
 		}
-		for _, field := range fields {
+		for _, field := range built {
 			if i, dup := pos[field.Name]; dup {
-				elems[i] = mergeMappedField(soltype.AsProperty(elems[i]), field)
+				fields[i] = mergeMappedField(soltype.AsProperty(fields[i]), field)
 				continue
 			}
-			pos[field.Name] = len(elems)
-			elems = append(elems, field)
+			pos[field.Name] = len(fields)
+			fields = append(fields, field)
 		}
 	}
-	return &soltype.ObjectType{Elems: elems, Inexact: obj.Inexact || inexact}
+	return reduced, fields, openKeys, true
 }
 
 // mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -455,14 +455,14 @@ func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
 		case *soltype.MappedElem:
 			// A mapped member contributes the fields it computes as one group, the same shape a
 			// spread's operand object contributes, so both merge under one rule in source order.
-			reduced, fields, openKeys, ok := e.expandMapped(el)
+			reduced, fields, inexactKeys, ok := e.expandMapped(el)
 			reducedElems[i] = reduced
 			if !ok {
 				ground = false
 				continue
 			}
 			operandElems = append(operandElems, fields)
-			inexact = inexact || openKeys
+			inexact = inexact || inexactKeys
 		default:
 			// An ordinary member has its value types reduced, then contributes as a one-field group.
 			re := e.reduceElem(el)
@@ -630,11 +630,11 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // Two keys that remap to one name merge into a single field whose type is their union, so no key's
 // contribution is lost. See mergeMappedField.
 //
-// openKeys reports that the key union was itself open, as `keyof {a: number, ...}` is. The caller
-// folds it into the object's inexact marker, so the fields for the known keys are listed and the
-// object stays open for the rest. A filter narrows which of the known keys survive but cannot rule
-// out the unlisted ones, so the result stays open there too.
-func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.MappedElem, fields []soltype.ObjTypeElem, openKeys bool, ok bool) {
+// inexactKeys reports that the key union was itself inexact, as `keyof {a: number, ...}` is. The
+// caller folds it into the object's inexact marker, so the fields for the known keys are listed and
+// the object stays inexact for the rest. A filter narrows which of the known keys survive but cannot
+// rule out the unlisted ones, so the result stays inexact there too.
+func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.MappedElem, fields []soltype.ObjTypeElem, inexactKeys bool, ok bool) {
 	keys := e.groundOperand(t.Keys)
 	// The unexpanded form keeps the reduced key set, so a later pass resumes from the ground it
 	// gained rather than re-expanding the operand from scratch.
@@ -646,7 +646,7 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 		return reduced, nil, false, false
 	}
 	source, homomorphic := e.homomorphicSource(t.Keys)
-	members, openKeys := mappedKeyMembers(keys)
+	members, inexactKeys := mappedKeyMembers(keys)
 	pos := make(map[string]int, len(members))
 	for _, member := range members {
 		built, ok := e.mappedFields(t, member, source, homomorphic)
@@ -662,11 +662,11 @@ func (e *typeEvaluator) expandMapped(t *soltype.MappedElem) (reduced *soltype.Ma
 			fields = append(fields, field)
 		}
 	}
-	return reduced, fields, openKeys, true
+	return reduced, fields, inexactKeys, true
 }
 
 // mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a
-// field for, and reports whether the key set is open. A union contributes its members and carries
+// field for, and reports whether the key set is inexact. A union contributes its members and carries
 // its own inexact marker through; `never` is the empty key set, so it contributes none; any other
 // type is a single key.
 func mappedKeyMembers(keys soltype.Type) ([]soltype.Type, bool) {

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -102,8 +102,6 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return t.Ty
 	case *soltype.CondType:
 		return e.reduceCond(t)
-	case *soltype.MappedType:
-		return e.reduceMapped(t)
 	case *soltype.TupleType:
 		return e.reduceTuple(t)
 	case *soltype.ObjectType:
@@ -435,6 +433,11 @@ func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 // symbolic rather than finalizing just that safe suffix: it is simpler and renders the way the
 // source wrote it, at the cost of re-reducing from scratch each pass.
 func (e *typeEvaluator) reduceObject(t *soltype.ObjectType) soltype.Type {
+	// A mapped member computes the whole member list, so it is reduced instead of merged. It is
+	// always alone in the list, which is why the two paths never meet.
+	if mapped, ok := soltype.AsMapped(t.Elems); ok {
+		return e.reduceMapped(t, mapped)
+	}
 	if !soltype.HasObjectSpread(t.Elems) {
 		return t
 	}
@@ -613,11 +616,16 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // is inexact. `keyof {a: number, ...}` reduces to `"a" | ...`, an open key set, so the object built
 // from it lists the fields for the known keys and stays open for the rest. A filter narrows which of
 // the known keys survive but cannot rule out the unlisted ones, so the result stays open there too.
-func (e *typeEvaluator) reduceMapped(t *soltype.MappedType) soltype.Type {
+func (e *typeEvaluator) reduceMapped(obj *soltype.ObjectType, t *soltype.MappedElem) soltype.Type {
 	keys := e.groundOperand(t.Keys)
-	symbolic := &soltype.MappedType{
-		Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
-		Optional: t.Optional, Readonly: t.Readonly, Inexact: t.Inexact,
+	// The symbolic form keeps the reduced key set, so a later pass resumes from the ground it gained
+	// rather than re-expanding the operand from scratch.
+	symbolic := &soltype.ObjectType{
+		Elems: []soltype.ObjTypeElem{&soltype.MappedElem{
+			Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
+			Optional: t.Optional, Readonly: t.Readonly,
+		}},
+		Inexact: obj.Inexact,
 	}
 	if !condOperandGround(keys) {
 		return symbolic
@@ -640,7 +648,7 @@ func (e *typeEvaluator) reduceMapped(t *soltype.MappedType) soltype.Type {
 			elems = append(elems, field)
 		}
 	}
-	return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact || inexact}
+	return &soltype.ObjectType{Elems: elems, Inexact: obj.Inexact || inexact}
 }
 
 // mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a
@@ -692,7 +700,7 @@ func mergeMappedField(earlier, later *soltype.PropertyElem) *soltype.PropertyEle
 //     `T[K]`, which is why mapped types build on indexed-access reduction.
 //
 // Each emitted field takes its `readonly` and `?` markers from mappedMarkers.
-func (e *typeEvaluator) mappedFields(t *soltype.MappedType, key soltype.Type, source *soltype.ObjectType, homomorphic bool) ([]*soltype.PropertyElem, bool) {
+func (e *typeEvaluator) mappedFields(t *soltype.MappedElem, key soltype.Type, source *soltype.ObjectType, homomorphic bool) ([]*soltype.PropertyElem, bool) {
 	name, ok := strLitName(key)
 	if !ok {
 		return nil, false
@@ -727,7 +735,7 @@ func (e *typeEvaluator) mappedFields(t *soltype.MappedType, key soltype.Type, so
 // A union names one field per string-literal member, and drops any `never` member, so a remapping
 // written as a conditional over a union of keys contributes each surviving name. ok=false when a
 // name position reduces to something that cannot name a field, which keeps the mapped type symbolic.
-func (e *typeEvaluator) remappedNames(t *soltype.MappedType, key soltype.Type) ([]string, bool) {
+func (e *typeEvaluator) remappedNames(t *soltype.MappedElem, key soltype.Type) ([]string, bool) {
 	remapped := e.groundOperand(substituteMappedKey(t.Name, t.Key, key))
 	members, _ := mappedKeyMembers(remapped)
 	names := make([]string, 0, len(members))
@@ -751,7 +759,7 @@ func (e *typeEvaluator) remappedNames(t *soltype.MappedType, key soltype.Type) (
 // property optional. Any other mapped type emits the field unmarked, and so does a homomorphic one
 // whose source carries no property under that name, such as one mapping over a class's projected
 // keys.
-func mappedMarkers(t *soltype.MappedType, key string, source *soltype.ObjectType, homomorphic bool) (optional, readonly bool) {
+func mappedMarkers(t *soltype.MappedElem, key string, source *soltype.ObjectType, homomorphic bool) (optional, readonly bool) {
 	optional = t.Optional == soltype.ModAdd
 	readonly = t.Readonly == soltype.ModAdd
 	if !homomorphic {
@@ -828,13 +836,13 @@ func (s *mappedKeySubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Ty
 // operator symbolic, rebuilt around the operand.
 func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Type {
 	switch op := operand.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType:
-		// The operand is itself an operator — a `keyof`, an indexed access, a conditional, or a
-		// mapped type. Reduce it first, then take keyof its value, so a ground conditional operand
-		// selects its branch and `keyof` projects that branch's keys, and a ground mapped type emits
-		// its fields and `keyof` projects their names. If the inner operator stays symbolic because
-		// its own operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the
-		// same shape forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+		// The operand is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
+		// it first, then take keyof its value, so a ground conditional operand selects its branch and
+		// `keyof` projects that branch's keys. If the inner operator stays symbolic because its own
+		// operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the same shape
+		// forever. A mapped member arrives inside an ObjectType, so the ObjectType arm below covers
+		// it: grounding the object emits the member's fields and `keyof` projects their names.
 		inner := e.reduce(op)
 		if isResidualOp(inner) {
 			return &soltype.KeyofType{Operand: inner, Exact: exact}
@@ -1003,13 +1011,13 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 	case *soltype.TypeofType:
 		// `(typeof x)[K]` resolves the query to the value's type, then indexes that type.
 		return e.reduceIndex(tgt.Ty, idx, exact)
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType:
-		// The target is itself an operator — a `keyof`, an indexed access, a conditional, or a mapped
-		// type. Reduce it first, then index its value, so a ground conditional target selects its
-		// branch and the access reduces over that, and a ground mapped type emits its fields and the
-		// access reads one. When the target stays symbolic because its own operands are not ground,
-		// keep the access wrapped around the reduced target rather than re-reducing the same shape
-		// forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
+		// The target is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
+		// it first, then index its value, so a ground conditional target selects its branch and the
+		// access reduces over that. When the target stays symbolic because its own operands are not
+		// ground, keep the access wrapped around the reduced target rather than re-reducing the same
+		// shape forever. A mapped member arrives inside an ObjectType, which grounds through the
+		// object path before the access reads one of its emitted fields.
 		inner := e.reduce(target)
 		if isResidualOp(inner) {
 			return &soltype.IndexType{Target: inner, Index: idx, Exact: exact}
@@ -1341,18 +1349,33 @@ func strLitName(t soltype.Type) (string, bool) {
 	return "", false
 }
 
-// isResidualOp reports whether t is an unreduced type-level operator node at its top level. That is
-// a `keyof`, an indexed access, a conditional, a mapped type, a `...P` tuple-spread element, a
-// template literal whose interpolation stayed abstract, or an intrinsic string operator over an
-// abstract operand. The evaluator consults it to stop re-reducing an operand whose reduction stayed
-// symbolic.
+// isResidualOp reports whether t is an unreduced type-level operator at its top level. That is a
+// `keyof`, an indexed access, a conditional, a `...P` tuple-spread element, a template literal whose
+// interpolation stayed abstract, an intrinsic string operator over an abstract operand, or an object
+// carrying a mapped member whose key set never ground. The evaluator consults it to stop re-reducing
+// an operand whose reduction stayed symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType,
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType,
 		*soltype.RestSpreadType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return true
 	}
-	return false
+	return objectHasMapped(t)
+}
+
+// objectHasMapped reports whether t is an object whose member list still carries an unreduced
+// `[K]: V for K in Keys` member, the mapped twin of objectHasSpread.
+func objectHasMapped(t soltype.Type) bool {
+	obj, ok := t.(*soltype.ObjectType)
+	return ok && soltype.HasMappedElem(obj.Elems)
+}
+
+// objectIsResidual reports whether t is an object carrying either unreduced member kind, the type-
+// level form of soltype.HasResidualElem. constrain consults it to decide whether to compare an
+// object inertly rather than decomposing it.
+func objectIsResidual(t soltype.Type) bool {
+	obj, ok := t.(*soltype.ObjectType)
+	return ok && soltype.HasResidualElem(obj.Elems)
 }
 
 // tupleHasSpread reports whether t is a tuple carrying at least one unreduced `...P` spread

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -24,7 +24,7 @@ const maxExpandDepth = 200
 // diagnostic rather than materializing the product.
 const maxTemplateLitCombinations = 10_000
 
-// typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T`, indexed
+// typeEvaluator reduces a residual type-level operator to its value. It reduces `keyof T`, indexed
 // access `T[K]`, the conditional `if C : E { … } else { … }`, the mapped type
 // `{[K]: V for K in Keys}`, template literals, and the intrinsic string operators such as
 // `Uppercase<T>`; later operators join as they land. Only constrain invokes it, to check a
@@ -394,10 +394,11 @@ func (e *typeEvaluator) groundTuple(t *soltype.TupleType) (*soltype.TupleType, b
 // groundOperand reduces an operator's operand toward a concrete type. It reduces any nested
 // operator, then expands a named alias to its body under the shared termination guard, so a spread
 // operand `Pair` over `type Pair = [number, string]` grounds to the referenced tuple and a template
-// interpolation `Dir` over `type Dir = "a" | "b"` grounds to the referenced union. A type parameter,
-// a recurring alias state, an exhausted budget, or an unresolved alias body each leaves the operand
-// unexpanded, which keeps the enclosing operator symbolic. The tuple-spread, template-literal, and
-// string-intrinsic reductions share it.
+// interpolation `Dir` over `type Dir = "a" | "b"` grounds to the referenced union. A mapped type's
+// key set grounds the same way, so `for K in Names` over `type Names = "a" | "b"` reaches the union.
+// A type parameter, a recurring alias state, an exhausted budget, or an unresolved alias body each
+// leaves the operand unexpanded, which keeps the enclosing operator symbolic. The tuple-spread,
+// template-literal, string-intrinsic, and mapped-type reductions share it.
 func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 	reduced := e.reduce(operand)
 	alias, ok := reduced.(*soltype.AliasType)
@@ -480,7 +481,7 @@ func (e *typeEvaluator) reduceElem(el soltype.ObjTypeElem) soltype.ObjTypeElem {
 }
 
 // groundObjectOperand reduces a `...A` spread operand toward the concrete object whose fields it
-// contributes, the object analogue of the tuple's groundSpreadOperand. It resolves a `typeof` query
+// contributes, the object analogue of groundOperand. It resolves a `typeof` query
 // to the value's type, projects a class instance body, and expands an alias to its body under the
 // active-state and depth guard reduceKeyofAlias uses, so a recursive alias reached through a spread
 // terminates. Any other kind — an object, a type variable, a nested operator — is reduced. It
@@ -579,7 +580,7 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 
 // reduceMapped reduces `{[K]: V for K in Keys}` to the object its keys and value expression
 // describe, mirroring the old checker's expandMappedElems (internal/checker/expand_type.go). It
-// emits one field per key of the Keys union, each built by mappedField with that key substituted
+// emits one field per key of the Keys union, each built by mappedFields with that key substituted
 // for K:
 //
 //	{[K]: T[K] for K in keyof T}   with T = {x: number, y: string}
@@ -587,21 +588,25 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 //
 // The whole mapped type stays symbolic unless every key resolves. Keys must ground to a union of
 // string-literal types, which is what a `keyof` over an object reduces to, and each key must reach
-// a field mappedField can build. A Keys operand that is a type parameter or an unreduced operator
+// a field mappedFields can build. A Keys operand that is a type parameter or an unreduced operator
 // keeps the mapped type inert, so `{[K]: T[K] for K in keyof T}` over an abstract T renders the way
 // the source wrote it and reduces later once T grounds.
 //
 // A key set the evaluator cannot enumerate leaves the mapped type symbolic too. A primitive key
 // constraint such as `{[K]: T for K in string}` names infinitely many keys, which an object with
-// named fields cannot express; TypeScript writes it as the index signature `{[k: string]: T}`.
-// soltype has no index-signature element yet — M7.5 introduces one for the library types it
-// ingests — so such a mapped type stays inert rather than reducing to a wrong shape.
+// named fields cannot express. TypeScript writes that as the index signature `{[k: string]: T}`.
+// soltype has no index-signature element, so such a mapped type stays inert rather than reducing to
+// a wrong shape. The same holds for a key that is a number literal, which names no object field.
+//
+// Two keys that remap to one name merge into a single field whose type is their union, so no key's
+// contribution is lost. See mergeMappedField.
 //
 // The result is inexact when the source object's trailing `...` said so, and also when the key union
 // is inexact. `keyof {a: number, ...}` reduces to `"a" | ...`, an open key set, so the object built
-// from it lists the fields for the known keys and stays open for the rest.
+// from it lists the fields for the known keys and stays open for the rest. A filter narrows which of
+// the known keys survive but cannot rule out the unlisted ones, so the result stays open there too.
 func (e *typeEvaluator) reduceMapped(t *soltype.MappedType) soltype.Type {
-	keys := e.groundMappedKeys(t.Keys)
+	keys := e.groundOperand(t.Keys)
 	symbolic := &soltype.MappedType{
 		Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
 		Optional: t.Optional, Readonly: t.Readonly, Inexact: t.Inexact,
@@ -609,18 +614,25 @@ func (e *typeEvaluator) reduceMapped(t *soltype.MappedType) soltype.Type {
 	if !condOperandGround(keys) {
 		return symbolic
 	}
+	source, homomorphic := e.homomorphicSource(t.Keys)
 	members, inexact := mappedKeyMembers(keys)
-	b := newObjElemBuilder(len(members))
+	var elems []soltype.ObjTypeElem
+	pos := make(map[string]int, len(members))
 	for _, member := range members {
-		elem, ok := e.mappedField(t, member)
+		fields, ok := e.mappedFields(t, member, source, homomorphic)
 		if !ok {
 			return symbolic
 		}
-		if elem != nil {
-			b.add(elem.Name, elem.Type, elem.Optional, elem.Readonly)
+		for _, field := range fields {
+			if i, dup := pos[field.Name]; dup {
+				elems[i] = mergeMappedField(soltype.AsProperty(elems[i]), field)
+				continue
+			}
+			pos[field.Name] = len(elems)
+			elems = append(elems, field)
 		}
 	}
-	return &soltype.ObjectType{Elems: b.elems, Inexact: t.Inexact || inexact}
+	return &soltype.ObjectType{Elems: elems, Inexact: t.Inexact || inexact}
 }
 
 // mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a
@@ -638,31 +650,41 @@ func mappedKeyMembers(keys soltype.Type) ([]soltype.Type, bool) {
 	}
 }
 
-// mappedField builds the one field a mapped type emits for a single key. ok=false means the key
-// resolved to nothing the field could be built from, which keeps the whole mapped type symbolic. A
-// nil element with ok=true means the field is deliberately dropped, which the `if C : E` filter and
-// a key remapped to `never` both do.
+// mergeMappedField combines two fields a key remapping gave the same name. Their value types union,
+// so reading the field yields whichever key's value the object actually holds, matching TypeScript.
+// A name reachable from an optional or readonly key carries that marker, so the merged field takes
+// each marker from either contributor. The union is built through newUnion with a nil Context, the
+// evaluator's rule for keeping subsumption from re-entering constrain.
+func mergeMappedField(earlier, later *soltype.PropertyElem) *soltype.PropertyElem {
+	return &soltype.PropertyElem{
+		Name:     earlier.Name,
+		Type:     newUnion(nil, []soltype.Type{earlier.Type, later.Type}, false),
+		Optional: earlier.Optional || later.Optional,
+		Readonly: earlier.Readonly || later.Readonly,
+	}
+}
+
+// mappedFields builds the fields a mapped type emits for a single key. ok=false means the key
+// resolved to nothing a field could be built from, which keeps the whole mapped type symbolic. An
+// empty slice with ok=true means the key is deliberately dropped, which the `if C : E` filter and a
+// key remapped to `never` both do. A key remapping that yields a union of names emits one field per
+// name.
 //
-// The steps, each with the key substituted for the mapped type's key variable:
+// The steps, each reading the original key rather than a remapped one, so the filter and the
+// remapping are independent and their order is not observable:
 //
-//  1. The key must be a string literal, since an object field is named by a string. A key that is
-//     a primitive, a number literal, or an unreduced operator has no field name to emit.
+//  1. The key must be a string literal, since an object field is named by a string. A key that is a
+//     primitive, a number literal, or an unreduced operator has no field name to emit.
 //  2. The `if Check : Extends` filter, when the source wrote one, decides `Check <: Extends` with
 //     the same assignability probe a conditional's branch selection uses. A key that fails the test
 //     is dropped, which is how `Omit` and `Pick` narrow a key set.
-//  3. The key-remapping expression in the brackets, when the source wrote one, reduces to the name
-//     the field takes. Reducing it to `never` drops the field, matching TypeScript's `as` clause.
+//  3. The key-remapping expression in the brackets, when the source wrote one, reduces to the names
+//     the key contributes. `never` drops the key, matching TypeScript's `as` clause.
 //  4. The value expression reduces to the field's type. It is normally an indexed access such as
 //     `T[K]`, which is why mapped types build on indexed-access reduction.
 //
-// The `readonly` and `?` markers are set when the source wrote the adding form. The removing forms
-// `-readonly` and `-?` clear a marker that is already clear, since a field this reduction emits
-// carries no marker of its own.
-//
-// TODO(#916-adjacent): TypeScript preserves the source member's `readonly` and `?` markers through
-// a mapped type whose constraint is written `keyof T`, so `Pick<T, K>` keeps an optional property
-// optional. This reduction always emits an unmarked field, matching the old checker.
-func (e *typeEvaluator) mappedField(t *soltype.MappedType, key soltype.Type) (*soltype.PropertyElem, bool) {
+// Each emitted field takes its `readonly` and `?` markers from mappedMarkers.
+func (e *typeEvaluator) mappedFields(t *soltype.MappedType, key soltype.Type, source *soltype.ObjectType, homomorphic bool) ([]*soltype.PropertyElem, bool) {
 	name, ok := strLitName(key)
 	if !ok {
 		return nil, false
@@ -677,38 +699,85 @@ func (e *typeEvaluator) mappedField(t *soltype.MappedType, key soltype.Type) (*s
 			return nil, true
 		}
 	}
+	names := []string{name}
 	if t.Name != nil {
-		remapped := e.reduce(substituteMappedKey(t.Name, t.Key, key))
-		if _, dropped := remapped.(*soltype.NeverType); dropped {
-			return nil, true
-		}
-		if name, ok = strLitName(remapped); !ok {
+		if names, ok = e.remappedNames(t, key); !ok {
 			return nil, false
 		}
 	}
-	return &soltype.PropertyElem{
-		Name:     name,
-		Type:     e.reduce(substituteMappedKey(t.Value, t.Key, key)),
-		Optional: t.Optional == soltype.ModAdd,
-		Readonly: t.Readonly == soltype.ModAdd,
-	}, true
+	optional, readonly := mappedMarkers(t, name, source, homomorphic)
+	value := e.reduce(substituteMappedKey(t.Value, t.Key, key))
+	fields := make([]*soltype.PropertyElem, len(names))
+	for i, n := range names {
+		fields[i] = &soltype.PropertyElem{Name: n, Type: value, Optional: optional, Readonly: readonly}
+	}
+	return fields, true
 }
 
-// groundMappedKeys reduces a mapped type's Keys operand toward the concrete key set to iterate. It
-// reduces any nested operator, so a `keyof T` over a ground T becomes that type's key union, then
-// expands a named alias to its body under the shared termination guard, so `for K in Names` over
-// `type Names = "a" | "b"` reaches the union. A type parameter, a recurring alias state, an
-// exhausted budget, or an unresolved alias body each leaves the operand unexpanded, which keeps the
-// mapped type symbolic. It mirrors groundSpreadOperand on the tuple side.
-func (e *typeEvaluator) groundMappedKeys(keys soltype.Type) soltype.Type {
-	reduced := e.reduce(keys)
-	alias, ok := reduced.(*soltype.AliasType)
-	if !ok {
-		return reduced
+// remappedNames reduces a mapped type's key-remapping expression for one key and reports the field
+// names it yields. A single string literal names one field and `never` names none, dropping the key.
+// A union names one field per string-literal member, and drops any `never` member, so a remapping
+// written as a conditional over a union of keys contributes each surviving name. ok=false when a
+// name position reduces to something that cannot name a field, which keeps the mapped type symbolic.
+func (e *typeEvaluator) remappedNames(t *soltype.MappedType, key soltype.Type) ([]string, bool) {
+	remapped := e.groundOperand(substituteMappedKey(t.Name, t.Key, key))
+	members, _ := mappedKeyMembers(remapped)
+	names := make([]string, 0, len(members))
+	for _, member := range members {
+		if _, dropped := member.(*soltype.NeverType); dropped {
+			continue
+		}
+		name, ok := strLitName(member)
+		if !ok {
+			return nil, false
+		}
+		names = append(names, name)
 	}
-	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
-		return e.groundMappedKeys(body)
-	})
+	return names, true
+}
+
+// mappedMarkers reports the `?` and `readonly` markers one emitted field carries. A written modifier
+// decides the marker outright: the adding form sets it and the removing form clears it. With no
+// modifier written, a homomorphic mapped type inherits the marker from the source member the key
+// names, so `{[K]: T[K] for K in keyof T}` is the identity on T and `Pick` keeps an optional
+// property optional. Any other mapped type emits the field unmarked, and so does a homomorphic one
+// whose source carries no property under that name, such as one mapping over a class's projected
+// keys.
+func mappedMarkers(t *soltype.MappedType, key string, source *soltype.ObjectType, homomorphic bool) (optional, readonly bool) {
+	optional = t.Optional == soltype.ModAdd
+	readonly = t.Readonly == soltype.ModAdd
+	if !homomorphic {
+		return optional, readonly
+	}
+	prop, found := source.Prop(key)
+	if !found {
+		return optional, readonly
+	}
+	if t.Optional == soltype.ModNone {
+		optional = prop.Optional
+	}
+	if t.Readonly == soltype.ModNone {
+		readonly = prop.Readonly
+	}
+	return optional, readonly
+}
+
+// homomorphicSource reports the object a mapped type's emitted fields inherit their `?` and
+// `readonly` markers from. A mapped type is homomorphic when its key set is written `keyof T` for
+// some T, which is TypeScript's rule and the shape every marker-preserving utility type takes:
+// `Partial`, `Readonly`, and `Pick` each map over `keyof T`. The operand grounds to a concrete
+// object the same way a spread operand does, so an alias or class named there resolves to the object
+// whose members carry the markers.
+//
+// Any other key set makes the mapped type non-homomorphic. `Record<Ks, V>` maps over a bare key
+// union with no source object to read a marker off, so its fields are unmarked, again matching
+// TypeScript.
+func (e *typeEvaluator) homomorphicSource(keys soltype.Type) (*soltype.ObjectType, bool) {
+	keyof, ok := keys.(*soltype.KeyofType)
+	if !ok {
+		return nil, false
+	}
+	return e.groundToObject(keyof.Operand)
 }
 
 // substituteMappedKey rewrites every reference to one mapped type's key variable to the key being
@@ -1306,12 +1375,12 @@ func strLitType(name string) soltype.Type {
 	return &soltype.LitType{Lit: &soltype.StrLit{Value: name}}
 }
 
-// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`, an
+// containsResidualOp reports whether t holds any unreduced type-level operator node: a `keyof`, an
 // indexed access, a conditional, a mapped type, or a tuple spread. constrain consults it to decide
-// whether a reduced operator fully grounded: a result with no residual is safe to recurse on, while
-// one that still carries a `keyof`, a `T[K]`, a `{[K]: V for K in Keys}`, or a `[...T, x]` — an
-// unexpanded type parameter or a budget-truncated expanding alias — must not, since re-reducing it
-// would loop.
+// whether a reduced operator fully grounded. A result with no residual is safe to recurse on. One
+// that still carries a `keyof`, a `T[K]`, a `{[K]: V for K in Keys}`, or a `[...T, x]` is not, since
+// re-reducing it would loop. Such a residual survives reduction when its operand is an unexpanded
+// type parameter, or an expanding alias the depth budget truncated.
 func containsResidualOp(t soltype.Type) bool {
 	f := &residualOpFinder{}
 	t.Accept(f, soltype.Positive)

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -25,11 +25,11 @@ const maxExpandDepth = 200
 const maxTemplateLitCombinations = 10_000
 
 // typeEvaluator reduces a residual type-level operator to its value. It handles `keyof T`, indexed
-// access `T[K]`, the conditional `if C : E { … } else { … }`, template literals, and the intrinsic
-// string operators such as `Uppercase<T>`; later operators join as they land. Only constrain invokes
-// it, to check a constraint against a residual. Annotation and display keep the residual symbolic, so
-// a stored type prints `keyof {x: number}` or `Point["x"]` the way the source wrote it, never the
-// reduced value.
+// access `T[K]`, the conditional `if C : E { … } else { … }`, the mapped type
+// `{[K]: V for K in Keys}`, template literals, and the intrinsic string operators such as
+// `Uppercase<T>`; later operators join as they land. Only constrain invokes it, to check a
+// constraint against a residual. Annotation and display keep the residual symbolic, so a stored type
+// prints `keyof {x: number}` or `Point["x"]` the way the source wrote it, never the reduced value.
 //
 // reduce projects the operand's keys: a ground `keyof {x: number}` yields `"x"`, and an alias or
 // class operand expands to the referenced type's keys, the transparent-but-named treatment an
@@ -97,6 +97,8 @@ func (e *typeEvaluator) reduce(t soltype.Type) soltype.Type {
 		return t.Ty
 	case *soltype.CondType:
 		return e.reduceCond(t)
+	case *soltype.MappedType:
+		return e.reduceMapped(t)
 	case *soltype.TupleType:
 		return e.reduceTuple(t)
 	case *soltype.ObjectType:
@@ -575,6 +577,164 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 	}
 }
 
+// reduceMapped reduces `{[K]: V for K in Keys}` to the object its keys and value expression
+// describe, mirroring the old checker's expandMappedElems (internal/checker/expand_type.go). It
+// emits one field per key of the Keys union, each built by mappedField with that key substituted
+// for K:
+//
+//	{[K]: T[K] for K in keyof T}   with T = {x: number, y: string}
+//	⇒ {x: number, y: string}
+//
+// The whole mapped type stays symbolic unless every key resolves. Keys must ground to a union of
+// string-literal types, which is what a `keyof` over an object reduces to, and each key must reach
+// a field mappedField can build. A Keys operand that is a type parameter or an unreduced operator
+// keeps the mapped type inert, so `{[K]: T[K] for K in keyof T}` over an abstract T renders the way
+// the source wrote it and reduces later once T grounds.
+//
+// A key set the evaluator cannot enumerate leaves the mapped type symbolic too. A primitive key
+// constraint such as `{[K]: T for K in string}` names infinitely many keys, which an object with
+// named fields cannot express; TypeScript writes it as the index signature `{[k: string]: T}`.
+// soltype has no index-signature element yet — M7.5 introduces one for the library types it
+// ingests — so such a mapped type stays inert rather than reducing to a wrong shape.
+//
+// The result is inexact when the source object's trailing `...` said so, and also when the key union
+// is inexact. `keyof {a: number, ...}` reduces to `"a" | ...`, an open key set, so the object built
+// from it lists the fields for the known keys and stays open for the rest.
+func (e *typeEvaluator) reduceMapped(t *soltype.MappedType) soltype.Type {
+	keys := e.groundMappedKeys(t.Keys)
+	symbolic := &soltype.MappedType{
+		Key: t.Key, Keys: keys, Value: t.Value, Name: t.Name, Check: t.Check, Extends: t.Extends,
+		Optional: t.Optional, Readonly: t.Readonly, Inexact: t.Inexact,
+	}
+	if !condOperandGround(keys) {
+		return symbolic
+	}
+	members, inexact := mappedKeyMembers(keys)
+	b := newObjElemBuilder(len(members))
+	for _, member := range members {
+		elem, ok := e.mappedField(t, member)
+		if !ok {
+			return symbolic
+		}
+		if elem != nil {
+			b.add(elem.Name, elem.Type, elem.Optional, elem.Readonly)
+		}
+	}
+	return &soltype.ObjectType{Elems: b.elems, Inexact: t.Inexact || inexact}
+}
+
+// mappedKeyMembers splits a mapped type's reduced Keys operand into the individual keys to emit a
+// field for, and reports whether the key set is open. A union contributes its members and carries
+// its own inexact marker through; `never` is the empty key set, so it contributes none; any other
+// type is a single key.
+func mappedKeyMembers(keys soltype.Type) ([]soltype.Type, bool) {
+	switch keys := keys.(type) {
+	case *soltype.UnionType:
+		return keys.Types, keys.Inexact
+	case *soltype.NeverType:
+		return nil, false
+	default:
+		return []soltype.Type{keys}, false
+	}
+}
+
+// mappedField builds the one field a mapped type emits for a single key. ok=false means the key
+// resolved to nothing the field could be built from, which keeps the whole mapped type symbolic. A
+// nil element with ok=true means the field is deliberately dropped, which the `if C : E` filter and
+// a key remapped to `never` both do.
+//
+// The steps, each with the key substituted for the mapped type's key variable:
+//
+//  1. The key must be a string literal, since an object field is named by a string. A key that is
+//     a primitive, a number literal, or an unreduced operator has no field name to emit.
+//  2. The `if Check : Extends` filter, when the source wrote one, decides `Check <: Extends` with
+//     the same assignability probe a conditional's branch selection uses. A key that fails the test
+//     is dropped, which is how `Omit` and `Pick` narrow a key set.
+//  3. The key-remapping expression in the brackets, when the source wrote one, reduces to the name
+//     the field takes. Reducing it to `never` drops the field, matching TypeScript's `as` clause.
+//  4. The value expression reduces to the field's type. It is normally an indexed access such as
+//     `T[K]`, which is why mapped types build on indexed-access reduction.
+//
+// The `readonly` and `?` markers are set when the source wrote the adding form. The removing forms
+// `-readonly` and `-?` clear a marker that is already clear, since a field this reduction emits
+// carries no marker of its own.
+//
+// TODO(#916-adjacent): TypeScript preserves the source member's `readonly` and `?` markers through
+// a mapped type whose constraint is written `keyof T`, so `Pick<T, K>` keeps an optional property
+// optional. This reduction always emits an unmarked field, matching the old checker.
+func (e *typeEvaluator) mappedField(t *soltype.MappedType, key soltype.Type) (*soltype.PropertyElem, bool) {
+	name, ok := strLitName(key)
+	if !ok {
+		return nil, false
+	}
+	if t.Check != nil && t.Extends != nil {
+		check := e.reduce(substituteMappedKey(t.Check, t.Key, key))
+		extends := e.reduce(substituteMappedKey(t.Extends, t.Key, key))
+		if !condOperandGround(check) || !condOperandGround(extends) {
+			return nil, false
+		}
+		if !e.ctx.condExtends(check, extends, e.seen) {
+			return nil, true
+		}
+	}
+	if t.Name != nil {
+		remapped := e.reduce(substituteMappedKey(t.Name, t.Key, key))
+		if _, dropped := remapped.(*soltype.NeverType); dropped {
+			return nil, true
+		}
+		if name, ok = strLitName(remapped); !ok {
+			return nil, false
+		}
+	}
+	return &soltype.PropertyElem{
+		Name:     name,
+		Type:     e.reduce(substituteMappedKey(t.Value, t.Key, key)),
+		Optional: t.Optional == soltype.ModAdd,
+		Readonly: t.Readonly == soltype.ModAdd,
+	}, true
+}
+
+// groundMappedKeys reduces a mapped type's Keys operand toward the concrete key set to iterate. It
+// reduces any nested operator, so a `keyof T` over a ground T becomes that type's key union, then
+// expands a named alias to its body under the shared termination guard, so `for K in Names` over
+// `type Names = "a" | "b"` reaches the union. A type parameter, a recurring alias state, an
+// exhausted budget, or an unresolved alias body each leaves the operand unexpanded, which keeps the
+// mapped type symbolic. It mirrors groundSpreadOperand on the tuple side.
+func (e *typeEvaluator) groundMappedKeys(keys soltype.Type) soltype.Type {
+	reduced := e.reduce(keys)
+	alias, ok := reduced.(*soltype.AliasType)
+	if !ok {
+		return reduced
+	}
+	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
+		return e.groundMappedKeys(body)
+	})
+}
+
+// substituteMappedKey rewrites every reference to one mapped type's key variable to the key being
+// emitted, so the value, key-remapping, and filter positions each read that key. It matches on the
+// binding id the `for K in …` clause introduced, so a nested mapped type's own key, which draws a
+// distinct id, is left for that mapped type's own reduction to fill.
+func substituteMappedKey(in soltype.Type, key *soltype.MappedKeyType, to soltype.Type) soltype.Type {
+	return in.Accept(&mappedKeySubst{id: key.ID, to: to}, soltype.Positive)
+}
+
+// mappedKeySubst is the rewriting visitor behind substituteMappedKey. It replaces a reference to the
+// bound key with the key type and skips that node's children, since a key is a leaf.
+type mappedKeySubst struct {
+	id int
+	to soltype.Type
+}
+
+func (s *mappedKeySubst) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if k, ok := t.(*soltype.MappedKeyType); ok && k.ID == s.id {
+		return soltype.EnterResult{Type: s.to, SkipChildren: true}
+	}
+	return soltype.EnterResult{}
+}
+
+func (s *mappedKeySubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
 // reduceKeyof reduces `keyof operand` to the union of the operand's keys, mirroring the old
 // checker's KeyOfType case (internal/checker/expand_type.go):
 //
@@ -591,12 +751,13 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // operator symbolic, rebuilt around the operand.
 func (e *typeEvaluator) reduceKeyof(operand soltype.Type, exact bool) soltype.Type {
 	switch op := operand.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
-		// The operand is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
-		// it first, then take keyof its value, so a ground conditional operand selects its branch and
-		// `keyof` projects that branch's keys. If the inner operator stays symbolic because its own
-		// operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the same shape
-		// forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType:
+		// The operand is itself an operator — a `keyof`, an indexed access, a conditional, or a
+		// mapped type. Reduce it first, then take keyof its value, so a ground conditional operand
+		// selects its branch and `keyof` projects that branch's keys, and a ground mapped type emits
+		// its fields and `keyof` projects their names. If the inner operator stays symbolic because
+		// its own operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the
+		// same shape forever.
 		inner := e.reduce(op)
 		if isResidualOp(inner) {
 			return &soltype.KeyofType{Operand: inner, Exact: exact}
@@ -761,12 +922,13 @@ func (e *typeEvaluator) reduceIndex(target, index soltype.Type, exact bool) solt
 	case *soltype.TypeofType:
 		// `(typeof x)[K]` resolves the query to the value's type, then indexes that type.
 		return e.reduceIndex(tgt.Ty, idx, exact)
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
-		// The target is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
-		// it first, then index its value, so a ground conditional target selects its branch and the
-		// access reduces over that. When the target stays symbolic because its own operands are not
-		// ground, keep the access wrapped around the reduced target rather than re-reducing the same
-		// shape forever.
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType:
+		// The target is itself an operator — a `keyof`, an indexed access, a conditional, or a mapped
+		// type. Reduce it first, then index its value, so a ground conditional target selects its
+		// branch and the access reduces over that, and a ground mapped type emits its fields and the
+		// access reads one. When the target stays symbolic because its own operands are not ground,
+		// keep the access wrapped around the reduced target rather than re-reducing the same shape
+		// forever.
 		inner := e.reduce(target)
 		if isResidualOp(inner) {
 			return &soltype.IndexType{Target: inner, Index: idx, Exact: exact}
@@ -1098,14 +1260,15 @@ func strLitName(t soltype.Type) (string, bool) {
 	return "", false
 }
 
-// isResidualOp reports whether t is an unreduced type-level operator node at its top level — a
-// `keyof`, an indexed access, a conditional, a `...P` tuple-spread element, a template literal whose
-// interpolation stayed abstract, or an intrinsic string operator over an abstract operand. The
-// evaluator consults it to stop re-reducing an operand whose reduction stayed symbolic.
+// isResidualOp reports whether t is an unreduced type-level operator node at its top level. That is
+// a `keyof`, an indexed access, a conditional, a mapped type, a `...P` tuple-spread element, a
+// template literal whose interpolation stayed abstract, or an intrinsic string operator over an
+// abstract operand. The evaluator consults it to stop re-reducing an operand whose reduction stayed
+// symbolic.
 func isResidualOp(t soltype.Type) bool {
 	switch t.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.RestSpreadType,
-		*soltype.TemplateLitType, *soltype.StringIntrinsicType:
+	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType, *soltype.MappedType,
+		*soltype.RestSpreadType, *soltype.TemplateLitType, *soltype.StringIntrinsicType:
 		return true
 	}
 	return false
@@ -1143,11 +1306,12 @@ func strLitType(name string) soltype.Type {
 	return &soltype.LitType{Lit: &soltype.StrLit{Value: name}}
 }
 
-// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`,
-// an indexed access, or a tuple spread. constrain consults it to decide whether a reduced operator
-// fully grounded: a result with no residual is safe to recurse on, while one that still carries a
-// `keyof`, a `T[K]`, or a `[...T, x]` — an unexpanded type parameter or a budget-truncated
-// expanding alias — must not, since re-reducing it would loop.
+// containsResidualOp reports whether t holds any unreduced type-level operator node — a `keyof`, an
+// indexed access, a conditional, a mapped type, or a tuple spread. constrain consults it to decide
+// whether a reduced operator fully grounded: a result with no residual is safe to recurse on, while
+// one that still carries a `keyof`, a `T[K]`, a `{[K]: V for K in Keys}`, or a `[...T, x]` — an
+// unexpanded type parameter or a budget-truncated expanding alias — must not, since re-reducing it
+// would loop.
 func containsResidualOp(t soltype.Type) bool {
 	f := &residualOpFinder{}
 	t.Accept(f, soltype.Positive)
@@ -1170,23 +1334,27 @@ func (f *residualOpFinder) ExitType(t soltype.Type, pol soltype.Polarity) soltyp
 	return t
 }
 
-// containsFreeVar reports whether t holds any type variable or skolem — an abstract leaf that makes
-// t non-ground. A conditional consults it to decide whether its Check and Extends are concrete
-// enough to probe `Check <: Extends`. A conditional whose Check is a bare type parameter stays
-// symbolic, since that parameter is a free variable.
+// containsFreeVar reports whether t holds any type variable, skolem, or unsubstituted mapped-type
+// key — an abstract leaf that makes t non-ground. A conditional consults it to decide whether its
+// Check and Extends are concrete enough to probe `Check <: Extends`. A conditional whose Check is a
+// bare type parameter stays symbolic, since that parameter is a free variable. A mapped type's key
+// counts the same way: a position naming it stands for whichever key the reduction has yet to
+// choose, so it is not ground until that key is substituted in.
 func containsFreeVar(t soltype.Type) bool {
 	f := &freeVarFinder{}
 	t.Accept(f, soltype.Positive)
 	return f.found
 }
 
-// freeVarFinder is the walking visitor behind containsFreeVar. It flags the first type variable or
-// skolem it reaches and skips that node's children, since one occurrence is enough.
+// freeVarFinder is the walking visitor behind containsFreeVar. It flags the first type variable,
+// skolem, or mapped-type key it reaches and skips that node's children, since one occurrence is
+// enough. A key inside the mapped type that binds it is reached only while that mapped type is
+// still symbolic, which containsResidualOp already reports, so no binding-aware walk is needed.
 type freeVarFinder struct{ found bool }
 
 func (f *freeVarFinder) EnterType(t soltype.Type, pol soltype.Polarity) soltype.EnterResult {
 	switch t.(type) {
-	case *soltype.TypeVarType, *soltype.SkolemType:
+	case *soltype.TypeVarType, *soltype.SkolemType, *soltype.MappedKeyType:
 		f.found = true
 		return soltype.EnterResult{SkipChildren: true}
 	}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -615,13 +615,17 @@ func mergeSpreadElem(earlier, later soltype.ObjTypeElem) soltype.ObjTypeElem {
 // wrote it and expands later once T grounds.
 //
 // A key set the evaluator cannot enumerate leaves the member unexpanded too. A primitive key
-// constraint such as `{[K]: T for K in string}` names infinitely many keys, which an object with
+// constraint such as `{[K]?: T for K in string}` names infinitely many keys, which an object with
 // named fields cannot express. TypeScript writes that as the index signature `{[k: string]: T}`.
 // soltype has no index-signature element, so such a member stays inert rather than expanding to a
 // wrong shape. The same holds for a key that is a number literal, which names no object field.
 //
 // TODO(#930): expand a primitive key constraint to an index-signature element once soltype carries
 // one, and give a number-literal key a field to name.
+//
+// TODO(#934): reject the required form over a primitive key. `{[K]: T for K in string}` asks for a
+// field at every key of an infinite set, which no object has, so it is uninhabited. Only the
+// `?`-adding form is meaningful there, and it is the one that becomes an index signature.
 //
 // Two keys that remap to one name merge into a single field whose type is their union, so no key's
 // contribution is lost. See mergeMappedField.

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -703,7 +703,9 @@ func mergeMappedField(earlier, later *soltype.PropertyElem) *soltype.PropertyEle
 //     primitive, a number literal, or an unreduced operator has no field name to emit.
 //  2. The `if Check : Extends` filter, when the source wrote one, decides `Check <: Extends` with
 //     the same assignability probe a conditional's branch selection uses. A key that fails the test
-//     is dropped, which is how `Omit` and `Pick` narrow a key set.
+//     is dropped, which is how `Omit` and `Pick` narrow a key set. Both operands are arbitrary type
+//     expressions with the key substituted, so a filter may test the value at that key rather than
+//     the key itself, as `if T[K] : number` does.
 //  3. The key-remapping expression in the brackets, when the source wrote one, reduces to the names
 //     the key contributes. `never` drops the key, matching TypeScript's `as` clause.
 //  4. The value expression reduces to the field's type. It is normally an indexed access such as


### PR DESCRIPTION
Adds support for reducing mapped types `{[K]: V for K in Keys}` to concrete object types in the type evaluator, mirroring TypeScript's behavior. Mapped types are stored unreduced so annotations print as written, but constrain reduces them to check constraints against the emitted fields.

Key changes:

- **MappedType and MappedKeyType AST nodes**: Added `soltype.MappedType` to represent the residual operator and `soltype.MappedKeyType` to represent the key binding variable K. Mapped types carry the key set, value expression, optional key remapping, filter condition, and modifiers (readonly/optional).

- **Type annotation resolution**: `resolveMappedTypeAnn` lowers `{[K]: V for K in Keys}` syntax to a MappedType residual. The key binding K is introduced in a child scope so the value, remapping, and filter expressions can reference it.

- **Mapped type reduction**: `reduceMapped` emits one field per key when the key set grounds to a union of string literals. It handles key filtering via the `if C : E` clause, key remapping via the bracketed expression (where `never` drops a key and unions emit multiple fields), and field markers (readonly/optional) inherited from homomorphic sources or set explicitly.

- **Key substitution and field building**: `mappedFields` builds fields for each key by substituting the key for K in the value, filter, and remapping expressions. `remappedNames` reduces the key-remapping expression to determine which field names a key contributes. `mappedMarkers` determines whether each field is optional or readonly based on the mapped type's modifiers and the source member's markers.

- **Structural equality for mapped types**: Extended `coalesce.go` to pair key bindings when comparing two mapped types, so separately-resolved instances of the same mapped type compare equal.

- **Visitor and printer support**: Added visitor methods for MappedType and MappedKeyType. The printer renders mapped types in surface syntax `{readonly [Name]+?: Value for Key in Keys if Check : Extends}` so stored types round-trip to source form.

- **Error handling**: Added `describe` support for mapped types so constraint violations render the symbolic form when the mapped type stays inert.

- **Never type annotation**: Added support for `never` type annotations, used in key remappings to drop fields.

Mapped types stay symbolic when the key set cannot be enumerated (type parameters, primitive constraints like `string`, number-literal keys) or when any operand reduces to an unresolved operator. This preserves the generic form for later instantiation and avoids emitting incorrect object shapes.

https://claude.ai/code/session_01KbPTAWyKNDYG6gEfQrUYpT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mapped type annotations, including key remapping, conditional filtering, optional and readonly modifiers, and inexact types.
  * Mapped types now reduce to concrete object shapes when keys can be resolved, while remaining symbolic when they cannot.
  * Added support for `never` type annotations.

* **Bug Fixes**
  * Improved type comparison, constraint checking, diagnostics, recursive alias handling, and mapped-type marker propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->