### PR TITLE
Add definition-time check for unbounded recursive type aliases

### DIFF
--- a/internal/soltype/print.go
+++ b/internal/soltype/print.go
@@ -121,19 +121,13 @@ const ElisionMark = "…"
 // with ElisionMark, so `Grow<{a: {a: {a: number}}}>` at maxDepth 3 reads `Grow<{a: {a: …}}>`. The
 // root sits at depth 0, so maxDepth 1 renders only the root's immediate children.
 //
-// An alias reference marked Truncated elides its whole argument list instead, `Grow<…>`, however
-// shallow the argument is. The evaluator sets that marker on a reference it gave up expanding, so
-// none of what the argument holds came from the source and rendering levels of it names nothing a
-// reader can act on.
+// A type reduction can build a type far larger than any the source wrote. Grounding one alias whose
+// body spreads another twice, repeated over a few dozen such aliases, reduces to a type exponential
+// in that count before the evaluator's budget stops it — see maxExpandKeyChars in internal/solver.
+// Print renders that in full, which is right for an identity key but useless in a diagnostic, where
+// it buries the one line a reader needs under tens of thousands of characters.
 //
-// A type reduction can build a type far larger than any the source wrote. An alias whose argument
-// grows every lap doubles that argument until the evaluator's budget stops it — see
-// maxExpandKeyChars in internal/solver. Print renders that in full, which is right for an identity
-// key but useless in a diagnostic, where it buries the one line a reader needs under tens of
-// thousands of characters. The depth limit bounds the same growth reached through a type that
-// carries no marker.
-//
-// maxDepth <= 0 elides nothing, so the zero value renders exactly as Print does, marker or not.
+// maxDepth <= 0 elides nothing, so the zero value renders exactly as Print does.
 func PrintElided(t Type, maxDepth int) string {
 	return (&namedPrinter{maxDepth: maxDepth}).printType(t)
 }
@@ -727,13 +721,6 @@ func (p *namedPrinter) printType(t Type) string {
 		}
 		if len(t.TypeArgs) == 0 && len(t.LifetimeArgs) == 0 {
 			return name
-		}
-		if p.maxDepth > 0 && t.Truncated {
-			// The evaluator gave up expanding this reference, so its arguments are what its own
-			// recursion had grown rather than what the source wrote. Rendering four levels of that
-			// ends in an ellipsis anyway and names nothing a reader can act on, so the whole
-			// argument list collapses to one. See AliasType.Truncated.
-			return name + "<" + ElisionMark + ">"
 		}
 		parts := make([]string, 0, len(t.LifetimeArgs)+len(t.TypeArgs))
 		for _, la := range t.LifetimeArgs {

--- a/internal/soltype/print_test.go
+++ b/internal/soltype/print_test.go
@@ -713,9 +713,6 @@ func TestPrintElided(t *testing.T) {
 		return ty
 	}
 	alias := func(arg Type) Type { return &AliasType{Name: "Grow", TypeArgs: []Type{arg}} }
-	truncated := func(arg Type) Type {
-		return &AliasType{Name: "Grow", TypeArgs: []Type{arg}, Truncated: true}
-	}
 
 	tests := []struct {
 		name     string
@@ -741,10 +738,6 @@ func TestPrintElided(t *testing.T) {
 			want:     "Grow<{a: {a: …}, b: {a: …}}>",
 		},
 		{"ZeroElidesNothing", alias(nest(3)), 0, "Grow<{a: {a: {a: number}}}>"},
-		// A reference the evaluator gave up expanding elides its whole argument list, however
-		// shallow the argument happens to be, since none of it came from the source.
-		{"TruncatedElidesArgs", truncated(nest(3)), 4, "Grow<…>"},
-		{"TruncatedElidesShallowArgs", truncated(numP()), 4, "Grow<…>"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -761,16 +754,4 @@ func TestPrintElidedZeroMatchesPrint(t *testing.T) {
 		&TupleType{Elems: []Type{strP(), boolP()}},
 	}}
 	require.Equal(t, Print(ty), PrintElided(ty, 0))
-}
-
-// Print and PrintQualified ignore the Truncated marker and render the arguments in full. Only a
-// diagnostic elides them. PrintQualified forms the identity key the recursion guard compares, and
-// collapsing every truncated reference to one `Grow<…>` would close a cycle between instantiations
-// that differ.
-func TestPrintTruncatedAliasRendersArgsInFull(t *testing.T) {
-	ty := &AliasType{Name: "Grow", TypeArgs: []Type{
-		&ObjectType{Elems: []ObjTypeElem{&PropertyElem{Name: "a", Type: numP()}}},
-	}, Truncated: true}
-	require.Equal(t, "Grow<{a: number}>", Print(ty))
-	require.Equal(t, "Grow<{a: number}>", PrintQualified(ty))
 }

--- a/internal/soltype/type.go
+++ b/internal/soltype/type.go
@@ -667,17 +667,6 @@ type AliasType struct {
 	// M9's cycle cache key on, so two borrows of one alias at different lifetimes never share a
 	// cache entry. A borrow's own lifetime rides a RefType wrapper, not this field.
 	LifetimeArgs []Lifetime
-	// Truncated marks a reference the type evaluator stopped expanding because its expansion
-	// budget ran out. That happens only for a recursion the evaluator cannot finish, one whose
-	// argument grows every lap so the reference never repeats a state the cycle guard would
-	// catch. TypeArgs on such a reference are whatever the walk had grown by the time it
-	// stopped, not anything the source wrote, so PrintElided renders them as a single ellipsis.
-	// See maxExpandKeyChars in internal/solver for how the budget is spent.
-	//
-	// Print and PrintQualified ignore it and render the arguments in full. PrintQualified forms
-	// the identity key the recursion guard and constrain's cycle set compare, and collapsing two
-	// truncated references to one key would close a cycle between instantiations that differ.
-	Truncated bool
 }
 
 // KeyofType is the residual `keyof Operand` type operator (M9 PR1a), the first of

--- a/internal/soltype/visitor.go
+++ b/internal/soltype/visitor.go
@@ -410,12 +410,7 @@ func (t *AliasType) Accept(v TypeVisitor, pol Polarity) Type {
 		// LifetimeArgs are lifetimes, not Types, so Accept never walks them; a
 		// lifetime-aware visitor freshens them in its EnterType, replacing the whole
 		// AliasType before this rebuild, so cur already holds the freshened lifetimes.
-		out = &AliasType{
-			Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs,
-			// Truncated rides along so a substitution over a residual keeps the marker the
-			// evaluator set, and a diagnostic naming the result still elides its arguments.
-			Truncated: cur.Truncated,
-		}
+		out = &AliasType{Name: cur.Name, TypeArgs: args, LifetimeArgs: cur.LifetimeArgs}
 	}
 	return v.ExitType(out, pol)
 }

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -55,6 +55,10 @@ type aliasShell struct {
 	decl *ast.TypeDecl
 	ns   string
 	lvl  int
+	// qname is the alias's dep_graph-qualified name. It is the key its AliasDef is
+	// registered under, and the Name every AliasType handle pointing at it carries.
+	// checkRegular matches a body's references against it to find the recursion cycles.
+	qname string
 	// declScope is scope, or a child holding a generic alias's type parameters. The body
 	// resolves here so it reads each `T` as the one shared var the def stores.
 	declScope *Scope
@@ -129,7 +133,7 @@ func (c *checker) preBindAlias(scope *Scope, lvl int, decl *ast.TypeDecl, ns str
 	})
 	c.recordType(decl.Name, t)
 
-	return &aliasShell{decl: decl, ns: ns, lvl: lvl, declScope: declScope, namedLts: aliasNamedLts, def: def}
+	return &aliasShell{decl: decl, ns: ns, lvl: lvl, qname: qname, declScope: declScope, namedLts: aliasNamedLts, def: def}
 }
 
 // resolveAliasLifetimeParams mints one lifetime variable per `<'a, ...>` parameter through

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -34,10 +34,11 @@ type AliasDef struct {
 	// diagnostic naming the alias showing the arguments the source wrote, and it stops the
 	// rejection from cascading into a reduction that would run until a budget cut it off.
 	//
-	// checkRegular sets it once every body in the alias's dep_graph component is resolved.
-	// Reduction is driven from constrain, which reaches an alias only through a reference an
-	// annotation resolved, and such a reference resolves only after the alias is bound, so a
-	// reduction always sees the finished flag.
+	// checkRegular sets it in the loop that immediately follows body resolution for the
+	// alias's dep_graph component, with no inference in between. That ordering is what makes
+	// the flag safe to read: until a body is filled, expandAlias yields ErrorType for the
+	// alias and expandAliasGuarded declines to expand it, so no reduction can reach a
+	// resolved body before the flag is set.
 	NotRegular bool
 }
 

