### PR TITLE
Cap alias expansion cost with monotonic budget

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -113,6 +113,25 @@ func PrintQualified(t Type) string {
 	return (&namedPrinter{qualify: true}).printType(t)
 }
 
+// ElisionMark stands for the subtree PrintElided dropped. It is U+2026, distinct from the `...`
+// that marks an inexact object or tuple, so a reader can tell an elided branch from an open one.
+const ElisionMark = "…"
+
+// PrintElided renders a type like Print but replaces every subtree nested deeper than maxDepth
+// with ElisionMark, so `Grow<{a: {a: {a: number}}}>` at maxDepth 3 reads `Grow<{a: {a: …}}>`. The
+// root sits at depth 0, so maxDepth 1 renders only the root's immediate children.
+//
+// A type reduction can build a type far larger than any the source wrote. An alias whose argument
+// grows every lap doubles that argument until the evaluator's budget stops it, and the residual
+// left behind carries the argument as it stood — see maxExpandKeyChars in internal/solver. Print
+// renders that in full, which is right for an identity key but useless in a diagnostic, where it
+// buries the one line a reader needs under tens of thousands of characters.
+//
+// maxDepth <= 0 elides nothing, so the zero value renders exactly as Print does.
+func PrintElided(t Type, maxDepth int) string {
+	return (&namedPrinter{maxDepth: maxDepth}).printType(t)
+}
+
 // PrintAsScheme renders a coalesced GENERALIZED type (M3): it collects the type's
 // free variables into a <T0, T1, …> quantifier prefix and renders each as its
 // assigned name. A type with no free variables renders exactly as Print would (no
@@ -496,6 +515,11 @@ type namedPrinter struct {
 	// name across namespaces stay distinct. PrintQualified sets it for identity-key use;
 	// plain Print leaves it false so user-facing output stays unqualified.
 	qualify bool
+	// maxDepth bounds how deep printType descends before it renders ElisionMark in place of a
+	// subtree. Zero, the value Print and PrintQualified leave, descends without limit. depth is
+	// the nesting of the node being rendered, counted from 0 at the root.
+	maxDepth int
+	depth    int
 }
 
 // printLifetime renders a lifetime in Escalier surface syntax: 'static for the
@@ -553,11 +577,35 @@ func (p *namedPrinter) printTypeMinPrec(t Type, minPrec int) string {
 	return result
 }
 
+// isPrintLeaf reports whether printType renders t without descending into another type. A leaf
+// costs nothing to render in full, so PrintElided keeps it at the depth boundary rather than
+// replacing a bare `number` with an ellipsis that tells the reader less than the type itself would.
+//
+// An InferType renders as a name in both forms, `infer U` at the binder and a bare `U` at a
+// reference, and a TypeofType renders as the identifier it names rather than the value's type, so
+// both are leaves. An alias or class reference is not, even though one with no type arguments
+// renders as a bare name: its argument list is exactly what a diagnostic needs bounded.
+func isPrintLeaf(t Type) bool {
+	switch t.(type) {
+	case *TypeVarType, *PrimType, *LitType, *NeverType, *UnknownType, *ErrorType,
+		*Void, *NullType, *UndefinedType, *MappedKeyType, *InferType, *TypeofType:
+		return true
+	}
+	return false
+}
+
 // printType renders a coalesced type. Under the lazy deep-mut form (PR 14) the
 // stored type already matches the surface annotation the user wrote, so the
 // printer needs no special elision pass — `mut {a: {x}}` is stored and printed
 // verbatim.
 func (p *namedPrinter) printType(t Type) string {
+	if p.maxDepth > 0 {
+		if p.depth >= p.maxDepth && !isPrintLeaf(t) {
+			return ElisionMark
+		}
+		p.depth++
+		defer func() { p.depth-- }()
+	}
 	switch t := t.(type) {
 	case *TypeVarType:
 		// A retained type parameter renders under its assigned name; otherwise a

--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -121,13 +121,19 @@ const ElisionMark = "…"
 // with ElisionMark, so `Grow<{a: {a: {a: number}}}>` at maxDepth 3 reads `Grow<{a: {a: …}}>`. The
 // root sits at depth 0, so maxDepth 1 renders only the root's immediate children.
 //
-// A type reduction can build a type far larger than any the source wrote. An alias whose argument
-// grows every lap doubles that argument until the evaluator's budget stops it, and the residual
-// left behind carries the argument as it stood — see maxExpandKeyChars in internal/solver. Print
-// renders that in full, which is right for an identity key but useless in a diagnostic, where it
-// buries the one line a reader needs under tens of thousands of characters.
+// An alias reference marked Truncated elides its whole argument list instead, `Grow<…>`, however
+// shallow the argument is. The evaluator sets that marker on a reference it gave up expanding, so
+// none of what the argument holds came from the source and rendering levels of it names nothing a
+// reader can act on.
 //
-// maxDepth <= 0 elides nothing, so the zero value renders exactly as Print does.
+// A type reduction can build a type far larger than any the source wrote. An alias whose argument
+// grows every lap doubles that argument until the evaluator's budget stops it — see
+// maxExpandKeyChars in internal/solver. Print renders that in full, which is right for an identity
+// key but useless in a diagnostic, where it buries the one line a reader needs under tens of
+// thousands of characters. The depth limit bounds the same growth reached through a type that
+// carries no marker.
+//
+// maxDepth <= 0 elides nothing, so the zero value renders exactly as Print does, marker or not.
 func PrintElided(t Type, maxDepth int) string {
 	return (&namedPrinter{maxDepth: maxDepth}).printType(t)
 }
@@ -721,6 +727,13 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
+		}
+		if p.maxDepth > 0 && t.Truncated {
+			// The evaluator gave up expanding this reference, so its arguments are what its own
+			// recursion had grown rather than what the source wrote. Rendering four levels of that
+			// ends in an ellipsis anyway and names nothing a reader can act on, so the whole
+			// argument list collapses to one. See AliasType.Truncated.
+			return name + "<" + ElisionMark + ">"
 		}
 		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.TypeArgs))
 		for _, la := range t.LifetimeArgs {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -713,6 +713,9 @@ func TestPrintElided(t *testing.T) {
 		return ty
 	}
 	alias := func(arg Type) Type { return &AliasType{Name: "Grow", TypeArgs: []Type{arg}} }
+	truncated := func(arg Type) Type {
+		return &AliasType{Name: "Grow", TypeArgs: []Type{arg}, Truncated: true}
+	}
 
 	tests := []struct {
 		name     string
@@ -738,6 +741,10 @@ func TestPrintElided(t *testing.T) {
 			want:     "Grow<{a: {a: …}, b: {a: …}}>",
 		},
 		{"ZeroElidesNothing", alias(nest(3)), 0, "Grow<{a: {a: {a: number}}}>"},
+		// A reference the evaluator gave up expanding elides its whole argument list, however
+		// shallow the argument happens to be, since none of it came from the source.
+		{"TruncatedElidesArgs", truncated(nest(3)), 4, "Grow<…>"},
+		{"TruncatedElidesShallowArgs", truncated(numP()), 4, "Grow<…>"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -754,4 +761,16 @@ func TestPrintElidedZeroMatchesPrint(t *testing.T) {
 		&TupleType{Elems: []Type{strP(), boolP()}},
 	}}
 	require.Equal(t, Print(ty), PrintElided(ty, 0))
+}
+
+// Print and PrintQualified ignore the Truncated marker and render the arguments in full. Only a
+// diagnostic elides them. PrintQualified forms the identity key the recursion guard compares, and
+// collapsing every truncated reference to one `Grow<…>` would close a cycle between instantiations
+// that differ.
+func TestPrintTruncatedAliasRendersArgsInFull(t *testing.T) {
+	ty := &AliasType{Name: "Grow", TypeArgs: []Type{
+		&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP()}}},
+	}, Truncated: true}
+	require.Equal(t, "Grow<{a: number}>", Print(ty))
+	require.Equal(t, "Grow<{a: number}>", PrintQualified(ty))
 }

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -693,3 +693,65 @@ func TestPrintSchemeParamsLeakAnchor(t *testing.T) {
 	got := PrintAsSchemeWith(ty, func(v *TypeVarType) bool { return v.Level > 1 }, nil)
 	require.Equal(t, "fn <T0>(x: T0) -> [T0, t99]", got)
 }