--- a/internal/solver/aliases.go
+++ b/internal/solver/aliases.go
@@ -27,6 +27,18 @@ type AliasDef struct {
 	// in the body and are substituted at expansion, so the level is recorded but not
 	// otherwise consulted.
 	Level int
+
+	// NotRegular marks an alias checkRegular rejected for expanding recursion. Expanding one
+	// lap of such an alias hands the next lap a strictly larger argument, so the evaluator
+	// refuses to expand it at all and leaves the operator over it symbolic. That keeps a
+	// diagnostic naming the alias showing the arguments the source wrote, and it stops the
+	// rejection from cascading into a reduction that would run until a budget cut it off.
+	//
+	// checkRegular sets it once every body in the alias's dep_graph component is resolved.
+	// Reduction is driven from constrain, which reaches an alias only through a reference an
+	// annotation resolved, and such a reference resolves only after the alias is bound, so a
+	// reduction always sees the finished flag.
+	NotRegular bool
 }
 
 // expandAlias unfolds an alias reference to its registered AliasDef Body, the shared

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -966,6 +966,7 @@ func (*ExtractorPatternArityError) isSolverError()          {}
 func (*AliasArityMismatchError) isSolverError()             {}
 func (*AliasLifetimeArityMismatchError) isSolverError()     {}
 func (*ReservedTypeNameError) isSolverError()               {}
+func (*NotRegularAliasError) isSolverError()                {}
 
 // MissingSelfReceiverError fires when a non-static instance method, getter, or
 // setter omits its `self` receiver. Such a member cannot read the instance, so the
@@ -1107,6 +1108,30 @@ func (e *ReservedTypeNameError) Span() ast.Span      { return e.Decl.Name.Span()
 func (e *ReservedTypeNameError) Related() []ast.Span { return nil }
 func (e *ReservedTypeNameError) Message() string {
 	return fmt.Sprintf("%q is a built-in type operator and cannot be redefined", e.Decl.Name.Name)
+}
+
+// NotRegularAliasError fires when a recursive type alias wraps one of its own type parameters in a
+// type constructor on the way around its recursion cycle, as `type Grow<T> = Grow<{a: T}>` does.
+// Every lap builds a strictly larger argument, so the alias expands to infinitely many distinct
+// instantiations and no expansion of it ever settles. Name is the alias's qualified name and Param
+// the parameter that grows.
+//
+// The message points at the two ways out. Breaking the cycle with a nominal type stops the
+// expansion, since a class or enum reference is not expanded the way an alias body is. Dropping the
+// wrapper leaves the parameter passed through, which is the regular recursion `List` uses.
+type NotRegularAliasError struct {
+	Decl  *ast.TypeDecl
+	Name  string
+	Param string
+}
+
+func (e *NotRegularAliasError) Span() ast.Span      { return e.Decl.Name.Span() }
+func (e *NotRegularAliasError) Related() []ast.Span { return nil }
+func (e *NotRegularAliasError) Message() string {
+	return fmt.Sprintf(
+		"recursive type alias `%s` grows type parameter `%s` under a type constructor, so its "+
+			"expansion is unbounded; break the recursion with a nominal type or pass `%s` through unwrapped",
+		e.Name, e.Param, e.Param)
 }
 
 // MultipleConstructorsError fires on the second and any later `constructor` block in

--- a/internal/solver/errors.go
+++ b/internal/solver/errors.go
@@ -1810,7 +1810,8 @@ func describeMapped(t *soltype.MappedElem) string {
 // describeMaxDepth bounds how deep describe renders a nominal reference's type arguments before
 // PrintElided replaces the rest with an ellipsis. A reduction can leave a residual whose alias
 // argument is far larger than any type the source wrote, and rendering that in full buries the
-// diagnostic. See maxExpandKeyChars for how such an argument grows.
+// diagnostic. Grounding a chain of aliases that each spread the one below them twice is the shape
+// that reaches that size; see maxExpandKeyChars.
 //
 // Three levels render every message the test suite asserts in full, so four leaves one level of
 // headroom over what a hand-written annotation reaches. An ordinary diagnostic is therefore

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -1,6 +1,7 @@
 package solver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/dep_graph"
@@ -8,6 +9,15 @@ import (
 	"github.com/escalier-lang/escalier/internal/soltype"
 	"github.com/stretchr/testify/require"
 )
+
+// notRegularMsg renders the full definition-time rejection checkRegular reports when alias grows
+// param, prefixed with span. Several cases below declare an expanding alias and differ only in
+// those three values. TestCheckRegularRejects spells the wording out literally.
+func notRegularMsg(span, alias, param string) string {
+	return fmt.Sprintf("%s: recursive type alias `%s` grows type parameter `%s` under a type "+
+		"constructor, so its expansion is unbounded; break the recursion with a nominal type or "+
+		"pass `%s` through unwrapped", span, alias, param, param)
+}
 
 // inferTypeNodes infers src and returns the raw soltype.Type of each top-level type binding
 // alongside the checker's Context, so a test can reduce a stored residual instead of only reading
@@ -569,18 +579,22 @@ func TestInferKeyofResidualErrorMessage(t *testing.T) {
 }
 
 // Checking a value against `keyof` of an expanding recursive alias terminates instead of looping.
-// The reduction is budget-truncated and leaves a `keyof A<…>` residual, so constrain does not
-// recurse on it — re-expanding would grow the operand without bound — and the residual stays
-// inert, conservatively rejecting the value. The point of the test is termination; the precise
-// rejection is a consequence of the truncation, which CheckRegular will reject at definition time
-// in a later milestone.
+// checkRegular rejects the alias at its declaration, and the annotation naming it still reduces, so
+// the second error is the value check against what that reduction produced. The reduction is
+// budget-truncated and yields a residual constrain does not recurse on, since re-expanding would
+// grow the operand without bound, so the residual stays inert and conservatively rejects the value.
+// The rejection blames the annotation as the source wrote it, `keyof A<number>`, rather than the
+// grown argument the walk gave up on. The point of the test is termination; the precise rejection
+// is a consequence of the truncation.
 func TestInferKeyofExpandingAliasTerminates(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type A<T> = {x: T} | A<{y: T}>
 		val k: keyof A<number> = "x"
 	`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &CannotConstrainError{}, errs[0])
+	require.Equal(t, []string{
+		notRegularMsg("2:8-2:9", "A", "T"),
+		`3:28-3:31: cannot constrain "x" <: keyof A<number>`,
+	}, messagesWithSpan(errs))
 }
 
 // Checking a value against a mapped type whose value expression reaches an expanding recursive
@@ -594,6 +608,9 @@ func TestInferKeyofExpandingAliasTerminates(t *testing.T) {
 // grown by the time the budget ran out, so its levels say nothing about the source; spelling them
 // out ran past a hundred thousand characters. Eliding also makes the messages independent of where
 // the shared pool happened to run out, which is why they can be asserted at all.
+//
+// checkRegular rejects each alias at its declaration, so that diagnostic leads every case. The
+// annotation naming the alias still reduces, which is what the value checks below exercise.
 func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 	tests := []struct {
 		name string
@@ -609,6 +626,7 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 				val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
 			`,
 			want: []string{
+				notRegularMsg("2:10-2:14", "Grow", "T"),
 				`3:47-3:48: cannot constrain 1 <: Grow<…>["a"]`,
 				`3:53-3:54: cannot constrain 2 <: Grow<…>["b"]`,
 			},
@@ -621,17 +639,13 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 				type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}
 				val x: Grow<{a: number}> = {a: 1}
 			`,
-			want: []string{`3:36-3:37: cannot constrain 1 <: Grow<…>["a"]`},
+			want: []string{notRegularMsg("2:10-2:14", "Grow", "T"), `3:36-3:37: cannot constrain 1 <: Grow<…>["a"]`},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
-			require.Len(t, errs, len(test.want))
-			for i, errVal := range errs {
-				require.IsType(t, &CannotConstrainError{}, errVal)
-				require.Equal(t, test.want[i], msgWithSpan(errVal))
-			}
+			require.Equal(t, test.want, messagesWithSpan(errs))
 		})
 	}
 }
@@ -645,11 +659,14 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 //
 // Neither case involves a mapped type, so the hazard the shared pool closes is in the guard rather
 // than in one operator's reduction.
+//
+// checkRegular rejects each alias at its declaration, so that diagnostic leads every case. The
+// annotation naming the alias still reduces, which is what the value checks below exercise.
 func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 	tests := []struct {
 		name string
 		src  string
-		want string
+		want []string
 	}{
 		{
 			// The recursion sits in an object spread's operand, which grounds the alias each lap.
@@ -658,7 +675,10 @@ func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 				type Grow<T> = {...Grow<{a: T, b: T}>}
 				val v: Grow<{a: number, b: number}> = 1
 			`,
-			want: `3:43-3:44: cannot constrain 1 <: {...Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>}`,
+			want: []string{
+				notRegularMsg("2:10-2:14", "Grow", "T"),
+				`3:43-3:44: cannot constrain 1 <: {...Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>}`,
+			},
 		},
 		{
 			// The recursion sits in an indexed access's target, which expands it each lap too.
@@ -667,15 +687,16 @@ func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 				type Grow<T> = Grow<{a: T, b: T}>["a"]
 				val v: Grow<{a: number, b: number}> = 1
 			`,
-			want: `3:43-3:44: cannot constrain 1 <: Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>["a"]`,
+			want: []string{
+				notRegularMsg("2:10-2:14", "Grow", "T"),
+				`3:43-3:44: cannot constrain 1 <: Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>["a"]`,
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, _, errs := inferSource(t, test.src)
-			require.Len(t, errs, 1)
-			require.IsType(t, &CannotConstrainError{}, errs[0])
-			require.Equal(t, test.want, msgWithSpan(errs[0]))
+			require.Equal(t, test.want, messagesWithSpan(errs))
 		})
 	}
 }
@@ -718,15 +739,17 @@ func TestInferKeyofKeyofIsNever(t *testing.T) {
 // An expanding recursive alias under `keyof` reduces to `never` on the `keyof keyof` rule rather
 // than running until maxExpandKeyChars stops it. The alias body is `keyof Grow<…>`, so one
 // expansion puts a `keyof` directly under a `keyof` and the rule answers without reducing the
-// operand that would have grown.
+// operand that would have grown. checkRegular rejects the alias at its declaration either way,
+// since the rule that shortcuts the reduction says nothing about whether the argument grows.
 func TestInferKeyofExpandingAliasIsNever(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type Grow<T> = keyof Grow<{a: T, b: T}>
 		val k: Grow<{a: number, b: number}> = "x"
 	`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &CannotConstrainError{}, errs[0])
-	require.Equal(t, `3:41-3:44: cannot constrain "x" <: never`, msgWithSpan(errs[0]))
+	require.Equal(t, []string{
+		notRegularMsg("2:8-2:12", "Grow", "T"),
+		`3:41-3:44: cannot constrain "x" <: never`,
+	}, messagesWithSpan(errs))
 }
 
 // A `typeof v` query is stored as a residual behind the value reference, so an annotation prints