+
+// PrintElided renders a type like Print but stops at maxDepth, standing in ElisionMark for every
+// subtree below it. A type reduction can leave a residual whose argument is far larger than
+// anything the source wrote, and a diagnostic naming it needs a bound; see describeMaxDepth in
+// internal/solver.
+//
+// The cases walk one nesting chain at each depth so the boundary is visible, then cover the two
+// rules that are not "cut everything below the line": a leaf at the boundary renders itself rather
+// than an ellipsis, since the ellipsis would tell the reader less than `number` does, and a
+// maxDepth of zero elides nothing so the zero value matches Print.
+func TestPrintElided(t *testing.T) {
+	// nest builds `{a: {a: … {a: number}}}` with depth levels of object wrapping.
+	nest := func(depth int) Type {
+		var ty Type = numP()
+		for range depth {
+			ty = &ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: ty}}}
+		}
+		return ty
+	}
+	alias := func(arg Type) Type { return &AliasType{Name: "Grow", TypeArgs: []Type{arg}} }
+
+	tests := []struct {
+		name     string
+		in       Type
+		maxDepth int
+		want     string
+	}{
+		{"AliasArgCutAtOne", alias(nest(3)), 1, "Grow<…>"},
+		{"AliasArgCutAtTwo", alias(nest(3)), 2, "Grow<{a: …}>"},
+		{"AliasArgCutAtFour", alias(nest(4)), 4, "Grow<{a: {a: {a: …}}}>"},
+		// The argument is shallower than the cut, so nothing elides.
+		{"ShallowerThanCut", alias(nest(1)), 4, "Grow<{a: number}>"},
+		// `number` sits exactly at the boundary. A leaf renders itself there.
+		{"LeafAtBoundary", alias(nest(2)), 3, "Grow<{a: {a: number}}>"},
+		// Every branch of a wide type is cut at the same depth.
+		{
+			name: "BranchesCutAlike",
+			in: alias(&ObjectType{Elems: []ObjTypeElem{
+				&PropertyElem{Name: "a", Type: nest(2)},
+				&PropertyElem{Name: "b", Type: nest(2)},
+			}}),
+			maxDepth: 3,
+			want:     "Grow<{a: {a: …}, b: {a: …}}>",
+		},
+		{"ZeroElidesNothing", alias(nest(3)), 0, "Grow<{a: {a: {a: number}}}>"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, PrintElided(test.in, test.maxDepth))
+		})
+	}
+}
+
+// PrintElided with no limit renders exactly what Print does, so a caller that opts out of eliding
+// is not quietly getting a second rendering of the same type.
+func TestPrintElidedZeroMatchesPrint(t *testing.T) {
+	ty := &UnionType{Types: []Type{
+		&FuncType{Params: []*FuncParam{identP("x", numP())}, Ret: strP()},
+		&TupleType{Elems: []Type{strP(), boolP()}},
+	}}
+	require.Equal(t, Print(ty), PrintElided(ty, 0))
+}

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -667,6 +667,17 @@ type AliasType struct {
 	// M9's cycle cache key on, so two borrows of one alias at different lifetimes never share a
 	// cache entry. A borrow's own lifetime rides a RefType wrapper, not this field.
 	LifetimeArgs []Lifetime
+	// Truncated marks a reference the type evaluator stopped expanding because its expansion
+	// budget ran out. That happens only for a recursion the evaluator cannot finish, one whose
+	// argument grows every lap so the reference never repeats a state the cycle guard would
+	// catch. TypeArgs on such a reference are whatever the walk had grown by the time it
+	// stopped, not anything the source wrote, so PrintElided renders them as a single ellipsis.
+	// See maxExpandKeyChars in internal/solver for how the budget is spent.
+	//
+	// Print and PrintQualified ignore it and render the arguments in full. PrintQualified forms
+	// the identity key the recursion guard and constrain's cycle set compare, and collapsing two
+	// truncated references to one key would close a cycle between instantiations that differ.
+	Truncated bool
 }
 
 // KeyofType is the residual `keyof Operand` type operator (M9 PR1a), the first of

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -410,7 +410,12 @@ func (t *AliasType) Accept(v TypeVisitor, pol Polarity) Type {
 		// LifetimeArgs are lifetimes, not Types, so Accept never walks them; a
 		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
 		// AliasType before this rebuild, so cur already holds the freshened lifetimes.
-		out = &AliasType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs}
+		out = &AliasType{
+			Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs,
+			// Truncated rides along so a substitution over a residual keeps the marker the
+			// evaluator set, and a diagnostic naming the result still elides its arguments.
+			Truncated: cur.Truncated,
+		}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1782,6 +1782,16 @@ func describeMapped(t *soltype.MappedElem) string {
 	return out
 }
 
+// describeMaxDepth bounds how deep describe renders a nominal reference's type arguments before
+// PrintElided replaces the rest with an ellipsis. A reduction can leave a residual whose alias
+// argument is far larger than any type the source wrote, and rendering that in full buries the
+// diagnostic. See maxExpandKeyChars for how such an argument grows.
+//
+// Three levels render every message the test suite asserts in full, so four leaves one level of
+// headroom over what a hand-written annotation reaches. An ordinary diagnostic is therefore
+// unaffected and only a machine-grown argument elides.
+const describeMaxDepth = 4
+
 func describe(t soltype.Type) string {
 	switch t := t.(type) {
 	case *soltype.PrimType:
@@ -1846,12 +1856,12 @@ func describe(t soltype.Type) string {
 	case *soltype.ClassType:
 		// A class instance renders nominally under its display name, `Point` or
 		// `Box<number>`, so a diagnostic naming it matches the printer's surface form.
-		return soltype.Print(t)
+		return soltype.PrintElided(t, describeMaxDepth)
 	case *soltype.AliasType:
 		// An alias reference renders under its own name, `Point` or `Box<number>`, so a
 		// diagnostic naming it matches the printer's surface form rather than the expanded
 		// body the constraint actually compares.
-		return soltype.Print(t)
+		return soltype.PrintElided(t, describeMaxDepth)
 	case *soltype.PromiseType:
 		// Rendered STRUCTURALLY (Promise<inner>), unlike the nominal function/tuple/
 		// object above. That is deliberate and consistent with the Union/Intersection

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -589,15 +589,16 @@ func TestInferKeyofExpandingAliasTerminates(t *testing.T) {
 // otherwise restart from the full remaining depth and make the walk a search tree exponential in
 // the budget. maxExpandKeyChars is monotonic, so the keys spend one shared pool.
 //
-// Each case asserts how many diagnostics the reduction produces and their kind, and nothing about
-// the residual each field truncates to. Where the shared budget runs out fixes that residual, so
-// its rendered form pins the backstop's arithmetic rather than any intended behavior. The point of
-// the test is that the checker finishes.
+// Each field reduces to a residual the evaluator gave up expanding, and the diagnostic names it
+// `Grow<…>` rather than spelling out the argument. That argument is whatever the recursion had
+// grown by the time the budget ran out, so its levels say nothing about the source; spelling them
+// out ran past a hundred thousand characters. Eliding also makes the messages independent of where
+// the shared pool happened to run out, which is why they can be asserted at all.
 func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 	tests := []struct {
-		name     string
-		src      string
-		wantErrs int
+		name string
+		src  string
+		want []string
 	}{
 		{
 			// Two keys per lap. Each key reduces `Grow<{a: T, b: T}>[K]`, so the walk branches
@@ -607,7 +608,10 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 				type Grow<T> = {[K]: Grow<{a: T, b: T}>[K] for K in keyof T}
 				val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
 			`,
-			wantErrs: 2,
+			want: []string{
+				`3:47-3:48: cannot constrain 1 <: Grow<…>["a"]`,
+				`3:53-3:54: cannot constrain 2 <: Grow<…>["b"]`,
+			},
 		},
 		{
 			// One key per lap. The walk does not branch and the argument gains one wrapper a lap,
@@ -617,15 +621,16 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 				type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}
 				val x: Grow<{a: number}> = {a: 1}
 			`,
-			wantErrs: 1,
+			want: []string{`3:36-3:37: cannot constrain 1 <: Grow<…>["a"]`},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
-			require.Len(t, errs, test.wantErrs)
-			for _, errVal := range errs {
+			require.Len(t, errs, len(test.want))
+			for i, errVal := range errs {
 				require.IsType(t, &CannotConstrainError{}, errVal)
+				require.Equal(t, test.want[i], msgWithSpan(errVal))
 			}
 		})
 	}
@@ -708,25 +713,6 @@ func TestInferKeyofKeyofIsNever(t *testing.T) {
 			require.Equal(t, "never", soltype.Print(expandResidual(ctx, types["Result"])))
 		})
 	}
-}
-
-// A diagnostic naming a truncated residual renders the alias argument elided rather than in full.
-// The argument doubles for as many laps as maxExpandKeyChars allows, so rendering it whole buries
-// the message under more than a hundred thousand characters. describeMaxDepth cuts it at four
-// levels, which is deeper than any argument a hand-written annotation carries.
-//
-// The elided form is stable even though where the budget ran out is not: everything past the cut
-// is an ellipsis, so the message depends only on the first four levels, and the walk passes those
-// long before the budget binds.
-func TestInferTruncatedResidualElidesInDiagnostic(t *testing.T) {
-	_, _, errs := inferSource(t, `
-		type Grow<T> = {[K]: Grow<{a: T, b: T}>[K] for K in keyof T}
-		val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
-	`)
-	require.Len(t, errs, 2)
-	require.Equal(t,
-		`3:45-3:46: cannot constrain 1 <: Grow<{a: {a: {a: …, b: …}, b: {a: …, b: …}}, b: {a: {a: …, b: …}, b: {a: …, b: …}}}>["a"]`,
-		msgWithSpan(errs[0]))
 }
 
 // An expanding recursive alias under `keyof` reduces to `never` on the `keyof keyof` rule rather

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -647,13 +647,13 @@ func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 		want string
 	}{
 		{
-			// The recursion sits under `keyof`, which expands the alias operand each lap.
-			name: "UnderKeyof",
+			// The recursion sits in an object spread's operand, which grounds the alias each lap.
+			name: "UnderObjectSpread",
 			src: `
-				type Grow<T> = keyof Grow<{a: T, b: T}>
-				val k: Grow<{a: number, b: number}> = "x"
+				type Grow<T> = {...Grow<{a: T, b: T}>}
+				val v: Grow<{a: number, b: number}> = 1
 			`,
-			want: `3:43-3:46: cannot constrain "x" <: keyof Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>`,
+			want: `3:43-3:44: cannot constrain 1 <: {...Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>}`,
 		},
 		{
 			// The recursion sits in an indexed access's target, which expands it each lap too.
@@ -673,6 +673,74 @@ func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 			require.Equal(t, test.want, msgWithSpan(errs[0]))
 		})
 	}