@@ -1375,19 +1398,21 @@ func TestInferTupleSpreadMutOperandRejected(t *testing.T) {
 }
 
 // Checking a value against a tuple spread of an expanding recursive alias terminates instead of
-// looping. The reduction is budget-truncated and leaves a `[...A<…>, …]` residual, so constrain
-// does not recurse on it — re-expanding would grow the operand without bound — and the residual
-// stays inert, conservatively rejecting the value. The point is termination; the precise rejection
-// is a consequence of the truncation, which CheckRegular will reject at definition time in a later
-// milestone.
+// looping. checkRegular rejects the alias at its declaration, and the annotation naming it still
+// reduces, so the second error is the value check against what that reduction produced. The
+// reduction is budget-truncated and leaves a `[...A<…>, …]` residual, so constrain does not recurse
+// on it — re-expanding would grow the operand without bound — and the residual stays inert,
+// conservatively rejecting the value. The point is termination; the precise rejection is a
+// consequence of the truncation.
 func TestInferTupleSpreadExpandingAliasTerminates(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type A<T> = [T, ...A<[T]>]
 		val r: [...A<number>, boolean] = [1, 2]
 	`)
-	require.Len(t, errs, 1)
-	require.IsType(t, &CannotConstrainError{}, errs[0])
-	require.Equal(t, "3:36-3:42: cannot constrain tuple <: [...A<number>, boolean]", msgWithSpan(errs[0]))
+	require.Equal(t, []string{
+		notRegularMsg("2:8-2:9", "A", "T"),
+		"3:36-3:42: cannot constrain tuple <: [...A<number>, boolean]",
+	}, messagesWithSpan(errs))
 }
 
 // `keyof` and indexed access over a tuple carrying an unreduced `...P` spread stay symbolic: the

--- a/internal/solver/infer_typeops_test.go
+++ b/internal/solver/infer_typeops_test.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/escalier-lang/escalier/internal/dep_graph"
@@ -598,19 +599,17 @@ func TestInferKeyofExpandingAliasTerminates(t *testing.T) {
 }
 
 // Checking a value against a mapped type whose value expression reaches an expanding recursive
-// alias terminates instead of looping. A mapped type reduces that expression once per key, so the
-// alias expands once per key, and maxExpandDepth is restored between the two — each key would
-// otherwise restart from the full remaining depth and make the walk a search tree exponential in
-// the budget. maxExpandKeyChars is monotonic, so the keys spend one shared pool.
+// alias terminates instead of looping. checkRegular rejects the alias at its declaration and marks
+// it NotRegular, so the evaluator declines to expand it and the mapped type's value expression
+// reduces to a residual over the unexpanded reference. That is what stops the walk here — a mapped
+// type reduces its value expression once per key, so an alias free to expand would branch by the
+// key count every lap.
 //
-// Each field reduces to a residual the evaluator gave up expanding, and the diagnostic names it
-// `Grow<…>` rather than spelling out the argument. That argument is whatever the recursion had
-// grown by the time the budget ran out, so its levels say nothing about the source; spelling them
-// out ran past a hundred thousand characters. Eliding also makes the messages independent of where
-// the shared pool happened to run out, which is why they can be asserted at all.
-//
-// checkRegular rejects each alias at its declaration, so that diagnostic leads every case. The
-// annotation naming the alias still reduces, which is what the value checks below exercise.
+// The rejection is what each field's diagnostic names, and it names the argument the source wrote.
+// One substitution shows through, because constrain expands a transparent alias once itself before
+// handing the body to the evaluator: `Grow<{a: number, b: number}>` renders with `T` already
+// replaced. That single lap is bounded by the size of the alias body, so the message stays short
+// whatever the recursion would have grown to.
 func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 	tests := []struct {
 		name string
@@ -618,28 +617,30 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 		want []string
 	}{
 		{
-			// Two keys per lap. Each key reduces `Grow<{a: T, b: T}>[K]`, so the walk branches
-			// twice per lap and the alias argument doubles along every branch.
-			name: "TwoKeysPerLap",
+			// Two keys, so the mapped type reduces its value expression twice. Each reduction meets
+			// the same unexpanded reference.
+			name: "TwoKeys",
 			src: `
 				type Grow<T> = {[K]: Grow<{a: T, b: T}>[K] for K in keyof T}
 				val x: Grow<{a: number, b: number}> = {a: 1, b: 2}
 			`,
 			want: []string{
 				notRegularMsg("2:10-2:14", "Grow", "T"),
-				`3:47-3:48: cannot constrain 1 <: Grow<…>["a"]`,
-				`3:53-3:54: cannot constrain 2 <: Grow<…>["b"]`,
+				`3:47-3:48: cannot constrain 1 <: Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>["a"]`,
+				`3:53-3:54: cannot constrain 2 <: Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>["b"]`,
 			},
 		},
 		{
-			// One key per lap. The walk does not branch and the argument gains one wrapper a lap,
-			// so maxExpandDepth is what stops it and the shared pool never binds.
-			name: "OneKeyPerLap",
+			// One key, so the mapped type reduces its value expression once.
+			name: "OneKey",
 			src: `
 				type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}
 				val x: Grow<{a: number}> = {a: 1}
 			`,
-			want: []string{notRegularMsg("2:10-2:14", "Grow", "T"), `3:36-3:37: cannot constrain 1 <: Grow<…>["a"]`},
+			want: []string{
+				notRegularMsg("2:10-2:14", "Grow", "T"),
+				`3:36-3:37: cannot constrain 1 <: Grow<{a: {a: number}}>["a"]`,
+			},
 		},
 	}
 	for _, test := range tests {
@@ -651,17 +652,17 @@ func TestInferMappedExpandingAliasTerminates(t *testing.T) {
 }
 
 // Checking a value against an alias whose argument doubles each lap terminates instead of looping.
-// The instantiation key the guard renders doubles with the argument, so a walk of a few dozen laps
-// would render a key of astronomical length even though it never branches. maxExpandDepth counts
-// laps rather than the size of what each lap expands, so it does not bound that on its own;
-// charging maxExpandKeyChars by the rendered key length stops the walk after a logarithmic number
-// of laps.
+// Left free to expand, each lap of these aliases would double the rendered instantiation key, so a
+// few dozen laps would render a key of astronomical length without ever branching. checkRegular
+// rejects both at their declarations, so the evaluator declines the first expansion and the walk
+// never starts.
 //
-// Neither case involves a mapped type, so the hazard the shared pool closes is in the guard rather
-// than in one operator's reduction.
+// Each case reaches the alias through a different operator, an object spread's operand and an
+// indexed access's target, so the refusal is shown to cover every reduction that grounds an operand
+// rather than one operator's path through expandAliasGuarded. Neither involves a mapped type.
 //
-// checkRegular rejects each alias at its declaration, so that diagnostic leads every case. The
-// annotation naming the alias still reduces, which is what the value checks below exercise.
+// The value check names the argument the source wrote, with the one substitution constrain performs
+// itself when it expands a transparent alias before handing the body to the evaluator.
 func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 	tests := []struct {
 		name string
@@ -701,6 +702,67 @@ func TestInferDoublingAliasArgumentTerminates(t *testing.T) {
 	}
 }
 
+// spreadChainSrc builds a chain of aliases, each spreading the one below it `fanOut` times, and a
+// value annotated with the top one so checking it has to ground the whole chain. No alias here
+// recurses, so checkRegular accepts every one, and none has a type parameter to grow. Grounding the
+// top alias costs fanOut^levels expansions, which is what makes these the shapes the two expansion
+// budgets exist for.
+func spreadChainSrc(levels, fanOut int) string {
+	var b strings.Builder
+	b.WriteString("type A0 = {a: number}\n")
+	for i := 1; i <= levels; i++ {
+		operands := make([]string, fanOut)
+		for j := range operands {
+			operands[j] = fmt.Sprintf("...A%d", i-1)
+		}
+		fmt.Fprintf(&b, "type A%d = {%s}\n", i, strings.Join(operands, ", "))
+	}
+	fmt.Fprintf(&b, "val v: A%d = 1\n", levels)
+	return b.String()
+}
+
+// The two expansion budgets each stop a shape the other does not, and neither shape involves
+// recursion, so checkRegular has nothing to say about either. Without the budgets both hang.
+//
+// Both cases reject the value, because the annotation never grounds to an object the number could
+// satisfy. The point is that inference finishes at all, and that it blames the top alias's
+// unexpanded body rather than a type the truncated walk had built.
+func TestInferSpreadChainBudgetsTerminate(t *testing.T) {
+	tests := []struct {
+		name   string
+		levels int
+		fanOut int
+		want   string
+	}{
+		{
+			// Deep and narrow. One expansion per level, so the reduction path is 250 deep while the
+			// keys it renders are three characters each and spend almost none of the shared pool.
+			// maxExpandDepth is the cap that binds.
+			name: "DeepChainBoundByDepth", levels: 250, fanOut: 1,
+			want: "252:15-252:16: cannot constrain 1 <: {...A249}",
+		},
+		{
+			// Shallow and wide. Two expansions per level over forty levels is 2^41 expansions, and
+			// maxExpandDepth is restored when each sibling branch finishes, so it never binds at a
+			// path depth of forty. The monotonic maxExpandKeyChars is what stops this one.
+			name: "WideFanBoundByKeyChars", levels: 40, fanOut: 2,
+			want: "42:14-42:15: cannot constrain 1 <: {...B39, ...B39}",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := spreadChainSrc(test.levels, test.fanOut)
+			// The wide case renders its operands under a second name so the two cases' expected
+			// messages stay distinguishable at a glance.
+			if test.fanOut > 1 {
+				src = strings.ReplaceAll(src, "A", "B")
+			}
+			_, _, errs := inferSource(t, src)
+			require.Equal(t, []string{test.want}, messagesWithSpan(errs))
+		})
+	}
+}
+
 // `keyof keyof X` reduces to `never` for every X. What the inner `keyof` projects is a key set —
 // string literals for an object, number literals for a tuple — and `keyof` over a literal is
 // already `never`, so the outer operator has no keys to name whatever the inner operand turns out
@@ -736,19 +798,21 @@ func TestInferKeyofKeyofIsNever(t *testing.T) {
 	}
 }
 
-// An expanding recursive alias under `keyof` reduces to `never` on the `keyof keyof` rule rather
-// than running until maxExpandKeyChars stops it. The alias body is `keyof Grow<…>`, so one
-// expansion puts a `keyof` directly under a `keyof` and the rule answers without reducing the
-// operand that would have grown. checkRegular rejects the alias at its declaration either way,
-// since the rule that shortcuts the reduction says nothing about whether the argument grows.
-func TestInferKeyofExpandingAliasIsNever(t *testing.T) {
+// `keyof` over an expanding recursive alias stays symbolic. checkRegular rejects the alias, so the
+// evaluator declines to expand it and the `keyof` has no ground operand to project keys from.
+//
+// The `keyof keyof T` ⇒ `never` rule does not fire here, even though this alias body is
+// `keyof Grow<…>` and one expansion would put a `keyof` directly under a `keyof`. Seeing that
+// requires expanding the rejected alias, which is exactly what the marker forbids. The rule still
+// answers for every operand the evaluator will expand — see TestInferKeyofKeyofIsNever.
+func TestInferKeyofExpandingAliasStaysSymbolic(t *testing.T) {
 	_, _, errs := inferSource(t, `
 		type Grow<T> = keyof Grow<{a: T, b: T}>
 		val k: Grow<{a: number, b: number}> = "x"
 	`)
 	require.Equal(t, []string{
 		notRegularMsg("2:8-2:12", "Grow", "T"),
-		`3:41-3:44: cannot constrain "x" <: never`,
+		`3:41-3:44: cannot constrain "x" <: keyof Grow<{a: {a: number, b: number}, b: {a: number, b: number}}>`,
 	}, messagesWithSpan(errs))
 }
 

--- a/internal/solver/module.go
+++ b/internal/solver/module.go
@@ -400,6 +400,9 @@ func (c *checker) inferComponent(
 	for _, sh := range aliasShells {
 		c.inferAliasBody(sh)
 	}
+	// Every body in the component is resolved, so the alias reference graph the regularity check
+	// reads is complete.
+	c.checkRegular(aliasShells)
 
 	// Report any remaining non-value decl as unsupported. A class was pre-bound above and
 	// is completed at its value key, so skip it rather than mis-reporting it.

--- a/internal/solver/regularity.go
+++ b/internal/solver/regularity.go
@@ -45,6 +45,13 @@ func (c *checker) checkRegular(shells []*aliasShell) {
 			continue
 		}
 		growing := growingParams(sh.def, group)
+		if growing.Len() == 0 {
+			continue
+		}
+		// Mark the alias so the evaluator declines to expand it. Every cycle that grows this
+		// alias's parameters runs through this alias, so refusing it alone breaks all of them, and
+		// a sibling in the same component that recurses regularly still expands.
+		sh.def.NotRegular = true
 		// Report in declaration order rather than by name, so a two-parameter alias blames its
 		// parameters the way the source lists them.
 		for _, p := range sh.def.TypeParams {

--- a/internal/solver/regularity.go
+++ b/internal/solver/regularity.go
@@ -1,0 +1,201 @@
+package solver
+
+import (
+	"slices"
+
+	"github.com/escalier-lang/escalier/internal/graph"
+	"github.com/escalier-lang/escalier/internal/set"
+	"github.com/escalier-lang/escalier/internal/soltype"
+)
+
+// A recursive alias is safe to expand exactly when it reaches finitely many distinct instantiation
+// states. Such recursion is called regular: a parameter travels around the cycle without gaining
+// structure. Expanding `List<number>` for `type List<T> = {head: T, tail?: List<T>}` yields a body
+// naming `List<number>` again, the identical state, and the evaluator's active-state guard closes
+// the recursion there.
+//
+// Recursion that wraps a parameter under a type constructor every lap never repeats a state. Each
+// lap of `type Grow<T> = Grow<{a: T}>` builds a strictly larger argument, so the reachable
+// instantiations are infinite and the guard never fires. Only maxExpandDepth and maxExpandKeyChars
+// stop that walk, and they stop it with a truncated residual rather than an explanation.
+//
+// checkRegular is the definition-time diagnostic for the second shape. It is decidable and
+// conservative, so it accepts every regular alias and rejects some terminating programs. An alias
+// whose growth is gated on a base-case conditional does terminate. Deciding that in general is the
+// halting problem, so the check rejects it too. The runtime budgets stay in place underneath as the
+// backstop for what the check cannot see, such as expansion reached through an imported type or a
+// chain of non-recursive aliases that fans out exponentially.
+//
+// Mutual recursion goes through the alias reference graph. A recursive reference means a reference
+// to any alias in the same strongly connected component, so `type A<T> = B<{x: T}>` paired with
+// `type B<U> = A<U>` is caught even though neither body names itself.
+
+// checkRegular reports every alias in shells whose recursion grows one of its own type parameters.
+// shells are the aliases of one dep_graph component, which is already a strongly connected set of
+// declarations, so no alias outside it can close a cycle with one inside it. Their bodies must be
+// resolved before the check runs, since it reads AliasDef.Body.
+func (c *checker) checkRegular(shells []*aliasShell) {
+	if len(shells) == 0 {
+		return
+	}
+	groups := recursionGroups(shells)
+	for _, sh := range shells {
+		group, recursive := groups[sh.qname]
+		if !recursive || len(sh.def.TypeParams) == 0 {
+			continue
+		}
+		growing := growingParams(sh.def, group)
+		// Report in declaration order rather than by name, so a two-parameter alias blames its
+		// parameters the way the source lists them.
+		for _, p := range sh.def.TypeParams {
+			if growing.Contains(p.Name) {
+				c.report(&NotRegularAliasError{Decl: sh.decl, Name: sh.qname, Param: p.Name})
+			}
+		}
+	}
+}
+
+// growingParams returns the names of def's type parameters that appear under a type constructor in
+// an argument of a recursive reference. Such a parameter is strictly larger on the next lap. group
+// is the set of alias names in def's recursion cycle, so a reference to any of them is recursive.
+func growingParams(def *AliasDef, group set.Set[string]) set.Set[string] {
+	params := map[*soltype.TypeVarType]string{}
+	for _, p := range def.TypeParams {
+		params[p.Var] = p.Name
+	}
+	finder := &expandingCallFinder{group: group, params: params, growing: set.NewSet[string]()}
+	def.Body.Accept(finder, soltype.Positive)
+	return finder.growing
+}
+
+// recursionGroups returns, for each alias that participates in a recursion cycle, the names of the
+// aliases in its cycle including itself. An alias that reaches no cycle is absent from the result.
+//
+// The cycles are the strongly connected components of the graph whose vertices are the aliases in
+// the component and whose edges are the alias references in their bodies. A component of two or
+// more aliases is a cycle. A component of one is a cycle only when that alias's body names itself.
+func recursionGroups(shells []*aliasShell) map[string]set.Set[string] {
+	names := make([]string, 0, len(shells))
+	for _, sh := range shells {
+		names = append(names, sh.qname)
+	}
+	within := set.FromSlice(names)
+	refs := map[string][]string{}
+	for _, sh := range shells {
+		collector := &aliasRefCollector{within: within, found: set.NewSet[string]()}
+		sh.def.Body.Accept(collector, soltype.Positive)
+		out := collector.found.ToSlice()
+		// Sort each alias's out-edges, and the seeds below, so the components come back in the same
+		// order for the same input and a diagnostic never depends on map iteration order.
+		slices.Sort(out)
+		refs[sh.qname] = out
+	}
+	slices.Sort(names)
+
+	groups := map[string]set.Set[string]{}
+	for _, component := range graph.StronglyConnectedComponents(names, func(n string) []string { return refs[n] }) {
+		if len(component) == 1 && !slices.Contains(refs[component[0]], component[0]) {
+			continue
+		}
+		group := set.FromSlice(component)
+		for _, name := range component {
+			groups[name] = group
+		}
+	}
+	return groups
+}
+
+// aliasRefCollector records which of a fixed set of alias names a type references. It rewrites
+// nothing, so every node it visits comes back unchanged.
+type aliasRefCollector struct {
+	within set.Set[string]
+	found  set.Set[string]
+}
+
+func (v *aliasRefCollector) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if a, ok := t.(*soltype.AliasType); ok && v.within.Contains(a.Name) {
+		v.found.Add(a.Name)
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *aliasRefCollector) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// expandingCallFinder walks an alias body and, at every reference into the alias's recursion cycle,
+// checks each type argument for a parameter that gained structure. It records the names of the
+// parameters that did and rewrites nothing.
+type expandingCallFinder struct {
+	group   set.Set[string]
+	params  map[*soltype.TypeVarType]string
+	growing set.Set[string]
+}
+
+func (v *expandingCallFinder) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	a, ok := t.(*soltype.AliasType)
+	if !ok || !v.group.Contains(a.Name) {
+		return soltype.EnterResult{}
+	}
+	// Each argument is measured from its own root, so the constructors enclosing the reference in
+	// the body do not count. The `{…}` around `DeepPartial<T[K]>` in
+	// `type DeepPartial<T> = {[K]?: DeepPartial<T[K]> for K in keyof T}` wraps the reference, not
+	// the argument, and that alias is regular.
+	for _, arg := range a.TypeArgs {
+		nested := &nestedParamFinder{params: v.params, growing: v.growing}
+		arg.Accept(nested, soltype.Positive)
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *expandingCallFinder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type { return t }
+
+// nestedParamFinder records which type parameters occur strictly below a type constructor in the
+// type it walks. A parameter passed through as the whole argument, the `T` of `List<T>`, is at
+// depth zero and leaves the argument the same size each lap. The same parameter under a
+// constructor, the `T` of `Grow<{a: T}>`, makes the argument one constructor larger each lap.
+type nestedParamFinder struct {
+	params  map[*soltype.TypeVarType]string
+	depth   int
+	growing set.Set[string]
+}
+
+func (v *nestedParamFinder) EnterType(t soltype.Type, _ soltype.Polarity) soltype.EnterResult {
+	if tv, ok := t.(*soltype.TypeVarType); ok {
+		if name, isParam := v.params[tv]; isParam && v.depth > 0 {
+			v.growing.Add(name)
+		}
+		return soltype.EnterResult{}
+	}
+	if growsItsOperands(t) {
+		v.depth++
+	}
+	return soltype.EnterResult{}
+}
+
+func (v *nestedParamFinder) ExitType(t soltype.Type, _ soltype.Polarity) soltype.Type {
+	if growsItsOperands(t) {
+		v.depth--
+	}
+	return t
+}
+
+// growsItsOperands reports whether a type makes its operands one constructor deeper. The two groups
+// split on whether an operand comes out of the type larger than it went in.
+//
+// A growing type builds a strictly larger term from its operands. Wrapping `T` in `{a: T}`, `[T]`,
+// `(T) -> T`, or `Box<T>` gives a term the recursion has to carry on every later lap.
+//
+// The rest hold their operands at the same depth. A union is a choice among its members, so `T` and
+// `T | number` are the same size as far as growth goes. The type-level operators — `keyof`, indexed
+// access, and the conditional — read a component out of their operand rather than wrapping it, so
+// `T[K]` is no larger than `T`. Treating them as growth would reject
+// `type DeepPartial<T> = {[K]?: DeepPartial<T[K]> for K in keyof T}`, which recurses on exactly
+// that shape.
+func growsItsOperands(t soltype.Type) bool {
+	switch t.(type) {
+	case *soltype.ObjectType, *soltype.TupleType, *soltype.FuncType, *soltype.RefType,
+		*soltype.PromiseType, *soltype.TemplateLitType, *soltype.ClassType, *soltype.AliasType:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/solver/regularity_test.go
+++ b/internal/solver/regularity_test.go
@@ -1,0 +1,180 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// checkRegular accepts an alias whose recursion carries its parameters around the cycle without
+// wrapping them. Each case names a shape the reachable-instantiation set stays finite for, so the
+// evaluator's active-state guard closes the recursion on its own.
+func TestCheckRegularAccepts(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			// The canonical regular recursion. `List<number>` expands to a body naming
+			// `List<number>` again, the identical instantiation state.
+			name: "PassThroughParameter",
+			src:  `type List<T> = {head: T, tail?: List<T>}`,
+		},
+		{
+			// A non-generic recursive alias has no parameter to grow, so no instantiation state
+			// varies from lap to lap.
+			name: "NoTypeParameters",
+			src:  `type Json = number | string | {items: Json}`,
+		},
+		{
+			// The recursive argument reads a component out of the parameter rather than wrapping
+			// it, so the argument is no larger than the parameter it came from.
+			name: "IndexedAccessArgument",
+			src:  `type DeepPartial<T> = {[K]?: DeepPartial<T[K]> for K in keyof T}`,
+		},
+		{
+			// A union is a choice among its members rather than a wrapper, so `T | number` carries
+			// T at the same size the bare parameter has.
+			name: "UnionArgument",
+			src: `
+				type Wrap<T> = {value: T}
+				type Chain<T> = {next?: Chain<T | number>} | Wrap<T>
+			`,
+		},
+		{
+			// The recursion passes a type an `infer` clause captured, which is a component of the
+			// checked type rather than a wrapper around the parameter.
+			name: "InferCapture",
+			src:  `type Flatten<T> = if T : [infer U] { Flatten<U> } else { T }`,
+		},
+		{
+			// The parameter is wrapped, but the reference is to an alias outside any cycle, so the
+			// expansion finishes after one step.
+			name: "NonRecursiveWrapping",
+			src: `
+				type Box<T> = {value: T}
+				type Wrap<T> = Box<{a: T}>
+			`,
+		},
+		{
+			// Mutual recursion that passes both parameters through is regular the same way a
+			// self-recursive pass-through is.
+			name: "MutualPassThrough",
+			src: `
+				type A<T> = {b?: B<T>}
+				type B<T> = {a?: A<T>}
+			`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, test.src)
+			require.Empty(t, messagesWithSpan(errs))
+		})
+	}
+}
+
+// checkRegular rejects an alias that wraps one of its own parameters in the argument of a recursive
+// reference. Each case names a shape whose argument is strictly larger every lap, so its
+// instantiation state never repeats and only the runtime budgets would stop the expansion.
+func TestCheckRegularRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The canonical rejection. The argument gains an object wrapper every lap.
+			name: "SelfRecursiveObjectWrapper",
+			src:  `type Grow<T> = Grow<{a: T}>`,
+			want: []string{
+				"2:10-2:14: recursive type alias `Grow` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+			},
+		},
+		{
+			// The recursive reference sits inside a union, which does not shield the growing
+			// argument from the check.
+			name: "RecursiveReferenceInUnion",
+			src:  `type A<T> = {x: T} | A<{y: T}>`,
+			want: []string{
+				"2:10-2:11: recursive type alias `A` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+			},
+		},
+		{
+			// The recursive reference sits under an indexed access. The access does not grow its
+			// target, but the argument it is applied to still does.
+			name: "UnderIndexedAccess",
+			src:  `type Grow<T> = Grow<{a: T, b: T}>["a"]`,
+			want: []string{
+				"2:10-2:14: recursive type alias `Grow` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+			},
+		},
+		{
+			// The reference is the value expression of a mapped type, which reduces it once per
+			// key. The enclosing object does not count against the argument, but the `{a: T}` the
+			// argument is written as does.
+			name: "InMappedValue",
+			src:  `type Grow<T> = {[K]: Grow<{a: T}>[K] for K in keyof T}`,
+			want: []string{
+				"2:10-2:14: recursive type alias `Grow` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+			},
+		},
+		{
+			// Mutual recursion. Neither body names itself, so the cycle is found through the alias
+			// reference graph, and only the alias that wraps its own parameter is blamed.
+			name: "MutualRecursion",
+			src: `
+				type A<T> = B<{x: T}>
+				type B<U> = A<U>
+			`,
+			want: []string{
+				"3:10-3:11: recursive type alias `A` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+			},
+		},
+		{
+			// Two parameters grow, so each is blamed on its own, in the order the source declares
+			// them rather than alphabetically.
+			name: "BothParametersGrow",
+			src:  `type Grow<T, U> = Grow<{a: U}, [T]>`,
+			want: []string{
+				"2:10-2:14: recursive type alias `Grow` grows type parameter `T` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `T` through unwrapped",
+				"2:10-2:14: recursive type alias `Grow` grows type parameter `U` under a type " +
+					"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+					"type or pass `U` through unwrapped",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, errs := inferSource(t, "\n\t\t\t\t"+test.src+"\n")
+			require.Equal(t, test.want, messagesWithSpan(errs))
+		})
+	}
+}
+
+// The check is sound but incomplete, and this is the incompleteness. `Grow` never expands past its
+// base case, since `Grow<never>` selects the `never` branch and stops. Deciding that in general is
+// the halting problem. The check sees only that the recursive argument wraps the parameter, so it
+// rejects the alias. The case is here so the boundary is pinned rather than discovered by a user.
+func TestCheckRegularRejectsTerminatingBaseCase(t *testing.T) {
+	_, _, errs := inferSource(t, `
+		type Grow<T> = if T : never { never } else { Grow<{a: T}> }
+	`)
+	require.Equal(t, []string{
+		"2:8-2:12: recursive type alias `Grow` grows type parameter `T` under a type " +
+			"constructor, so its expansion is unbounded; break the recursion with a nominal " +
+			"type or pass `T` through unwrapped",
+	}, messagesWithSpan(errs))
+}

--- a/internal/solver/typeops.go
+++ b/internal/solver/typeops.go
@@ -11,45 +11,42 @@ import (
 )
 
 // maxExpandDepth caps how many times an alias may expand along one reduction path. The
-// active-state guard already stops a regular recursive alias, whose instantiation state repeats.
-// This budget backstops an expanding recursive alias such as `type Grow<T> = Grow<Array<T>>`,
-// whose argument grows every lap so its state never repeats and the active guard never matches.
-// No finite analytical bound exists for that fragment, so the budget stops the walk and the
-// operator over the unexpanded alias stays symbolic.
+// active-state guard already stops a regular recursive alias, whose instantiation state repeats,
+// and checkRegular rejects a declared alias whose argument grows every lap so its state never
+// repeats. This budget is the backstop for growing recursion that reaches the evaluator without
+// passing that check, which is how an alias ingested from a library rather than declared in source
+// arrives. No finite analytical bound exists for that fragment, so the budget stops the walk and
+// the operator over the unexpanded alias stays symbolic.
 const maxExpandDepth = 200
 
-// maxExpandKeyChars caps the total cost of alias expansion across a whole reduction, counted in
-// the length of the rendered instantiation keys. maxExpandDepth alone does not bound that cost,
-// for two reasons that compound in the same shapes:
+// maxExpandKeyChars caps the total cost of alias expansion across a whole reduction, counted in the
+// length of the rendered instantiation keys. What it bounds that maxExpandDepth cannot is expansion
+// that is wide rather than deep, and that involves no recursion at all:
 //
-//   - It is restored when a branch finishes, which is right for a sequential walk but not for a
-//     caller that expands one operand per member. A mapped type reduces its value expression once
-//     per key, so every key restarts from the full remaining depth and the walk branches by the
-//     key count each lap.
-//   - It counts laps, not the size of what each lap expands. An alias whose argument grows by a
-//     constant factor each lap, such as `type Grow<T> = keyof Grow<{a: T, b: T}>`, doubles its
-//     rendered key every lap, so a few dozen laps render a key of astronomical length. That one
-//     needs no mapped type to diverge.
+//	type A0<T> = {a: T}
+//	type A1<T> = {...A0<T>, ...A0<T>}
+//	type A2<T> = {...A1<T>, ...A1<T>}
+//	…
 //
-// One monotonic budget bounds both. It is never restored, so siblings spend a shared pool. Every
-// alias reference charges the length of the key it rendered, so an argument that grows by a
-// constant factor exhausts the pool after a logarithmic number of laps. A key is never empty, so
-// the budget also caps how many aliases a reduction expands.
+// Grounding `A40<number>` expands two references per lap over forty laps, so a full walk is 2^41
+// expansions. Every alias here passes its parameter through unwrapped, so checkRegular accepts them
+// all, and the reduction path is only forty deep, so maxExpandDepth never binds. maxExpandDepth is
+// also restored when a branch finishes, which is right for a sequential walk but leaves each of the
+// two sibling references restarting from the full remaining depth.
+//
+// This budget is monotonic instead. It is never restored, so every sibling in that tree spends one
+// shared pool, and a key is never empty, so the pool also caps how many aliases a reduction expands
+// in total. The 2^41 walk above stops after roughly ten thousand expansions.
 //
 // The budget is read before a key is rendered, so an exhausted budget costs nothing further. The
 // reference that exhausts it still pays its own render, which overshoots by that key's length.
 //
 // The value is a backstop, not a derived maximum. The largest spend across the test suite by a
 // reduction that is not deliberately divergent is under 500 characters, so it leaves two orders of
-// magnitude of headroom. It is also high enough that an alias whose argument grows by a fixed
-// amount each lap, rather than by a factor, stays under it for all maxExpandDepth laps. depth
-// therefore remains the governing cap for that shape, and this budget binds only on faster growth
-// or on sibling branching.
+// magnitude of headroom.
 //
-// Truncation leaves the operator over the unexpanded alias symbolic, the same outcome as
-// exhausting maxExpandDepth, and marks that alias reference Truncated. A diagnostic naming the
-// residual renders it `Grow<…>` rather than spelling out the argument the walk had grown, so how
-// much the budget allowed before stopping never reaches the message.
+// An exhausted budget leaves the operator over the unexpanded alias symbolic, the same outcome as
+// exhausting maxExpandDepth. The reference keeps the arguments it was built with.
 const maxExpandKeyChars = 100_000
 
 // maxTemplateLitCombinations caps how many string literals a template literal may reduce to. Its
@@ -70,19 +67,22 @@ const maxTemplateLitCombinations = 10_000
 // alias itself gets under constrain. A `keyof T` over a type parameter has no ground key set, so
 // it stays the symbolic KeyofType.
 //
-// A recursive alias reached through an operand is made safe by a three-part termination strategy:
+// An alias reached through an operand is made safe by a four-part termination strategy:
 //
+//   - checkRegular rejects an alias whose recursion grows one of its own parameters every lap and
+//     marks its AliasDef NotRegular. The evaluator declines to expand such an alias at all, so the
+//     one shape with no finite analytical bound never starts unfolding. See
+//     internal/solver/regularity.go.
 //   - active holds the alias instantiations currently being expanded, each keyed by the alias
 //     name together with its rendered arguments. When one recurs with the identical key, the
 //     evaluator leaves that reference as the unexpanded alias node rather than expanding it again.
-//     A recursive alias such as `type List<T> = {head: T, tail: List<T> | null}` therefore reduces
-//     to a finite type whose recursive position points back to the alias instead of unfolding
-//     forever.
-//   - depth caps expansions along one path. It backstops an expanding recursion whose argument
-//     grows every lap, so its key never repeats and the active guard never fires.
-//   - keyChars caps the total cost of expansion across the whole reduction, so branches that each
-//     restart from the full depth, and laps whose argument grows by a constant factor, cannot
-//     turn that per-path cap into an exponential walk. See maxExpandKeyChars.
+//     A recursive alias such as `type List<T> = {head: T, tail?: List<T>}` therefore reduces to a
+//     finite type whose recursive position points back to the alias instead of unfolding forever.
+//   - depth caps expansions along one path, the backstop for growing recursion that reaches the
+//     evaluator without passing checkRegular.
+//   - keyChars caps the total cost of expansion across the whole reduction, so sibling branches
+//     that each restart from the full depth cannot turn that per-path cap into an exponential
+//     walk. See maxExpandKeyChars.
 //
 // The evaluator mutates no solver state — no bound or variable is touched. It accumulates
 // reduction diagnostics on errs, but a fresh evaluator is minted per reduction, so nothing
@@ -965,27 +965,31 @@ func (e *typeEvaluator) reduceKeyofAlias(op *soltype.AliasType, inexact bool) so
 // expandAliasGuarded expands a named alias to its body and applies cont to the result, under the
 // termination guard that makes reduction safe over a recursive alias. The alias stays on the
 // active path for the whole reduction of its body, so a member that re-references it, directly
-// or through a chain, sees it active and stops. A recurring instantiation state, an exhausted
-// budget, or an unresolved body each leaves the alias unexpanded, so the operator over it stays
-// symbolic.
+// or through a chain, sees it active and stops. Four conditions leave the alias unexpanded, so the
+// operator over it stays symbolic: a definition checkRegular rejected, a recurring instantiation
+// state, an exhausted budget, and an unresolved body.
 //
-// fallback builds that symbolic result around the alias reference it is handed, which is op except
-// when the budget ran out — there it is a copy marked Truncated, so a diagnostic naming it elides
-// the arguments the walk had grown rather than spelling them out. A caller whose symbolic form is
-// the bare reference returns the argument unchanged.
+// fallback builds that symbolic result around op, the alias reference as the source wrote it. A
+// caller whose symbolic form is the bare reference returns the argument unchanged.
 //
 // Every reduction that expands an alias routes through here, so one guard covers `keyof`, indexed
 // access, and the operand-grounding both spread forms use, and the budgets are shared across them.
 func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback func(*soltype.AliasType) soltype.Type, cont func(body soltype.Type) soltype.Type) soltype.Type {
+	if def, ok := e.ctx.aliasDef(op.Name); ok && def.NotRegular {
+		// checkRegular rejected this alias at its declaration because one lap of its recursion
+		// hands the next a strictly larger argument. Expanding even one lap would start growing
+		// that argument, and the walk would run until a budget cut it off, so decline outright.
+		// The reference keeps the arguments the source wrote, which is what a diagnostic names.
+		return fallback(op)
+	}
 	if e.depth <= 0 || e.keyChars <= 0 {
-		return fallback(markTruncated(op))
+		return fallback(op)
 	}
 	key := soltype.PrintQualified(op)
 	e.keyChars -= len(key)
 	if e.active.Contains(key) {
 		// A repeated instantiation state is a regular recursion the evaluator represents by
-		// pointing back at the alias, so op is the reference the source wrote and renders as
-		// written. Only a budget exhaustion carries a grown argument worth hiding.
+		// pointing back at the alias.
 		return fallback(op)
 	}
 	body := e.ctx.expandAlias(op)
@@ -1003,19 +1007,8 @@ func (e *typeEvaluator) expandAliasGuarded(op *soltype.AliasType, fallback func(
 }
 
 // aliasItself is the fallback for a caller whose symbolic form is the bare alias reference, so the
-// grounding walks keep whichever reference expandAliasGuarded handed back.
+// grounding walks keep the reference unchanged when expandAliasGuarded declines to expand it.
 func aliasItself(op *soltype.AliasType) soltype.Type { return op }
-
-// markTruncated copies op with the Truncated marker set, so tagging one reference never mutates a
-// node the annotation it came from still points at. A reference already marked is returned as is.
-func markTruncated(op *soltype.AliasType) *soltype.AliasType {
-	if op.Truncated {
-		return op
-	}
-	marked := *op
-	marked.Truncated = true
-	return &marked
-}
 
 // keyofObject projects an object's property, getter, and setter names as string-literal types
 // and unions them. An empty projection collapses to `never`, the union identity newUnion returns

--- a/planning/simple_sub/m9-implementation-plan.md
+++ b/planning/simple_sub/m9-implementation-plan.md
@@ -89,11 +89,13 @@ spike work rather than inventing it:
   it adds **no new mutable solver state**.
 - **CheckRegular** — [regularity.go](../../internal/simplesub/regularity.go): the
   optional level-2 static check that rejects *expanding* recursion at definition
-  time, accepting `List` / `Json` / `DeepPartial` and rejecting `Grow`.
+  time, accepting `List` / `Json` / `DeepPartial` and rejecting `Grow`. PR9 lands
+  it, and PR9b replaces its condition with productivity.
 - **The lazy/coinductive alternative** — [lazy.go](../../internal/simplesub/lazy.go):
   an Amadio–Cardelli seen-set that decides regular recursive subtyping with no
   budget. M9 keeps the eager evaluator as the backbone and borrows the
-  coinductive seen-set only where recursive-vs-recursive comparison needs it.
+  coinductive seen-set only where recursive-vs-recursive comparison needs it,
+  which is PR9b.
 
 ## What M9 adds (the delta)
 
@@ -116,7 +118,10 @@ spike work rather than inventing it:
 5. **Exactness propagation through reduction** — the first milestone where
    exactness is *computed by* an operator, not merely checked — plus the
    `Exact<T>` / `Inexact<T>` intrinsics.
-6. **`CheckRegular`** as a definition-time diagnostic for expanding recursion.
+6. **A definition-time recursion check.** `CheckRegular` first, rejecting an alias
+   whose recursion grows one of its own parameters, then the productivity condition
+   that supersedes it and the coinductive comparison the types it newly accepts
+   require.
 7. **`FuncType.Throws` and `FuncType.Yields` fields** with parallel arms in
    `constrain` / `extrude` / `LevelOf` / the printer, plus per-body inference
    variables that accumulate lowers from `throw e` / `yield e`.
@@ -128,7 +133,7 @@ spike work rather than inventing it:
 
 ## PR-by-PR breakdown
 
-Fifteen PRs across five tracks. Track A builds the evaluator and the core
+Sixteen PRs across five tracks. Track A builds the evaluator and the core
 operators in dependency order. Track B adds spread and template-literal
 operators, which hang off the backbone but are independent of each other. Track C
 adds exactness propagation and the recursion static-check. Track D is the two
@@ -431,6 +436,70 @@ are complementary: a precise early error where decidable, safe termination alway
 **Depends on** PR1b (evaluator + cycle cache) and PR3b (conditionals recursing on
 an `infer` binding are an accept case). Independent of PR4–PR8.
 
+### PR9b — Productivity check + coinductive comparison
+
+PR9's condition is sound but rejects a family of types that are well defined and
+that TypeScript accepts. This PR replaces it with the condition that actually
+decides whether a recursive alias denotes a type, and adds the comparison
+machinery the newly accepted types need.
+
+Two terms do the work here. Recursion is **productive** when every cycle through an
+alias passes under a type constructor in its body, so each lap emits one level of
+structure. Recursion is **regular** when the type has finitely many distinct
+subtrees, so a finite μ-knot represents it. PR9 checks a proxy for regularity. This
+PR checks productivity instead.
+
+The two conditions come apart on exactly the cases that motivate the PR:
+
+- `type Deep<T> = {a: Deep<{b: T}>}` is productive and non-regular. It emits
+  `{a: …}` every lap, so `Deep<number>` is a well-defined infinite tree, but its
+  payloads are `{b: number}`, `{b: {b: number}}`, and so on, all distinct. PR9
+  rejects it. TypeScript accepts it.
+- `type Grow<T> = Grow<{a: T}>` is non-productive. No lap emits a constructor, so
+  the equation `G(T) = G({a: T})` is satisfied by every constant function and
+  pins down no type at all. PR9 rejects it for the wrong reason; this PR rejects
+  it for the right one.
+
+**Data structures.** No new `soltype` node. `AliasDef.NotRegular` is renamed
+`NotProductive` and keeps its meaning, a marker the evaluator reads to decline
+expansion. `NotRegularAliasError` is replaced by a productivity diagnostic that
+names the cycle rather than a growing parameter. `constrain` gains the seen-set of
+`(sub, super)` pairs described below, threaded the way its existing alias-cycle set
+already is.
+
+**Algorithms.**
+- **Productivity replaces regularity.** The SCC machinery from PR9 stays as is.
+  The nesting walk moves from the arguments of a recursive reference to the
+  reference's own position in the alias body: an alias is rejected when some cycle
+  returns to it without passing under a type constructor. This accepts `List`,
+  `DeepPartial`, the self-referential `type SelfA = {a: SelfA}`, and `Deep`, and
+  rejects `Grow` and `type Bad = Bad`. It is the guard condition from coinductive
+  type theory.
+- **Coinductive comparison.** A non-regular type has no finite normal form, so the
+  eager evaluator cannot materialize `Deep<number>` and productivity alone would
+  accept a type nothing can use. Promote the Amadio–Cardelli seen-set from
+  [lazy.go](../../internal/simplesub/lazy.go): `constrain` records the
+  `(sub, super)` pair it is deciding and succeeds when that pair recurs, so
+  `Deep<number> <: Deep<number>` closes with no unfolding at all. The eager
+  evaluator stays the backbone. The seen-set covers recursive-against-recursive
+  comparison, which is the one case with no normal form to compare.
+- **Refusing to expand a rejected alias carries over.** PR9 marks a rejected alias
+  so the evaluator never expands it, which keeps a diagnostic naming the arguments
+  the source wrote rather than ones the expansion had grown. A non-productive alias
+  is refused the same way, for the same reason.
+- **The expansion budgets stay.** Neither condition bounds a reduction that is wide
+  rather than deep. A chain of non-recursive aliases that each spread the one below
+  them twice is exponential in the chain length, and no recursion check sees it, so
+  `maxExpandDepth` and `maxExpandKeyChars` remain as the backstop.
+
+**Accept.** `type Deep<T> = {a: Deep<{b: T}>}` is accepted and a value checks
+against `Deep<number>`. `type Grow<T> = Grow<{a: T}>` and `type Bad = Bad` are
+rejected with a productivity diagnostic. Every alias PR9 accepted still passes,
+including the DOM-shaped `type Node = {parent?: Node, children: [Node]}`, which
+keeps reducing under `keyof`, indexed access, and mapped types.
+
+**Depends on** PR9. Independent of PR4–PR8 and PR10–PR13.
+
 ### PR10 — `throws T` clause on functions
 
 Orthogonal to the evaluator. Touches only `FuncType` and the function-inference
@@ -544,6 +613,15 @@ no operator-track review burden. PR13 is verification-heavy but low-risk; if the
 utility corpus balloons it splits cleanly by category (mapped-based,
 conditional-based, template-based).
 
+PR9b is the one PR that carries both a condition change and new comparison
+machinery, and the two cannot land apart: relaxing the check without the
+coinductive seen-set accepts types the eager evaluator cannot materialize, and
+adding the seen-set without relaxing the check leaves nothing for it to decide. It
+stays within the band because the condition change reuses PR9's SCC walk and the
+seen-set is promoted from the spike rather than designed here. If it does need
+splitting, the seam is to land the seen-set first as a no-op fast path for
+comparisons the evaluator already settles, then flip the condition.
+
 ## Dependency graph
 
 ```