+}
+
+// `keyof keyof X` reduces to `never` for every X. What the inner `keyof` projects is a key set —
+// string literals for an object, number literals for a tuple — and `keyof` over a literal is
+// already `never`, so the outer operator has no keys to name whatever the inner operand turns out
+// to be. Each case names an operand shape the inner `keyof` treats differently and asserts the
+// same answer.
+func TestInferKeyofKeyofIsNever(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		// The inner `keyof` grounds to `"a" | "b"`, whose members are string literals.
+		{"Object", `type Result = keyof keyof {a: number, b: string}`},
+		// The inner `keyof` grounds to `0 | 1`, whose members are number literals.
+		{"Tuple", `type Result = keyof keyof [number, string]`},
+		// The inner `keyof` grounds to `never`, the empty key set.
+		{"Never", `type Result = keyof keyof never`},
+		// The inner `keyof` stays symbolic over a type parameter. The rule still holds, since
+		// `keyof T` names a key set for every T.
+		{"TypeParam", `type Result<T> = keyof keyof T`},
+		// The operand is an alias, which the inner `keyof` would expand.
+		{"Alias", `
+			type Obj = {a: number}
+			type Result = keyof keyof Obj
+		`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			types, ctx, errs := inferTypeNodes(t, test.src)
+			require.Empty(t, errs)
+			require.Contains(t, types, "Result")
+			require.Equal(t, "never", soltype.Print(expandResidual(ctx, types["Result"])))
+		})
+	}
+}
+
+// A diagnostic naming a truncated residual renders the alias argument elided rather than in full.
+// The argument doubles for as many laps as maxExpandKeyChars allows, so rendering it whole buries
+// the message under more than a hundred thousand characters. describeMaxDepth cuts it at four
+// levels, which is deeper than any argument a hand-written annotation carries.
+//
+// The elided form is stable even though where the budget ran out is not: everything past the cut
+// is an ellipsis, so the message depends only on the first four levels, and the walk passes those
+// long before the budget binds.
+func TestInferTruncatedResidualElidesInDiagnostic(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Grow<T> = {[K]: Grow<{a: T, b: T}>[K] for K in keyof T}
+		val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
+	`)
+	require.Len(t, errs, 2)
+	require.Equal(t,
+		`3:45-3:46: cannot constrain 1 <: Grow<{a: {a: {a: …, b: …}, b: {a: …, b: …}}, b: {a: {a: …, b: …}, b: {a: …, b: …}}}>["a"]`,
+		msgWithSpan(errs[0]))
+}
+
+// An expanding recursive alias under `keyof` reduces to `never` on the `keyof keyof` rule rather
+// than running until maxExpandKeyChars stops it. The alias body is `keyof Grow<…>`, so one
+// expansion puts a `keyof` directly under a `keyof` and the rule answers without reducing the
+// operand that would have grown.
+func TestInferKeyofExpandingAliasIsNever(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Grow<T> = keyof Grow<{a: T, b: T}>
+		val k: Grow<{a: number, b: number}> = "x"
+	`)
+	require.Len(t, errs, 1)
+	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, `3:41-3:44: cannot constrain "x" <: never`, msgWithSpan(errs[0]))
 }
 
 // A `typeof v` query is stored as a residual behind the value reference, so an annotation prints

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -583,6 +583,98 @@ func TestInferKeyofExpandingAliasTerminates(t *testing.T) {
 	require.IsType(t, &CannotConstrainError{}, errs[0])
 }
 
+// Checking a value against a mapped type whose value expression reaches an expanding recursive
+// alias terminates instead of looping. A mapped type reduces that expression once per key, so the
+// alias expands once per key, and maxExpandDepth is restored between the two — each key would
+// otherwise restart from the full remaining depth and make the walk a search tree exponential in
+// the budget. maxExpandKeyChars is monotonic, so the keys spend one shared pool.
+//
+// Each case asserts how many diagnostics the reduction produces and their kind, and nothing about
+// the residual each field truncates to. Where the shared budget runs out fixes that residual, so
+// its rendered form pins the backstop's arithmetic rather than any intended behavior. The point of
+// the test is that the checker finishes.
+func TestInferMappedExpandingAliasTerminates(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		wantErrs int
+	}{
+		{
+			// Two keys per lap. Each key reduces `Grow<{a: T, b: T}>[K]`, so the walk branches
+			// twice per lap and the alias argument doubles along every branch.
+			name: "TwoKeysPerLap",
+			src: `
+				type Grow<T> = {[K]: Grow<{a: T, b: T}>[K] for K in keyof T}
+				val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
+			`,
+			wantErrs: 2,
+		},
+		{
+			// One key per lap. The walk does not branch and the argument gains one wrapper a lap,
+			// so maxExpandDepth is what stops it and the shared pool never binds.
+			name: "OneKeyPerLap",
+			src: `
+				type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}
+				val x: Grow<{a: number}> = {a: 1}
+			`,
+			wantErrs: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, test.wantErrs)
+			for _, errVal := range errs {
+				require.IsType(t, &CannotConstrainError{}, errVal)
+			}
+		})
+	}
+}
+
+// Checking a value against an alias whose argument doubles each lap terminates instead of looping.
+// The instantiation key the guard renders doubles with the argument, so a walk of a few dozen laps
+// would render a key of astronomical length even though it never branches. maxExpandDepth counts
+// laps rather than the size of what each lap expands, so it does not bound that on its own;
+// charging maxExpandKeyChars by the rendered key length stops the walk after a logarithmic number
+// of laps.
+//
+// Neither case involves a mapped type, so the hazard the shared pool closes is in the guard rather
+// than in one operator's reduction.
+func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// The recursion sits under `keyof`, which expands the alias operand each lap.
+			name: "UnderKeyof",
+			src: `
+				type Grow<T> = keyof Grow<{a: T, b: T}>
+				val k: Grow<{a: number, b: number}> = "x"
+			`,
+			want: `3:43-3:46: cannot constrain "x" <: keyof Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>`,
+		},
+		{
+			// The recursion sits in an indexed access's target, which expands it each lap too.
+			name: "UnderIndexedAccess",
+			src: `
+				type Grow<T> = Grow<{a: T, b: T}>["a"]
+				val v: Grow<{a: number, b: number}> = 1
+			`,
+			want: `3:43-3:44: cannot constrain 1 <: Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>["a"]`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Len(t, errs, 1)
+			require.IsType(t, &CannotConstrainError{}, errs[0])
+			require.Equal(t, test.want, msgWithSpan(errs[0]))
+		})
+	}
+}
+
 // A `typeof v` query is stored as a residual behind the value reference, so an annotation prints
 // `typeof v` the way the source wrote it rather than the resolved type. It resolves a bare name
 // and a member chain; reducing the residual yields the referenced value's type. The value's

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -876,6 +876,7 @@ func (s *mappedKeySubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Ty
 //     union and unioning them for an intersection;
 //   - `keyof` of a primitive, literal, `never`, or `unknown` is `never`, since none has
 //     enumerable keys;
+//   - `keyof` of a `keyof` is `never` for the same reason, since a key set holds only literals;
 //   - an alias expands to its body and a class projects its instance body, and `keyof` reduces
 //     over that under the termination guard;
 //   - a `typeof` query resolves to the value's type, and `keyof` reduces over that.
@@ -884,9 +885,23 @@ func (s *mappedKeySubst) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Ty
 // operator symbolic, rebuilt around the operand.
 func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.Type {
 	switch op := operand.(type) {
-	case *soltype.KeyofType, *soltype.IndexType, *soltype.CondType:
-		// The operand is itself an operator — a `keyof`, an indexed access, or a conditional. Reduce
-		// it first, then take keyof its value, so a ground conditional operand selects its branch and
+	case *soltype.KeyofType:
+		// `keyof keyof X` is `never` for every X, so the inner operand needs no reduction at all.
+		// A key set is a union of string literals for an object and of number literals for a
+		// tuple, and the LitType arm below already reduces `keyof` over either to `never`;
+		// keyofDistribute carries that through the union, and `keyof never` is `never` too. The
+		// rule holds even when the inner `keyof` stays symbolic over a type parameter, since what
+		// `keyof T` projects is a key set whatever T turns out to be.
+		//
+		// Reducing the inner operand would be wasted work and, over an expanding recursive alias
+		// such as `type Grow<T> = keyof Grow<{a: T, b: T}>`, work the evaluator only escapes by
+		// spending maxExpandKeyChars. The one cost is that a diagnostic only the inner reduction
+		// would raise goes unreported, as in `keyof keyof {a: number}["z"]`, where the unknown key
+		// is never reached. The result is `never` either way.
+		return &soltype.NeverType{}
+	case *soltype.IndexType, *soltype.CondType:
+		// The operand is itself an operator — an indexed access or a conditional. Reduce it first,
+		// then take keyof its value, so a ground conditional operand selects its branch and
 		// `keyof` projects that branch's keys. If the inner operator stays symbolic because its own
 		// operands are not ground, wrap it as `keyof <inner>` rather than re-reducing the same shape
 		// forever. A mapped member arrives inside an ObjectType, so the ObjectType arm below covers

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -16,12 +16,41 @@ import (
 // whose argument grows every lap so its state never repeats and the active guard never matches.
 // No finite analytical bound exists for that fragment, so the budget stops the walk and the
 // operator over the unexpanded alias stays symbolic.
-//
-// TODO(#929): expandAliasGuarded restores the budget after each sibling, so a caller that expands
-// one operand per member gives every member the full remaining budget. A mapped type reduces its
-// value expression once per key, which makes an expanding alias reached from there an exponential
-// walk rather than a capped one.
 const maxExpandDepth = 200
+
+// maxExpandKeyChars caps the total cost of alias expansion across a whole reduction, counted in
+// the length of the rendered instantiation keys. maxExpandDepth alone does not bound that cost,
+// for two reasons that compound in the same shapes:
+//
+//   - It is restored when a branch finishes, which is right for a sequential walk but not for a
+//     caller that expands one operand per member. A mapped type reduces its value expression once
+//     per key, so every key restarts from the full remaining depth and the walk branches by the
+//     key count each lap.
+//   - It counts laps, not the size of what each lap expands. An alias whose argument grows by a
+//     constant factor each lap, such as `type Grow<T> = keyof Grow<{a: T, b: T}>`, doubles its
+//     rendered key every lap, so a few dozen laps render a key of astronomical length. That one
+//     needs no mapped type to diverge.
+//
+// One monotonic budget bounds both. It is never restored, so siblings spend a shared pool. Every
+// alias reference charges the length of the key it rendered, so an argument that grows by a
+// constant factor exhausts the pool after a logarithmic number of laps. A key is never empty, so
+// the budget also caps how many aliases a reduction expands.
+//
+// The budget is read before a key is rendered, so an exhausted budget costs nothing further. The
+// reference that exhausts it still pays its own render, which overshoots by that key's length.
+//
+// The value is a backstop, not a derived maximum. The largest spend across the test suite by a
+// reduction that is not deliberately divergent is under 500 characters, so it leaves two orders of
+// magnitude of headroom. It is also high enough that an alias whose argument grows by a fixed
+// amount each lap, rather than by a factor, stays under it for all maxExpandDepth laps. depth
+// therefore remains the governing cap for that shape, and this budget binds only on faster growth
+// or on sibling branching.
+//
+// The budget also bounds the diagnostic a divergent alias produces. Truncation leaves the operator
+// over the unexpanded alias symbolic, the same outcome as exhausting maxExpandDepth. An error
+// message naming that residual renders the argument the walk had grown by the time it stopped,
+// which is at most what the last reference charged.
+const maxExpandKeyChars = 100_000
 
 // maxTemplateLitCombinations caps how many string literals a template literal may reduce to. Its
 // cartesian product over interpolated unions grows multiplicatively, so `${A}${B}${C}` over three
@@ -41,7 +70,7 @@ const maxTemplateLitCombinations = 10_000
 // alias itself gets under constrain. A `keyof T` over a type parameter has no ground key set, so
 // it stays the symbolic KeyofType.
 //
-// A recursive alias reached through an operand is made safe by a two-part termination strategy:
+// A recursive alias reached through an operand is made safe by a three-part termination strategy:
 //
 //   - active holds the alias instantiations currently being expanded, each keyed by the alias
 //     name together with its rendered arguments. When one recurs with the identical key, the
@@ -51,6 +80,9 @@ const maxTemplateLitCombinations = 10_000
 //     forever.
 //   - depth caps expansions along one path. It backstops an expanding recursion whose argument
 //     grows every lap, so its key never repeats and the active guard never fires.
+//   - keyChars caps the total cost of expansion across the whole reduction, so branches that each
+//     restart from the full depth, and laps whose argument grows by a constant factor, cannot
+//     turn that per-path cap into an exponential walk. See maxExpandKeyChars.
 //
 // The evaluator mutates no solver state — no bound or variable is touched. It accumulates
 // reduction diagnostics on errs, but a fresh evaluator is minted per reduction, so nothing
@@ -64,6 +96,10 @@ type typeEvaluator struct {
 	ctx    *Context
 	active set.Set[string]
 	depth  int
+	// keyChars is the expansion budget left for the whole reduction, counted in the length of the
+	// instantiation keys rendered so far. depth is restored when a branch finishes; keyChars is
+	// not, so siblings spend one shared pool. See maxExpandKeyChars.
+	keyChars int
 	// seen is the enclosing constraint's cycle-detection set, carried in so a conditional's
 	// `Check <: Extends` probe shares the caller's alias-cycle guard. A conditional reduces by
 	// re-entering constrain to decide its branch, and constrain expands an alias operand and
@@ -83,7 +119,13 @@ type typeEvaluator struct {
 }
 
 func newTypeEvaluator(ctx *Context, seen set.Set[constraintKey]) *typeEvaluator {
-	return &typeEvaluator{ctx: ctx, active: set.NewSet[string](), depth: maxExpandDepth, seen: seen}
+	return &typeEvaluator{
+		ctx:      ctx,
+		active:   set.NewSet[string](),
+		depth:    maxExpandDepth,
+		keyChars: maxExpandKeyChars,
+		seen:     seen,
+	}
 }
 
 // reduce reduces one type-level operator node to its value, returning any other type
@@ -495,12 +537,12 @@ func (e *typeEvaluator) reduceElem(el soltype.ObjTypeElem) soltype.ObjTypeElem {
 }
 
 // groundObjectOperand reduces a `...A` spread operand toward the concrete object whose fields it
-// contributes, the object analogue of groundOperand. It resolves a `typeof` query
-// to the value's type, projects a class instance body, and expands an alias to its body under the
-// active-state and depth guard reduceKeyofAlias uses, so a recursive alias reached through a spread
-// terminates. Any other kind — an object, a type variable, a nested operator — is reduced. It
-// returns the reduced operand rather than an ok flag, so a caller keeps that reduced form when the
-// operand does not ground, matching how reduceTuple keeps the operand it could not splice.
+// contributes, the object analogue of groundOperand. It resolves a `typeof` query to the value's
+// type, projects a class instance body, and expands an alias to its body under the termination
+// guard reduceKeyofAlias uses, so a recursive alias reached through a spread terminates. Any other
+// kind — an object, a type variable, a nested operator — is reduced. It returns the reduced
+// operand rather than an ok flag, so a caller keeps that reduced form when the operand does not
+// ground, matching how reduceTuple keeps the operand it could not splice.
 func (e *typeEvaluator) groundObjectOperand(operand soltype.Type) soltype.Type {
 	switch op := operand.(type) {
 	case *soltype.TypeofType:
@@ -511,20 +553,9 @@ func (e *typeEvaluator) groundObjectOperand(operand soltype.Type) soltype.Type {
 		}
 		return op
 	case *soltype.AliasType:
-		key := soltype.PrintQualified(op)
-		if e.active.Contains(key) || e.depth <= 0 {
-			return op
-		}
-		body := e.ctx.expandAlias(op)
-		if _, unresolved := body.(*soltype.ErrorType); unresolved {
-			return op
-		}
-		e.active.Add(key)
-		e.depth--
-		red := e.groundObjectOperand(body)
-		e.active.Remove(key)
-		e.depth++
-		return red
+		return e.expandAliasGuarded(op, op, func(body soltype.Type) soltype.Type {
+			return e.groundObjectOperand(body)
+		})
 	default:
 		return e.reduce(operand)
 	}
@@ -914,14 +945,21 @@ func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, inexact bool) so
 }
 
 // expandAliasGuarded expands a named alias to its body and applies cont to the result, under the
-// two-part termination guard that makes reduction safe over a recursive alias. The alias stays on
-// the active path for the whole reduction of its body, so a member that re-references it, directly
+// termination guard that makes reduction safe over a recursive alias. The alias stays on the
+// active path for the whole reduction of its body, so a member that re-references it, directly
 // or through a chain, sees it active and stops. A recurring instantiation state, an exhausted
 // budget, or an unresolved body each returns fallback with the alias left unexpanded, so the
 // operator over it stays symbolic.
+//
+// Every reduction that expands an alias routes through here, so one guard covers `keyof`, indexed
+// access, and the operand-grounding both spread forms use, and the budgets are shared across them.
 func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback soltype.Type, cont func(body soltype.Type) soltype.Type) soltype.Type {
+	if e.depth <= 0 || e.keyChars <= 0 {
+		return fallback
+	}
 	key := soltype.PrintQualified(op)
-	if e.active.Contains(key) || e.depth <= 0 {
+	e.keyChars -= len(key)
+	if e.active.Contains(key) {
 		return fallback
 	}
 	body := e.ctx.expandAlias(op)
@@ -1223,20 +1261,9 @@ func (e *typeEvaluator) reduceIndexIntersection(tgt *soltype.IntersectionType, i
 // unexpanded and symbolic.
 func (e *typeEvaluator) reduceIndexAlias(op *soltype.AliasType, index soltype.Type, inexact bool) soltype.Type {
 	symbolic := &soltype.IndexType{Target: op, Index: index, Inexact: inexact}
-	key := soltype.PrintQualified(op)
-	if e.active.Contains(key) || e.depth <= 0 {
-		return symbolic
-	}
-	body := e.ctx.expandAlias(op)
-	if _, unresolved := body.(*soltype.ErrorType); unresolved {
-		return symbolic
-	}
-	e.active.Add(key)
-	e.depth--
-	result := e.reduceIndex(body, index, inexact)
-	e.active.Remove(key)
-	e.depth++
-	return result
+	return e.expandAliasGuarded(op, symbolic, func(body soltype.Type) soltype.Type {
+		return e.reduceIndex(body, index, inexact)
+	})
 }
 
 // indexObject reduces `obj[key]` for a ground object. A string-literal key selects the named

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -46,10 +46,10 @@ const maxExpandDepth = 200
 // therefore remains the governing cap for that shape, and this budget binds only on faster growth
 // or on sibling branching.
 //
-// The budget also bounds the diagnostic a divergent alias produces. Truncation leaves the operator
-// over the unexpanded alias symbolic, the same outcome as exhausting maxExpandDepth. An error
-// message naming that residual renders the argument the walk had grown by the time it stopped,
-// which is at most what the last reference charged.
+// Truncation leaves the operator over the unexpanded alias symbolic, the same outcome as
+// exhausting maxExpandDepth, and marks that alias reference Truncated. A diagnostic naming the
+// residual renders it `Grow<…>` rather than spelling out the argument the walk had grown, so how
+// much the budget allowed before stopping never reaches the message.
 const maxExpandKeyChars = 100_000
 
 // maxTemplateLitCombinations caps how many string literals a template literal may reduce to. Its
@@ -450,7 +450,7 @@ func (e *typeEvaluator) groundOperand(operand soltype.Type) soltype.Type {
 	if !ok {
 		return reduced
 	}
-	return e.expandAliasGuarded(alias, reduced, func(body soltype.Type) soltype.Type {
+	return e.expandAliasGuarded(alias, aliasItself, func(body soltype.Type) soltype.Type {
 		return e.groundOperand(body)
 	})
 }
@@ -553,7 +553,7 @@ func (e *typeEvaluator) groundObjectOperand(operand soltype.Type) soltype.Type {
 		}
 		return op
 	case *soltype.AliasType:
-		return e.expandAliasGuarded(op, op, func(body soltype.Type) soltype.Type {
+		return e.expandAliasGuarded(op, aliasItself, func(body soltype.Type) soltype.Type {
 			return e.groundObjectOperand(body)
 		})
 	default:
@@ -888,10 +888,11 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 	case *soltype.KeyofType:
 		// `keyof keyof X` is `never` for every X, so the inner operand needs no reduction at all.
 		// A key set is a union of string literals for an object and of number literals for a
-		// tuple, and the LitType arm below already reduces `keyof` over either to `never`;
-		// keyofDistribute carries that through the union, and `keyof never` is `never` too. The
-		// rule holds even when the inner `keyof` stays symbolic over a type parameter, since what
-		// `keyof T` projects is a key set whatever T turns out to be.
+		// tuple, and the LitType arm below already reduces `keyof` over either to `never`.
+		// keyofUnion intersects those, so a key set of more than one member still yields
+		// `never`, and `keyof never` is `never` too. The rule holds even when the inner `keyof`
+		// stays symbolic over a type parameter, since what `keyof T` projects is a key set
+		// whatever T turns out to be.
 		//
 		// Reducing the inner operand would be wasted work and, over an expanding recursive alias
 		// such as `type Grow<T> = keyof Grow<{a: T, b: T}>`, work the evaluator only escapes by
@@ -953,7 +954,9 @@ func (e *typeEvaluator) reduceKeyof(operand soltype.Type, inexact bool) soltype.
 // reduceKeyofAlias reduces `keyof Alias` by expanding the alias and reducing `keyof` over its
 // body under the termination guard, leaving the alias symbolic when the guard blocks expansion.
 func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, inexact bool) soltype.Type {
-	symbolic := &soltype.KeyofType{Operand: op, Inexact: inexact}
+	symbolic := func(a *soltype.AliasType) soltype.Type {
+		return &soltype.KeyofType{Operand: a, Inexact: inexact}
+	}
 	return e.expandAliasGuarded(op, symbolic, func(body soltype.Type) soltype.Type {
 		return e.reduceKeyof(body, inexact)
 	})
@@ -963,25 +966,33 @@ func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, inexact bool) so
 // termination guard that makes reduction safe over a recursive alias. The alias stays on the
 // active path for the whole reduction of its body, so a member that re-references it, directly
 // or through a chain, sees it active and stops. A recurring instantiation state, an exhausted
-// budget, or an unresolved body each returns fallback with the alias left unexpanded, so the
-// operator over it stays symbolic.
+// budget, or an unresolved body each leaves the alias unexpanded, so the operator over it stays
+// symbolic.
+//
+// fallback builds that symbolic result around the alias reference it is handed, which is op except
+// when the budget ran out — there it is a copy marked Truncated, so a diagnostic naming it elides
+// the arguments the walk had grown rather than spelling them out. A caller whose symbolic form is
+// the bare reference returns the argument unchanged.
 //
 // Every reduction that expands an alias routes through here, so one guard covers `keyof`, indexed
 // access, and the operand-grounding both spread forms use, and the budgets are shared across them.
-func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback soltype.Type, cont func(body soltype.Type) soltype.Type) soltype.Type {
+func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback func(*soltype.AliasType) soltype.Type, cont func(body soltype.Type) soltype.Type) soltype.Type {
 	if e.depth <= 0 || e.keyChars <= 0 {
-		return fallback
+		return fallback(markTruncated(op))
 	}
 	key := soltype.PrintQualified(op)
 	e.keyChars -= len(key)
 	if e.active.Contains(key) {
-		return fallback
+		// A repeated instantiation state is a regular recursion the evaluator represents by
+		// pointing back at the alias, so op is the reference the source wrote and renders as
+		// written. Only a budget exhaustion carries a grown argument worth hiding.
+		return fallback(op)
 	}
 	body := e.ctx.expandAlias(op)
 	if _, unresolved := body.(*soltype.ErrorType); unresolved {
 		// expandAlias yields ErrorType for an unregistered alias, or one whose body a dep-graph
 		// sibling has not filled yet. Keep the operator symbolic rather than reducing over `error`.
-		return fallback
+		return fallback(op)
 	}
 	e.active.Add(key)
 	e.depth--
@@ -989,6 +1000,21 @@ func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback solty
 	e.active.Remove(key)
 	e.depth++
 	return result
+}
+
+// aliasItself is the fallback for a caller whose symbolic form is the bare alias reference, so the
+// grounding walks keep whichever reference expandAliasGuarded handed back.
+func aliasItself(op *soltype.AliasType) soltype.Type { return op }
+
+// markTruncated copies op with the Truncated marker set, so tagging one reference never mutates a
+// node the annotation it came from still points at. A reference already marked is returned as is.
+func markTruncated(op *soltype.AliasType) *soltype.AliasType {
+	if op.Truncated {
+		return op
+	}
+	marked := *op
+	marked.Truncated = true
+	return &marked
 }
 
 // keyofObject projects an object's property, getter, and setter names as string-literal types
@@ -1275,7 +1301,9 @@ func (e *typeEvaluator) reduceIndexIntersection(tgt *soltype.IntersectionType, i
 // instantiation state, an exhausted budget, or an unresolved body each leaves the access
 // unexpanded and symbolic.
 func (e *typeEvaluator) reduceIndexAlias(op *soltype.AliasType, index soltype.Type, inexact bool) soltype.Type {
-	symbolic := &soltype.IndexType{Target: op, Index: index, Inexact: inexact}
+	symbolic := func(a *soltype.AliasType) soltype.Type {
+		return &soltype.IndexType{Target: a, Index: index, Inexact: inexact}
+	}
 	return e.expandAliasGuarded(op, symbolic, func(body soltype.Type) soltype.Type {
 		return e.reduceIndex(body, index, inexact)
 	})


### PR DESCRIPTION
The type evaluator's alias expansion uses two guards to prevent infinite loops: an active-state cycle detector and a per-path depth limit. However, these alone don't bound the total cost when a mapped type reduces its value expression once per key (restarting depth each time) or when an alias argument grows by a constant factor each lap (doubling the rendered key size).

This change adds a monotonic budget that counts the total length of rendered instantiation keys across a whole reduction. Unlike depth, this budget is never restored, so siblings spend a shared pool. An alias reference that grows by a constant factor exhausts the pool after logarithmic laps rather than exponential branching.

**Key changes:**

- Add `maxExpandKeyChars` constant (100,000 characters) as a backstop budget for total expansion cost across a reduction
- Add `keyChars` field to `typeEvaluator` to track remaining budget; initialize to `maxExpandKeyChars` in `newTypeEvaluator`
- Refactor `expandAliasGuarded` to charge the rendered key length against the budget and accept a fallback function that builds the symbolic result, allowing callers to mark truncated references
- Add `markTruncated` helper to copy an alias reference with the `Truncated` marker set, and `aliasItself` helper for callers whose symbolic form is the bare reference
- Update `reduceKeyofAlias` and `reduceIndexAlias` to use the refactored `expandAliasGuarded` signature
- Simplify `groundObjectOperand` to use `expandAliasGuarded` instead of hand-rolling the guard
- Add `Truncated` field to `AliasType` to mark references the evaluator gave up expanding, so diagnostics can elide their arguments
- Add `PrintElided` function to render types with depth-limited argument lists, replacing deep-grown arguments with ellipsis
- Add `describeMaxDepth` constant (4 levels) to bound how deep diagnostics render nominal references
- Update `describe` to use `PrintElided` for class and alias types
- Add special case in `reduceKeyof` to reduce `keyof keyof X` directly to `never` without reducing the inner operand, avoiding wasted work on expanding recursive aliases

**Tests added:**

- `TestInferMappedExpandingAliasTerminates`: Verifies that mapped types with expanding recursive aliases terminate and render truncated references
- `TestInferDoublingAliasArgumentTerminates`: Verifies that aliases whose arguments double each lap terminate via the key-length budget
- `TestInferKeyofKeyofIsNever`: Verifies that `keyof keyof X` reduces to `never` for all operand shapes
- `TestInferKeyofExpandingAliasIsNever`: Verifies that expanding recursive aliases under `keyof` reduce to `never` via the `keyof keyof` rule
- `TestPrintElided`: Tests depth-limited rendering of types
- `TestPrintElidedZeroMatchesPrint`: Verifies that zero depth limit matches `Print`
- `TestPrintTruncatedAliasRendersArgsInFull`: Verifies that `Print` and `PrintQualified` ignore the `Truncated` marker

https://claude.ai/code/session_01PxEDpSKea4f7WkN7KsLLYq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic type rendering that abbreviates deeply nested types with an ellipsis.
  * Large or truncated generic type arguments now display in a compact form within solver error messages.

* **Bug Fixes**
  * Improved safeguards against runaway recursive type expansion.
  * Corrected `keyof keyof` reduction to consistently produce `never`.
  * Preserved truncation information during type transformations.

* **Tests**
  * Added coverage for nested type elision, recursive alias termination, and `keyof` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->