@@ -557,6 +635,7 @@ PR1a (residual-node representation + inert plumbing)
       ├─► PR3a (conditional types: branch selection)
       │    └─► PR3b (infer clauses + distribution)   ── also needs PR2
       │         ├─► PR9 (CheckRegular)          ── also needs PR1b
+      │         │    └─► PR9b (productivity check + coinductive comparison)
       │         └─► PR12 (Awaited<T>)           ── also needs PR1b, M7.5
       ├─► PR5 (object spread types)
       ├─► PR6 (tuple spread types)
@@ -588,6 +667,7 @@ graph TD
     PR7["PR7 (template literal types + intrinsics)"]
     PR8["PR8 (exactness propagation + Exact/Inexact)"]
     PR9["PR9 (CheckRegular static check)"]
+    PR9b["PR9b (productivity + coinductive comparison)"]
     PR10["PR10 (throws clause)"]
     PR11["PR11 (generators)"]
     PR12["PR12 (Awaited<T>)"]
@@ -611,6 +691,7 @@ graph TD
     PR3a --> PR4
     PR3b --> PR9
     PR1b --> PR9
+    PR9 --> PR9b
     PR3b --> PR12
     PR1b --> PR12
     PR3b --> PR13
@@ -639,7 +720,8 @@ graph TD
   off PR1b) is the operator core. PR5, PR6, and PR7 are mutually independent and can
   be built concurrently once PR1b lands.
 - **Track C** — PR8 (exactness) is a barrier that waits for all operators; PR9
-  (CheckRegular) needs only PR1b + PR3b and runs alongside PR4–PR8.
+  (CheckRegular) needs only PR1b + PR3b and runs alongside PR4–PR8. PR9b follows
+  PR9 and depends on nothing else, so it can land at any point after it.
 - **Track D** — PR10 (throws) has no operator dependency and can start on day one
   alongside PR1a; PR11 (generators) follows PR10.
 - **Track E** — PR13 is the final join, waiting on PR2, PR3b, PR4, PR7, PR12.


### PR DESCRIPTION
Adds `checkRegular`, a definition-time diagnostic that rejects recursive type aliases whose arguments grow under type constructors on each recursion lap. Such aliases expand to infinitely many distinct instantiations and never settle, so they are unsafe to expand.

The check is sound but incomplete: it conservatively rejects some terminating programs (those with base-case conditionals) since deciding termination in general is the halting problem. Runtime expansion budgets remain as a backstop for cases the check cannot see, such as expansion through imported types or chains of non-recursive aliases.

**Key changes:**

- New `regularity.go` module implements the check by walking alias bodies to find recursive references and detect parameters that gain structure (appear under type constructors in recursive call arguments). Mutual recursion is handled through strongly connected components of the alias reference graph.
- `checkRegular` is called after all alias bodies in a component are resolved, ensuring the reference graph is complete.
- New `NotRegularAliasError` reports the qualified alias name and the specific parameter that grows, with guidance to either break the cycle with a nominal type or pass the parameter through unwrapped.
- Test suite covers both accepted cases (pass-through parameters, indexed access, unions, infer captures, non-recursive wrapping, mutual recursion) and rejected cases (self-recursive and mutual wrapping, parameters under constructors in various contexts).
- Updated existing tests that exercise expanding aliases to expect the new definition-time diagnostic alongside the runtime truncation errors.

https://claude.ai/code/session_01RHJBmCS5RgFn4R8iz3e2ko

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for recursive type aliases to detect unbounded type expansion.
  * Added clear diagnostics identifying the recursive alias and growing type parameter.
  * Recursive aliases are now checked automatically during type analysis.

* **Bug Fixes**
  * Prevented potentially non-terminating recursive type inference.
  * Improved error reporting with precise source locations and expansion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->